### PR TITLE
refactor(memory): creation-site skill cards — drop finalize extraction

### DIFF
--- a/assistant/src/__tests__/jobs-store-skill-card-upsert.test.ts
+++ b/assistant/src/__tests__/jobs-store-skill-card-upsert.test.ts
@@ -1,0 +1,191 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { and, eq } from "drizzle-orm";
+
+import { getMemoryDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { upsertSkillCardInsertJob } from "../persistence/jobs-store.js";
+import { memoryJobs } from "../persistence/schema/index.js";
+
+function skillEntry(skillId: string, name = `Skill ${skillId}`) {
+  return { skillId, name, description: `Does ${skillId}` };
+}
+
+function pendingRows() {
+  const db = getMemoryDb()!;
+  return db
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.type, "skill_card_insert"))
+    .all();
+}
+
+function parsedSkills(payload: string): Array<{ skillId: string }> {
+  return (JSON.parse(payload) as { skills: Array<{ skillId: string }> }).skills;
+}
+
+describe("upsertSkillCardInsertJob payload merge", () => {
+  beforeAll(async () => {
+    await initializeDb();
+  });
+
+  beforeEach(() => {
+    const db = getMemoryDb()!;
+    db.run("DELETE FROM memory_jobs");
+  });
+
+  test("inserts a fresh pending row when none exists for the run", () => {
+    upsertSkillCardInsertJob({
+      sourceConversationId: "src-1",
+      runConversationId: "run-1",
+      skills: [skillEntry("skill-a")],
+    });
+
+    const rows = pendingRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("pending");
+    const payload = JSON.parse(rows[0]!.payload) as Record<string, unknown>;
+    expect(payload.sourceConversationId).toBe("src-1");
+    expect(payload.runConversationId).toBe("run-1");
+    expect(parsedSkills(rows[0]!.payload).map((s) => s.skillId)).toEqual([
+      "skill-a",
+    ]);
+  });
+
+  test("a second create in the same run merges its skill into the pending payload", () => {
+    upsertSkillCardInsertJob({
+      sourceConversationId: "src-1",
+      runConversationId: "run-1",
+      skills: [skillEntry("skill-a")],
+    });
+    upsertSkillCardInsertJob({
+      sourceConversationId: "src-1",
+      runConversationId: "run-1",
+      skills: [skillEntry("skill-b")],
+    });
+
+    const rows = pendingRows();
+    expect(rows).toHaveLength(1);
+    expect(parsedSkills(rows[0]!.payload).map((s) => s.skillId)).toEqual([
+      "skill-a",
+      "skill-b",
+    ]);
+  });
+
+  test("re-enqueueing the same skill is deduplicated by skillId (pending entry wins)", () => {
+    upsertSkillCardInsertJob({
+      sourceConversationId: "src-1",
+      runConversationId: "run-1",
+      skills: [skillEntry("skill-a", "Original Name")],
+    });
+    // The handler's still-mid-turn re-upsert replays the whole snapshot.
+    upsertSkillCardInsertJob({
+      sourceConversationId: "src-1",
+      runConversationId: "run-1",
+      skills: [skillEntry("skill-a", "Replayed Name"), skillEntry("skill-b")],
+    });
+
+    const rows = pendingRows();
+    expect(rows).toHaveLength(1);
+    const skills = parsedSkills(rows[0]!.payload) as Array<{
+      skillId: string;
+      name: string;
+    }>;
+    expect(skills.map((s) => s.skillId)).toEqual(["skill-a", "skill-b"]);
+    expect(skills[0]!.name).toBe("Original Name");
+  });
+
+  test("the earliest runAfter wins across merges", () => {
+    const later = Date.now() + 300_000;
+    const sooner = Date.now();
+    upsertSkillCardInsertJob(
+      {
+        sourceConversationId: "src-1",
+        runConversationId: "run-1",
+        skills: [skillEntry("skill-a")],
+      },
+      later,
+    );
+    upsertSkillCardInsertJob(
+      {
+        sourceConversationId: "src-1",
+        runConversationId: "run-1",
+        skills: [skillEntry("skill-b")],
+      },
+      sooner,
+    );
+    // A later-scheduled follow-up must not push the sooner row back out.
+    upsertSkillCardInsertJob(
+      {
+        sourceConversationId: "src-1",
+        runConversationId: "run-1",
+        skills: [skillEntry("skill-c")],
+      },
+      later,
+    );
+
+    const rows = pendingRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.runAfter).toBe(sooner);
+    expect(parsedSkills(rows[0]!.payload).map((s) => s.skillId)).toEqual([
+      "skill-a",
+      "skill-b",
+      "skill-c",
+    ]);
+  });
+
+  test("distinct runs keep distinct pending rows", () => {
+    upsertSkillCardInsertJob({
+      sourceConversationId: "src-1",
+      runConversationId: "run-1",
+      skills: [skillEntry("skill-a")],
+    });
+    upsertSkillCardInsertJob({
+      sourceConversationId: "src-1",
+      runConversationId: "run-2",
+      skills: [skillEntry("skill-b")],
+    });
+
+    const rows = pendingRows();
+    expect(rows).toHaveLength(2);
+    const byRun = new Map(
+      rows.map((r) => [
+        (JSON.parse(r.payload) as { runConversationId: string })
+          .runConversationId,
+        parsedSkills(r.payload).map((s) => s.skillId),
+      ]),
+    );
+    expect(byRun.get("run-1")).toEqual(["skill-a"]);
+    expect(byRun.get("run-2")).toEqual(["skill-b"]);
+  });
+
+  test("a non-pending row does not coalesce — a fresh pending row is created", () => {
+    // The claimed row a handler re-upserts from is `running`; its replacement
+    // must be a NEW pending row, never a mutation of the claimed one.
+    upsertSkillCardInsertJob({
+      sourceConversationId: "src-1",
+      runConversationId: "run-1",
+      skills: [skillEntry("skill-a")],
+    });
+    const db = getMemoryDb()!;
+    db.update(memoryJobs)
+      .set({ status: "running" })
+      .where(
+        and(
+          eq(memoryJobs.type, "skill_card_insert"),
+          eq(memoryJobs.status, "pending"),
+        ),
+      )
+      .run();
+
+    upsertSkillCardInsertJob({
+      sourceConversationId: "src-1",
+      runConversationId: "run-1",
+      skills: [skillEntry("skill-a")],
+    });
+
+    const rows = pendingRows();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.status).sort()).toEqual(["pending", "running"]);
+  });
+});

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -17,6 +17,36 @@ mock.module("../daemon/skill-memory-refresh.js", () => ({
   refreshSkillCapabilityMemories: mockRefreshSkillCapabilityMemories,
 }));
 
+// Skill-card enqueue recorder. Snapshot + override (rather than a full module
+// replacement) because other modules in this import graph (e.g. the managed
+// store's capability seeding) import sibling jobs-store exports that must
+// keep working.
+import * as realJobsStore from "../persistence/jobs-store.js";
+
+let skillCardJobUpserts: Array<{
+  payload: {
+    sourceConversationId: string;
+    runConversationId: string;
+  } & Record<string, unknown>;
+  runAfter: number | undefined;
+}> = [];
+let skillCardUpsertThrows = false;
+mock.module("../persistence/jobs-store.js", () => ({
+  ...realJobsStore,
+  upsertSkillCardInsertJob: (
+    payload: {
+      sourceConversationId: string;
+      runConversationId: string;
+    } & Record<string, unknown>,
+    runAfter?: number,
+  ) => {
+    if (skillCardUpsertThrows) {
+      throw new Error("jobs db unavailable");
+    }
+    skillCardJobUpserts.push({ payload, runAfter });
+  },
+}));
+
 /**
  * Build the injected catalog seam for the ownership-backstop tests. Seeds the
  * given non-managed (bundled / plugin / workspace) or managed entry so the
@@ -56,6 +86,8 @@ function installMetaFor(skillId: string) {
 beforeEach(() => {
   mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
   mockRefreshSkillCapabilityMemories.mockClear();
+  skillCardJobUpserts = [];
+  skillCardUpsertThrows = false;
 });
 
 afterEach(() => {
@@ -1092,5 +1124,234 @@ describe("scaffold_managed_skill tool", () => {
     expect(existsSync(join(TEST_DIR, "skills", "fresh-proc", "SKILL.md"))).toBe(
       true,
     );
+  });
+
+  // ── Skill-card enqueue at the creation site ─────────────────────────────
+
+  /** Lineage seam resolving the fork parent of the retrospective run. */
+  function lineageSeam() {
+    return {
+      getConversation: (id: string) =>
+        id === "retro-run-conv"
+          ? { forkParentConversationId: "source-conv" }
+          : null,
+    };
+  }
+
+  test("retrospective CREATE enqueues one skill_card_insert job with the normalized payload and resolved source id", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: " card-skill ",
+        name: "  Card\nSkill  ",
+        description: " Does\r\ncard things ",
+        body_markdown: "Do the procedure.",
+        emoji: " 🧭 ",
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      lineageSeam(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(skillCardJobUpserts).toHaveLength(1);
+    // The payload carries the executor's post-normalization values — the
+    // same trimmed/newline-collapsed strings persisted to the frontmatter —
+    // so the card links and labels the skill exactly as it exists on disk.
+    expect(skillCardJobUpserts[0]!.payload).toEqual({
+      sourceConversationId: "source-conv",
+      runConversationId: "retro-run-conv",
+      skills: [
+        {
+          skillId: "card-skill",
+          name: "Card Skill",
+          description: "Does card things",
+          emoji: "🧭",
+        },
+      ],
+    });
+  });
+
+  test("a whitespace-only emoji is omitted from the card payload", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "no-emoji-card",
+        name: "No Emoji",
+        description: "Card without an emoji",
+        body_markdown: "Do the procedure.",
+        emoji: " \n ",
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      lineageSeam(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(skillCardJobUpserts).toHaveLength(1);
+    const skill = (
+      skillCardJobUpserts[0]!.payload.skills as Record<string, unknown>[]
+    )[0]!;
+    expect(skill.skillId).toBe("no-emoji-card");
+    expect("emoji" in skill).toBe(false);
+  });
+
+  test("retrospective CREATE with an unresolvable fork parent skips the enqueue but the scaffold still succeeds", async () => {
+    // Three unresolvable shapes: the run row is gone, the run is not a fork,
+    // and the lineage lookup throws.
+    const cases: Array<{
+      skillId: string;
+      lookup: () => { forkParentConversationId: string | null } | null;
+    }> = [
+      { skillId: "no-card-no-row", lookup: () => null },
+      {
+        skillId: "no-card-no-parent",
+        lookup: () => ({ forkParentConversationId: null }),
+      },
+      {
+        skillId: "no-card-throwing-lookup",
+        lookup: () => {
+          throw new Error("db unavailable");
+        },
+      },
+    ];
+
+    for (const { skillId, lookup } of cases) {
+      const result = await executeScaffoldManagedSkill(
+        {
+          skill_id: skillId,
+          name: "No Card",
+          description: "Fork parent not resolvable",
+          body_markdown: "Do the procedure.",
+        },
+        makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+        { getConversation: lookup },
+      );
+
+      expect(result.isError).toBe(false);
+      expect(existsSync(join(TEST_DIR, "skills", skillId, "SKILL.md"))).toBe(
+        true,
+      );
+    }
+    expect(skillCardJobUpserts).toHaveLength(0);
+  });
+
+  test("retrospective overwrite of an EXISTING skill (a refinement) does not enqueue a card", async () => {
+    // First pass: genuine create — enqueues.
+    await executeScaffoldManagedSkill(
+      {
+        skill_id: "refined-skill",
+        name: "Refined Skill",
+        description: "First pass",
+        body_markdown: "V1 procedure.",
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      lineageSeam(),
+    );
+    expect(skillCardJobUpserts).toHaveLength(1);
+    skillCardJobUpserts = [];
+
+    // Second pass: overwrite of the pre-existing skill — a refinement, no card.
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "refined-skill",
+        name: "Refined Skill",
+        description: "Refined",
+        body_markdown: "V2 procedure.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      lineageSeam(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(skillCardJobUpserts).toHaveLength(0);
+  });
+
+  test("retrospective overwrite:true on a skill that did NOT previously exist is still a create and enqueues", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "overwrite-fresh",
+        name: "Overwrite Fresh",
+        description: "Overwrite flag on a fresh id",
+        body_markdown: "Do the procedure.",
+        overwrite: true,
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      lineageSeam(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(skillCardJobUpserts).toHaveLength(1);
+    expect(skillCardJobUpserts[0]!.payload.skills).toEqual([
+      {
+        skillId: "overwrite-fresh",
+        name: "Overwrite Fresh",
+        description: "Overwrite flag on a fresh id",
+      },
+    ]);
+  });
+
+  test("user-origin create never enqueues a card, even with resolvable lineage", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "user-no-card",
+        name: "User No Card",
+        description: "Authored interactively",
+        body_markdown: "Do the thing.",
+      },
+      makeContext({ conversationId: "retro-run-conv" }),
+      lineageSeam(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(skillCardJobUpserts).toHaveLength(0);
+  });
+
+  test("a throwing enqueue never fails the scaffold — the skill is already created", async () => {
+    skillCardUpsertThrows = true;
+
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "enqueue-throws",
+        name: "Enqueue Throws",
+        description: "Jobs DB unavailable at enqueue time",
+        body_markdown: "Do the procedure.",
+      },
+      makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+      lineageSeam(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(
+      existsSync(join(TEST_DIR, "skills", "enqueue-throws", "SKILL.md")),
+    ).toBe(true);
+    expect(installMetaFor("enqueue-throws")?.author).toBe("assistant");
+  });
+
+  test("two creates in the same run enqueue one upsert per skill under the same run id (merge happens in the jobs store)", async () => {
+    for (const skillId of ["run-skill-a", "run-skill-b"]) {
+      const result = await executeScaffoldManagedSkill(
+        {
+          skill_id: skillId,
+          name: `Skill ${skillId}`,
+          description: `Does ${skillId}`,
+          body_markdown: "Do the procedure.",
+        },
+        makeRetrospectiveContext({ conversationId: "retro-run-conv" }),
+        lineageSeam(),
+      );
+      expect(result.isError).toBe(false);
+    }
+
+    // One upsert per created skill, all keyed to the same run + source — the
+    // jobs-store upsert coalesces them into a single pending payload (covered
+    // by jobs-store-skill-card-upsert.test.ts).
+    expect(skillCardJobUpserts).toHaveLength(2);
+    for (const upsert of skillCardJobUpserts) {
+      expect(upsert.payload.sourceConversationId).toBe("source-conv");
+      expect(upsert.payload.runConversationId).toBe("retro-run-conv");
+    }
+    expect(
+      skillCardJobUpserts.flatMap((u) =>
+        (u.payload.skills as Array<{ skillId: string }>).map((s) => s.skillId),
+      ),
+    ).toEqual(["run-skill-a", "run-skill-b"]);
   });
 });

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -278,17 +278,18 @@ export function upsertMemoryRetrospectiveJob(
 }
 
 /**
- * Upsert a pending `skill_card_insert` job — the deferred delivery of a
- * retrospective run's skill card into a source conversation that was mid-turn
- * at insert time (see `memory-retrospective-skill-card.ts`). Keyed by
- * `runConversationId`: one pending delivery exists per authoring run, so the
- * handler's own still-mid-turn re-upsert (and any duplicate enqueue) coalesces
- * into a single row instead of stacking deliveries — the message-level
- * `clientMessageId` dedup remains the final backstop against a double card.
- * The earliest `runAfter` wins, mirroring `upsertMemoryRetrospectiveJob`; the
- * stored payload is kept as-is since every enqueue for a given run carries the
- * same snapshot (the skill list is derived from that run's persisted
- * messages).
+ * Upsert a pending `skill_card_insert` job — the durable delivery of a
+ * retrospective run's skill card into its source conversation (see
+ * `memory-retrospective-skill-card.ts`; the scaffold executor enqueues one at
+ * the creation site per authored skill). Keyed by `runConversationId`: one
+ * pending delivery exists per authoring run. A follow-up enqueue for the same
+ * run MERGES into the pending row instead of stacking deliveries — its
+ * `skills` entries are appended, deduplicated by `skillId` (the pending entry
+ * wins), so a run that authors several skills coalesces into a single card
+ * and the handler's own still-mid-turn re-upsert of an identical snapshot is
+ * a no-op append. The earliest `runAfter` wins, mirroring
+ * `upsertMemoryRetrospectiveJob`; the message-level `clientMessageId` dedup
+ * remains the final backstop against a double card.
  */
 export function upsertSkillCardInsertJob(
   payload: {
@@ -310,16 +311,62 @@ export function upsertSkillCardInsertJob(
     )
     .get();
   if (existing) {
-    const nextRunAfter = Math.min(existing.runAfter, runAfter);
-    if (nextRunAfter !== existing.runAfter) {
-      db.update(memoryJobs)
-        .set({ runAfter: nextRunAfter, updatedAt: Date.now() })
-        .where(eq(memoryJobs.id, existing.id))
-        .run();
+    let existingPayload: Record<string, unknown> = {};
+    try {
+      existingPayload = JSON.parse(existing.payload) as Record<string, unknown>;
+    } catch {
+      existingPayload = {};
     }
+    const mergedPayload = {
+      ...existingPayload,
+      ...payload,
+      skills: mergeSkillCardEntries(existingPayload.skills, payload.skills),
+    };
+    db.update(memoryJobs)
+      .set({
+        payload: JSON.stringify(mergedPayload),
+        runAfter: Math.min(existing.runAfter, runAfter),
+        updatedAt: Date.now(),
+      })
+      .where(eq(memoryJobs.id, existing.id))
+      .run();
     return;
   }
   enqueueMemoryJob("skill_card_insert", payload, runAfter);
+}
+
+/**
+ * Append incoming skill-card entries to the already-pending list,
+ * deduplicated by `skillId` — the pending entry wins over a re-enqueue of the
+ * same skill. Entries are opaque to the queue beyond the `skillId` key;
+ * malformed values (non-arrays, entries without a non-empty string `skillId`)
+ * contribute nothing rather than corrupting the pending payload.
+ */
+function mergeSkillCardEntries(
+  existing: unknown,
+  incoming: unknown,
+): unknown[] {
+  const merged: unknown[] = [];
+  const seen = new Set<string>();
+  const candidates = [
+    ...(Array.isArray(existing) ? existing : []),
+    ...(Array.isArray(incoming) ? incoming : []),
+  ];
+  for (const entry of candidates) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const skillId = (entry as Record<string, unknown>).skillId;
+    if (typeof skillId !== "string" || skillId.length === 0) {
+      continue;
+    }
+    if (seen.has(skillId)) {
+      continue;
+    }
+    seen.add(skillId);
+    merged.push(entry);
+  }
+  return merged;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -271,9 +271,6 @@ mock.module("../../../../persistence/jobs-store.js", () => ({
   ) => {
     retrospectiveJobUpserts.push({ payload, runAfter });
   },
-  // The skill-card module's mid-turn deferral path; exercised in
-  // memory-retrospective-skill-card.test.ts, inert here.
-  upsertSkillCardInsertJob: () => {},
 }));
 
 // proc-to-skills gate. Drives both `buildForkInstruction`'s skill-authoring

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
@@ -388,21 +388,51 @@ describe("memory-retrospective skill card", () => {
     expect(skillCardJobUpserts).toHaveLength(0);
   });
 
-  test("handler batches a multi-skill payload into ONE card message", async () => {
-    // A run that authors several skills coalesces into one pending job (the
-    // jobs-store upsert merges by runConversationId), so the handler must
-    // render every skill in a single ui_surface block.
+  test("multi-skill run: A's job defers mid-run, B merges, the post-run attempt delivers ONE card with both skills", async () => {
+    // The creation-site sequence end to end. Skill A's enqueue fires DURING
+    // the fork run (the source is idle between turns), so the worker can
+    // claim it before skill B's enqueue lands — delivering there would let
+    // B's job dedup against the inserted message and vanish. The handler
+    // must defer while the run is processing; B then merges into the
+    // re-upserted pending row (the jobs-store coalesce is covered by
+    // jobs-store-skill-card-upsert.test.ts), and the post-run attempt
+    // renders every skill in a single ui_surface block.
+    processingConversationIds = ["run-conv-1"];
+    const skillA = {
+      skillId: "skill-a",
+      name: "Skill A",
+      description: "Does A",
+    };
+    const skillB = {
+      skillId: "skill-b",
+      name: "Skill B",
+      description: "Does B",
+    };
+
+    // Skill A's job is claimed mid-run: no insert, deferral re-upserted.
     await skillCardInsertJob(
       makeInsertJob({
         sourceConversationId: "src-conv-9",
         runConversationId: "run-conv-1",
-        skills: [
-          { skillId: "skill-a", name: "Skill A", description: "Does A" },
-          { skillId: "skill-b", name: "Skill B", description: "Does B" },
-        ],
+        skills: [skillA],
       }),
     );
+    expect(addMessageCalls).toHaveLength(0);
+    expect(skillCardJobUpserts).toHaveLength(1);
+    const deferred = skillCardJobUpserts[0]!.payload;
+    expect(deferred.skills).toEqual([skillA]);
 
+    // Skill B's creation-site enqueue merges into that pending row.
+    const merged = {
+      ...deferred,
+      skills: [...(deferred.skills as unknown[]), skillB],
+    };
+
+    // The run finishes; the deferred job fires with the merged payload.
+    processingConversationIds = [];
+    await skillCardInsertJob(makeInsertJob(merged));
+
+    expect(skillCardJobUpserts).toHaveLength(1); // no further deferral
     expect(addMessageCalls).toHaveLength(1);
     const blocks = JSON.parse(addMessageCalls[0]!.content) as Array<{
       type: string;
@@ -422,6 +452,40 @@ describe("memory-retrospective skill card", () => {
       _surfaceFallback: true,
     });
     expect(publishedConversationIds).toEqual(["src-conv-9"]);
+  });
+
+  test("handler defers while the run conversation is still processing: no insert, re-upsert at the same delay", async () => {
+    // Enqueues fire at the creation site DURING the fork run; the source is
+    // usually idle then, so without the run gate the card would deliver
+    // before later creations from the same run merge in (see module header).
+    processingConversationIds = ["run-conv-1"];
+    const before = Date.now();
+
+    await skillCardInsertJob(makeInsertJob(insertJobPayload()));
+
+    expect(addMessageCalls).toHaveLength(0);
+    expect(publishedConversationIds).toHaveLength(0);
+    expect(skillCardJobUpserts).toHaveLength(1);
+    expect(skillCardJobUpserts[0]!.payload).toEqual(insertJobPayload());
+    expect(skillCardJobUpserts[0]!.runAfter).toBeGreaterThanOrEqual(
+      before + SKILL_CARD_INSERT_RETRY_DELAY_MS,
+    );
+  });
+
+  test("handler delivers when the run conversation is missing: a GC'd fork counts as finished", async () => {
+    // Superseded-fork GC can delete the run conversation before delivery. A
+    // fork can't be processing once its row is gone, so a missing run must
+    // never strand the card — even against a stale processing read (the
+    // explicit getConversation check wins over isConversationProcessing).
+    conversationOverrides["run-conv-1"] = null;
+    processingConversationIds = ["run-conv-1"];
+
+    await skillCardInsertJob(makeInsertJob(insertJobPayload()));
+
+    expect(addMessageCalls).toHaveLength(1);
+    expect(syncedToDisk).toHaveLength(1);
+    expect(publishedConversationIds).toEqual(["src-conv-9"]);
+    expect(skillCardJobUpserts).toHaveLength(0);
   });
 
   test("handler with a still-mid-turn source re-upserts itself at the same delay and inserts nothing", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
@@ -4,8 +4,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Mock state. Reset between tests.
 // ---------------------------------------------------------------------------
 
-let newMessages: Array<{ id: string; createdAt: number }> = [];
-
 let addMessageCalls: Array<{
   conversationId: string;
   role: string;
@@ -37,17 +35,9 @@ type ConversationStub = {
 } | null;
 let conversationOverrides: Record<string, ConversationStub> = {};
 
-type StubMessage = {
-  role: string;
-  content: string;
-  createdAt: number;
-  metadata: string | null;
-};
-let messagesByConversationId: Record<string, StubMessage[]> = {};
-
 mock.module("../../../../persistence/conversation-crud.js", () => ({
-  getMessagesAfter: (_id: string, _afterId: string | null) => newMessages,
-  getMessages: (id: string) => messagesByConversationId[id] ?? [],
+  getMessagesAfter: (_id: string, _afterId: string | null) => [],
+  getMessages: (_id: string) => [],
   getConversation: (id: string) => {
     if (id in conversationOverrides) {
       return conversationOverrides[id] ?? undefined;
@@ -119,45 +109,6 @@ mock.module("../../../../runtime/sync/resource-sync-events.js", () => ({
   },
 }));
 
-let mockProcToSkillsActive = false;
-mock.module("../../../../config/memory-v3-gate.js", () => ({
-  isProcToSkillsActive: () => mockProcToSkillsActive,
-  isMemoryV3Live: () => mockProcToSkillsActive,
-}));
-
-mock.module("../memory-retrospective-state.js", () => ({
-  getRetrospectiveState: (_id: string) => null,
-  upsertRetrospectiveState: async (_args: unknown) => {},
-  bumpRetrospectiveLastRunAt: async (_id: string, _at: number) => {},
-  appendToRememberedLog: (existing: string[], newEntries: string[]) => [
-    ...existing,
-    ...newEntries,
-  ],
-}));
-
-mock.module("../find-most-recent-retrospective-for.js", () => ({
-  findMostRecentRetrospectiveFor: (_id: string) => null,
-}));
-
-mock.module("../../../../daemon/trust-context.js", () => ({
-  INTERNAL_GUARDIAN_TRUST_CONTEXT: { trustClass: "guardian" },
-}));
-
-mock.module("../../../../prompts/persona-resolver.js", () => ({
-  resolveUserSlug: (_trustContext: unknown) => "alice",
-}));
-
-// Optional hook run inside the wake mock, before it reports success. Lets a
-// test flip the source conversation to mid-turn DURING the retrospective run
-// (the real race: a user turn starts while the fork wake is in flight).
-let onWake: (() => void) | null = null;
-mock.module("../../../../runtime/agent-wake.js", () => ({
-  wakeAgentForOpportunity: async (_opts: unknown) => {
-    onWake?.();
-    return { invoked: true };
-  },
-}));
-
 // Deferred-insert job recorder (`upsertSkillCardInsertJob` is the coalescing
 // upsert the mid-turn branch and the handler's re-upsert both call).
 let skillCardJobUpserts: Array<{
@@ -176,9 +127,7 @@ mock.module("../../../../persistence/jobs-store.js", () => ({
 }));
 
 import type { MemoryJob } from "../../../../persistence/jobs-store.js";
-import { memoryRetrospectiveJob } from "../memory-retrospective-job.js";
 import {
-  extractRetrospectiveRunSkillScaffolds,
   insertSkillCardMessage,
   SKILL_CARD_INSERT_RETRY_DELAY_MS,
   skillCardInsertJob,
@@ -187,92 +136,6 @@ import {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function scaffoldMsg(
-  toolUseId: string,
-  input: Record<string, unknown>,
-  opts: { createdAt?: number; metadata?: string | null } = {},
-): StubMessage {
-  return {
-    role: "assistant",
-    content: JSON.stringify([
-      {
-        type: "tool_use",
-        id: toolUseId,
-        name: "scaffold_managed_skill",
-        input,
-      },
-    ]),
-    createdAt: opts.createdAt ?? 2000,
-    metadata: opts.metadata ?? null,
-  };
-}
-
-function toolResultMsg(
-  toolUseId: string,
-  opts: {
-    isError?: boolean;
-    createdAt?: number;
-    metadata?: string | null;
-  } = {},
-): StubMessage {
-  return {
-    role: "user",
-    content: JSON.stringify([
-      {
-        type: "tool_result",
-        tool_use_id: toolUseId,
-        content: opts.isError ? "Error: scaffold failed" : "ok",
-        ...(opts.isError ? { is_error: true } : {}),
-      },
-    ]),
-    createdAt: opts.createdAt ?? 2001,
-    metadata: opts.metadata ?? null,
-  };
-}
-
-function skillInput(
-  id: string,
-  overrides: Record<string, unknown> = {},
-): Record<string, unknown> {
-  return {
-    skill_id: id,
-    name: `Skill ${id}`,
-    description: `Does ${id}`,
-    ...overrides,
-  };
-}
-
-function makeConfig(): Parameters<typeof memoryRetrospectiveJob>[1] {
-  return {
-    memory: {
-      v2: { enabled: true },
-      retrospective: {
-        keepSupersededRuns: false,
-        matchConversationProfile: false,
-      },
-    },
-    ui: {},
-  } as unknown as Parameters<typeof memoryRetrospectiveJob>[1];
-}
-
-function makeJob(conversationId = "src-conv-1"): MemoryJob<{
-  conversationId?: string;
-}> {
-  return {
-    id: "job-1",
-    type: "memory_retrospective",
-    payload: { conversationId },
-    status: "pending",
-    attempts: 0,
-    deferrals: 0,
-    runAfter: 0,
-    lastError: null,
-    startedAt: null,
-    createdAt: 0,
-    updatedAt: 0,
-  };
-}
 
 /** A claimed `skill_card_insert` job carrying the given payload. */
 function makeInsertJob(payload: Record<string, unknown>): MemoryJob {
@@ -291,41 +154,8 @@ function makeInsertJob(payload: Record<string, unknown>): MemoryJob {
   };
 }
 
-/** Card messages persisted to the given conversation (assistant role). */
-function cardMessagesFor(conversationId: string) {
-  return addMessageCalls.filter(
-    (c) => c.conversationId === conversationId && c.role === "assistant",
-  );
-}
-
-/**
- * Stage the job's own fork conversation ("fork-conv-1") as a fork-kind row
- * whose post-fork tail contains the given messages. A stamped copied-prefix
- * row establishes the fork boundary at createdAt 1000.
- */
-function stageForkTail(tailMessages: StubMessage[]): void {
-  conversationOverrides["fork-conv-1"] = {
-    source: "memory-retrospective-fork",
-    forkParentMessageId: null,
-  };
-  messagesByConversationId["fork-conv-1"] = [
-    {
-      role: "user",
-      content: JSON.stringify([{ type: "text", text: "hi" }]),
-      createdAt: 1000,
-      metadata: JSON.stringify({ forkSourceMessageId: "m-src-1" }),
-    },
-    ...tailMessages,
-  ];
-}
-
 describe("memory-retrospective skill card", () => {
   beforeEach(() => {
-    newMessages = [
-      { id: "m1", createdAt: Date.parse("2026-05-11T10:00:00Z") },
-      { id: "m2", createdAt: Date.parse("2026-05-11T10:05:00Z") },
-      { id: "m3", createdAt: Date.parse("2026-05-11T10:10:00Z") },
-    ];
     addMessageCalls = [];
     addMessageThrowsFor = null;
     addMessageDeduplicatesFor = null;
@@ -334,200 +164,7 @@ describe("memory-retrospective skill card", () => {
     syncedToDisk = [];
     publishedConversationIds = [];
     conversationOverrides = {};
-    messagesByConversationId = {};
-    mockProcToSkillsActive = false;
-    onWake = null;
     skillCardJobUpserts = [];
-  });
-
-  // -------------------------------------------------------------------------
-  // extractRetrospectiveRunSkillScaffolds
-  // -------------------------------------------------------------------------
-
-  test("extractor returns only successful, non-overwrite scaffolds", async () => {
-    conversationOverrides["retro-1"] = {
-      source: "memory-retrospective",
-      forkParentMessageId: null,
-    };
-    messagesByConversationId["retro-1"] = [
-      // Successful create — included.
-      scaffoldMsg("tu-1", skillInput("skill-a", { emoji: "🧭" }), {
-        createdAt: 2000,
-      }),
-      toolResultMsg("tu-1", { createdAt: 2001 }),
-      // Errored result — excluded.
-      scaffoldMsg("tu-2", skillInput("skill-b"), { createdAt: 2002 }),
-      toolResultMsg("tu-2", { isError: true, createdAt: 2003 }),
-      // Refinement (overwrite: true) — excluded even though it succeeded.
-      scaffoldMsg("tu-3", skillInput("skill-c", { overwrite: true }), {
-        createdAt: 2004,
-      }),
-      toolResultMsg("tu-3", { createdAt: 2005 }),
-      // No result at all (interrupted run) — excluded.
-      scaffoldMsg("tu-4", skillInput("skill-d"), { createdAt: 2006 }),
-      // A different tool — ignored.
-      {
-        role: "assistant",
-        content: JSON.stringify([
-          {
-            type: "tool_use",
-            id: "tu-5",
-            name: "remember",
-            input: { content: "a fact" },
-          },
-        ]),
-        createdAt: 2007,
-        metadata: null,
-      },
-      toolResultMsg("tu-5", { createdAt: 2008 }),
-    ];
-
-    const skills = await extractRetrospectiveRunSkillScaffolds("retro-1");
-
-    expect(skills).toEqual([
-      {
-        skillId: "skill-a",
-        name: "Skill skill-a",
-        description: "Does skill-a",
-        emoji: "🧭",
-      },
-    ]);
-  });
-
-  test("extractor resolves the run's source itself and scopes fork-kind runs to the post-fork tail", async () => {
-    // The fork-kind source comes from the conversation row (getConversation),
-    // not a caller-supplied parameter — tail scoping proves it was read.
-    conversationOverrides["retro-fork-1"] = {
-      source: "memory-retrospective-fork",
-      forkParentMessageId: null,
-    };
-    messagesByConversationId["retro-fork-1"] = [
-      // Copied prefix (stamped): a source-inline scaffold that must not leak
-      // into this run's card.
-      scaffoldMsg("tu-prefix", skillInput("prefix-skill"), {
-        createdAt: 1000,
-        metadata: JSON.stringify({ forkSourceMessageId: "m-src-1" }),
-      }),
-      toolResultMsg("tu-prefix", {
-        createdAt: 1100,
-        metadata: JSON.stringify({ forkSourceMessageId: "m-src-2" }),
-      }),
-      // Post-fork tail: this run's own scaffold.
-      scaffoldMsg("tu-tail", skillInput("tail-skill"), { createdAt: 2000 }),
-      toolResultMsg("tu-tail", { createdAt: 2100 }),
-    ];
-
-    const skills = await extractRetrospectiveRunSkillScaffolds("retro-fork-1");
-
-    expect(skills.map((s) => s.skillId)).toEqual(["tail-skill"]);
-  });
-
-  test("extractor attributes every row to a fork-kind run with an empty copied prefix", async () => {
-    // No stamps, and the conversation opens with the run's own instruction
-    // row: the copied prefix is empty, so the scaffold is the run's work.
-    conversationOverrides["retro-fork-2"] = {
-      source: "memory-retrospective-fork",
-      forkParentMessageId: null,
-    };
-    messagesByConversationId["retro-fork-2"] = [
-      {
-        role: "user",
-        content: JSON.stringify([{ type: "text", text: "review the above" }]),
-        createdAt: 900,
-        metadata: JSON.stringify({
-          kind: "memory_retrospective_instruction",
-          hidden: true,
-        }),
-      },
-      scaffoldMsg("tu-1", skillInput("skill-a"), { createdAt: 1000 }),
-      toolResultMsg("tu-1", { createdAt: 1100 }),
-    ];
-
-    const skills = await extractRetrospectiveRunSkillScaffolds("retro-fork-2");
-
-    expect(skills.map((s) => s.skillId)).toEqual(["skill-a"]);
-  });
-
-  test("extractor degrades to empty for a stampless fork-kind run without a leading instruction row", async () => {
-    // Indeterminate shape (copied rows whose metadata lost its stamps):
-    // attributing it would surface source-authored scaffolds as run work.
-    conversationOverrides["retro-fork-3"] = {
-      source: "memory-retrospective-fork",
-      forkParentMessageId: null,
-    };
-    messagesByConversationId["retro-fork-3"] = [
-      scaffoldMsg("tu-1", skillInput("skill-a"), { createdAt: 1000 }),
-      toolResultMsg("tu-1", { createdAt: 1100 }),
-    ];
-
-    const skills = await extractRetrospectiveRunSkillScaffolds("retro-fork-3");
-
-    expect(skills).toEqual([]);
-  });
-
-  test("extractor normalizes padded/newline-carrying inputs to the persisted values", async () => {
-    // `executeScaffoldManagedSkill` trims skill_id (and newline-collapses +
-    // trims name/description/emoji) before persisting: a padded " my-skill "
-    // input creates skill `my-skill`, so a card built from the raw input
-    // would link an id that does not exist.
-    conversationOverrides["retro-2"] = {
-      source: "memory-retrospective",
-      forkParentMessageId: null,
-    };
-    messagesByConversationId["retro-2"] = [
-      scaffoldMsg(
-        "tu-1",
-        {
-          skill_id: " my-skill ",
-          name: "  My\nSkill  ",
-          description: " Does\r\nthings ",
-          emoji: " 🧭 ",
-        },
-        { createdAt: 2000 },
-      ),
-      toolResultMsg("tu-1", { createdAt: 2001 }),
-    ];
-
-    const skills = await extractRetrospectiveRunSkillScaffolds("retro-2");
-
-    expect(skills).toEqual([
-      {
-        skillId: "my-skill",
-        name: "My Skill",
-        description: "Does things",
-        emoji: "🧭",
-      },
-    ]);
-  });
-
-  test("extractor drops an emoji that is whitespace-only after normalization", async () => {
-    conversationOverrides["retro-3"] = {
-      source: "memory-retrospective",
-      forkParentMessageId: null,
-    };
-    messagesByConversationId["retro-3"] = [
-      scaffoldMsg(
-        "tu-1",
-        {
-          skill_id: "skill-a",
-          name: "Skill A",
-          description: "Does A",
-          emoji: " \n ",
-        },
-        { createdAt: 2000 },
-      ),
-      toolResultMsg("tu-1", { createdAt: 2001 }),
-    ];
-
-    const skills = await extractRetrospectiveRunSkillScaffolds("retro-3");
-
-    expect(skills).toHaveLength(1);
-    expect(skills[0]).toEqual({
-      skillId: "skill-a",
-      name: "Skill A",
-      description: "Does A",
-    });
-    expect("emoji" in skills[0]!).toBe(false);
   });
 
   // -------------------------------------------------------------------------
@@ -644,7 +281,7 @@ describe("memory-retrospective skill card", () => {
 
     await insertSkillCardMessage("src-conv-9", "run-conv-1", skills);
     await insertSkillCardMessage("src-conv-9", "run-conv-2", skills);
-    // Retried finalize of run 1: same clientMessageId → persistence dedups.
+    // Retried delivery of run 1: same clientMessageId → persistence dedups.
     await insertSkillCardMessage("src-conv-9", "run-conv-1", skills);
 
     // Multiple cards over a conversation's life are expected — one per
@@ -666,7 +303,7 @@ describe("memory-retrospective skill card", () => {
     expect(publishedConversationIds).toEqual(["src-conv-9", "src-conv-9"]);
   });
 
-  test("deduplicated insert (retried finalize) skips disk sync and publish", async () => {
+  test("deduplicated insert (retried delivery) skips disk sync and publish", async () => {
     addMessageDeduplicatesFor = "src-conv-9";
 
     await insertSkillCardMessage("src-conv-9", "run-conv-1", [
@@ -692,7 +329,7 @@ describe("memory-retrospective skill card", () => {
   });
 
   // -------------------------------------------------------------------------
-  // skillCardInsertJob (deferred delivery handler)
+  // skillCardInsertJob (delivery handler)
   // -------------------------------------------------------------------------
 
   function insertJobPayload(): Record<string, unknown> {
@@ -751,6 +388,42 @@ describe("memory-retrospective skill card", () => {
     expect(skillCardJobUpserts).toHaveLength(0);
   });
 
+  test("handler batches a multi-skill payload into ONE card message", async () => {
+    // A run that authors several skills coalesces into one pending job (the
+    // jobs-store upsert merges by runConversationId), so the handler must
+    // render every skill in a single ui_surface block.
+    await skillCardInsertJob(
+      makeInsertJob({
+        sourceConversationId: "src-conv-9",
+        runConversationId: "run-conv-1",
+        skills: [
+          { skillId: "skill-a", name: "Skill A", description: "Does A" },
+          { skillId: "skill-b", name: "Skill B", description: "Does B" },
+        ],
+      }),
+    );
+
+    expect(addMessageCalls).toHaveLength(1);
+    const blocks = JSON.parse(addMessageCalls[0]!.content) as Array<{
+      type: string;
+      data?: { skills: Array<{ skillId: string }> };
+      text?: string;
+      _surfaceFallback?: boolean;
+    }>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.type).toBe("ui_surface");
+    expect(blocks[0]!.data!.skills.map((s) => s.skillId)).toEqual([
+      "skill-a",
+      "skill-b",
+    ]);
+    expect(blocks[1]).toEqual({
+      type: "text",
+      text: "New skill learned: Skill A, Skill B",
+      _surfaceFallback: true,
+    });
+    expect(publishedConversationIds).toEqual(["src-conv-9"]);
+  });
+
   test("handler with a still-mid-turn source re-upserts itself at the same delay and inserts nothing", async () => {
     processingConversationIds = ["src-conv-9"];
     const before = Date.now();
@@ -803,124 +476,14 @@ describe("memory-retrospective skill card", () => {
   });
 
   test("handler propagates persistence failures so the jobs worker retries", async () => {
-    // Unlike the best-effort finalize entry point, the deferred handler must
-    // surface transient insert errors to the worker's retry machinery — the
-    // card is only droppable when the source conversation is gone.
+    // Unlike the best-effort `insertSkillCardMessage` entry point, the job
+    // handler must surface transient insert errors to the worker's retry
+    // machinery — the card is only droppable when the source conversation is
+    // gone.
     addMessageThrowsFor = "src-conv-9";
 
     await expect(
       skillCardInsertJob(makeInsertJob(insertJobPayload())),
     ).rejects.toThrow("insert failed for src-conv-9");
-  });
-
-  // -------------------------------------------------------------------------
-  // Finalize wiring (proc-to-skills gate), via the job handler
-  // -------------------------------------------------------------------------
-
-  test("two skills authored in one run batch into ONE card message on the source conversation", async () => {
-    mockProcToSkillsActive = true;
-    stageForkTail([
-      scaffoldMsg("tu-1", skillInput("skill-a"), { createdAt: 2000 }),
-      toolResultMsg("tu-1", { createdAt: 2001 }),
-      scaffoldMsg("tu-2", skillInput("skill-b"), { createdAt: 2002 }),
-      toolResultMsg("tu-2", { createdAt: 2003 }),
-    ]);
-
-    const outcome = await memoryRetrospectiveJob(makeJob(), makeConfig());
-
-    expect(outcome.kind).toBe("invoked");
-    const cards = cardMessagesFor("src-conv-1");
-    expect(cards).toHaveLength(1);
-    const blocks = JSON.parse(cards[0]!.content) as Array<{
-      type: string;
-      surfaceId?: string;
-      data?: { skills: Array<{ skillId: string }> };
-      text?: string;
-      _surfaceFallback?: boolean;
-    }>;
-    expect(blocks).toHaveLength(2);
-    expect(blocks[0]!.type).toBe("ui_surface");
-    expect(blocks[0]!.surfaceId).toBe("skill-card-fork-conv-1");
-    expect(blocks[0]!.data!.skills.map((s) => s.skillId)).toEqual([
-      "skill-a",
-      "skill-b",
-    ]);
-    expect(blocks[1]).toEqual({
-      type: "text",
-      text: "New skill learned: Skill skill-a, Skill skill-b",
-      _surfaceFallback: true,
-    });
-    expect(publishedConversationIds).toEqual(["src-conv-1"]);
-  });
-
-  test("a source turn starting during the run defers the finalize card into a skill_card_insert job", async () => {
-    // The real race: the source is idle when the retrospective job starts
-    // (so the run proceeds), but a user turn begins while the fork wake is
-    // in flight. Finalize must queue the card, not splice it into the
-    // in-progress turn's history.
-    mockProcToSkillsActive = true;
-    stageForkTail([
-      scaffoldMsg("tu-1", skillInput("skill-a"), { createdAt: 2000 }),
-      toolResultMsg("tu-1", { createdAt: 2001 }),
-    ]);
-    onWake = () => {
-      processingConversationIds = ["src-conv-1"];
-    };
-
-    const outcome = await memoryRetrospectiveJob(makeJob(), makeConfig());
-
-    expect(outcome.kind).toBe("invoked");
-    expect(cardMessagesFor("src-conv-1")).toHaveLength(0);
-    expect(skillCardJobUpserts).toHaveLength(1);
-    expect(skillCardJobUpserts[0]!.payload).toEqual({
-      sourceConversationId: "src-conv-1",
-      runConversationId: "fork-conv-1",
-      skills: [
-        {
-          skillId: "skill-a",
-          name: "Skill skill-a",
-          description: "Does skill-a",
-        },
-      ],
-    });
-  });
-
-  test("proc-to-skills inactive: finalize inserts nothing even when scaffolds occurred", async () => {
-    stageForkTail([
-      scaffoldMsg("tu-1", skillInput("skill-a"), { createdAt: 2000 }),
-      toolResultMsg("tu-1", { createdAt: 2001 }),
-    ]);
-
-    const outcome = await memoryRetrospectiveJob(makeJob(), makeConfig());
-
-    expect(outcome.kind).toBe("invoked");
-    expect(cardMessagesFor("src-conv-1")).toHaveLength(0);
-    expect(publishedConversationIds).toHaveLength(0);
-  });
-
-  test("no scaffolds in the run: finalize inserts nothing", async () => {
-    mockProcToSkillsActive = true;
-    stageForkTail([
-      {
-        role: "assistant",
-        content: JSON.stringify([
-          {
-            type: "tool_use",
-            id: "tu-1",
-            name: "remember",
-            input: { content: "a fact" },
-          },
-        ]),
-        createdAt: 2000,
-        metadata: null,
-      },
-      toolResultMsg("tu-1", { createdAt: 2001 }),
-    ]);
-
-    const outcome = await memoryRetrospectiveJob(makeJob(), makeConfig());
-
-    expect(outcome.kind).toBe("invoked");
-    expect(cardMessagesFor("src-conv-1")).toHaveLength(0);
-    expect(publishedConversationIds).toHaveLength(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
@@ -54,10 +54,10 @@ export const MEMORY_RETROSPECTIVE_INSTRUCTION_KIND =
 
 /**
  * `metadata.kind` value stamped on the assistant-role message carrying the
- * `skill_card` ui_surface that a retrospective inserts into its SOURCE
- * conversation after authoring new skills. Lets clients and operators
- * identify the card row; the block itself is provider-stripped so it never
- * reaches the model as renderable content.
+ * `skill_card` ui_surface that the `skill_card_insert` delivery job appends
+ * to a retrospective's SOURCE conversation after the run authors new skills.
+ * Lets clients and operators identify the card row; the block itself is
+ * provider-stripped so it never reaches the model as renderable content.
  */
 export const SKILL_CARD_MESSAGE_KIND = "skill-authored-card";
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -89,10 +89,6 @@ import {
 } from "./memory-retrospective-constants.js";
 import { loadRetrospectiveRunMessages } from "./memory-retrospective-fork-boundary.js";
 import {
-  extractRetrospectiveRunSkillScaffolds,
-  insertSkillCardMessage,
-} from "./memory-retrospective-skill-card.js";
-import {
   appendToRememberedLog,
   bumpRetrospectiveLastRunAt,
   getRetrospectiveState,
@@ -692,42 +688,11 @@ async function finalizeSuccessfulRetrospective(args: {
     rememberedLog: appendToRememberedLog(priorRemembers, runRemembers),
   });
 
-  // Surface newly created skills as a `skill_card` ui_surface message on the
-  // source conversation. Gated on proc-to-skills being active (the run can
-  // only author skills when it is). `insertSkillCardMessage` is best-effort —
-  // a card failure never fails the job — and defers delivery through a
-  // durable `skill_card_insert` job when the source is mid-turn, so the card
-  // still always lands once the turn ends. Every gate outcome logs at info
-  // level so a missing card is one-grep diagnosable in the field
-  // ("skill-card:" / "skill card:").
-  if (isProcToSkillsActive(config)) {
-    const authoredSkills = await extractRetrospectiveRunSkillScaffolds(
-      retrospectiveConversationId,
-    );
-    log.info(
-      {
-        sourceConversationId,
-        retrospectiveConversationId,
-        scaffoldCount: authoredSkills.length,
-      },
-      "skill-card: gate passed; extracted skill scaffolds from the run",
-    );
-    if (authoredSkills.length > 0) {
-      await insertSkillCardMessage(
-        sourceConversationId,
-        retrospectiveConversationId,
-        authoredSkills,
-      );
-    }
-  } else {
-    log.info(
-      {
-        sourceConversationId,
-        retrospectiveConversationId,
-      },
-      "skill-card: skipped — proc-to-skills inactive",
-    );
-  }
+  // Skill cards are not a finalize concern: when the run authors a skill, the
+  // scaffold executor enqueues the durable `skill_card_insert` delivery job at
+  // the creation site (see `executeScaffoldManagedSkill` and
+  // `memory-retrospective-skill-card.ts`), so the GC below can never destroy
+  // the card's inputs.
 
   await deleteSupersededPriorRetrospective(config, prior, sourceConversationId);
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -15,6 +15,19 @@
 // still send a non-empty assistant turn and flat-text consumers (CLI, search,
 // channel replies) see readable content.
 //
+// Enqueues fire at the creation site — one per scaffold call, DURING the
+// retrospective fork run — and the jobs-store upsert coalesces them by run
+// conversation id into a single pending row. Delivery therefore defers while
+// the RUN conversation is still processing: the source conversation is
+// usually idle mid-run, so without this gate the worker could deliver skill
+// A's card before skill B's enqueue lands, and B's job would then dedup
+// against the inserted message (`clientMessageId` is run-derived) and never
+// appear on any card. Holding delivery until the run finishes guarantees
+// every creation from that run has merged into the pending row first — the
+// card is always complete. A run conversation that no longer exists
+// (superseded-fork GC) counts as finished: a fork can't be processing once
+// its row is gone, and the card must still deliver.
+//
 // A source conversation that is MID-TURN never gets the card inserted
 // directly — incremental checkpoint persistence writes tool turns to the DB
 // while the agent loop is still running, so a card row could land between a
@@ -22,9 +35,10 @@
 // history linearly (the OpenAI-compatible chat-completions provider) would
 // then emit `assistant(tool_calls) → assistant(text) → tool(...)`, and strict
 // backends reject `tool` messages that don't directly follow their
-// `tool_calls` message — wedging the conversation. A mid-turn delivery
-// attempt re-upserts the job on a short cadence until the turn ends, so the
-// card is still always delivered (queue-until-turn-end).
+// `tool_calls` message — wedging the conversation. A deferred delivery
+// attempt (run still processing OR source mid-turn) re-upserts the job on a
+// short cadence until both gates clear, so the card is still always
+// delivered (queue-until-run-and-turn-end).
 //
 // The job handler (`skillCardInsertJob`) lets persistence errors propagate so
 // the jobs worker's retry machinery covers transient failures; the
@@ -62,21 +76,22 @@ export interface AuthoredSkill {
 }
 
 /**
- * Delay before a deferred `skill_card_insert` job (re-)checks the source
- * conversation's turn state. Each still-mid-turn attempt re-upserts itself at
- * this cadence, so the loop self-resolves as soon as the turn ends; there is
- * no attempt cap because the exit conditions (turn ended → insert, source
- * deleted → drop) are guaranteed to be reached.
+ * Delay before a deferred `skill_card_insert` job (re-)checks its delivery
+ * gates (run conversation finished, source conversation idle). Each deferred
+ * attempt re-upserts itself at this cadence, so the loop self-resolves as
+ * soon as the gates clear; there is no attempt cap because the exit
+ * conditions (run finished/GC'd and turn ended → insert, source deleted →
+ * drop) are guaranteed to be reached.
  */
 export const SKILL_CARD_INSERT_RETRY_DELAY_MS = 30_000;
 
 /**
  * Best-effort insert-or-defer entry point: insert the skill card into the
- * source conversation — or, when the source is mid-turn, queue a durable
- * `skill_card_insert` job so the card lands after the turn ends (see the
- * module header for why a mid-turn insert must never happen). Failures
- * (insert AND enqueue) are logged and never thrown, so a card problem never
- * fails the caller.
+ * source conversation — or, when the run is still processing or the source
+ * is mid-turn, queue a durable `skill_card_insert` job so the card lands
+ * after both gates clear (see the module header for why an early insert must
+ * never happen). Failures (insert AND enqueue) are logged and never thrown,
+ * so a card problem never fails the caller.
  */
 export async function insertSkillCardMessage(
   sourceConversationId: string,
@@ -111,14 +126,16 @@ interface SkillCardInsertJobPayload {
 
 /**
  * Job handler for `skill_card_insert` (registered in `job-handlers.ts`): the
- * delivery of a retrospective run's authored-skill card. Re-checks the source
- * conversation — deleted → drop with a log; mid-turn → re-upsert itself at
+ * delivery of a retrospective run's authored-skill card. Re-checks the
+ * delivery gates — source deleted → drop with a log; run conversation still
+ * processing OR source mid-turn → re-upsert itself at
  * {@link SKILL_CARD_INSERT_RETRY_DELAY_MS} (the currently claimed row is
- * `running`, so the upsert creates a fresh pending row and the attempt
- * counter never accumulates); idle → insert. A malformed payload is dropped
- * with a warning. Persistence errors PROPAGATE so the jobs worker's standard
- * retry-with-backoff covers transient failures; a retried insert after a
- * success is deduplicated by `clientMessageId`.
+ * `running`, so the upsert creates a fresh pending row that later enqueues
+ * from the same run merge into, and the attempt counter never accumulates);
+ * run finished (or GC'd) and source idle → insert. A malformed payload is
+ * dropped with a warning. Persistence errors PROPAGATE so the jobs worker's
+ * standard retry-with-backoff covers transient failures; a retried insert
+ * after a success is deduplicated by `clientMessageId`.
  */
 export async function skillCardInsertJob(job: MemoryJob): Promise<void> {
   const payload = parseSkillCardInsertPayload(job.payload);
@@ -185,9 +202,9 @@ function parseSkillCardInsertPayload(
 
 /**
  * Shared insert-or-defer core behind both {@link insertSkillCardMessage} and
- * {@link skillCardInsertJob}. When the source is idle, appends the
- * `skill_card` ui_surface message (plus its `_surfaceFallback` text sibling)
- * and notifies connected clients. The `surfaceId` (doubling as the insert's
+ * {@link skillCardInsertJob}. When the run conversation has finished (or was
+ * GC'd) and the source is idle, appends the `skill_card` ui_surface message
+ * (plus its `_surfaceFallback` text sibling) and notifies connected clients. The `surfaceId` (doubling as the insert's
  * idempotency nonce via `clientMessageId`) is derived from the run
  * conversation id, so a retried delivery cannot produce two cards for one
  * run — a deduplicated insert also skips the disk-view sync and client
@@ -209,6 +226,32 @@ async function insertOrDeferSkillCard(
     log.info(
       { sourceConversationId, runConversationId },
       "skill card: source conversation no longer exists; skipping",
+    );
+    return;
+  }
+  // Run still processing: defer rather than insert. Enqueues fire per
+  // scaffold call DURING the fork run, and the jobs-store upsert coalesces
+  // them by run conversation id — delivering before the run finishes could
+  // let a later creation from the same run dedup against this insert's
+  // run-derived `clientMessageId` and never appear on any card (see module
+  // header). A missing run conversation counts as finished: superseded-fork
+  // GC deletes the row, and a fork can't be processing without one, so the
+  // card must still deliver. (`isConversationProcessing` already reads
+  // `false` for a nonexistent id; the explicit existence check pins that
+  // missing-row-wins semantics against its in-memory fast path.)
+  const runConversation = await getConversation(runConversationId);
+  if (runConversation && (await isConversationProcessing(runConversationId))) {
+    upsertSkillCardInsertJob(
+      { sourceConversationId, runConversationId, skills },
+      Date.now() + SKILL_CARD_INSERT_RETRY_DELAY_MS,
+    );
+    log.info(
+      {
+        sourceConversationId,
+        runConversationId,
+        retryDelayMs: SKILL_CARD_INSERT_RETRY_DELAY_MS,
+      },
+      "skill card: run conversation is still processing; deferred via skill_card_insert job",
     );
     return;
   }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -1,15 +1,19 @@
 // ---------------------------------------------------------------------------
-// Memory retrospective — skill-authored card insertion.
+// Memory retrospective — skill-authored card delivery.
 // ---------------------------------------------------------------------------
 //
-// When a retrospective run authors NEW managed skills (successful
-// `scaffold_managed_skill` calls without `overwrite: true`), the finalize
-// path surfaces them to the user as a single `skill_card` ui_surface message
-// appended to the SOURCE conversation. The ui_surface block is rendered by
-// the web client's surface router and is paired with a `_surfaceFallback`
-// text block (the approval-card pattern) so providers that drop `ui_surface`
-// blocks still send a non-empty assistant turn and flat-text consumers (CLI,
-// search, channel replies) see readable content.
+// When a retrospective pass genuinely CREATES a managed skill, the scaffold
+// executor (`executeScaffoldManagedSkill`) enqueues a durable
+// `skill_card_insert` job at the creation site — the executor knows
+// created-vs-overwrote, the request origin, and the fork-parent source
+// conversation as facts, so no message archaeology is needed. This module
+// owns the DELIVERY half of that flow: the job handler surfaces the authored
+// skills to the user as a single `skill_card` ui_surface message appended to
+// the SOURCE conversation. The ui_surface block is rendered by the web
+// client's surface router and is paired with a `_surfaceFallback` text block
+// (the approval-card pattern) so providers that drop `ui_surface` blocks
+// still send a non-empty assistant turn and flat-text consumers (CLI, search,
+// channel replies) see readable content.
 //
 // A source conversation that is MID-TURN never gets the card inserted
 // directly — incremental checkpoint persistence writes tool turns to the DB
@@ -18,19 +22,16 @@
 // history linearly (the OpenAI-compatible chat-completions provider) would
 // then emit `assistant(tool_calls) → assistant(text) → tool(...)`, and strict
 // backends reject `tool` messages that don't directly follow their
-// `tool_calls` message — wedging the conversation. Instead, the insert is
-// DEFERRED via a durable `skill_card_insert` job that re-checks on a short
-// cadence and re-upserts itself until the turn ends, so the card is still
-// always delivered (queue-until-turn-end).
+// `tool_calls` message — wedging the conversation. A mid-turn delivery
+// attempt re-upserts the job on a short cadence until the turn ends, so the
+// card is still always delivered (queue-until-turn-end).
 //
-// The finalize entry point (`insertSkillCardMessage`) is best-effort: a card
-// failure must never fail the retrospective job. Once queued, the job handler
-// (`skillCardInsertJob`) lets persistence errors propagate so the jobs
-// worker's retry machinery covers transient failures.
+// The job handler (`skillCardInsertJob`) lets persistence errors propagate so
+// the jobs worker's retry machinery covers transient failures; the
+// message-level `clientMessageId` dedup makes retried deliveries idempotent.
 
 import {
   addMessage,
-  type ContentBlock,
   getConversation,
   isConversationProcessing,
   syncMessageToDisk,
@@ -43,163 +44,21 @@ import {
 import { publishConversationMessagesChanged } from "../../../runtime/sync/resource-sync-events.js";
 import { getLogger } from "./logging.js";
 import { SKILL_CARD_MESSAGE_KIND } from "./memory-retrospective-constants.js";
-import { loadRetrospectiveRunMessages } from "./memory-retrospective-fork-boundary.js";
 
 const log = getLogger("memory-retrospective-skill-card");
 
-/** A newly created skill extracted from a retrospective run's fork tail. */
+/**
+ * A skill authored by a retrospective run, as recorded by the scaffold
+ * executor at creation time. All values are the executor's post-normalization
+ * (trimmed, newline-collapsed) values — exactly what was persisted to the
+ * skill's frontmatter — so the card always links and labels the skill as it
+ * exists on disk.
+ */
 export interface AuthoredSkill {
   skillId: string;
   name: string;
   description: string;
   emoji?: string;
-}
-
-/**
- * Pull the newly created skills out of a retrospective run's own work.
- * Mirrors `extractRetrospectiveRunRemembers`: the run conversation's
- * `source` kind is resolved internally, and `loadRetrospectiveRunMessages`
- * scopes fork-kind rows to the post-fork tail (the copied prefix contains
- * the source conversation's own inline tool calls) and returns `null` on
- * load failure or an undetectable fork boundary — treated here as "the run
- * authored nothing".
- *
- * A `scaffold_managed_skill` call counts only when it is a CREATE
- * (`input.overwrite !== true` — refinements never get a card) and its paired
- * `tool_result` (matched by `tool_use_id` in a later user-role message)
- * exists and is not an error. Robust to malformed content JSON — unparseable
- * rows are skipped, not propagated.
- */
-export async function extractRetrospectiveRunSkillScaffolds(
-  retrospectiveConversationId: string,
-): Promise<AuthoredSkill[]> {
-  const runMessages = await loadRetrospectiveRunMessages(
-    retrospectiveConversationId,
-    (await getConversation(retrospectiveConversationId))?.source ?? null,
-  );
-  if (runMessages == null) {
-    return [];
-  }
-  return extractSuccessfulScaffolds(runMessages);
-}
-
-interface MessageLike {
-  role: string;
-  content: string | ContentBlock[];
-}
-
-function parseBlocks(msg: MessageLike): Array<Record<string, unknown>> {
-  let blocks: unknown = msg.content;
-  if (typeof blocks === "string") {
-    try {
-      blocks = JSON.parse(blocks);
-    } catch {
-      return [];
-    }
-  }
-  if (!Array.isArray(blocks)) {
-    return [];
-  }
-  return blocks.filter(
-    (b): b is Record<string, unknown> => !!b && typeof b === "object",
-  );
-}
-
-/**
- * Single ordered pass: assistant-role `scaffold_managed_skill` tool_use
- * blocks become pending candidates keyed by tool_use id; a later user-role
- * `tool_result` with a matching `tool_use_id` resolves the candidate —
- * success promotes it to the result list, an error discards it. Candidates
- * whose result never arrives (interrupted run) are not verifiably created
- * and are dropped.
- */
-function extractSuccessfulScaffolds(messages: MessageLike[]): AuthoredSkill[] {
-  const pending = new Map<string, AuthoredSkill>();
-  const authored: AuthoredSkill[] = [];
-  for (const msg of messages) {
-    if (msg.role === "assistant") {
-      for (const b of parseBlocks(msg)) {
-        if (b.type !== "tool_use" || b.name !== "scaffold_managed_skill") {
-          continue;
-        }
-        if (typeof b.id !== "string") {
-          continue;
-        }
-        const skill = readScaffoldInput(b.input);
-        if (skill) {
-          pending.set(b.id, skill);
-        }
-      }
-    } else if (msg.role === "user") {
-      for (const b of parseBlocks(msg)) {
-        // guard:allow-tool-result-only — only the local tool executor's
-        // `tool_result` can resolve a `scaffold_managed_skill` candidate; a
-        // `web_search_tool_result` pairs a `server_tool_use`, never a scaffold
-        // call, so it can never match a pending id and is correctly skipped.
-        if (b.type !== "tool_result" || typeof b.tool_use_id !== "string") {
-          continue;
-        }
-        const skill = pending.get(b.tool_use_id);
-        if (!skill) {
-          continue;
-        }
-        pending.delete(b.tool_use_id);
-        if (b.is_error !== true) {
-          authored.push(skill);
-        }
-      }
-    }
-  }
-  return authored;
-}
-
-/**
- * Mirror of the scaffold executor's frontmatter normalization (collapse
- * embedded newlines to a space, trim). Kept local because the executor's
- * `sanitizeFrontmatterValue` is not exported; the two must stay in step so
- * the card shows the values as persisted.
- */
-function normalizeCardText(value: string): string {
-  return value.replace(/[\r\n]+/g, " ").trim();
-}
-
-/**
- * Read a card entry from a `scaffold_managed_skill` tool_use input. Returns
- * `null` for refinements (`overwrite: true`) and for inputs missing a usable
- * `skill_id`/`name` (the web card drops entries without both, so there is
- * nothing to render).
- *
- * Values are NORMALIZED, not stored raw: `executeScaffoldManagedSkill` trims
- * `skill_id` (and newline-collapses + trims name/description/emoji) before
- * persisting, so a successful call with a padded `" my-skill "` creates skill
- * `my-skill` — a card built from the raw input would link `%20my-skill%20`
- * and the detail route would 404 on the skill it just announced.
- */
-function readScaffoldInput(input: unknown): AuthoredSkill | null {
-  if (!input || typeof input !== "object") {
-    return null;
-  }
-  const rec = input as Record<string, unknown>;
-  if (rec.overwrite === true) {
-    return null;
-  }
-  const skillId = typeof rec.skill_id === "string" ? rec.skill_id.trim() : "";
-  const name = typeof rec.name === "string" ? normalizeCardText(rec.name) : "";
-  if (skillId.length === 0 || name.length === 0) {
-    return null;
-  }
-  const description =
-    typeof rec.description === "string"
-      ? normalizeCardText(rec.description)
-      : "";
-  const emoji =
-    typeof rec.emoji === "string" ? normalizeCardText(rec.emoji) : "";
-  return {
-    skillId,
-    name,
-    description,
-    ...(emoji.length > 0 ? { emoji } : {}),
-  };
 }
 
 /**
@@ -212,15 +71,12 @@ function readScaffoldInput(input: unknown): AuthoredSkill | null {
 export const SKILL_CARD_INSERT_RETRY_DELAY_MS = 30_000;
 
 /**
- * Insert the skill card into the source conversation — or, when the source is
- * mid-turn, queue a durable `skill_card_insert` job so the card lands after
- * the turn ends (see the module header for why a mid-turn insert must never
- * happen). Delivery is guaranteed once queued; a card is never dropped except
- * when the source conversation itself no longer exists.
- *
- * This finalize entry point is best-effort — failures (insert AND enqueue)
- * are logged and never thrown, so a card failure never fails the
- * retrospective job.
+ * Best-effort insert-or-defer entry point: insert the skill card into the
+ * source conversation — or, when the source is mid-turn, queue a durable
+ * `skill_card_insert` job so the card lands after the turn ends (see the
+ * module header for why a mid-turn insert must never happen). Failures
+ * (insert AND enqueue) are logged and never thrown, so a card problem never
+ * fails the caller.
  */
 export async function insertSkillCardMessage(
   sourceConversationId: string,
@@ -242,10 +98,10 @@ export async function insertSkillCardMessage(
 }
 
 /**
- * Payload of a deferred `skill_card_insert` job. The authored-skill list is
- * snapshotted at enqueue time: the run conversation may be GC'd as a
- * superseded prior before the job fires, so the handler must not re-extract
- * from it.
+ * Payload of a `skill_card_insert` job. The authored-skill list is recorded
+ * by the scaffold executor at creation time and is self-contained: the run
+ * conversation may be GC'd as a superseded prior before the job fires, so the
+ * handler must never need to read it.
  */
 interface SkillCardInsertJobPayload {
   sourceConversationId: string;
@@ -255,15 +111,14 @@ interface SkillCardInsertJobPayload {
 
 /**
  * Job handler for `skill_card_insert` (registered in `job-handlers.ts`): the
- * deferred half of {@link insertSkillCardMessage}. Re-checks the source
- * conversation — deleted → drop with a log; still mid-turn → re-upsert itself
- * at {@link SKILL_CARD_INSERT_RETRY_DELAY_MS} (the currently claimed row is
+ * delivery of a retrospective run's authored-skill card. Re-checks the source
+ * conversation — deleted → drop with a log; mid-turn → re-upsert itself at
+ * {@link SKILL_CARD_INSERT_RETRY_DELAY_MS} (the currently claimed row is
  * `running`, so the upsert creates a fresh pending row and the attempt
  * counter never accumulates); idle → insert. A malformed payload is dropped
- * with a warning. Unlike the finalize entry point, persistence errors
- * PROPAGATE so the jobs worker's standard retry-with-backoff covers transient
- * failures; a retried insert after a success is deduplicated by
- * `clientMessageId`.
+ * with a warning. Persistence errors PROPAGATE so the jobs worker's standard
+ * retry-with-backoff covers transient failures; a retried insert after a
+ * success is deduplicated by `clientMessageId`.
  */
 export async function skillCardInsertJob(job: MemoryJob): Promise<void> {
   const payload = parseSkillCardInsertPayload(job.payload);
@@ -341,7 +196,7 @@ function parseSkillCardInsertPayload(
  *
  * The retrospective accounting excludes `SKILL_CARD_MESSAGE_KIND` rows from
  * re-trigger counting, so a delivered card never wakes another pass. Errors
- * propagate to the caller — the finalize entry point swallows them, the job
+ * propagate to the caller — `insertSkillCardMessage` swallows them, the job
  * handler surfaces them to the worker's retry machinery.
  */
 async function insertOrDeferSkillCard(

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -5,13 +5,17 @@ import type { SkillSource } from "../../config/skills.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { refreshSkillCapabilityMemories } from "../../daemon/skill-memory-refresh.js";
 import { getConversation } from "../../persistence/conversation-crud.js";
+import { upsertSkillCardInsertJob } from "../../persistence/jobs-store.js";
 import { MEMORY_RETROSPECTIVE_ORIGIN } from "../../plugins/defaults/memory/memory-retrospective-constants.js";
 import { readInstallMeta } from "../../skills/install-meta.js";
 import {
   createManagedSkill,
   getManagedSkillDir,
 } from "../../skills/managed-store.js";
+import { getLogger } from "../../util/logger.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+const log = getLogger("scaffold-managed-skill");
 
 /** Strip embedded newlines/carriage returns to prevent YAML frontmatter injection. */
 function sanitizeFrontmatterValue(value: string): string {
@@ -195,6 +199,13 @@ export async function executeScaffoldManagedSkill(
     context.requestOrigin === MEMORY_RETROSPECTIVE_ORIGIN;
   const author = fromRetrospective ? "assistant" : "user";
 
+  // Whether a managed SKILL.md already existed before this call. Resolved for
+  // retrospective calls only — it drives both the ownership backstop below and
+  // the created-vs-refined discriminant for the skill-card enqueue: only a
+  // genuine CREATE (no pre-existing skill, regardless of the `overwrite` flag)
+  // gets a card.
+  let managedSkillExistedBefore = false;
+
   // Ownership backstop (retrospective origin only): the retrospective may author
   // a skill ONLY if it owns it. Fail closed on either of two collisions.
   if (fromRetrospective) {
@@ -224,9 +235,9 @@ export async function executeScaffoldManagedSkill(
     // unverifiable (missing/corrupt meta) managed skills alike, matching the
     // prune side where such skills are never pruned.
     const managedDir = getManagedSkillDir(id);
-    const managedSkillExists = existsSync(join(managedDir, "SKILL.md"));
+    managedSkillExistedBefore = existsSync(join(managedDir, "SKILL.md"));
     if (
-      managedSkillExists &&
+      managedSkillExistedBefore &&
       readInstallMeta(managedDir)?.author !== "assistant"
     ) {
       return {
@@ -255,15 +266,21 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
+  // Normalized frontmatter values, shared by the persisted SKILL.md and the
+  // skill-card payload below so the card always shows the values as persisted.
+  const normalizedName = sanitizeFrontmatterValue(name);
+  const normalizedDescription = sanitizeFrontmatterValue(description);
+  const normalizedEmoji =
+    typeof input.emoji === "string"
+      ? sanitizeFrontmatterValue(input.emoji)
+      : undefined;
+
   const result = createManagedSkill({
     id,
-    name: sanitizeFrontmatterValue(name),
-    description: sanitizeFrontmatterValue(description),
+    name: normalizedName,
+    description: normalizedDescription,
     bodyMarkdown: bodyMarkdown,
-    emoji:
-      typeof input.emoji === "string"
-        ? sanitizeFrontmatterValue(input.emoji)
-        : undefined,
+    emoji: normalizedEmoji,
     overwrite: input.overwrite === true,
     includes,
     activationHints,
@@ -280,6 +297,50 @@ export async function executeScaffoldManagedSkill(
   }
 
   refreshSkillCapabilityMemories();
+
+  // Surface a genuine retrospective CREATE to the user as a skill card on the
+  // source conversation, via the durable `skill_card_insert` delivery job
+  // (memory-retrospective-skill-card.ts). The creation site is the one place
+  // that knows created-vs-refined (`managedSkillExistedBefore` — an
+  // `overwrite: true` call on a skill that did not previously exist is still a
+  // create), the request origin, and the fork-parent lineage as facts.
+  // Refinements of a pre-existing skill never get a card, and delivery needs a
+  // resolved source conversation to land in. Best-effort: an enqueue failure
+  // must never fail the scaffold — the skill is already created.
+  if (
+    fromRetrospective &&
+    !managedSkillExistedBefore &&
+    sourceConversationId &&
+    retrospectiveConversationId
+  ) {
+    try {
+      upsertSkillCardInsertJob({
+        sourceConversationId,
+        runConversationId: retrospectiveConversationId,
+        skills: [
+          {
+            skillId: id,
+            name: normalizedName,
+            description: normalizedDescription,
+            ...(normalizedEmoji ? { emoji: normalizedEmoji } : {}),
+          },
+        ],
+      });
+      log.info(
+        {
+          skillId: id,
+          sourceConversationId,
+          runConversationId: retrospectiveConversationId,
+        },
+        "skill card: enqueued skill_card_insert for retrospective-authored skill",
+      );
+    } catch (err) {
+      log.warn(
+        { err, skillId: id, sourceConversationId },
+        "skill card: failed to enqueue skill_card_insert; skill creation unaffected",
+      );
+    }
+  }
 
   return {
     content: JSON.stringify({


### PR DESCRIPTION
## Summary
- The skill-creation card is now enqueued by executeScaffoldManagedSkill itself when a retrospective-origin call genuinely creates a skill — the executor knows created-vs-overwrote, origin, and source conversation as facts, not inferences
- Deletes the finalize-time fork-message extraction (tool_use/tool_result pairing), which field debugging showed returning scaffoldCount: 0 for a run that verifiably created a skill, with the fork GC destroying the evidence needed to diagnose it
- Delivery half unchanged: durable skill_card_insert job, mid-turn deferral, per-run message dedup; multi-skill runs merge into one pending job payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)