### PR TITLE
cli: adopt static-help split for conversations through plugins (batch of 16)

### DIFF
--- a/assistant/src/__tests__/cli-memory-v2-reembed-skills.test.ts
+++ b/assistant/src/__tests__/cli-memory-v2-reembed-skills.test.ts
@@ -51,6 +51,8 @@ mock.module("../plugins/defaults/memory/v2/skill-store.js", () => ({
 // Imports under test (after mocks)
 // ---------------------------------------------------------------------------
 
+const { applyCommandHelp } = await import("../cli/lib/cli-command-help.js");
+const { memoryHelp } = await import("../cli/commands/memory/index.help.js");
 const { registerMemoryV2Command } =
   await import("../cli/commands/memory/memory-v2.js");
 const { ROUTES: memoryV2Routes, MEMORY_V2_DISABLED_CODE } =
@@ -69,6 +71,7 @@ function buildProgram(): Command {
     writeOut: () => {},
   });
   const memory = program.command("memory");
+  applyCommandHelp(memory, memoryHelp);
   registerMemoryV2Command(memory);
   return program;
 }

--- a/assistant/src/__tests__/conversations-defer-cli.test.ts
+++ b/assistant/src/__tests__/conversations-defer-cli.test.ts
@@ -69,7 +69,9 @@ describe("parseDuration", () => {
 
 import { Command } from "commander";
 
+import { conversationsHelp } from "../cli/commands/conversations.help.js";
 import { registerConversationsDeferCommand } from "../cli/commands/conversations-defer.js";
+import { applyCommandHelp } from "../cli/lib/cli-command-help.js";
 
 describe("defer CLI option inheritance", () => {
   let savedExitCode: typeof process.exitCode;
@@ -88,6 +90,7 @@ describe("defer CLI option inheritance", () => {
     const program = new Command();
     program.exitOverride(); // throw instead of calling process.exit
     const conversations = program.command("conversations");
+    applyCommandHelp(conversations, conversationsHelp);
     registerConversationsDeferCommand(conversations);
     return program;
   }

--- a/assistant/src/cli/commands/__tests__/conversations-import.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-import.test.ts
@@ -82,9 +82,10 @@ mock.module("../../logger.js", () => ({
 // Import module under test (after mocks)
 // ---------------------------------------------------------------------------
 
-const { registerConversationsImportCommand } = await import(
-  "../conversations-import.js"
-);
+const { registerConversationsImportCommand } =
+  await import("../conversations-import.js");
+const { applyCommandHelp } = await import("../../lib/cli-command-help.js");
+const { conversationsHelp } = await import("../conversations.help.js");
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -109,6 +110,7 @@ async function runCommand(args: string[]): Promise<{ exitCode: number }> {
       writeOut: () => {},
     });
     const conversations = program.command("conversations");
+    applyCommandHelp(conversations, conversationsHelp);
     registerConversationsImportCommand(conversations);
     await program.parseAsync(["node", "assistant", ...args]);
   } catch {
@@ -181,7 +183,12 @@ describe("conversations import — valid input", () => {
     expect(lastIpcCall).not.toBeNull();
     expect(lastIpcCall!.method).toBe("conversations_import");
     expect(
-      ((lastIpcCall!.params as Record<string, unknown>).body as Record<string, unknown>).conversations,
+      (
+        (lastIpcCall!.params as Record<string, unknown>).body as Record<
+          string,
+          unknown
+        >
+      ).conversations,
     ).toHaveLength(1);
   });
 
@@ -201,8 +208,12 @@ describe("conversations import — valid input", () => {
     await runCommand(["conversations", "import", "--file", filePath]);
 
     expect(lastIpcCall).not.toBeNull();
-    const convs = ((lastIpcCall!.params as Record<string, unknown>)
-      .body as Record<string, unknown>).conversations as Array<Record<string, unknown>>;
+    const convs = (
+      (lastIpcCall!.params as Record<string, unknown>).body as Record<
+        string,
+        unknown
+      >
+    ).conversations as Array<Record<string, unknown>>;
     expect(convs[0]!.sourceKey).toBe("chatgpt:abc123");
     expect(convs[0]!.title).toBe("Exported Chat");
   });
@@ -226,20 +237,16 @@ describe("conversations import — empty array", () => {
 
     expect(exitCode).toBe(0);
     expect(lastIpcCall).toBeNull();
-    expect(mockLogInfo.some((m) => m.includes("No conversations to import"))).toBe(true);
+    expect(
+      mockLogInfo.some((m) => m.includes("No conversations to import")),
+    ).toBe(true);
   });
 
   test("--json outputs JSON for empty array without calling IPC", async () => {
     const payload = { conversations: [] };
     const filePath = makeTmpFile(JSON.stringify(payload));
 
-    await runCommand([
-      "conversations",
-      "import",
-      "--file",
-      filePath,
-      "--json",
-    ]);
+    await runCommand(["conversations", "import", "--file", filePath, "--json"]);
 
     expect(lastIpcCall).toBeNull();
     const jsonOut = mockLogInfo.find((m) => m.startsWith("{"));
@@ -273,13 +280,7 @@ describe("conversations import — invalid JSON", () => {
   test("--json outputs error JSON for invalid JSON", async () => {
     const filePath = makeTmpFile("{bad json}");
 
-    await runCommand([
-      "conversations",
-      "import",
-      "--file",
-      filePath,
-      "--json",
-    ]);
+    await runCommand(["conversations", "import", "--file", filePath, "--json"]);
 
     expect(lastIpcCall).toBeNull();
     const jsonOut = mockLogInfo.find((m) => m.startsWith("{"));
@@ -385,9 +386,7 @@ describe("conversations import — file errors", () => {
 
     expect(exitCode).toBe(1);
     expect(lastIpcCall).toBeNull();
-    expect(
-      mockLogError.some((m) => m.includes("File not found")),
-    ).toBe(true);
+    expect(mockLogError.some((m) => m.includes("File not found"))).toBe(true);
   });
 });
 

--- a/assistant/src/cli/commands/__tests__/inference-models.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-models.test.ts
@@ -27,6 +27,8 @@ mock.module("../../../util/logger.js", () => ({
 }));
 
 const { attachModelsSubcommand } = await import("../inference-models.js");
+const { applyCommandHelp } = await import("../../lib/cli-command-help.js");
+const { inferenceHelp } = await import("../inference.help.js");
 
 beforeEach(() => {
   lastIpcCall = null;
@@ -45,6 +47,7 @@ async function run(args: string[]): Promise<string> {
     const program = new Command();
     program.exitOverride();
     const inference = program.command("inference");
+    applyCommandHelp(inference, inferenceHelp);
     attachModelsSubcommand(inference);
     await program.parseAsync(["node", "assistant", "inference", ...args]);
   } catch {

--- a/assistant/src/cli/commands/__tests__/inference-profiles.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-profiles.test.ts
@@ -31,6 +31,8 @@ mock.module("../../../util/logger.js", () => ({
 }));
 
 const { attachProfilesSubcommand } = await import("../inference-profiles.js");
+const { applyCommandHelp } = await import("../../lib/cli-command-help.js");
+const { inferenceHelp } = await import("../inference.help.js");
 
 beforeEach(() => {
   lastIpcCall = null;
@@ -58,6 +60,7 @@ async function run(
     const program = new Command();
     program.exitOverride();
     const inference = program.command("inference");
+    applyCommandHelp(inference, inferenceHelp);
     attachProfilesSubcommand(inference);
     await program.parseAsync(["node", "assistant", "inference", ...args]);
   } catch (err: unknown) {

--- a/assistant/src/cli/commands/__tests__/inference-providers.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-providers.test.ts
@@ -29,6 +29,8 @@ mock.module("../../../util/logger.js", () => ({
 }));
 
 const { attachProvidersSubcommand } = await import("../inference-providers.js");
+const { applyCommandHelp } = await import("../../lib/cli-command-help.js");
+const { inferenceHelp } = await import("../inference.help.js");
 
 const CONNECTION_RESULT = {
   name: "local-llm",
@@ -64,6 +66,7 @@ async function run(
     const program = new Command();
     program.exitOverride();
     const inference = program.command("inference");
+    applyCommandHelp(inference, inferenceHelp);
     attachProvidersSubcommand(inference);
     await program.parseAsync(["node", "assistant", "inference", ...args]);
   } catch {

--- a/assistant/src/cli/commands/__tests__/inference-session.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-session.test.ts
@@ -50,7 +50,9 @@ mock.module("../../../util/logger.js", () => ({
 
 mock.module("../../../config/loader.js", () => ({
   loadConfig: () => ({ llm: { profileSession: { defaultTtlSeconds: 1800 } } }),
-  getConfigReadOnly: () => ({ llm: { profileSession: { defaultTtlSeconds: 1800 } } }),
+  getConfigReadOnly: () => ({
+    llm: { profileSession: { defaultTtlSeconds: 1800 } },
+  }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -58,6 +60,8 @@ mock.module("../../../config/loader.js", () => ({
 // ---------------------------------------------------------------------------
 
 const { attachSessionSubcommand } = await import("../inference-session.js");
+const { applyCommandHelp } = await import("../../lib/cli-command-help.js");
+const { inferenceHelp } = await import("../inference.help.js");
 
 // ---------------------------------------------------------------------------
 // Env var helpers
@@ -115,6 +119,7 @@ async function runCommand(
     const program = new Command();
     program.exitOverride();
     const inferenceCmd = program.command("inference");
+    applyCommandHelp(inferenceCmd, inferenceHelp);
     attachSessionSubcommand(inferenceCmd);
     await program.parseAsync(["node", "assistant", "inference", ...args]);
   } catch (err: unknown) {
@@ -373,12 +378,7 @@ describe("session list", () => {
       result: { sessions: [] },
     };
 
-    await runCommand([
-      "session",
-      "list",
-      "--conversation-id",
-      "conv-xyz",
-    ]);
+    await runCommand(["session", "list", "--conversation-id", "conv-xyz"]);
 
     expect(lastIpcCall).not.toBeNull();
     expect(lastIpcCall!.params).toEqual({

--- a/assistant/src/cli/commands/conversations-defer.ts
+++ b/assistant/src/cli/commands/conversations-defer.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
-import { registerCommand } from "../lib/register-command.js";
+import { subcommand } from "../lib/cli-command-help.js";
 import { log } from "../logger.js";
 import { resolveConversationId } from "../utils/conversation-id.js";
 import { parseDuration } from "../utils/parse-duration.js";
@@ -13,50 +13,65 @@ export { parseDuration };
 // ---------------------------------------------------------------------------
 
 export function registerConversationsDeferCommand(parent: Command): void {
-  registerCommand(parent, {
-    name: "defer [conversationId]",
-    transport: "ipc",
-    description: "Create a deferred wake for a conversation",
-    build: (defer) => {
-      defer
-    .option("--in <duration>", "Delay before firing (e.g. 60, 60s, 5m, 1h)")
-    .option("--at <iso8601>", "Absolute ISO 8601 fire time")
-    .option("--hint <text>", "Hint message for the wake")
-    .option("--name <text>", "Name for the deferred wake", "Deferred wake")
-    .option("--json", "Output result as JSON")
-    .addHelpText(
-      "after",
-      `
-Create a deferred wake that fires after a delay or at a specific time.
-The conversation ID is resolved from the positional argument, the
-$__SKILL_CONTEXT_JSON env var, or $__CONVERSATION_ID.
+  const defer = subcommand(parent, "defer");
 
-Requires the assistant to be running. Communicates via IPC socket.
+  defer.action(
+    async (
+      conversationIdArg: string | undefined,
+      opts: {
+        in?: string;
+        at?: string;
+        hint?: string;
+        name: string;
+        json?: boolean;
+      },
+    ) => {
+      let conversationId: string;
+      try {
+        conversationId = resolveConversationId({
+          explicit: conversationIdArg,
+          failureHelp:
+            "No conversation ID provided. Pass it as an argument, or set $__SKILL_CONTEXT_JSON or $__CONVERSATION_ID.",
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: false, error: msg }));
+        } else {
+          log.error(`Error: ${msg}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
 
-Examples:
-  $ assistant conversations defer --in 60 --hint "check progress"
-  $ assistant conversations defer conv-123 --in 5m --hint "follow up"
-  $ assistant conversations defer --at 2026-04-23T15:00:00Z --hint "meeting time"
-  $ assistant conversations defer --in 1h30m --hint "remind me" --json`,
-    )
-    .action(
-      async (
-        conversationIdArg: string | undefined,
-        opts: {
-          in?: string;
-          at?: string;
-          hint?: string;
-          name: string;
-          json?: boolean;
-        },
-      ) => {
-        let conversationId: string;
+      if (!opts.in && !opts.at) {
+        const msg = "Either --in or --at must be provided";
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: false, error: msg }));
+        } else {
+          log.error(`Error: ${msg}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!opts.hint) {
+        const msg = "--hint is required when creating a deferred wake";
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: false, error: msg }));
+        } else {
+          log.error(`Error: ${msg}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      let delaySeconds: number | undefined;
+      let fireAt: number | undefined;
+
+      if (opts.in) {
         try {
-          conversationId = resolveConversationId({
-            explicit: conversationIdArg,
-            failureHelp:
-              "No conversation ID provided. Pass it as an argument, or set $__SKILL_CONTEXT_JSON or $__CONVERSATION_ID.",
-          });
+          delaySeconds = parseDuration(opts.in);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           if (opts.json) {
@@ -67,9 +82,12 @@ Examples:
           process.exitCode = 1;
           return;
         }
+      }
 
-        if (!opts.in && !opts.at) {
-          const msg = "Either --in or --at must be provided";
+      if (opts.at) {
+        fireAt = new Date(opts.at).getTime();
+        if (isNaN(fireAt)) {
+          const msg = `Invalid ISO 8601 date: "${opts.at}"`;
           if (opts.json) {
             log.info(JSON.stringify({ ok: false, error: msg }));
           } else {
@@ -78,9 +96,8 @@ Examples:
           process.exitCode = 1;
           return;
         }
-
-        if (!opts.hint) {
-          const msg = "--hint is required when creating a deferred wake";
+        if (fireAt <= Date.now()) {
+          const msg = "The --at time must be in the future";
           if (opts.json) {
             log.info(JSON.stringify({ ok: false, error: msg }));
           } else {
@@ -89,108 +106,51 @@ Examples:
           process.exitCode = 1;
           return;
         }
+      }
 
-        let delaySeconds: number | undefined;
-        let fireAt: number | undefined;
+      const result = await cliIpcCall<{
+        id: string;
+        name: string;
+        fireAt: number;
+        conversationId: string;
+      }>("defer_create", {
+        body: {
+          conversationId,
+          hint: opts.hint,
+          delaySeconds,
+          fireAt,
+          name: opts.name,
+        },
+      });
 
-        if (opts.in) {
-          try {
-            delaySeconds = parseDuration(opts.in);
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            if (opts.json) {
-              log.info(JSON.stringify({ ok: false, error: msg }));
-            } else {
-              log.error(`Error: ${msg}`);
-            }
-            process.exitCode = 1;
-            return;
-          }
-        }
-
-        if (opts.at) {
-          fireAt = new Date(opts.at).getTime();
-          if (isNaN(fireAt)) {
-            const msg = `Invalid ISO 8601 date: "${opts.at}"`;
-            if (opts.json) {
-              log.info(JSON.stringify({ ok: false, error: msg }));
-            } else {
-              log.error(`Error: ${msg}`);
-            }
-            process.exitCode = 1;
-            return;
-          }
-          if (fireAt <= Date.now()) {
-            const msg = "The --at time must be in the future";
-            if (opts.json) {
-              log.info(JSON.stringify({ ok: false, error: msg }));
-            } else {
-              log.error(`Error: ${msg}`);
-            }
-            process.exitCode = 1;
-            return;
-          }
-        }
-
-        const result = await cliIpcCall<{
-          id: string;
-          name: string;
-          fireAt: number;
-          conversationId: string;
-        }>("defer_create", {
-          body: {
-            conversationId,
-            hint: opts.hint,
-            delaySeconds,
-            fireAt,
-            name: opts.name,
-          },
-        });
-
-        if (!result.ok) {
-          if (opts.json) {
-            log.info(JSON.stringify({ ok: false, error: result.error }));
-          } else {
-            log.error(`Error: ${result.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
-
-        const created = result.result!;
+      if (!result.ok) {
         if (opts.json) {
-          log.info(JSON.stringify({ ok: true, ...created }));
+          log.info(JSON.stringify({ ok: false, error: result.error }));
         } else {
-          const fireDate = new Date(created.fireAt).toISOString();
-          log.info(
-            `Created deferred wake "${created.name}" (${created.id}) — fires at ${fireDate}`,
-          );
+          log.error(`Error: ${result.error}`);
         }
-      },
-    );
+        process.exitCode = 1;
+        return;
+      }
+
+      const created = result.result!;
+      if (opts.json) {
+        log.info(JSON.stringify({ ok: true, ...created }));
+      } else {
+        const fireDate = new Date(created.fireAt).toISOString();
+        log.info(
+          `Created deferred wake "${created.name}" (${created.id}) — fires at ${fireDate}`,
+        );
+      }
+    },
+  );
 
   // -----------------------------------------------------------------------
   // defer list
   // -----------------------------------------------------------------------
 
-  defer
-    .command("list")
-    .description("List pending deferred wakes")
-    .option("--conversation-id <id>", "Filter by conversation ID")
-    .option("--json", "Output result as JSON")
-    .addHelpText(
-      "after",
-      `
-List all pending deferred wakes, optionally filtered by conversation ID.
-
-Requires the assistant to be running. Communicates via IPC socket.
-
-Examples:
-  $ assistant conversations defer list
-  $ assistant conversations defer list --conversation-id conv-123
-  $ assistant conversations defer list --json`,
-    )
-    .action(async (opts: { conversationId?: string; json?: boolean }) => {
+  subcommand(defer, "list").action(
+    async (opts: { conversationId?: string; json?: boolean }) => {
       const result = await cliIpcCall<{
         defers: Array<{
           id: string;
@@ -232,81 +192,60 @@ Examples:
         const fireDate = new Date(d.fireAt).toISOString();
         log.info(`${d.id.padEnd(38)}${fireDate.padEnd(28)}${d.hint}`);
       }
-    });
+    },
+  );
 
   // -----------------------------------------------------------------------
   // defer cancel
   // -----------------------------------------------------------------------
 
-  defer
-    .command("cancel [deferId]")
-    .description("Cancel a deferred wake by ID, or all with --all")
-    .option("--all", "Cancel all pending deferred wakes")
-    .option("--conversation-id <id>", "Filter by conversation ID (with --all)")
-    .option("--json", "Output result as JSON")
-    .addHelpText(
-      "after",
-      `
-Cancel a single deferred wake by ID, or all pending wakes with --all.
-
-Requires the assistant to be running. Communicates via IPC socket.
-
-Examples:
-  $ assistant conversations defer cancel <deferId>
-  $ assistant conversations defer cancel --all
-  $ assistant conversations defer cancel --all --conversation-id conv-123
-  $ assistant conversations defer cancel --all --json`,
-    )
-    .action(
-      async (
-        deferId: string | undefined,
-        opts: { all?: boolean; conversationId?: string; json?: boolean },
-      ) => {
-        if (!deferId && !opts.all) {
-          const msg =
-            "Provide a defer ID to cancel, or use --all to cancel all";
-          if (opts.json) {
-            log.info(JSON.stringify({ ok: false, error: msg }));
-          } else {
-            log.error(`Error: ${msg}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
-
-        const ipcParams: Record<string, unknown> = {};
-        if (deferId) {
-          ipcParams.id = deferId;
-        }
-        if (opts.all) {
-          ipcParams.all = true;
-          if (opts.conversationId) {
-            ipcParams.conversationId = opts.conversationId;
-          }
-        }
-
-        const result = await cliIpcCall<{ cancelled: number }>("defer_cancel", {
-          body: ipcParams,
-        });
-
-        if (!result.ok) {
-          if (opts.json) {
-            log.info(JSON.stringify({ ok: false, error: result.error }));
-          } else {
-            log.error(`Error: ${result.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
-
-        const { cancelled } = result.result!;
+  subcommand(defer, "cancel").action(
+    async (
+      deferId: string | undefined,
+      opts: { all?: boolean; conversationId?: string; json?: boolean },
+    ) => {
+      if (!deferId && !opts.all) {
+        const msg = "Provide a defer ID to cancel, or use --all to cancel all";
         if (opts.json) {
-          log.info(JSON.stringify({ ok: true, cancelled }));
+          log.info(JSON.stringify({ ok: false, error: msg }));
         } else {
-          log.info(`Cancelled ${cancelled} deferred wake(s)`);
+          log.error(`Error: ${msg}`);
         }
-      },
-    );
+        process.exitCode = 1;
+        return;
+      }
+
+      const ipcParams: Record<string, unknown> = {};
+      if (deferId) {
+        ipcParams.id = deferId;
+      }
+      if (opts.all) {
+        ipcParams.all = true;
+        if (opts.conversationId) {
+          ipcParams.conversationId = opts.conversationId;
+        }
+      }
+
+      const result = await cliIpcCall<{ cancelled: number }>("defer_cancel", {
+        body: ipcParams,
+      });
+
+      if (!result.ok) {
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: false, error: result.error }));
+        } else {
+          log.error(`Error: ${result.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const { cancelled } = result.result!;
+      if (opts.json) {
+        log.info(JSON.stringify({ ok: true, cancelled }));
+      } else {
+        log.info(`Cancelled ${cancelled} deferred wake(s)`);
+      }
     },
-  });
+  );
 }

--- a/assistant/src/cli/commands/conversations-import.ts
+++ b/assistant/src/cli/commands/conversations-import.ts
@@ -4,7 +4,7 @@ import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
 import { readStdinSync } from "../../util/read-stdin.js";
-import { registerCommand } from "../lib/register-command.js";
+import { subcommand } from "../lib/cli-command-help.js";
 import { log } from "../logger.js";
 
 // -- Import payload schema (local, no daemon imports) --
@@ -79,122 +79,89 @@ function validatePayload(raw: unknown): ImportPayload {
 export function registerConversationsImportCommand(
   conversations: Command,
 ): void {
-  registerCommand(conversations, {
-    name: "import",
-    transport: "ipc",
-    description: "Import conversations from a standard JSON format",
-    build: (cmd) => {
-      cmd
-        .option("--file <path>", "Read JSON from file instead of stdin")
-        .option("--json", "Output result as machine-readable JSON")
-        .addHelpText(
-          "after",
-          `
-Imports conversations into the assistant from a standard JSON format.
-Reads from stdin by default, or from a file with --file.
-
-The input JSON must have the shape:
-  { "conversations": [{ "title": "...", "messages": [...] }] }
-
-Each conversation may include:
-  sourceKey         External key for dedup (e.g. "chatgpt:abc123")
-  createdAt         Unix epoch milliseconds for the conversation
-  updatedAt         Unix epoch milliseconds for the conversation
-  messages[].role   "user" or "assistant"
-  messages[].content  String or array of {type, text} content blocks
-  messages[].createdAt  Unix epoch milliseconds for the message
-
-Messages are indexed for memory search after import. Re-importing with
-the same sourceKey will skip already-imported conversations.
-
-Examples:
-  $ bun run scripts/parse-export.ts --file export.zip | assistant conversations import --json
-  $ assistant conversations import --file import.json --json
-  $ cat data.json | assistant conversations import`,
-        )
-        .action(async (opts: { file?: string; json?: boolean }) => {
-          let raw: string;
-          try {
-            if (opts.file) {
-              if (!existsSync(opts.file)) {
-                throw new Error(`File not found: ${opts.file}`);
-              }
-              raw = readFileSync(opts.file, "utf-8");
-            } else {
-              if (process.stdin.isTTY) {
-                throw new Error(
-                  "No input provided. Pipe JSON into stdin or use --file <path>.",
-                );
-              }
-              raw = readStdinSync();
-            }
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            if (opts.json) {
-              log.info(JSON.stringify({ ok: false, error: msg }));
-            } else {
-              log.error(`Error: ${msg}`);
-            }
-            process.exitCode = 1;
-            return;
+  subcommand(conversations, "import").action(
+    async (opts: { file?: string; json?: boolean }) => {
+      let raw: string;
+      try {
+        if (opts.file) {
+          if (!existsSync(opts.file)) {
+            throw new Error(`File not found: ${opts.file}`);
           }
-
-          let payload: ImportPayload;
-          try {
-            const parsed = JSON.parse(raw);
-            payload = validatePayload(parsed);
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            if (opts.json) {
-              log.info(JSON.stringify({ ok: false, error: msg }));
-            } else {
-              log.error(`Error: ${msg}`);
-            }
-            process.exitCode = 1;
-            return;
-          }
-
-          if (payload.conversations.length === 0) {
-            const result = { ok: true, imported: 0, skipped: 0, messages: 0 };
-            if (opts.json) {
-              log.info(JSON.stringify(result));
-            } else {
-              log.info("No conversations to import.");
-            }
-            return;
-          }
-
-          const r = await cliIpcCall<ImportResult>("conversations_import", {
-            body: {
-              conversations: payload.conversations as unknown as Record<
-                string,
-                unknown
-              >[],
-            },
-          });
-          if (!r.ok)
-            return exitFromIpcResult(
-              r as { ok: false; error?: string; statusCode?: number },
+          raw = readFileSync(opts.file, "utf-8");
+        } else {
+          if (process.stdin.isTTY) {
+            throw new Error(
+              "No input provided. Pipe JSON into stdin or use --file <path>.",
             );
-
-          const result = r.result!;
-          if (opts.json) {
-            log.info(JSON.stringify(result));
-          } else {
-            const lines = [
-              `Imported ${result.imported} conversation(s) with ${result.messages} message(s).`,
-            ];
-            if (result.skipped > 0) {
-              lines.push(
-                `Skipped ${result.skipped} already-imported conversation(s).`,
-              );
-            }
-            if (result.errors.length > 0) {
-              lines.push(`Failed: ${result.errors.length} conversation(s).`);
-            }
-            log.info(lines.join("\n"));
           }
-        });
+          raw = readStdinSync();
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: false, error: msg }));
+        } else {
+          log.error(`Error: ${msg}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      let payload: ImportPayload;
+      try {
+        const parsed = JSON.parse(raw);
+        payload = validatePayload(parsed);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: false, error: msg }));
+        } else {
+          log.error(`Error: ${msg}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (payload.conversations.length === 0) {
+        const result = { ok: true, imported: 0, skipped: 0, messages: 0 };
+        if (opts.json) {
+          log.info(JSON.stringify(result));
+        } else {
+          log.info("No conversations to import.");
+        }
+        return;
+      }
+
+      const r = await cliIpcCall<ImportResult>("conversations_import", {
+        body: {
+          conversations: payload.conversations as unknown as Record<
+            string,
+            unknown
+          >[],
+        },
+      });
+      if (!r.ok)
+        return exitFromIpcResult(
+          r as { ok: false; error?: string; statusCode?: number },
+        );
+
+      const result = r.result!;
+      if (opts.json) {
+        log.info(JSON.stringify(result));
+      } else {
+        const lines = [
+          `Imported ${result.imported} conversation(s) with ${result.messages} message(s).`,
+        ];
+        if (result.skipped > 0) {
+          lines.push(
+            `Skipped ${result.skipped} already-imported conversation(s).`,
+          );
+        }
+        if (result.errors.length > 0) {
+          lines.push(`Failed: ${result.errors.length} conversation(s).`);
+        }
+        log.info(lines.join("\n"));
+      }
     },
-  });
+  );
 }

--- a/assistant/src/cli/commands/conversations.help.ts
+++ b/assistant/src/cli/commands/conversations.help.ts
@@ -1,0 +1,364 @@
+/** Declarative help for the `assistant conversations` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const conversationsHelp: CliCommandHelp = {
+  name: "conversations",
+  description: "Manage conversations",
+  helpText: `
+Conversations with the assistant. Each conversation has a unique ID and a
+title. All subcommands communicate via IPC and require the assistant to be
+running.
+
+Examples:
+  $ assistant conversations list
+  $ assistant conversations new "Project planning"
+  $ assistant conversations export
+  $ assistant conversations clear`,
+  subcommands: [
+    {
+      name: "import",
+      description: "Import conversations from a standard JSON format",
+      options: [
+        {
+          flags: "--file <path>",
+          description: "Read JSON from file instead of stdin",
+        },
+        {
+          flags: "--json",
+          description: "Output result as machine-readable JSON",
+        },
+      ],
+      helpText: `
+Imports conversations into the assistant from a standard JSON format.
+Reads from stdin by default, or from a file with --file.
+
+The input JSON must have the shape:
+  { "conversations": [{ "title": "...", "messages": [...] }] }
+
+Each conversation may include:
+  sourceKey         External key for dedup (e.g. "chatgpt:abc123")
+  createdAt         Unix epoch milliseconds for the conversation
+  updatedAt         Unix epoch milliseconds for the conversation
+  messages[].role   "user" or "assistant"
+  messages[].content  String or array of {type, text} content blocks
+  messages[].createdAt  Unix epoch milliseconds for the message
+
+Messages are indexed for memory search after import. Re-importing with
+the same sourceKey will skip already-imported conversations.
+
+Examples:
+  $ bun run scripts/parse-export.ts --file export.zip | assistant conversations import --json
+  $ assistant conversations import --file import.json --json
+  $ cat data.json | assistant conversations import`,
+    },
+    {
+      name: "defer",
+      args: "[conversationId]",
+      description: "Create a deferred wake for a conversation",
+      options: [
+        {
+          flags: "--in <duration>",
+          description: "Delay before firing (e.g. 60, 60s, 5m, 1h)",
+        },
+        {
+          flags: "--at <iso8601>",
+          description: "Absolute ISO 8601 fire time",
+        },
+        {
+          flags: "--hint <text>",
+          description: "Hint message for the wake",
+        },
+        {
+          flags: "--name <text>",
+          description: "Name for the deferred wake",
+          defaultValue: "Deferred wake",
+        },
+        {
+          flags: "--json",
+          description: "Output result as JSON",
+        },
+      ],
+      helpText: `
+Create a deferred wake that fires after a delay or at a specific time.
+The conversation ID is resolved from the positional argument, the
+$__SKILL_CONTEXT_JSON env var, or $__CONVERSATION_ID.
+
+Requires the assistant to be running. Communicates via IPC socket.
+
+Examples:
+  $ assistant conversations defer --in 60 --hint "check progress"
+  $ assistant conversations defer conv-123 --in 5m --hint "follow up"
+  $ assistant conversations defer --at 2026-04-23T15:00:00Z --hint "meeting time"
+  $ assistant conversations defer --in 1h30m --hint "remind me" --json`,
+      subcommands: [
+        {
+          name: "list",
+          description: "List pending deferred wakes",
+          options: [
+            {
+              flags: "--conversation-id <id>",
+              description: "Filter by conversation ID",
+            },
+            {
+              flags: "--json",
+              description: "Output result as JSON",
+            },
+          ],
+          helpText: `
+List all pending deferred wakes, optionally filtered by conversation ID.
+
+Requires the assistant to be running. Communicates via IPC socket.
+
+Examples:
+  $ assistant conversations defer list
+  $ assistant conversations defer list --conversation-id conv-123
+  $ assistant conversations defer list --json`,
+        },
+        {
+          name: "cancel",
+          args: "[deferId]",
+          description: "Cancel a deferred wake by ID, or all with --all",
+          options: [
+            {
+              flags: "--all",
+              description: "Cancel all pending deferred wakes",
+            },
+            {
+              flags: "--conversation-id <id>",
+              description: "Filter by conversation ID (with --all)",
+            },
+            {
+              flags: "--json",
+              description: "Output result as JSON",
+            },
+          ],
+          helpText: `
+Cancel a single deferred wake by ID, or all pending wakes with --all.
+
+Requires the assistant to be running. Communicates via IPC socket.
+
+Examples:
+  $ assistant conversations defer cancel <deferId>
+  $ assistant conversations defer cancel --all
+  $ assistant conversations defer cancel --all --conversation-id conv-123
+  $ assistant conversations defer cancel --all --json`,
+        },
+      ],
+    },
+    {
+      name: "list",
+      description: "List conversations (excludes archived by default)",
+      options: [
+        {
+          flags: "--include-archived",
+          description: "Include archived conversations in the output",
+        },
+      ],
+      helpText: `
+Shows conversations with their ID, title, and a relative timestamp (e.g.
+"3 hours ago"). Conversations are listed in order of most recently updated.
+Rows currently mid-turn — i.e. the agent loop is actively running on the
+in-memory conversation — are prefixed with "●"; idle rows are prefixed
+with " " (two spaces) so columns stay aligned.
+
+Archived conversations are excluded by default; pass --include-archived to
+include them.
+
+Examples:
+  $ assistant conversations list
+  $ assistant conversations list --include-archived`,
+    },
+    {
+      name: "new",
+      args: "[title]",
+      description: "Create a new conversation",
+      options: [
+        {
+          flags: "--content-file <path>",
+          description: "Seed messages from a JSON file",
+        },
+        {
+          flags: "--json",
+          description: "Output result as JSON",
+        },
+      ],
+      helpText: `
+Arguments:
+  title   Optional conversation title (string). If omitted, a default title is
+          assigned by the assistant.
+
+The content file must be a JSON array of { role, content } messages.
+
+Creates a new conversation and prints its title, ID, and generated conversation
+key.
+
+Examples:
+  $ assistant conversations new
+  $ assistant conversations new "Project planning"
+  $ assistant conversations new --content-file /tmp/seed.json
+  $ assistant conversations new "Bug triage 2026-03-05"`,
+    },
+    {
+      name: "rename",
+      args: "<conversationId> <title>",
+      description: "Rename a conversation",
+      helpText: `
+Arguments:
+  conversationId   Conversation ID (or unique prefix). Supports prefix matching.
+                   Run 'assistant conversations list' to find IDs.
+  title            The new title for the conversation. Should be concise (under
+                   60 characters) and descriptive of the current topic.
+
+Renames the conversation to the given title and marks it as a manual rename
+(auto-generated titles will not overwrite it).
+
+Examples:
+  $ assistant conversations rename abc123 "Project planning"
+  $ assistant conversations rename abc123 "Bug triage 2026-04-22"`,
+    },
+    {
+      name: "export",
+      args: "[conversationId]",
+      description: "Export a conversation as markdown or JSON",
+      options: [
+        {
+          flags: "-f, --format <format>",
+          description: "Output format: md or json",
+          defaultValue: "md",
+        },
+        {
+          flags: "-o, --output <file>",
+          description: "Write to file instead of stdout",
+        },
+      ],
+      helpText: `
+Arguments:
+  conversationId   Optional conversation ID (or unique prefix). Defaults to the
+                   most recent conversation. Supports prefix matching — e.g.
+                   "abc123" matches the first conversation whose ID starts with
+                   "abc123". Run 'assistant conversations list' to find IDs.
+
+Two output formats are available:
+  md    Markdown conversation transcript (default). Human-readable rendering
+        of messages with role headers.
+  json  Structured JSON export with full metadata, message content arrays,
+        and timestamps.
+
+Examples:
+  $ assistant conversations export
+  $ assistant conversations export --format json -o conversation.json
+  $ assistant conversations export abc123 --format md`,
+    },
+    {
+      name: "slack",
+      description: "Manage Slack conversation bindings",
+      subcommands: [
+        {
+          name: "detach",
+          args: "[conversationId]",
+          description: "Detach the assistant from a Slack thread",
+          options: [
+            {
+              flags: "--channel <id>",
+              description: "Slack channel ID",
+            },
+            {
+              flags: "--thread <ts>",
+              description: "Slack thread timestamp",
+            },
+            {
+              flags: "--json",
+              description: "Output result as JSON",
+            },
+          ],
+          helpText: `
+Arguments:
+  conversationId   Optional conversation ID. Defaults to the current skill or
+                   tool conversation when available.
+
+Detaches the assistant from Socket Mode listening for the Slack thread bound
+to a conversation, or for explicit --channel and --thread identifiers.
+
+Examples:
+  $ assistant conversations slack detach
+  $ assistant conversations slack detach conv-123
+  $ assistant conversations slack mute --channel C123 --thread 1700000000.000100
+  $ assistant conversations slack detach --json`,
+        },
+      ],
+    },
+    {
+      name: "clear",
+      description:
+        "Clear all conversations, messages, and vector data (dev only)",
+      helpText: `
+Permanently deletes ALL conversations, messages, and associated data.
+Prompts for confirmation (y/N) before proceeding.
+
+Requires the assistant to be running. Communicates via IPC socket.
+
+Intended for development use. This action cannot be undone.
+
+Examples:
+  $ assistant conversations clear`,
+    },
+    {
+      name: "wake",
+      args: "<conversationId>",
+      description:
+        "Wake the agent on an existing conversation with an internal hint",
+      options: [
+        {
+          flags: "--hint <text>",
+          description:
+            "Hint message visible to the LLM (not persisted to transcript)",
+          required: true,
+        },
+        {
+          flags: "--source <label>",
+          description: "Source label for logging (e.g. github-notification)",
+          defaultValue: "cli",
+        },
+        {
+          flags: "--persist",
+          description:
+            "Persist the trigger as a transcript-visible background event instead of an ephemeral hint",
+        },
+        {
+          flags: "--external-content <string>",
+          description:
+            "Raw third-party data to fence as untrusted content (implies --persist). The caller reads the data and passes it as a string. Visible in the process table (ps) and bounded by ARG_MAX",
+        },
+        {
+          flags: "--json",
+          description: "Output result as JSON",
+        },
+      ],
+      helpText: `
+Arguments:
+  conversationId   Conversation ID to wake.
+
+Wake the assistant's agent loop on an existing conversation without a user
+message. The hint is injected as a non-persisted internal message visible
+only to the LLM — it never appears in the transcript or SSE feed. If the
+agent produces output (text or tool calls), it is persisted and emitted to
+connected clients. Otherwise the wake is a silent no-op.
+
+--hint is TRUSTED framing authored by you. Any attacker-influenceable data
+(email bodies, PR text, fetched web pages, notification payloads) MUST be
+passed via --external-content — never inlined into --hint. Untrusted content is
+fenced inside <external_content> so the model treats it as data, never
+instructions, and implies --persist. The caller reads the data and passes it as
+a string; it is visible in the process table via 'ps' and bounded by ARG_MAX.
+
+Requires the assistant to be running. Communicates via IPC socket.
+
+Examples:
+  $ assistant conversations wake abc123 --hint "PR #25933 received a review requesting changes"
+  $ assistant conversations wake abc123 --hint "CI failed on commit abc" --source github-ci
+  $ assistant conversations wake abc123 --hint "New Slack DM from Vargas" --source slack --json
+  $ assistant conversations wake abc123 --hint "New Slack msgs to triage" --external-content "$slack_dump"`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -7,10 +7,12 @@ import {
   exitCodeFromIpcResult,
   exitFromIpcResult,
 } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { timeAgo } from "../lib/time-ago.js";
 import { log } from "../logger.js";
 import { tryResolveConversationId } from "../utils/conversation-id.js";
+import { conversationsHelp } from "./conversations.help.js";
 import { registerConversationsDeferCommand } from "./conversations-defer.js";
 import { registerConversationsImportCommand } from "./conversations-import.js";
 
@@ -149,55 +151,21 @@ async function createConversationCli(
 
 export function registerConversationsCommand(program: Command): void {
   registerCommand(program, {
-    name: "conversations",
+    name: conversationsHelp.name,
     transport: "ipc",
-    description: "Manage conversations",
+    description: conversationsHelp.description,
     build: (conversations) => {
+      applyCommandHelp(conversations, conversationsHelp);
+
       registerConversationsImportCommand(conversations);
       registerConversationsDeferCommand(conversations);
-
-      conversations.addHelpText(
-        "after",
-        `
-Conversations with the assistant. Each conversation has a unique ID and a
-title. All subcommands communicate via IPC and require the assistant to be
-running.
-
-Examples:
-  $ assistant conversations list
-  $ assistant conversations new "Project planning"
-  $ assistant conversations export
-  $ assistant conversations clear`,
-      );
 
       // -------------------------------------------------------------------
       // list
       // -------------------------------------------------------------------
 
-      conversations
-        .command("list")
-        .description("List conversations (excludes archived by default)")
-        .option(
-          "--include-archived",
-          "Include archived conversations in the output",
-        )
-        .addHelpText(
-          "after",
-          `
-Shows conversations with their ID, title, and a relative timestamp (e.g.
-"3 hours ago"). Conversations are listed in order of most recently updated.
-Rows currently mid-turn — i.e. the agent loop is actively running on the
-in-memory conversation — are prefixed with "●"; idle rows are prefixed
-with " " (two spaces) so columns stay aligned.
-
-Archived conversations are excluded by default; pass --include-archived to
-include them.
-
-Examples:
-  $ assistant conversations list
-  $ assistant conversations list --include-archived`,
-        )
-        .action(async (opts?: { includeArchived?: boolean }) => {
+      subcommand(conversations, "list").action(
+        async (opts?: { includeArchived?: boolean }) => {
           const result = await cliIpcCall<{
             conversations: Array<{
               id: string;
@@ -225,61 +193,21 @@ Examples:
               );
             }
           }
-        });
+        },
+      );
 
       // -------------------------------------------------------------------
       // new
       // -------------------------------------------------------------------
 
-      conversations
-        .command("new [title]")
-        .description("Create a new conversation")
-        .option("--content-file <path>", "Seed messages from a JSON file")
-        .option("--json", "Output result as JSON")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  title   Optional conversation title (string). If omitted, a default title is
-          assigned by the assistant.
-
-The content file must be a JSON array of { role, content } messages.
-
-Creates a new conversation and prints its title, ID, and generated conversation
-key.
-
-Examples:
-  $ assistant conversations new
-  $ assistant conversations new "Project planning"
-  $ assistant conversations new --content-file /tmp/seed.json
-  $ assistant conversations new "Bug triage 2026-03-05"`,
-        )
-        .action(createConversationCli);
+      subcommand(conversations, "new").action(createConversationCli);
 
       // -------------------------------------------------------------------
       // rename
       // -------------------------------------------------------------------
 
-      conversations
-        .command("rename <conversationId> <title>")
-        .description("Rename a conversation")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  conversationId   Conversation ID (or unique prefix). Supports prefix matching.
-                   Run 'assistant conversations list' to find IDs.
-  title            The new title for the conversation. Should be concise (under
-                   60 characters) and descriptive of the current topic.
-
-Renames the conversation to the given title and marks it as a manual rename
-(auto-generated titles will not overwrite it).
-
-Examples:
-  $ assistant conversations rename abc123 "Project planning"
-  $ assistant conversations rename abc123 "Bug triage 2026-04-22"`,
-        )
-        .action(async (conversationId: string, title: string) => {
+      subcommand(conversations, "rename").action(
+        async (conversationId: string, title: string) => {
           const trimmedTitle = title.trim();
           if (!trimmedTitle) {
             log.error("Error: title must be a non-empty string");
@@ -311,100 +239,55 @@ Examples:
           log.info(
             `Renamed conversation to "${trimmedTitle}" (${conversationId})`,
           );
-        });
+        },
+      );
 
       // -------------------------------------------------------------------
       // export
       // -------------------------------------------------------------------
 
-      conversations
-        .command("export [conversationId]")
-        .description("Export a conversation as markdown or JSON")
-        .option("-f, --format <format>", "Output format: md or json", "md")
-        .option("-o, --output <file>", "Write to file instead of stdout")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  conversationId   Optional conversation ID (or unique prefix). Defaults to the
-                   most recent conversation. Supports prefix matching — e.g.
-                   "abc123" matches the first conversation whose ID starts with
-                   "abc123". Run 'assistant conversations list' to find IDs.
+      subcommand(conversations, "export").action(
+        async (
+          conversationId?: string,
+          opts?: { format: string; output?: string },
+        ) => {
+          const format = opts?.format ?? "md";
+          if (format !== "md" && format !== "json") {
+            log.error('Error: format must be "md" or "json"');
+            process.exit(1);
+          }
 
-Two output formats are available:
-  md    Markdown conversation transcript (default). Human-readable rendering
-        of messages with role headers.
-  json  Structured JSON export with full metadata, message content arrays,
-        and timestamps.
+          const result = await cliIpcCall<{
+            output: string;
+            conversationId: string;
+          }>("conversation_export_cli", {
+            body: { conversationId, format },
+          });
 
-Examples:
-  $ assistant conversations export
-  $ assistant conversations export --format json -o conversation.json
-  $ assistant conversations export abc123 --format md`,
-        )
-        .action(
-          async (
-            conversationId?: string,
-            opts?: { format: string; output?: string },
-          ) => {
-            const format = opts?.format ?? "md";
-            if (format !== "md" && format !== "json") {
-              log.error('Error: format must be "md" or "json"');
-              process.exit(1);
-            }
+          if (!result.ok) return exitFromIpcResult(result);
 
-            const result = await cliIpcCall<{
-              output: string;
-              conversationId: string;
-            }>("conversation_export_cli", {
-              body: { conversationId, format },
-            });
+          const exported = result.result!;
 
-            if (!result.ok) return exitFromIpcResult(result);
-
-            const exported = result.result!;
-
-            if (opts?.output) {
-              const { writeFileSync } = await import("node:fs");
-              writeFileSync(opts.output, exported.output);
-              log.info(`Exported to ${opts.output}`);
-            } else {
-              process.stdout.write(exported.output);
-            }
-          },
-        );
+          if (opts?.output) {
+            const { writeFileSync } = await import("node:fs");
+            writeFileSync(opts.output, exported.output);
+            log.info(`Exported to ${opts.output}`);
+          } else {
+            process.stdout.write(exported.output);
+          }
+        },
+      );
 
       // -------------------------------------------------------------------
       // slack
       // -------------------------------------------------------------------
 
-      const slack = conversations
-        .command("slack")
-        .description("Manage Slack conversation bindings");
+      const slack = subcommand(conversations, "slack");
 
-      slack
-        .command("detach [conversationId]")
+      // The "mute" alias is not expressible in CliCommandHelp, so it is
+      // applied imperatively on top of the declared subcommand.
+      subcommand(slack, "detach")
         .alias("mute")
-        .description("Detach the assistant from a Slack thread")
-        .option("--channel <id>", "Slack channel ID")
-        .option("--thread <ts>", "Slack thread timestamp")
-        .option("--json", "Output result as JSON")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  conversationId   Optional conversation ID. Defaults to the current skill or
-                   tool conversation when available.
-
-Detaches the assistant from Socket Mode listening for the Slack thread bound
-to a conversation, or for explicit --channel and --thread identifiers.
-
-Examples:
-  $ assistant conversations slack detach
-  $ assistant conversations slack detach conv-123
-  $ assistant conversations slack mute --channel C123 --thread 1700000000.000100
-  $ assistant conversations slack detach --json`,
-        )
         .action(
           async (
             conversationIdArg: string | undefined,
@@ -483,185 +366,117 @@ Examples:
       // clear
       // -------------------------------------------------------------------
 
-      conversations
-        .command("clear")
-        .description(
-          "Clear all conversations, messages, and vector data (dev only)",
-        )
-        .addHelpText(
-          "after",
-          `
-Permanently deletes ALL conversations, messages, and associated data.
-Prompts for confirmation (y/N) before proceeding.
+      subcommand(conversations, "clear").action(async () => {
+        log.info(
+          "This will permanently delete all conversations, messages, and vector data.",
+        );
 
-Requires the assistant to be running. Communicates via IPC socket.
-
-Intended for development use. This action cannot be undone.
-
-Examples:
-  $ assistant conversations clear`,
-        )
-        .action(async () => {
-          log.info(
-            "This will permanently delete all conversations, messages, and vector data.",
-          );
-
-          const readline = await import("node:readline");
-          const rl = readline.createInterface({
-            input: process.stdin,
-            output: process.stdout,
-          });
-          const answer = await new Promise<string>((resolve) => {
-            rl.question("Are you sure? (y/N) ", resolve);
-          });
-          rl.close();
-          if (answer.toLowerCase() !== "y") {
-            log.info("Cancelled");
-            return;
-          }
-
-          const result = await cliIpcCall<{ cleared: number }>(
-            "conversations_clear_cli",
-            {
-              headers: {
-                "x-confirm-destructive": "clear-all-conversations",
-              },
-            },
-          );
-
-          if (!result.ok) return exitFromIpcResult(result);
-
-          log.info(`Cleared ${result.result!.cleared} conversations. Done.`);
+        const readline = await import("node:readline");
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
         });
+        const answer = await new Promise<string>((resolve) => {
+          rl.question("Are you sure? (y/N) ", resolve);
+        });
+        rl.close();
+        if (answer.toLowerCase() !== "y") {
+          log.info("Cancelled");
+          return;
+        }
+
+        const result = await cliIpcCall<{ cleared: number }>(
+          "conversations_clear_cli",
+          {
+            headers: {
+              "x-confirm-destructive": "clear-all-conversations",
+            },
+          },
+        );
+
+        if (!result.ok) return exitFromIpcResult(result);
+
+        log.info(`Cleared ${result.result!.cleared} conversations. Done.`);
+      });
 
       // -------------------------------------------------------------------
       // wake
       // -------------------------------------------------------------------
 
-      conversations
-        .command("wake <conversationId>")
-        .description(
-          "Wake the agent on an existing conversation with an internal hint",
-        )
-        .requiredOption(
-          "--hint <text>",
-          "Hint message visible to the LLM (not persisted to transcript)",
-        )
-        .option(
-          "--source <label>",
-          "Source label for logging (e.g. github-notification)",
-          "cli",
-        )
-        .option(
-          "--persist",
-          "Persist the trigger as a transcript-visible background event instead of an ephemeral hint",
-        )
-        .option(
-          "--external-content <string>",
-          "Raw third-party data to fence as untrusted content (implies --persist). The caller reads the data and passes it as a string. Visible in the process table (ps) and bounded by ARG_MAX",
-        )
-        .option("--json", "Output result as JSON")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  conversationId   Conversation ID to wake.
-
-Wake the assistant's agent loop on an existing conversation without a user
-message. The hint is injected as a non-persisted internal message visible
-only to the LLM — it never appears in the transcript or SSE feed. If the
-agent produces output (text or tool calls), it is persisted and emitted to
-connected clients. Otherwise the wake is a silent no-op.
-
---hint is TRUSTED framing authored by you. Any attacker-influenceable data
-(email bodies, PR text, fetched web pages, notification payloads) MUST be
-passed via --external-content — never inlined into --hint. Untrusted content is
-fenced inside <external_content> so the model treats it as data, never
-instructions, and implies --persist. The caller reads the data and passes it as
-a string; it is visible in the process table via 'ps' and bounded by ARG_MAX.
-
-Requires the assistant to be running. Communicates via IPC socket.
-
-Examples:
-  $ assistant conversations wake abc123 --hint "PR #25933 received a review requesting changes"
-  $ assistant conversations wake abc123 --hint "CI failed on commit abc" --source github-ci
-  $ assistant conversations wake abc123 --hint "New Slack DM from Vargas" --source slack --json
-  $ assistant conversations wake abc123 --hint "New Slack msgs to triage" --external-content "$slack_dump"`,
-        )
-        .action(
-          async (
-            conversationId: string,
-            opts: {
-              hint: string;
-              source: string;
-              persist?: boolean;
-              externalContent?: string;
-              json?: boolean;
-            },
-          ) => {
-            // A script-mode schedule injects __SCHEDULE_RUN_ID into its env
-            // (see schedule/run-script.ts). When set, thread it through so the
-            // woken turn's usage is attributed to the firing.
-            const cronRunId = process.env.__SCHEDULE_RUN_ID;
-
-            // Fencing only exists on the persisted-event path, so
-            // --external-content implies --persist.
-            const externalContent = opts.externalContent;
-            const persist = opts.persist || externalContent !== undefined;
-
-            const result = await cliIpcCall<{
-              invoked: boolean;
-              producedToolCalls: boolean;
-              reason?: "not_found" | "archived" | "timeout" | "no_resolver";
-            }>("wake_conversation", {
-              body: {
-                conversationId,
-                hint: opts.hint,
-                source: opts.source,
-                ...(cronRunId ? { cronRunId } : {}),
-                ...(persist ? { persist: true } : {}),
-                ...(externalContent !== undefined ? { externalContent } : {}),
-              },
-            });
-
-            if (!result.ok) {
-              if (opts.json) {
-                log.info(JSON.stringify({ ok: false, error: result.error }));
-              } else {
-                log.error(`Error: ${result.error}`);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            const wake = result.result!;
-            if (opts.json) {
-              log.info(JSON.stringify({ ok: true, ...wake }));
-              return;
-            }
-            if (wake.invoked) {
-              log.info(
-                wake.producedToolCalls
-                  ? `Wake produced output on conversation ${conversationId}`
-                  : `Wake invoked on ${conversationId} (no output produced)`,
-              );
-            } else if (wake.reason === "timeout") {
-              log.info(
-                `Conversation ${conversationId} is busy — wake skipped (retry later)`,
-              );
-            } else if (wake.reason === "archived") {
-              log.error(
-                `Could not wake conversation ${conversationId} — conversation is archived`,
-              );
-              process.exitCode = 1;
-            } else {
-              log.error(
-                `Could not wake conversation ${conversationId} — conversation not found`,
-              );
-              process.exitCode = 1;
-            }
+      subcommand(conversations, "wake").action(
+        async (
+          conversationId: string,
+          opts: {
+            hint: string;
+            source: string;
+            persist?: boolean;
+            externalContent?: string;
+            json?: boolean;
           },
-        );
+        ) => {
+          // A script-mode schedule injects __SCHEDULE_RUN_ID into its env
+          // (see schedule/run-script.ts). When set, thread it through so the
+          // woken turn's usage is attributed to the firing.
+          const cronRunId = process.env.__SCHEDULE_RUN_ID;
+
+          // Fencing only exists on the persisted-event path, so
+          // --external-content implies --persist.
+          const externalContent = opts.externalContent;
+          const persist = opts.persist || externalContent !== undefined;
+
+          const result = await cliIpcCall<{
+            invoked: boolean;
+            producedToolCalls: boolean;
+            reason?: "not_found" | "archived" | "timeout" | "no_resolver";
+          }>("wake_conversation", {
+            body: {
+              conversationId,
+              hint: opts.hint,
+              source: opts.source,
+              ...(cronRunId ? { cronRunId } : {}),
+              ...(persist ? { persist: true } : {}),
+              ...(externalContent !== undefined ? { externalContent } : {}),
+            },
+          });
+
+          if (!result.ok) {
+            if (opts.json) {
+              log.info(JSON.stringify({ ok: false, error: result.error }));
+            } else {
+              log.error(`Error: ${result.error}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          const wake = result.result!;
+          if (opts.json) {
+            log.info(JSON.stringify({ ok: true, ...wake }));
+            return;
+          }
+          if (wake.invoked) {
+            log.info(
+              wake.producedToolCalls
+                ? `Wake produced output on conversation ${conversationId}`
+                : `Wake invoked on ${conversationId} (no output produced)`,
+            );
+          } else if (wake.reason === "timeout") {
+            log.info(
+              `Conversation ${conversationId} is busy — wake skipped (retry later)`,
+            );
+          } else if (wake.reason === "archived") {
+            log.error(
+              `Could not wake conversation ${conversationId} — conversation is archived`,
+            );
+            process.exitCode = 1;
+          } else {
+            log.error(
+              `Could not wake conversation ${conversationId} — conversation not found`,
+            );
+            process.exitCode = 1;
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/credentials.help.ts
+++ b/assistant/src/cli/commands/credentials.help.ts
@@ -1,0 +1,277 @@
+/** Declarative help for the `assistant credentials` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const credentialsHelp: CliCommandHelp = {
+  name: "credentials",
+  description:
+    "Manage credentials in the encrypted vault (API keys, tokens, passwords)",
+  options: [
+    {
+      flags: "--json",
+      description: "Machine-readable compact JSON output",
+    },
+  ],
+  helpText: `
+Credentials are identified by --service and --field flags, matching the
+storage convention used internally (credential/{service}/{field}):
+
+  --service twilio --field account_sid        Twilio account SID
+  --service twilio --field auth_token         Twilio auth token
+  --service telegram --field bot_token        Telegram bot token
+  --service slack_channel --field bot_token   Slack channel bot token
+  --service github --field token              GitHub personal access token
+
+Secrets are stored in AES-256-GCM encrypted storage. Metadata (policy,
+timestamps, labels) is tracked separately and never contains secret values.
+
+Examples:
+  $ assistant credentials list
+  $ assistant credentials list --search twilio
+  $ assistant credentials set --service twilio --field account_sid AC1234567890
+  $ assistant credentials inspect --service twilio --field account_sid
+  $ assistant credentials reveal --service twilio --field account_sid
+  $ assistant credentials delete --service twilio --field auth_token`,
+  subcommands: [
+    {
+      name: "list",
+      description:
+        "List all stored credentials with metadata and masked values",
+      options: [
+        {
+          flags: "--search <query>",
+          description:
+            "Filter credentials by substring match on service, field, label, or description",
+        },
+      ],
+      helpText: `
+Lists all credentials in the vault. Each entry includes the same fields as
+"inspect" — scrubbed value, timestamps, policy, and metadata.
+
+The --search flag filters results by case-insensitive substring match against
+the credential's service name, field name, label, or description. For example, --search
+twilio matches twilio:account_sid, twilio:auth_token, and twilio:phone_number.
+
+Returns an array of credential objects. Empty array if no credentials exist
+or none match the search query.
+
+Examples:
+  $ assistant credentials list
+  $ assistant credentials list --search twilio
+  $ assistant credentials list --search bot_token
+  $ assistant credentials list --json`,
+    },
+    {
+      name: "status",
+      description: "Show the active credential backend and its configuration",
+      helpText: `
+Shows which credential storage backend this process is using and backend-specific
+path or connection details. Run this to diagnose credential lookup mismatches —
+for example, when the CLI and the daemon are reading from different stores.
+
+Backend types:
+  encrypted-store   Direct file read from keys.enc (standalone CLI, no daemon)
+  ces-rpc           Delegates to the running CES process via stdio RPC (daemon)
+  ces-http          Delegates to CES sidecar over HTTP (containerized/Docker mode)
+
+Also shows the CREDENTIAL_SECURITY_DIR, GATEWAY_SECURITY_DIR, and
+VELLUM_WORKSPACE_DIR env vars so you can confirm which instance directory this
+process is scoped to.
+
+Examples:
+  $ assistant credentials status
+  $ assistant credentials status --json`,
+    },
+    {
+      name: "set",
+      args: "<value>",
+      description: "Store a secret and create or update its metadata",
+      options: [
+        {
+          flags: "--service <service>",
+          description: "Service namespace (e.g. google)",
+          required: true,
+        },
+        {
+          flags: "--field <field>",
+          description: "Field name (e.g. client_secret)",
+          required: true,
+        },
+        {
+          flags: "--label <label>",
+          description: 'Human-friendly label (e.g. "prod", "work")',
+        },
+        {
+          flags: "--description <description>",
+          description: "What this credential is used for",
+        },
+        {
+          flags: "--allowed-tools <tools>",
+          description:
+            "Comma-separated tool names that may use this credential",
+        },
+      ],
+      helpText: `
+Arguments:
+  value   The secret value to store
+
+If the credential already exists, the secret is overwritten and metadata is
+updated with any provided flags. Omitted flags leave existing metadata intact.
+
+Examples:
+  $ assistant credentials set --service twilio --field account_sid AC1234567890
+  $ assistant credentials set --service fal --field api_key key_live_abc --label "fal-prod" --description "Image generation"
+  $ assistant credentials set --service github --field token ghp_abc --allowed-tools "bash,host_bash"`,
+    },
+    {
+      name: "delete",
+      description: "Remove a secret and its metadata from the vault",
+      options: [
+        {
+          flags: "--service <service>",
+          description: "Service namespace",
+          required: true,
+        },
+        {
+          flags: "--field <field>",
+          description: "Field name",
+          required: true,
+        },
+      ],
+      helpText: `
+Deletes both the encrypted secret and all associated metadata (policy,
+timestamps, injection templates). This action cannot be undone.
+
+Examples:
+  $ assistant credentials delete --service twilio --field auth_token
+  $ assistant credentials delete --service github --field token`,
+    },
+    {
+      name: "inspect",
+      args: "[id]",
+      description: "Show metadata and a masked preview of a stored credential",
+      options: [
+        {
+          flags: "--service <service>",
+          description: "Service namespace",
+        },
+        {
+          flags: "--field <field>",
+          description: "Field name",
+        },
+      ],
+      helpText: `
+Arguments:
+  id   (optional) Credential UUID for lookup by ID
+
+Shows everything known about a credential without revealing the secret value.
+The secret is masked to show only the last 4 characters (e.g. ****c123).
+
+Displayed fields include: label, creation/update timestamps, allowed tools,
+allowed domains, OAuth2 scopes, account info, and injection template count.
+
+Use --service and --field to look up by service/field, or pass a UUID as a
+positional argument. One of the two forms is required.
+
+Examples:
+  $ assistant credentials inspect --service twilio --field account_sid
+  $ assistant credentials inspect 7a3b1c2d-4e5f-6789-abcd-ef0123456789
+  $ assistant credentials inspect --json --service slack_channel --field bot_token`,
+    },
+    {
+      name: "reveal",
+      args: "[id]",
+      description: "Print the plaintext value of a credential",
+      options: [
+        {
+          flags: "--service <service>",
+          description: "Service namespace",
+        },
+        {
+          flags: "--field <field>",
+          description: "Field name",
+        },
+      ],
+      helpText: `
+Arguments:
+  id   (optional) Credential UUID for lookup by ID
+
+Prints the raw secret value to stdout for piping into other tools. In JSON
+mode the value is returned as {"ok": true, "value": "..."}. In human mode
+only the bare secret is printed (no labels or decoration) so it can be
+captured with shell substitution.
+
+Use --service and --field to look up by service/field, or pass a UUID as a
+positional argument. One of the two forms is required.
+
+Examples:
+  $ assistant credentials reveal --service twilio --field auth_token
+  $ assistant credentials reveal 7a3b1c2d-4e5f-6789-abcd-ef0123456789
+  $ assistant credentials reveal --json --service twilio --field account_sid
+  $ export TWILIO_TOKEN=$(assistant credentials reveal --service twilio --field auth_token)`,
+    },
+    {
+      name: "prompt",
+      description:
+        "Securely prompt the user for a credential via the app UI and store it",
+      options: [
+        {
+          flags: "--service <service>",
+          description: "Service namespace (e.g. sentry)",
+          required: true,
+        },
+        {
+          flags: "--field <field>",
+          description: "Field name (e.g. auth_token)",
+          required: true,
+        },
+        {
+          flags: "--label <label>",
+          description: "Display label for the prompt UI",
+          required: true,
+        },
+        {
+          flags: "--description <description>",
+          description: "Context shown in the prompt UI",
+        },
+        {
+          flags: "--placeholder <placeholder>",
+          description: "Placeholder text for the input",
+        },
+        {
+          flags: "--usage-description <description>",
+          description:
+            "Human-readable description of intended usage, stored in credential metadata and shown as the prompt's purpose",
+        },
+        {
+          flags: "--allowed-domains <domains>",
+          description:
+            "Comma-separated domains where this credential may be used",
+        },
+        {
+          flags: "--allowed-tools <tools>",
+          description:
+            "Comma-separated tool names that may use this credential",
+        },
+        {
+          flags: "--injection-templates <json>",
+          description: "JSON array of injection template objects",
+        },
+      ],
+      helpText: `
+Opens a secure credential input prompt in the user's connected app (desktop,
+web, etc.). The user enters the secret through the UI — it never passes through
+the conversation or CLI output. On success the credential is stored in the
+encrypted vault with the specified metadata.
+
+Requires the assistant to be running with at least one connected client.
+
+Examples:
+  $ assistant credentials prompt --service sentry --field auth_token \\
+      --label "Sentry Auth Token" --placeholder "sntrys_..." \\
+      --usage-description "Read Sentry issues and events" \\
+      --allowed-domains "sentry.io" \\
+      --injection-templates '[{"hostPattern":"sentry.io","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]'`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -2,10 +2,12 @@ import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
 import type { CredentialPromptResult } from "../../runtime/routes/credential-prompt-routes.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
 import { tryResolveConversationId } from "../utils/conversation-id.js";
+import { credentialsHelp } from "./credentials.help.js";
 
 // ---------------------------------------------------------------------------
 // Format-aware error output
@@ -110,70 +112,18 @@ interface CredentialsStatusResponse {
 
 export function registerCredentialsCommand(program: Command): void {
   registerCommand(program, {
-    name: "credentials",
+    name: credentialsHelp.name,
     transport: "ipc",
-    description:
-      "Manage credentials in the encrypted vault (API keys, tokens, passwords)",
+    description: credentialsHelp.description,
     build: (credential) => {
-      credential.option("--json", "Machine-readable compact JSON output");
-
-      credential.addHelpText(
-        "after",
-        `
-Credentials are identified by --service and --field flags, matching the
-storage convention used internally (credential/{service}/{field}):
-
-  --service twilio --field account_sid        Twilio account SID
-  --service twilio --field auth_token         Twilio auth token
-  --service telegram --field bot_token        Telegram bot token
-  --service slack_channel --field bot_token   Slack channel bot token
-  --service github --field token              GitHub personal access token
-
-Secrets are stored in AES-256-GCM encrypted storage. Metadata (policy,
-timestamps, labels) is tracked separately and never contains secret values.
-
-Examples:
-  $ assistant credentials list
-  $ assistant credentials list --search twilio
-  $ assistant credentials set --service twilio --field account_sid AC1234567890
-  $ assistant credentials inspect --service twilio --field account_sid
-  $ assistant credentials reveal --service twilio --field account_sid
-  $ assistant credentials delete --service twilio --field auth_token`,
-      );
+      applyCommandHelp(credential, credentialsHelp);
 
       // -----------------------------------------------------------------------
       // list
       // -----------------------------------------------------------------------
 
-      credential
-        .command("list")
-        .description(
-          "List all stored credentials with metadata and masked values",
-        )
-        .option(
-          "--search <query>",
-          "Filter credentials by substring match on service, field, label, or description",
-        )
-        .addHelpText(
-          "after",
-          `
-Lists all credentials in the vault. Each entry includes the same fields as
-"inspect" — scrubbed value, timestamps, policy, and metadata.
-
-The --search flag filters results by case-insensitive substring match against
-the credential's service name, field name, label, or description. For example, --search
-twilio matches twilio:account_sid, twilio:auth_token, and twilio:phone_number.
-
-Returns an array of credential objects. Empty array if no credentials exist
-or none match the search query.
-
-Examples:
-  $ assistant credentials list
-  $ assistant credentials list --search twilio
-  $ assistant credentials list --search bot_token
-  $ assistant credentials list --json`,
-        )
-        .action(async (opts: { search?: string }, cmd: Command) => {
+      subcommand(credential, "list").action(
+        async (opts: { search?: string }, cmd: Command) => {
           const r = await cliIpcCall<CredentialsListResponse>(
             "credentials_list",
             { body: { search: opts.search } },
@@ -216,36 +166,15 @@ Examples:
               }
             }
           }
-        });
+        },
+      );
 
       // -----------------------------------------------------------------------
       // status
       // -----------------------------------------------------------------------
 
-      credential
-        .command("status")
-        .description("Show the active credential backend and its configuration")
-        .addHelpText(
-          "after",
-          `
-Shows which credential storage backend this process is using and backend-specific
-path or connection details. Run this to diagnose credential lookup mismatches —
-for example, when the CLI and the daemon are reading from different stores.
-
-Backend types:
-  encrypted-store   Direct file read from keys.enc (standalone CLI, no daemon)
-  ces-rpc           Delegates to the running CES process via stdio RPC (daemon)
-  ces-http          Delegates to CES sidecar over HTTP (containerized/Docker mode)
-
-Also shows the CREDENTIAL_SECURITY_DIR, GATEWAY_SECURITY_DIR, and
-VELLUM_WORKSPACE_DIR env vars so you can confirm which instance directory this
-process is scoped to.
-
-Examples:
-  $ assistant credentials status
-  $ assistant credentials status --json`,
-        )
-        .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      subcommand(credential, "status").action(
+        async (_opts: Record<string, unknown>, cmd: Command) => {
           const r =
             await cliIpcCall<CredentialsStatusResponse>("credentials_status");
           if (!r.ok) {
@@ -274,463 +203,313 @@ Examples:
               log.info(`  URL:         ${info.url}`);
             }
           }
-        });
+        },
+      );
 
       // -----------------------------------------------------------------------
       // set
       // -----------------------------------------------------------------------
 
-      credential
-        .command("set <value>")
-        .description("Store a secret and create or update its metadata")
-        .requiredOption(
-          "--service <service>",
-          "Service namespace (e.g. google)",
-        )
-        .requiredOption("--field <field>", "Field name (e.g. client_secret)")
-        .option("--label <label>", 'Human-friendly label (e.g. "prod", "work")')
-        .option(
-          "--description <description>",
-          "What this credential is used for",
-        )
-        .option(
-          "--allowed-tools <tools>",
-          "Comma-separated tool names that may use this credential",
-        )
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  value   The secret value to store
-
-If the credential already exists, the secret is overwritten and metadata is
-updated with any provided flags. Omitted flags leave existing metadata intact.
-
-Examples:
-  $ assistant credentials set --service twilio --field account_sid AC1234567890
-  $ assistant credentials set --service fal --field api_key key_live_abc --label "fal-prod" --description "Image generation"
-  $ assistant credentials set --service github --field token ghp_abc --allowed-tools "bash,host_bash"`,
-        )
-        .action(
-          async (
-            value: string,
-            opts: {
-              service: string;
-              field: string;
-              label?: string;
-              description?: string;
-              allowedTools?: string;
-            },
-            cmd: Command,
-          ) => {
-            const allowedTools = opts.allowedTools
-              ? opts.allowedTools.split(",").map((t) => t.trim())
-              : undefined;
-
-            const r = await cliIpcCall<{
-              credentialId: string;
-              service: string;
-              field: string;
-            }>("credentials_set", {
-              body: {
-                service: opts.service,
-                field: opts.field,
-                value,
-                label: opts.label,
-                description: opts.description,
-                allowedTools,
-              },
-            });
-
-            if (!r.ok) {
-              writeError(
-                cmd,
-                r.error ??
-                  `Failed to store credential ${opts.service}:${opts.field}`,
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, {
-                ok: true,
-                credentialId: r.result!.credentialId,
-                service: opts.service,
-                field: opts.field,
-              });
-            } else {
-              log.info(
-                `Stored credential ${opts.service}:${opts.field} (${r.result!.credentialId})`,
-              );
-            }
+      subcommand(credential, "set").action(
+        async (
+          value: string,
+          opts: {
+            service: string;
+            field: string;
+            label?: string;
+            description?: string;
+            allowedTools?: string;
           },
-        );
+          cmd: Command,
+        ) => {
+          const allowedTools = opts.allowedTools
+            ? opts.allowedTools.split(",").map((t) => t.trim())
+            : undefined;
+
+          const r = await cliIpcCall<{
+            credentialId: string;
+            service: string;
+            field: string;
+          }>("credentials_set", {
+            body: {
+              service: opts.service,
+              field: opts.field,
+              value,
+              label: opts.label,
+              description: opts.description,
+              allowedTools,
+            },
+          });
+
+          if (!r.ok) {
+            writeError(
+              cmd,
+              r.error ??
+                `Failed to store credential ${opts.service}:${opts.field}`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, {
+              ok: true,
+              credentialId: r.result!.credentialId,
+              service: opts.service,
+              field: opts.field,
+            });
+          } else {
+            log.info(
+              `Stored credential ${opts.service}:${opts.field} (${r.result!.credentialId})`,
+            );
+          }
+        },
+      );
 
       // -----------------------------------------------------------------------
       // delete
       // -----------------------------------------------------------------------
 
-      credential
-        .command("delete")
-        .description("Remove a secret and its metadata from the vault")
-        .requiredOption("--service <service>", "Service namespace")
-        .requiredOption("--field <field>", "Field name")
-        .addHelpText(
-          "after",
-          `
-Deletes both the encrypted secret and all associated metadata (policy,
-timestamps, injection templates). This action cannot be undone.
+      subcommand(credential, "delete").action(
+        async (opts: { service: string; field: string }, cmd: Command) => {
+          const r = await cliIpcCall<{
+            service: string;
+            field: string;
+          }>("credentials_delete", {
+            body: { service: opts.service, field: opts.field },
+          });
 
-Examples:
-  $ assistant credentials delete --service twilio --field auth_token
-  $ assistant credentials delete --service github --field token`,
-        )
-        .action(
-          async (opts: { service: string; field: string }, cmd: Command) => {
-            const r = await cliIpcCall<{
-              service: string;
-              field: string;
-            }>("credentials_delete", {
-              body: { service: opts.service, field: opts.field },
+          if (!r.ok) {
+            writeError(
+              cmd,
+              r.error ??
+                `Failed to delete credential ${opts.service}:${opts.field}`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, {
+              ok: true,
+              service: opts.service,
+              field: opts.field,
             });
-
-            if (!r.ok) {
-              writeError(
-                cmd,
-                r.error ??
-                  `Failed to delete credential ${opts.service}:${opts.field}`,
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, {
-                ok: true,
-                service: opts.service,
-                field: opts.field,
-              });
-            } else {
-              log.info(`Deleted credential ${opts.service}:${opts.field}`);
-            }
-          },
-        );
+          } else {
+            log.info(`Deleted credential ${opts.service}:${opts.field}`);
+          }
+        },
+      );
 
       // -----------------------------------------------------------------------
       // inspect
       // -----------------------------------------------------------------------
 
-      credential
-        .command("inspect [id]")
-        .description(
-          "Show metadata and a masked preview of a stored credential",
-        )
-        .option("--service <service>", "Service namespace")
-        .option("--field <field>", "Field name")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  id   (optional) Credential UUID for lookup by ID
-
-Shows everything known about a credential without revealing the secret value.
-The secret is masked to show only the last 4 characters (e.g. ****c123).
-
-Displayed fields include: label, creation/update timestamps, allowed tools,
-allowed domains, OAuth2 scopes, account info, and injection template count.
-
-Use --service and --field to look up by service/field, or pass a UUID as a
-positional argument. One of the two forms is required.
-
-Examples:
-  $ assistant credentials inspect --service twilio --field account_sid
-  $ assistant credentials inspect 7a3b1c2d-4e5f-6789-abcd-ef0123456789
-  $ assistant credentials inspect --json --service slack_channel --field bot_token`,
-        )
-        .action(
-          async (
-            id: string | undefined,
-            opts: { service?: string; field?: string },
-            cmd: Command,
-          ) => {
-            if (!opts.service && !opts.field && !id) {
-              writeError(
-                cmd,
-                "Either --service and --field flags or a credential UUID is required",
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            const r = await cliIpcCall<Record<string, unknown>>(
-              "credentials_inspect",
-              {
-                body: {
-                  service: opts.service,
-                  field: opts.field,
-                  id,
-                },
-              },
+      subcommand(credential, "inspect").action(
+        async (
+          id: string | undefined,
+          opts: { service?: string; field?: string },
+          cmd: Command,
+        ) => {
+          if (!opts.service && !opts.field && !id) {
+            writeError(
+              cmd,
+              "Either --service and --field flags or a credential UUID is required",
             );
+            process.exitCode = 1;
+            return;
+          }
 
-            if (!r.ok) {
-              writeError(cmd, r.error ?? "Credential not found");
-              process.exitCode = 1;
-              return;
+          const r = await cliIpcCall<Record<string, unknown>>(
+            "credentials_inspect",
+            {
+              body: {
+                service: opts.service,
+                field: opts.field,
+                id,
+              },
+            },
+          );
+
+          if (!r.ok) {
+            writeError(cmd, r.error ?? "Credential not found");
+            process.exitCode = 1;
+            return;
+          }
+
+          const output = r.result!;
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, { ok: true, ...output });
+          } else {
+            printCredentialHuman(output);
+            if (output.brokerUnreachable) {
+              log.info(
+                "    ⚠ Credential store is unreachable — ensure the assistant is running",
+              );
             }
-
-            const output = r.result!;
-
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, { ok: true, ...output });
-            } else {
-              printCredentialHuman(output);
-              if (output.brokerUnreachable) {
-                log.info(
-                  "    ⚠ Credential store is unreachable — ensure the assistant is running",
-                );
-              }
-            }
-          },
-        );
+          }
+        },
+      );
 
       // -----------------------------------------------------------------------
       // reveal
       // -----------------------------------------------------------------------
 
-      credential
-        .command("reveal [id]")
-        .description("Print the plaintext value of a credential")
-        .option("--service <service>", "Service namespace")
-        .option("--field <field>", "Field name")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  id   (optional) Credential UUID for lookup by ID
-
-Prints the raw secret value to stdout for piping into other tools. In JSON
-mode the value is returned as {"ok": true, "value": "..."}. In human mode
-only the bare secret is printed (no labels or decoration) so it can be
-captured with shell substitution.
-
-Use --service and --field to look up by service/field, or pass a UUID as a
-positional argument. One of the two forms is required.
-
-Examples:
-  $ assistant credentials reveal --service twilio --field auth_token
-  $ assistant credentials reveal 7a3b1c2d-4e5f-6789-abcd-ef0123456789
-  $ assistant credentials reveal --json --service twilio --field account_sid
-  $ export TWILIO_TOKEN=$(assistant credentials reveal --service twilio --field auth_token)`,
-        )
-        .action(
-          async (
-            id: string | undefined,
-            opts: { service?: string; field?: string },
-            cmd: Command,
-          ) => {
-            if (!opts.service && !opts.field && !id) {
-              writeError(
-                cmd,
-                "Either --service and --field flags or a credential UUID is required",
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            const r = await cliIpcCall<{ value: string }>(
-              "credentials_reveal",
-              {
-                body: {
-                  service: opts.service,
-                  field: opts.field,
-                  id,
-                },
-              },
+      subcommand(credential, "reveal").action(
+        async (
+          id: string | undefined,
+          opts: { service?: string; field?: string },
+          cmd: Command,
+        ) => {
+          if (!opts.service && !opts.field && !id) {
+            writeError(
+              cmd,
+              "Either --service and --field flags or a credential UUID is required",
             );
+            process.exitCode = 1;
+            return;
+          }
 
-            if (!r.ok) {
-              writeError(cmd, r.error ?? "Credential not found");
-              process.exitCode = 1;
-              return;
-            }
+          const r = await cliIpcCall<{ value: string }>("credentials_reveal", {
+            body: {
+              service: opts.service,
+              field: opts.field,
+              id,
+            },
+          });
 
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, { ok: true, value: r.result!.value });
-            } else {
-              process.stdout.write(r.result!.value + "\n");
-            }
-          },
-        );
+          if (!r.ok) {
+            writeError(cmd, r.error ?? "Credential not found");
+            process.exitCode = 1;
+            return;
+          }
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, { ok: true, value: r.result!.value });
+          } else {
+            process.stdout.write(r.result!.value + "\n");
+          }
+        },
+      );
 
       // -----------------------------------------------------------------------
       // prompt
       // -----------------------------------------------------------------------
 
-      credential
-        .command("prompt")
-        .description(
-          "Securely prompt the user for a credential via the app UI and store it",
-        )
-        .requiredOption(
-          "--service <service>",
-          "Service namespace (e.g. sentry)",
-        )
-        .requiredOption("--field <field>", "Field name (e.g. auth_token)")
-        .requiredOption("--label <label>", "Display label for the prompt UI")
-        .option("--description <description>", "Context shown in the prompt UI")
-        .option("--placeholder <placeholder>", "Placeholder text for the input")
-        .option(
-          "--usage-description <description>",
-          "Human-readable description of intended usage, stored in credential metadata and shown as the prompt's purpose",
-        )
-        .option(
-          "--allowed-domains <domains>",
-          "Comma-separated domains where this credential may be used",
-        )
-        .option(
-          "--allowed-tools <tools>",
-          "Comma-separated tool names that may use this credential",
-        )
-        .option(
-          "--injection-templates <json>",
-          "JSON array of injection template objects",
-        )
-        .addHelpText(
-          "after",
-          `
-Opens a secure credential input prompt in the user's connected app (desktop,
-web, etc.). The user enters the secret through the UI — it never passes through
-the conversation or CLI output. On success the credential is stored in the
-encrypted vault with the specified metadata.
+      subcommand(credential, "prompt").action(
+        async (
+          opts: {
+            service: string;
+            field: string;
+            label: string;
+            description?: string;
+            placeholder?: string;
+            usageDescription?: string;
+            allowedDomains?: string;
+            allowedTools?: string;
+            injectionTemplates?: string;
+          },
+          cmd: Command,
+        ) => {
+          const allowedDomains = opts.allowedDomains
+            ? opts.allowedDomains.split(",").map((d) => d.trim())
+            : undefined;
+          const allowedTools = opts.allowedTools
+            ? opts.allowedTools.split(",").map((t) => t.trim())
+            : undefined;
 
-Requires the assistant to be running with at least one connected client.
-
-Examples:
-  $ assistant credentials prompt --service sentry --field auth_token \\
-      --label "Sentry Auth Token" --placeholder "sntrys_..." \\
-      --usage-description "Read Sentry issues and events" \\
-      --allowed-domains "sentry.io" \\
-      --injection-templates '[{"hostPattern":"sentry.io","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]'`,
-        )
-        .action(
-          async (
-            opts: {
-              service: string;
-              field: string;
-              label: string;
-              description?: string;
-              placeholder?: string;
-              usageDescription?: string;
-              allowedDomains?: string;
-              allowedTools?: string;
-              injectionTemplates?: string;
-            },
-            cmd: Command,
-          ) => {
-            const allowedDomains = opts.allowedDomains
-              ? opts.allowedDomains.split(",").map((d) => d.trim())
-              : undefined;
-            const allowedTools = opts.allowedTools
-              ? opts.allowedTools.split(",").map((t) => t.trim())
-              : undefined;
-
-            let injectionTemplates: unknown[] | undefined;
-            if (opts.injectionTemplates) {
-              try {
-                injectionTemplates = JSON.parse(opts.injectionTemplates);
-                if (!Array.isArray(injectionTemplates)) {
-                  writeError(cmd, "--injection-templates must be a JSON array");
-                  process.exitCode = 1;
-                  return;
-                }
-              } catch {
-                writeError(cmd, "--injection-templates must be valid JSON");
+          let injectionTemplates: unknown[] | undefined;
+          if (opts.injectionTemplates) {
+            try {
+              injectionTemplates = JSON.parse(opts.injectionTemplates);
+              if (!Array.isArray(injectionTemplates)) {
+                writeError(cmd, "--injection-templates must be a JSON array");
                 process.exitCode = 1;
                 return;
               }
+            } catch {
+              writeError(cmd, "--injection-templates must be valid JSON");
+              process.exitCode = 1;
+              return;
             }
+          }
 
-            const PROMPT_TIMEOUT_MS = 310_000; // 5 min + 10s buffer
-            const ipc = await cliIpcCall<CredentialPromptResult>(
-              "credentials_prompt",
-              {
-                body: {
-                  service: opts.service,
-                  field: opts.field,
-                  label: opts.label,
-                  description: opts.description,
-                  placeholder: opts.placeholder,
-                  usageDescription: opts.usageDescription,
-                  allowedDomains,
-                  allowedTools,
-                  injectionTemplates,
-                  conversationId: tryResolveConversationId(),
-                },
+          const PROMPT_TIMEOUT_MS = 310_000; // 5 min + 10s buffer
+          const ipc = await cliIpcCall<CredentialPromptResult>(
+            "credentials_prompt",
+            {
+              body: {
+                service: opts.service,
+                field: opts.field,
+                label: opts.label,
+                description: opts.description,
+                placeholder: opts.placeholder,
+                usageDescription: opts.usageDescription,
+                allowedDomains,
+                allowedTools,
+                injectionTemplates,
+                conversationId: tryResolveConversationId(),
               },
-              { timeoutMs: PROMPT_TIMEOUT_MS },
+            },
+            { timeoutMs: PROMPT_TIMEOUT_MS },
+          );
+
+          if (!ipc.ok) {
+            writeError(cmd, ipc.error ?? "Failed to connect to the assistant");
+            process.exitCode = 1;
+            return;
+          }
+
+          if (!ipc.result?.ok) {
+            // A pending one-time collection link is not success (nothing is
+            // stored yet) and not an error. Exit 75 (EX_TEMPFAIL) so setup
+            // skills that chain on exit 0 = stored do not proceed with a
+            // missing credential, while the message hands the model the
+            // link to relay in-channel.
+            if (ipc.result?.pending) {
+              if (shouldOutputJson(cmd)) {
+                writeOutput(cmd, ipc.result);
+              } else {
+                log.info(
+                  ipc.result.message ??
+                    "A one-time credential link was generated — the value is not stored yet",
+                );
+              }
+              process.exitCode = 75;
+              return;
+            }
+            // An explicit user cancel is a valid outcome, not a failure.
+            // Surface it as an informational message and exit 130 — the
+            // conventional "user interrupt" (SIGINT) code — so callers and
+            // setup skills can tell a deliberate cancel apart from a genuine
+            // error (which stays exit 1). Nothing was stored either way.
+            if (ipc.result?.cancelled) {
+              if (shouldOutputJson(cmd)) {
+                writeOutput(cmd, ipc.result);
+              } else {
+                log.info(
+                  ipc.result.error ?? "Credential prompt cancelled by the user",
+                );
+              }
+              process.exitCode = 130;
+              return;
+            }
+            writeError(cmd, ipc.result?.error ?? "Credential prompt failed");
+            process.exitCode = 1;
+            return;
+          }
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, ipc.result);
+          } else {
+            log.info(
+              ipc.result.message ??
+                `Stored credential ${opts.service}:${opts.field}`,
             );
-
-            if (!ipc.ok) {
-              writeError(
-                cmd,
-                ipc.error ?? "Failed to connect to the assistant",
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            if (!ipc.result?.ok) {
-              // A pending one-time collection link is not success (nothing is
-              // stored yet) and not an error. Exit 75 (EX_TEMPFAIL) so setup
-              // skills that chain on exit 0 = stored do not proceed with a
-              // missing credential, while the message hands the model the
-              // link to relay in-channel.
-              if (ipc.result?.pending) {
-                if (shouldOutputJson(cmd)) {
-                  writeOutput(cmd, ipc.result);
-                } else {
-                  log.info(
-                    ipc.result.message ??
-                      "A one-time credential link was generated — the value is not stored yet",
-                  );
-                }
-                process.exitCode = 75;
-                return;
-              }
-              // An explicit user cancel is a valid outcome, not a failure.
-              // Surface it as an informational message and exit 130 — the
-              // conventional "user interrupt" (SIGINT) code — so callers and
-              // setup skills can tell a deliberate cancel apart from a genuine
-              // error (which stays exit 1). Nothing was stored either way.
-              if (ipc.result?.cancelled) {
-                if (shouldOutputJson(cmd)) {
-                  writeOutput(cmd, ipc.result);
-                } else {
-                  log.info(
-                    ipc.result.error ??
-                      "Credential prompt cancelled by the user",
-                  );
-                }
-                process.exitCode = 130;
-                return;
-              }
-              writeError(cmd, ipc.result?.error ?? "Credential prompt failed");
-              process.exitCode = 1;
-              return;
-            }
-
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, ipc.result);
-            } else {
-              log.info(
-                ipc.result.message ??
-                  `Stored credential ${opts.service}:${opts.field}`,
-              );
-            }
-          },
-        );
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/db/index.help.ts
+++ b/assistant/src/cli/commands/db/index.help.ts
@@ -1,0 +1,22 @@
+/** Declarative help for the `assistant db` command. */
+
+import type { CliCommandHelp } from "../../lib/cli-command-help.js";
+
+export const dbHelp: CliCommandHelp = {
+  name: "db",
+  description: "Inspect and repair the assistant SQLite database",
+  options: [
+    { flags: "--json", description: "Machine-readable compact JSON output" },
+  ],
+  subcommands: [
+    {
+      name: "status",
+      description:
+        "Show database path, size, key pragmas, and the 5 largest tables",
+    },
+    {
+      name: "repair",
+      description: "Run the database repair sequence (integrity check, …)",
+    },
+  ],
+};

--- a/assistant/src/cli/commands/db/index.ts
+++ b/assistant/src/cli/commands/db/index.ts
@@ -11,17 +11,19 @@
 
 import type { Command } from "commander";
 
+import { applyCommandHelp } from "../../lib/cli-command-help.js";
 import { registerCommand } from "../../lib/register-command.js";
+import { dbHelp } from "./index.help.js";
 import { registerDbRepair } from "./repair.js";
 import { registerDbStatus } from "./status.js";
 
 export function registerDbCommand(program: Command): void {
   registerCommand(program, {
-    name: "db",
+    name: dbHelp.name,
     transport: "local",
-    description: "Inspect and repair the assistant SQLite database",
+    description: dbHelp.description,
     build: (db) => {
-      db.option("--json", "Machine-readable compact JSON output");
+      applyCommandHelp(db, dbHelp);
       registerDbStatus(db);
       registerDbRepair(db);
     },

--- a/assistant/src/cli/commands/db/repair.ts
+++ b/assistant/src/cli/commands/db/repair.ts
@@ -21,6 +21,7 @@ import type { Command } from "commander";
 
 import { getDbPath } from "../../../util/platform.js";
 import { dim, green, red } from "../../lib/cli-colors.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 import { integrityCheckStep } from "./repair-step-integrity.js";
 import type { RepairReport, RepairStep, StepResult } from "./repair-steps.js";
@@ -104,50 +105,47 @@ function renderSummary(report: RepairReport): string {
 // ---------------------------------------------------------------------------
 
 export function registerDbRepair(parent: Command): void {
-  parent
-    .command("repair")
-    .description("Run the database repair sequence (integrity check, …)")
-    .action(async function (this: Command) {
-      const dbPath = getDbPath();
+  subcommand(parent, "repair").action(async function (this: Command) {
+    const dbPath = getDbPath();
 
-      if (!existsSync(dbPath)) {
-        if (shouldOutputJson(this)) {
-          writeOutput(this, {
-            dbPath,
-            missing: true,
-            steps: [],
-            okCount: 0,
-            errorCount: 0,
-            halted: false,
-          });
-        } else {
-          process.stderr.write(renderMissingDb(dbPath));
-        }
-        process.exit(1);
-      }
-
-      const isJson = shouldOutputJson(this);
-
-      const report = await runRepairSteps(
-        { dbPath },
-        repairSteps(),
-        isJson
-          ? {}
-          : {
-              onStart: emitStepStart,
-              onFinish: emitStepFinish,
-            },
-      );
-
-      if (isJson) {
-        writeOutput(this, report);
+    if (!existsSync(dbPath)) {
+      if (shouldOutputJson(this)) {
+        writeOutput(this, {
+          dbPath,
+          missing: true,
+          steps: [],
+          okCount: 0,
+          errorCount: 0,
+          halted: false,
+        });
       } else {
-        process.stdout.write(renderSummary(report));
+        process.stderr.write(renderMissingDb(dbPath));
       }
+      process.exit(1);
+    }
 
-      // Exit non-zero if any step failed — makes the command scriptable.
-      if (report.errorCount > 0) {
-        process.exit(1);
-      }
-    });
+    const isJson = shouldOutputJson(this);
+
+    const report = await runRepairSteps(
+      { dbPath },
+      repairSteps(),
+      isJson
+        ? {}
+        : {
+            onStart: emitStepStart,
+            onFinish: emitStepFinish,
+          },
+    );
+
+    if (isJson) {
+      writeOutput(this, report);
+    } else {
+      process.stdout.write(renderSummary(report));
+    }
+
+    // Exit non-zero if any step failed — makes the command scriptable.
+    if (report.errorCount > 0) {
+      process.exit(1);
+    }
+  });
 }

--- a/assistant/src/cli/commands/db/status.ts
+++ b/assistant/src/cli/commands/db/status.ts
@@ -33,6 +33,7 @@ import { getMemoryDbPath } from "../../../util/memory-db-path.js";
 import { getDbPath } from "../../../util/platform.js";
 import { getTelemetryDbPath } from "../../../util/telemetry-db-path.js";
 import { red } from "../../lib/cli-colors.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 import {
   formatAge,
@@ -482,100 +483,95 @@ function renderMissing(path: string): string {
 // ---------------------------------------------------------------------------
 
 export function registerDbStatus(parent: Command): void {
-  parent
-    .command("status")
-    .description(
-      "Show database path, size, key pragmas, and the 5 largest tables",
-    )
-    .action(function (this: Command) {
-      const file = readFileFacts(getDbPath());
+  subcommand(parent, "status").action(function (this: Command) {
+    const file = readFileFacts(getDbPath());
 
-      if (!file.exists) {
-        if (shouldOutputJson(this)) {
-          const report: StatusReport = { file, db: null };
-          writeOutput(this, report);
-        } else {
-          process.stderr.write(renderMissing(file.path));
-        }
-        process.exit(1);
-      }
-
-      let db: DbFacts;
-      try {
-        db = readDbFacts(file.path);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (shouldOutputJson(this)) {
-          const report: StatusReport = { file, db: null };
-          writeOutput(this, { ...report, openError: msg });
-        } else {
-          process.stderr.write(
-            `${red("ERROR")}  Failed to open ${file.path}: ${msg}\n` +
-              `\nThe file exists but bun:sqlite couldn't open it. Run\n` +
-              `\`assistant db repair\` (when available) for a full integrity check.\n`,
-          );
-        }
-        process.exit(1);
-      }
-
-      // Best-effort probe of the dedicated append-only DB. It may not exist
-      // yet (fresh install that has never started the daemon), and a probe
-      // failure must never mask the main-DB report.
-      const logsFile = readFileFacts(getLogsDbPath());
-      let logsDb: DbFacts | null = null;
-      if (logsFile.exists) {
-        try {
-          logsDb = readDbFacts(logsFile.path);
-        } catch {
-          logsDb = null;
-        }
-      }
-
-      // Same best-effort probe for the dedicated memory DB.
-      const memoryFile = readFileFacts(getMemoryDbPath());
-      let memoryDb: DbFacts | null = null;
-      if (memoryFile.exists) {
-        try {
-          memoryDb = readDbFacts(memoryFile.path);
-        } catch {
-          memoryDb = null;
-        }
-      }
-
-      // Same best-effort probe for the dedicated telemetry DB.
-      const telemetryFile = readFileFacts(getTelemetryDbPath());
-      let telemetryDb: DbFacts | null = null;
-      if (telemetryFile.exists) {
-        try {
-          telemetryDb = readDbFacts(telemetryFile.path);
-        } catch {
-          telemetryDb = null;
-        }
-      }
-
-      // Cross-database migration summary from the main DB's checkpoint ledger.
-      let migration: MigrationSummary | null = null;
-      try {
-        migration = readMigrationSummary(file.path);
-      } catch {
-        migration = null;
-      }
-
-      const report: StatusReport = {
-        file,
-        db,
-        migration: migration ?? undefined,
-        logsFile,
-        logsDb,
-        memoryFile,
-        memoryDb,
-        telemetryFile,
-        telemetryDb,
-      };
+    if (!file.exists) {
       if (shouldOutputJson(this)) {
+        const report: StatusReport = { file, db: null };
         writeOutput(this, report);
       } else {
-        process.stdout.write(renderHuman(report));
+        process.stderr.write(renderMissing(file.path));
       }
-    });
+      process.exit(1);
+    }
+
+    let db: DbFacts;
+    try {
+      db = readDbFacts(file.path);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (shouldOutputJson(this)) {
+        const report: StatusReport = { file, db: null };
+        writeOutput(this, { ...report, openError: msg });
+      } else {
+        process.stderr.write(
+          `${red("ERROR")}  Failed to open ${file.path}: ${msg}\n` +
+            `\nThe file exists but bun:sqlite couldn't open it. Run\n` +
+            `\`assistant db repair\` (when available) for a full integrity check.\n`,
+        );
+      }
+      process.exit(1);
+    }
+
+    // Best-effort probe of the dedicated append-only DB. It may not exist
+    // yet (fresh install that has never started the daemon), and a probe
+    // failure must never mask the main-DB report.
+    const logsFile = readFileFacts(getLogsDbPath());
+    let logsDb: DbFacts | null = null;
+    if (logsFile.exists) {
+      try {
+        logsDb = readDbFacts(logsFile.path);
+      } catch {
+        logsDb = null;
+      }
+    }
+
+    // Same best-effort probe for the dedicated memory DB.
+    const memoryFile = readFileFacts(getMemoryDbPath());
+    let memoryDb: DbFacts | null = null;
+    if (memoryFile.exists) {
+      try {
+        memoryDb = readDbFacts(memoryFile.path);
+      } catch {
+        memoryDb = null;
+      }
+    }
+
+    // Same best-effort probe for the dedicated telemetry DB.
+    const telemetryFile = readFileFacts(getTelemetryDbPath());
+    let telemetryDb: DbFacts | null = null;
+    if (telemetryFile.exists) {
+      try {
+        telemetryDb = readDbFacts(telemetryFile.path);
+      } catch {
+        telemetryDb = null;
+      }
+    }
+
+    // Cross-database migration summary from the main DB's checkpoint ledger.
+    let migration: MigrationSummary | null = null;
+    try {
+      migration = readMigrationSummary(file.path);
+    } catch {
+      migration = null;
+    }
+
+    const report: StatusReport = {
+      file,
+      db,
+      migration: migration ?? undefined,
+      logsFile,
+      logsDb,
+      memoryFile,
+      memoryDb,
+      telemetryFile,
+      telemetryDb,
+    };
+    if (shouldOutputJson(this)) {
+      writeOutput(this, report);
+    } else {
+      process.stdout.write(renderHuman(report));
+    }
+  });
 }

--- a/assistant/src/cli/commands/domain.help.ts
+++ b/assistant/src/cli/commands/domain.help.ts
@@ -1,0 +1,34 @@
+/** Declarative help for the `assistant domain` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const domainHelp: CliCommandHelp = {
+  name: "domain",
+  description: "Register and manage this assistant's custom subdomain",
+  options: [
+    {
+      flags: "--json",
+      description: "Machine-readable compact JSON output",
+    },
+  ],
+  subcommands: [
+    {
+      name: "register",
+      args: "[subdomain]",
+      description: "Register a custom subdomain for this assistant",
+      options: [
+        {
+          flags: "--email-username <username>",
+          description:
+            "Also register an email address (e.g. --email-username hello → hello@<subdomain>.domain)",
+        },
+      ],
+    },
+    {
+      name: "status",
+      args: "<subdomain>",
+      description:
+        "Show registration and DNS verification status for a subdomain",
+    },
+  ],
+};

--- a/assistant/src/cli/commands/domain.ts
+++ b/assistant/src/cli/commands/domain.ts
@@ -3,9 +3,11 @@ import { createRequire } from "node:module";
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { getCliLogger } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
+import { domainHelp } from "./domain.help.js";
 
 const loadModule = createRequire(import.meta.url);
 
@@ -37,12 +39,15 @@ function handleDomainIpcError(
 
 export function registerDomainCommand(program: Command): void {
   registerCommand(program, {
-    name: "domain",
+    name: domainHelp.name,
     transport: "ipc",
-    description: "Register and manage this assistant's custom subdomain",
+    description: domainHelp.description,
     build: (domain) => {
-      domain.option("--json", "Machine-readable compact JSON output");
+      applyCommandHelp(domain, domainHelp);
 
+      // The help text below interpolates runtime-resolved domains, so it
+      // cannot be expressed as static data in the .help module and stays
+      // registered imperatively as a callback.
       domain.addHelpText(
         "after",
         () => `
@@ -56,13 +61,7 @@ Examples:
   $ assistant domain status velly`,
       );
 
-      domain
-        .command("register [subdomain]")
-        .option(
-          "--email-username <username>",
-          "Also register an email address (e.g. --email-username hello → hello@<subdomain>.domain)",
-        )
-        .description("Register a custom subdomain for this assistant")
+      subcommand(domain, "register")
         .addHelpText("after", () => {
           const { baseDomain } = envDomains();
           return `
@@ -151,11 +150,7 @@ Examples:
           },
         );
 
-      domain
-        .command("status <subdomain>")
-        .description(
-          "Show registration and DNS verification status for a subdomain",
-        )
+      subcommand(domain, "status")
         .addHelpText(
           "after",
           () => `

--- a/assistant/src/cli/commands/email.help.ts
+++ b/assistant/src/cli/commands/email.help.ts
@@ -1,0 +1,169 @@
+/** Declarative help for the `assistant email` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const emailHelp: CliCommandHelp = {
+  name: "email",
+  description:
+    "Get your own email address — register, send, receive, and manage email natively",
+  options: [
+    { flags: "--json", description: "Machine-readable compact JSON output" },
+  ],
+  helpText: `
+Set up and manage this assistant's native email address on the Vellum
+platform. No third-party email provider or browser sign-up needed.
+
+Examples:
+  $ assistant email register mybot
+  $ assistant email unregister --confirm
+  $ assistant email send user@example.com -s "Hello" -b "Hi there"
+  $ assistant email status
+  $ assistant email list
+  $ assistant email attachment msg_abc1 --list
+  $ assistant email attachment msg_abc1 att_xyz1
+  $ assistant email register mybot --json`,
+  subcommands: [
+    {
+      name: "register",
+      args: "<username>",
+      description: "Register an email address for this assistant",
+    },
+    {
+      name: "unregister",
+      description: "Remove the email address registered for this assistant",
+      options: [
+        { flags: "--confirm", description: "Skip confirmation prompt" },
+      ],
+    },
+    {
+      name: "status",
+      description: "Show email address info and usage for this assistant",
+    },
+    {
+      name: "list",
+      description: "List received and sent emails for this assistant",
+      options: [
+        {
+          flags: "-d, --direction <direction>",
+          description: "Filter by direction: inbound, outbound, or all",
+          defaultValue: "all",
+        },
+        {
+          flags: "-l, --limit <count>",
+          description: "Maximum number of results",
+          defaultValue: "20",
+        },
+        {
+          flags: "--since <date>",
+          description: "Only show messages since this date (ISO 8601)",
+        },
+      ],
+      helpText: `
+Lists email messages for this assistant. Shows subject, from, to,
+direction, and timestamp for each message.
+
+Examples:
+  $ assistant email list
+  $ assistant email list --direction inbound --limit 5
+  $ assistant email list --since 2026-04-01 --json`,
+    },
+    {
+      name: "download",
+      args: "<message-id>",
+      description: "Download a specific email message",
+      options: [
+        {
+          flags: "--format <type>",
+          description: "Output format: text, html, json (default: text)",
+          defaultValue: "text",
+        },
+        {
+          flags: "-o, --output <path>",
+          description: "Write to file instead of stdout",
+        },
+      ],
+    },
+    {
+      name: "send",
+      args: "<to...>",
+      description: "Send an email from this assistant",
+      options: [
+        { flags: "-s, --subject <text>", description: "Subject line" },
+        { flags: "-b, --body <text>", description: "Email body (plain text)" },
+        { flags: "-f, --file <path>", description: "Read body from file" },
+        { flags: "--html <path>", description: "HTML body file (optional)" },
+        { flags: "--cc <address>", description: "CC recipient (repeatable)" },
+        { flags: "--bcc <address>", description: "BCC recipient (repeatable)" },
+        {
+          flags: "--reply-to <email_id>",
+          description:
+            "Reply to an email by its ID (auto-resolves threading headers and subject)",
+        },
+      ],
+      helpText: `
+Arguments:
+  to   Recipient email address(es) — one or more
+
+Sends an email from the assistant's registered email address via the
+Vellum runtime proxy. The "from" address is automatically resolved
+from the assistant's registered email address.
+
+Body source priority: --body flag > --file flag > stdin (if not a TTY).
+
+When --reply-to is provided, the platform auto-resolves In-Reply-To,
+References, and Subject headers from the referenced email. You can
+still override subject with -s.
+
+Examples:
+  $ assistant email send user@example.com -s "Hello" -b "Hi there"
+  ✓ Sent to user@example.com (delivery_id: abc123)
+
+  $ assistant email send a@example.com b@example.com --cc c@example.com -s "Team" -b "Hi all"
+  ✓ Sent to a@example.com, b@example.com (delivery_id: abc123)
+
+  $ assistant email send user@example.com --bcc boss@example.com -s "FYI" -b "See below"
+  ✓ Sent to user@example.com (delivery_id: def456)
+
+  $ assistant email send user@example.com -b "Thanks!" --reply-to 019d96e4-e5d2-7201-890e-04a21e8f95bb
+  ✓ Sent to user@example.com (delivery_id: ghi789)
+
+  $ assistant email send user@example.com -s "Hello" -b "Hi" --json
+  {"delivery_id":"abc123","status":"accepted"}`,
+    },
+    {
+      name: "attachment",
+      args: "<message-id> [attachment-id]",
+      description: "Download email attachments",
+      options: [
+        {
+          flags: "--all",
+          description: "Download all attachments for the message",
+        },
+        {
+          flags: "-o, --output <dir>",
+          description: "Output directory (default: current directory)",
+          defaultValue: ".",
+        },
+        {
+          flags: "--list",
+          description: "List attachments without downloading",
+        },
+      ],
+      helpText: `
+Arguments:
+message-id      Email message ID (from \`assistant email list --json\`)
+attachment-id   Attachment ID (optional — required unless --all or --list)
+
+Download one or all attachments from a specific email message. Use
+--list to see available attachments without downloading.
+
+Examples:
+$ assistant email attachment msg_abc1 --list
+$ assistant email attachment msg_abc1 att_xyz1
+$ assistant email attachment msg_abc1 att_xyz1 -o ./downloads/
+$ assistant email attachment msg_abc1 --all
+$ assistant email attachment msg_abc1 --all -o ./attachments/
+$ assistant email attachment msg_abc1 --list --json`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/email.ts
+++ b/assistant/src/cli/commands/email.ts
@@ -15,9 +15,11 @@ import {
   exitFromIpcResult,
 } from "../../ipc/cli-client.js";
 import { readStdinSync } from "../../util/read-stdin.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { getCliLogger } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
+import { emailHelp } from "./email.help.js";
 
 const loadModule = createRequire(import.meta.url);
 
@@ -65,34 +67,16 @@ function assistantDomain(): string {
 
 export function registerEmailCommand(program: Command): void {
   registerCommand(program, {
-    name: "email",
+    name: emailHelp.name,
     transport: "ipc",
-    description:
-      "Get your own email address — register, send, receive, and manage email natively",
+    description: emailHelp.description,
     build: (email) => {
-      // Keep the --json option at the email namespace level
-      email.option("--json", "Machine-readable compact JSON output");
+      applyCommandHelp(email, emailHelp);
 
-      email.addHelpText(
-        "after",
-        `
-Set up and manage this assistant's native email address on the Vellum
-platform. No third-party email provider or browser sign-up needed.
-
-Examples:
-  $ assistant email register mybot
-  $ assistant email unregister --confirm
-  $ assistant email send user@example.com -s "Hello" -b "Hi there"
-  $ assistant email status
-  $ assistant email list
-  $ assistant email attachment msg_abc1 --list
-  $ assistant email attachment msg_abc1 att_xyz1
-  $ assistant email register mybot --json`,
-      );
-
-      email
-        .command("register <username>")
-        .description("Register an email address for this assistant")
+      // The per-subcommand help texts that interpolate the assistant domain
+      // are runtime-computed (lazy config load), so they stay imperative
+      // here rather than in the declarative help module.
+      subcommand(email, "register")
         .addHelpText(
           "after",
           () => `
@@ -129,10 +113,7 @@ Examples:
           }
         });
 
-      email
-        .command("unregister")
-        .description("Remove the email address registered for this assistant")
-        .option("--confirm", "Skip confirmation prompt")
+      subcommand(email, "unregister")
         .addHelpText(
           "after",
           () => `
@@ -190,9 +171,7 @@ Examples:
           }
         });
 
-      email
-        .command("status")
-        .description("Show email address info and usage for this assistant")
+      subcommand(email, "status")
         .addHelpText(
           "after",
           () => `
@@ -249,100 +228,68 @@ Examples:
           }
         });
 
-      email
-        .command("list")
-        .description("List received and sent emails for this assistant")
-        .option(
-          "-d, --direction <direction>",
-          "Filter by direction: inbound, outbound, or all",
-          "all",
-        )
-        .option("-l, --limit <count>", "Maximum number of results", "20")
-        .option(
-          "--since <date>",
-          "Only show messages since this date (ISO 8601)",
-        )
-        .addHelpText(
-          "after",
-          `
-Lists email messages for this assistant. Shows subject, from, to,
-direction, and timestamp for each message.
-
-Examples:
-  $ assistant email list
-  $ assistant email list --direction inbound --limit 5
-  $ assistant email list --since 2026-04-01 --json`,
-        )
-        .action(
-          async (
-            opts: {
-              direction?: string;
-              limit?: string;
-              since?: string;
-            },
-            cmd: Command,
-          ) => {
-            const params: Record<string, string> = {};
-            if (opts.direction && opts.direction !== "all") {
-              params.direction = opts.direction;
-            }
-            if (opts.limit) {
-              params.limit = opts.limit;
-            }
-            if (opts.since) {
-              params.since = opts.since;
-            }
-
-            const r = await cliIpcCall<{
-              results: {
-                id: string;
-                direction: string;
-                from_address: string;
-                to_addresses: string[];
-                subject: string;
-                created_at: string;
-              }[];
-              count: number;
-            }>("email_list", { queryParams: params });
-            if (!r.ok) {
-              return handleEmailIpcError(
-                { ok: false, error: r.error, statusCode: r.statusCode },
-                cmd,
-              );
-            }
-            const data = r.result!;
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, data);
-            } else {
-              const messages = data.results ?? [];
-              if (messages.length === 0) {
-                log.info("No email messages found.");
-              } else {
-                for (const msg of messages) {
-                  const dir = msg.direction === "inbound" ? "←" : "→";
-                  const to = Array.isArray(msg.to_addresses)
-                    ? msg.to_addresses.join(", ")
-                    : "";
-                  const date = new Date(msg.created_at).toLocaleString();
-                  log.info(
-                    `${dir} ${date}  ${msg.from_address} → ${to}  "${msg.subject || "(no subject)"}"`,
-                  );
-                }
-                log.info(`\n${data.count} total message(s)`);
-              }
-            }
+      subcommand(email, "list").action(
+        async (
+          opts: {
+            direction?: string;
+            limit?: string;
+            since?: string;
           },
-        );
+          cmd: Command,
+        ) => {
+          const params: Record<string, string> = {};
+          if (opts.direction && opts.direction !== "all") {
+            params.direction = opts.direction;
+          }
+          if (opts.limit) {
+            params.limit = opts.limit;
+          }
+          if (opts.since) {
+            params.since = opts.since;
+          }
 
-      email
-        .command("download <message-id>")
-        .description("Download a specific email message")
-        .option(
-          "--format <type>",
-          "Output format: text, html, json (default: text)",
-          "text",
-        )
-        .option("-o, --output <path>", "Write to file instead of stdout")
+          const r = await cliIpcCall<{
+            results: {
+              id: string;
+              direction: string;
+              from_address: string;
+              to_addresses: string[];
+              subject: string;
+              created_at: string;
+            }[];
+            count: number;
+          }>("email_list", { queryParams: params });
+          if (!r.ok) {
+            return handleEmailIpcError(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+          }
+          const data = r.result!;
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, data);
+          } else {
+            const messages = data.results ?? [];
+            if (messages.length === 0) {
+              log.info("No email messages found.");
+            } else {
+              for (const msg of messages) {
+                const dir = msg.direction === "inbound" ? "←" : "→";
+                const to = Array.isArray(msg.to_addresses)
+                  ? msg.to_addresses.join(", ")
+                  : "";
+                const date = new Date(msg.created_at).toLocaleString();
+                log.info(
+                  `${dir} ${date}  ${msg.from_address} → ${to}  "${msg.subject || "(no subject)"}"`,
+                );
+              }
+              log.info(`\n${data.count} total message(s)`);
+            }
+          }
+        },
+      );
+
+      subcommand(email, "download")
         .addHelpText(
           "after",
           () => `
@@ -449,141 +396,136 @@ Examples:
           },
         );
 
-      email
-        .command("send <to...>")
-        .description("Send an email from this assistant")
-        .option("-s, --subject <text>", "Subject line")
-        .option("-b, --body <text>", "Email body (plain text)")
-        .option("-f, --file <path>", "Read body from file")
-        .option("--html <path>", "HTML body file (optional)")
-        .option(
-          "--cc <address>",
-          "CC recipient (repeatable)",
-          (val: string, prev: string[]) => [...prev, val],
-          [] as string[],
-        )
-        .option(
-          "--bcc <address>",
-          "BCC recipient (repeatable)",
-          (val: string, prev: string[]) => [...prev, val],
-          [] as string[],
-        )
-        .option(
-          "--reply-to <email_id>",
-          "Reply to an email by its ID (auto-resolves threading headers and subject)",
-        )
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  to   Recipient email address(es) — one or more
-
-Sends an email from the assistant's registered email address via the
-Vellum runtime proxy. The "from" address is automatically resolved
-from the assistant's registered email address.
-
-Body source priority: --body flag > --file flag > stdin (if not a TTY).
-
-When --reply-to is provided, the platform auto-resolves In-Reply-To,
-References, and Subject headers from the referenced email. You can
-still override subject with -s.
-
-Examples:
-  $ assistant email send user@example.com -s "Hello" -b "Hi there"
-  ✓ Sent to user@example.com (delivery_id: abc123)
-
-  $ assistant email send a@example.com b@example.com --cc c@example.com -s "Team" -b "Hi all"
-  ✓ Sent to a@example.com, b@example.com (delivery_id: abc123)
-
-  $ assistant email send user@example.com --bcc boss@example.com -s "FYI" -b "See below"
-  ✓ Sent to user@example.com (delivery_id: def456)
-
-  $ assistant email send user@example.com -b "Thanks!" --reply-to 019d96e4-e5d2-7201-890e-04a21e8f95bb
-  ✓ Sent to user@example.com (delivery_id: ghi789)
-
-  $ assistant email send user@example.com -s "Hello" -b "Hi" --json
-  {"delivery_id":"abc123","status":"accepted"}`,
-        )
-        .action(
-          async (
-            to: string[],
-            opts: {
-              subject?: string;
-              body?: string;
-              file?: string;
-              html?: string;
-              cc?: string[];
-              bcc?: string[];
-              replyTo?: string;
-            },
-            cmd: Command,
-          ) => {
-            // Resolve body text: --body > --file > stdin
-            let text = opts.body;
-            if (!text && opts.file) {
-              try {
-                text = readFileSync(opts.file, "utf-8");
-              } catch (err) {
-                log.error(
-                  `Failed to read --file ${opts.file}: ${err instanceof Error ? err.message : String(err)}`,
-                );
-                process.exitCode = 1;
-                return;
-              }
-            }
-            if (!text && !process.stdin.isTTY) {
-              try {
-                text = readStdinSync();
-              } catch (err) {
-                log.error(
-                  `Failed to read body from stdin: ${err instanceof Error ? err.message : String(err)}`,
-                );
-                process.exitCode = 1;
-                return;
-              }
-            }
-            if (!text) {
+      // --cc / --bcc accumulate repeated flags into an array with an `[]`
+      // default. CliOptionHelp can only express scalar defaults and no parse
+      // functions, so the accumulator parser and array default are attached
+      // imperatively to the declaratively-registered options.
+      const send = subcommand(email, "send");
+      const collect = (val: string, prev: string[]) => [...prev, val];
+      for (const flags of ["--cc <address>", "--bcc <address>"]) {
+        const option = send.options.find((o) => o.flags === flags);
+        if (!option) {
+          throw new Error(
+            `Option "${flags}" not found on "email send" — is it declared in email.help.ts?`,
+          );
+        }
+        option.argParser(collect).default([] as string[]);
+        send.setOptionValueWithSource(option.attributeName(), [], "default");
+      }
+      send.action(
+        async (
+          to: string[],
+          opts: {
+            subject?: string;
+            body?: string;
+            file?: string;
+            html?: string;
+            cc?: string[];
+            bcc?: string[];
+            replyTo?: string;
+          },
+          cmd: Command,
+        ) => {
+          // Resolve body text: --body > --file > stdin
+          let text = opts.body;
+          if (!text && opts.file) {
+            try {
+              text = readFileSync(opts.file, "utf-8");
+            } catch (err) {
               log.error(
-                "Email body is required. Use --body, --file, or pipe via stdin.",
+                `Failed to read --file ${opts.file}: ${err instanceof Error ? err.message : String(err)}`,
               );
               process.exitCode = 1;
               return;
             }
+          }
+          if (!text && !process.stdin.isTTY) {
+            try {
+              text = readStdinSync();
+            } catch (err) {
+              log.error(
+                `Failed to read body from stdin: ${err instanceof Error ? err.message : String(err)}`,
+              );
+              process.exitCode = 1;
+              return;
+            }
+          }
+          if (!text) {
+            log.error(
+              "Email body is required. Use --body, --file, or pipe via stdin.",
+            );
+            process.exitCode = 1;
+            return;
+          }
 
-            // Read HTML file if --html given; pass raw content to route
-            let html: string | undefined;
-            if (opts.html) {
-              try {
-                html = readFileSync(opts.html, "utf-8");
-              } catch (err) {
-                log.error(
-                  `Failed to read --html ${opts.html}: ${err instanceof Error ? err.message : String(err)}`,
-                );
-                process.exitCode = 1;
-                return;
-              }
+          // Read HTML file if --html given; pass raw content to route
+          let html: string | undefined;
+          if (opts.html) {
+            try {
+              html = readFileSync(opts.html, "utf-8");
+            } catch (err) {
+              log.error(
+                `Failed to read --html ${opts.html}: ${err instanceof Error ? err.message : String(err)}`,
+              );
+              process.exitCode = 1;
+              return;
             }
+          }
 
-            const params: Record<string, unknown> = { to, text };
-            if (opts.subject) {
-              params.subject = opts.subject;
-            }
-            if (html) {
-              params.html = html;
-            }
-            if (opts.cc && opts.cc.length > 0) {
-              params.cc = opts.cc;
-            }
-            if (opts.bcc && opts.bcc.length > 0) {
-              params.bcc = opts.bcc;
-            }
-            if (opts.replyTo) {
-              params.reply_to = opts.replyTo;
-            }
+          const params: Record<string, unknown> = { to, text };
+          if (opts.subject) {
+            params.subject = opts.subject;
+          }
+          if (html) {
+            params.html = html;
+          }
+          if (opts.cc && opts.cc.length > 0) {
+            params.cc = opts.cc;
+          }
+          if (opts.bcc && opts.bcc.length > 0) {
+            params.bcc = opts.bcc;
+          }
+          if (opts.replyTo) {
+            params.reply_to = opts.replyTo;
+          }
 
-            const r = await cliIpcCall<{ delivery_id: string; status: string }>(
-              "email_send",
-              { body: params },
+          const r = await cliIpcCall<{ delivery_id: string; status: string }>(
+            "email_send",
+            { body: params },
+          );
+          if (!r.ok) {
+            return handleEmailIpcError(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+          }
+          const data = r.result!;
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, data);
+          } else {
+            log.info(
+              `✓ Sent to ${to.join(", ")} (delivery_id: ${data.delivery_id})`,
+            );
+          }
+        },
+      );
+
+      subcommand(email, "attachment").action(
+        async (
+          messageId: string,
+          attachmentId: string | undefined,
+          opts: {
+            all?: boolean;
+            output?: string;
+            list?: boolean;
+          },
+          cmd: Command,
+        ) => {
+          if (opts.list) {
+            // List mode — show attachment metadata without downloading
+            const r = await cliIpcCall<{ results: AttachmentMeta[] }>(
+              "email_attachment_list",
+              { queryParams: { messageId } },
             );
             if (!r.ok) {
               return handleEmailIpcError(
@@ -595,202 +537,137 @@ Examples:
             if (shouldOutputJson(cmd)) {
               writeOutput(cmd, data);
             } else {
-              log.info(
-                `✓ Sent to ${to.join(", ")} (delivery_id: ${data.delivery_id})`,
-              );
+              const attachments = data.results ?? [];
+              if (attachments.length === 0) {
+                log.info("No attachments for this message.");
+              } else {
+                for (const att of attachments) {
+                  log.info(
+                    `  ${att.id}  ${att.filename}  (${att.content_type}, ${formatBytes(att.size_bytes)})`,
+                  );
+                }
+                log.info(`\n${attachments.length} attachment(s)`);
+              }
             }
-          },
-        );
+            return;
+          }
 
-      email
-        .command("attachment <message-id> [attachment-id]")
-        .description("Download email attachments")
-        .option("--all", "Download all attachments for the message")
-        .option(
-          "-o, --output <dir>",
-          "Output directory (default: current directory)",
-          ".",
-        )
-        .option("--list", "List attachments without downloading")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-message-id      Email message ID (from \`assistant email list --json\`)
-attachment-id   Attachment ID (optional — required unless --all or --list)
+          if (!opts.all && !attachmentId) {
+            log.error(
+              "Specify an attachment ID, or use --all to download all. Use --list to see available.",
+            );
+            process.exitCode = 1;
+            return;
+          }
 
-Download one or all attachments from a specific email message. Use
---list to see available attachments without downloading.
+          // Ensure output directory exists and download attachment(s)
+          const outDir = opts.output ?? ".";
+          try {
+            mkdirSync(outDir, { recursive: true });
+          } catch (err) {
+            log.error(
+              `Failed to create output directory ${outDir}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exitCode = 1;
+            return;
+          }
 
-Examples:
-$ assistant email attachment msg_abc1 --list
-$ assistant email attachment msg_abc1 att_xyz1
-$ assistant email attachment msg_abc1 att_xyz1 -o ./downloads/
-$ assistant email attachment msg_abc1 --all
-$ assistant email attachment msg_abc1 --all -o ./attachments/
-$ assistant email attachment msg_abc1 --list --json`,
-        )
-        .action(
-          async (
-            messageId: string,
-            attachmentId: string | undefined,
-            opts: {
-              all?: boolean;
-              output?: string;
-              list?: boolean;
-            },
-            cmd: Command,
-          ) => {
-            if (opts.list) {
-              // List mode — show attachment metadata without downloading
-              const r = await cliIpcCall<{ results: AttachmentMeta[] }>(
+          try {
+            if (opts.all) {
+              // Download all attachments — list first to get filenames
+              const listR = await cliIpcCall<{ results: AttachmentMeta[] }>(
                 "email_attachment_list",
                 { queryParams: { messageId } },
               );
-              if (!r.ok) {
+              if (!listR.ok) {
                 return handleEmailIpcError(
-                  { ok: false, error: r.error, statusCode: r.statusCode },
+                  {
+                    ok: false,
+                    error: listR.error,
+                    statusCode: listR.statusCode,
+                  },
                   cmd,
                 );
               }
-              const data = r.result!;
+              const attachments = listR.result!.results ?? [];
+              if (attachments.length === 0) {
+                log.error("No attachments for this message.");
+                process.exitCode = 1;
+                return;
+              }
+
+              const downloaded: { filename: string; size_bytes: number }[] = [];
+              for (const att of attachments) {
+                const dest = join(outDir, safeFilename(att.filename));
+                await streamDownloadAttachment(att.id, messageId, dest);
+                downloaded.push({
+                  filename: att.filename,
+                  size_bytes: att.size_bytes,
+                });
+              }
+
               if (shouldOutputJson(cmd)) {
-                writeOutput(cmd, data);
+                writeOutput(cmd, {
+                  downloaded: downloaded.length,
+                  directory: outDir,
+                  files: downloaded,
+                });
               } else {
-                const attachments = data.results ?? [];
-                if (attachments.length === 0) {
-                  log.info("No attachments for this message.");
-                } else {
-                  for (const att of attachments) {
-                    log.info(
-                      `  ${att.id}  ${att.filename}  (${att.content_type}, ${formatBytes(att.size_bytes)})`,
-                    );
-                  }
-                  log.info(`\n${attachments.length} attachment(s)`);
+                log.info(
+                  `✓ Downloaded ${downloaded.length} attachment(s) to ${outDir}`,
+                );
+                for (const f of downloaded) {
+                  log.info(`  - ${f.filename} (${formatBytes(f.size_bytes)})`);
                 }
               }
-              return;
-            }
-
-            if (!opts.all && !attachmentId) {
-              log.error(
-                "Specify an attachment ID, or use --all to download all. Use --list to see available.",
+            } else {
+              // Download single attachment — look up metadata from the list first
+              const listR = await cliIpcCall<{ results: AttachmentMeta[] }>(
+                "email_attachment_list",
+                { queryParams: { messageId } },
               );
-              process.exitCode = 1;
-              return;
-            }
-
-            // Ensure output directory exists and download attachment(s)
-            const outDir = opts.output ?? ".";
-            try {
-              mkdirSync(outDir, { recursive: true });
-            } catch (err) {
-              log.error(
-                `Failed to create output directory ${outDir}: ${err instanceof Error ? err.message : String(err)}`,
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            try {
-              if (opts.all) {
-                // Download all attachments — list first to get filenames
-                const listR = await cliIpcCall<{ results: AttachmentMeta[] }>(
-                  "email_attachment_list",
-                  { queryParams: { messageId } },
+              if (!listR.ok) {
+                return handleEmailIpcError(
+                  {
+                    ok: false,
+                    error: listR.error,
+                    statusCode: listR.statusCode,
+                  },
+                  cmd,
                 );
-                if (!listR.ok) {
-                  return handleEmailIpcError(
-                    {
-                      ok: false,
-                      error: listR.error,
-                      statusCode: listR.statusCode,
-                    },
-                    cmd,
-                  );
-                }
-                const attachments = listR.result!.results ?? [];
-                if (attachments.length === 0) {
-                  log.error("No attachments for this message.");
-                  process.exitCode = 1;
-                  return;
-                }
-
-                const downloaded: { filename: string; size_bytes: number }[] =
-                  [];
-                for (const att of attachments) {
-                  const dest = join(outDir, safeFilename(att.filename));
-                  await streamDownloadAttachment(att.id, messageId, dest);
-                  downloaded.push({
-                    filename: att.filename,
-                    size_bytes: att.size_bytes,
-                  });
-                }
-
-                if (shouldOutputJson(cmd)) {
-                  writeOutput(cmd, {
-                    downloaded: downloaded.length,
-                    directory: outDir,
-                    files: downloaded,
-                  });
-                } else {
-                  log.info(
-                    `✓ Downloaded ${downloaded.length} attachment(s) to ${outDir}`,
-                  );
-                  for (const f of downloaded) {
-                    log.info(
-                      `  - ${f.filename} (${formatBytes(f.size_bytes)})`,
-                    );
-                  }
-                }
-              } else {
-                // Download single attachment — look up metadata from the list first
-                const listR = await cliIpcCall<{ results: AttachmentMeta[] }>(
-                  "email_attachment_list",
-                  { queryParams: { messageId } },
-                );
-                if (!listR.ok) {
-                  return handleEmailIpcError(
-                    {
-                      ok: false,
-                      error: listR.error,
-                      statusCode: listR.statusCode,
-                    },
-                    cmd,
-                  );
-                }
-                const meta = (listR.result!.results ?? []).find(
-                  (a) => a.id === attachmentId,
-                );
-                if (!meta) {
-                  log.error(`Attachment not found: ${attachmentId}`);
-                  process.exitCode = 2;
-                  return;
-                }
-                const dest = join(outDir, safeFilename(meta.filename));
-                await streamDownloadAttachment(attachmentId!, messageId, dest);
-
-                if (shouldOutputJson(cmd)) {
-                  writeOutput(cmd, {
-                    filename: meta.filename,
-                    size_bytes: meta.size_bytes,
-                    saved: dest,
-                  });
-                } else {
-                  log.info(
-                    `✓ Downloaded ${meta.filename} (${formatBytes(meta.size_bytes)})`,
-                  );
-                }
               }
-            } catch (err) {
-              log.error(
-                `Failed to download attachment: ${err instanceof Error ? err.message : String(err)}`,
+              const meta = (listR.result!.results ?? []).find(
+                (a) => a.id === attachmentId,
               );
-              process.exitCode = 1;
-              return;
+              if (!meta) {
+                log.error(`Attachment not found: ${attachmentId}`);
+                process.exitCode = 2;
+                return;
+              }
+              const dest = join(outDir, safeFilename(meta.filename));
+              await streamDownloadAttachment(attachmentId!, messageId, dest);
+
+              if (shouldOutputJson(cmd)) {
+                writeOutput(cmd, {
+                  filename: meta.filename,
+                  size_bytes: meta.size_bytes,
+                  saved: dest,
+                });
+              } else {
+                log.info(
+                  `✓ Downloaded ${meta.filename} (${formatBytes(meta.size_bytes)})`,
+                );
+              }
             }
-          },
-        );
+          } catch (err) {
+            log.error(
+              `Failed to download attachment: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/gateway.help.ts
+++ b/assistant/src/cli/commands/gateway.help.ts
@@ -1,0 +1,85 @@
+/** Declarative help for the `assistant gateway` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const gatewayHelp: CliCommandHelp = {
+  name: "gateway",
+  description: "Gateway management",
+  helpText: `
+The gateway is the channel ingress layer — it handles inbound HTTP requests,
+manages trust rules, routes traffic to the assistant, and records
+structured logs for all inbound activity.
+
+Examples:
+  $ assistant gateway logs tail
+  $ assistant gateway logs tail -n 50
+  $ assistant gateway logs tail --level warn
+  $ assistant gateway logs tail --module cors`,
+  subcommands: [
+    {
+      name: "logs",
+      description: "Gateway log operations",
+      helpText: `
+Gateway logs are structured JSON (ndjson) entries emitted by the gateway
+process. Each entry carries a timestamp, numeric pino log level, optional
+module tag, and a message. Use 'tail' to inspect recent entries.
+
+Examples:
+  $ assistant gateway logs tail
+  $ assistant gateway logs tail --level error --module cors`,
+      subcommands: [
+        {
+          name: "tail",
+          description: "Show last N gateway log entries",
+          options: [
+            {
+              flags: "-n <number>",
+              description: "Number of lines (default: 10)",
+            },
+            {
+              flags: "-q, --quiet",
+              description: "Suppress column headers",
+            },
+            {
+              flags: "--level <level>",
+              description:
+                "Minimum log level (trace|debug|info|warn|error|fatal)",
+              defaultValue: "info",
+            },
+            {
+              flags: "--module <name>",
+              description: "Filter to exact module name",
+            },
+            {
+              flags: "--raw",
+              description: "Output raw ndjson (one JSON object per line)",
+            },
+          ],
+          helpText: `
+Arguments:
+  -n <number>        Number of entries to return, clamped to 1–1000 (default: 10).
+  --level <level>    Minimum log level to include. One of:
+                       trace | debug | info | warn | error | fatal
+                     Defaults to "info". Use "trace" or "debug" for verbose output.
+  --module <name>    Filter to entries whose module tag exactly matches <name>.
+                     Useful for isolating a specific subsystem (e.g. "cors", "trust").
+  --raw              Emit raw ndjson — one JSON object per line — instead of the
+                     formatted table. Useful for piping to jq or other JSON tools.
+  -q, --quiet        Suppress the column-header line in table output.
+
+Output format (default table):
+  TIME (24 chars)  LEVEL (5 chars)  MODULE (up to 12 chars)  MESSAGE (truncated at 120 chars)
+
+Truncation:
+  When more matching entries exist beyond the requested -n window, a dim
+  "(showing last N matching entries — earlier entries exist)" footer is printed.
+
+Examples:
+  $ assistant gateway logs tail
+  $ assistant gateway logs tail -n 50 --level warn
+  $ assistant gateway logs tail --module cors --raw | jq .msg`,
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/gateway.ts
+++ b/assistant/src/cli/commands/gateway.ts
@@ -8,8 +8,10 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { gatewayHelp } from "./gateway.help.js";
 
 // -- Types --------------------------------------------------------------------
 
@@ -58,133 +60,74 @@ function colorLevel(name: string, levelNum: number): string {
 
 export function registerGatewayCommand(program: Command): void {
   registerCommand(program, {
-    name: "gateway",
+    name: gatewayHelp.name,
     transport: "ipc",
-    description: "Gateway management",
+    description: gatewayHelp.description,
     build: (gateway) => {
+      applyCommandHelp(gateway, gatewayHelp);
 
-  gateway.addHelpText(
-    "after",
-    `
-The gateway is the channel ingress layer — it handles inbound HTTP requests,
-manages trust rules, routes traffic to the assistant, and records
-structured logs for all inbound activity.
+      const logs = subcommand(gateway, "logs");
 
-Examples:
-  $ assistant gateway logs tail
-  $ assistant gateway logs tail -n 50
-  $ assistant gateway logs tail --level warn
-  $ assistant gateway logs tail --module cors`,
-  );
-
-  const logs = gateway.command("logs").description("Gateway log operations");
-
-  logs.addHelpText(
-    "after",
-    `
-Gateway logs are structured JSON (ndjson) entries emitted by the gateway
-process. Each entry carries a timestamp, numeric pino log level, optional
-module tag, and a message. Use 'tail' to inspect recent entries.
-
-Examples:
-  $ assistant gateway logs tail
-  $ assistant gateway logs tail --level error --module cors`,
-  );
-
-  logs
-    .command("tail")
-    .description("Show last N gateway log entries")
-    .option("-n <number>", "Number of lines (default: 10)")
-    .option("-q, --quiet", "Suppress column headers")
-    .option(
-      "--level <level>",
-      "Minimum log level (trace|debug|info|warn|error|fatal)",
-      "info",
-    )
-    .option("--module <name>", "Filter to exact module name")
-    .option("--raw", "Output raw ndjson (one JSON object per line)")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  -n <number>        Number of entries to return, clamped to 1–1000 (default: 10).
-  --level <level>    Minimum log level to include. One of:
-                       trace | debug | info | warn | error | fatal
-                     Defaults to "info". Use "trace" or "debug" for verbose output.
-  --module <name>    Filter to entries whose module tag exactly matches <name>.
-                     Useful for isolating a specific subsystem (e.g. "cors", "trust").
-  --raw              Emit raw ndjson — one JSON object per line — instead of the
-                     formatted table. Useful for piping to jq or other JSON tools.
-  -q, --quiet        Suppress the column-header line in table output.
-
-Output format (default table):
-  TIME (24 chars)  LEVEL (5 chars)  MODULE (up to 12 chars)  MESSAGE (truncated at 120 chars)
-
-Truncation:
-  When more matching entries exist beyond the requested -n window, a dim
-  "(showing last N matching entries — earlier entries exist)" footer is printed.
-
-Examples:
-  $ assistant gateway logs tail
-  $ assistant gateway logs tail -n 50 --level warn
-  $ assistant gateway logs tail --module cors --raw | jq .msg`,
-    )
-    .action(async (opts) => {
-      const n = Math.max(1, Math.min(1000, parseInt(opts.n ?? "10", 10) || 10));
-      const params: Record<string, unknown> = { n };
-      if (opts.level && opts.level !== "info") params.level = opts.level;
-      if (opts.module) params.module = opts.module;
-
-      const result = await cliIpcCall<{ lines: PinoEntry[]; truncated: boolean }>(
-        "gateway_logs_tail",
-        { body: params },
-      );
-
-      if (!result.ok) {
-        log.error(result.error ?? "Failed to fetch gateway logs");
-        process.exitCode = 1;
-        return;
-      }
-
-      const { lines, truncated } = result.result!;
-
-      if (opts.raw) {
-        for (const entry of lines) process.stdout.write(JSON.stringify(entry) + "\n");
-        return;
-      }
-
-      if (lines.length === 0) {
-        if (!opts.quiet) process.stdout.write("No log entries found.\n");
-        return;
-      }
-
-      const moduleWidth = Math.min(
-        12,
-        Math.max(6, ...lines.map((l) => l.module?.length ?? 0)),
-      );
-
-      if (!opts.quiet) {
-        process.stdout.write(
-          `${"TIME".padEnd(24)}  ${"LEVEL".padEnd(5)}  ${"MODULE".padEnd(moduleWidth)}  MESSAGE\n`,
+      subcommand(logs, "tail").action(async (opts) => {
+        const n = Math.max(
+          1,
+          Math.min(1000, parseInt(opts.n ?? "10", 10) || 10),
         );
-      }
+        const params: Record<string, unknown> = { n };
+        if (opts.level && opts.level !== "info") params.level = opts.level;
+        if (opts.module) params.module = opts.module;
 
-      for (const entry of lines) {
-        const time = formatTime(entry.time).padEnd(24);
-        const lvlName = levelName(entry.level).padEnd(5);
-        const lvlColored = colorLevel(lvlName, entry.level);
-        const mod = (entry.module ?? "").padEnd(moduleWidth);
-        const msg = entry.msg ?? "";
-        const msgTrunc = msg.length > 120 ? msg.slice(0, 120) + "…" : msg;
-        process.stdout.write(`${time}  ${lvlColored}  ${mod}  ${msgTrunc}\n`);
-      }
+        const result = await cliIpcCall<{
+          lines: PinoEntry[];
+          truncated: boolean;
+        }>("gateway_logs_tail", { body: params });
 
-      if (truncated) {
-        const footer = `(showing last ${n} matching entries — earlier entries exist)`;
-        const dim = process.stdout.isTTY ? `\x1b[2m${footer}\x1b[0m` : footer;
-        process.stdout.write(dim + "\n");
-      }
-    });
+        if (!result.ok) {
+          log.error(result.error ?? "Failed to fetch gateway logs");
+          process.exitCode = 1;
+          return;
+        }
+
+        const { lines, truncated } = result.result!;
+
+        if (opts.raw) {
+          for (const entry of lines)
+            process.stdout.write(JSON.stringify(entry) + "\n");
+          return;
+        }
+
+        if (lines.length === 0) {
+          if (!opts.quiet) process.stdout.write("No log entries found.\n");
+          return;
+        }
+
+        const moduleWidth = Math.min(
+          12,
+          Math.max(6, ...lines.map((l) => l.module?.length ?? 0)),
+        );
+
+        if (!opts.quiet) {
+          process.stdout.write(
+            `${"TIME".padEnd(24)}  ${"LEVEL".padEnd(5)}  ${"MODULE".padEnd(moduleWidth)}  MESSAGE\n`,
+          );
+        }
+
+        for (const entry of lines) {
+          const time = formatTime(entry.time).padEnd(24);
+          const lvlName = levelName(entry.level).padEnd(5);
+          const lvlColored = colorLevel(lvlName, entry.level);
+          const mod = (entry.module ?? "").padEnd(moduleWidth);
+          const msg = entry.msg ?? "";
+          const msgTrunc = msg.length > 120 ? msg.slice(0, 120) + "…" : msg;
+          process.stdout.write(`${time}  ${lvlColored}  ${mod}  ${msgTrunc}\n`);
+        }
+
+        if (truncated) {
+          const footer = `(showing last ${n} matching entries — earlier entries exist)`;
+          const dim = process.stdout.isTTY ? `\x1b[2m${footer}\x1b[0m` : footer;
+          process.stdout.write(dim + "\n");
+        }
+      });
     },
   });
 }

--- a/assistant/src/cli/commands/image-generation.help.ts
+++ b/assistant/src/cli/commands/image-generation.help.ts
@@ -1,0 +1,72 @@
+/** Declarative help for the `assistant image-generation` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const imageGenerationHelp: CliCommandHelp = {
+  name: "image-generation",
+  description: "AI image generation and editing",
+  helpText: `
+Modes:
+  managed    — Uses platform-managed credentials (requires login to Vellum).
+  your-own   — Uses your own Gemini or OpenAI API key depending on the configured model.
+
+Supported models: pass a tier alias, the assistant resolves it to the
+current model for that tier.
+  fast     (default) quickest, good quality
+  quality  higher fidelity, slower
+  openai   OpenAI's model
+A concrete model ID is also accepted; unknown values return an error
+listing the currently available models.
+
+Examples:
+  $ assistant image-generation generate --prompt "A sunset over the ocean"
+  $ assistant image-generation generate --prompt "Remove background" --mode edit --source photo.png
+  $ assistant image-generation generate --prompt "Logo design" --variants 3 --output-dir ./output
+  $ assistant image-generation generate --prompt "A cat" --json`,
+  subcommands: [
+    {
+      name: "generate",
+      description: "Generate or edit images using AI",
+      options: [
+        {
+          flags: "--prompt <text>",
+          description: "Description of the image to generate or edits to apply",
+          required: true,
+        },
+        {
+          flags: "--mode <mode>",
+          description: "generate (default) or edit",
+          defaultValue: "generate",
+        },
+        {
+          flags: "--source <path...>",
+          description: "Source image file path for edit mode (repeatable)",
+        },
+        { flags: "--model <model-id>", description: "Model override" },
+        {
+          flags: "--variants <n>",
+          description: "Number of variants (1-4, default 1)",
+          defaultValue: 1,
+        },
+        {
+          flags: "--output-dir <dir>",
+          description: "Directory to save images",
+        },
+        { flags: "--json", description: "Output structured JSON" },
+      ],
+      helpText: `
+Notes:
+  Edit mode (--mode edit) requires at least one --source image file.
+  Output files are named image-1.png, image-2.png, etc. (extension matches MIME type).
+  Default output directory is the system temp directory.
+  Uses your own Gemini or OpenAI API key depending on the configured model.
+
+Examples:
+  $ assistant image-generation generate --prompt "A mountain landscape at dawn"
+  $ assistant image-generation generate --prompt "Make it darker" --mode edit --source input.png
+  $ assistant image-generation generate --prompt "Logo variations" --variants 4 --output-dir ./logos
+  $ assistant image-generation generate --prompt "A robot" --model quality --json
+  $ assistant image-generation generate --prompt "A robot" --model openai --json`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -5,8 +5,10 @@ import { join } from "node:path";
 import { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { imageGenerationHelp } from "./image-generation.help.js";
 
 // ---------------------------------------------------------------------------
 // MIME type → file extension mapping
@@ -55,70 +57,13 @@ function mimeForExtension(filePath: string): string {
 
 export function registerImageGenerationCommand(program: Command): void {
   registerCommand(program, {
-    name: "image-generation",
+    name: imageGenerationHelp.name,
     transport: "ipc",
-    description: "AI image generation and editing",
+    description: imageGenerationHelp.description,
     build: (imageGen) => {
-      imageGen.addHelpText(
-        "after",
-        `
-Modes:
-  managed    — Uses platform-managed credentials (requires login to Vellum).
-  your-own   — Uses your own Gemini or OpenAI API key depending on the configured model.
+      applyCommandHelp(imageGen, imageGenerationHelp);
 
-Supported models: pass a tier alias, the assistant resolves it to the
-current model for that tier.
-  fast     (default) quickest, good quality
-  quality  higher fidelity, slower
-  openai   OpenAI's model
-A concrete model ID is also accepted; unknown values return an error
-listing the currently available models.
-
-Examples:
-  $ assistant image-generation generate --prompt "A sunset over the ocean"
-  $ assistant image-generation generate --prompt "Remove background" --mode edit --source photo.png
-  $ assistant image-generation generate --prompt "Logo design" --variants 3 --output-dir ./output
-  $ assistant image-generation generate --prompt "A cat" --json`,
-      );
-
-      const generate = imageGen
-        .command("generate")
-        .description("Generate or edit images using AI")
-        .requiredOption(
-          "--prompt <text>",
-          "Description of the image to generate or edits to apply",
-        )
-        .option("--mode <mode>", "generate (default) or edit", "generate")
-        .option(
-          "--source <path...>",
-          "Source image file path for edit mode (repeatable)",
-        )
-        .option("--model <model-id>", "Model override")
-        .option(
-          "--variants <n>",
-          "Number of variants (1-4, default 1)",
-          (v: string) => parseInt(v, 10),
-          1,
-        )
-        .option("--output-dir <dir>", "Directory to save images")
-        .option("--json", "Output structured JSON");
-
-      generate.addHelpText(
-        "after",
-        `
-Notes:
-  Edit mode (--mode edit) requires at least one --source image file.
-  Output files are named image-1.png, image-2.png, etc. (extension matches MIME type).
-  Default output directory is the system temp directory.
-  Uses your own Gemini or OpenAI API key depending on the configured model.
-
-Examples:
-  $ assistant image-generation generate --prompt "A mountain landscape at dawn"
-  $ assistant image-generation generate --prompt "Make it darker" --mode edit --source input.png
-  $ assistant image-generation generate --prompt "Logo variations" --variants 4 --output-dir ./logos
-  $ assistant image-generation generate --prompt "A robot" --model quality --json
-  $ assistant image-generation generate --prompt "A robot" --model openai --json`,
-      );
+      const generate = subcommand(imageGen, "generate");
 
       generate.action(async (opts) => {
         const jsonOutput = opts.json === true;
@@ -127,7 +72,13 @@ Examples:
           opts.mode === "edit" ? "edit" : "generate";
         const sourcePaths: string[] | undefined = opts.source;
         const modelOverride: string | undefined = opts.model;
-        const rawVariants = opts.variants ?? 1;
+        // --variants was declaratively registered without a parse function,
+        // so a user-supplied value arrives as a string; coerce it here
+        // (matching the previous parseInt argParser). The default stays 1.
+        const rawVariants =
+          typeof opts.variants === "string"
+            ? parseInt(opts.variants, 10)
+            : (opts.variants ?? 1);
         const variants: number = Number.isNaN(rawVariants)
           ? 1
           : Math.max(1, Math.min(rawVariants, 4));

--- a/assistant/src/cli/commands/inference-callsites.ts
+++ b/assistant/src/cli/commands/inference-callsites.ts
@@ -13,6 +13,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { subcommand } from "../lib/cli-command-help.js";
 import { renderTable, writeCliError, writeLine } from "../lib/cli-output.js";
 
 type Source = "override" | "active" | "call_site" | "default";
@@ -64,57 +65,40 @@ function formatCtxIn(tokens: number | undefined): string {
 }
 
 export function attachCallsitesSubcommand(inference: Command): void {
-  const callsites = inference
-    .command("callsites")
-    .description("Inspect how each LLM call site resolves to a profile");
+  const callsites = subcommand(inference, "callsites");
 
-  callsites
-    .command("list")
-    .description("List the effective resolution for every call site")
-    .option("--json", "Output as machine-readable JSON")
-    .action(async (opts: { json?: boolean }) => {
-      const ipcResult = await cliIpcCall<{ callSites: CallSiteSummary[] }>(
-        "inference_callsites_list",
-        {},
+  subcommand(callsites, "list").action(async (opts: { json?: boolean }) => {
+    const ipcResult = await cliIpcCall<{ callSites: CallSiteSummary[] }>(
+      "inference_callsites_list",
+      {},
+    );
+    if (!ipcResult.ok) {
+      writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+      return;
+    }
+    const rows = ipcResult.result!.callSites;
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify({ ok: true, callSites: rows }) + "\n",
       );
-      if (!ipcResult.ok) {
-        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
-        return;
-      }
-      const rows = ipcResult.result!.callSites;
-      if (opts.json) {
-        process.stdout.write(
-          JSON.stringify({ ok: true, callSites: rows }) + "\n",
-        );
-        return;
-      }
-      renderTable(
-        [
-          "CALL SITE",
-          "PROFILE",
-          "SRC",
-          "PROVIDER",
-          "MODEL",
-          "EFFORT",
-          "CTX-IN",
-        ],
-        rows.map((r) => [
-          r.callSite,
-          r.profile ?? "(anchor)",
-          SOURCE_LABEL[r.source],
-          r.provider,
-          r.model,
-          r.effort,
-          formatCtxIn(r.maxInputTokens),
-        ]),
-      );
-    });
+      return;
+    }
+    renderTable(
+      ["CALL SITE", "PROFILE", "SRC", "PROVIDER", "MODEL", "EFFORT", "CTX-IN"],
+      rows.map((r) => [
+        r.callSite,
+        r.profile ?? "(anchor)",
+        SOURCE_LABEL[r.source],
+        r.provider,
+        r.model,
+        r.effort,
+        formatCtxIn(r.maxInputTokens),
+      ]),
+    );
+  });
 
-  callsites
-    .command("get <site>")
-    .description("Show the resolution detail and chain for one call site")
-    .option("--json", "Output as machine-readable JSON")
-    .action(async (site: string, opts: { json?: boolean }) => {
+  subcommand(callsites, "get").action(
+    async (site: string, opts: { json?: boolean }) => {
       const ipcResult = await cliIpcCall<CallSiteDetail>(
         "inference_callsites_get",
         { pathParams: { site } },
@@ -154,5 +138,6 @@ export function attachCallsitesSubcommand(inference: Command): void {
           `  resolution error [${d.resolutionError.reason}]: ${d.resolutionError.message}`,
         );
       }
-    });
+    },
+  );
 }

--- a/assistant/src/cli/commands/inference-models.ts
+++ b/assistant/src/cli/commands/inference-models.ts
@@ -11,6 +11,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { subcommand } from "../lib/cli-command-help.js";
 import { renderTable, writeCliError, writeLine } from "../lib/cli-output.js";
 
 interface CatalogModel {
@@ -26,27 +27,10 @@ interface CatalogModel {
 }
 
 export function attachModelsSubcommand(inference: Command): void {
-  const models = inference
-    .command("models")
-    .description("Inspect the inference model catalog");
+  const models = subcommand(inference, "models");
 
-  models
-    .command("list")
-    .description("List catalog models (optionally filtered by provider)")
-    .option("--provider <p>", "Filter by provider id")
-    .option("--json", "Output as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Lists every model in the code-owned provider catalog. Use the ids here
-when creating an inference profile:
-
-Examples:
-  $ assistant inference models list
-  $ assistant inference models list --provider anthropic
-  $ assistant inference models list --json`,
-    )
-    .action(async (opts: { provider?: string; json?: boolean }) => {
+  subcommand(models, "list").action(
+    async (opts: { provider?: string; json?: boolean }) => {
       const ipcResult = await cliIpcCall<{ models: CatalogModel[] }>(
         "inference_models_list",
         { queryParams: opts.provider ? { provider: opts.provider } : {} },
@@ -80,5 +64,6 @@ Examples:
             : "-",
         ]),
       );
-    });
+    },
+  );
 }

--- a/assistant/src/cli/commands/inference-profiles.ts
+++ b/assistant/src/cli/commands/inference-profiles.ts
@@ -16,6 +16,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { subcommand } from "../lib/cli-command-help.js";
 import { renderTable, writeCliError, writeLine } from "../lib/cli-output.js";
 
 interface ProfileSummary {
@@ -122,90 +123,45 @@ function printWriteResult(
   );
 }
 
-function addWriteFlags(cmd: Command): Command {
-  return cmd
-    .option("--provider <p>", "LLM provider (e.g. anthropic, openai)")
-    .option("--model <id>", "Model id (see 'assistant inference models list')")
-    .option("--connection <name>", "Provider connection name to use")
-    .option("--label <text>", "Human-readable label")
-    .option(
-      "--effort <tier>",
-      "Reasoning effort (none|low|medium|high|xhigh|max)",
-    )
-    .option("--max-tokens <n>", "Max response tokens")
-    .option("--temperature <x>", "Sampling temperature")
-    .option("--thinking <on|off>", "Enable or disable thinking")
-    .option("--description <text>", "Profile description")
-    .option("--allow-unlisted", "Allow a model not in the catalog (warns)")
-    .option("--json", "Output as machine-readable JSON");
-}
-
 export function attachProfilesSubcommand(inference: Command): void {
-  const profiles = inference
-    .command("profiles")
-    .description("Manage inference profiles (named model configurations)");
-
-  profiles.addHelpText(
-    "after",
-    `
-Profiles are named model configurations. Managed defaults (balanced,
-quality-optimized, cost-optimized) are read-only; create your own to
-customize provider, model, and tuning.
-
-Examples:
-  $ assistant inference profiles list
-  $ assistant inference profiles create my-fast --provider anthropic \\
-      --model claude-haiku-4-5 --connection anthropic-personal --effort low
-  $ assistant inference profiles update my-fast --effort high
-  $ assistant inference profiles active my-fast
-  $ assistant inference profiles delete my-fast`,
-  );
+  const profiles = subcommand(inference, "profiles");
 
   // ── list ────────────────────────────────────────────────────────────
-  profiles
-    .command("list")
-    .description("List the effective profile catalog")
-    .option("--json", "Output as machine-readable JSON")
-    .action(async (opts: { json?: boolean }) => {
-      const ipcResult = await cliIpcCall<{ profiles: ProfileSummary[] }>(
-        "inference_profiles_list",
-        {},
-      );
-      if (!ipcResult.ok) {
-        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
-        return;
-      }
-      const rows = ipcResult.result!.profiles;
-      if (opts.json) {
-        process.stdout.write(
-          JSON.stringify({ ok: true, profiles: rows }) + "\n",
-        );
-        return;
-      }
-      if (rows.length === 0) {
-        writeLine("No profiles found.");
-        return;
-      }
-      renderTable(
-        ["NAME", "LABEL", "PROVIDER", "MODEL", "STATUS", "SOURCE", "AVAIL"],
-        rows.map((p) => [
-          p.name,
-          p.label ?? "-",
-          p.provider ?? "-",
-          p.model ?? "-",
-          p.status,
-          p.source,
-          p.availability ? p.availability.status : "-",
-        ]),
-      );
-    });
+  subcommand(profiles, "list").action(async (opts: { json?: boolean }) => {
+    const ipcResult = await cliIpcCall<{ profiles: ProfileSummary[] }>(
+      "inference_profiles_list",
+      {},
+    );
+    if (!ipcResult.ok) {
+      writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+      return;
+    }
+    const rows = ipcResult.result!.profiles;
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ ok: true, profiles: rows }) + "\n");
+      return;
+    }
+    if (rows.length === 0) {
+      writeLine("No profiles found.");
+      return;
+    }
+    renderTable(
+      ["NAME", "LABEL", "PROVIDER", "MODEL", "STATUS", "SOURCE", "AVAIL"],
+      rows.map((p) => [
+        p.name,
+        p.label ?? "-",
+        p.provider ?? "-",
+        p.model ?? "-",
+        p.status,
+        p.source,
+        p.availability ? p.availability.status : "-",
+      ]),
+    );
+  });
 
   // ── get ─────────────────────────────────────────────────────────────
-  profiles
-    .command("get <name>")
-    .description("Show a single effective profile")
-    .option("--json", "Output as machine-readable JSON")
-    .action(async (name: string, opts: { json?: boolean }) => {
+  subcommand(profiles, "get").action(
+    async (name: string, opts: { json?: boolean }) => {
       const ipcResult = await cliIpcCall<{
         name: string;
         entry: Record<string, unknown>;
@@ -230,73 +186,67 @@ Examples:
           writeLine(`    ${result.availability.message}`);
         }
       }
-    });
+    },
+  );
 
   // ── create ──────────────────────────────────────────────────────────
-  addWriteFlags(
-    profiles
-      .command("create <name>")
-      .description("Create a validated custom profile"),
-  ).action(async (name: string, opts: WriteFlags) => {
-    if (!opts.provider) {
-      writeCliError("--provider is required.", opts.json);
-      return;
-    }
-    if (!opts.model) {
-      writeCliError("--model is required.", opts.json);
-      return;
-    }
-    const built = buildWriteBody(opts);
-    if (!built.ok) {
-      writeCliError(built.error, opts.json);
-      return;
-    }
-    const ipcResult = await cliIpcCall<ProfileWriteResult>(
-      "inference_profiles_create",
-      { body: { ...built.body, name } },
-    );
-    if (!ipcResult.ok) {
-      writeCliError(ipcResult.error ?? "Unknown error", opts.json);
-      return;
-    }
-    printWriteResult("created", ipcResult.result!, opts.json);
-  });
+  subcommand(profiles, "create").action(
+    async (name: string, opts: WriteFlags) => {
+      if (!opts.provider) {
+        writeCliError("--provider is required.", opts.json);
+        return;
+      }
+      if (!opts.model) {
+        writeCliError("--model is required.", opts.json);
+        return;
+      }
+      const built = buildWriteBody(opts);
+      if (!built.ok) {
+        writeCliError(built.error, opts.json);
+        return;
+      }
+      const ipcResult = await cliIpcCall<ProfileWriteResult>(
+        "inference_profiles_create",
+        { body: { ...built.body, name } },
+      );
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+      printWriteResult("created", ipcResult.result!, opts.json);
+    },
+  );
 
   // ── update ──────────────────────────────────────────────────────────
-  addWriteFlags(
-    profiles
-      .command("update <name>")
-      .description("Partially update a custom profile"),
-  ).action(async (name: string, opts: WriteFlags) => {
-    const built = buildWriteBody(opts);
-    if (!built.ok) {
-      writeCliError(built.error, opts.json);
-      return;
-    }
-    if (Object.keys(built.body).length === 0) {
-      writeCliError(
-        "Nothing to update — pass at least one field flag.",
-        opts.json,
+  subcommand(profiles, "update").action(
+    async (name: string, opts: WriteFlags) => {
+      const built = buildWriteBody(opts);
+      if (!built.ok) {
+        writeCliError(built.error, opts.json);
+        return;
+      }
+      if (Object.keys(built.body).length === 0) {
+        writeCliError(
+          "Nothing to update — pass at least one field flag.",
+          opts.json,
+        );
+        return;
+      }
+      const ipcResult = await cliIpcCall<ProfileWriteResult>(
+        "inference_profiles_update",
+        { pathParams: { name }, body: built.body },
       );
-      return;
-    }
-    const ipcResult = await cliIpcCall<ProfileWriteResult>(
-      "inference_profiles_update",
-      { pathParams: { name }, body: built.body },
-    );
-    if (!ipcResult.ok) {
-      writeCliError(ipcResult.error ?? "Unknown error", opts.json);
-      return;
-    }
-    printWriteResult("updated", ipcResult.result!, opts.json);
-  });
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+      printWriteResult("updated", ipcResult.result!, opts.json);
+    },
+  );
 
   // ── delete ──────────────────────────────────────────────────────────
-  profiles
-    .command("delete <name>")
-    .description("Delete a custom profile")
-    .option("--json", "Output as machine-readable JSON")
-    .action(async (name: string, opts: { json?: boolean }) => {
+  subcommand(profiles, "delete").action(
+    async (name: string, opts: { json?: boolean }) => {
       const ipcResult = await cliIpcCall<{ ok: true; name: string }>(
         "inference_profiles_delete",
         { pathParams: { name } },
@@ -312,24 +262,12 @@ Examples:
         return;
       }
       writeLine(`profile ${name} deleted`);
-    });
+    },
+  );
 
   // ── active ──────────────────────────────────────────────────────────
-  profiles
-    .command("active [name]")
-    .description("Read or set the active (chat) profile")
-    .option("--json", "Output as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-With no argument, prints the active profile. With a name, sets it — the
-same deep-merge write the model picker performs.
-
-Examples:
-  $ assistant inference profiles active
-  $ assistant inference profiles active balanced`,
-    )
-    .action(async (name: string | undefined, opts: { json?: boolean }) => {
+  subcommand(profiles, "active").action(
+    async (name: string | undefined, opts: { json?: boolean }) => {
       if (name === undefined) {
         const ipcResult = await cliIpcCall<{
           llm?: { activeProfile?: string };
@@ -367,5 +305,6 @@ Examples:
         return;
       }
       writeLine(`active profile set to ${activeProfile}`);
-    });
+    },
+  );
 }

--- a/assistant/src/cli/commands/inference-providers-default.ts
+++ b/assistant/src/cli/commands/inference-providers-default.ts
@@ -8,6 +8,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { subcommand } from "../lib/cli-command-help.js";
 import { writeCliError, writeLine } from "../lib/cli-output.js";
 
 interface DefaultProviderStatus {
@@ -37,53 +38,37 @@ function printStatus(status: DefaultProviderStatus, json?: boolean): void {
 }
 
 export function attachDefaultProviderSubcommand(providers: Command): void {
-  providers
-    .command("default [name]")
-    .description("Read or set the default provider (prints availability)")
-    .option("--connection <name>", "Pin a specific connection when setting")
-    .option("--json", "Output as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-With no argument, prints the default provider and whether it is usable.
-With a provider name, sets it (optionally pinning a connection).
-
-Examples:
-  $ assistant inference providers default
-  $ assistant inference providers default anthropic
-  $ assistant inference providers default anthropic --connection anthropic-personal`,
-    )
-    .action(
-      async (
-        name: string | undefined,
-        opts: { connection?: string; json?: boolean },
-      ) => {
-        if (name === undefined) {
-          const ipcResult = await cliIpcCall<DefaultProviderStatus>(
-            "llm_default_provider_get",
-            {},
-          );
-          if (!ipcResult.ok) {
-            writeCliError(ipcResult.error ?? "Unknown error", opts.json);
-            return;
-          }
-          printStatus(ipcResult.result!, opts.json);
-          return;
-        }
-
-        const body: Record<string, unknown> = { provider: name };
-        if (opts.connection !== undefined) {
-          body.connectionName = opts.connection;
-        }
+  subcommand(providers, "default").action(
+    async (
+      name: string | undefined,
+      opts: { connection?: string; json?: boolean },
+    ) => {
+      if (name === undefined) {
         const ipcResult = await cliIpcCall<DefaultProviderStatus>(
-          "llm_default_provider_put",
-          { body },
+          "llm_default_provider_get",
+          {},
         );
         if (!ipcResult.ok) {
           writeCliError(ipcResult.error ?? "Unknown error", opts.json);
           return;
         }
         printStatus(ipcResult.result!, opts.json);
-      },
-    );
+        return;
+      }
+
+      const body: Record<string, unknown> = { provider: name };
+      if (opts.connection !== undefined) {
+        body.connectionName = opts.connection;
+      }
+      const ipcResult = await cliIpcCall<DefaultProviderStatus>(
+        "llm_default_provider_put",
+        { body },
+      );
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error", opts.json);
+        return;
+      }
+      printStatus(ipcResult.result!, opts.json);
+    },
+  );
 }

--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -18,6 +18,7 @@ import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import type { OAuth2Config } from "../../security/oauth2.js";
+import { subcommand } from "../lib/cli-command-help.js";
 import { writeCliError } from "../lib/cli-output.js";
 import { attachDefaultProviderSubcommand } from "./inference-providers-default.js";
 
@@ -64,12 +65,8 @@ function formatAuth(auth: AuthInfo): string {
 // ---------------------------------------------------------------------------
 
 function attachListSubcommand(connections: Command): void {
-  connections
-    .command("list")
-    .description("List all provider connections")
-    .option("--provider <p>", "Filter by provider")
-    .option("--json", "Output as JSON")
-    .action(async (opts: { provider?: string; json?: boolean }) => {
+  subcommand(connections, "list").action(
+    async (opts: { provider?: string; json?: boolean }) => {
       const ipcResult = await cliIpcCall<{ connections: ProviderConnection[] }>(
         "inference_provider_connections_list",
         {
@@ -101,7 +98,8 @@ function attachListSubcommand(connections: Command): void {
           `${conn.name}  provider=${conn.provider}  auth=${formatAuth(conn.auth)}\n`,
         );
       }
-    });
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -109,11 +107,8 @@ function attachListSubcommand(connections: Command): void {
 // ---------------------------------------------------------------------------
 
 function attachGetSubcommand(connections: Command): void {
-  connections
-    .command("get <name>")
-    .description("Show a single provider connection")
-    .option("--json", "Output as JSON")
-    .action(async (name: string, opts: { json?: boolean }) => {
+  subcommand(connections, "get").action(
+    async (name: string, opts: { json?: boolean }) => {
       const ipcResult = await cliIpcCall<ProviderConnection>(
         "inference_provider_connections_get",
         {
@@ -144,7 +139,8 @@ function attachGetSubcommand(connections: Command): void {
       process.stdout.write(
         `updated:  ${new Date(conn.updatedAt).toISOString()}\n`,
       );
-    });
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -216,22 +212,10 @@ function buildCustomProviderFields(opts: {
 // ---------------------------------------------------------------------------
 
 function attachCreateSubcommand(connections: Command): void {
-  connections
-    .command("create <name>")
-    .description("Create a new provider connection")
-    .requiredOption(
-      "--provider <p>",
-      "Provider (anthropic|openai|gemini|ollama|...)",
-    )
-    .requiredOption("--auth <type>", "Auth type: api_key|platform|none")
-    .option(
-      "--credential <vault-key>",
-      "Vault credential name (required for --auth api_key)",
-    )
-    .option(
-      "--base-url <url>",
-      "Endpoint base URL (required for --provider openai-compatible)",
-    )
+  // `--model` uses an array-accumulating collector, which the declarative
+  // help contract cannot express — it is registered imperatively here (with
+  // the trailing `--json` after it, preserving option order).
+  subcommand(connections, "create")
     .option(
       "--model <id>",
       "Model id offered by this connection (repeatable; required for openai-compatible)",
@@ -303,18 +287,8 @@ function attachCreateSubcommand(connections: Command): void {
 // ---------------------------------------------------------------------------
 
 function attachUpdateSubcommand(connections: Command): void {
-  connections
-    .command("update <name>")
-    .description("Update a connection's auth")
-    .requiredOption("--auth <type>", "Auth type: api_key|platform|none")
-    .option(
-      "--credential <vault-key>",
-      "Vault credential name (required for --auth api_key)",
-    )
-    .option(
-      "--base-url <url>",
-      "Endpoint base URL (openai-compatible connections)",
-    )
+  // `--model` collector registered imperatively — see the note on `create`.
+  subcommand(connections, "update")
     .option(
       "--model <id>",
       "Model id offered by this connection (repeatable; openai-compatible)",
@@ -373,11 +347,8 @@ function attachUpdateSubcommand(connections: Command): void {
 // ---------------------------------------------------------------------------
 
 function attachDeleteSubcommand(connections: Command): void {
-  connections
-    .command("delete <name>")
-    .description("Delete a provider connection")
-    .option("--json", "Output as JSON")
-    .action(async (name: string, opts: { json?: boolean }) => {
+  subcommand(connections, "delete").action(
+    async (name: string, opts: { json?: boolean }) => {
       const ipcResult = await cliIpcCall<{ ok: true }>(
         "inference_provider_connections_delete",
         {
@@ -395,7 +366,8 @@ function attachDeleteSubcommand(connections: Command): void {
       } else {
         process.stdout.write(`Deleted connection "${name}"\n`);
       }
-    });
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -416,11 +388,8 @@ const OPENAI_CODEX_OAUTH_CONFIG: OAuth2Config = {
 // ---------------------------------------------------------------------------
 
 function attachLoginChatgptSubcommand(providers: Command): void {
-  providers
-    .command("login-chatgpt")
-    .description("Authenticate with ChatGPT via browser OAuth flow")
-    .option("--json", "Output as JSON")
-    .action(async (opts: { json?: boolean }) => {
+  subcommand(providers, "login-chatgpt").action(
+    async (opts: { json?: boolean }) => {
       try {
         // Deferred: loads the OAuth and secure-key graphs on demand.
         const [{ startOAuth2Flow }, { setSecureKeyAsync }] = await Promise.all([
@@ -529,7 +498,8 @@ function attachLoginChatgptSubcommand(providers: Command): void {
         const message = err instanceof Error ? err.message : String(err);
         writeCliError(message, opts.json);
       }
-    });
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -537,40 +507,8 @@ function attachLoginChatgptSubcommand(providers: Command): void {
 // ---------------------------------------------------------------------------
 
 export function attachProvidersSubcommand(inference: Command): void {
-  const providers = inference
-    .command("providers")
-    .description("Inference provider admin commands");
-
-  const connections = providers
-    .command("connections")
-    .description("Manage provider connections (auth configs for inference)");
-
-  connections.addHelpText(
-    "after",
-    `
-Provider connections map a name to a (provider, auth) pair.
-Profiles reference connections via the 'provider_connection' field.
-
-Canonical connections (seeded on every boot):
-  anthropic-managed  → provider=anthropic, auth=platform
-  openai-managed     → provider=openai,    auth=platform
-  gemini-managed     → provider=gemini,    auth=platform
-
-Examples:
-  $ assistant inference providers connections list
-  $ assistant inference providers connections get anthropic-managed
-  $ assistant inference providers connections create anthropic-personal \\
-      --provider anthropic --auth api_key --credential credential/anthropic/api_key
-  $ assistant inference providers connections create local-llm \\
-      --provider openai-compatible --auth none \\
-      --base-url http://localhost:1234/v1 --model my-model
-  $ assistant inference providers connections update anthropic-personal --auth platform
-  $ assistant inference providers connections delete anthropic-personal
-
-After creating or updating a connection, validate it with a live call through
-a profile that uses it:
-  $ assistant inference send --profile <profile> "Reply with OK"`,
-  );
+  const providers = subcommand(inference, "providers");
+  const connections = subcommand(providers, "connections");
 
   attachListSubcommand(connections);
   attachGetSubcommand(connections);

--- a/assistant/src/cli/commands/inference-session.ts
+++ b/assistant/src/cli/commands/inference-session.ts
@@ -12,6 +12,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { subcommand } from "../lib/cli-command-help.js";
 import { log } from "../logger.js";
 import { resolveConversationId } from "../utils/conversation-id.js";
 import { parseDuration } from "../utils/parse-duration.js";
@@ -91,289 +92,222 @@ function writeLine(msg: string): void {
 // ── Registration ─────────────────────────────────────────────────────
 
 export function attachSessionSubcommand(parent: Command): void {
-  const session = parent
-    .command("session")
-    .description("Manage conversation-scoped inference profile sessions");
-
-  session.addHelpText(
-    "after",
-    `
-Inference profile sessions pin a named model profile to a specific
-conversation for the duration of the session.
-
-Examples:
-  $ assistant inference session open balanced --ttl 30m
-  $ assistant inference session open fast --ttl never
-  $ assistant inference session close
-  $ assistant inference session list`,
-  );
+  const session = subcommand(parent, "session");
 
   // ── profile open ──────────────────────────────────────────────────
 
-  session
-    .command("open <profileName>")
-    .description("Open a profile session for the current conversation")
-    .option(
-      "--ttl <duration>",
-      'Session TTL (e.g. 30m, 1h, "never" for sticky; default: 30m)',
-    )
-    .option(
-      "--conversation-id <id>",
-      "Conversation ID (auto-resolved from context if omitted)",
-    )
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Opens a profile session that pins the given profile to the current
-conversation. The session expires after --ttl, or is sticky (no
-expiry) if --ttl never is specified. If --ttl is omitted, the session
-defaults to 30m.
-
-Examples:
-  $ assistant inference session open balanced --ttl 30m
-  $ assistant inference session open fast --ttl never
-  $ assistant inference session open balanced            # uses default 30m TTL
-  $ assistant inference session open balanced --json`,
-    )
-    .action(
-      async (
-        profileName: string,
-        opts: {
-          ttl?: string;
-          conversationId?: string;
-          json?: boolean;
-        },
-      ) => {
-        let conversationId: string;
-        try {
-          conversationId = resolveConversationId({
-            explicit: opts.conversationId,
-            failureHelp: CONV_ID_HELP,
-          });
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (opts.json) {
-            process.stdout.write(JSON.stringify({ ok: false, error: msg }) + "\n");
-          } else {
-            log.error(`Error: ${msg}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
-
-        // Parse TTL
-        let ttlSeconds: number | null | undefined; // undefined = omit from body
-        let requestedTtlSeconds: number | undefined;
-
-        if (opts.ttl !== undefined) {
-          if (opts.ttl === "never") {
-            ttlSeconds = null;
-          } else {
-            try {
-              ttlSeconds = parseDuration(opts.ttl);
-              requestedTtlSeconds = ttlSeconds;
-            } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              if (opts.json) {
-                process.stdout.write(JSON.stringify({ ok: false, error: msg }) + "\n");
-              } else {
-                log.error(`Error: ${msg}`);
-              }
-              process.exitCode = 1;
-              return;
-            }
-          }
-        }
-
-        const effectiveTtlSeconds =
-          ttlSeconds !== undefined ? ttlSeconds : DEFAULT_TTL_SECONDS;
-        const body: Record<string, unknown> = {
-          conversationId,
-          profile: profileName,
-          ttlSeconds: effectiveTtlSeconds,
-        };
-
-        const ipcResult = await cliIpcCall<OpenResult>(
-          "inference_profile_open",
-          { body },
-        );
-
-        if (!ipcResult.ok) {
-          if (opts.json) {
-            process.stdout.write(JSON.stringify({ ok: false, error: ipcResult.error }) + "\n");
-          } else {
-            log.error(`Error: ${ipcResult.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
-
-        const result = ipcResult.result!;
-        const { sessionId, expiresAt, replaced } = result;
-        const resultTtlSeconds = result.ttlSeconds;
-
+  subcommand(session, "open").action(
+    async (
+      profileName: string,
+      opts: {
+        ttl?: string;
+        conversationId?: string;
+        json?: boolean;
+      },
+    ) => {
+      let conversationId: string;
+      try {
+        conversationId = resolveConversationId({
+          explicit: opts.conversationId,
+          failureHelp: CONV_ID_HELP,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
         if (opts.json) {
           process.stdout.write(
-            JSON.stringify({
-              ok: true,
-              conversationId: result.conversationId,
-              profile: profileName,
-              sessionId,
-              expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
-              ttlSeconds: resultTtlSeconds,
-              replaced: replaced
-                ? {
-                    ...replaced,
-                    expiresAt: replaced.expiresAt
-                      ? new Date(replaced.expiresAt).toISOString()
-                      : null,
-                  }
-                : null,
-            }) + "\n",
+            JSON.stringify({ ok: false, error: msg }) + "\n",
           );
         } else {
-          // Warn if TTL was clamped by the server (human-readable mode only)
-          if (
-            typeof requestedTtlSeconds === "number" &&
-            typeof resultTtlSeconds === "number" &&
-            requestedTtlSeconds !== resultTtlSeconds
-          ) {
-            writeLine(`note: ttl clamped to ${formatDuration(resultTtlSeconds)} (config maxTtlSeconds)`);
-          }
+          log.error(`Error: ${msg}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
 
-          // Human-readable output
-          if (resultTtlSeconds == null) {
-            writeLine(`profile ${profileName} active (sticky, no expiry)`);
-          } else {
-            const expireStr = expiresAt != null ? formatLocalTime(expiresAt) : "?";
-            writeLine(
-              `profile ${profileName} active for ${formatDuration(resultTtlSeconds)} (until ${expireStr})`,
-            );
-          }
+      // Parse TTL
+      let ttlSeconds: number | null | undefined; // undefined = omit from body
+      let requestedTtlSeconds: number | undefined;
 
-          if (replaced) {
-            const replacedExpiry = replaced.expiresAt
-              ? formatLocalTime(replaced.expiresAt)
-              : "?";
-            writeLine(
-              `replaced: ${replaced.profile} (was active until ${replacedExpiry})`,
-            );
+      if (opts.ttl !== undefined) {
+        if (opts.ttl === "never") {
+          ttlSeconds = null;
+        } else {
+          try {
+            ttlSeconds = parseDuration(opts.ttl);
+            requestedTtlSeconds = ttlSeconds;
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: msg }) + "\n",
+              );
+            } else {
+              log.error(`Error: ${msg}`);
+            }
+            process.exitCode = 1;
+            return;
           }
         }
-      },
-    );
+      }
+
+      const effectiveTtlSeconds =
+        ttlSeconds !== undefined ? ttlSeconds : DEFAULT_TTL_SECONDS;
+      const body: Record<string, unknown> = {
+        conversationId,
+        profile: profileName,
+        ttlSeconds: effectiveTtlSeconds,
+      };
+
+      const ipcResult = await cliIpcCall<OpenResult>("inference_profile_open", {
+        body,
+      });
+
+      if (!ipcResult.ok) {
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
+          );
+        } else {
+          log.error(`Error: ${ipcResult.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = ipcResult.result!;
+      const { sessionId, expiresAt, replaced } = result;
+      const resultTtlSeconds = result.ttlSeconds;
+
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({
+            ok: true,
+            conversationId: result.conversationId,
+            profile: profileName,
+            sessionId,
+            expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
+            ttlSeconds: resultTtlSeconds,
+            replaced: replaced
+              ? {
+                  ...replaced,
+                  expiresAt: replaced.expiresAt
+                    ? new Date(replaced.expiresAt).toISOString()
+                    : null,
+                }
+              : null,
+          }) + "\n",
+        );
+      } else {
+        // Warn if TTL was clamped by the server (human-readable mode only)
+        if (
+          typeof requestedTtlSeconds === "number" &&
+          typeof resultTtlSeconds === "number" &&
+          requestedTtlSeconds !== resultTtlSeconds
+        ) {
+          writeLine(
+            `note: ttl clamped to ${formatDuration(resultTtlSeconds)} (config maxTtlSeconds)`,
+          );
+        }
+
+        // Human-readable output
+        if (resultTtlSeconds == null) {
+          writeLine(`profile ${profileName} active (sticky, no expiry)`);
+        } else {
+          const expireStr =
+            expiresAt != null ? formatLocalTime(expiresAt) : "?";
+          writeLine(
+            `profile ${profileName} active for ${formatDuration(resultTtlSeconds)} (until ${expireStr})`,
+          );
+        }
+
+        if (replaced) {
+          const replacedExpiry = replaced.expiresAt
+            ? formatLocalTime(replaced.expiresAt)
+            : "?";
+          writeLine(
+            `replaced: ${replaced.profile} (was active until ${replacedExpiry})`,
+          );
+        }
+      }
+    },
+  );
 
   // ── profile close ─────────────────────────────────────────────────
 
-  session
-    .command("close")
-    .description("Close the active profile session for the current conversation")
-    .option(
-      "--conversation-id <id>",
-      "Conversation ID (auto-resolved from context if omitted)",
-    )
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Closes the active profile session for the conversation. This is
-idempotent — if no session is active the command succeeds with
-a "no active profile session" message.
-
-Examples:
-  $ assistant inference session close
-  $ assistant inference session close --json`,
-    )
-    .action(
-      async (opts: { conversationId?: string; json?: boolean }) => {
-        let conversationId: string;
-        try {
-          conversationId = resolveConversationId({
-            explicit: opts.conversationId,
-            failureHelp: CONV_ID_HELP,
-          });
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (opts.json) {
-            process.stdout.write(JSON.stringify({ ok: false, error: msg }) + "\n");
-          } else {
-            log.error(`Error: ${msg}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
-
-        const ipcResult = await cliIpcCall<CloseResult>(
-          "inference_profile_close",
-          { body: { conversationId } },
-        );
-
-        if (!ipcResult.ok) {
-          if (opts.json) {
-            process.stdout.write(JSON.stringify({ ok: false, error: ipcResult.error }) + "\n");
-          } else {
-            log.error(`Error: ${ipcResult.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
-
-        const result = ipcResult.result!;
-
+  subcommand(session, "close").action(
+    async (opts: { conversationId?: string; json?: boolean }) => {
+      let conversationId: string;
+      try {
+        conversationId = resolveConversationId({
+          explicit: opts.conversationId,
+          failureHelp: CONV_ID_HELP,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
         if (opts.json) {
           process.stdout.write(
-            JSON.stringify({
-              ok: true,
-              conversationId: result.conversationId,
-              closed: result.closed,
-              noop: result.noop,
-            }) + "\n",
+            JSON.stringify({ ok: false, error: msg }) + "\n",
           );
         } else {
-          if (result.noop || !result.closed) {
-            writeLine("no active profile session");
-          } else {
-            writeLine(`closed profile ${result.closed.profile}`);
-          }
+          log.error(`Error: ${msg}`);
         }
-      },
-    );
+        process.exitCode = 1;
+        return;
+      }
 
-  // ── profile list ──────────────────────────────────────────────────
-
-  session
-    .command("list")
-    .description("List active profile sessions")
-    .option(
-      "--conversation-id <id>",
-      "Filter to a specific conversation ID",
-    )
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Lists all active inference profile sessions. Optionally filter by
-conversation ID.
-
-Examples:
-  $ assistant inference session list
-  $ assistant inference session list --conversation-id conv-abc123
-  $ assistant inference session list --json`,
-    )
-    .action(async (opts: { conversationId?: string; json?: boolean }) => {
-      const ipcResult = await cliIpcCall<ListResult>(
-        "inference_profile_list",
-        {
-          queryParams: opts.conversationId
-            ? { conversationId: opts.conversationId }
-            : {},
-        },
+      const ipcResult = await cliIpcCall<CloseResult>(
+        "inference_profile_close",
+        { body: { conversationId } },
       );
 
       if (!ipcResult.ok) {
         if (opts.json) {
-          process.stdout.write(JSON.stringify({ ok: false, error: ipcResult.error }) + "\n");
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
+          );
+        } else {
+          log.error(`Error: ${ipcResult.error}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = ipcResult.result!;
+
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({
+            ok: true,
+            conversationId: result.conversationId,
+            closed: result.closed,
+            noop: result.noop,
+          }) + "\n",
+        );
+      } else {
+        if (result.noop || !result.closed) {
+          writeLine("no active profile session");
+        } else {
+          writeLine(`closed profile ${result.closed.profile}`);
+        }
+      }
+    },
+  );
+
+  // ── profile list ──────────────────────────────────────────────────
+
+  subcommand(session, "list").action(
+    async (opts: { conversationId?: string; json?: boolean }) => {
+      const ipcResult = await cliIpcCall<ListResult>("inference_profile_list", {
+        queryParams: opts.conversationId
+          ? { conversationId: opts.conversationId }
+          : {},
+      });
+
+      if (!ipcResult.ok) {
+        if (opts.json) {
+          process.stdout.write(
+            JSON.stringify({ ok: false, error: ipcResult.error }) + "\n",
+          );
         } else {
           log.error(`Error: ${ipcResult.error}`);
         }
@@ -389,7 +323,10 @@ Examples:
             ok: true,
             sessions: sessions.map((s) => ({
               ...s,
-              expiresAt: s.expiresAt != null ? new Date(s.expiresAt).toISOString() : null,
+              expiresAt:
+                s.expiresAt != null
+                  ? new Date(s.expiresAt).toISOString()
+                  : null,
             })),
           }) + "\n",
         );
@@ -405,11 +342,14 @@ Examples:
       for (const s of sessions) {
         const convId = s.conversationId.padEnd(14);
         const profile = s.profile.padEnd(16);
-        const remaining = `${formatDuration(s.remainingSeconds)} left`.padEnd(12);
+        const remaining = `${formatDuration(s.remainingSeconds)} left`.padEnd(
+          12,
+        );
         const rawTitle = s.conversationTitle ?? "...";
         const title =
           rawTitle.length > 30 ? rawTitle.slice(0, 30) + "..." : rawTitle;
         writeLine(`  ${convId}  ${profile}  ${remaining}  "${title}"`);
       }
-    });
+    },
+  );
 }

--- a/assistant/src/cli/commands/inference.help.ts
+++ b/assistant/src/cli/commands/inference.help.ts
@@ -1,0 +1,485 @@
+/** Declarative help for the `assistant inference` command. */
+
+import type {
+  CliCommandHelp,
+  CliOptionHelp,
+  CliSubcommandHelp,
+} from "../lib/cli-command-help.js";
+
+/**
+ * Shared write flags for `profiles create` / `profiles update` (mirrors the
+ * former `addWriteFlags` helper so both subcommands stay in sync).
+ */
+const profileWriteOptions: CliOptionHelp[] = [
+  {
+    flags: "--provider <p>",
+    description: "LLM provider (e.g. anthropic, openai)",
+  },
+  {
+    flags: "--model <id>",
+    description: "Model id (see 'assistant inference models list')",
+  },
+  {
+    flags: "--connection <name>",
+    description: "Provider connection name to use",
+  },
+  { flags: "--label <text>", description: "Human-readable label" },
+  {
+    flags: "--effort <tier>",
+    description: "Reasoning effort (none|low|medium|high|xhigh|max)",
+  },
+  { flags: "--max-tokens <n>", description: "Max response tokens" },
+  { flags: "--temperature <x>", description: "Sampling temperature" },
+  { flags: "--thinking <on|off>", description: "Enable or disable thinking" },
+  { flags: "--description <text>", description: "Profile description" },
+  {
+    flags: "--allow-unlisted",
+    description: "Allow a model not in the catalog (warns)",
+  },
+  { flags: "--json", description: "Output as machine-readable JSON" },
+];
+
+/** `send` is shared verbatim between `inference` and its `llm` alias. */
+const sendSubcommandHelp: CliSubcommandHelp = {
+  name: "send",
+  description: "Send a message to the configured LLM and print the response",
+  arguments: [
+    { name: "[message...]", description: "User message (joined with spaces)" },
+  ],
+  options: [
+    {
+      flags: "--system-prompt <text>",
+      description: "System prompt for the model",
+    },
+    { flags: "--model <model-id>", description: "Model override" },
+    {
+      flags: "--profile <name>",
+      description:
+        "Apply a named inference profile from llm.profiles for this single call",
+    },
+    { flags: "--max-tokens <n>", description: "Max response tokens" },
+    {
+      flags: "--timeout-seconds <seconds>",
+      description: "Maximum time to wait for the inference response",
+    },
+    { flags: "--json", description: "Output structured JSON" },
+  ],
+  helpText: `
+Behavioral notes:
+  - If no message argument is provided, reads from stdin.
+  - If --model is omitted, uses the configured default model.
+  - --profile applies a named profile from llm.profiles for this single call
+    only. It does NOT open a session — to pin a profile to a conversation,
+    use 'assistant inference profile open <name>'.
+  - --profile layers below --model: --model still wins on the model field.
+  - Long-running requests wait up to 32 minutes by default. Use
+    --timeout-seconds to adjust the wait budget for this call.
+  - Requires a configured LLM provider (see 'assistant config set').
+
+Examples:
+  $ assistant inference send "What is 2+2?"
+  $ echo "Summarize this" | assistant inference send
+  $ assistant llm send --system-prompt "You are a poet" "Write a haiku"
+  $ assistant inference send --timeout-seconds 300 "Draft a long memo"
+  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"
+  $ assistant inference send --profile balanced "Explain RFC 1149"`,
+};
+
+export const inferenceHelp: CliCommandHelp = {
+  name: "inference",
+  description: "LLM inference operations",
+  helpText: `
+The inference command group sends requests to your configured LLM provider.
+The provider is resolved from your assistant config (llm.default.provider).
+
+Examples:
+  $ assistant inference send "What is the capital of France?"
+  $ echo "Explain quantum computing" | assistant inference send
+  $ assistant llm send --system-prompt "Be concise" "What is TCP?"
+  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"
+  $ assistant inference send --profile balanced "Explain RFC 1149"`,
+  subcommands: [
+    sendSubcommandHelp,
+    {
+      name: "session",
+      description: "Manage conversation-scoped inference profile sessions",
+      helpText: `
+Inference profile sessions pin a named model profile to a specific
+conversation for the duration of the session.
+
+Examples:
+  $ assistant inference session open balanced --ttl 30m
+  $ assistant inference session open fast --ttl never
+  $ assistant inference session close
+  $ assistant inference session list`,
+      subcommands: [
+        {
+          name: "open",
+          args: "<profileName>",
+          description: "Open a profile session for the current conversation",
+          options: [
+            {
+              flags: "--ttl <duration>",
+              description:
+                'Session TTL (e.g. 30m, 1h, "never" for sticky; default: 30m)',
+            },
+            {
+              flags: "--conversation-id <id>",
+              description:
+                "Conversation ID (auto-resolved from context if omitted)",
+            },
+            {
+              flags: "--json",
+              description: "Output result as machine-readable JSON",
+            },
+          ],
+          helpText: `
+Opens a profile session that pins the given profile to the current
+conversation. The session expires after --ttl, or is sticky (no
+expiry) if --ttl never is specified. If --ttl is omitted, the session
+defaults to 30m.
+
+Examples:
+  $ assistant inference session open balanced --ttl 30m
+  $ assistant inference session open fast --ttl never
+  $ assistant inference session open balanced            # uses default 30m TTL
+  $ assistant inference session open balanced --json`,
+        },
+        {
+          name: "close",
+          description:
+            "Close the active profile session for the current conversation",
+          options: [
+            {
+              flags: "--conversation-id <id>",
+              description:
+                "Conversation ID (auto-resolved from context if omitted)",
+            },
+            {
+              flags: "--json",
+              description: "Output result as machine-readable JSON",
+            },
+          ],
+          helpText: `
+Closes the active profile session for the conversation. This is
+idempotent — if no session is active the command succeeds with
+a "no active profile session" message.
+
+Examples:
+  $ assistant inference session close
+  $ assistant inference session close --json`,
+        },
+        {
+          name: "list",
+          description: "List active profile sessions",
+          options: [
+            {
+              flags: "--conversation-id <id>",
+              description: "Filter to a specific conversation ID",
+            },
+            {
+              flags: "--json",
+              description: "Output result as machine-readable JSON",
+            },
+          ],
+          helpText: `
+Lists all active inference profile sessions. Optionally filter by
+conversation ID.
+
+Examples:
+  $ assistant inference session list
+  $ assistant inference session list --conversation-id conv-abc123
+  $ assistant inference session list --json`,
+        },
+      ],
+    },
+    {
+      name: "providers",
+      description: "Inference provider admin commands",
+      subcommands: [
+        {
+          name: "connections",
+          description:
+            "Manage provider connections (auth configs for inference)",
+          helpText: `
+Provider connections map a name to a (provider, auth) pair.
+Profiles reference connections via the 'provider_connection' field.
+
+Canonical connections (seeded on every boot):
+  anthropic-managed  → provider=anthropic, auth=platform
+  openai-managed     → provider=openai,    auth=platform
+  gemini-managed     → provider=gemini,    auth=platform
+
+Examples:
+  $ assistant inference providers connections list
+  $ assistant inference providers connections get anthropic-managed
+  $ assistant inference providers connections create anthropic-personal \\
+      --provider anthropic --auth api_key --credential credential/anthropic/api_key
+  $ assistant inference providers connections create local-llm \\
+      --provider openai-compatible --auth none \\
+      --base-url http://localhost:1234/v1 --model my-model
+  $ assistant inference providers connections update anthropic-personal --auth platform
+  $ assistant inference providers connections delete anthropic-personal
+
+After creating or updating a connection, validate it with a live call through
+a profile that uses it:
+  $ assistant inference send --profile <profile> "Reply with OK"`,
+          subcommands: [
+            {
+              name: "list",
+              description: "List all provider connections",
+              options: [
+                { flags: "--provider <p>", description: "Filter by provider" },
+                { flags: "--json", description: "Output as JSON" },
+              ],
+            },
+            {
+              name: "get",
+              args: "<name>",
+              description: "Show a single provider connection",
+              options: [{ flags: "--json", description: "Output as JSON" }],
+            },
+            {
+              // NOTE: the repeatable `--model` collector option and the
+              // trailing `--json` are registered imperatively in
+              // `inference-providers.ts` (array-accumulating parser functions
+              // are not expressible as plain help data).
+              name: "create",
+              args: "<name>",
+              description: "Create a new provider connection",
+              options: [
+                {
+                  flags: "--provider <p>",
+                  description: "Provider (anthropic|openai|gemini|ollama|...)",
+                  required: true,
+                },
+                {
+                  flags: "--auth <type>",
+                  description: "Auth type: api_key|platform|none",
+                  required: true,
+                },
+                {
+                  flags: "--credential <vault-key>",
+                  description:
+                    "Vault credential name (required for --auth api_key)",
+                },
+                {
+                  flags: "--base-url <url>",
+                  description:
+                    "Endpoint base URL (required for --provider openai-compatible)",
+                },
+              ],
+            },
+            {
+              // NOTE: `--model` + `--json` registered imperatively — see `create`.
+              name: "update",
+              args: "<name>",
+              description: "Update a connection's auth",
+              options: [
+                {
+                  flags: "--auth <type>",
+                  description: "Auth type: api_key|platform|none",
+                  required: true,
+                },
+                {
+                  flags: "--credential <vault-key>",
+                  description:
+                    "Vault credential name (required for --auth api_key)",
+                },
+                {
+                  flags: "--base-url <url>",
+                  description:
+                    "Endpoint base URL (openai-compatible connections)",
+                },
+              ],
+            },
+            {
+              name: "delete",
+              args: "<name>",
+              description: "Delete a provider connection",
+              options: [{ flags: "--json", description: "Output as JSON" }],
+            },
+          ],
+        },
+        {
+          name: "login-chatgpt",
+          description: "Authenticate with ChatGPT via browser OAuth flow",
+          options: [{ flags: "--json", description: "Output as JSON" }],
+        },
+        {
+          name: "default",
+          args: "[name]",
+          description: "Read or set the default provider (prints availability)",
+          options: [
+            {
+              flags: "--connection <name>",
+              description: "Pin a specific connection when setting",
+            },
+            {
+              flags: "--json",
+              description: "Output as machine-readable JSON",
+            },
+          ],
+          helpText: `
+With no argument, prints the default provider and whether it is usable.
+With a provider name, sets it (optionally pinning a connection).
+
+Examples:
+  $ assistant inference providers default
+  $ assistant inference providers default anthropic
+  $ assistant inference providers default anthropic --connection anthropic-personal`,
+        },
+      ],
+    },
+    {
+      name: "models",
+      description: "Inspect the inference model catalog",
+      subcommands: [
+        {
+          name: "list",
+          description: "List catalog models (optionally filtered by provider)",
+          options: [
+            { flags: "--provider <p>", description: "Filter by provider id" },
+            {
+              flags: "--json",
+              description: "Output as machine-readable JSON",
+            },
+          ],
+          helpText: `
+Lists every model in the code-owned provider catalog. Use the ids here
+when creating an inference profile:
+
+Examples:
+  $ assistant inference models list
+  $ assistant inference models list --provider anthropic
+  $ assistant inference models list --json`,
+        },
+      ],
+    },
+    {
+      name: "profiles",
+      description: "Manage inference profiles (named model configurations)",
+      helpText: `
+Profiles are named model configurations. Managed defaults (balanced,
+quality-optimized, cost-optimized) are read-only; create your own to
+customize provider, model, and tuning.
+
+Examples:
+  $ assistant inference profiles list
+  $ assistant inference profiles create my-fast --provider anthropic \\
+      --model claude-haiku-4-5 --connection anthropic-personal --effort low
+  $ assistant inference profiles update my-fast --effort high
+  $ assistant inference profiles active my-fast
+  $ assistant inference profiles delete my-fast`,
+      subcommands: [
+        {
+          name: "list",
+          description: "List the effective profile catalog",
+          options: [
+            {
+              flags: "--json",
+              description: "Output as machine-readable JSON",
+            },
+          ],
+        },
+        {
+          name: "get",
+          args: "<name>",
+          description: "Show a single effective profile",
+          options: [
+            {
+              flags: "--json",
+              description: "Output as machine-readable JSON",
+            },
+          ],
+        },
+        {
+          name: "create",
+          args: "<name>",
+          description: "Create a validated custom profile",
+          options: profileWriteOptions,
+        },
+        {
+          name: "update",
+          args: "<name>",
+          description: "Partially update a custom profile",
+          options: profileWriteOptions,
+        },
+        {
+          name: "delete",
+          args: "<name>",
+          description: "Delete a custom profile",
+          options: [
+            {
+              flags: "--json",
+              description: "Output as machine-readable JSON",
+            },
+          ],
+        },
+        {
+          name: "active",
+          args: "[name]",
+          description: "Read or set the active (chat) profile",
+          options: [
+            {
+              flags: "--json",
+              description: "Output as machine-readable JSON",
+            },
+          ],
+          helpText: `
+With no argument, prints the active profile. With a name, sets it — the
+same deep-merge write the model picker performs.
+
+Examples:
+  $ assistant inference profiles active
+  $ assistant inference profiles active balanced`,
+        },
+      ],
+    },
+    {
+      name: "callsites",
+      description: "Inspect how each LLM call site resolves to a profile",
+      subcommands: [
+        {
+          name: "list",
+          description: "List the effective resolution for every call site",
+          options: [
+            {
+              flags: "--json",
+              description: "Output as machine-readable JSON",
+            },
+          ],
+        },
+        {
+          name: "get",
+          args: "<site>",
+          description: "Show the resolution detail and chain for one call site",
+          options: [
+            {
+              flags: "--json",
+              description: "Output as machine-readable JSON",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+/** Declarative help for the `assistant llm` alias (exposes only `send`). */
+export const llmHelp: CliCommandHelp = {
+  name: "llm",
+  description: "LLM inference operations (alias for 'inference send')",
+  helpText: `
+The llm command group is a shorthand for 'assistant inference send'. It sends
+requests to your configured LLM provider, resolved from your assistant config
+(llm.default.provider). For profile session management, use 'assistant inference session'.
+
+Examples:
+  $ assistant llm send "What is the capital of France?"
+  $ echo "Explain quantum computing" | assistant llm send
+  $ assistant llm send --system-prompt "Be concise" "What is TCP?"
+  $ assistant llm send --model claude-sonnet-4-20250514 --json "Hello"
+  $ assistant llm send --profile balanced "Explain RFC 1149"`,
+  subcommands: [sendSubcommandHelp],
+};

--- a/assistant/src/cli/commands/inference.ts
+++ b/assistant/src/cli/commands/inference.ts
@@ -13,8 +13,10 @@ import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import { readStdinSync } from "../../util/read-stdin.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { inferenceHelp, llmHelp } from "./inference.help.js";
 import { attachCallsitesSubcommand } from "./inference-callsites.js";
 import { attachModelsSubcommand } from "./inference-models.js";
 import { attachProfilesSubcommand } from "./inference-profiles.js";
@@ -83,143 +85,109 @@ function writeCliError(message: string, jsonOutput?: boolean): void {
 // ── Send subcommand ──────────────────────────────────────────────────
 
 /**
- * Attach the `send` subcommand to the given command group (`inference` or
- * `llm`). Both groups share the same implementation.
+ * Attach the `send` subcommand's action to the given command group
+ * (`inference` or `llm`). Both groups share the same implementation.
  */
 function attachSendSubcommand(group: Command): void {
-  group
-    .command("send")
-    .description("Send a message to the configured LLM and print the response")
-    .option("--system-prompt <text>", "System prompt for the model")
-    .option("--model <model-id>", "Model override")
-    .option(
-      "--profile <name>",
-      "Apply a named inference profile from llm.profiles for this single call",
-    )
-    .option("--max-tokens <n>", "Max response tokens", undefined)
-    .option(
-      "--timeout-seconds <seconds>",
-      "Maximum time to wait for the inference response",
-      undefined,
-    )
-    .option("--json", "Output structured JSON")
-    .argument("[message...]", "User message (joined with spaces)")
-    .addHelpText(
-      "after",
-      `
-Behavioral notes:
-  - If no message argument is provided, reads from stdin.
-  - If --model is omitted, uses the configured default model.
-  - --profile applies a named profile from llm.profiles for this single call
-    only. It does NOT open a session — to pin a profile to a conversation,
-    use 'assistant inference profile open <name>'.
-  - --profile layers below --model: --model still wins on the model field.
-  - Long-running requests wait up to 32 minutes by default. Use
-    --timeout-seconds to adjust the wait budget for this call.
-  - Requires a configured LLM provider (see 'assistant config set').
-
-Examples:
-  $ assistant inference send "What is 2+2?"
-  $ echo "Summarize this" | assistant inference send
-  $ assistant llm send --system-prompt "You are a poet" "Write a haiku"
-  $ assistant inference send --timeout-seconds 300 "Draft a long memo"
-  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"
-  $ assistant inference send --profile balanced "Explain RFC 1149"`,
-    )
-    .action(
-      async (
-        messageParts: string[],
-        opts: {
-          systemPrompt?: string;
-          model?: string;
-          profile?: string;
-          maxTokens?: string;
-          timeoutSeconds?: string;
-          json?: boolean;
-        },
-      ) => {
-        const { systemPrompt, model, profile, json: jsonOutput } = opts;
-        const parsedMaxTokens = parsePositiveIntegerOption(
-          opts.maxTokens,
-          "--max-tokens",
-        );
-        const parsedTimeoutSeconds = parsePositiveIntegerOption(
-          opts.timeoutSeconds,
-          "--timeout-seconds",
-          { max: MAX_INFERENCE_TIMEOUT_SECONDS },
-        );
-
-        if (!parsedMaxTokens.ok) {
-          writeCliError(parsedMaxTokens.error, jsonOutput);
-          return;
-        }
-
-        if (!parsedTimeoutSeconds.ok) {
-          writeCliError(parsedTimeoutSeconds.error, jsonOutput);
-          return;
-        }
-
-        const maxTokens = parsedMaxTokens.value;
-        const timeoutMs =
-          parsedTimeoutSeconds.value !== undefined
-            ? parsedTimeoutSeconds.value * 1000
-            : DEFAULT_INFERENCE_IPC_TIMEOUT_MS;
-
-        // Determine user message: positional args or stdin.
-        let messageText = messageParts.length > 0 ? messageParts.join(" ") : "";
-
-        if (!messageText && !process.stdin.isTTY) {
-          try {
-            messageText = readStdinSync().trim();
-          } catch {
-            // stdin not available or empty
-          }
-        }
-
-        if (!messageText) {
-          const msg =
-            "No message provided. Pass a message as an argument or pipe via stdin.";
-          writeCliError(msg, jsonOutput);
-          return;
-        }
-
-        // Build IPC body
-        const body: Record<string, unknown> = { message: messageText };
-        if (systemPrompt) body.systemPrompt = systemPrompt;
-        if (model) body.model = model;
-        if (profile) body.profile = profile;
-        if (maxTokens) body.maxTokens = maxTokens;
-
-        const ipcResult = await cliIpcCall<InferenceSendResult>(
-          "inference_send",
-          { body },
-          { timeoutMs },
-        );
-
-        if (!ipcResult.ok) {
-          writeCliError(
-            ipcResult.error ?? "Unknown error occurred",
-            jsonOutput,
-          );
-          return;
-        }
-
-        const result = ipcResult.result!;
-
-        if (jsonOutput) {
-          process.stdout.write(
-            JSON.stringify({
-              ok: true,
-              response: result.response,
-              model: result.model,
-              usage: result.usage,
-            }) + "\n",
-          );
-        } else {
-          process.stdout.write(result.response + "\n");
-        }
+  subcommand(group, "send").action(
+    async (
+      messageParts: string[],
+      opts: {
+        systemPrompt?: string;
+        model?: string;
+        profile?: string;
+        maxTokens?: string;
+        timeoutSeconds?: string;
+        json?: boolean;
       },
-    );
+    ) => {
+      const { systemPrompt, model, profile, json: jsonOutput } = opts;
+      const parsedMaxTokens = parsePositiveIntegerOption(
+        opts.maxTokens,
+        "--max-tokens",
+      );
+      const parsedTimeoutSeconds = parsePositiveIntegerOption(
+        opts.timeoutSeconds,
+        "--timeout-seconds",
+        { max: MAX_INFERENCE_TIMEOUT_SECONDS },
+      );
+
+      if (!parsedMaxTokens.ok) {
+        writeCliError(parsedMaxTokens.error, jsonOutput);
+        return;
+      }
+
+      if (!parsedTimeoutSeconds.ok) {
+        writeCliError(parsedTimeoutSeconds.error, jsonOutput);
+        return;
+      }
+
+      const maxTokens = parsedMaxTokens.value;
+      const timeoutMs =
+        parsedTimeoutSeconds.value !== undefined
+          ? parsedTimeoutSeconds.value * 1000
+          : DEFAULT_INFERENCE_IPC_TIMEOUT_MS;
+
+      // Determine user message: positional args or stdin.
+      let messageText = messageParts.length > 0 ? messageParts.join(" ") : "";
+
+      if (!messageText && !process.stdin.isTTY) {
+        try {
+          messageText = readStdinSync().trim();
+        } catch {
+          // stdin not available or empty
+        }
+      }
+
+      if (!messageText) {
+        const msg =
+          "No message provided. Pass a message as an argument or pipe via stdin.";
+        writeCliError(msg, jsonOutput);
+        return;
+      }
+
+      // Build IPC body
+      const body: Record<string, unknown> = { message: messageText };
+      if (systemPrompt) {
+        body.systemPrompt = systemPrompt;
+      }
+      if (model) {
+        body.model = model;
+      }
+      if (profile) {
+        body.profile = profile;
+      }
+      if (maxTokens) {
+        body.maxTokens = maxTokens;
+      }
+
+      const ipcResult = await cliIpcCall<InferenceSendResult>(
+        "inference_send",
+        { body },
+        { timeoutMs },
+      );
+
+      if (!ipcResult.ok) {
+        writeCliError(ipcResult.error ?? "Unknown error occurred", jsonOutput);
+        return;
+      }
+
+      const result = ipcResult.result!;
+
+      if (jsonOutput) {
+        process.stdout.write(
+          JSON.stringify({
+            ok: true,
+            response: result.response,
+            model: result.model,
+            usage: result.usage,
+          }) + "\n",
+        );
+      } else {
+        process.stdout.write(result.response + "\n");
+      }
+    },
+  );
 }
 
 // ── Registration ─────────────────────────────────────────────────────
@@ -230,23 +198,11 @@ Examples:
  */
 export function registerInferenceCommand(program: Command): void {
   registerCommand(program, {
-    name: "inference",
+    name: inferenceHelp.name,
     transport: "ipc",
-    description: "LLM inference operations",
+    description: inferenceHelp.description,
     build: (inference) => {
-      inference.addHelpText(
-        "after",
-        `
-The inference command group sends requests to your configured LLM provider.
-The provider is resolved from your assistant config (llm.default.provider).
-
-Examples:
-  $ assistant inference send "What is the capital of France?"
-  $ echo "Explain quantum computing" | assistant inference send
-  $ assistant llm send --system-prompt "Be concise" "What is TCP?"
-  $ assistant inference send --model claude-sonnet-4-20250514 --json "Hello"
-  $ assistant inference send --profile balanced "Explain RFC 1149"`,
-      );
+      applyCommandHelp(inference, inferenceHelp);
 
       attachSendSubcommand(inference);
       attachSessionSubcommand(inference);
@@ -257,24 +213,7 @@ Examples:
     },
   });
 
-  const llm = program
-    .command("llm")
-    .description("LLM inference operations (alias for 'inference send')");
-
-  llm.addHelpText(
-    "after",
-    `
-The llm command group is a shorthand for 'assistant inference send'. It sends
-requests to your configured LLM provider, resolved from your assistant config
-(llm.default.provider). For profile session management, use 'assistant inference session'.
-
-Examples:
-  $ assistant llm send "What is the capital of France?"
-  $ echo "Explain quantum computing" | assistant llm send
-  $ assistant llm send --system-prompt "Be concise" "What is TCP?"
-  $ assistant llm send --model claude-sonnet-4-20250514 --json "Hello"
-  $ assistant llm send --profile balanced "Explain RFC 1149"`,
-  );
-
+  const llm = program.command(llmHelp.name).description(llmHelp.description);
+  applyCommandHelp(llm, llmHelp);
   attachSendSubcommand(llm);
 }

--- a/assistant/src/cli/commands/keys.help.ts
+++ b/assistant/src/cli/commands/keys.help.ts
@@ -1,0 +1,46 @@
+/** Declarative help for the `assistant keys` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const keysHelp: CliCommandHelp = {
+  name: "keys",
+  description: "Manage API keys in secure storage",
+  subcommands: [
+    {
+      name: "list",
+      description: "List all stored API key names",
+    },
+    {
+      name: "set",
+      args: "<provider> <key>",
+      description:
+        "Store an API key (e.g. assistant keys set anthropic sk-ant-...)",
+      helpText: `
+Arguments:
+  provider   Provider name (e.g. anthropic, openai, gemini)
+  key        The API key value to store
+
+If a key already exists for the given provider, it is silently overwritten.
+
+Examples:
+  $ assistant keys set anthropic sk-ant-abc123
+  $ assistant keys set openai sk-proj-xyz789
+  $ assistant keys set fireworks fw-abc123`,
+    },
+    {
+      name: "delete",
+      args: "<provider>",
+      description: "Delete a stored API key",
+      helpText: `
+Arguments:
+  provider   Provider name whose key should be removed from secure storage
+
+Removes the API key for the given provider from secure local storage. If
+no key exists for the provider, exits with an error.
+
+Examples:
+  $ assistant keys delete openai
+  $ assistant keys delete anthropic`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/keys.ts
+++ b/assistant/src/cli/commands/keys.ts
@@ -2,8 +2,10 @@ import { createRequire } from "node:module";
 
 import type { Command } from "commander";
 
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { keysHelp } from "./keys.help.js";
 
 const loadModule = createRequire(import.meta.url);
 
@@ -21,10 +23,15 @@ function apiKeyProviders(): readonly string[] {
 
 export function registerKeysCommand(program: Command): void {
   registerCommand(program, {
-    name: "keys",
+    name: keysHelp.name,
     transport: "local",
-    description: "Manage API keys in secure storage",
+    description: keysHelp.description,
     build: (keys) => {
+      applyCommandHelp(keys, keysHelp);
+
+      // These help texts interpolate the lazily-loaded provider catalog at
+      // render time, so they stay imperative here rather than in the
+      // declarative help module.
       keys.addHelpText(
         "after",
         () => `
@@ -39,9 +46,7 @@ Examples:
   $ assistant keys delete openai`,
       );
 
-      keys
-        .command("list")
-        .description("List all stored API key names")
+      subcommand(keys, "list")
         .addHelpText(
           "after",
           () => `
@@ -75,73 +80,34 @@ Examples:
           }
         });
 
-      keys
-        .command("set <provider> <key>")
-        .description(
-          "Store an API key (e.g. assistant keys set anthropic sk-ant-...)",
-        )
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  provider   Provider name (e.g. anthropic, openai, gemini)
-  key        The API key value to store
+      subcommand(keys, "set").action(async (provider: string, key: string) => {
+        const { setSecureKeyViaDaemon } =
+          await import("../lib/daemon-credential-client.js");
+        const setResult = await setSecureKeyViaDaemon("api_key", provider, key);
+        if (setResult.ok) {
+          log.info(`Stored API key for "${provider}"`);
+        } else {
+          const detail = setResult.error ? `: ${setResult.error}` : "";
+          log.error(`Failed to store API key for "${provider}"${detail}`);
+          process.exit(1);
+        }
+      });
 
-If a key already exists for the given provider, it is silently overwritten.
-
-Examples:
-  $ assistant keys set anthropic sk-ant-abc123
-  $ assistant keys set openai sk-proj-xyz789
-  $ assistant keys set fireworks fw-abc123`,
-        )
-        .action(async (provider: string, key: string) => {
-          const { setSecureKeyViaDaemon } =
-            await import("../lib/daemon-credential-client.js");
-          const setResult = await setSecureKeyViaDaemon(
-            "api_key",
-            provider,
-            key,
-          );
-          if (setResult.ok) {
-            log.info(`Stored API key for "${provider}"`);
-          } else {
-            const detail = setResult.error ? `: ${setResult.error}` : "";
-            log.error(`Failed to store API key for "${provider}"${detail}`);
-            process.exit(1);
-          }
-        });
-
-      keys
-        .command("delete <provider>")
-        .description("Delete a stored API key")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  provider   Provider name whose key should be removed from secure storage
-
-Removes the API key for the given provider from secure local storage. If
-no key exists for the provider, exits with an error.
-
-Examples:
-  $ assistant keys delete openai
-  $ assistant keys delete anthropic`,
-        )
-        .action(async (provider: string) => {
-          const { deleteSecureKeyViaDaemon } =
-            await import("../lib/daemon-credential-client.js");
-          const delResult = await deleteSecureKeyViaDaemon("api_key", provider);
-          if (delResult.result === "deleted") {
-            log.info(`Deleted API key for "${provider}"`);
-          } else if (delResult.result === "error") {
-            const detail = delResult.error ? `: ${delResult.error}` : "";
-            log.error(`Failed to delete API key for "${provider}"${detail}`);
-            process.exit(1);
-          } else {
-            log.error(`No API key found for "${provider}"`);
-            process.exit(1);
-          }
-        });
+      subcommand(keys, "delete").action(async (provider: string) => {
+        const { deleteSecureKeyViaDaemon } =
+          await import("../lib/daemon-credential-client.js");
+        const delResult = await deleteSecureKeyViaDaemon("api_key", provider);
+        if (delResult.result === "deleted") {
+          log.info(`Deleted API key for "${provider}"`);
+        } else if (delResult.result === "error") {
+          const detail = delResult.error ? `: ${delResult.error}` : "";
+          log.error(`Failed to delete API key for "${provider}"${detail}`);
+          process.exit(1);
+        } else {
+          log.error(`No API key found for "${provider}"`);
+          process.exit(1);
+        }
+      });
     },
   });
 }

--- a/assistant/src/cli/commands/mcp.help.ts
+++ b/assistant/src/cli/commands/mcp.help.ts
@@ -1,0 +1,167 @@
+/** Declarative help for the `assistant mcp` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const mcpHelp: CliCommandHelp = {
+  name: "mcp",
+  description: "Manage MCP (Model Context Protocol) servers",
+  helpText: `
+MCP servers extend the assistant's capabilities with external tools. Servers
+are configured in the assistant's config.json under the mcp.servers key. Each
+server uses one of three transport types:
+
+  stdio             Local process communicating over stdin/stdout
+  sse               Remote server using Server-Sent Events
+  streamable-http   Remote server using Streamable HTTP transport
+
+MCP server configuration changes are detected automatically by the running
+assistant. You can also run 'vellum mcp reload' to trigger a manual reload.
+
+Examples:
+  $ assistant mcp list
+  $ assistant mcp add my-server -t stdio -c npx -a my-mcp-server
+  $ assistant mcp auth my-server
+  $ assistant mcp remove my-server`,
+  subcommands: [
+    {
+      name: "list",
+      description: "List configured MCP servers and their status",
+      options: [{ flags: "--json", description: "Output as JSON" }],
+      helpText: `
+Shows each configured MCP server with its current status and configuration:
+
+  Name         The server identifier used in config.json
+  Status       Health check result:
+                 ✓  Connected and responding
+                 ✗  Error or disabled
+                 !  Needs authentication (OAuth required)
+  Transport    stdio, sse, or streamable-http
+  URL/Command  The server URL (sse/streamable-http) or command (stdio)
+  Risk         Default risk level: low, medium, or high
+  Allowed      Tool allowlist filter (if configured)
+  Blocked      Tool blocklist filter (if configured)
+
+Health checks run on the daemon side. With --json, outputs the raw server
+list including health status.
+
+Examples:
+  $ assistant mcp list
+  $ assistant mcp list --json`,
+    },
+    {
+      name: "reload",
+      description: "Reload MCP server connections in the running assistant",
+      helpText: `
+Signals the running assistant to disconnect and reconnect all MCP servers
+using the current configuration from disk. Active sessions pick up new tools
+on their next turn automatically. The assistant must be running.
+
+Examples:
+  $ vellum mcp reload
+  $ vellum mcp reload   # after editing config.json to add a new server
+  $ vellum mcp reload   # after running "vellum mcp auth <server>"`,
+    },
+    {
+      // NOTE: the repeatable `-H, --header` collector option and the trailing
+      // `--disabled` are registered imperatively in `mcp.ts` (array-accumulating
+      // parser functions are not expressible as plain help data).
+      name: "add",
+      args: "<name>",
+      description: "Add an MCP server configuration",
+      options: [
+        {
+          flags: "-t, --transport-type <type>",
+          description: "Transport type: stdio, sse, or streamable-http",
+          required: true,
+        },
+        {
+          flags: "-u, --url <url>",
+          description: "Server URL (for sse/streamable-http)",
+        },
+        {
+          flags: "-c, --command <cmd>",
+          description: "Command to run (for stdio)",
+        },
+        {
+          flags: "-a, --args <args...>",
+          description: "Command arguments (for stdio)",
+        },
+        {
+          flags: "-r, --risk <level>",
+          description: "Default risk level: low, medium, or high",
+          defaultValue: "high",
+        },
+      ],
+      helpText: `
+Arguments:
+  name   Unique identifier for the server (used as the key in config.json)
+
+Transport-specific requirements:
+  stdio             Requires --command (and optional --args for arguments)
+  sse               Requires --url pointing to the SSE endpoint
+  streamable-http   Requires --url pointing to the HTTP endpoint
+
+The --risk flag sets the default risk level for all tools from this server
+(defaults to "high" if not specified). The server starts enabled unless
+--disabled is passed.
+
+The --header (-H) flag adds custom HTTP headers to sse/streamable-http
+transports. Use it for Bearer Token or API Key authentication. The flag
+is repeatable — pass multiple -H flags for multiple headers.
+
+If a server with the same name already exists, the command fails. Remove the
+existing server first with "assistant mcp remove <name>".
+
+Examples:
+  $ assistant mcp add my-server -t stdio -c npx -a my-mcp-server
+  $ assistant mcp add remote-api -t streamable-http -u https://api.example.com/mcp -r medium
+  $ assistant mcp add legacy-sse -t sse -u https://old.example.com/events --disabled
+  $ assistant mcp add authed-api -t sse -u https://api.example.com/mcp -H 'Authorization: Bearer tok123'
+  $ assistant mcp add apikey-srv -t streamable-http -u https://srv.example.com/mcp -H 'X-API-Key: sk_live_abc'`,
+    },
+    {
+      name: "auth",
+      args: "<name>",
+      description: "Authenticate with an MCP server via OAuth",
+      helpText: `
+Arguments:
+  name   Name of a configured MCP server to authenticate with
+
+Only works with sse or streamable-http transports (stdio servers do not use
+OAuth). Opens a browser for OAuth authorization with the remote server. The
+running assistant handles the OAuth callback and token exchange.
+
+The command waits up to 2.5 minutes for the user to complete the browser-based
+OAuth flow. If the server already has valid cached tokens, the command succeeds
+immediately without opening a browser. Tokens are cached locally for future use
+by the assistant.
+
+After successful authentication, the running assistant detects the change
+automatically. You can also run 'vellum mcp reload' to apply immediately.
+
+Examples:
+  $ assistant mcp auth my-server
+  $ assistant mcp auth remote-api`,
+    },
+    {
+      name: "remove",
+      args: "<name>",
+      description: "Remove an MCP server configuration",
+      helpText: `
+Arguments:
+  name   Name of the MCP server to remove
+
+Removes the server entry from config.json and performs best-effort cleanup of
+any stored OAuth credentials (tokens, client info, discovery metadata) for
+sse/streamable-http servers. If no OAuth credentials exist, the cleanup is
+silently skipped.
+
+After removal, the running assistant detects the change automatically. You
+can also run 'vellum mcp reload' to apply immediately.
+
+Examples:
+  $ assistant mcp remove my-server
+  $ assistant mcp remove legacy-sse`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/mcp.ts
+++ b/assistant/src/cli/commands/mcp.ts
@@ -1,9 +1,11 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { openInHostBrowser } from "../lib/open-browser.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { mcpHelp } from "./mcp.help.js";
 
 // ---------------------------------------------------------------------------
 // Shared types for IPC responses
@@ -105,138 +107,67 @@ function printServerEntry(entry: McpServerEntry): void {
 
 export function registerMcpCommand(program: Command): void {
   registerCommand(program, {
-    name: "mcp",
+    name: mcpHelp.name,
     transport: "ipc",
-    description: "Manage MCP (Model Context Protocol) servers",
+    description: mcpHelp.description,
     build: (mcp) => {
-      mcp.addHelpText(
-        "after",
-        `
-MCP servers extend the assistant's capabilities with external tools. Servers
-are configured in the assistant's config.json under the mcp.servers key. Each
-server uses one of three transport types:
+      applyCommandHelp(mcp, mcpHelp);
 
-  stdio             Local process communicating over stdin/stdout
-  sse               Remote server using Server-Sent Events
-  streamable-http   Remote server using Streamable HTTP transport
+      subcommand(mcp, "list").action(async (opts: { json?: boolean }) => {
+        const result = await cliIpcCall<{ servers: McpServerEntry[] }>(
+          "internal_mcp_list",
+        );
 
-MCP server configuration changes are detected automatically by the running
-assistant. You can also run 'vellum mcp reload' to trigger a manual reload.
+        if (!result.ok) {
+          return exitFromIpcResult({
+            ok: false,
+            error: result.error,
+            statusCode: result.statusCode,
+          });
+        }
 
-Examples:
-  $ assistant mcp list
-  $ assistant mcp add my-server -t stdio -c npx -a my-mcp-server
-  $ assistant mcp auth my-server
-  $ assistant mcp remove my-server`,
-      );
+        const servers = result.result?.servers ?? [];
 
-      mcp
-        .command("list")
-        .description("List configured MCP servers and their status")
-        .option("--json", "Output as JSON")
-        .addHelpText(
-          "after",
-          `
-Shows each configured MCP server with its current status and configuration:
-
-  Name         The server identifier used in config.json
-  Status       Health check result:
-                 ✓  Connected and responding
-                 ✗  Error or disabled
-                 !  Needs authentication (OAuth required)
-  Transport    stdio, sse, or streamable-http
-  URL/Command  The server URL (sse/streamable-http) or command (stdio)
-  Risk         Default risk level: low, medium, or high
-  Allowed      Tool allowlist filter (if configured)
-  Blocked      Tool blocklist filter (if configured)
-
-Health checks run on the daemon side. With --json, outputs the raw server
-list including health status.
-
-Examples:
-  $ assistant mcp list
-  $ assistant mcp list --json`,
-        )
-        .action(async (opts: { json?: boolean }) => {
-          const result = await cliIpcCall<{ servers: McpServerEntry[] }>(
-            "internal_mcp_list",
-          );
-
-          if (!result.ok) {
-            return exitFromIpcResult({
-              ok: false,
-              error: result.error,
-              statusCode: result.statusCode,
-            });
-          }
-
-          const servers = result.result?.servers ?? [];
-
-          if (servers.length === 0) {
-            if (opts.json) {
-              process.stdout.write(JSON.stringify([], null, 2) + "\n");
-            } else {
-              log.info("No MCP servers configured.");
-            }
-            return;
-          }
-
+        if (servers.length === 0) {
           if (opts.json) {
-            process.stdout.write(JSON.stringify(servers, null, 2) + "\n");
-            return;
-          }
-
-          log.info(`${servers.length} MCP server(s) configured:\n`);
-
-          for (const entry of servers) {
-            printServerEntry(entry);
-          }
-        });
-
-      mcp
-        .command("reload")
-        .description("Reload MCP server connections in the running assistant")
-        .addHelpText(
-          "after",
-          `
-Signals the running assistant to disconnect and reconnect all MCP servers
-using the current configuration from disk. Active sessions pick up new tools
-on their next turn automatically. The assistant must be running.
-
-Examples:
-  $ vellum mcp reload
-  $ vellum mcp reload   # after editing config.json to add a new server
-  $ vellum mcp reload   # after running "vellum mcp auth <server>"`,
-        )
-        .action(async () => {
-          const result = await cliIpcCall("internal_mcp_reload", { body: {} });
-          if (!result.ok) {
-            log.warn(
-              `Could not signal reload: ${result.error}. ` +
-                `Run 'assistant mcp reload' once the assistant is up.`,
-            );
+            process.stdout.write(JSON.stringify([], null, 2) + "\n");
           } else {
-            log.info(
-              "MCP reload signal sent. The running assistant will reconnect servers shortly.",
-            );
+            log.info("No MCP servers configured.");
           }
-        });
+          return;
+        }
 
-      mcp
-        .command("add <name>")
-        .description("Add an MCP server configuration")
-        .requiredOption(
-          "-t, --transport-type <type>",
-          "Transport type: stdio, sse, or streamable-http",
-        )
-        .option("-u, --url <url>", "Server URL (for sse/streamable-http)")
-        .option("-c, --command <cmd>", "Command to run (for stdio)")
-        .option("-a, --args <args...>", "Command arguments (for stdio)")
-        .option(
-          "-r, --risk <level>",
-          "Default risk level: low, medium, or high",
-          "high",
-        )
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(servers, null, 2) + "\n");
+          return;
+        }
+
+        log.info(`${servers.length} MCP server(s) configured:\n`);
+
+        for (const entry of servers) {
+          printServerEntry(entry);
+        }
+      });
+
+      subcommand(mcp, "reload").action(async () => {
+        const result = await cliIpcCall("internal_mcp_reload", { body: {} });
+        if (!result.ok) {
+          log.warn(
+            `Could not signal reload: ${result.error}. ` +
+              `Run 'assistant mcp reload' once the assistant is up.`,
+          );
+        } else {
+          log.info(
+            "MCP reload signal sent. The running assistant will reconnect servers shortly.",
+          );
+        }
+      });
+
+      // `-H, --header` uses an array-accumulating collector, which the
+      // declarative help contract cannot express — it is registered
+      // imperatively here (with the trailing `--disabled` after it,
+      // preserving option order).
+      subcommand(mcp, "add")
         .option(
           "-H, --header <key:value>",
           "Custom HTTP header (repeatable, for sse/streamable-http). E.g. -H 'Authorization: Bearer tok123'",
@@ -247,35 +178,6 @@ Examples:
           [] as string[],
         )
         .option("--disabled", "Add as disabled")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  name   Unique identifier for the server (used as the key in config.json)
-
-Transport-specific requirements:
-  stdio             Requires --command (and optional --args for arguments)
-  sse               Requires --url pointing to the SSE endpoint
-  streamable-http   Requires --url pointing to the HTTP endpoint
-
-The --risk flag sets the default risk level for all tools from this server
-(defaults to "high" if not specified). The server starts enabled unless
---disabled is passed.
-
-The --header (-H) flag adds custom HTTP headers to sse/streamable-http
-transports. Use it for Bearer Token or API Key authentication. The flag
-is repeatable — pass multiple -H flags for multiple headers.
-
-If a server with the same name already exists, the command fails. Remove the
-existing server first with "assistant mcp remove <name>".
-
-Examples:
-  $ assistant mcp add my-server -t stdio -c npx -a my-mcp-server
-  $ assistant mcp add remote-api -t streamable-http -u https://api.example.com/mcp -r medium
-  $ assistant mcp add legacy-sse -t sse -u https://old.example.com/events --disabled
-  $ assistant mcp add authed-api -t sse -u https://api.example.com/mcp -H 'Authorization: Bearer tok123'
-  $ assistant mcp add apikey-srv -t streamable-http -u https://srv.example.com/mcp -H 'X-API-Key: sk_live_abc'`,
-        )
         .action(
           async (
             name: string,
@@ -334,136 +236,90 @@ Examples:
           },
         );
 
-      mcp
-        .command("auth <name>")
-        .description("Authenticate with an MCP server via OAuth")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  name   Name of a configured MCP server to authenticate with
+      subcommand(mcp, "auth").action(async (name: string) => {
+        // IPC-first path — attempt daemon-orchestrated flow (works on hosted assistants)
+        const startResult = await cliIpcCall<{
+          auth_url: string;
+          state: string;
+          already_authenticated?: boolean;
+        }>("internal_mcp_auth_start", { body: { serverId: name } });
 
-Only works with sse or streamable-http transports (stdio servers do not use
-OAuth). Opens a browser for OAuth authorization with the remote server. The
-running assistant handles the OAuth callback and token exchange.
+        if (startResult.ok && startResult.result?.already_authenticated) {
+          log.info(`Server "${name}" is already authenticated.`);
+          process.exit(0);
+          return;
+        }
 
-The command waits up to 2.5 minutes for the user to complete the browser-based
-OAuth flow. If the server already has valid cached tokens, the command succeeds
-immediately without opening a browser. Tokens are cached locally for future use
-by the assistant.
+        if (startResult.ok && startResult.result?.auth_url) {
+          const authUrl = startResult.result.auth_url;
+          log.info(`Opening browser for "${name}" OAuth authorization...`);
+          openInHostBrowser(authUrl);
+          log.info(`If the browser did not open, visit:\n${authUrl}`);
+          log.info(
+            "Waiting for authorization in browser... (press Ctrl+C to cancel)",
+          );
 
-After successful authentication, the running assistant detects the change
-automatically. You can also run 'vellum mcp reload' to apply immediately.
+          const finalStatus = await pollMcpAuthStatus(name, {
+            intervalMs: 2_000,
+            timeoutMs: 150_000, // matches existing OAUTH_TIMEOUT_MS
+          });
 
-Examples:
-  $ assistant mcp auth my-server
-  $ assistant mcp auth remote-api`,
-        )
-        .action(async (name: string) => {
-          // IPC-first path — attempt daemon-orchestrated flow (works on hosted assistants)
-          const startResult = await cliIpcCall<{
-            auth_url: string;
-            state: string;
-            already_authenticated?: boolean;
-          }>("internal_mcp_auth_start", { body: { serverId: name } });
-
-          if (startResult.ok && startResult.result?.already_authenticated) {
-            log.info(`Server "${name}" is already authenticated.`);
+          if (finalStatus.status === "complete") {
+            log.info(`Authentication successful for "${name}".`);
+            log.info(
+              "The running assistant has picked up this change automatically.",
+            );
             process.exit(0);
             return;
           }
 
-          if (startResult.ok && startResult.result?.auth_url) {
-            const authUrl = startResult.result.auth_url;
-            log.info(`Opening browser for "${name}" OAuth authorization...`);
-            openInHostBrowser(authUrl);
-            log.info(`If the browser did not open, visit:\n${authUrl}`);
-            log.info(
-              "Waiting for authorization in browser... (press Ctrl+C to cancel)",
-            );
-
-            const finalStatus = await pollMcpAuthStatus(name, {
-              intervalMs: 2_000,
-              timeoutMs: 150_000, // matches existing OAUTH_TIMEOUT_MS
-            });
-
-            if (finalStatus.status === "complete") {
-              log.info(`Authentication successful for "${name}".`);
-              log.info(
-                "The running assistant has picked up this change automatically.",
-              );
-              process.exit(0);
-              return;
-            }
-
-            const errMsg = finalStatus.error ?? "Unknown error";
-            if (errMsg.includes("denied") || errMsg.includes("cancelled")) {
-              log.error(`Authorization cancelled for "${name}".`);
-            } else if (errMsg.includes("timed out")) {
-              log.error(
-                `Authorization timed out for "${name}". Try again with: assistant mcp auth ${name}`,
-              );
-            } else {
-              log.error(`OAuth failed for "${name}": ${errMsg}`);
-            }
-            process.exitCode = 1;
-            return;
-          }
-
-          // Any !startResult.ok case: surface error and exit 1
-          const ipcErrMsg = startResult.error ?? "Unknown error";
-          if (
-            ipcErrMsg.startsWith("Could not connect to assistant daemon") ||
-            ipcErrMsg.startsWith("Unknown method:")
-          ) {
+          const errMsg = finalStatus.error ?? "Unknown error";
+          if (errMsg.includes("denied") || errMsg.includes("cancelled")) {
+            log.error(`Authorization cancelled for "${name}".`);
+          } else if (errMsg.includes("timed out")) {
             log.error(
-              `MCP OAuth requires the assistant to be running. Is it running?`,
+              `Authorization timed out for "${name}". Try again with: assistant mcp auth ${name}`,
             );
           } else {
-            log.error(`MCP OAuth failed via assistant: ${ipcErrMsg}`);
+            log.error(`OAuth failed for "${name}": ${errMsg}`);
           }
           process.exitCode = 1;
-        });
+          return;
+        }
 
-      mcp
-        .command("remove <name>")
-        .description("Remove an MCP server configuration")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  name   Name of the MCP server to remove
-
-Removes the server entry from config.json and performs best-effort cleanup of
-any stored OAuth credentials (tokens, client info, discovery metadata) for
-sse/streamable-http servers. If no OAuth credentials exist, the cleanup is
-silently skipped.
-
-After removal, the running assistant detects the change automatically. You
-can also run 'vellum mcp reload' to apply immediately.
-
-Examples:
-  $ assistant mcp remove my-server
-  $ assistant mcp remove legacy-sse`,
-        )
-        .action(async (name: string) => {
-          const result = await cliIpcCall<{ removed: true }>(
-            "internal_mcp_remove",
-            { body: { name } },
+        // Any !startResult.ok case: surface error and exit 1
+        const ipcErrMsg = startResult.error ?? "Unknown error";
+        if (
+          ipcErrMsg.startsWith("Could not connect to assistant daemon") ||
+          ipcErrMsg.startsWith("Unknown method:")
+        ) {
+          log.error(
+            `MCP OAuth requires the assistant to be running. Is it running?`,
           );
+        } else {
+          log.error(`MCP OAuth failed via assistant: ${ipcErrMsg}`);
+        }
+        process.exitCode = 1;
+      });
 
-          if (!result.ok) {
-            log.error(result.error ?? `Failed to remove MCP server "${name}".`);
-            process.exitCode = 1;
-            return;
-          }
+      subcommand(mcp, "remove").action(async (name: string) => {
+        const result = await cliIpcCall<{ removed: true }>(
+          "internal_mcp_remove",
+          { body: { name } },
+        );
 
-          log.info(`Removed MCP server "${name}".`);
-          log.info(
-            "The running assistant will pick up this change automatically. " +
-              "Or run 'vellum mcp reload' to apply now.",
-          );
-        });
+        if (!result.ok) {
+          log.error(result.error ?? `Failed to remove MCP server "${name}".`);
+          process.exitCode = 1;
+          return;
+        }
+
+        log.info(`Removed MCP server "${name}".`);
+        log.info(
+          "The running assistant will pick up this change automatically. " +
+            "Or run 'vellum mcp reload' to apply now.",
+        );
+      });
     },
   });
 }

--- a/assistant/src/cli/commands/memory/__tests__/memory-items.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-items.test.ts
@@ -15,6 +15,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
+import { applyCommandHelp } from "../../../lib/cli-command-help.js";
+import { memoryHelp } from "../index.help.js";
+
 // ---------------------------------------------------------------------------
 // Mock state
 // ---------------------------------------------------------------------------
@@ -91,6 +94,7 @@ function buildProgram(): Command {
     writeOut: () => {},
   });
   const memory = program.command("memory");
+  applyCommandHelp(memory, memoryHelp);
   registerMemoryItemsCommand(memory);
   return program;
 }

--- a/assistant/src/cli/commands/memory/__tests__/memory-v2.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-v2.test.ts
@@ -15,6 +15,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
+import { applyCommandHelp } from "../../../lib/cli-command-help.js";
+import { memoryHelp } from "../index.help.js";
+
 // ---------------------------------------------------------------------------
 // Mock state
 // ---------------------------------------------------------------------------
@@ -83,6 +86,7 @@ function buildProgram(): Command {
     writeOut: () => {},
   });
   const memory = program.command("memory");
+  applyCommandHelp(memory, memoryHelp);
   registerMemoryV2Command(memory);
   return program;
 }

--- a/assistant/src/cli/commands/memory/__tests__/memory-v3.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/memory-v3.test.ts
@@ -14,6 +14,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
+import { applyCommandHelp } from "../../../lib/cli-command-help.js";
+import { memoryHelp } from "../index.help.js";
+
 // ---------------------------------------------------------------------------
 // Mock state
 // ---------------------------------------------------------------------------
@@ -83,6 +86,7 @@ function buildProgram(): Command {
     writeOut: () => {},
   });
   const memory = program.command("memory");
+  applyCommandHelp(memory, memoryHelp);
   registerMemoryV3Command(memory);
   return program;
 }

--- a/assistant/src/cli/commands/memory/__tests__/worker.test.ts
+++ b/assistant/src/cli/commands/memory/__tests__/worker.test.ts
@@ -13,6 +13,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
+import { applyCommandHelp } from "../../../lib/cli-command-help.js";
+import { memoryHelp } from "../index.help.js";
+
 // ---------------------------------------------------------------------------
 // Mock state
 // ---------------------------------------------------------------------------
@@ -68,6 +71,7 @@ function buildProgram(): Command {
   program.exitOverride();
   program.configureOutput({ writeErr: () => {}, writeOut: () => {} });
   const memory = program.command("memory");
+  applyCommandHelp(memory, memoryHelp);
   registerMemoryWorkerCommand(memory);
   return program;
 }

--- a/assistant/src/cli/commands/memory/index.help.ts
+++ b/assistant/src/cli/commands/memory/index.help.ts
@@ -1,0 +1,817 @@
+/** Declarative help for the `assistant memory` command. */
+
+import type { CliCommandHelp } from "../../lib/cli-command-help.js";
+
+/**
+ * Memory kinds accepted by the daemon's memory-item routes. Mirrored here
+ * for help text only — the route validates and rejects unknown kinds.
+ */
+export const MEMORY_KINDS =
+  "episodic, semantic, procedural, emotional, prospective, behavioral, narrative, shared";
+
+export const memoryHelp: CliCommandHelp = {
+  name: "memory",
+  description:
+    "Manage memory items and maintain the assistant memory subsystem",
+  helpText: `
+The 'nodes' subgroup provides content-based list, delete, and update over
+memory v2 graph nodes — address facts by text, not UUID (requires memory v2).
+
+The 'items' subgroup exposes full CRUD over individual memory items
+(remembered facts) — list, get, create, update, delete.
+
+The memory subsystem retrieves concept pages two ways: the v2 concept-page
+activation model (prose pages with directed edges) and the v3 section-lane
+model (section-grain lanes cached as live shadow state). Each subgroup exposes
+operator-facing maintenance verbs — reindexing, backfills, validation, and evals.
+
+Examples:
+  $ assistant memory nodes list --search "coffee"
+  $ assistant memory nodes delete "User prefers TypeScript"
+  $ assistant memory nodes update "User prefers TypeScript" "User prefers TypeScript and Bun"
+  $ assistant memory items list --search "coffee"
+  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --statement "Prefers tea"
+  $ assistant memory items delete 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant memory v2 validate
+  $ assistant memory v3 rebuild-index`,
+  subcommands: [
+    {
+      name: "nodes",
+      description:
+        "Content-based list, delete, and update of memory graph nodes",
+      helpText: `
+Memory nodes are raw graph records (content, type, fidelity) produced by the
+memory v2 subsystem. Unlike 'memory items', which addresses nodes by UUID, these
+commands address nodes by content text — matching the way an operator refers to
+a remembered fact without first looking up its ID.
+
+All subcommands require memory v2 to be enabled and the assistant to be running.
+
+Examples:
+  $ assistant memory nodes list
+  $ assistant memory nodes list --search "TypeScript" --limit 20
+  $ assistant memory nodes delete "User prefers TypeScript"
+  $ assistant memory nodes update "User prefers TypeScript" "User prefers TypeScript and Bun"`,
+      subcommands: [
+        {
+          name: "list",
+          description: "List active memory graph nodes",
+          options: [
+            {
+              flags: "--search <query>",
+              description: "Filter nodes whose content contains <query>",
+            },
+            {
+              flags: "--limit <n>",
+              description: "Max results (default 50, max 200)",
+            },
+            {
+              flags: "--json",
+              description: "Machine-readable compact JSON output",
+            },
+          ],
+          helpText: `
+Behavior:
+  Returns active (non-deleted) memory graph nodes ordered by significance.
+  With --search, all nodes are scanned so the filter is exhaustive regardless
+  of graph size. Without --search the query is capped at --limit rows at the
+  DB level for efficiency.
+
+Examples:
+  $ assistant memory nodes list
+  $ assistant memory nodes list --search "coffee" --limit 10
+  $ assistant memory nodes list --json`,
+        },
+        {
+          name: "delete",
+          args: "<content>",
+          description: "Delete a memory node by content match",
+          options: [
+            {
+              flags: "--json",
+              description: "Machine-readable compact JSON output",
+            },
+          ],
+          helpText: `
+Arguments:
+  <content>  The text of the memory to delete. Exact match (case-insensitive)
+             takes priority; if no exact match exists, a substring match is
+             tried. Fails when 0 or more than 1 nodes match — use
+             'assistant memory nodes list --search <query>' to find exact text.
+
+Behavior:
+  Hard-deletes the graph node and removes it from the recall index. This
+  operation is permanent; use 'assistant memory nodes update' to correct
+  content instead of deleting it.
+
+Examples:
+  $ assistant memory nodes delete "User prefers TypeScript"
+  $ assistant memory nodes delete "User prefers TypeScript" --json`,
+        },
+        {
+          name: "update",
+          args: "<old-content> <new-content>",
+          description: "Update a memory node's content in place",
+          options: [
+            {
+              flags: "--json",
+              description: "Machine-readable compact JSON output",
+            },
+          ],
+          helpText: `
+Arguments:
+  <old-content>  Text of the memory to update. Exact match (case-insensitive)
+                 takes priority over substring match. Fails when 0 or more than
+                 1 nodes match.
+  <new-content>  Replacement text. Fails if another active node already has
+                 this content (prevents duplicates).
+
+Behavior:
+  Replaces the node's content and re-embeds it so recall stays consistent.
+  Use this to correct a fact rather than deleting and re-adding it — the edit
+  history is preserved on the node.
+
+Examples:
+  $ assistant memory nodes update "User prefers TypeScript" "User prefers TypeScript and Bun"
+  $ assistant memory nodes update "old fact" "corrected fact" --json`,
+        },
+      ],
+    },
+    {
+      name: "items",
+      description: "Manage individual memory items (full CRUD)",
+      helpText: `
+Memory items are individual remembered facts (graph nodes) with a kind
+(${MEMORY_KINDS}),
+a subject line, and a statement. Items are normally created by the
+assistant via the remember tool; 'items create' exists for manual seeding
+and repair.
+
+Examples:
+  $ assistant memory items list --search "coffee"
+  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --statement "Prefers tea"
+  $ assistant memory items delete 9f2c4f3a-3f1a-41e4-88e7-abc123`,
+      subcommands: [
+        {
+          name: "list",
+          description:
+            "List memory items with filtering, search, and pagination",
+          options: [
+            {
+              flags: "--kind <kind>",
+              description: `Filter by kind (${MEMORY_KINDS})`,
+            },
+            {
+              flags: "--status <status>",
+              description:
+                "Filter by status: active (default), inactive, or all",
+            },
+            {
+              flags: "--search <query>",
+              description: "Semantic/full-text search query",
+            },
+            {
+              flags: "--sort <field>",
+              description:
+                "Sort field: lastSeenAt (default), importance, kind, or firstSeenAt",
+            },
+            {
+              flags: "--order <order>",
+              description: "asc or desc (default desc)",
+            },
+            { flags: "--limit <n>", description: "Max results (default 100)" },
+            {
+              flags: "--offset <n>",
+              description: "Pagination offset (default 0)",
+            },
+            {
+              flags: "--json",
+              description: "Machine-readable compact JSON output",
+            },
+          ],
+          helpText: `
+Behavior:
+  Lists memory items (remembered facts) from the assistant's memory store.
+  With --search, results are ranked by semantic relevance when the embedding
+  backend is available, falling back to substring match otherwise. Deleted
+  items are hidden unless --status inactive or --status all is passed.
+
+Examples:
+  $ assistant memory items list
+  $ assistant memory items list --kind semantic --limit 20
+  $ assistant memory items list --search "favorite restaurants" --json`,
+        },
+        {
+          name: "get",
+          args: "<id>",
+          description: "Get a single memory item by ID",
+          options: [
+            {
+              flags: "--json",
+              description: "Machine-readable compact JSON output",
+            },
+          ],
+          helpText: `
+Arguments:
+  <id>   Memory item ID (UUID) — run 'assistant memory items list' to find it.
+
+Examples:
+  $ assistant memory items get 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant memory items get 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
+        },
+        {
+          name: "create",
+          description: "Create a new memory item",
+          options: [
+            {
+              flags: "--kind <kind>",
+              description: `Memory kind (${MEMORY_KINDS})`,
+              required: true,
+            },
+            {
+              flags: "--statement <text>",
+              description: "Statement content of the memory",
+              required: true,
+            },
+            {
+              flags: "--subject <text>",
+              description: "Subject line (defaults to the statement)",
+            },
+            {
+              flags: "--importance <n>",
+              description: "Importance score 0-1 (default 0.8)",
+            },
+            {
+              flags: "--json",
+              description: "Machine-readable compact JSON output",
+            },
+          ],
+          helpText: `
+Behavior:
+  Creates a memory graph node and enqueues its embedding so it becomes
+  recallable. Fails with a conflict error if an active item with identical
+  content already exists. Memories are normally formed by the assistant via
+  the remember tool — use this for manual seeding and repair.
+
+Examples:
+  $ assistant memory items create --kind semantic --statement "User prefers dark mode"
+  $ assistant memory items create --kind procedural --subject "Deploys" \\
+      --statement "Deploys go out Tuesdays after standup" --importance 0.9`,
+        },
+        {
+          name: "update",
+          args: "<id>",
+          description: "Update fields on an existing memory item",
+          options: [
+            {
+              flags: "--subject <text>",
+              description: "Replace the subject line",
+            },
+            {
+              flags: "--statement <text>",
+              description: "Replace the statement content",
+            },
+            {
+              flags: "--kind <kind>",
+              description: `Change the kind (${MEMORY_KINDS})`,
+            },
+            {
+              flags: "--status <status>",
+              description:
+                "Set status: active (restores a deleted item) or superseded",
+            },
+            {
+              flags: "--importance <n>",
+              description: "Set importance score 0-1",
+            },
+            {
+              flags: "--json",
+              description: "Machine-readable compact JSON output",
+            },
+          ],
+          helpText: `
+Arguments:
+  <id>   Memory item ID (UUID) — run 'assistant memory items list' to find it.
+
+Behavior:
+  Partially updates the given fields; anything not passed is left unchanged.
+  Content changes trigger re-embedding so recall stays consistent. Setting
+  --status active restores a previously deleted item; --status superseded
+  retires it (same effect as 'assistant memory items delete'). Fails with a
+  conflict error when the new content duplicates another active item.
+
+Examples:
+  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --statement "Prefers tea over coffee"
+  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --importance 0.9 --kind semantic
+  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --status active`,
+        },
+        {
+          name: "delete",
+          args: "<id>",
+          description: "Delete a memory item",
+          options: [
+            { flags: "--force", description: "Skip the confirmation prompt" },
+            {
+              flags: "--json",
+              description: "Machine-readable compact JSON output",
+            },
+          ],
+          helpText: `
+Options:
+  --force  Skip the destructive y/N confirmation prompt. Required when stdin
+           is not a TTY (e.g. in scripts and CI).
+  --json   Output the deletion result as compact JSON.
+
+Arguments:
+  <id>   Memory item ID (UUID) — run 'assistant memory items list' to find it.
+
+Behavior:
+  Soft-deletes the memory item — it stops being recalled and its embeddings
+  are removed from the index, but the underlying record is retained. A
+  deleted item can be restored with
+  'assistant memory items update <id> --status active'.
+
+Examples:
+  $ assistant memory items delete 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant memory items delete 9f2c4f3a-3f1a-41e4-88e7-abc123 --force --json`,
+        },
+      ],
+    },
+    {
+      name: "v2",
+      description: "Memory v2 subsystem operations (concept-page model)",
+      helpText: `
+The v2 memory subsystem stores prose concept pages with directed edges in
+each page's frontmatter and uses activation-based retrieval. Pages live
+under /workspace/memory/concepts/ and are gated behind the
+memory.v2.enabled config field.
+
+Mutating subcommands return a jobId enqueued on the memory job queue,
+except reembed-skills which runs synchronously inside the assistant.
+Read-only subcommands print diagnostic reports without mutating state.
+
+Examples:
+  $ assistant memory v2 validate
+  $ assistant memory v2 reembed
+  $ assistant memory v2 reembed-skills
+  $ assistant memory v2 activation`,
+      subcommands: [
+        {
+          name: "reembed",
+          description:
+            "Refresh dense + sparse vectors for every concept page in Qdrant",
+          helpText: `
+Fans out an embed_concept_page job per concept page slug (plus the four
+reserved meta-file slugs) so each page's dense and sparse vectors get
+recomputed against the current embedding backend. Useful after upgrading
+the embedding model or recovering a corrupted Qdrant collection.
+
+The fan-out runs on the background memory worker — this command returns
+once the parent job is enqueued.
+
+Examples:
+  $ assistant memory v2 reembed`,
+        },
+        {
+          name: "reembed-skills",
+          description:
+            "Re-seed v2 skill entries from the current skill catalog (synchronous)",
+          helpText: `
+Re-runs the v2 skill catalog seed against the current skill set, replacing
+both the in-process skill cache and the skill entries in the unified
+memory_v2_concept_pages Qdrant collection (under the skills/<id> slug
+prefix). Useful after editing a skill's SKILL.md, after a feature-flag flip
+changes the enabled-skill set, or to recover corrupted skill embeddings.
+
+Unlike 'reembed' (concept pages), this runs synchronously inside the
+assistant — the command returns only once the seed completes. Requires
+memory.v2.enabled to be true.
+
+Examples:
+  $ assistant memory v2 reembed-skills`,
+        },
+        {
+          name: "activation",
+          description:
+            "Refresh persisted activation state for every active conversation",
+          helpText: `
+Walks every conversation row in the activation_state table and
+recomputes the persisted state without rendering or injecting a memory
+block. Useful after tuning the activation params (d, c_user, c_assistant,
+c_now, k, hops) so subsequent retrievals reflect the new weights without
+waiting for organic per-turn updates.
+
+The job runs on the background memory worker — this command returns once
+the job is enqueued.
+
+Examples:
+  $ assistant memory v2 activation`,
+        },
+        {
+          name: "validate",
+          description:
+            "Print a diagnostic report of v2 workspace state (read-only)",
+          helpText: `
+Walks the v2 concept-page tree on disk and reports:
+  - Page count
+  - Edge count (total and unique outgoing targets)
+  - Missing outgoing edge targets (orphan edges)
+  - Oversized pages (over the per-folder size cap)
+  - Parse failures (missing or malformed frontmatter)
+
+Read-only — does not mutate the workspace. Exits non-zero if any
+violations are reported.
+
+Examples:
+  $ assistant memory v2 validate`,
+        },
+        {
+          name: "ema",
+          description:
+            "List concept pages by injection-frequency EMA score (read-only)",
+          options: [
+            {
+              flags: "-n, --limit <count>",
+              description:
+                "Maximum rows to print (default 25; ignored with --all)",
+              defaultValue: "25",
+            },
+            {
+              flags: "--all",
+              description: "Print every page, including zero-score pages",
+            },
+            {
+              flags: "--include-zeros",
+              description:
+                "Include pages with score 0 in the default-limited view",
+            },
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted table",
+            },
+          ],
+          helpText: `
+EMA score is the time-decayed sum Σ exp(-λ × (now - tᵢ)) with a 3-day
+half-life, computed from memory_v2_injection_events. A score of 1.0 means
+roughly one router selection in the last few minutes; 0.5 means a single
+selection ~3 days ago. Pages that have never been router-selected since
+EMA tracking began report 0.
+
+Examples:
+  $ assistant memory v2 ema
+  $ assistant memory v2 ema -n 100
+  $ assistant memory v2 ema --all --json | jq '.entries | length'`,
+        },
+        {
+          name: "simulate",
+          description:
+            "Dry-run the v4 router against a synthetic query (read-only)",
+          options: [
+            {
+              flags: "-q, --query <text>",
+              description: "User query to route the simulated turn against",
+              required: true,
+            },
+            {
+              flags: "--tier1-size <n>",
+              description:
+                "Override memory.v2.router.tier1_size for this run (number or 'null')",
+            },
+            {
+              flags: "--tier2-size <n>",
+              description:
+                "Override memory.v2.router.tier2_size for this run (number or 'null')",
+            },
+            {
+              flags: "--batch-size <n>",
+              description:
+                "Override memory.v2.router.batch_size for this run (number or 'null')",
+            },
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a grouped report",
+            },
+          ],
+          helpText: `
+Runs the v4 router read-only against the live page index + EMA scores, with
+optional tier/batch overrides applied on top of the live config. NO writes:
+no row is appended to memory_v2_injection_events or memory_v2_activation_logs,
+and no activation state is mutated. Use this to preview the effect of a
+config knob change before flipping it in workspace config.json.
+
+Limitations:
+  - priorEverInjected is empty (single-turn simulation; live router dedups
+    against pages already in context).
+  - NOW.md is read at simulate-time, not historical-turn time.
+  - assistantMessage is empty.
+
+Pass 'null' to an override flag to explicitly disable that tier for this run
+(e.g. --tier2-size null reverts to tier1 → tier3). Omitting an override
+inherits the live config value.
+
+Examples:
+  $ assistant memory v2 simulate -q "what should we ship next"
+  $ assistant memory v2 simulate -q "..." --tier1-size 100 --tier2-size 200 --batch-size 50
+  $ assistant memory v2 simulate -q "..." --json | jq '.selectedSlugs'`,
+        },
+        {
+          name: "compare",
+          description:
+            "Compare retrievers against the router's logged picks over a sample of real turns (read-only)",
+          // The repeatable `--conversation <id>` option (accumulator parser +
+          // array default) and the options registered after it live in
+          // memory-v2.ts — the contract cannot express parser functions or
+          // array defaults, and option order must match registration order.
+          options: [
+            {
+              flags: "--limit <n>",
+              description:
+                "How many historical turns to sample (default 20). Each re-runs the router = one LLM call.",
+            },
+            {
+              flags: "--strategy <recent|random>",
+              description:
+                "Sampling strategy over historical turns (default recent)",
+            },
+            {
+              flags: "--k <list>",
+              description:
+                "Comma-separated recall@k cutoffs (default 5,10,25,50)",
+            },
+          ],
+          helpText: `
+Runs the comparison harness read-only: samples historical 'router'-mode turns
+from memory_v2_activation_logs, reconstructs each turn's inputs, re-runs each
+retriever, and scores selections against the logged picks (recall@k). NO writes.
+
+Cost: each scored turn re-runs the router (one LLM call), so --limit is the
+cost knob — start small. Today the only retriever is the router itself, so this
+is the harness self-test (router graded against its own logged picks); the gap
+from 1.0 is input-reconstruction drift (NOW.md / config moved since the turn).
+
+Examples:
+  $ assistant memory v2 compare --limit 20
+  $ assistant memory v2 compare --limit 50 --strategy random --k 5,10,25
+  $ assistant memory v2 compare --limit 20 --trace conv-abc:7
+  $ assistant memory v2 compare --limit 20 --json | jq '.retrievers[0].aggregate'`,
+        },
+      ],
+    },
+    {
+      name: "v3",
+      description: "Memory v3 live-lane maintenance (section-lane model)",
+      helpText: `
+The v3 memory subsystem retrieves concept pages over section-grain lanes and
+caches them as live shadow lanes inside the assistant. These commands maintain
+that live state safely.
+
+Examples:
+  $ assistant memory v3 rebuild-index
+  $ assistant memory v3 backfill-sections`,
+      subcommands: [
+        {
+          name: "rebuild-index",
+          description: "Invalidate the v3 lanes so the next turn rebuilds",
+          helpText: `
+Drops the assistant's cached v3 shadow lanes so the section index is rebuilt
+from the current on-disk state on the next turn. Useful after editing concept
+pages out-of-band.
+
+Examples:
+  $ assistant memory v3 rebuild-index`,
+        },
+        {
+          name: "backfill-sections",
+          description:
+            "One-time: embed every page's sections into the dense store (incl skills/CLI)",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+          helpText: `
+Embeds EVERY concept page's sections — including synthetic skill and CLI
+capability rows — into the section dense store in one pass, then advances
+the maintain checkpoint so the next incremental pass only re-embeds future
+edits. Use this once on an existing install before the section-lane A/B and
+cutover: the dense collection starts empty, and the periodic maintenance
+pass only re-embeds pages edited since its last run (and never the synthetic
+rows), so most of the corpus would otherwise never be embedded.
+
+Idempotent and safe to re-run. Runs inside the assistant so it uses the live
+configuration and advances the checkpoint the assistant reads.
+
+Examples:
+  $ assistant memory v3 backfill-sections
+  $ assistant memory v3 backfill-sections --json | jq '.sections'`,
+        },
+        {
+          name: "eval",
+          description:
+            "Build blinded A/B retrieval-eval packets (snapshot corpus vs staged wiki)",
+          // The repeatable `--exclude-conversation <id>` option (accumulator
+          // parser + array default) and the `--json` option after it live in
+          // memory-v3.ts — the contract cannot express parser functions or
+          // array defaults, and option order must match registration order.
+          options: [
+            {
+              flags: "--staging <dir>",
+              description:
+                "Staged v3 wiki dir (relative to the workspace, or absolute)",
+              required: true,
+            },
+            {
+              flags: "--snapshot <dir>",
+              description:
+                "Read-only v2 snapshot dir (relative to the workspace, or absolute)",
+              required: true,
+            },
+            {
+              flags: "--out <dir>",
+              description: "Output dir for packets.json + key.json",
+              required: true,
+            },
+            {
+              flags: "--turns <n>",
+              description: "Number of recent turns to mine",
+              defaultValue: "30",
+            },
+            {
+              flags: "--k <n>",
+              description: "Pages per memory set",
+              defaultValue: "8",
+            },
+            {
+              flags: "--seed <n>",
+              description: "Blinding seed (reproducible A/B assignment)",
+              defaultValue: "1",
+            },
+            {
+              flags: "--no-dense",
+              description:
+                "Needle-only: skip section embedding (fast, cheaper, lower fidelity)",
+            },
+            {
+              flags: "--turns-file <path>",
+              description:
+                "Pin the exact turns from a prior key.json/packets.json (reproducible re-judge); overrides --turns",
+            },
+          ],
+          helpText: `
+Mines recent user turns, retrieves the top pages from each corpus per turn, and
+writes blinded A/B packets (plus a separate unblinding key) for a blind-judge
+workflow. Both corpora are read in memory — nothing in the live lanes or Qdrant
+is touched. With the dense lane on (default) it embeds every section of both
+corpora, which can take a while on a large corpus; use --no-dense for a fast
+lexical-only pass.
+
+To iterate on the staged wiki reproducibly, mine the turns ONCE and pin them on
+every re-run with --turns-file (pointing at the first run's key.json), so the
+comparison stays fixed while only the staged corpus changes. Re-runs that
+re-mine drift onto a different turn set and are not comparable. Likewise, do not
+compare a --no-dense run against a dense one, and check eval-meta.json's
+embedding identity is the same across runs.
+
+Examples:
+  $ assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval
+  $ assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval --turns-file .mv3/eval/key.json
+  $ assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval --exclude-conversation <migration-conv-id>`,
+        },
+        {
+          name: "eval-tally",
+          description:
+            "Unblind + tally blind-judge verdicts against key.json with a noise-aware win/tie/loss verdict",
+          options: [
+            {
+              flags: "--verdicts <path>",
+              description:
+                "JSON file: array of { turn, winner, scoreA, scoreB } (one or more per turn for a panel)",
+              required: true,
+            },
+            {
+              flags: "--key <path>",
+              description:
+                "key.json from `eval` — the per-turn A/B → snapshot/staging unblinding map",
+              required: true,
+            },
+            {
+              flags: "--alpha <p>",
+              description:
+                "Significance threshold for the sign test (the wiki only FAILS on a significant snapshot lead)",
+              defaultValue: "0.05",
+            },
+            {
+              flags: "--out <path>",
+              description: "Also write the full tally JSON to this path",
+            },
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+          helpText: `
+Joins the blind-judge verdicts to the unblinding key (A/B is shuffled PER TURN,
+so the winner must be mapped turn-by-turn — a global A-vs-B count is wrong) and
+applies a two-sided sign test: the wiki only FAILS when the snapshot's win lead
+is statistically significant. A within-noise difference is a tie, which passes
+the win-or-tie gate. Pass a judge PANEL (multiple verdicts per turn, e.g. from
+re-judging under several seeds) to control single-vote noise.
+
+Example:
+  $ assistant memory v3 eval-tally --verdicts .mv3/eval/verdicts.json --key .mv3/eval/key.json`,
+        },
+      ],
+    },
+    {
+      name: "retrospective",
+      description: "Run and inspect memory retrospectives (direct, no IPC)",
+      helpText: `
+Runs memory retrospectives directly against the workspace database — the CLI
+process imports the retrospective machinery and calls it in-process, so no
+running daemon is required.
+
+Examples:
+  $ assistant memory retrospective run <conversationId>`,
+      subcommands: [
+        {
+          name: "run",
+          description: "Run a fork-based retrospective on a conversation",
+          arguments: [
+            {
+              name: "<conversationId>",
+              description: "Source conversation to retrospective",
+            },
+          ],
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+          helpText: `
+Forks the source conversation through its latest message, persists a
+retrospective instruction, and wakes the fork so the agent reviews the new
+messages and calls \`remember\` on anything worth saving. Runs entirely in the
+CLI process — no IPC round-trip to the daemon.
+
+Examples:
+  $ assistant memory retrospective run abc123`,
+        },
+      ],
+    },
+    {
+      name: "worker",
+      description: "Manage the memory jobs worker process (start/stop/status)",
+      helpText: `
+The memory worker processes embedding, consolidation, and cleanup jobs in a
+separate OS process so they do not block the assistant's main event loop. The
+daemon owns the process, so it is spawned as a child of the daemon and shows up
+in \`assistant ps\`.
+
+\`start\` enables memory.worker.enabled and \`stop\` disables it, so the
+assistant's synchronous in-process runner stands down (start) or takes back over
+(stop) without a restart.
+
+Examples:
+  $ assistant memory worker start
+  $ assistant memory worker status
+  $ assistant memory worker stop`,
+      subcommands: [
+        {
+          name: "start",
+          description:
+            "Start the memory worker process and enable memory.worker.enabled",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+        },
+        {
+          name: "stop",
+          description:
+            "Stop the memory worker process and disable memory.worker.enabled",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+        },
+        {
+          name: "status",
+          description:
+            "Report worker process state, memory.worker.enabled, and the synchronous runner",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/memory/index.ts
+++ b/assistant/src/cli/commands/memory/index.ts
@@ -1,6 +1,8 @@
 import type { Command } from "commander";
 
+import { applyCommandHelp } from "../../lib/cli-command-help.js";
 import { registerCommand } from "../../lib/register-command.js";
+import { memoryHelp } from "./index.help.js";
 import { registerMemoryItemsCommand } from "./items.js";
 import { registerMemoryRetrospectiveCommand } from "./memory-retrospective.js";
 import { registerMemoryV2Command } from "./memory-v2.js";
@@ -10,35 +12,11 @@ import { registerMemoryWorkerCommand } from "./worker.js";
 
 export function registerMemoryCommand(program: Command): void {
   registerCommand(program, {
-    name: "memory",
+    name: memoryHelp.name,
     transport: "ipc",
-    description:
-      "Manage memory items and maintain the assistant memory subsystem",
+    description: memoryHelp.description,
     build: (memory) => {
-      memory.addHelpText(
-        "after",
-        `
-The 'nodes' subgroup provides content-based list, delete, and update over
-memory v2 graph nodes — address facts by text, not UUID (requires memory v2).
-
-The 'items' subgroup exposes full CRUD over individual memory items
-(remembered facts) — list, get, create, update, delete.
-
-The memory subsystem retrieves concept pages two ways: the v2 concept-page
-activation model (prose pages with directed edges) and the v3 section-lane
-model (section-grain lanes cached as live shadow state). Each subgroup exposes
-operator-facing maintenance verbs — reindexing, backfills, validation, and evals.
-
-Examples:
-  $ assistant memory nodes list --search "coffee"
-  $ assistant memory nodes delete "User prefers TypeScript"
-  $ assistant memory nodes update "User prefers TypeScript" "User prefers TypeScript and Bun"
-  $ assistant memory items list --search "coffee"
-  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --statement "Prefers tea"
-  $ assistant memory items delete 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant memory v2 validate
-  $ assistant memory v3 rebuild-index`,
-      );
+      applyCommandHelp(memory, memoryHelp);
 
       registerMemoryNodesCommand(memory);
       registerMemoryItemsCommand(memory);

--- a/assistant/src/cli/commands/memory/items.ts
+++ b/assistant/src/cli/commands/memory/items.ts
@@ -14,17 +14,10 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { confirmPrompt } from "../../lib/confirm-prompt.js";
-import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { writeOutput } from "../../output.js";
-
-/**
- * Memory kinds accepted by the daemon's memory-item routes. Mirrored here
- * for help text only — the route validates and rejects unknown kinds.
- */
-const MEMORY_KINDS =
-  "episodic, semantic, procedural, emotional, prospective, behavioral, narrative, shared";
 
 interface MemoryItemPayload {
   id: string;
@@ -81,410 +74,270 @@ function requireId(
 }
 
 export function registerMemoryItemsCommand(memory: Command): void {
-  registerCommand(memory, {
-    name: "items",
-    transport: "ipc",
-    description: "Manage individual memory items (full CRUD)",
-    build: (items) => {
-      items.addHelpText(
-        "after",
-        `
-Memory items are individual remembered facts (graph nodes) with a kind
-(${MEMORY_KINDS}),
-a subject line, and a statement. Items are normally created by the
-assistant via the remember tool; 'items create' exists for manual seeding
-and repair.
+  const items = subcommand(memory, "items");
 
-Examples:
-  $ assistant memory items list --search "coffee"
-  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --statement "Prefers tea"
-  $ assistant memory items delete 9f2c4f3a-3f1a-41e4-88e7-abc123`,
-      );
+  // ── list ──────────────────────────────────────────────────────────────
 
-      // ── list ──────────────────────────────────────────────────────────────
+  subcommand(items, "list")
+    .alias("ls")
+    .action(
+      async (
+        opts: {
+          kind?: string;
+          status?: string;
+          search?: string;
+          sort?: string;
+          order?: string;
+          limit?: string;
+          offset?: string;
+          json?: boolean;
+        },
+        cmd: Command,
+      ) => {
+        const queryParams: Record<string, string> = {};
+        if (opts.kind) {
+          queryParams.kind = opts.kind;
+        }
+        if (opts.status) {
+          queryParams.status = opts.status;
+        }
+        if (opts.search) {
+          queryParams.search = opts.search;
+        }
+        if (opts.sort) {
+          queryParams.sort = opts.sort;
+        }
+        if (opts.order) {
+          queryParams.order = opts.order;
+        }
+        if (opts.limit) {
+          queryParams.limit = opts.limit;
+        }
+        if (opts.offset) {
+          queryParams.offset = opts.offset;
+        }
 
-      items
-        .command("list")
-        .alias("ls")
-        .description("List memory items with filtering, search, and pagination")
-        .option("--kind <kind>", `Filter by kind (${MEMORY_KINDS})`)
-        .option(
-          "--status <status>",
-          "Filter by status: active (default), inactive, or all",
-        )
-        .option("--search <query>", "Semantic/full-text search query")
-        .option(
-          "--sort <field>",
-          "Sort field: lastSeenAt (default), importance, kind, or firstSeenAt",
-        )
-        .option("--order <order>", "asc or desc (default desc)")
-        .option("--limit <n>", "Max results (default 100)")
-        .option("--offset <n>", "Pagination offset (default 0)")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Behavior:
-  Lists memory items (remembered facts) from the assistant's memory store.
-  With --search, results are ranked by semantic relevance when the embedding
-  backend is available, falling back to substring match otherwise. Deleted
-  items are hidden unless --status inactive or --status all is passed.
-
-Examples:
-  $ assistant memory items list
-  $ assistant memory items list --kind semantic --limit 20
-  $ assistant memory items list --search "favorite restaurants" --json`,
-        )
-        .action(
-          async (
-            opts: {
-              kind?: string;
-              status?: string;
-              search?: string;
-              sort?: string;
-              order?: string;
-              limit?: string;
-              offset?: string;
-              json?: boolean;
-            },
-            cmd: Command,
-          ) => {
-            const queryParams: Record<string, string> = {};
-            if (opts.kind) {
-              queryParams.kind = opts.kind;
-            }
-            if (opts.status) {
-              queryParams.status = opts.status;
-            }
-            if (opts.search) {
-              queryParams.search = opts.search;
-            }
-            if (opts.sort) {
-              queryParams.sort = opts.sort;
-            }
-            if (opts.order) {
-              queryParams.order = opts.order;
-            }
-            if (opts.limit) {
-              queryParams.limit = opts.limit;
-            }
-            if (opts.offset) {
-              queryParams.offset = opts.offset;
-            }
-
-            const result = await cliIpcCall<ListMemoryItemsResponse>(
-              "listMemoryItems",
-              { queryParams },
-            );
-
-            if (!result.ok) {
-              return exitFromIpcResult(result, cmd);
-            }
-
-            const response = result.result ?? {
-              items: [],
-              total: 0,
-              kindCounts: {},
-            };
-
-            if (opts.json) {
-              writeOutput(cmd, response);
-              return;
-            }
-
-            if (response.items.length === 0) {
-              log.info("No memory items found.");
-              return;
-            }
-
-            const kindWidth = Math.max(
-              4,
-              ...response.items.map((item) => item.kind.length),
-            );
-            console.log(
-              `${"ID".padEnd(36)}  ${"KIND".padEnd(kindWidth)}  ${"IMP".padEnd(4)}  SUBJECT`,
-            );
-            for (const item of response.items) {
-              console.log(
-                `${item.id.padEnd(36)}  ${item.kind.padEnd(kindWidth)}  ${item.importance.toFixed(2)}  ${item.subject}`,
-              );
-            }
-            console.log(
-              `\n${response.items.length} of ${response.total} memory item(s)`,
-            );
-          },
+        const result = await cliIpcCall<ListMemoryItemsResponse>(
+          "listMemoryItems",
+          { queryParams },
         );
 
-      // ── get ───────────────────────────────────────────────────────────────
+        if (!result.ok) {
+          return exitFromIpcResult(result, cmd);
+        }
 
-      items
-        .command("get <id>")
-        .description("Get a single memory item by ID")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  <id>   Memory item ID (UUID) — run 'assistant memory items list' to find it.
+        const response = result.result ?? {
+          items: [],
+          total: 0,
+          kindCounts: {},
+        };
 
-Examples:
-  $ assistant memory items get 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant memory items get 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
-        )
-        .action(async (id: string, opts: { json?: boolean }, cmd: Command) => {
-          const itemId = requireId(id, opts, cmd);
-          if (!itemId) {
+        if (opts.json) {
+          writeOutput(cmd, response);
+          return;
+        }
+
+        if (response.items.length === 0) {
+          log.info("No memory items found.");
+          return;
+        }
+
+        const kindWidth = Math.max(
+          4,
+          ...response.items.map((item) => item.kind.length),
+        );
+        console.log(
+          `${"ID".padEnd(36)}  ${"KIND".padEnd(kindWidth)}  ${"IMP".padEnd(4)}  SUBJECT`,
+        );
+        for (const item of response.items) {
+          console.log(
+            `${item.id.padEnd(36)}  ${item.kind.padEnd(kindWidth)}  ${item.importance.toFixed(2)}  ${item.subject}`,
+          );
+        }
+        console.log(
+          `\n${response.items.length} of ${response.total} memory item(s)`,
+        );
+      },
+    );
+
+  // ── get ───────────────────────────────────────────────────────────────
+
+  subcommand(items, "get").action(
+    async (id: string, opts: { json?: boolean }, cmd: Command) => {
+      const itemId = requireId(id, opts, cmd);
+      if (!itemId) {
+        return;
+      }
+
+      const result = await cliIpcCall<MemoryItemResponse>("getMemoryItem", {
+        pathParams: { id: itemId },
+      });
+
+      if (!result.ok) {
+        return exitFromIpcResult(result, cmd);
+      }
+
+      writeOutput(cmd, result.result);
+    },
+  );
+
+  // ── create ────────────────────────────────────────────────────────────
+
+  subcommand(items, "create").action(
+    async (
+      opts: {
+        kind: string;
+        statement: string;
+        subject?: string;
+        importance?: string;
+        json?: boolean;
+      },
+      cmd: Command,
+    ) => {
+      const body: Record<string, unknown> = {
+        kind: opts.kind,
+        statement: opts.statement,
+      };
+      if (opts.subject !== undefined) {
+        body.subject = opts.subject;
+      }
+      if (opts.importance !== undefined) {
+        const parsed = parseImportance(opts.importance);
+        if (parsed == null) {
+          return;
+        }
+        body.importance = parsed;
+      }
+
+      const result = await cliIpcCall<MemoryItemResponse>("createMemoryItem", {
+        body,
+      });
+
+      if (!result.ok) {
+        return exitFromIpcResult(result, cmd);
+      }
+
+      if (opts.json) {
+        writeOutput(cmd, result.result);
+        return;
+      }
+
+      log.info(`Created memory item: ${result.result?.item.id}`);
+    },
+  );
+
+  // ── update ────────────────────────────────────────────────────────────
+
+  subcommand(items, "update").action(
+    async (
+      id: string,
+      opts: {
+        subject?: string;
+        statement?: string;
+        kind?: string;
+        status?: string;
+        importance?: string;
+        json?: boolean;
+      },
+      cmd: Command,
+    ) => {
+      const itemId = requireId(id, opts, cmd);
+      if (!itemId) {
+        return;
+      }
+
+      const body: Record<string, unknown> = {};
+      if (opts.subject !== undefined) {
+        body.subject = opts.subject;
+      }
+      if (opts.statement !== undefined) {
+        body.statement = opts.statement;
+      }
+      if (opts.kind !== undefined) {
+        body.kind = opts.kind;
+      }
+      if (opts.status !== undefined) {
+        body.status = opts.status;
+      }
+      if (opts.importance !== undefined) {
+        const parsed = parseImportance(opts.importance);
+        if (parsed == null) {
+          return;
+        }
+        body.importance = parsed;
+      }
+
+      if (Object.keys(body).length === 0) {
+        log.error(
+          "At least one update flag is required. Run 'assistant memory items update --help' for the available flags.",
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = await cliIpcCall<MemoryItemResponse>("updateMemoryItem", {
+        pathParams: { id: itemId },
+        body,
+      });
+
+      if (!result.ok) {
+        return exitFromIpcResult(result, cmd);
+      }
+
+      if (opts.json) {
+        writeOutput(cmd, result.result);
+        return;
+      }
+
+      log.info(`Updated memory item: ${itemId}`);
+    },
+  );
+
+  // ── delete ────────────────────────────────────────────────────────────
+
+  subcommand(items, "delete")
+    .alias("rm")
+    .action(
+      async (
+        id: string,
+        opts: { force?: boolean; json?: boolean },
+        cmd: Command,
+      ) => {
+        const itemId = requireId(id, opts, cmd);
+        if (!itemId) {
+          return;
+        }
+
+        if (!opts.force) {
+          const decision = await confirmPrompt({
+            question: `Delete memory item "${itemId}"? [y/N] `,
+            isTTY: Boolean(process.stdin.isTTY),
+            refuseNonInteractiveMessage: `Refusing to delete memory item "${itemId}" non-interactively. Pass --force to confirm.`,
+          });
+          if (decision === "non-interactive") {
+            process.exitCode = 1;
             return;
           }
-
-          const result = await cliIpcCall<MemoryItemResponse>("getMemoryItem", {
-            pathParams: { id: itemId },
-          });
-
-          if (!result.ok) {
-            return exitFromIpcResult(result, cmd);
+          if (decision === "denied") {
+            log.info("Delete cancelled.");
+            return;
           }
+        }
 
-          writeOutput(cmd, result.result);
+        const result = await cliIpcCall<null>("deleteMemoryItem", {
+          pathParams: { id: itemId },
         });
 
-      // ── create ────────────────────────────────────────────────────────────
+        if (!result.ok) {
+          return exitFromIpcResult(result, cmd);
+        }
 
-      items
-        .command("create")
-        .description("Create a new memory item")
-        .requiredOption("--kind <kind>", `Memory kind (${MEMORY_KINDS})`)
-        .requiredOption("--statement <text>", "Statement content of the memory")
-        .option("--subject <text>", "Subject line (defaults to the statement)")
-        .option("--importance <n>", "Importance score 0-1 (default 0.8)")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Behavior:
-  Creates a memory graph node and enqueues its embedding so it becomes
-  recallable. Fails with a conflict error if an active item with identical
-  content already exists. Memories are normally formed by the assistant via
-  the remember tool — use this for manual seeding and repair.
+        if (opts.json) {
+          writeOutput(cmd, { deleted: true, id: itemId });
+          return;
+        }
 
-Examples:
-  $ assistant memory items create --kind semantic --statement "User prefers dark mode"
-  $ assistant memory items create --kind procedural --subject "Deploys" \\
-      --statement "Deploys go out Tuesdays after standup" --importance 0.9`,
-        )
-        .action(
-          async (
-            opts: {
-              kind: string;
-              statement: string;
-              subject?: string;
-              importance?: string;
-              json?: boolean;
-            },
-            cmd: Command,
-          ) => {
-            const body: Record<string, unknown> = {
-              kind: opts.kind,
-              statement: opts.statement,
-            };
-            if (opts.subject !== undefined) {
-              body.subject = opts.subject;
-            }
-            if (opts.importance !== undefined) {
-              const parsed = parseImportance(opts.importance);
-              if (parsed == null) {
-                return;
-              }
-              body.importance = parsed;
-            }
-
-            const result = await cliIpcCall<MemoryItemResponse>(
-              "createMemoryItem",
-              { body },
-            );
-
-            if (!result.ok) {
-              return exitFromIpcResult(result, cmd);
-            }
-
-            if (opts.json) {
-              writeOutput(cmd, result.result);
-              return;
-            }
-
-            log.info(`Created memory item: ${result.result?.item.id}`);
-          },
-        );
-
-      // ── update ────────────────────────────────────────────────────────────
-
-      items
-        .command("update <id>")
-        .description("Update fields on an existing memory item")
-        .option("--subject <text>", "Replace the subject line")
-        .option("--statement <text>", "Replace the statement content")
-        .option("--kind <kind>", `Change the kind (${MEMORY_KINDS})`)
-        .option(
-          "--status <status>",
-          "Set status: active (restores a deleted item) or superseded",
-        )
-        .option("--importance <n>", "Set importance score 0-1")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  <id>   Memory item ID (UUID) — run 'assistant memory items list' to find it.
-
-Behavior:
-  Partially updates the given fields; anything not passed is left unchanged.
-  Content changes trigger re-embedding so recall stays consistent. Setting
-  --status active restores a previously deleted item; --status superseded
-  retires it (same effect as 'assistant memory items delete'). Fails with a
-  conflict error when the new content duplicates another active item.
-
-Examples:
-  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --statement "Prefers tea over coffee"
-  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --importance 0.9 --kind semantic
-  $ assistant memory items update 9f2c4f3a-3f1a-41e4-88e7-abc123 --status active`,
-        )
-        .action(
-          async (
-            id: string,
-            opts: {
-              subject?: string;
-              statement?: string;
-              kind?: string;
-              status?: string;
-              importance?: string;
-              json?: boolean;
-            },
-            cmd: Command,
-          ) => {
-            const itemId = requireId(id, opts, cmd);
-            if (!itemId) {
-              return;
-            }
-
-            const body: Record<string, unknown> = {};
-            if (opts.subject !== undefined) {
-              body.subject = opts.subject;
-            }
-            if (opts.statement !== undefined) {
-              body.statement = opts.statement;
-            }
-            if (opts.kind !== undefined) {
-              body.kind = opts.kind;
-            }
-            if (opts.status !== undefined) {
-              body.status = opts.status;
-            }
-            if (opts.importance !== undefined) {
-              const parsed = parseImportance(opts.importance);
-              if (parsed == null) {
-                return;
-              }
-              body.importance = parsed;
-            }
-
-            if (Object.keys(body).length === 0) {
-              log.error(
-                "At least one update flag is required. Run 'assistant memory items update --help' for the available flags.",
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            const result = await cliIpcCall<MemoryItemResponse>(
-              "updateMemoryItem",
-              { pathParams: { id: itemId }, body },
-            );
-
-            if (!result.ok) {
-              return exitFromIpcResult(result, cmd);
-            }
-
-            if (opts.json) {
-              writeOutput(cmd, result.result);
-              return;
-            }
-
-            log.info(`Updated memory item: ${itemId}`);
-          },
-        );
-
-      // ── delete ────────────────────────────────────────────────────────────
-
-      items
-        .command("delete <id>")
-        .alias("rm")
-        .description("Delete a memory item")
-        .option("--force", "Skip the confirmation prompt")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --force  Skip the destructive y/N confirmation prompt. Required when stdin
-           is not a TTY (e.g. in scripts and CI).
-  --json   Output the deletion result as compact JSON.
-
-Arguments:
-  <id>   Memory item ID (UUID) — run 'assistant memory items list' to find it.
-
-Behavior:
-  Soft-deletes the memory item — it stops being recalled and its embeddings
-  are removed from the index, but the underlying record is retained. A
-  deleted item can be restored with
-  'assistant memory items update <id> --status active'.
-
-Examples:
-  $ assistant memory items delete 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant memory items delete 9f2c4f3a-3f1a-41e4-88e7-abc123 --force --json`,
-        )
-        .action(
-          async (
-            id: string,
-            opts: { force?: boolean; json?: boolean },
-            cmd: Command,
-          ) => {
-            const itemId = requireId(id, opts, cmd);
-            if (!itemId) {
-              return;
-            }
-
-            if (!opts.force) {
-              const decision = await confirmPrompt({
-                question: `Delete memory item "${itemId}"? [y/N] `,
-                isTTY: Boolean(process.stdin.isTTY),
-                refuseNonInteractiveMessage: `Refusing to delete memory item "${itemId}" non-interactively. Pass --force to confirm.`,
-              });
-              if (decision === "non-interactive") {
-                process.exitCode = 1;
-                return;
-              }
-              if (decision === "denied") {
-                log.info("Delete cancelled.");
-                return;
-              }
-            }
-
-            const result = await cliIpcCall<null>("deleteMemoryItem", {
-              pathParams: { id: itemId },
-            });
-
-            if (!result.ok) {
-              return exitFromIpcResult(result, cmd);
-            }
-
-            if (opts.json) {
-              writeOutput(cmd, { deleted: true, id: itemId });
-              return;
-            }
-
-            log.info(`Deleted memory item: ${itemId}`);
-          },
-        );
-    },
-  });
+        log.info(`Deleted memory item: ${itemId}`);
+      },
+    );
 }

--- a/assistant/src/cli/commands/memory/memory-retrospective.ts
+++ b/assistant/src/cli/commands/memory/memory-retrospective.ts
@@ -14,86 +14,46 @@
 import type { Command } from "commander";
 
 import type { MemoryRetrospectiveOutcome } from "../../../plugins/defaults/memory/memory-retrospective-job.js";
-import { registerCommand } from "../../lib/register-command.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
 export function registerMemoryRetrospectiveCommand(memory: Command): void {
-  registerCommand(memory, {
-    name: "retrospective",
-    transport: "local",
-    description: "Run and inspect memory retrospectives (direct, no IPC)",
-    build: (retro) => {
-      retro.addHelpText(
-        "after",
-        `
-Runs memory retrospectives directly against the workspace database — the CLI
-process imports the retrospective machinery and calls it in-process, so no
-running daemon is required.
+  const retro = subcommand(memory, "retrospective");
 
-Examples:
-  $ assistant memory retrospective run <conversationId>`,
-      );
+  // ── run ───────────────────────────────────────────────────────────────
 
-      // ── run ───────────────────────────────────────────────────────────────
+  subcommand(retro, "run").action(
+    async (conversationId: string, opts: { json?: boolean }, cmd: Command) => {
+      // Deferred: loads the config loader and retrospective job graph.
+      const [{ getConfig }, { runForkBasedRetrospective }] = await Promise.all([
+        import("../../../config/loader.js"),
+        import("../../../plugins/defaults/memory/memory-retrospective-job.js"),
+      ]);
+      const config = getConfig();
+      let outcome: MemoryRetrospectiveOutcome;
+      try {
+        outcome = await runForkBasedRetrospective(conversationId, config);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error({ err, conversationId }, "memory-retrospective: run threw");
+        if (opts.json === true) {
+          writeOutput(cmd, { kind: "error", error: msg });
+        } else {
+          log.error(msg);
+        }
+        process.exitCode = 1;
+        return;
+      }
 
-      retro
-        .command("run")
-        .description("Run a fork-based retrospective on a conversation")
-        .argument("<conversationId>", "Source conversation to retrospective")
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .addHelpText(
-          "after",
-          `
-Forks the source conversation through its latest message, persists a
-retrospective instruction, and wakes the fork so the agent reviews the new
-messages and calls \`remember\` on anything worth saving. Runs entirely in the
-CLI process — no IPC round-trip to the daemon.
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, outcome);
+        return;
+      }
 
-Examples:
-  $ assistant memory retrospective run abc123`,
-        )
-        .action(
-          async (
-            conversationId: string,
-            opts: { json?: boolean },
-            cmd: Command,
-          ) => {
-            // Deferred: loads the config loader and retrospective job graph.
-            const [{ getConfig }, { runForkBasedRetrospective }] =
-              await Promise.all([
-                import("../../../config/loader.js"),
-                import("../../../plugins/defaults/memory/memory-retrospective-job.js"),
-              ]);
-            const config = getConfig();
-            let outcome: MemoryRetrospectiveOutcome;
-            try {
-              outcome = await runForkBasedRetrospective(conversationId, config);
-            } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              log.error(
-                { err, conversationId },
-                "memory-retrospective: run threw",
-              );
-              if (opts.json === true) {
-                writeOutput(cmd, { kind: "error", error: msg });
-              } else {
-                log.error(msg);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, outcome);
-              return;
-            }
-
-            renderOutcome(outcome);
-          },
-        );
+      renderOutcome(outcome);
     },
-  });
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/memory/memory-v2.ts
+++ b/assistant/src/cli/commands/memory/memory-v2.ts
@@ -28,7 +28,7 @@ import type {
   MemoryV2ValidateResult,
 } from "../../../plugins/defaults/memory/routes/memory-v2-routes.js";
 import type { ComparisonReport } from "../../../plugins/defaults/memory/v2/harness/runner.js";
-import { registerCommand } from "../../lib/register-command.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { log } from "../../logger.js";
 import {
   renderComparisonReport,
@@ -64,668 +64,457 @@ async function runBackfillOp(op: MemoryV2BackfillOp): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export function registerMemoryV2Command(memory: Command): void {
-  registerCommand(memory, {
-    name: "v2",
-    transport: "ipc",
-    description: "Memory v2 subsystem operations (concept-page model)",
-    build: (v2) => {
-      v2.addHelpText(
-        "after",
-        `
-The v2 memory subsystem stores prose concept pages with directed edges in
-each page's frontmatter and uses activation-based retrieval. Pages live
-under /workspace/memory/concepts/ and are gated behind the
-memory.v2.enabled config field.
+  const v2 = subcommand(memory, "v2");
 
-Mutating subcommands return a jobId enqueued on the memory job queue,
-except reembed-skills which runs synchronously inside the assistant.
-Read-only subcommands print diagnostic reports without mutating state.
+  // ── reembed ───────────────────────────────────────────────────────────
 
-Examples:
-  $ assistant memory v2 validate
-  $ assistant memory v2 reembed
-  $ assistant memory v2 reembed-skills
-  $ assistant memory v2 activation`,
+  subcommand(v2, "reembed").action(async () => {
+    await runBackfillOp("reembed");
+  });
+
+  // ── reembed-skills ────────────────────────────────────────────────────
+
+  subcommand(v2, "reembed-skills").action(async () => {
+    const result = await cliIpcCall<MemoryV2ReembedSkillsResult>(
+      "memory_v2_reembed_skills",
+      { body: {} },
+    );
+
+    if (!result.ok) {
+      log.error(result.error ?? "Failed to re-seed v2 skill entries");
+      process.exitCode = 1;
+      return;
+    }
+
+    log.info("Skill re-seed complete.");
+  });
+
+  // ── activation ────────────────────────────────────────────────────────
+
+  subcommand(v2, "activation").action(async () => {
+    await runBackfillOp("activation-recompute");
+  });
+
+  // ── validate ──────────────────────────────────────────────────────────
+
+  subcommand(v2, "validate").action(async () => {
+    const result = await cliIpcCall<MemoryV2ValidateResult>(
+      "memory_v2_validate",
+      { body: {} },
+    );
+
+    if (!result.ok) {
+      log.error(result.error ?? "Failed to validate memory v2 state");
+      process.exitCode = 1;
+      return;
+    }
+
+    const report = result.result!;
+    log.info(`Pages: ${report.pageCount}`);
+    log.info(`Edges: ${report.edgeCount}`);
+    log.info(
+      `Missing edge endpoints: ${
+        report.missingEdgeEndpoints.length === 0
+          ? "none"
+          : report.missingEdgeEndpoints.length
+      }`,
+    );
+    for (const m of report.missingEdgeEndpoints) {
+      log.info(`  - ${m.from} → ${m.to}`);
+    }
+    log.info(
+      `Oversized pages: ${
+        report.oversizedPages.length === 0
+          ? "none"
+          : report.oversizedPages.length
+      }`,
+    );
+    for (const p of report.oversizedPages) {
+      log.info(`  - ${p.slug}: ${p.chars} chars`);
+    }
+    log.info(
+      `Parse failures: ${
+        report.parseFailures.length === 0 ? "none" : report.parseFailures.length
+      }`,
+    );
+    for (const p of report.parseFailures) {
+      log.info(`  - ${p.slug}: ${p.error}`);
+    }
+
+    if (
+      report.missingEdgeEndpoints.length > 0 ||
+      report.oversizedPages.length > 0 ||
+      report.parseFailures.length > 0
+    ) {
+      process.exitCode = 1;
+    }
+  });
+
+  // ── ema ───────────────────────────────────────────────────────────────
+
+  subcommand(v2, "ema").action(
+    async (opts: {
+      limit: string;
+      all?: boolean;
+      includeZeros?: boolean;
+      json?: boolean;
+    }) => {
+      const result = await cliIpcCall<MemoryV2EmaScoresResult>(
+        "memory_v2_ema_scores",
+        { body: {} },
       );
 
-      // ── reembed ───────────────────────────────────────────────────────────
+      if (!result.ok) {
+        log.error(result.error ?? "Failed to fetch EMA scores");
+        process.exitCode = 1;
+        return;
+      }
 
-      v2.command("reembed")
-        .description(
-          "Refresh dense + sparse vectors for every concept page in Qdrant",
-        )
-        .addHelpText(
-          "after",
-          `
-Fans out an embed_concept_page job per concept page slug (plus the four
-reserved meta-file slugs) so each page's dense and sparse vectors get
-recomputed against the current embedding backend. Useful after upgrading
-the embedding model or recovering a corrupted Qdrant collection.
+      const allEntries = result.result!.entries;
+      const includeZeros = opts.all === true || opts.includeZeros === true;
+      const visible = includeZeros
+        ? allEntries
+        : allEntries.filter((e) => e.score > 0);
 
-The fan-out runs on the background memory worker — this command returns
-once the parent job is enqueued.
+      const limit = opts.all === true ? visible.length : Number(opts.limit);
+      if (!opts.all && (!Number.isFinite(limit) || limit < 1)) {
+        log.error(`--limit must be a positive integer (got "${opts.limit}")`);
+        process.exitCode = 1;
+        return;
+      }
+      const rows = visible.slice(0, limit);
 
-Examples:
-  $ assistant memory v2 reembed`,
-        )
-        .action(async () => {
-          await runBackfillOp("reembed");
-        });
-
-      // ── reembed-skills ────────────────────────────────────────────────────
-
-      v2.command("reembed-skills")
-        .description(
-          "Re-seed v2 skill entries from the current skill catalog (synchronous)",
-        )
-        .addHelpText(
-          "after",
-          `
-Re-runs the v2 skill catalog seed against the current skill set, replacing
-both the in-process skill cache and the skill entries in the unified
-memory_v2_concept_pages Qdrant collection (under the skills/<id> slug
-prefix). Useful after editing a skill's SKILL.md, after a feature-flag flip
-changes the enabled-skill set, or to recover corrupted skill embeddings.
-
-Unlike 'reembed' (concept pages), this runs synchronously inside the
-assistant — the command returns only once the seed completes. Requires
-memory.v2.enabled to be true.
-
-Examples:
-  $ assistant memory v2 reembed-skills`,
-        )
-        .action(async () => {
-          const result = await cliIpcCall<MemoryV2ReembedSkillsResult>(
-            "memory_v2_reembed_skills",
-            { body: {} },
-          );
-
-          if (!result.ok) {
-            log.error(result.error ?? "Failed to re-seed v2 skill entries");
-            process.exitCode = 1;
-            return;
-          }
-
-          log.info("Skill re-seed complete.");
-        });
-
-      // ── activation ────────────────────────────────────────────────────────
-
-      v2.command("activation")
-        .description(
-          "Refresh persisted activation state for every active conversation",
-        )
-        .addHelpText(
-          "after",
-          `
-Walks every conversation row in the activation_state table and
-recomputes the persisted state without rendering or injecting a memory
-block. Useful after tuning the activation params (d, c_user, c_assistant,
-c_now, k, hops) so subsequent retrievals reflect the new weights without
-waiting for organic per-turn updates.
-
-The job runs on the background memory worker — this command returns once
-the job is enqueued.
-
-Examples:
-  $ assistant memory v2 activation`,
-        )
-        .action(async () => {
-          await runBackfillOp("activation-recompute");
-        });
-
-      // ── validate ──────────────────────────────────────────────────────────
-
-      v2.command("validate")
-        .description(
-          "Print a diagnostic report of v2 workspace state (read-only)",
-        )
-        .addHelpText(
-          "after",
-          `
-Walks the v2 concept-page tree on disk and reports:
-  - Page count
-  - Edge count (total and unique outgoing targets)
-  - Missing outgoing edge targets (orphan edges)
-  - Oversized pages (over the per-folder size cap)
-  - Parse failures (missing or malformed frontmatter)
-
-Read-only — does not mutate the workspace. Exits non-zero if any
-violations are reported.
-
-Examples:
-  $ assistant memory v2 validate`,
-        )
-        .action(async () => {
-          const result = await cliIpcCall<MemoryV2ValidateResult>(
-            "memory_v2_validate",
-            { body: {} },
-          );
-
-          if (!result.ok) {
-            log.error(result.error ?? "Failed to validate memory v2 state");
-            process.exitCode = 1;
-            return;
-          }
-
-          const report = result.result!;
-          log.info(`Pages: ${report.pageCount}`);
-          log.info(`Edges: ${report.edgeCount}`);
-          log.info(
-            `Missing edge endpoints: ${
-              report.missingEdgeEndpoints.length === 0
-                ? "none"
-                : report.missingEdgeEndpoints.length
-            }`,
-          );
-          for (const m of report.missingEdgeEndpoints) {
-            log.info(`  - ${m.from} → ${m.to}`);
-          }
-          log.info(
-            `Oversized pages: ${
-              report.oversizedPages.length === 0
-                ? "none"
-                : report.oversizedPages.length
-            }`,
-          );
-          for (const p of report.oversizedPages) {
-            log.info(`  - ${p.slug}: ${p.chars} chars`);
-          }
-          log.info(
-            `Parse failures: ${
-              report.parseFailures.length === 0
-                ? "none"
-                : report.parseFailures.length
-            }`,
-          );
-          for (const p of report.parseFailures) {
-            log.info(`  - ${p.slug}: ${p.error}`);
-          }
-
-          if (
-            report.missingEdgeEndpoints.length > 0 ||
-            report.oversizedPages.length > 0 ||
-            report.parseFailures.length > 0
-          ) {
-            process.exitCode = 1;
-          }
-        });
-
-      // ── ema ───────────────────────────────────────────────────────────────
-
-      v2.command("ema")
-        .description(
-          "List concept pages by injection-frequency EMA score (read-only)",
-        )
-        .option(
-          "-n, --limit <count>",
-          "Maximum rows to print (default 25; ignored with --all)",
-          "25",
-        )
-        .option("--all", "Print every page, including zero-score pages")
-        .option(
-          "--include-zeros",
-          "Include pages with score 0 in the default-limited view",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted table")
-        .addHelpText(
-          "after",
-          `
-EMA score is the time-decayed sum Σ exp(-λ × (now - tᵢ)) with a 3-day
-half-life, computed from memory_v2_injection_events. A score of 1.0 means
-roughly one router selection in the last few minutes; 0.5 means a single
-selection ~3 days ago. Pages that have never been router-selected since
-EMA tracking began report 0.
-
-Examples:
-  $ assistant memory v2 ema
-  $ assistant memory v2 ema -n 100
-  $ assistant memory v2 ema --all --json | jq '.entries | length'`,
-        )
-        .action(
-          async (opts: {
-            limit: string;
-            all?: boolean;
-            includeZeros?: boolean;
-            json?: boolean;
-          }) => {
-            const result = await cliIpcCall<MemoryV2EmaScoresResult>(
-              "memory_v2_ema_scores",
-              { body: {} },
-            );
-
-            if (!result.ok) {
-              log.error(result.error ?? "Failed to fetch EMA scores");
-              process.exitCode = 1;
-              return;
-            }
-
-            const allEntries = result.result!.entries;
-            const includeZeros =
-              opts.all === true || opts.includeZeros === true;
-            const visible = includeZeros
-              ? allEntries
-              : allEntries.filter((e) => e.score > 0);
-
-            const limit =
-              opts.all === true ? visible.length : Number(opts.limit);
-            if (!opts.all && (!Number.isFinite(limit) || limit < 1)) {
-              log.error(
-                `--limit must be a positive integer (got "${opts.limit}")`,
-              );
-              process.exitCode = 1;
-              return;
-            }
-            const rows = visible.slice(0, limit);
-
-            if (opts.json === true) {
-              log.info(
-                JSON.stringify(
-                  {
-                    entries: rows,
-                    totalScored: allEntries.filter((e) => e.score > 0).length,
-                    totalPages: allEntries.length,
-                  },
-                  null,
-                  2,
-                ),
-              );
-              return;
-            }
-
-            if (rows.length === 0) {
-              log.info(
-                "No concept pages have any EMA signal yet. Send a few turns through the router and try again.",
-              );
-              return;
-            }
-
-            const slugWidth = Math.min(
-              60,
-              Math.max(...rows.map((r) => r.slug.length)),
-            );
-            const header = `${"slug".padEnd(slugWidth)}  ${"score".padStart(8)}  modified`;
-            log.info(header);
-            log.info("-".repeat(header.length));
-            for (const row of rows) {
-              const slug =
-                row.slug.length > slugWidth
-                  ? row.slug.slice(0, slugWidth - 1) + "…"
-                  : row.slug.padEnd(slugWidth);
-              const score = row.score.toFixed(3).padStart(8);
-              const modified =
-                row.modifiedAt > 0
-                  ? new Date(row.modifiedAt).toISOString().slice(0, 10)
-                  : "—";
-              log.info(`${slug}  ${score}  ${modified}`);
-            }
-            const totalScored = allEntries.filter((e) => e.score > 0).length;
-            log.info(
-              `\n${rows.length} of ${visible.length} shown (${totalScored} total with score > 0, ${allEntries.length} pages indexed).`,
-            );
-          },
+      if (opts.json === true) {
+        log.info(
+          JSON.stringify(
+            {
+              entries: rows,
+              totalScored: allEntries.filter((e) => e.score > 0).length,
+              totalPages: allEntries.length,
+            },
+            null,
+            2,
+          ),
         );
+        return;
+      }
 
-      // ── simulate ──────────────────────────────────────────────────────────
-
-      v2.command("simulate")
-        .description(
-          "Dry-run the v4 router against a synthetic query (read-only)",
-        )
-        .requiredOption(
-          "-q, --query <text>",
-          "User query to route the simulated turn against",
-        )
-        .option(
-          "--tier1-size <n>",
-          "Override memory.v2.router.tier1_size for this run (number or 'null')",
-        )
-        .option(
-          "--tier2-size <n>",
-          "Override memory.v2.router.tier2_size for this run (number or 'null')",
-        )
-        .option(
-          "--batch-size <n>",
-          "Override memory.v2.router.batch_size for this run (number or 'null')",
-        )
-        .option("--json", "Emit raw JSON instead of a grouped report")
-        .addHelpText(
-          "after",
-          `
-Runs the v4 router read-only against the live page index + EMA scores, with
-optional tier/batch overrides applied on top of the live config. NO writes:
-no row is appended to memory_v2_injection_events or memory_v2_activation_logs,
-and no activation state is mutated. Use this to preview the effect of a
-config knob change before flipping it in workspace config.json.
-
-Limitations:
-  - priorEverInjected is empty (single-turn simulation; live router dedups
-    against pages already in context).
-  - NOW.md is read at simulate-time, not historical-turn time.
-  - assistantMessage is empty.
-
-Pass 'null' to an override flag to explicitly disable that tier for this run
-(e.g. --tier2-size null reverts to tier1 → tier3). Omitting an override
-inherits the live config value.
-
-Examples:
-  $ assistant memory v2 simulate -q "what should we ship next"
-  $ assistant memory v2 simulate -q "..." --tier1-size 100 --tier2-size 200 --batch-size 50
-  $ assistant memory v2 simulate -q "..." --json | jq '.selectedSlugs'`,
-        )
-        .action(
-          async (opts: {
-            query: string;
-            tier1Size?: string;
-            tier2Size?: string;
-            batchSize?: string;
-            json?: boolean;
-          }) => {
-            const parseOverride = (
-              flag: string,
-              raw: string | undefined,
-            ): number | null | undefined => {
-              if (raw === undefined) return undefined;
-              if (raw === "null") return null;
-              const parsed = Number(raw);
-              if (!Number.isInteger(parsed) || parsed < 1) {
-                log.error(
-                  `${flag} must be a positive integer or 'null' (got "${raw}")`,
-                );
-                process.exitCode = 1;
-                throw new Error("invalid-override");
-              }
-              return parsed;
-            };
-
-            let configOverrides:
-              | {
-                  tier1_size?: number | null;
-                  tier2_size?: number | null;
-                  batch_size?: number | null;
-                }
-              | undefined;
-            try {
-              const t1 = parseOverride("--tier1-size", opts.tier1Size);
-              const t2 = parseOverride("--tier2-size", opts.tier2Size);
-              const bs = parseOverride("--batch-size", opts.batchSize);
-              configOverrides = {
-                ...(t1 !== undefined ? { tier1_size: t1 } : {}),
-                ...(t2 !== undefined ? { tier2_size: t2 } : {}),
-                ...(bs !== undefined ? { batch_size: bs } : {}),
-              };
-              if (Object.keys(configOverrides).length === 0) {
-                configOverrides = undefined;
-              }
-            } catch {
-              return;
-            }
-
-            const result = await cliIpcCall<MemoryV2SimulateRouterResult>(
-              "memory_v2_simulate_router",
-              {
-                body: {
-                  // The CLI flag is still named `--query` for backwards
-                  // compatibility. It becomes the just-arrived
-                  // `userMessage` of a single (empty assistant, user)
-                  // pair — i.e. a first-turn scenario. nowText uses
-                  // the server default (live NOW.md), preserving the
-                  // existing single-turn CLI semantics.
-                  recentTurnPairs: [
-                    { assistantMessage: "", userMessage: opts.query },
-                  ],
-                  ...(configOverrides ? { configOverrides } : {}),
-                },
-              },
-            );
-
-            if (!result.ok) {
-              log.error(result.error ?? "Failed to simulate router");
-              process.exitCode = 1;
-              return;
-            }
-
-            const payload = result.result!;
-
-            if (opts.json === true) {
-              log.info(JSON.stringify(payload, null, 2));
-              return;
-            }
-
-            log.info("Memory Router Simulation");
-            log.info("========================");
-            log.info(`Query: ${JSON.stringify(opts.query)}`);
-            log.info("");
-            log.info("Config (effective):");
-            const formatKnob = (
-              key: keyof MemoryV2SimulateRouterResult["effectiveConfig"],
-            ): string => {
-              const eff = payload.effectiveConfig[key];
-              const override = (
-                payload.overrides as Record<string, number | null | undefined>
-              )[key];
-              const effStr = eff === null ? "null" : String(eff);
-              if (override === undefined) {
-                return `  ${key}: ${effStr}`;
-              }
-              return `  ${key}: ${effStr}  (override)`;
-            };
-            log.info(formatKnob("tier1_size"));
-            log.info(formatKnob("tier2_size"));
-            log.info(formatKnob("batch_size"));
-            log.info(`  max_page_ids: ${payload.effectiveConfig.max_page_ids}`);
-            log.info("");
-            log.info(`Total candidate pages: ${payload.totalCandidatePages}`);
-            log.info(
-              `Selected: ${payload.selectedSlugs.length} / ${payload.effectiveConfig.max_page_ids} pages`,
-            );
-            if (payload.failureReason) {
-              log.info(`Failure: ${payload.failureReason}`);
-            }
-            log.info("");
-
-            const grouped = new Map<string, string[]>();
-            for (const slug of payload.selectedSlugs) {
-              const source = payload.sourceBySlug[slug] ?? "unknown";
-              const bucket = grouped.get(source) ?? [];
-              bucket.push(slug);
-              grouped.set(source, bucket);
-            }
-            const sortedKeys = [...grouped.keys()].sort((a, b) => {
-              const order = (s: string) => {
-                if (s === "tier1") return 0;
-                if (s === "tier2") return 1;
-                if (s.startsWith("tier3:")) {
-                  return 2 + Number(s.slice("tier3:".length));
-                }
-                return Number.MAX_SAFE_INTEGER;
-              };
-              return order(a) - order(b);
-            });
-
-            for (const key of sortedKeys) {
-              const label = key.startsWith("tier3:")
-                ? `tier 3 · b${key.slice("tier3:".length)}`
-                : key === "tier1"
-                  ? "tier 1"
-                  : key === "tier2"
-                    ? "tier 2"
-                    : key;
-              log.info(label);
-              for (const slug of grouped.get(key)!) {
-                if (key === "tier2") {
-                  const score = payload.scores[slug] ?? 0;
-                  log.info(`  - ${slug}  (EMA ${score.toFixed(3)})`);
-                } else {
-                  log.info(`  - ${slug}`);
-                }
-              }
-              log.info("");
-            }
-          },
+      if (rows.length === 0) {
+        log.info(
+          "No concept pages have any EMA signal yet. Send a few turns through the router and try again.",
         );
+        return;
+      }
 
-      // ── compare ─────────────────────────────────────────────────────────
-
-      v2.command("compare")
-        .description(
-          "Compare retrievers against the router's logged picks over a sample of real turns (read-only)",
-        )
-        .option(
-          "--limit <n>",
-          "How many historical turns to sample (default 20). Each re-runs the router = one LLM call.",
-        )
-        .option(
-          "--strategy <recent|random>",
-          "Sampling strategy over historical turns (default recent)",
-        )
-        .option(
-          "--k <list>",
-          "Comma-separated recall@k cutoffs (default 5,10,25,50)",
-        )
-        .option(
-          "--conversation <id>",
-          "Restrict to a conversation id (repeatable)",
-          (val: string, acc: string[]) => {
-            acc.push(val);
-            return acc;
-          },
-          [] as string[],
-        )
-        .option(
-          "--trace <conversationId:turn>",
-          "Print the per-retriever breakdown for one scored turn",
-        )
-        .option(
-          "--include-not-injected",
-          "Also count router picks cut by the injection cap as ground truth",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted report")
-        .addHelpText(
-          "after",
-          `
-Runs the comparison harness read-only: samples historical 'router'-mode turns
-from memory_v2_activation_logs, reconstructs each turn's inputs, re-runs each
-retriever, and scores selections against the logged picks (recall@k). NO writes.
-
-Cost: each scored turn re-runs the router (one LLM call), so --limit is the
-cost knob — start small. Today the only retriever is the router itself, so this
-is the harness self-test (router graded against its own logged picks); the gap
-from 1.0 is input-reconstruction drift (NOW.md / config moved since the turn).
-
-Examples:
-  $ assistant memory v2 compare --limit 20
-  $ assistant memory v2 compare --limit 50 --strategy random --k 5,10,25
-  $ assistant memory v2 compare --limit 20 --trace conv-abc:7
-  $ assistant memory v2 compare --limit 20 --json | jq '.retrievers[0].aggregate'`,
-        )
-        .action(
-          async (opts: {
-            limit?: string;
-            strategy?: string;
-            k?: string;
-            conversation?: string[];
-            trace?: string;
-            includeNotInjected?: boolean;
-            json?: boolean;
-          }) => {
-            let limit: number | undefined;
-            if (opts.limit !== undefined) {
-              const parsed = Number(opts.limit);
-              if (!Number.isInteger(parsed) || parsed < 1) {
-                log.error(
-                  `--limit must be a positive integer (got "${opts.limit}")`,
-                );
-                process.exitCode = 1;
-                return;
-              }
-              limit = parsed;
-            }
-
-            if (
-              opts.strategy !== undefined &&
-              opts.strategy !== "recent" &&
-              opts.strategy !== "random"
-            ) {
-              log.error(
-                `--strategy must be "recent" or "random" (got "${opts.strategy}")`,
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            let ks: number[] | undefined;
-            if (opts.k !== undefined) {
-              ks = opts.k.split(",").map((s) => Number(s.trim()));
-              if (ks.some((k) => !Number.isInteger(k) || k < 1)) {
-                log.error(
-                  `--k must be a comma-separated list of positive integers (got "${opts.k}")`,
-                );
-                process.exitCode = 1;
-                return;
-              }
-            }
-
-            const conversationIds =
-              opts.conversation && opts.conversation.length > 0
-                ? opts.conversation
-                : undefined;
-
-            const result = await cliIpcCall<ComparisonReport>(
-              "memory_v2_compare_retrievers",
-              {
-                body: {
-                  ...(limit !== undefined ? { limit } : {}),
-                  ...(opts.strategy !== undefined
-                    ? { strategy: opts.strategy }
-                    : {}),
-                  ...(ks !== undefined ? { ks } : {}),
-                  ...(conversationIds !== undefined ? { conversationIds } : {}),
-                  ...(opts.includeNotInjected === true
-                    ? { includeNotInjected: true }
-                    : {}),
-                },
-              },
-            );
-
-            if (!result.ok) {
-              log.error(result.error ?? "Failed to compare retrievers");
-              process.exitCode = 1;
-              return;
-            }
-
-            const payload = result.result!;
-
-            if (opts.json === true) {
-              log.info(JSON.stringify(payload, null, 2));
-              return;
-            }
-
-            log.info(renderComparisonReport(payload));
-
-            if (opts.trace !== undefined) {
-              const sep = opts.trace.lastIndexOf(":");
-              if (sep <= 0 || sep === opts.trace.length - 1) {
-                log.error(
-                  `--trace must be "<conversationId>:<turn>" (got "${opts.trace}")`,
-                );
-                process.exitCode = 1;
-                return;
-              }
-              const conversationId = opts.trace.slice(0, sep);
-              const turn = Number(opts.trace.slice(sep + 1));
-              if (!Number.isInteger(turn)) {
-                log.error(
-                  `--trace turn must be an integer (got "${opts.trace.slice(sep + 1)}")`,
-                );
-                process.exitCode = 1;
-                return;
-              }
-              log.info("");
-              log.info(renderTurnTrace(payload, conversationId, turn));
-            }
-          },
-        );
+      const slugWidth = Math.min(
+        60,
+        Math.max(...rows.map((r) => r.slug.length)),
+      );
+      const header = `${"slug".padEnd(slugWidth)}  ${"score".padStart(8)}  modified`;
+      log.info(header);
+      log.info("-".repeat(header.length));
+      for (const row of rows) {
+        const slug =
+          row.slug.length > slugWidth
+            ? row.slug.slice(0, slugWidth - 1) + "…"
+            : row.slug.padEnd(slugWidth);
+        const score = row.score.toFixed(3).padStart(8);
+        const modified =
+          row.modifiedAt > 0
+            ? new Date(row.modifiedAt).toISOString().slice(0, 10)
+            : "—";
+        log.info(`${slug}  ${score}  ${modified}`);
+      }
+      const totalScored = allEntries.filter((e) => e.score > 0).length;
+      log.info(
+        `\n${rows.length} of ${visible.length} shown (${totalScored} total with score > 0, ${allEntries.length} pages indexed).`,
+      );
     },
-  });
+  );
+
+  // ── simulate ──────────────────────────────────────────────────────────
+
+  subcommand(v2, "simulate").action(
+    async (opts: {
+      query: string;
+      tier1Size?: string;
+      tier2Size?: string;
+      batchSize?: string;
+      json?: boolean;
+    }) => {
+      const parseOverride = (
+        flag: string,
+        raw: string | undefined,
+      ): number | null | undefined => {
+        if (raw === undefined) return undefined;
+        if (raw === "null") return null;
+        const parsed = Number(raw);
+        if (!Number.isInteger(parsed) || parsed < 1) {
+          log.error(
+            `${flag} must be a positive integer or 'null' (got "${raw}")`,
+          );
+          process.exitCode = 1;
+          throw new Error("invalid-override");
+        }
+        return parsed;
+      };
+
+      let configOverrides:
+        | {
+            tier1_size?: number | null;
+            tier2_size?: number | null;
+            batch_size?: number | null;
+          }
+        | undefined;
+      try {
+        const t1 = parseOverride("--tier1-size", opts.tier1Size);
+        const t2 = parseOverride("--tier2-size", opts.tier2Size);
+        const bs = parseOverride("--batch-size", opts.batchSize);
+        configOverrides = {
+          ...(t1 !== undefined ? { tier1_size: t1 } : {}),
+          ...(t2 !== undefined ? { tier2_size: t2 } : {}),
+          ...(bs !== undefined ? { batch_size: bs } : {}),
+        };
+        if (Object.keys(configOverrides).length === 0) {
+          configOverrides = undefined;
+        }
+      } catch {
+        return;
+      }
+
+      const result = await cliIpcCall<MemoryV2SimulateRouterResult>(
+        "memory_v2_simulate_router",
+        {
+          body: {
+            // The CLI flag is still named `--query` for backwards
+            // compatibility. It becomes the just-arrived
+            // `userMessage` of a single (empty assistant, user)
+            // pair — i.e. a first-turn scenario. nowText uses
+            // the server default (live NOW.md), preserving the
+            // existing single-turn CLI semantics.
+            recentTurnPairs: [
+              { assistantMessage: "", userMessage: opts.query },
+            ],
+            ...(configOverrides ? { configOverrides } : {}),
+          },
+        },
+      );
+
+      if (!result.ok) {
+        log.error(result.error ?? "Failed to simulate router");
+        process.exitCode = 1;
+        return;
+      }
+
+      const payload = result.result!;
+
+      if (opts.json === true) {
+        log.info(JSON.stringify(payload, null, 2));
+        return;
+      }
+
+      log.info("Memory Router Simulation");
+      log.info("========================");
+      log.info(`Query: ${JSON.stringify(opts.query)}`);
+      log.info("");
+      log.info("Config (effective):");
+      const formatKnob = (
+        key: keyof MemoryV2SimulateRouterResult["effectiveConfig"],
+      ): string => {
+        const eff = payload.effectiveConfig[key];
+        const override = (
+          payload.overrides as Record<string, number | null | undefined>
+        )[key];
+        const effStr = eff === null ? "null" : String(eff);
+        if (override === undefined) {
+          return `  ${key}: ${effStr}`;
+        }
+        return `  ${key}: ${effStr}  (override)`;
+      };
+      log.info(formatKnob("tier1_size"));
+      log.info(formatKnob("tier2_size"));
+      log.info(formatKnob("batch_size"));
+      log.info(`  max_page_ids: ${payload.effectiveConfig.max_page_ids}`);
+      log.info("");
+      log.info(`Total candidate pages: ${payload.totalCandidatePages}`);
+      log.info(
+        `Selected: ${payload.selectedSlugs.length} / ${payload.effectiveConfig.max_page_ids} pages`,
+      );
+      if (payload.failureReason) {
+        log.info(`Failure: ${payload.failureReason}`);
+      }
+      log.info("");
+
+      const grouped = new Map<string, string[]>();
+      for (const slug of payload.selectedSlugs) {
+        const source = payload.sourceBySlug[slug] ?? "unknown";
+        const bucket = grouped.get(source) ?? [];
+        bucket.push(slug);
+        grouped.set(source, bucket);
+      }
+      const sortedKeys = [...grouped.keys()].sort((a, b) => {
+        const order = (s: string) => {
+          if (s === "tier1") return 0;
+          if (s === "tier2") return 1;
+          if (s.startsWith("tier3:")) {
+            return 2 + Number(s.slice("tier3:".length));
+          }
+          return Number.MAX_SAFE_INTEGER;
+        };
+        return order(a) - order(b);
+      });
+
+      for (const key of sortedKeys) {
+        const label = key.startsWith("tier3:")
+          ? `tier 3 · b${key.slice("tier3:".length)}`
+          : key === "tier1"
+            ? "tier 1"
+            : key === "tier2"
+              ? "tier 2"
+              : key;
+        log.info(label);
+        for (const slug of grouped.get(key)!) {
+          if (key === "tier2") {
+            const score = payload.scores[slug] ?? 0;
+            log.info(`  - ${slug}  (EMA ${score.toFixed(3)})`);
+          } else {
+            log.info(`  - ${slug}`);
+          }
+        }
+        log.info("");
+      }
+    },
+  );
+
+  // ── compare ─────────────────────────────────────────────────────────
+
+  // The repeatable `--conversation` option (accumulator parser + array
+  // default) and the options that must follow it in help order are not
+  // expressible in the declarative help contract, so they stay imperative.
+  subcommand(v2, "compare")
+    .option(
+      "--conversation <id>",
+      "Restrict to a conversation id (repeatable)",
+      (val: string, acc: string[]) => {
+        acc.push(val);
+        return acc;
+      },
+      [] as string[],
+    )
+    .option(
+      "--trace <conversationId:turn>",
+      "Print the per-retriever breakdown for one scored turn",
+    )
+    .option(
+      "--include-not-injected",
+      "Also count router picks cut by the injection cap as ground truth",
+    )
+    .option("--json", "Emit raw JSON instead of a formatted report")
+    .action(
+      async (opts: {
+        limit?: string;
+        strategy?: string;
+        k?: string;
+        conversation?: string[];
+        trace?: string;
+        includeNotInjected?: boolean;
+        json?: boolean;
+      }) => {
+        let limit: number | undefined;
+        if (opts.limit !== undefined) {
+          const parsed = Number(opts.limit);
+          if (!Number.isInteger(parsed) || parsed < 1) {
+            log.error(
+              `--limit must be a positive integer (got "${opts.limit}")`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+          limit = parsed;
+        }
+
+        if (
+          opts.strategy !== undefined &&
+          opts.strategy !== "recent" &&
+          opts.strategy !== "random"
+        ) {
+          log.error(
+            `--strategy must be "recent" or "random" (got "${opts.strategy}")`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+
+        let ks: number[] | undefined;
+        if (opts.k !== undefined) {
+          ks = opts.k.split(",").map((s) => Number(s.trim()));
+          if (ks.some((k) => !Number.isInteger(k) || k < 1)) {
+            log.error(
+              `--k must be a comma-separated list of positive integers (got "${opts.k}")`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+        }
+
+        const conversationIds =
+          opts.conversation && opts.conversation.length > 0
+            ? opts.conversation
+            : undefined;
+
+        const result = await cliIpcCall<ComparisonReport>(
+          "memory_v2_compare_retrievers",
+          {
+            body: {
+              ...(limit !== undefined ? { limit } : {}),
+              ...(opts.strategy !== undefined
+                ? { strategy: opts.strategy }
+                : {}),
+              ...(ks !== undefined ? { ks } : {}),
+              ...(conversationIds !== undefined ? { conversationIds } : {}),
+              ...(opts.includeNotInjected === true
+                ? { includeNotInjected: true }
+                : {}),
+            },
+          },
+        );
+
+        if (!result.ok) {
+          log.error(result.error ?? "Failed to compare retrievers");
+          process.exitCode = 1;
+          return;
+        }
+
+        const payload = result.result!;
+
+        if (opts.json === true) {
+          log.info(JSON.stringify(payload, null, 2));
+          return;
+        }
+
+        log.info(renderComparisonReport(payload));
+
+        if (opts.trace !== undefined) {
+          const sep = opts.trace.lastIndexOf(":");
+          if (sep <= 0 || sep === opts.trace.length - 1) {
+            log.error(
+              `--trace must be "<conversationId>:<turn>" (got "${opts.trace}")`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+          const conversationId = opts.trace.slice(0, sep);
+          const turn = Number(opts.trace.slice(sep + 1));
+          if (!Number.isInteger(turn)) {
+            log.error(
+              `--trace turn must be an integer (got "${opts.trace.slice(sep + 1)}")`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+          log.info("");
+          log.info(renderTurnTrace(payload, conversationId, turn));
+        }
+      },
+    );
 }

--- a/assistant/src/cli/commands/memory/memory-v3.ts
+++ b/assistant/src/cli/commands/memory/memory-v3.ts
@@ -28,7 +28,7 @@ import type {
   MemoryV3BackfillSectionsResult,
   MemoryV3RebuildIndexResult,
 } from "../../../plugins/defaults/memory/routes/memory-v3-routes.js";
-import { registerCommand } from "../../lib/register-command.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { log } from "../../logger.js";
 
 /**
@@ -98,300 +98,175 @@ function formatTally(r: MemoryEvalTallyResult): string {
 }
 
 export function registerMemoryV3Command(memory: Command): void {
-  registerCommand(memory, {
-    name: "v3",
-    transport: "ipc",
-    description: "Memory v3 live-lane maintenance (section-lane model)",
-    build: (v3) => {
-      v3.addHelpText(
-        "after",
-        `
-The v3 memory subsystem retrieves concept pages over section-grain lanes and
-caches them as live shadow lanes inside the assistant. These commands maintain
-that live state safely.
+  const v3 = subcommand(memory, "v3");
 
-Examples:
-  $ assistant memory v3 rebuild-index
-  $ assistant memory v3 backfill-sections`,
-      );
+  // ── rebuild-index ─────────────────────────────────────────────────────
 
-      // ── rebuild-index ─────────────────────────────────────────────────────
-
-      v3.command("rebuild-index")
-        .description("Invalidate the v3 lanes so the next turn rebuilds")
-        .addHelpText(
-          "after",
-          `
-Drops the assistant's cached v3 shadow lanes so the section index is rebuilt
-from the current on-disk state on the next turn. Useful after editing concept
-pages out-of-band.
-
-Examples:
-  $ assistant memory v3 rebuild-index`,
-        )
-        .action(async () => {
-          const result = await cliIpcCall<MemoryV3RebuildIndexResult>(
-            "memory_v3_rebuild_index",
-            { body: {} },
-          );
-          if (!result.ok) {
-            log.error(result.error ?? "Failed to invalidate the v3 lanes");
-            process.exitCode = 1;
-            return;
-          }
-          log.info("v3 lanes invalidated; next turn will rebuild.");
-        });
-
-      // ── backfill-sections ─────────────────────────────────────────────────
-
-      v3.command("backfill-sections")
-        .description(
-          "One-time: embed every page's sections into the dense store (incl skills/CLI)",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .addHelpText(
-          "after",
-          `
-Embeds EVERY concept page's sections — including synthetic skill and CLI
-capability rows — into the section dense store in one pass, then advances
-the maintain checkpoint so the next incremental pass only re-embeds future
-edits. Use this once on an existing install before the section-lane A/B and
-cutover: the dense collection starts empty, and the periodic maintenance
-pass only re-embeds pages edited since its last run (and never the synthetic
-rows), so most of the corpus would otherwise never be embedded.
-
-Idempotent and safe to re-run. Runs inside the assistant so it uses the live
-configuration and advances the checkpoint the assistant reads.
-
-Examples:
-  $ assistant memory v3 backfill-sections
-  $ assistant memory v3 backfill-sections --json | jq '.sections'`,
-        )
-        .action(async (opts: { json?: boolean }) => {
-          const result = await cliIpcCall<MemoryV3BackfillSectionsResult>(
-            "memory_v3_backfill_sections",
-            { body: {} },
-            { timeoutMs: BACKFILL_IPC_TIMEOUT_MS },
-          );
-          if (!result.ok) {
-            log.error(result.error ?? "Failed to backfill section embeddings");
-            process.exitCode = 1;
-            return;
-          }
-          const payload = result.result!;
-          if (opts.json === true) {
-            log.info(JSON.stringify(payload, null, 2));
-            return;
-          }
-          log.info(
-            `Embedded ${payload.sections} sections across ${payload.articles} pages` +
-              (payload.failures > 0
-                ? ` (${payload.failures} page(s) failed — see assistant logs).`
-                : "."),
-          );
-        });
-
-      // ── eval ──────────────────────────────────────────────────────────────
-
-      v3.command("eval")
-        .description(
-          "Build blinded A/B retrieval-eval packets (snapshot corpus vs staged wiki)",
-        )
-        .requiredOption(
-          "--staging <dir>",
-          "Staged v3 wiki dir (relative to the workspace, or absolute)",
-        )
-        .requiredOption(
-          "--snapshot <dir>",
-          "Read-only v2 snapshot dir (relative to the workspace, or absolute)",
-        )
-        .requiredOption("--out <dir>", "Output dir for packets.json + key.json")
-        .option("--turns <n>", "Number of recent turns to mine", "30")
-        .option("--k <n>", "Pages per memory set", "8")
-        .option(
-          "--seed <n>",
-          "Blinding seed (reproducible A/B assignment)",
-          "1",
-        )
-        .option(
-          "--no-dense",
-          "Needle-only: skip section embedding (fast, cheaper, lower fidelity)",
-        )
-        .option(
-          "--turns-file <path>",
-          "Pin the exact turns from a prior key.json/packets.json (reproducible re-judge); overrides --turns",
-        )
-        .option(
-          "--exclude-conversation <id>",
-          "Conversation id to omit from mining (repeatable; e.g. the migration's own chat)",
-          collectRepeatable,
-          [],
-        )
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .addHelpText(
-          "after",
-          `
-Mines recent user turns, retrieves the top pages from each corpus per turn, and
-writes blinded A/B packets (plus a separate unblinding key) for a blind-judge
-workflow. Both corpora are read in memory — nothing in the live lanes or Qdrant
-is touched. With the dense lane on (default) it embeds every section of both
-corpora, which can take a while on a large corpus; use --no-dense for a fast
-lexical-only pass.
-
-To iterate on the staged wiki reproducibly, mine the turns ONCE and pin them on
-every re-run with --turns-file (pointing at the first run's key.json), so the
-comparison stays fixed while only the staged corpus changes. Re-runs that
-re-mine drift onto a different turn set and are not comparable. Likewise, do not
-compare a --no-dense run against a dense one, and check eval-meta.json's
-embedding identity is the same across runs.
-
-Examples:
-  $ assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval
-  $ assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval --turns-file .mv3/eval/key.json
-  $ assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval --exclude-conversation <migration-conv-id>`,
-        )
-        .action(
-          async (opts: {
-            staging: string;
-            snapshot: string;
-            out: string;
-            turns: string;
-            k: string;
-            seed: string;
-            dense: boolean;
-            turnsFile?: string;
-            excludeConversation: string[];
-            json?: boolean;
-          }) => {
-            let turnIds: string[] | undefined;
-            if (opts.turnsFile !== undefined) {
-              try {
-                turnIds = readTurnIdsFromFile(opts.turnsFile);
-              } catch (err) {
-                log.error(err instanceof Error ? err.message : String(err));
-                process.exitCode = 1;
-                return;
-              }
-            }
-            const result = await cliIpcCall<MemoryEvalRunResult>(
-              "memory_eval_run",
-              {
-                body: {
-                  stagingDir: opts.staging,
-                  snapshotDir: opts.snapshot,
-                  outDir: opts.out,
-                  turns: Number(opts.turns),
-                  k: Number(opts.k),
-                  seed: Number(opts.seed),
-                  dense: opts.dense,
-                  ...(turnIds ? { turnIds } : {}),
-                  ...(opts.excludeConversation.length > 0
-                    ? { excludeConversationIds: opts.excludeConversation }
-                    : {}),
-                },
-              },
-              { timeoutMs: EVAL_IPC_TIMEOUT_MS },
-            );
-            if (!result.ok) {
-              log.error(result.error ?? "Failed to build eval packets");
-              process.exitCode = 1;
-              return;
-            }
-            const payload = result.result!;
-            if (opts.json === true) {
-              log.info(JSON.stringify(payload, null, 2));
-              return;
-            }
-            const emb = payload.embedding;
-            const embStr = payload.dense
-              ? `${emb.provider}/${emb.model}/${emb.dims ?? "?"}d`
-              : "needle-only (no dense)";
-            log.info(
-              `Wrote ${payload.packetsWritten} packets from ${payload.turnsMined}/${payload.turnsRequested} turns ` +
-                `(snapshot ${payload.snapshotPages} pages vs staged ${payload.stagingPages} pages, ` +
-                `dense=${payload.dense}, embedding=${embStr}).\n` +
-                `  packets: ${payload.packetsPath}\n  key:     ${payload.keyPath}\n  meta:    ${payload.metaPath}\n` +
-                `  Re-judge reproducibly with: --turns-file ${payload.keyPath}`,
-            );
-            if (payload.turnsMined < payload.turnsRequested) {
-              log.warn(
-                `Only ${payload.turnsMined} of ${payload.turnsRequested} requested turns were mined ` +
-                  `(pinned turns may have been deleted, or there are too few recent user turns).`,
-              );
-            }
-          },
-        );
-
-      v3.command("eval-tally")
-        .description(
-          "Unblind + tally blind-judge verdicts against key.json with a noise-aware win/tie/loss verdict",
-        )
-        .requiredOption(
-          "--verdicts <path>",
-          "JSON file: array of { turn, winner, scoreA, scoreB } (one or more per turn for a panel)",
-        )
-        .requiredOption(
-          "--key <path>",
-          "key.json from `eval` — the per-turn A/B → snapshot/staging unblinding map",
-        )
-        .option(
-          "--alpha <p>",
-          "Significance threshold for the sign test (the wiki only FAILS on a significant snapshot lead)",
-          "0.05",
-        )
-        .option("--out <path>", "Also write the full tally JSON to this path")
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .addHelpText(
-          "after",
-          `
-Joins the blind-judge verdicts to the unblinding key (A/B is shuffled PER TURN,
-so the winner must be mapped turn-by-turn — a global A-vs-B count is wrong) and
-applies a two-sided sign test: the wiki only FAILS when the snapshot's win lead
-is statistically significant. A within-noise difference is a tie, which passes
-the win-or-tie gate. Pass a judge PANEL (multiple verdicts per turn, e.g. from
-re-judging under several seeds) to control single-vote noise.
-
-Example:
-  $ assistant memory v3 eval-tally --verdicts .mv3/eval/verdicts.json --key .mv3/eval/key.json`,
-        )
-        .action(
-          async (opts: {
-            verdicts: string;
-            key: string;
-            alpha: string;
-            out?: string;
-            json?: boolean;
-          }) => {
-            let verdicts: unknown[];
-            let key: unknown[];
-            try {
-              verdicts = readJsonArray<unknown>(opts.verdicts, "verdicts");
-              key = readJsonArray<unknown>(opts.key, "key");
-            } catch (err) {
-              log.error(err instanceof Error ? err.message : String(err));
-              process.exitCode = 1;
-              return;
-            }
-            const result = await cliIpcCall<MemoryEvalTallyResult>(
-              "memory_eval_tally",
-              { body: { verdicts, key, alpha: Number(opts.alpha) } },
-            );
-            if (!result.ok) {
-              log.error(result.error ?? "Failed to tally verdicts");
-              process.exitCode = 1;
-              return;
-            }
-            const payload = result.result!;
-            if (opts.out !== undefined) {
-              writeFileSync(opts.out, JSON.stringify(payload, null, 2));
-            }
-            if (opts.json === true) {
-              log.info(JSON.stringify(payload, null, 2));
-              return;
-            }
-            log.info(formatTally(payload));
-          },
-        );
-    },
+  subcommand(v3, "rebuild-index").action(async () => {
+    const result = await cliIpcCall<MemoryV3RebuildIndexResult>(
+      "memory_v3_rebuild_index",
+      { body: {} },
+    );
+    if (!result.ok) {
+      log.error(result.error ?? "Failed to invalidate the v3 lanes");
+      process.exitCode = 1;
+      return;
+    }
+    log.info("v3 lanes invalidated; next turn will rebuild.");
   });
+
+  // ── backfill-sections ─────────────────────────────────────────────────
+
+  subcommand(v3, "backfill-sections").action(
+    async (opts: { json?: boolean }) => {
+      const result = await cliIpcCall<MemoryV3BackfillSectionsResult>(
+        "memory_v3_backfill_sections",
+        { body: {} },
+        { timeoutMs: BACKFILL_IPC_TIMEOUT_MS },
+      );
+      if (!result.ok) {
+        log.error(result.error ?? "Failed to backfill section embeddings");
+        process.exitCode = 1;
+        return;
+      }
+      const payload = result.result!;
+      if (opts.json === true) {
+        log.info(JSON.stringify(payload, null, 2));
+        return;
+      }
+      log.info(
+        `Embedded ${payload.sections} sections across ${payload.articles} pages` +
+          (payload.failures > 0
+            ? ` (${payload.failures} page(s) failed — see assistant logs).`
+            : "."),
+      );
+    },
+  );
+
+  // ── eval ──────────────────────────────────────────────────────────────
+
+  // The repeatable `--exclude-conversation` option (accumulator parser +
+  // array default) and the `--json` option that must follow it in help order
+  // are not expressible in the declarative help contract, so they stay
+  // imperative.
+  subcommand(v3, "eval")
+    .option(
+      "--exclude-conversation <id>",
+      "Conversation id to omit from mining (repeatable; e.g. the migration's own chat)",
+      collectRepeatable,
+      [],
+    )
+    .option("--json", "Emit raw JSON instead of a formatted summary")
+    .action(
+      async (opts: {
+        staging: string;
+        snapshot: string;
+        out: string;
+        turns: string;
+        k: string;
+        seed: string;
+        dense: boolean;
+        turnsFile?: string;
+        excludeConversation: string[];
+        json?: boolean;
+      }) => {
+        let turnIds: string[] | undefined;
+        if (opts.turnsFile !== undefined) {
+          try {
+            turnIds = readTurnIdsFromFile(opts.turnsFile);
+          } catch (err) {
+            log.error(err instanceof Error ? err.message : String(err));
+            process.exitCode = 1;
+            return;
+          }
+        }
+        const result = await cliIpcCall<MemoryEvalRunResult>(
+          "memory_eval_run",
+          {
+            body: {
+              stagingDir: opts.staging,
+              snapshotDir: opts.snapshot,
+              outDir: opts.out,
+              turns: Number(opts.turns),
+              k: Number(opts.k),
+              seed: Number(opts.seed),
+              dense: opts.dense,
+              ...(turnIds ? { turnIds } : {}),
+              ...(opts.excludeConversation.length > 0
+                ? { excludeConversationIds: opts.excludeConversation }
+                : {}),
+            },
+          },
+          { timeoutMs: EVAL_IPC_TIMEOUT_MS },
+        );
+        if (!result.ok) {
+          log.error(result.error ?? "Failed to build eval packets");
+          process.exitCode = 1;
+          return;
+        }
+        const payload = result.result!;
+        if (opts.json === true) {
+          log.info(JSON.stringify(payload, null, 2));
+          return;
+        }
+        const emb = payload.embedding;
+        const embStr = payload.dense
+          ? `${emb.provider}/${emb.model}/${emb.dims ?? "?"}d`
+          : "needle-only (no dense)";
+        log.info(
+          `Wrote ${payload.packetsWritten} packets from ${payload.turnsMined}/${payload.turnsRequested} turns ` +
+            `(snapshot ${payload.snapshotPages} pages vs staged ${payload.stagingPages} pages, ` +
+            `dense=${payload.dense}, embedding=${embStr}).\n` +
+            `  packets: ${payload.packetsPath}\n  key:     ${payload.keyPath}\n  meta:    ${payload.metaPath}\n` +
+            `  Re-judge reproducibly with: --turns-file ${payload.keyPath}`,
+        );
+        if (payload.turnsMined < payload.turnsRequested) {
+          log.warn(
+            `Only ${payload.turnsMined} of ${payload.turnsRequested} requested turns were mined ` +
+              `(pinned turns may have been deleted, or there are too few recent user turns).`,
+          );
+        }
+      },
+    );
+
+  // ── eval-tally ────────────────────────────────────────────────────────
+
+  subcommand(v3, "eval-tally").action(
+    async (opts: {
+      verdicts: string;
+      key: string;
+      alpha: string;
+      out?: string;
+      json?: boolean;
+    }) => {
+      let verdicts: unknown[];
+      let key: unknown[];
+      try {
+        verdicts = readJsonArray<unknown>(opts.verdicts, "verdicts");
+        key = readJsonArray<unknown>(opts.key, "key");
+      } catch (err) {
+        log.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+        return;
+      }
+      const result = await cliIpcCall<MemoryEvalTallyResult>(
+        "memory_eval_tally",
+        { body: { verdicts, key, alpha: Number(opts.alpha) } },
+      );
+      if (!result.ok) {
+        log.error(result.error ?? "Failed to tally verdicts");
+        process.exitCode = 1;
+        return;
+      }
+      const payload = result.result!;
+      if (opts.out !== undefined) {
+        writeFileSync(opts.out, JSON.stringify(payload, null, 2));
+      }
+      if (opts.json === true) {
+        log.info(JSON.stringify(payload, null, 2));
+        return;
+      }
+      log.info(formatTally(payload));
+    },
+  );
 }

--- a/assistant/src/cli/commands/memory/nodes.ts
+++ b/assistant/src/cli/commands/memory/nodes.ts
@@ -16,7 +16,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
-import { registerCommand } from "../../lib/register-command.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { log } from "../../logger.js";
 import { writeOutput } from "../../output.js";
 
@@ -42,260 +42,165 @@ interface MemoryNodeMutationResult {
 }
 
 export function registerMemoryNodesCommand(memory: Command): void {
-  registerCommand(memory, {
-    name: "nodes",
-    transport: "ipc",
-    description: "Content-based list, delete, and update of memory graph nodes",
-    build: (nodes) => {
-      nodes.addHelpText(
-        "after",
-        `
-Memory nodes are raw graph records (content, type, fidelity) produced by the
-memory v2 subsystem. Unlike 'memory items', which addresses nodes by UUID, these
-commands address nodes by content text — matching the way an operator refers to
-a remembered fact without first looking up its ID.
+  const nodes = subcommand(memory, "nodes");
 
-All subcommands require memory v2 to be enabled and the assistant to be running.
+  // ── list ──────────────────────────────────────────────────────────────
 
-Examples:
-  $ assistant memory nodes list
-  $ assistant memory nodes list --search "TypeScript" --limit 20
-  $ assistant memory nodes delete "User prefers TypeScript"
-  $ assistant memory nodes update "User prefers TypeScript" "User prefers TypeScript and Bun"`,
-      );
+  subcommand(nodes, "list")
+    .alias("ls")
+    .action(
+      async (
+        opts: { search?: string; limit?: string; json?: boolean },
+        cmd: Command,
+      ) => {
+        const queryParams: Record<string, string> = {};
+        if (opts.search) {
+          queryParams.search = opts.search;
+        }
+        if (opts.limit) {
+          queryParams.limit = opts.limit;
+        }
+        const r = await cliIpcCall<ListMemoryNodesResult>("listMemoryNodes", {
+          queryParams,
+        });
+        if (!r.ok) {
+          exitFromIpcResult(r, cmd);
+        }
+        const result = r.result!;
 
-      // ── list ──────────────────────────────────────────────────────────────
+        if (!result.success) {
+          log.error(result.message);
+          process.exitCode = 1;
+          return;
+        }
 
-      nodes
-        .command("list")
-        .alias("ls")
-        .description("List active memory graph nodes")
-        .option(
-          "--search <query>",
-          "Filter nodes whose content contains <query>",
-        )
-        .option("--limit <n>", "Max results (default 50, max 200)")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Behavior:
-  Returns active (non-deleted) memory graph nodes ordered by significance.
-  With --search, all nodes are scanned so the filter is exhaustive regardless
-  of graph size. Without --search the query is capped at --limit rows at the
-  DB level for efficiency.
+        if (opts.json) {
+          writeOutput(cmd, { nodes: result.nodes, total: result.total });
+          return;
+        }
 
-Examples:
-  $ assistant memory nodes list
-  $ assistant memory nodes list --search "coffee" --limit 10
-  $ assistant memory nodes list --json`,
-        )
-        .action(
-          async (
-            opts: { search?: string; limit?: string; json?: boolean },
-            cmd: Command,
-          ) => {
-            const queryParams: Record<string, string> = {};
-            if (opts.search) {
-              queryParams.search = opts.search;
-            }
-            if (opts.limit) {
-              queryParams.limit = opts.limit;
-            }
-            const r = await cliIpcCall<ListMemoryNodesResult>(
-              "listMemoryNodes",
-              { queryParams },
-            );
-            if (!r.ok) {
-              exitFromIpcResult(r, cmd);
-            }
-            const result = r.result!;
+        if (result.nodes.length === 0) {
+          log.info(
+            opts.search
+              ? `No memory nodes found matching "${opts.search}".`
+              : "No memory nodes found. The memory graph is empty.",
+          );
+          return;
+        }
 
-            if (!result.success) {
-              log.error(result.message);
-              process.exitCode = 1;
-              return;
-            }
+        const CONTENT_WIDTH = 60;
+        const truncate = (s: string) =>
+          s.length > CONTENT_WIDTH ? s.slice(0, CONTENT_WIDTH - 1) + "…" : s;
 
-            if (opts.json) {
-              writeOutput(cmd, { nodes: result.nodes, total: result.total });
-              return;
-            }
-
-            if (result.nodes.length === 0) {
-              log.info(
-                opts.search
-                  ? `No memory nodes found matching "${opts.search}".`
-                  : "No memory nodes found. The memory graph is empty.",
-              );
-              return;
-            }
-
-            const CONTENT_WIDTH = 60;
-            const truncate = (s: string) =>
-              s.length > CONTENT_WIDTH
-                ? s.slice(0, CONTENT_WIDTH - 1) + "…"
-                : s;
-
-            const typeWidth = Math.max(
-              4,
-              ...result.nodes.map((n) => n.type.length),
-            );
-            const fidelityWidth = Math.max(
-              7,
-              ...result.nodes.map((n) => n.fidelity.length),
-            );
-
-            console.log(
-              `${"CONTENT".padEnd(CONTENT_WIDTH)}  ${"TYPE".padEnd(
-                typeWidth,
-              )}  ${"FIDELITY".padEnd(fidelityWidth)}  CREATED`,
-            );
-
-            for (const n of result.nodes) {
-              const created = new Date(n.created).toLocaleString("en-US", {
-                month: "short",
-                day: "numeric",
-                hour: "numeric",
-                minute: "2-digit",
-              });
-              console.log(
-                `${truncate(n.content).padEnd(CONTENT_WIDTH)}  ${n.type.padEnd(
-                  typeWidth,
-                )}  ${n.fidelity.padEnd(fidelityWidth)}  ${created}`,
-              );
-            }
-
-            console.log(
-              `\n${result.total} node${result.total === 1 ? "" : "s"}${
-                opts.search ? ` matching "${opts.search}"` : ""
-              }`,
-            );
-          },
+        const typeWidth = Math.max(
+          4,
+          ...result.nodes.map((n) => n.type.length),
+        );
+        const fidelityWidth = Math.max(
+          7,
+          ...result.nodes.map((n) => n.fidelity.length),
         );
 
-      // ── delete ────────────────────────────────────────────────────────────
-
-      nodes
-        .command("delete <content>")
-        .alias("rm")
-        .description("Delete a memory node by content match")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  <content>  The text of the memory to delete. Exact match (case-insensitive)
-             takes priority; if no exact match exists, a substring match is
-             tried. Fails when 0 or more than 1 nodes match — use
-             'assistant memory nodes list --search <query>' to find exact text.
-
-Behavior:
-  Hard-deletes the graph node and removes it from the recall index. This
-  operation is permanent; use 'assistant memory nodes update' to correct
-  content instead of deleting it.
-
-Examples:
-  $ assistant memory nodes delete "User prefers TypeScript"
-  $ assistant memory nodes delete "User prefers TypeScript" --json`,
-        )
-        .action(
-          async (content: string, opts: { json?: boolean }, cmd: Command) => {
-            if (!content.trim()) {
-              log.error(
-                "content is required. Run 'assistant memory nodes list' to find the exact text.",
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            const r = await cliIpcCall<MemoryNodeMutationResult>(
-              "deleteMemoryNode",
-              { body: { content } },
-            );
-            if (!r.ok) {
-              exitFromIpcResult(r, cmd);
-            }
-            const result = r.result!;
-
-            if (!result.success) {
-              log.error(result.message);
-              process.exitCode = 1;
-              return;
-            }
-
-            if (opts.json) {
-              writeOutput(cmd, result);
-              return;
-            }
-
-            log.info(result.message);
-          },
+        console.log(
+          `${"CONTENT".padEnd(CONTENT_WIDTH)}  ${"TYPE".padEnd(
+            typeWidth,
+          )}  ${"FIDELITY".padEnd(fidelityWidth)}  CREATED`,
         );
 
-      // ── update ────────────────────────────────────────────────────────────
+        for (const n of result.nodes) {
+          const created = new Date(n.created).toLocaleString("en-US", {
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+          });
+          console.log(
+            `${truncate(n.content).padEnd(CONTENT_WIDTH)}  ${n.type.padEnd(
+              typeWidth,
+            )}  ${n.fidelity.padEnd(fidelityWidth)}  ${created}`,
+          );
+        }
 
-      nodes
-        .command("update <old-content> <new-content>")
-        .description("Update a memory node's content in place")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  <old-content>  Text of the memory to update. Exact match (case-insensitive)
-                 takes priority over substring match. Fails when 0 or more than
-                 1 nodes match.
-  <new-content>  Replacement text. Fails if another active node already has
-                 this content (prevents duplicates).
-
-Behavior:
-  Replaces the node's content and re-embeds it so recall stays consistent.
-  Use this to correct a fact rather than deleting and re-adding it — the edit
-  history is preserved on the node.
-
-Examples:
-  $ assistant memory nodes update "User prefers TypeScript" "User prefers TypeScript and Bun"
-  $ assistant memory nodes update "old fact" "corrected fact" --json`,
-        )
-        .action(
-          async (
-            oldContent: string,
-            newContent: string,
-            opts: { json?: boolean },
-            cmd: Command,
-          ) => {
-            if (!oldContent.trim() || !newContent.trim()) {
-              log.error(
-                "Both <old-content> and <new-content> are required. Run 'assistant memory nodes list' to find the exact text.",
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            const r = await cliIpcCall<MemoryNodeMutationResult>(
-              "updateMemoryNode",
-              { body: { oldContent, newContent } },
-            );
-            if (!r.ok) {
-              exitFromIpcResult(r, cmd);
-            }
-            const result = r.result!;
-
-            if (!result.success) {
-              log.error(result.message);
-              process.exitCode = 1;
-              return;
-            }
-
-            if (opts.json) {
-              writeOutput(cmd, result);
-              return;
-            }
-
-            log.info(result.message);
-          },
+        console.log(
+          `\n${result.total} node${result.total === 1 ? "" : "s"}${
+            opts.search ? ` matching "${opts.search}"` : ""
+          }`,
         );
+      },
+    );
+
+  // ── delete ────────────────────────────────────────────────────────────
+
+  subcommand(nodes, "delete")
+    .alias("rm")
+    .action(async (content: string, opts: { json?: boolean }, cmd: Command) => {
+      if (!content.trim()) {
+        log.error(
+          "content is required. Run 'assistant memory nodes list' to find the exact text.",
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const r = await cliIpcCall<MemoryNodeMutationResult>("deleteMemoryNode", {
+        body: { content },
+      });
+      if (!r.ok) {
+        exitFromIpcResult(r, cmd);
+      }
+      const result = r.result!;
+
+      if (!result.success) {
+        log.error(result.message);
+        process.exitCode = 1;
+        return;
+      }
+
+      if (opts.json) {
+        writeOutput(cmd, result);
+        return;
+      }
+
+      log.info(result.message);
+    });
+
+  // ── update ────────────────────────────────────────────────────────────
+
+  subcommand(nodes, "update").action(
+    async (
+      oldContent: string,
+      newContent: string,
+      opts: { json?: boolean },
+      cmd: Command,
+    ) => {
+      if (!oldContent.trim() || !newContent.trim()) {
+        log.error(
+          "Both <old-content> and <new-content> are required. Run 'assistant memory nodes list' to find the exact text.",
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const r = await cliIpcCall<MemoryNodeMutationResult>("updateMemoryNode", {
+        body: { oldContent, newContent },
+      });
+      if (!r.ok) {
+        exitFromIpcResult(r, cmd);
+      }
+      const result = r.result!;
+
+      if (!result.success) {
+        log.error(result.message);
+        process.exitCode = 1;
+        return;
+      }
+
+      if (opts.json) {
+        writeOutput(cmd, result);
+        return;
+      }
+
+      log.info(result.message);
     },
-  });
+  );
 }

--- a/assistant/src/cli/commands/memory/worker.ts
+++ b/assistant/src/cli/commands/memory/worker.ts
@@ -14,7 +14,7 @@
  *   - `status` — report the worker process state, the `memory.worker.enabled`
  *     config value, and whether the synchronous in-process runner is going.
  *
- * All three are thin IPC wrappers (transport: "ipc"): the daemon owns the
+ * All three are thin IPC wrappers: the daemon owns the
  * worker process so it is spawned as a *child of the daemon* — which is what
  * makes it appear in `assistant ps` and lets the daemon tear it down on
  * shutdown. (If the CLI spawned the worker itself, the short-lived CLI process
@@ -24,7 +24,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
-import { registerCommand } from "../../lib/register-command.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -58,108 +58,73 @@ interface StatusResponse {
 // ---------------------------------------------------------------------------
 
 export function registerMemoryWorkerCommand(memory: Command): void {
-  registerCommand(memory, {
-    name: "worker",
-    transport: "ipc",
-    description: "Manage the memory jobs worker process (start/stop/status)",
-    build: (worker) => {
-      worker.addHelpText(
-        "after",
-        `
-The memory worker processes embedding, consolidation, and cleanup jobs in a
-separate OS process so they do not block the assistant's main event loop. The
-daemon owns the process, so it is spawned as a child of the daemon and shows up
-in \`assistant ps\`.
+  const worker = subcommand(memory, "worker");
 
-\`start\` enables memory.worker.enabled and \`stop\` disables it, so the
-assistant's synchronous in-process runner stands down (start) or takes back over
-(stop) without a restart.
+  subcommand(worker, "start").action(
+    async (_opts: { json?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<StartResponse>("memory_worker_start");
+      if (!r.ok) return exitFromIpcResult(r);
+      const res = r.result!;
 
-Examples:
-  $ assistant memory worker start
-  $ assistant memory worker status
-  $ assistant memory worker stop`,
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, res);
+        return;
+      }
+      log.info(
+        res.alreadyRunning
+          ? `Memory worker is already running (PID ${res.pid})`
+          : `Memory worker started (PID ${res.pid})`,
       );
-
-      worker
-        .command("start")
-        .description(
-          "Start the memory worker process and enable memory.worker.enabled",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (_opts: { json?: boolean }, cmd: Command) => {
-          const r = await cliIpcCall<StartResponse>("memory_worker_start");
-          if (!r.ok) return exitFromIpcResult(r);
-          const res = r.result!;
-
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, res);
-            return;
-          }
-          log.info(
-            res.alreadyRunning
-              ? `Memory worker is already running (PID ${res.pid})`
-              : `Memory worker started (PID ${res.pid})`,
-          );
-          log.info(
-            "Enabled memory.worker.enabled; the synchronous in-process runner will stand down",
-          );
-        });
-
-      worker
-        .command("stop")
-        .description(
-          "Stop the memory worker process and disable memory.worker.enabled",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (_opts: { json?: boolean }, cmd: Command) => {
-          const r = await cliIpcCall<StopResponse>("memory_worker_stop");
-          if (!r.ok) return exitFromIpcResult(r);
-          const res = r.result!;
-
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, res);
-            return;
-          }
-          if (res.workerWasRunning) {
-            log.info(`Memory worker stop signal sent (PID ${res.pid})`);
-          } else {
-            log.info("Memory worker process was not running");
-          }
-          log.info(
-            "Disabled memory.worker.enabled; the synchronous in-process runner will take over",
-          );
-        });
-
-      worker
-        .command("status")
-        .description(
-          "Report worker process state, memory.worker.enabled, and the synchronous runner",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (_opts: { json?: boolean }, cmd: Command) => {
-          const r = await cliIpcCall<StatusResponse>("memory_worker_status");
-          if (!r.ok) return exitFromIpcResult(r);
-          const res = r.result!;
-
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, res);
-            return;
-          }
-          if (res.status === "running") {
-            log.info(`Memory worker process is running (PID ${res.pid})`);
-          } else {
-            log.info("Memory worker process is not running");
-          }
-          log.info(`memory.worker.enabled: ${res.workerEnabled}`);
-          if (res.syncRunner.status === "running") {
-            log.info(
-              `Synchronous in-process runner is running (PID ${res.syncRunner.pid})`,
-            );
-          } else {
-            log.info("Synchronous in-process runner is not running");
-          }
-        });
+      log.info(
+        "Enabled memory.worker.enabled; the synchronous in-process runner will stand down",
+      );
     },
-  });
+  );
+
+  subcommand(worker, "stop").action(
+    async (_opts: { json?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<StopResponse>("memory_worker_stop");
+      if (!r.ok) return exitFromIpcResult(r);
+      const res = r.result!;
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, res);
+        return;
+      }
+      if (res.workerWasRunning) {
+        log.info(`Memory worker stop signal sent (PID ${res.pid})`);
+      } else {
+        log.info("Memory worker process was not running");
+      }
+      log.info(
+        "Disabled memory.worker.enabled; the synchronous in-process runner will take over",
+      );
+    },
+  );
+
+  subcommand(worker, "status").action(
+    async (_opts: { json?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<StatusResponse>("memory_worker_status");
+      if (!r.ok) return exitFromIpcResult(r);
+      const res = r.result!;
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, res);
+        return;
+      }
+      if (res.status === "running") {
+        log.info(`Memory worker process is running (PID ${res.pid})`);
+      } else {
+        log.info("Memory worker process is not running");
+      }
+      log.info(`memory.worker.enabled: ${res.workerEnabled}`);
+      if (res.syncRunner.status === "running") {
+        log.info(
+          `Synchronous in-process runner is running (PID ${res.syncRunner.pid})`,
+        );
+      } else {
+        log.info("Synchronous in-process runner is not running");
+      }
+    },
+  );
 }

--- a/assistant/src/cli/commands/notifications.help.ts
+++ b/assistant/src/cli/commands/notifications.help.ts
@@ -1,0 +1,293 @@
+/** Declarative help for the `assistant notifications` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const NOTIFICATION_SOURCE_CHANNEL_VALUES = [
+  "assistant_tool",
+  "vellum",
+  "phone",
+  "telegram",
+  "slack",
+  "scheduler",
+  "watcher",
+] as const;
+
+export const URGENCY_VALUES = ["low", "medium", "high", "critical"] as const;
+
+export const NOTIFICATION_STATUS_VALUES = [
+  "new",
+  "seen",
+  "acted_on",
+  "dismissed",
+] as const;
+
+export const NOTIFICATION_CATEGORY_VALUES = [
+  "security",
+  "scheduling",
+  "background",
+  "email",
+  "system",
+] as const;
+
+export const DEFAULT_SOURCE_CHANNEL = "assistant_tool";
+const SOURCE_CHANNEL_HELP = NOTIFICATION_SOURCE_CHANNEL_VALUES.join(", ");
+const URGENCY_HELP = URGENCY_VALUES.join(", ");
+const STATUS_HELP = NOTIFICATION_STATUS_VALUES.join(", ");
+const CATEGORY_HELP = NOTIFICATION_CATEGORY_VALUES.join(", ");
+
+export const notificationsHelp: CliCommandHelp = {
+  name: "notifications",
+  description:
+    "Send and inspect notifications through the unified notification router",
+  options: [
+    { flags: "--json", description: "Machine-readable compact JSON output" },
+  ],
+  helpText: `
+Notifications flow through a unified pipeline: a signal is emitted with a
+source channel, event name, and attention hints. The decision engine evaluates
+whether and where to deliver the notification based on connected channels,
+urgency, and user preferences.
+
+Minimal usage: only --message is required. Add --urgent for a push + visual
+flag in the inbox. Source channel/event name fall back to assistant_tool /
+assistant.share when omitted.
+
+Examples:
+  $ assistant notifications send --message "Build finished"
+  $ assistant notifications send --message "Pager: prod is down" --urgent
+  $ assistant notifications send --message "Build green" --conversation-id 649c4645-3a6f-4ded-a713-504f02ca806b`,
+  subcommands: [
+    {
+      name: "send",
+      description:
+        "Send a notification through the unified notification router. Only --message is required; pass --urgent for a push + visual flag.",
+      options: [
+        {
+          flags: "--message <message>",
+          description:
+            "Notification body. Markdown (GFM) renders in the detail panel; the OS banner shows plain text.",
+          required: true,
+        },
+        {
+          flags: "--urgent",
+          description:
+            "Mark this notification as urgent (fires push + visual flag in inbox)",
+          defaultValue: false,
+        },
+        {
+          flags: "--source-channel <channel>",
+          description: `Source channel producing this notification. One of: ${SOURCE_CHANNEL_HELP} (default: ${DEFAULT_SOURCE_CHANNEL})`,
+        },
+        {
+          flags: "--source-event-name <name>",
+          description:
+            "Event name for audit, routing, and dedupe grouping (default: assistant.share)",
+        },
+        {
+          flags: "--title <title>",
+          description:
+            "Short headline (≤ 8 words). Always provide one — the auto-derived fallback just truncates --message.",
+        },
+        {
+          flags: "--urgency <urgency>",
+          description: `Urgency hint. One of: ${URGENCY_HELP} (default: low; use --urgent for critical)`,
+        },
+        {
+          flags: "--requires-action",
+          description:
+            "Whether the notification expects user action (default: false; use --urgent to force true)",
+        },
+        {
+          flags: "--no-requires-action",
+          description: "Mark that the notification does not expect user action",
+        },
+        {
+          flags: "--is-async-background",
+          description:
+            "Whether the event is asynchronous/background work (default: false)",
+        },
+        {
+          flags: "--no-is-async-background",
+          description:
+            "Mark that the event is not asynchronous/background work",
+        },
+        {
+          flags: "--visible-in-source-now",
+          description:
+            "Set true when user is already viewing the source context (default: false)",
+        },
+        {
+          flags: "--no-visible-in-source-now",
+          description: "Mark that the user is not viewing the source context",
+        },
+        {
+          flags: "--deadline-at <epoch>",
+          description: "Optional deadline timestamp in epoch milliseconds",
+        },
+        {
+          flags: "--preferred-channels <channels>",
+          description:
+            "Comma-separated channel hints (e.g. vellum,telegram,slack)",
+        },
+        {
+          flags: "--session-id <id>",
+          description:
+            "Source session or conversation ID (default: cli-<timestamp>)",
+        },
+        {
+          flags: "--dedupe-key <key>",
+          description:
+            "Optional dedupe key to suppress duplicate notifications",
+        },
+        {
+          flags: "--deep-link-metadata <json>",
+          description:
+            "Optional JSON metadata clients can use for deep linking",
+        },
+        {
+          flags: "--conversation-id <id>",
+          description:
+            "Local vellum conversation ID to deliver into. When set, the notification reuses the specified conversation instead of starting a new one — bypasses the LLM's conversation-routing decision via affinity hint.",
+        },
+      ],
+      helpText: `
+Arguments:
+  --message            The notification body text (required, must be non-empty)
+  --urgent             Shortcut that maps to urgency=critical + requires-action=true
+
+Behavioral notes:
+  - The signal is emitted through the full notification pipeline: event store,
+    decision engine, deterministic checks, and channel dispatch.
+  - --urgent overrides --urgency and --requires-action defaults so the signal
+    is treated as critical and requires user action. Explicit --urgency /
+    --requires-action flags still win for back-compat.
+  - Without --urgent, --urgency defaults to low and --requires-action to false.
+  - --preferred-channels are hints only; the decision engine may override them.
+  - --dedupe-key suppresses duplicate signals with the same key.
+  - --conversation-id pins delivery to an existing vellum conversation
+    deterministically. Other channels (telegram, slack) continue to use
+    binding-based pairing for their external threads.
+
+Examples:
+  $ assistant notifications send --message "Task complete"
+  $ assistant notifications send --message "Pager: prod is down" --urgent
+  $ assistant notifications send --message "Build green" --conversation-id 649c4645-3a6f-4ded-a713-504f02ca806b`,
+    },
+    {
+      name: "list",
+      description:
+        "List notifications surfaced to the user via the home feed. Excludes dismissed items by default.",
+      options: [
+        {
+          flags: "--all",
+          description:
+            "Include dismissed items (default: only new/seen/acted_on)",
+          defaultValue: false,
+        },
+        {
+          flags: "--status <status>",
+          description: `Filter by status. One of: ${STATUS_HELP}; repeatable. Overrides --all default behavior.`,
+        },
+        {
+          flags: "--before <iso>",
+          description:
+            "Only items with createdAt strictly before this ISO-8601 timestamp",
+        },
+        {
+          flags: "--after <iso>",
+          description:
+            "Only items with createdAt strictly after this ISO-8601 timestamp",
+        },
+        {
+          flags: "--urgency <urgency>",
+          description: `Filter by urgency. One of: ${URGENCY_HELP}; repeatable`,
+        },
+        {
+          flags: "--category <category>",
+          description: `Filter by category. One of: ${CATEGORY_HELP}; repeatable`,
+        },
+        {
+          flags: "--conversation-id <id>",
+          description: "Only items tied to this conversation id",
+        },
+        {
+          flags: "--from-assistant",
+          description: "Only items emitted by the assistant",
+          defaultValue: false,
+        },
+        {
+          flags: "--noteworthy",
+          description: "Only items flagged as noteworthy",
+          defaultValue: false,
+        },
+        {
+          flags: "--limit <n>",
+          description:
+            "Maximum number of items to return (default: 20, max: 200)",
+        },
+        {
+          flags: "--offset <n>",
+          description: "Pagination offset (default: 0)",
+        },
+      ],
+      helpText: `
+Reads the home feed at $VELLUM_WORKSPACE_DIR/data/home-feed.json — the
+user's notification inbox. Items are ordered by priority then recency,
+matching what the user sees in the macOS Home page. The home feed covers
+background/async notifications mirrored from the unified pipeline;
+real-time chat pushes that did not mirror to the feed will not appear.
+
+Examples:
+  $ assistant notifications list
+  $ assistant notifications list --all
+  $ assistant notifications list --status new --status seen
+  $ assistant notifications list --after 2026-05-28T00:00:00Z --urgency high
+  $ assistant notifications list --conversation-id 7fab234c --json
+  $ assistant notifications list --limit 5 --offset 5`,
+    },
+    {
+      name: "edit",
+      description:
+        "Edit an already-sent notification. Patches the home-feed entry and updates the delivered channel message in place where supported (Slack today).",
+      options: [
+        {
+          flags: "--id <id>",
+          description:
+            "Feed item id (notif:<uuid>) from `notifications list --json`. Bare uuids without the `notif:` prefix are also accepted.",
+          required: true,
+        },
+        {
+          flags: "--message <message>",
+          description:
+            "New notification body. Updates the home-feed summary and the delivered channel message text where supported.",
+        },
+        {
+          flags: "--title <title>",
+          description: "New short headline (≤ 8 words).",
+        },
+        {
+          flags: "--urgency <urgency>",
+          description: `Set urgency. One of: ${URGENCY_HELP}. Feed-only — does not re-push channel messages.`,
+        },
+        {
+          flags: "--status <status>",
+          description: `Set lifecycle status. One of: ${STATUS_HELP}. Feed-only.`,
+        },
+      ],
+      helpText: `
+At least one of --message, --title, --urgency, or --status must be
+supplied. --urgency and --status only update the home-feed entry —
+they never re-push channel messages.
+
+Channel updates are best-effort: Slack messages get updated via
+chat.update; other channels (push, email, SMS) cannot be edited and
+are reported as "unsupported".
+
+Examples:
+  $ assistant notifications edit --id notif:abc12345-... --message "Fixed body"
+  $ assistant notifications edit --id abc12345-... --title "Backup complete"
+  $ assistant notifications edit --id notif:abc12345-... --urgency low
+  $ assistant notifications edit --id notif:abc12345-... --status dismissed`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -6,10 +6,19 @@ import {
   exitCodeFromIpcResult,
   exitFromIpcResult,
 } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
 import { tryResolveConversationId } from "../utils/conversation-id.js";
+import {
+  DEFAULT_SOURCE_CHANNEL,
+  NOTIFICATION_CATEGORY_VALUES,
+  NOTIFICATION_SOURCE_CHANNEL_VALUES,
+  NOTIFICATION_STATUS_VALUES,
+  notificationsHelp,
+  URGENCY_VALUES,
+} from "./notifications.help.js";
 
 // ---------------------------------------------------------------------------
 // Local types & helpers
@@ -22,39 +31,6 @@ interface ListHomeFeedPayload {
   hasMore: boolean;
   updatedAt: string;
 }
-
-const NOTIFICATION_SOURCE_CHANNEL_VALUES = [
-  "assistant_tool",
-  "vellum",
-  "phone",
-  "telegram",
-  "slack",
-  "scheduler",
-  "watcher",
-] as const;
-
-const URGENCY_VALUES = ["low", "medium", "high", "critical"] as const;
-
-const NOTIFICATION_STATUS_VALUES = [
-  "new",
-  "seen",
-  "acted_on",
-  "dismissed",
-] as const;
-
-const NOTIFICATION_CATEGORY_VALUES = [
-  "security",
-  "scheduling",
-  "background",
-  "email",
-  "system",
-] as const;
-
-const DEFAULT_SOURCE_CHANNEL = "assistant_tool";
-const SOURCE_CHANNEL_HELP = NOTIFICATION_SOURCE_CHANNEL_VALUES.join(", ");
-const URGENCY_HELP = URGENCY_VALUES.join(", ");
-const STATUS_HELP = NOTIFICATION_STATUS_VALUES.join(", ");
-const CATEGORY_HELP = NOTIFICATION_CATEGORY_VALUES.join(", ");
 
 function parseBoundedInt(
   raw: string | undefined,
@@ -134,356 +110,234 @@ function validateEnumFlag(
 
 export function registerNotificationsCommand(program: Command): void {
   registerCommand(program, {
-    name: "notifications",
+    name: notificationsHelp.name,
     transport: "ipc",
-    description:
-      "Send and inspect notifications through the unified notification router",
+    description: notificationsHelp.description,
     build: (notifications) => {
-      notifications.option("--json", "Machine-readable compact JSON output");
-
-      notifications.addHelpText(
-        "after",
-        `
-Notifications flow through a unified pipeline: a signal is emitted with a
-source channel, event name, and attention hints. The decision engine evaluates
-whether and where to deliver the notification based on connected channels,
-urgency, and user preferences.
-
-Minimal usage: only --message is required. Add --urgent for a push + visual
-flag in the inbox. Source channel/event name fall back to assistant_tool /
-assistant.share when omitted.
-
-Examples:
-  $ assistant notifications send --message "Build finished"
-  $ assistant notifications send --message "Pager: prod is down" --urgent
-  $ assistant notifications send --message "Build green" --conversation-id 649c4645-3a6f-4ded-a713-504f02ca806b`,
-      );
+      applyCommandHelp(notifications, notificationsHelp);
 
       // -------------------------------------------------------------------------
       // send
       // -------------------------------------------------------------------------
 
-      notifications
-        .command("send")
-        .description(
-          "Send a notification through the unified notification router. Only --message is required; pass --urgent for a push + visual flag.",
-        )
-        .requiredOption(
-          "--message <message>",
-          "Notification body. Markdown (GFM) renders in the detail panel; the OS banner shows plain text.",
-        )
-        .option(
-          "--urgent",
-          "Mark this notification as urgent (fires push + visual flag in inbox)",
-          false,
-        )
-        .option(
-          "--source-channel <channel>",
-          `Source channel producing this notification. One of: ${SOURCE_CHANNEL_HELP} (default: ${DEFAULT_SOURCE_CHANNEL})`,
-        )
-        .option(
-          "--source-event-name <name>",
-          "Event name for audit, routing, and dedupe grouping (default: assistant.share)",
-        )
-        .option(
-          "--title <title>",
-          "Short headline (≤ 8 words). Always provide one — the auto-derived fallback just truncates --message.",
-        )
-        .option(
-          "--urgency <urgency>",
-          `Urgency hint. One of: ${URGENCY_HELP} (default: low; use --urgent for critical)`,
-        )
-        .option(
-          "--requires-action",
-          "Whether the notification expects user action (default: false; use --urgent to force true)",
-        )
-        .option(
-          "--no-requires-action",
-          "Mark that the notification does not expect user action",
-        )
-        .option(
-          "--is-async-background",
-          "Whether the event is asynchronous/background work (default: false)",
-        )
-        .option(
-          "--no-is-async-background",
-          "Mark that the event is not asynchronous/background work",
-        )
-        .option(
-          "--visible-in-source-now",
-          "Set true when user is already viewing the source context (default: false)",
-        )
-        .option(
-          "--no-visible-in-source-now",
-          "Mark that the user is not viewing the source context",
-        )
-        .option(
-          "--deadline-at <epoch>",
-          "Optional deadline timestamp in epoch milliseconds",
-        )
-        .option(
-          "--preferred-channels <channels>",
-          "Comma-separated channel hints (e.g. vellum,telegram,slack)",
-        )
-        .option(
-          "--session-id <id>",
-          "Source session or conversation ID (default: cli-<timestamp>)",
-        )
-        .option(
-          "--dedupe-key <key>",
-          "Optional dedupe key to suppress duplicate notifications",
-        )
-        .option(
-          "--deep-link-metadata <json>",
-          "Optional JSON metadata clients can use for deep linking",
-        )
-        .option(
-          "--conversation-id <id>",
-          "Local vellum conversation ID to deliver into. When set, the notification reuses the specified conversation instead of starting a new one — bypasses the LLM's conversation-routing decision via affinity hint.",
-        )
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  --message            The notification body text (required, must be non-empty)
-  --urgent             Shortcut that maps to urgency=critical + requires-action=true
-
-Behavioral notes:
-  - The signal is emitted through the full notification pipeline: event store,
-    decision engine, deterministic checks, and channel dispatch.
-  - --urgent overrides --urgency and --requires-action defaults so the signal
-    is treated as critical and requires user action. Explicit --urgency /
-    --requires-action flags still win for back-compat.
-  - Without --urgent, --urgency defaults to low and --requires-action to false.
-  - --preferred-channels are hints only; the decision engine may override them.
-  - --dedupe-key suppresses duplicate signals with the same key.
-  - --conversation-id pins delivery to an existing vellum conversation
-    deterministically. Other channels (telegram, slack) continue to use
-    binding-based pairing for their external threads.
-
-Examples:
-  $ assistant notifications send --message "Task complete"
-  $ assistant notifications send --message "Pager: prod is down" --urgent
-  $ assistant notifications send --message "Build green" --conversation-id 649c4645-3a6f-4ded-a713-504f02ca806b`,
-        )
-        .action(
-          async (
-            opts: {
-              sourceChannel?: string;
-              sourceEventName?: string;
-              message: string;
-              urgent: boolean;
-              title?: string;
-              urgency?: string;
-              requiresAction?: boolean;
-              isAsyncBackground: boolean;
-              visibleInSourceNow: boolean;
-              deadlineAt?: string;
-              preferredChannels?: string;
-              sessionId?: string;
-              dedupeKey?: string;
-              deepLinkMetadata?: string;
-              conversationId?: string;
-            },
-            cmd: Command,
-          ) => {
-            try {
-              // Apply defaults for optional source fields (minimal-surface
-              // ergonomics; explicit values from the CLI still win).
-              const sourceChannel =
-                opts.sourceChannel ?? DEFAULT_SOURCE_CHANNEL;
-              const sourceEventName = opts.sourceEventName ?? "assistant.share";
-
-              const sourceChannelError = validateEnumValue(
-                sourceChannel,
-                "source-channel",
-                NOTIFICATION_SOURCE_CHANNEL_VALUES,
-              );
-              if (sourceChannelError.error) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error: sourceChannelError.error,
-                });
-                process.exitCode = 1;
-                return;
-              }
-
-              // Validate --message (keep basic validation for immediate CLI feedback)
-              const message = opts.message.trim();
-              if (message.length === 0) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error: "Message must be a non-empty string",
-                });
-                process.exitCode = 1;
-                return;
-              }
-
-              // --urgent is a shortcut for urgency=critical + requiresAction=true.
-              // Explicit --urgency / --requires-action flags still win so the
-              // back-compat path keeps working during the deprecation window.
-              const urgentDefaults = opts.urgent
-                ? { urgency: "critical", requiresAction: true }
-                : { urgency: "low", requiresAction: false };
-
-              // Validate --urgency
-              const urgency = opts.urgency ?? urgentDefaults.urgency;
-              const urgencyError = validateEnumValue(
-                urgency,
-                "urgency",
-                URGENCY_VALUES,
-              );
-              if (urgencyError.error) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error: urgencyError.error,
-                });
-                process.exitCode = 1;
-                return;
-              }
-              const requiresAction =
-                opts.requiresAction ?? urgentDefaults.requiresAction;
-
-              // Parse --deadline-at
-              let deadlineAt: number | undefined;
-              if (opts.deadlineAt != null) {
-                const parsed = Number(opts.deadlineAt);
-                if (!Number.isFinite(parsed)) {
-                  writeOutput(cmd, {
-                    ok: false,
-                    error: `Invalid deadline-at "${opts.deadlineAt}". Must be a finite number (epoch milliseconds)`,
-                  });
-                  process.exitCode = 1;
-                  return;
-                }
-                deadlineAt = parsed;
-              }
-
-              // Parse --preferred-channels
-              let preferredChannels: string[] | undefined;
-              if (opts.preferredChannels) {
-                preferredChannels = opts.preferredChannels
-                  .split(",")
-                  .map((ch) => ch.trim())
-                  .filter((ch) => ch.length > 0);
-              }
-
-              // Parse --deep-link-metadata
-              let deepLinkMetadata: Record<string, unknown> | undefined;
-              if (opts.deepLinkMetadata != null) {
-                try {
-                  deepLinkMetadata = JSON.parse(
-                    opts.deepLinkMetadata,
-                  ) as Record<string, unknown>;
-                } catch {
-                  writeOutput(cmd, {
-                    ok: false,
-                    error: `Invalid deep-link-metadata: must be a valid JSON string`,
-                  });
-                  process.exitCode = 1;
-                  return;
-                }
-              }
-
-              // Validate --conversation-id if provided
-              const conversationId = opts.conversationId?.trim();
-              if (opts.conversationId != null && !conversationId) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error: "Conversation ID must be a non-empty string",
-                });
-                process.exitCode = 1;
-                return;
-              }
-
-              // Picks up __CONVERSATION_ID / __SKILL_CONTEXT_JSON env vars
-              // so deferred-emit can buffer notifications when called from a
-              // background job that hasn't confirmed success yet.
-              const originatingConversationId = tryResolveConversationId();
-
-              // The signal's `sourceContextId` doubles as the home-feed's
-              // navigation target — `resolveHomeFeedMirror` looks it up via
-              // `getConversation()` and only renders a "Go to Convo" button
-              // when it resolves to a real row. Prefer the conversation the
-              // CLI was invoked from (env-derived) so notifications emitted
-              // by background jobs and skills link back to their producing
-              // convo; an explicit --session-id still wins to preserve
-              // caller intent, and --conversation-id is the last resort
-              // before the unresolvable `cli-<ts>` sentinel.
-              const sourceContextId =
-                opts.sessionId ??
-                originatingConversationId ??
-                conversationId ??
-                `cli-${Date.now()}`;
-
-              const result = await cliIpcCall<{
-                signalId: string;
-                dispatched: boolean;
-                deduplicated: boolean;
-                reason: string;
-              }>("emit_notification_signal", {
-                body: {
-                  sourceChannel,
-                  sourceEventName,
-                  sourceContextId,
-                  attentionHints: {
-                    requiresAction,
-                    urgency,
-                    deadlineAt,
-                    isAsyncBackground: opts.isAsyncBackground ?? false,
-                    visibleInSourceNow: opts.visibleInSourceNow ?? false,
-                  },
-                  contextPayload: {
-                    requestedMessage: message,
-                    requestedBySource: sourceChannel,
-                    ...(opts.title ? { requestedTitle: opts.title } : {}),
-                    ...(preferredChannels?.length ? { preferredChannels } : {}),
-                    ...(deepLinkMetadata ? { deepLinkMetadata } : {}),
-                  },
-                  ...(opts.dedupeKey ? { dedupeKey: opts.dedupeKey } : {}),
-                  ...(conversationId
-                    ? { conversationAffinityHint: { vellum: conversationId } }
-                    : {}),
-                  ...(originatingConversationId
-                    ? { originatingConversationId }
-                    : {}),
-                  throwOnError: true,
-                },
-              });
-
-              if (!result.ok) {
-                if (shouldOutputJson(cmd)) {
-                  writeOutput(cmd, { ok: false, error: result.error });
-                  process.exitCode = exitCodeFromIpcResult(result);
-                  return;
-                }
-                return exitFromIpcResult(result);
-              }
-
-              const signal = result.result!;
-
-              writeOutput(cmd, {
-                ok: true,
-                signalId: signal.signalId,
-                dispatched: signal.dispatched,
-                reason: signal.reason,
-              });
-
-              if (!shouldOutputJson(cmd)) {
-                log.info(
-                  `Signal ${signal.signalId} emitted (dispatched: ${signal.dispatched})`,
-                );
-                if (signal.reason) {
-                  log.info(`  Reason: ${signal.reason}`);
-                }
-              }
-            } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              writeOutput(cmd, { ok: false, error: message });
-              process.exitCode = 1;
-            }
+      subcommand(notifications, "send").action(
+        async (
+          opts: {
+            sourceChannel?: string;
+            sourceEventName?: string;
+            message: string;
+            urgent: boolean;
+            title?: string;
+            urgency?: string;
+            requiresAction?: boolean;
+            isAsyncBackground: boolean;
+            visibleInSourceNow: boolean;
+            deadlineAt?: string;
+            preferredChannels?: string;
+            sessionId?: string;
+            dedupeKey?: string;
+            deepLinkMetadata?: string;
+            conversationId?: string;
           },
-        );
+          cmd: Command,
+        ) => {
+          try {
+            // Apply defaults for optional source fields (minimal-surface
+            // ergonomics; explicit values from the CLI still win).
+            const sourceChannel = opts.sourceChannel ?? DEFAULT_SOURCE_CHANNEL;
+            const sourceEventName = opts.sourceEventName ?? "assistant.share";
+
+            const sourceChannelError = validateEnumValue(
+              sourceChannel,
+              "source-channel",
+              NOTIFICATION_SOURCE_CHANNEL_VALUES,
+            );
+            if (sourceChannelError.error) {
+              writeOutput(cmd, {
+                ok: false,
+                error: sourceChannelError.error,
+              });
+              process.exitCode = 1;
+              return;
+            }
+
+            // Validate --message (keep basic validation for immediate CLI feedback)
+            const message = opts.message.trim();
+            if (message.length === 0) {
+              writeOutput(cmd, {
+                ok: false,
+                error: "Message must be a non-empty string",
+              });
+              process.exitCode = 1;
+              return;
+            }
+
+            // --urgent is a shortcut for urgency=critical + requiresAction=true.
+            // Explicit --urgency / --requires-action flags still win so the
+            // back-compat path keeps working during the deprecation window.
+            const urgentDefaults = opts.urgent
+              ? { urgency: "critical", requiresAction: true }
+              : { urgency: "low", requiresAction: false };
+
+            // Validate --urgency
+            const urgency = opts.urgency ?? urgentDefaults.urgency;
+            const urgencyError = validateEnumValue(
+              urgency,
+              "urgency",
+              URGENCY_VALUES,
+            );
+            if (urgencyError.error) {
+              writeOutput(cmd, {
+                ok: false,
+                error: urgencyError.error,
+              });
+              process.exitCode = 1;
+              return;
+            }
+            const requiresAction =
+              opts.requiresAction ?? urgentDefaults.requiresAction;
+
+            // Parse --deadline-at
+            let deadlineAt: number | undefined;
+            if (opts.deadlineAt != null) {
+              const parsed = Number(opts.deadlineAt);
+              if (!Number.isFinite(parsed)) {
+                writeOutput(cmd, {
+                  ok: false,
+                  error: `Invalid deadline-at "${opts.deadlineAt}". Must be a finite number (epoch milliseconds)`,
+                });
+                process.exitCode = 1;
+                return;
+              }
+              deadlineAt = parsed;
+            }
+
+            // Parse --preferred-channels
+            let preferredChannels: string[] | undefined;
+            if (opts.preferredChannels) {
+              preferredChannels = opts.preferredChannels
+                .split(",")
+                .map((ch) => ch.trim())
+                .filter((ch) => ch.length > 0);
+            }
+
+            // Parse --deep-link-metadata
+            let deepLinkMetadata: Record<string, unknown> | undefined;
+            if (opts.deepLinkMetadata != null) {
+              try {
+                deepLinkMetadata = JSON.parse(opts.deepLinkMetadata) as Record<
+                  string,
+                  unknown
+                >;
+              } catch {
+                writeOutput(cmd, {
+                  ok: false,
+                  error: `Invalid deep-link-metadata: must be a valid JSON string`,
+                });
+                process.exitCode = 1;
+                return;
+              }
+            }
+
+            // Validate --conversation-id if provided
+            const conversationId = opts.conversationId?.trim();
+            if (opts.conversationId != null && !conversationId) {
+              writeOutput(cmd, {
+                ok: false,
+                error: "Conversation ID must be a non-empty string",
+              });
+              process.exitCode = 1;
+              return;
+            }
+
+            // Picks up __CONVERSATION_ID / __SKILL_CONTEXT_JSON env vars
+            // so deferred-emit can buffer notifications when called from a
+            // background job that hasn't confirmed success yet.
+            const originatingConversationId = tryResolveConversationId();
+
+            // The signal's `sourceContextId` doubles as the home-feed's
+            // navigation target — `resolveHomeFeedMirror` looks it up via
+            // `getConversation()` and only renders a "Go to Convo" button
+            // when it resolves to a real row. Prefer the conversation the
+            // CLI was invoked from (env-derived) so notifications emitted
+            // by background jobs and skills link back to their producing
+            // convo; an explicit --session-id still wins to preserve
+            // caller intent, and --conversation-id is the last resort
+            // before the unresolvable `cli-<ts>` sentinel.
+            const sourceContextId =
+              opts.sessionId ??
+              originatingConversationId ??
+              conversationId ??
+              `cli-${Date.now()}`;
+
+            const result = await cliIpcCall<{
+              signalId: string;
+              dispatched: boolean;
+              deduplicated: boolean;
+              reason: string;
+            }>("emit_notification_signal", {
+              body: {
+                sourceChannel,
+                sourceEventName,
+                sourceContextId,
+                attentionHints: {
+                  requiresAction,
+                  urgency,
+                  deadlineAt,
+                  isAsyncBackground: opts.isAsyncBackground ?? false,
+                  visibleInSourceNow: opts.visibleInSourceNow ?? false,
+                },
+                contextPayload: {
+                  requestedMessage: message,
+                  requestedBySource: sourceChannel,
+                  ...(opts.title ? { requestedTitle: opts.title } : {}),
+                  ...(preferredChannels?.length ? { preferredChannels } : {}),
+                  ...(deepLinkMetadata ? { deepLinkMetadata } : {}),
+                },
+                ...(opts.dedupeKey ? { dedupeKey: opts.dedupeKey } : {}),
+                ...(conversationId
+                  ? { conversationAffinityHint: { vellum: conversationId } }
+                  : {}),
+                ...(originatingConversationId
+                  ? { originatingConversationId }
+                  : {}),
+                throwOnError: true,
+              },
+            });
+
+            if (!result.ok) {
+              if (shouldOutputJson(cmd)) {
+                writeOutput(cmd, { ok: false, error: result.error });
+                process.exitCode = exitCodeFromIpcResult(result);
+                return;
+              }
+              return exitFromIpcResult(result);
+            }
+
+            const signal = result.result!;
+
+            writeOutput(cmd, {
+              ok: true,
+              signalId: signal.signalId,
+              dispatched: signal.dispatched,
+              reason: signal.reason,
+            });
+
+            if (!shouldOutputJson(cmd)) {
+              log.info(
+                `Signal ${signal.signalId} emitted (dispatched: ${signal.dispatched})`,
+              );
+              if (signal.reason) {
+                log.info(`  Reason: ${signal.reason}`);
+              }
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            writeOutput(cmd, { ok: false, error: message });
+            process.exitCode = 1;
+          }
+        },
+      );
 
       // -------------------------------------------------------------------------
       // list
@@ -497,332 +351,241 @@ Examples:
         prev: string[] | undefined,
       ): string[] => [...(prev ?? []), value];
 
-      notifications
-        .command("list")
-        .description(
-          "List notifications surfaced to the user via the home feed. Excludes dismissed items by default.",
-        )
-        .option(
-          "--all",
-          "Include dismissed items (default: only new/seen/acted_on)",
-          false,
-        )
-        .option(
-          "--status <status>",
-          `Filter by status. One of: ${STATUS_HELP}; repeatable. Overrides --all default behavior.`,
-          collectFlag,
-        )
-        .option(
-          "--before <iso>",
-          "Only items with createdAt strictly before this ISO-8601 timestamp",
-        )
-        .option(
-          "--after <iso>",
-          "Only items with createdAt strictly after this ISO-8601 timestamp",
-        )
-        .option(
-          "--urgency <urgency>",
-          `Filter by urgency. One of: ${URGENCY_HELP}; repeatable`,
-          collectFlag,
-        )
-        .option(
-          "--category <category>",
-          `Filter by category. One of: ${CATEGORY_HELP}; repeatable`,
-          collectFlag,
-        )
-        .option(
-          "--conversation-id <id>",
-          "Only items tied to this conversation id",
-        )
-        .option(
-          "--from-assistant",
-          "Only items emitted by the assistant",
-          false,
-        )
-        .option("--noteworthy", "Only items flagged as noteworthy", false)
-        .option(
-          "--limit <n>",
-          "Maximum number of items to return (default: 20, max: 200)",
-        )
-        .option("--offset <n>", "Pagination offset (default: 0)")
-        .addHelpText(
-          "after",
-          `
-Reads the home feed at $VELLUM_WORKSPACE_DIR/data/home-feed.json — the
-user's notification inbox. Items are ordered by priority then recency,
-matching what the user sees in the macOS Home page. The home feed covers
-background/async notifications mirrored from the unified pipeline;
-real-time chat pushes that did not mirror to the feed will not appear.
+      const list = subcommand(notifications, "list");
 
-Examples:
-  $ assistant notifications list
-  $ assistant notifications list --all
-  $ assistant notifications list --status new --status seen
-  $ assistant notifications list --after 2026-05-28T00:00:00Z --urgency high
-  $ assistant notifications list --conversation-id 7fab234c --json
-  $ assistant notifications list --limit 5 --offset 5`,
-        )
-        .action(
-          async (
-            opts: {
-              all?: boolean;
-              status?: string[];
-              before?: string;
-              after?: string;
-              urgency?: string[];
-              category?: string[];
-              conversationId?: string;
-              fromAssistant?: boolean;
-              noteworthy?: boolean;
-              limit?: string;
-              offset?: string;
-            },
-            cmd: Command,
-          ) => {
-            try {
-              const enumChecks: Array<{ error?: string }> = [
-                validateEnumFlag(
-                  opts.status,
-                  "status",
-                  NOTIFICATION_STATUS_VALUES,
-                ),
-                validateEnumFlag(opts.urgency, "urgency", URGENCY_VALUES),
-                validateEnumFlag(
-                  opts.category,
-                  "category",
-                  NOTIFICATION_CATEGORY_VALUES,
-                ),
-              ];
-              const enumError = enumChecks.find((c) => c.error);
-              if (enumError) {
-                writeOutput(cmd, { ok: false, error: enumError.error });
-                process.exitCode = 1;
-                return;
-              }
+      // The declarative help contract carries plain data only, so the
+      // repeatable flags are declared there without their collector and get
+      // it attached here before any parsing happens.
+      for (const flags of [
+        "--status <status>",
+        "--urgency <urgency>",
+        "--category <category>",
+      ]) {
+        list.options.find((o) => o.flags === flags)!.argParser(collectFlag);
+      }
 
-              const limit = parseBoundedInt(opts.limit, "limit", {
-                min: 1,
-                max: 200,
-              });
-              if (limit.error) {
-                writeOutput(cmd, { ok: false, error: limit.error });
-                process.exitCode = 1;
-                return;
-              }
-              const offset = parseBoundedInt(opts.offset, "offset", {
-                min: 0,
-              });
-              if (offset.error) {
-                writeOutput(cmd, { ok: false, error: offset.error });
-                process.exitCode = 1;
-                return;
-              }
-
-              if (opts.conversationId != null) {
-                const trimmed = opts.conversationId.trim();
-                if (trimmed.length === 0) {
-                  writeOutput(cmd, {
-                    ok: false,
-                    error: "Conversation ID must be a non-empty string",
-                  });
-                  process.exitCode = 1;
-                  return;
-                }
-              }
-
-              const body: Record<string, unknown> = {};
-              if (opts.all) body.includeDismissed = true;
-              if (opts.status?.length) body.statuses = opts.status;
-              if (opts.before) body.before = opts.before;
-              if (opts.after) body.after = opts.after;
-              if (opts.urgency?.length) body.urgencies = opts.urgency;
-              if (opts.category?.length) body.categories = opts.category;
-              if (opts.conversationId)
-                body.conversationId = opts.conversationId.trim();
-              if (opts.fromAssistant) body.fromAssistant = true;
-              if (opts.noteworthy) body.noteworthy = true;
-              if (limit.value !== undefined) body.limit = limit.value;
-              if (offset.value !== undefined) body.offset = offset.value;
-
-              const result = await cliIpcCall<ListHomeFeedPayload>(
-                "list_home_feed",
-                { body },
-              );
-
-              if (!result.ok) {
-                writeOutput(cmd, { ok: false, error: result.error });
-                process.exitCode = exitCodeFromIpcResult(result);
-                return;
-              }
-
-              const payload = result.result!;
-              writeOutput(cmd, { ok: true, ...payload });
-
-              if (!shouldOutputJson(cmd)) {
-                renderFeedItemsHuman(payload);
-              }
-            } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              writeOutput(cmd, { ok: false, error: message });
-              process.exitCode = 1;
-            }
+      list.action(
+        async (
+          opts: {
+            all?: boolean;
+            status?: string[];
+            before?: string;
+            after?: string;
+            urgency?: string[];
+            category?: string[];
+            conversationId?: string;
+            fromAssistant?: boolean;
+            noteworthy?: boolean;
+            limit?: string;
+            offset?: string;
           },
-        );
+          cmd: Command,
+        ) => {
+          try {
+            const enumChecks: Array<{ error?: string }> = [
+              validateEnumFlag(
+                opts.status,
+                "status",
+                NOTIFICATION_STATUS_VALUES,
+              ),
+              validateEnumFlag(opts.urgency, "urgency", URGENCY_VALUES),
+              validateEnumFlag(
+                opts.category,
+                "category",
+                NOTIFICATION_CATEGORY_VALUES,
+              ),
+            ];
+            const enumError = enumChecks.find((c) => c.error);
+            if (enumError) {
+              writeOutput(cmd, { ok: false, error: enumError.error });
+              process.exitCode = 1;
+              return;
+            }
+
+            const limit = parseBoundedInt(opts.limit, "limit", {
+              min: 1,
+              max: 200,
+            });
+            if (limit.error) {
+              writeOutput(cmd, { ok: false, error: limit.error });
+              process.exitCode = 1;
+              return;
+            }
+            const offset = parseBoundedInt(opts.offset, "offset", {
+              min: 0,
+            });
+            if (offset.error) {
+              writeOutput(cmd, { ok: false, error: offset.error });
+              process.exitCode = 1;
+              return;
+            }
+
+            if (opts.conversationId != null) {
+              const trimmed = opts.conversationId.trim();
+              if (trimmed.length === 0) {
+                writeOutput(cmd, {
+                  ok: false,
+                  error: "Conversation ID must be a non-empty string",
+                });
+                process.exitCode = 1;
+                return;
+              }
+            }
+
+            const body: Record<string, unknown> = {};
+            if (opts.all) body.includeDismissed = true;
+            if (opts.status?.length) body.statuses = opts.status;
+            if (opts.before) body.before = opts.before;
+            if (opts.after) body.after = opts.after;
+            if (opts.urgency?.length) body.urgencies = opts.urgency;
+            if (opts.category?.length) body.categories = opts.category;
+            if (opts.conversationId)
+              body.conversationId = opts.conversationId.trim();
+            if (opts.fromAssistant) body.fromAssistant = true;
+            if (opts.noteworthy) body.noteworthy = true;
+            if (limit.value !== undefined) body.limit = limit.value;
+            if (offset.value !== undefined) body.offset = offset.value;
+
+            const result = await cliIpcCall<ListHomeFeedPayload>(
+              "list_home_feed",
+              { body },
+            );
+
+            if (!result.ok) {
+              writeOutput(cmd, { ok: false, error: result.error });
+              process.exitCode = exitCodeFromIpcResult(result);
+              return;
+            }
+
+            const payload = result.result!;
+            writeOutput(cmd, { ok: true, ...payload });
+
+            if (!shouldOutputJson(cmd)) {
+              renderFeedItemsHuman(payload);
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            writeOutput(cmd, { ok: false, error: message });
+            process.exitCode = 1;
+          }
+        },
+      );
 
       // -------------------------------------------------------------------------
       // edit
       // -------------------------------------------------------------------------
 
-      notifications
-        .command("edit")
-        .description(
-          "Edit an already-sent notification. Patches the home-feed entry and updates the delivered channel message in place where supported (Slack today).",
-        )
-        .requiredOption(
-          "--id <id>",
-          "Feed item id (notif:<uuid>) from `notifications list --json`. Bare uuids without the `notif:` prefix are also accepted.",
-        )
-        .option(
-          "--message <message>",
-          "New notification body. Updates the home-feed summary and the delivered channel message text where supported.",
-        )
-        .option("--title <title>", "New short headline (≤ 8 words).")
-        .option(
-          "--urgency <urgency>",
-          `Set urgency. One of: ${URGENCY_HELP}. Feed-only — does not re-push channel messages.`,
-        )
-        .option(
-          "--status <status>",
-          `Set lifecycle status. One of: ${STATUS_HELP}. Feed-only.`,
-        )
-        .addHelpText(
-          "after",
-          `
-At least one of --message, --title, --urgency, or --status must be
-supplied. --urgency and --status only update the home-feed entry —
-they never re-push channel messages.
+      subcommand(notifications, "edit").action(
+        async (
+          opts: {
+            id: string;
+            message?: string;
+            title?: string;
+            urgency?: string;
+            status?: string;
+          },
+          cmd: Command,
+        ) => {
+          try {
+            const id = opts.id.trim();
+            if (!id) {
+              writeOutput(cmd, {
+                ok: false,
+                error: "--id must be a non-empty string",
+              });
+              process.exitCode = 1;
+              return;
+            }
 
-Channel updates are best-effort: Slack messages get updated via
-chat.update; other channels (push, email, SMS) cannot be edited and
-are reported as "unsupported".
+            if (
+              opts.message === undefined &&
+              opts.title === undefined &&
+              opts.urgency === undefined &&
+              opts.status === undefined
+            ) {
+              writeOutput(cmd, {
+                ok: false,
+                error:
+                  "At least one of --message, --title, --urgency, or --status must be supplied",
+              });
+              process.exitCode = 1;
+              return;
+            }
 
-Examples:
-  $ assistant notifications edit --id notif:abc12345-... --message "Fixed body"
-  $ assistant notifications edit --id abc12345-... --title "Backup complete"
-  $ assistant notifications edit --id notif:abc12345-... --urgency low
-  $ assistant notifications edit --id notif:abc12345-... --status dismissed`,
-        )
-        .action(
-          async (
-            opts: {
-              id: string;
-              message?: string;
-              title?: string;
-              urgency?: string;
-              status?: string;
-            },
-            cmd: Command,
-          ) => {
-            try {
-              const id = opts.id.trim();
-              if (!id) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error: "--id must be a non-empty string",
-                });
-                process.exitCode = 1;
-                return;
-              }
+            const urgencyError = validateEnumValue(
+              opts.urgency,
+              "urgency",
+              URGENCY_VALUES,
+            );
+            if (urgencyError.error) {
+              writeOutput(cmd, {
+                ok: false,
+                error: urgencyError.error,
+              });
+              process.exitCode = 1;
+              return;
+            }
+            const statusError = validateEnumValue(
+              opts.status,
+              "status",
+              NOTIFICATION_STATUS_VALUES,
+            );
+            if (statusError.error) {
+              writeOutput(cmd, {
+                ok: false,
+                error: statusError.error,
+              });
+              process.exitCode = 1;
+              return;
+            }
 
-              if (
-                opts.message === undefined &&
-                opts.title === undefined &&
-                opts.urgency === undefined &&
-                opts.status === undefined
-              ) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error:
-                    "At least one of --message, --title, --urgency, or --status must be supplied",
-                });
-                process.exitCode = 1;
-                return;
-              }
+            const body: Record<string, unknown> = { id };
+            if (opts.message !== undefined) body.body = opts.message;
+            if (opts.title !== undefined) body.title = opts.title;
+            if (opts.urgency !== undefined) body.urgency = opts.urgency;
+            if (opts.status !== undefined) body.status = opts.status;
 
-              const urgencyError = validateEnumValue(
-                opts.urgency,
-                "urgency",
-                URGENCY_VALUES,
-              );
-              if (urgencyError.error) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error: urgencyError.error,
-                });
-                process.exitCode = 1;
-                return;
-              }
-              const statusError = validateEnumValue(
-                opts.status,
-                "status",
-                NOTIFICATION_STATUS_VALUES,
-              );
-              if (statusError.error) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error: statusError.error,
-                });
-                process.exitCode = 1;
-                return;
-              }
+            const result = await cliIpcCall<{
+              feedItem: FeedItem;
+              channels: Array<{
+                channel: string;
+                deliveryId: string;
+                outcome: "updated" | "unsupported" | "skipped" | "failed";
+                reason?: string;
+              }>;
+            }>("edit_notification", { body });
 
-              const body: Record<string, unknown> = { id };
-              if (opts.message !== undefined) body.body = opts.message;
-              if (opts.title !== undefined) body.title = opts.title;
-              if (opts.urgency !== undefined) body.urgency = opts.urgency;
-              if (opts.status !== undefined) body.status = opts.status;
+            if (!result.ok) {
+              writeOutput(cmd, { ok: false, error: result.error });
+              process.exitCode = exitCodeFromIpcResult(result);
+              return;
+            }
 
-              const result = await cliIpcCall<{
-                feedItem: FeedItem;
-                channels: Array<{
-                  channel: string;
-                  deliveryId: string;
-                  outcome: "updated" | "unsupported" | "skipped" | "failed";
-                  reason?: string;
-                }>;
-              }>("edit_notification", { body });
+            const payload = result.result!;
+            writeOutput(cmd, { ok: true, ...payload });
 
-              if (!result.ok) {
-                writeOutput(cmd, { ok: false, error: result.error });
-                process.exitCode = exitCodeFromIpcResult(result);
-                return;
-              }
-
-              const payload = result.result!;
-              writeOutput(cmd, { ok: true, ...payload });
-
-              if (!shouldOutputJson(cmd)) {
-                const item = payload.feedItem;
-                log.info(`Updated ${item.id}`);
-                const headline = item.title ?? item.summary;
-                log.info(`  ${headline}`);
-                if (payload.channels.length === 0) {
-                  log.info("  No channel deliveries to update.");
-                } else {
-                  log.info("  Channels:");
-                  for (const ch of payload.channels) {
-                    const reason = ch.reason ? ` — ${ch.reason}` : "";
-                    log.info(`    ${ch.channel}: ${ch.outcome}${reason}`);
-                  }
+            if (!shouldOutputJson(cmd)) {
+              const item = payload.feedItem;
+              log.info(`Updated ${item.id}`);
+              const headline = item.title ?? item.summary;
+              log.info(`  ${headline}`);
+              if (payload.channels.length === 0) {
+                log.info("  No channel deliveries to update.");
+              } else {
+                log.info("  Channels:");
+                for (const ch of payload.channels) {
+                  const reason = ch.reason ? ` — ${ch.reason}` : "";
+                  log.info(`    ${ch.channel}: ${ch.outcome}${reason}`);
                 }
               }
-            } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              writeOutput(cmd, { ok: false, error: message });
-              process.exitCode = 1;
             }
-          },
-        );
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            writeOutput(cmd, { ok: false, error: message });
+            process.exitCode = 1;
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
-import { registerCommand } from "../../lib/register-command.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -55,330 +55,197 @@ function resolveCredentialPath(input: string): string {
 }
 
 export function registerAppCommands(oauth: Command): void {
-  registerCommand(oauth, {
-    name: "apps",
-    transport: "ipc",
-    description: "Manage custom OAuth app registrations",
-    build: (apps) => {
-      apps.addHelpText(
-        "after",
-        `
-Apps represent custom OAuth client registrations — a client_id and optional
-client_secret linked to a provider. Each provider can have multiple apps
-(e.g. different client IDs for different environments). Only needed if using
-a provider with a mode of "your-own" set.
+  const apps = subcommand(oauth, "apps");
 
-Examples:
-  $ assistant oauth apps list
-  $ assistant oauth apps list --provider-key google
-  $ assistant oauth apps get --id <uuid>
-  $ assistant oauth apps get --provider google
-  $ assistant oauth apps upsert --provider google --client-id abc123
-  $ assistant oauth apps delete <id>`,
-      );
+  // -----------------------------------------------------------------------
+  // apps list
+  // -----------------------------------------------------------------------
 
-      // -----------------------------------------------------------------------
-      // apps list
-      // -----------------------------------------------------------------------
+  subcommand(apps, "list").action(
+    async (opts: { providerKey?: string }, cmd: Command) => {
+      if (!opts.providerKey) {
+        // The IPC route requires provider_key. To support listing all
+        // apps, we first need to know the providers. For simplicity
+        // and backward compatibility, list providers first, then
+        // aggregate.
+        const provR = await cliIpcCall<{
+          providers: Array<{ provider_key: string }>;
+        }>("oauth_providers_get", { queryParams: {} });
 
-      apps
-        .command("list")
-        .description("List all OAuth app registrations")
-        .option(
-          "--provider-key <key>",
-          "Filter by provider key (exact match). Run 'assistant oauth providers list' to see available keys.",
-        )
-        .addHelpText(
-          "after",
-          `
-Returns registered OAuth apps with their provider key, client ID, and
-timestamps. Output is an array of app objects.
+        if (!provR.ok) return exitFromIpcResult(provR);
 
-When --provider-key is specified, only apps whose provider exactly matches
-the given value are returned. Without the flag, all apps are listed.
-
-Examples:
-  $ assistant oauth apps list
-  $ assistant oauth apps list --provider-key google
-  $ assistant oauth apps list --provider-key slack --json`,
-        )
-        .action(async (opts: { providerKey?: string }, cmd: Command) => {
-          if (!opts.providerKey) {
-            // The IPC route requires provider_key. To support listing all
-            // apps, we first need to know the providers. For simplicity
-            // and backward compatibility, list providers first, then
-            // aggregate.
-            const provR = await cliIpcCall<{
-              providers: Array<{ provider_key: string }>;
-            }>("oauth_providers_get", { queryParams: {} });
-
-            if (!provR.ok) return exitFromIpcResult(provR);
-
-            const allRows: ReturnType<typeof formatAppRow>[] = [];
-            for (const p of provR.result?.providers ?? []) {
-              const r = await cliIpcCall<{
-                apps: AppRow[];
-              }>("oauth_apps_get", {
-                queryParams: { provider_key: p.provider_key },
-              });
-              if (r.ok && r.result?.apps) {
-                allRows.push(...r.result.apps.map(formatAppRow));
-              }
-            }
-
-            if (!shouldOutputJson(cmd)) {
-              log.info(`Found ${allRows.length} app(s)`);
-            }
-            writeOutput(cmd, allRows);
-            return;
+        const allRows: ReturnType<typeof formatAppRow>[] = [];
+        for (const p of provR.result?.providers ?? []) {
+          const r = await cliIpcCall<{
+            apps: AppRow[];
+          }>("oauth_apps_get", {
+            queryParams: { provider_key: p.provider_key },
+          });
+          if (r.ok && r.result?.apps) {
+            allRows.push(...r.result.apps.map(formatAppRow));
           }
+        }
 
-          const r = await cliIpcCall<{ apps: AppRow[] }>(
-            "oauth_apps_get",
-            { queryParams: { provider_key: opts.providerKey } },
-          );
+        if (!shouldOutputJson(cmd)) {
+          log.info(`Found ${allRows.length} app(s)`);
+        }
+        writeOutput(cmd, allRows);
+        return;
+      }
 
-          if (!r.ok) return exitFromIpcResult(r);
+      const r = await cliIpcCall<{ apps: AppRow[] }>("oauth_apps_get", {
+        queryParams: { provider_key: opts.providerKey },
+      });
 
-          const rows = (r.result?.apps ?? []).map(formatAppRow);
+      if (!r.ok) return exitFromIpcResult(r);
 
-          if (!shouldOutputJson(cmd)) {
-            log.info(`Found ${rows.length} app(s)`);
-          }
+      const rows = (r.result?.apps ?? []).map(formatAppRow);
 
-          writeOutput(cmd, rows);
-        });
+      if (!shouldOutputJson(cmd)) {
+        log.info(`Found ${rows.length} app(s)`);
+      }
 
-      // -----------------------------------------------------------------------
-      // apps get
-      // -----------------------------------------------------------------------
-
-      apps
-        .command("get")
-        .description(
-          "Look up an OAuth app by ID, provider + client-id, or provider",
-        )
-        .option("--id <id>", "App ID (UUID) from 'assistant oauth apps list'")
-        .option(
-          "--provider <key>",
-          "Provider key (e.g. google) from 'assistant oauth providers list'",
-        )
-        .option(
-          "--client-id <id>",
-          "OAuth client ID (requires --provider). Find registered client IDs via 'assistant oauth apps list'.",
-        )
-        .addHelpText(
-          "after",
-          `
-Three lookup modes are supported:
-
-  1. By app ID:
-     $ assistant oauth apps get --id <uuid>
-
-  2. By provider + client ID (exact match):
-     $ assistant oauth apps get --provider google --client-id abc123
-
-  3. By provider only (returns the most recently created app):
-     $ assistant oauth apps get --provider google
-
-At least --id or --provider must be specified.`,
-        )
-        .action(
-          async (
-            opts: { id?: string; provider?: string; clientId?: string },
-            cmd: Command,
-          ) => {
-            if (!opts.id && !opts.provider) {
-              writeOutput(cmd, {
-                ok: false,
-                error:
-                  "Provide --id, --provider, or --provider + --client-id. Run 'assistant oauth apps list' to see all registered apps.",
-              });
-              process.exitCode = 1;
-              return;
-            }
-
-            const queryParams: Record<string, string> = {};
-            if (opts.id) queryParams.id = opts.id;
-            if (opts.provider) queryParams.provider = opts.provider;
-            if (opts.clientId) queryParams.client_id = opts.clientId;
-
-            const r = await cliIpcCall<{ app: AppRow }>(
-              "oauth_apps_by_query_get",
-              { queryParams },
-            );
-
-            if (!r.ok) {
-              if (r.statusCode === 404) {
-                const lookup = opts.id
-                  ? `id=${opts.id}`
-                  : opts.provider && opts.clientId
-                    ? `provider=${opts.provider}, clientId=${opts.clientId}`
-                    : `provider=${opts.provider}`;
-                writeOutput(cmd, {
-                  ok: false,
-                  error: `No app found for ${lookup}. Run 'assistant oauth apps list' to see registered apps, or 'assistant oauth apps upsert --help' to register a new one.`,
-                });
-                process.exitCode = 1;
-                return;
-              }
-              return exitFromIpcResult(r);
-            }
-
-            const row = r.result?.app;
-            writeOutput(cmd, row ? formatAppRow(row) : null);
-          },
-        );
-
-      // -----------------------------------------------------------------------
-      // apps upsert
-      // -----------------------------------------------------------------------
-
-      apps
-        .command("upsert")
-        .description("Create or return an existing OAuth app registration")
-        .requiredOption(
-          "--provider <key>",
-          "Provider key (e.g. google) from 'assistant oauth providers list'",
-        )
-        .requiredOption(
-          "--client-id <id>",
-          "OAuth client ID from the provider's developer console",
-        )
-        .option(
-          "--client-secret <secret>",
-          "OAuth client secret (stored in credential store)",
-        )
-        .option(
-          "--client-secret-credential-path <path>",
-          "Credential reference in service:field format (e.g. google:client_secret). Mutually exclusive with --client-secret.",
-        )
-        .addHelpText(
-          "after",
-          `
-Creates a new app registration or returns the existing one if an app with the
-same provider and client ID already exists. The client secret, if provided, is
-stored in the secure credential store — not in the database.
-
-When an existing app is matched and a --client-secret is provided, the stored
-secret is updated. The app row itself is returned as-is.
-
-You can supply the client secret directly via --client-secret, or reference an
-existing credential in the store via --client-secret-credential-path. These two
-options are mutually exclusive — providing both is an error.
-
-Examples:
-  $ assistant oauth apps upsert --provider google --client-id abc123
-  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret s3cret
-  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "slack:client_secret"
-  $ assistant oauth apps upsert --provider google --client-id abc123 --json`,
-        )
-        .action(
-          async (
-            opts: {
-              provider: string;
-              clientId: string;
-              clientSecret?: string;
-              clientSecretCredentialPath?: string;
-            },
-            cmd: Command,
-          ) => {
-            if (opts.clientSecret && opts.clientSecretCredentialPath) {
-              writeOutput(cmd, {
-                ok: false,
-                error:
-                  "Cannot provide both --client-secret and --client-secret-credential-path",
-              });
-              process.exitCode = 1;
-              return;
-            }
-
-            const body: Record<string, unknown> = {
-              provider_key: opts.provider,
-              client_id: opts.clientId,
-            };
-
-            if (opts.clientSecret) {
-              body.client_secret = opts.clientSecret;
-            } else if (opts.clientSecretCredentialPath) {
-              body.client_secret_credential_path = resolveCredentialPath(
-                opts.clientSecretCredentialPath,
-              );
-            }
-
-            const r = await cliIpcCall<{ app: AppRow }>(
-              "oauth_apps_upsert",
-              { body },
-            );
-
-            if (!r.ok) {
-              writeOutput(cmd, {
-                ok: false,
-                error: r.error ?? "Unknown error",
-              });
-              process.exitCode = 1;
-              return;
-            }
-
-            const row = r.result?.app;
-            if (row) {
-              if (!shouldOutputJson(cmd)) {
-                log.info(
-                  `Upserted app: ${row.id} (provider: ${row.provider_key})`,
-                );
-              }
-              writeOutput(cmd, formatAppRow(row));
-            }
-          },
-        );
-
-      // -----------------------------------------------------------------------
-      // apps delete <id>
-      // -----------------------------------------------------------------------
-
-      apps
-        .command("delete <id>")
-        .description("Delete an OAuth app registration by ID")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  id   The app UUID to delete (as returned by "apps list" or "apps get")
-
-Permanently removes the app registration and its stored client secret from
-the credential store. Any OAuth connections that reference this app will no longer be
-able to refresh tokens.
-
-Exits with code 1 if the app ID is not found.
-
-Examples:
-  $ assistant oauth apps delete 550e8400-e29b-41d4-a716-446655440000
-  $ assistant oauth apps delete 550e8400-e29b-41d4-a716-446655440000 --json`,
-        )
-        .action(async (id: string, _opts: unknown, cmd: Command) => {
-          const r = await cliIpcCall<{ ok: boolean }>(
-            "oauth_apps_delete",
-            { pathParams: { id } },
-          );
-
-          if (!r.ok) {
-            if (r.statusCode === 404) {
-              writeOutput(cmd, {
-                ok: false,
-                error: `App not found: ${id}. Run 'assistant oauth apps list' to see registered apps and their IDs.`,
-              });
-              process.exitCode = 1;
-              return;
-            }
-            return exitFromIpcResult(r);
-          }
-
-          if (!shouldOutputJson(cmd)) {
-            log.info(`Deleted app: ${id}`);
-          }
-
-          writeOutput(cmd, { ok: true, id });
-        });
+      writeOutput(cmd, rows);
     },
-  });
+  );
+
+  // -----------------------------------------------------------------------
+  // apps get
+  // -----------------------------------------------------------------------
+
+  subcommand(apps, "get").action(
+    async (
+      opts: { id?: string; provider?: string; clientId?: string },
+      cmd: Command,
+    ) => {
+      if (!opts.id && !opts.provider) {
+        writeOutput(cmd, {
+          ok: false,
+          error:
+            "Provide --id, --provider, or --provider + --client-id. Run 'assistant oauth apps list' to see all registered apps.",
+        });
+        process.exitCode = 1;
+        return;
+      }
+
+      const queryParams: Record<string, string> = {};
+      if (opts.id) queryParams.id = opts.id;
+      if (opts.provider) queryParams.provider = opts.provider;
+      if (opts.clientId) queryParams.client_id = opts.clientId;
+
+      const r = await cliIpcCall<{ app: AppRow }>("oauth_apps_by_query_get", {
+        queryParams,
+      });
+
+      if (!r.ok) {
+        if (r.statusCode === 404) {
+          const lookup = opts.id
+            ? `id=${opts.id}`
+            : opts.provider && opts.clientId
+              ? `provider=${opts.provider}, clientId=${opts.clientId}`
+              : `provider=${opts.provider}`;
+          writeOutput(cmd, {
+            ok: false,
+            error: `No app found for ${lookup}. Run 'assistant oauth apps list' to see registered apps, or 'assistant oauth apps upsert --help' to register a new one.`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+        return exitFromIpcResult(r);
+      }
+
+      const row = r.result?.app;
+      writeOutput(cmd, row ? formatAppRow(row) : null);
+    },
+  );
+
+  // -----------------------------------------------------------------------
+  // apps upsert
+  // -----------------------------------------------------------------------
+
+  subcommand(apps, "upsert").action(
+    async (
+      opts: {
+        provider: string;
+        clientId: string;
+        clientSecret?: string;
+        clientSecretCredentialPath?: string;
+      },
+      cmd: Command,
+    ) => {
+      if (opts.clientSecret && opts.clientSecretCredentialPath) {
+        writeOutput(cmd, {
+          ok: false,
+          error:
+            "Cannot provide both --client-secret and --client-secret-credential-path",
+        });
+        process.exitCode = 1;
+        return;
+      }
+
+      const body: Record<string, unknown> = {
+        provider_key: opts.provider,
+        client_id: opts.clientId,
+      };
+
+      if (opts.clientSecret) {
+        body.client_secret = opts.clientSecret;
+      } else if (opts.clientSecretCredentialPath) {
+        body.client_secret_credential_path = resolveCredentialPath(
+          opts.clientSecretCredentialPath,
+        );
+      }
+
+      const r = await cliIpcCall<{ app: AppRow }>("oauth_apps_upsert", {
+        body,
+      });
+
+      if (!r.ok) {
+        writeOutput(cmd, {
+          ok: false,
+          error: r.error ?? "Unknown error",
+        });
+        process.exitCode = 1;
+        return;
+      }
+
+      const row = r.result?.app;
+      if (row) {
+        if (!shouldOutputJson(cmd)) {
+          log.info(`Upserted app: ${row.id} (provider: ${row.provider_key})`);
+        }
+        writeOutput(cmd, formatAppRow(row));
+      }
+    },
+  );
+
+  // -----------------------------------------------------------------------
+  // apps delete <id>
+  // -----------------------------------------------------------------------
+
+  subcommand(apps, "delete").action(
+    async (id: string, _opts: unknown, cmd: Command) => {
+      const r = await cliIpcCall<{ ok: boolean }>("oauth_apps_delete", {
+        pathParams: { id },
+      });
+
+      if (!r.ok) {
+        if (r.statusCode === 404) {
+          writeOutput(cmd, {
+            ok: false,
+            error: `App not found: ${id}. Run 'assistant oauth apps list' to see registered apps and their IDs.`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+        return exitFromIpcResult(r);
+      }
+
+      if (!shouldOutputJson(cmd)) {
+        log.info(`Deleted app: ${id}`);
+      }
+
+      writeOutput(cmd, { ok: true, id });
+    },
+  );
 }

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { openInHostBrowser } from "../../lib/open-browser.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -58,22 +59,9 @@ async function pollOAuthConnectStatus(
 // ---------------------------------------------------------------------------
 
 export function registerConnectCommand(oauth: Command): void {
-  oauth
-    .command("connect <provider>")
-    .description(
-      "Initiate an OAuth authorization flow for a specified provider",
-    )
-    .option("--scopes <scopes...>", "Scopes to request for the authorization")
-    .option(
-      "--no-browser",
-      "Print the auth URL instead of opening it in the browser",
-    )
-    .option("--client-id <id>", "BYO app client ID disambiguation")
-    .option(
-      "--callback-transport <transport>",
-      `How the OAuth callback is delivered after authorization. Use "loopback" when oauth connection is initiated from a local client, such as the macos desktop app (starts a temporary localhost server to receive the callback — no tunnel or public URL needed). Use "gateway" when the oauth connection is initiated from a web client (routes the callback through the public ingress URL — requires ingress.publicBaseUrl to be configured).`,
-      "loopback",
-    )
+  subcommand(oauth, "connect")
+    // The preAction validation hook is imperative behaviour, not help data,
+    // so it stays here alongside the action handler.
     .hook("preAction", (thisCommand) => {
       const transport = thisCommand.opts().callbackTransport;
       if (transport !== "loopback" && transport !== "gateway") {
@@ -82,25 +70,6 @@ export function registerConnectCommand(oauth: Command): void {
         );
       }
     })
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  provider   Provider name (e.g. google, slack, notion).
-             Run 'assistant oauth providers list' to see available providers.
-
-When --scopes is provided, the specified scopes replace the provider's
-defaults entirely (use full scope URLs).
-By default, the browser opens automatically and the command waits for
-completion. Use --no-browser to print the URL instead (useful for headless
-or SSH sessions).
-
-Examples:
-  $ assistant oauth connect google
-  $ assistant oauth connect google --no-browser
-  $ assistant oauth connect google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
-  $ assistant oauth connect google --client-id abc123`,
-    )
     .action(
       async (
         provider: string,

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -11,76 +12,48 @@ const log = getCliLogger("cli");
 // ---------------------------------------------------------------------------
 
 export function registerDisconnectCommand(oauth: Command): void {
-  oauth
-    .command("disconnect <provider>")
-    .description(
-      "Disconnect an OAuth provider and remove associated credentials",
-    )
-    .option(
-      "--account <identifier>",
-      "Account identifier to disconnect (e.g. email address)",
-    )
-    .option("--connection-id <id>", "Exact connection ID to disconnect")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  provider   Provider name (e.g. google, slack, notion).
-             Run 'assistant oauth providers list' to see available providers.
+  subcommand(oauth, "disconnect").action(
+    async (
+      provider: string,
+      opts: { account?: string; connectionId?: string },
+      cmd: Command,
+    ) => {
+      const jsonMode = shouldOutputJson(cmd);
 
-At most one of --account or --connection-id may be specified. Use the values
-shown by 'assistant oauth status <provider>' to find the right identifier.
+      const writeError = (
+        error: string,
+        extra?: Record<string, unknown>,
+      ): void => {
+        writeOutput(cmd, { ok: false, error, ...extra });
+        process.exitCode = 1;
+      };
 
-When a provider has multiple active connections and neither flag is given,
-the command errors with a list of connections and a hint to disambiguate.
+      try {
+        const body: Record<string, unknown> = { provider };
+        if (opts.account) body.account = opts.account;
+        if (opts.connectionId) body.connection_id = opts.connectionId;
 
-Examples:
-  $ assistant oauth disconnect google
-  $ assistant oauth disconnect google --account user@gmail.com
-  $ assistant oauth disconnect google --connection-id conn_abc123`,
-    )
-    .action(
-      async (
-        provider: string,
-        opts: { account?: string; connectionId?: string },
-        cmd: Command,
-      ) => {
-        const jsonMode = shouldOutputJson(cmd);
+        const r = await cliIpcCall<{
+          ok: boolean;
+          provider: string;
+          connectionId: string;
+          account?: string;
+        }>("oauth_disconnect", { body });
 
-        const writeError = (
-          error: string,
-          extra?: Record<string, unknown>,
-        ): void => {
-          writeOutput(cmd, { ok: false, error, ...extra });
-          process.exitCode = 1;
-        };
+        if (!r.ok) return exitFromIpcResult(r);
 
-        try {
-          const body: Record<string, unknown> = { provider };
-          if (opts.account) body.account = opts.account;
-          if (opts.connectionId) body.connection_id = opts.connectionId;
+        const result = r.result!;
+        writeOutput(cmd, result);
 
-          const r = await cliIpcCall<{
-            ok: boolean;
-            provider: string;
-            connectionId: string;
-            account?: string;
-          }>("oauth_disconnect", { body });
-
-          if (!r.ok) return exitFromIpcResult(r);
-
-          const result = r.result!;
-          writeOutput(cmd, result);
-
-          if (!jsonMode) {
-            log.info(
-              `Disconnected ${result.provider} connection ${result.connectionId}`,
-            );
-          }
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          writeError(message);
+        if (!jsonMode) {
+          log.info(
+            `Disconnected ${result.provider} connection ${result.connectionId}`,
+          );
         }
-      },
-    );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeError(message);
+      }
+    },
+  );
 }

--- a/assistant/src/cli/commands/oauth/index.help.ts
+++ b/assistant/src/cli/commands/oauth/index.help.ts
@@ -1,0 +1,855 @@
+/** Declarative help for the `assistant oauth` command. */
+
+import type { CliCommandHelp } from "../../lib/cli-command-help.js";
+
+export const oauthHelp: CliCommandHelp = {
+  name: "oauth",
+  description:
+    "Manage the full OAuth lifecycle — registering providers, creating apps, connecting accounts, and making authenticated requests",
+  options: [
+    { flags: "--json", description: "Machine-readable compact JSON output" },
+  ],
+  helpText: `
+OAuth providers may support up to two modes – "managed" and "your-own".
+  managed:
+    Requires a Vellum Platform account. For providers that support it, managed mode offloads the burden of needing to create and register an oauth app.
+    Vellum Platform manages oauth token management and refresh and proxies requests to the provier.
+  you-own:
+    Provides ultimate control and removes dependency on Vellum Platform, but requires that you set up your own oauth app and register it
+    via \`assistant oauth apps upsert\`.
+All commands are intended to work regardless of the provider's mode. Check and set the mode for a given provider with \`assistant oauth mode\`.
+
+You can define entirely new oauth providers to integrate with even if they do not show up using \`assistant oauth providers list\` using
+\`assistant oauth providers register\`. Custom-registered providers only support "your-own" mode.
+
+
+Examples:
+  assistant oauth providers list
+  assistant oauth providers get google
+  assistant oauth mode google --set=managed
+  assistant oauth connect google
+  assistant oauth status google
+  assistant oauth ping google
+  assistant oauth request --provider google /gmail/v1/users/me/messages
+  assistant oauth disconnect google`,
+  subcommands: [
+    {
+      name: "providers",
+      description:
+        "Fetch configured OAuth providers and register custom providers of your own",
+      helpText: `
+Providers define the protocol-level configuration for an OAuth integration:
+authorization URL, token URL, default scopes, and other endpoint details.
+
+They are seeded on startup for built-in integrations (e.g. Google, Slack,
+GitHub) but can also be registered dynamically via the "register" subcommand.
+
+Each provider is identified by a provider key (e.g. "google").`,
+      subcommands: [
+        {
+          name: "list",
+          description: "List all registered OAuth providers",
+          options: [
+            {
+              flags: "--provider-key <key>",
+              description:
+                'Filter by provider key substring (case-insensitive). Comma-separated values are OR\'d (e.g. "google,slack")',
+            },
+            {
+              flags: "--supports-managed",
+              description: "Only show providers that support managed mode",
+            },
+          ],
+          helpText: `
+Returns registered OAuth providers, including both built-in providers
+seeded at startup and any dynamically registered via "providers register".
+
+When --provider-key is specified, only providers whose key contains the
+given substring (case-insensitive) are returned. Multiple substrings can
+be OR'd together using commas (e.g. "google,slack" matches any provider
+whose key contains "google" OR "slack"). Without the flag, all providers
+are listed.
+
+Each provider row includes its key, auth URL, token URL, default scopes,
+and configuration timestamps.
+
+Examples:
+  $ assistant oauth providers list
+  $ assistant oauth providers list --provider-key google
+  $ assistant oauth providers list --provider-key "google,slack"
+  $ assistant oauth providers list --provider-key notion --json
+  $ assistant oauth providers list --supports-managed
+  $ assistant oauth providers list --supports-managed --json`,
+        },
+        {
+          name: "get",
+          args: "<provider-key>",
+          description: "Show details of a specific OAuth provider",
+          helpText: `
+Arguments:
+  provider-key   Provider key (e.g. "google").
+                 Must match the key used during registration or seeding.
+
+Returns the full provider configuration including auth URL, token URL,
+default scopes, available scopes, and extra parameters. Exits with code 1
+if the provider key is not found.
+
+Examples:
+  $ assistant oauth providers get google
+  $ assistant oauth providers get twitter --json`,
+        },
+        {
+          name: "register",
+          description: "Register a new OAuth provider configuration",
+          options: [
+            {
+              flags: "--provider-key <key>",
+              description:
+                "Unique provider key (e.g. \"custom-service\"). Must not collide with an existing key from 'assistant oauth providers list'.",
+              required: true,
+            },
+            {
+              flags: "--auth-url <url>",
+              description:
+                "OAuth authorization endpoint URL (e.g. https://accounts.example.com/o/oauth2/auth)",
+              required: true,
+            },
+            {
+              flags: "--token-url <url>",
+              description:
+                "OAuth token endpoint URL (e.g. https://oauth2.example.com/token)",
+              required: true,
+            },
+            {
+              flags: "--refresh-url <url>",
+              description:
+                "OAuth token refresh endpoint URL. Defaults to --token-url when omitted.",
+            },
+            {
+              flags: "--base-url <url>",
+              description: "API base URL for the service",
+            },
+            {
+              flags: "--userinfo-url <url>",
+              description: "OpenID Connect userinfo endpoint URL",
+            },
+            {
+              flags: "--scopes <scopes>",
+              description:
+                'Comma-separated default scopes (e.g. "read,write,profile")',
+            },
+            {
+              flags: "--scope-separator <sep>",
+              description:
+                'Separator used to join scopes in the authorize URL (default: " ").',
+            },
+            {
+              flags: "--token-auth-method <method>",
+              description:
+                'How the client authenticates at the token endpoint: "client_secret_post" or "client_secret_basic"',
+            },
+            {
+              flags: "--token-exchange-body-format <format>",
+              description:
+                'Body encoding for the token exchange request: "form" (default) or "json"',
+              defaultValue: "form",
+            },
+            {
+              flags: "--ping-url <url>",
+              description: "Health-check endpoint URL for token validation",
+            },
+            {
+              flags: "--ping-method <method>",
+              description:
+                "HTTP method for the ping endpoint: GET (default) or POST",
+            },
+            {
+              flags: "--ping-headers <json>",
+              description: "JSON object of extra headers for the ping request",
+            },
+            {
+              flags: "--ping-body <json>",
+              description: "JSON body to send with the ping request",
+            },
+            {
+              flags: "--revoke-url <url>",
+              description: "OAuth token revocation endpoint URL",
+            },
+            {
+              flags: "--revoke-body-template <json>",
+              description: "JSON object body template for the revoke request",
+            },
+            {
+              flags: "--display-name <name>",
+              description: "Human-readable display name for the provider",
+            },
+            {
+              flags: "--description <text>",
+              description: "Short description of the provider",
+            },
+            {
+              flags: "--dashboard-url <url>",
+              description:
+                "URL to the provider's developer console / dashboard",
+            },
+            {
+              flags: "--logo-url <url>",
+              description:
+                "URL to the provider's logo image. Mutually exclusive with --logo-simpleicons-slug.",
+            },
+            {
+              flags: "--logo-simpleicons-slug <slug>",
+              description:
+                'Simple Icons slug (e.g. "notion"). Mutually exclusive with --logo-url.',
+            },
+            {
+              flags: "--client-id-placeholder <text>",
+              description:
+                "Placeholder text shown in the client ID input field",
+            },
+            {
+              flags: "--no-client-secret",
+              description:
+                "Mark this provider as not requiring a client secret",
+            },
+            {
+              flags: "--loopback-port <port>",
+              description: "Fixed port for the local OAuth callback server",
+            },
+            {
+              flags: "--injection-templates <json>",
+              description: "JSON array of token injection templates",
+            },
+            {
+              flags: "--app-type <type>",
+              description:
+                'What the provider calls its OAuth apps (e.g. "OAuth App")',
+            },
+            {
+              flags: "--identity-url <url>",
+              description: "Identity verification endpoint URL",
+            },
+            {
+              flags: "--identity-method <method>",
+              description:
+                "HTTP method for the identity endpoint: GET (default) or POST",
+            },
+            {
+              flags: "--identity-headers <json>",
+              description:
+                "JSON object of extra headers for the identity request",
+            },
+            {
+              flags: "--identity-body <body>",
+              description: "JSON body to send with the identity request",
+            },
+            {
+              flags: "--identity-response-paths <paths>",
+              description:
+                "Comma-separated dot-notation paths to extract identity from the response",
+            },
+            {
+              flags: "--identity-format <template>",
+              description: "Format template for the extracted identity",
+            },
+            {
+              flags: "--identity-ok-field <field>",
+              description:
+                "Dot-notation path to a boolean field that must be truthy for the response to be valid",
+            },
+            {
+              flags: "--setup-notes <json>",
+              description:
+                "JSON array of setup instruction notes shown during guided setup",
+            },
+            {
+              flags: "--available-scopes <value>",
+              description:
+                "Available scopes: either a JSON array of {scope, description?} objects or a URL",
+            },
+          ],
+          helpText: `
+Registers a new OAuth provider configuration in the local store for custom
+integrations not covered by the built-in provider seeds. The provider key
+must be unique — if it collides with an existing key, the command fails.
+Run 'assistant oauth providers list' to see existing keys.
+
+On success, returns the full provider row including generated timestamps.
+After registering, create an OAuth app with 'assistant oauth apps create'
+and then connect with 'assistant oauth connect <provider-key>'.
+
+Examples:
+  $ assistant oauth providers register \\
+      --provider-key custom-api \\
+      --auth-url https://custom-api.example.com/oauth/authorize \\
+      --token-url https://custom-api.example.com/oauth/token
+  $ assistant oauth providers register \\
+      --provider-key my-service \\
+      --auth-url https://my-service.com/auth \\
+      --token-url https://my-service.com/token \\
+      --scopes read,write --json`,
+        },
+        {
+          name: "update",
+          args: "<provider-key>",
+          description: "Update an existing custom OAuth provider configuration",
+          options: [
+            {
+              flags: "--auth-url <url>",
+              description: "OAuth authorization endpoint URL",
+            },
+            {
+              flags: "--token-url <url>",
+              description: "OAuth token endpoint URL",
+            },
+            {
+              flags: "--refresh-url <url>",
+              description: "OAuth token refresh endpoint URL",
+            },
+            {
+              flags: "--base-url <url>",
+              description: "API base URL for the service",
+            },
+            {
+              flags: "--userinfo-url <url>",
+              description: "OpenID Connect userinfo endpoint URL",
+            },
+            {
+              flags: "--scopes <scopes>",
+              description:
+                'Comma-separated default scopes (e.g. "read,write,profile")',
+            },
+            {
+              flags: "--scope-separator <sep>",
+              description: "Separator used to join scopes in the authorize URL",
+            },
+            {
+              flags: "--token-auth-method <method>",
+              description: "How the client authenticates at the token endpoint",
+            },
+            {
+              flags: "--token-exchange-body-format <format>",
+              description:
+                'Body encoding for the token exchange request: "form" or "json"',
+            },
+            {
+              flags: "--ping-url <url>",
+              description: "Health-check endpoint URL",
+            },
+            {
+              flags: "--ping-method <method>",
+              description:
+                "HTTP method for the ping endpoint: GET (default) or POST",
+            },
+            {
+              flags: "--ping-headers <json>",
+              description: "JSON object of extra headers for the ping request",
+            },
+            {
+              flags: "--ping-body <json>",
+              description: "JSON body for the ping request",
+            },
+            {
+              flags: "--revoke-url <url>",
+              description:
+                "OAuth token revocation endpoint URL. Pass empty string to clear.",
+            },
+            {
+              flags: "--revoke-body-template <json>",
+              description:
+                "JSON object body template for the revoke request. Pass empty string to clear.",
+            },
+            {
+              flags: "--display-name <name>",
+              description: "Human-readable display name",
+            },
+            {
+              flags: "--description <text>",
+              description: "Short description",
+            },
+            {
+              flags: "--dashboard-url <url>",
+              description: "Developer console / dashboard URL",
+            },
+            {
+              flags: "--logo-url <url>",
+              description:
+                "URL to the provider's logo image. Mutually exclusive with --logo-simpleicons-slug.",
+            },
+            {
+              flags: "--logo-simpleicons-slug <slug>",
+              description:
+                "Simple Icons slug. Mutually exclusive with --logo-url.",
+            },
+            {
+              flags: "--client-id-placeholder <text>",
+              description: "Placeholder for client ID input",
+            },
+            {
+              flags: "--no-client-secret",
+              description: "Mark as not requiring a client secret",
+            },
+            {
+              flags: "--loopback-port <port>",
+              description: "Fixed port for the local OAuth callback server",
+            },
+            {
+              flags: "--injection-templates <json>",
+              description: "JSON array of token injection templates",
+            },
+            {
+              flags: "--app-type <type>",
+              description: "What the provider calls its OAuth apps",
+            },
+            {
+              flags: "--identity-url <url>",
+              description: "Identity verification endpoint URL",
+            },
+            {
+              flags: "--identity-method <method>",
+              description: "HTTP method for identity endpoint",
+            },
+            {
+              flags: "--identity-headers <json>",
+              description: "JSON object of extra headers for identity request",
+            },
+            {
+              flags: "--identity-body <body>",
+              description: "JSON body for identity request",
+            },
+            {
+              flags: "--identity-response-paths <paths>",
+              description: "Comma-separated dot-notation paths",
+            },
+            {
+              flags: "--identity-format <template>",
+              description: "Format template for extracted identity",
+            },
+            {
+              flags: "--identity-ok-field <field>",
+              description: "Dot-notation path to a boolean ok field",
+            },
+            {
+              flags: "--setup-notes <json>",
+              description: "JSON array of setup instruction notes",
+            },
+            {
+              flags: "--available-scopes <value>",
+              description: "Available scopes: JSON array or URL",
+            },
+          ],
+          helpText: `
+Arguments:
+  provider-key   Provider key to update (e.g. "custom-api").
+                 Run 'assistant oauth providers list' to see all registered providers.
+
+Only the fields you specify are updated — all other fields remain unchanged.
+Built-in providers (e.g. "google", "slack") cannot be updated; they are
+managed by the system and reset on startup.
+
+Examples:
+  $ assistant oauth providers update custom-api --display-name "My Custom API"
+  $ assistant oauth providers update custom-api --scopes read,write --auth-url https://new.example.com/auth
+  $ assistant oauth providers update custom-api --ping-url https://api.example.com/me --json
+  $ assistant oauth providers update custom-api --logo-url ""`,
+        },
+        {
+          name: "delete",
+          args: "<provider-key>",
+          description:
+            "Delete a custom OAuth provider and optionally its associated apps and connections",
+          options: [
+            {
+              flags: "--force",
+              description:
+                "Cascade-delete all associated apps and connections before removing the provider",
+            },
+          ],
+          helpText: `
+Arguments:
+  provider-key   Provider key to delete (e.g. "custom-api").
+                 Run 'assistant oauth providers list' to see registered providers.
+
+When --force is specified, all OAuth connections and apps that depend on
+this provider are deleted before the provider itself is removed. Without
+--force, the command refuses to delete a provider that has dependents and
+exits with an error listing the counts.
+
+Built-in providers (e.g. "google", "slack") can be deleted, but a warning
+is emitted because they will be re-created automatically on the next
+assistant startup.
+
+Examples:
+  $ assistant oauth providers delete custom-api
+  $ assistant oauth providers delete custom-api --force
+  $ assistant oauth providers delete custom-api --force --json`,
+        },
+      ],
+    },
+    {
+      name: "mode",
+      args: "<provider>",
+      description: "Get or set the OAuth mode for a provider",
+      options: [
+        {
+          flags: "--set <mode>",
+          description:
+            'Set the mode to "managed" (platform-handled credentials) or "your-own" (bring-your-own client ID and secret). Omit to show the current mode.',
+        },
+      ],
+      helpText: `
+Arguments:
+  provider   Provider name (e.g. google, slack).
+             Run "assistant oauth providers list" to see available providers.
+
+Modes:
+  managed    OAuth credentials are managed by the Vellum platform. The
+             assistant connects via a platform-hosted authorization flow.
+             No local client ID or secret is needed.
+  your-own   You supply your own OAuth app credentials (client ID and
+             secret). The assistant runs the OAuth flow locally.
+
+Examples:
+  $ assistant oauth mode google
+  $ assistant oauth mode google --set your-own
+  $ assistant oauth mode google --set managed`,
+    },
+    {
+      name: "apps",
+      description: "Manage custom OAuth app registrations",
+      helpText: `
+Apps represent custom OAuth client registrations — a client_id and optional
+client_secret linked to a provider. Each provider can have multiple apps
+(e.g. different client IDs for different environments). Only needed if using
+a provider with a mode of "your-own" set.
+
+Examples:
+  $ assistant oauth apps list
+  $ assistant oauth apps list --provider-key google
+  $ assistant oauth apps get --id <uuid>
+  $ assistant oauth apps get --provider google
+  $ assistant oauth apps upsert --provider google --client-id abc123
+  $ assistant oauth apps delete <id>`,
+      subcommands: [
+        {
+          name: "list",
+          description: "List all OAuth app registrations",
+          options: [
+            {
+              flags: "--provider-key <key>",
+              description:
+                "Filter by provider key (exact match). Run 'assistant oauth providers list' to see available keys.",
+            },
+          ],
+          helpText: `
+Returns registered OAuth apps with their provider key, client ID, and
+timestamps. Output is an array of app objects.
+
+When --provider-key is specified, only apps whose provider exactly matches
+the given value are returned. Without the flag, all apps are listed.
+
+Examples:
+  $ assistant oauth apps list
+  $ assistant oauth apps list --provider-key google
+  $ assistant oauth apps list --provider-key slack --json`,
+        },
+        {
+          name: "get",
+          description:
+            "Look up an OAuth app by ID, provider + client-id, or provider",
+          options: [
+            {
+              flags: "--id <id>",
+              description: "App ID (UUID) from 'assistant oauth apps list'",
+            },
+            {
+              flags: "--provider <key>",
+              description:
+                "Provider key (e.g. google) from 'assistant oauth providers list'",
+            },
+            {
+              flags: "--client-id <id>",
+              description:
+                "OAuth client ID (requires --provider). Find registered client IDs via 'assistant oauth apps list'.",
+            },
+          ],
+          helpText: `
+Three lookup modes are supported:
+
+  1. By app ID:
+     $ assistant oauth apps get --id <uuid>
+
+  2. By provider + client ID (exact match):
+     $ assistant oauth apps get --provider google --client-id abc123
+
+  3. By provider only (returns the most recently created app):
+     $ assistant oauth apps get --provider google
+
+At least --id or --provider must be specified.`,
+        },
+        {
+          name: "upsert",
+          description: "Create or return an existing OAuth app registration",
+          options: [
+            {
+              flags: "--provider <key>",
+              description:
+                "Provider key (e.g. google) from 'assistant oauth providers list'",
+              required: true,
+            },
+            {
+              flags: "--client-id <id>",
+              description:
+                "OAuth client ID from the provider's developer console",
+              required: true,
+            },
+            {
+              flags: "--client-secret <secret>",
+              description: "OAuth client secret (stored in credential store)",
+            },
+            {
+              flags: "--client-secret-credential-path <path>",
+              description:
+                "Credential reference in service:field format (e.g. google:client_secret). Mutually exclusive with --client-secret.",
+            },
+          ],
+          helpText: `
+Creates a new app registration or returns the existing one if an app with the
+same provider and client ID already exists. The client secret, if provided, is
+stored in the secure credential store — not in the database.
+
+When an existing app is matched and a --client-secret is provided, the stored
+secret is updated. The app row itself is returned as-is.
+
+You can supply the client secret directly via --client-secret, or reference an
+existing credential in the store via --client-secret-credential-path. These two
+options are mutually exclusive — providing both is an error.
+
+Examples:
+  $ assistant oauth apps upsert --provider google --client-id abc123
+  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret s3cret
+  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "slack:client_secret"
+  $ assistant oauth apps upsert --provider google --client-id abc123 --json`,
+        },
+        {
+          name: "delete",
+          args: "<id>",
+          description: "Delete an OAuth app registration by ID",
+          helpText: `
+Arguments:
+  id   The app UUID to delete (as returned by "apps list" or "apps get")
+
+Permanently removes the app registration and its stored client secret from
+the credential store. Any OAuth connections that reference this app will no longer be
+able to refresh tokens.
+
+Exits with code 1 if the app ID is not found.
+
+Examples:
+  $ assistant oauth apps delete 550e8400-e29b-41d4-a716-446655440000
+  $ assistant oauth apps delete 550e8400-e29b-41d4-a716-446655440000 --json`,
+        },
+      ],
+    },
+    {
+      name: "connect",
+      args: "<provider>",
+      description:
+        "Initiate an OAuth authorization flow for a specified provider",
+      options: [
+        {
+          flags: "--scopes <scopes...>",
+          description: "Scopes to request for the authorization",
+        },
+        {
+          flags: "--no-browser",
+          description:
+            "Print the auth URL instead of opening it in the browser",
+        },
+        {
+          flags: "--client-id <id>",
+          description: "BYO app client ID disambiguation",
+        },
+        {
+          flags: "--callback-transport <transport>",
+          description: `How the OAuth callback is delivered after authorization. Use "loopback" when oauth connection is initiated from a local client, such as the macos desktop app (starts a temporary localhost server to receive the callback — no tunnel or public URL needed). Use "gateway" when the oauth connection is initiated from a web client (routes the callback through the public ingress URL — requires ingress.publicBaseUrl to be configured).`,
+          defaultValue: "loopback",
+        },
+      ],
+      helpText: `
+Arguments:
+  provider   Provider name (e.g. google, slack, notion).
+             Run 'assistant oauth providers list' to see available providers.
+
+When --scopes is provided, the specified scopes replace the provider's
+defaults entirely (use full scope URLs).
+By default, the browser opens automatically and the command waits for
+completion. Use --no-browser to print the URL instead (useful for headless
+or SSH sessions).
+
+Examples:
+  $ assistant oauth connect google
+  $ assistant oauth connect google --no-browser
+  $ assistant oauth connect google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
+  $ assistant oauth connect google --client-id abc123`,
+    },
+    {
+      name: "status",
+      args: "<provider>",
+      description: "Show OAuth connection status for a specified provider",
+      helpText: `
+Arguments:
+  provider   Provider name (e.g. google, slack).
+             Run 'assistant oauth providers list' to see all available providers.
+
+The output includes connection IDs and account identifiers that can be used
+as inputs to other commands:
+  - 'assistant oauth disconnect <provider>' to remove a connection
+  - 'assistant oauth request --provider <provider> --account <account>' to
+    make authenticated requests as a specific account
+
+Examples:
+  $ assistant oauth status google
+  $ assistant oauth status google --json`,
+    },
+    {
+      name: "ping",
+      args: "<provider>",
+      description:
+        "Verify an OAuth token is valid by hitting the provider's configured health-check endpoint",
+      options: [
+        {
+          flags: "--account <account>",
+          description: "Account identifier for multi-account",
+        },
+        {
+          flags: "--client-id <id>",
+          description: "BYO app client ID disambiguation",
+        },
+      ],
+      helpText: `
+Arguments:
+  provider   Provider name (e.g. google, slack).
+             Run 'assistant oauth providers list' to see available providers.
+
+Hits the provider's configured ping URL with the stored OAuth token and
+reports whether the token is valid. Use 'assistant oauth status <provider>'
+to find account identifiers for --account.
+
+Examples:
+  $ assistant oauth ping google
+  $ assistant oauth ping google --json
+  $ assistant oauth ping google --account user@example.com`,
+    },
+    {
+      name: "request",
+      args: "<url>",
+      description:
+        "The recommended way to make an authenticated request to an OAuth provider (supports a curl-like interface)",
+      // Options are registered imperatively in request.ts: the repeatable
+      // "-H, --header" flag needs a Commander collect parser (function +
+      // array default), which the declarative contract cannot express, and
+      // the remaining options must keep their registration order around it.
+      helpText: `
+This is the first-class mechanism for making authenticated HTTP requests
+to an OAuth provider. By using this CLI, you follow security best-practices
+regarding how the OAuth token is used. This approach is preferred over retrieving
+the token (using \`assistant oauth token\`) and making the request directly.
+
+This command resolves the OAuth connection automatically (regardless of whether
+the provider's mode is set to "managed" or "your-own") and injects tokens transparently.
+
+URL can be absolute (https://api.x.com/2/tweets) or relative (/2/tweets).
+An absolute URL sets the host and full path explicitly. A relative path is
+joined onto the provider's configured default base URL — the base URL shown by
+'assistant oauth providers get <provider>'. For providers whose default base
+URL points at one specific service, a relative path for a different service on
+the same provider will resolve against the wrong host or path and fail (often
+with an opaque HTML 404). When in doubt, pass an absolute URL: it is the safe
+form for any service other than the provider's default.
+
+Note: The Authorization header is set automatically. User-supplied
+-H "Authorization: ..." will be overridden by the OAuth bearer token.
+
+Examples:
+  $ assistant oauth request --provider twitter https://api.x.com/2/tweets
+  $ assistant oauth request --provider google /gmail/v1/users/me/messages -G
+  $ assistant oauth request --provider twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
+  $ assistant oauth request --provider google https://www.googleapis.com/calendar/v3/calendars/primary/events
+  $ assistant oauth request --provider slack -H "Content-Type: application/json" -d '{"channel":"C123"}' /api/chat.postMessage --json`,
+    },
+    {
+      name: "disconnect",
+      args: "<provider>",
+      description:
+        "Disconnect an OAuth provider and remove associated credentials",
+      options: [
+        {
+          flags: "--account <identifier>",
+          description: "Account identifier to disconnect (e.g. email address)",
+        },
+        {
+          flags: "--connection-id <id>",
+          description: "Exact connection ID to disconnect",
+        },
+      ],
+      helpText: `
+Arguments:
+  provider   Provider name (e.g. google, slack, notion).
+             Run 'assistant oauth providers list' to see available providers.
+
+At most one of --account or --connection-id may be specified. Use the values
+shown by 'assistant oauth status <provider>' to find the right identifier.
+
+When a provider has multiple active connections and neither flag is given,
+the command errors with a list of connections and a hint to disambiguate.
+
+Examples:
+  $ assistant oauth disconnect google
+  $ assistant oauth disconnect google --account user@gmail.com
+  $ assistant oauth disconnect google --connection-id conn_abc123`,
+    },
+    {
+      name: "token",
+      args: "<provider>",
+      description:
+        'An escape hatch to retrieve a valid OAuth access token for a provider whose mode is "your-own" for direct use.',
+      options: [
+        {
+          flags: "--account <account>",
+          description:
+            "Account identifier for account disambiguation (e.g. user@gmail.com)",
+        },
+        {
+          flags: "--client-id <id>",
+          description:
+            "Filter by OAuth client ID when multiple OAuth apps exist for the provider",
+        },
+      ],
+      helpText: `
+Arguments:
+  provider   Provider name (e.g. google, slack).
+             Run 'assistant oauth providers list' to see all available
+             providers.
+
+This command is discouraged and should be used sparingly. Only use if you
+need direct access to the token (i.e. \`assistant oauth request\` is
+insufficient) and you are comfortable with the security implications.
+
+Token retrieval is only supported for providers with mode set to "your-own".
+Platform-managed providers handle tokens internally — use
+'assistant oauth ping <provider>' to verify connectivity or
+'assistant oauth request --provider <provider> <url>' to make
+authenticated requests.
+
+Use 'assistant oauth status <provider>' to find account identifiers for
+--account.
+
+Examples:
+  $ assistant oauth token google
+  $ assistant oauth token twitter --json
+  $ assistant oauth token google --account user@gmail.com
+  $ assistant oauth token google --client-id abc123`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -1,9 +1,11 @@
 import type { Command } from "commander";
 
+import { applyCommandHelp } from "../../lib/cli-command-help.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { registerAppCommands } from "./apps.js";
 import { registerConnectCommand } from "./connect.js";
 import { registerDisconnectCommand } from "./disconnect.js";
+import { oauthHelp } from "./index.help.js";
 import { registerModeCommand } from "./mode.js";
 import { registerPingCommand } from "./ping.js";
 import { registerProviderCommands } from "./providers.js";
@@ -13,39 +15,11 @@ import { registerTokenCommand } from "./token.js";
 
 export function registerOAuthCommand(program: Command): void {
   registerCommand(program, {
-    name: "oauth",
+    name: oauthHelp.name,
     transport: "ipc",
-    description:
-      "Manage the full OAuth lifecycle — registering providers, creating apps, connecting accounts, and making authenticated requests",
+    description: oauthHelp.description,
     build: (oauth) => {
-      oauth.option("--json", "Machine-readable compact JSON output");
-
-      oauth.addHelpText(
-        "after",
-        `
-OAuth providers may support up to two modes – "managed" and "your-own".
-  managed:
-    Requires a Vellum Platform account. For providers that support it, managed mode offloads the burden of needing to create and register an oauth app.
-    Vellum Platform manages oauth token management and refresh and proxies requests to the provier.
-  you-own:
-    Provides ultimate control and removes dependency on Vellum Platform, but requires that you set up your own oauth app and register it
-    via \`assistant oauth apps upsert\`.
-All commands are intended to work regardless of the provider's mode. Check and set the mode for a given provider with \`assistant oauth mode\`.
-
-You can define entirely new oauth providers to integrate with even if they do not show up using \`assistant oauth providers list\` using
-\`assistant oauth providers register\`. Custom-registered providers only support "your-own" mode.
-
-
-Examples:
-  assistant oauth providers list
-  assistant oauth providers get google
-  assistant oauth mode google --set=managed
-  assistant oauth connect google
-  assistant oauth status google
-  assistant oauth ping google
-  assistant oauth request --provider google /gmail/v1/users/me/messages
-  assistant oauth disconnect google`,
-      );
+      applyCommandHelp(oauth, oauthHelp);
 
       // -----------------------------------------------------------------------
       // providers — subcommand group

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -11,33 +12,8 @@ const log = getCliLogger("cli");
 // ---------------------------------------------------------------------------
 
 export function registerModeCommand(oauth: Command): void {
-  oauth
-    .command("mode <provider>")
-    .description("Get or set the OAuth mode for a provider")
-    .option(
-      "--set <mode>",
-      'Set the mode to "managed" (platform-handled credentials) or "your-own" (bring-your-own client ID and secret). Omit to show the current mode.',
-    )
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  provider   Provider name (e.g. google, slack).
-             Run "assistant oauth providers list" to see available providers.
-
-Modes:
-  managed    OAuth credentials are managed by the Vellum platform. The
-             assistant connects via a platform-hosted authorization flow.
-             No local client ID or secret is needed.
-  your-own   You supply your own OAuth app credentials (client ID and
-             secret). The assistant runs the OAuth flow locally.
-
-Examples:
-  $ assistant oauth mode google
-  $ assistant oauth mode google --set your-own
-  $ assistant oauth mode google --set managed`,
-    )
-    .action(async (provider: string, opts: { set?: string }, cmd: Command) => {
+  subcommand(oauth, "mode").action(
+    async (provider: string, opts: { set?: string }, cmd: Command) => {
       try {
         if (opts.set === undefined) {
           // GET mode
@@ -107,5 +83,6 @@ Examples:
         writeOutput(cmd, { ok: false, error: message });
         process.exitCode = 1;
       }
-    });
+    },
+  );
 }

--- a/assistant/src/cli/commands/oauth/ping.ts
+++ b/assistant/src/cli/commands/oauth/ping.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -11,78 +12,55 @@ const log = getCliLogger("cli");
 // ---------------------------------------------------------------------------
 
 export function registerPingCommand(oauth: Command): void {
-  oauth
-    .command("ping <provider>")
-    .description(
-      "Verify an OAuth token is valid by hitting the provider's configured health-check endpoint",
-    )
-    .option("--account <account>", "Account identifier for multi-account")
-    .option("--client-id <id>", "BYO app client ID disambiguation")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  provider   Provider name (e.g. google, slack).
-             Run 'assistant oauth providers list' to see available providers.
+  subcommand(oauth, "ping").action(
+    async (
+      provider: string,
+      opts: {
+        account?: string;
+        clientId?: string;
+      },
+      cmd: Command,
+    ) => {
+      const jsonMode = shouldOutputJson(cmd);
 
-Hits the provider's configured ping URL with the stored OAuth token and
-reports whether the token is valid. Use 'assistant oauth status <provider>'
-to find account identifiers for --account.
+      try {
+        const body: Record<string, unknown> = { provider };
+        if (opts.account) body.account = opts.account;
+        if (opts.clientId) body.client_id = opts.clientId;
 
-Examples:
-  $ assistant oauth ping google
-  $ assistant oauth ping google --json
-  $ assistant oauth ping google --account user@example.com`,
-    )
-    .action(
-      async (
-        provider: string,
-        opts: {
-          account?: string;
-          clientId?: string;
-        },
-        cmd: Command,
-      ) => {
-        const jsonMode = shouldOutputJson(cmd);
+        const r = await cliIpcCall<{
+          ok: boolean;
+          provider: string;
+          status: number;
+          error?: string;
+          hint?: string;
+        }>("oauth_ping", { body });
 
-        try {
-          const body: Record<string, unknown> = { provider };
-          if (opts.account) body.account = opts.account;
-          if (opts.clientId) body.client_id = opts.clientId;
+        if (!r.ok) return exitFromIpcResult(r);
 
-          const r = await cliIpcCall<{
-            ok: boolean;
-            provider: string;
-            status: number;
-            error?: string;
-            hint?: string;
-          }>("oauth_ping", { body });
+        const result = r.result!;
 
-          if (!r.ok) return exitFromIpcResult(r);
-
-          const result = r.result!;
-
-          if (result.ok) {
-            if (!jsonMode) {
-              log.info(`${provider}: OK (HTTP ${result.status})`);
-            }
-            writeOutput(cmd, result);
-          } else {
-            writeOutput(cmd, result);
-            process.exitCode = 1;
+        if (result.ok) {
+          if (!jsonMode) {
+            log.info(`${provider}: OK (HTTP ${result.status})`);
           }
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-
-          writeOutput(cmd, {
-            ok: false,
-            error: message,
-            hint:
-              `Run 'assistant oauth status ${provider}' to check connection health. ` +
-              `To reconnect, run 'assistant oauth connect --help'.`,
-          });
+          writeOutput(cmd, result);
+        } else {
+          writeOutput(cmd, result);
           process.exitCode = 1;
         }
-      },
-    );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+
+        writeOutput(cmd, {
+          ok: false,
+          error: message,
+          hint:
+            `Run 'assistant oauth status ${provider}' to check connection health. ` +
+            `To reconnect, run 'assistant oauth connect --help'.`,
+        });
+        process.exitCode = 1;
+      }
+    },
+  );
 }

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -1,7 +1,7 @@
 import { type Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
-import { registerCommand } from "../../lib/register-command.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -206,789 +206,430 @@ function resolveLogoUrlFromFlags(opts: {
 }
 
 export function registerProviderCommands(oauth: Command): void {
-  registerCommand(oauth, {
-    name: "providers",
-    transport: "ipc",
-    description:
-      "Fetch configured OAuth providers and register custom providers of your own",
-    build: (providers) => {
-      providers.addHelpText(
-        "after",
-        `
-Providers define the protocol-level configuration for an OAuth integration:
-authorization URL, token URL, default scopes, and other endpoint details.
+  const providers = subcommand(oauth, "providers");
 
-They are seeded on startup for built-in integrations (e.g. Google, Slack,
-GitHub) but can also be registered dynamically via the "register" subcommand.
+  // -----------------------------------------------------------------------
+  // providers list
+  // -----------------------------------------------------------------------
 
-Each provider is identified by a provider key (e.g. "google").`,
+  subcommand(providers, "list").action(
+    async (
+      opts: { providerKey?: string; supportsManaged?: boolean },
+      cmd: Command,
+    ) => {
+      const queryParams: Record<string, string> = {};
+      if (opts.supportsManaged) {
+        queryParams.supports_managed_mode = "true";
+      }
+      const r = await cliIpcCall<{
+        providers: Array<Record<string, unknown>>;
+      }>("oauth_providers_get", {
+        queryParams,
+      });
+
+      if (!r.ok) return exitFromIpcResult(r);
+
+      // The route returns snake_case summaries; map to camelCase for
+      // display consistency with the existing CLI contract.
+      let rows: SerializedProvider[] = (r.result?.providers ?? []).map((p) => ({
+        providerKey: p.provider_key as string,
+        displayName: p.display_name as string | null,
+        description: p.description as string | null,
+        supportsManagedMode: p.supports_managed_mode as boolean,
+        managedServiceIsPaid: p.managed_service_is_paid as boolean,
+        requiresClientSecret: p.requires_client_secret as boolean,
+        logoUrl: p.logo_url as string | null,
+        dashboardUrl: p.dashboard_url as string | null,
+        clientIdPlaceholder: p.client_id_placeholder as string | null,
+        featureFlag: p.feature_flag as string | null,
+      }));
+
+      if (opts.providerKey) {
+        const needles = opts.providerKey
+          .split(",")
+          .map((n) => n.trim().toLowerCase())
+          .filter(Boolean);
+        rows = rows.filter(
+          (r) =>
+            r &&
+            needles.some((needle) =>
+              r.providerKey.toLowerCase().includes(needle),
+            ),
+        );
+      }
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, rows);
+      } else {
+        const lines = rows.map(formatProviderSummary);
+        process.stdout.write(
+          `${rows.length} provider(s):\n\n${lines.join("\n\n")}\n`,
+        );
+      }
+    },
+  );
+
+  // -----------------------------------------------------------------------
+  // providers get <provider-key>
+  // -----------------------------------------------------------------------
+
+  subcommand(providers, "get").action(
+    async (provider: string, _opts: unknown, cmd: Command) => {
+      const r = await cliIpcCall<{ provider: SerializedProvider }>(
+        "oauth_providers_by_providerKey_get",
+        { pathParams: { providerKey: provider } },
       );
 
-      // -----------------------------------------------------------------------
-      // providers list
-      // -----------------------------------------------------------------------
+      if (!r.ok) {
+        if (r.statusCode === 404) {
+          writeOutput(cmd, {
+            ok: false,
+            error: `Provider not found: "${provider}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+        return exitFromIpcResult(r);
+      }
 
-      providers
-        .command("list")
-        .description("List all registered OAuth providers")
-        .option(
-          "--provider-key <key>",
-          'Filter by provider key substring (case-insensitive). Comma-separated values are OR\'d (e.g. "google,slack")',
-        )
-        .option(
-          "--supports-managed",
-          "Only show providers that support managed mode",
-        )
-        .addHelpText(
-          "after",
-          `
-Returns registered OAuth providers, including both built-in providers
-seeded at startup and any dynamically registered via "providers register".
-
-When --provider-key is specified, only providers whose key contains the
-given substring (case-insensitive) are returned. Multiple substrings can
-be OR'd together using commas (e.g. "google,slack" matches any provider
-whose key contains "google" OR "slack"). Without the flag, all providers
-are listed.
-
-Each provider row includes its key, auth URL, token URL, default scopes,
-and configuration timestamps.
-
-Examples:
-  $ assistant oauth providers list
-  $ assistant oauth providers list --provider-key google
-  $ assistant oauth providers list --provider-key "google,slack"
-  $ assistant oauth providers list --provider-key notion --json
-  $ assistant oauth providers list --supports-managed
-  $ assistant oauth providers list --supports-managed --json`,
-        )
-        .action(
-          async (
-            opts: { providerKey?: string; supportsManaged?: boolean },
-            cmd: Command,
-          ) => {
-            const queryParams: Record<string, string> = {};
-            if (opts.supportsManaged) {
-              queryParams.supports_managed_mode = "true";
-            }
-            const r = await cliIpcCall<{
-              providers: Array<Record<string, unknown>>;
-            }>("oauth_providers_get", {
-              queryParams,
-            });
-
-            if (!r.ok) return exitFromIpcResult(r);
-
-            // The route returns snake_case summaries; map to camelCase for
-            // display consistency with the existing CLI contract.
-            let rows: SerializedProvider[] = (r.result?.providers ?? []).map(
-              (p) => ({
-                providerKey: p.provider_key as string,
-                displayName: p.display_name as string | null,
-                description: p.description as string | null,
-                supportsManagedMode: p.supports_managed_mode as boolean,
-                managedServiceIsPaid: p.managed_service_is_paid as boolean,
-                requiresClientSecret: p.requires_client_secret as boolean,
-                logoUrl: p.logo_url as string | null,
-                dashboardUrl: p.dashboard_url as string | null,
-                clientIdPlaceholder: p.client_id_placeholder as string | null,
-                featureFlag: p.feature_flag as string | null,
-              }),
-            );
-
-            if (opts.providerKey) {
-              const needles = opts.providerKey
-                .split(",")
-                .map((n) => n.trim().toLowerCase())
-                .filter(Boolean);
-              rows = rows.filter(
-                (r) =>
-                  r &&
-                  needles.some((needle) =>
-                    r.providerKey.toLowerCase().includes(needle),
-                  ),
-              );
-            }
-
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, rows);
-            } else {
-              const lines = rows.map(formatProviderSummary);
-              process.stdout.write(
-                `${rows.length} provider(s):\n\n${lines.join("\n\n")}\n`,
-              );
-            }
-          },
-        );
-
-      // -----------------------------------------------------------------------
-      // providers get <provider-key>
-      // -----------------------------------------------------------------------
-
-      providers
-        .command("get <provider-key>")
-        .description("Show details of a specific OAuth provider")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  provider-key   Provider key (e.g. "google").
-                 Must match the key used during registration or seeding.
-
-Returns the full provider configuration including auth URL, token URL,
-default scopes, available scopes, and extra parameters. Exits with code 1
-if the provider key is not found.
-
-Examples:
-  $ assistant oauth providers get google
-  $ assistant oauth providers get twitter --json`,
-        )
-        .action(async (provider: string, _opts: unknown, cmd: Command) => {
-          const r = await cliIpcCall<{ provider: SerializedProvider }>(
-            "oauth_providers_by_providerKey_get",
-            { pathParams: { providerKey: provider } },
-          );
-
-          if (!r.ok) {
-            if (r.statusCode === 404) {
-              writeOutput(cmd, {
-                ok: false,
-                error: `Provider not found: "${provider}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,
-              });
-              process.exitCode = 1;
-              return;
-            }
-            return exitFromIpcResult(r);
-          }
-
-          const parsed = r.result?.provider;
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, parsed);
-          } else if (parsed) {
-            process.stdout.write(formatProviderDetail(parsed) + "\n");
-          }
-        });
-
-      // -----------------------------------------------------------------------
-      // providers register
-      // -----------------------------------------------------------------------
-
-      providers
-        .command("register")
-        .description("Register a new OAuth provider configuration")
-        .requiredOption(
-          "--provider-key <key>",
-          "Unique provider key (e.g. \"custom-service\"). Must not collide with an existing key from 'assistant oauth providers list'.",
-        )
-        .requiredOption(
-          "--auth-url <url>",
-          "OAuth authorization endpoint URL (e.g. https://accounts.example.com/o/oauth2/auth)",
-        )
-        .requiredOption(
-          "--token-url <url>",
-          "OAuth token endpoint URL (e.g. https://oauth2.example.com/token)",
-        )
-        .option(
-          "--refresh-url <url>",
-          "OAuth token refresh endpoint URL. Defaults to --token-url when omitted.",
-        )
-        .option("--base-url <url>", "API base URL for the service")
-        .option("--userinfo-url <url>", "OpenID Connect userinfo endpoint URL")
-        .option(
-          "--scopes <scopes>",
-          'Comma-separated default scopes (e.g. "read,write,profile")',
-        )
-        .option(
-          "--scope-separator <sep>",
-          'Separator used to join scopes in the authorize URL (default: " ").',
-        )
-        .option(
-          "--token-auth-method <method>",
-          'How the client authenticates at the token endpoint: "client_secret_post" or "client_secret_basic"',
-        )
-        .option(
-          "--token-exchange-body-format <format>",
-          'Body encoding for the token exchange request: "form" (default) or "json"',
-          "form",
-        )
-        .option(
-          "--ping-url <url>",
-          "Health-check endpoint URL for token validation",
-        )
-        .option(
-          "--ping-method <method>",
-          "HTTP method for the ping endpoint: GET (default) or POST",
-        )
-        .option(
-          "--ping-headers <json>",
-          "JSON object of extra headers for the ping request",
-        )
-        .option(
-          "--ping-body <json>",
-          "JSON body to send with the ping request",
-        )
-        .option(
-          "--revoke-url <url>",
-          "OAuth token revocation endpoint URL",
-        )
-        .option(
-          "--revoke-body-template <json>",
-          "JSON object body template for the revoke request",
-        )
-        .option(
-          "--display-name <name>",
-          "Human-readable display name for the provider",
-        )
-        .option("--description <text>", "Short description of the provider")
-        .option(
-          "--dashboard-url <url>",
-          "URL to the provider's developer console / dashboard",
-        )
-        .option(
-          "--logo-url <url>",
-          "URL to the provider's logo image. Mutually exclusive with --logo-simpleicons-slug.",
-        )
-        .option(
-          "--logo-simpleicons-slug <slug>",
-          'Simple Icons slug (e.g. "notion"). Mutually exclusive with --logo-url.',
-        )
-        .option(
-          "--client-id-placeholder <text>",
-          "Placeholder text shown in the client ID input field",
-        )
-        .option(
-          "--no-client-secret",
-          "Mark this provider as not requiring a client secret",
-        )
-        .option(
-          "--loopback-port <port>",
-          "Fixed port for the local OAuth callback server",
-        )
-        .option(
-          "--injection-templates <json>",
-          "JSON array of token injection templates",
-        )
-        .option(
-          "--app-type <type>",
-          'What the provider calls its OAuth apps (e.g. "OAuth App")',
-        )
-        .option(
-          "--identity-url <url>",
-          "Identity verification endpoint URL",
-        )
-        .option(
-          "--identity-method <method>",
-          "HTTP method for the identity endpoint: GET (default) or POST",
-        )
-        .option(
-          "--identity-headers <json>",
-          "JSON object of extra headers for the identity request",
-        )
-        .option(
-          "--identity-body <body>",
-          "JSON body to send with the identity request",
-        )
-        .option(
-          "--identity-response-paths <paths>",
-          "Comma-separated dot-notation paths to extract identity from the response",
-        )
-        .option(
-          "--identity-format <template>",
-          "Format template for the extracted identity",
-        )
-        .option(
-          "--identity-ok-field <field>",
-          "Dot-notation path to a boolean field that must be truthy for the response to be valid",
-        )
-        .option(
-          "--setup-notes <json>",
-          "JSON array of setup instruction notes shown during guided setup",
-        )
-        .option(
-          "--available-scopes <value>",
-          "Available scopes: either a JSON array of {scope, description?} objects or a URL",
-        )
-        .addHelpText(
-          "after",
-          `
-Registers a new OAuth provider configuration in the local store for custom
-integrations not covered by the built-in provider seeds. The provider key
-must be unique — if it collides with an existing key, the command fails.
-Run 'assistant oauth providers list' to see existing keys.
-
-On success, returns the full provider row including generated timestamps.
-After registering, create an OAuth app with 'assistant oauth apps create'
-and then connect with 'assistant oauth connect <provider-key>'.
-
-Examples:
-  $ assistant oauth providers register \\
-      --provider-key custom-api \\
-      --auth-url https://custom-api.example.com/oauth/authorize \\
-      --token-url https://custom-api.example.com/oauth/token
-  $ assistant oauth providers register \\
-      --provider-key my-service \\
-      --auth-url https://my-service.com/auth \\
-      --token-url https://my-service.com/token \\
-      --scopes read,write --json`,
-        )
-        .action(
-          async (
-            opts: {
-              providerKey: string;
-              authUrl: string;
-              tokenUrl: string;
-              refreshUrl?: string;
-              baseUrl?: string;
-              userinfoUrl?: string;
-              scopes?: string;
-              scopeSeparator?: string;
-              tokenAuthMethod?: string;
-              tokenExchangeBodyFormat?: string;
-              pingUrl?: string;
-              pingMethod?: string;
-              pingHeaders?: string;
-              pingBody?: string;
-              revokeUrl?: string;
-              revokeBodyTemplate?: string;
-              displayName?: string;
-              description?: string;
-              dashboardUrl?: string;
-              logoUrl?: string;
-              logoSimpleiconsSlug?: string;
-              clientIdPlaceholder?: string;
-              clientSecret: boolean;
-              loopbackPort?: string;
-              injectionTemplates?: string;
-              appType?: string;
-              identityUrl?: string;
-              identityMethod?: string;
-              identityHeaders?: string;
-              identityBody?: string;
-              identityResponsePaths?: string;
-              identityFormat?: string;
-              identityOkField?: string;
-              setupNotes?: string;
-              availableScopes?: string;
-            },
-            cmd: Command,
-          ) => {
-            try {
-              const resolvedLogoUrl = resolveLogoUrlFromFlags(opts);
-              if (resolvedLogoUrl === null) {
-                throw new Error(
-                  "Cannot clear logo_url with empty --logo-url during registration. Omit the flag instead.",
-                );
-              }
-
-              const body: Record<string, unknown> = {
-                provider_key: opts.providerKey,
-                auth_url: opts.authUrl,
-                token_url: opts.tokenUrl,
-              };
-
-              if (opts.refreshUrl !== undefined)
-                body.refresh_url = opts.refreshUrl;
-              if (opts.baseUrl !== undefined) body.base_url = opts.baseUrl;
-              if (opts.userinfoUrl !== undefined)
-                body.userinfo_url = opts.userinfoUrl;
-              body.default_scopes = opts.scopes ? opts.scopes.split(",") : [];
-              if (opts.scopeSeparator !== undefined)
-                body.scope_separator = opts.scopeSeparator;
-              if (opts.tokenAuthMethod !== undefined)
-                body.token_endpoint_auth_method = opts.tokenAuthMethod;
-              if (opts.tokenExchangeBodyFormat !== undefined)
-                body.token_exchange_body_format = opts.tokenExchangeBodyFormat;
-              if (opts.pingUrl !== undefined) body.ping_url = opts.pingUrl;
-              if (opts.pingMethod !== undefined)
-                body.ping_method = opts.pingMethod;
-              if (opts.pingHeaders !== undefined)
-                body.ping_headers = JSON.parse(opts.pingHeaders);
-              if (opts.pingBody !== undefined)
-                body.ping_body = JSON.parse(opts.pingBody);
-              if (opts.revokeUrl !== undefined) body.revoke_url = opts.revokeUrl;
-              if (opts.revokeBodyTemplate !== undefined)
-                body.revoke_body_template = JSON.parse(opts.revokeBodyTemplate);
-              if (opts.displayName !== undefined)
-                body.display_name = opts.displayName;
-              if (opts.description !== undefined)
-                body.description = opts.description;
-              if (opts.dashboardUrl !== undefined)
-                body.dashboard_url = opts.dashboardUrl;
-              if (resolvedLogoUrl !== undefined)
-                body.logo_url = resolvedLogoUrl;
-              if (opts.clientIdPlaceholder !== undefined)
-                body.client_id_placeholder = opts.clientIdPlaceholder;
-              body.requires_client_secret = opts.clientSecret;
-              if (opts.loopbackPort !== undefined)
-                body.loopback_port = parseInt(opts.loopbackPort, 10);
-              if (opts.injectionTemplates !== undefined)
-                body.injection_templates = JSON.parse(opts.injectionTemplates);
-              if (opts.appType !== undefined) body.app_type = opts.appType;
-              if (opts.identityUrl !== undefined)
-                body.identity_url = opts.identityUrl;
-              if (opts.identityMethod !== undefined)
-                body.identity_method = opts.identityMethod;
-              if (opts.identityHeaders !== undefined)
-                body.identity_headers = JSON.parse(opts.identityHeaders);
-              if (opts.identityBody !== undefined)
-                body.identity_body = JSON.parse(opts.identityBody);
-              if (opts.identityResponsePaths !== undefined)
-                body.identity_response_paths =
-                  opts.identityResponsePaths.split(",");
-              if (opts.identityFormat !== undefined)
-                body.identity_format = opts.identityFormat;
-              if (opts.identityOkField !== undefined)
-                body.identity_ok_field = opts.identityOkField;
-              if (opts.setupNotes !== undefined)
-                body.setup_notes = JSON.parse(opts.setupNotes);
-              if (opts.availableScopes !== undefined) {
-                body.available_scopes = opts.availableScopes.startsWith("http")
-                  ? opts.availableScopes
-                  : JSON.parse(opts.availableScopes);
-              }
-
-              const r = await cliIpcCall<{ provider: SerializedProvider }>(
-                "oauth_providers_post",
-                { body },
-              );
-
-              if (!r.ok) {
-                let message = r.error ?? "Unknown error";
-                if (message.includes("already exists")) {
-                  message += ` Run 'assistant oauth providers list' to see existing providers, or choose a different --provider-key.`;
-                }
-                writeOutput(cmd, { ok: false, error: message });
-                process.exitCode = 1;
-                return;
-              }
-
-              writeOutput(cmd, r.result?.provider);
-            } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              writeOutput(cmd, { ok: false, error: message });
-              process.exitCode = 1;
-            }
-          },
-        );
-
-      // -----------------------------------------------------------------------
-      // providers update <provider-key>
-      // -----------------------------------------------------------------------
-
-      providers
-        .command("update <provider-key>")
-        .description("Update an existing custom OAuth provider configuration")
-        .option(
-          "--auth-url <url>",
-          "OAuth authorization endpoint URL",
-        )
-        .option(
-          "--token-url <url>",
-          "OAuth token endpoint URL",
-        )
-        .option(
-          "--refresh-url <url>",
-          "OAuth token refresh endpoint URL",
-        )
-        .option("--base-url <url>", "API base URL for the service")
-        .option("--userinfo-url <url>", "OpenID Connect userinfo endpoint URL")
-        .option(
-          "--scopes <scopes>",
-          'Comma-separated default scopes (e.g. "read,write,profile")',
-        )
-        .option(
-          "--scope-separator <sep>",
-          'Separator used to join scopes in the authorize URL',
-        )
-        .option(
-          "--token-auth-method <method>",
-          'How the client authenticates at the token endpoint',
-        )
-        .option(
-          "--token-exchange-body-format <format>",
-          'Body encoding for the token exchange request: "form" or "json"',
-        )
-        .option("--ping-url <url>", "Health-check endpoint URL")
-        .option(
-          "--ping-method <method>",
-          "HTTP method for the ping endpoint: GET (default) or POST",
-        )
-        .option("--ping-headers <json>", "JSON object of extra headers for the ping request")
-        .option("--ping-body <json>", "JSON body for the ping request")
-        .option(
-          "--revoke-url <url>",
-          "OAuth token revocation endpoint URL. Pass empty string to clear.",
-        )
-        .option(
-          "--revoke-body-template <json>",
-          "JSON object body template for the revoke request. Pass empty string to clear.",
-        )
-        .option("--display-name <name>", "Human-readable display name")
-        .option("--description <text>", "Short description")
-        .option("--dashboard-url <url>", "Developer console / dashboard URL")
-        .option(
-          "--logo-url <url>",
-          "URL to the provider's logo image. Mutually exclusive with --logo-simpleicons-slug.",
-        )
-        .option(
-          "--logo-simpleicons-slug <slug>",
-          'Simple Icons slug. Mutually exclusive with --logo-url.',
-        )
-        .option("--client-id-placeholder <text>", "Placeholder for client ID input")
-        .option("--no-client-secret", "Mark as not requiring a client secret")
-        .option("--loopback-port <port>", "Fixed port for the local OAuth callback server")
-        .option("--injection-templates <json>", "JSON array of token injection templates")
-        .option("--app-type <type>", "What the provider calls its OAuth apps")
-        .option("--identity-url <url>", "Identity verification endpoint URL")
-        .option("--identity-method <method>", "HTTP method for identity endpoint")
-        .option("--identity-headers <json>", "JSON object of extra headers for identity request")
-        .option("--identity-body <body>", "JSON body for identity request")
-        .option("--identity-response-paths <paths>", "Comma-separated dot-notation paths")
-        .option("--identity-format <template>", "Format template for extracted identity")
-        .option("--identity-ok-field <field>", "Dot-notation path to a boolean ok field")
-        .option("--setup-notes <json>", "JSON array of setup instruction notes")
-        .option("--available-scopes <value>", "Available scopes: JSON array or URL")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  provider-key   Provider key to update (e.g. "custom-api").
-                 Run 'assistant oauth providers list' to see all registered providers.
-
-Only the fields you specify are updated — all other fields remain unchanged.
-Built-in providers (e.g. "google", "slack") cannot be updated; they are
-managed by the system and reset on startup.
-
-Examples:
-  $ assistant oauth providers update custom-api --display-name "My Custom API"
-  $ assistant oauth providers update custom-api --scopes read,write --auth-url https://new.example.com/auth
-  $ assistant oauth providers update custom-api --ping-url https://api.example.com/me --json
-  $ assistant oauth providers update custom-api --logo-url ""`,
-        )
-        .action(
-          async (
-            provider: string,
-            opts: {
-              authUrl?: string;
-              tokenUrl?: string;
-              refreshUrl?: string;
-              baseUrl?: string;
-              userinfoUrl?: string;
-              scopes?: string;
-              scopeSeparator?: string;
-              tokenAuthMethod?: string;
-              tokenExchangeBodyFormat?: string;
-              pingUrl?: string;
-              pingMethod?: string;
-              pingHeaders?: string;
-              pingBody?: string;
-              revokeUrl?: string;
-              revokeBodyTemplate?: string;
-              displayName?: string;
-              description?: string;
-              dashboardUrl?: string;
-              logoUrl?: string;
-              logoSimpleiconsSlug?: string;
-              clientIdPlaceholder?: string;
-              clientSecret: boolean;
-              loopbackPort?: string;
-              injectionTemplates?: string;
-              appType?: string;
-              identityUrl?: string;
-              identityMethod?: string;
-              identityHeaders?: string;
-              identityBody?: string;
-              identityResponsePaths?: string;
-              identityFormat?: string;
-              identityOkField?: string;
-              setupNotes?: string;
-              availableScopes?: string;
-            },
-            cmd: Command,
-          ) => {
-            try {
-              const body: Record<string, unknown> = {};
-
-              if (opts.authUrl !== undefined) body.auth_url = opts.authUrl;
-              if (opts.tokenUrl !== undefined) body.token_url = opts.tokenUrl;
-              if (opts.refreshUrl !== undefined)
-                body.refresh_url = opts.refreshUrl;
-              if (opts.baseUrl !== undefined) body.base_url = opts.baseUrl;
-              if (opts.userinfoUrl !== undefined)
-                body.userinfo_url = opts.userinfoUrl;
-              if (opts.scopes !== undefined)
-                body.default_scopes = opts.scopes.split(",");
-              if (opts.scopeSeparator !== undefined)
-                body.scope_separator = opts.scopeSeparator;
-              if (opts.tokenAuthMethod !== undefined)
-                body.token_endpoint_auth_method = opts.tokenAuthMethod;
-              if (opts.tokenExchangeBodyFormat !== undefined)
-                body.token_exchange_body_format = opts.tokenExchangeBodyFormat;
-              if (opts.pingUrl !== undefined) body.ping_url = opts.pingUrl;
-              if (opts.pingMethod !== undefined)
-                body.ping_method = opts.pingMethod;
-              if (opts.pingHeaders !== undefined)
-                body.ping_headers = JSON.parse(opts.pingHeaders);
-              if (opts.pingBody !== undefined)
-                body.ping_body = JSON.parse(opts.pingBody);
-              if (opts.revokeUrl !== undefined) {
-                body.revoke_url =
-                  opts.revokeUrl === "" ? null : opts.revokeUrl;
-              }
-              if (opts.revokeBodyTemplate !== undefined) {
-                body.revoke_body_template =
-                  opts.revokeBodyTemplate === ""
-                    ? null
-                    : JSON.parse(opts.revokeBodyTemplate);
-              }
-              if (opts.displayName !== undefined)
-                body.display_name = opts.displayName;
-              if (opts.description !== undefined)
-                body.description = opts.description;
-              if (opts.dashboardUrl !== undefined)
-                body.dashboard_url = opts.dashboardUrl;
-              if (opts.clientIdPlaceholder !== undefined)
-                body.client_id_placeholder = opts.clientIdPlaceholder;
-
-              const resolvedLogoUrl = resolveLogoUrlFromFlags(opts);
-              if (resolvedLogoUrl !== undefined) {
-                body.logo_url = resolvedLogoUrl;
-              }
-
-              if (cmd.getOptionValueSource("clientSecret") === "cli") {
-                body.requires_client_secret = opts.clientSecret;
-              }
-
-              if (opts.loopbackPort !== undefined)
-                body.loopback_port = parseInt(opts.loopbackPort, 10);
-              if (opts.injectionTemplates !== undefined)
-                body.injection_templates = JSON.parse(opts.injectionTemplates);
-              if (opts.appType !== undefined) body.app_type = opts.appType;
-              if (opts.identityUrl !== undefined)
-                body.identity_url = opts.identityUrl;
-              if (opts.identityMethod !== undefined)
-                body.identity_method = opts.identityMethod;
-              if (opts.identityHeaders !== undefined)
-                body.identity_headers = JSON.parse(opts.identityHeaders);
-              if (opts.identityBody !== undefined)
-                body.identity_body = JSON.parse(opts.identityBody);
-              if (opts.identityResponsePaths !== undefined)
-                body.identity_response_paths =
-                  opts.identityResponsePaths.split(",");
-              if (opts.identityFormat !== undefined)
-                body.identity_format = opts.identityFormat;
-              if (opts.identityOkField !== undefined)
-                body.identity_ok_field = opts.identityOkField;
-              if (opts.setupNotes !== undefined)
-                body.setup_notes = JSON.parse(opts.setupNotes);
-              if (opts.availableScopes !== undefined) {
-                if (opts.availableScopes === "") {
-                  body.available_scopes = null;
-                } else {
-                  body.available_scopes =
-                    opts.availableScopes.startsWith("http")
-                      ? opts.availableScopes
-                      : JSON.parse(opts.availableScopes);
-                }
-              }
-
-              if (Object.keys(body).length === 0) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error:
-                    "Nothing to update. Provide at least one option to change (e.g. --auth-url, --scopes, --display-name). Run 'assistant oauth providers update --help' for all options.",
-                });
-                process.exitCode = 1;
-                return;
-              }
-
-              const r = await cliIpcCall<{ provider: SerializedProvider }>(
-                "oauth_providers_by_providerKey_patch",
-                { pathParams: { providerKey: provider }, body },
-              );
-
-              if (!r.ok) {
-                writeOutput(cmd, {
-                  ok: false,
-                  error: r.error ?? "Unknown error",
-                });
-                process.exitCode = 1;
-                return;
-              }
-
-              writeOutput(cmd, r.result?.provider);
-            } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              writeOutput(cmd, { ok: false, error: message });
-              process.exitCode = 1;
-            }
-          },
-        );
-
-      // -----------------------------------------------------------------------
-      // providers delete <provider-key>
-      // -----------------------------------------------------------------------
-
-      providers
-        .command("delete <provider-key>")
-        .description(
-          "Delete a custom OAuth provider and optionally its associated apps and connections",
-        )
-        .option(
-          "--force",
-          "Cascade-delete all associated apps and connections before removing the provider",
-        )
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  provider-key   Provider key to delete (e.g. "custom-api").
-                 Run 'assistant oauth providers list' to see registered providers.
-
-When --force is specified, all OAuth connections and apps that depend on
-this provider are deleted before the provider itself is removed. Without
---force, the command refuses to delete a provider that has dependents and
-exits with an error listing the counts.
-
-Built-in providers (e.g. "google", "slack") can be deleted, but a warning
-is emitted because they will be re-created automatically on the next
-assistant startup.
-
-Examples:
-  $ assistant oauth providers delete custom-api
-  $ assistant oauth providers delete custom-api --force
-  $ assistant oauth providers delete custom-api --force --json`,
-        )
-        .action(
-          async (provider: string, opts: { force?: boolean }, cmd: Command) => {
-            const r = await cliIpcCall<{
-              ok: boolean;
-              deleted: {
-                provider: number;
-                apps: number;
-                connections: number;
-              };
-            }>("oauth_providers_by_providerKey_delete", {
-              pathParams: { providerKey: provider },
-              body: { force: opts.force ?? false },
-            });
-
-            if (!r.ok) {
-              writeOutput(cmd, {
-                ok: false,
-                error: r.error ?? "Unknown error",
-              });
-              process.exitCode = 1;
-              return;
-            }
-
-            if (!shouldOutputJson(cmd)) {
-              log.info(`Deleted provider: ${provider}`);
-            }
-
-            writeOutput(cmd, r.result);
-          },
-        );
+      const parsed = r.result?.provider;
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, parsed);
+      } else if (parsed) {
+        process.stdout.write(formatProviderDetail(parsed) + "\n");
+      }
     },
-  });
+  );
+
+  // -----------------------------------------------------------------------
+  // providers register
+  // -----------------------------------------------------------------------
+
+  subcommand(providers, "register").action(
+    async (
+      opts: {
+        providerKey: string;
+        authUrl: string;
+        tokenUrl: string;
+        refreshUrl?: string;
+        baseUrl?: string;
+        userinfoUrl?: string;
+        scopes?: string;
+        scopeSeparator?: string;
+        tokenAuthMethod?: string;
+        tokenExchangeBodyFormat?: string;
+        pingUrl?: string;
+        pingMethod?: string;
+        pingHeaders?: string;
+        pingBody?: string;
+        revokeUrl?: string;
+        revokeBodyTemplate?: string;
+        displayName?: string;
+        description?: string;
+        dashboardUrl?: string;
+        logoUrl?: string;
+        logoSimpleiconsSlug?: string;
+        clientIdPlaceholder?: string;
+        clientSecret: boolean;
+        loopbackPort?: string;
+        injectionTemplates?: string;
+        appType?: string;
+        identityUrl?: string;
+        identityMethod?: string;
+        identityHeaders?: string;
+        identityBody?: string;
+        identityResponsePaths?: string;
+        identityFormat?: string;
+        identityOkField?: string;
+        setupNotes?: string;
+        availableScopes?: string;
+      },
+      cmd: Command,
+    ) => {
+      try {
+        const resolvedLogoUrl = resolveLogoUrlFromFlags(opts);
+        if (resolvedLogoUrl === null) {
+          throw new Error(
+            "Cannot clear logo_url with empty --logo-url during registration. Omit the flag instead.",
+          );
+        }
+
+        const body: Record<string, unknown> = {
+          provider_key: opts.providerKey,
+          auth_url: opts.authUrl,
+          token_url: opts.tokenUrl,
+        };
+
+        if (opts.refreshUrl !== undefined) body.refresh_url = opts.refreshUrl;
+        if (opts.baseUrl !== undefined) body.base_url = opts.baseUrl;
+        if (opts.userinfoUrl !== undefined)
+          body.userinfo_url = opts.userinfoUrl;
+        body.default_scopes = opts.scopes ? opts.scopes.split(",") : [];
+        if (opts.scopeSeparator !== undefined)
+          body.scope_separator = opts.scopeSeparator;
+        if (opts.tokenAuthMethod !== undefined)
+          body.token_endpoint_auth_method = opts.tokenAuthMethod;
+        if (opts.tokenExchangeBodyFormat !== undefined)
+          body.token_exchange_body_format = opts.tokenExchangeBodyFormat;
+        if (opts.pingUrl !== undefined) body.ping_url = opts.pingUrl;
+        if (opts.pingMethod !== undefined) body.ping_method = opts.pingMethod;
+        if (opts.pingHeaders !== undefined)
+          body.ping_headers = JSON.parse(opts.pingHeaders);
+        if (opts.pingBody !== undefined)
+          body.ping_body = JSON.parse(opts.pingBody);
+        if (opts.revokeUrl !== undefined) body.revoke_url = opts.revokeUrl;
+        if (opts.revokeBodyTemplate !== undefined)
+          body.revoke_body_template = JSON.parse(opts.revokeBodyTemplate);
+        if (opts.displayName !== undefined)
+          body.display_name = opts.displayName;
+        if (opts.description !== undefined) body.description = opts.description;
+        if (opts.dashboardUrl !== undefined)
+          body.dashboard_url = opts.dashboardUrl;
+        if (resolvedLogoUrl !== undefined) body.logo_url = resolvedLogoUrl;
+        if (opts.clientIdPlaceholder !== undefined)
+          body.client_id_placeholder = opts.clientIdPlaceholder;
+        body.requires_client_secret = opts.clientSecret;
+        if (opts.loopbackPort !== undefined)
+          body.loopback_port = parseInt(opts.loopbackPort, 10);
+        if (opts.injectionTemplates !== undefined)
+          body.injection_templates = JSON.parse(opts.injectionTemplates);
+        if (opts.appType !== undefined) body.app_type = opts.appType;
+        if (opts.identityUrl !== undefined)
+          body.identity_url = opts.identityUrl;
+        if (opts.identityMethod !== undefined)
+          body.identity_method = opts.identityMethod;
+        if (opts.identityHeaders !== undefined)
+          body.identity_headers = JSON.parse(opts.identityHeaders);
+        if (opts.identityBody !== undefined)
+          body.identity_body = JSON.parse(opts.identityBody);
+        if (opts.identityResponsePaths !== undefined)
+          body.identity_response_paths = opts.identityResponsePaths.split(",");
+        if (opts.identityFormat !== undefined)
+          body.identity_format = opts.identityFormat;
+        if (opts.identityOkField !== undefined)
+          body.identity_ok_field = opts.identityOkField;
+        if (opts.setupNotes !== undefined)
+          body.setup_notes = JSON.parse(opts.setupNotes);
+        if (opts.availableScopes !== undefined) {
+          body.available_scopes = opts.availableScopes.startsWith("http")
+            ? opts.availableScopes
+            : JSON.parse(opts.availableScopes);
+        }
+
+        const r = await cliIpcCall<{ provider: SerializedProvider }>(
+          "oauth_providers_post",
+          { body },
+        );
+
+        if (!r.ok) {
+          let message = r.error ?? "Unknown error";
+          if (message.includes("already exists")) {
+            message += ` Run 'assistant oauth providers list' to see existing providers, or choose a different --provider-key.`;
+          }
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+          return;
+        }
+
+        writeOutput(cmd, r.result?.provider);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    },
+  );
+
+  // -----------------------------------------------------------------------
+  // providers update <provider-key>
+  // -----------------------------------------------------------------------
+
+  subcommand(providers, "update").action(
+    async (
+      provider: string,
+      opts: {
+        authUrl?: string;
+        tokenUrl?: string;
+        refreshUrl?: string;
+        baseUrl?: string;
+        userinfoUrl?: string;
+        scopes?: string;
+        scopeSeparator?: string;
+        tokenAuthMethod?: string;
+        tokenExchangeBodyFormat?: string;
+        pingUrl?: string;
+        pingMethod?: string;
+        pingHeaders?: string;
+        pingBody?: string;
+        revokeUrl?: string;
+        revokeBodyTemplate?: string;
+        displayName?: string;
+        description?: string;
+        dashboardUrl?: string;
+        logoUrl?: string;
+        logoSimpleiconsSlug?: string;
+        clientIdPlaceholder?: string;
+        clientSecret: boolean;
+        loopbackPort?: string;
+        injectionTemplates?: string;
+        appType?: string;
+        identityUrl?: string;
+        identityMethod?: string;
+        identityHeaders?: string;
+        identityBody?: string;
+        identityResponsePaths?: string;
+        identityFormat?: string;
+        identityOkField?: string;
+        setupNotes?: string;
+        availableScopes?: string;
+      },
+      cmd: Command,
+    ) => {
+      try {
+        const body: Record<string, unknown> = {};
+
+        if (opts.authUrl !== undefined) body.auth_url = opts.authUrl;
+        if (opts.tokenUrl !== undefined) body.token_url = opts.tokenUrl;
+        if (opts.refreshUrl !== undefined) body.refresh_url = opts.refreshUrl;
+        if (opts.baseUrl !== undefined) body.base_url = opts.baseUrl;
+        if (opts.userinfoUrl !== undefined)
+          body.userinfo_url = opts.userinfoUrl;
+        if (opts.scopes !== undefined)
+          body.default_scopes = opts.scopes.split(",");
+        if (opts.scopeSeparator !== undefined)
+          body.scope_separator = opts.scopeSeparator;
+        if (opts.tokenAuthMethod !== undefined)
+          body.token_endpoint_auth_method = opts.tokenAuthMethod;
+        if (opts.tokenExchangeBodyFormat !== undefined)
+          body.token_exchange_body_format = opts.tokenExchangeBodyFormat;
+        if (opts.pingUrl !== undefined) body.ping_url = opts.pingUrl;
+        if (opts.pingMethod !== undefined) body.ping_method = opts.pingMethod;
+        if (opts.pingHeaders !== undefined)
+          body.ping_headers = JSON.parse(opts.pingHeaders);
+        if (opts.pingBody !== undefined)
+          body.ping_body = JSON.parse(opts.pingBody);
+        if (opts.revokeUrl !== undefined) {
+          body.revoke_url = opts.revokeUrl === "" ? null : opts.revokeUrl;
+        }
+        if (opts.revokeBodyTemplate !== undefined) {
+          body.revoke_body_template =
+            opts.revokeBodyTemplate === ""
+              ? null
+              : JSON.parse(opts.revokeBodyTemplate);
+        }
+        if (opts.displayName !== undefined)
+          body.display_name = opts.displayName;
+        if (opts.description !== undefined) body.description = opts.description;
+        if (opts.dashboardUrl !== undefined)
+          body.dashboard_url = opts.dashboardUrl;
+        if (opts.clientIdPlaceholder !== undefined)
+          body.client_id_placeholder = opts.clientIdPlaceholder;
+
+        const resolvedLogoUrl = resolveLogoUrlFromFlags(opts);
+        if (resolvedLogoUrl !== undefined) {
+          body.logo_url = resolvedLogoUrl;
+        }
+
+        if (cmd.getOptionValueSource("clientSecret") === "cli") {
+          body.requires_client_secret = opts.clientSecret;
+        }
+
+        if (opts.loopbackPort !== undefined)
+          body.loopback_port = parseInt(opts.loopbackPort, 10);
+        if (opts.injectionTemplates !== undefined)
+          body.injection_templates = JSON.parse(opts.injectionTemplates);
+        if (opts.appType !== undefined) body.app_type = opts.appType;
+        if (opts.identityUrl !== undefined)
+          body.identity_url = opts.identityUrl;
+        if (opts.identityMethod !== undefined)
+          body.identity_method = opts.identityMethod;
+        if (opts.identityHeaders !== undefined)
+          body.identity_headers = JSON.parse(opts.identityHeaders);
+        if (opts.identityBody !== undefined)
+          body.identity_body = JSON.parse(opts.identityBody);
+        if (opts.identityResponsePaths !== undefined)
+          body.identity_response_paths = opts.identityResponsePaths.split(",");
+        if (opts.identityFormat !== undefined)
+          body.identity_format = opts.identityFormat;
+        if (opts.identityOkField !== undefined)
+          body.identity_ok_field = opts.identityOkField;
+        if (opts.setupNotes !== undefined)
+          body.setup_notes = JSON.parse(opts.setupNotes);
+        if (opts.availableScopes !== undefined) {
+          if (opts.availableScopes === "") {
+            body.available_scopes = null;
+          } else {
+            body.available_scopes = opts.availableScopes.startsWith("http")
+              ? opts.availableScopes
+              : JSON.parse(opts.availableScopes);
+          }
+        }
+
+        if (Object.keys(body).length === 0) {
+          writeOutput(cmd, {
+            ok: false,
+            error:
+              "Nothing to update. Provide at least one option to change (e.g. --auth-url, --scopes, --display-name). Run 'assistant oauth providers update --help' for all options.",
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        const r = await cliIpcCall<{ provider: SerializedProvider }>(
+          "oauth_providers_by_providerKey_patch",
+          { pathParams: { providerKey: provider }, body },
+        );
+
+        if (!r.ok) {
+          writeOutput(cmd, {
+            ok: false,
+            error: r.error ?? "Unknown error",
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        writeOutput(cmd, r.result?.provider);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    },
+  );
+
+  // -----------------------------------------------------------------------
+  // providers delete <provider-key>
+  // -----------------------------------------------------------------------
+
+  subcommand(providers, "delete").action(
+    async (provider: string, opts: { force?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<{
+        ok: boolean;
+        deleted: {
+          provider: number;
+          apps: number;
+          connections: number;
+        };
+      }>("oauth_providers_by_providerKey_delete", {
+        pathParams: { providerKey: provider },
+        body: { force: opts.force ?? false },
+      });
+
+      if (!r.ok) {
+        writeOutput(cmd, {
+          ok: false,
+          error: r.error ?? "Unknown error",
+        });
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!shouldOutputJson(cmd)) {
+        log.info(`Deleted provider: ${provider}`);
+      }
+
+      writeOutput(cmd, r.result);
+    },
+  );
 }

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -4,6 +4,7 @@ import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
 import { readStdinSync } from "../../../util/read-stdin.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
 // ---------------------------------------------------------------------------
@@ -74,11 +75,11 @@ function readBodyData(data: string): unknown {
 // ---------------------------------------------------------------------------
 
 export function registerRequestCommand(oauth: Command): void {
-  oauth
-    .command("request <url>")
-    .description(
-      "The recommended way to make an authenticated request to an OAuth provider (supports a curl-like interface)",
-    )
+  // Options are registered imperatively (not in index.help.ts): the
+  // repeatable "-H, --header" flag needs a Commander collect parser
+  // (function + array default) that the declarative help contract cannot
+  // express, and option order around it must be preserved for help output.
+  subcommand(oauth, "request")
     .requiredOption("--provider <key>", "Provider name (e.g. google, slack)")
     .option("-X, --request <method>", "HTTP method (default: GET)")
     .option(
@@ -99,36 +100,6 @@ export function registerRequestCommand(oauth: Command): void {
     .option("-i, --include", "Show response headers on stderr")
     .option("--account <account>", "Account identifier for multi-account")
     .option("--client-id <id>", "BYO app client ID disambiguation")
-    .addHelpText(
-      "after",
-      `
-This is the first-class mechanism for making authenticated HTTP requests
-to an OAuth provider. By using this CLI, you follow security best-practices
-regarding how the OAuth token is used. This approach is preferred over retrieving
-the token (using \`assistant oauth token\`) and making the request directly.
-
-This command resolves the OAuth connection automatically (regardless of whether
-the provider's mode is set to "managed" or "your-own") and injects tokens transparently.
-
-URL can be absolute (https://api.x.com/2/tweets) or relative (/2/tweets).
-An absolute URL sets the host and full path explicitly. A relative path is
-joined onto the provider's configured default base URL — the base URL shown by
-'assistant oauth providers get <provider>'. For providers whose default base
-URL points at one specific service, a relative path for a different service on
-the same provider will resolve against the wrong host or path and fail (often
-with an opaque HTML 404). When in doubt, pass an absolute URL: it is the safe
-form for any service other than the provider's default.
-
-Note: The Authorization header is set automatically. User-supplied
--H "Authorization: ..." will be overridden by the OAuth bearer token.
-
-Examples:
-  $ assistant oauth request --provider twitter https://api.x.com/2/tweets
-  $ assistant oauth request --provider google /gmail/v1/users/me/messages -G
-  $ assistant oauth request --provider twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
-  $ assistant oauth request --provider google https://www.googleapis.com/calendar/v3/calendars/primary/events
-  $ assistant oauth request --provider slack -H "Content-Type: application/json" -d '{"channel":"C123"}' /api/chat.postMessage --json`,
-    )
     .action(
       async (
         url: string,

--- a/assistant/src/cli/commands/oauth/status.ts
+++ b/assistant/src/cli/commands/oauth/status.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
 /**
@@ -69,69 +70,45 @@ function formatConnection(c: ConnectionSummary, mode: string): string {
 // ---------------------------------------------------------------------------
 
 export function registerStatusCommand(oauth: Command): void {
-  oauth
-    .command("status <provider>")
-    .description("Show OAuth connection status for a specified provider")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  provider   Provider name (e.g. google, slack).
-             Run 'assistant oauth providers list' to see all available providers.
+  subcommand(oauth, "status").action(
+    async (provider: string, _opts: Record<string, unknown>, cmd: Command) => {
+      try {
+        const r = await cliIpcCall<{
+          ok: boolean;
+          provider: string;
+          mode: string;
+          connections: ConnectionSummary[];
+        }>("oauth_status", {
+          queryParams: { provider },
+        });
 
-The output includes connection IDs and account identifiers that can be used
-as inputs to other commands:
-  - 'assistant oauth disconnect <provider>' to remove a connection
-  - 'assistant oauth request --provider <provider> --account <account>' to
-    make authenticated requests as a specific account
-
-Examples:
-  $ assistant oauth status google
-  $ assistant oauth status google --json`,
-    )
-    .action(
-      async (
-        provider: string,
-        _opts: Record<string, unknown>,
-        cmd: Command,
-      ) => {
-        try {
-          const r = await cliIpcCall<{
-            ok: boolean;
-            provider: string;
-            mode: string;
-            connections: ConnectionSummary[];
-          }>("oauth_status", {
-            queryParams: { provider },
-          });
-
-          if (!r.ok) {
-            return exitFromIpcResult(r);
-          }
-
-          const result = r.result!;
-          const { connections, mode } = result;
-
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, result);
-            return;
-          }
-
-          // Text output
-          if (connections.length === 0) {
-            process.stdout.write(await noConnectionsMessage(provider));
-            return;
-          }
-
-          const blocks = connections.map((c) => formatConnection(c, mode));
-          process.stdout.write(
-            `${provider} (${mode}) — ${connections.length} active connection(s):\n\n${blocks.join("\n\n")}\n`,
-          );
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          writeOutput(cmd, { ok: false, error: message });
-          process.exitCode = 1;
+        if (!r.ok) {
+          return exitFromIpcResult(r);
         }
-      },
-    );
+
+        const result = r.result!;
+        const { connections, mode } = result;
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, result);
+          return;
+        }
+
+        // Text output
+        if (connections.length === 0) {
+          process.stdout.write(await noConnectionsMessage(provider));
+          return;
+        }
+
+        const blocks = connections.map((c) => formatConnection(c, mode));
+        process.stdout.write(
+          `${provider} (${mode}) — ${connections.length} active connection(s):\n\n${blocks.join("\n\n")}\n`,
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    },
+  );
 }

--- a/assistant/src/cli/commands/oauth/token.ts
+++ b/assistant/src/cli/commands/oauth/token.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
 // ---------------------------------------------------------------------------
@@ -8,76 +9,36 @@ import { shouldOutputJson, writeOutput } from "../../output.js";
 // ---------------------------------------------------------------------------
 
 export function registerTokenCommand(oauth: Command): void {
-  oauth
-    .command("token <provider>")
-    .description(
-      'An escape hatch to retrieve a valid OAuth access token for a provider whose mode is "your-own" for direct use.',
-    )
-    .option(
-      "--account <account>",
-      "Account identifier for account disambiguation (e.g. user@gmail.com)",
-    )
-    .option(
-      "--client-id <id>",
-      "Filter by OAuth client ID when multiple OAuth apps exist for the provider",
-    )
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  provider   Provider name (e.g. google, slack).
-             Run 'assistant oauth providers list' to see all available
-             providers.
+  subcommand(oauth, "token").action(
+    async (
+      provider: string,
+      opts: { account?: string; clientId?: string },
+      cmd: Command,
+    ) => {
+      try {
+        const body: Record<string, unknown> = { provider };
+        if (opts.account) body.account = opts.account;
+        if (opts.clientId) body.client_id = opts.clientId;
 
-This command is discouraged and should be used sparingly. Only use if you
-need direct access to the token (i.e. \`assistant oauth request\` is
-insufficient) and you are comfortable with the security implications.
+        const r = await cliIpcCall<{ ok: boolean; token: string }>(
+          "oauth_token",
+          { body },
+        );
 
-Token retrieval is only supported for providers with mode set to "your-own".
-Platform-managed providers handle tokens internally — use
-'assistant oauth ping <provider>' to verify connectivity or
-'assistant oauth request --provider <provider> <url>' to make
-authenticated requests.
+        if (!r.ok) return exitFromIpcResult(r);
 
-Use 'assistant oauth status <provider>' to find account identifiers for
---account.
+        const result = r.result!;
 
-Examples:
-  $ assistant oauth token google
-  $ assistant oauth token twitter --json
-  $ assistant oauth token google --account user@gmail.com
-  $ assistant oauth token google --client-id abc123`,
-    )
-    .action(
-      async (
-        provider: string,
-        opts: { account?: string; clientId?: string },
-        cmd: Command,
-      ) => {
-        try {
-          const body: Record<string, unknown> = { provider };
-          if (opts.account) body.account = opts.account;
-          if (opts.clientId) body.client_id = opts.clientId;
-
-          const r = await cliIpcCall<{ ok: boolean; token: string }>(
-            "oauth_token",
-            { body },
-          );
-
-          if (!r.ok) return exitFromIpcResult(r);
-
-          const result = r.result!;
-
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, result);
-          } else {
-            process.stdout.write(result.token + "\n");
-          }
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          writeOutput(cmd, { ok: false, error: message });
-          process.exitCode = 1;
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, result);
+        } else {
+          process.stdout.write(result.token + "\n");
         }
-      },
-    );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    },
+  );
 }

--- a/assistant/src/cli/commands/pending.help.ts
+++ b/assistant/src/cli/commands/pending.help.ts
@@ -1,0 +1,26 @@
+/** Declarative help for the `assistant pending` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const pendingHelp: CliCommandHelp = {
+  name: "pending",
+  description:
+    "Inspect pending interactions (confirmations, secrets, host proxy requests)",
+  subcommands: [
+    {
+      name: "list",
+      description: "List all pending interactions across all conversations",
+      options: [
+        {
+          flags: "--kind <kind>",
+          description: "Filter by kind (confirmation, secret, host_bash, etc.)",
+        },
+        {
+          flags: "--conversation <id>",
+          description: "Filter by conversation ID",
+        },
+        { flags: "--json", description: "Output as JSON" },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/pending.ts
+++ b/assistant/src/cli/commands/pending.ts
@@ -1,8 +1,10 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { pendingHelp } from "./pending.help.js";
 
 interface PendingInteractionEntry {
   requestId: string;
@@ -18,94 +20,91 @@ interface PendingInteractionsResponse {
 
 export function registerPendingCommand(program: Command): void {
   registerCommand(program, {
-    name: "pending",
+    name: pendingHelp.name,
     transport: "ipc",
-    description: "Inspect pending interactions (confirmations, secrets, host proxy requests)",
+    description: pendingHelp.description,
     build: (pending) => {
-      pending
-    .command("list")
-    .alias("ls")
-    .description("List all pending interactions across all conversations")
-    .option(
-      "--kind <kind>",
-      "Filter by kind (confirmation, secret, host_bash, etc.)",
-    )
-    .option("--conversation <id>", "Filter by conversation ID")
-    .option("--json", "Output as JSON")
-    .action(
-      async (opts: {
-        kind?: string;
-        conversation?: string;
-        json?: boolean;
-      }) => {
-        try {
-          const response =
-            await cliIpcCall<PendingInteractionsResponse>(
-              "pending_interactions",
-            );
+      applyCommandHelp(pending, pendingHelp);
 
-          if (!response.ok) {
-            return exitFromIpcResult({
-              ok: false,
-              error: response.error,
-              statusCode: response.statusCode,
-            });
-          }
-          if (!response.result) {
-            log.error(
-              "pending_interactions returned ok with no result body",
-            );
-            process.exitCode = 1;
-            return;
-          }
+      // The "ls" alias is not expressible in CliCommandHelp, so it is
+      // attached imperatively after the declarative registration.
+      subcommand(pending, "list")
+        .alias("ls")
+        .action(
+          async (opts: {
+            kind?: string;
+            conversation?: string;
+            json?: boolean;
+          }) => {
+            try {
+              const response = await cliIpcCall<PendingInteractionsResponse>(
+                "pending_interactions",
+              );
 
-          let interactions = response.result.interactions;
+              if (!response.ok) {
+                return exitFromIpcResult({
+                  ok: false,
+                  error: response.error,
+                  statusCode: response.statusCode,
+                });
+              }
+              if (!response.result) {
+                log.error(
+                  "pending_interactions returned ok with no result body",
+                );
+                process.exitCode = 1;
+                return;
+              }
 
-          if (opts.kind) {
-            interactions = interactions.filter(
-              (i: PendingInteractionEntry) => i.kind === opts.kind,
-            );
-          }
-          if (opts.conversation) {
-            interactions = interactions.filter(
-              (i: PendingInteractionEntry) =>
-                i.conversationId === opts.conversation,
-            );
-          }
+              let interactions = response.result.interactions;
 
-          if (opts.json) {
-            console.log(JSON.stringify(interactions, null, 2));
-            return;
-          }
+              if (opts.kind) {
+                interactions = interactions.filter(
+                  (i: PendingInteractionEntry) => i.kind === opts.kind,
+                );
+              }
+              if (opts.conversation) {
+                interactions = interactions.filter(
+                  (i: PendingInteractionEntry) =>
+                    i.conversationId === opts.conversation,
+                );
+              }
 
-          if (interactions.length === 0) {
-            console.log("No pending interactions.");
-            return;
-          }
+              if (opts.json) {
+                console.log(JSON.stringify(interactions, null, 2));
+                return;
+              }
 
-          const kindWidth = Math.max(
-            4,
-            ...interactions.map((i: PendingInteractionEntry) => i.kind.length),
-          );
-          const header = `${"KIND".padEnd(kindWidth)}  ${"REQUEST ID".padEnd(36)}  ${"CONVERSATION".padEnd(36)}  DETAILS`;
-          console.log(header);
+              if (interactions.length === 0) {
+                console.log("No pending interactions.");
+                return;
+              }
 
-          for (const i of interactions) {
-            const details = i.toolName
-              ? `${i.toolName} (${i.riskLevel ?? "?"})`
-              : "";
-            console.log(
-              `${i.kind.padEnd(kindWidth)}  ${i.requestId.padEnd(36)}  ${i.conversationId.padEnd(36)}  ${details}`,
-            );
-          }
+              const kindWidth = Math.max(
+                4,
+                ...interactions.map(
+                  (i: PendingInteractionEntry) => i.kind.length,
+                ),
+              );
+              const header = `${"KIND".padEnd(kindWidth)}  ${"REQUEST ID".padEnd(36)}  ${"CONVERSATION".padEnd(36)}  DETAILS`;
+              console.log(header);
 
-          console.log(`\n${interactions.length} pending interaction(s)`);
-        } catch (err) {
-          log.error({ err }, "Failed to list pending interactions");
-          process.exitCode = 1;
-        }
-      },
-    );
+              for (const i of interactions) {
+                const details = i.toolName
+                  ? `${i.toolName} (${i.riskLevel ?? "?"})`
+                  : "";
+                console.log(
+                  `${i.kind.padEnd(kindWidth)}  ${i.requestId.padEnd(36)}  ${i.conversationId.padEnd(36)}  ${details}`,
+                );
+              }
+
+              console.log(`\n${interactions.length} pending interaction(s)`);
+            } catch (err) {
+              log.error({ err }, "Failed to list pending interactions");
+              process.exitCode = 1;
+            }
+          },
+        );
     },
   });
 }

--- a/assistant/src/cli/commands/platform/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/connect.test.ts
@@ -24,11 +24,13 @@ mock.module("../../../../ipc/cli-client.js", () => ({
 }));
 
 const { registerPlatformConnectCommand } = await import("../connect.js");
+const { applyCommandHelp } = await import("../../../lib/cli-command-help.js");
+const { platformHelp } = await import("../index.help.js");
 
 function buildProgram(): Command {
   const program = new Command();
   program.exitOverride();
-  program.option("--json", "JSON output");
+  applyCommandHelp(program, platformHelp);
   registerPlatformConnectCommand(program);
   return program;
 }

--- a/assistant/src/cli/commands/platform/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/disconnect.test.ts
@@ -26,14 +26,14 @@ mock.module("../../../../ipc/cli-client.js", () => ({
   },
 }));
 
-const { registerPlatformDisconnectCommand } = await import(
-  "../disconnect.js"
-);
+const { registerPlatformDisconnectCommand } = await import("../disconnect.js");
+const { applyCommandHelp } = await import("../../../lib/cli-command-help.js");
+const { platformHelp } = await import("../index.help.js");
 
 function buildProgram(): Command {
   const program = new Command();
   program.exitOverride();
-  program.option("--json", "JSON output");
+  applyCommandHelp(program, platformHelp);
   registerPlatformDisconnectCommand(program);
   return program;
 }

--- a/assistant/src/cli/commands/platform/connect.ts
+++ b/assistant/src/cli/commands/platform/connect.ts
@@ -1,35 +1,23 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
 export function registerPlatformConnectCommand(platform: Command): void {
-  platform
-    .command("connect")
-    .description(
-      "Connect this assistant to the Vellum Platform by storing credentials",
-    )
-    .addHelpText(
-      "after",
-      `
-Initiates a platform connection flow. Emits a signal for connected clients
-to show a platform login UI where the user can sign in and store credentials.
-
-Use 'assistant platform status' to check the current connection state and
-'assistant platform disconnect' to remove stored credentials.
-
-Examples:
-  $ assistant platform connect
-  $ assistant platform connect --json`,
-    )
-    .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+  subcommand(platform, "connect").action(
+    async (_opts: Record<string, unknown>, cmd: Command) => {
       const r = await cliIpcCall<{
         alreadyConnected?: boolean;
         baseUrl?: string;
         showPlatformLogin?: boolean;
       }>("platform_connect", {});
-      if (!r.ok) return exitFromIpcResult({ ok: false, error: r.error, statusCode: r.statusCode }, cmd);
+      if (!r.ok)
+        return exitFromIpcResult(
+          { ok: false, error: r.error, statusCode: r.statusCode },
+          cmd,
+        );
 
       writeOutput(cmd, { ok: true, ...r.result });
 
@@ -46,5 +34,6 @@ Examples:
           );
         }
       }
-    });
+    },
+  );
 }

--- a/assistant/src/cli/commands/platform/disconnect.ts
+++ b/assistant/src/cli/commands/platform/disconnect.ts
@@ -1,44 +1,29 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
 export function registerPlatformDisconnectCommand(platform: Command): void {
-  platform
-    .command("disconnect")
-    .description(
-      "Disconnect from the Vellum Platform by removing stored credentials",
-    )
-    .addHelpText(
-      "after",
-      `
-Removes all stored platform credentials from the assistant's secure
-credential store. After disconnecting, platform-managed features (managed
-proxy, managed OAuth, callback routing) will no longer be available until
-you reconnect with 'assistant platform connect'.
-
-Use 'assistant platform status' to check the current connection state
-before disconnecting.
-
-Examples:
-  $ assistant platform disconnect
-  $ assistant platform disconnect --json`,
-    )
-    .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+  subcommand(platform, "disconnect").action(
+    async (_opts: Record<string, unknown>, cmd: Command) => {
       const r = await cliIpcCall<{
         disconnected: boolean;
         previousBaseUrl: string | null;
       }>("platform_disconnect", {});
-      if (!r.ok) return exitFromIpcResult({ ok: false, error: r.error, statusCode: r.statusCode }, cmd);
+      if (!r.ok)
+        return exitFromIpcResult(
+          { ok: false, error: r.error, statusCode: r.statusCode },
+          cmd,
+        );
 
       writeOutput(cmd, { ok: true, ...r.result });
 
       if (!shouldOutputJson(cmd)) {
         const prev = r.result?.previousBaseUrl;
-        log.info(
-          `Disconnected from platform${prev ? ` at ${prev}` : ""}`,
-        );
+        log.info(`Disconnected from platform${prev ? ` at ${prev}` : ""}`);
       }
-    });
+    },
+  );
 }

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -1,0 +1,186 @@
+/** Declarative help for the `assistant platform` command. */
+
+import type { CliCommandHelp } from "../../lib/cli-command-help.js";
+
+export const platformHelp: CliCommandHelp = {
+  name: "platform",
+  description: "Manage Vellum Platform integration",
+  options: [
+    { flags: "--json", description: "Machine-readable compact JSON output" },
+  ],
+  helpText: `
+The platform subsystem manages the connection to Vellum Platform. Use
+'connect', 'status', and 'disconnect' to manage platform credentials.
+Any assistant using the managed LLM proxy can use these commands.
+
+External service callbacks (Telegram webhooks, Twilio webhooks, email,
+OAuth redirects) route through the platform's gateway proxy via
+'callback-routes'. Works for both platform-managed and self-hosted
+assistants.
+
+Examples:
+  $ assistant platform status --json
+  $ assistant platform credits --json
+  $ assistant platform connect
+  $ assistant platform disconnect
+  $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json`,
+  subcommands: [
+    {
+      name: "connect",
+      description:
+        "Connect this assistant to the Vellum Platform by storing credentials",
+      helpText: `
+Initiates a platform connection flow. Emits a signal for connected clients
+to show a platform login UI where the user can sign in and store credentials.
+
+Use 'assistant platform status' to check the current connection state and
+'assistant platform disconnect' to remove stored credentials.
+
+Examples:
+  $ assistant platform connect
+  $ assistant platform connect --json`,
+    },
+    {
+      name: "status",
+      description:
+        "Show current platform deployment context and connection status",
+      helpText: `
+Reads platform-related environment variables and stored credentials to report
+the current platform deployment context and connection state.
+
+Fields:
+  isPlatform          Whether IS_PLATFORM is set (boolean)
+  baseUrl             VELLUM_PLATFORM_URL — the platform gateway base URL
+  assistantId         This assistant's platform UUID
+  hasAssistantApiKey  Whether a stored assistant API key is available
+  hasWebhookSecret    Whether a stored webhook secret is available (needed
+                      for email and other inbound webhook channels)
+  available           Whether callback registration prerequisites are satisfied
+  organizationId      The platform organization ID (from stored credentials)
+  userId              The platform user ID (from stored credentials)
+  velayTunnel         Live Velay tunnel status from the gateway IPC socket
+                      (null when the gateway is not running)
+
+Examples:
+  $ assistant platform status
+  $ assistant platform status --json`,
+    },
+    {
+      name: "credits",
+      description: "Show the organization's remaining credit balance",
+      helpText: `
+Fetches the org's credit balance from the platform billing summary.
+
+Fields:
+  remaining   Effective balance (settled minus pending charges) in USD
+  settled     On-ledger balance in USD
+  pending     Estimated pending compute charges not yet settled, in USD
+  unit        Balance currency (USD)
+  stale       True when pending-charge data may be stale or unavailable
+  as_of       When this balance was read (response receipt time)
+
+Combine with 'assistant usage daily' to compute runway (remaining divided
+by rolling daily average) and warn before credits run out.
+
+Requires platform credentials (run 'assistant platform connect' first or
+ensure VELLUM_PLATFORM_URL is set and credentials are stored).
+
+Examples:
+  $ assistant platform credits
+  $ assistant platform credits --json`,
+    },
+    {
+      name: "disconnect",
+      description:
+        "Disconnect from the Vellum Platform by removing stored credentials",
+      helpText: `
+Removes all stored platform credentials from the assistant's secure
+credential store. After disconnecting, platform-managed features (managed
+proxy, managed OAuth, callback routing) will no longer be available until
+you reconnect with 'assistant platform connect'.
+
+Use 'assistant platform status' to check the current connection state
+before disconnecting.
+
+Examples:
+  $ assistant platform disconnect
+  $ assistant platform disconnect --json`,
+    },
+    {
+      name: "callback-routes",
+      description: "Manage platform callback route registrations",
+      helpText: `
+Callback routes tell the platform gateway how to forward inbound provider
+webhooks to the correct assistant instance. Each route maps a callback path
+and type to a stable external URL that external services (Telegram, Twilio,
+email, OAuth providers) should use.
+
+Examples:
+  $ assistant platform callback-routes list
+  $ assistant platform callback-routes list --json
+  $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json
+  $ assistant platform callback-routes register --path webhooks/twilio/voice --type twilio_voice --json`,
+      subcommands: [
+        {
+          name: "register",
+          description: "Register a callback route with the platform gateway",
+          options: [
+            {
+              flags: "--path <path>",
+              description:
+                "Callback path (e.g. webhooks/telegram, webhooks/twilio/voice)",
+              required: true,
+            },
+            {
+              flags: "--type <type>",
+              description:
+                "Route type identifier (e.g. telegram, twilio_voice, twilio_status, oauth)",
+              required: true,
+            },
+          ],
+          helpText: `
+Registers a callback route with the platform's internal gateway endpoint so
+the platform knows how to forward inbound provider webhooks to this
+platform-managed assistant instance.
+
+Arguments:
+  --path    The path portion after the ingress base URL. Leading/trailing
+            slashes are stripped by the platform.
+  --type    The route type identifier used by the platform to classify and
+            route the callback.
+
+Known callback path/type combinations:
+  --path webhooks/telegram          --type telegram
+  --path webhooks/twilio/voice      --type twilio_voice
+  --path webhooks/twilio/status     --type twilio_status
+  --path webhooks/resend            --type resend
+  --path webhooks/mailgun           --type mailgun
+  --path webhooks/email             --type email
+  --path oauth/callback             --type oauth
+
+Works for both platform-managed and self-hosted assistants. Requires
+VELLUM_PLATFORM_URL and a platform assistant ID. Returns the platform-provided
+stable callback URL that external services should use.
+
+Examples:
+  $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json
+  $ assistant platform callback-routes register --path webhooks/twilio/voice --type twilio_voice --json`,
+        },
+        {
+          name: "list",
+          description: "List registered callback routes for this assistant",
+          helpText: `
+Lists all callback routes registered with the platform for this assistant.
+Shows the route type, callback URL, and path for each registered webhook.
+
+Requires platform credentials (run 'assistant platform connect' first or
+ensure IS_PLATFORM and VELLUM_PLATFORM_URL are set and credentials are stored).
+
+Examples:
+  $ assistant platform callback-routes list
+  $ assistant platform callback-routes list --json`,
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/platform/index.ts
+++ b/assistant/src/cli/commands/platform/index.ts
@@ -7,11 +7,13 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../../lib/cli-command-help.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 import { registerPlatformConnectCommand } from "./connect.js";
 import { registerPlatformDisconnectCommand } from "./disconnect.js";
+import { platformHelp } from "./index.help.js";
 
 interface PlatformStatusResult {
   isPlatform: boolean;
@@ -36,31 +38,11 @@ interface PlatformCreditsResult {
 
 export function registerPlatformCommand(program: Command): void {
   registerCommand(program, {
-    name: "platform",
+    name: platformHelp.name,
     transport: "ipc",
-    description: "Manage Vellum Platform integration",
+    description: platformHelp.description,
     build: (platform) => {
-      platform.option("--json", "Machine-readable compact JSON output");
-
-      platform.addHelpText(
-        "after",
-        `
-The platform subsystem manages the connection to Vellum Platform. Use
-'connect', 'status', and 'disconnect' to manage platform credentials.
-Any assistant using the managed LLM proxy can use these commands.
-
-External service callbacks (Telegram webhooks, Twilio webhooks, email,
-OAuth redirects) route through the platform's gateway proxy via
-'callback-routes'. Works for both platform-managed and self-hosted
-assistants.
-
-Examples:
-  $ assistant platform status --json
-  $ assistant platform credits --json
-  $ assistant platform connect
-  $ assistant platform disconnect
-  $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json`,
-      );
+      applyCommandHelp(platform, platformHelp);
 
       // -----------------------------------------------------------------------
       // connect
@@ -72,35 +54,8 @@ Examples:
       // status
       // -----------------------------------------------------------------------
 
-      platform
-        .command("status")
-        .description(
-          "Show current platform deployment context and connection status",
-        )
-        .addHelpText(
-          "after",
-          `
-Reads platform-related environment variables and stored credentials to report
-the current platform deployment context and connection state.
-
-Fields:
-  isPlatform          Whether IS_PLATFORM is set (boolean)
-  baseUrl             VELLUM_PLATFORM_URL — the platform gateway base URL
-  assistantId         This assistant's platform UUID
-  hasAssistantApiKey  Whether a stored assistant API key is available
-  hasWebhookSecret    Whether a stored webhook secret is available (needed
-                      for email and other inbound webhook channels)
-  available           Whether callback registration prerequisites are satisfied
-  organizationId      The platform organization ID (from stored credentials)
-  userId              The platform user ID (from stored credentials)
-  velayTunnel         Live Velay tunnel status from the gateway IPC socket
-                      (null when the gateway is not running)
-
-Examples:
-  $ assistant platform status
-  $ assistant platform status --json`,
-        )
-        .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      subcommand(platform, "status").action(
+        async (_opts: Record<string, unknown>, cmd: Command) => {
           const r = await cliIpcCall<PlatformStatusResult>(
             "platform_status",
             {},
@@ -141,39 +96,15 @@ Examples:
               log.info(`Velay tunnel: (gateway not running)`);
             }
           }
-        });
+        },
+      );
 
       // -----------------------------------------------------------------------
       // credits
       // -----------------------------------------------------------------------
 
-      platform
-        .command("credits")
-        .description("Show the organization's remaining credit balance")
-        .addHelpText(
-          "after",
-          `
-Fetches the org's credit balance from the platform billing summary.
-
-Fields:
-  remaining   Effective balance (settled minus pending charges) in USD
-  settled     On-ledger balance in USD
-  pending     Estimated pending compute charges not yet settled, in USD
-  unit        Balance currency (USD)
-  stale       True when pending-charge data may be stale or unavailable
-  as_of       When this balance was read (response receipt time)
-
-Combine with 'assistant usage daily' to compute runway (remaining divided
-by rolling daily average) and warn before credits run out.
-
-Requires platform credentials (run 'assistant platform connect' first or
-ensure VELLUM_PLATFORM_URL is set and credentials are stored).
-
-Examples:
-  $ assistant platform credits
-  $ assistant platform credits --json`,
-        )
-        .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      subcommand(platform, "credits").action(
+        async (_opts: Record<string, unknown>, cmd: Command) => {
           const r = await cliIpcCall<PlatformCreditsResult>(
             "platform_credits",
             {},
@@ -199,7 +130,8 @@ Examples:
               `Settled:   $${result.settled.toFixed(2)}   Pending: $${result.pending.toFixed(2)}`,
             );
           }
-        });
+        },
+      );
 
       // -----------------------------------------------------------------------
       // disconnect
@@ -211,71 +143,14 @@ Examples:
       // callback-routes
       // -----------------------------------------------------------------------
 
-      const callbackRoutes = platform
-        .command("callback-routes")
-        .description("Manage platform callback route registrations");
-
-      callbackRoutes.addHelpText(
-        "after",
-        `
-Callback routes tell the platform gateway how to forward inbound provider
-webhooks to the correct assistant instance. Each route maps a callback path
-and type to a stable external URL that external services (Telegram, Twilio,
-email, OAuth providers) should use.
-
-Examples:
-  $ assistant platform callback-routes list
-  $ assistant platform callback-routes list --json
-  $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json
-  $ assistant platform callback-routes register --path webhooks/twilio/voice --type twilio_voice --json`,
-      );
+      const callbackRoutes = subcommand(platform, "callback-routes");
 
       // -----------------------------------------------------------------------
       // callback-routes register
       // -----------------------------------------------------------------------
 
-      callbackRoutes
-        .command("register")
-        .description("Register a callback route with the platform gateway")
-        .requiredOption(
-          "--path <path>",
-          "Callback path (e.g. webhooks/telegram, webhooks/twilio/voice)",
-        )
-        .requiredOption(
-          "--type <type>",
-          "Route type identifier (e.g. telegram, twilio_voice, twilio_status, oauth)",
-        )
-        .addHelpText(
-          "after",
-          `
-Registers a callback route with the platform's internal gateway endpoint so
-the platform knows how to forward inbound provider webhooks to this
-platform-managed assistant instance.
-
-Arguments:
-  --path    The path portion after the ingress base URL. Leading/trailing
-            slashes are stripped by the platform.
-  --type    The route type identifier used by the platform to classify and
-            route the callback.
-
-Known callback path/type combinations:
-  --path webhooks/telegram          --type telegram
-  --path webhooks/twilio/voice      --type twilio_voice
-  --path webhooks/twilio/status     --type twilio_status
-  --path webhooks/resend            --type resend
-  --path webhooks/mailgun           --type mailgun
-  --path webhooks/email             --type email
-  --path oauth/callback             --type oauth
-
-Works for both platform-managed and self-hosted assistants. Requires
-VELLUM_PLATFORM_URL and a platform assistant ID. Returns the platform-provided
-stable callback URL that external services should use.
-
-Examples:
-  $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json
-  $ assistant platform callback-routes register --path webhooks/twilio/voice --type twilio_voice --json`,
-        )
-        .action(async (opts: { path: string; type: string }, cmd: Command) => {
+      subcommand(callbackRoutes, "register").action(
+        async (opts: { path: string; type: string }, cmd: Command) => {
           const r = await cliIpcCall<{
             callbackUrl: string;
             callbackPath: string;
@@ -294,29 +169,15 @@ Examples:
           if (!shouldOutputJson(cmd)) {
             log.info(`Callback route registered: ${r.result!.callbackUrl}`);
           }
-        });
+        },
+      );
 
       // -----------------------------------------------------------------------
       // callback-routes list
       // -----------------------------------------------------------------------
 
-      callbackRoutes
-        .command("list")
-        .description("List registered callback routes for this assistant")
-        .addHelpText(
-          "after",
-          `
-Lists all callback routes registered with the platform for this assistant.
-Shows the route type, callback URL, and path for each registered webhook.
-
-Requires platform credentials (run 'assistant platform connect' first or
-ensure IS_PLATFORM and VELLUM_PLATFORM_URL are set and credentials are stored).
-
-Examples:
-  $ assistant platform callback-routes list
-  $ assistant platform callback-routes list --json`,
-        )
-        .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      subcommand(callbackRoutes, "list").action(
+        async (_opts: Record<string, unknown>, cmd: Command) => {
           const r = await cliIpcCall<{
             routes: Array<{
               id: string;
@@ -349,7 +210,8 @@ Examples:
               }
             }
           }
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -1,0 +1,247 @@
+/** Declarative help for the `assistant plugins` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+import {
+  DEFAULT_PIN_HISTORY_LIMIT,
+  DEFAULT_PLUGIN_REF,
+  DEFAULT_PLUGIN_UPGRADE_STRATEGY,
+  PLUGIN_UPGRADE_STRATEGIES,
+} from "../lib/plugin-constants.js";
+
+export const pluginsHelp: CliCommandHelp = {
+  name: "plugins",
+  description:
+    "List, search, install, and manage external plugins (`list` shows what is installed, `search` queries the marketplace)",
+  helpText: `
+Examples:
+  $ assistant plugins install example
+  $ assistant plugins install example --force
+  $ assistant plugins install https://github.com/owner/repo
+  $ assistant plugins install https://github.com/owner/repo/tree/main/sub/path --name my-plugin
+  $ assistant plugins install example --ref my-feature-branch
+  $ assistant plugins versions example
+  $ assistant plugins versions example --json
+  $ assistant plugins install example --pin <sha> --force
+  $ assistant plugins list
+  $ assistant plugins list --json
+  $ assistant plugins list --all
+  $ assistant plugins list --all --json
+  $ assistant plugins inspect example
+  $ assistant plugins inspect example --json
+  $ assistant plugins diff example
+  $ assistant plugins diff example --json
+  $ assistant plugins upgrade example
+  $ assistant plugins upgrade example --dry-run
+  $ assistant plugins upgrade example --strategy ours
+  $ assistant plugins upgrade example --strategy theirs
+  $ assistant plugins upgrade example --strategy assistant
+  $ assistant plugins search example
+  $ assistant plugins search "^example"
+  $ assistant plugins search example --json
+  $ assistant plugins uninstall example
+  $ assistant plugins enable example
+  $ assistant plugins disable example`,
+  subcommands: [
+    {
+      name: "install",
+      args: "<name-or-url>",
+      description:
+        "Install a plugin by name from the Vellum platform (content is served as a verified tarball from the plugin's pinned commit), or directly from a GitHub URL (untrusted)",
+      options: [
+        { flags: "--force", description: "Overwrite an existing install" },
+        {
+          flags: "--ref <ref>",
+          description: `Marketplace manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF}). Marketplace installs only — for a GitHub URL, put the ref in the URL (.../tree/<ref>/...)`,
+        },
+        {
+          flags: "--pin <sha>",
+          description:
+            "Install a specific reviewed marketplace pin (full commit SHA); run `plugins versions <name>` to list them. Marketplace installs only",
+        },
+        {
+          flags: "--allow-unreviewed",
+          description:
+            "With --pin, install a SHA that is not in the reviewed marketplace history (advanced; the curated adapter may not match). Marketplace installs only",
+        },
+        {
+          flags: "--name <name>",
+          description:
+            "Install directory name for a GitHub-URL install (default: derived from the repo or sub-path leaf). Ignored for marketplace installs",
+        },
+      ],
+      helpText: `
+A GitHub URL (anything containing a slash) installs directly from that repo,
+bypassing the marketplace whitelist. Such a plugin is UNTRUSTED — it has not
+been reviewed and its hooks/tools run with full assistant access — so the
+install prints a warning. Use it for a plugin still under development that is
+not in the catalog yet. The ref comes from the URL's /tree/<ref>/ segment, or
+defaults to the repository's default branch.
+
+Examples:
+  $ assistant plugins install https://github.com/owner/repo
+  $ assistant plugins install https://github.com/owner/repo/tree/my-branch/path/to/plugin
+  $ assistant plugins install owner/repo --name my-plugin --force`,
+    },
+    {
+      name: "versions",
+      args: "<name>",
+      description:
+        "List the recent reviewed marketplace pins for a plugin, newest first. Install an older one with `plugins install <name> --pin <sha>`",
+      options: [
+        {
+          flags: "--json",
+          description: "Emit machine-readable JSON instead of a table",
+        },
+        {
+          flags: "--limit <n>",
+          description: `Maximum number of pins to show (default: ${DEFAULT_PIN_HISTORY_LIMIT})`,
+        },
+      ],
+    },
+    {
+      name: "list",
+      description: "List plugins installed in your workspace.",
+      options: [
+        {
+          flags: "--json",
+          description: "Emit machine-readable JSON instead of a table",
+        },
+        {
+          flags: "--all",
+          description:
+            "Include first-party default plugins and disabled plugins in the listing",
+        },
+      ],
+    },
+    {
+      name: "inspect",
+      args: "<name>",
+      description:
+        "Show a plugin's local install metadata, the marketplace pin, whether an update is available, and the surfaces (skills, hooks, tools) it contributes",
+      options: [
+        {
+          flags: "--json",
+          description: "Emit machine-readable JSON instead of a summary",
+        },
+      ],
+    },
+    {
+      name: "diff",
+      args: "<name>",
+      description:
+        "Show a unified diff of local edits to an installed plugin against the commit it was installed at",
+      options: [
+        {
+          flags: "--json",
+          description:
+            "Emit the machine-readable diff result as JSON (files: { path, status, diff, binary, reconstructed }[]) instead of a unified diff",
+        },
+      ],
+      helpText: `
+Arguments:
+  name   Install name (kebab-case directory under the workspace plugins dir);
+         run 'assistant plugins list' to see installed names.
+
+The baseline is the exact commit the plugin was installed at (recorded in its
+install-meta.json), re-materialized through the install pipeline — so an
+install-time adapter transform never reads as a local change. To compare
+against the marketplace's current pin instead, use 'plugins upgrade --dry-run'.
+
+Examples:
+  $ assistant plugins diff example
+  $ assistant plugins diff example --json`,
+    },
+    {
+      name: "search",
+      args: "<query>",
+      description:
+        "Search the plugins/marketplace.json catalog for plugin names matching <query> (case-insensitive regex)",
+      options: [
+        {
+          flags: "--json",
+          description: "Emit machine-readable JSON instead of a table",
+        },
+      ],
+    },
+    {
+      name: "publish",
+      description:
+        "Validate and submit the plugin in the current directory to the Vellum marketplace catalog",
+      options: [
+        {
+          flags: "--print",
+          description:
+            "Print the entry JSON without submitting to the platform",
+        },
+        {
+          flags: "--path <dir>",
+          description: "Validate a plugin at the given path instead of CWD",
+        },
+        { flags: "--force", description: "Skip the confirmation prompt" },
+        {
+          flags: "--json",
+          description: "Emit machine-readable JSON instead of human output",
+        },
+        {
+          flags: "--category <cat>",
+          description: "Set the category, skipping the interactive prompt",
+        },
+      ],
+      helpText: `
+
+Validates the plugin in the current directory (or --path), resolves the
+git commit SHA and GitHub remote, and submits the entry to the Vellum
+platform API. The platform creates a pull request against
+vellum-ai/vellum-assistant adding the plugin to the marketplace catalog.
+
+Requires a connected Vellum platform account (run \`assistant platform connect\`).
+Use --print to validate and print the entry without submitting.
+
+Examples:
+$ assistant plugins publish
+$ assistant plugins publish --print
+$ assistant plugins publish --path ./my-plugin --category productivity
+$ assistant plugins publish --json`,
+    },
+    {
+      name: "uninstall",
+      args: "<name>",
+      description: "Remove a plugin from <workspaceDir>/plugins/<name>/",
+      options: [
+        { flags: "--force", description: "Skip the confirmation prompt" },
+      ],
+    },
+    {
+      name: "disable",
+      args: "<name>",
+      description:
+        "Disable a plugin by creating a .disabled sentinel file. Works for both user-installed and default plugins. Takes effect immediately in a running assistant.",
+    },
+    {
+      name: "enable",
+      args: "<name>",
+      description:
+        "Re-enable a disabled plugin by removing the .disabled sentinel file. Takes effect immediately.",
+    },
+    {
+      name: "upgrade",
+      args: "<name>",
+      description:
+        "Upgrade an installed plugin to the marketplace's current pin",
+      options: [
+        {
+          flags: "--dry-run",
+          description: "Show what would change without modifying the install",
+        },
+        {
+          flags: "--strategy <strategy>",
+          description: `How to reconcile local edits with the pin: ${PLUGIN_UPGRADE_STRATEGIES.join(", ")} (default: ${DEFAULT_PLUGIN_UPGRADE_STRATEGY})`,
+        },
+        {
+          flags: "--json",
+          description: "Emit machine-readable JSON instead of a summary",
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -11,6 +11,7 @@ import { createRequire } from "node:module";
 import type { Command } from "commander";
 
 import { yellow } from "../lib/cli-colors.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
 import type { PluginDiffResult } from "../lib/diff-plugin.js";
 import type {
@@ -29,9 +30,7 @@ import {
   parseGitHubPluginSpec,
 } from "../lib/parse-github-plugin-spec.js";
 import {
-  DEFAULT_PIN_HISTORY_LIMIT,
   DEFAULT_PLUGIN_REF,
-  DEFAULT_PLUGIN_UPGRADE_STRATEGY,
   PLUGIN_UPGRADE_STRATEGIES,
   type PluginUpgradeStrategy,
 } from "../lib/plugin-constants.js";
@@ -48,6 +47,7 @@ import {
 } from "../lib/toggle-plugin.js";
 import type { PluginUpgradeResult } from "../lib/upgrade-plugin.js";
 import { getCliLogger } from "../logger.js";
+import { pluginsHelp } from "./plugins.help.js";
 
 const loadModule = createRequire(import.meta.url);
 
@@ -104,10 +104,9 @@ const log = getCliLogger("plugins");
 
 export function registerPluginsCommand(program: Command): void {
   registerCommand(program, {
-    name: "plugins",
+    name: pluginsHelp.name,
     transport: "local",
-    description:
-      "List, search, install, and manage external plugins (`list` shows what is installed, `search` queries the marketplace)",
+    description: pluginsHelp.description,
     build: (plugins) => {
       // Materialize the `@vellumai/plugin-api` shim once for the whole command
       // group, before any subcommand action runs. A subcommand that resolves a
@@ -123,235 +122,147 @@ export function registerPluginsCommand(program: Command): void {
         await ensurePluginApiShim().catch(() => {});
       });
 
-      plugins.addHelpText(
-        "after",
-        `
-Examples:
-  $ assistant plugins install example
-  $ assistant plugins install example --force
-  $ assistant plugins install https://github.com/owner/repo
-  $ assistant plugins install https://github.com/owner/repo/tree/main/sub/path --name my-plugin
-  $ assistant plugins install example --ref my-feature-branch
-  $ assistant plugins versions example
-  $ assistant plugins versions example --json
-  $ assistant plugins install example --pin <sha> --force
-  $ assistant plugins list
-  $ assistant plugins list --json
-  $ assistant plugins list --all
-  $ assistant plugins list --all --json
-  $ assistant plugins inspect example
-  $ assistant plugins inspect example --json
-  $ assistant plugins diff example
-  $ assistant plugins diff example --json
-  $ assistant plugins upgrade example
-  $ assistant plugins upgrade example --dry-run
-  $ assistant plugins upgrade example --strategy ours
-  $ assistant plugins upgrade example --strategy theirs
-  $ assistant plugins upgrade example --strategy assistant
-  $ assistant plugins search example
-  $ assistant plugins search "^example"
-  $ assistant plugins search example --json
-  $ assistant plugins uninstall example
-  $ assistant plugins enable example
-  $ assistant plugins disable example`,
+      applyCommandHelp(plugins, pluginsHelp);
+
+      subcommand(plugins, "install").action(
+        async (
+          nameOrUrl: string,
+          opts: {
+            force?: boolean;
+            ref?: string;
+            pin?: string;
+            allowUnreviewed?: boolean;
+            name?: string;
+          },
+        ) => {
+          try {
+            const direct = looksLikeGitHubSpec(nameOrUrl);
+            // A plain marketplace install by name is platform-managed: the
+            // content flows through the platform install endpoint (which
+            // serves a verified `.tgz`), not a GitHub clone. The advanced
+            // pin/ref/allow-unreviewed selectors still resolve a specific
+            // reviewed revision through the marketplace-git path, and a
+            // GitHub URL installs directly (untrusted).
+            const usesMarketplaceGit =
+              !direct && Boolean(opts.pin || opts.ref || opts.allowUnreviewed);
+
+            let result;
+            let untrusted = false;
+            if (!direct && !usesMarketplaceGit) {
+              result = await libs.installPlatform.installPluginViaPlatform(
+                { name: nameOrUrl, force: opts.force },
+                { fetch: globalThis.fetch.bind(globalThis) },
+              );
+            } else {
+              const installOpts = direct
+                ? resolveDirectInstallOptions(nameOrUrl, opts)
+                : await resolveInstallOptions(nameOrUrl, opts);
+              if (installOpts === null) {
+                process.exitCode = 1;
+                return;
+              }
+              if (installOpts.directSource) {
+                printUntrustedPluginWarning(
+                  installOpts.name,
+                  installOpts.directSource,
+                );
+                untrusted = true;
+              }
+              result = await libs.installGitHub.installPlugin(installOpts, {
+                fetch: globalThis.fetch.bind(globalThis),
+              });
+            }
+            log.info(
+              {
+                name: result.name,
+                target: result.target,
+                fileCount: result.fileCount,
+                ref: result.ref,
+                commit: result.commit,
+                untrusted,
+              },
+              "external plugin installed",
+            );
+            const pinned = result.commit
+              ? ` at ${result.commit.slice(0, 7)}`
+              : "";
+            const label = untrusted ? "untrusted plugin" : "plugin";
+            console.log(
+              `Installed ${label} "${result.name}" (${result.fileCount} file${result.fileCount === 1 ? "" : "s"})${pinned} → ${result.target}`,
+            );
+          } catch (err) {
+            if (err instanceof libs.installGitHub.PluginAlreadyInstalledError) {
+              console.error(`${err.message}\nPass --force to overwrite.`);
+              process.exitCode = 1;
+              return;
+            }
+            if (err instanceof libs.installGitHub.PluginNotFoundError) {
+              console.error(err.message);
+              process.exitCode = 1;
+              return;
+            }
+            if (
+              err instanceof libs.installGitHub.InvalidPluginNameError ||
+              err instanceof libs.pinHistory.PluginPinHistoryError
+            ) {
+              console.error(err.message);
+              process.exitCode = 1;
+              return;
+            }
+            const message = err instanceof Error ? err.message : String(err);
+            console.error(`Plugin install failed: ${message}`);
+            process.exitCode = 1;
+          }
+        },
       );
 
-      plugins
-        .command("install <name-or-url>")
-        .description(
-          "Install a plugin by name from the Vellum platform (content is served as a verified tarball from the plugin's pinned commit), or directly from a GitHub URL (untrusted)",
-        )
-        .option("--force", "Overwrite an existing install")
-        .option(
-          "--ref <ref>",
-          `Marketplace manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF}). Marketplace installs only — for a GitHub URL, put the ref in the URL (.../tree/<ref>/...)`,
-        )
-        .option(
-          "--pin <sha>",
-          "Install a specific reviewed marketplace pin (full commit SHA); run `plugins versions <name>` to list them. Marketplace installs only",
-        )
-        .option(
-          "--allow-unreviewed",
-          "With --pin, install a SHA that is not in the reviewed marketplace history (advanced; the curated adapter may not match). Marketplace installs only",
-        )
-        .option(
-          "--name <name>",
-          "Install directory name for a GitHub-URL install (default: derived from the repo or sub-path leaf). Ignored for marketplace installs",
-        )
-        .addHelpText(
-          "after",
-          `
-A GitHub URL (anything containing a slash) installs directly from that repo,
-bypassing the marketplace whitelist. Such a plugin is UNTRUSTED — it has not
-been reviewed and its hooks/tools run with full assistant access — so the
-install prints a warning. Use it for a plugin still under development that is
-not in the catalog yet. The ref comes from the URL's /tree/<ref>/ segment, or
-defaults to the repository's default branch.
-
-Examples:
-  $ assistant plugins install https://github.com/owner/repo
-  $ assistant plugins install https://github.com/owner/repo/tree/my-branch/path/to/plugin
-  $ assistant plugins install owner/repo --name my-plugin --force`,
-        )
-        .action(
-          async (
-            nameOrUrl: string,
-            opts: {
-              force?: boolean;
-              ref?: string;
-              pin?: string;
-              allowUnreviewed?: boolean;
-              name?: string;
-            },
-          ) => {
-            try {
-              const direct = looksLikeGitHubSpec(nameOrUrl);
-              // A plain marketplace install by name is platform-managed: the
-              // content flows through the platform install endpoint (which
-              // serves a verified `.tgz`), not a GitHub clone. The advanced
-              // pin/ref/allow-unreviewed selectors still resolve a specific
-              // reviewed revision through the marketplace-git path, and a
-              // GitHub URL installs directly (untrusted).
-              const usesMarketplaceGit =
-                !direct &&
-                Boolean(opts.pin || opts.ref || opts.allowUnreviewed);
-
-              let result;
-              let untrusted = false;
-              if (!direct && !usesMarketplaceGit) {
-                result = await libs.installPlatform.installPluginViaPlatform(
-                  { name: nameOrUrl, force: opts.force },
-                  { fetch: globalThis.fetch.bind(globalThis) },
-                );
-              } else {
-                const installOpts = direct
-                  ? resolveDirectInstallOptions(nameOrUrl, opts)
-                  : await resolveInstallOptions(nameOrUrl, opts);
-                if (installOpts === null) {
-                  process.exitCode = 1;
-                  return;
-                }
-                if (installOpts.directSource) {
-                  printUntrustedPluginWarning(
-                    installOpts.name,
-                    installOpts.directSource,
-                  );
-                  untrusted = true;
-                }
-                result = await libs.installGitHub.installPlugin(installOpts, {
-                  fetch: globalThis.fetch.bind(globalThis),
-                });
-              }
-              log.info(
-                {
-                  name: result.name,
-                  target: result.target,
-                  fileCount: result.fileCount,
-                  ref: result.ref,
-                  commit: result.commit,
-                  untrusted,
-                },
-                "external plugin installed",
-              );
-              const pinned = result.commit
-                ? ` at ${result.commit.slice(0, 7)}`
-                : "";
-              const label = untrusted ? "untrusted plugin" : "plugin";
-              console.log(
-                `Installed ${label} "${result.name}" (${result.fileCount} file${result.fileCount === 1 ? "" : "s"})${pinned} → ${result.target}`,
-              );
-            } catch (err) {
-              if (
-                err instanceof libs.installGitHub.PluginAlreadyInstalledError
-              ) {
-                console.error(`${err.message}\nPass --force to overwrite.`);
-                process.exitCode = 1;
-                return;
-              }
-              if (err instanceof libs.installGitHub.PluginNotFoundError) {
-                console.error(err.message);
-                process.exitCode = 1;
-                return;
-              }
-              if (
-                err instanceof libs.installGitHub.InvalidPluginNameError ||
-                err instanceof libs.pinHistory.PluginPinHistoryError
-              ) {
-                console.error(err.message);
-                process.exitCode = 1;
-                return;
-              }
-              const message = err instanceof Error ? err.message : String(err);
-              console.error(`Plugin install failed: ${message}`);
+      subcommand(plugins, "versions").action(
+        async (name: string, opts: { json?: boolean; limit?: string }) => {
+          let limit: number | undefined;
+          if (opts.limit !== undefined) {
+            limit = Number.parseInt(opts.limit, 10);
+            if (!Number.isInteger(limit) || limit < 1) {
+              console.error("--limit must be a positive integer.");
               process.exitCode = 1;
+              return;
             }
-          },
-        );
+          }
+          try {
+            const history = await libs.pinHistory.listPinHistory(
+              name,
+              { fetch: globalThis.fetch.bind(globalThis) },
+              limit !== undefined ? { limit } : {},
+            );
 
-      plugins
-        .command("versions <name>")
-        .description(
-          "List the recent reviewed marketplace pins for a plugin, newest first. Install an older one with `plugins install <name> --pin <sha>`",
-        )
-        .option("--json", "Emit machine-readable JSON instead of a table")
-        .option(
-          "--limit <n>",
-          `Maximum number of pins to show (default: ${DEFAULT_PIN_HISTORY_LIMIT})`,
-        )
-        .action(
-          async (name: string, opts: { json?: boolean; limit?: string }) => {
-            let limit: number | undefined;
-            if (opts.limit !== undefined) {
-              limit = Number.parseInt(opts.limit, 10);
-              if (!Number.isInteger(limit) || limit < 1) {
-                console.error("--limit must be a positive integer.");
-                process.exitCode = 1;
-                return;
-              }
+            if (opts.json) {
+              process.stdout.write(JSON.stringify(history, null, 2) + "\n");
+              return;
             }
-            try {
-              const history = await libs.pinHistory.listPinHistory(
-                name,
-                { fetch: globalThis.fetch.bind(globalThis) },
-                limit !== undefined ? { limit } : {},
-              );
 
-              if (opts.json) {
-                process.stdout.write(JSON.stringify(history, null, 2) + "\n");
-                return;
-              }
-
-              // Logged after the JSON early-return so the logger's stdout
-              // writes never corrupt --json output.
-              log.info({ name, count: history.length }, "plugin versions");
-              for (const line of formatVersions(name, history)) {
-                console.log(line);
-              }
-            } catch (err) {
-              if (
-                err instanceof libs.installGitHub.InvalidPluginNameError ||
-                err instanceof libs.pinHistory.PluginPinHistoryError
-              ) {
-                console.error(err.message);
-                process.exitCode = 1;
-                return;
-              }
-              const message = err instanceof Error ? err.message : String(err);
-              console.error(`Plugin versions failed: ${message}`);
+            // Logged after the JSON early-return so the logger's stdout
+            // writes never corrupt --json output.
+            log.info({ name, count: history.length }, "plugin versions");
+            for (const line of formatVersions(name, history)) {
+              console.log(line);
+            }
+          } catch (err) {
+            if (
+              err instanceof libs.installGitHub.InvalidPluginNameError ||
+              err instanceof libs.pinHistory.PluginPinHistoryError
+            ) {
+              console.error(err.message);
               process.exitCode = 1;
+              return;
             }
-          },
-        );
+            const message = err instanceof Error ? err.message : String(err);
+            console.error(`Plugin versions failed: ${message}`);
+            process.exitCode = 1;
+          }
+        },
+      );
 
-      plugins
-        .command("list")
-        .description("List plugins installed in your workspace.")
-        .option("--json", "Emit machine-readable JSON instead of a table")
-        .option(
-          "--all",
-          "Include first-party default plugins and disabled plugins in the listing",
-        )
-        .action((opts: { json?: boolean; all?: boolean }) => {
+      subcommand(plugins, "list").action(
+        (opts: { json?: boolean; all?: boolean }) => {
           if (opts.all) {
             const all = libs.installed.listAllPlugins();
 
@@ -429,15 +340,11 @@ Examples:
           console.log(
             `${installed.length} plugin${installed.length === 1 ? "" : "s"} installed.`,
           );
-        });
+        },
+      );
 
-      plugins
-        .command("inspect <name>")
-        .description(
-          "Show a plugin's local install metadata, the marketplace pin, whether an update is available, and the surfaces (skills, hooks, tools) it contributes",
-        )
-        .option("--json", "Emit machine-readable JSON instead of a summary")
-        .action(async (name: string, opts: { json?: boolean }) => {
+      subcommand(plugins, "inspect").action(
+        async (name: string, opts: { json?: boolean }) => {
           try {
             const inspection = await libs.inspect.inspectPlugin(
               { name },
@@ -478,34 +385,11 @@ Examples:
             console.error(`Plugin inspect failed: ${message}`);
             process.exitCode = 1;
           }
-        });
+        },
+      );
 
-      plugins
-        .command("diff <name>")
-        .description(
-          "Show a unified diff of local edits to an installed plugin against the commit it was installed at",
-        )
-        .option(
-          "--json",
-          "Emit the machine-readable diff result as JSON (files: { path, status, diff, binary, reconstructed }[]) instead of a unified diff",
-        )
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  name   Install name (kebab-case directory under the workspace plugins dir);
-         run 'assistant plugins list' to see installed names.
-
-The baseline is the exact commit the plugin was installed at (recorded in its
-install-meta.json), re-materialized through the install pipeline — so an
-install-time adapter transform never reads as a local change. To compare
-against the marketplace's current pin instead, use 'plugins upgrade --dry-run'.
-
-Examples:
-  $ assistant plugins diff example
-  $ assistant plugins diff example --json`,
-        )
-        .action(async (name: string, opts: { json?: boolean }) => {
+      subcommand(plugins, "diff").action(
+        async (name: string, opts: { json?: boolean }) => {
           try {
             const result = await libs.diff.diffPlugin(
               { name },
@@ -545,15 +429,11 @@ Examples:
             console.error(`Plugin diff failed: ${message}`);
             process.exitCode = 1;
           }
-        });
+        },
+      );
 
-      plugins
-        .command("search <query>")
-        .description(
-          "Search the plugins/marketplace.json catalog for plugin names matching <query> (case-insensitive regex)",
-        )
-        .option("--json", "Emit machine-readable JSON instead of a table")
-        .action(async (query: string, opts: { json?: boolean }) => {
+      subcommand(plugins, "search").action(
+        async (query: string, opts: { json?: boolean }) => {
           try {
             const result = await libs.search.searchPlugins(
               { query },
@@ -604,65 +484,26 @@ Examples:
             console.error(`Plugin search failed: ${message}`);
             process.exitCode = 1;
           }
-        });
+        },
+      );
 
-      plugins
-        .command("publish")
-        .description(
-          "Validate and submit the plugin in the current directory to the Vellum marketplace catalog",
-        )
-        .option(
-          "--print",
-          "Print the entry JSON without submitting to the platform",
-        )
-        .option(
-          "--path <dir>",
-          "Validate a plugin at the given path instead of CWD",
-        )
-        .option("--force", "Skip the confirmation prompt")
-        .option("--json", "Emit machine-readable JSON instead of human output")
-        .option(
-          "--category <cat>",
-          "Set the category, skipping the interactive prompt",
-        )
-        .addHelpText(
-          "after",
-          `
+      subcommand(plugins, "publish").action(
+        async (opts: {
+          print?: boolean;
+          path?: string;
+          force?: boolean;
+          json?: boolean;
+          category?: string;
+        }) => {
+          const ok = await runPublish(opts, { confirmPrompt });
+          if (!ok) {
+            process.exitCode = 1;
+          }
+        },
+      );
 
-Validates the plugin in the current directory (or --path), resolves the
-git commit SHA and GitHub remote, and submits the entry to the Vellum
-platform API. The platform creates a pull request against
-vellum-ai/vellum-assistant adding the plugin to the marketplace catalog.
-
-Requires a connected Vellum platform account (run \`assistant platform connect\`).
-Use --print to validate and print the entry without submitting.
-
-Examples:
-$ assistant plugins publish
-$ assistant plugins publish --print
-$ assistant plugins publish --path ./my-plugin --category productivity
-$ assistant plugins publish --json`,
-        )
-        .action(
-          async (opts: {
-            print?: boolean;
-            path?: string;
-            force?: boolean;
-            json?: boolean;
-            category?: string;
-          }) => {
-            const ok = await runPublish(opts, { confirmPrompt });
-            if (!ok) {
-              process.exitCode = 1;
-            }
-          },
-        );
-
-      plugins
-        .command("uninstall <name>")
-        .description("Remove a plugin from <workspaceDir>/plugins/<name>/")
-        .option("--force", "Skip the confirmation prompt")
-        .action(async (name: string, opts: { force?: boolean }) => {
+      subcommand(plugins, "uninstall").action(
+        async (name: string, opts: { force?: boolean }) => {
           try {
             if (!opts.force) {
               const result = await confirmPrompt({
@@ -702,138 +543,113 @@ $ assistant plugins publish --json`,
             console.error(`Plugin uninstall failed: ${message}`);
             process.exitCode = 1;
           }
-        });
+        },
+      );
 
-      plugins
-        .command("disable <name>")
-        .description(
-          "Disable a plugin by creating a .disabled sentinel file. Works for both user-installed and default plugins. Takes effect immediately in a running assistant.",
-        )
-        .action((name: string) => {
+      subcommand(plugins, "disable").action((name: string) => {
+        try {
+          const result = disablePlugin(name);
+          log.info({ name: result.name }, "plugin disabled");
+          console.log(`Disabled plugin "${result.name}".`);
+        } catch (err) {
+          if (
+            err instanceof PluginAlreadyInStateException ||
+            err instanceof ToggleInvalidPluginNameError ||
+            err instanceof PluginDirectoryNotFoundError
+          ) {
+            console.error(err.message);
+            process.exitCode = 1;
+            return;
+          }
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`Plugin disable failed: ${message}`);
+          process.exitCode = 1;
+        }
+      });
+
+      subcommand(plugins, "enable").action((name: string) => {
+        try {
+          const result = enablePlugin(name);
+          log.info({ name: result.name }, "plugin enabled");
+          console.log(`Enabled plugin "${result.name}".`);
+        } catch (err) {
+          if (
+            err instanceof PluginAlreadyInStateException ||
+            err instanceof ToggleInvalidPluginNameError
+          ) {
+            console.error(err.message);
+            process.exitCode = 1;
+            return;
+          }
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`Plugin enable failed: ${message}`);
+          process.exitCode = 1;
+        }
+      });
+
+      subcommand(plugins, "upgrade").action(
+        async (
+          name: string,
+          opts: { dryRun?: boolean; strategy?: string; json?: boolean },
+        ) => {
+          const strategy = opts.strategy;
+          if (
+            strategy !== undefined &&
+            !(PLUGIN_UPGRADE_STRATEGIES as readonly string[]).includes(strategy)
+          ) {
+            console.error(
+              `Invalid --strategy "${strategy}". Expected one of: ${PLUGIN_UPGRADE_STRATEGIES.join(", ")}.`,
+            );
+            process.exitCode = 1;
+            return;
+          }
           try {
-            const result = disablePlugin(name);
-            log.info({ name: result.name }, "plugin disabled");
-            console.log(`Disabled plugin "${result.name}".`);
+            const result = await libs.upgrade.upgradePlugin(
+              {
+                name,
+                dryRun: opts.dryRun,
+                strategy: strategy as PluginUpgradeStrategy | undefined,
+              },
+              { fetch: globalThis.fetch.bind(globalThis) },
+            );
+
+            if (opts.json) {
+              process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+              return;
+            }
+
+            // Logged after the JSON early-return: the CLI logger writes
+            // info to stdout, which would otherwise corrupt --json output.
+            log.info(
+              {
+                name: result.name,
+                outcome: result.outcome,
+                from: result.fromCommit,
+                to: result.toCommit,
+              },
+              "plugin upgrade",
+            );
+
+            for (const line of formatUpgrade(result)) {
+              console.log(line);
+            }
           } catch (err) {
             if (
-              err instanceof PluginAlreadyInStateException ||
-              err instanceof ToggleInvalidPluginNameError ||
-              err instanceof PluginDirectoryNotFoundError
+              err instanceof libs.uninstall.PluginNotInstalledError ||
+              err instanceof libs.upgrade.PluginNotUpgradableError ||
+              err instanceof libs.upgrade.PluginMergeBaselineError ||
+              err instanceof libs.installGitHub.InvalidPluginNameError
             ) {
               console.error(err.message);
               process.exitCode = 1;
               return;
             }
             const message = err instanceof Error ? err.message : String(err);
-            console.error(`Plugin disable failed: ${message}`);
+            console.error(`Plugin upgrade failed: ${message}`);
             process.exitCode = 1;
           }
-        });
-
-      plugins
-        .command("enable <name>")
-        .description(
-          "Re-enable a disabled plugin by removing the .disabled sentinel file. Takes effect immediately.",
-        )
-        .action((name: string) => {
-          try {
-            const result = enablePlugin(name);
-            log.info({ name: result.name }, "plugin enabled");
-            console.log(`Enabled plugin "${result.name}".`);
-          } catch (err) {
-            if (
-              err instanceof PluginAlreadyInStateException ||
-              err instanceof ToggleInvalidPluginNameError
-            ) {
-              console.error(err.message);
-              process.exitCode = 1;
-              return;
-            }
-            const message = err instanceof Error ? err.message : String(err);
-            console.error(`Plugin enable failed: ${message}`);
-            process.exitCode = 1;
-          }
-        });
-
-      plugins
-        .command("upgrade <name>")
-        .description(
-          "Upgrade an installed plugin to the marketplace's current pin",
-        )
-        .option(
-          "--dry-run",
-          "Show what would change without modifying the install",
-        )
-        .option(
-          "--strategy <strategy>",
-          `How to reconcile local edits with the pin: ${PLUGIN_UPGRADE_STRATEGIES.join(", ")} (default: ${DEFAULT_PLUGIN_UPGRADE_STRATEGY})`,
-        )
-        .option("--json", "Emit machine-readable JSON instead of a summary")
-        .action(
-          async (
-            name: string,
-            opts: { dryRun?: boolean; strategy?: string; json?: boolean },
-          ) => {
-            const strategy = opts.strategy;
-            if (
-              strategy !== undefined &&
-              !(PLUGIN_UPGRADE_STRATEGIES as readonly string[]).includes(
-                strategy,
-              )
-            ) {
-              console.error(
-                `Invalid --strategy "${strategy}". Expected one of: ${PLUGIN_UPGRADE_STRATEGIES.join(", ")}.`,
-              );
-              process.exitCode = 1;
-              return;
-            }
-            try {
-              const result = await libs.upgrade.upgradePlugin(
-                {
-                  name,
-                  dryRun: opts.dryRun,
-                  strategy: strategy as PluginUpgradeStrategy | undefined,
-                },
-                { fetch: globalThis.fetch.bind(globalThis) },
-              );
-
-              if (opts.json) {
-                process.stdout.write(JSON.stringify(result, null, 2) + "\n");
-                return;
-              }
-
-              // Logged after the JSON early-return: the CLI logger writes
-              // info to stdout, which would otherwise corrupt --json output.
-              log.info(
-                {
-                  name: result.name,
-                  outcome: result.outcome,
-                  from: result.fromCommit,
-                  to: result.toCommit,
-                },
-                "plugin upgrade",
-              );
-
-              for (const line of formatUpgrade(result)) {
-                console.log(line);
-              }
-            } catch (err) {
-              if (
-                err instanceof libs.uninstall.PluginNotInstalledError ||
-                err instanceof libs.upgrade.PluginNotUpgradableError ||
-                err instanceof libs.upgrade.PluginMergeBaselineError ||
-                err instanceof libs.installGitHub.InvalidPluginNameError
-              ) {
-                console.error(err.message);
-                process.exitCode = 1;
-                return;
-              }
-              const message = err instanceof Error ? err.message : String(err);
-              console.error(`Plugin upgrade failed: ${message}`);
-              process.exitCode = 1;
-            }
-          },
-        );
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/index.help.ts
+++ b/assistant/src/cli/index.help.ts
@@ -26,6 +26,22 @@ import { clientsHelp } from "./commands/clients.help.js";
 import { completionsHelp } from "./commands/completions.help.js";
 import { configHelp } from "./commands/config.help.js";
 import { contactsHelp } from "./commands/contacts.help.js";
+import { conversationsHelp } from "./commands/conversations.help.js";
+import { credentialsHelp } from "./commands/credentials.help.js";
+import { dbHelp } from "./commands/db/index.help.js";
+import { domainHelp } from "./commands/domain.help.js";
+import { emailHelp } from "./commands/email.help.js";
+import { gatewayHelp } from "./commands/gateway.help.js";
+import { imageGenerationHelp } from "./commands/image-generation.help.js";
+import { inferenceHelp, llmHelp } from "./commands/inference.help.js";
+import { keysHelp } from "./commands/keys.help.js";
+import { mcpHelp } from "./commands/mcp.help.js";
+import { memoryHelp } from "./commands/memory/index.help.js";
+import { notificationsHelp } from "./commands/notifications.help.js";
+import { oauthHelp } from "./commands/oauth/index.help.js";
+import { pendingHelp } from "./commands/pending.help.js";
+import { platformHelp } from "./commands/platform/index.help.js";
+import { pluginsHelp } from "./commands/plugins.help.js";
 import type { CliCommandHelp } from "./lib/cli-command-help.js";
 
 export const CLI_COMMAND_HELP: readonly CliCommandHelp[] = [
@@ -44,4 +60,21 @@ export const CLI_COMMAND_HELP: readonly CliCommandHelp[] = [
   completionsHelp,
   configHelp,
   contactsHelp,
+  conversationsHelp,
+  credentialsHelp,
+  dbHelp,
+  domainHelp,
+  emailHelp,
+  gatewayHelp,
+  imageGenerationHelp,
+  inferenceHelp,
+  keysHelp,
+  llmHelp,
+  mcpHelp,
+  memoryHelp,
+  notificationsHelp,
+  oauthHelp,
+  pendingHelp,
+  platformHelp,
+  pluginsHelp,
 ];


### PR DESCRIPTION
## Prompt / plan

Fifth batch of the static-help migration (after #37732, #37785, #37822, #37836): **conversations, credentials, db, domain, email, gateway, image-generation, inference (+ the `llm` alias command), keys, mcp, memory, notifications, oauth, pending, platform, plugins**. Registry now covers **32 top-level commands (~75% of the surface)**; the remaining tail is monitoring → webhooks.

**No contract changes this round** — batch 4's contract (nested subcommands, `args`/`arguments`, `choices`, typed defaults, `isDefault`) covered all 16.

## Structure

- Directory namespaces (`db/`, `memory/`, `oauth/`, `platform/`) and sibling-file namespaces (`conversations-*`, `inference-*`) declare the whole tree in one `index.help.ts` / `<entry>.help.ts`; sibling registrars switch to `subcommand()` lookups with action bodies byte-identical.
- The `llm` alias command (registered inside `inference.ts`, no file of its own) gets its own `llmHelp` sharing the `send` subtree.
- Constants interpolated into help prose move into the help modules and are imported back where logic needs them (notifications enum lists, memory kinds); `plugins.help.ts` reuses the existing dependency-free `cli/lib/plugin-constants.ts`.
- Memory/platform `__tests__` that build trees by calling sibling registrars directly now apply the declared help first.

## What stays imperative (by design — behavior/runtime, not help data)

Each site carries an explanatory comment:
- **Repeatable accumulator options** (collect parsers + `[]` defaults, which a pure-data contract can't express and whose semantics can't move into actions without dropping repeatability): `email send --cc/--bcc`, `oauth request -H`, `mcp add -H`, `inference providers connections create/update --model`, `notifications list --status/--urgency/--category`, `memory v2 compare --conversation`, `memory v3 eval --exclude-conversation`. Where rendering order matters, the options following a collector register imperatively too, so `--help` output is unchanged.
- **Runtime-computed help callbacks** (lazy config interpolation): `domain` (envDomains), `email register/unregister/status/download` (assistantDomain), `keys` top-level/`list` (apiKeyProviders).
- **Aliases**: `conversations slack detach|mute`, `pending list|ls`, `memory nodes/items list|ls`, `delete|rm`.
- **Hooks**: `oauth connect` preAction validation, `plugins` preAction shim materializer.
- `image-generation --variants` parser fn moved into the action (identical NaN/clamp semantics).

## Test plan

- **Byte-for-byte identical fully-rendered `--help` output across all 154 command/subcommand nodes** — this batch's parity check upgraded from `helpInformation()` to full `outputHelp()` capture, so it covers `addHelpText` after-text, lazy help callbacks, aliases, and `(default: …)` rendering, diffed against a pre-split baseline (plus a separate pristine-HEAD diff for the `llm` alias).
- 21 affected CLI test files green per-file (216 tests: conversations, email, inference-send, notifications, db repair/status, memory suite, oauth status, platform suite, mcp-cli), plus the indexer suite (cli-command-store 13, injection 39, lifecycle-memory-v2-seed 13, memory-v2-startup 9).
- `tsc` clean, `eslint` 0 errors (only pre-existing `curly` warnings on unchanged action bodies), `prettier` + `knip` clean; all 32 registry entries render sane capability content (167 KB total).

## CLI verb checklist

Help/registration restructure only — no verbs added/removed/renamed, no routes touched, byte-identical help output. Section N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_