### PR TITLE
memory: seed CLI capabilities from declarative help, not the CLI action graph

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -91,7 +91,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../agent/image-optimize.js",
     "../../../../api/responses/memory-v3-selection-log.js",
     "../../../../channels/types.js",
-    "../../../../cli/program.js",
     "../../../../config/assistant-feature-flags.js",
     "../../../../config/default-profile-catalog.js",
     "../../../../config/loader.js",

--- a/assistant/src/cli/__tests__/cli-command-help-coverage.test.ts
+++ b/assistant/src/cli/__tests__/cli-command-help-coverage.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Coverage guard: every top-level `assistant` CLI command must declare its
+ * help as pure data in `CLI_COMMAND_HELP` (via a `<command>.help.ts` module).
+ *
+ * The memory capability indexer seeds CLI commands purely from
+ * `CLI_COMMAND_HELP` — it does NOT walk the Commander tree — so a command that
+ * registers without a declarative help entry would be silently invisible to
+ * semantic discovery. This test fails loudly in that case, standing in for the
+ * old `buildCliProgramTree()` fallback that used to catch such gaps at runtime.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { CLI_COMMAND_HELP } from "../index.help.js";
+import { buildCliProgramTree } from "../program.js";
+
+describe("CLI declarative help coverage", () => {
+  test("every registered command has a CLI_COMMAND_HELP entry", () => {
+    const declared = new Set(CLI_COMMAND_HELP.map((h) => h.name));
+    const program = buildCliProgramTree();
+
+    // Commander auto-injects a `help` builtin that carries no capability of its
+    // own; every other top-level command must be declared.
+    const missing = program.commands
+      .map((command) => command.name())
+      .filter((name) => name !== "help" && !declared.has(name));
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
+++ b/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
@@ -5,9 +5,9 @@
 // semantic retrieval.
 // ---------------------------------------------------------------------------
 
+import { CLI_COMMAND_HELP } from "@vellumai/plugin-api";
 import { and, eq, like, sql } from "drizzle-orm";
 
-import { buildCliProgram } from "../../../../cli/program.js";
 import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../../config/loader.js";
 import { resolveSkillStates } from "../../../../config/skill-state.js";
@@ -189,12 +189,10 @@ export function seedSkillGraphNodes(): void {
  */
 export async function seedCliGraphNodes(): Promise<void> {
   try {
-    const program = await buildCliProgram();
-
     const seenKeys = new Set<string>();
-    for (const cmd of program.commands) {
-      upsertCliCapabilityNode(cmd.name(), cmd.description());
-      seenKeys.add(`${CLI_SOURCE_PREFIX}${cmd.name()}`);
+    for (const help of CLI_COMMAND_HELP) {
+      upsertCliCapabilityNode(help.name, help.description);
+      seenKeys.add(`${CLI_SOURCE_PREFIX}${help.name}`);
     }
 
     pruneStaleCapabilities(CLI_SOURCE_PREFIX, seenKeys);

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/cli-command-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/cli-command-store.test.ts
@@ -2,9 +2,8 @@
  * Tests for `assistant/src/memory/v2/cli-command-store.ts`.
  *
  * Coverage matrix:
- *   - `seedV2CliCommandEntries` enumerates the program tree and upserts one
- *     `cli-commands/<name>` point per top-level subcommand.
- *   - It skips the auto-injected `help` builtin.
+ *   - `seedV2CliCommandEntries` renders one `cli-commands/<name>` point per
+ *     declarative command entry (`CLI_COMMAND_HELP`) and upserts it.
  *   - It calls `pruneSlugsWithPrefixExcept("cli-commands/", ...)` with the
  *     current id list under the `cli-command` kind so stale rows clear.
  *   - The legacy `kind` backfill runs once per process before pruning.
@@ -13,13 +12,14 @@
  *   - It swallows embedding-backend errors and leaves prior cache intact.
  *   - Stale in-flight results yield to the latest requested generation.
  *
- * Hermetic by design: the embedding backend, Qdrant module, and CLI program
- * tree are module-mocked so the suite never touches a real backend or the
- * full Commander wire-up.
+ * Hermetic by design: the embedding backend and Qdrant module are
+ * module-mocked, and the declarative command list is staged per test — the
+ * seed reads pure data from `@vellumai/plugin-api`, so it never imports the
+ * CLI's action graph.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { Command } from "commander";
+import type { CliCommandHelp } from "../../../../../cli/lib/cli-command-help.js";
 
 // ---------------------------------------------------------------------------
 // Programmable test state
@@ -45,14 +45,8 @@ interface BackfillCall {
   allowedSuffixes: ReadonlySet<string>;
 }
 
-interface CommandSpec {
-  name: string;
-  description: string;
-  helpText: string;
-}
-
 interface TestState {
-  commands: CommandSpec[];
+  commands: CliCommandHelp[];
   embedThrows: Error | null;
   embedReturn: number[][];
   sparseReturn: { indices: number[]; values: number[] };
@@ -77,6 +71,25 @@ const state: TestState = {
   callSequence: [],
 };
 
+/** Build a minimal declarative help fixture. */
+function help(
+  name: string,
+  description: string,
+  helpText?: string,
+): CliCommandHelp {
+  return { name, description, ...(helpText ? { helpText } : {}) };
+}
+
+/**
+ * Stage the declarative command list. Mutates `state.commands` in place so the
+ * stable array reference captured by the `cli/index.help.js` mock (below) sees
+ * the update — reassigning `state.commands` would not propagate.
+ */
+function setCommands(...commands: CliCommandHelp[]): void {
+  state.commands.length = 0;
+  state.commands.push(...commands);
+}
+
 mock.module("../../../../../config/loader.js", () => ({
   getConfig: () => ({
     memory: {
@@ -86,27 +99,12 @@ mock.module("../../../../../config/loader.js", () => ({
   }),
 }));
 
-// Stub the CLI program tree so tests don't need to wire the entire Commander
-// registration graph. Each test stages `state.commands`; the mock returns a
-// fresh `Command` tree whose children carry the staged help text.
-mock.module("../../../../../cli/program.js", () => ({
-  buildCliProgramTree: () => {
-    const program = new Command();
-    program.name("assistant");
-    for (const spec of state.commands) {
-      const child = program.command(spec.name).description(spec.description);
-      // helpInformation() is built from Commander state — stub it directly so
-      // the seeded content matches the test fixture verbatim.
-      child.helpInformation = () => spec.helpText;
-    }
-    return program;
-  },
-}));
-
-// Keep the suite driven entirely by the mocked program tree above: no commands
-// are sourced from the declarative `cli/index.help.ts` aggregate.
+// Stage the declarative command list per test. The store imports
+// `CLI_COMMAND_HELP` from `@vellumai/plugin-api`, which re-exports it from
+// `cli/index.help.js` — mocking that module drives the seed with pure data,
+// so no test wires the Commander action graph.
 mock.module("../../../../../cli/index.help.js", () => ({
-  CLI_COMMAND_HELP: [],
+  CLI_COMMAND_HELP: state.commands,
 }));
 
 mock.module(
@@ -171,7 +169,7 @@ const {
 } = await import("../cli-command-store.js");
 
 function resetState(): void {
-  state.commands = [];
+  state.commands.length = 0;
   state.embedThrows = null;
   state.embedReturn = [];
   state.sparseReturn = { indices: [1], values: [1] };
@@ -188,19 +186,11 @@ beforeEach(resetState);
 afterEach(resetState);
 
 describe("seedV2CliCommandEntries", () => {
-  test("upserts each top-level command under cli-commands/<name>", async () => {
-    state.commands = [
-      {
-        name: "attachment",
-        description: "Manage file attachments for conversations",
-        helpText: "Usage: assistant attachment ...",
-      },
-      {
-        name: "browser",
-        description: "Control the browser via the running assistant.",
-        helpText: "Usage: assistant browser ...",
-      },
-    ];
+  test("upserts each declarative command under cli-commands/<name>", async () => {
+    setCommands(
+      help("attachment", "Manage file attachments for conversations"),
+      help("browser", "Control the browser via the running assistant."),
+    );
     state.embedReturn = [
       [0.1, 0.2, 0.3],
       [0.4, 0.5, 0.6],
@@ -214,36 +204,8 @@ describe("seedV2CliCommandEntries", () => {
     expect(state.upsertCalls.every((c) => c.kind === "cli-command")).toBe(true);
   });
 
-  test("skips Commander's auto-injected `help` builtin", async () => {
-    state.commands = [
-      {
-        name: "attachment",
-        description: "Manage file attachments",
-        helpText: "Usage: assistant attachment ...",
-      },
-      {
-        name: "help",
-        description: "display help for command",
-        helpText: "Usage: assistant help ...",
-      },
-    ];
-    state.embedReturn = [[0.1, 0.2, 0.3]];
-
-    await seedV2CliCommandEntries();
-
-    expect(state.upsertCalls.map((c) => c.slug)).toEqual([
-      "cli-commands/attachment",
-    ]);
-  });
-
   test("calls pruneSlugsWithPrefixExcept with kind: 'cli-command'", async () => {
-    state.commands = [
-      {
-        name: "config",
-        description: "Manage configuration",
-        helpText: "...",
-      },
-    ];
+    setCommands(help("config", "Manage configuration"));
     state.embedReturn = [[0.1, 0.2, 0.3]];
 
     await seedV2CliCommandEntries();
@@ -255,13 +217,7 @@ describe("seedV2CliCommandEntries", () => {
   });
 
   test("runs backfill before prune so legacy kindless points are reachable", async () => {
-    state.commands = [
-      {
-        name: "config",
-        description: "Manage configuration",
-        helpText: "...",
-      },
-    ];
+    setCommands(help("config", "Manage configuration"));
     state.embedReturn = [[0.1, 0.2, 0.3]];
 
     await seedV2CliCommandEntries();
@@ -277,9 +233,7 @@ describe("seedV2CliCommandEntries", () => {
   });
 
   test("backfill only runs once across repeated seeds in the same process", async () => {
-    state.commands = [
-      { name: "config", description: "Manage configuration", helpText: "..." },
-    ];
+    setCommands(help("config", "Manage configuration"));
     state.embedReturn = [[0.1, 0.2, 0.3]];
 
     await seedV2CliCommandEntries();
@@ -291,13 +245,13 @@ describe("seedV2CliCommandEntries", () => {
   });
 
   test("populates the entries cache so getCliCommandCapability resolves both forms", async () => {
-    state.commands = [
-      {
-        name: "attachment",
-        description: "Manage file attachments",
-        helpText: "Usage: assistant attachment ...",
-      },
-    ];
+    setCommands(
+      help(
+        "attachment",
+        "Manage file attachments",
+        "Register a file-backed attachment with the assistant",
+      ),
+    );
     state.embedReturn = [[0.1, 0.2, 0.3]];
 
     expect(getCliCommandCapability("attachment")).toBeNull();
@@ -311,7 +265,9 @@ describe("seedV2CliCommandEntries", () => {
     expect(byId?.description).toBe("Manage file attachments");
     expect(byId?.content).toContain('"assistant attachment"');
     expect(byId?.content).toContain("Manage file attachments");
-    expect(byId?.content).toContain("Usage: assistant attachment ...");
+    expect(byId?.content).toContain(
+      "Register a file-backed attachment with the assistant",
+    );
     expect(bySlug).toEqual(byId);
 
     expect(getCliCommandCapability("unknown-command")).toBeNull();
@@ -325,10 +281,10 @@ describe("seedV2CliCommandEntries", () => {
   });
 
   test("listCliCommandEntries returns frozen sorted snapshots", async () => {
-    state.commands = [
-      { name: "browser", description: "Control browser", helpText: "..." },
-      { name: "attachment", description: "Manage attachments", helpText: "." },
-    ];
+    setCommands(
+      help("browser", "Control browser"),
+      help("attachment", "Manage attachments"),
+    );
     state.embedReturn = [
       [0.1, 0.2, 0.3],
       [0.4, 0.5, 0.6],
@@ -342,9 +298,7 @@ describe("seedV2CliCommandEntries", () => {
   });
 
   test("swallows embedWithBackend errors and leaves prior cache intact", async () => {
-    state.commands = [
-      { name: "config", description: "Manage configuration", helpText: "..." },
-    ];
+    setCommands(help("config", "Manage configuration"));
     state.embedReturn = [[0.1, 0.2, 0.3]];
 
     await seedV2CliCommandEntries();
@@ -364,9 +318,7 @@ describe("seedV2CliCommandEntries", () => {
   });
 
   test("propagates embedding errors when throwOnError is set", async () => {
-    state.commands = [
-      { name: "config", description: "Manage configuration", helpText: "..." },
-    ];
+    setCommands(help("config", "Manage configuration"));
     state.embedThrows = new Error("backend exploded");
 
     await expect(
@@ -374,15 +326,13 @@ describe("seedV2CliCommandEntries", () => {
     ).rejects.toThrow("backend exploded");
   });
 
-  test("populates the cache from the Commander tree on the first seed even when the embedding backend is unavailable (cold-start needle resilience)", async () => {
+  test("populates the cache from the declarative help on the first seed even when the embedding backend is unavailable (cold-start needle resilience)", async () => {
     // Cold-start race: the startup seed runs before the managed embedding
     // credential is provisioned, so the first `embedWithBackend` throws. The
     // in-memory cache (read by the v3 needle lane and the page index) must
-    // still populate from the local Commander tree so CLI commands are
+    // still populate from the declarative help so CLI commands are
     // discoverable from first boot; only the dense Qdrant upsert is deferred.
-    state.commands = [
-      { name: "config", description: "Manage configuration", helpText: "..." },
-    ];
+    setCommands(help("config", "Manage configuration"));
     state.embedThrows = new Error(
       'Embedding backend "gemini" is not configured',
     );
@@ -400,15 +350,11 @@ describe("seedV2CliCommandEntries", () => {
   });
 
   test("skips stale in-flight seed results when a newer refresh is requested", async () => {
-    state.commands = [
-      { name: "config", description: "Manage configuration", helpText: "..." },
-    ];
+    setCommands(help("config", "Manage configuration"));
     state.embedReturn = [[0.1, 0.2, 0.3]];
 
     const firstSeed = seedV2CliCommandEntries();
-    state.commands = [
-      { name: "browser", description: "Control browser", helpText: "..." },
-    ];
+    setCommands(help("browser", "Control browser"));
     const secondSeed = seedV2CliCommandEntries();
 
     await Promise.all([firstSeed, secondSeed]);
@@ -421,7 +367,7 @@ describe("seedV2CliCommandEntries", () => {
   });
 
   test("empty command set still calls prune to clear stale rows", async () => {
-    state.commands = [];
+    setCommands();
 
     await seedV2CliCommandEntries();
 

--- a/assistant/src/plugins/defaults/memory/v2/cli-command-content.ts
+++ b/assistant/src/plugins/defaults/memory/v2/cli-command-content.ts
@@ -18,7 +18,7 @@ type CliCommandHelp = (typeof CLI_COMMAND_HELP)[number];
 /** Subcommand element type — recursive via its own `subcommands` field. */
 type CliSubcommandHelp = NonNullable<CliCommandHelp["subcommands"]>[number];
 
-export function buildCliCommandContent(
+function buildCliCommandContent(
   name: string,
   description: string,
   helpText: string,

--- a/assistant/src/plugins/defaults/memory/v2/cli-command-store.ts
+++ b/assistant/src/plugins/defaults/memory/v2/cli-command-store.ts
@@ -2,22 +2,26 @@
 // Memory v2 — `assistant` CLI subcommands → embedded capability entries
 // ---------------------------------------------------------------------------
 //
-// Enumerate the top-level `assistant` CLI subcommands, render each as a prose
-// capability statement that wraps the full `helpInformation()` output, embed
-// dense + sparse, and upsert into `memory_v2_concept_pages` under the slug
-// `cli-commands/<name>`. The router scores these alongside concept pages and
-// skill entries; the injection layer surfaces hits under `### CLI Commands
-// You Can Use` so the model can semantically discover a CLI capability it
-// would not otherwise know to reach for.
+// Enumerate the top-level `assistant` CLI commands from their declarative help
+// (`CLI_COMMAND_HELP`, exposed via `@vellumai/plugin-api`), render each as a
+// prose capability statement, embed dense + sparse, and upsert into
+// `memory_v2_concept_pages` under the slug `cli-commands/<name>`. The router
+// scores these alongside concept pages and skill entries; the injection layer
+// surfaces hits under `### CLI Commands You Can Use` so the model can
+// semantically discover a CLI capability it would not otherwise know to reach
+// for.
+//
+// The declarative help is pure data, so the seed reads it without importing the
+// CLI's action graph (`cli/program.ts`) — the graph pulls in provider and
+// workspace modules that were a recurring source of test-mock cascades and
+// circular imports.
 //
 // Mirrors `skill-store.ts` deliberately: same single-flight + generation
 // coalescing, same dense + sparse + corpus-stats-aware sparse encoding, same
 // payload-kind discriminator, same atomic cache replacement. Differences:
-//   - No remote catalog — the source of truth is the local Commander tree.
-//   - No per-entry feature-flag filter — flag gating already happens during
-//     `buildCliProgramTree` (e.g. email/plugins commands are conditionally
-//     registered).
-//   - No MCP-style augmentation — Commander's description is the canonical
+//   - No remote catalog — the source of truth is the declarative CLI help.
+//   - No per-entry feature-flag filter.
+//   - No MCP-style augmentation — the declared description is the canonical
 //     summary.
 
 import { CLI_COMMAND_HELP } from "@vellumai/plugin-api";
@@ -27,10 +31,7 @@ import { generateSparseEmbedding } from "../../../../persistence/embeddings/embe
 import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import { embedWithBackend } from "../embeddings.js";
 import { getLogger } from "../logging.js";
-import {
-  buildCliCommandContent,
-  buildCliCommandHelpContent,
-} from "./cli-command-content.js";
+import { buildCliCommandHelpContent } from "./cli-command-content.js";
 import { invalidatePageIndex } from "./page-index.js";
 import {
   backfillKindOnPointsWithPrefix,
@@ -110,8 +111,12 @@ export async function seedV2CliCommandEntries(
 }
 
 function startSeedDrainIfNeeded(): void {
-  if (activeSeedDrain) return;
-  if (processedSeedGeneration >= requestedSeedGeneration) return;
+  if (activeSeedDrain) {
+    return;
+  }
+  if (processedSeedGeneration >= requestedSeedGeneration) {
+    return;
+  }
 
   activeSeedDrain = drainSeedQueue().finally(() => {
     activeSeedDrain = null;
@@ -131,7 +136,9 @@ async function drainSeedQueue(): Promise<void> {
 function resolveSeedWaiters(): void {
   for (let i = seedWaiters.length - 1; i >= 0; i -= 1) {
     const waiter = seedWaiters[i]!;
-    if (waiter.generation > processedSeedGeneration) continue;
+    if (waiter.generation > processedSeedGeneration) {
+      continue;
+    }
     seedWaiters.splice(i, 1);
     waiter.resolve();
   }
@@ -141,43 +148,18 @@ async function runSeedV2CliCommandEntries(generation: number): Promise<void> {
   try {
     const config = getConfig();
     const seeds: CliCommandEntry[] = [];
-    const declarativeNames = new Set<string>();
 
-    // Commands that have adopted the static-help split are read from their
-    // declarative help (exposed via `@vellumai/plugin-api`) — pure data, no CLI
-    // action graph. Content is rendered from that data here in the plugin.
+    // Every top-level `assistant` CLI command declares its help as pure data
+    // (`CLI_COMMAND_HELP`, exposed via `@vellumai/plugin-api`); render each into
+    // a capability statement here in the plugin. Reading declarative help keeps
+    // the CLI's action graph — and the daemon/provider modules it imports — out
+    // of this plugin's import tree, so the seed never touches `cli/program.ts`.
     for (const help of CLI_COMMAND_HELP) {
-      declarativeNames.add(help.name);
       seeds.push({
         id: help.name,
         description: help.description,
         content: buildCliCommandHelpContent(help),
       });
-    }
-
-    // Remaining commands still come from the Commander tree. Dynamic import so
-    // callers that only need `getCliCommandCapability` or `listCliCommandEntries`
-    // (e.g. the render path inside `injection.ts` and the `page-index.ts`
-    // dependency loader) never drag the full CLI command graph into their import
-    // tree. The CLI tree pulls in many provider and workspace modules whose
-    // presence has been a recurring source of test-mock cascades and
-    // circular-import surprises.
-    const { buildCliProgramTree } = await import("../../../../cli/program.js");
-    const program = buildCliProgramTree();
-
-    for (const cmd of program.commands) {
-      const name = cmd.name();
-      // Skip the `help` builtin Commander adds automatically — it carries no
-      // capability information of its own — and commands already sourced
-      // declaratively above.
-      if (name === "help" || declarativeNames.has(name)) continue;
-      const description = cmd.description();
-      const content = buildCliCommandContent(
-        name,
-        description,
-        cmd.helpInformation(),
-      );
-      seeds.push({ id: name, description, content });
     }
 
     // Sparse (BM25/TF) encoding is computed locally; only the dense vectors
@@ -342,7 +324,9 @@ export function isCliCommandSlug(slug: string): boolean {
  * copies on each call.
  */
 export function listCliCommandEntries(): CliCommandEntry[] {
-  if (!entries) return [];
+  if (!entries) {
+    return [];
+  }
   return [...entries.values()]
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
     .map((entry) => Object.freeze({ ...entry }));


### PR DESCRIPTION
## Prompt / plan

The payoff of the CLI static-help migration (#37732 → #37887): now that **every** `assistant` CLI command declares its help as pure data (`CLI_COMMAND_HELP`, via `@vellumai/plugin-api`), the memory plugin no longer needs to walk the Commander tree to enumerate CLI capabilities. Both seeders switch to the declarative list and drop their `cli/program.js` imports:

- **`v2/cli-command-store.ts`**: remove the `buildCliProgramTree()` fallback loop — dead now that all 48 commands are declarative — and its `buildCliCommandContent` import.
- **`graph/capability-seed.ts`** (`seedCliGraphNodes`): iterate `CLI_COMMAND_HELP` for name + description instead of `await buildCliProgram()`.

`buildCliCommandContent` is now internal to `cli-command-content.ts` (only `buildCliCommandHelpContent` calls it), so it is no longer exported.

## Import-cycle impact — the campaign's target

`cli/program.ts` pulls in the entire CLI action graph (every command module + the daemon/provider/workspace modules they import). Reaching it from the memory plugin dragged all of that into the plugin's static import graph and kept it inside the core dependency cycle.

Measured with `madge` + Tarjan SCC over `src`:

| | core (largest) SCC | `cli/program` in core? | memory→`cli/program` reachable? |
|---|---|---|---|
| main | **224** | yes | yes |
| this PR | **182** (−42) | **no** | **no** (zero edges) |

This is the single biggest core-SCC cut of the campaign, and it fully severs the memory plugin from the CLI action graph.

## Tests

- **`cli-command-store.test.ts` rewritten** to drive the seed from a staged `CLI_COMMAND_HELP` (mutated in place so the mocked module's stable array reference sees the update) instead of a mocked Commander tree. The old "skips the `help` builtin" case no longer applies (the store never walks the tree). 12 pass.
- **New `cli/__tests__/cli-command-help-coverage.test.ts`** — asserts every command `buildCliProgramTree()` registers has a `CLI_COMMAND_HELP` entry. This is a loud guard replacing the fallback's silent catch-all: a future command added without declarative help now fails CI instead of silently missing semantic discovery.
- Green across the memory-indexer + skills-seeding suites (injection 39, lifecycle-seed 13, startup 9, reembed-skills 11, candidate-match 12, and the capability-seed-mocking skill tests). `tsc`/`eslint`/`prettier`/`knip` clean.

## CLI verb checklist

No CLI verbs touched — this changes only how the memory plugin reads existing declarative help. Section N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWL4FYZVRGkJkMwL46PY3m)_