### PR TITLE
fix: watcher-inventory checkpoint must not advance on telemetry-DB degradation

### DIFF
--- a/assistant/src/watcher/__tests__/telemetry.test.ts
+++ b/assistant/src/watcher/__tests__/telemetry.test.ts
@@ -8,12 +8,17 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { LifecycleEvent } from "../../persistence/lifecycle-events-store.js";
+
 const checkpoints = new Map<string, string>();
 const recordedEvents: string[] = [];
 let fakeEnabledWatchers: Array<{ providerId: string }> = [];
-let recordImpl: (name: string) => void = (name) => {
+let shareAnalytics = true;
+const recordAndReturnEvent = (name: string): LifecycleEvent => {
   recordedEvents.push(name);
+  return { id: "evt-1", eventName: name, createdAt: 0 };
 };
+let recordImpl: (name: string) => LifecycleEvent | null = recordAndReturnEvent;
 
 mock.module("../../persistence/checkpoints.js", () => ({
   getMemoryCheckpoint: (key: string) => checkpoints.get(key) ?? null,
@@ -23,10 +28,11 @@ mock.module("../../persistence/checkpoints.js", () => ({
 }));
 
 mock.module("../../persistence/lifecycle-events-store.js", () => ({
-  recordLifecycleEvent: (name: string) => {
-    recordImpl(name);
-    return null;
-  },
+  recordLifecycleEvent: (name: string) => recordImpl(name),
+}));
+
+mock.module("../../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 mock.module("../watcher-store.js", () => ({
@@ -48,9 +54,8 @@ beforeEach(() => {
   checkpoints.clear();
   recordedEvents.length = 0;
   fakeEnabledWatchers = [];
-  recordImpl = (name) => {
-    recordedEvents.push(name);
-  };
+  shareAnalytics = true;
+  recordImpl = recordAndReturnEvent;
 });
 
 describe("recordWatcherInventoryIfDue", () => {
@@ -108,13 +113,38 @@ describe("recordWatcherInventoryIfDue", () => {
     // instead of skipping a day of inventory.
     expect(checkpoints.get(INVENTORY_KEY)).toBeUndefined();
 
-    recordImpl = (name) => {
-      recordedEvents.push(name);
-    };
+    recordImpl = recordAndReturnEvent;
     recordWatcherInventoryIfDue(BASE + 3);
 
     expect(recordedEvents).toEqual(["watcher_enabled:gmail"]);
     expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE + 3));
+  });
+
+  test("leaves the checkpoint for retry when the telemetry DB is unavailable with consent on", () => {
+    fakeEnabledWatchers = [{ providerId: "gmail" }];
+    // Degraded mode: consent granted but the store reports nothing recorded.
+    recordImpl = () => null;
+
+    recordWatcherInventoryIfDue(BASE + 2);
+    expect(checkpoints.get(INVENTORY_KEY)).toBeUndefined();
+
+    recordImpl = recordAndReturnEvent;
+    recordWatcherInventoryIfDue(BASE + 3);
+
+    expect(recordedEvents).toEqual(["watcher_enabled:gmail"]);
+    expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE + 3));
+  });
+
+  test("advances the checkpoint when consent is off", () => {
+    fakeEnabledWatchers = [{ providerId: "gmail" }];
+    shareAnalytics = false;
+    // Consent-off skip: the store records nothing and returns null.
+    recordImpl = () => null;
+
+    recordWatcherInventoryIfDue(BASE + 4);
+
+    expect(recordedEvents).toEqual([]);
+    expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE + 4));
   });
 });
 

--- a/assistant/src/watcher/telemetry.ts
+++ b/assistant/src/watcher/telemetry.ts
@@ -24,6 +24,7 @@ import {
   setMemoryCheckpoint,
 } from "../persistence/checkpoints.js";
 import { recordLifecycleEvent } from "../persistence/lifecycle-events-store.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { getLogger } from "../util/logger.js";
 import { listWatchers } from "./watcher-store.js";
 
@@ -32,22 +33,38 @@ const log = getLogger("watcher-telemetry");
 const INVENTORY_CHECKPOINT_KEY = "telemetry:watchers:inventory_last_recorded";
 export const WATCHER_INVENTORY_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
+let warnedInventoryDbUnavailable = false;
+
 /**
  * Record one `watcher_enabled:<providerId>` lifecycle event per enabled
  * watcher, at most once per 24h. Called from every watcher tick; the
  * checkpoint advances only after the events are recorded, so a transient
- * storage failure retries on the next tick instead of skipping a day.
- * Retries can duplicate events for watchers recorded before the failure
- * point — an acceptable overcount for best-effort telemetry, where losing
- * a full day's inventory would not be.
+ * storage failure (a throw, or a degraded-mode `null` while analytics
+ * consent is granted) retries on the next tick instead of skipping a day.
+ * A consent-off `null` is a deliberate skip and still advances. Retries
+ * can duplicate events for watchers recorded before the failure point —
+ * an acceptable overcount for best-effort telemetry, where losing a full
+ * day's inventory would not be.
  */
 export function recordWatcherInventoryIfDue(now: number): void {
   try {
     const last = Number(getMemoryCheckpoint(INVENTORY_CHECKPOINT_KEY) ?? "0");
     if (now - last < WATCHER_INVENTORY_INTERVAL_MS) return;
     for (const watcher of listWatchers({ enabledOnly: true })) {
-      recordLifecycleEvent(`watcher_enabled:${watcher.providerId}`);
+      const recorded = recordLifecycleEvent(
+        `watcher_enabled:${watcher.providerId}`,
+      );
+      if (recorded === null && getCachedShareAnalytics()) {
+        if (!warnedInventoryDbUnavailable) {
+          warnedInventoryDbUnavailable = true;
+          log.warn(
+            "Telemetry DB unavailable; watcher inventory retries next tick",
+          );
+        }
+        return;
+      }
     }
+    warnedInventoryDbUnavailable = false;
     setMemoryCheckpoint(INVENTORY_CHECKPOINT_KEY, String(now));
   } catch (err) {
     log.warn({ err }, "Failed to record watcher inventory telemetry");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for telemetry-db-move.md.

**Gap:** watcher-inventory retry contract silently defeated
**What was expected:** transient storage failure retries next tick instead of skipping a day
**What was found:** recordLifecycleEvent now returns null on telemetry-DB unavailability, so the checkpoint advanced and a day of inventory was dropped