### PR TITLE
feat(speech): default to managed mode on Vellum connection + stt_mode/tts_mode settings (B4)

### DIFF
--- a/assistant/src/__tests__/managed-speech-defaults.test.ts
+++ b/assistant/src/__tests__/managed-speech-defaults.test.ts
@@ -25,7 +25,7 @@ mock.module("../calls/telephony-tts-capability.js", () => ({
   ttsSecretResolves: async () => mockTtsSecretResolves,
 }));
 
-import { invalidateConfigCache } from "../config/loader.js";
+import { getConfig, invalidateConfigCache } from "../config/loader.js";
 import { maybeDefaultSpeechToManaged } from "../config/managed-speech-defaults.js";
 
 const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
@@ -70,6 +70,10 @@ describe("maybeDefaultSpeechToManaged", () => {
     const config = readConfig();
     expect((config.services as any)?.stt?.mode).toBe("managed");
     expect((config.services as any)?.tts?.mode).toBe("managed");
+    // Sparse configs must stay schema-valid: SttServiceSchema requires
+    // `provider` whenever the stt object exists.
+    expect((config.services as any)?.stt?.provider).toBeDefined();
+    expect(getConfig().services.stt.mode).toBe("managed");
   });
 
   test("leaves a service alone when its BYOK credential resolves", async () => {
@@ -97,14 +101,20 @@ describe("maybeDefaultSpeechToManaged", () => {
   test("no-ops when services are already managed", async () => {
     mockManagedSpeechAvailable = true;
     writeConfig({
-      services: { stt: { mode: "managed" }, tts: { mode: "managed" } },
+      services: {
+        stt: { mode: "managed", provider: "deepgram" },
+        tts: { mode: "managed" },
+      },
     });
 
     await maybeDefaultSpeechToManaged();
 
     const config = readConfig();
     expect(config).toEqual({
-      services: { stt: { mode: "managed" }, tts: { mode: "managed" } },
+      services: {
+        stt: { mode: "managed", provider: "deepgram" },
+        tts: { mode: "managed" },
+      },
     });
   });
 

--- a/assistant/src/__tests__/managed-speech-defaults.test.ts
+++ b/assistant/src/__tests__/managed-speech-defaults.test.ts
@@ -1,0 +1,128 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as actualTtsCapability from "../calls/telephony-tts-capability.js";
+import * as actualManagedSpeech from "../platform/managed-speech.js";
+import * as actualResolve from "../providers/speech-to-text/resolve.js";
+
+let mockManagedSpeechAvailable = false;
+let mockSttKeyResolves = false;
+let mockTtsSecretResolves = false;
+
+mock.module("../platform/managed-speech.js", () => ({
+  ...actualManagedSpeech,
+  managedSpeechAvailable: async () => mockManagedSpeechAvailable,
+}));
+
+mock.module("../providers/speech-to-text/resolve.js", () => ({
+  ...actualResolve,
+  sttProviderKeyResolves: async () => mockSttKeyResolves,
+}));
+
+mock.module("../calls/telephony-tts-capability.js", () => ({
+  ...actualTtsCapability,
+  ttsSecretResolves: async () => mockTtsSecretResolves,
+}));
+
+import { invalidateConfigCache } from "../config/loader.js";
+import { maybeDefaultSpeechToManaged } from "../config/managed-speech-defaults.js";
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  if (!existsSync(WORKSPACE_DIR)) {
+    mkdirSync(WORKSPACE_DIR, { recursive: true });
+  }
+}
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj));
+  invalidateConfigCache();
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+}
+
+beforeEach(() => {
+  ensureTestDir();
+  writeConfig({});
+  mockManagedSpeechAvailable = false;
+  mockSttKeyResolves = false;
+  mockTtsSecretResolves = false;
+});
+
+describe("maybeDefaultSpeechToManaged", () => {
+  test("no-ops when managed speech is unavailable", async () => {
+    await maybeDefaultSpeechToManaged();
+
+    const config = readConfig();
+    expect(config.services).toBeUndefined();
+  });
+
+  test("defaults both services to managed when no BYOK credentials resolve", async () => {
+    mockManagedSpeechAvailable = true;
+
+    await maybeDefaultSpeechToManaged();
+
+    const config = readConfig();
+    expect((config.services as any)?.stt?.mode).toBe("managed");
+    expect((config.services as any)?.tts?.mode).toBe("managed");
+  });
+
+  test("leaves a service alone when its BYOK credential resolves", async () => {
+    mockManagedSpeechAvailable = true;
+    mockSttKeyResolves = true;
+
+    await maybeDefaultSpeechToManaged();
+
+    const config = readConfig();
+    expect((config.services as any)?.stt?.mode).toBeUndefined();
+    expect((config.services as any)?.tts?.mode).toBe("managed");
+  });
+
+  test("no-ops when both BYOK credentials resolve", async () => {
+    mockManagedSpeechAvailable = true;
+    mockSttKeyResolves = true;
+    mockTtsSecretResolves = true;
+
+    await maybeDefaultSpeechToManaged();
+
+    const config = readConfig();
+    expect(config.services).toBeUndefined();
+  });
+
+  test("no-ops when services are already managed", async () => {
+    mockManagedSpeechAvailable = true;
+    writeConfig({
+      services: { stt: { mode: "managed" }, tts: { mode: "managed" } },
+    });
+
+    await maybeDefaultSpeechToManaged();
+
+    const config = readConfig();
+    expect(config).toEqual({
+      services: { stt: { mode: "managed" }, tts: { mode: "managed" } },
+    });
+  });
+
+  test("never downgrades an explicit your-own mode with resolving credentials", async () => {
+    mockManagedSpeechAvailable = true;
+    mockSttKeyResolves = true;
+    mockTtsSecretResolves = true;
+    writeConfig({
+      services: {
+        stt: { mode: "your-own", provider: "deepgram" },
+        tts: { mode: "your-own", provider: "elevenlabs" },
+      },
+    });
+
+    await maybeDefaultSpeechToManaged();
+
+    const config = readConfig();
+    expect((config.services as any).stt.mode).toBe("your-own");
+    expect((config.services as any).tts.mode).toBe("your-own");
+  });
+});

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -342,7 +342,7 @@ describe("voice_config_update — deepgram", () => {
 // ---------------------------------------------------------------------------
 
 describe("voice_config_update — stt_mode / tts_mode", () => {
-  test("persists stt_mode your-own to services.stt.mode", async () => {
+  test("persists stt_mode your-own to services.stt.mode with a provider", async () => {
     const result = await run(
       { setting: "stt_mode", value: "your-own" },
       makeContext(),
@@ -351,6 +351,26 @@ describe("voice_config_update — stt_mode / tts_mode", () => {
     expect(result.isError).toBe(false);
     const config = readConfig();
     expect((config.services as any)?.stt?.mode).toBe("your-own");
+    // SttServiceSchema requires `provider` whenever the stt object exists —
+    // a mode-only write would invalidate a sparse config.
+    expect((config.services as any)?.stt?.provider).toBeDefined();
+  });
+
+  test("switching stt_mode to your-own replaces a vellum provider", async () => {
+    writeConfig({
+      services: { stt: { mode: "managed", provider: "vellum" } },
+    });
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "stt_mode", value: "your-own" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.services as any)?.stt?.mode).toBe("your-own");
+    expect((config.services as any)?.stt?.provider).toBe("deepgram");
   });
 
   test("persists tts_mode managed when platform connection is available", async () => {

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -356,6 +356,23 @@ describe("voice_config_update — stt_mode / tts_mode", () => {
     expect((config.services as any)?.stt?.provider).toBeDefined();
   });
 
+  test("switching tts_mode to your-own replaces a vellum provider", async () => {
+    writeConfig({
+      services: { tts: { mode: "managed", provider: "vellum" } },
+    });
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "tts_mode", value: "your-own" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.services as any)?.tts?.mode).toBe("your-own");
+    expect((config.services as any)?.tts?.provider).toBe("elevenlabs");
+  });
+
   test("switching stt_mode to your-own replaces a vellum provider", async () => {
     writeConfig({
       services: { stt: { mode: "managed", provider: "vellum" } },

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -1,6 +1,15 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as actualManagedSpeech from "../platform/managed-speech.js";
+
+let mockManagedSpeechAvailable = false;
+
+mock.module("../platform/managed-speech.js", () => ({
+  ...actualManagedSpeech,
+  managedSpeechAvailable: async () => mockManagedSpeechAvailable,
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before imports that depend on platform/logger
@@ -56,6 +65,7 @@ beforeEach(() => {
   ensureTestDir();
   writeConfig({});
   invalidateConfigCache();
+  mockManagedSpeechAvailable = false;
 });
 
 afterEach(() => {
@@ -324,6 +334,73 @@ describe("voice_config_update — deepgram", () => {
     expect(messages[0].type).toBe("client_settings_update");
     expect(messages[0].key).toBe("ttsProvider");
     expect(messages[0].value).toBe("deepgram");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: stt_mode / tts_mode
+// ---------------------------------------------------------------------------
+
+describe("voice_config_update — stt_mode / tts_mode", () => {
+  test("persists stt_mode your-own to services.stt.mode", async () => {
+    const result = await run(
+      { setting: "stt_mode", value: "your-own" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.services as any)?.stt?.mode).toBe("your-own");
+  });
+
+  test("persists tts_mode managed when platform connection is available", async () => {
+    mockManagedSpeechAvailable = true;
+
+    const result = await run(
+      { setting: "tts_mode", value: "managed" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.services as any)?.tts?.mode).toBe("managed");
+  });
+
+  test("rejects managed mode without a platform connection", async () => {
+    mockManagedSpeechAvailable = false;
+
+    const result = await run(
+      { setting: "stt_mode", value: "managed" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("assistant platform connect");
+    const config = readConfig();
+    expect((config.services as any)?.stt?.mode).toBeUndefined();
+  });
+
+  test("rejects invalid mode value", async () => {
+    const result = await run(
+      { setting: "tts_mode", value: "bogus" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("tts_mode must be one of");
+  });
+
+  test("does not broadcast mode changes to the desktop client", async () => {
+    const messages: any[] = [];
+    const ctx = makeContext({
+      sendToClient: (msg: any) => messages.push(msg),
+    });
+
+    const result = await run({ setting: "stt_mode", value: "your-own" }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(messages).toHaveLength(0);
+    expect(result.content).not.toContain("broadcast");
   });
 });
 

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "voice_config_update",
-      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (valid providers: elevenlabs, fish-audio, deepgram, xai — defined by the provider catalog). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Deepgram uses the same API key as speech-to-text and requires no additional voice config. Changes persist to services.tts config and take effect immediately.",
+      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (valid providers: elevenlabs, fish-audio, deepgram, xai — defined by the provider catalog). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Deepgram uses the same API key as speech-to-text and requires no additional voice config. Use stt_mode / tts_mode to switch between \"your-own\" (bring your own provider API key) and \"managed\" (Vellum-managed speech, billed to your organization; requires a Vellum platform connection via 'assistant platform connect'). Changes persist to services.stt / services.tts config and take effect immediately.",
       "category": "system",
       "risk": "low",
       "input_schema": {
@@ -15,13 +15,15 @@
               "activation_key",
               "conversation_timeout",
               "fish_audio_reference_id",
+              "stt_mode",
+              "tts_mode",
               "tts_provider",
               "tts_voice_id"
             ],
-            "description": "The voice setting to change. tts_provider selects the global TTS provider from the provider catalog (valid providers: elevenlabs, fish-audio, deepgram, xai). tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference. Deepgram uses its default model and shares the STT API key."
+            "description": "The voice setting to change. tts_provider selects the global TTS provider from the provider catalog (valid providers: elevenlabs, fish-audio, deepgram, xai). tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference. Deepgram uses its default model and shares the STT API key. stt_mode / tts_mode select \"your-own\" or \"managed\" speech for each service."
           },
           "value": {
-            "description": "The new value for the setting. For tts_provider: one of elevenlabs, fish-audio, deepgram, xai. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
+            "description": "The new value for the setting. For tts_provider: one of elevenlabs, fish-audio, deepgram, xai. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string. For stt_mode / tts_mode: \"your-own\" or \"managed\"."
           }
         }
       },

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -271,6 +271,14 @@ export async function run(
 
   if (setting === "tts_mode") {
     setNestedValue(raw, "services.tts.mode", validation.coerced);
+    // TtsServiceSchema forbids provider "vellum" outside managed mode, so
+    // switching to your-own must also replace a vellum provider.
+    if (
+      validation.coerced === "your-own" &&
+      getConfig().services.tts.provider === "vellum"
+    ) {
+      setNestedValue(raw, "services.tts.provider", "elevenlabs");
+    }
     saveRawConfig(raw);
     invalidateConfigCache();
   }

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -1,4 +1,5 @@
 import { normalizeActivationKey } from "../../../../daemon/handlers/config-voice.js";
+import { managedSpeechAvailable } from "../../../../platform/managed-speech.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -15,24 +16,30 @@ import { VALID_CONVERSATION_TIMEOUTS } from "../../../schemas/elevenlabs.js";
 /**
  * Valid voice config settings and their UserDefaults key mappings.
  *
- * All config paths are canonical (`services.tts.*`).
+ * All config paths are canonical (`services.tts.*` / `services.stt.*`).
+ * Settings without a userDefaultsKey are daemon-config-only and are not
+ * broadcast to the desktop client.
  */
+type VoiceSettingMeta = { userDefaultsKey?: string; type: "string" | "number" };
+
 const VOICE_SETTINGS = {
   activation_key: {
     userDefaultsKey: "pttActivationKey",
-    type: "string" as const,
+    type: "string",
   },
   conversation_timeout: {
     userDefaultsKey: "voiceConversationTimeoutSeconds",
-    type: "number" as const,
+    type: "number",
   },
-  tts_provider: { userDefaultsKey: "ttsProvider", type: "string" as const },
-  tts_voice_id: { userDefaultsKey: "ttsVoiceId", type: "string" as const },
+  tts_provider: { userDefaultsKey: "ttsProvider", type: "string" },
+  tts_voice_id: { userDefaultsKey: "ttsVoiceId", type: "string" },
   fish_audio_reference_id: {
     userDefaultsKey: "fishAudioReferenceId",
-    type: "string" as const,
+    type: "string",
   },
-} as const;
+  stt_mode: { type: "string" },
+  tts_mode: { type: "string" },
+} satisfies Record<string, VoiceSettingMeta>;
 
 type VoiceSettingName = keyof typeof VOICE_SETTINGS;
 
@@ -46,7 +53,11 @@ const FRIENDLY_NAMES: Record<VoiceSettingName, string> = {
   tts_provider: "TTS provider",
   tts_voice_id: "ElevenLabs voice",
   fish_audio_reference_id: "Fish Audio voice",
+  stt_mode: "Speech-to-text mode",
+  tts_mode: "Text-to-speech mode",
 };
+
+const VALID_SPEECH_MODES = ["your-own", "managed"] as const;
 
 function validateSetting(
   setting: string,
@@ -117,6 +128,21 @@ function validateSetting(
       }
       return { ok: true, coerced: value.trim() };
     }
+    case "stt_mode":
+    case "tts_mode": {
+      if (
+        typeof value !== "string" ||
+        !VALID_SPEECH_MODES.includes(
+          value.trim() as (typeof VALID_SPEECH_MODES)[number],
+        )
+      ) {
+        return {
+          ok: false,
+          error: `${setting} must be one of: ${VALID_SPEECH_MODES.join(", ")}`,
+        };
+      }
+      return { ok: true, coerced: value.trim() };
+    }
     case "fish_audio_reference_id": {
       if (typeof value !== "string" || value.trim().length === 0) {
         return {
@@ -159,13 +185,25 @@ export async function run(
     return { content: `Error: ${validation.error}`, isError: true };
   }
 
-  const meta = VOICE_SETTINGS[setting as VoiceSettingName];
+  if (
+    (setting === "stt_mode" || setting === "tts_mode") &&
+    validation.coerced === "managed" &&
+    !(await managedSpeechAvailable())
+  ) {
+    return {
+      content:
+        "Error: managed speech requires a Vellum platform connection. Run 'assistant platform connect' first.",
+      isError: true,
+    };
+  }
+
+  const meta: VoiceSettingMeta = VOICE_SETTINGS[setting as VoiceSettingName];
   const friendlyName = FRIENDLY_NAMES[setting as VoiceSettingName];
 
   // Send client_settings_update message to write to UserDefaults.
   // Always stringify the value — Swift's ClientSettingsUpdate.value is typed
   // as String, so a bare JSON number would fail to decode.
-  if (context.sendToClient) {
+  if (context.sendToClient && meta.userDefaultsKey) {
     context.sendToClient({
       type: "client_settings_update",
       key: meta.userDefaultsKey,
@@ -212,10 +250,25 @@ export async function run(
     invalidateConfigCache();
   }
 
+  if (setting === "stt_mode") {
+    setNestedValue(raw, "services.stt.mode", validation.coerced);
+    saveRawConfig(raw);
+    invalidateConfigCache();
+  }
+
+  if (setting === "tts_mode") {
+    setNestedValue(raw, "services.tts.mode", validation.coerced);
+    saveRawConfig(raw);
+    invalidateConfigCache();
+  }
+
+  const broadcastNote = meta.userDefaultsKey
+    ? " The change has been broadcast to the desktop client."
+    : "";
   return {
     content: `${friendlyName} updated to ${JSON.stringify(
       validation.coerced,
-    )}. The change has been broadcast to the desktop client.`,
+    )}.${broadcastNote}`,
     isError: false,
   };
 }

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../../../tools/types.js";
 import { listCatalogProviderIds } from "../../../../tts/provider-catalog.js";
 import {
+  getConfig,
   invalidateConfigCache,
   loadRawConfig,
   saveRawConfig,
@@ -252,6 +253,18 @@ export async function run(
 
   if (setting === "stt_mode") {
     setNestedValue(raw, "services.stt.mode", validation.coerced);
+    // SttServiceSchema requires `provider` whenever the stt object exists and
+    // forbids provider "vellum" outside managed mode, so writing `mode` alone
+    // (or keeping "vellum" when switching to your-own) would make the saved
+    // config invalid.
+    const currentProvider = getConfig().services.stt.provider;
+    setNestedValue(
+      raw,
+      "services.stt.provider",
+      currentProvider === "vellum" && validation.coerced === "your-own"
+        ? "deepgram"
+        : currentProvider,
+    );
     saveRawConfig(raw);
     invalidateConfigCache();
   }

--- a/assistant/src/config/managed-speech-defaults.ts
+++ b/assistant/src/config/managed-speech-defaults.ts
@@ -1,0 +1,110 @@
+/**
+ * Managed-speech defaulting on Vellum connection.
+ *
+ * When the platform connection completes and a speech service has no working
+ * BYOK credential, default that service to `mode: "managed"` so a fresh
+ * Vellum connection gets voice features with zero configuration. A service
+ * whose BYOK credential is already configured is never modified — connecting
+ * Vellum must not silently reroute an existing voice setup — and a service
+ * already in managed mode is left alone.
+ */
+
+import { ttsSecretResolves } from "../calls/telephony-tts-capability.js";
+import { managedSpeechAvailable } from "../platform/managed-speech.js";
+import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
+import { sttProviderKeyResolves } from "../providers/speech-to-text/resolve.js";
+import type { SttProviderId } from "../stt/types.js";
+import { getCatalogProvider } from "../tts/provider-catalog.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getConfig,
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "./loader.js";
+import { effectiveTtsProvider } from "./schemas/tts.js";
+
+const log = getLogger("managed-speech-defaults");
+
+/** Whether the configured BYOK STT provider has a usable credential. */
+async function sttByokCredentialResolves(provider: string): Promise<boolean> {
+  const entry = getProviderEntry(provider as SttProviderId);
+  if (!entry) {
+    return false;
+  }
+  return sttProviderKeyResolves(entry.credentialProvider);
+}
+
+/** Whether the configured BYOK TTS provider has all its secrets. */
+async function ttsByokCredentialsResolve(provider: string): Promise<boolean> {
+  let entry;
+  try {
+    entry = getCatalogProvider(provider);
+  } catch {
+    return false;
+  }
+  for (const secret of entry.secretRequirements) {
+    if (!(await ttsSecretResolves(secret.credentialStoreKey))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Default unconfigured speech services to managed mode.
+ *
+ * Safe to call repeatedly (idempotent) and safe to fire-and-forget: it
+ * no-ops unless the platform connection is fully usable, and it only ever
+ * flips `mode` from `"your-own"` to `"managed"` for services with no
+ * working BYOK credential.
+ */
+export async function maybeDefaultSpeechToManaged(): Promise<void> {
+  try {
+    if (!(await managedSpeechAvailable())) {
+      return;
+    }
+
+    const services = getConfig().services;
+    const updates: string[] = [];
+
+    if (
+      services.stt.mode !== "managed" &&
+      !(await sttByokCredentialResolves(services.stt.provider))
+    ) {
+      updates.push("services.stt.mode");
+    }
+
+    if (services.tts.mode !== "managed") {
+      const byokProvider = effectiveTtsProvider({
+        mode: "your-own",
+        provider: services.tts.provider,
+      });
+      if (!(await ttsByokCredentialsResolve(byokProvider))) {
+        updates.push("services.tts.mode");
+      }
+    }
+
+    if (updates.length === 0) {
+      return;
+    }
+
+    const raw = loadRawConfig();
+    for (const path of updates) {
+      setNestedValue(raw, path, "managed");
+    }
+    saveRawConfig(raw);
+    invalidateConfigCache();
+    log.info(
+      { defaulted: updates },
+      "Defaulted unconfigured speech services to managed mode after Vellum connection",
+    );
+  } catch (err) {
+    // Convenience defaulting must never break credential storage.
+    log.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      "Managed speech defaulting failed (non-fatal)",
+    );
+  }
+}

--- a/assistant/src/config/managed-speech-defaults.ts
+++ b/assistant/src/config/managed-speech-defaults.ts
@@ -94,6 +94,11 @@ export async function maybeDefaultSpeechToManaged(): Promise<void> {
     for (const path of updates) {
       setNestedValue(raw, path, "managed");
     }
+    // SttServiceSchema requires `provider` whenever the stt object exists, so
+    // a sparse config would become invalid if we wrote `mode` alone.
+    if (updates.includes("services.stt.mode")) {
+      setNestedValue(raw, "services.stt.provider", services.stt.provider);
+    }
     saveRawConfig(raw);
     invalidateConfigCache();
     log.info(

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -323,12 +323,15 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
       }
       if (
         service === "vellum" &&
-        (field === "assistant_api_key" || field === "platform_assistant_id")
+        (field === "assistant_api_key" ||
+          field === "platform_assistant_id" ||
+          field === "platform_base_url")
       ) {
-        // Managed-speech availability needs both the API key and the assistant
-        // ID, and the store order varies — fire on either field; the hook
-        // no-ops until the connection is complete. Detached — must not block
-        // the response.
+        // Managed-speech availability needs the API key, the assistant ID,
+        // and the base URL, and the CLI connect path stores all three
+        // concurrently — fire on each so the last write to land triggers the
+        // defaulting; the hook no-ops until the connection is complete.
+        // Detached — must not block the response.
         void maybeDefaultSpeechToManaged();
       }
       log.info({ service, field }, "Credential added via HTTP");

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -17,6 +17,7 @@ import {
   setPlatformUserId,
 } from "../../config/env.js";
 import { getConfig, invalidateConfigCache } from "../../config/loader.js";
+import { maybeDefaultSpeechToManaged } from "../../config/managed-speech-defaults.js";
 import { getCesClient } from "../../credential-execution/ces-runtime.js";
 import type { CesClient } from "../../credential-execution/client.js";
 import { evictConversationsForReload } from "../../daemon/conversation-store.js";
@@ -319,6 +320,16 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
             }
           }
         }
+      }
+      if (
+        service === "vellum" &&
+        (field === "assistant_api_key" || field === "platform_assistant_id")
+      ) {
+        // Managed-speech availability needs both the API key and the assistant
+        // ID, and the store order varies — fire on either field; the hook
+        // no-ops until the connection is complete. Detached — must not block
+        // the response.
+        void maybeDefaultSpeechToManaged();
       }
       log.info({ service, field }, "Credential added via HTTP");
       return { success: true, type, name };

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -246,4 +246,24 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
       services: { stt: { provider: "deepgram", mode: "your-own" } },
     });
   });
+
+  test("a provider change with no key keeps managed mode", async () => {
+    // Switching the BYOK preference without supplying a credential must not
+    // trade a working managed setup for a credential-less provider.
+    daemonConfigData = {
+      services: { stt: { provider: "deepgram", mode: "managed" } },
+    };
+    renderCard();
+
+    openProviderDropdown();
+    selectOption("OpenAI");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const sttBody = configPatchCalls[0]!.body as {
+      services: { stt: Record<string, unknown> };
+    };
+    expect(sttBody.services.stt.mode).toBeUndefined();
+    expect(credentialsSetCalls).toHaveLength(0);
+  });
 });

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -75,10 +75,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { SpeechToTextCard } = await import(
-  "@/domains/settings/ai/speech-to-text-card"
-);
-const { LS_STT_PROVIDER } = await import("@/domains/settings/ai/local-storage-keys");
+const { SpeechToTextCard } =
+  await import("@/domains/settings/ai/speech-to-text-card");
+const { LS_STT_PROVIDER } =
+  await import("@/domains/settings/ai/local-storage-keys");
 
 function renderCard() {
   const queryClient = new QueryClient({
@@ -95,7 +95,9 @@ function openProviderDropdown(): void {
   const trigger = document.querySelector<HTMLButtonElement>(
     'button[role="combobox"][aria-label="STT provider"]',
   );
-  if (!trigger) {throw new Error("expected the STT provider dropdown trigger");}
+  if (!trigger) {
+    throw new Error("expected the STT provider dropdown trigger");
+  }
   fireEvent.click(trigger);
 }
 
@@ -170,7 +172,9 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
     expect(credentialsSetCalls).toHaveLength(1);
-    expect(credentialsSetCalls[0]!.path).toEqual({ assistant_id: ASSISTANT_ID });
+    expect(credentialsSetCalls[0]!.path).toEqual({
+      assistant_id: ASSISTANT_ID,
+    });
     expect(credentialsSetCalls[0]!.body).toMatchObject({
       service: "deepgram",
       field: "api_key",
@@ -220,8 +224,26 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     // The provider is unchanged and the daemon already has one, so no config
     // PATCH must fire (which would re-assert / risk clobbering the provider).
     const sttBody = configPatchCalls[0]?.body as
-      | { services?: { stt?: Record<string, unknown> } }
-      | undefined;
+      { services?: { stt?: Record<string, unknown> } } | undefined;
     expect(sttBody?.services?.stt ?? {}).not.toHaveProperty("provider");
+  });
+
+  test("saving a key switches a managed-mode daemon back to your-own", async () => {
+    // Managed speech was auto-defaulted on connection; saving a BYOK key from
+    // this card is explicit intent to use it, so the mode must flip too —
+    // otherwise the key appears to save but the daemon stays on managed.
+    daemonConfigData = {
+      services: { stt: { provider: "deepgram", mode: "managed" } },
+    };
+    renderCard();
+
+    const keyInput = screen.getByPlaceholderText(/Enter your Deepgram API key/);
+    fireEvent.change(keyInput, { target: { value: "dg-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { stt: { provider: "deepgram", mode: "your-own" } },
+    });
   });
 });

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -189,20 +189,23 @@ export function SpeechToTextCard() {
         // Only PATCH the provider when it truly diverges from the persisted
         // value (or the daemon has none yet); otherwise a re-save with just a
         // new key would silently switch a provider set elsewhere — including
-        // one the dropdown can't represent. Saving from this card is explicit
-        // BYOK intent, so a managed-mode daemon is also switched back to
-        // your-own — otherwise the saved key would appear to take effect while
-        // the daemon kept using managed speech.
+        // one the dropdown can't represent. Saving a key from this card is
+        // explicit BYOK intent, so a managed-mode daemon is also switched
+        // back to your-own — otherwise the saved key would appear to take
+        // effect while the daemon kept using managed speech. Without an
+        // effective key the mode stays managed: flipping would trade a
+        // working managed setup for a credential-less BYOK provider.
+        const escapeManaged = daemonManaged && effectiveKey.length > 0;
         const shouldSetProvider =
           draftProvider !== serverProvider || !daemonHasProvider;
-        if (shouldSetProvider || daemonManaged) {
+        if (shouldSetProvider || escapeManaged) {
           const { response: cfgRes } = await configPatch({
             path: { assistant_id: assistantId },
             body: {
               services: {
                 stt: {
                   provider: daemon.provider,
-                  ...(daemonManaged ? { mode: "your-own" } : {}),
+                  ...(escapeManaged ? { mode: "your-own" } : {}),
                 },
               },
             },

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -6,8 +6,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import {
-    configGetOptions,
-    configGetQueryKey,
+  configGetOptions,
+  configGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { configPatch, credentialsSetPost } from "@/generated/daemon/sdk.gen";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
@@ -19,13 +19,19 @@ import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import {
-    ByoServiceCard,
-    CredentialsGuide,
-    ResetButton,
-    SaveButton,
+  ByoServiceCard,
+  CredentialsGuide,
+  ResetButton,
+  SaveButton,
 } from "@/domains/settings/ai/shared-ui";
-import { LS_STT_API_KEY_PREFIX, LS_STT_PROVIDER } from "@/domains/settings/ai/local-storage-keys";
-import { MACOS_NATIVE_STT_PROVIDER_ID, STT_PROVIDERS } from "@/domains/settings/ai/provider-catalogs";
+import {
+  LS_STT_API_KEY_PREFIX,
+  LS_STT_PROVIDER,
+} from "@/domains/settings/ai/local-storage-keys";
+import {
+  MACOS_NATIVE_STT_PROVIDER_ID,
+  STT_PROVIDERS,
+} from "@/domains/settings/ai/provider-catalogs";
 
 /**
  * How the daemon addresses each card provider: `provider` is the
@@ -76,10 +82,11 @@ export function SpeechToTextCard() {
     staleTime: 30_000,
   });
   // `services.stt` falls under the ConfigGetResponse index signature
-  // (`unknown`), so narrow it explicitly to read the provider.
-  const daemonSttProvider = (
-    daemonConfig?.services?.stt as { provider?: string } | undefined
-  )?.provider;
+  // (`unknown`), so narrow it explicitly to read the provider and mode.
+  const daemonStt = daemonConfig?.services?.stt as
+    { provider?: string; mode?: string } | undefined;
+  const daemonSttProvider = daemonStt?.provider;
+  const daemonManaged = daemonStt?.mode === "managed";
 
   const serverProvider = useMemo(() => {
     const mapped = daemonSttProvider
@@ -87,7 +94,9 @@ export function SpeechToTextCard() {
       : undefined;
     // Keep the dropdown on a representable value even when the daemon uses one
     // the card can't show, so we never coerce or clobber it.
-    if (mapped && providers.some((p) => p.id === mapped)) {return mapped;}
+    if (mapped && providers.some((p) => p.id === mapped)) {
+      return mapped;
+    }
     const stored = getLocalSetting(LS_STT_PROVIDER, defaultProviderId);
     return providers.some((p) => p.id === stored) ? stored : defaultProviderId;
   }, [daemonSttProvider, providers, defaultProviderId]);
@@ -172,23 +181,37 @@ export function SpeechToTextCard() {
             throwOnError: false,
           });
           if (!keyRes?.ok) {
-            throw new Error(`Failed to store API key (HTTP ${keyRes?.status ?? "?"})`);
+            throw new Error(
+              `Failed to store API key (HTTP ${keyRes?.status ?? "?"})`,
+            );
           }
         }
         // Only PATCH the provider when it truly diverges from the persisted
         // value (or the daemon has none yet); otherwise a re-save with just a
         // new key would silently switch a provider set elsewhere — including
-        // one the dropdown can't represent.
+        // one the dropdown can't represent. Saving from this card is explicit
+        // BYOK intent, so a managed-mode daemon is also switched back to
+        // your-own — otherwise the saved key would appear to take effect while
+        // the daemon kept using managed speech.
         const shouldSetProvider =
           draftProvider !== serverProvider || !daemonHasProvider;
-        if (shouldSetProvider) {
+        if (shouldSetProvider || daemonManaged) {
           const { response: cfgRes } = await configPatch({
             path: { assistant_id: assistantId },
-            body: { services: { stt: { provider: daemon.provider } } },
+            body: {
+              services: {
+                stt: {
+                  provider: daemon.provider,
+                  ...(daemonManaged ? { mode: "your-own" } : {}),
+                },
+              },
+            },
             throwOnError: false,
           });
           if (!cfgRes?.ok) {
-            throw new Error(`Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`);
+            throw new Error(
+              `Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`,
+            );
           }
         }
       }
@@ -217,6 +240,7 @@ export function SpeechToTextCard() {
     selectedProvider,
     serverProvider,
     daemonHasProvider,
+    daemonManaged,
     queryClient,
   ]);
 
@@ -231,10 +255,7 @@ export function SpeechToTextCard() {
     : selectedProvider.apiKeyPlaceholder;
 
   return (
-    <ByoServiceCard
-      title="Speech-to-Text"
-      subtitle={selectedProvider.subtitle}
-    >
+    <ByoServiceCard title="Speech-to-Text" subtitle={selectedProvider.subtitle}>
       <div className="space-y-4">
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -67,9 +67,8 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { TextToSpeechCard } = await import(
-  "@/domains/settings/ai/text-to-speech-card"
-);
+const { TextToSpeechCard } =
+  await import("@/domains/settings/ai/text-to-speech-card");
 
 function renderCard() {
   const queryClient = new QueryClient({
@@ -86,12 +85,16 @@ function selectProvider(label: string): void {
   const trigger = document.querySelector<HTMLButtonElement>(
     'button[role="combobox"][aria-label="TTS provider"]',
   );
-  if (!trigger) {throw new Error("expected the TTS provider dropdown trigger");}
+  if (!trigger) {
+    throw new Error("expected the TTS provider dropdown trigger");
+  }
   fireEvent.click(trigger);
   const option = Array.from(
     document.querySelectorAll<HTMLElement>('[role="option"]'),
   ).find((o) => o.textContent?.trim() === label);
-  if (!option) {throw new Error(`expected option "${label}"`);}
+  if (!option) {
+    throw new Error(`expected option "${label}"`);
+  }
   fireEvent.click(option);
 }
 
@@ -122,7 +125,9 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
     expect(credentialsSetCalls).toHaveLength(1);
-    expect(credentialsSetCalls[0]!.path).toEqual({ assistant_id: ASSISTANT_ID });
+    expect(credentialsSetCalls[0]!.path).toEqual({
+      assistant_id: ASSISTANT_ID,
+    });
     expect(credentialsSetCalls[0]!.body).toMatchObject({
       service: "fish-audio",
       field: "api_key",
@@ -153,8 +158,52 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     // The config PATCH (if any) must not carry a `provider` key — re-saving a
     // key must not switch the live provider.
     const ttsBody = configPatchCalls[0]?.body as
-      | { services?: { tts?: Record<string, unknown> } }
-      | undefined;
+      { services?: { tts?: Record<string, unknown> } } | undefined;
     expect(ttsBody?.services?.tts ?? {}).not.toHaveProperty("provider");
+  });
+
+  test("saving a key switches a managed-mode daemon back to your-own", async () => {
+    // Managed speech was auto-defaulted on connection; saving a BYOK key from
+    // this card is explicit intent to use it, so the mode must flip too —
+    // otherwise the key appears to save but the daemon stays on managed.
+    daemonConfigData = {
+      services: { tts: { provider: "fish-audio", mode: "managed" } },
+    };
+    renderCard();
+
+    fireEvent.change(screen.getByPlaceholderText(/Fish Audio API key/), {
+      target: { value: "fish-secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { tts: { provider: "fish-audio", mode: "your-own" } },
+    });
+  });
+
+  test("a managed daemon reporting the reserved vellum provider gets a representable one", async () => {
+    // A managed daemon may report provider "vellum", which the dropdown cannot
+    // show and which is schema-invalid outside managed mode — the PATCH must
+    // carry the card's selected provider instead.
+    daemonConfigData = {
+      services: { tts: { provider: "vellum", mode: "managed" } },
+    };
+    renderCard();
+
+    // The dropdown falls back to the first representable provider
+    // (ElevenLabs, whose key placeholder is "sk_…").
+    fireEvent.change(screen.getByPlaceholderText("sk_…"), {
+      target: { value: "byok-secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const ttsBody = configPatchCalls[0]!.body as {
+      services: { tts: Record<string, unknown> };
+    };
+    expect(ttsBody.services.tts.mode).toBe("your-own");
+    expect(ttsBody.services.tts.provider).toBeDefined();
+    expect(ttsBody.services.tts.provider).not.toBe("vellum");
   });
 });

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -205,5 +205,12 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     expect(ttsBody.services.tts.mode).toBe("your-own");
     expect(ttsBody.services.tts.provider).toBeDefined();
     expect(ttsBody.services.tts.provider).not.toBe("vellum");
+    // The credential must land under the same provider the PATCH activates —
+    // storing it under the reserved id would leave the activated provider
+    // keyless while the save appears successful.
+    expect(credentialsSetCalls).toHaveLength(1);
+    expect((credentialsSetCalls[0]!.body as { service: string }).service).toBe(
+      ttsBody.services.tts.provider as string,
+    );
   });
 });

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -182,6 +182,28 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     });
   });
 
+  test("a voice-ID-only save with no key keeps managed mode", async () => {
+    // Editing a voice preference without supplying a credential must not
+    // trade a working managed setup for a credential-less BYOK provider.
+    daemonConfigData = {
+      services: { tts: { provider: "fish-audio", mode: "managed" } },
+    };
+    renderCard();
+
+    fireEvent.change(screen.getByPlaceholderText("Enter a voice ID"), {
+      target: { value: "voice-456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const ttsBody = configPatchCalls[0]!.body as {
+      services: { tts: Record<string, unknown> };
+    };
+    expect(ttsBody.services.tts.mode).toBeUndefined();
+    expect(ttsBody.services.tts.provider).toBeUndefined();
+    expect(credentialsSetCalls).toHaveLength(0);
+  });
+
   test("a managed daemon reporting the reserved vellum provider gets a representable one", async () => {
     // A managed daemon may report provider "vellum", which the dropdown cannot
     // show and which is schema-invalid outside managed mode — the PATCH must

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -164,17 +164,21 @@ export function TextToSpeechCard() {
       }
       // Only PATCH the provider when it truly diverges from the persisted
       // value (or the daemon has none yet); otherwise a re-save with just a new
-      // key/voice would silently switch a provider set elsewhere. Saving from
-      // this card is explicit BYOK intent, so a managed-mode daemon is also
-      // switched back to your-own — otherwise the saved key would appear to
-      // take effect while the daemon kept using managed speech.
+      // key/voice would silently switch a provider set elsewhere. Saving a key
+      // from this card is explicit BYOK intent, so a managed-mode daemon is
+      // also switched back to your-own — otherwise the key would appear to
+      // take effect while the daemon kept using managed speech. Without an
+      // effective key (e.g. a voice-ID-only save) the mode stays managed:
+      // flipping would trade a working managed setup for a credential-less
+      // BYOK provider.
+      const escapeManaged = daemonManaged && effectiveKey.length > 0;
       const shouldSetProvider =
         draftProvider !== serverProvider || !daemonHasProvider;
       const ttsBody = {
-        ...(shouldSetProvider || daemonManaged
+        ...(shouldSetProvider || escapeManaged
           ? { provider: activeProvider }
           : {}),
-        ...(daemonManaged ? { mode: "your-own" } : {}),
+        ...(escapeManaged ? { mode: "your-own" } : {}),
         ...(voiceField
           ? {
               providers: { [activeProvider]: { [voiceField]: trimmedVoiceId } },

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -4,9 +4,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import {
-    configGetOptions,
-    configGetQueryKey,
-    ttsProvidersGetOptions,
+  configGetOptions,
+  configGetQueryKey,
+  ttsProvidersGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { configPatch, credentialsSetPost } from "@/generated/daemon/sdk.gen";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
@@ -20,12 +20,16 @@ import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import {
-    ByoServiceCard,
-    CredentialsGuide,
-    ResetButton,
-    SaveButton,
+  ByoServiceCard,
+  CredentialsGuide,
+  ResetButton,
+  SaveButton,
 } from "@/domains/settings/ai/shared-ui";
-import { LS_TTS_API_KEY_PREFIX, LS_TTS_PROVIDER, LS_TTS_VOICE_ID_PREFIX } from "@/domains/settings/ai/local-storage-keys";
+import {
+  LS_TTS_API_KEY_PREFIX,
+  LS_TTS_PROVIDER,
+  LS_TTS_VOICE_ID_PREFIX,
+} from "@/domains/settings/ai/local-storage-keys";
 import { TTS_PROVIDERS } from "@/domains/settings/ai/provider-catalogs";
 
 /**
@@ -41,7 +45,8 @@ const TTS_VOICE_CONFIG_FIELD: Record<string, "voiceId" | "referenceId"> = {
 
 export function TextToSpeechCard() {
   const assistantId = useActiveAssistantId();
-  const assistantName = useAssistantIdentityStore.use.name() ?? "your assistant";
+  const assistantName =
+    useAssistantIdentityStore.use.name() ?? "your assistant";
   const isOrgReady = useIsOrgReady();
   const queryClient = useQueryClient();
 
@@ -62,14 +67,16 @@ export function TextToSpeechCard() {
     staleTime: 30_000,
   });
   // `services.tts` falls under the ConfigGetResponse index signature (`unknown`),
-  // so narrow it explicitly to read the provider.
-  const daemonTtsProvider = (
-    daemonConfig?.services?.tts as { provider?: string } | undefined
-  )?.provider;
+  // so narrow it explicitly to read the provider and mode.
+  const daemonTts = daemonConfig?.services?.tts as
+    { provider?: string; mode?: string } | undefined;
+  const daemonTtsProvider = daemonTts?.provider;
+  const daemonManaged = daemonTts?.mode === "managed";
 
   const defaultProviderId = providers[0]?.id ?? "elevenlabs";
   const serverProvider = useMemo(
-    () => daemonTtsProvider ?? getLocalSetting(LS_TTS_PROVIDER, defaultProviderId),
+    () =>
+      daemonTtsProvider ?? getLocalSetting(LS_TTS_PROVIDER, defaultProviderId),
     [daemonTtsProvider, defaultProviderId],
   );
   const daemonHasProvider = !!daemonTtsProvider;
@@ -143,15 +150,27 @@ export function TextToSpeechCard() {
           throwOnError: false,
         });
         if (!keyRes?.ok) {
-          throw new Error(`Failed to store API key (HTTP ${keyRes?.status ?? "?"})`);
+          throw new Error(
+            `Failed to store API key (HTTP ${keyRes?.status ?? "?"})`,
+          );
         }
       }
       // Only PATCH the provider when it truly diverges from the persisted
       // value (or the daemon has none yet); otherwise a re-save with just a new
-      // key/voice would silently switch a provider set elsewhere.
-      const shouldSetProvider = draftProvider !== serverProvider || !daemonHasProvider;
+      // key/voice would silently switch a provider set elsewhere. Saving from
+      // this card is explicit BYOK intent, so a managed-mode daemon is also
+      // switched back to your-own — otherwise the saved key would appear to
+      // take effect while the daemon kept using managed speech. The provider
+      // comes from selectedProvider (always catalog-representable) because a
+      // managed daemon may report the reserved "vellum" provider, which is
+      // invalid outside managed mode.
+      const shouldSetProvider =
+        draftProvider !== serverProvider || !daemonHasProvider;
       const ttsBody = {
         ...(shouldSetProvider ? { provider: draftProvider } : {}),
+        ...(daemonManaged
+          ? { mode: "your-own", provider: selectedProvider.id }
+          : {}),
         ...(voiceField
           ? { providers: { [draftProvider]: { [voiceField]: trimmedVoiceId } } }
           : {}),
@@ -163,7 +182,9 @@ export function TextToSpeechCard() {
           throwOnError: false,
         });
         if (!cfgRes?.ok) {
-          throw new Error(`Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`);
+          throw new Error(
+            `Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`,
+          );
         }
       }
 
@@ -191,6 +212,7 @@ export function TextToSpeechCard() {
     selectedProvider,
     serverProvider,
     daemonHasProvider,
+    daemonManaged,
     queryClient,
   ]);
 
@@ -252,10 +274,7 @@ export function TextToSpeechCard() {
     : selectedProvider.apiKeyPlaceholder;
 
   return (
-    <ByoServiceCard
-      title="Text-to-Speech"
-      subtitle={selectedProvider.subtitle}
-    >
+    <ByoServiceCard title="Text-to-Speech" subtitle={selectedProvider.subtitle}>
       <div className="space-y-4">
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
@@ -303,11 +322,7 @@ export function TextToSpeechCard() {
         <CredentialsGuide guide={selectedProvider.credentialsGuide} />
 
         <div className="flex items-center gap-2">
-          <Button
-            variant="outlined"
-            onClick={handleTest}
-            disabled={testing}
-          >
+          <Button variant="outlined" onClick={handleTest} disabled={testing}>
             {testing ? "Testing…" : "Test"}
           </Button>
           <div className="ml-auto flex items-center gap-2">

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -119,12 +119,19 @@ export function TextToSpeechCard() {
     const trimmedKey = apiKeyText.trim();
     const trimmedVoiceId = voiceIdText.trim();
 
+    // The provider everything is saved under. Matches draftProvider except
+    // when the daemon reports one the dropdown can't represent (e.g. the
+    // reserved managed-mode "vellum" id) — then it is the rendered fallback,
+    // so the credential, local state, and config PATCH all target the same
+    // provider the save activates.
+    const activeProvider = selectedProvider.id;
+
     // Local settings back the client-side voice path; keep them in sync.
-    setLocalSetting(LS_TTS_PROVIDER, draftProvider);
+    setLocalSetting(LS_TTS_PROVIDER, activeProvider);
     if (trimmedKey.length > 0) {
-      setLocalSetting(LS_TTS_API_KEY_PREFIX + draftProvider, trimmedKey);
+      setLocalSetting(LS_TTS_API_KEY_PREFIX + activeProvider, trimmedKey);
     }
-    setLocalSetting(LS_TTS_VOICE_ID_PREFIX + draftProvider, trimmedVoiceId);
+    setLocalSetting(LS_TTS_VOICE_ID_PREFIX + activeProvider, trimmedVoiceId);
 
     // Provision the daemon too: the server-side live-voice session reads the
     // credential store (CES) and `services.tts` config, never localStorage.
@@ -133,8 +140,8 @@ export function TextToSpeechCard() {
     const effectiveKey =
       trimmedKey.length > 0
         ? trimmedKey
-        : getLocalSetting(LS_TTS_API_KEY_PREFIX + draftProvider, "");
-    const voiceField = TTS_VOICE_CONFIG_FIELD[draftProvider];
+        : getLocalSetting(LS_TTS_API_KEY_PREFIX + activeProvider, "");
+    const voiceField = TTS_VOICE_CONFIG_FIELD[activeProvider];
 
     setSaving(true);
     try {
@@ -142,7 +149,7 @@ export function TextToSpeechCard() {
         const { response: keyRes } = await credentialsSetPost({
           path: { assistant_id: assistantId },
           body: {
-            service: draftProvider,
+            service: activeProvider,
             field: "api_key",
             value: effectiveKey,
             label: `${selectedProvider.displayName} API Key`,
@@ -160,19 +167,18 @@ export function TextToSpeechCard() {
       // key/voice would silently switch a provider set elsewhere. Saving from
       // this card is explicit BYOK intent, so a managed-mode daemon is also
       // switched back to your-own — otherwise the saved key would appear to
-      // take effect while the daemon kept using managed speech. The provider
-      // comes from selectedProvider (always catalog-representable) because a
-      // managed daemon may report the reserved "vellum" provider, which is
-      // invalid outside managed mode.
+      // take effect while the daemon kept using managed speech.
       const shouldSetProvider =
         draftProvider !== serverProvider || !daemonHasProvider;
       const ttsBody = {
-        ...(shouldSetProvider ? { provider: draftProvider } : {}),
-        ...(daemonManaged
-          ? { mode: "your-own", provider: selectedProvider.id }
+        ...(shouldSetProvider || daemonManaged
+          ? { provider: activeProvider }
           : {}),
+        ...(daemonManaged ? { mode: "your-own" } : {}),
         ...(voiceField
-          ? { providers: { [draftProvider]: { [voiceField]: trimmedVoiceId } } }
+          ? {
+              providers: { [activeProvider]: { [voiceField]: trimmedVoiceId } },
+            }
           : {}),
       };
       if (Object.keys(ttsBody).length > 0) {


### PR DESCRIPTION
Final PR of the managed-speech batch plan (B4 of B1–B4; B1 #37841, B2 #37845, B3 #37857 merged).

## What

**Managed-mode defaulting on connection** — `maybeDefaultSpeechToManaged()` (new `assistant/src/config/managed-speech-defaults.ts`): when the Vellum platform connection completes, any speech service with no working BYOK credential is flipped to `mode: "managed"` so a fresh connection gets voice features with zero configuration.

Guarantees:
- A service whose BYOK credential resolves is **never** modified — connecting Vellum must not silently reroute an existing voice setup.
- Never downgrades `managed` → `your-own`.
- No-ops entirely unless `managedSpeechAvailable()` (API key + assistant ID both provisioned).
- Idempotent and fire-and-forget; failures are logged, never surfaced to the credential-store request.

Wired into `secret-routes.ts` on both the `vellum:assistant_api_key` and `vellum:platform_assistant_id` stores — availability needs both fields and store order varies, so the hook fires on either and no-ops until the connection is complete (same detached pattern as the existing capability reseed).

**Settings UX** — `voice_config_update` tool gains `stt_mode` / `tts_mode` settings (`"your-own" | "managed"`), persisting to `services.stt.mode` / `services.tts.mode`. Setting `managed` without a platform connection is rejected with an actionable error (`run 'assistant platform connect'`). Mode settings are daemon-config-only: no `client_settings_update` broadcast and the success message drops the desktop-client note. TOOLS.json manifest updated to match.

## Tests
- `managed-speech-defaults.test.ts` — all defaulting quadrants: unavailable no-op, both-default, resolve-one-leave-it, both-resolve no-op, already-managed no-op, never-downgrade.
- `voice-config-update.test.ts` — mode round-trip to canonical config paths, connection-gated `managed` rejection, invalid-value rejection, no client broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->