### PR TITLE
fix: skill_loaded_events relocation drain must not resurrect deleted conversations' rows

### DIFF
--- a/assistant/src/persistence/migrations/330-move-skill-loaded-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/330-move-skill-loaded-events-to-telemetry-db.test.ts
@@ -42,11 +42,25 @@ function resetState(): void {
   getSqlite().exec(
     `DROP TABLE IF EXISTS main."skill_loaded_events__relocating"`,
   );
+  getSqlite().exec(
+    `DELETE FROM conversations WHERE id IN ('conv-a', 'conv-b', 'conv-live')`,
+  );
+}
+
+/** The drain only copies rows whose conversation is live (or NULL). */
+function seedConversation(id: string): void {
+  getSqlite()
+    .prepare(
+      `INSERT OR IGNORE INTO conversations (id, created_at, updated_at) VALUES (?, 0, 0)`,
+    )
+    .run(id);
 }
 
 function seedSourceTable(): void {
   const sqlite = getSqlite();
   sqlite.exec(`CREATE TABLE main.skill_loaded_events (${SOURCE_COLUMNS})`);
+  seedConversation("conv-a");
+  seedConversation("conv-b");
   const insert = sqlite.prepare(
     `INSERT INTO main.skill_loaded_events (id, created_at, conversation_id, skill_name)
      VALUES (?, ?, ?, ?)`,
@@ -140,6 +154,35 @@ describe("migration 330: move skill_loaded_events to the telemetry DB", () => {
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
     expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
+  });
+
+  test("the drain purges rows whose conversation no longer exists (redaction across boots)", async () => {
+    resetState();
+    const sqlite = getSqlite();
+    sqlite.exec(`CREATE TABLE main.skill_loaded_events (${SOURCE_COLUMNS})`);
+    seedConversation("conv-live");
+    const insert = sqlite.prepare(
+      `INSERT INTO main.skill_loaded_events (id, created_at, conversation_id, skill_name)
+       VALUES (?, ?, ?, ?)`,
+    );
+    insert.run("live-1", 1000, "conv-live", "web-research");
+    insert.run("null-1", 2000, null, "tasks");
+    // Simulates a conversation deleted while its rows sat staged between boots:
+    // the redaction paths only delete on the telemetry connection, so the drain
+    // itself must purge this row rather than resurrect it.
+    insert.run("dead-1", 3000, "conv-deleted", "calendar");
+
+    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+
+    expect(existsInMain("skill_loaded_events")).toBe(false);
+    expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
+
+    const moved = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    expect(moved.map((r) => r.id)).toEqual(["live-1", "null-1"]);
+    const dead = getTelemetrySqlite()!
+      .query(`SELECT 1 FROM skill_loaded_events WHERE id = 'dead-1'`)
+      .get();
+    expect(dead).toBeNull();
   });
 
   test("per-conversation redaction deletes rows on the telemetry connection", () => {

--- a/assistant/src/persistence/migrations/330-move-skill-loaded-events-to-telemetry-db.ts
+++ b/assistant/src/persistence/migrations/330-move-skill-loaded-events-to-telemetry-db.ts
@@ -13,13 +13,21 @@ import {
 } from "./helpers/relocation.js";
 
 /**
- * How to drain `skill_loaded_events` from `main` into the telemetry DB. The
- * table is a telemetry outbox — every unflushed row is worth keeping until
- * the usage telemetry reporter ships it — so all rows are copied verbatim.
+ * How to drain `skill_loaded_events` from `main` into the telemetry DB.
+ *
+ * `copyWhere` is a liveness filter: only rows whose conversation still exists
+ * (or that have none) are copied; the rest are purged without copying. The
+ * table has per-conversation redaction semantics, and a drain can span boots —
+ * the redaction paths delete only on the telemetry connection and cannot see
+ * the staging table, so a conversation deleted mid-drain must not have its
+ * staged rows resurrected on the next boot. The staging table and
+ * `conversations` both live in `main`, so the predicate resolves there.
  */
 export const SKILL_LOADED_EVENTS_RELOCATION: RelocationSpec = {
   table: "skill_loaded_events",
   targetDbPath: getTelemetryDbPath,
+  copyWhere:
+    "conversation_id IS NULL OR EXISTS (SELECT 1 FROM conversations WHERE conversations.id = conversation_id)",
   columns: [
     "id",
     "created_at",
@@ -78,7 +86,11 @@ function ensureSkillLoadedEventsSchema(telemetryRaw: Database): void {
  * Unlike the other moved outboxes this table has per-conversation redaction
  * semantics: deleting a conversation (or clearing all) must delete its
  * unshipped rows. Those cleanup paths (`conversation-crud.ts`,
- * `job-handlers/cleanup.ts`) delete over the telemetry connection too.
+ * `job-handlers/cleanup.ts`) delete over the telemetry connection too — which
+ * cannot see rows parked in `main.skill_loaded_events__relocating` while a
+ * drain is interrupted across boots. The spec's `copyWhere` liveness filter
+ * closes that gap: on resume, rows whose conversation no longer exists are
+ * purged instead of copied, so redacted rows never reach the telemetry DB.
  *
  * Like migrations 297/298/326/327/328/329 the move is incremental: create the
  * table (and index) on the telemetry connection, rename any populated


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for telemetry-db-move.md.

**Gap:** rows stranded in skill_loaded_events__relocating escaped redaction
**What was expected:** unshipped skill events of a deleted conversation never ship
**What was found:** a resumed multi-boot drain copied staged rows unconditionally, resurrecting rows whose conversation was deleted between boots; fixed with a copyWhere liveness filter (purge-without-copy)