### PR TITLE
Remove analytics toggle from onboarding privacy step

### DIFF
--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -13,7 +13,8 @@ export interface UserConsent {
   privacy_policy_accepted_at: string | null;
   ai_data_sharing_accepted_version: string;
   ai_data_sharing_accepted_at: string | null;
-  share_analytics: boolean;
+  /** Null until the user makes an explicit choice (settings or review-terms). */
+  share_analytics: boolean | null;
   share_diagnostics: boolean;
   share_analytics_accepted_version: string;
   share_analytics_accepted_at: string | null;

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -18,7 +18,6 @@ import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboardi
 import { isLocalMode } from "@/lib/local-mode";
 import {
     usePrivacyConsent,
-    useShareAnalytics,
     useShareDiagnostics,
     useTosAccepted,
 } from "@/domains/onboarding/prefs";
@@ -40,7 +39,6 @@ export function PrivacyScreen() {
     useClientFeatureFlagStore.use.stringFlags().preChatOnboardingExperiment20260606 ?? "control";
   const preferredFunnelVariant =
     onboardingFunnelVariantFromExperiment(preChatExperimentArm);
-  const [shareAnalytics] = useShareAnalytics();
   const [shareDiagnostics, setShareDiagnosticsReal] = useShareDiagnostics();
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
   const [privacyConsent, setPrivacyConsentReal] = usePrivacyConsent();
@@ -68,7 +66,9 @@ export function PrivacyScreen() {
       return;
     }
 
-    saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
+    // Analytics isn't asked here — the server keeps share_analytics null
+    // until the user opts in via settings or review-terms.
+    saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics: null, shareDiagnostics, hasPlatformSession });
     if (!isNative) {
       const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
@@ -100,7 +100,6 @@ export function PrivacyScreen() {
     navigate,
     preferredFunnelVariant,
     searchParams,
-    shareAnalytics,
     shareDiagnostics,
     tosAccepted,
     userId,
@@ -136,7 +135,7 @@ export function PrivacyScreen() {
         <PrivacyPreferencesCard
           electron={electron}
           showAnalytics={false}
-          shareAnalytics={shareAnalytics}
+          shareAnalytics={false}
           shareDiagnostics={shareDiagnostics}
           onShareAnalyticsChange={noop}
           onShareDiagnosticsChange={setShareDiagnostics}

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -40,7 +40,7 @@ export function PrivacyScreen() {
     useClientFeatureFlagStore.use.stringFlags().preChatOnboardingExperiment20260606 ?? "control";
   const preferredFunnelVariant =
     onboardingFunnelVariantFromExperiment(preChatExperimentArm);
-  const [shareAnalytics, setShareAnalyticsReal] = useShareAnalytics();
+  const [shareAnalytics] = useShareAnalytics();
   const [shareDiagnostics, setShareDiagnosticsReal] = useShareDiagnostics();
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
   const [privacyConsent, setPrivacyConsentReal] = usePrivacyConsent();
@@ -54,7 +54,6 @@ export function PrivacyScreen() {
 
   const isPreview = searchParams.get("preview") === "true";
   const noop = useCallback((_next: boolean) => {}, []);
-  const setShareAnalytics = isPreview ? noop : setShareAnalyticsReal;
   const setShareDiagnostics = isPreview ? noop : setShareDiagnosticsReal;
   const setTosAccepted = isPreview ? noop : setTosAcceptedReal;
   const setPrivacyConsent = isPreview ? noop : setPrivacyConsentReal;
@@ -136,9 +135,10 @@ export function PrivacyScreen() {
 
         <PrivacyPreferencesCard
           electron={electron}
+          showAnalytics={false}
           shareAnalytics={shareAnalytics}
           shareDiagnostics={shareDiagnostics}
-          onShareAnalyticsChange={setShareAnalytics}
+          onShareAnalyticsChange={noop}
           onShareDiagnosticsChange={setShareDiagnostics}
           className="mt-8 w-full"
           style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -81,7 +81,17 @@ export function ReviewTermsScreen() {
       : "We've updated our terms. Please review and accept to continue.";
 
   const onContinue = useCallback(() => {
-    saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
+    // Only persist analytics when its toggle was actually on screen — a user
+    // routed here for other stale sections must not silently grant (or
+    // re-stamp) analytics consent; the server keeps null until they choose.
+    saveConsent({
+      userId,
+      tos: tosAccepted,
+      privacy: privacyConsent,
+      shareAnalytics: showAnalytics ? shareAnalytics : null,
+      shareDiagnostics,
+      hasPlatformSession,
+    });
 
     const destination = sanitizeReturnTo(searchParams.get("returnTo"), routes.assistant);
     void navigate(destination, { replace: true });
@@ -92,6 +102,7 @@ export function ReviewTermsScreen() {
     searchParams,
     shareAnalytics,
     shareDiagnostics,
+    showAnalytics,
     tosAccepted,
     userId,
   ]);

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -581,6 +581,57 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
+  test("never-asked analytics (null on a real record) hydrates current but earns no device ack", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: true,
+      // The resolver reads a null share_analytics as "nothing to re-review".
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      hasServerRecord: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    // No bounce to review-terms...
+    expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    // ...but no versioned ack either: only an explicit choice may attest a
+    // confirmation that could later backfill a server version stamp.
+    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
+      diagnosticsCurrent: true,
+    });
+    // A null server value never overwrites the device-local preference.
+    expect(setShareAnalyticsMock).not.toHaveBeenCalled();
+  });
+
+  test("no-record fallback without an analytics device ack stays current and backfills without analytics", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    restoreConsentForUserMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      analyticsCurrent: false,
+      diagnosticsCurrent: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    // Never-asked analytics (no server record, no device ack) must not bounce
+    // the user to review-terms.
+    expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    // The backfill seeds the server without any analytics fields — the server
+    // keeps share_analytics null until the user makes an explicit choice.
+    const body = patchConsentMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("share_analytics" in body).toBe(false);
+    expect("share_analytics_accepted_version" in body).toBe(false);
+    expect(body.share_diagnostics_accepted_version).toEqual(expect.any(String));
+    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
+      diagnosticsCurrent: true,
+    });
+  });
+
   test("initSession falls through to device keys when server versions are empty", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
 

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -358,13 +358,23 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       let privacy = resolved.privacy;
       let analyticsCurrent = resolved.analyticsCurrent;
       let diagnosticsCurrent = resolved.diagnosticsCurrent;
+      // Genuine "confirmed under the current version" attestation, distinct
+      // from `analyticsCurrent`, which also reads never-asked (null server
+      // value — onboarding doesn't show the analytics toggle) as "nothing to
+      // re-review". Only the genuine ack may be device-persisted or backfill
+      // a server version stamp.
+      let analyticsAck =
+        resolved.shareAnalytics !== null && resolved.analyticsCurrent;
 
       // Fall back to device keys for a TRULY empty record: the device ack
       // keys are the only consent evidence, so they drive all four axes and
       // seed the server via the backfill.
       if (!resolved.hasServerRecord) {
         const deviceConsent = restoreConsentForUser(nextUserId);
-        analyticsCurrent = deviceConsent.analyticsCurrent;
+        // No server record means no explicit analytics consent exists —
+        // never-asked, so nothing to re-review regardless of the device ack.
+        analyticsCurrent = true;
+        analyticsAck = deviceConsent.analyticsCurrent;
         diagnosticsCurrent = deviceConsent.diagnosticsCurrent;
         // The chokepoint above closed the reporting gate because the server has
         // no record yet. Reopen it from the device-confirmed consent so an
@@ -384,7 +394,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
             buildDeviceConsentBackfill({
               tos: true,
               privacy: true,
-              analytics: analyticsCurrent,
+              analytics: analyticsAck,
               diagnostics: diagnosticsCurrent,
               shareValues: {
                 analytics: store.shareAnalytics,
@@ -418,6 +428,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         }
         if (analyticsFromDevice) {
           analyticsCurrent = true;
+          analyticsAck = true;
         }
         if (diagnosticsFromDevice) {
           diagnosticsCurrent = true;
@@ -453,8 +464,11 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       store.setAnalyticsConsentCurrent(analyticsCurrent);
       store.setDiagnosticsConsentCurrent(diagnosticsCurrent);
       persistConsentForUser(nextUserId, tos, privacy);
+      // A false analytics ack is never written: absent ≡ false for every
+      // reader, and writing false would erase a genuine device attestation
+      // whose backfill patch simply hasn't landed on the server yet.
       persistToggleConsent(nextUserId, {
-        analyticsCurrent,
+        ...(analyticsAck ? { analyticsCurrent: true } : {}),
         diagnosticsCurrent,
       });
       syncOrganizationState(nextUserId);
@@ -469,7 +483,12 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   const store = useOnboardingStore.getState();
   store.setTosAccepted(consent.tos);
   store.setPrivacyConsent(consent.privacy);
-  store.setAnalyticsConsentCurrent(consent.analyticsCurrent);
+  // An absent device ack here can't be told apart from never-asked (the
+  // onboarding flow doesn't show the analytics toggle), and only the server
+  // can attest an explicit stale consent — never bounce to review-terms on
+  // device evidence alone. A genuinely stale consent re-bounces on the next
+  // successful sync.
+  store.setAnalyticsConsentCurrent(true);
   store.setDiagnosticsConsentCurrent(consent.diagnosticsCurrent);
   syncOrganizationState(nextUserId);
   store.setConsentHydrated(true);

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -157,6 +157,20 @@ describe("resolveServerConsent", () => {
     expect(r.diagnosticsCurrent).toBe(false);
   });
 
+  test("null share_analytics (never asked) resolves analytics current — nothing to re-review", () => {
+    const resolved = resolveServerConsent(
+      makeConsent({ share_analytics: null, share_analytics_accepted_version: "" }),
+    );
+    expect(resolved.analyticsCurrent).toBe(true);
+  });
+
+  test("an explicit analytics choice under a stale version still requires re-review", () => {
+    const resolved = resolveServerConsent(
+      makeConsent({ share_analytics: false, share_analytics_accepted_version: "2026-01-01" }),
+    );
+    expect(resolved.analyticsCurrent).toBe(false);
+  });
+
   test("reports stale toggles for empty versions", () => {
     const r = resolveServerConsent(
       makeConsent({
@@ -476,6 +490,27 @@ describe("saveConsent", () => {
     expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+  });
+
+  test("null shareAnalytics (toggle not shown) omits analytics from the patch and skips its ack", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: true,
+      hasPlatformSession: true,
+    });
+    const body = patchConsentMock.mock.calls[0][0];
+    expect("share_analytics" in body).toBe(false);
+    expect("share_analytics_accepted_version" in body).toBe(false);
+    expect(body.share_diagnostics).toBe(true);
+    expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
+    expect(storeState.setShareAnalytics).not.toHaveBeenCalled();
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBe(null);
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+    // Never-asked has nothing to re-review — must not bounce to review-terms.
+    expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
   });
 
   test("marks consent hydrated — an explicit acceptance is authoritative", () => {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -226,10 +226,16 @@ export function resolveServerConsent(
       versionIsCurrent(consent.ai_data_sharing_accepted_version, PRIVACY_CONSENT_VERSION),
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
-    analyticsCurrent: versionIsCurrent(
-      consent.share_analytics_accepted_version,
-      ANALYTICS_CONSENT_VERSION,
-    ),
+    // Analytics re-review is owed only for an explicit choice on record.
+    // Onboarding doesn't show the analytics toggle, so `share_analytics`
+    // stays null until the user opts in via settings or review-terms — null
+    // reads as "nothing to re-review", not as stale consent.
+    analyticsCurrent:
+      consent.share_analytics === null ||
+      versionIsCurrent(
+        consent.share_analytics_accepted_version,
+        ANALYTICS_CONSENT_VERSION,
+      ),
     diagnosticsCurrent: versionIsCurrent(
       consent.share_diagnostics_accepted_version,
       DIAGNOSTICS_CONSENT_VERSION,
@@ -246,14 +252,23 @@ export function saveConsent(opts: {
   userId: string | null;
   tos: boolean;
   privacy: boolean;
-  shareAnalytics: boolean;
+  /**
+   * Null when the analytics toggle wasn't shown on the saving surface. No
+   * explicit choice is recorded anywhere — the server keeps
+   * `share_analytics` null and no versioned device ack is stamped — but the
+   * in-memory currency flag is still set: never-asked consent has nothing to
+   * re-review, so it must not bounce the user to review-terms.
+   */
+  shareAnalytics: boolean | null;
   shareDiagnostics: boolean;
   hasPlatformSession: boolean;
 }): void {
   const store = useOnboardingStore.getState();
   store.setTosAccepted(opts.tos);
   store.setPrivacyConsent(opts.privacy);
-  store.setShareAnalytics(opts.shareAnalytics);
+  if (opts.shareAnalytics !== null) {
+    store.setShareAnalytics(opts.shareAnalytics);
+  }
   store.setShareDiagnostics(opts.shareDiagnostics);
   store.setAnalyticsConsentCurrent(true);
   store.setDiagnosticsConsentCurrent(true);
@@ -264,16 +279,23 @@ export function saveConsent(opts: {
   setDiagnosticsReportingGate(opts.shareDiagnostics);
 
   persistConsentForUser(opts.userId, opts.tos, opts.privacy);
-  persistToggleConsent(opts.userId, { analyticsCurrent: true, diagnosticsCurrent: true });
+  persistToggleConsent(opts.userId, {
+    ...(opts.shareAnalytics !== null ? { analyticsCurrent: true } : {}),
+    diagnosticsCurrent: true,
+  });
 
   if (opts.hasPlatformSession) {
     void patchConsent({
       tos_accepted_version: opts.tos ? TOS_CONSENT_VERSION : "",
       privacy_policy_accepted_version: opts.privacy ? PRIVACY_CONSENT_VERSION : "",
       ai_data_sharing_accepted_version: opts.privacy ? PRIVACY_CONSENT_VERSION : "",
-      share_analytics: opts.shareAnalytics,
+      ...(opts.shareAnalytics !== null
+        ? {
+            share_analytics: opts.shareAnalytics,
+            share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
+          }
+        : {}),
       share_diagnostics: opts.shareDiagnostics,
-      share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
       share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
     }).catch(() => {});
   }


### PR DESCRIPTION
## Summary
- Hide the Share Analytics toggle on the onboarding privacy screen via the existing `showAnalytics` prop on the shared `PrivacyPreferencesCard`; the Share Diagnostics toggle stays.
- Onboarding records **no** analytics consent: `saveConsent` now takes `shareAnalytics: boolean | null` — null (toggle not shown) omits `share_analytics` and `share_analytics_accepted_version` from the server patch, skips the store share value, and stamps no versioned device ack, so the backend keeps `share_analytics` null (no explicit consent).
- A null analytics consent never bounces users to review-terms: `resolveServerConsent` reads a null `share_analytics` as "nothing to re-review", while an explicit choice under a stale version still requires re-review. The auth-store sync and device-key fallback follow the same rule, and only a genuine explicit confirmation can backfill a server version stamp.
- The review-terms screen persists analytics only when its toggle was actually on screen — a user routed there for other stale sections can't silently grant analytics. Both toggles remain on review-terms and the privacy settings page (UI untouched).

## Notes for review
- `UserConsent.share_analytics` is now typed `boolean | null`; the platform API must keep returning null until an explicit choice is patched (settings `savePreferenceToggle` or review-terms with the toggle shown).
- New tests cover the null-resolution rule, the null `saveConsent` patch shape, and both auth-store sync branches.

## Original prompt
Remove the analytics consent toggle from the onboarding privacy step while keeping the diagnostics toggle there; both toggles on the review-terms page and the permissions & privacy settings page stay untouched. Follow-up direction: onboarding must not persist analytics consent to the backend — it stays null (no explicit consent) — and a null value for this toggle specifically must not bounce users to the review-terms page.
