### PR TITLE
refactor(tools): drop coreToolsSnapshot; inline the ui/app tool arrays

### DIFF
--- a/assistant/src/__tests__/set-permission-mode.test.ts
+++ b/assistant/src/__tests__/set-permission-mode.test.ts
@@ -11,6 +11,11 @@ beforeEach(() => {
 });
 
 afterAll(() => {
+  // The test above runs a full initializeTools(), leaving the process-global
+  // registry hot; clear it so a combined `bun test` run doesn't leak this
+  // initialization into a later file that expects to initialize under its own
+  // env/mocks.
+  __clearRegistryForTesting();
   mock.restore();
 });
 

--- a/assistant/src/__tests__/ui-file-upload-surface.test.ts
+++ b/assistant/src/__tests__/ui-file-upload-surface.test.ts
@@ -6,10 +6,8 @@ import type {
   UiSurfaceShowFileUpload,
 } from "../daemon/message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
-import {
-  allUiSurfaceTools,
-  uiShowTool,
-} from "../tools/ui-surface/definitions.js";
+import { explicitTools } from "../tools/tool-manifest.js";
+import { uiShowTool } from "../tools/ui-surface/definitions.js";
 
 // ---------------------------------------------------------------------------
 // FileUploadSurfaceData shape
@@ -97,11 +95,10 @@ describe("ui_show tool includes file_upload", () => {
 
 describe("UI surface tool registration", () => {
   test("registers only the base UI surface tools", () => {
-    expect(allUiSurfaceTools.map((tool) => tool.name)).toEqual([
-      "ui_show",
-      "ui_update",
-      "ui_dismiss",
-    ]);
+    const uiToolNames = explicitTools
+      .map((tool) => tool.name)
+      .filter((name) => name?.startsWith("ui_"));
+    expect(uiToolNames).toEqual(["ui_show", "ui_update", "ui_dismiss"]);
   });
 });
 

--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -44,7 +44,7 @@ function proxyExecute(toolName: string) {
 // app_open
 // ---------------------------------------------------------------------------
 
-const appOpenTool = {
+export const appOpenTool = {
   name: "app_open",
   description:
     "Open a persistent app in a dynamic_page surface on the connected client.",
@@ -71,9 +71,3 @@ const appOpenTool = {
 
   execute: proxyExecute("app_open"),
 } satisfies ToolDefinition;
-
-// ---------------------------------------------------------------------------
-// Proxy-only tools registered in the core daemon registry
-// ---------------------------------------------------------------------------
-
-export const coreAppProxyTools: ToolDefinition[] = [appOpenTool];

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -28,12 +28,12 @@ const DEFAULT_TOOL_OWNER: OwnerInfo = Object.freeze({
   id: "default",
 });
 
-// Snapshot of core tools (with their owners) captured after initializeTools()
-// completes. Lets __resetRegistryForTesting() restore the core baseline — tools
-// and ownership together — synchronously, without re-running the async
-// initializeTools() bootstrap.
-let coreToolsSnapshot: Map<string, { tool: Tool; owner: OwnerInfo }> | null =
-  null;
+// Flips true once initializeTools() has registered the core manifest tools
+// (the read-only baseline: file_read/web_fetch/etc.). Only ever goes
+// false→true, so a true reading is stable for the process lifetime; callers
+// that must not run before the baseline exists gate on it via
+// {@link areCoreToolsInitialized}.
+let coreToolsInitialized = false;
 
 // Cached promise for the one-time tool-registry initialization. `initializeTools`
 // returns this so repeated calls (across entry points, or an eventual
@@ -195,14 +195,14 @@ export function getTool(name: string): Tool | undefined {
 }
 
 /**
- * True once {@link initializeTools} has populated the core registry (the core
- * snapshot is captured at the end of init). Callers that must not run before the
- * read-only baseline (`file_read`/`web_fetch`/etc.) exists — e.g. the scheduler
- * deferring boot-time workflow triggers — gate on this. It only ever flips
- * false→true, so a true reading is stable for the process lifetime.
+ * True once {@link initializeTools} has registered the core manifest tools.
+ * Callers that must not run before the read-only baseline
+ * (`file_read`/`web_fetch`/etc.) exists — e.g. the scheduler deferring
+ * boot-time workflow triggers — gate on this. It only ever flips false→true,
+ * so a true reading is stable for the process lifetime.
  */
 export function areCoreToolsInitialized(): boolean {
-  return coreToolsSnapshot !== null;
+  return coreToolsInitialized;
 }
 
 export function getAllTools(): Tool[] {
@@ -1071,45 +1071,10 @@ export function initializeTools(): Promise<void> {
 }
 
 async function runToolInitialization(): Promise<void> {
-  // Capture tool names already in the registry before any manifest
-  // registrations.  In production this is empty; in tests a non-skill tool
-  // may have been registered before the first initializeTools() call.
-  const preExisting = new Set(tools.keys());
-
   for (const tool of explicitTools) {
     registerTool(tool);
   }
-
-  // Snapshot core tools for __resetRegistryForTesting().  We include every
-  // non-skill tool that was registered by the manifest, while excluding
-  // arbitrary test tools that were registered before init.
-  //
-  // A pre-existing tool is included only if it is a known manifest tool
-  // (declared in explicitTools) — e.g. a test registered a manifest tool
-  // directly before its first initializeTools() call.
-  if (!coreToolsSnapshot) {
-    // Core tool literals always set `name` (verified by `registerTool` —
-    // it throws on missing name). The `!` assertion reflects that
-    // invariant at the iteration site.
-    const manifestToolNames = new Set<string>(
-      explicitTools.map((t) => t.name!),
-    );
-
-    coreToolsSnapshot = new Map<string, { tool: Tool; owner: OwnerInfo }>();
-    for (const [name, tool] of tools) {
-      const owner = ownersByName.get(name);
-      if (owner?.kind === "skill" || owner?.kind === "plugin") {
-        continue;
-      }
-      // Exclude pre-existing tools not declared in the manifest
-      if (preExisting.has(name) && !manifestToolNames.has(name)) {
-        continue;
-      }
-      // Every registered tool carries an owner (built-ins get DEFAULT_TOOL_OWNER
-      // stamped by registerTool), so `owner` is defined here.
-      coreToolsSnapshot.set(name, { tool, owner: owner! });
-    }
-  }
+  coreToolsInitialized = true;
 
   log.info({ count: tools.size }, "Tools initialized");
 
@@ -1118,8 +1083,6 @@ async function runToolInitialization(): Promise<void> {
   // registrations get a chance to claim names. This ordering makes
   // workspace tools the canonical owner per name:
   //   core registrations → workspace tools → MCP → plugins.
-  // Workspace tools land after the core snapshot above so they're never
-  // baked into the test-reset baseline.
   //
   // `loadWorkspaceTools` is idempotent: this is the first reconcile, and
   // conversation reads re-run it later to pick up on-disk edits without a
@@ -1146,9 +1109,11 @@ async function runToolInitialization(): Promise<void> {
  * exclusively for test isolation - prevents cross-file contamination
  * when multiple test suites share a single Bun process.
  *
- * Restores core tools from a snapshot taken after the first
- * initializeTools() call, so the reset is synchronous and does not
- * depend on re-running the async init bootstrap.
+ * Re-registers the core manifest tools synchronously (the async workspace /
+ * plugin reconciles are NOT re-run, so their file-backed tools drop out of
+ * the baseline). `registerTool` reuses the finalized instances memoized on
+ * first init, so restored tools keep their identity. A no-op restore when
+ * init never ran in this process — nothing to re-register yet.
  */
 export function __resetRegistryForTesting(): void {
   tools.clear();
@@ -1156,19 +1121,18 @@ export function __resetRegistryForTesting(): void {
   skillRefCount.clear();
   pluginRefCount.clear();
   pulledPluginFingerprints.clear();
-  // Drop the override stash too — the snapshot already represents the
-  // pre-override baseline, so leaving stashed entries here would let a
-  // later registerWorkspaceTools() falsely report "overridesCore: true"
+  // Drop the override stash too — re-registering the core baseline below
+  // restores the pre-override state, so leaving stashed entries here would let
+  // a later registerWorkspaceTools() falsely report "overridesCore: true"
   // against a fresh registry.
   coreToolOverrides.clear();
   // Clear the cached init promise so a later initializeTools() re-runs against
   // the freshly reset registry rather than returning the previous settled run.
   toolsInitPromise = null;
 
-  if (coreToolsSnapshot) {
-    for (const [name, { tool, owner }] of coreToolsSnapshot) {
-      tools.set(name, tool);
-      ownersByName.set(name, owner);
+  if (coreToolsInitialized) {
+    for (const tool of explicitTools) {
+      registerTool(tool);
     }
   }
 }

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -7,7 +7,7 @@
  */
 
 import { recallTool, rememberTool } from "../plugins/defaults/memory/tools.js";
-import { coreAppProxyTools } from "./apps/definitions.js";
+import { appOpenTool } from "./apps/definitions.js";
 import { askQuestionTool } from "./ask-question/ask-question-tool.js";
 import { fileEditTool } from "./filesystem/edit.js";
 import { fileListTool } from "./filesystem/list.js";
@@ -27,7 +27,11 @@ import { notifyParentTool } from "./subagent/notify-parent.js";
 import { requestSystemPermissionTool } from "./system/request-permission.js";
 import { shellTool } from "./terminal/shell.js";
 import type { ToolDefinition } from "./types.js";
-import { allUiSurfaceTools } from "./ui-surface/definitions.js";
+import {
+  uiDismissTool,
+  uiShowTool,
+  uiUpdateTool,
+} from "./ui-surface/definitions.js";
 
 // ── Explicit tool instances ─────────────────────────────────────────
 // Core tools registered by initializeTools(). Tool modules only export
@@ -62,6 +66,8 @@ export const explicitTools: ToolDefinition[] = [
   hostFileEditTool,
   hostFileTransferTool,
   hostShellTool,
-  ...allUiSurfaceTools,
-  ...coreAppProxyTools,
+  uiShowTool,
+  uiUpdateTool,
+  uiDismissTool,
+  appOpenTool,
 ];

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -362,7 +362,7 @@ export const uiUpdateTool = {
 // ui_dismiss
 // ---------------------------------------------------------------------------
 
-const uiDismissTool = {
+export const uiDismissTool = {
   name: "ui_dismiss",
   description: "Dismiss a currently displayed surface.",
   category: "ui-surface",
@@ -382,9 +382,3 @@ const uiDismissTool = {
 
   execute: proxyExecute("ui_dismiss"),
 } satisfies ToolDefinition;
-
-export const allUiSurfaceTools: ToolDefinition[] = [
-  uiShowTool,
-  uiUpdateTool,
-  uiDismissTool,
-];


### PR DESCRIPTION
## Prompt / plan

Follow-ups on #37874: rip out `coreToolsSnapshot`, and inline the two tool-definition arrays per review.

## 1. Remove `coreToolsSnapshot`

The snapshot captured every core tool + owner at first init so `__resetRegistryForTesting` could restore the baseline synchronously, and so `areCoreToolsInitialized` had a signal. Now that `explicitTools` is the single static declarative list of core tools, neither needs a snapshot:

- **`areCoreToolsInitialized`** reads a plain `coreToolsInitialized` boolean, flipped true right after the `explicitTools` registration loop. Same false→true-once semantics; same gate for the scheduler / schedule-routes boot-time-workflow deferral.
- **`__resetRegistryForTesting`** clears the maps and re-registers `explicitTools` directly. `registerTool` reuses the instances memoized in `finalizedByDefinition` on first init, so restored tools keep their identity (`getTool(x)` returns the same object as before the reset). The async workspace/plugin reconciles are still not re-run, so file-backed tools stay out of the baseline — identical to what the snapshot guaranteed. The `preExisting`/snapshot bookkeeping in `runToolInitialization` is gone.

Net: `runToolInitialization` is now just `register explicitTools → flag → loadWorkspaceTools → loadPluginTools`.

## 2. Inline the tool arrays (review: dvargasfuertes)

Delete the `coreAppProxyTools` and `allUiSurfaceTools` aggregate exports; export the underlying `appOpenTool` / `uiDismissTool` and list `appOpenTool`, `uiShowTool`, `uiUpdateTool`, `uiDismissTool` directly in `explicitTools`. The one external consumer — `ui-file-upload-surface`'s "registers only the base UI surface tools" guard — now filters the `ui_*` names out of `explicitTools`, which is a stronger check (it verifies they're actually in the manifest, not just in a sibling array).

## 3. Reset registry in set-permission-mode afterAll (review: codex P2)

The test runs a full `initializeTools()`; its `afterAll` now `__clearRegistryForTesting()` so a combined `bun test` run can't inherit this initialization into a later file.

## Test plan

- Full suite (per-file runner): only the 8 known environmental failures; zero regressions.
- Per-file green for every suite touching this path: `registry` (heavy `__resetRegistryForTesting` user), `set-permission-mode`, `ui-file-upload-surface`, `schedule-routes-workflow-validation` + `task-scheduler` (the `areCoreToolsInitialized` gate consumers), `skill-tool-manifest`, `workspace-tool-loader`, `plugin-tool-contribution`, `app-control-tool-schemas`.
- `tsc` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ok5MKKrM4ZnmqG3AeXWtc)_