### PR TITLE
fix: auth-fallback route must fail (not skip) on telemetry-DB degradation so the gateway retries

### DIFF
--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 // Toggle for the share_analytics opt-out the real store consults. The store
 // module is intentionally NOT mocked here — it has its own DB-backed tests, and
@@ -28,11 +28,14 @@ mock.module("../telemetry/watchdog-direct-emit.js", () => ({
   },
 }));
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
+import * as dbConnection from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { authFallbackEvents } from "../persistence/schema/index.js";
 import { GATEWAY_PRINCIPALS } from "../runtime/auth/route-policy.js";
-import { RouteError } from "../runtime/routes/errors.js";
+import {
+  RouteError,
+  ServiceUnavailableError,
+} from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/internal-telemetry-routes.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
 import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-events-store.js";
@@ -64,7 +67,7 @@ const VALID_BODY = {
 describe("internal-telemetry-routes: auth-fallback", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    getTelemetryDb()!.delete(authFallbackEvents).run();
+    dbConnection.getTelemetryDb()!.delete(authFallbackEvents).run();
   });
 
   test("route is locked to service-token callers (GATEWAY_PRINCIPALS + internal.write)", () => {
@@ -95,6 +98,19 @@ describe("internal-telemetry-routes: auth-fallback", () => {
     shareAnalytics = false;
     expect(call(VALID_BODY)).toEqual({ skipped: true });
     expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+  });
+
+  test("throws 503 when consent is on but the telemetry DB is unavailable, so the gateway re-queues", () => {
+    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+    try {
+      expect(() => call(VALID_BODY)).toThrow(ServiceUnavailableError);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+
+    // Once the DB is back the same batch records normally.
+    expect(call(VALID_BODY)).toEqual({ recorded: 1 });
   });
 
   test("rejects a malformed body without persisting", () => {

--- a/assistant/src/runtime/routes/internal-telemetry-routes.ts
+++ b/assistant/src/runtime/routes/internal-telemetry-routes.ts
@@ -16,6 +16,7 @@
 
 import { z } from "zod";
 
+import { getCachedShareAnalytics } from "../../platform/consent-cache.js";
 import {
   type AuthFallbackCount,
   recordAuthFallbackCounts,
@@ -23,7 +24,7 @@ import {
 import { emitWatchdogEventDirect } from "../../telemetry/watchdog-direct-emit.js";
 import { getLogger } from "../../util/logger.js";
 import { GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
-import { BadRequestError } from "./errors.js";
+import { BadRequestError, ServiceUnavailableError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("internal-telemetry-routes");
@@ -60,8 +61,15 @@ function handleRecordAuthFallback({ body }: RouteHandlerArgs) {
 
   const recorded = recordAuthFallbackCounts(window_start, window_end, mapped);
   if (recorded === 0) {
-    // Counts dropped: share_analytics consent is off (honoring the opt-out)
-    // or the telemetry database is unavailable (degraded mode).
+    if (getCachedShareAnalytics()) {
+      // Consent is on but nothing was recorded (the body guarantees counts),
+      // so the telemetry DB is unavailable. Fail so the gateway's reporter
+      // merges the batch back and retries next flush instead of losing it.
+      throw new ServiceUnavailableError(
+        "Telemetry database unavailable; retry the auth-fallback batch",
+      );
+    }
+    // share_analytics consent is off: drop the counts to honor the opt-out.
     return { skipped: true };
   }
   log.debug({ recorded }, "Recorded auth-fallback counts");

--- a/assistant/src/security/auth-fallback-events-store.ts
+++ b/assistant/src/security/auth-fallback-events-store.ts
@@ -30,7 +30,8 @@ export interface AuthFallbackEvent {
  * one row per count entry, all sharing the same flush window. Returns the
  * number of rows recorded, or 0 when usage data collection is disabled (the
  * counts are dropped to honor the opt-out, matching the rest of telemetry) or
- * the telemetry database is unavailable (degraded mode).
+ * the telemetry database is unavailable (degraded mode). Callers that must
+ * tell those apart check `getCachedShareAnalytics()` themselves.
  */
 export function recordAuthFallbackCounts(
   windowStart: number,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for telemetry-db-move.md.

**Gap:** degraded telemetry DB silently discarded gateway auth-fallback windows
**What was expected:** gateway merge-back retry on daemon-side storage failure
**What was found:** recordAuthFallbackCounts returns 0 for both consent-off and db-degraded; the route mapped both to 200 {skipped}, destroying every window during degradation