### PR TITLE
refactor(memory): plugin gateway for the memory-db connection

### DIFF
--- a/assistant/src/plugins/defaults/memory/memory-db.ts
+++ b/assistant/src/plugins/defaults/memory/memory-db.ts
@@ -1,22 +1,48 @@
-import { getMemorySqlite } from "../../../persistence/db-connection.js";
+import {
+  getMemoryDb as getMemoryDbConnection,
+  getMemorySqlite as getMemorySqliteConnection,
+} from "../../../persistence/db-connection.js";
 import { getLogger } from "./logging.js";
 
 const log = getLogger("memory-db");
 
 /**
- * The plugin's accessor for the dedicated memory database
- * (`assistant-memory.db`), where the memory plugin's relocated tables live
- * (`memory_v2_injection_events`, with more to follow).
+ * The memory plugin's gateway to the dedicated memory database
+ * (`assistant-memory.db`), where its relocated tables live
+ * (`memory_v2_injection_events`, with more to follow). This is the single
+ * place plugin code resolves the memory connection; plugin modules import
+ * these accessors from here rather than reaching into
+ * `persistence/db-connection` directly.
  *
- * Fail-soft: returns `null` when the file cannot be opened, logging a warn
- * tagged with the calling context. Callers degrade rather than throw — the
- * memory database holds scoring signal and derived state, and losing it must
- * never break routing or a turn. This is the single place plugin code
- * resolves the memory connection; new plugin modules should import it from
- * here rather than reaching into `persistence/db-connection` directly.
+ * The connection's open/pragma/caching lifecycle stays in persistence — these
+ * are thin wrappers over the host accessors, so plugin and host code share the
+ * one cached `"memory"` connection. (Host/runtime code keeps calling the
+ * persistence accessors directly; the plugin-boundary guard forbids host code
+ * from importing this plugin module.)
+ */
+
+/**
+ * Get-or-open the memory connection's Drizzle instance, or `null` when the
+ * file cannot be opened (logged by the persistence layer; the daemon stays up).
+ */
+export function getMemoryDb() {
+  return getMemoryDbConnection();
+}
+
+/** Underlying bun:sqlite Database for the memory connection, or `null`. */
+export function getMemorySqlite() {
+  return getMemorySqliteConnection();
+}
+
+/**
+ * Fail-soft memory-connection accessor for reads/writes that must degrade
+ * rather than throw: returns `null` when the file cannot be opened, logging a
+ * warn tagged with the calling context. Callers degrade — the memory database
+ * holds scoring signal and derived state, and losing it must never break
+ * routing or a turn.
  */
 export function memorySqliteOrNull(context: string) {
-  const sqlite = getMemorySqlite();
+  const sqlite = getMemorySqliteConnection();
   if (!sqlite) {
     log.warn(
       { context },

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-startup-cleanup.ts
@@ -52,13 +52,14 @@ import {
   sql,
 } from "drizzle-orm";
 
-import { getDb, getMemoryDb } from "../../../persistence/db-connection.js";
+import { getDb } from "../../../persistence/db-connection.js";
 import {
   conversations,
   memoryJobs,
 } from "../../../persistence/schema/index.js";
 import { getMemoryConfig } from "./config.js";
 import { getLogger } from "./logging.js";
+import { getMemoryDb } from "./memory-db.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
 import { loadRetrospectiveRunMessages } from "./memory-retrospective-fork-boundary.js";
 


### PR DESCRIPTION
## Prompt / plan

Follow-up to #37824 (which relocated `memory_v2_injection_events` into `assistant-memory.db` via migration 326 and added the plugin-owned fail-soft `memorySqliteOrNull`). Prompt: *"move `getMemorySqlite` into the plugin too."*

The plugin-import boundary guards drew the line for us: **host code (runtime routes) must not depend on a plugin's internals**, and the DB open/pragma/caching lifecycle is host-owned wrapping logic. So rather than relocate the accessor (and pull host callers into the plugin), this gives the memory plugin a thin **gateway** for its own code and leaves the host accessors where they are.

### What changed

- **`plugins/defaults/memory/memory-db.ts`**: now the plugin's single gateway to `assistant-memory.db` — exports `getMemoryDb` / `getMemorySqlite` / `memorySqliteOrNull` as thin wrappers over the persistence accessors. Plugin code resolves the memory connection here instead of importing `persistence/db-connection` directly.
- **`memory-retrospective-startup-cleanup.ts`**: resolves `getMemoryDb` through the gateway.

That's the whole diff (2 files). The connection lifecycle stays host-owned in `persistence/db-connection.ts`; host/runtime code keeps calling those accessors directly (the boundary guard forbids host→plugin imports). Cutting it here — exposing the DB-init/wrapping logic to plugins properly is a future `@vellumai/plugin-api` concern, not this PR.

### Deferred (unchanged)

`jobs-store`, `raw-query`, and relocation migrations 298 & 326 keep resolving through `persistence/db-connection`. They share the `"memory"` singleton slot, so everything resolves the same connection.

## Test plan

- `tsc --noEmit`: clean (0 errors). `eslint`: 0 errors on touched files.
- Ran each affected file in isolation (as CI does) — all green:
  - `plugin-import-boundary-guard.test.ts` (5), `plugin-import-boundary-reverse-guard.test.ts` (1) — both boundary guards pass with the gateway.
  - `memory-retrospective-startup-cleanup.test.ts` (12), `injection-events.test.ts` (15), `db-memory-attach.test.ts` (5), `memory-v2-simulate-route.test.ts` (6).

<!-- CLI verb checklist: no new routes added; deleting section. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)