### PR TITLE
feat(voice): content-scoped voice room, minimize-to-bar, in-room controls

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -327,16 +327,12 @@ export function ChatLayout() {
     consumeSidebarCollapse();
   }, [sidebarCollapseRequested, consumeSidebarCollapse]);
 
-  // The full-screen voice room takes over the viewport, so the sidebar reads as
-  // collapsed and the chat body blurs while it is visible. This override is
-  // EPHEMERAL — it is OR'd into the rendered collapsed value (`sideMenuCollapsed`
-  // below) rather than routed through `setCollapsed`, so it never touches the
-  // persistence effect above. Keeping it out of the persisted `collapsed` state
-  // means a reload / tab-close while the room is open cannot write the forced
-  // value to `localStorage`: on exit the override drops and the sidebar returns
-  // to exactly the user's persisted value.
+  // Voice-room visibility. On desktop the room is a content-scoped overlay
+  // (mounted inside `<main>` below) that deliberately leaves the sidebar and
+  // header interactive, so the user can keep navigating mid-session — any
+  // navigation away hands the session off to the title-bar pill. Only the
+  // mobile mount is a full-viewport takeover.
   const voiceRoomVisible = useIsVoiceRoomVisible();
-  const sideMenuCollapsed = collapsed || voiceRoomVisible;
 
   const drawerVisible = isMobile && drawerOpen;
 
@@ -728,12 +724,15 @@ export function ChatLayout() {
     />
   );
 
-  // Blur + freeze the chat body under the voice room. The room is an opaque
-  // overlay, so this mainly matters for the header strip peeking around it and
-  // to stop stray interaction with the covered chat.
-  const mainRoomClass = voiceRoomVisible
-    ? "pointer-events-none blur-sm opacity-40 transition-[filter,opacity]"
-    : "";
+  // Blur + freeze the chat body under the MOBILE voice room, which is a
+  // full-viewport takeover. The room is an opaque overlay, so this mainly
+  // matters for the fade transition and to stop stray interaction with the
+  // covered chat. Desktop must NOT get this: its room renders inside `<main>`
+  // itself, so blurring/freezing main would blur and freeze the room too.
+  const mainRoomClass =
+    voiceRoomVisible && isMobile
+      ? "pointer-events-none blur-sm opacity-40 transition-[filter,opacity]"
+      : "";
 
   return (
     <>
@@ -741,7 +740,7 @@ export function ChatLayout() {
         <ChatLayoutHeader
           isMobile={isMobile}
           drawerOpen={drawerOpen}
-          collapsed={sideMenuCollapsed}
+          collapsed={collapsed}
           sidebarWidth={sidebarWidth}
           toggleSidebar={toggleSidebar}
           topBarCenter={topBarCenter}
@@ -848,16 +847,19 @@ export function ChatLayout() {
             aria-label="Navigation"
           >
             {renderSideMenu({
-              collapsed: sideMenuCollapsed,
+              collapsed,
               variant: "rail",
               width: sidebarWidth,
               onWidthChange: handleSidebarWidthChange,
             })}
           </aside>
-          <main
-            className={`flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
-          >
+          <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">
             <Outlet />
+            {/* Desktop voice room — content-scoped (`absolute inset-0` within
+                this `<main>`), so the header and sidebar stay visible and
+                interactive during a session. Self-gates on
+                `useIsVoiceRoomVisible()`. */}
+            <VoiceRoom variant="content" />
           </main>
         </div>
       )}
@@ -868,12 +870,12 @@ export function ChatLayout() {
           overlay; it never remounts the chat, so a suggestion click's
           navigate + `?prompt=` auto-send isn't raced by a remount. */}
       {isFocused ? <ResearchResultsOverlay /> : null}
-      {/* Full-screen live-voice room — a purely additive overlay mounted at
-          layout scope, next to the other full-viewport overlays. Self-gates on
-          `useIsVoiceRoomVisible()` (the exact complement of the title-bar
-          session pill); the composer's voice bar and transcript render
-          underneath, hidden by it. */}
-      <VoiceRoom />
+      {/* Mobile live-voice room — a full-viewport takeover mounted at layout
+          scope, next to the other full-viewport overlays (the desktop mount is
+          content-scoped inside `<main>` above). Self-gates on
+          `useIsVoiceRoomVisible()`; the composer's voice bar and transcript
+          render underneath, hidden by it. */}
+      {isMobile ? <VoiceRoom variant="fullscreen" /> : null}
       {/* First step of the focused flow: the gcal "Let's chat tomorrow" page,
           shown over the streaming research output until connect/skip. Self-gates
           on `checkinPending`; top-level so it can compose the onboarding screen. */}

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -37,6 +37,7 @@ import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
     dismissLiveVoiceFailure,
     endLiveVoiceSession,
+    expandLiveVoiceRoom,
     getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
     releaseLiveVoiceTurn,
@@ -259,6 +260,9 @@ export function ChatComposer({
   // global live-voice store but must never swap its row.
   const ownsLiveVoiceSession = useIsLiveVoiceSessionOwnedBy(conversationId);
   const isLiveVoiceActive = showVoiceInput && ownsLiveVoiceSession;
+  // Whether the user minimized the voice room (Escape / its minimize control)
+  // — the case where this bar is the session surface and offers re-expand.
+  const liveVoiceRoomMinimized = useLiveVoiceStore.use.roomMinimized();
   // Whether the session has any speech transcript to show. A boolean
   // *presence* subscription, not the text itself: zustand only re-renders
   // when the selected value changes identity, so per-delta transcript
@@ -731,6 +735,11 @@ export function ChatComposer({
                 getAmplitude={getLiveVoiceInputAmplitude}
                 onEnd={endLiveVoiceSession}
                 onSend={releaseLiveVoiceTurn}
+                // Expand is offered only while the room is actually minimized
+                // — the one case where this bar is on screen and the room can
+                // be reopened. In pop-outs the room never mounts, so the flag
+                // never flips there and no dead control renders.
+                onExpand={liveVoiceRoomMinimized ? expandLiveVoiceRoom : undefined}
               />
             ) : (
               <div className="flex items-center justify-between gap-1 px-2 pb-2">

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -23,6 +23,7 @@ afterEach(() => {
 function renderBar(state: LiveVoiceSessionState, overrides?: {
   onEnd?: () => void;
   onSend?: () => void;
+  onExpand?: () => void;
 }) {
   return render(
     <VoiceComposerBar
@@ -30,6 +31,7 @@ function renderBar(state: LiveVoiceSessionState, overrides?: {
       getAmplitude={() => 0.5}
       onEnd={overrides?.onEnd ?? (() => {})}
       onSend={overrides?.onSend ?? (() => {})}
+      onExpand={overrides?.onExpand}
     />,
   );
 }
@@ -111,6 +113,20 @@ describe("VoiceComposerBar — callbacks", () => {
     renderBar("thinking", { onSend });
     fireEvent.click(screen.getByRole("button", { name: "Send now" }));
     expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceComposerBar — expand (reopen the minimized voice room)", () => {
+  test("no expand control without onExpand — the room is not minimized", () => {
+    renderBar("listening");
+    expect(screen.queryByRole("button", { name: "Open voice room" })).toBeNull();
+  });
+
+  test("clicking expand fires onExpand", () => {
+    const onExpand = mock(() => {});
+    renderBar("listening", { onExpand });
+    fireEvent.click(screen.getByRole("button", { name: "Open voice room" }));
+    expect(onExpand).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -15,7 +15,7 @@
  * layout shift.
  */
 
-import { ArrowUp, Mic, X } from "lucide-react";
+import { ArrowUp, Maximize2, Mic, X } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
@@ -34,6 +34,13 @@ export interface VoiceComposerBarProps {
   onEnd: () => void;
   /** Green ↑ — manually release the current turn (send now). */
   onSend: () => void;
+  /**
+   * Re-expand the minimized voice room. The composer passes this only while
+   * the room is actually minimized — the one case where this bar is visible
+   * AND the room could be reopened — so the control never dead-renders (e.g.
+   * in pop-outs, where the room never mounts). Absent → no expand button.
+   */
+  onExpand?: () => void;
 }
 
 export function VoiceComposerBar({
@@ -41,6 +48,7 @@ export function VoiceComposerBar({
   getAmplitude,
   onEnd,
   onSend,
+  onExpand,
 }: VoiceComposerBarProps) {
   return (
     <div
@@ -68,6 +76,15 @@ export function VoiceComposerBar({
         className="min-w-0 flex-1"
       />
       <div className="flex shrink-0 items-center gap-1">
+        {onExpand ? (
+          <Button
+            variant="ghost"
+            iconOnly={<Maximize2 className="h-4 w-4" strokeWidth={2.5} />}
+            onClick={onExpand}
+            aria-label="Open voice room"
+            tooltip="Open voice room"
+          />
+        ) : null}
         <Button
           variant="danger"
           iconOnly={<X className="h-4 w-4" strokeWidth={2.5} />}

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -11,11 +11,13 @@ import { makeControlsSpies } from "@/domains/chat/voice/live-voice/live-voice-fa
 import {
   dismissLiveVoiceFailure,
   endLiveVoiceSession,
+  expandLiveVoiceRoom,
   getLiveVoiceInputAmplitude,
   isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
   liveVoiceStateLabel,
+  minimizeLiveVoiceRoom,
   releaseLiveVoiceTurn,
   useLiveVoiceStore,
   type LiveVoiceSessionState,
@@ -107,6 +109,31 @@ describe("useLiveVoiceStore — reconnecting", () => {
     useLiveVoiceStore.getState().setReconnecting(true);
     useLiveVoiceStore.getState().reset();
     expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
+  });
+});
+
+describe("useLiveVoiceStore — room minimize", () => {
+  test("defaults to expanded", () => {
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
+  });
+
+  test("the module-level helpers minimize and re-expand the room", () => {
+    minimizeLiveVoiceRoom();
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    expandLiveVoiceRoom();
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
+  });
+
+  test("reset clears a minimized room", () => {
+    minimizeLiveVoiceRoom();
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
+  });
+
+  test("setSessionContext re-expands — a fresh session always opens with the room", () => {
+    minimizeLiveVoiceRoom();
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -191,6 +191,14 @@ export interface LiveVoiceState {
   /** Smoothed RMS mic amplitude in [0, 1] for UI / barge-in. */
   inputAmplitude: number;
   /**
+   * True while the user has minimized the voice room for the active session
+   * (Escape / the room's minimize control). The room hides but the session —
+   * and the owning composer's voice bar — stay live; expanding from the voice
+   * bar flips this back. Session-scoped: cleared on `reset` and on
+   * `setSessionContext`, so every new session opens with the room expanded.
+   */
+  roomMinimized: boolean;
+  /**
    * Latency measurements for the last turn, `null` until a turn is measured.
    * Debug surface only — per the minimal-treatment note on
    * {@link LIVE_VOICE_STATE_LABELS}, no surface renders this: the controller
@@ -247,6 +255,8 @@ export interface LiveVoiceActions {
    */
   clearUserTranscripts: () => void;
   setInputAmplitude: (amplitude: number) => void;
+  /** Minimize (or re-expand) the voice room for the active session. */
+  setRoomMinimized: (minimized: boolean) => void;
   /**
    * Replace the last turn's latency pair wholesale (never patch a member in
    * place) so subscribers of the atomic selector see one consistent object.
@@ -347,6 +357,7 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   finalTranscript: "",
   assistantTranscript: "",
   inputAmplitude: 0,
+  roomMinimized: false,
   lastTurnLatency: null,
   outputAmplitudeProvider: null,
   error: null,
@@ -359,7 +370,14 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   setState: (state) => set({ state }),
   setReconnecting: (reconnecting) => set({ reconnecting }),
   setSessionContext: (assistantId, conversationId) =>
-    set({ assistantId, conversationId, startedConversationId: conversationId }),
+    // A fresh session always opens with the room expanded, even if the
+    // controller starts it without an intervening `reset`.
+    set({
+      assistantId,
+      conversationId,
+      startedConversationId: conversationId,
+      roomMinimized: false,
+    }),
   setConversationId: (conversationId) => set({ conversationId }),
   setControls: (controls) => set({ controls }),
   setStarter: (starter) => set({ starter }),
@@ -370,6 +388,7 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   clearAssistantTranscript: () => set({ assistantTranscript: "" }),
   clearUserTranscripts: () => set({ partialTranscript: "", finalTranscript: "" }),
   setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
+  setRoomMinimized: (roomMinimized) => set({ roomMinimized }),
   setLastTurnLatency: (lastTurnLatency) => set({ lastTurnLatency }),
   setOutputAmplitudeProvider: (outputAmplitudeProvider) =>
     set({ outputAmplitudeProvider }),
@@ -421,6 +440,20 @@ export function endLiveVoiceSession(): void {
  */
 export function releaseLiveVoiceTurn(): void {
   useLiveVoiceStore.getState().controls?.release();
+}
+
+/**
+ * Minimize the voice room without ending the session — the room hides and the
+ * owning composer's voice bar becomes the session surface. Module-level for
+ * the same stable-identity reasons as {@link endLiveVoiceSession}.
+ */
+export function minimizeLiveVoiceRoom(): void {
+  useLiveVoiceStore.getState().setRoomMinimized(true);
+}
+
+/** Re-expand a minimized voice room. Counterpart to {@link minimizeLiveVoiceRoom}. */
+export function expandLiveVoiceRoom(): void {
+  useLiveVoiceStore.getState().setRoomMinimized(false);
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
@@ -3,12 +3,14 @@
  * visible.
  *
  * The room is the owning-composer's voice surface: it shows exactly when a
- * session is active AND the composer currently on screen owns it AND this is
- * the main window (never a pop-out — see below). Its popout-free core,
- * {@link useOwningComposerSurfaceVisible}, is the precise complement of the
- * title-bar session pill, whose host consumes that primitive's negation
- * (`sessionActive && !owningSurfaceVisible`) so the two surfaces can never both
- * render — or both hide — for an active owned session.
+ * session is active AND the composer currently on screen owns it AND the user
+ * has not minimized it AND this is the main window (never a pop-out — see
+ * below). Its popout-free core, {@link useOwningComposerSurfaceVisible}, is the
+ * precise complement of the title-bar session pill, whose host consumes that
+ * primitive's negation (`sessionActive && !owningSurfaceVisible`) so the two
+ * surfaces can never both render — or both hide — for an active owned session.
+ * (While minimized, the owning composer's voice bar — always rendered under
+ * the room — is the visible session surface, so the pill stays hidden.)
  *
  * The inputs mirror {@link VoiceSessionPillHost} one-for-one:
  * - `composerOnScreen` — shared via {@link useComposerOnScreen}: a conversation
@@ -65,12 +67,20 @@ export function useOwningComposerSurfaceVisible(): boolean {
 }
 
 /**
- * Whether the full-screen voice room should render. See the module docstring
- * for the exact-complement contract with the title-bar session pill and the
- * pop-out exclusion.
+ * Whether the voice room should render. See the module docstring for the
+ * complement contract with the title-bar session pill and the pop-out
+ * exclusion.
+ *
+ * Also ANDs in `!roomMinimized`: minimizing (Escape / the room's minimize
+ * control) hides the room while the session stays live. The owning composer's
+ * voice bar — which always renders under the room for an owned session — then
+ * becomes the visible session surface, so `useOwningComposerSurfaceVisible`
+ * (and therefore the pill) deliberately ignores the flag: an owned, on-screen,
+ * minimized session is controlled from the voice bar, not the pill.
  */
 export function useIsVoiceRoomVisible(): boolean {
   const owningSurfaceVisible = useOwningComposerSurfaceVisible();
+  const roomMinimized = useLiveVoiceStore.use.roomMinimized();
   const location = useLocation();
   // Capture pop-out mode once at mount: pop-out URLs carry `?popout=1` only on
   // the window's initial load (in-window navigation drops the query), and this
@@ -78,5 +88,5 @@ export function useIsVoiceRoomVisible(): boolean {
   // window's lifetime value — mirroring `ChatLayout`'s own capture.
   const [isPopout] = useState(() => isPopoutWindow(location.search));
 
-  return owningSurfaceVisible && !isPopout;
+  return owningSurfaceVisible && !roomMinimized && !isPopout;
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
@@ -7,11 +7,16 @@
  * The waves always drift horizontally (a slow CSS loop); the user's live mic
  * amplitude drives how high they rise and how bright they are, written
  * imperatively to `--voice-amp` from a requestAnimationFrame loop — never React
- * state, matching `voice-avatar.tsx`. Purely decorative; the cyan→indigo accent
- * is a fixed constant (like the listening sonar), not a theme token.
+ * state, matching `voice-avatar.tsx`. The polled amplitude is near-instant RMS
+ * (see `createAmplitudeSmoother`), so the loop runs it through a VU-meter-style
+ * attack/release smoother before writing — raw, it jerks the waves' large
+ * vertical travel every frame. Purely decorative; the cyan→indigo accent is a
+ * fixed constant (like the listening sonar), not a theme token.
  */
 
 import { useEffect, useRef } from "react";
+
+import { createAmplitudeSmoother } from "./voice-motion";
 
 // Wave geometry is authored in a fixed viewBox; the path spans two viewBox
 // widths so a `-1200px` horizontal drift loops seamlessly (each wave's cycle
@@ -84,11 +89,17 @@ export function VoiceListeningWaves({
     if (!node) {
       return;
     }
+    // Rise quickly with speech onset (~80 ms) but settle gently (~350 ms), so
+    // the band swells and subsides instead of twitching with raw RMS.
+    const smoother = createAmplitudeSmoother({ attackMs: 80, releaseMs: 350 });
     let raf = 0;
     let lastWritten = "";
-    const tick = () => {
-      const amp = Math.min(1, Math.max(0, getAmplitudeRef.current()));
-      const next = amp.toFixed(3);
+    let lastTime = performance.now();
+    const tick = (now: number) => {
+      const dt = now - lastTime;
+      lastTime = now;
+      const target = Math.min(1, Math.max(0, getAmplitudeRef.current()));
+      const next = smoother.step(target, dt).toFixed(3);
       if (next !== lastWritten) {
         lastWritten = next;
         node.style.setProperty("--voice-amp", next);

--- a/clients/web/src/domains/chat/voice/voice-room/voice-motion.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-motion.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for `createAmplitudeSmoother` — the VU-meter ballistic behind the
+ * listening waves. The contract that matters: fast attack / slow release
+ * asymmetry, and frame-rate independence (same elapsed time → same value,
+ * regardless of how many frames it was split across).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { createAmplitudeSmoother } from "@/domains/chat/voice/voice-room/voice-motion";
+
+const BALLISTICS = { attackMs: 80, releaseMs: 350 };
+
+describe("createAmplitudeSmoother", () => {
+  test("one attack time constant reaches ~63% of a step target", () => {
+    const smoother = createAmplitudeSmoother(BALLISTICS);
+    const value = smoother.step(1, BALLISTICS.attackMs);
+    expect(value).toBeCloseTo(1 - Math.exp(-1), 3);
+  });
+
+  test("release is slower than attack for the same elapsed time", () => {
+    const rising = createAmplitudeSmoother(BALLISTICS);
+    const risen = rising.step(1, 100);
+
+    const falling = createAmplitudeSmoother(BALLISTICS);
+    falling.step(1, 1_000_000); // effectively settle at 1
+    const fallen = falling.step(0, 100);
+
+    // In 100 ms the attack covers more of its gap (1 - risen below the target)
+    // than the release covers of its own (fallen still near 1).
+    expect(risen).toBeGreaterThan(1 - fallen);
+  });
+
+  test("frame-rate independent: many small steps equal one large step", () => {
+    const fine = createAmplitudeSmoother(BALLISTICS);
+    let fineValue = 0;
+    for (let i = 0; i < 16; i++) {
+      fineValue = fine.step(1, 1);
+    }
+
+    const coarse = createAmplitudeSmoother(BALLISTICS);
+    const coarseValue = coarse.step(1, 16);
+
+    expect(fineValue).toBeCloseTo(coarseValue, 6);
+  });
+
+  test("a non-positive dt leaves the value unchanged", () => {
+    const smoother = createAmplitudeSmoother(BALLISTICS);
+    const value = smoother.step(1, 50);
+    expect(smoother.step(0, 0)).toBe(value);
+    expect(smoother.step(0, -5)).toBe(value);
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-motion.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-motion.ts
@@ -16,3 +16,37 @@ export const AVATAR_ENTER_SPRING = {
   stiffness: 200,
   damping: 18,
 };
+
+/**
+ * Frame-rate-independent asymmetric exponential smoother for amplitude-driven
+ * visuals (a VU-meter-style ballistic: fast attack, slower release).
+ *
+ * The live mic amplitude in the store is close to instantaneous RMS — the
+ * capture worklet posts a chunk per ~2.7 ms render quantum, so its per-chunk
+ * EMA (tuned for the dictation path's much larger buffers) barely filters it —
+ * and speech RMS swings hard at millisecond scale. Writing it raw into a large
+ * transform (the listening waves' rise) reads as chop. This smooths at the
+ * visual consumer instead of the source, so the engine's barge-in / silence
+ * thresholds keep seeing the responsive signal they were tuned against.
+ *
+ * `step(target, dtMs)` advances toward `target` with time constants `attackMs`
+ * (rising) / `releaseMs` (falling): time-based `1 - exp(-dt/τ)` blending, so
+ * the feel is identical at 60 Hz, 120 Hz, or across dropped frames.
+ */
+export function createAmplitudeSmoother({
+  attackMs,
+  releaseMs,
+}: {
+  attackMs: number;
+  releaseMs: number;
+}): { step: (target: number, dtMs: number) => number } {
+  let value = 0;
+  return {
+    step(target: number, dtMs: number): number {
+      const tau = target > value ? attackMs : releaseMs;
+      const k = 1 - Math.exp(-Math.max(0, dtMs) / tau);
+      value += (target - value) * k;
+      return value;
+    },
+  };
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -9,14 +9,15 @@
  * assistant-avatar React Query graph — irrelevant to room chrome, and stubbed
  * so the exit control's independence from avatar readiness is testable).
  *
- * Exit is the load-bearing behavior: the ✕ control and the global Escape key
- * both end the session, the control renders even with no assistant resolved,
- * and the key listeners are removed on unmount (no leaks).
+ * Exit and minimize are the load-bearing behaviors: the ✕ control ends the
+ * session, Escape / the minimize control collapse the room WITHOUT ending the
+ * session (the composer's voice bar takes over), the ✕ renders even with no
+ * assistant resolved, and the key listeners are removed on unmount (no leaks).
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import type { MainView } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
@@ -30,6 +31,7 @@ import {
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useConversationStore } from "@/stores/conversation-store";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 const OWNING_CONVERSATION_ID = "conv-owning";
 const OTHER_CONVERSATION_ID = "conv-other";
@@ -112,6 +114,11 @@ beforeEach(() => {
   useConversationStore
     .getState()
     .setActiveConversationId(OWNING_CONVERSATION_ID);
+  // Captions default off; individual tests flip them through the room control.
+  useVoicePrefsStore.setState({
+    showUserTranscript: false,
+    showAssistantTranscript: false,
+  });
 });
 
 afterEach(() => {
@@ -200,27 +207,6 @@ describe("VoiceRoom — exit", () => {
     expect(controls.stop).toHaveBeenCalledTimes(1);
   });
 
-  test("Escape ends the session via controls.stop", () => {
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-    expect(controls.stop).toHaveBeenCalledTimes(1);
-  });
-
-  test("Escape ends the session even when an editable element holds focus (global exit)", () => {
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    // The room can open while the composer textarea still owns focus; Escape is
-    // a global exit and must fire regardless of the editable target guard.
-    const input = document.createElement("input");
-    document.body.appendChild(input);
-    input.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
-    );
-    expect(controls.stop).toHaveBeenCalledTimes(1);
-    input.remove();
-  });
-
   test("the exit control renders even with no assistant resolved", () => {
     startOwnedSession("listening");
     useLiveVoiceStore.setState({ assistantId: null });
@@ -229,19 +215,159 @@ describe("VoiceRoom — exit", () => {
     expect(screen.getByTestId("voice-avatar").textContent).toBe("no-assistant");
   });
 
-  test("key listeners are removed on unmount — no stray Escape teardown", () => {
+  test("key listeners are removed on unmount — no stray Escape handling", () => {
     startOwnedSession("listening");
     const { unmount } = render(<VoiceRoom />);
     unmount();
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
     expect(controls.stop).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceRoom — minimize (session keeps running)", () => {
+  test("Escape minimizes the room without ending the session", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    // act: minimizing flips the store flag, which re-renders (unmounts) the room.
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    expect(controls.stop).not.toHaveBeenCalled();
+  });
+
+  test("Escape minimizes even when an editable element holds focus (global key)", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    // The room can open while the composer textarea still owns focus; the key
+    // is global and must fire regardless of the editable target guard.
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    expect(controls.stop).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  test("the minimize control minimizes without ending the session", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Minimize voice room" }),
+    );
+    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    expect(controls.stop).not.toHaveBeenCalled();
+  });
+
+  test("a minimized room does not render for an owned active session", () => {
+    startOwnedSession("listening");
+    useLiveVoiceStore.getState().setRoomMinimized(true);
+    render(<VoiceRoom />);
+    expect(roomDialog()).toBeNull();
+  });
+});
+
+describe("VoiceRoom — send now (manual turn release)", () => {
+  const sendNowButton = () => screen.queryByRole("button", { name: /Send now/ });
+
+  test("the Send now control releases the turn while listening", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    fireEvent.click(sendNowButton()!);
+    expect(controls.release).toHaveBeenCalledTimes(1);
+  });
+
+  test("no Send now control outside listening", () => {
+    startOwnedSession("speaking");
+    render(<VoiceRoom />);
+    expect(sendNowButton()).toBeNull();
+  });
+
+  test("Enter releases the turn while listening", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(controls.release).toHaveBeenCalledTimes(1);
+  });
+
+  test("Enter is inert outside listening", () => {
+    startOwnedSession("speaking");
+    render(<VoiceRoom />);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(controls.release).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceRoom — captions toggle", () => {
+  test("toggling captions on flips both persisted transcript prefs", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    fireEvent.click(screen.getByRole("button", { name: "Show captions" }));
+    const prefs = useVoicePrefsStore.getState();
+    expect(prefs.showUserTranscript).toBe(true);
+    expect(prefs.showAssistantTranscript).toBe(true);
+  });
+
+  test("with any transcript pref on, the control offers to hide and clears both", () => {
+    useVoicePrefsStore.setState({ showUserTranscript: true });
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    fireEvent.click(screen.getByRole("button", { name: "Hide captions" }));
+    const prefs = useVoicePrefsStore.getState();
+    expect(prefs.showUserTranscript).toBe(false);
+    expect(prefs.showAssistantTranscript).toBe(false);
+  });
+});
+
+describe("VoiceRoom — connect feedback", () => {
+  test("shows the connecting label while the session connects", () => {
+    startOwnedSession("connecting");
+    render(<VoiceRoom />);
+    expect(
+      screen.getByTestId("voice-room-connect-label").textContent,
+    ).toBe("Connecting…");
+  });
+
+  test("relabels to Reconnecting… while retrying a dropped connection", () => {
+    startOwnedSession("connecting");
+    useLiveVoiceStore.getState().setReconnecting(true);
+    render(<VoiceRoom />);
+    expect(
+      screen.getByTestId("voice-room-connect-label").textContent,
+    ).toBe("Reconnecting…");
+  });
+
+  test("no connect label once listening", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(screen.queryByTestId("voice-room-connect-label")).toBeNull();
+  });
+});
+
+describe("VoiceRoom — placement variants", () => {
+  test("the fullscreen (mobile) variant is modal", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom variant="fullscreen" />);
+    expect(roomDialog()!.getAttribute("aria-modal")).toBe("true");
+  });
+
+  test("the content (desktop) variant is not modal — surrounding chrome stays usable", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom variant="content" />);
+    expect(roomDialog()!.getAttribute("aria-modal")).toBeNull();
   });
 });
 
 describe("VoiceRoom — no push-to-talk affordance (hands-free)", () => {
   // Sessions are hands-free (server-VAD): the user just speaks, so the room
   // offers no push-to-talk control. Space is not intercepted and there is no
-  // tappable "Speak" orb — only Escape / ✕ are wired (see the exit suite).
+  // tappable "Speak" orb — the "Send now" control is a manual turn RELEASE
+  // (like the composer bar's ↑), not a hold-to-talk affordance.
   test("Space does not release the current turn while listening", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -272,37 +272,6 @@ describe("VoiceRoom — minimize (session keeps running)", () => {
   });
 });
 
-describe("VoiceRoom — send now (manual turn release)", () => {
-  const sendNowButton = () => screen.queryByRole("button", { name: /Send now/ });
-
-  test("the Send now control releases the turn while listening", () => {
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    fireEvent.click(sendNowButton()!);
-    expect(controls.release).toHaveBeenCalledTimes(1);
-  });
-
-  test("no Send now control outside listening", () => {
-    startOwnedSession("speaking");
-    render(<VoiceRoom />);
-    expect(sendNowButton()).toBeNull();
-  });
-
-  test("Enter releases the turn while listening", () => {
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
-    expect(controls.release).toHaveBeenCalledTimes(1);
-  });
-
-  test("Enter is inert outside listening", () => {
-    startOwnedSession("speaking");
-    render(<VoiceRoom />);
-    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
-    expect(controls.release).not.toHaveBeenCalled();
-  });
-});
-
 describe("VoiceRoom — captions toggle", () => {
   test("toggling captions on flips both persisted transcript prefs", () => {
     startOwnedSession("listening");
@@ -363,11 +332,12 @@ describe("VoiceRoom — placement variants", () => {
   });
 });
 
-describe("VoiceRoom — no push-to-talk affordance (hands-free)", () => {
+describe("VoiceRoom — no push-to-talk / manual-release affordance (hands-free)", () => {
   // Sessions are hands-free (server-VAD): the user just speaks, so the room
-  // offers no push-to-talk control. Space is not intercepted and there is no
-  // tappable "Speak" orb — the "Send now" control is a manual turn RELEASE
-  // (like the composer bar's ↑), not a hold-to-talk affordance.
+  // offers no push-to-talk control and no manual "send now" — the controller's
+  // `release` seam is a no-op for hands-free sessions, so such a control would
+  // be dead (PR #37913 review). Space and Enter are not intercepted; a focused
+  // room control keeps its native Enter activation.
   test("Space does not release the current turn while listening", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
@@ -382,9 +352,23 @@ describe("VoiceRoom — no push-to-talk affordance (hands-free)", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
-  test("there is no tappable Speak orb", () => {
+  test("Enter is not intercepted while listening — no dead send-now shortcut", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      cancelable: true,
+    });
+    window.dispatchEvent(event);
+    expect(controls.release).not.toHaveBeenCalled();
+    // No preventDefault: a focused room control keeps native Enter activation.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("there is no tappable Speak orb and no Send now control", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     expect(screen.queryByRole("button", { name: "Speak" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Send now/ })).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -1,36 +1,55 @@
 /**
- * Full-screen "voice room" — the owning-composer surface for a live-voice
- * session. A deep-dark ambient void with the assistant's state-driven avatar at
- * its center, mounted at layout scope (see `chat-layout.tsx`) as a purely
- * additive overlay: the composer's voice bar and display transcript still
- * render underneath, hidden by this layer, so removing the room leaves the old
- * UI intact.
+ * "Voice room" — the owning-composer surface for a live-voice session. A
+ * deep-dark ambient void with the assistant's state-driven avatar at its
+ * center, mounted by `chat-layout.tsx` as a purely additive overlay: the
+ * composer's voice bar and display transcript still render underneath, hidden
+ * by this layer, so removing the room leaves the old UI intact.
  *
- * Visibility is a pure function of {@link useIsVoiceRoomVisible} — the exact
- * complement of the title-bar session pill. Any session end (user exit, Escape,
- * `failed`, conversation timeout, stop from elsewhere) flips that predicate
- * false and unmounts the room; a `failed` session surfaces through the existing
- * composer Notice / pill failure chip, never a dead room.
+ * Two placement variants (see `chat-layout.tsx` for the mounts):
+ *
+ * - `"fullscreen"` (mobile) — `fixed inset-0` over the whole viewport,
+ *   modal, with safe-area padding for notched iOS shells.
+ * - `"content"` (desktop) — `absolute inset-0` inside the layout's `<main>`,
+ *   leaving the header and sidebar visible AND interactive so the user can
+ *   keep navigating; any navigation away hands the session off to the
+ *   title-bar pill. Deliberately not `aria-modal`: the surrounding chrome
+ *   stays usable.
+ *
+ * Visibility is a pure function of {@link useIsVoiceRoomVisible} — active
+ * session, owned by the on-screen composer, not minimized, main window. Any
+ * session end (user exit, `failed`, conversation timeout, stop from elsewhere)
+ * flips that predicate false and unmounts the room; a `failed` session
+ * surfaces through the existing composer Notice / pill failure chip, never a
+ * dead room.
  *
  * Sessions are hands-free (server-VAD): the user just speaks, so there is no
- * push-to-talk control. Exit is first-class — a persistent ✕ control (always
- * rendered, even while the avatar/assistant data is loading or failed) plus a
- * global Escape handler, both attached only while the room is mounted.
+ * push-to-talk control — but while `listening` a subtle "Send now" control
+ * (and the Enter key) manually releases the turn for users who don't want to
+ * wait out the silence detector. Exit is first-class: a persistent ✕ control
+ * (always rendered, even while the avatar/assistant data is loading or
+ * failed) ends the session; Escape and the minimize control collapse the room
+ * to the composer's voice bar WITHOUT ending the session (the bar's expand
+ * control reopens it). Key handlers attach only while the room is mounted.
  */
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect } from "react";
-import { X } from "lucide-react";
+import { ArrowUp, Captions, CaptionsOff, Minimize2, X } from "lucide-react";
+
+import { Tooltip, cn } from "@vellumai/design-library";
 
 import {
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   getLiveVoiceOutputAmplitude,
   liveVoiceStateLabel,
+  minimizeLiveVoiceRoom,
+  releaseLiveVoiceTurn,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 import { resolveWaveAccentHex } from "./wave-accent";
 
@@ -58,20 +77,33 @@ const SAFE_AREA_LEFT =
 const SAFE_AREA_RIGHT =
   "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))";
 
-export function VoiceRoom() {
+/** Shared white-on-dark treatment for the room's icon controls. */
+const ROOM_CONTROL_CLASS =
+  "flex size-10 items-center justify-center rounded-full text-white/70 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60";
+
+export type VoiceRoomVariant = "fullscreen" | "content";
+
+export interface VoiceRoomProps {
+  /** Placement variant — see the module docstring. Defaults to fullscreen. */
+  variant?: VoiceRoomVariant;
+}
+
+export function VoiceRoom({ variant = "fullscreen" }: VoiceRoomProps) {
   const visible = useIsVoiceRoomVisible();
 
   return (
-    <AnimatePresence>{visible ? <VoiceRoomOverlay key="voice-room" /> : null}</AnimatePresence>
+    <AnimatePresence>
+      {visible ? <VoiceRoomOverlay key="voice-room" variant={variant} /> : null}
+    </AnimatePresence>
   );
 }
 
 /**
  * The mounted room. Split from {@link VoiceRoom} so its store subscriptions and
- * Escape handler only exist while the room is actually visible and are torn
+ * key handlers only exist while the room is actually visible and are torn
  * down cleanly on exit.
  */
-function VoiceRoomOverlay() {
+function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const state = useLiveVoiceStore.use.state();
   const reconnecting = useLiveVoiceStore.use.reconnecting();
   const assistantId = useLiveVoiceStore.use.assistantId();
@@ -79,6 +111,19 @@ function VoiceRoomOverlay() {
 
   const visual = toVoiceAvatarVisual(state, reconnecting);
   const stateLabel = liveVoiceStateLabel(state, reconnecting);
+
+  // Captions = the two persisted transcript prefs, toggled together from the
+  // room. Bound to the same `voice-prefs` store as the settings page and the
+  // first-run card, so a choice made here is the choice those surfaces show.
+  const showUserTranscript = useVoicePrefsStore.use.showUserTranscript();
+  const showAssistantTranscript =
+    useVoicePrefsStore.use.showAssistantTranscript();
+  const captionsOn = showUserTranscript || showAssistantTranscript;
+  const toggleCaptions = () => {
+    const prefs = useVoicePrefsStore.getState();
+    prefs.setShowUserTranscript(!captionsOn);
+    prefs.setShowAssistantTranscript(!captionsOn);
+  };
 
   // Publish the session assistant's avatar accent on the room itself (not just
   // the html-level var, which tracks the *active* assistant) so the listening
@@ -89,14 +134,25 @@ function VoiceRoomOverlay() {
   const { components, traits } = useAssistantAvatar(assistantId);
   const accentHex = resolveWaveAccentHex(components, traits);
 
-  // Global Escape exit, live only while the room is mounted. It fires even when
-  // the composer textarea (or any other focused element) still holds focus as
-  // the room opens, so it is intentionally not guarded by the event target.
+  // Global keys, live only while the room is mounted. Escape minimizes the
+  // room (the session keeps running; the composer's voice bar takes over as
+  // the control surface) — ending is reserved for the explicit ✕. Enter is a
+  // manual turn release ("send now") while listening. Both fire even when the
+  // composer textarea (or any other focused element) still holds focus as the
+  // room opens, so they are intentionally not guarded by the event target.
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
-        endLiveVoiceSession();
+        minimizeLiveVoiceRoom();
+        return;
+      }
+      if (
+        event.key === "Enter" &&
+        useLiveVoiceStore.getState().state === "listening"
+      ) {
+        event.preventDefault();
+        releaseLiveVoiceTurn();
       }
     }
     window.addEventListener("keydown", onKeyDown);
@@ -105,15 +161,27 @@ function VoiceRoomOverlay() {
 
   return (
     <motion.div
-      className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden"
+      className={cn(
+        "flex items-center justify-center overflow-hidden",
+        // Both variants sit at z-50: the highest tier used inside the chat
+        // content (e.g. the quote-reply bubble), with DOM order — the room
+        // mounts after the Outlet — breaking the tie in the room's favor.
+        variant === "fullscreen"
+          ? "fixed inset-0 z-50"
+          : "absolute inset-0 z-50 rounded-xl",
+      )}
       data-theme="dark"
       role="dialog"
-      aria-modal="true"
+      // Only the fullscreen room is modal: the content variant deliberately
+      // leaves the header and sidebar interactive so the user can navigate
+      // mid-session (the pill takes over as the control surface).
+      aria-modal={variant === "fullscreen" || undefined}
       aria-label="Voice session"
-      // This `fixed inset-0` overlay covers `ChatLayoutHeader`, so it loses the
+      // The fullscreen overlay covers `ChatLayoutHeader`, so it loses the
       // header's safe-area protection — pad the centered avatar inside the
-      // notch/home-indicator per docs/CAPACITOR.md. The ambient void is
-      // `absolute inset-0` and stays full-bleed behind the padding.
+      // notch/home-indicator per docs/CAPACITOR.md. Inert for the desktop
+      // content variant. The ambient void is `absolute inset-0` and stays
+      // full-bleed behind the padding.
       style={{
         paddingTop: SAFE_AREA_TOP,
         paddingBottom: SAFE_AREA_BOTTOM,
@@ -140,17 +208,15 @@ function VoiceRoomOverlay() {
       ) : null}
 
       {/* Optional muted echo of the live transcript, floating above (user) and
-          below (assistant) the centered avatar. Pref-gated and absolutely
-          positioned, so it never shifts the avatar and stays absent by default. */}
+          below (assistant) the centered avatar. Pref-gated (the captions
+          control above) and absolutely positioned, so it never shifts the
+          avatar and stays absent by default. */}
       <VoiceAmbientTranscript />
 
-      {/* Persistent exit control — rendered above all room chrome and never
-          gated behind avatar readiness, so exit works even mid-load / on
-          failure. */}
-      <button
-        type="button"
-        onClick={endLiveVoiceSession}
-        aria-label="Exit voice session"
+      {/* Room controls — captions toggle, minimize, and the persistent exit.
+          Rendered above all room chrome; ✕ is never gated behind avatar
+          readiness, so ending works even mid-load / on failure. */}
+      <div
         // Absolute position is relative to the padding box, so the overlay's
         // safe-area padding does not shift this — inset it from the notch /
         // Dynamic Island directly, clamped to the desktop 1.25rem gap.
@@ -158,10 +224,44 @@ function VoiceRoomOverlay() {
           top: `max(1.25rem, ${SAFE_AREA_TOP})`,
           right: `max(1.25rem, ${SAFE_AREA_RIGHT})`,
         }}
-        className="absolute z-10 flex size-10 items-center justify-center rounded-full text-white/70 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+        className="absolute z-10 flex items-center gap-1"
       >
-        <X className="size-5" />
-      </button>
+        <Tooltip content={captionsOn ? "Hide captions" : "Show captions"}>
+          <button
+            type="button"
+            onClick={toggleCaptions}
+            aria-label={captionsOn ? "Hide captions" : "Show captions"}
+            aria-pressed={captionsOn}
+            className={ROOM_CONTROL_CLASS}
+          >
+            {captionsOn ? (
+              <Captions className="size-5" />
+            ) : (
+              <CaptionsOff className="size-5" />
+            )}
+          </button>
+        </Tooltip>
+        <Tooltip content="Minimize (Esc)">
+          <button
+            type="button"
+            onClick={minimizeLiveVoiceRoom}
+            aria-label="Minimize voice room"
+            className={ROOM_CONTROL_CLASS}
+          >
+            <Minimize2 className="size-5" />
+          </button>
+        </Tooltip>
+        <Tooltip content="End voice session">
+          <button
+            type="button"
+            onClick={endLiveVoiceSession}
+            aria-label="Exit voice session"
+            className={ROOM_CONTROL_CLASS}
+          >
+            <X className="size-5" />
+          </button>
+        </Tooltip>
+      </div>
 
       {/* The avatar springs to center once on entry (the wrapper owns the
           one-time entry spring); per-state expression is the avatar's own CSS
@@ -183,6 +283,57 @@ function VoiceRoomOverlay() {
           size={AVATAR_SIZE}
         />
       </motion.div>
+
+      {/* Connect feedback: until the session reaches `listening` the avatar
+          shows the idle visual, which otherwise reads as dead air — surface
+          the "Connecting…" / "Reconnecting…" label so the user knows when to
+          start talking. aria-hidden: the sr-only live region below already
+          announces every state change. */}
+      <AnimatePresence>
+        {state === "connecting" ? (
+          <motion.p
+            key="connect-label"
+            data-testid="voice-room-connect-label"
+            aria-hidden
+            className="pointer-events-none absolute left-1/2 top-[calc(50%+8.5rem)] z-0 -translate-x-1/2 text-sm text-[var(--content-tertiary)]"
+            initial={reduce ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: reduce ? 0 : 0.3 }}
+          >
+            {stateLabel}
+          </motion.p>
+        ) : null}
+      </AnimatePresence>
+
+      {/* Manual turn release while listening — for users who don't want to
+          wait out the server-VAD silence detector. Mirrors the green ↑ on the
+          composer voice bar and the title-bar pill, in the room's own muted
+          idiom. */}
+      <AnimatePresence>
+        {state === "listening" ? (
+          <motion.div
+            key="send-now"
+            className="absolute left-1/2 z-10 -translate-x-1/2"
+            style={{ bottom: `max(2.5rem, ${SAFE_AREA_BOTTOM})` }}
+            initial={reduce ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            transition={{ duration: reduce ? 0 : 0.25 }}
+          >
+            <Tooltip content="Send now (Enter)">
+              <button
+                type="button"
+                onClick={releaseLiveVoiceTurn}
+                className="flex items-center gap-1.5 rounded-full border border-white/15 px-4 py-2 text-sm text-white/60 transition hover:border-white/30 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+              >
+                <ArrowUp aria-hidden className="size-4" />
+                Send now
+              </button>
+            </Tooltip>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
 
       {/* Screen readers get session-state changes here; the avatar is the
           visual channel, so this stays off-screen. */}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -23,18 +23,19 @@
  * dead room.
  *
  * Sessions are hands-free (server-VAD): the user just speaks, so there is no
- * push-to-talk control — but while `listening` a subtle "Send now" control
- * (and the Enter key) manually releases the turn for users who don't want to
- * wait out the silence detector. Exit is first-class: a persistent ✕ control
- * (always rendered, even while the avatar/assistant data is loading or
- * failed) ends the session; Escape and the minimize control collapse the room
- * to the composer's voice bar WITHOUT ending the session (the bar's expand
- * control reopens it). Key handlers attach only while the room is mounted.
+ * push-to-talk control — and deliberately no manual "send now" either: the
+ * controller's `release` seam is a no-op for hands-free sessions, so such a
+ * control would be dead (PR #37913 review). Exit is first-class: a persistent
+ * ✕ control (always rendered, even while the avatar/assistant data is loading
+ * or failed) ends the session; Escape and the minimize control collapse the
+ * room to the composer's voice bar WITHOUT ending the session (the bar's
+ * expand control reopens it). The key handler attaches only while the room is
+ * mounted.
  */
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect } from "react";
-import { ArrowUp, Captions, CaptionsOff, Minimize2, X } from "lucide-react";
+import { Captions, CaptionsOff, Minimize2, X } from "lucide-react";
 
 import { Tooltip, cn } from "@vellumai/design-library";
 
@@ -44,7 +45,6 @@ import {
   getLiveVoiceOutputAmplitude,
   liveVoiceStateLabel,
   minimizeLiveVoiceRoom,
-  releaseLiveVoiceTurn,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
@@ -134,25 +134,17 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const { components, traits } = useAssistantAvatar(assistantId);
   const accentHex = resolveWaveAccentHex(components, traits);
 
-  // Global keys, live only while the room is mounted. Escape minimizes the
-  // room (the session keeps running; the composer's voice bar takes over as
-  // the control surface) — ending is reserved for the explicit ✕. Enter is a
-  // manual turn release ("send now") while listening. Both fire even when the
-  // composer textarea (or any other focused element) still holds focus as the
-  // room opens, so they are intentionally not guarded by the event target.
+  // Global Escape, live only while the room is mounted: minimizes the room
+  // (the session keeps running; the composer's voice bar takes over as the
+  // control surface) — ending is reserved for the explicit ✕. It fires even
+  // when the composer textarea (or any other focused element) still holds
+  // focus as the room opens, so it is intentionally not guarded by the event
+  // target.
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
         minimizeLiveVoiceRoom();
-        return;
-      }
-      if (
-        event.key === "Enter" &&
-        useLiveVoiceStore.getState().state === "listening"
-      ) {
-        event.preventDefault();
-        releaseLiveVoiceTurn();
       }
     }
     window.addEventListener("keydown", onKeyDown);
@@ -303,35 +295,6 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           >
             {stateLabel}
           </motion.p>
-        ) : null}
-      </AnimatePresence>
-
-      {/* Manual turn release while listening — for users who don't want to
-          wait out the server-VAD silence detector. Mirrors the green ↑ on the
-          composer voice bar and the title-bar pill, in the room's own muted
-          idiom. */}
-      <AnimatePresence>
-        {state === "listening" ? (
-          <motion.div
-            key="send-now"
-            className="absolute left-1/2 z-10 -translate-x-1/2"
-            style={{ bottom: `max(2.5rem, ${SAFE_AREA_BOTTOM})` }}
-            initial={reduce ? false : { opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 8 }}
-            transition={{ duration: reduce ? 0 : 0.25 }}
-          >
-            <Tooltip content="Send now (Enter)">
-              <button
-                type="button"
-                onClick={releaseLiveVoiceTurn}
-                className="flex items-center gap-1.5 rounded-full border border-white/15 px-4 py-2 text-sm text-white/60 transition hover:border-white/30 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
-              >
-                <ArrowUp aria-hidden className="size-4" />
-                Send now
-              </button>
-            </Tooltip>
-          </motion.div>
         ) : null}
       </AnimatePresence>
 


### PR DESCRIPTION
Closes JARVIS-1269.

Low-hanging UX improvements to make live-voice mode feel like an ambient companion instead of a modal takeover:

## What changed

1. **Desktop room is content-scoped.** `VoiceRoom` gains a `variant` prop: on desktop it mounts inside the layout's `<main>` as an `absolute inset-0` island, so the sidebar and header stay visible **and interactive** — navigating mid-session hands the session off to the existing title-bar pill. Mobile keeps the `fixed` full-viewport takeover (with `aria-modal`; the content variant is deliberately non-modal). The forced sidebar collapse and the desktop blur are gone.
2. **Escape minimizes instead of ending the session.** A new session-scoped `roomMinimized` flag in the live-voice store collapses the room to the composer's voice bar (Escape or the new minimize control); the bar shows an "Open voice room" expand button only while minimized, so it can never dead-render in pop-outs (where the room never mounts). ✕ remains the only destructive control; new sessions always open expanded.
3. **In-room captions toggle** bound to the same persisted transcript prefs as Settings → Voice and the first-run card.
4. **Visible "Connecting… / Reconnecting…" label** under the avatar, so session entry no longer reads as dead air (the avatar shows the idle visual until `listening`).
5. **Smooth listening waves.** The waves' rAF loop now runs the near-instant mic RMS through a frame-rate-independent VU-meter ballistic (80 ms attack / 350 ms release, `createAmplitudeSmoother`) instead of writing it raw into a large translateY — smoothing lives at the visual consumer so the engine's barge-in / silence signal is untouched.
6. **Tooltips** on all room controls (design-library `Tooltip`).

~~An in-room "Send now" + Enter shortcut~~ was cut after review: hands-free (server-VAD) sessions no-op the controller's `release` seam, so the control was dead — removing the Enter interception also restores native Enter activation on focused room controls.

## Invariants kept

- The pill's visibility contract is untouched (`sessionActive && !owningSurfaceVisible`); while minimized on the owning thread, the composer voice bar is the visible session surface, so exactly one control surface renders at all times.
- Pop-out and mobile behavior unchanged aside from the minimize affordance.

## Tests

Updated/extended `voice-room.test.tsx`, `live-voice-store.test.ts`, `voice-composer-bar.test.tsx`, new `voice-motion.test.ts`; adjacent suites (`voice-session-pill-host`, `chat-composer`, `use-live-voice*`) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)