### PR TITLE
fix: trim dead guardian-request wire surface; share pure helpers via the contract

### DIFF
--- a/assistant/src/__tests__/guardian-card-withdrawal.test.ts
+++ b/assistant/src/__tests__/guardian-card-withdrawal.test.ts
@@ -284,7 +284,7 @@ describe("recordApprovalCardDelivery", () => {
     });
 
     const resolved =
-      await bridgeState.module.getPendingRequestByDestinationMessage(
+      await bridgeState.module.getPendingRequestByDestinationMessageOrNull(
         "slack",
         "C-guardian",
         "1700000000.5678",

--- a/assistant/src/__tests__/guardian-gateway-sim.ts
+++ b/assistant/src/__tests__/guardian-gateway-sim.ts
@@ -16,10 +16,16 @@
  *   variants degrade to their fallback like the production client.
  *
  * Per the test-machinery isolation rules this helper imports nothing from
- * `src/`; the wire shapes are declared structurally.
+ * `src/`; the wire shapes are declared structurally and the pure derivations
+ * come from the shared contract package.
  */
 
 import { randomUUID } from "node:crypto";
+
+import {
+  deriveGuardianRequestSourceType,
+  isGuardianRequestExpired,
+} from "@vellumai/gateway-client";
 
 export interface SimGuardianRequest {
   id: string;
@@ -90,14 +96,6 @@ export interface MintedSession {
   ttlSeconds: number;
 }
 
-function computeSourceType(
-  sourceChannel: string | null | undefined,
-): "voice" | "desktop" | "channel" {
-  if (sourceChannel === "phone") return "voice";
-  if (sourceChannel === "vellum") return "desktop";
-  return "channel";
-}
-
 let codeCounter = 0;
 function generateCode(): string {
   codeCounter += 1;
@@ -137,7 +135,9 @@ export function createGuardianGatewaySim() {
       id: params.id ?? randomUUID(),
       kind: params.kind,
       sourceChannel: params.sourceChannel ?? null,
-      sourceType: params.sourceType ?? computeSourceType(params.sourceChannel),
+      sourceType:
+        params.sourceType ??
+        deriveGuardianRequestSourceType(params.sourceChannel ?? null),
       sourceConversationId: params.sourceConversationId ?? null,
       requesterExternalUserId: params.requesterExternalUserId ?? null,
       requesterChatId: params.requesterChatId ?? null,
@@ -191,7 +191,9 @@ export function createGuardianGatewaySim() {
   }
 
   function throwIfReadError(): void {
-    if (state.readError) throw state.readError;
+    if (state.readError) {
+      throw state.readError;
+    }
   }
 
   // ── Client-module implementations ───────────────────────────────────
@@ -265,7 +267,9 @@ export function createGuardianGatewaySim() {
     >,
   ): Promise<void> {
     const row = requests.get(id);
-    if (!row) throw new Error(`sim: request ${id} not found`);
+    if (!row) {
+      throw new Error(`sim: request ${id} not found`);
+    }
     Object.assign(row, patch, { updatedAt: Date.now() });
   }
 
@@ -279,7 +283,9 @@ export function createGuardianGatewaySim() {
   > {
     state.beforeDecide?.();
     state.decideCalls.push(params);
-    if (state.decideError) throw state.decideError;
+    if (state.decideError) {
+      throw state.decideError;
+    }
     const row = requests.get(params.id);
     if (!row || row.status !== params.expectedStatus) {
       return { applied: false, reason: "status_conflict" };
@@ -289,7 +295,9 @@ export function createGuardianGatewaySim() {
       throw state.outcomeError;
     }
     row.status = params.status;
-    if (params.answerText !== undefined) row.answerText = params.answerText;
+    if (params.answerText !== undefined) {
+      row.answerText = params.answerText;
+    }
     if (params.decidedByExternalUserId !== undefined) {
       row.decidedByExternalUserId = params.decidedByExternalUserId;
     }
@@ -297,7 +305,9 @@ export function createGuardianGatewaySim() {
       row.decidedByPrincipalId = params.decidedByPrincipalId;
     }
     row.updatedAt = Date.now();
-    if (params.aclOutcome) state.appliedOutcomes.push(params.aclOutcome);
+    if (params.aclOutcome) {
+      state.appliedOutcomes.push(params.aclOutcome);
+    }
 
     let mintedSession: MintedSession | undefined;
     if (params.aclOutcome?.type === "mint_outbound_session") {
@@ -316,10 +326,15 @@ export function createGuardianGatewaySim() {
     };
   }
 
-  async function reopenGuardianRequest(
+  /**
+   * Test-internal terminal → pending CAS (not part of the client-module
+   * surface): the store bridge uses it to mirror the gateway decide
+   * transaction's rollback after a failed ACL outcome.
+   */
+  function reopenRequest(
     id: string,
     fromStatus: SimGuardianRequest["status"],
-  ): Promise<void> {
+  ): void {
     const row = requests.get(id);
     if (!row || row.status !== fromStatus) {
       throw new Error(`sim: reopen CAS miss for ${id}`);
@@ -346,10 +361,12 @@ export function createGuardianGatewaySim() {
     let expired = 0;
     const now = Date.now();
     for (const row of requests.values()) {
-      if (row.status !== "pending") continue;
+      if (row.status !== "pending") {
+        continue;
+      }
       const interactionBound =
         row.kind === "tool_approval" || row.kind === "pending_question";
-      if (interactionBound || (row.expiresAt !== null && row.expiresAt < now)) {
+      if (interactionBound || isGuardianRequestExpired(row, now)) {
         row.status = "expired";
         row.updatedAt = now;
         expired += 1;
@@ -364,11 +381,7 @@ export function createGuardianGatewaySim() {
     const cutoff = now ?? Date.now();
     const expired: SimGuardianRequest[] = [];
     for (const row of requests.values()) {
-      if (
-        row.status === "pending" &&
-        row.expiresAt !== null &&
-        row.expiresAt < cutoff
-      ) {
+      if (row.status === "pending" && isGuardianRequestExpired(row, cutoff)) {
         row.status = "expired";
         row.updatedAt = cutoff;
         expired.push({ ...row });
@@ -390,7 +403,9 @@ export function createGuardianGatewaySim() {
     >,
   ): Promise<void> {
     const row = deliveries.find((d) => d.id === id);
-    if (!row) throw new Error(`sim: delivery ${id} not found`);
+    if (!row) {
+      throw new Error(`sim: delivery ${id} not found`);
+    }
     Object.assign(row, patch, { updatedAt: Date.now() });
   }
 
@@ -415,7 +430,9 @@ export function createGuardianGatewaySim() {
         d.destinationChatId === chatId &&
         d.destinationMessageId === messageId,
     );
-    if (!delivery) return null;
+    if (!delivery) {
+      return null;
+    }
     const request = requests.get(delivery.requestId);
     return request?.status === "pending" ? { ...request } : null;
   }
@@ -441,10 +458,14 @@ export function createGuardianGatewaySim() {
     const seen = new Set<string>();
     const result: SimGuardianRequest[] = [];
     for (const delivery of matched) {
-      if (seen.has(delivery.requestId)) continue;
+      if (seen.has(delivery.requestId)) {
+        continue;
+      }
       seen.add(delivery.requestId);
       const request = requests.get(delivery.requestId);
-      if (request?.status === "pending") result.push({ ...request });
+      if (request?.status === "pending") {
+        result.push({ ...request });
+      }
     }
     return result;
   }
@@ -461,7 +482,7 @@ export function createGuardianGatewaySim() {
       if (
         row.status === "pending" &&
         row.sourceConversationId === conversationId &&
-        !(row.expiresAt !== null && row.expiresAt < now)
+        !isGuardianRequestExpired(row, now)
       ) {
         seen.add(row.id);
         result.push({ ...row });
@@ -472,10 +493,7 @@ export function createGuardianGatewaySim() {
       ...(channel ? { channel } : {}),
     });
     for (const row of byDestination) {
-      if (
-        !seen.has(row.id) &&
-        !(row.expiresAt !== null && row.expiresAt < now)
-      ) {
+      if (!seen.has(row.id) && !isGuardianRequestExpired(row, now)) {
         seen.add(row.id);
         result.push(row);
       }
@@ -490,8 +508,12 @@ export function createGuardianGatewaySim() {
   ): Promise<boolean> {
     throwIfReadError();
     const request = requests.get(requestId);
-    if (!request) return false;
-    if (request.sourceConversationId === conversationId) return true;
+    if (!request) {
+      return false;
+    }
+    if (request.sourceConversationId === conversationId) {
+      return true;
+    }
     return deliveries.some(
       (d) =>
         d.requestId === requestId &&
@@ -517,7 +539,9 @@ export function createGuardianGatewaySim() {
   ): Promise<SimGuardianRequest | null> {
     throwIfReadError();
     for (const row of requests.values()) {
-      if (row.pendingQuestionId === pendingQuestionId) return { ...row };
+      if (row.pendingQuestionId === pendingQuestionId) {
+        return { ...row };
+      }
     }
     return null;
   }
@@ -541,18 +565,19 @@ export function createGuardianGatewaySim() {
     };
   }
 
-  /** Drop-in replacement for the gateway-guardian-requests client module. */
+  /**
+   * Drop-in replacement for the gateway-guardian-requests client module —
+   * same surface: reads whose only callers are deny paths appear solely as
+   * their degrading variant.
+   */
   const module = {
     createGuardianRequest,
     getGuardianRequest,
     getGuardianRequestOrNull: degrade(getGuardianRequest, null),
-    getGuardianRequestByCode,
     getGuardianRequestByCodeOrNull: degrade(getGuardianRequestByCode, null),
-    listGuardianRequests,
     listGuardianRequestsOrEmpty: degrade(listGuardianRequests, []),
     updateGuardianRequest,
     decideGuardianRequest,
-    reopenGuardianRequest,
     expireGuardianRequest,
     expireInteractionBoundGuardianRequests,
     sweepExpiredGuardianRequests,
@@ -563,26 +588,22 @@ export function createGuardianGatewaySim() {
       listGuardianRequestDeliveries,
       [],
     ),
-    getPendingRequestByDestinationMessage,
     getPendingRequestByDestinationMessageOrNull: degrade(
       getPendingRequestByDestinationMessage,
       null,
     ),
-    listPendingRequestsByDestination,
     listPendingRequestsByDestinationOrEmpty: degrade(
       listPendingRequestsByDestination,
       [],
     ),
     listPendingRequestsByScope,
     listPendingRequestsByScopeOrEmpty: degrade(listPendingRequestsByScope, []),
-    isGuardianRequestInScope,
     isGuardianRequestInScopeOrFalse: degrade(isGuardianRequestInScope, false),
     getPendingRequestByCallSession,
     getPendingRequestByCallSessionOrNull: degrade(
       getPendingRequestByCallSession,
       null,
     ),
-    getRequestByPendingQuestion,
     getRequestByPendingQuestionOrNull: degrade(
       getRequestByPendingQuestion,
       null,
@@ -597,6 +618,7 @@ export function createGuardianGatewaySim() {
     seedRequest,
     seedDelivery,
     getRequest,
+    reopenRequest,
     module,
   };
 }

--- a/assistant/src/__tests__/helpers/gateway-guardian-requests-store-bridge.ts
+++ b/assistant/src/__tests__/helpers/gateway-guardian-requests-store-bridge.ts
@@ -131,7 +131,7 @@ async function decideGuardianRequest(
     ({ mintedSession } = await applyAclOutcome(aclOutcome));
   } catch (err) {
     // Mirror the gateway transaction rollback: the CAS never lands.
-    await bridgeState.module.reopenGuardianRequest(parsed.id, parsed.status);
+    bridgeState.reopenRequest(parsed.id, parsed.status);
     throw err;
   }
 

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -275,7 +275,7 @@ describe("ToolApprovalHandler / grant-miss escalation", () => {
     expect(result.result.content).toContain("verified channel identity");
 
     // No guardian request should have been created
-    const requests = await sim.module.listGuardianRequests({
+    const requests = await sim.module.listGuardianRequestsOrEmpty({
       kind: "tool_grant_request",
       status: "pending",
     });
@@ -607,7 +607,7 @@ describe("inline wait-and-resume", () => {
     expect(elapsed).toBeLessThan(200);
 
     // No guardian request created
-    const requests = await sim.module.listGuardianRequests({
+    const requests = await sim.module.listGuardianRequestsOrEmpty({
       kind: "tool_grant_request",
       status: "pending",
     });

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -522,7 +522,7 @@ describe("(d) unknown actor flow: fail-closed with no interactive approval", () 
     expect(result.result.content).toContain("verified channel identity");
 
     // No guardian request created — unknown actors don't escalate
-    const requests = await sim.module.listGuardianRequests({
+    const requests = await sim.module.listGuardianRequestsOrEmpty({
       kind: "tool_grant_request",
       status: "pending",
     });

--- a/assistant/src/channels/__tests__/gateway-guardian-requests.test.ts
+++ b/assistant/src/channels/__tests__/gateway-guardian-requests.test.ts
@@ -315,20 +315,22 @@ describe("request lookups", () => {
     expect(await client.getGuardianRequest("req-404")).toBeNull();
   });
 
-  test("getGuardianRequestByCode maps the method and params", async () => {
+  test("getGuardianRequestByCodeOrNull maps the method and params", async () => {
     const request = makeWireRequest();
     ipcResponse = request;
-    expect(await client.getGuardianRequestByCode("AB12")).toEqual(request);
+    expect(await client.getGuardianRequestByCodeOrNull("AB12")).toEqual(
+      request,
+    );
     expect(ipcCalls[0]).toEqual({
       method: "guardian_requests_get_by_code",
       params: { code: "AB12" },
     });
   });
 
-  test("getPendingRequestByDestinationMessage maps the destination triple", async () => {
+  test("getPendingRequestByDestinationMessageOrNull maps the destination triple", async () => {
     ipcResponse = null;
     expect(
-      await client.getPendingRequestByDestinationMessage(
+      await client.getPendingRequestByDestinationMessageOrNull(
         "telegram",
         "chat-456",
         "msg-1",
@@ -340,7 +342,7 @@ describe("request lookups", () => {
     });
   });
 
-  test("getPendingRequestByCallSession and getRequestByPendingQuestion map params", async () => {
+  test("getPendingRequestByCallSession and getRequestByPendingQuestionOrNull map params", async () => {
     const request = makeWireRequest({ callSessionId: "call-1" });
     ipcResponse = request;
     expect(await client.getPendingRequestByCallSession("call-1")).toEqual(
@@ -352,7 +354,7 @@ describe("request lookups", () => {
     });
 
     ipcResponse = makeWireRequest({ pendingQuestionId: "pq-1" });
-    await client.getRequestByPendingQuestion("pq-1");
+    await client.getRequestByPendingQuestionOrNull("pq-1");
     expect(ipcCalls[1]).toEqual({
       method: "guardian_requests_get_by_pending_question",
       params: { pendingQuestionId: "pq-1" },
@@ -364,9 +366,9 @@ describe("request lookups", () => {
     await expect(client.getGuardianRequest("req-1")).rejects.toThrow(
       "guardian_requests_get",
     );
-    await expect(client.getGuardianRequestByCode("AB12")).rejects.toThrow(
-      "guardian_requests_get_by_code",
-    );
+    await expect(
+      client.getPendingRequestByCallSession("call-1"),
+    ).rejects.toThrow("guardian_requests_get_by_call_session");
   });
 
   test("OrNull variants degrade to null and log instead of throwing", async () => {
@@ -399,11 +401,11 @@ describe("request lookups", () => {
 });
 
 describe("request lists", () => {
-  test("listGuardianRequests passes filters through and validates the array", async () => {
+  test("listGuardianRequestsOrEmpty passes filters through and validates the array", async () => {
     const requests = [makeWireRequest(), makeWireRequest({ id: "req-2" })];
     ipcResponse = requests;
 
-    const result = await client.listGuardianRequests({
+    const result = await client.listGuardianRequestsOrEmpty({
       status: "pending",
       guardianPrincipalId: "principal-1",
       sourceType: "channel",
@@ -422,9 +424,9 @@ describe("request lists", () => {
     expect(result).toEqual(requests);
   });
 
-  test("listPendingRequestsByDestination and listPendingRequestsByScope map params", async () => {
+  test("listPendingRequestsByDestinationOrEmpty and listPendingRequestsByScope map params", async () => {
     ipcResponse = [];
-    await client.listPendingRequestsByDestination({
+    await client.listPendingRequestsByDestinationOrEmpty({
       channel: "telegram",
       chatId: "chat-456",
     });
@@ -442,14 +444,14 @@ describe("request lists", () => {
 
   test("throwing lists throw on transport failure and malformed payloads", async () => {
     ipcError = new Error("gateway unavailable");
-    await expect(client.listGuardianRequests()).rejects.toThrow(
+    await expect(client.listPendingRequestsByScope("conv-1")).rejects.toThrow(
       "gateway unavailable",
     );
 
     ipcError = null;
     ipcResponse = [{ id: "req-1" }];
-    await expect(client.listGuardianRequests()).rejects.toThrow(
-      "guardian_requests_list",
+    await expect(client.listPendingRequestsByScope("conv-1")).rejects.toThrow(
+      "guardian_requests_list_pending_by_scope",
     );
   });
 
@@ -486,16 +488,10 @@ describe("mutations", () => {
     ]);
   });
 
-  test("reopenGuardianRequest and expireGuardianRequest map params", async () => {
+  test("expireGuardianRequest maps params", async () => {
     ipcResponse = { ok: true };
-    await client.reopenGuardianRequest("req-1", "expired");
-    expect(ipcCalls[0]).toEqual({
-      method: "guardian_requests_reopen",
-      params: { id: "req-1", fromStatus: "expired" },
-    });
-
     await client.expireGuardianRequest("req-1");
-    expect(ipcCalls[1]).toEqual({
+    expect(ipcCalls[0]).toEqual({
       method: "guardian_requests_expire",
       params: { id: "req-1" },
     });
@@ -513,9 +509,9 @@ describe("mutations", () => {
 
   test("mutations throw when the gateway does not ack ok", async () => {
     ipcResponse = { ok: false };
-    await expect(
-      client.reopenGuardianRequest("req-1", "expired"),
-    ).rejects.toThrow("guardian_requests_reopen");
+    await expect(client.expireGuardianRequest("req-1")).rejects.toThrow(
+      "guardian_requests_expire",
+    );
   });
 });
 
@@ -631,11 +627,15 @@ describe("deliveries", () => {
   });
 });
 
-describe("isGuardianRequestInScope", () => {
+describe("isGuardianRequestInScopeOrFalse", () => {
   test("returns the gateway scope verdict", async () => {
     ipcResponse = { inScope: true };
     expect(
-      await client.isGuardianRequestInScope("req-1", "conv-1", "telegram"),
+      await client.isGuardianRequestInScopeOrFalse(
+        "req-1",
+        "conv-1",
+        "telegram",
+      ),
     ).toBe(true);
     expect(ipcCalls).toEqual([
       {
@@ -649,21 +649,21 @@ describe("isGuardianRequestInScope", () => {
     ]);
 
     ipcResponse = { inScope: false };
-    expect(await client.isGuardianRequestInScope("req-1", "conv-2")).toBe(
-      false,
-    );
+    expect(
+      await client.isGuardianRequestInScopeOrFalse("req-1", "conv-2"),
+    ).toBe(false);
   });
 
-  test("throws on a malformed response; OrFalse degrades to not-in-scope", async () => {
+  test("degrades to not-in-scope on malformed responses and transport failures", async () => {
     ipcResponse = { allowed: true };
-    await expect(
-      client.isGuardianRequestInScope("req-1", "conv-1"),
-    ).rejects.toThrow("guardian_requests_in_scope");
+    expect(
+      await client.isGuardianRequestInScopeOrFalse("req-1", "conv-1"),
+    ).toBe(false);
 
     ipcError = new Error("gateway unavailable");
     expect(
       await client.isGuardianRequestInScopeOrFalse("req-1", "conv-1"),
     ).toBe(false);
-    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls).toHaveLength(2);
   });
 });

--- a/assistant/src/channels/gateway-guardian-requests.ts
+++ b/assistant/src/channels/gateway-guardian-requests.ts
@@ -11,14 +11,14 @@
  * pinned to.
  *
  * Error posture (fail-closed — there is no local fallback):
- * - Lifecycle writes (create, update, decide, reopen, expire, sweep,
- *   delivery writes) THROW on any transport failure or malformed response.
- *   A guardian decision that cannot persist must fail loudly, never fake
- *   success.
- * - Reads used for hints/dedup/scope export a throwing default plus a
- *   degrading variant (`...OrNull` / `...OrEmpty` / `...OrFalse`) that logs
- *   the failure and returns the empty value — for deny-path callers that
- *   must degrade to "no data" instead of blocking.
+ * - Lifecycle writes (create, update, decide, expire, sweep, delivery
+ *   writes) THROW on any transport failure or malformed response. A guardian
+ *   decision that cannot persist must fail loudly, never fake success.
+ * - Reads used for hints/dedup/scope THROW by default; ones whose only
+ *   callers are deny paths that must degrade to "no data" instead of
+ *   blocking are exported solely as a degrading variant (`...OrNull` /
+ *   `...OrEmpty` / `...OrFalse`) that logs the failure and returns the
+ *   empty value.
  */
 
 import {
@@ -39,7 +39,6 @@ import {
   GuardianRequestMutationIpcResponseSchema,
   type GuardianRequestPatch,
   type GuardianRequestsIpcMethod,
-  type GuardianRequestStatus,
   type GuardianRequestWire,
   type ListGuardianRequestsIpcParams,
   type ListPendingGuardianRequestsByDestinationIpcParams,
@@ -142,7 +141,7 @@ export const getGuardianRequestOrNull = degradeOnFailure(
  * Look up a PENDING guardian request by its short request code. Throws on
  * transport failure.
  */
-export async function getGuardianRequestByCode(
+async function getGuardianRequestByCode(
   code: string,
 ): Promise<GuardianRequestWire | null> {
   return callGateway(
@@ -159,7 +158,7 @@ export const getGuardianRequestByCodeOrNull = degradeOnFailure(
 );
 
 /** List guardian requests matching the filters. Throws on transport failure. */
-export async function listGuardianRequests(
+async function listGuardianRequests(
   filters: ListGuardianRequestsIpcParams = {},
 ): Promise<GuardianRequestWire[]> {
   return callGateway(
@@ -199,17 +198,6 @@ export async function decideGuardianRequest(
     params as unknown as Record<string, unknown>,
     DecideGuardianRequestIpcResponseSchema,
   );
-}
-
-/**
- * Reopen a terminal request back to pending (CAS from `fromStatus`). Throws
- * on any failure (fail-closed).
- */
-export async function reopenGuardianRequest(
-  id: string,
-  fromStatus: GuardianRequestStatus,
-): Promise<void> {
-  await callMutation(GUARDIAN_REQUESTS_IPC_METHODS.reopen, { id, fromStatus });
 }
 
 /**
@@ -297,7 +285,7 @@ export const listGuardianRequestDeliveriesOrEmpty = degradeOnFailure(
  * Reaction routing: the pending request whose delivered card is the
  * reacted-to message. Throws on transport failure.
  */
-export async function getPendingRequestByDestinationMessage(
+async function getPendingRequestByDestinationMessage(
   channel: string,
   chatId: string,
   messageId: string,
@@ -320,7 +308,7 @@ export const getPendingRequestByDestinationMessageOrNull = degradeOnFailure(
  * (`conversationId`, optionally narrowed by `channel`) or chat
  * (`channel` + `chatId`). Throws on transport failure.
  */
-export async function listPendingRequestsByDestination(
+async function listPendingRequestsByDestination(
   params: ListPendingGuardianRequestsByDestinationIpcParams,
 ): Promise<GuardianRequestWire[]> {
   return callGateway(
@@ -362,7 +350,7 @@ export const listPendingRequestsByScopeOrEmpty = degradeOnFailure(
  * match, or delivery match optionally narrowed by `channel`)? Throws on
  * transport failure.
  */
-export async function isGuardianRequestInScope(
+async function isGuardianRequestInScope(
   requestId: string,
   conversationId: string,
   channel?: string,
@@ -405,7 +393,7 @@ export const getPendingRequestByCallSessionOrNull = degradeOnFailure(
  * The request carrying a specific voice pending-question id. Throws on
  * transport failure.
  */
-export async function getRequestByPendingQuestion(
+async function getRequestByPendingQuestion(
   pendingQuestionId: string,
 ): Promise<GuardianRequestWire | null> {
   return callGateway(

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -23,6 +23,8 @@
  * to allow for incremental migration and independent testability.
  */
 
+import { isGuardianRequestExpired } from "@vellumai/gateway-client";
+
 import {
   applyGuardianDecision,
   type GuardianDecisionResult,
@@ -59,13 +61,6 @@ import type {
 import { parseReactionCallbackData } from "./routes/channel-route-shared.js";
 
 const log = getLogger("guardian-reply-router");
-
-/** True when a request has passed its `expiresAt` deadline. */
-function isRequestExpired(
-  request: Pick<GuardianRequestWire, "expiresAt">,
-): boolean {
-  return Boolean(request.expiresAt && request.expiresAt < Date.now());
-}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -280,7 +275,7 @@ async function findPendingGuardianRequests(
   // Exclude requests that have passed their expiresAt deadline — they can
   // no longer be resolved and should not trigger disambiguation or NL
   // classification.
-  return results.filter((r) => !isRequestExpired(r));
+  return results.filter((r) => !isGuardianRequestExpired(r));
 }
 
 /** Map an approval action string to the NL engine's allowed actions for guardians. */
@@ -1011,9 +1006,7 @@ function failureReplyText(
  * code without any decision text. Provides context about the request and
  * tells the guardian how to approve or reject it.
  */
-function composeCodeOnlyClarification(
-  request: GuardianRequestWire,
-): string {
+function composeCodeOnlyClarification(request: GuardianRequestWire): string {
   const code = request.requestCode ?? "unknown";
   const mode = resolveRequestInstructionMode(request);
   return buildGuardianCodeOnlyClarification(mode, {

--- a/gateway/src/approvals/guardian-request-service.ts
+++ b/gateway/src/approvals/guardian-request-service.ts
@@ -3,8 +3,8 @@
  *
  * Thin lifecycle layer over the guardian-request store, serving the
  * `guardian_requests_*` IPC routes. Store-row ↔ wire-DTO mapping lives here:
- * the row type is the wire DTO minus `sourceType`, which the mapper computes
- * from `sourceChannel` (phone → voice, vellum → desktop, else channel).
+ * the row type is the wire DTO minus `sourceType`, which the mapper derives
+ * from `sourceChannel` via the shared contract helper.
  *
  * Create integrity: the store throws `GuardianRequestIntegrityError` (with a
  * machine-readable `code` the IPC error envelope mirrors into `errorCode`)
@@ -20,22 +20,22 @@
  * post-commit, best-effort.
  */
 
-import type {
-  CreateGuardianRequestDeliveryIpcParams,
-  CreateGuardianRequestIpcParams,
-  CreateOutboundSessionIpcResponse,
-  DecideGuardianRequestIpcParams,
-  DecideGuardianRequestIpcResponse,
-  ExpireInteractionBoundIpcResponse,
-  GuardianRequestAclOutcome,
-  GuardianRequestDeliveryWire,
-  GuardianRequestPatch,
-  GuardianRequestStatus,
-  GuardianRequestWire,
-  ListGuardianRequestsIpcParams,
-  ListPendingGuardianRequestsByDestinationIpcParams,
-  SweepExpiredGuardianRequestsIpcResponse,
-  UpdateGuardianRequestDeliveryIpcParams,
+import {
+  type CreateGuardianRequestDeliveryIpcParams,
+  type CreateGuardianRequestIpcParams,
+  type CreateOutboundSessionIpcResponse,
+  type DecideGuardianRequestIpcParams,
+  type DecideGuardianRequestIpcResponse,
+  deriveGuardianRequestSourceType,
+  type ExpireInteractionBoundIpcResponse,
+  type GuardianRequestAclOutcome,
+  type GuardianRequestDeliveryWire,
+  type GuardianRequestPatch,
+  type GuardianRequestWire,
+  type ListGuardianRequestsIpcParams,
+  type ListPendingGuardianRequestsByDestinationIpcParams,
+  type SweepExpiredGuardianRequestsIpcResponse,
+  type UpdateGuardianRequestDeliveryIpcParams,
 } from "@vellumai/gateway-client";
 
 import { getGatewayDb } from "../db/connection.js";
@@ -44,7 +44,6 @@ import type { GuardianRequest } from "../db/guardian-request-store.js";
 import {
   createDelivery,
   createGuardianRequest as storeCreateGuardianRequest,
-  deriveSourceType,
   expireAllPendingInteractionBound,
   expireGuardianRequest as storeExpireGuardianRequest,
   getByPendingQuestionId,
@@ -77,11 +76,12 @@ const log = getLogger("guardian-request-service");
 // Stateless facade over the gateway DB (the connection resolves per call).
 const contactStore = new ContactStore();
 
-/** Map a store row onto the wire DTO by computing `sourceType`. */
-export function toGuardianRequestWire(
-  row: GuardianRequest,
-): GuardianRequestWire {
-  return { ...row, sourceType: deriveSourceType(row.sourceChannel) };
+/** Map a store row onto the wire DTO by deriving `sourceType`. */
+function toGuardianRequestWire(row: GuardianRequest): GuardianRequestWire {
+  return {
+    ...row,
+    sourceType: deriveGuardianRequestSourceType(row.sourceChannel),
+  };
 }
 
 function toWireOrNull(row: GuardianRequest | null): GuardianRequestWire | null {
@@ -120,14 +120,6 @@ export function updateGuardianRequest(
   patch: GuardianRequestPatch,
 ): void {
   storeUpdateGuardianRequest(id, patch);
-}
-
-/** CAS reopen (`fromStatus` → pending); a missed swap is a no-op. */
-export function reopenGuardianRequest(
-  id: string,
-  fromStatus: GuardianRequestStatus,
-): void {
-  resolveGuardianRequest(id, fromStatus, { status: "pending" });
 }
 
 export function expireGuardianRequest(id: string): void {

--- a/gateway/src/db/__tests__/guardian-request-store.test.ts
+++ b/gateway/src/db/__tests__/guardian-request-store.test.ts
@@ -7,7 +7,6 @@ import { guardianRequestDeliveries, guardianRequests } from "../schema.js";
 import {
   createDelivery,
   createGuardianRequest,
-  deriveSourceType,
   expireAllPendingInteractionBound,
   expireGuardianRequest,
   generateRequestCode,
@@ -145,6 +144,8 @@ describe("createGuardianRequest", () => {
       expect((thrown as GuardianRequestIntegrityError).code).toBe(
         "guardian_principal_required",
       );
+      // Surfaces as a 4xx client error over IPC.
+      expect((thrown as GuardianRequestIntegrityError).statusCode).toBe(400);
     }
     expect(listGuardianRequests()).toHaveLength(0);
   });
@@ -289,15 +290,6 @@ describe("listGuardianRequests", () => {
         .map((r) => r.id)
         .sort(),
     ).toEqual([telegram.id, channelless.id].sort());
-  });
-});
-
-describe("deriveSourceType", () => {
-  test("maps phone → voice, vellum → desktop, else channel", () => {
-    expect(deriveSourceType("phone")).toBe("voice");
-    expect(deriveSourceType("vellum")).toBe("desktop");
-    expect(deriveSourceType("telegram")).toBe("channel");
-    expect(deriveSourceType(null)).toBe("channel");
   });
 });
 

--- a/gateway/src/db/guardian-request-store.ts
+++ b/gateway/src/db/guardian-request-store.ts
@@ -19,11 +19,11 @@ import {
   or,
 } from "drizzle-orm";
 
-import type {
-  GuardianRequestDeliveryWire,
-  GuardianRequestSourceType,
-  GuardianRequestStatus,
-  GuardianRequestWire,
+import {
+  type GuardianRequestDeliveryWire,
+  type GuardianRequestStatus,
+  type GuardianRequestWire,
+  isGuardianRequestExpired,
 } from "@vellumai/gateway-client";
 
 import { getGatewayDb } from "./connection.js";
@@ -41,11 +41,6 @@ function rawClient(): Database {
 // Types (single-sourced from the shared contract)
 // ---------------------------------------------------------------------------
 
-export type {
-  GuardianRequestSourceType,
-  GuardianRequestStatus,
-} from "@vellumai/gateway-client";
-
 /**
  * Request row as the store returns it — the wire DTO minus `sourceType`,
  * which is computed by the service mapper (the column is not stored).
@@ -57,9 +52,11 @@ export type GuardianRequestDelivery = GuardianRequestDeliveryWire;
 
 /**
  * Thrown when a create violates a store integrity invariant. Carries a
- * stable machine-readable `code` so the IPC layer can map it onto the wire.
+ * stable machine-readable `code` and a 4xx `statusCode` so the IPC error
+ * envelope surfaces it as a client error.
  */
 export class GuardianRequestIntegrityError extends Error {
+  readonly statusCode = 400;
   readonly code = "guardian_principal_required";
 
   constructor(message: string) {
@@ -69,38 +66,8 @@ export class GuardianRequestIntegrityError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// Expiry / source-type helpers
+// Source-type filter translation
 // ---------------------------------------------------------------------------
-
-/**
- * Returns true when a request has passed its `expiresAt` deadline.
- * Requests without an `expiresAt` are never considered expired by this check.
- */
-export function isRequestExpired(
-  request: Pick<GuardianRequest, "expiresAt">,
-): boolean {
-  if (!request.expiresAt) {
-    return false;
-  }
-  return request.expiresAt < Date.now();
-}
-
-/**
- * Derive the presentation-level source type from the provenance channel.
- * The gateway table does not store source_type — it is mechanical:
- * phone → voice, vellum → desktop, everything else (incl. null) → channel.
- */
-export function deriveSourceType(
-  sourceChannel: string | null,
-): GuardianRequestSourceType {
-  if (sourceChannel === "phone") {
-    return "voice";
-  }
-  if (sourceChannel === "vellum") {
-    return "desktop";
-  }
-  return "channel";
-}
 
 function sourceTypeCondition(sourceType: string) {
   if (sourceType === "voice") {
@@ -237,7 +204,9 @@ export interface CreateGuardianRequestParams {
 /**
  * Request kinds that require a guardian decision (approve/deny). These kinds
  * MUST have a `guardianPrincipalId` bound at creation time so the decision
- * can be attributed to a specific principal. Informational kinds are exempt.
+ * can be attributed to a specific principal. The contract already requires
+ * the principal for every admitted kind — this guard is a second layer of
+ * defense for callers that reach the store without IPC-schema validation.
  */
 const DECISIONABLE_KINDS = new Set([
   "tool_approval",
@@ -846,7 +815,7 @@ export function listPendingByConversationScope(
   const result: GuardianRequest[] = [];
 
   for (const req of [...bySource, ...byDestination]) {
-    if (!seen.has(req.id) && !isRequestExpired(req)) {
+    if (!seen.has(req.id) && !isGuardianRequestExpired(req)) {
       seen.add(req.id);
       result.push(req);
     }

--- a/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
+++ b/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
@@ -392,7 +392,7 @@ describe("guardian_requests_update", () => {
   });
 });
 
-describe("guardian_requests_expire / reopen", () => {
+describe("guardian_requests_expire", () => {
   test("expire CAS-expires the request and bulk-expires its deliveries", async () => {
     const created = await createRequest({});
     const delivery = GuardianRequestDeliverySchema.parse(
@@ -410,20 +410,16 @@ describe("guardian_requests_expire / reopen", () => {
     expect(getDeliveryRow(delivery.id)?.status).toBe("expired");
   });
 
-  test("reopen CAS-transitions fromStatus back to pending; a missed swap is a no-op", async () => {
+  test("guardian_requests_reopen is not a route — the retired method 404s", async () => {
     const created = await createRequest({});
     await call(METHODS.expire, { id: created.id });
 
-    // Wrong fromStatus: acks without touching the row.
-    expect(
-      await call(METHODS.reopen, { id: created.id, fromStatus: "denied" }),
-    ).toEqual({ ok: true });
+    const res = await rpc("guardian_requests_reopen", {
+      id: created.id,
+      fromStatus: "expired",
+    });
+    expect(res.statusCode).toBe(404);
     expect(getRequestRow(created.id)?.status).toBe("expired");
-
-    expect(
-      await call(METHODS.reopen, { id: created.id, fromStatus: "expired" }),
-    ).toEqual({ ok: true });
-    expect(getRequestRow(created.id)?.status).toBe("pending");
   });
 });
 
@@ -737,7 +733,6 @@ describe("schema rejection", () => {
           },
         },
       ],
-      [METHODS.reopen, { id: "req-x" }], // fromStatus required
       [METHODS.expire, {}],
       [METHODS.sweepExpired, { now: "yesterday" }],
       [METHODS.createDelivery, { requestId: "req-x" }], // channel required

--- a/gateway/src/ipc/guardian-request-handlers.ts
+++ b/gateway/src/ipc/guardian-request-handlers.ts
@@ -30,7 +30,6 @@ import {
   ListGuardianRequestsIpcParamsSchema,
   ListPendingGuardianRequestsByDestinationIpcParamsSchema,
   ListPendingGuardianRequestsByScopeIpcParamsSchema,
-  ReopenGuardianRequestIpcParamsSchema,
   SweepExpiredGuardianRequestsIpcParamsSchema,
   UpdateGuardianRequestDeliveryIpcParamsSchema,
   UpdateGuardianRequestIpcParamsSchema,
@@ -53,7 +52,6 @@ import {
   listGuardianRequests,
   listPendingRequestsByDestination,
   listPendingRequestsByScope,
-  reopenGuardianRequest,
   sweepExpiredRequests,
   updateGuardianRequest,
   updateGuardianRequestDelivery,
@@ -133,17 +131,6 @@ export const guardianRequestRoutes: IpcRoute[] = [
     handler: async (params?: Record<string, unknown>) => {
       const input = DecideGuardianRequestIpcParamsSchema.parse(params);
       return decideGuardianRequest(input);
-    },
-  },
-  {
-    // CAS `fromStatus` → pending; a missed swap acks without reopening.
-    method: GUARDIAN_REQUESTS_IPC_METHODS.reopen,
-    schema: ReopenGuardianRequestIpcParamsSchema,
-    handler: (params?: Record<string, unknown>) => {
-      const { id, fromStatus } =
-        ReopenGuardianRequestIpcParamsSchema.parse(params);
-      reopenGuardianRequest(id, fromStatus);
-      return { ok: true };
     },
   },
   {

--- a/packages/gateway-client/src/__tests__/guardian-request-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/guardian-request-contract.test.ts
@@ -12,6 +12,7 @@ import {
   CreateGuardianRequestIpcParamsSchema,
   DecideGuardianRequestIpcParamsSchema,
   DecideGuardianRequestIpcResponseSchema,
+  deriveGuardianRequestSourceType,
   ExpireGuardianRequestIpcParamsSchema,
   ExpireInteractionBoundIpcResponseSchema,
   GetGuardianRequestByCallSessionIpcParamsSchema,
@@ -26,10 +27,10 @@ import {
   GuardianRequestLookupIpcResponseSchema,
   GuardianRequestMutationIpcResponseSchema,
   GuardianRequestSchema,
+  isGuardianRequestExpired,
   ListGuardianRequestsIpcParamsSchema,
   ListPendingGuardianRequestsByDestinationIpcParamsSchema,
   ListPendingGuardianRequestsByScopeIpcParamsSchema,
-  ReopenGuardianRequestIpcParamsSchema,
   SweepExpiredGuardianRequestsIpcParamsSchema,
   SweepExpiredGuardianRequestsIpcResponseSchema,
   UpdateGuardianRequestIpcParamsSchema,
@@ -37,10 +38,10 @@ import {
 } from "../guardian-request-contract.js";
 
 describe("IPC method names", () => {
-  test("exposes 19 unique methods under the guardian_requests_ prefix", () => {
+  test("exposes 18 unique methods under the guardian_requests_ prefix", () => {
     const methods = Object.values(GUARDIAN_REQUESTS_IPC_METHODS);
-    expect(methods).toHaveLength(19);
-    expect(new Set(methods).size).toBe(19);
+    expect(methods).toHaveLength(18);
+    expect(new Set(methods).size).toBe(18);
     for (const method of methods) {
       expect(method).toMatch(/^guardian_requests_[a-z_]+$/);
     }
@@ -107,6 +108,24 @@ const pendingQuestion: GuardianRequestWire = {
   decidedByPrincipalId: "principal-1",
   expiresAt: null,
 };
+
+describe("shared pure helpers", () => {
+  test("deriveGuardianRequestSourceType maps phone → voice, vellum → desktop, else channel", () => {
+    expect(deriveGuardianRequestSourceType("phone")).toBe("voice");
+    expect(deriveGuardianRequestSourceType("vellum")).toBe("desktop");
+    expect(deriveGuardianRequestSourceType("telegram")).toBe("channel");
+    expect(deriveGuardianRequestSourceType(null)).toBe("channel");
+  });
+
+  test("isGuardianRequestExpired compares expiresAt to now; null never expires", () => {
+    const now = 1_700_000_000_000;
+    expect(isGuardianRequestExpired({ expiresAt: now - 1 }, now)).toBe(true);
+    expect(isGuardianRequestExpired({ expiresAt: now }, now)).toBe(false);
+    expect(isGuardianRequestExpired({ expiresAt: now + 1 }, now)).toBe(false);
+    expect(isGuardianRequestExpired({ expiresAt: null }, now)).toBe(false);
+    expect(isGuardianRequestExpired({ expiresAt: Date.now() - 1 })).toBe(true);
+  });
+});
 
 describe("GuardianRequestSchema", () => {
   test("round-trips channel and voice requests", () => {
@@ -419,11 +438,8 @@ describe("decide IPC schemas", () => {
   });
 });
 
-describe("reopen + expiry IPC schemas", () => {
-  test("reopen, expire, and sweep round-trip", () => {
-    const reopen = { id: "req-1", fromStatus: "approved" } as const;
-    expect(ReopenGuardianRequestIpcParamsSchema.parse(reopen)).toEqual(reopen);
-
+describe("expiry IPC schemas", () => {
+  test("expire and sweep round-trip", () => {
     expect(ExpireGuardianRequestIpcParamsSchema.parse({ id: "req-1" })).toEqual(
       { id: "req-1" },
     );

--- a/packages/gateway-client/src/guardian-request-contract.ts
+++ b/packages/gateway-client/src/guardian-request-contract.ts
@@ -15,6 +15,11 @@
  * daemon's client-facing HTTP surface owns the distinct `guardian_actions_*`
  * operationIds (`guardian_actions_pending` / `guardian_actions_decision`),
  * which do not change.
+ *
+ * Destination lookups are deliberately split into a single-message lookup
+ * (`get_by_destination_message`) and a pending-list read
+ * (`list_pending_by_destination`) so each response schema has exactly one
+ * shape instead of a params-dependent polymorphic result.
  */
 
 import { z } from "zod";
@@ -66,6 +71,38 @@ export const GuardianRequestSourceTypeSchema = z.enum(
 export type GuardianRequestSourceType = z.infer<
   typeof GuardianRequestSourceTypeSchema
 >;
+
+// ---------------------------------------------------------------------------
+// Shared pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the presentation-level source type from the provenance channel:
+ * phone → voice, vellum → desktop, everything else (incl. null) → channel.
+ * `sourceType` is never stored — gateway and daemon both derive it here.
+ */
+export function deriveGuardianRequestSourceType(
+  sourceChannel: string | null,
+): GuardianRequestSourceType {
+  if (sourceChannel === "phone") {
+    return "voice";
+  }
+  if (sourceChannel === "vellum") {
+    return "desktop";
+  }
+  return "channel";
+}
+
+/**
+ * True when a request has passed its `expiresAt` deadline. Requests without
+ * an `expiresAt` never expire by this check.
+ */
+export function isGuardianRequestExpired(
+  request: Pick<GuardianRequestWire, "expiresAt">,
+  now = Date.now(),
+): boolean {
+  return Boolean(request.expiresAt && request.expiresAt < now);
+}
 
 // ---------------------------------------------------------------------------
 // Wire DTOs
@@ -142,11 +179,6 @@ export type GuardianRequestDeliveryWire = z.infer<
 /**
  * Gateway IPC method names for the guardian-request lifecycle. Keys match the
  * daemon-side wrapper names; values are the wire method strings.
- *
- * Destination lookups are split into `get_by_destination_message` (single
- * nullable DTO — reaction routing) and `list_pending_by_destination` (DTO
- * array — reply routing by chat or conversation) so each response schema has
- * exactly one shape instead of a params-dependent polymorphic result.
  */
 export const GUARDIAN_REQUESTS_IPC_METHODS = {
   create: "guardian_requests_create",
@@ -155,7 +187,6 @@ export const GUARDIAN_REQUESTS_IPC_METHODS = {
   list: "guardian_requests_list",
   update: "guardian_requests_update",
   decide: "guardian_requests_decide",
-  reopen: "guardian_requests_reopen",
   expire: "guardian_requests_expire",
   expireInteractionBound: "guardian_requests_expire_interaction_bound",
   sweepExpired: "guardian_requests_sweep_expired",
@@ -387,11 +418,10 @@ const OUTCOME_TYPES_BY_DECISION_STATUS: Record<
 /**
  * Request for `guardian_requests_decide` (status CAS + optional ACL outcome).
  * Decisions only resolve a pending request to approved/denied — expiry has
- * `guardian_requests_expire`/`_sweep_expired`, terminal→pending has
- * `guardian_requests_reopen` — so a malformed call can never apply an
- * `aclOutcome` while leaving the request decidable again. The outcome type
- * must agree with the status: activation/minting only on approval,
- * seeding/blocking only on denial.
+ * `guardian_requests_expire`/`_sweep_expired` — so a malformed call can never
+ * apply an `aclOutcome` while leaving the request decidable again. The
+ * outcome type must agree with the status: activation/minting only on
+ * approval, seeding/blocking only on denial.
  */
 export const DecideGuardianRequestIpcParamsSchema = z
   .object({
@@ -442,21 +472,8 @@ export type DecideGuardianRequestIpcResponse = z.infer<
 >;
 
 // ---------------------------------------------------------------------------
-// Reopen / expiry
+// Expiry
 // ---------------------------------------------------------------------------
-
-/**
- * Request for `guardian_requests_reopen` (terminal → pending CAS). Kept for
- * the migration flip window; deleted once genuinely unused.
- */
-export const ReopenGuardianRequestIpcParamsSchema = z.object({
-  id: z.string().min(1),
-  fromStatus: GuardianRequestStatusSchema,
-});
-
-export type ReopenGuardianRequestIpcParams = z.infer<
-  typeof ReopenGuardianRequestIpcParamsSchema
->;
 
 /**
  * Request for `guardian_requests_expire` (CAS pending → expired; also expires

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -198,7 +198,7 @@ export type {
 } from "./verification-session-contract.js";
 
 // Guardian-request contract (shared gateway ↔ daemon) — status/kind enums,
-// wire DTOs + guardian_requests_* IPC schemas
+// wire DTOs, pure helpers + guardian_requests_* IPC schemas
 export {
   CreateGuardianRequestDeliveryIpcParamsSchema,
   CreateGuardianRequestDeliveryIpcResponseSchema,
@@ -206,6 +206,7 @@ export {
   CreateGuardianRequestIpcResponseSchema,
   DecideGuardianRequestIpcParamsSchema,
   DecideGuardianRequestIpcResponseSchema,
+  deriveGuardianRequestSourceType,
   ExpireGuardianRequestIpcParamsSchema,
   ExpireInteractionBoundIpcParamsSchema,
   ExpireInteractionBoundIpcResponseSchema,
@@ -229,11 +230,11 @@ export {
   GuardianRequestSchema,
   GuardianRequestSourceTypeSchema,
   GuardianRequestStatusSchema,
+  isGuardianRequestExpired,
   ListGuardianRequestDeliveriesIpcParamsSchema,
   ListGuardianRequestsIpcParamsSchema,
   ListPendingGuardianRequestsByDestinationIpcParamsSchema,
   ListPendingGuardianRequestsByScopeIpcParamsSchema,
-  ReopenGuardianRequestIpcParamsSchema,
   SweepExpiredGuardianRequestsIpcParamsSchema,
   SweepExpiredGuardianRequestsIpcResponseSchema,
   UpdateGuardianRequestDeliveryIpcParamsSchema,
@@ -272,7 +273,6 @@ export type {
   ListGuardianRequestsIpcParams,
   ListPendingGuardianRequestsByDestinationIpcParams,
   ListPendingGuardianRequestsByScopeIpcParams,
-  ReopenGuardianRequestIpcParams,
   SweepExpiredGuardianRequestsIpcParams,
   SweepExpiredGuardianRequestsIpcResponse,
   UpdateGuardianRequestDeliveryIpcParams,


### PR DESCRIPTION
## Summary
Fixes gaps from the guardian-requests-gateway-native self-review: deletes the caller-less guardian_requests_reopen wire chain, unexports unconsumed throwing read variants and the service mapper, moves deriveSourceType/isRequestExpired into the shared contract, 400-shapes the store integrity guard, documents the destination-lookup split.