### PR TITLE
chore: telemetry-move review polish (schema comments, unused exports, test normalization)

### DIFF
--- a/assistant/src/persistence/migrations/327-move-onboarding-events-to-telemetry-db.ts
+++ b/assistant/src/persistence/migrations/327-move-onboarding-events-to-telemetry-db.ts
@@ -17,7 +17,7 @@ import {
  * table is a pure telemetry outbox — every row is worth keeping until the
  * usage telemetry reporter flushes it — so all rows are copied verbatim.
  */
-export const ONBOARDING_EVENTS_RELOCATION: RelocationSpec = {
+const ONBOARDING_EVENTS_RELOCATION: RelocationSpec = {
   table: "onboarding_events",
   targetDbPath: getTelemetryDbPath,
   columns: [

--- a/assistant/src/persistence/migrations/328-move-auth-fallback-events-to-telemetry-db.ts
+++ b/assistant/src/persistence/migrations/328-move-auth-fallback-events-to-telemetry-db.ts
@@ -17,7 +17,7 @@ import {
  * table is a pure telemetry outbox — every row is worth keeping until the
  * usage telemetry reporter flushes it — so all rows are copied verbatim.
  */
-export const AUTH_FALLBACK_EVENTS_RELOCATION: RelocationSpec = {
+const AUTH_FALLBACK_EVENTS_RELOCATION: RelocationSpec = {
   table: "auth_fallback_events",
   targetDbPath: getTelemetryDbPath,
   columns: [

--- a/assistant/src/persistence/migrations/329-move-lifecycle-events-to-telemetry-db.ts
+++ b/assistant/src/persistence/migrations/329-move-lifecycle-events-to-telemetry-db.ts
@@ -18,7 +18,7 @@ import {
  * usage telemetry reporter flushes it (and, by design, forever after: the
  * table is never deleted from) — so all rows are copied verbatim.
  */
-export const LIFECYCLE_EVENTS_RELOCATION: RelocationSpec = {
+const LIFECYCLE_EVENTS_RELOCATION: RelocationSpec = {
   table: "lifecycle_events",
   targetDbPath: getTelemetryDbPath,
   columns: ["id", "event_name", "created_at"],

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -274,12 +274,16 @@ export const llmUsageEvents = sqliteTable(
   ],
 );
 
+// Lives on the dedicated telemetry database (assistant-telemetry.db)
+// alongside watchdog_events.
 export const lifecycleEvents = sqliteTable("lifecycle_events", {
   id: text("id").primaryKey(),
   eventName: text("event_name").notNull(), // 'app_open' | 'hatch'
   createdAt: integer("created_at").notNull(),
 });
 
+// Lives on the dedicated telemetry database (assistant-telemetry.db)
+// alongside watchdog_events.
 export const onboardingEvents = sqliteTable("onboarding_events", {
   id: text("id").primaryKey(),
   createdAt: integer("created_at").notNull(),
@@ -301,7 +305,9 @@ export const onboardingEvents = sqliteTable("onboarding_events", {
 // Aggregated legacy-loopback auth-fallback counts forwarded by the gateway.
 // One row per (guard, path, failure_kind) per flush window; `count` is how many
 // requests fell back to the loopback exemption in that window. Flushed to the
-// platform telemetry endpoint by the usage telemetry reporter.
+// platform telemetry endpoint by the usage telemetry reporter. Lives on the
+// dedicated telemetry database (assistant-telemetry.db) alongside
+// watchdog_events.
 export const authFallbackEvents = sqliteTable("auth_fallback_events", {
   id: text("id").primaryKey(),
   createdAt: integer("created_at").notNull(),
@@ -323,7 +329,9 @@ export const activationSessions = sqliteTable("activation_sessions", {
 
 // One row per `skill_loaded` telemetry event, emitted when a Vellum-produced
 // skill is activated in a conversation — see skill-loaded-events-store.ts for
-// the data contract. Flushed by the usage telemetry reporter.
+// the data contract. Flushed by the usage telemetry reporter. Lives on the
+// dedicated telemetry database (assistant-telemetry.db) alongside
+// watchdog_events.
 export const skillLoadedEvents = sqliteTable(
   "skill_loaded_events",
   {

--- a/assistant/src/runtime/routes/internal-telemetry-routes.ts
+++ b/assistant/src/runtime/routes/internal-telemetry-routes.ts
@@ -60,7 +60,8 @@ function handleRecordAuthFallback({ body }: RouteHandlerArgs) {
 
   const recorded = recordAuthFallbackCounts(window_start, window_end, mapped);
   if (recorded === 0) {
-    // share_analytics consent off — counts dropped to honor the opt-out.
+    // Counts dropped: share_analytics consent is off (honoring the opt-out)
+    // or the telemetry database is unavailable (degraded mode).
     return { skipped: true };
   }
   log.debug({ recorded }, "Recorded auth-fallback counts");

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -399,9 +399,9 @@ beforeEach(() => {
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
-  getTelemetryDb()?.delete(skillLoadedEvents).run();
-  getTelemetryDb()?.delete(authFallbackEvents).run();
-  getTelemetryDb()?.delete(configSettingEvents).run();
+  getTelemetryDb()!.delete(skillLoadedEvents).run();
+  getTelemetryDb()!.delete(authFallbackEvents).run();
+  getTelemetryDb()!.delete(configSettingEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
   delete process.env.IS_PLATFORM;
   mockGetPlatformBaseUrl.mockReset();
@@ -1938,11 +1938,7 @@ describe("UsageTelemetryReporter", () => {
 
     // The last row by the reporter's (createdAt, id) cursor order is the one
     // whose watermark should be persisted after a successful upload.
-    const telemetryDb = getTelemetryDb();
-    if (!telemetryDb) {
-      throw new Error("telemetry DB unavailable in test");
-    }
-    const rows = telemetryDb
+    const rows = getTelemetryDb()!
       .select()
       .from(authFallbackEvents)
       .orderBy(authFallbackEvents.createdAt, authFallbackEvents.id)
@@ -2616,9 +2612,7 @@ describe("UsageTelemetryReporter", () => {
 
     // The last row by the reporter's (createdAt, id) cursor order is the one
     // whose watermark should be persisted after a successful upload.
-    const telemetryDb = getTelemetryDb();
-    if (!telemetryDb) throw new Error("telemetry DB unavailable in test");
-    const rows = telemetryDb
+    const rows = getTelemetryDb()!
       .select()
       .from(configSettingEvents)
       .orderBy(configSettingEvents.createdAt, configSettingEvents.id)


### PR DESCRIPTION
## Summary
Fixes polish gaps identified during plan review for telemetry-db-move.md:
- Location notes on the four moved tables in schema/infrastructure.ts
- Un-export unused RelocationSpecs (327/328/329), matching the 297 precedent
- Normalize telemetry-DB null handling in the reporter test
- Clarify internal-telemetry-routes skipped-comment (degraded vs consent-off)