### PR TITLE
cli: adopt static-help split for the final 16 commands (100% coverage)

### DIFF
--- a/assistant/src/cli/commands/monitoring.help.ts
+++ b/assistant/src/cli/commands/monitoring.help.ts
@@ -1,0 +1,57 @@
+/** Declarative help for the `assistant monitoring` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const monitoringHelp: CliCommandHelp = {
+  name: "monitoring",
+  description: "Manage the resource monitor process (start/stop/status)",
+  helpText: `
+The resource monitor samples the container's own cgroup memory + workspace disk
+in a separate OS process, off the assistant's main event loop, so it keeps
+recording during a main-thread freeze and its samples survive an OOM SIGKILL.
+The daemon owns the process, so it is spawned as a child of the daemon and shows
+up in \`assistant ps\`.
+
+The monitor runs by default — the daemon spawns it at every boot. \`stop\`
+pauses it for the current daemon session only; it respawns on the next boot.
+Samples and high-memory snapshots are written under the data directory
+reported by \`status\`.
+
+Examples:
+  $ assistant monitoring start
+  $ assistant monitoring status
+  $ assistant monitoring stop`,
+  subcommands: [
+    {
+      name: "start",
+      description: "Start the resource monitor process",
+      options: [
+        {
+          flags: "--json",
+          description: "Emit raw JSON instead of a formatted summary",
+        },
+      ],
+    },
+    {
+      name: "stop",
+      description:
+        "Stop the resource monitor process until the next daemon boot",
+      options: [
+        {
+          flags: "--json",
+          description: "Emit raw JSON instead of a formatted summary",
+        },
+      ],
+    },
+    {
+      name: "status",
+      description: "Report the monitor process state and the latest sample",
+      options: [
+        {
+          flags: "--json",
+          description: "Emit raw JSON instead of a formatted summary",
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/monitoring.ts
+++ b/assistant/src/cli/commands/monitoring.ts
@@ -24,9 +24,11 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
+import { monitoringHelp } from "./monitoring.help.js";
 
 interface ReclaimCounters {
   pgscanDirect: number | null;
@@ -112,35 +114,14 @@ function formatMib(bytes: number): string {
 
 export function registerMonitoringCommand(program: Command): void {
   registerCommand(program, {
-    name: "monitoring",
+    name: monitoringHelp.name,
     transport: "ipc",
-    description: "Manage the resource monitor process (start/stop/status)",
+    description: monitoringHelp.description,
     build: (monitor) => {
-      monitor.addHelpText(
-        "after",
-        `
-The resource monitor samples the container's own cgroup memory + workspace disk
-in a separate OS process, off the assistant's main event loop, so it keeps
-recording during a main-thread freeze and its samples survive an OOM SIGKILL.
-The daemon owns the process, so it is spawned as a child of the daemon and shows
-up in \`assistant ps\`.
+      applyCommandHelp(monitor, monitoringHelp);
 
-The monitor runs by default — the daemon spawns it at every boot. \`stop\`
-pauses it for the current daemon session only; it respawns on the next boot.
-Samples and high-memory snapshots are written under the data directory
-reported by \`status\`.
-
-Examples:
-  $ assistant monitoring start
-  $ assistant monitoring status
-  $ assistant monitoring stop`,
-      );
-
-      monitor
-        .command("start")
-        .description("Start the resource monitor process")
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (_opts: { json?: boolean }, cmd: Command) => {
+      subcommand(monitor, "start").action(
+        async (_opts: { json?: boolean }, cmd: Command) => {
           const r = await cliIpcCall<StartResponse>("monitoring_start");
           if (!r.ok) {
             return exitFromIpcResult(r);
@@ -156,15 +137,11 @@ Examples:
               ? `Resource monitor is already running (PID ${res.pid})`
               : `Resource monitor started (PID ${res.pid})`,
           );
-        });
+        },
+      );
 
-      monitor
-        .command("stop")
-        .description(
-          "Stop the resource monitor process until the next daemon boot",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (_opts: { json?: boolean }, cmd: Command) => {
+      subcommand(monitor, "stop").action(
+        async (_opts: { json?: boolean }, cmd: Command) => {
           const r = await cliIpcCall<StopResponse>("monitoring_stop");
           if (!r.ok) {
             return exitFromIpcResult(r);
@@ -181,13 +158,11 @@ Examples:
             log.info("Resource monitor process was not running");
           }
           log.info("The monitor respawns on the next daemon boot");
-        });
+        },
+      );
 
-      monitor
-        .command("status")
-        .description("Report the monitor process state and the latest sample")
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (_opts: { json?: boolean }, cmd: Command) => {
+      subcommand(monitor, "status").action(
+        async (_opts: { json?: boolean }, cmd: Command) => {
           const r = await cliIpcCall<StatusResponse>("monitoring_status");
           if (!r.ok) {
             return exitFromIpcResult(r);
@@ -271,7 +246,8 @@ Examples:
               .join(", ");
             log.info(`  Processing: ${items}`);
           }
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/ps.help.ts
+++ b/assistant/src/cli/commands/ps.help.ts
@@ -1,0 +1,26 @@
+/** Declarative help for the `assistant ps` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const psHelp: CliCommandHelp = {
+  name: "ps",
+  description: "Show the assistant daemon's live process tree",
+  options: [
+    {
+      flags: "--json",
+      description: "Machine-readable JSON output",
+    },
+  ],
+  helpText: `
+Walks the daemon's OS process tree and reports every descendant process
+parented to the assistant runtime — qdrant, the embed worker, the memory
+worker (when the daemon owns it), MCP servers, and any other live children.
+The tree is built from the native process table (/proc on Linux, ps on
+macOS), so it reflects what is actually running, not a fixed subsystem list.
+
+Each node shows its PID; every listed process is live by definition.
+
+Examples:
+  $ assistant ps
+  $ assistant ps --json`,
+};

--- a/assistant/src/cli/commands/ps.ts
+++ b/assistant/src/cli/commands/ps.ts
@@ -10,9 +10,11 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
+import { psHelp } from "./ps.help.js";
 
 interface ProcessEntry {
   name: string;
@@ -44,25 +46,11 @@ function renderEntry(entry: ProcessEntry, depth: number): void {
 
 export function registerPsCommand(program: Command): void {
   registerCommand(program, {
-    name: "ps",
+    name: psHelp.name,
     transport: "ipc",
-    description: "Show the assistant daemon's live process tree",
+    description: psHelp.description,
     build: (ps) => {
-      ps.option("--json", "Machine-readable JSON output").addHelpText(
-        "after",
-        `
-Walks the daemon's OS process tree and reports every descendant process
-parented to the assistant runtime — qdrant, the embed worker, the memory
-worker (when the daemon owns it), MCP servers, and any other live children.
-The tree is built from the native process table (/proc on Linux, ps on
-macOS), so it reflects what is actually running, not a fixed subsystem list.
-
-Each node shows its PID; every listed process is live by definition.
-
-Examples:
-  $ assistant ps
-  $ assistant ps --json`,
-      );
+      applyCommandHelp(ps, psHelp);
 
       ps.action(async (_opts, cmd: Command) => {
         const r = await cliIpcCall<PsResponse>("ps");

--- a/assistant/src/cli/commands/routes.help.ts
+++ b/assistant/src/cli/commands/routes.help.ts
@@ -1,0 +1,66 @@
+/** Declarative help for the `assistant routes` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const routesHelp: CliCommandHelp = {
+  name: "routes",
+  description:
+    "Manage user-defined authenticated HTTP route handlers under /x/*",
+  helpText: `
+User-defined routes let you expose custom HTTP endpoints by dropping handler
+files into /workspace/routes/. Each file exports named HTTP method functions
+(GET, POST, etc.) and becomes reachable at /x/<path>.
+
+These routes require edge authentication — they are intended for
+assistant-internal or user-facing endpoints, not for unauthenticated provider
+webhooks.
+
+Routes are managed by creating and deleting files — no add/remove commands
+needed.
+
+Examples:
+  $ assistant routes list
+  $ assistant routes list --json
+  $ assistant routes inspect my-dashboard-api/submit`,
+  subcommands: [
+    {
+      name: "list",
+      description: "List all user-defined route handlers and their public URLs",
+      options: [
+        {
+          flags: "--json",
+          description: "Machine-readable JSON output",
+        },
+      ],
+      helpText: `
+Scans /workspace/routes/ for handler files (.ts, .js) and displays the route
+path, exported HTTP methods, optional description, and file location.
+
+Examples:
+  $ assistant routes list
+  $ assistant routes list --json`,
+    },
+    {
+      name: "inspect",
+      args: "<path>",
+      description: "Show details of a specific user-defined route handler",
+      options: [
+        {
+          flags: "--json",
+          description: "Machine-readable JSON output",
+        },
+      ],
+      helpText: `
+Arguments:
+  path   Route path relative to /x/ (e.g. "my-dashboard-api/submit").
+         Do not include the /x/ prefix.
+
+Loads the handler file and displays exported methods, description, file path,
+public URL, file size, and last modified time.
+
+Examples:
+  $ assistant routes inspect my-dashboard-api/submit
+  $ assistant routes inspect items --json`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/routes.ts
+++ b/assistant/src/cli/commands/routes.ts
@@ -7,8 +7,10 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { routesHelp } from "./routes.help.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,138 +48,86 @@ function formatMethods(methods: string[]): string {
 
 export function registerRoutesCommand(program: Command): void {
   registerCommand(program, {
-    name: "routes",
+    name: routesHelp.name,
     transport: "ipc",
-    description:
-      "Manage user-defined authenticated HTTP route handlers under /x/*",
+    description: routesHelp.description,
     build: (routes) => {
-      routes.addHelpText(
-        "after",
-        `
-User-defined routes let you expose custom HTTP endpoints by dropping handler
-files into /workspace/routes/. Each file exports named HTTP method functions
-(GET, POST, etc.) and becomes reachable at /x/<path>.
+      applyCommandHelp(routes, routesHelp);
 
-These routes require edge authentication — they are intended for
-assistant-internal or user-facing endpoints, not for unauthenticated provider
-webhooks.
+      subcommand(routes, "list").action(async (opts: { json?: boolean }) => {
+        const r = await cliIpcCall<{ routes: DiscoveredRoute[] }>(
+          "user_routes_list",
+        );
+        if (!r.ok) return exitFromIpcResult(r);
 
-Routes are managed by creating and deleting files — no add/remove commands
-needed.
+        const discovered = r.result!.routes;
 
-Examples:
-  $ assistant routes list
-  $ assistant routes list --json
-  $ assistant routes inspect my-dashboard-api/submit`,
-      );
+        if (opts.json) {
+          console.log(JSON.stringify({ ok: true, routes: discovered }));
+          return;
+        }
 
-      routes
-        .command("list")
-        .description(
-          "List all user-defined route handlers and their public URLs",
-        )
-        .option("--json", "Machine-readable JSON output")
-        .addHelpText(
-          "after",
-          `
-Scans /workspace/routes/ for handler files (.ts, .js) and displays the route
-path, exported HTTP methods, optional description, and file location.
-
-Examples:
-  $ assistant routes list
-  $ assistant routes list --json`,
-        )
-        .action(async (opts: { json?: boolean }) => {
-          const r = await cliIpcCall<{ routes: DiscoveredRoute[] }>(
-            "user_routes_list",
+        if (discovered.length === 0) {
+          log.info("No route handlers found in /workspace/routes/.");
+          log.info(
+            "Create a .ts or .js file exporting named HTTP method functions (GET, POST, etc.).",
           );
-          if (!r.ok) return exitFromIpcResult(r);
+          return;
+        }
 
-          const discovered = r.result!.routes;
+        log.info("");
+        const routeCol = "ROUTE PATH";
+        const methodsCol = "METHODS";
+        const descCol = "DESCRIPTION";
+        const fileCol = "FILE";
 
-          if (opts.json) {
-            console.log(JSON.stringify({ ok: true, routes: discovered }));
-            return;
-          }
+        const routeWidth = Math.max(
+          routeCol.length,
+          ...discovered.map((r) => r.routePath.length),
+        );
+        const methodsWidth = Math.max(
+          methodsCol.length,
+          ...discovered.map((r) => formatMethods(r.methods).length),
+        );
+        const descWidth = Math.max(
+          descCol.length,
+          ...discovered.map((r) => (r.description ?? "").length),
+        );
 
-          if (discovered.length === 0) {
-            log.info("No route handlers found in /workspace/routes/.");
-            log.info(
-              "Create a .ts or .js file exporting named HTTP method functions (GET, POST, etc.).",
-            );
-            return;
-          }
+        const header = [
+          routeCol.padEnd(routeWidth),
+          methodsCol.padEnd(methodsWidth),
+          descCol.padEnd(descWidth),
+          fileCol,
+        ].join("    ");
 
-          log.info("");
-          const routeCol = "ROUTE PATH";
-          const methodsCol = "METHODS";
-          const descCol = "DESCRIPTION";
-          const fileCol = "FILE";
+        log.info(`  ${header}`);
 
-          const routeWidth = Math.max(
-            routeCol.length,
-            ...discovered.map((r) => r.routePath.length),
-          );
-          const methodsWidth = Math.max(
-            methodsCol.length,
-            ...discovered.map((r) => formatMethods(r.methods).length),
-          );
-          const descWidth = Math.max(
-            descCol.length,
-            ...discovered.map((r) => (r.description ?? "").length),
-          );
-
-          const header = [
-            routeCol.padEnd(routeWidth),
-            methodsCol.padEnd(methodsWidth),
-            descCol.padEnd(descWidth),
-            fileCol,
+        for (const route of discovered) {
+          const cols = [
+            route.routePath.padEnd(routeWidth),
+            formatMethods(route.methods).padEnd(methodsWidth),
+            (route.description ?? "").padEnd(descWidth),
+            `routes/${route.filePath}`,
           ].join("    ");
+          log.info(`  ${cols}`);
+        }
 
-          log.info(`  ${header}`);
+        log.info("");
+        const countLabel = discovered.length === 1 ? "route" : "routes";
+        const summary = `${discovered.length} ${countLabel}`;
+        const firstPublicUrl = discovered.find((r) => r.publicUrl)?.publicUrl;
+        if (firstPublicUrl) {
+          const publicBase = firstPublicUrl.replace(/\/x\/.*$/, "");
+          log.info(`  ${summary} • Public base: ${publicBase}`);
+        } else {
+          log.info(`  ${summary}`);
+        }
+        log.info("");
+      });
 
-          for (const route of discovered) {
-            const cols = [
-              route.routePath.padEnd(routeWidth),
-              formatMethods(route.methods).padEnd(methodsWidth),
-              (route.description ?? "").padEnd(descWidth),
-              `routes/${route.filePath}`,
-            ].join("    ");
-            log.info(`  ${cols}`);
-          }
-
-          log.info("");
-          const countLabel = discovered.length === 1 ? "route" : "routes";
-          const summary = `${discovered.length} ${countLabel}`;
-          const firstPublicUrl = discovered.find((r) => r.publicUrl)?.publicUrl;
-          if (firstPublicUrl) {
-            const publicBase = firstPublicUrl.replace(/\/x\/.*$/, "");
-            log.info(`  ${summary} • Public base: ${publicBase}`);
-          } else {
-            log.info(`  ${summary}`);
-          }
-          log.info("");
-        });
-
-      routes
-        .command("inspect <path>")
-        .description("Show details of a specific user-defined route handler")
-        .option("--json", "Machine-readable JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  path   Route path relative to /x/ (e.g. "my-dashboard-api/submit").
-         Do not include the /x/ prefix.
-
-Loads the handler file and displays exported methods, description, file path,
-public URL, file size, and last modified time.
-
-Examples:
-  $ assistant routes inspect my-dashboard-api/submit
-  $ assistant routes inspect items --json`,
-        )
-        .action(async (routePath: string, opts: { json?: boolean }) => {
+      subcommand(routes, "inspect").action(
+        async (routePath: string, opts: { json?: boolean }) => {
           const r = await cliIpcCall<{ route: InspectedRoute }>(
             "user_routes_inspect",
             { path: routePath },
@@ -213,7 +163,8 @@ Examples:
           log.info(`  File Size:   ${route.fileSize} bytes`);
           log.info(`  Modified:    ${route.modifiedAt}`);
           log.info("");
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/schedules-worker.ts
+++ b/assistant/src/cli/commands/schedules-worker.ts
@@ -28,7 +28,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
-import { registerCommand } from "../lib/register-command.js";
+import { subcommand } from "../lib/cli-command-help.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
 
@@ -62,114 +62,79 @@ interface StatusResponse {
 // ---------------------------------------------------------------------------
 
 export function registerSchedulesWorkerCommand(schedules: Command): void {
-  registerCommand(schedules, {
-    name: "worker",
-    transport: "ipc",
-    description: "Manage the schedule worker process (start/stop/status)",
-    build: (worker) => {
-      worker.addHelpText(
-        "after",
-        `
-The schedule worker runs scheduled jobs in a separate OS process so expensive
-scheduled work executes off the assistant's main event loop. The assistant
-owns the process, so it is spawned as a child of the assistant and shows up
-in \`assistant ps\`.
+  const worker = subcommand(schedules, "worker");
 
-\`start\` enables schedules.worker.enabled and \`stop\` disables it, so the
-assistant's scheduler hands schedule execution to the worker (start) or takes
-it back (stop) without a restart.
+  subcommand(worker, "start").action(
+    async (_opts: { json?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<StartResponse>("schedules_worker_start");
+      if (!r.ok) {
+        return exitFromIpcResult(r);
+      }
+      const res = r.result!;
 
-Examples:
-  $ assistant schedules worker start
-  $ assistant schedules worker status
-  $ assistant schedules worker stop`,
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, res);
+        return;
+      }
+      log.info(
+        res.alreadyRunning
+          ? `Schedule worker is already running (PID ${res.pid})`
+          : `Schedule worker started (PID ${res.pid})`,
       );
-
-      worker
-        .command("start")
-        .description(
-          "Start the schedule worker process and enable schedules.worker.enabled",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (_opts: { json?: boolean }, cmd: Command) => {
-          const r = await cliIpcCall<StartResponse>("schedules_worker_start");
-          if (!r.ok) {
-            return exitFromIpcResult(r);
-          }
-          const res = r.result!;
-
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, res);
-            return;
-          }
-          log.info(
-            res.alreadyRunning
-              ? `Schedule worker is already running (PID ${res.pid})`
-              : `Schedule worker started (PID ${res.pid})`,
-          );
-          log.info(
-            "Enabled schedules.worker.enabled; the assistant's scheduler will leave schedule execution to the worker",
-          );
-        });
-
-      worker
-        .command("stop")
-        .description(
-          "Stop the schedule worker process and disable schedules.worker.enabled",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (_opts: { json?: boolean }, cmd: Command) => {
-          const r = await cliIpcCall<StopResponse>("schedules_worker_stop");
-          if (!r.ok) {
-            return exitFromIpcResult(r);
-          }
-          const res = r.result!;
-
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, res);
-            return;
-          }
-          if (res.workerWasRunning) {
-            log.info(`Schedule worker stop signal sent (PID ${res.pid})`);
-          } else {
-            log.info("Schedule worker process was not running");
-          }
-          log.info(
-            "Disabled schedules.worker.enabled; the assistant's scheduler will run schedules again",
-          );
-        });
-
-      worker
-        .command("status")
-        .description(
-          "Report worker process state, schedules.worker.enabled, and the in-process scheduler",
-        )
-        .option("--json", "Emit raw JSON instead of a formatted summary")
-        .action(async (_opts: { json?: boolean }, cmd: Command) => {
-          const r = await cliIpcCall<StatusResponse>("schedules_worker_status");
-          if (!r.ok) {
-            return exitFromIpcResult(r);
-          }
-          const res = r.result!;
-
-          if (shouldOutputJson(cmd)) {
-            writeOutput(cmd, res);
-            return;
-          }
-          if (res.status === "running") {
-            log.info(`Schedule worker process is running (PID ${res.pid})`);
-          } else {
-            log.info("Schedule worker process is not running");
-          }
-          log.info(`schedules.worker.enabled: ${res.workerEnabled}`);
-          if (res.inProcessScheduler.status === "running") {
-            log.info(
-              `In-process scheduler is running (PID ${res.inProcessScheduler.pid})`,
-            );
-          } else {
-            log.info("In-process scheduler is not running");
-          }
-        });
+      log.info(
+        "Enabled schedules.worker.enabled; the assistant's scheduler will leave schedule execution to the worker",
+      );
     },
-  });
+  );
+
+  subcommand(worker, "stop").action(
+    async (_opts: { json?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<StopResponse>("schedules_worker_stop");
+      if (!r.ok) {
+        return exitFromIpcResult(r);
+      }
+      const res = r.result!;
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, res);
+        return;
+      }
+      if (res.workerWasRunning) {
+        log.info(`Schedule worker stop signal sent (PID ${res.pid})`);
+      } else {
+        log.info("Schedule worker process was not running");
+      }
+      log.info(
+        "Disabled schedules.worker.enabled; the assistant's scheduler will run schedules again",
+      );
+    },
+  );
+
+  subcommand(worker, "status").action(
+    async (_opts: { json?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<StatusResponse>("schedules_worker_status");
+      if (!r.ok) {
+        return exitFromIpcResult(r);
+      }
+      const res = r.result!;
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, res);
+        return;
+      }
+      if (res.status === "running") {
+        log.info(`Schedule worker process is running (PID ${res.pid})`);
+      } else {
+        log.info("Schedule worker process is not running");
+      }
+      log.info(`schedules.worker.enabled: ${res.workerEnabled}`);
+      if (res.inProcessScheduler.status === "running") {
+        log.info(
+          `In-process scheduler is running (PID ${res.inProcessScheduler.pid})`,
+        );
+      } else {
+        log.info("In-process scheduler is not running");
+      }
+    },
+  );
 }

--- a/assistant/src/cli/commands/schedules.help.ts
+++ b/assistant/src/cli/commands/schedules.help.ts
@@ -1,0 +1,519 @@
+/** Declarative help for the `assistant schedules` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const schedulesHelp: CliCommandHelp = {
+  name: "schedules",
+  description: "Manage scheduled jobs",
+  helpText: `
+Schedules are recurring or one-shot jobs run by the assistant.
+
+This namespace exposes full CRUD against the assistant's schedule store:
+create, list, get, update, enable/disable, cancel, delete, plus run history
+and manual one-time execution. One documented exception: 'create' is limited
+to 'execute' mode — notify/script/wake schedules are created via the
+in-assistant schedule_create tool, but can be inspected and updated here.
+
+The 'worker' subgroup manages the schedule worker process, which runs
+scheduled jobs in a separate OS process when enabled.
+
+Examples:
+  $ assistant schedules list
+  $ assistant schedules get <schedule-id>
+  $ assistant schedules update <schedule-id> --expression '0 9 * * *'
+  $ assistant schedules runs <schedule-id> --limit 25 --json
+  $ assistant schedules execute <schedule-id>
+  $ assistant schedules worker start`,
+  subcommands: [
+    {
+      name: "list",
+      description: "List assistant schedules",
+      options: [
+        {
+          flags: "--all",
+          description: "Include deferred schedules that are hidden by default",
+        },
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  --all    Include deferred schedules that are normally hidden.
+  --json   Output the raw schedule list as compact JSON.
+
+Examples:
+  $ assistant schedules list
+  $ assistant schedules list --all
+  $ assistant schedules list --json`,
+    },
+    {
+      name: "get",
+      args: "<id>",
+      description: "Show full details for a single schedule",
+      options: [
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  --json   Output the raw schedule object as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
+
+Behavior:
+  Prints every stored field of the schedule: name, description, mode,
+  expression/syntax, timezone, enabled state, status, next/last run times,
+  message or script body, inference profile (shown as 'default (mainAgent)'
+  when none is pinned), routing intent, and retry policy. Works for
+  deferred schedules that 'assistant schedules list' hides by default.
+  Aliased as 'inspect'.
+
+Examples:
+  $ assistant schedules get 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant schedules inspect 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant schedules get 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
+    },
+    {
+      name: "runs",
+      args: "<id>",
+      description: "List recent runs for a schedule",
+      options: [
+        {
+          flags: "--limit <count>",
+          description: "Max runs to return (default 10, max 100)",
+        },
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  --limit <count>   Max runs to return. The assistant clamps values to 1-100.
+  --json            Output the raw run list as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list' to find it.
+
+Examples:
+  $ assistant schedules runs 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant schedules runs 9f2c4f3a-3f1a-41e4-88e7-abc123 --limit 25
+  $ assistant schedules runs 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
+    },
+    {
+      name: "create",
+      args: "<name>",
+      description: "Create a new recurring schedule",
+      options: [
+        {
+          flags: "-e, --expression <expr>",
+          description: "Cron or RRULE expression that schedules the fire times",
+          required: true,
+        },
+        {
+          flags: "-d, --description <text>",
+          description:
+            "Authored description explaining what the schedule is for",
+          required: true,
+        },
+        {
+          flags: "-m, --message <text>",
+          description:
+            "Message body sent to the assistant on each fire (required for execute mode)",
+        },
+        {
+          flags: "--mode <mode>",
+          description:
+            "Schedule mode: 'execute' (default), 'script', or 'workflow'",
+        },
+        {
+          flags: "--script <command>",
+          description:
+            "Shell command to run on each fire (required for --mode script)",
+        },
+        {
+          flags: "--timeout-ms <ms>",
+          description:
+            "Script execution timeout override in ms (--mode script)",
+        },
+        {
+          flags: "-t, --timezone <tz>",
+          description:
+            "IANA timezone for the expression (e.g. America/New_York)",
+        },
+        {
+          flags: "--profile <name>",
+          description:
+            "Inference profile (llm.profiles key) the schedule's runs use; defaults to the mainAgent model selection when omitted",
+        },
+        {
+          flags: "--no-enabled",
+          description: "Create the schedule in a disabled state",
+        },
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  -e, --expression <expr>   Cron (e.g. '*/30 * * * *') or RRULE expression.
+  -d, --description <text>  Authored description explaining what the schedule is for.
+  -m, --message <text>      Message body sent on each fire (execute mode).
+  --mode <mode>             execute (default), script, or workflow.
+  --script <command>        Shell command for --mode script.
+  --timeout-ms <ms>         Script timeout override in ms (--mode script).
+  -t, --timezone <tz>       IANA timezone applied to the expression.
+  --profile <name>          Inference profile (llm.profiles key) the schedule's
+                            runs use. When omitted, runs use the default —
+                            the mainAgent call site's model selection.
+  --no-enabled              Create the schedule disabled. Defaults to enabled.
+  --json                    Output the updated schedule list as compact JSON.
+
+Arguments:
+  <name>   Display name for the schedule.
+
+Behavior:
+  Defaults to 'execute' mode (requires --message). Pass --mode script with
+  --script to run a shell command on each fire with no LLM call; the script's
+  env includes $VELLUM_WORKSPACE_DIR and $__SCHEDULE_ID (this schedule's id).
+  notify/wake schedules remain reachable only through the schedule_create tool.
+
+Examples:
+  $ assistant schedules create "GitHub watcher" \\
+      --mode script \\
+      --script 'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts' \\
+      --expression '*/15 * * * *' \\
+      --description 'Polls GitHub notifications' --json
+  $ assistant schedules create "Heartbeat" \\
+      --expression '*/30 * * * *' \\
+      --description 'Checks service heartbeat every 30 minutes' \\
+      --message 'run heartbeat'
+  $ assistant schedules create "Morning summary" \\
+      --expression '0 9 * * MON-FRI' \\
+      --description 'Summarizes weekday activity' \\
+      --timezone America/New_York \\
+      --message 'write the morning summary'
+  $ assistant schedules create "Drafted" \\
+      --expression '0 0 * * *' \\
+      --description 'Placeholder daily schedule' \\
+      --message 'placeholder' \\
+      --no-enabled --json`,
+    },
+    {
+      name: "update",
+      args: "<id>",
+      description: "Update fields on an existing schedule",
+      options: [
+        { flags: "--name <text>", description: "New display name" },
+        {
+          flags: "-d, --description <text>",
+          description:
+            "New authored description explaining what the schedule is for",
+        },
+        {
+          flags: "-e, --expression <expr>",
+          description: "New cron or RRULE expression for the fire times",
+        },
+        {
+          flags: "-t, --timezone <tz>",
+          description:
+            "IANA timezone for the expression (e.g. America/New_York)",
+        },
+        {
+          flags: "-m, --message <text>",
+          description: "New message body sent to the assistant on each fire",
+        },
+        {
+          flags: "--script <command>",
+          description: "Shell command for script-mode schedules",
+        },
+        {
+          flags: "--mode <mode>",
+          description:
+            "One of: notify, execute, script, wake (wake only when the schedule already has a wake conversation target)",
+        },
+        {
+          flags: "--routing-intent <intent>",
+          description: "One of: single_channel, multi_channel, all_channels",
+        },
+        {
+          flags: "--quiet",
+          description: "Suppress notifications for this schedule",
+        },
+        {
+          flags: "--no-quiet",
+          description: "Re-enable notifications for this schedule",
+        },
+        {
+          flags: "--reuse-conversation",
+          description: "Reuse one conversation across recurring fires",
+        },
+        {
+          flags: "--no-reuse-conversation",
+          description: "Start a fresh conversation on each fire",
+        },
+        {
+          flags: "--max-retries <count>",
+          description: "Maximum retry attempts (integer)",
+        },
+        {
+          flags: "--retry-backoff-ms <ms>",
+          description: "Retry backoff in milliseconds (integer)",
+        },
+        {
+          flags: "--timeout-ms <ms>",
+          description:
+            "Script-mode execution timeout in milliseconds (integer)",
+        },
+        {
+          flags: "--clear-timeout",
+          description:
+            "Clear the script timeout override and use the assistant default",
+        },
+        {
+          flags: "--profile <name>",
+          description:
+            "Inference profile (llm.profiles key) the schedule's runs use; the default when unset is the mainAgent model selection",
+        },
+        {
+          flags: "--clear-profile",
+          description:
+            "Clear the inference profile and revert to the default mainAgent model selection",
+        },
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  --name <text>             New display name.
+  -d, --description <text>  New authored description (must be non-empty).
+  -e, --expression <expr>   Cron (e.g. '*/30 * * * *') or RRULE expression.
+  -t, --timezone <tz>       IANA timezone applied to the expression.
+  -m, --message <text>      New message body sent on each fire.
+  --script <command>        Shell command for script-mode schedules.
+  --mode <mode>             notify, execute, script, or wake.
+  --routing-intent <intent> single_channel, multi_channel, or all_channels.
+  --quiet / --no-quiet      Toggle notification suppression.
+  --reuse-conversation / --no-reuse-conversation
+                            Toggle conversation reuse across recurring fires.
+  --max-retries <count>     Maximum retry attempts.
+  --retry-backoff-ms <ms>   Retry backoff in milliseconds.
+  --timeout-ms <ms>         Script-mode execution timeout in milliseconds.
+  --clear-timeout           Remove the timeout override (mutually exclusive
+                            with --timeout-ms).
+  --profile <name>          Inference profile (llm.profiles key) the schedule's
+                            runs use. When no profile is set, runs use the
+                            default — the mainAgent call site's model selection.
+  --clear-profile           Remove the inference profile and revert to the
+                            default mainAgent model selection (mutually
+                            exclusive with --profile).
+  --json                    Output the updated schedule list as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
+
+Behavior:
+  Partially updates the schedule: only fields for flags you pass are changed,
+  everything else is preserved. At least one update flag is required. To
+  enable or disable a schedule, use 'assistant schedules enable <id>' or
+  'assistant schedules disable <id>' instead.
+
+Examples:
+  $ assistant schedules update 9f2c4f3a-3f1a-41e4-88e7-abc123 \\
+      --expression '0 9 * * MON-FRI' --timezone America/New_York
+  $ assistant schedules update 9f2c4f3a-3f1a-41e4-88e7-abc123 \\
+      --name "Morning summary" --message 'write the morning summary'
+  $ assistant schedules update 9f2c4f3a-3f1a-41e4-88e7-abc123 \\
+      --max-retries 5 --retry-backoff-ms 30000 --json`,
+    },
+    {
+      name: "enable",
+      args: "<id>",
+      description: "Enable a schedule",
+      options: [
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  --json   Output the updated schedule list as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
+
+Behavior:
+  Enables the schedule so it can run on future matching times. This does not
+  execute the schedule immediately; use 'assistant schedules execute <id>' for
+  manual run-now behavior.
+
+Examples:
+  $ assistant schedules enable 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant schedules enable 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
+    },
+    {
+      name: "disable",
+      args: "<id>",
+      description: "Disable a schedule",
+      options: [
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  --json   Output the updated schedule list as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
+
+Behavior:
+  Disables the schedule so future scheduled fires are skipped until it is
+  enabled again. Existing run history is preserved.
+
+Examples:
+  $ assistant schedules disable 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant schedules disable 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
+    },
+    {
+      name: "cancel",
+      args: "<id>",
+      description: "Cancel a pending one-shot schedule",
+      options: [
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  --json   Output the updated schedule list as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find
+         pending one-shot/deferred schedules.
+
+Behavior:
+  Cancels a pending one-shot schedule. Recurring schedules are not cancellable;
+  use 'assistant schedules disable <id>' to pause recurring schedules.
+
+Examples:
+  $ assistant schedules cancel 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant schedules cancel 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
+    },
+    {
+      name: "delete",
+      args: "<id>",
+      description: "Permanently delete a schedule and its run history",
+      options: [
+        { flags: "--force", description: "Skip the confirmation prompt" },
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  --force  Skip the destructive y/N confirmation prompt. Required when stdin
+           is not a TTY (e.g. in scripts and CI).
+  --json   Output the updated schedule list as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
+
+Behavior:
+  Permanently removes the schedule and its run history. This cannot be undone.
+  To temporarily pause a recurring schedule, use
+  'assistant schedules disable <id>' instead.
+
+Examples:
+  $ assistant schedules delete 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant schedules delete 9f2c4f3a-3f1a-41e4-88e7-abc123 --force
+  $ assistant schedules delete 9f2c4f3a-3f1a-41e4-88e7-abc123 --force --json`,
+    },
+    {
+      name: "execute",
+      args: "<id>",
+      description: "Execute a schedule one time immediately",
+      options: [
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
+      helpText: `
+Options:
+  --json   Output the run-now result as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list' to find it.
+
+Examples:
+  $ assistant schedules execute 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant schedules execute 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
+    },
+    {
+      name: "worker",
+      description: "Manage the schedule worker process (start/stop/status)",
+      helpText: `
+The schedule worker runs scheduled jobs in a separate OS process so expensive
+scheduled work executes off the assistant's main event loop. The assistant
+owns the process, so it is spawned as a child of the assistant and shows up
+in \`assistant ps\`.
+
+\`start\` enables schedules.worker.enabled and \`stop\` disables it, so the
+assistant's scheduler hands schedule execution to the worker (start) or takes
+it back (stop) without a restart.
+
+Examples:
+  $ assistant schedules worker start
+  $ assistant schedules worker status
+  $ assistant schedules worker stop`,
+      subcommands: [
+        {
+          name: "start",
+          description:
+            "Start the schedule worker process and enable schedules.worker.enabled",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+        },
+        {
+          name: "stop",
+          description:
+            "Stop the schedule worker process and disable schedules.worker.enabled",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+        },
+        {
+          name: "status",
+          description:
+            "Report worker process state, schedules.worker.enabled, and the in-process scheduler",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -1,11 +1,13 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { formatCostUsd } from "../lib/cli-output.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { writeOutput } from "../output.js";
+import { schedulesHelp } from "./schedules.help.js";
 import { registerSchedulesWorkerCommand } from "./schedules-worker.js";
 
 interface ScheduleRecord {
@@ -65,181 +67,115 @@ interface ListScheduleRunsResponse {
 
 export function registerSchedulesCommand(program: Command): void {
   registerCommand(program, {
-    name: "schedules",
+    name: schedulesHelp.name,
     transport: "ipc",
-    description: "Manage scheduled jobs",
+    description: schedulesHelp.description,
     build: (schedules) => {
-      schedules.addHelpText(
-        "after",
-        `
-Schedules are recurring or one-shot jobs run by the assistant.
+      applyCommandHelp(schedules, schedulesHelp);
 
-This namespace exposes full CRUD against the assistant's schedule store:
-create, list, get, update, enable/disable, cancel, delete, plus run history
-and manual one-time execution. One documented exception: 'create' is limited
-to 'execute' mode — notify/script/wake schedules are created via the
-in-assistant schedule_create tool, but can be inspected and updated here.
+      subcommand(schedules, "list").action(
+        async (opts: { all?: boolean; json?: boolean }, cmd: Command) => {
+          const queryParams: Record<string, string> = {};
+          if (opts.all) {
+            queryParams.include_all = "true";
+          }
 
-The 'worker' subgroup manages the schedule worker process, which runs
-scheduled jobs in a separate OS process when enabled.
+          const result = await cliIpcCall<ListSchedulesResponse>(
+            "listSchedules",
+            { queryParams },
+          );
 
-Examples:
-  $ assistant schedules list
-  $ assistant schedules get <schedule-id>
-  $ assistant schedules update <schedule-id> --expression '0 9 * * *'
-  $ assistant schedules runs <schedule-id> --limit 25 --json
-  $ assistant schedules execute <schedule-id>
-  $ assistant schedules worker start`,
-      );
-
-      schedules
-        .command("list")
-        .description("List assistant schedules")
-        .option(
-          "--all",
-          "Include deferred schedules that are hidden by default",
-        )
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --all    Include deferred schedules that are normally hidden.
-  --json   Output the raw schedule list as compact JSON.
-
-Examples:
-  $ assistant schedules list
-  $ assistant schedules list --all
-  $ assistant schedules list --json`,
-        )
-        .action(
-          async (opts: { all?: boolean; json?: boolean }, cmd: Command) => {
-            const queryParams: Record<string, string> = {};
-            if (opts.all) {
-              queryParams.include_all = "true";
-            }
-
-            const result = await cliIpcCall<ListSchedulesResponse>(
-              "listSchedules",
-              { queryParams },
-            );
-
-            if (!result.ok) {
-              if (opts.json) {
-                writeOutput(cmd, { ok: false, error: result.error });
-              } else {
-                log.error(result.error ?? "Failed to list schedules");
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            const response = result.result ?? { schedules: [] };
-            const entries = [...response.schedules].sort(
-              (a, b) => a.nextRunAt - b.nextRunAt,
-            );
-
+          if (!result.ok) {
             if (opts.json) {
-              writeOutput(cmd, { schedules: entries });
-              return;
+              writeOutput(cmd, { ok: false, error: result.error });
+            } else {
+              log.error(result.error ?? "Failed to list schedules");
             }
+            process.exitCode = 1;
+            return;
+          }
 
-            if (entries.length === 0) {
-              log.info("No schedules found.");
-              return;
-            }
+          const response = result.result ?? { schedules: [] };
+          const entries = [...response.schedules].sort(
+            (a, b) => a.nextRunAt - b.nextRunAt,
+          );
 
-            const rows = entries.map((schedule) => ({
-              id: schedule.id,
-              name: schedule.name,
-              enabled: schedule.enabled ? "enabled" : "disabled",
-              mode: schedule.mode,
-              schedule: describeSchedule(schedule),
-              nextRun: formatTimestamp(schedule.nextRunAt),
-              lastStatus: schedule.lastStatus ?? "—",
-            }));
+          if (opts.json) {
+            writeOutput(cmd, { schedules: entries });
+            return;
+          }
 
-            const headers = [
-              "ID",
-              "NAME",
-              "ENABLED",
-              "MODE",
-              "SCHEDULE",
-              "NEXT RUN",
-              "LAST STATUS",
-            ];
-            const widths = [
-              headers[0].length,
-              headers[1].length,
-              headers[2].length,
-              headers[3].length,
-              headers[4].length,
-              headers[5].length,
-              headers[6].length,
-            ];
+          if (entries.length === 0) {
+            log.info("No schedules found.");
+            return;
+          }
 
-            for (const row of rows) {
-              widths[0] = Math.max(widths[0], row.id.length);
-              widths[1] = Math.max(widths[1], row.name.length);
-              widths[2] = Math.max(widths[2], row.enabled.length);
-              widths[3] = Math.max(widths[3], row.mode.length);
-              widths[4] = Math.max(widths[4], row.schedule.length);
-              widths[5] = Math.max(widths[5], row.nextRun.length);
-              widths[6] = Math.max(widths[6], row.lastStatus.length);
-            }
+          const rows = entries.map((schedule) => ({
+            id: schedule.id,
+            name: schedule.name,
+            enabled: schedule.enabled ? "enabled" : "disabled",
+            mode: schedule.mode,
+            schedule: describeSchedule(schedule),
+            nextRun: formatTimestamp(schedule.nextRunAt),
+            lastStatus: schedule.lastStatus ?? "—",
+          }));
 
-            const pad = (value: string, width: number) => value.padEnd(width);
+          const headers = [
+            "ID",
+            "NAME",
+            "ENABLED",
+            "MODE",
+            "SCHEDULE",
+            "NEXT RUN",
+            "LAST STATUS",
+          ];
+          const widths = [
+            headers[0].length,
+            headers[1].length,
+            headers[2].length,
+            headers[3].length,
+            headers[4].length,
+            headers[5].length,
+            headers[6].length,
+          ];
+
+          for (const row of rows) {
+            widths[0] = Math.max(widths[0], row.id.length);
+            widths[1] = Math.max(widths[1], row.name.length);
+            widths[2] = Math.max(widths[2], row.enabled.length);
+            widths[3] = Math.max(widths[3], row.mode.length);
+            widths[4] = Math.max(widths[4], row.schedule.length);
+            widths[5] = Math.max(widths[5], row.nextRun.length);
+            widths[6] = Math.max(widths[6], row.lastStatus.length);
+          }
+
+          const pad = (value: string, width: number) => value.padEnd(width);
+          log.info(
+            headers
+              .map((header, index) => pad(header, widths[index]!))
+              .join("  "),
+          );
+          log.info(widths.map((width) => "─".repeat(width)).join("  "));
+          for (const row of rows) {
             log.info(
-              headers
-                .map((header, index) => pad(header, widths[index]!))
+              [
+                row.id,
+                row.name,
+                row.enabled,
+                row.mode,
+                row.schedule,
+                row.nextRun,
+                row.lastStatus,
+              ]
+                .map((value, index) => pad(value, widths[index]!))
                 .join("  "),
             );
-            log.info(widths.map((width) => "─".repeat(width)).join("  "));
-            for (const row of rows) {
-              log.info(
-                [
-                  row.id,
-                  row.name,
-                  row.enabled,
-                  row.mode,
-                  row.schedule,
-                  row.nextRun,
-                  row.lastStatus,
-                ]
-                  .map((value, index) => pad(value, widths[index]!))
-                  .join("  "),
-              );
-            }
-          },
-        );
+          }
+        },
+      );
 
-      schedules
-        .command("get <id>")
+      subcommand(schedules, "get")
         .alias("inspect")
-        .description("Show full details for a single schedule")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --json   Output the raw schedule object as compact JSON.
-
-Arguments:
-  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
-
-Behavior:
-  Prints every stored field of the schedule: name, description, mode,
-  expression/syntax, timezone, enabled state, status, next/last run times,
-  message or script body, inference profile (shown as 'default (mainAgent)'
-  when none is pinned), routing intent, and retry policy. Works for
-  deferred schedules that 'assistant schedules list' hides by default.
-  Aliased as 'inspect'.
-
-Examples:
-  $ assistant schedules get 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant schedules inspect 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant schedules get 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
-        )
         .action(async (id: string, opts: { json?: boolean }, cmd: Command) => {
           const scheduleId = id.trim();
           const result = await cliIpcCall<GetScheduleResponse>("getSchedule", {
@@ -303,670 +239,397 @@ Examples:
           }
         });
 
-      schedules
-        .command("runs <id>")
-        .description("List recent runs for a schedule")
-        .option("--limit <count>", "Max runs to return (default 10, max 100)")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --limit <count>   Max runs to return. The assistant clamps values to 1-100.
-  --json            Output the raw run list as compact JSON.
+      subcommand(schedules, "runs").action(
+        async (
+          id: string,
+          opts: { limit?: string; json?: boolean },
+          cmd: Command,
+        ) => {
+          const scheduleId = id.trim();
+          const queryParams: Record<string, string> = {};
+          if (opts.limit != null) {
+            queryParams.limit = opts.limit;
+          }
 
-Arguments:
-  <id>   Schedule ID (UUID) — run 'assistant schedules list' to find it.
+          const result = await cliIpcCall<ListScheduleRunsResponse>(
+            "listScheduleRuns",
+            { pathParams: { id: scheduleId }, queryParams },
+          );
 
-Examples:
-  $ assistant schedules runs 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant schedules runs 9f2c4f3a-3f1a-41e4-88e7-abc123 --limit 25
-  $ assistant schedules runs 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
-        )
-        .action(
-          async (
-            id: string,
-            opts: { limit?: string; json?: boolean },
-            cmd: Command,
-          ) => {
-            const scheduleId = id.trim();
-            const queryParams: Record<string, string> = {};
-            if (opts.limit != null) {
-              queryParams.limit = opts.limit;
-            }
+          if (!result.ok) {
+            return exitFromIpcResult(result, cmd);
+          }
 
-            const result = await cliIpcCall<ListScheduleRunsResponse>(
-              "listScheduleRuns",
-              { pathParams: { id: scheduleId }, queryParams },
-            );
+          const response = result.result ?? { runs: [] };
+          if (opts.json) {
+            writeOutput(cmd, response);
+            return;
+          }
 
-            if (!result.ok) {
-              return exitFromIpcResult(result, cmd);
-            }
+          const runs = response.runs;
+          if (runs.length === 0) {
+            log.info(`No runs found for schedule ${scheduleId}.`);
+            return;
+          }
 
-            const response = result.result ?? { runs: [] };
-            if (opts.json) {
-              writeOutput(cmd, response);
-              return;
-            }
+          const rows = runs.map((run) => ({
+            id: run.id,
+            status: run.status,
+            startedAt: formatTimestamp(run.startedAt),
+            finishedAt: formatNullableTimestamp(run.finishedAt),
+            duration: formatDuration(run.durationMs),
+            cost: formatRunCost(run.estimatedCostUsd),
+            conversation: run.conversationId ?? "—",
+            error: run.error ?? "—",
+          }));
 
-            const runs = response.runs;
-            if (runs.length === 0) {
-              log.info(`No runs found for schedule ${scheduleId}.`);
-              return;
-            }
+          const headers = [
+            "ID",
+            "STATUS",
+            "STARTED",
+            "FINISHED",
+            "DURATION",
+            "COST",
+            "CONVERSATION",
+            "ERROR",
+          ];
+          const widths = [
+            headers[0].length,
+            headers[1].length,
+            headers[2].length,
+            headers[3].length,
+            headers[4].length,
+            headers[5].length,
+            headers[6].length,
+            headers[7].length,
+          ];
 
-            const rows = runs.map((run) => ({
-              id: run.id,
-              status: run.status,
-              startedAt: formatTimestamp(run.startedAt),
-              finishedAt: formatNullableTimestamp(run.finishedAt),
-              duration: formatDuration(run.durationMs),
-              cost: formatRunCost(run.estimatedCostUsd),
-              conversation: run.conversationId ?? "—",
-              error: run.error ?? "—",
-            }));
+          for (const row of rows) {
+            widths[0] = Math.max(widths[0], row.id.length);
+            widths[1] = Math.max(widths[1], row.status.length);
+            widths[2] = Math.max(widths[2], row.startedAt.length);
+            widths[3] = Math.max(widths[3], row.finishedAt.length);
+            widths[4] = Math.max(widths[4], row.duration.length);
+            widths[5] = Math.max(widths[5], row.cost.length);
+            widths[6] = Math.max(widths[6], row.conversation.length);
+            widths[7] = Math.max(widths[7], row.error.length);
+          }
 
-            const headers = [
-              "ID",
-              "STATUS",
-              "STARTED",
-              "FINISHED",
-              "DURATION",
-              "COST",
-              "CONVERSATION",
-              "ERROR",
-            ];
-            const widths = [
-              headers[0].length,
-              headers[1].length,
-              headers[2].length,
-              headers[3].length,
-              headers[4].length,
-              headers[5].length,
-              headers[6].length,
-              headers[7].length,
-            ];
-
-            for (const row of rows) {
-              widths[0] = Math.max(widths[0], row.id.length);
-              widths[1] = Math.max(widths[1], row.status.length);
-              widths[2] = Math.max(widths[2], row.startedAt.length);
-              widths[3] = Math.max(widths[3], row.finishedAt.length);
-              widths[4] = Math.max(widths[4], row.duration.length);
-              widths[5] = Math.max(widths[5], row.cost.length);
-              widths[6] = Math.max(widths[6], row.conversation.length);
-              widths[7] = Math.max(widths[7], row.error.length);
-            }
-
-            const pad = (value: string, width: number) => value.padEnd(width);
+          const pad = (value: string, width: number) => value.padEnd(width);
+          log.info(
+            headers
+              .map((header, index) => pad(header, widths[index]!))
+              .join("  "),
+          );
+          log.info(widths.map((width) => "─".repeat(width)).join("  "));
+          for (const row of rows) {
             log.info(
-              headers
-                .map((header, index) => pad(header, widths[index]!))
+              [
+                row.id,
+                row.status,
+                row.startedAt,
+                row.finishedAt,
+                row.duration,
+                row.cost,
+                row.conversation,
+                row.error,
+              ]
+                .map((value, index) => pad(value, widths[index]!))
                 .join("  "),
             );
-            log.info(widths.map((width) => "─".repeat(width)).join("  "));
-            for (const row of rows) {
-              log.info(
-                [
-                  row.id,
-                  row.status,
-                  row.startedAt,
-                  row.finishedAt,
-                  row.duration,
-                  row.cost,
-                  row.conversation,
-                  row.error,
-                ]
-                  .map((value, index) => pad(value, widths[index]!))
-                  .join("  "),
-              );
-            }
+          }
+        },
+      );
+
+      subcommand(schedules, "create").action(
+        async (
+          name: string,
+          opts: {
+            expression: string;
+            description: string;
+            message?: string;
+            mode?: string;
+            script?: string;
+            timeoutMs?: string;
+            timezone?: string;
+            profile?: string;
+            enabled: boolean;
+            json?: boolean;
           },
-        );
-
-      schedules
-        .command("create <name>")
-        .description("Create a new recurring schedule")
-        .requiredOption(
-          "-e, --expression <expr>",
-          "Cron or RRULE expression that schedules the fire times",
-        )
-        .requiredOption(
-          "-d, --description <text>",
-          "Authored description explaining what the schedule is for",
-        )
-        .option(
-          "-m, --message <text>",
-          "Message body sent to the assistant on each fire (required for execute mode)",
-        )
-        .option(
-          "--mode <mode>",
-          "Schedule mode: 'execute' (default), 'script', or 'workflow'",
-        )
-        .option(
-          "--script <command>",
-          "Shell command to run on each fire (required for --mode script)",
-        )
-        .option(
-          "--timeout-ms <ms>",
-          "Script execution timeout override in ms (--mode script)",
-        )
-        .option(
-          "-t, --timezone <tz>",
-          "IANA timezone for the expression (e.g. America/New_York)",
-        )
-        .option(
-          "--profile <name>",
-          "Inference profile (llm.profiles key) the schedule's runs use; defaults to the mainAgent model selection when omitted",
-        )
-        .option("--no-enabled", "Create the schedule in a disabled state")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  -e, --expression <expr>   Cron (e.g. '*/30 * * * *') or RRULE expression.
-  -d, --description <text>  Authored description explaining what the schedule is for.
-  -m, --message <text>      Message body sent on each fire (execute mode).
-  --mode <mode>             execute (default), script, or workflow.
-  --script <command>        Shell command for --mode script.
-  --timeout-ms <ms>         Script timeout override in ms (--mode script).
-  -t, --timezone <tz>       IANA timezone applied to the expression.
-  --profile <name>          Inference profile (llm.profiles key) the schedule's
-                            runs use. When omitted, runs use the default —
-                            the mainAgent call site's model selection.
-  --no-enabled              Create the schedule disabled. Defaults to enabled.
-  --json                    Output the updated schedule list as compact JSON.
-
-Arguments:
-  <name>   Display name for the schedule.
-
-Behavior:
-  Defaults to 'execute' mode (requires --message). Pass --mode script with
-  --script to run a shell command on each fire with no LLM call; the script's
-  env includes $VELLUM_WORKSPACE_DIR and $__SCHEDULE_ID (this schedule's id).
-  notify/wake schedules remain reachable only through the schedule_create tool.
-
-Examples:
-  $ assistant schedules create "GitHub watcher" \\
-      --mode script \\
-      --script 'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts' \\
-      --expression '*/15 * * * *' \\
-      --description 'Polls GitHub notifications' --json
-  $ assistant schedules create "Heartbeat" \\
-      --expression '*/30 * * * *' \\
-      --description 'Checks service heartbeat every 30 minutes' \\
-      --message 'run heartbeat'
-  $ assistant schedules create "Morning summary" \\
-      --expression '0 9 * * MON-FRI' \\
-      --description 'Summarizes weekday activity' \\
-      --timezone America/New_York \\
-      --message 'write the morning summary'
-  $ assistant schedules create "Drafted" \\
-      --expression '0 0 * * *' \\
-      --description 'Placeholder daily schedule' \\
-      --message 'placeholder' \\
-      --no-enabled --json`,
-        )
-        .action(
-          async (
-            name: string,
-            opts: {
-              expression: string;
-              description: string;
-              message?: string;
-              mode?: string;
-              script?: string;
-              timeoutMs?: string;
-              timezone?: string;
-              profile?: string;
-              enabled: boolean;
-              json?: boolean;
-            },
-            cmd: Command,
-          ) => {
-            const scheduleName = name.trim();
-            if (!scheduleName) {
-              const error = "name is required";
-              if (opts.json) {
-                writeOutput(cmd, { ok: false, error });
-              } else {
-                log.error(error);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            const description = opts.description.trim();
-            if (!description) {
-              const error = "description is required";
-              if (opts.json) {
-                writeOutput(cmd, { ok: false, error });
-              } else {
-                log.error(error);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            const mode = opts.mode ?? "execute";
-            if (mode === "script" && !opts.script) {
-              const error = "--script is required for --mode script";
-              if (opts.json) {
-                writeOutput(cmd, { ok: false, error });
-              } else {
-                log.error(error);
-              }
-              process.exitCode = 1;
-              return;
-            }
-            if (mode === "execute" && !opts.message) {
-              const error = "--message is required for execute mode";
-              if (opts.json) {
-                writeOutput(cmd, { ok: false, error });
-              } else {
-                log.error(error);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            const body: Record<string, unknown> = {
-              name: scheduleName,
-              expression: opts.expression,
-              description,
-              enabled: opts.enabled,
-            };
-            // Omit mode for the default; the route treats absent as 'execute'.
-            if (mode !== "execute") {
-              body.mode = mode;
-            }
-            if (opts.message != null) {
-              body.message = opts.message;
-            }
-            if (opts.script != null) {
-              body.script = opts.script;
-            }
-            if (opts.timeoutMs != null) {
-              body.timeoutMs = Number(opts.timeoutMs);
-            }
-            if (opts.timezone != null) {
-              body.timezone = opts.timezone;
-            }
-            if (opts.profile != null) {
-              body.inferenceProfile = opts.profile;
-            }
-
-            const result = await cliIpcCall<GetScheduleResponse>(
-              "createSchedule",
-              { body },
-            );
-
-            if (!result.ok) {
-              return exitFromIpcResult(result, cmd);
-            }
-
+          cmd: Command,
+        ) => {
+          const scheduleName = name.trim();
+          if (!scheduleName) {
+            const error = "name is required";
             if (opts.json) {
-              writeOutput(cmd, result.result ?? {});
-              return;
+              writeOutput(cmd, { ok: false, error });
+            } else {
+              log.error(error);
             }
+            process.exitCode = 1;
+            return;
+          }
 
-            log.info(`Created schedule: ${scheduleName}`);
-          },
-        );
-
-      schedules
-        .command("update <id>")
-        .description("Update fields on an existing schedule")
-        .option("--name <text>", "New display name")
-        .option(
-          "-d, --description <text>",
-          "New authored description explaining what the schedule is for",
-        )
-        .option(
-          "-e, --expression <expr>",
-          "New cron or RRULE expression for the fire times",
-        )
-        .option(
-          "-t, --timezone <tz>",
-          "IANA timezone for the expression (e.g. America/New_York)",
-        )
-        .option(
-          "-m, --message <text>",
-          "New message body sent to the assistant on each fire",
-        )
-        .option("--script <command>", "Shell command for script-mode schedules")
-        .option(
-          "--mode <mode>",
-          "One of: notify, execute, script, wake (wake only when the schedule already has a wake conversation target)",
-        )
-        .option(
-          "--routing-intent <intent>",
-          "One of: single_channel, multi_channel, all_channels",
-        )
-        .option("--quiet", "Suppress notifications for this schedule")
-        .option("--no-quiet", "Re-enable notifications for this schedule")
-        .option(
-          "--reuse-conversation",
-          "Reuse one conversation across recurring fires",
-        )
-        .option(
-          "--no-reuse-conversation",
-          "Start a fresh conversation on each fire",
-        )
-        .option("--max-retries <count>", "Maximum retry attempts (integer)")
-        .option(
-          "--retry-backoff-ms <ms>",
-          "Retry backoff in milliseconds (integer)",
-        )
-        .option(
-          "--timeout-ms <ms>",
-          "Script-mode execution timeout in milliseconds (integer)",
-        )
-        .option(
-          "--clear-timeout",
-          "Clear the script timeout override and use the assistant default",
-        )
-        .option(
-          "--profile <name>",
-          "Inference profile (llm.profiles key) the schedule's runs use; the default when unset is the mainAgent model selection",
-        )
-        .option(
-          "--clear-profile",
-          "Clear the inference profile and revert to the default mainAgent model selection",
-        )
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --name <text>             New display name.
-  -d, --description <text>  New authored description (must be non-empty).
-  -e, --expression <expr>   Cron (e.g. '*/30 * * * *') or RRULE expression.
-  -t, --timezone <tz>       IANA timezone applied to the expression.
-  -m, --message <text>      New message body sent on each fire.
-  --script <command>        Shell command for script-mode schedules.
-  --mode <mode>             notify, execute, script, or wake.
-  --routing-intent <intent> single_channel, multi_channel, or all_channels.
-  --quiet / --no-quiet      Toggle notification suppression.
-  --reuse-conversation / --no-reuse-conversation
-                            Toggle conversation reuse across recurring fires.
-  --max-retries <count>     Maximum retry attempts.
-  --retry-backoff-ms <ms>   Retry backoff in milliseconds.
-  --timeout-ms <ms>         Script-mode execution timeout in milliseconds.
-  --clear-timeout           Remove the timeout override (mutually exclusive
-                            with --timeout-ms).
-  --profile <name>          Inference profile (llm.profiles key) the schedule's
-                            runs use. When no profile is set, runs use the
-                            default — the mainAgent call site's model selection.
-  --clear-profile           Remove the inference profile and revert to the
-                            default mainAgent model selection (mutually
-                            exclusive with --profile).
-  --json                    Output the updated schedule list as compact JSON.
-
-Arguments:
-  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
-
-Behavior:
-  Partially updates the schedule: only fields for flags you pass are changed,
-  everything else is preserved. At least one update flag is required. To
-  enable or disable a schedule, use 'assistant schedules enable <id>' or
-  'assistant schedules disable <id>' instead.
-
-Examples:
-  $ assistant schedules update 9f2c4f3a-3f1a-41e4-88e7-abc123 \\
-      --expression '0 9 * * MON-FRI' --timezone America/New_York
-  $ assistant schedules update 9f2c4f3a-3f1a-41e4-88e7-abc123 \\
-      --name "Morning summary" --message 'write the morning summary'
-  $ assistant schedules update 9f2c4f3a-3f1a-41e4-88e7-abc123 \\
-      --max-retries 5 --retry-backoff-ms 30000 --json`,
-        )
-        .action(
-          async (
-            id: string,
-            opts: {
-              name?: string;
-              description?: string;
-              expression?: string;
-              timezone?: string;
-              message?: string;
-              script?: string;
-              mode?: string;
-              routingIntent?: string;
-              quiet?: boolean;
-              reuseConversation?: boolean;
-              maxRetries?: string;
-              retryBackoffMs?: string;
-              timeoutMs?: string;
-              clearTimeout?: boolean;
-              profile?: string;
-              clearProfile?: boolean;
-              json?: boolean;
-            },
-            cmd: Command,
-          ) => {
-            const scheduleId = id.trim();
-            const fail = (error: string) => {
-              if (opts.json) {
-                writeOutput(cmd, { ok: false, error });
-              } else {
-                log.error(error);
-              }
-              process.exitCode = 1;
-            };
-
-            const parseInteger = (
-              flag: string,
-              value: string,
-            ): number | null => {
-              const parsed = Number(value);
-              if (!Number.isInteger(parsed)) {
-                fail(`${flag} must be an integer, got "${value}"`);
-                return null;
-              }
-              return parsed;
-            };
-
-            if (opts.clearTimeout && opts.timeoutMs != null) {
-              fail(
-                "--timeout-ms and --clear-timeout are mutually exclusive; pass --timeout-ms to set a timeout or --clear-timeout to remove it",
-              );
-              return;
-            }
-
-            if (opts.clearProfile && opts.profile != null) {
-              fail(
-                "--profile and --clear-profile are mutually exclusive; pass --profile to set a profile or --clear-profile to revert to the default mainAgent model selection",
-              );
-              return;
-            }
-
-            // Wake mode requires a wake conversation target, which this CLI
-            // cannot set. Allow `--mode wake` only when the schedule already
-            // has one — otherwise the scheduler would skip every fire as a
-            // no-op.
-            if (opts.mode === "wake") {
-              const existing = await cliIpcCall<GetScheduleResponse>(
-                "getSchedule",
-                { pathParams: { id: scheduleId } },
-              );
-              if (!existing.ok) {
-                return exitFromIpcResult(existing, cmd);
-              }
-              if (!existing.result?.schedule.wakeConversationId) {
-                fail(
-                  "--mode wake requires the schedule to already have a wake conversation target; this CLI cannot set one. Create wake schedules with the schedule tool instead.",
-                );
-                return;
-              }
-            }
-
-            const body: Record<string, unknown> = {};
-            if (opts.name != null) {
-              body.name = opts.name;
-            }
-            if (opts.description != null) {
-              body.description = opts.description;
-            }
-            if (opts.expression != null) {
-              body.expression = opts.expression;
-            }
-            if (opts.timezone != null) {
-              body.timezone = opts.timezone;
-            }
-            if (opts.message != null) {
-              body.message = opts.message;
-            }
-            if (opts.script != null) {
-              body.script = opts.script;
-            }
-            if (opts.mode != null) {
-              body.mode = opts.mode;
-            }
-            if (opts.routingIntent != null) {
-              body.routingIntent = opts.routingIntent;
-            }
-            if (opts.quiet != null) {
-              body.quiet = opts.quiet;
-            }
-            if (opts.reuseConversation != null) {
-              body.reuseConversation = opts.reuseConversation;
-            }
-            if (opts.maxRetries != null) {
-              const parsed = parseInteger("--max-retries", opts.maxRetries);
-              if (parsed == null) {
-                return;
-              }
-              body.maxRetries = parsed;
-            }
-            if (opts.retryBackoffMs != null) {
-              const parsed = parseInteger(
-                "--retry-backoff-ms",
-                opts.retryBackoffMs,
-              );
-              if (parsed == null) {
-                return;
-              }
-              body.retryBackoffMs = parsed;
-            }
-            if (opts.timeoutMs != null) {
-              const parsed = parseInteger("--timeout-ms", opts.timeoutMs);
-              if (parsed == null) {
-                return;
-              }
-              body.timeoutMs = parsed;
-            }
-            if (opts.clearTimeout) {
-              body.timeoutMs = null;
-            }
-            if (opts.profile != null) {
-              body.inferenceProfile = opts.profile;
-            }
-            if (opts.clearProfile) {
-              body.inferenceProfile = null;
-            }
-
-            if (Object.keys(body).length === 0) {
-              fail(
-                "At least one update flag is required. Run 'assistant schedules update --help' for the available flags.",
-              );
-              return;
-            }
-
-            const result = await cliIpcCall<ListSchedulesResponse>(
-              "updateSchedule",
-              { pathParams: { id: scheduleId }, body },
-            );
-
-            if (!result.ok) {
-              return exitFromIpcResult(result, cmd);
-            }
-
-            const response = result.result ?? { schedules: [] };
+          const description = opts.description.trim();
+          if (!description) {
+            const error = "description is required";
             if (opts.json) {
-              writeOutput(cmd, response);
+              writeOutput(cmd, { ok: false, error });
+            } else {
+              log.error(error);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          const mode = opts.mode ?? "execute";
+          if (mode === "script" && !opts.script) {
+            const error = "--script is required for --mode script";
+            if (opts.json) {
+              writeOutput(cmd, { ok: false, error });
+            } else {
+              log.error(error);
+            }
+            process.exitCode = 1;
+            return;
+          }
+          if (mode === "execute" && !opts.message) {
+            const error = "--message is required for execute mode";
+            if (opts.json) {
+              writeOutput(cmd, { ok: false, error });
+            } else {
+              log.error(error);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          const body: Record<string, unknown> = {
+            name: scheduleName,
+            expression: opts.expression,
+            description,
+            enabled: opts.enabled,
+          };
+          // Omit mode for the default; the route treats absent as 'execute'.
+          if (mode !== "execute") {
+            body.mode = mode;
+          }
+          if (opts.message != null) {
+            body.message = opts.message;
+          }
+          if (opts.script != null) {
+            body.script = opts.script;
+          }
+          if (opts.timeoutMs != null) {
+            body.timeoutMs = Number(opts.timeoutMs);
+          }
+          if (opts.timezone != null) {
+            body.timezone = opts.timezone;
+          }
+          if (opts.profile != null) {
+            body.inferenceProfile = opts.profile;
+          }
+
+          const result = await cliIpcCall<GetScheduleResponse>(
+            "createSchedule",
+            { body },
+          );
+
+          if (!result.ok) {
+            return exitFromIpcResult(result, cmd);
+          }
+
+          if (opts.json) {
+            writeOutput(cmd, result.result ?? {});
+            return;
+          }
+
+          log.info(`Created schedule: ${scheduleName}`);
+        },
+      );
+
+      subcommand(schedules, "update").action(
+        async (
+          id: string,
+          opts: {
+            name?: string;
+            description?: string;
+            expression?: string;
+            timezone?: string;
+            message?: string;
+            script?: string;
+            mode?: string;
+            routingIntent?: string;
+            quiet?: boolean;
+            reuseConversation?: boolean;
+            maxRetries?: string;
+            retryBackoffMs?: string;
+            timeoutMs?: string;
+            clearTimeout?: boolean;
+            profile?: string;
+            clearProfile?: boolean;
+            json?: boolean;
+          },
+          cmd: Command,
+        ) => {
+          const scheduleId = id.trim();
+          const fail = (error: string) => {
+            if (opts.json) {
+              writeOutput(cmd, { ok: false, error });
+            } else {
+              log.error(error);
+            }
+            process.exitCode = 1;
+          };
+
+          const parseInteger = (flag: string, value: string): number | null => {
+            const parsed = Number(value);
+            if (!Number.isInteger(parsed)) {
+              fail(`${flag} must be an integer, got "${value}"`);
+              return null;
+            }
+            return parsed;
+          };
+
+          if (opts.clearTimeout && opts.timeoutMs != null) {
+            fail(
+              "--timeout-ms and --clear-timeout are mutually exclusive; pass --timeout-ms to set a timeout or --clear-timeout to remove it",
+            );
+            return;
+          }
+
+          if (opts.clearProfile && opts.profile != null) {
+            fail(
+              "--profile and --clear-profile are mutually exclusive; pass --profile to set a profile or --clear-profile to revert to the default mainAgent model selection",
+            );
+            return;
+          }
+
+          // Wake mode requires a wake conversation target, which this CLI
+          // cannot set. Allow `--mode wake` only when the schedule already
+          // has one — otherwise the scheduler would skip every fire as a
+          // no-op.
+          if (opts.mode === "wake") {
+            const existing = await cliIpcCall<GetScheduleResponse>(
+              "getSchedule",
+              { pathParams: { id: scheduleId } },
+            );
+            if (!existing.ok) {
+              return exitFromIpcResult(existing, cmd);
+            }
+            if (!existing.result?.schedule.wakeConversationId) {
+              fail(
+                "--mode wake requires the schedule to already have a wake conversation target; this CLI cannot set one. Create wake schedules with the schedule tool instead.",
+              );
               return;
             }
+          }
 
-            log.info(`Updated schedule: ${scheduleId}`);
-          },
-        );
+          const body: Record<string, unknown> = {};
+          if (opts.name != null) {
+            body.name = opts.name;
+          }
+          if (opts.description != null) {
+            body.description = opts.description;
+          }
+          if (opts.expression != null) {
+            body.expression = opts.expression;
+          }
+          if (opts.timezone != null) {
+            body.timezone = opts.timezone;
+          }
+          if (opts.message != null) {
+            body.message = opts.message;
+          }
+          if (opts.script != null) {
+            body.script = opts.script;
+          }
+          if (opts.mode != null) {
+            body.mode = opts.mode;
+          }
+          if (opts.routingIntent != null) {
+            body.routingIntent = opts.routingIntent;
+          }
+          if (opts.quiet != null) {
+            body.quiet = opts.quiet;
+          }
+          if (opts.reuseConversation != null) {
+            body.reuseConversation = opts.reuseConversation;
+          }
+          if (opts.maxRetries != null) {
+            const parsed = parseInteger("--max-retries", opts.maxRetries);
+            if (parsed == null) {
+              return;
+            }
+            body.maxRetries = parsed;
+          }
+          if (opts.retryBackoffMs != null) {
+            const parsed = parseInteger(
+              "--retry-backoff-ms",
+              opts.retryBackoffMs,
+            );
+            if (parsed == null) {
+              return;
+            }
+            body.retryBackoffMs = parsed;
+          }
+          if (opts.timeoutMs != null) {
+            const parsed = parseInteger("--timeout-ms", opts.timeoutMs);
+            if (parsed == null) {
+              return;
+            }
+            body.timeoutMs = parsed;
+          }
+          if (opts.clearTimeout) {
+            body.timeoutMs = null;
+          }
+          if (opts.profile != null) {
+            body.inferenceProfile = opts.profile;
+          }
+          if (opts.clearProfile) {
+            body.inferenceProfile = null;
+          }
 
-      schedules
-        .command("enable <id>")
-        .description("Enable a schedule")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --json   Output the updated schedule list as compact JSON.
+          if (Object.keys(body).length === 0) {
+            fail(
+              "At least one update flag is required. Run 'assistant schedules update --help' for the available flags.",
+            );
+            return;
+          }
 
-Arguments:
-  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
+          const result = await cliIpcCall<ListSchedulesResponse>(
+            "updateSchedule",
+            { pathParams: { id: scheduleId }, body },
+          );
 
-Behavior:
-  Enables the schedule so it can run on future matching times. This does not
-  execute the schedule immediately; use 'assistant schedules execute <id>' for
-  manual run-now behavior.
+          if (!result.ok) {
+            return exitFromIpcResult(result, cmd);
+          }
 
-Examples:
-  $ assistant schedules enable 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant schedules enable 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
-        )
-        .action(async (id: string, opts: { json?: boolean }, cmd: Command) => {
+          const response = result.result ?? { schedules: [] };
+          if (opts.json) {
+            writeOutput(cmd, response);
+            return;
+          }
+
+          log.info(`Updated schedule: ${scheduleId}`);
+        },
+      );
+
+      subcommand(schedules, "enable").action(
+        async (id: string, opts: { json?: boolean }, cmd: Command) => {
           await toggleScheduleEnabled(id, true, opts, cmd);
-        });
+        },
+      );
 
-      schedules
-        .command("disable <id>")
-        .description("Disable a schedule")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --json   Output the updated schedule list as compact JSON.
-
-Arguments:
-  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
-
-Behavior:
-  Disables the schedule so future scheduled fires are skipped until it is
-  enabled again. Existing run history is preserved.
-
-Examples:
-  $ assistant schedules disable 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant schedules disable 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
-        )
-        .action(async (id: string, opts: { json?: boolean }, cmd: Command) => {
+      subcommand(schedules, "disable").action(
+        async (id: string, opts: { json?: boolean }, cmd: Command) => {
           await toggleScheduleEnabled(id, false, opts, cmd);
-        });
+        },
+      );
 
-      schedules
-        .command("cancel <id>")
-        .description("Cancel a pending one-shot schedule")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --json   Output the updated schedule list as compact JSON.
-
-Arguments:
-  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find
-         pending one-shot/deferred schedules.
-
-Behavior:
-  Cancels a pending one-shot schedule. Recurring schedules are not cancellable;
-  use 'assistant schedules disable <id>' to pause recurring schedules.
-
-Examples:
-  $ assistant schedules cancel 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant schedules cancel 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
-        )
-        .action(async (id: string, opts: { json?: boolean }, cmd: Command) => {
+      subcommand(schedules, "cancel").action(
+        async (id: string, opts: { json?: boolean }, cmd: Command) => {
           const scheduleId = id.trim();
           const result = await cliIpcCall<ListSchedulesResponse>(
             "cancelSchedule",
@@ -984,105 +647,64 @@ Examples:
           }
 
           log.info(`Cancelled schedule: ${scheduleId}`);
-        });
+        },
+      );
 
-      schedules
-        .command("delete <id>")
-        .description("Permanently delete a schedule and its run history")
-        .option("--force", "Skip the confirmation prompt")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --force  Skip the destructive y/N confirmation prompt. Required when stdin
-           is not a TTY (e.g. in scripts and CI).
-  --json   Output the updated schedule list as compact JSON.
+      subcommand(schedules, "delete").action(
+        async (
+          id: string,
+          opts: { force?: boolean; json?: boolean },
+          cmd: Command,
+        ) => {
+          const scheduleId = id.trim();
+          if (!scheduleId) {
+            const error = "Schedule ID is required";
+            if (opts.json) {
+              writeOutput(cmd, { ok: false, error });
+            } else {
+              log.error(error);
+            }
+            process.exitCode = 1;
+            return;
+          }
 
-Arguments:
-  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
-
-Behavior:
-  Permanently removes the schedule and its run history. This cannot be undone.
-  To temporarily pause a recurring schedule, use
-  'assistant schedules disable <id>' instead.
-
-Examples:
-  $ assistant schedules delete 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant schedules delete 9f2c4f3a-3f1a-41e4-88e7-abc123 --force
-  $ assistant schedules delete 9f2c4f3a-3f1a-41e4-88e7-abc123 --force --json`,
-        )
-        .action(
-          async (
-            id: string,
-            opts: { force?: boolean; json?: boolean },
-            cmd: Command,
-          ) => {
-            const scheduleId = id.trim();
-            if (!scheduleId) {
-              const error = "Schedule ID is required";
-              if (opts.json) {
-                writeOutput(cmd, { ok: false, error });
-              } else {
-                log.error(error);
-              }
+          if (!opts.force) {
+            const decision = await confirmPrompt({
+              question: `Delete schedule "${scheduleId}"? [y/N] `,
+              isTTY: Boolean(process.stdin.isTTY),
+              refuseNonInteractiveMessage: `Refusing to delete schedule "${scheduleId}" non-interactively. Pass --force to confirm.`,
+            });
+            if (decision === "non-interactive") {
               process.exitCode = 1;
               return;
             }
-
-            if (!opts.force) {
-              const decision = await confirmPrompt({
-                question: `Delete schedule "${scheduleId}"? [y/N] `,
-                isTTY: Boolean(process.stdin.isTTY),
-                refuseNonInteractiveMessage: `Refusing to delete schedule "${scheduleId}" non-interactively. Pass --force to confirm.`,
-              });
-              if (decision === "non-interactive") {
-                process.exitCode = 1;
-                return;
-              }
-              if (decision === "denied") {
-                log.info("Delete cancelled.");
-                return;
-              }
-            }
-
-            const result = await cliIpcCall<ListSchedulesResponse>(
-              "deleteSchedule",
-              { pathParams: { id: scheduleId } },
-            );
-
-            if (!result.ok) {
-              return exitFromIpcResult(result, cmd);
-            }
-
-            const response = result.result ?? { schedules: [] };
-            if (opts.json) {
-              writeOutput(cmd, response);
+            if (decision === "denied") {
+              log.info("Delete cancelled.");
               return;
             }
+          }
 
-            log.info(`Deleted schedule: ${scheduleId}`);
-          },
-        );
+          const result = await cliIpcCall<ListSchedulesResponse>(
+            "deleteSchedule",
+            { pathParams: { id: scheduleId } },
+          );
 
-      schedules
-        .command("execute <id>")
-        .description("Execute a schedule one time immediately")
-        .option("--json", "Machine-readable compact JSON output")
-        .addHelpText(
-          "after",
-          `
-Options:
-  --json   Output the run-now result as compact JSON.
+          if (!result.ok) {
+            return exitFromIpcResult(result, cmd);
+          }
 
-Arguments:
-  <id>   Schedule ID (UUID) — run 'assistant schedules list' to find it.
+          const response = result.result ?? { schedules: [] };
+          if (opts.json) {
+            writeOutput(cmd, response);
+            return;
+          }
 
-Examples:
-  $ assistant schedules execute 9f2c4f3a-3f1a-41e4-88e7-abc123
-  $ assistant schedules execute 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
-        )
-        .action(async (id: string, opts: { json?: boolean }, cmd: Command) => {
+          log.info(`Deleted schedule: ${scheduleId}`);
+        },
+      );
+
+      subcommand(schedules, "execute").action(
+        async (id: string, opts: { json?: boolean }, cmd: Command) => {
           const scheduleId = id.trim();
           if (!scheduleId) {
             const error = "Schedule ID is required";
@@ -1123,7 +745,8 @@ Examples:
           }
 
           log.info(`Executed schedule: ${scheduleId}`);
-        });
+        },
+      );
 
       registerSchedulesWorkerCommand(schedules);
     },

--- a/assistant/src/cli/commands/sequence.help.ts
+++ b/assistant/src/cli/commands/sequence.help.ts
@@ -1,0 +1,183 @@
+/** Declarative help for the `assistant sequence` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const sequenceHelp: CliCommandHelp = {
+  name: "sequence",
+  description: "Manage email sequences",
+  options: [{ flags: "--json", description: "Machine-readable JSON output" }],
+  helpText: `
+Email sequences are automated multi-step email campaigns. Each sequence
+contains ordered steps with configurable delays, subject/body templates,
+and optional approval gates. Contacts are enrolled into a sequence and
+progress through steps on a schedule.
+
+Lifecycle: active -> paused -> active (resume) or active -> archived.
+Enrollments track individual contacts through the sequence with statuses:
+active, paused, completed, replied, cancelled, failed.
+
+Guardrails enforce rate limits, daily send caps, cooldown periods, and
+duplicate enrollment checks to prevent abuse.
+
+Examples:
+  $ assistant sequence list --status active
+  $ assistant sequence get seq_abc123
+  $ assistant sequence pause seq_abc123
+  $ assistant sequence stats`,
+  subcommands: [
+    {
+      name: "list",
+      description: "List all sequences",
+      options: [
+        {
+          flags: "--status <status>",
+          description: "Filter by status (active, paused, archived)",
+        },
+      ],
+      helpText: `
+Lists all sequences with summary info: name, ID, status, step count,
+and active enrollment count.
+
+--status filters by sequence status. Valid values: active, paused, archived.
+If omitted, returns all sequences regardless of status.
+
+Examples:
+  $ assistant sequence list
+  $ assistant sequence list --status active
+  $ assistant sequence list --status paused --json`,
+    },
+    {
+      name: "get",
+      args: "<id>",
+      description: "Get sequence details with enrollment stats",
+      helpText: `
+Arguments:
+  id   The sequence ID (e.g. seq_abc123). Run 'assistant sequence list' to find IDs.
+
+Returns full sequence details: name, status, channel, description, exit-on-reply
+setting, all steps with delay and approval configuration, and enrollment
+breakdown by status (active, paused, completed, replied, cancelled, failed).
+
+Examples:
+  $ assistant sequence get seq_abc123
+  $ assistant sequence get seq_abc123 --json`,
+    },
+    {
+      name: "pause",
+      args: "<id>",
+      description: "Pause a sequence",
+      helpText: `
+Arguments:
+  id   The sequence ID to pause (e.g. seq_abc123). Run 'assistant sequence list' to find IDs.
+
+Pauses a sequence, halting all scheduled step deliveries. Existing active
+enrollments remain in their current state but no new steps will be sent
+until the sequence is resumed. No-op if the sequence is already paused.
+
+Examples:
+  $ assistant sequence pause seq_abc123
+  $ assistant sequence pause seq_abc123 --json`,
+    },
+    {
+      name: "resume",
+      args: "<id>",
+      description: "Resume a paused sequence",
+      helpText: `
+Arguments:
+  id   The sequence ID to resume (e.g. seq_abc123). Run 'assistant sequence list' to find IDs.
+
+Resumes a paused sequence, re-enabling scheduled step deliveries for all
+active enrollments. No-op if the sequence is already active.
+
+Examples:
+  $ assistant sequence resume seq_abc123
+  $ assistant sequence resume seq_abc123 --json`,
+    },
+    {
+      name: "cancel-enrollment",
+      args: "<enrollmentId>",
+      description: "Cancel a specific enrollment",
+      helpText: `
+Arguments:
+  enrollmentId   The enrollment ID to cancel (e.g. enr_xyz789). Run 'assistant sequence get <id>'
+                 to see enrollment IDs for a sequence.
+
+Immediately cancels a specific enrollment, stopping all future step
+deliveries for that contact in this sequence. The enrollment status
+changes to "cancelled". This does not affect the sequence itself or
+other enrollments.
+
+Examples:
+  $ assistant sequence cancel-enrollment enr_xyz789
+  $ assistant sequence cancel-enrollment enr_xyz789 --json`,
+    },
+    {
+      name: "stats",
+      description: "Overall sequence stats",
+      helpText: `
+Returns aggregate statistics across all sequences: total and active
+sequence counts, total and active enrollment counts.
+
+Examples:
+  $ assistant sequence stats
+  $ assistant sequence stats --json`,
+    },
+    {
+      name: "guardrails",
+      description: "View or update guardrail settings",
+      helpText: `
+Guardrails are sequence-specific safety limits that prevent excessive
+sending and protect deliverability. They enforce daily send caps, per-sequence
+hourly rate limits, minimum delays between steps, maximum concurrent active
+enrollments, duplicate enrollment prevention, and cooldown periods.
+
+Examples:
+  $ assistant sequence guardrails show
+  $ assistant sequence guardrails set dailySendCap 200
+  $ assistant sequence guardrails set cooldown_days 7`,
+      subcommands: [
+        {
+          name: "show",
+          description: "Show current guardrail configuration",
+          helpText: `
+Displays the current guardrail configuration with all safety limits:
+
+  Daily send cap          Max emails sent per day across all sequences
+  Hourly rate (per-seq)   Max emails per hour within a single sequence
+  Min step delay          Minimum seconds between consecutive step deliveries
+  Max active enrollments  Max concurrent active enrollments per sequence
+  Duplicate check         Whether duplicate enrollment in the same sequence is blocked
+  Cooldown period         Time before a contact can be re-enrolled after completion
+
+Examples:
+  $ assistant sequence guardrails show
+  $ assistant sequence guardrails show --json`,
+        },
+        {
+          name: "set",
+          args: "<key> <value>",
+          description: "Update a guardrail setting",
+          helpText: `
+Arguments:
+  key     The guardrail setting name (see valid keys below)
+  value   The new value (numeric for limits/caps, true/false for booleans)
+
+Valid keys:
+  dailySendCap (or daily_send_cap)            Max emails sent per day across all sequences (numeric)
+  perSequenceHourlyRate (or hourly_rate)       Max emails per hour per sequence (numeric)
+  minimumStepDelaySec (or min_delay)           Minimum delay in seconds between sequence steps (numeric)
+  maxActiveEnrollments (or max_enrollments)    Max concurrent active enrollments per sequence (numeric)
+  duplicateEnrollmentCheck (or duplicate_check) Prevent enrolling a contact already active in same sequence (true/false)
+  cooldownPeriodMs                             Cooldown period in milliseconds before re-enrolling a contact (numeric)
+  cooldown_days                                Cooldown period in days (converted to ms internally) (numeric)
+
+Examples:
+  $ assistant sequence guardrails set dailySendCap 200
+  $ assistant sequence guardrails set hourly_rate 50
+  $ assistant sequence guardrails set duplicate_check true
+  $ assistant sequence guardrails set cooldown_days 7`,
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/sequence.ts
+++ b/assistant/src/cli/commands/sequence.ts
@@ -7,7 +7,9 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
+import { sequenceHelp } from "./sequence.help.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -32,7 +34,12 @@ interface SequenceSummary {
   id: string;
   name: string;
   status: string;
-  steps: { index: number; subjectTemplate: string; delaySeconds: number; requireApproval?: boolean }[];
+  steps: {
+    index: number;
+    subjectTemplate: string;
+    delaySeconds: number;
+    requireApproval?: boolean;
+  }[];
   activeEnrollments: number;
   description?: string;
   channel?: string;
@@ -54,223 +61,122 @@ interface GuardrailConfig {
 
 export function registerSequenceCommand(program: Command): void {
   registerCommand(program, {
-    name: "sequence",
+    name: sequenceHelp.name,
     transport: "ipc",
-    description: "Manage email sequences",
+    description: sequenceHelp.description,
     build: (seqCmd) => {
-      seqCmd.option("--json", "Machine-readable JSON output");
-
-      seqCmd.addHelpText(
-        "after",
-        `
-Email sequences are automated multi-step email campaigns. Each sequence
-contains ordered steps with configurable delays, subject/body templates,
-and optional approval gates. Contacts are enrolled into a sequence and
-progress through steps on a schedule.
-
-Lifecycle: active -> paused -> active (resume) or active -> archived.
-Enrollments track individual contacts through the sequence with statuses:
-active, paused, completed, replied, cancelled, failed.
-
-Guardrails enforce rate limits, daily send caps, cooldown periods, and
-duplicate enrollment checks to prevent abuse.
-
-Examples:
-  $ assistant sequence list --status active
-  $ assistant sequence get seq_abc123
-  $ assistant sequence pause seq_abc123
-  $ assistant sequence stats`,
-      );
+      applyCommandHelp(seqCmd, sequenceHelp);
 
       // ── list ──────────────────────────────────────────────────────
-      seqCmd
-        .command("list")
-        .description("List all sequences")
-        .option("--status <status>", "Filter by status (active, paused, archived)")
-        .addHelpText(
-          "after",
-          `
-Lists all sequences with summary info: name, ID, status, step count,
-and active enrollment count.
+      subcommand(seqCmd, "list").action(async (opts: { status?: string }) => {
+        const json = resolveJson(seqCmd);
+        const params: Record<string, unknown> = {};
+        if (opts.status) params.status = opts.status;
 
---status filters by sequence status. Valid values: active, paused, archived.
-If omitted, returns all sequences regardless of status.
+        const r = await cliIpcCall<{ sequences: SequenceSummary[] }>(
+          "sequence_list",
+          params,
+        );
+        if (!r.ok) return exitFromIpcResult(r);
 
-Examples:
-  $ assistant sequence list
-  $ assistant sequence list --status active
-  $ assistant sequence list --status paused --json`,
-        )
-        .action(async (opts: { status?: string }) => {
-          const json = resolveJson(seqCmd);
-          const params: Record<string, unknown> = {};
-          if (opts.status) params.status = opts.status;
+        const seqs = r.result!.sequences;
 
-          const r = await cliIpcCall<{ sequences: SequenceSummary[] }>(
-            "sequence_list",
-            params,
+        if (json) {
+          console.log(JSON.stringify({ ok: true, sequences: seqs }));
+          return;
+        }
+
+        if (seqs.length === 0) {
+          process.stdout.write("No sequences found.\n");
+          return;
+        }
+
+        process.stdout.write(`${seqs.length} sequence(s):\n\n`);
+        for (const seq of seqs) {
+          process.stdout.write(
+            `  ${seq.name} (${seq.id}) — ${seq.status}, ${seq.steps.length} steps, ${seq.activeEnrollments} active\n`,
           );
-          if (!r.ok) return exitFromIpcResult(r);
-
-          const seqs = r.result!.sequences;
-
-          if (json) {
-            console.log(JSON.stringify({ ok: true, sequences: seqs }));
-            return;
-          }
-
-          if (seqs.length === 0) {
-            process.stdout.write("No sequences found.\n");
-            return;
-          }
-
-          process.stdout.write(`${seqs.length} sequence(s):\n\n`);
-          for (const seq of seqs) {
-            process.stdout.write(
-              `  ${seq.name} (${seq.id}) — ${seq.status}, ${seq.steps.length} steps, ${seq.activeEnrollments} active\n`,
-            );
-          }
-          process.stdout.write("\n");
-        });
+        }
+        process.stdout.write("\n");
+      });
 
       // ── get ────────────────────────────────────────────────────────
-      seqCmd
-        .command("get <id>")
-        .description("Get sequence details with enrollment stats")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  id   The sequence ID (e.g. seq_abc123). Run 'assistant sequence list' to find IDs.
+      subcommand(seqCmd, "get").action(async (id: string) => {
+        const json = resolveJson(seqCmd);
+        const r = await cliIpcCall<{
+          sequence: SequenceSummary;
+          enrollments: { total: number; byStatus: Record<string, number> };
+        }>("sequence_get", { id });
+        if (!r.ok) return exitFromIpcResult(r);
 
-Returns full sequence details: name, status, channel, description, exit-on-reply
-setting, all steps with delay and approval configuration, and enrollment
-breakdown by status (active, paused, completed, replied, cancelled, failed).
+        const { sequence: seq, enrollments } = r.result!;
 
-Examples:
-  $ assistant sequence get seq_abc123
-  $ assistant sequence get seq_abc123 --json`,
-        )
-        .action(async (id: string) => {
-          const json = resolveJson(seqCmd);
-          const r = await cliIpcCall<{
-            sequence: SequenceSummary;
-            enrollments: { total: number; byStatus: Record<string, number> };
-          }>("sequence_get", { id });
-          if (!r.ok) return exitFromIpcResult(r);
+        if (json) {
+          console.log(JSON.stringify({ ok: true, sequence: seq, enrollments }));
+          return;
+        }
 
-          const { sequence: seq, enrollments } = r.result!;
+        process.stdout.write(`  Name:          ${seq.name}\n`);
+        process.stdout.write(`  ID:            ${seq.id}\n`);
+        process.stdout.write(`  Status:        ${seq.status}\n`);
+        if (seq.channel)
+          process.stdout.write(`  Channel:       ${seq.channel}\n`);
+        if (seq.description)
+          process.stdout.write(`  Description:   ${seq.description}\n`);
+        process.stdout.write(`  Exit on reply: ${seq.exitOnReply}\n`);
+        process.stdout.write(
+          `  Active:        ${seq.activeEnrollments} enrollment(s)\n\n`,
+        );
 
-          if (json) {
-            console.log(JSON.stringify({ ok: true, sequence: seq, enrollments }));
-            return;
-          }
+        process.stdout.write(`  Steps (${seq.steps.length}):\n`);
+        for (const step of seq.steps) {
+          const delay = formatDuration(step.delaySeconds * 1000);
+          const approval = step.requireApproval ? " [approval required]" : "";
+          process.stdout.write(
+            `    ${step.index + 1}. "${step.subjectTemplate}" — delay: ${delay}${approval}\n`,
+          );
+        }
 
-          process.stdout.write(`  Name:          ${seq.name}\n`);
-          process.stdout.write(`  ID:            ${seq.id}\n`);
-          process.stdout.write(`  Status:        ${seq.status}\n`);
-          if (seq.channel) process.stdout.write(`  Channel:       ${seq.channel}\n`);
-          if (seq.description)
-            process.stdout.write(`  Description:   ${seq.description}\n`);
-          process.stdout.write(`  Exit on reply: ${seq.exitOnReply}\n`);
-          process.stdout.write(`  Active:        ${seq.activeEnrollments} enrollment(s)\n\n`);
-
-          process.stdout.write(`  Steps (${seq.steps.length}):\n`);
-          for (const step of seq.steps) {
-            const delay = formatDuration(step.delaySeconds * 1000);
-            const approval = step.requireApproval ? " [approval required]" : "";
-            process.stdout.write(
-              `    ${step.index + 1}. "${step.subjectTemplate}" — delay: ${delay}${approval}\n`,
-            );
-          }
-
-          process.stdout.write(`\n  Enrollments: ${enrollments.total} total\n`);
-          for (const [status, count] of Object.entries(enrollments.byStatus)) {
-            process.stdout.write(`    ${status}: ${count}\n`);
-          }
-          process.stdout.write("\n");
-        });
+        process.stdout.write(`\n  Enrollments: ${enrollments.total} total\n`);
+        for (const [status, count] of Object.entries(enrollments.byStatus)) {
+          process.stdout.write(`    ${status}: ${count}\n`);
+        }
+        process.stdout.write("\n");
+      });
 
       // ── pause ──────────────────────────────────────────────────────
-      seqCmd
-        .command("pause <id>")
-        .description("Pause a sequence")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  id   The sequence ID to pause (e.g. seq_abc123). Run 'assistant sequence list' to find IDs.
-
-Pauses a sequence, halting all scheduled step deliveries. Existing active
-enrollments remain in their current state but no new steps will be sent
-until the sequence is resumed. No-op if the sequence is already paused.
-
-Examples:
-  $ assistant sequence pause seq_abc123
-  $ assistant sequence pause seq_abc123 --json`,
-        )
-        .action(async (id: string) => {
-          const json = resolveJson(seqCmd);
-          const r = await cliIpcCall<{ message: string }>("sequence_pause", { id });
-          if (!r.ok) return exitFromIpcResult(r);
-
-          if (json) {
-            console.log(JSON.stringify({ ok: true, message: r.result!.message }));
-          } else {
-            process.stdout.write(r.result!.message + "\n");
-          }
+      subcommand(seqCmd, "pause").action(async (id: string) => {
+        const json = resolveJson(seqCmd);
+        const r = await cliIpcCall<{ message: string }>("sequence_pause", {
+          id,
         });
+        if (!r.ok) return exitFromIpcResult(r);
+
+        if (json) {
+          console.log(JSON.stringify({ ok: true, message: r.result!.message }));
+        } else {
+          process.stdout.write(r.result!.message + "\n");
+        }
+      });
 
       // ── resume ─────────────────────────────────────────────────────
-      seqCmd
-        .command("resume <id>")
-        .description("Resume a paused sequence")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  id   The sequence ID to resume (e.g. seq_abc123). Run 'assistant sequence list' to find IDs.
-
-Resumes a paused sequence, re-enabling scheduled step deliveries for all
-active enrollments. No-op if the sequence is already active.
-
-Examples:
-  $ assistant sequence resume seq_abc123
-  $ assistant sequence resume seq_abc123 --json`,
-        )
-        .action(async (id: string) => {
-          const json = resolveJson(seqCmd);
-          const r = await cliIpcCall<{ message: string }>("sequence_resume", { id });
-          if (!r.ok) return exitFromIpcResult(r);
-
-          if (json) {
-            console.log(JSON.stringify({ ok: true, message: r.result!.message }));
-          } else {
-            process.stdout.write(r.result!.message + "\n");
-          }
+      subcommand(seqCmd, "resume").action(async (id: string) => {
+        const json = resolveJson(seqCmd);
+        const r = await cliIpcCall<{ message: string }>("sequence_resume", {
+          id,
         });
+        if (!r.ok) return exitFromIpcResult(r);
+
+        if (json) {
+          console.log(JSON.stringify({ ok: true, message: r.result!.message }));
+        } else {
+          process.stdout.write(r.result!.message + "\n");
+        }
+      });
 
       // ── cancel-enrollment ──────────────────────────────────────────
-      seqCmd
-        .command("cancel-enrollment <enrollmentId>")
-        .description("Cancel a specific enrollment")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  enrollmentId   The enrollment ID to cancel (e.g. enr_xyz789). Run 'assistant sequence get <id>'
-                 to see enrollment IDs for a sequence.
-
-Immediately cancels a specific enrollment, stopping all future step
-deliveries for that contact in this sequence. The enrollment status
-changes to "cancelled". This does not affect the sequence itself or
-other enrollments.
-
-Examples:
-  $ assistant sequence cancel-enrollment enr_xyz789
-  $ assistant sequence cancel-enrollment enr_xyz789 --json`,
-        )
-        .action(async (enrollmentId: string) => {
+      subcommand(seqCmd, "cancel-enrollment").action(
+        async (enrollmentId: string) => {
           const json = resolveJson(seqCmd);
           const r = await cliIpcCall<{ message: string }>(
             "sequence_cancel_enrollment",
@@ -279,154 +185,85 @@ Examples:
           if (!r.ok) return exitFromIpcResult(r);
 
           if (json) {
-            console.log(JSON.stringify({ ok: true, message: r.result!.message }));
+            console.log(
+              JSON.stringify({ ok: true, message: r.result!.message }),
+            );
           } else {
             process.stdout.write(r.result!.message + "\n");
           }
-        });
-
-      // ── stats ──────────────────────────────────────────────────────
-      seqCmd
-        .command("stats")
-        .description("Overall sequence stats")
-        .addHelpText(
-          "after",
-          `
-Returns aggregate statistics across all sequences: total and active
-sequence counts, total and active enrollment counts.
-
-Examples:
-  $ assistant sequence stats
-  $ assistant sequence stats --json`,
-        )
-        .action(async () => {
-          const json = resolveJson(seqCmd);
-          const r = await cliIpcCall<{
-            totalSequences: number;
-            activeSequences: number;
-            totalEnrollments: number;
-            activeEnrollments: number;
-          }>("sequence_stats");
-          if (!r.ok) return exitFromIpcResult(r);
-
-          const stats = r.result!;
-
-          if (json) {
-            console.log(JSON.stringify({ ok: true, ...stats }));
-            return;
-          }
-
-          process.stdout.write(`Sequence Stats:\n`);
-          process.stdout.write(
-            `  Sequences:   ${stats.totalSequences} total, ${stats.activeSequences} active\n`,
-          );
-          process.stdout.write(
-            `  Enrollments: ${stats.totalEnrollments} total, ${stats.activeEnrollments} active\n\n`,
-          );
-        });
-
-      // ── guardrails ─────────────────────────────────────────────────
-      const guardrailsCmd = seqCmd
-        .command("guardrails")
-        .description("View or update guardrail settings");
-
-      guardrailsCmd.addHelpText(
-        "after",
-        `
-Guardrails are sequence-specific safety limits that prevent excessive
-sending and protect deliverability. They enforce daily send caps, per-sequence
-hourly rate limits, minimum delays between steps, maximum concurrent active
-enrollments, duplicate enrollment prevention, and cooldown periods.
-
-Examples:
-  $ assistant sequence guardrails show
-  $ assistant sequence guardrails set dailySendCap 200
-  $ assistant sequence guardrails set cooldown_days 7`,
+        },
       );
 
-      guardrailsCmd
-        .command("show")
-        .description("Show current guardrail configuration")
-        .addHelpText(
-          "after",
-          `
-Displays the current guardrail configuration with all safety limits:
+      // ── stats ──────────────────────────────────────────────────────
+      subcommand(seqCmd, "stats").action(async () => {
+        const json = resolveJson(seqCmd);
+        const r = await cliIpcCall<{
+          totalSequences: number;
+          activeSequences: number;
+          totalEnrollments: number;
+          activeEnrollments: number;
+        }>("sequence_stats");
+        if (!r.ok) return exitFromIpcResult(r);
 
-  Daily send cap          Max emails sent per day across all sequences
-  Hourly rate (per-seq)   Max emails per hour within a single sequence
-  Min step delay          Minimum seconds between consecutive step deliveries
-  Max active enrollments  Max concurrent active enrollments per sequence
-  Duplicate check         Whether duplicate enrollment in the same sequence is blocked
-  Cooldown period         Time before a contact can be re-enrolled after completion
+        const stats = r.result!;
 
-Examples:
-  $ assistant sequence guardrails show
-  $ assistant sequence guardrails show --json`,
-        )
-        .action(async () => {
+        if (json) {
+          console.log(JSON.stringify({ ok: true, ...stats }));
+          return;
+        }
+
+        process.stdout.write(`Sequence Stats:\n`);
+        process.stdout.write(
+          `  Sequences:   ${stats.totalSequences} total, ${stats.activeSequences} active\n`,
+        );
+        process.stdout.write(
+          `  Enrollments: ${stats.totalEnrollments} total, ${stats.activeEnrollments} active\n\n`,
+        );
+      });
+
+      // ── guardrails ─────────────────────────────────────────────────
+      const guardrailsCmd = subcommand(seqCmd, "guardrails");
+
+      subcommand(guardrailsCmd, "show").action(async () => {
+        const json = resolveJson(seqCmd);
+        const r = await cliIpcCall<{ config: GuardrailConfig }>(
+          "sequence_guardrails_show",
+        );
+        if (!r.ok) return exitFromIpcResult(r);
+
+        const cfg = r.result!.config;
+
+        if (json) {
+          console.log(JSON.stringify({ ok: true, config: cfg }));
+          return;
+        }
+
+        process.stdout.write("Guardrail Configuration:\n");
+        process.stdout.write(`  Daily send cap:         ${cfg.dailySendCap}\n`);
+        process.stdout.write(
+          `  Hourly rate (per-seq):  ${cfg.perSequenceHourlyRate}\n`,
+        );
+        process.stdout.write(
+          `  Min step delay:         ${cfg.minimumStepDelaySec}s\n`,
+        );
+        process.stdout.write(
+          `  Max active enrollments: ${cfg.maxActiveEnrollments}\n`,
+        );
+        process.stdout.write(
+          `  Duplicate check:        ${cfg.duplicateEnrollmentCheck}\n`,
+        );
+        process.stdout.write(
+          `  Cooldown period:        ${formatDuration(cfg.cooldownPeriodMs)}\n\n`,
+        );
+      });
+
+      subcommand(guardrailsCmd, "set").action(
+        async (key: string, value: string) => {
           const json = resolveJson(seqCmd);
-          const r = await cliIpcCall<{ config: GuardrailConfig }>(
-            "sequence_guardrails_show",
-          );
-          if (!r.ok) return exitFromIpcResult(r);
-
-          const cfg = r.result!.config;
-
-          if (json) {
-            console.log(JSON.stringify({ ok: true, config: cfg }));
-            return;
-          }
-
-          process.stdout.write("Guardrail Configuration:\n");
-          process.stdout.write(`  Daily send cap:         ${cfg.dailySendCap}\n`);
-          process.stdout.write(
-            `  Hourly rate (per-seq):  ${cfg.perSequenceHourlyRate}\n`,
-          );
-          process.stdout.write(
-            `  Min step delay:         ${cfg.minimumStepDelaySec}s\n`,
-          );
-          process.stdout.write(
-            `  Max active enrollments: ${cfg.maxActiveEnrollments}\n`,
-          );
-          process.stdout.write(
-            `  Duplicate check:        ${cfg.duplicateEnrollmentCheck}\n`,
-          );
-          process.stdout.write(
-            `  Cooldown period:        ${formatDuration(cfg.cooldownPeriodMs)}\n\n`,
-          );
-        });
-
-      guardrailsCmd
-        .command("set <key> <value>")
-        .description("Update a guardrail setting")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  key     The guardrail setting name (see valid keys below)
-  value   The new value (numeric for limits/caps, true/false for booleans)
-
-Valid keys:
-  dailySendCap (or daily_send_cap)            Max emails sent per day across all sequences (numeric)
-  perSequenceHourlyRate (or hourly_rate)       Max emails per hour per sequence (numeric)
-  minimumStepDelaySec (or min_delay)           Minimum delay in seconds between sequence steps (numeric)
-  maxActiveEnrollments (or max_enrollments)    Max concurrent active enrollments per sequence (numeric)
-  duplicateEnrollmentCheck (or duplicate_check) Prevent enrolling a contact already active in same sequence (true/false)
-  cooldownPeriodMs                             Cooldown period in milliseconds before re-enrolling a contact (numeric)
-  cooldown_days                                Cooldown period in days (converted to ms internally) (numeric)
-
-Examples:
-  $ assistant sequence guardrails set dailySendCap 200
-  $ assistant sequence guardrails set hourly_rate 50
-  $ assistant sequence guardrails set duplicate_check true
-  $ assistant sequence guardrails set cooldown_days 7`,
-        )
-        .action(async (key: string, value: string) => {
-          const json = resolveJson(seqCmd);
-          const r = await cliIpcCall<{ message: string; config: GuardrailConfig }>(
-            "sequence_guardrails_set",
-            { key, value },
-          );
+          const r = await cliIpcCall<{
+            message: string;
+            config: GuardrailConfig;
+          }>("sequence_guardrails_set", { key, value });
           if (!r.ok) return exitFromIpcResult(r);
 
           if (json) {
@@ -440,7 +277,8 @@ Examples:
           } else {
             process.stdout.write(r.result!.message + "\n");
           }
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/skills.help.ts
+++ b/assistant/src/cli/commands/skills.help.ts
@@ -1,0 +1,159 @@
+/** Declarative help for the `assistant skills` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const skillsHelp: CliCommandHelp = {
+  name: "skills",
+  description: "Browse and install skills from the Vellum catalog",
+  helpText: `
+Manage skills from the Vellum catalog. Skills extend the assistant's
+capabilities with pre-built workflows and tools.
+
+Examples:
+  $ assistant skills list
+  $ assistant skills list --json
+  $ assistant skills inspect slack
+  $ assistant skills inspect resend-setup --json
+  $ assistant skills search react
+  $ assistant skills search react --limit 5 --json
+  $ assistant skills install weather
+  $ assistant skills install weather --overwrite
+  $ assistant skills uninstall weather
+  $ assistant skills add vercel-labs/skills@find-skills
+  $ assistant skills add vercel-labs/skills/find-skills --overwrite`,
+  subcommands: [
+    {
+      name: "list",
+      description: "List bundled and installed skills",
+      options: [
+        { flags: "--json", description: "Machine-readable JSON output" },
+      ],
+      helpText: `
+Lists all bundled and installed skills with their source, state, and
+description. Use 'assistant skills inspect <id>' for detailed metadata
+or 'assistant skills search' to discover catalog skills.
+
+Examples:
+  $ assistant skills list
+  $ assistant skills list --json`,
+    },
+    {
+      name: "inspect",
+      args: "<skill-id>",
+      description: "Show detailed information about a skill",
+      options: [
+        { flags: "--json", description: "Machine-readable JSON output" },
+      ],
+      helpText: `
+Arguments:
+  skill-id   Skill identifier. Run 'assistant skills list' to see available IDs.
+
+Displays detailed metadata about a skill including its source, state,
+description, install metadata (origin, version, content hash), config
+entries, tool manifest, activation hints, and feature flags.
+
+Examples:
+  $ assistant skills inspect slack
+  $ assistant skills inspect resend-setup --json`,
+    },
+    {
+      name: "search",
+      args: "<query>",
+      description:
+        "Search the Vellum catalog, skills.sh, and clawhub community registries",
+      options: [
+        {
+          flags: "--limit <n>",
+          description: "Maximum number of community results",
+          defaultValue: "10",
+        },
+        { flags: "--json", description: "Machine-readable JSON output" },
+      ],
+      helpText: `
+Arguments:
+  query    Free-text search term matched against skill names, descriptions,
+           and tags. Searches the Vellum catalog, the skills.sh community
+           registry, and the clawhub registry.
+
+Displays results from all sources with clear labels. When a skill ID
+exists in both the Vellum catalog and a community registry, a conflict
+note is shown with guidance on which install command to use.
+
+Examples:
+  $ assistant skills search react
+  $ assistant skills search "file management" --limit 3
+  $ assistant skills search deploy --json`,
+    },
+    {
+      name: "install",
+      args: "<skill-id>",
+      description: "Install a skill from the catalog",
+      options: [
+        {
+          flags: "--overwrite",
+          description: "Replace an already installed skill",
+        },
+        { flags: "--json", description: "Machine-readable JSON output" },
+      ],
+      helpText: `
+Arguments:
+  skill-id   Skill identifier from the Vellum catalog. Run 'assistant skills list'
+             to see available IDs. For community skills, use 'assistant skills add'.
+
+Downloads and installs the skill into the workspace skills directory. If the
+skill is already installed, use --overwrite to replace it.
+
+Examples:
+  $ assistant skills install weather
+  $ assistant skills install weather --overwrite
+  $ assistant skills install weather --json`,
+    },
+    {
+      name: "uninstall",
+      args: "<skill-id>",
+      description: "Uninstall a previously installed skill",
+      options: [
+        { flags: "--json", description: "Machine-readable JSON output" },
+      ],
+      helpText: `
+Arguments:
+  skill-id   Skill identifier to remove. Run 'assistant skills list' to see
+             installed skills.
+
+Removes the skill directory from the workspace. This action cannot be undone.
+
+Examples:
+  $ assistant skills uninstall weather
+  $ assistant skills uninstall weather --json`,
+    },
+    {
+      name: "add",
+      args: "<source>",
+      description:
+        "Install a community skill from the skills.sh registry (GitHub)",
+      options: [
+        {
+          flags: "--overwrite",
+          description: "Replace an already installed skill",
+        },
+        { flags: "--json", description: "Machine-readable JSON output" },
+      ],
+      helpText: `
+Arguments:
+  source   Skill source in one of these formats:
+             owner/repo@skill-name
+             owner/repo/skill-name
+             https://github.com/owner/repo/tree/<branch>/skills/skill-name
+
+Notes:
+  Fetches the skill's SKILL.md and supporting files from the specified GitHub
+  repository and installs them into the workspace skills directory. An
+  install-meta.json file is written with origin metadata for provenance tracking.
+
+Examples:
+  $ assistant skills add vercel-labs/skills@find-skills
+  $ assistant skills add vercel-labs/skills/find-skills
+  $ assistant skills add vercel-labs/skills@find-skills --overwrite`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -1,8 +1,10 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { skillsHelp } from "./skills.help.js";
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -48,46 +50,14 @@ function exitFromCliResult(
 
 export function registerSkillsCommand(program: Command): void {
   registerCommand(program, {
-    name: "skills",
+    name: skillsHelp.name,
     transport: "ipc",
-    description: "Browse and install skills from the Vellum catalog",
+    description: skillsHelp.description,
     build: (skills) => {
-      skills.addHelpText(
-        "after",
-        `
-Manage skills from the Vellum catalog. Skills extend the assistant's
-capabilities with pre-built workflows and tools.
+      applyCommandHelp(skills, skillsHelp);
 
-Examples:
-  $ assistant skills list
-  $ assistant skills list --json
-  $ assistant skills inspect slack
-  $ assistant skills inspect resend-setup --json
-  $ assistant skills search react
-  $ assistant skills search react --limit 5 --json
-  $ assistant skills install weather
-  $ assistant skills install weather --overwrite
-  $ assistant skills uninstall weather
-  $ assistant skills add vercel-labs/skills@find-skills
-  $ assistant skills add vercel-labs/skills/find-skills --overwrite`,
-      );
-
-      skills
-        .command("list")
-        .description("List bundled and installed skills")
-        .option("--json", "Machine-readable JSON output")
-        .addHelpText(
-          "after",
-          `
-Lists all bundled and installed skills with their source, state, and
-description. Use 'assistant skills inspect <id>' for detailed metadata
-or 'assistant skills search' to discover catalog skills.
-
-Examples:
-  $ assistant skills list
-  $ assistant skills list --json`,
-        )
-        .action(async (opts: { json?: boolean }, _cmd) => {
+      subcommand(skills, "list").action(
+        async (opts: { json?: boolean }, _cmd) => {
           const r = await cliIpcCall<{
             skills: Array<{
               id: string;
@@ -154,27 +124,11 @@ Examples:
             );
             log.info(`    ${emoji}${s.name} — ${s.description}`);
           }
-        });
+        },
+      );
 
-      skills
-        .command("inspect <skill-id>")
-        .description("Show detailed information about a skill")
-        .option("--json", "Machine-readable JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  skill-id   Skill identifier. Run 'assistant skills list' to see available IDs.
-
-Displays detailed metadata about a skill including its source, state,
-description, install metadata (origin, version, content hash), config
-entries, tool manifest, activation hints, and feature flags.
-
-Examples:
-  $ assistant skills inspect slack
-  $ assistant skills inspect resend-setup --json`,
-        )
-        .action(async (skillId: string, opts: { json?: boolean }, _cmd) => {
+      subcommand(skills, "inspect").action(
+        async (skillId: string, opts: { json?: boolean }, _cmd) => {
           const r = await cliIpcCall<{
             id: string;
             name: string;
@@ -261,268 +215,201 @@ Examples:
                 `    Config keys: ${detail.config.configKeys.join(", ")}`,
               );
           }
-        });
+        },
+      );
 
-      skills
-        .command("search <query>")
-        .description(
-          "Search the Vellum catalog, skills.sh, and clawhub community registries",
-        )
-        .option("--limit <n>", "Maximum number of community results", "10")
-        .option("--json", "Machine-readable JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  query    Free-text search term matched against skill names, descriptions,
-           and tags. Searches the Vellum catalog, the skills.sh community
-           registry, and the clawhub registry.
+      subcommand(skills, "search").action(
+        async (query: string, opts: { limit: string; json?: boolean }) => {
+          const json = opts.json ?? false;
+          const limit = parseInt(opts.limit, 10) || 10;
 
-Displays results from all sources with clear labels. When a skill ID
-exists in both the Vellum catalog and a community registry, a conflict
-note is shown with guidance on which install command to use.
+          // Step 1: Vellum catalog (installed + remote available)
+          const catalogR = await cliIpcCall<{
+            skills: Array<{
+              id: string;
+              name: string;
+              description: string;
+              emoji?: string;
+              origin: string;
+              kind: string;
+              status: string;
+              updatedAt?: string;
+            }>;
+          }>("listSkills", { queryParams: { include: "catalog", q: query } });
+          const vellumSkills = catalogR.ok
+            ? catalogR.result!.skills.filter((s) => s.origin === "vellum")
+            : [];
 
-Examples:
-  $ assistant skills search react
-  $ assistant skills search "file management" --limit 3
-  $ assistant skills search deploy --json`,
-        )
-        .action(
-          async (query: string, opts: { limit: string; json?: boolean }) => {
-            const json = opts.json ?? false;
-            const limit = parseInt(opts.limit, 10) || 10;
+          // Step 2: community (skills.sh with audits + clawhub) + local bundled/installed
+          const communityR = await cliIpcCall<{
+            skills: Array<{
+              id: string;
+              name: string;
+              description: string;
+              emoji?: string;
+              origin: string;
+              kind: string;
+              status: string;
+              slug?: string;
+              author?: string;
+              stars?: number;
+              installs?: number;
+              publishedAt?: string;
+              version?: string;
+              sourceRepo?: string;
+            }>;
+          }>("searchSkills", {
+            queryParams: { q: query, limit: String(limit) },
+          });
+          const communitySkills = communityR.ok
+            ? communityR.result!.skills.filter((s) => s.origin !== "vellum")
+            : [];
 
-            // Step 1: Vellum catalog (installed + remote available)
-            const catalogR = await cliIpcCall<{
-              skills: Array<{
-                id: string;
-                name: string;
-                description: string;
-                emoji?: string;
-                origin: string;
-                kind: string;
-                status: string;
-                updatedAt?: string;
-              }>;
-            }>("listSkills", { queryParams: { include: "catalog", q: query } });
-            const vellumSkills = catalogR.ok
-              ? catalogR.result!.skills.filter((s) => s.origin === "vellum")
-              : [];
+          // Deduplicate by id — vellum wins
+          const seen = new Set(vellumSkills.map((s) => s.id));
+          const dedupedCommunity = communitySkills.filter((s) => {
+            if (seen.has(s.id)) return false;
+            seen.add(s.id);
+            return true;
+          });
+          const clawhubResults = dedupedCommunity
+            .filter((s) => s.origin === "clawhub")
+            .slice(0, limit);
+          const skillsshResults = dedupedCommunity
+            .filter((s) => s.origin === "skillssh")
+            .slice(0, limit);
 
-            // Step 2: community (skills.sh with audits + clawhub) + local bundled/installed
-            const communityR = await cliIpcCall<{
-              skills: Array<{
-                id: string;
-                name: string;
-                description: string;
-                emoji?: string;
-                origin: string;
-                kind: string;
-                status: string;
-                slug?: string;
-                author?: string;
-                stars?: number;
-                installs?: number;
-                publishedAt?: string;
-                version?: string;
-                sourceRepo?: string;
-              }>;
-            }>("searchSkills", {
-              queryParams: { q: query, limit: String(limit) },
-            });
-            const communitySkills = communityR.ok
-              ? communityR.result!.skills.filter((s) => s.origin !== "vellum")
-              : [];
+          const hasResults =
+            vellumSkills.length > 0 ||
+            clawhubResults.length > 0 ||
+            skillsshResults.length > 0;
 
-            // Deduplicate by id — vellum wins
-            const seen = new Set(vellumSkills.map((s) => s.id));
-            const dedupedCommunity = communitySkills.filter((s) => {
-              if (seen.has(s.id)) return false;
-              seen.add(s.id);
-              return true;
-            });
-            const clawhubResults = dedupedCommunity
-              .filter((s) => s.origin === "clawhub")
-              .slice(0, limit);
-            const skillsshResults = dedupedCommunity
-              .filter((s) => s.origin === "skillssh")
-              .slice(0, limit);
+          if (json) {
+            console.log(
+              JSON.stringify({
+                ok: true,
+                catalog: vellumSkills,
+                community: skillsshResults,
+                clawhub: clawhubResults,
+                ...(catalogR.ok ? {} : { catalogError: catalogR.error }),
+                ...(communityR.ok ? {} : { communityError: communityR.error }),
+              }),
+            );
+            return;
+          }
 
-            const hasResults =
-              vellumSkills.length > 0 ||
-              clawhubResults.length > 0 ||
-              skillsshResults.length > 0;
+          if (!hasResults) {
+            log.info(`No skills found for "${query}".`);
+            if (!catalogR.ok)
+              log.warn(`(Vellum catalog unavailable: ${catalogR.error})`);
+            if (!communityR.ok)
+              log.warn(`(Community registry unavailable: ${communityR.error})`);
+            return;
+          }
 
+          if (vellumSkills.length > 0) {
+            log.info(`Vellum catalog (${vellumSkills.length}):\n`);
+            for (const s of vellumSkills) {
+              const emoji = s.emoji ? `${s.emoji} ` : "";
+              const badge = s.kind === "installed" ? " [installed]" : "";
+              log.info(`  ${emoji}${s.name}${badge}`);
+              if (s.name !== s.id) log.info(`    ID: ${s.id}`);
+              log.info(`    ${s.description}`);
+              if (s.updatedAt) log.info(`    Updated: ${s.updatedAt}`);
+              if (s.kind !== "installed")
+                log.info(`    Install: assistant skills install ${s.id}`);
+              log.info("");
+            }
+          }
+
+          if (skillsshResults.length > 0) {
+            log.info(`Community — skills.sh (${skillsshResults.length}):\n`);
+            for (const r of skillsshResults) {
+              const badge = r.kind === "installed" ? " [installed]" : "";
+              log.info(`  ${r.name}${badge}`);
+              if (r.name !== r.id) log.info(`    ID: ${r.id}`);
+              if (r.sourceRepo) log.info(`    Source: ${r.sourceRepo}`);
+              if (r.installs !== undefined)
+                log.info(`    Installs: ${r.installs}`);
+              if (r.kind !== "installed")
+                // Use the fully-qualified 3-segment id (owner/repo/skill) — this
+                // matches the `owner/repo/skill-name` form accepted by
+                // `resolveSkillSource()`. Building `sourceRepo@slug` fails for
+                // skills.sh because the registry returns `slug` as the full id,
+                // producing `owner/repo@owner/repo/skill` which the parser rejects.
+                log.info(`    Install: assistant skills add ${r.id}`);
+              log.info("");
+            }
+          } else if (!communityR.ok) {
+            log.warn(`\n(skills.sh registry unavailable: ${communityR.error})`);
+          }
+
+          if (clawhubResults.length > 0) {
+            log.info(`Community — Clawhub (${clawhubResults.length}):\n`);
+            for (const r of clawhubResults) {
+              const badge = r.kind === "installed" ? " [installed]" : "";
+              log.info(`  ${r.name}${badge}`);
+              if (r.name !== r.id) log.info(`    ID: ${r.id}`);
+              if (r.author) log.info(`    Author: ${r.author}`);
+              if (r.description) log.info(`    ${r.description}`);
+              if (r.stars) log.info(`    Stars: ${r.stars}`);
+              if (r.installs) log.info(`    Installs: ${r.installs}`);
+              if (r.kind !== "installed")
+                log.info(`    Install: npx clawhub install ${r.slug ?? r.id}`);
+              log.info("");
+            }
+          }
+        },
+      );
+
+      subcommand(skills, "install").action(
+        async (
+          skillId: string,
+          opts: { overwrite?: boolean; json?: boolean },
+          _cmd,
+        ) => {
+          const json = opts.json ?? false;
+
+          // Restrict to catalog-only; community installs use `skills add`.
+          const installR = await cliIpcCall<{
+            ok: boolean;
+            skillId?: string;
+          }>("installSkill", {
+            body: {
+              slug: skillId,
+              overwrite: opts.overwrite ?? false,
+              catalogOnly: true,
+            },
+          });
+          if (!installR.ok) {
             if (json) {
               console.log(
                 JSON.stringify({
-                  ok: true,
-                  catalog: vellumSkills,
-                  community: skillsshResults,
-                  clawhub: clawhubResults,
-                  ...(catalogR.ok ? {} : { catalogError: catalogR.error }),
-                  ...(communityR.ok
-                    ? {}
-                    : { communityError: communityR.error }),
+                  ok: false,
+                  error: installR.error,
                 }),
-              );
-              return;
-            }
-
-            if (!hasResults) {
-              log.info(`No skills found for "${query}".`);
-              if (!catalogR.ok)
-                log.warn(`(Vellum catalog unavailable: ${catalogR.error})`);
-              if (!communityR.ok)
-                log.warn(
-                  `(Community registry unavailable: ${communityR.error})`,
-                );
-              return;
-            }
-
-            if (vellumSkills.length > 0) {
-              log.info(`Vellum catalog (${vellumSkills.length}):\n`);
-              for (const s of vellumSkills) {
-                const emoji = s.emoji ? `${s.emoji} ` : "";
-                const badge = s.kind === "installed" ? " [installed]" : "";
-                log.info(`  ${emoji}${s.name}${badge}`);
-                if (s.name !== s.id) log.info(`    ID: ${s.id}`);
-                log.info(`    ${s.description}`);
-                if (s.updatedAt) log.info(`    Updated: ${s.updatedAt}`);
-                if (s.kind !== "installed")
-                  log.info(`    Install: assistant skills install ${s.id}`);
-                log.info("");
-              }
-            }
-
-            if (skillsshResults.length > 0) {
-              log.info(`Community — skills.sh (${skillsshResults.length}):\n`);
-              for (const r of skillsshResults) {
-                const badge = r.kind === "installed" ? " [installed]" : "";
-                log.info(`  ${r.name}${badge}`);
-                if (r.name !== r.id) log.info(`    ID: ${r.id}`);
-                if (r.sourceRepo) log.info(`    Source: ${r.sourceRepo}`);
-                if (r.installs !== undefined)
-                  log.info(`    Installs: ${r.installs}`);
-                if (r.kind !== "installed")
-                  // Use the fully-qualified 3-segment id (owner/repo/skill) — this
-                  // matches the `owner/repo/skill-name` form accepted by
-                  // `resolveSkillSource()`. Building `sourceRepo@slug` fails for
-                  // skills.sh because the registry returns `slug` as the full id,
-                  // producing `owner/repo@owner/repo/skill` which the parser rejects.
-                  log.info(`    Install: assistant skills add ${r.id}`);
-                log.info("");
-              }
-            } else if (!communityR.ok) {
-              log.warn(
-                `\n(skills.sh registry unavailable: ${communityR.error})`,
-              );
-            }
-
-            if (clawhubResults.length > 0) {
-              log.info(`Community — Clawhub (${clawhubResults.length}):\n`);
-              for (const r of clawhubResults) {
-                const badge = r.kind === "installed" ? " [installed]" : "";
-                log.info(`  ${r.name}${badge}`);
-                if (r.name !== r.id) log.info(`    ID: ${r.id}`);
-                if (r.author) log.info(`    Author: ${r.author}`);
-                if (r.description) log.info(`    ${r.description}`);
-                if (r.stars) log.info(`    Stars: ${r.stars}`);
-                if (r.installs) log.info(`    Installs: ${r.installs}`);
-                if (r.kind !== "installed")
-                  log.info(
-                    `    Install: npx clawhub install ${r.slug ?? r.id}`,
-                  );
-                log.info("");
-              }
-            }
-          },
-        );
-
-      skills
-        .command("install <skill-id>")
-        .description("Install a skill from the catalog")
-        .option("--overwrite", "Replace an already installed skill")
-        .option("--json", "Machine-readable JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  skill-id   Skill identifier from the Vellum catalog. Run 'assistant skills list'
-             to see available IDs. For community skills, use 'assistant skills add'.
-
-Downloads and installs the skill into the workspace skills directory. If the
-skill is already installed, use --overwrite to replace it.
-
-Examples:
-  $ assistant skills install weather
-  $ assistant skills install weather --overwrite
-  $ assistant skills install weather --json`,
-        )
-        .action(
-          async (
-            skillId: string,
-            opts: { overwrite?: boolean; json?: boolean },
-            _cmd,
-          ) => {
-            const json = opts.json ?? false;
-
-            // Restrict to catalog-only; community installs use `skills add`.
-            const installR = await cliIpcCall<{
-              ok: boolean;
-              skillId?: string;
-            }>("installSkill", {
-              body: {
-                slug: skillId,
-                overwrite: opts.overwrite ?? false,
-                catalogOnly: true,
-              },
-            });
-            if (!installR.ok) {
-              if (json) {
-                console.log(
-                  JSON.stringify({
-                    ok: false,
-                    error: installR.error,
-                  }),
-                );
-                process.exitCode = 1;
-                return;
-              }
-              log.error(installR.error);
-              log.error(
-                `Run 'assistant skills search ${skillId}' to check available skills.`,
               );
               process.exitCode = 1;
               return;
             }
+            log.error(installR.error);
+            log.error(
+              `Run 'assistant skills search ${skillId}' to check available skills.`,
+            );
+            process.exitCode = 1;
+            return;
+          }
 
-            if (json) {
-              console.log(JSON.stringify({ ok: true, skillId }));
-            } else {
-              log.info(`Installed skill "${skillId}".`);
-            }
-          },
-        );
+          if (json) {
+            console.log(JSON.stringify({ ok: true, skillId }));
+          } else {
+            log.info(`Installed skill "${skillId}".`);
+          }
+        },
+      );
 
-      skills
-        .command("uninstall <skill-id>")
-        .description("Uninstall a previously installed skill")
-        .option("--json", "Machine-readable JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  skill-id   Skill identifier to remove. Run 'assistant skills list' to see
-             installed skills.
-
-Removes the skill directory from the workspace. This action cannot be undone.
-
-Examples:
-  $ assistant skills uninstall weather
-  $ assistant skills uninstall weather --json`,
-        )
-        .action(async (skillId: string, opts: { json?: boolean }, _cmd) => {
+      subcommand(skills, "uninstall").action(
+        async (skillId: string, opts: { json?: boolean }, _cmd) => {
           const r = await cliIpcCall<null>("deleteSkill", {
             pathParams: { id: skillId },
           });
@@ -536,77 +423,52 @@ Examples:
           } else {
             log.info(`Uninstalled skill "${skillId}".`);
           }
-        });
+        },
+      );
 
-      skills
-        .command("add <source>")
-        .description(
-          "Install a community skill from the skills.sh registry (GitHub)",
-        )
-        .option("--overwrite", "Replace an already installed skill")
-        .option("--json", "Machine-readable JSON output")
-        .addHelpText(
-          "after",
-          `
-Arguments:
-  source   Skill source in one of these formats:
-             owner/repo@skill-name
-             owner/repo/skill-name
-             https://github.com/owner/repo/tree/<branch>/skills/skill-name
+      subcommand(skills, "add").action(
+        async (
+          source: string,
+          opts: { overwrite?: boolean; json?: boolean },
+          _cmd,
+        ) => {
+          const json = opts.json ?? false;
 
-Notes:
-  Fetches the skill's SKILL.md and supporting files from the specified GitHub
-  repository and installs them into the workspace skills directory. An
-  install-meta.json file is written with origin metadata for provenance tracking.
-
-Examples:
-  $ assistant skills add vercel-labs/skills@find-skills
-  $ assistant skills add vercel-labs/skills/find-skills
-  $ assistant skills add vercel-labs/skills@find-skills --overwrite`,
-        )
-        .action(
-          async (
-            source: string,
-            opts: { overwrite?: boolean; json?: boolean },
-            _cmd,
-          ) => {
-            const json = opts.json ?? false;
-
-            // `add` is the community-install entry point (skills.sh-flavoured
-            // sources: `owner/repo@skill`, `owner/repo/skill`, or full GitHub
-            // URL). Pass `origin: "skillssh"` so the daemon routes via
-            // `resolveSkillSource()` + `installExternalSkill()` regardless of
-            // slug shape — the auto-detect (`looksLikeSkillsShSlug`) only
-            // recognises 3-segment `/`-delimited slugs, so the `@`-format
-            // documented in the help text otherwise misroutes to clawhub.
-            const r = await cliIpcCall<{ ok: boolean; skillId?: string }>(
-              "installSkill",
-              {
-                body: {
-                  slug: source,
-                  origin: "skillssh",
-                  overwrite: opts.overwrite ?? false,
-                },
+          // `add` is the community-install entry point (skills.sh-flavoured
+          // sources: `owner/repo@skill`, `owner/repo/skill`, or full GitHub
+          // URL). Pass `origin: "skillssh"` so the daemon routes via
+          // `resolveSkillSource()` + `installExternalSkill()` regardless of
+          // slug shape — the auto-detect (`looksLikeSkillsShSlug`) only
+          // recognises 3-segment `/`-delimited slugs, so the `@`-format
+          // documented in the help text otherwise misroutes to clawhub.
+          const r = await cliIpcCall<{ ok: boolean; skillId?: string }>(
+            "installSkill",
+            {
+              body: {
+                slug: source,
+                origin: "skillssh",
+                overwrite: opts.overwrite ?? false,
               },
+            },
+          );
+          if (!r.ok)
+            return exitFromCliResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              json,
             );
-            if (!r.ok)
-              return exitFromCliResult(
-                { ok: false, error: r.error, statusCode: r.statusCode },
-                json,
-              );
 
-            if (json) {
-              console.log(
-                JSON.stringify({
-                  ok: true,
-                  skillId: r.result?.skillId ?? source,
-                }),
-              );
-            } else {
-              log.info(`Installed skill from ${source}.`);
-            }
-          },
-        );
+          if (json) {
+            console.log(
+              JSON.stringify({
+                ok: true,
+                skillId: r.result?.skillId ?? source,
+              }),
+            );
+          } else {
+            log.info(`Installed skill from ${source}.`);
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/status.help.ts
+++ b/assistant/src/cli/commands/status.help.ts
@@ -1,0 +1,8 @@
+/** Declarative help for the `assistant status` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const statusHelp: CliCommandHelp = {
+  name: "status",
+  description: "Show assistant version, workspace, and runtime health",
+};

--- a/assistant/src/cli/commands/status.ts
+++ b/assistant/src/cli/commands/status.ts
@@ -6,7 +6,9 @@ import { cliIpcCall } from "../../ipc/cli-client.js";
 import { getAssistantSocketPath } from "../../ipc/socket-path.js";
 import { getWorkspaceDirDisplay } from "../../util/platform.js";
 import { APP_VERSION } from "../../version.js";
+import { applyCommandHelp } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
+import { statusHelp } from "./status.help.js";
 
 interface HealthResponse {
   version: string;
@@ -21,17 +23,21 @@ function fmtMb(mb: number): string {
 
 export function registerStatusCommand(program: Command): void {
   registerCommand(program, {
-    name: "status",
+    name: statusHelp.name,
     transport: "ipc",
-    description: "Show assistant version, workspace, and runtime health",
+    description: statusHelp.description,
     build: (cmd) => {
+      applyCommandHelp(cmd, statusHelp);
+
       cmd.action(async () => {
         const result = await cliIpcCall<HealthResponse>("health");
 
         if (!result.ok) {
           // Only ENOENT/ECONNREFUSED/connect-timeout produce this prefix; other
           // failures (daemon-side error, framing error, abort) are real failures.
-          if (result.error?.startsWith("Could not connect to the assistant at ")) {
+          if (
+            result.error?.startsWith("Could not connect to the assistant at ")
+          ) {
             const socketPath = getAssistantSocketPath();
             const socketExists = existsSync(socketPath);
             const workspace = getWorkspaceDirDisplay();

--- a/assistant/src/cli/commands/stt.help.ts
+++ b/assistant/src/cli/commands/stt.help.ts
@@ -1,0 +1,52 @@
+/** Declarative help for the `assistant stt` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const sttHelp: CliCommandHelp = {
+  name: "stt",
+  description: "Speech-to-text operations",
+  helpText: `
+Speech-to-text commands use your configured STT provider to transcribe
+audio and video files. The provider is set via:
+
+  $ assistant config set services.stt.provider <provider>
+
+Supported providers: openai-whisper, deepgram, google-gemini, xai.
+
+Examples:
+  $ assistant stt transcribe --file /path/to/meeting.wav
+  $ assistant stt transcribe --file /path/to/video.mp4 --json`,
+  subcommands: [
+    {
+      name: "transcribe",
+      description: "Transcribe an audio or video file to text",
+      options: [
+        {
+          flags: "--file <path>",
+          description: "Absolute path to the audio/video file",
+          required: true,
+        },
+        {
+          flags: "--json",
+          description:
+            "Output structured JSON instead of plain transcript text",
+        },
+      ],
+      helpText: `
+Transcribes an audio or video file using the configured speech-to-text
+provider. Video files automatically have their audio extracted via ffmpeg.
+Large files (>25MB as WAV) are automatically split into chunks and
+transcribed sequentially.
+
+Supported audio formats: .mp3, .wav, .m4a, .aac, .ogg, .flac, .aiff, .wma
+Supported video formats: .mp4, .mov, .avi, .mkv, .webm, .m4v, .mpeg, .mpg
+
+Requires ffmpeg and ffprobe to be installed and on PATH.
+
+Examples:
+  $ assistant stt transcribe --file /path/to/recording.wav
+  $ assistant stt transcribe --file /path/to/meeting.mp4
+  $ assistant stt transcribe --file /path/to/podcast.mp3 --json`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/stt.ts
+++ b/assistant/src/cli/commands/stt.ts
@@ -11,8 +11,10 @@ import { extname, resolve } from "node:path";
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { sttHelp } from "./stt.help.js";
 
 // ---------------------------------------------------------------------------
 // Constants (client-side extension validation only)
@@ -45,57 +47,16 @@ const AUDIO_EXTENSIONS = new Set([
 
 export function registerSttCommand(program: Command): void {
   registerCommand(program, {
-    name: "stt",
+    name: sttHelp.name,
     transport: "ipc",
-    description: "Speech-to-text operations",
+    description: sttHelp.description,
     build: (sttCmd) => {
-      sttCmd.addHelpText(
-        "after",
-        `
-Speech-to-text commands use your configured STT provider to transcribe
-audio and video files. The provider is set via:
-
-  $ assistant config set services.stt.provider <provider>
-
-Supported providers: openai-whisper, deepgram, google-gemini, xai.
-
-Examples:
-  $ assistant stt transcribe --file /path/to/meeting.wav
-  $ assistant stt transcribe --file /path/to/video.mp4 --json`,
-      );
+      applyCommandHelp(sttCmd, sttHelp);
 
       // ── transcribe ──────────────────────────────────────────────────────
 
-      sttCmd
-        .command("transcribe")
-        .description("Transcribe an audio or video file to text")
-        .requiredOption(
-          "--file <path>",
-          "Absolute path to the audio/video file",
-        )
-        .option(
-          "--json",
-          "Output structured JSON instead of plain transcript text",
-        )
-        .addHelpText(
-          "after",
-          `
-Transcribes an audio or video file using the configured speech-to-text
-provider. Video files automatically have their audio extracted via ffmpeg.
-Large files (>25MB as WAV) are automatically split into chunks and
-transcribed sequentially.
-
-Supported audio formats: .mp3, .wav, .m4a, .aac, .ogg, .flac, .aiff, .wma
-Supported video formats: .mp4, .mov, .avi, .mkv, .webm, .m4v, .mpeg, .mpg
-
-Requires ffmpeg and ffprobe to be installed and on PATH.
-
-Examples:
-  $ assistant stt transcribe --file /path/to/recording.wav
-  $ assistant stt transcribe --file /path/to/meeting.mp4
-  $ assistant stt transcribe --file /path/to/podcast.mp3 --json`,
-        )
-        .action(async (opts: { file: string; json?: boolean }) => {
+      subcommand(sttCmd, "transcribe").action(
+        async (opts: { file: string; json?: boolean }) => {
           const filePath = resolve(opts.file);
           const jsonOutput = opts.json ?? false;
 
@@ -165,7 +126,8 @@ Examples:
           } else {
             process.stdout.write(transcript + "\n");
           }
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/telemetry.help.ts
+++ b/assistant/src/cli/commands/telemetry.help.ts
@@ -1,0 +1,14 @@
+/** Declarative help for the `assistant telemetry` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const telemetryHelp: CliCommandHelp = {
+  name: "telemetry",
+  description: "Manage telemetry reporting",
+  subcommands: [
+    {
+      name: "flush",
+      description: "Force-flush all pending telemetry events to the platform",
+    },
+  ],
+};

--- a/assistant/src/cli/commands/telemetry.ts
+++ b/assistant/src/cli/commands/telemetry.ts
@@ -1,40 +1,42 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { telemetryHelp } from "./telemetry.help.js";
 
 export function registerTelemetryCommand(program: Command): void {
   registerCommand(program, {
-    name: "telemetry",
+    name: telemetryHelp.name,
     transport: "ipc",
-    description: "Manage telemetry reporting",
+    description: telemetryHelp.description,
     build: (telemetry) => {
-      telemetry
-        .command("flush")
-        .description(
-          "Force-flush all pending telemetry events to the platform",
-        )
-        .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      applyCommandHelp(telemetry, telemetryHelp);
+
+      subcommand(telemetry, "flush").action(
+        async (_opts: Record<string, unknown>, cmd: Command) => {
           const r = await cliIpcCall<
             { flushed: true } | { flushed: false; reason: string }
           >("telemetry_flush", {});
           if (!r.ok)
-            return exitFromIpcResult({
-              ok: false,
-              error: r.error,
-              statusCode: r.statusCode,
-            }, cmd);
+            return exitFromIpcResult(
+              {
+                ok: false,
+                error: r.error,
+                statusCode: r.statusCode,
+              },
+              cmd,
+            );
 
           const result = r.result!;
           if (result.flushed) {
             log.info("Telemetry flushed successfully.");
           } else {
-            log.info(
-              `Telemetry flush skipped: ${result.reason}`,
-            );
+            log.info(`Telemetry flush skipped: ${result.reason}`);
           }
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/tools-run.ts
+++ b/assistant/src/cli/commands/tools-run.ts
@@ -13,7 +13,7 @@ import { readFileSync } from "node:fs";
 
 import type { Command } from "commander";
 
-import { registerCommand } from "../lib/register-command.js";
+import { subcommand } from "../lib/cli-command-help.js";
 
 /**
  * Resolve the `--input` / `--input-file` options to a parsed JSON object.
@@ -62,53 +62,38 @@ function resolveToolInput(opts: {
 }
 
 export function registerToolsRunCommand(parent: Command): void {
-  registerCommand(parent, {
-    name: "run",
-    transport: "local",
-    description: "Execute a single registered tool directly",
-    build: (run) => {
-      run
-        .argument("<name>", "Name of the registered tool to execute")
-        .option("--input <json>", "Tool input as a JSON object (default: {})")
-        .option(
-          "--input-file <path>",
-          'Read JSON input from a file ("-" reads stdin)',
-        )
-        .option("--json", "Emit the full machine-readable result as JSON")
-        .action(
-          async (
-            name: string,
-            opts: { input?: string; inputFile?: string; json?: boolean },
-          ) => {
-            const input = resolveToolInput(opts);
+  subcommand(parent, "run").action(
+    async (
+      name: string,
+      opts: { input?: string; inputFile?: string; json?: boolean },
+    ) => {
+      const input = resolveToolInput(opts);
 
-            // Deferred: the executor graph loads only when a tool runs.
-            const { runToolStandalone, UnknownToolError } =
-              await import("../../tools/run-standalone.js");
+      // Deferred: the executor graph loads only when a tool runs.
+      const { runToolStandalone, UnknownToolError } =
+        await import("../../tools/run-standalone.js");
 
-            let result;
-            try {
-              result = await runToolStandalone(name, input);
-            } catch (error) {
-              if (error instanceof UnknownToolError) {
-                process.stderr.write(`Error: ${error.message}\n`);
-                process.exit(2);
-              }
-              throw error;
-            }
+      let result;
+      try {
+        result = await runToolStandalone(name, input);
+      } catch (error) {
+        if (error instanceof UnknownToolError) {
+          process.stderr.write(`Error: ${error.message}\n`);
+          process.exit(2);
+        }
+        throw error;
+      }
 
-            if (opts.json) {
-              console.log(JSON.stringify(result, null, 2));
-            } else {
-              console.log(result.content);
-            }
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(result.content);
+      }
 
-            // A tool error exits non-zero so scripts and `&&` chains can react.
-            if (result.isError) {
-              process.exit(1);
-            }
-          },
-        );
+      // A tool error exits non-zero so scripts and `&&` chains can react.
+      if (result.isError) {
+        process.exit(1);
+      }
     },
-  });
+  );
 }

--- a/assistant/src/cli/commands/tools.help.ts
+++ b/assistant/src/cli/commands/tools.help.ts
@@ -1,0 +1,81 @@
+/** Declarative help for the `assistant tools` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const toolsHelp: CliCommandHelp = {
+  name: "tools",
+  description: "Inspect tools registered with the running assistant",
+  helpText: `
+Tools are registered with the daemon from four sources: core built-ins,
+skills, external plugins, and MCP servers. The "source" column reports the
+origin as "core" or "<kind>:<id>" (e.g. "plugin:echo", "skill:my-skill",
+"mcp:linear"). The risk level is the author-asserted default band used for
+permission gating, not the runtime-classified risk of a specific call.
+
+By default the global registry is listed. Pass --conversation to scope the
+list to the tools available to one conversation as of its most recent turn —
+including skill/MCP tools it registered over its lifecycle.
+
+'tools run' executes a single tool directly, outside the agent loop. It runs
+in-process from the filesystem (core built-ins + workspace tools), and is
+non-interactive and non-guardian: read-only / low-risk tools execute, while
+prompt-gated tools are auto-denied (there is no client to approve them). A
+tool error exits non-zero so it composes in scripts.
+
+Examples:
+  $ assistant tools list
+  $ assistant tools ls
+  $ assistant tools list --json
+  $ assistant tools list --conversation conv_abc123
+  $ assistant tools list --agent researcher
+  $ assistant tools list --agent subagent_abc123 --json
+  $ assistant tools run web_fetch --input '{"url":"https://example.com"}'
+  $ assistant tools run file_read --input-file args.json
+  $ echo '{"path":"."}' | assistant tools run list_dir --input-file -`,
+  subcommands: [
+    {
+      name: "list",
+      description: "List all registered tools with their source and risk level",
+      options: [
+        {
+          flags: "--json",
+          description: "Emit machine-readable JSON instead of a table",
+        },
+        {
+          flags: "--conversation <id>",
+          description:
+            "Scope to one conversation's tools as of its most recent turn — run 'assistant conversations list' to find the id",
+        },
+        {
+          flags: "--agent <role|subagent-id>",
+          description:
+            "Show tools available to a subagent role (general, researcher, coder, planner, investigator, advisor) or a live subagent by its id. Simulates the subagent tool projection: role allowlist + subagent-only gating.",
+        },
+      ],
+    },
+    {
+      name: "run",
+      description: "Execute a single registered tool directly",
+      arguments: [
+        {
+          name: "<name>",
+          description: "Name of the registered tool to execute",
+        },
+      ],
+      options: [
+        {
+          flags: "--input <json>",
+          description: "Tool input as a JSON object (default: {})",
+        },
+        {
+          flags: "--input-file <path>",
+          description: 'Read JSON input from a file ("-" reads stdin)',
+        },
+        {
+          flags: "--json",
+          description: "Emit the full machine-readable result as JSON",
+        },
+      ],
+    },
+  ],
+};

--- a/assistant/src/cli/commands/tools.ts
+++ b/assistant/src/cli/commands/tools.ts
@@ -11,7 +11,9 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
+import { toolsHelp } from "./tools.help.js";
 import { registerToolsRunCommand } from "./tools-run.js";
 
 interface ToolListEntry {
@@ -30,107 +32,65 @@ interface ToolsGetResponse {
 
 export function registerToolsCommand(program: Command): void {
   registerCommand(program, {
-    name: "tools",
+    name: toolsHelp.name,
     transport: "ipc",
-    description: "Inspect tools registered with the running assistant",
+    description: toolsHelp.description,
     build: (tools) => {
-      tools.addHelpText(
-        "after",
-        `
-Tools are registered with the daemon from four sources: core built-ins,
-skills, external plugins, and MCP servers. The "source" column reports the
-origin as "core" or "<kind>:<id>" (e.g. "plugin:echo", "skill:my-skill",
-"mcp:linear"). The risk level is the author-asserted default band used for
-permission gating, not the runtime-classified risk of a specific call.
+      applyCommandHelp(tools, toolsHelp);
 
-By default the global registry is listed. Pass --conversation to scope the
-list to the tools available to one conversation as of its most recent turn —
-including skill/MCP tools it registered over its lifecycle.
-
-'tools run' executes a single tool directly, outside the agent loop. It runs
-in-process from the filesystem (core built-ins + workspace tools), and is
-non-interactive and non-guardian: read-only / low-risk tools execute, while
-prompt-gated tools are auto-denied (there is no client to approve them). A
-tool error exits non-zero so it composes in scripts.
-
-Examples:
-  $ assistant tools list
-  $ assistant tools ls
-  $ assistant tools list --json
-  $ assistant tools list --conversation conv_abc123
-  $ assistant tools list --agent researcher
-  $ assistant tools list --agent subagent_abc123 --json
-  $ assistant tools run web_fetch --input '{"url":"https://example.com"}'
-  $ assistant tools run file_read --input-file args.json
-  $ echo '{"path":"."}' | assistant tools run list_dir --input-file -`,
-      );
-
-      tools
-        .command("list")
+      // `list` keeps its `ls` alias imperatively — the help contract cannot
+      // express command aliases.
+      subcommand(tools, "list")
         .alias("ls")
-        .description(
-          "List all registered tools with their source and risk level",
-        )
-        .option("--json", "Emit machine-readable JSON instead of a table")
-        .option(
-          "--conversation <id>",
-          "Scope to one conversation's tools as of its most recent turn — run 'assistant conversations list' to find the id",
-        )
-        .option(
-          "--agent <role|subagent-id>",
-          "Show tools available to a subagent role (general, researcher, coder, planner, investigator, advisor) or a live subagent by its id. Simulates the subagent tool projection: role allowlist + subagent-only gating.",
-        )
         .action(
           async (opts: {
             json?: boolean;
             conversation?: string;
             agent?: string;
           }) => {
-            const response = await cliIpcCall<ToolsGetResponse>(
-              "tools_get",
-              {
-                queryParams: {
-                  ...(opts.conversation
-                    ? { conversationId: opts.conversation }
-                    : {}),
-                  ...(opts.agent ? { agent: opts.agent } : {}),
-                },
+            const response = await cliIpcCall<ToolsGetResponse>("tools_get", {
+              queryParams: {
+                ...(opts.conversation
+                  ? { conversationId: opts.conversation }
+                  : {}),
+                ...(opts.agent ? { agent: opts.agent } : {}),
               },
-            );
-          if (!response.ok) {
-            return exitFromIpcResult(response);
-          }
+            });
+            if (!response.ok) {
+              return exitFromIpcResult(response);
+            }
 
-          const tools = response.result?.tools ?? [];
+            const tools = response.result?.tools ?? [];
 
-          if (opts.json) {
-            console.log(JSON.stringify(tools, null, 2));
-            return;
-          }
+            if (opts.json) {
+              console.log(JSON.stringify(tools, null, 2));
+              return;
+            }
 
-          if (tools.length === 0) {
-            console.log("No tools registered.");
-            return;
-          }
+            if (tools.length === 0) {
+              console.log("No tools registered.");
+              return;
+            }
 
-          const nameW = Math.max(4, ...tools.map((t) => t.name.length));
-          const sourceW = Math.max(6, ...tools.map((t) => t.source.length));
-          const riskW = Math.max(4, ...tools.map((t) => t.riskLevel.length));
+            const nameW = Math.max(4, ...tools.map((t) => t.name.length));
+            const sourceW = Math.max(6, ...tools.map((t) => t.source.length));
+            const riskW = Math.max(4, ...tools.map((t) => t.riskLevel.length));
 
-          console.log(
-            `${"NAME".padEnd(nameW)}  ${"SOURCE".padEnd(sourceW)}  ${"RISK".padEnd(riskW)}  DESCRIPTION`,
-          );
-          for (const t of tools) {
-            const description =
-              t.description.length > 50
-                ? `${t.description.slice(0, 50)}…`
-                : t.description;
             console.log(
-              `${t.name.padEnd(nameW)}  ${t.source.padEnd(sourceW)}  ${t.riskLevel.padEnd(riskW)}  ${description}`,
+              `${"NAME".padEnd(nameW)}  ${"SOURCE".padEnd(sourceW)}  ${"RISK".padEnd(riskW)}  DESCRIPTION`,
             );
-          }
-          console.log(`\n${tools.length} tool(s)`);
-        });
+            for (const t of tools) {
+              const description =
+                t.description.length > 50
+                  ? `${t.description.slice(0, 50)}…`
+                  : t.description;
+              console.log(
+                `${t.name.padEnd(nameW)}  ${t.source.padEnd(sourceW)}  ${t.riskLevel.padEnd(riskW)}  ${description}`,
+              );
+            }
+            console.log(`\n${tools.length} tool(s)`);
+          },
+        );
 
       // `run` executes a tool in-process (transport: "local"), so it lives in
       // its own file and is composed in here as a sibling subcommand.

--- a/assistant/src/cli/commands/trust.help.ts
+++ b/assistant/src/cli/commands/trust.help.ts
@@ -1,0 +1,43 @@
+/** Declarative help for the `assistant trust` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const trustHelp: CliCommandHelp = {
+  name: "trust",
+  description: "View tool trust rules (allow-list patterns for tool use)",
+  helpText: `
+Trust rules define which tool invocations the assistant is allowed to
+execute without prompting. Each rule matches a specific tool and a
+pattern (regular expression) against the tool input.
+
+Examples:
+  $ assistant trust list                List user-modified trust rules
+  $ assistant trust list --all          Include unmodified defaults`,
+  subcommands: [
+    {
+      name: "list",
+      description: "List trust rules",
+      options: [
+        { flags: "--all", description: "Include unmodified default rules" },
+        { flags: "--tool <name>", description: "Filter by tool name" },
+        {
+          flags: "--json",
+          description: "Output result as machine-readable JSON",
+        },
+      ],
+      helpText: `
+Patterns are regular expressions (regex), not globs.
+
+Options:
+  --all           Include unmodified default rules in the output.
+  --tool <name>   Filter results to rules for the named tool.
+  --json          Output as compact JSON instead of a table.
+
+Examples:
+  $ assistant trust list
+  $ assistant trust list --all
+  $ assistant trust list --tool bash
+  $ assistant trust list --json`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/trust.ts
+++ b/assistant/src/cli/commands/trust.ts
@@ -8,8 +8,10 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { trustHelp } from "./trust.help.js";
 
 // -- Types --------------------------------------------------------------------
 
@@ -27,121 +29,92 @@ interface TrustRule {
 
 export function registerTrustCommand(program: Command): void {
   registerCommand(program, {
-    name: "trust",
+    name: trustHelp.name,
     transport: "ipc",
-    description: "View tool trust rules (allow-list patterns for tool use)",
+    description: trustHelp.description,
     build: (trust) => {
+      applyCommandHelp(trust, trustHelp);
 
-  trust.addHelpText(
-    "after",
-    `
-Trust rules define which tool invocations the assistant is allowed to
-execute without prompting. Each rule matches a specific tool and a
-pattern (regular expression) against the tool input.
+      // ── list ──────────────────────────────────────────────────────────────────
 
-Examples:
-  $ assistant trust list                List user-modified trust rules
-  $ assistant trust list --all          Include unmodified defaults`,
-  );
+      subcommand(trust, "list").action(
+        async (opts: { all?: boolean; tool?: string; json?: boolean }) => {
+          const params: Record<string, unknown> = {
+            ...(opts.all ? { include_all: true } : {}),
+            ...(opts.tool ? { tool: opts.tool } : {}),
+          };
 
-  // ── list ──────────────────────────────────────────────────────────────────
-
-  trust
-    .command("list")
-    .description("List trust rules")
-    .option("--all", "Include unmodified default rules")
-    .option("--tool <name>", "Filter by tool name")
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Patterns are regular expressions (regex), not globs.
-
-Options:
-  --all           Include unmodified default rules in the output.
-  --tool <name>   Filter results to rules for the named tool.
-  --json          Output as compact JSON instead of a table.
-
-Examples:
-  $ assistant trust list
-  $ assistant trust list --all
-  $ assistant trust list --tool bash
-  $ assistant trust list --json`,
-    )
-    .action(async (opts: { all?: boolean; tool?: string; json?: boolean }) => {
-      const params: Record<string, unknown> = {
-        ...(opts.all ? { include_all: true } : {}),
-        ...(opts.tool ? { tool: opts.tool } : {}),
-      };
-
-      const result = await cliIpcCall<{ rules: TrustRule[] }>(
-        "trust_rules_list",
-        { body: params },
-      );
-
-      if (!result.ok) {
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: false, error: result.error }) + "\n",
+          const result = await cliIpcCall<{ rules: TrustRule[] }>(
+            "trust_rules_list",
+            { body: params },
           );
-        } else {
-          log.error(result.error ?? "Failed to list trust rules");
-        }
-        process.exitCode = 1;
-        return;
-      }
 
-      if (opts.json) {
-        process.stdout.write(
-          JSON.stringify({ ok: true, data: result.result }) + "\n",
-        );
-        return;
-      }
+          if (!result.ok) {
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: result.error }) + "\n",
+              );
+            } else {
+              log.error(result.error ?? "Failed to list trust rules");
+            }
+            process.exitCode = 1;
+            return;
+          }
 
-      const { rules } = result.result!;
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: true, data: result.result }) + "\n",
+            );
+            return;
+          }
 
-      if (rules.length === 0) {
-        log.info("No trust rules found.");
-        return;
-      }
+          const { rules } = result.result!;
 
-      // Table output
-      const showOrigin = !!opts.all;
-      const header = [
-        "ID",
-        "TOOL",
-        "PATTERN",
-        "RISK",
-        ...(showOrigin ? ["ORIGIN"] : []),
-        "MODIFIED",
-      ];
+          if (rules.length === 0) {
+            log.info("No trust rules found.");
+            return;
+          }
 
-      const rows: string[][] = rules.map((r: TrustRule) => [
-        r.id.slice(0, 16),
-        r.tool,
-        r.pattern,
-        r.risk,
-        ...(showOrigin ? [r.origin] : []),
-        r.updatedAt.slice(0, 10),
-      ]);
+          // Table output
+          const showOrigin = !!opts.all;
+          const header = [
+            "ID",
+            "TOOL",
+            "PATTERN",
+            "RISK",
+            ...(showOrigin ? ["ORIGIN"] : []),
+            "MODIFIED",
+          ];
 
-      // Calculate column widths
-      const colWidths = header.map((h: string, i: number) =>
-        Math.max(h.length, ...rows.map((row: string[]) => row[i].length)),
+          const rows: string[][] = rules.map((r: TrustRule) => [
+            r.id.slice(0, 16),
+            r.tool,
+            r.pattern,
+            r.risk,
+            ...(showOrigin ? [r.origin] : []),
+            r.updatedAt.slice(0, 10),
+          ]);
+
+          // Calculate column widths
+          const colWidths = header.map((h: string, i: number) =>
+            Math.max(h.length, ...rows.map((row: string[]) => row[i].length)),
+          );
+
+          const pad = (s: string, w: number) => s.padEnd(w);
+          const line = header
+            .map((h: string, i: number) => pad(h, colWidths[i]))
+            .join("  ");
+          log.info(line);
+          log.info(colWidths.map((w: number) => "─".repeat(w)).join("  "));
+          for (const row of rows) {
+            log.info(
+              row
+                .map((c: string, i: number) => pad(c, colWidths[i]))
+                .join("  "),
+            );
+          }
+        },
       );
-
-      const pad = (s: string, w: number) => s.padEnd(w);
-      const line = header
-        .map((h: string, i: number) => pad(h, colWidths[i]))
-        .join("  ");
-      log.info(line);
-      log.info(colWidths.map((w: number) => "─".repeat(w)).join("  "));
-      for (const row of rows) {
-        log.info(
-          row.map((c: string, i: number) => pad(c, colWidths[i])).join("  "),
-        );
-      }
-    });
     },
   });
 }

--- a/assistant/src/cli/commands/tts.help.ts
+++ b/assistant/src/cli/commands/tts.help.ts
@@ -1,0 +1,88 @@
+/** Declarative help for the `assistant tts` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const ttsHelp: CliCommandHelp = {
+  name: "tts",
+  description: "Text-to-speech operations",
+  helpText: `
+TTS commands use your configured TTS provider to synthesize text to audio.
+The provider is set via:
+
+  $ assistant config set services.tts.provider <provider>
+
+Built-in providers: elevenlabs, fish-audio, deepgram, xai.
+
+Examples:
+  $ assistant tts synthesize --text "hello world"
+  $ assistant tts synthesize "spoken sentence"
+  $ echo "piped input" | assistant tts synthesize`,
+  subcommands: [
+    {
+      name: "synthesize",
+      description: "Synthesize text to audio using the configured TTS provider",
+      arguments: [
+        {
+          name: "[text...]",
+          description:
+            "Text to synthesize (joined with spaces; alternative to --text or stdin)",
+        },
+      ],
+      options: [
+        {
+          flags: "--text <text>",
+          description:
+            "Text to synthesize to audio (alternative: pass as positional arg or pipe via stdin)",
+        },
+        {
+          flags: "--output <path>",
+          description:
+            "Path to write the audio file (defaults to system temp dir with auto-generated name)",
+        },
+        {
+          flags: "--voice <id>",
+          description:
+            "Provider-specific voice identifier (ElevenLabs voiceId, Fish Audio referenceId, etc.) — overrides configured default",
+        },
+        {
+          flags: "--use-case <case>",
+          description:
+            "Synthesis use case: 'message-playback' (default, higher quality) or 'phone-call' (lower latency)",
+          defaultValue: "message-playback",
+        },
+        {
+          flags: "--json",
+          description: "Output structured JSON instead of plain file path",
+        },
+      ],
+      helpText: `
+Input modes (pick one):
+  --text <text>         Text to synthesize to audio.
+  [text...]             Positional argument(s) joined with spaces.
+  stdin                 Piped input when neither --text nor a positional is given.
+
+Options:
+  --output <path>       Path to write the audio file. When omitted, a file is
+                        written to the system temp directory with a random
+                        name and the extension derived from the provider's
+                        returned MIME type (mp3 for ElevenLabs, wav for
+                        Deepgram/Fish Audio in WAV mode). Parent directories
+                        are created as needed.
+  --voice <id>          Provider-specific voice identifier that overrides the
+                        configured default. Format depends on the provider
+                        (e.g. an ElevenLabs voiceId or a Fish Audio referenceId).
+  --use-case <case>     Synthesis use case — 'message-playback' (default,
+                        higher quality) or 'phone-call' (lower latency).
+  --json                Output a single-line JSON object on stdout instead of
+                        the plain file path. Errors are also emitted as JSON.
+
+Examples:
+  $ assistant tts synthesize --text "hello world"
+  $ assistant tts synthesize "spoken sentence" --output /tmp/out.mp3
+  $ echo "hello" | assistant tts synthesize
+  $ assistant tts synthesize --text "hi" --voice <voice-id>
+  $ assistant tts synthesize --text "hi" --use-case phone-call
+  $ assistant tts synthesize --text "hi" --json`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/tts.ts
+++ b/assistant/src/cli/commands/tts.ts
@@ -14,8 +14,10 @@ import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
 import { readStdinSync } from "../../util/read-stdin.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { ttsHelp } from "./tts.help.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -61,209 +63,135 @@ function extensionForMime(mimeType: string): string {
 
 export function registerTtsCommand(program: Command): void {
   registerCommand(program, {
-    name: "tts",
+    name: ttsHelp.name,
     transport: "ipc",
-    description: "Text-to-speech operations",
+    description: ttsHelp.description,
     build: (ttsCmd) => {
-      const builtinProviders = "elevenlabs, fish-audio, deepgram, xai";
-
-      ttsCmd.addHelpText(
-        "after",
-        `
-TTS commands use your configured TTS provider to synthesize text to audio.
-The provider is set via:
-
-  $ assistant config set services.tts.provider <provider>
-
-Built-in providers: ${builtinProviders}.
-
-Examples:
-  $ assistant tts synthesize --text "hello world"
-  $ assistant tts synthesize "spoken sentence"
-  $ echo "piped input" | assistant tts synthesize`,
-      );
+      applyCommandHelp(ttsCmd, ttsHelp);
 
       // ── synthesize ──────────────────────────────────────────────────────
 
-      ttsCmd
-        .command("synthesize")
-        .description(
-          "Synthesize text to audio using the configured TTS provider",
-        )
-        .option(
-          "--text <text>",
-          "Text to synthesize to audio (alternative: pass as positional arg or pipe via stdin)",
-        )
-        .option(
-          "--output <path>",
-          "Path to write the audio file (defaults to system temp dir with auto-generated name)",
-        )
-        .option(
-          "--voice <id>",
-          "Provider-specific voice identifier (ElevenLabs voiceId, Fish Audio referenceId, etc.) — overrides configured default",
-        )
-        .option(
-          "--use-case <case>",
-          "Synthesis use case: 'message-playback' (default, higher quality) or 'phone-call' (lower latency)",
-          "message-playback",
-        )
-        .option("--json", "Output structured JSON instead of plain file path")
-        .argument(
-          "[text...]",
-          "Text to synthesize (joined with spaces; alternative to --text or stdin)",
-        )
-        .addHelpText(
-          "after",
-          `
-Input modes (pick one):
-  --text <text>         Text to synthesize to audio.
-  [text...]             Positional argument(s) joined with spaces.
-  stdin                 Piped input when neither --text nor a positional is given.
+      subcommand(ttsCmd, "synthesize").action(
+        async (
+          positionalParts: string[],
+          opts: {
+            text?: string;
+            output?: string;
+            voice?: string;
+            useCase: string;
+            json?: boolean;
+          },
+          cmd: Command,
+        ) => {
+          const jsonOutput = opts.json ?? false;
 
-Options:
-  --output <path>       Path to write the audio file. When omitted, a file is
-                        written to the system temp directory with a random
-                        name and the extension derived from the provider's
-                        returned MIME type (mp3 for ElevenLabs, wav for
-                        Deepgram/Fish Audio in WAV mode). Parent directories
-                        are created as needed.
-  --voice <id>          Provider-specific voice identifier that overrides the
-                        configured default. Format depends on the provider
-                        (e.g. an ElevenLabs voiceId or a Fish Audio referenceId).
-  --use-case <case>     Synthesis use case — 'message-playback' (default,
-                        higher quality) or 'phone-call' (lower latency).
-  --json                Output a single-line JSON object on stdout instead of
-                        the plain file path. Errors are also emitted as JSON.
-
-Examples:
-  $ assistant tts synthesize --text "hello world"
-  $ assistant tts synthesize "spoken sentence" --output /tmp/out.mp3
-  $ echo "hello" | assistant tts synthesize
-  $ assistant tts synthesize --text "hi" --voice <voice-id>
-  $ assistant tts synthesize --text "hi" --use-case phone-call
-  $ assistant tts synthesize --text "hi" --json`,
-        )
-        .action(
-          async (
-            positionalParts: string[],
-            opts: {
-              text?: string;
-              output?: string;
-              voice?: string;
-              useCase: string;
-              json?: boolean;
-            },
-            cmd: Command,
-          ) => {
-            const jsonOutput = opts.json ?? false;
-
-            const emitError = (msg: string): void => {
-              if (jsonOutput) {
-                process.stdout.write(
-                  JSON.stringify({ ok: false, error: msg }) + "\n",
-                );
-              } else {
-                log.error(msg);
-              }
-            };
-
-            // Resolve effective text from --text, positional args, or stdin.
-            let messageText =
-              opts.text ??
-              (positionalParts.length > 0 ? positionalParts.join(" ") : "");
-            if (!messageText && !process.stdin.isTTY) {
-              try {
-                messageText = readStdinSync().trim();
-              } catch {
-                /* stdin unavailable */
-              }
-            }
-            if (!messageText) {
-              emitError(
-                "No text provided. Pass --text, a positional argument, or pipe via stdin.",
-              );
-              process.exitCode = 1;
-              return;
-            }
-
-            // Validate --use-case
-            if (!VALID_USE_CASES.includes(opts.useCase as TtsUseCaseCli)) {
-              emitError(
-                `Invalid --use-case: '${opts.useCase}'. Must be one of: ${VALID_USE_CASES.join(", ")}.`,
-              );
-              process.exitCode = 1;
-              return;
-            }
-            const useCase = opts.useCase as TtsUseCaseCli;
-
-            // Call the daemon via IPC.
-            const r = await cliIpcCall<{
-              audioBase64: string;
-              contentType: string;
-            }>("tts_synthesize_cli", {
-              body: {
-                text: messageText,
-                useCase,
-                ...(opts.voice && { voiceId: opts.voice }),
-              },
-            });
-
-            if (!r.ok) {
-              if (jsonOutput) {
-                emitError(r.error ?? "TTS synthesis failed");
-                process.exitCode = 1;
-                return;
-              }
-              return exitFromIpcResult(
-                { ok: false, error: r.error, statusCode: r.statusCode },
-                cmd,
-              );
-            }
-
-            const { audioBase64, contentType } = r.result!;
-
-            // Decode base64 audio.
-            const audioBuffer = Buffer.from(audioBase64, "base64");
-
-            // Determine output file path.
-            const filePath =
-              opts.output ??
-              join(
-                tmpdir(),
-                `vellum-tts-${randomUUID()}.${extensionForMime(contentType)}`,
-              );
-
-            // Write audio to disk.
-            try {
-              const dir = dirname(filePath);
-              if (opts.output) {
-                mkdirSync(dir, { recursive: true });
-              } else if (!existsSync(dir)) {
-                mkdirSync(dir, { recursive: true });
-              }
-
-              writeFileSync(filePath, audioBuffer);
-            } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              emitError(`Failed to write audio to ${filePath}: ${msg}`);
-              process.exitCode = 1;
-              return;
-            }
-
+          const emitError = (msg: string): void => {
             if (jsonOutput) {
               process.stdout.write(
-                JSON.stringify({
-                  ok: true,
-                  path: filePath,
-                  contentType,
-                  sizeBytes: audioBuffer.length,
-                }) + "\n",
+                JSON.stringify({ ok: false, error: msg }) + "\n",
               );
             } else {
-              process.stdout.write(filePath + "\n");
+              log.error(msg);
             }
-          },
-        );
+          };
+
+          // Resolve effective text from --text, positional args, or stdin.
+          let messageText =
+            opts.text ??
+            (positionalParts.length > 0 ? positionalParts.join(" ") : "");
+          if (!messageText && !process.stdin.isTTY) {
+            try {
+              messageText = readStdinSync().trim();
+            } catch {
+              /* stdin unavailable */
+            }
+          }
+          if (!messageText) {
+            emitError(
+              "No text provided. Pass --text, a positional argument, or pipe via stdin.",
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          // Validate --use-case
+          if (!VALID_USE_CASES.includes(opts.useCase as TtsUseCaseCli)) {
+            emitError(
+              `Invalid --use-case: '${opts.useCase}'. Must be one of: ${VALID_USE_CASES.join(", ")}.`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+          const useCase = opts.useCase as TtsUseCaseCli;
+
+          // Call the daemon via IPC.
+          const r = await cliIpcCall<{
+            audioBase64: string;
+            contentType: string;
+          }>("tts_synthesize_cli", {
+            body: {
+              text: messageText,
+              useCase,
+              ...(opts.voice && { voiceId: opts.voice }),
+            },
+          });
+
+          if (!r.ok) {
+            if (jsonOutput) {
+              emitError(r.error ?? "TTS synthesis failed");
+              process.exitCode = 1;
+              return;
+            }
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+          }
+
+          const { audioBase64, contentType } = r.result!;
+
+          // Decode base64 audio.
+          const audioBuffer = Buffer.from(audioBase64, "base64");
+
+          // Determine output file path.
+          const filePath =
+            opts.output ??
+            join(
+              tmpdir(),
+              `vellum-tts-${randomUUID()}.${extensionForMime(contentType)}`,
+            );
+
+          // Write audio to disk.
+          try {
+            const dir = dirname(filePath);
+            if (opts.output) {
+              mkdirSync(dir, { recursive: true });
+            } else if (!existsSync(dir)) {
+              mkdirSync(dir, { recursive: true });
+            }
+
+            writeFileSync(filePath, audioBuffer);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            emitError(`Failed to write audio to ${filePath}: ${msg}`);
+            process.exitCode = 1;
+            return;
+          }
+
+          if (jsonOutput) {
+            process.stdout.write(
+              JSON.stringify({
+                ok: true,
+                path: filePath,
+                contentType,
+                sizeBytes: audioBuffer.length,
+              }) + "\n",
+            );
+          } else {
+            process.stdout.write(filePath + "\n");
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/ui.help.ts
+++ b/assistant/src/cli/commands/ui.help.ts
@@ -1,0 +1,213 @@
+/** Declarative help for the `assistant ui` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+/**
+ * Default request timeout in milliseconds (5 minutes). This is the time
+ * the daemon will wait for the user to respond before the surface
+ * auto-cancels with `status: "timed_out"`.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5m
+
+/**
+ * Default timeout for `ui snapshot` (30s). Sized for a hidden-window render
+ * and capture, not a human response.
+ */
+export const DEFAULT_SNAPSHOT_TIMEOUT_MS = 30_000;
+
+export const uiHelp: CliCommandHelp = {
+  name: "ui",
+  description: "Present interactive UI surfaces to the user",
+  helpText: `
+Script-facing commands that present interactive surfaces (confirmations,
+forms) to the user via the running assistant and block until the user
+responds or the request times out.
+
+The conversation ID is resolved automatically when running inside a skill
+or bash tool context (__SKILL_CONTEXT_JSON or __CONVERSATION_ID).
+Override with --conversation-id if needed.
+
+Examples:
+  $ echo '{"message":"Delete all logs?"}' | assistant ui request --json
+  $ assistant ui confirm --title "Deploy to production?" --message "This will push to prod."
+  $ assistant ui confirm --message "Are you sure?" --json`,
+  subcommands: [
+    {
+      name: "request",
+      description:
+        "Present an interactive surface and block until the user responds",
+      options: [
+        {
+          flags: "--payload <json>",
+          description: "JSON object describing the surface data",
+        },
+        {
+          flags: "--surface-type <type>",
+          description: 'Surface type: "confirmation" or "form"',
+          defaultValue: "confirmation",
+        },
+        {
+          flags: "--title <title>",
+          description: "Title displayed on the surface",
+        },
+        {
+          flags: "--actions <json>",
+          description:
+            "JSON array of action objects defining custom buttons/options",
+        },
+        {
+          flags: "--conversation-id <id>",
+          description:
+            "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill or bash tool context if omitted)",
+        },
+        {
+          flags: "--timeout <ms>",
+          description: "Request timeout in milliseconds",
+          defaultValue: String(DEFAULT_REQUEST_TIMEOUT_MS),
+        },
+        {
+          flags: "--json",
+          description: "Output result as machine-readable JSON",
+        },
+      ],
+      helpText: `
+Sends a UI interaction request to the running assistant and blocks until
+the user responds or the timeout elapses. The payload describes the
+surface content and can be provided via --payload or piped through stdin.
+
+The response includes the user's action (submitted, cancelled, timed_out)
+and any submitted data.
+
+Custom actions can be defined via --actions to control the buttons shown
+on the surface. Each action requires an "id" and "label", with an optional
+"variant" hint ("primary", "danger", or "secondary").
+
+Arguments:
+  (none — payload via --payload flag or stdin)
+
+Options:
+  --payload <json>         JSON object with surface data
+  --surface-type <type>    "confirmation" (default) or "form"
+  --title <title>          Surface title
+  --actions <json>         JSON array of custom action objects
+  --conversation-id <id>   Explicit conversation ID
+  --timeout <ms>           Request timeout in milliseconds (default: 300000)
+  --json                   Output as JSON
+
+Examples:
+  $ echo '{"message":"Proceed?"}' | assistant ui request
+  $ assistant ui request --payload '{"message":"Proceed?"}' --json
+  $ assistant ui request --payload '{"fields":[]}' --surface-type form --json
+  $ assistant ui request --payload '{"message":"Choose an option"}' \\
+      --actions '[{"id":"approve","label":"Approve","variant":"primary"},{"id":"reject","label":"Reject","variant":"danger"}]'`,
+    },
+    {
+      name: "confirm",
+      description:
+        "Present a yes/no confirmation prompt; exits 0 on confirm, 1 on deny/cancel/timeout",
+      options: [
+        {
+          flags: "--title <title>",
+          description: "Title displayed on the confirmation prompt",
+        },
+        {
+          flags: "--message <message>",
+          description: "Message body shown in the confirmation prompt",
+        },
+        {
+          flags: "--confirm-label <label>",
+          description: 'Label for the confirm button (default: "Confirm")',
+          defaultValue: "Confirm",
+        },
+        {
+          flags: "--deny-label <label>",
+          description: 'Label for the deny button (default: "Deny")',
+          defaultValue: "Deny",
+        },
+        {
+          flags: "--conversation-id <id>",
+          description:
+            "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill or bash tool context if omitted)",
+        },
+        {
+          flags: "--timeout <ms>",
+          description: "Request timeout in milliseconds",
+          defaultValue: String(DEFAULT_REQUEST_TIMEOUT_MS),
+        },
+        {
+          flags: "--json",
+          description: "Output result as machine-readable JSON",
+        },
+      ],
+      helpText: `
+Ergonomic wrapper around "ui request" for binary yes/no gating. Presents
+a confirmation surface to the user and blocks until they respond.
+
+Exit codes:
+  0  — User confirmed
+  1  — User denied, cancelled, or the request timed out
+
+The --json flag outputs the full interaction result for scripts that need
+to inspect the response details.
+
+Options:
+  --title <title>            Prompt title
+  --message <message>        Prompt body text
+  --confirm-label <label>    Confirm button label (default: "Confirm")
+  --deny-label <label>       Deny button label (default: "Deny")
+  --conversation-id <id>     Explicit conversation ID
+  --timeout <ms>             Request timeout in ms (default: 300000)
+  --json                     Output as JSON
+
+Examples:
+  $ assistant ui confirm --message "Delete all data?"
+  $ assistant ui confirm --title "Deploy" --message "Push to prod?" --json
+  $ assistant ui confirm --message "Proceed?" --confirm-label "Yes" --deny-label "No"`,
+    },
+    {
+      name: "snapshot",
+      description:
+        "Capture a PNG of a staged app view with the current workspace theme applied",
+      options: [
+        {
+          flags: "--view <view>",
+          description: 'Staged composition to capture: "sampler" or "chat"',
+          defaultValue: "sampler",
+        },
+        {
+          flags: "--out <path>",
+          description: "File path to write the PNG to",
+        },
+        {
+          flags: "--timeout <ms>",
+          description: "How long to wait for the desktop client capture",
+          defaultValue: String(DEFAULT_SNAPSHOT_TIMEOUT_MS),
+        },
+        {
+          flags: "--json",
+          description:
+            "Output result as machine-readable JSON (PNG inline as base64)",
+        },
+      ],
+      helpText: `
+Asks the connected desktop app to render a staged view of its own UI —
+fixed generic content, no user data — with the workspace theme from
+ui/theme.json applied, capture it offscreen, and return the PNG. Use it
+to see theming work without asking the user for screenshots.
+
+Views:
+  sampler  Dense style sheet: text ramp, accent, buttons, card, inputs,
+           borders, chat bubbles. Answers "does the palette read".
+  chat     A staged conversation with a composer. Answers "does it feel
+           like the app".
+
+Requires the desktop app to be running. If the workspace theme file is
+invalid, the capture shows the built-in theme and the validation issues
+are printed.
+
+Examples:
+  $ assistant ui snapshot --view sampler --out /tmp/theme-sampler.png
+  $ assistant ui snapshot --view chat --out /tmp/theme-chat.png`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/ui.ts
+++ b/assistant/src/cli/commands/ui.ts
@@ -26,18 +26,17 @@ import type {
 } from "../../runtime/interactive-ui-types.js";
 import type { UiSnapshotResult } from "../../runtime/routes/ui-snapshot-routes.js";
 import { readStdinSync } from "../../util/read-stdin.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { resolveConversationId } from "../utils/conversation-id.js";
+import {
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  DEFAULT_SNAPSHOT_TIMEOUT_MS,
+  uiHelp,
+} from "./ui.help.js";
 
 // ── Constants ─────────────────────────────────────────────────────────
-
-/**
- * Default request timeout in milliseconds (5 minutes). This is the time
- * the daemon will wait for the user to respond before the surface
- * auto-cancels with `status: "timed_out"`.
- */
-const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5m
 
 /**
  * Extra buffer added to the IPC call timeout beyond the request timeout
@@ -45,12 +44,6 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5m
  * surface and send the response.
  */
 const IPC_TIMEOUT_BUFFER_MS = 10_000; // 10s
-
-/**
- * Default timeout for `ui snapshot` (30s). Sized for a hidden-window render
- * and capture, not a human response.
- */
-const DEFAULT_SNAPSHOT_TIMEOUT_MS = 30_000;
 
 const CONV_ID_HELP =
   "No conversation ID available.\n" +
@@ -256,572 +249,400 @@ function parseStrictPositiveInt(value: string): number {
 
 export function registerUiCommand(program: Command): void {
   registerCommand(program, {
-    name: "ui",
+    name: uiHelp.name,
     transport: "ipc",
-    description: "Present interactive UI surfaces to the user",
+    description: uiHelp.description,
     build: (ui) => {
-      ui.addHelpText(
-        "after",
-        `
-Script-facing commands that present interactive surfaces (confirmations,
-forms) to the user via the running assistant and block until the user
-responds or the request times out.
-
-The conversation ID is resolved automatically when running inside a skill
-or bash tool context (__SKILL_CONTEXT_JSON or __CONVERSATION_ID).
-Override with --conversation-id if needed.
-
-Examples:
-  $ echo '{"message":"Delete all logs?"}' | assistant ui request --json
-  $ assistant ui confirm --title "Deploy to production?" --message "This will push to prod."
-  $ assistant ui confirm --message "Are you sure?" --json`,
-      );
+      applyCommandHelp(ui, uiHelp);
 
       // ── ui request ───────────────────────────────────────────────────
 
-      ui.command("request")
-        .description(
-          "Present an interactive surface and block until the user responds",
-        )
-        .option("--payload <json>", "JSON object describing the surface data")
-        .option(
-          "--surface-type <type>",
-          'Surface type: "confirmation" or "form"',
-          "confirmation",
-        )
-        .option("--title <title>", "Title displayed on the surface")
-        .option(
-          "--actions <json>",
-          "JSON array of action objects defining custom buttons/options",
-        )
-        .option(
-          "--conversation-id <id>",
-          "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill or bash tool context if omitted)",
-        )
-        .option(
-          "--timeout <ms>",
-          "Request timeout in milliseconds",
-          String(DEFAULT_REQUEST_TIMEOUT_MS),
-        )
-        .option("--json", "Output result as machine-readable JSON")
-        .addHelpText(
-          "after",
-          `
-Sends a UI interaction request to the running assistant and blocks until
-the user responds or the timeout elapses. The payload describes the
-surface content and can be provided via --payload or piped through stdin.
-
-The response includes the user's action (submitted, cancelled, timed_out)
-and any submitted data.
-
-Custom actions can be defined via --actions to control the buttons shown
-on the surface. Each action requires an "id" and "label", with an optional
-"variant" hint ("primary", "danger", or "secondary").
-
-Arguments:
-  (none — payload via --payload flag or stdin)
-
-Options:
-  --payload <json>         JSON object with surface data
-  --surface-type <type>    "confirmation" (default) or "form"
-  --title <title>          Surface title
-  --actions <json>         JSON array of custom action objects
-  --conversation-id <id>   Explicit conversation ID
-  --timeout <ms>           Request timeout in milliseconds (default: 300000)
-  --json                   Output as JSON
-
-Examples:
-  $ echo '{"message":"Proceed?"}' | assistant ui request
-  $ assistant ui request --payload '{"message":"Proceed?"}' --json
-  $ assistant ui request --payload '{"fields":[]}' --surface-type form --json
-  $ assistant ui request --payload '{"message":"Choose an option"}' \\
-      --actions '[{"id":"approve","label":"Approve","variant":"primary"},{"id":"reject","label":"Reject","variant":"danger"}]'`,
-        )
-        .action(
-          async (opts: {
-            payload?: string;
-            surfaceType?: string;
-            title?: string;
-            actions?: string;
-            conversationId?: string;
-            timeout?: string;
-            json?: boolean;
-          }) => {
-            // Parse payload
-            let data: Record<string, unknown>;
-            try {
-              data = readPayload(opts.payload);
-            } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              if (opts.json) {
-                process.stdout.write(
-                  JSON.stringify({ ok: false, error: msg }) + "\n",
-                );
-              } else {
-                log.error(msg);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            // Resolve conversation ID
-            let conversationId: string;
-            try {
-              conversationId = resolveConversationId({
-                explicit: opts.conversationId,
-                failureHelp: CONV_ID_HELP,
-              });
-            } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              if (opts.json) {
-                process.stdout.write(
-                  JSON.stringify({ ok: false, error: msg }) + "\n",
-                );
-              } else {
-                log.error(msg);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            // Parse actions (if provided)
-            let actions: InteractiveUiAction[] | undefined;
-            if (opts.actions !== undefined) {
-              try {
-                actions = parseActions(opts.actions);
-              } catch (err) {
-                const msg = err instanceof Error ? err.message : String(err);
-                if (opts.json) {
-                  process.stdout.write(
-                    JSON.stringify({ ok: false, error: msg }) + "\n",
-                  );
-                } else {
-                  log.error(msg);
-                }
-                process.exitCode = 1;
-                return;
-              }
-            }
-
-            // Parse timeout
-            const rawTimeout =
-              opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
-            const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
-            if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
-              const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
-              if (opts.json) {
-                process.stdout.write(
-                  JSON.stringify({ ok: false, error: msg }) + "\n",
-                );
-              } else {
-                log.error(msg);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            // Build IPC params
-            const ipcParams: Record<string, unknown> = {
-              conversationId,
-              surfaceType: opts.surfaceType ?? "confirmation",
-              data,
-              timeoutMs: requestTimeoutMs,
-            };
-            if (opts.title) {
-              ipcParams.title = opts.title;
-            }
-            if (actions) {
-              ipcParams.actions = actions;
-            }
-
-            // Call IPC with timeout budget = request timeout + buffer
-            const ipcTimeoutMs = requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS;
-            const result = await cliIpcCall<InteractiveUiResult>(
-              "ui_request",
-              { body: ipcParams },
-              {
-                timeoutMs: ipcTimeoutMs,
-              },
-            );
-
-            if (!result.ok) {
-              if (opts.json) {
-                process.stdout.write(
-                  JSON.stringify({ ok: false, error: result.error }) + "\n",
-                );
-              } else {
-                log.error(`Error: ${result.error}`);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
+      subcommand(ui, "request").action(
+        async (opts: {
+          payload?: string;
+          surfaceType?: string;
+          title?: string;
+          actions?: string;
+          conversationId?: string;
+          timeout?: string;
+          json?: boolean;
+        }) => {
+          // Parse payload
+          let data: Record<string, unknown>;
+          try {
+            data = readPayload(opts.payload);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
             if (opts.json) {
               process.stdout.write(
-                JSON.stringify({ ok: true, ...result.result }) + "\n",
+                JSON.stringify({ ok: false, error: msg }) + "\n",
               );
             } else {
-              const r = result.result!;
-              if (r.status === "submitted") {
-                log.info(
-                  `User responded: ${r.actionId ?? "submitted"}${r.summary ? ` — ${r.summary}` : ""}`,
-                );
-              } else if (r.status === "timed_out") {
-                log.info("Request timed out without a response.");
-              } else {
-                log.info("Request was cancelled.");
-              }
+              log.error(msg);
             }
-          },
-        );
+            process.exitCode = 1;
+            return;
+          }
+
+          // Resolve conversation ID
+          let conversationId: string;
+          try {
+            conversationId = resolveConversationId({
+              explicit: opts.conversationId,
+              failureHelp: CONV_ID_HELP,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: msg }) + "\n",
+              );
+            } else {
+              log.error(msg);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          // Parse actions (if provided)
+          let actions: InteractiveUiAction[] | undefined;
+          if (opts.actions !== undefined) {
+            try {
+              actions = parseActions(opts.actions);
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              if (opts.json) {
+                process.stdout.write(
+                  JSON.stringify({ ok: false, error: msg }) + "\n",
+                );
+              } else {
+                log.error(msg);
+              }
+              process.exitCode = 1;
+              return;
+            }
+          }
+
+          // Parse timeout
+          const rawTimeout = opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
+          const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
+          if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
+            const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: msg }) + "\n",
+              );
+            } else {
+              log.error(msg);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          // Build IPC params
+          const ipcParams: Record<string, unknown> = {
+            conversationId,
+            surfaceType: opts.surfaceType ?? "confirmation",
+            data,
+            timeoutMs: requestTimeoutMs,
+          };
+          if (opts.title) {
+            ipcParams.title = opts.title;
+          }
+          if (actions) {
+            ipcParams.actions = actions;
+          }
+
+          // Call IPC with timeout budget = request timeout + buffer
+          const ipcTimeoutMs = requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS;
+          const result = await cliIpcCall<InteractiveUiResult>(
+            "ui_request",
+            { body: ipcParams },
+            {
+              timeoutMs: ipcTimeoutMs,
+            },
+          );
+
+          if (!result.ok) {
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: result.error }) + "\n",
+              );
+            } else {
+              log.error(`Error: ${result.error}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: true, ...result.result }) + "\n",
+            );
+          } else {
+            const r = result.result!;
+            if (r.status === "submitted") {
+              log.info(
+                `User responded: ${r.actionId ?? "submitted"}${r.summary ? ` — ${r.summary}` : ""}`,
+              );
+            } else if (r.status === "timed_out") {
+              log.info("Request timed out without a response.");
+            } else {
+              log.info("Request was cancelled.");
+            }
+          }
+        },
+      );
 
       // ── ui confirm ──────────────────────────────────────────────────
 
-      ui.command("confirm")
-        .description(
-          "Present a yes/no confirmation prompt; exits 0 on confirm, 1 on deny/cancel/timeout",
-        )
-        .option("--title <title>", "Title displayed on the confirmation prompt")
-        .option(
-          "--message <message>",
-          "Message body shown in the confirmation prompt",
-        )
-        .option(
-          "--confirm-label <label>",
-          'Label for the confirm button (default: "Confirm")',
-          "Confirm",
-        )
-        .option(
-          "--deny-label <label>",
-          'Label for the deny button (default: "Deny")',
-          "Deny",
-        )
-        .option(
-          "--conversation-id <id>",
-          "Conversation ID — run 'assistant conversations list' to find it (auto-resolved from skill or bash tool context if omitted)",
-        )
-        .option(
-          "--timeout <ms>",
-          "Request timeout in milliseconds",
-          String(DEFAULT_REQUEST_TIMEOUT_MS),
-        )
-        .option("--json", "Output result as machine-readable JSON")
-        .addHelpText(
-          "after",
-          `
-Ergonomic wrapper around "ui request" for binary yes/no gating. Presents
-a confirmation surface to the user and blocks until they respond.
-
-Exit codes:
-  0  — User confirmed
-  1  — User denied, cancelled, or the request timed out
-
-The --json flag outputs the full interaction result for scripts that need
-to inspect the response details.
-
-Options:
-  --title <title>            Prompt title
-  --message <message>        Prompt body text
-  --confirm-label <label>    Confirm button label (default: "Confirm")
-  --deny-label <label>       Deny button label (default: "Deny")
-  --conversation-id <id>     Explicit conversation ID
-  --timeout <ms>             Request timeout in ms (default: 300000)
-  --json                     Output as JSON
-
-Examples:
-  $ assistant ui confirm --message "Delete all data?"
-  $ assistant ui confirm --title "Deploy" --message "Push to prod?" --json
-  $ assistant ui confirm --message "Proceed?" --confirm-label "Yes" --deny-label "No"`,
-        )
-        .action(
-          async (opts: {
-            title?: string;
-            message?: string;
-            confirmLabel?: string;
-            denyLabel?: string;
-            conversationId?: string;
-            timeout?: string;
-            json?: boolean;
-          }) => {
-            // Resolve conversation ID
-            let conversationId: string;
-            try {
-              conversationId = resolveConversationId({
-                explicit: opts.conversationId,
-                failureHelp: CONV_ID_HELP,
-              });
-            } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              if (opts.json) {
-                process.stdout.write(
-                  JSON.stringify({ ok: false, error: msg }) + "\n",
-                );
-              } else {
-                log.error(msg);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            // Parse timeout
-            const rawTimeout =
-              opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
-            const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
-            if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
-              const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
-              if (opts.json) {
-                process.stdout.write(
-                  JSON.stringify({ ok: false, error: msg }) + "\n",
-                );
-              } else {
-                log.error(msg);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            // Build confirmation surface data
-            const confirmLabel = opts.confirmLabel ?? "Confirm";
-            const denyLabel = opts.denyLabel ?? "Deny";
-            const data: Record<string, unknown> = {};
-            if (opts.message) data.message = opts.message;
-            // Pass custom labels via data payload so the renderer reads them
-            // from ConfirmationSurfaceData.confirmLabel / .cancelLabel.
-            data.confirmLabel = confirmLabel;
-            data.cancelLabel = denyLabel;
-
-            // Build IPC params
-            const ipcParams: Record<string, unknown> = {
-              conversationId,
-              surfaceType: "confirmation",
-              data,
-              actions: [
-                {
-                  id: "confirm",
-                  label: confirmLabel,
-                  variant: "primary",
-                },
-                {
-                  id: "deny",
-                  label: denyLabel,
-                  variant: "secondary",
-                },
-              ],
-              timeoutMs: requestTimeoutMs,
-            };
-            if (opts.title) {
-              ipcParams.title = opts.title;
-            }
-
-            // Call IPC with timeout budget
-            const ipcTimeoutMs = requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS;
-            const result = await cliIpcCall<InteractiveUiResult>(
-              "ui_request",
-              { body: ipcParams },
-              {
-                timeoutMs: ipcTimeoutMs,
-              },
-            );
-
-            if (!result.ok) {
-              if (opts.json) {
-                process.stdout.write(
-                  JSON.stringify({ ok: false, error: result.error }) + "\n",
-                );
-              } else {
-                log.error(`Error: ${result.error}`);
-              }
-              process.exitCode = 1;
-              return;
-            }
-
-            const r = result.result!;
-            const confirmed =
-              r.status === "submitted" && r.actionId === "confirm";
-
+      subcommand(ui, "confirm").action(
+        async (opts: {
+          title?: string;
+          message?: string;
+          confirmLabel?: string;
+          denyLabel?: string;
+          conversationId?: string;
+          timeout?: string;
+          json?: boolean;
+        }) => {
+          // Resolve conversation ID
+          let conversationId: string;
+          try {
+            conversationId = resolveConversationId({
+              explicit: opts.conversationId,
+              failureHelp: CONV_ID_HELP,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
             if (opts.json) {
-              const jsonOut: Record<string, unknown> = {
-                ok: true,
-                confirmed,
-                status: r.status,
-                actionId: r.actionId,
-                surfaceId: r.surfaceId,
-              };
-              if (r.decisionToken !== undefined) {
-                jsonOut.decisionToken = r.decisionToken;
-              }
-              if (r.summary !== undefined) {
-                jsonOut.summary = r.summary;
-              }
-              process.stdout.write(JSON.stringify(jsonOut) + "\n");
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: msg }) + "\n",
+              );
             } else {
-              if (confirmed) {
-                log.info("Confirmed.");
-              } else if (r.status === "timed_out") {
-                log.info("Confirmation timed out.");
-              } else if (r.status === "cancelled") {
-                log.info("Confirmation cancelled.");
-              } else {
-                log.info("Denied.");
-              }
+              log.error(msg);
             }
+            process.exitCode = 1;
+            return;
+          }
 
-            if (!confirmed) {
-              process.exitCode = 1;
+          // Parse timeout
+          const rawTimeout = opts.timeout ?? String(DEFAULT_REQUEST_TIMEOUT_MS);
+          const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
+          if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
+            const msg = `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`;
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: msg }) + "\n",
+              );
+            } else {
+              log.error(msg);
             }
-          },
-        );
+            process.exitCode = 1;
+            return;
+          }
+
+          // Build confirmation surface data
+          const confirmLabel = opts.confirmLabel ?? "Confirm";
+          const denyLabel = opts.denyLabel ?? "Deny";
+          const data: Record<string, unknown> = {};
+          if (opts.message) data.message = opts.message;
+          // Pass custom labels via data payload so the renderer reads them
+          // from ConfirmationSurfaceData.confirmLabel / .cancelLabel.
+          data.confirmLabel = confirmLabel;
+          data.cancelLabel = denyLabel;
+
+          // Build IPC params
+          const ipcParams: Record<string, unknown> = {
+            conversationId,
+            surfaceType: "confirmation",
+            data,
+            actions: [
+              {
+                id: "confirm",
+                label: confirmLabel,
+                variant: "primary",
+              },
+              {
+                id: "deny",
+                label: denyLabel,
+                variant: "secondary",
+              },
+            ],
+            timeoutMs: requestTimeoutMs,
+          };
+          if (opts.title) {
+            ipcParams.title = opts.title;
+          }
+
+          // Call IPC with timeout budget
+          const ipcTimeoutMs = requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS;
+          const result = await cliIpcCall<InteractiveUiResult>(
+            "ui_request",
+            { body: ipcParams },
+            {
+              timeoutMs: ipcTimeoutMs,
+            },
+          );
+
+          if (!result.ok) {
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: result.error }) + "\n",
+              );
+            } else {
+              log.error(`Error: ${result.error}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          const r = result.result!;
+          const confirmed =
+            r.status === "submitted" && r.actionId === "confirm";
+
+          if (opts.json) {
+            const jsonOut: Record<string, unknown> = {
+              ok: true,
+              confirmed,
+              status: r.status,
+              actionId: r.actionId,
+              surfaceId: r.surfaceId,
+            };
+            if (r.decisionToken !== undefined) {
+              jsonOut.decisionToken = r.decisionToken;
+            }
+            if (r.summary !== undefined) {
+              jsonOut.summary = r.summary;
+            }
+            process.stdout.write(JSON.stringify(jsonOut) + "\n");
+          } else {
+            if (confirmed) {
+              log.info("Confirmed.");
+            } else if (r.status === "timed_out") {
+              log.info("Confirmation timed out.");
+            } else if (r.status === "cancelled") {
+              log.info("Confirmation cancelled.");
+            } else {
+              log.info("Denied.");
+            }
+          }
+
+          if (!confirmed) {
+            process.exitCode = 1;
+          }
+        },
+      );
 
       // ── ui snapshot ─────────────────────────────────────────────────
 
-      ui.command("snapshot")
-        .description(
-          "Capture a PNG of a staged app view with the current workspace theme applied",
-        )
-        .option(
-          "--view <view>",
-          'Staged composition to capture: "sampler" or "chat"',
-          "sampler",
-        )
-        .option("--out <path>", "File path to write the PNG to")
-        .option(
-          "--timeout <ms>",
-          "How long to wait for the desktop client capture",
-          String(DEFAULT_SNAPSHOT_TIMEOUT_MS),
-        )
-        .option(
-          "--json",
-          "Output result as machine-readable JSON (PNG inline as base64)",
-        )
-        .addHelpText(
-          "after",
-          `
-Asks the connected desktop app to render a staged view of its own UI —
-fixed generic content, no user data — with the workspace theme from
-ui/theme.json applied, capture it offscreen, and return the PNG. Use it
-to see theming work without asking the user for screenshots.
-
-Views:
-  sampler  Dense style sheet: text ramp, accent, buttons, card, inputs,
-           borders, chat bubbles. Answers "does the palette read".
-  chat     A staged conversation with a composer. Answers "does it feel
-           like the app".
-
-Requires the desktop app to be running. If the workspace theme file is
-invalid, the capture shows the built-in theme and the validation issues
-are printed.
-
-Examples:
-  $ assistant ui snapshot --view sampler --out /tmp/theme-sampler.png
-  $ assistant ui snapshot --view chat --out /tmp/theme-chat.png`,
-        )
-        .action(
-          async (opts: {
-            view?: string;
-            out?: string;
-            timeout?: string;
-            json?: boolean;
-          }) => {
-            const emitError = (msg: string): void => {
-              if (opts.json) {
-                process.stdout.write(
-                  JSON.stringify({ ok: false, error: msg }) + "\n",
-                );
-              } else {
-                log.error(msg);
-              }
-              process.exitCode = 1;
-            };
-
-            const view = opts.view ?? "sampler";
-            if (view !== "sampler" && view !== "chat") {
-              emitError(
-                `Invalid --view value "${view}". Must be "sampler" or "chat".`,
-              );
-              return;
-            }
-
-            if (!opts.out && !opts.json) {
-              emitError(
-                "Provide --out <path> to write the PNG (or --json for inline base64 output).",
-              );
-              return;
-            }
-
-            const rawTimeout =
-              opts.timeout ?? String(DEFAULT_SNAPSHOT_TIMEOUT_MS);
-            const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
-            if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
-              emitError(
-                `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`,
-              );
-              return;
-            }
-
-            const result = await cliIpcCall<UiSnapshotResult>(
-              "ui_snapshot",
-              { body: { view, timeoutMs: requestTimeoutMs } },
-              { timeoutMs: requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS },
-            );
-
-            if (!result.ok) {
-              emitError(`Error: ${result.error}`);
-              return;
-            }
-
-            const snapshot = result.result!;
-
-            if (snapshot.themeSource === "invalid" && !opts.json) {
-              log.warn(
-                "The workspace theme file is invalid — the capture shows the built-in theme.",
-              );
-              for (const issue of snapshot.themeIssues) {
-                log.warn(`  - ${issue}`);
-              }
-            }
-
-            if (!snapshot.ok || !snapshot.pngBase64) {
-              emitError(snapshot.error ?? "The capture returned no image.");
-              return;
-            }
-
-            if (opts.out) {
-              try {
-                writeFileSync(
-                  String(opts.out),
-                  Buffer.from(snapshot.pngBase64, "base64"),
-                );
-              } catch (err) {
-                const msg = err instanceof Error ? err.message : String(err);
-                emitError(`Failed to write PNG to ${opts.out}: ${msg}`);
-                return;
-              }
-            }
-
+      subcommand(ui, "snapshot").action(
+        async (opts: {
+          view?: string;
+          out?: string;
+          timeout?: string;
+          json?: boolean;
+        }) => {
+          const emitError = (msg: string): void => {
             if (opts.json) {
-              const jsonOut: Record<string, unknown> = {
-                ok: true,
-                view,
-                widthPx: snapshot.widthPx,
-                heightPx: snapshot.heightPx,
-                themeSource: snapshot.themeSource,
-                themeIssues: snapshot.themeIssues,
-              };
-              if (opts.out) {
-                jsonOut.out = opts.out;
-              } else {
-                jsonOut.pngBase64 = snapshot.pngBase64;
-              }
-              process.stdout.write(JSON.stringify(jsonOut) + "\n");
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: msg }) + "\n",
+              );
             } else {
-              const dims =
-                snapshot.widthPx && snapshot.heightPx
-                  ? ` (${snapshot.widthPx}x${snapshot.heightPx})`
-                  : "";
-              log.info(`Snapshot saved to ${opts.out}${dims}`);
+              log.error(msg);
             }
-          },
-        );
+            process.exitCode = 1;
+          };
+
+          const view = opts.view ?? "sampler";
+          if (view !== "sampler" && view !== "chat") {
+            emitError(
+              `Invalid --view value "${view}". Must be "sampler" or "chat".`,
+            );
+            return;
+          }
+
+          if (!opts.out && !opts.json) {
+            emitError(
+              "Provide --out <path> to write the PNG (or --json for inline base64 output).",
+            );
+            return;
+          }
+
+          const rawTimeout =
+            opts.timeout ?? String(DEFAULT_SNAPSHOT_TIMEOUT_MS);
+          const requestTimeoutMs = parseStrictPositiveInt(rawTimeout);
+          if (isNaN(requestTimeoutMs) || requestTimeoutMs <= 0) {
+            emitError(
+              `Invalid --timeout value "${opts.timeout}". Must be a positive integer (milliseconds).`,
+            );
+            return;
+          }
+
+          const result = await cliIpcCall<UiSnapshotResult>(
+            "ui_snapshot",
+            { body: { view, timeoutMs: requestTimeoutMs } },
+            { timeoutMs: requestTimeoutMs + IPC_TIMEOUT_BUFFER_MS },
+          );
+
+          if (!result.ok) {
+            emitError(`Error: ${result.error}`);
+            return;
+          }
+
+          const snapshot = result.result!;
+
+          if (snapshot.themeSource === "invalid" && !opts.json) {
+            log.warn(
+              "The workspace theme file is invalid — the capture shows the built-in theme.",
+            );
+            for (const issue of snapshot.themeIssues) {
+              log.warn(`  - ${issue}`);
+            }
+          }
+
+          if (!snapshot.ok || !snapshot.pngBase64) {
+            emitError(snapshot.error ?? "The capture returned no image.");
+            return;
+          }
+
+          if (opts.out) {
+            try {
+              writeFileSync(
+                String(opts.out),
+                Buffer.from(snapshot.pngBase64, "base64"),
+              );
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              emitError(`Failed to write PNG to ${opts.out}: ${msg}`);
+              return;
+            }
+          }
+
+          if (opts.json) {
+            const jsonOut: Record<string, unknown> = {
+              ok: true,
+              view,
+              widthPx: snapshot.widthPx,
+              heightPx: snapshot.heightPx,
+              themeSource: snapshot.themeSource,
+              themeIssues: snapshot.themeIssues,
+            };
+            if (opts.out) {
+              jsonOut.out = opts.out;
+            } else {
+              jsonOut.pngBase64 = snapshot.pngBase64;
+            }
+            process.stdout.write(JSON.stringify(jsonOut) + "\n");
+          } else {
+            const dims =
+              snapshot.widthPx && snapshot.heightPx
+                ? ` (${snapshot.widthPx}x${snapshot.heightPx})`
+                : "";
+            log.info(`Snapshot saved to ${opts.out}${dims}`);
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/usage.help.ts
+++ b/assistant/src/cli/commands/usage.help.ts
@@ -1,0 +1,147 @@
+/** Declarative help for the `assistant usage` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const usageHelp: CliCommandHelp = {
+  name: "usage",
+  description: "Query LLM token usage and cost data",
+  helpText: `
+Queries LLM usage event data via the daemon to display token consumption
+and cost data. Requires the assistant to be running.
+
+Time range can be specified with --range presets (today, week, month, all)
+or explicit --from / --to epoch-millisecond timestamps.
+
+Examples:
+  $ assistant usage totals
+  $ assistant usage daily --range week
+  $ assistant usage breakdown --group-by provider
+  $ assistant usage totals --range all --json`,
+  subcommands: [
+    {
+      name: "totals",
+      isDefault: true,
+      description: "Aggregate totals for a time range",
+      options: [
+        {
+          flags: "-r, --range <preset>",
+          description: "Time range preset: today, week, month, all",
+          defaultValue: "today",
+        },
+        {
+          flags: "--from <epoch_ms>",
+          description: "Start of range (epoch ms)",
+        },
+        { flags: "--to <epoch_ms>", description: "End of range (epoch ms)" },
+        {
+          flags: "--schedule <id>",
+          description:
+            "Filter to a schedule id — run 'assistant schedules list' to find it; attributes usage by that schedule's cron run windows",
+        },
+        { flags: "--json", description: "Output raw JSON" },
+      ],
+      helpText: `
+Shows aggregate token counts and estimated cost across all LLM calls
+within the time range.
+
+Columns: estimated cost, LLM call count, input/output tokens, cache
+creation/read tokens, unpriced event count (if any).
+
+Pass --schedule <id> to restrict totals to a single schedule's cron run
+windows. Find schedule ids with 'assistant schedules list'.
+
+Examples:
+  $ assistant usage totals
+  $ assistant usage totals --range all
+  $ assistant usage totals --schedule sched-abc123
+  $ assistant usage totals --from 1709856000000 --to 1709942400000`,
+    },
+    {
+      name: "daily",
+      description: "Per-day token and cost breakdown",
+      options: [
+        {
+          flags: "-r, --range <preset>",
+          description: "Time range preset: today, week, month, all",
+          defaultValue: "today",
+        },
+        {
+          flags: "--from <epoch_ms>",
+          description: "Start of range (epoch ms)",
+        },
+        { flags: "--to <epoch_ms>", description: "End of range (epoch ms)" },
+        {
+          flags: "--schedule <id>",
+          description:
+            "Filter to a schedule id — run 'assistant schedules list' to find it; attributes usage by that schedule's cron run windows",
+        },
+        { flags: "--json", description: "Output raw JSON" },
+      ],
+      helpText: `
+Shows one row per day (UTC) with input tokens, output tokens, estimated
+cost, and LLM call count.
+
+Pass --schedule <id> to restrict the breakdown to a single schedule's cron
+run windows. Find schedule ids with 'assistant schedules list'.
+
+Examples:
+  $ assistant usage daily
+  $ assistant usage daily --range week
+  $ assistant usage daily --schedule sched-abc123
+  $ assistant usage daily --range month --json`,
+    },
+    {
+      name: "breakdown",
+      description:
+        "Grouped breakdown by task, profile, provider, model, or conversation",
+      options: [
+        {
+          flags: "-r, --range <preset>",
+          description: "Time range preset: today, week, month, all",
+          defaultValue: "today",
+        },
+        {
+          flags: "--from <epoch_ms>",
+          description: "Start of range (epoch ms)",
+        },
+        { flags: "--to <epoch_ms>", description: "End of range (epoch ms)" },
+        {
+          flags: "--schedule <id>",
+          description:
+            "Filter to a schedule id — run 'assistant schedules list' to find it; attributes usage by that schedule's cron run windows",
+        },
+        { flags: "--json", description: "Output raw JSON" },
+        {
+          flags: "-g, --group-by <dimension>",
+          description:
+            "Grouping dimension: call_site, inference_profile, provider, model, conversation, actor",
+          defaultValue: "model",
+        },
+      ],
+      helpText: `
+Grouping dimensions:
+  call_site          Groups by user-facing task (Main Agent, Memory Extraction,
+                     Conversation Title, etc.)
+  inference_profile  Groups by inference profile; unset historical rows are
+                     shown as Default / Unset
+  provider           Groups by LLM provider (anthropic, openai, etc.)
+  model              Groups by model name (claude-sonnet-4-20250514, etc.)
+  conversation       Groups by conversation ID
+  actor              Legacy/internal subsystem grouping (main_agent, etc.)
+
+Shows one row per group with input/output tokens, estimated cost, and
+call count. Rows are sorted by cost descending.
+
+Pass --schedule <id> to restrict the breakdown to a single schedule's cron
+run windows. Find schedule ids with 'assistant schedules list'.
+
+Examples:
+  $ assistant usage breakdown
+  $ assistant usage breakdown --group-by call_site
+  $ assistant usage breakdown --group-by inference_profile
+  $ assistant usage breakdown --group-by provider
+  $ assistant usage breakdown --schedule sched-abc123
+  $ assistant usage breakdown --group-by actor --range week`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/usage.ts
+++ b/assistant/src/cli/commands/usage.ts
@@ -1,9 +1,11 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { formatCostUsd } from "../lib/cli-output.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { usageHelp } from "./usage.help.js";
 
 // ── Formatting helpers ───────────────────────────────────────────
 
@@ -204,218 +206,97 @@ const VALID_GROUP_BY_DIMENSIONS = [
 
 export function registerUsageCommand(program: Command): void {
   registerCommand(program, {
-    name: "usage",
+    name: usageHelp.name,
     transport: "ipc",
-    description: "Query LLM token usage and cost data",
+    description: usageHelp.description,
     build: (usage) => {
-      usage.addHelpText(
-        "after",
-        `
-Queries LLM usage event data via the daemon to display token consumption
-and cost data. Requires the assistant to be running.
+      applyCommandHelp(usage, usageHelp);
 
-Time range can be specified with --range presets (today, week, month, all)
-or explicit --from / --to epoch-millisecond timestamps.
-
-Examples:
-  $ assistant usage totals
-  $ assistant usage daily --range week
-  $ assistant usage breakdown --group-by provider
-  $ assistant usage totals --range all --json`,
+      subcommand(usage, "totals").action(
+        async (opts: {
+          range: string;
+          from?: string;
+          to?: string;
+          schedule?: string;
+          json?: boolean;
+        }) => {
+          const { from, to } = resolveRange(opts);
+          const response = await cliIpcCall<UsageTotals>("usage_totals", {
+            queryParams: buildUsageQueryParams(from, to, opts.schedule),
+          });
+          if (!response.ok) {
+            return exitFromIpcResult(response);
+          }
+          const totals = response.result!;
+          if (opts.json) {
+            log.info(JSON.stringify(totals, null, 2));
+          } else {
+            printTotalsTable(totals);
+          }
+        },
       );
 
-      const rangeOption = [
-        "-r, --range <preset>",
-        "Time range preset: today, week, month, all",
-        "today",
-      ] as const;
-      const fromOption = [
-        "--from <epoch_ms>",
-        "Start of range (epoch ms)",
-      ] as const;
-      const toOption = ["--to <epoch_ms>", "End of range (epoch ms)"] as const;
-      const jsonOption = ["--json", "Output raw JSON"] as const;
-      const scheduleOption = [
-        "--schedule <id>",
-        "Filter to a schedule id — run 'assistant schedules list' to find it; attributes usage by that schedule's cron run windows",
-      ] as const;
+      subcommand(usage, "daily").action(
+        async (opts: {
+          range: string;
+          from?: string;
+          to?: string;
+          schedule?: string;
+          json?: boolean;
+        }) => {
+          const { from, to } = resolveRange(opts);
+          const response = await cliIpcCall<{ buckets: UsageDayBucket[] }>(
+            "usage_daily",
+            { queryParams: buildUsageQueryParams(from, to, opts.schedule) },
+          );
+          if (!response.ok) {
+            return exitFromIpcResult(response);
+          }
+          const { buckets } = response.result!;
+          if (opts.json) {
+            log.info(JSON.stringify({ buckets }, null, 2));
+          } else {
+            printDailyTable(buckets);
+          }
+        },
+      );
 
-      usage
-        .command("totals", { isDefault: true })
-        .description("Aggregate totals for a time range")
-        .option(...rangeOption)
-        .option(...fromOption)
-        .option(...toOption)
-        .option(...scheduleOption)
-        .option(...jsonOption)
-        .addHelpText(
-          "after",
-          `
-Shows aggregate token counts and estimated cost across all LLM calls
-within the time range.
-
-Columns: estimated cost, LLM call count, input/output tokens, cache
-creation/read tokens, unpriced event count (if any).
-
-Pass --schedule <id> to restrict totals to a single schedule's cron run
-windows. Find schedule ids with 'assistant schedules list'.
-
-Examples:
-  $ assistant usage totals
-  $ assistant usage totals --range all
-  $ assistant usage totals --schedule sched-abc123
-  $ assistant usage totals --from 1709856000000 --to 1709942400000`,
-        )
-        .action(
-          async (opts: {
-            range: string;
-            from?: string;
-            to?: string;
-            schedule?: string;
-            json?: boolean;
-          }) => {
-            const { from, to } = resolveRange(opts);
-            const response = await cliIpcCall<UsageTotals>("usage_totals", {
-              queryParams: buildUsageQueryParams(from, to, opts.schedule),
-            });
-            if (!response.ok) {
-              return exitFromIpcResult(response);
-            }
-            const totals = response.result!;
-            if (opts.json) {
-              log.info(JSON.stringify(totals, null, 2));
-            } else {
-              printTotalsTable(totals);
-            }
-          },
-        );
-
-      usage
-        .command("daily")
-        .description("Per-day token and cost breakdown")
-        .option(...rangeOption)
-        .option(...fromOption)
-        .option(...toOption)
-        .option(...scheduleOption)
-        .option(...jsonOption)
-        .addHelpText(
-          "after",
-          `
-Shows one row per day (UTC) with input tokens, output tokens, estimated
-cost, and LLM call count.
-
-Pass --schedule <id> to restrict the breakdown to a single schedule's cron
-run windows. Find schedule ids with 'assistant schedules list'.
-
-Examples:
-  $ assistant usage daily
-  $ assistant usage daily --range week
-  $ assistant usage daily --schedule sched-abc123
-  $ assistant usage daily --range month --json`,
-        )
-        .action(
-          async (opts: {
-            range: string;
-            from?: string;
-            to?: string;
-            schedule?: string;
-            json?: boolean;
-          }) => {
-            const { from, to } = resolveRange(opts);
-            const response = await cliIpcCall<{ buckets: UsageDayBucket[] }>(
-              "usage_daily",
-              { queryParams: buildUsageQueryParams(from, to, opts.schedule) },
+      subcommand(usage, "breakdown").action(
+        async (opts: {
+          range: string;
+          from?: string;
+          to?: string;
+          schedule?: string;
+          json?: boolean;
+          groupBy: string;
+        }) => {
+          const validDimensions = new Set<string>(VALID_GROUP_BY_DIMENSIONS);
+          if (!validDimensions.has(opts.groupBy)) {
+            log.error(
+              `Invalid --group-by value: '${opts.groupBy}'. Must be one of: ${VALID_GROUP_BY_DIMENSIONS.join(", ")}`,
             );
-            if (!response.ok) {
-              return exitFromIpcResult(response);
-            }
-            const { buckets } = response.result!;
-            if (opts.json) {
-              log.info(JSON.stringify({ buckets }, null, 2));
-            } else {
-              printDailyTable(buckets);
-            }
-          },
-        );
-
-      usage
-        .command("breakdown")
-        .description(
-          "Grouped breakdown by task, profile, provider, model, or conversation",
-        )
-        .option(...rangeOption)
-        .option(...fromOption)
-        .option(...toOption)
-        .option(...scheduleOption)
-        .option(...jsonOption)
-        .option(
-          "-g, --group-by <dimension>",
-          "Grouping dimension: call_site, inference_profile, provider, model, conversation, actor",
-          "model",
-        )
-        .addHelpText(
-          "after",
-          `
-Grouping dimensions:
-  call_site          Groups by user-facing task (Main Agent, Memory Extraction,
-                     Conversation Title, etc.)
-  inference_profile  Groups by inference profile; unset historical rows are
-                     shown as Default / Unset
-  provider           Groups by LLM provider (anthropic, openai, etc.)
-  model              Groups by model name (claude-sonnet-4-20250514, etc.)
-  conversation       Groups by conversation ID
-  actor              Legacy/internal subsystem grouping (main_agent, etc.)
-
-Shows one row per group with input/output tokens, estimated cost, and
-call count. Rows are sorted by cost descending.
-
-Pass --schedule <id> to restrict the breakdown to a single schedule's cron
-run windows. Find schedule ids with 'assistant schedules list'.
-
-Examples:
-  $ assistant usage breakdown
-  $ assistant usage breakdown --group-by call_site
-  $ assistant usage breakdown --group-by inference_profile
-  $ assistant usage breakdown --group-by provider
-  $ assistant usage breakdown --schedule sched-abc123
-  $ assistant usage breakdown --group-by actor --range week`,
-        )
-        .action(
-          async (opts: {
-            range: string;
-            from?: string;
-            to?: string;
-            schedule?: string;
-            json?: boolean;
-            groupBy: string;
-          }) => {
-            const validDimensions = new Set<string>(VALID_GROUP_BY_DIMENSIONS);
-            if (!validDimensions.has(opts.groupBy)) {
-              log.error(
-                `Invalid --group-by value: '${opts.groupBy}'. Must be one of: ${VALID_GROUP_BY_DIMENSIONS.join(", ")}`,
-              );
-              process.exit(1);
-            }
-            const { from, to } = resolveRange(opts);
-            const response = await cliIpcCall<{
-              breakdown: UsageGroupBreakdown[];
-            }>("usage_breakdown", {
-              queryParams: {
-                ...buildUsageQueryParams(from, to, opts.schedule),
-                groupBy: opts.groupBy,
-              },
-            });
-            if (!response.ok) {
-              return exitFromIpcResult(response);
-            }
-            const { breakdown } = response.result!;
-            if (opts.json) {
-              log.info(JSON.stringify({ breakdown }, null, 2));
-            } else {
-              printBreakdownTable(breakdown, opts.groupBy);
-            }
-          },
-        );
+            process.exit(1);
+          }
+          const { from, to } = resolveRange(opts);
+          const response = await cliIpcCall<{
+            breakdown: UsageGroupBreakdown[];
+          }>("usage_breakdown", {
+            queryParams: {
+              ...buildUsageQueryParams(from, to, opts.schedule),
+              groupBy: opts.groupBy,
+            },
+          });
+          if (!response.ok) {
+            return exitFromIpcResult(response);
+          }
+          const { breakdown } = response.result!;
+          if (opts.json) {
+            log.info(JSON.stringify({ breakdown }, null, 2));
+          } else {
+            printBreakdownTable(breakdown, opts.groupBy);
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/watchers.help.ts
+++ b/assistant/src/cli/commands/watchers.help.ts
@@ -1,0 +1,211 @@
+/** Declarative help for the `assistant watchers` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const watchersHelp: CliCommandHelp = {
+  name: "watchers",
+  description: "Manage polling watchers that monitor external services",
+  helpText: `
+Watchers poll external services (Gmail, Google Calendar, GitHub, Linear,
+Outlook) on a configurable interval and process detected events via an
+action prompt sent to a background conversation. Each watcher targets a
+single provider and is identified by a UUID returned at creation time.
+
+Watchers can be paused/resumed with --enabled/--disabled on update, and
+recent activity is available via the digest subcommand.
+
+Examples:
+  $ assistant watchers create --name "My Gmail" --provider gmail --action-prompt "Summarize new emails"
+  $ assistant watchers list
+  $ assistant watchers list --id <watcherId>
+  $ assistant watchers digest --hours 8`,
+  subcommands: [
+    {
+      name: "list",
+      description: "List all watchers or show details for a specific watcher",
+      options: [
+        {
+          flags: "--id <watcherId>",
+          description:
+            "Show details for a specific watcher — run 'assistant watchers list' to find IDs",
+        },
+        { flags: "--enabled-only", description: "Only show enabled watchers" },
+        {
+          flags: "--json",
+          description: "Output result as machine-readable JSON",
+        },
+      ],
+      helpText: `
+Arguments:
+  --id <watcherId>   UUID of the watcher to inspect. Omit to list all
+                     watchers. Run 'assistant watchers list' to discover IDs.
+  --enabled-only     Filter to only enabled watchers.
+
+When --id is provided, returns detailed info including the watcher's
+configuration and its most recent events. Without --id, returns a
+summary table of all watchers.
+
+Examples:
+  $ assistant watchers list
+  $ assistant watchers list --enabled-only
+  $ assistant watchers list --id abc123-def4-5678-abcd-ef1234567890
+  $ assistant watchers list --json`,
+    },
+    {
+      name: "create",
+      description: "Create a new watcher",
+      options: [
+        { flags: "--name <name>", description: "Watcher name", required: true },
+        {
+          flags: "--provider <provider>",
+          description:
+            "Provider ID (gmail, google-calendar, github, linear, outlook, outlook-calendar)",
+          required: true,
+        },
+        {
+          flags: "--action-prompt <prompt>",
+          description: "Action prompt for the watcher",
+          required: true,
+        },
+        {
+          flags: "--poll-interval <ms>",
+          description:
+            "Poll interval in milliseconds (default: 60000, min: 15000)",
+        },
+        {
+          flags: "--config <json>",
+          description: "Provider-specific config as JSON string",
+        },
+        {
+          flags: "--credential-service <service>",
+          description: "Credential service override",
+        },
+        {
+          flags: "--json",
+          description: "Output result as machine-readable JSON",
+        },
+      ],
+      helpText: `
+Arguments:
+  --name <name>                Human-readable label (e.g. "Work Gmail")
+  --provider <provider>        Service to poll: gmail, google-calendar, github,
+                               linear, outlook, outlook-calendar
+  --action-prompt <prompt>     LLM instructions for processing detected events.
+                               Sent with event data to a background conversation.
+  --poll-interval <ms>         Milliseconds between polls. Default 60000 (1 min),
+                               minimum 15000 (15 sec).
+  --config <json>              Provider-specific settings as a JSON string.
+  --credential-service <svc>   Override the default credential service for the
+                               provider. Rarely needed.
+
+The watcher starts polling immediately after creation. Each provider
+requires appropriate OAuth credentials to be configured beforehand.
+
+Examples:
+  $ assistant watchers create --name "My Gmail" --provider gmail --action-prompt "Summarize new emails and notify me if anything is urgent"
+  $ assistant watchers create --name "PR Reviews" --provider github --action-prompt "Notify me of new review requests" --poll-interval 30000
+  $ assistant watchers create --name "Team Linear" --provider linear --action-prompt "Flag high-priority issues" --config '{"teamId":"TEAM-1"}'`,
+    },
+    {
+      name: "update",
+      args: "<watcherId>",
+      description: "Update an existing watcher",
+      options: [
+        { flags: "--name <name>", description: "New watcher name" },
+        {
+          flags: "--action-prompt <prompt>",
+          description: "New action prompt",
+        },
+        {
+          flags: "--poll-interval <ms>",
+          description: "New poll interval in milliseconds (min: 15000)",
+        },
+        { flags: "--enabled", description: "Enable the watcher" },
+        { flags: "--disabled", description: "Disable the watcher" },
+        {
+          flags: "--config <json>",
+          description: "New provider-specific config as JSON string",
+        },
+        {
+          flags: "--json",
+          description: "Output result as machine-readable JSON",
+        },
+      ],
+      helpText: `
+Arguments:
+  watcherId              UUID of the watcher to update — run 'assistant
+                         watchers list' to find IDs.
+
+Only the fields you specify are changed; omitted fields keep their
+current values. Use --enabled/--disabled to pause and resume polling
+without deleting the watcher.
+
+Examples:
+  $ assistant watchers update abc123 --action-prompt "Flag urgent emails and ignore newsletters"
+  $ assistant watchers update abc123 --disabled
+  $ assistant watchers update abc123 --enabled --poll-interval 120000`,
+    },
+    {
+      name: "delete",
+      args: "<watcherId>",
+      description: "Delete a watcher and all its event history",
+      options: [
+        {
+          flags: "--json",
+          description: "Output result as machine-readable JSON",
+        },
+      ],
+      helpText: `
+Arguments:
+  watcherId   UUID of the watcher to delete — run 'assistant watchers list'
+              to find IDs.
+
+Permanently removes the watcher and all its stored event history. This
+action is irreversible. Disable the watcher with 'assistant watchers
+update <id> --disabled' if you want to pause it instead.
+
+Examples:
+  $ assistant watchers delete abc123-def4-5678-abcd-ef1234567890
+  $ assistant watchers delete abc123 --json`,
+    },
+    {
+      name: "digest",
+      description: "Show recent watcher events grouped by watcher",
+      options: [
+        {
+          flags: "--id <watcherId>",
+          description:
+            "Filter to a single watcher — run 'assistant watchers list' to find IDs",
+        },
+        {
+          flags: "--hours <n>",
+          description: "Hours to look back (default: 24)",
+        },
+        {
+          flags: "--limit <n>",
+          description: "Maximum events to return (default: 50)",
+        },
+        {
+          flags: "--json",
+          description: "Output result as machine-readable JSON",
+        },
+      ],
+      helpText: `
+Arguments:
+  --id <watcherId>   UUID of a watcher to filter by. Omit to show events
+                     from all watchers. Run 'assistant watchers list' to
+                     discover IDs.
+  --hours <n>        Lookback window in hours. Defaults to 24.
+  --limit <n>        Maximum number of events returned. Defaults to 50.
+
+Events are grouped by watcher and sorted by creation time (newest first).
+Use this to review what your watchers have detected recently.
+
+Examples:
+  $ assistant watchers digest
+  $ assistant watchers digest --hours 8
+  $ assistant watchers digest --id abc123 --hours 4 --limit 10
+  $ assistant watchers digest --json`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/watchers.ts
+++ b/assistant/src/cli/commands/watchers.ts
@@ -9,8 +9,10 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { watchersHelp } from "./watchers.help.js";
 
 // -- Types for IPC results ----------------------------------------------------
 
@@ -39,476 +41,318 @@ interface WatcherEvent {
 
 export function registerWatchersCommand(program: Command): void {
   registerCommand(program, {
-    name: "watchers",
+    name: watchersHelp.name,
     transport: "ipc",
-    description: "Manage polling watchers that monitor external services",
+    description: watchersHelp.description,
     build: (watchers) => {
+      applyCommandHelp(watchers, watchersHelp);
 
-  watchers.addHelpText(
-    "after",
-    `
-Watchers poll external services (Gmail, Google Calendar, GitHub, Linear,
-Outlook) on a configurable interval and process detected events via an
-action prompt sent to a background conversation. Each watcher targets a
-single provider and is identified by a UUID returned at creation time.
+      // ── list ────────────────────────────────────────────────────────────
 
-Watchers can be paused/resumed with --enabled/--disabled on update, and
-recent activity is available via the digest subcommand.
-
-Examples:
-  $ assistant watchers create --name "My Gmail" --provider gmail --action-prompt "Summarize new emails"
-  $ assistant watchers list
-  $ assistant watchers list --id <watcherId>
-  $ assistant watchers digest --hours 8`,
-  );
-
-  // ── list ────────────────────────────────────────────────────────────
-
-  watchers
-    .command("list")
-    .description("List all watchers or show details for a specific watcher")
-    .option(
-      "--id <watcherId>",
-      "Show details for a specific watcher — run 'assistant watchers list' to find IDs",
-    )
-    .option("--enabled-only", "Only show enabled watchers")
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  --id <watcherId>   UUID of the watcher to inspect. Omit to list all
-                     watchers. Run 'assistant watchers list' to discover IDs.
-  --enabled-only     Filter to only enabled watchers.
-
-When --id is provided, returns detailed info including the watcher's
-configuration and its most recent events. Without --id, returns a
-summary table of all watchers.
-
-Examples:
-  $ assistant watchers list
-  $ assistant watchers list --enabled-only
-  $ assistant watchers list --id abc123-def4-5678-abcd-ef1234567890
-  $ assistant watchers list --json`,
-    )
-    .action(
-      async (opts: { id?: string; enabledOnly?: boolean; json?: boolean }) => {
-        const params: Record<string, unknown> = {};
-        if (opts.id) params.watcher_id = opts.id;
-        if (opts.enabledOnly) params.enabled_only = true;
-
-        const result = await cliIpcCall<
-          WatcherRecord[] | { watcher: WatcherRecord; events: WatcherEvent[] }
-        >("watcher_list", { body: params });
-
-        if (!result.ok) {
-          if (opts.json) {
-            process.stdout.write(
-              JSON.stringify({ ok: false, error: result.error }) + "\n",
-            );
-          } else {
-            log.error(`Error: ${result.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
-
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: true, data: result.result }) + "\n",
-          );
-          return;
-        }
-
-        // When --id is provided, the result is a detail object
-        if (opts.id) {
-          const detail = result.result as {
-            watcher: WatcherRecord;
-            events: WatcherEvent[];
-          };
-          const w = detail.watcher;
-          log.info(`Watcher: ${w.name} (${w.id})`);
-          log.info(`  Provider:      ${w.providerId}`);
-          log.info(`  Enabled:       ${w.enabled}`);
-          log.info(`  Poll interval: ${w.pollIntervalMs}ms`);
-          log.info(`  Action prompt: ${w.actionPrompt}`);
-          if (w.configJson) {
-            log.info(`  Config:        ${w.configJson}`);
-          }
-          if (detail.events.length > 0) {
-            log.info(`  Recent events: ${detail.events.length}`);
-            for (const e of detail.events) {
-              log.info(
-                `    [${new Date(e.createdAt).toISOString()}] ${e.eventType}: ${e.summary ?? "(no summary)"}`,
-              );
-            }
-          }
-          return;
-        }
-
-        // List mode: array of watchers
-        const list = result.result as WatcherRecord[];
-        if (list.length === 0) {
-          log.info("No watchers found.");
-          return;
-        }
-
-        for (const w of list) {
-          const status = w.enabled ? "enabled" : "disabled";
-          log.info(`  ${w.id}  ${w.name}  ${w.providerId}  ${status}`);
-        }
-      },
-    );
-
-  // ── create ──────────────────────────────────────────────────────────
-
-  watchers
-    .command("create")
-    .description("Create a new watcher")
-    .requiredOption("--name <name>", "Watcher name")
-    .requiredOption(
-      "--provider <provider>",
-      "Provider ID (gmail, google-calendar, github, linear, outlook, outlook-calendar)",
-    )
-    .requiredOption("--action-prompt <prompt>", "Action prompt for the watcher")
-    .option(
-      "--poll-interval <ms>",
-      "Poll interval in milliseconds (default: 60000, min: 15000)",
-      parseInt,
-    )
-    .option("--config <json>", "Provider-specific config as JSON string")
-    .option("--credential-service <service>", "Credential service override")
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  --name <name>                Human-readable label (e.g. "Work Gmail")
-  --provider <provider>        Service to poll: gmail, google-calendar, github,
-                               linear, outlook, outlook-calendar
-  --action-prompt <prompt>     LLM instructions for processing detected events.
-                               Sent with event data to a background conversation.
-  --poll-interval <ms>         Milliseconds between polls. Default 60000 (1 min),
-                               minimum 15000 (15 sec).
-  --config <json>              Provider-specific settings as a JSON string.
-  --credential-service <svc>   Override the default credential service for the
-                               provider. Rarely needed.
-
-The watcher starts polling immediately after creation. Each provider
-requires appropriate OAuth credentials to be configured beforehand.
-
-Examples:
-  $ assistant watchers create --name "My Gmail" --provider gmail --action-prompt "Summarize new emails and notify me if anything is urgent"
-  $ assistant watchers create --name "PR Reviews" --provider github --action-prompt "Notify me of new review requests" --poll-interval 30000
-  $ assistant watchers create --name "Team Linear" --provider linear --action-prompt "Flag high-priority issues" --config '{"teamId":"TEAM-1"}'`,
-    )
-    .action(
-      async (opts: {
-        name: string;
-        provider: string;
-        actionPrompt: string;
-        pollInterval?: number;
-        config?: string;
-        credentialService?: string;
-        json?: boolean;
-      }) => {
-        const params: Record<string, unknown> = {
-          name: opts.name,
-          provider: opts.provider,
-          action_prompt: opts.actionPrompt,
-        };
-
-        if (opts.pollInterval !== undefined) {
-          params.poll_interval_ms = opts.pollInterval;
-        }
-        if (opts.config !== undefined) {
-          try {
-            params.config = JSON.parse(opts.config);
-          } catch {
-            const msg = `Invalid --config JSON: ${opts.config}`;
-            if (opts.json) {
-              process.stdout.write(
-                JSON.stringify({ ok: false, error: msg }) + "\n",
-              );
-            } else {
-              log.error(msg);
-            }
-            process.exitCode = 1;
-            return;
-          }
-        }
-        if (opts.credentialService) {
-          params.credential_service = opts.credentialService;
-        }
-
-        const result = await cliIpcCall<WatcherRecord>(
-          "watcher_create",
-          { body: params },
-        );
-
-        if (!result.ok) {
-          if (opts.json) {
-            process.stdout.write(
-              JSON.stringify({ ok: false, error: result.error }) + "\n",
-            );
-          } else {
-            log.error(`Error: ${result.error}`);
-          }
-          process.exitCode = 1;
-          return;
-        }
-
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: true, data: result.result }) + "\n",
-          );
-        } else {
-          const w = result.result!;
-          log.info(`Created watcher: ${w.name} (${w.id})`);
-        }
-      },
-    );
-
-  // ── update ──────────────────────────────────────────────────────────
-
-  watchers
-    .command("update <watcherId>")
-    .description("Update an existing watcher")
-    .option("--name <name>", "New watcher name")
-    .option("--action-prompt <prompt>", "New action prompt")
-    .option(
-      "--poll-interval <ms>",
-      "New poll interval in milliseconds (min: 15000)",
-      parseInt,
-    )
-    .option("--enabled", "Enable the watcher")
-    .option("--disabled", "Disable the watcher")
-    .option("--config <json>", "New provider-specific config as JSON string")
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  watcherId              UUID of the watcher to update — run 'assistant
-                         watchers list' to find IDs.
-
-Only the fields you specify are changed; omitted fields keep their
-current values. Use --enabled/--disabled to pause and resume polling
-without deleting the watcher.
-
-Examples:
-  $ assistant watchers update abc123 --action-prompt "Flag urgent emails and ignore newsletters"
-  $ assistant watchers update abc123 --disabled
-  $ assistant watchers update abc123 --enabled --poll-interval 120000`,
-    )
-    .action(
-      async (
-        watcherId: string,
-        opts: {
-          name?: string;
-          actionPrompt?: string;
-          pollInterval?: number;
-          enabled?: boolean;
-          disabled?: boolean;
-          config?: string;
+      subcommand(watchers, "list").action(
+        async (opts: {
+          id?: string;
+          enabledOnly?: boolean;
           json?: boolean;
-        },
-      ) => {
-        const params: Record<string, unknown> = {
-          watcher_id: watcherId,
-        };
+        }) => {
+          const params: Record<string, unknown> = {};
+          if (opts.id) params.watcher_id = opts.id;
+          if (opts.enabledOnly) params.enabled_only = true;
 
-        if (opts.name !== undefined) params.name = opts.name;
-        if (opts.actionPrompt !== undefined)
-          params.action_prompt = opts.actionPrompt;
-        if (opts.pollInterval !== undefined)
-          params.poll_interval_ms = opts.pollInterval;
-        if (opts.enabled) params.enabled = true;
-        if (opts.disabled) params.enabled = false;
-        if (opts.config !== undefined) {
-          try {
-            params.config = JSON.parse(opts.config);
-          } catch {
-            const msg = `Invalid --config JSON: ${opts.config}`;
+          const result = await cliIpcCall<
+            WatcherRecord[] | { watcher: WatcherRecord; events: WatcherEvent[] }
+          >("watcher_list", { body: params });
+
+          if (!result.ok) {
             if (opts.json) {
               process.stdout.write(
-                JSON.stringify({ ok: false, error: msg }) + "\n",
+                JSON.stringify({ ok: false, error: result.error }) + "\n",
               );
             } else {
-              log.error(msg);
+              log.error(`Error: ${result.error}`);
             }
             process.exitCode = 1;
             return;
           }
-        }
 
-        const result = await cliIpcCall<WatcherRecord>(
-          "watcher_update",
-          { body: params },
-        );
-
-        if (!result.ok) {
           if (opts.json) {
             process.stdout.write(
-              JSON.stringify({ ok: false, error: result.error }) + "\n",
+              JSON.stringify({ ok: true, data: result.result }) + "\n",
             );
-          } else {
-            log.error(`Error: ${result.error}`);
+            return;
           }
-          process.exitCode = 1;
-          return;
-        }
 
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: true, data: result.result }) + "\n",
-          );
-        } else {
-          const w = result.result!;
-          log.info(`Updated watcher: ${w.name} (${w.id})`);
-        }
-      },
-    );
+          // When --id is provided, the result is a detail object
+          if (opts.id) {
+            const detail = result.result as {
+              watcher: WatcherRecord;
+              events: WatcherEvent[];
+            };
+            const w = detail.watcher;
+            log.info(`Watcher: ${w.name} (${w.id})`);
+            log.info(`  Provider:      ${w.providerId}`);
+            log.info(`  Enabled:       ${w.enabled}`);
+            log.info(`  Poll interval: ${w.pollIntervalMs}ms`);
+            log.info(`  Action prompt: ${w.actionPrompt}`);
+            if (w.configJson) {
+              log.info(`  Config:        ${w.configJson}`);
+            }
+            if (detail.events.length > 0) {
+              log.info(`  Recent events: ${detail.events.length}`);
+              for (const e of detail.events) {
+                log.info(
+                  `    [${new Date(e.createdAt).toISOString()}] ${e.eventType}: ${e.summary ?? "(no summary)"}`,
+                );
+              }
+            }
+            return;
+          }
 
-  // ── delete ──────────────────────────────────────────────────────────
+          // List mode: array of watchers
+          const list = result.result as WatcherRecord[];
+          if (list.length === 0) {
+            log.info("No watchers found.");
+            return;
+          }
 
-  watchers
-    .command("delete <watcherId>")
-    .description("Delete a watcher and all its event history")
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  watcherId   UUID of the watcher to delete — run 'assistant watchers list'
-              to find IDs.
-
-Permanently removes the watcher and all its stored event history. This
-action is irreversible. Disable the watcher with 'assistant watchers
-update <id> --disabled' if you want to pause it instead.
-
-Examples:
-  $ assistant watchers delete abc123-def4-5678-abcd-ef1234567890
-  $ assistant watchers delete abc123 --json`,
-    )
-    .action(async (watcherId: string, opts: { json?: boolean }) => {
-      const result = await cliIpcCall<{ deleted: boolean; name: string }>(
-        "watcher_delete",
-        { body: { watcher_id: watcherId } },
+          for (const w of list) {
+            const status = w.enabled ? "enabled" : "disabled";
+            log.info(`  ${w.id}  ${w.name}  ${w.providerId}  ${status}`);
+          }
+        },
       );
 
-      if (!result.ok) {
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: false, error: result.error }) + "\n",
-          );
-        } else {
-          log.error(`Error: ${result.error}`);
-        }
-        process.exitCode = 1;
-        return;
-      }
+      // ── create ──────────────────────────────────────────────────────────
 
-      if (opts.json) {
-        process.stdout.write(
-          JSON.stringify({ ok: true, data: result.result }) + "\n",
-        );
-      } else {
-        log.info(`Deleted watcher: ${result.result!.name}`);
-      }
-    });
+      subcommand(watchers, "create").action(
+        async (opts: {
+          name: string;
+          provider: string;
+          actionPrompt: string;
+          pollInterval?: string;
+          config?: string;
+          credentialService?: string;
+          json?: boolean;
+        }) => {
+          const params: Record<string, unknown> = {
+            name: opts.name,
+            provider: opts.provider,
+            action_prompt: opts.actionPrompt,
+          };
 
-  // ── digest ──────────────────────────────────────────────────────────
+          if (opts.pollInterval !== undefined) {
+            params.poll_interval_ms = parseInt(opts.pollInterval);
+          }
+          if (opts.config !== undefined) {
+            try {
+              params.config = JSON.parse(opts.config);
+            } catch {
+              const msg = `Invalid --config JSON: ${opts.config}`;
+              if (opts.json) {
+                process.stdout.write(
+                  JSON.stringify({ ok: false, error: msg }) + "\n",
+                );
+              } else {
+                log.error(msg);
+              }
+              process.exitCode = 1;
+              return;
+            }
+          }
+          if (opts.credentialService) {
+            params.credential_service = opts.credentialService;
+          }
 
-  watchers
-    .command("digest")
-    .description("Show recent watcher events grouped by watcher")
-    .option(
-      "--id <watcherId>",
-      "Filter to a single watcher — run 'assistant watchers list' to find IDs",
-    )
-    .option("--hours <n>", "Hours to look back (default: 24)", parseInt)
-    .option("--limit <n>", "Maximum events to return (default: 50)", parseInt)
-    .option("--json", "Output result as machine-readable JSON")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  --id <watcherId>   UUID of a watcher to filter by. Omit to show events
-                     from all watchers. Run 'assistant watchers list' to
-                     discover IDs.
-  --hours <n>        Lookback window in hours. Defaults to 24.
-  --limit <n>        Maximum number of events returned. Defaults to 50.
+          const result = await cliIpcCall<WatcherRecord>("watcher_create", {
+            body: params,
+          });
 
-Events are grouped by watcher and sorted by creation time (newest first).
-Use this to review what your watchers have detected recently.
+          if (!result.ok) {
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: result.error }) + "\n",
+              );
+            } else {
+              log.error(`Error: ${result.error}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
 
-Examples:
-  $ assistant watchers digest
-  $ assistant watchers digest --hours 8
-  $ assistant watchers digest --id abc123 --hours 4 --limit 10
-  $ assistant watchers digest --json`,
-    )
-    .action(
-      async (opts: {
-        id?: string;
-        hours?: number;
-        limit?: number;
-        json?: boolean;
-      }) => {
-        const params: Record<string, unknown> = {};
-        if (opts.id) params.watcher_id = opts.id;
-        if (opts.hours !== undefined) params.hours = opts.hours;
-        if (opts.limit !== undefined) params.limit = opts.limit;
-
-        const result = await cliIpcCall<{
-          events: WatcherEvent[];
-          watcherNames: Record<string, string>;
-        }>("watcher_digest", { body: params });
-
-        if (!result.ok) {
           if (opts.json) {
             process.stdout.write(
-              JSON.stringify({ ok: false, error: result.error }) + "\n",
+              JSON.stringify({ ok: true, data: result.result }) + "\n",
             );
           } else {
-            log.error(`Error: ${result.error}`);
+            const w = result.result!;
+            log.info(`Created watcher: ${w.name} (${w.id})`);
           }
-          process.exitCode = 1;
-          return;
-        }
+        },
+      );
 
-        if (opts.json) {
-          process.stdout.write(
-            JSON.stringify({ ok: true, data: result.result }) + "\n",
-          );
-          return;
-        }
+      // ── update ──────────────────────────────────────────────────────────
 
-        const { events, watcherNames } = result.result!;
-        if (events.length === 0) {
-          log.info("No events found.");
-          return;
-        }
+      subcommand(watchers, "update").action(
+        async (
+          watcherId: string,
+          opts: {
+            name?: string;
+            actionPrompt?: string;
+            pollInterval?: string;
+            enabled?: boolean;
+            disabled?: boolean;
+            config?: string;
+            json?: boolean;
+          },
+        ) => {
+          const params: Record<string, unknown> = {
+            watcher_id: watcherId,
+          };
 
-        // Group events by watcher
-        const grouped: Record<string, WatcherEvent[]> = {};
-        for (const e of events) {
-          if (!grouped[e.watcherId]) grouped[e.watcherId] = [];
-          grouped[e.watcherId].push(e);
-        }
+          if (opts.name !== undefined) params.name = opts.name;
+          if (opts.actionPrompt !== undefined)
+            params.action_prompt = opts.actionPrompt;
+          if (opts.pollInterval !== undefined)
+            params.poll_interval_ms = parseInt(opts.pollInterval);
+          if (opts.enabled) params.enabled = true;
+          if (opts.disabled) params.enabled = false;
+          if (opts.config !== undefined) {
+            try {
+              params.config = JSON.parse(opts.config);
+            } catch {
+              const msg = `Invalid --config JSON: ${opts.config}`;
+              if (opts.json) {
+                process.stdout.write(
+                  JSON.stringify({ ok: false, error: msg }) + "\n",
+                );
+              } else {
+                log.error(msg);
+              }
+              process.exitCode = 1;
+              return;
+            }
+          }
 
-        for (const [watcherId, watcherEvents] of Object.entries(grouped)) {
-          const name = watcherNames[watcherId] ?? watcherId;
-          log.info(`${name} (${watcherId}):`);
-          for (const e of watcherEvents) {
-            log.info(
-              `  [${new Date(e.createdAt).toISOString()}] ${e.eventType}: ${e.summary ?? "(no summary)"}`,
+          const result = await cliIpcCall<WatcherRecord>("watcher_update", {
+            body: params,
+          });
+
+          if (!result.ok) {
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: result.error }) + "\n",
+              );
+            } else {
+              log.error(`Error: ${result.error}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: true, data: result.result }) + "\n",
             );
+          } else {
+            const w = result.result!;
+            log.info(`Updated watcher: ${w.name} (${w.id})`);
           }
-        }
-      },
-    );
+        },
+      );
+
+      // ── delete ──────────────────────────────────────────────────────────
+
+      subcommand(watchers, "delete").action(
+        async (watcherId: string, opts: { json?: boolean }) => {
+          const result = await cliIpcCall<{ deleted: boolean; name: string }>(
+            "watcher_delete",
+            { body: { watcher_id: watcherId } },
+          );
+
+          if (!result.ok) {
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: result.error }) + "\n",
+              );
+            } else {
+              log.error(`Error: ${result.error}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: true, data: result.result }) + "\n",
+            );
+          } else {
+            log.info(`Deleted watcher: ${result.result!.name}`);
+          }
+        },
+      );
+
+      // ── digest ──────────────────────────────────────────────────────────
+
+      subcommand(watchers, "digest").action(
+        async (opts: {
+          id?: string;
+          hours?: string;
+          limit?: string;
+          json?: boolean;
+        }) => {
+          const params: Record<string, unknown> = {};
+          if (opts.id) params.watcher_id = opts.id;
+          if (opts.hours !== undefined) params.hours = parseInt(opts.hours);
+          if (opts.limit !== undefined) params.limit = parseInt(opts.limit);
+
+          const result = await cliIpcCall<{
+            events: WatcherEvent[];
+            watcherNames: Record<string, string>;
+          }>("watcher_digest", { body: params });
+
+          if (!result.ok) {
+            if (opts.json) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: result.error }) + "\n",
+              );
+            } else {
+              log.error(`Error: ${result.error}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          if (opts.json) {
+            process.stdout.write(
+              JSON.stringify({ ok: true, data: result.result }) + "\n",
+            );
+            return;
+          }
+
+          const { events, watcherNames } = result.result!;
+          if (events.length === 0) {
+            log.info("No events found.");
+            return;
+          }
+
+          // Group events by watcher
+          const grouped: Record<string, WatcherEvent[]> = {};
+          for (const e of events) {
+            if (!grouped[e.watcherId]) grouped[e.watcherId] = [];
+            grouped[e.watcherId].push(e);
+          }
+
+          for (const [watcherId, watcherEvents] of Object.entries(grouped)) {
+            const name = watcherNames[watcherId] ?? watcherId;
+            log.info(`${name} (${watcherId}):`);
+            for (const e of watcherEvents) {
+              log.info(
+                `  [${new Date(e.createdAt).toISOString()}] ${e.eventType}: ${e.summary ?? "(no summary)"}`,
+              );
+            }
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/commands/webhooks.help.ts
+++ b/assistant/src/cli/commands/webhooks.help.ts
@@ -1,0 +1,95 @@
+/** Declarative help for the `assistant webhooks` command. */
+
+import type { CliCommandHelp } from "../lib/cli-command-help.js";
+
+export const webhooksHelp: CliCommandHelp = {
+  name: "webhooks",
+  description: "Manage webhook callback URLs for external integrations",
+  options: [
+    { flags: "--json", description: "Machine-readable compact JSON output" },
+  ],
+  helpText: `
+Resolves a stable callback URL that external services (Telegram, Twilio,
+email providers, OAuth) should use to reach this assistant.
+
+On platform-managed assistants, this registers a callback route with the
+platform gateway. On self-hosted assistants, it uses the configured
+ingress.publicBaseUrl.
+
+The webhook path is derived from the type: underscores become path
+separators, prefixed with webhooks/.
+
+  telegram       → webhooks/telegram
+  twilio_voice   → webhooks/twilio/voice
+  twilio_status  → webhooks/twilio/status
+  resend         → webhooks/resend
+
+Examples:
+  $ assistant webhooks register telegram
+  $ assistant webhooks register resend --source "@bot_handle"
+  $ assistant webhooks list
+  $ assistant webhooks list --json`,
+  subcommands: [
+    {
+      name: "register",
+      args: "<type>",
+      description:
+        "Get a callback URL for a webhook type, registering with the platform if needed",
+      options: [
+        {
+          flags: "--path <path>",
+          description: "Override the derived webhook path",
+        },
+        {
+          flags: "--source <label>",
+          description:
+            "Human-readable source label for admin display (e.g. bot handle, phone number)",
+        },
+      ],
+      helpText: `
+Resolves a callback URL for the given webhook type. On platform-managed
+assistants (IS_PLATFORM=true), registers a callback route with the platform
+gateway and returns the stable external URL. On self-hosted assistants,
+reads ingress.publicBaseUrl from config and appends the webhook path.
+
+Arguments:
+  type   The webhook type to register. The path is derived automatically:
+         underscores become path separators, prefixed with webhooks/.
+
+           telegram       → webhooks/telegram
+           twilio_voice   → webhooks/twilio/voice
+           twilio_status  → webhooks/twilio/status
+           resend         → webhooks/resend
+           mailgun        → webhooks/mailgun
+           email          → webhooks/email
+           oauth_callback → webhooks/oauth/callback
+
+Options:
+  --path <path>     Override the derived webhook path.
+  --source <label>  Human-readable source label (e.g. bot handle, phone number)
+                    for admin display.
+
+Examples:
+  $ assistant webhooks register telegram --source "@my_bot"
+  $ assistant webhooks register twilio_voice --json
+  $ assistant webhooks register resend --json
+  $ assistant webhooks register custom_provider --path webhooks/my-provider --json`,
+    },
+    {
+      name: "list",
+      description: "List registered webhook callback routes",
+      helpText: `
+Lists all webhook callback routes registered with the platform for this
+assistant. Only available when platform credentials are configured (either
+via IS_PLATFORM or 'assistant platform connect').
+
+Self-hosted assistants without platform credentials do not have a persistent
+webhook registry — use 'assistant webhooks register <type>' to resolve URLs
+on demand.
+
+Examples:
+  $ assistant webhooks list
+  $ assistant webhooks list --json`,
+    },
+  ],
+};

--- a/assistant/src/cli/commands/webhooks.ts
+++ b/assistant/src/cli/commands/webhooks.ts
@@ -10,137 +10,61 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
+import { webhooksHelp } from "./webhooks.help.js";
 
 export function registerWebhooksCommand(program: Command): void {
   registerCommand(program, {
-    name: "webhooks",
+    name: webhooksHelp.name,
     transport: "ipc",
-    description: "Manage webhook callback URLs for external integrations",
+    description: webhooksHelp.description,
     build: (webhooks) => {
-      webhooks.option("--json", "Machine-readable compact JSON output");
-      webhooks.addHelpText(
-        "after",
-        `
-Resolves a stable callback URL that external services (Telegram, Twilio,
-email providers, OAuth) should use to reach this assistant.
-
-On platform-managed assistants, this registers a callback route with the
-platform gateway. On self-hosted assistants, it uses the configured
-ingress.publicBaseUrl.
-
-The webhook path is derived from the type: underscores become path
-separators, prefixed with webhooks/.
-
-  telegram       → webhooks/telegram
-  twilio_voice   → webhooks/twilio/voice
-  twilio_status  → webhooks/twilio/status
-  resend         → webhooks/resend
-
-Examples:
-  $ assistant webhooks register telegram
-  $ assistant webhooks register resend --source "@bot_handle"
-  $ assistant webhooks list
-  $ assistant webhooks list --json`,
-      );
+      applyCommandHelp(webhooks, webhooksHelp);
 
       // -----------------------------------------------------------------------
       // webhooks register <type>
       // -----------------------------------------------------------------------
 
-      webhooks
-        .command("register <type>")
-        .description(
-          "Get a callback URL for a webhook type, registering with the platform if needed",
-        )
-        .addHelpText(
-          "after",
-          `
-Resolves a callback URL for the given webhook type. On platform-managed
-assistants (IS_PLATFORM=true), registers a callback route with the platform
-gateway and returns the stable external URL. On self-hosted assistants,
-reads ingress.publicBaseUrl from config and appends the webhook path.
-
-Arguments:
-  type   The webhook type to register. The path is derived automatically:
-         underscores become path separators, prefixed with webhooks/.
-
-           telegram       → webhooks/telegram
-           twilio_voice   → webhooks/twilio/voice
-           twilio_status  → webhooks/twilio/status
-           resend         → webhooks/resend
-           mailgun        → webhooks/mailgun
-           email          → webhooks/email
-           oauth_callback → webhooks/oauth/callback
-
-Options:
-  --path <path>     Override the derived webhook path.
-  --source <label>  Human-readable source label (e.g. bot handle, phone number)
-                    for admin display.
-
-Examples:
-  $ assistant webhooks register telegram --source "@my_bot"
-  $ assistant webhooks register twilio_voice --json
-  $ assistant webhooks register resend --json
-  $ assistant webhooks register custom_provider --path webhooks/my-provider --json`,
-        )
-        .option("--path <path>", "Override the derived webhook path")
-        .option(
-          "--source <label>",
-          "Human-readable source label for admin display (e.g. bot handle, phone number)",
-        )
-        .action(
-          async (
-            type: string,
-            opts: { path?: string; source?: string },
-            cmd: Command,
-          ) => {
-            const r = await cliIpcCall<{
-              callbackUrl: string;
-              type: string;
-              path: string;
-              mode: "platform" | "self-hosted";
-            }>("webhooks_register", {
-              body: {
-                type,
-                path: opts.path,
-                source: opts.source,
-              },
-            });
-            if (!r.ok) return exitFromIpcResult({ ok: false, error: r.error, statusCode: r.statusCode }, cmd);
-            if (shouldOutputJson(cmd)) {
-              writeOutput(cmd, { ok: true, ...r.result });
-            } else {
-              process.stdout.write(r.result!.callbackUrl + "\n");
-            }
-          },
-        );
+      subcommand(webhooks, "register").action(
+        async (
+          type: string,
+          opts: { path?: string; source?: string },
+          cmd: Command,
+        ) => {
+          const r = await cliIpcCall<{
+            callbackUrl: string;
+            type: string;
+            path: string;
+            mode: "platform" | "self-hosted";
+          }>("webhooks_register", {
+            body: {
+              type,
+              path: opts.path,
+              source: opts.source,
+            },
+          });
+          if (!r.ok)
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, { ok: true, ...r.result });
+          } else {
+            process.stdout.write(r.result!.callbackUrl + "\n");
+          }
+        },
+      );
 
       // -----------------------------------------------------------------------
       // webhooks list
       // -----------------------------------------------------------------------
 
-      webhooks
-        .command("list")
-        .description("List registered webhook callback routes")
-        .addHelpText(
-          "after",
-          `
-Lists all webhook callback routes registered with the platform for this
-assistant. Only available when platform credentials are configured (either
-via IS_PLATFORM or 'assistant platform connect').
-
-Self-hosted assistants without platform credentials do not have a persistent
-webhook registry — use 'assistant webhooks register <type>' to resolve URLs
-on demand.
-
-Examples:
-  $ assistant webhooks list
-  $ assistant webhooks list --json`,
-        )
-        .action(async (_opts: Record<string, unknown>, cmd: Command) => {
+      subcommand(webhooks, "list").action(
+        async (_opts: Record<string, unknown>, cmd: Command) => {
           const r = await cliIpcCall<{
             routes: Array<{
               id: string;
@@ -151,7 +75,11 @@ Examples:
               source_identifier: string | null;
             }>;
           }>("webhooks_list", {});
-          if (!r.ok) return exitFromIpcResult({ ok: false, error: r.error, statusCode: r.statusCode }, cmd);
+          if (!r.ok)
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
           if (shouldOutputJson(cmd)) {
             writeOutput(cmd, { ok: true, routes: r.result!.routes });
           } else {
@@ -170,7 +98,8 @@ Examples:
               }
             }
           }
-        });
+        },
+      );
     },
   });
 }

--- a/assistant/src/cli/index.help.ts
+++ b/assistant/src/cli/index.help.ts
@@ -37,11 +37,27 @@ import { inferenceHelp, llmHelp } from "./commands/inference.help.js";
 import { keysHelp } from "./commands/keys.help.js";
 import { mcpHelp } from "./commands/mcp.help.js";
 import { memoryHelp } from "./commands/memory/index.help.js";
+import { monitoringHelp } from "./commands/monitoring.help.js";
 import { notificationsHelp } from "./commands/notifications.help.js";
 import { oauthHelp } from "./commands/oauth/index.help.js";
 import { pendingHelp } from "./commands/pending.help.js";
 import { platformHelp } from "./commands/platform/index.help.js";
 import { pluginsHelp } from "./commands/plugins.help.js";
+import { psHelp } from "./commands/ps.help.js";
+import { routesHelp } from "./commands/routes.help.js";
+import { schedulesHelp } from "./commands/schedules.help.js";
+import { sequenceHelp } from "./commands/sequence.help.js";
+import { skillsHelp } from "./commands/skills.help.js";
+import { statusHelp } from "./commands/status.help.js";
+import { sttHelp } from "./commands/stt.help.js";
+import { telemetryHelp } from "./commands/telemetry.help.js";
+import { toolsHelp } from "./commands/tools.help.js";
+import { trustHelp } from "./commands/trust.help.js";
+import { ttsHelp } from "./commands/tts.help.js";
+import { uiHelp } from "./commands/ui.help.js";
+import { usageHelp } from "./commands/usage.help.js";
+import { watchersHelp } from "./commands/watchers.help.js";
+import { webhooksHelp } from "./commands/webhooks.help.js";
 import type { CliCommandHelp } from "./lib/cli-command-help.js";
 
 export const CLI_COMMAND_HELP: readonly CliCommandHelp[] = [
@@ -77,4 +93,20 @@ export const CLI_COMMAND_HELP: readonly CliCommandHelp[] = [
   pendingHelp,
   platformHelp,
   pluginsHelp,
+  monitoringHelp,
+  psHelp,
+  routesHelp,
+  schedulesHelp,
+  sequenceHelp,
+  skillsHelp,
+  statusHelp,
+  sttHelp,
+  telemetryHelp,
+  toolsHelp,
+  trustHelp,
+  ttsHelp,
+  uiHelp,
+  usageHelp,
+  watchersHelp,
+  webhooksHelp,
 ];


### PR DESCRIPTION
## Prompt / plan

Final batch of the static-help migration (after #37732, #37785, #37822, #37836, #37873): **monitoring, ps, routes, schedules (+ its worker sibling), sequence, status, skills, stt, telemetry, tools, trust, tts, ui, usage, watchers, webhooks**.

With this, **every top-level `assistant` CLI command declares its help as pure data** — the registry now covers **48/48** registered commands (including the `llm` alias). Confirmed programmatically: every command `buildCliProgramTree()` registers has a matching `CLI_COMMAND_HELP` entry (48 registered = 48 declared, zero gap).

**No contract changes** — the frozen `CliCommandHelp` shape covered all 16. Directory/sibling namespaces (`schedules` + `schedules-worker`, `sequence guardrails`) declare their whole tree in one help module; siblings switch to `subcommand()` lookups with action bodies byte-identical.

## What stays imperative (behavior, not help data — each commented)

- **Aliases**: `schedules get|inspect`, `tools list|ls`.
- **Coercions moved into actions** (parser fn → plain-data option + in-action coercion, identical semantics): `watchers create/update --poll-interval`, `watchers digest --hours/--limit`.
- Constants interpolated into help prose moved into the help modules and imported back where logic needs them (`ui request/snapshot` timeouts).

`tools run` (sibling `tools-run.ts`) dropped its `transport: "local"` tag when switching from a nested `registerCommand` to a `subcommand()` lookup — `transport` is descriptive metadata nothing reads at runtime, so no behavior change.

## Test plan

- **Byte-for-byte identical fully-rendered `--help` output across all 69 command/subcommand nodes** (full `outputHelp()` capture, so it covers `addHelpText`), diffed against a pre-split baseline.
- **Coverage assertion**: every command in `buildCliProgramTree()` has a declarative entry (48 = 48).
- **Exhaustive test gate**: all 57 test files that build a Command tree pass (this is the gate that would have caught the #37873 stragglers — it covers both `register*Command` and `attach*Subcommand` builders). The four commands' own suites plus the memory-indexer suite (`cli-command-store` 13, `injection` 39, `lifecycle-memory-v2-seed` 13, `memory-v2-startup` 9) are green.
- `tsc` clean, `eslint` 0 errors (only pre-existing `curly` warnings on byte-identical action bodies), `prettier` + `knip` clean; all 48 registry entries render sane content (220 KB total).

## Follow-up

This completes the prerequisite for **retiring the memory indexer's `buildCliProgramTree()` fallback** in `cli-command-store.ts` — the daemon-core import edge this campaign targets. I'm keeping that in a separate focused PR because it also requires rewriting the store's fallback-path test (which mocks `buildCliProgramTree`) and adding a coverage-guard test, which is a distinct concern from this mechanical help split.

## CLI verb checklist

Help/registration restructure only — no verbs added/removed/renamed, no routes touched, byte-identical help output. Section N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_