### PR TITLE
feat(voice): mic mute, turn-scoped stop-response, working send-now, leaner first-run card

### DIFF
--- a/clients/web/src/components/avatar/chat-avatar.tsx
+++ b/clients/web/src/components/avatar/chat-avatar.tsx
@@ -13,6 +13,13 @@ export interface ChatAvatarProps {
   className?: string;
   interactive?: boolean;
   isAssistantBusy?: boolean;
+  /**
+   * Stamp `data-voice-origin` on the avatar's root so the live-voice room can
+   * find this on-screen avatar and grow its entrance from here. Set on the
+   * assistant avatar the user sees before starting voice (the empty-state
+   * greeting, the latest-turn transcript avatar).
+   */
+  originAnchor?: boolean;
 }
 
 /** Ring geometry. Thickness is a fixed 1px hairline; gap scales with size. */
@@ -73,9 +80,12 @@ function ChatAvatarComponent({
   className,
   interactive = false,
   isAssistantBusy = false,
+  originAnchor = false,
 }: ChatAvatarProps) {
   const reduce = useReducedMotion();
   const [isPoking, setIsPoking] = useState(false);
+  // Spread onto whichever root renders, so the room can locate this avatar.
+  const anchorProps = originAnchor ? { "data-voice-origin": "" } : {};
 
   const triggerBounce = useCallback(() => {
     // Sound is independent of motion preference, so it plays before the
@@ -122,6 +132,7 @@ function ChatAvatarComponent({
   if (preferCharacter) {
     return (
       <motion.div
+        {...anchorProps}
         className={className}
         style={wrapperStyle}
         onClick={handleClick}
@@ -142,6 +153,7 @@ function ChatAvatarComponent({
   if (customImageUrl) {
     return (
       <motion.div
+        {...anchorProps}
         onClick={handleClick}
         initial={initial}
         animate={animate}
@@ -170,6 +182,7 @@ function ChatAvatarComponent({
 
   return (
     <motion.div
+      {...anchorProps}
       className={`flex items-center justify-center rounded-full bg-[var(--primary-base)] text-[var(--content-inset)] ${className ?? ""}`}
       style={{ ...wrapperStyle, fontSize: size * 0.45 }}
       onClick={handleClick}

--- a/clients/web/src/components/avatar/eye-bbox.ts
+++ b/clients/web/src/components/avatar/eye-bbox.ts
@@ -1,9 +1,8 @@
 /**
- * Bounding-box helpers for the onboarding eye art.
+ * Bounding-box helpers for avatar eye art.
  *
- * SPIKE — research-onboarding flow.
- *
- * The peeking/motion eye components size and frame the chosen avatar's eye art
+ * The peeking/motion eye components (onboarding's bottom eyes, the voice
+ * room's eyes) size and frame an avatar's eye art
  * from the union bounding box of its SVG paths. This parser walks the path
  * command-by-command, tracking the current point, so single-coordinate commands
  * — `H`/`V` (horizontal/vertical lineto) — update one axis while every other

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -327,11 +327,9 @@ export function ChatLayout() {
     consumeSidebarCollapse();
   }, [sidebarCollapseRequested, consumeSidebarCollapse]);
 
-  // Voice-room visibility. On desktop the room is a content-scoped overlay
-  // (mounted inside `<main>` below) that deliberately leaves the sidebar and
-  // header interactive, so the user can keep navigating mid-session — any
-  // navigation away hands the session off to the title-bar pill. Only the
-  // mobile mount is a full-viewport takeover.
+  // Voice-room visibility. The room is a full-viewport takeover on every
+  // platform (mounted at layout scope below): it covers the header and
+  // sidebar, and ending the session is the only way out of it.
   const voiceRoomVisible = useIsVoiceRoomVisible();
 
   const drawerVisible = isMobile && drawerOpen;
@@ -730,15 +728,12 @@ export function ChatLayout() {
     />
   );
 
-  // Blur + freeze the chat body under the MOBILE voice room, which is a
-  // full-viewport takeover. The room is an opaque overlay, so this mainly
-  // matters for the fade transition and to stop stray interaction with the
-  // covered chat. Desktop must NOT get this: its room renders inside `<main>`
-  // itself, so blurring/freezing main would blur and freeze the room too.
-  const mainRoomClass =
-    voiceRoomVisible && isMobile
-      ? "pointer-events-none blur-sm opacity-40 transition-[filter,opacity]"
-      : "";
+  // Blur + freeze the chat body under the voice room, a full-viewport
+  // takeover. The room is an opaque overlay, so this mainly matters for the
+  // fade transition and to stop stray interaction with the covered chat.
+  const mainRoomClass = voiceRoomVisible
+    ? "pointer-events-none blur-sm opacity-40 transition-[filter,opacity]"
+    : "";
 
   return (
     <>
@@ -859,13 +854,10 @@ export function ChatLayout() {
               onWidthChange: handleSidebarWidthChange,
             })}
           </aside>
-          <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">
+          <main
+            className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
+          >
             <Outlet />
-            {/* Desktop voice room — content-scoped (`absolute inset-0` within
-                this `<main>`), so the header and sidebar stay visible and
-                interactive during a session. Self-gates on
-                `useIsVoiceRoomVisible()`. */}
-            <VoiceRoom variant="content" />
           </main>
         </div>
       )}
@@ -876,12 +868,11 @@ export function ChatLayout() {
           overlay; it never remounts the chat, so a suggestion click's
           navigate + `?prompt=` auto-send isn't raced by a remount. */}
       {isFocused ? <ResearchResultsOverlay /> : null}
-      {/* Mobile live-voice room — a full-viewport takeover mounted at layout
-          scope, next to the other full-viewport overlays (the desktop mount is
-          content-scoped inside `<main>` above). Self-gates on
-          `useIsVoiceRoomVisible()`; the composer's voice bar and transcript
-          render underneath, hidden by it. */}
-      {isMobile ? <VoiceRoom variant="fullscreen" /> : null}
+      {/* Live-voice room — a full-viewport takeover mounted at layout scope,
+          next to the other full-viewport overlays. Self-gates on
+          `useIsVoiceRoomVisible()` (which excludes pop-outs); the composer's
+          voice bar and transcript render underneath, hidden by it. */}
+      <VoiceRoom />
       {/* First step of the focused flow: the gcal "Let's chat tomorrow" page,
           shown over the streaming research output until connect/skip. Self-gates
           on `checkinPending`; top-level so it can compose the onboarding screen. */}

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -40,6 +40,7 @@ import {
     getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
     releaseLiveVoiceTurn,
+    setLiveVoiceEntryOrigin,
     setLiveVoiceMuted,
     stopLiveVoiceResponse,
     useIsLiveVoiceSessionOwnedBy,
@@ -304,30 +305,41 @@ export function ChatComposer({
   // `voice-mode` flag off this path is unreachable and the app-editing variant
   // (no voice entry point) never renders the card.
   const [firstRunCardOpen, setFirstRunCardOpen] = useState(false);
+  // Where the user tapped to start — captured at click so the room's entrance
+  // grows from the on-screen control, not screen-center. Stashed here because
+  // the first-run card path defers the actual start to its own handler.
+  const liveVoiceEntryOriginRef = useRef<{ x: number; y: number } | null>(null);
   const startLiveVoiceSession = useCallback(() => {
     if (!assistantId) {
       return;
     }
+    // Publish the entry origin BEFORE starting: the starter drives
+    // `setSessionContext`, which deliberately leaves `entryOrigin` intact.
+    setLiveVoiceEntryOrigin(liveVoiceEntryOriginRef.current);
     useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
   }, [assistantId, conversationId]);
-  const handleLiveVoiceStart = useCallback(() => {
-    if (!assistantId) {
-      return;
-    }
-    // First-run preferences card — shown on every platform EXCEPT Capacitor
-    // iOS. On the iOS shell a dismissible pre-prompt before the live-voice
-    // `getUserMedia` permission alert violates `docs/CAPACITOR.md` § OS
-    // permission requests (Apple HIG / App Store Review 5.1.1(iv)) and the
-    // `voice/live-voice/pcm-capture.ts` caller contract, which require any
-    // pre-permission UI to lead directly to the system alert. On iOS we
-    // therefore start directly (same as the returning-user path) so the OS
-    // alert is reached without an intervening dismissible modal.
-    if (!useVoicePrefsStore.getState().firstRunSeen && !isNativeIOS()) {
-      setFirstRunCardOpen(true);
-      return;
-    }
-    startLiveVoiceSession();
-  }, [assistantId, startLiveVoiceSession]);
+  const handleLiveVoiceStart = useCallback(
+    (origin?: { x: number; y: number }) => {
+      if (!assistantId) {
+        return;
+      }
+      liveVoiceEntryOriginRef.current = origin ?? null;
+      // First-run preferences card — shown on every platform EXCEPT Capacitor
+      // iOS. On the iOS shell a dismissible pre-prompt before the live-voice
+      // `getUserMedia` permission alert violates `docs/CAPACITOR.md` § OS
+      // permission requests (Apple HIG / App Store Review 5.1.1(iv)) and the
+      // `voice/live-voice/pcm-capture.ts` caller contract, which require any
+      // pre-permission UI to lead directly to the system alert. On iOS we
+      // therefore start directly (same as the returning-user path) so the OS
+      // alert is reached without an intervening dismissible modal.
+      if (!useVoicePrefsStore.getState().firstRunSeen && !isNativeIOS()) {
+        setFirstRunCardOpen(true);
+        return;
+      }
+      startLiveVoiceSession();
+    },
+    [assistantId, startLiveVoiceSession],
+  );
   const handleFirstRunStart = useCallback(() => {
     useVoicePrefsStore.getState().markFirstRunSeen();
     setFirstRunCardOpen(false);

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -41,6 +41,8 @@ import {
     getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
     releaseLiveVoiceTurn,
+    setLiveVoiceMuted,
+    stopLiveVoiceResponse,
     useIsLiveVoiceSessionOwnedBy,
     useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -263,6 +265,11 @@ export function ChatComposer({
   // Whether the user minimized the voice room (Escape / its minimize control)
   // — the case where this bar is the session surface and offers re-expand.
   const liveVoiceRoomMinimized = useLiveVoiceStore.use.roomMinimized();
+  // Mic mute state (controller-published) for the voice bar's toggle.
+  const liveVoiceMuted = useLiveVoiceStore.use.muted();
+  // Hands-free sessions get the turn-scoped ■ stop; a manual (version-skew
+  // fallback) session must not — its interrupt ends the whole session.
+  const liveVoiceHandsFree = useLiveVoiceStore.use.handsFree();
   // Whether the session has any speech transcript to show. A boolean
   // *presence* subscription, not the text itself: zustand only re-renders
   // when the selected value changes identity, so per-delta transcript
@@ -733,8 +740,13 @@ export function ChatComposer({
               <VoiceComposerBar
                 state={liveVoiceState}
                 getAmplitude={getLiveVoiceInputAmplitude}
+                muted={liveVoiceMuted}
+                onToggleMute={() => setLiveVoiceMuted(!liveVoiceMuted)}
                 onEnd={endLiveVoiceSession}
                 onSend={releaseLiveVoiceTurn}
+                // Turn-scoped stop is hands-free-only; a manual session's
+                // interrupt ends the whole session (✕ owns that).
+                onStop={liveVoiceHandsFree ? stopLiveVoiceResponse : undefined}
                 // Expand is offered only while the room is actually minimized
                 // — the one case where this bar is on screen and the room can
                 // be reopened. In pop-outs the room never mounts, so the flag

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -166,6 +166,31 @@ export interface ChatComposerProps {
   onCancelEdit?: () => void;
 }
 
+/**
+ * Viewport-space center of the on-screen assistant avatar the live-voice room
+ * grows its entrance from — the last on-screen `[data-voice-origin]` element
+ * (the greeting avatar on a fresh chat, the latest-turn avatar in a
+ * conversation). `null` when none is visible (falls back to the tapped button,
+ * then screen-center).
+ */
+function measureVoiceOriginAvatar(): { x: number; y: number } | null {
+  if (typeof document === "undefined") return null;
+  let best: DOMRect | null = null;
+  for (const node of document.querySelectorAll("[data-voice-origin]")) {
+    const rect = node.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) continue;
+    const onScreen =
+      rect.bottom > 0 &&
+      rect.top < window.innerHeight &&
+      rect.right > 0 &&
+      rect.left < window.innerWidth;
+    // Keep the last on-screen one in DOM order (the most recent avatar).
+    if (onScreen) best = rect;
+  }
+  if (!best) return null;
+  return { x: best.left + best.width / 2, y: best.top + best.height / 2 };
+}
+
 export function ChatComposer({
   placeholder = "What would you like to do?",
   onSubmit,
@@ -313,9 +338,15 @@ export function ChatComposer({
     if (!assistantId) {
       return;
     }
-    // Publish the entry origin BEFORE starting: the starter drives
-    // `setSessionContext`, which deliberately leaves `entryOrigin` intact.
-    setLiveVoiceEntryOrigin(liveVoiceEntryOriginRef.current);
+    // Grow the room's entrance from the assistant avatar the user sees — the
+    // empty-state greeting avatar, or the latest-turn avatar below the most
+    // recent response (both tagged `data-voice-origin`). Fall back to the
+    // tapped voice button, then to screen-center (null).
+    const origin =
+      measureVoiceOriginAvatar() ?? liveVoiceEntryOriginRef.current;
+    // Publish the origin BEFORE starting; the controller carries it across its
+    // start-time `reset()` (see the live-voice store's `entryOrigin`).
+    setLiveVoiceEntryOrigin(origin);
     useLiveVoiceStore.getState().starter?.(assistantId, conversationId ?? null);
   }, [assistantId, conversationId]);
   const handleLiveVoiceStart = useCallback(

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -37,7 +37,6 @@ import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
     dismissLiveVoiceFailure,
     endLiveVoiceSession,
-    expandLiveVoiceRoom,
     getLiveVoiceInputAmplitude,
     isLiveVoiceSessionActive,
     releaseLiveVoiceTurn,
@@ -262,9 +261,6 @@ export function ChatComposer({
   // global live-voice store but must never swap its row.
   const ownsLiveVoiceSession = useIsLiveVoiceSessionOwnedBy(conversationId);
   const isLiveVoiceActive = showVoiceInput && ownsLiveVoiceSession;
-  // Whether the user minimized the voice room (Escape / its minimize control)
-  // — the case where this bar is the session surface and offers re-expand.
-  const liveVoiceRoomMinimized = useLiveVoiceStore.use.roomMinimized();
   // Mic mute state (controller-published) for the voice bar's toggle.
   const liveVoiceMuted = useLiveVoiceStore.use.muted();
   // Hands-free sessions get the turn-scoped ■ stop; a manual (version-skew
@@ -747,11 +743,6 @@ export function ChatComposer({
                 // Turn-scoped stop is hands-free-only; a manual session's
                 // interrupt ends the whole session (✕ owns that).
                 onStop={liveVoiceHandsFree ? stopLiveVoiceResponse : undefined}
-                // Expand is offered only while the room is actually minimized
-                // — the one case where this bar is on screen and the room can
-                // be reopened. In pop-outs the room never mounts, so the flag
-                // never flips there and no dead control renders.
-                onExpand={liveVoiceRoomMinimized ? expandLiveVoiceRoom : undefined}
               />
             ) : (
               <div className="flex items-center justify-between gap-1 px-2 pb-2">

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -26,7 +26,6 @@ function renderBar(state: LiveVoiceSessionState, overrides?: {
   onEnd?: () => void;
   onSend?: () => void;
   onStop?: () => void;
-  onExpand?: () => void;
 }) {
   return render(
     <VoiceComposerBar
@@ -37,7 +36,6 @@ function renderBar(state: LiveVoiceSessionState, overrides?: {
       onEnd={overrides?.onEnd ?? (() => {})}
       onSend={overrides?.onSend ?? (() => {})}
       onStop={overrides?.onStop}
-      onExpand={overrides?.onExpand}
     />,
   );
 }
@@ -161,20 +159,6 @@ describe("VoiceComposerBar — stop response", () => {
     expect(
       screen.queryByRole("button", { name: "Stop assistant response" }),
     ).toBeNull();
-  });
-});
-
-describe("VoiceComposerBar — expand (reopen the minimized voice room)", () => {
-  test("no expand control without onExpand — the room is not minimized", () => {
-    renderBar("listening");
-    expect(screen.queryByRole("button", { name: "Open voice room" })).toBeNull();
-  });
-
-  test("clicking expand fires onExpand", () => {
-    const onExpand = mock(() => {});
-    renderBar("listening", { onExpand });
-    fireEvent.click(screen.getByRole("button", { name: "Open voice room" }));
-    expect(onExpand).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -21,16 +21,22 @@ afterEach(() => {
 });
 
 function renderBar(state: LiveVoiceSessionState, overrides?: {
+  muted?: boolean;
+  onToggleMute?: () => void;
   onEnd?: () => void;
   onSend?: () => void;
+  onStop?: () => void;
   onExpand?: () => void;
 }) {
   return render(
     <VoiceComposerBar
       state={state}
       getAmplitude={() => 0.5}
+      muted={overrides?.muted ?? false}
+      onToggleMute={overrides?.onToggleMute ?? (() => {})}
       onEnd={overrides?.onEnd ?? (() => {})}
       onSend={overrides?.onSend ?? (() => {})}
+      onStop={overrides?.onStop}
       onExpand={overrides?.onExpand}
     />,
   );
@@ -113,6 +119,48 @@ describe("VoiceComposerBar — callbacks", () => {
     renderBar("thinking", { onSend });
     fireEvent.click(screen.getByRole("button", { name: "Send now" }));
     expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("VoiceComposerBar — mute toggle", () => {
+  test("shows 'Mute microphone' when live and fires onToggleMute", () => {
+    const onToggleMute = mock(() => {});
+    renderBar("listening", { onToggleMute });
+    fireEvent.click(screen.getByRole("button", { name: "Mute microphone" }));
+    expect(onToggleMute).toHaveBeenCalledTimes(1);
+  });
+
+  test("muted: offers unmute and replaces the state label with 'Muted'", () => {
+    renderBar("listening", { muted: true });
+    expect(
+      screen.getByRole("button", { name: "Unmute microphone" }),
+    ).toBeTruthy();
+    expect(screen.getByText("Muted")).toBeTruthy();
+    expect(screen.queryByText("Listening…")).toBeNull();
+  });
+});
+
+describe("VoiceComposerBar — stop response", () => {
+  test("■ renders only while speaking with onStop wired, and fires it", () => {
+    const onStop = mock(() => {});
+    renderBar("speaking", { onStop });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Stop assistant response" }),
+    );
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  test("no ■ outside speaking, or without onStop (manual session)", () => {
+    const { unmount } = renderBar("listening", { onStop: () => {} });
+    expect(
+      screen.queryByRole("button", { name: "Stop assistant response" }),
+    ).toBeNull();
+    unmount();
+
+    renderBar("speaking");
+    expect(
+      screen.queryByRole("button", { name: "Stop assistant response" }),
+    ).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -1,21 +1,22 @@
 /**
  * Voice-session composer bar (Light 53): while a live-voice session is
- * active the composer's action row is replaced by this bar — a small mic
- * glyph and muted state label on the left, the dotted timeline waveform
- * filling the middle, and end (✕) / send-now (↑) controls on the right.
+ * active the composer's action row is replaced by this bar — a mic mute
+ * toggle and muted state label on the left, the dotted timeline waveform
+ * filling the middle, and the session controls on the right: optional
+ * expand (reopen the minimized room), optional ■ stop-response (while the
+ * assistant speaks), end (✕), and send-now (↑).
  *
  * Purely presentational: the composer observes the live-voice store and
- * wires `state`, an amplitude poll function, and the two callbacks. The
- * green ↑ is a manual "send now" (push-to-talk release) and is only
- * meaningful while the session is listening; the red ✕ ends the session
- * and is always available.
+ * wires `state`, an amplitude poll function, and the callbacks. The green ↑
+ * is a manual "send now" (turn release) and is only meaningful while the
+ * session is listening; the red ✕ ends the session and is always available.
  *
  * Layout mirrors the composer's bottom action row (`px-2 pb-2`, regular
  * `h-8` icon buttons) so swapping the rows in during a session causes no
  * layout shift.
  */
 
-import { ArrowUp, Maximize2, Mic, X } from "lucide-react";
+import { ArrowUp, Maximize2, Mic, MicOff, Square, X } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
@@ -30,10 +31,20 @@ export interface VoiceComposerBarProps {
   state: LiveVoiceSessionState;
   /** Polled ~30 Hz by the waveform's draw loop — no re-render per sample. */
   getAmplitude: () => number;
+  /** Whether the mic is muted — drives the left-side mute toggle. */
+  muted: boolean;
+  /** Toggle the mic mute without ending the session. */
+  onToggleMute: () => void;
   /** Red ✕ — end the voice session. */
   onEnd: () => void;
   /** Green ↑ — manually release the current turn (send now). */
   onSend: () => void;
+  /**
+   * ■ — stop the in-flight assistant response without ending the session.
+   * Rendered only while `speaking`; the composer passes it only for
+   * hands-free sessions, where the interrupt is turn-scoped.
+   */
+  onStop?: () => void;
   /**
    * Re-expand the minimized voice room. The composer passes this only while
    * the room is actually minimized — the one case where this bar is visible
@@ -46,8 +57,11 @@ export interface VoiceComposerBarProps {
 export function VoiceComposerBar({
   state,
   getAmplitude,
+  muted,
+  onToggleMute,
   onEnd,
   onSend,
+  onStop,
   onExpand,
 }: VoiceComposerBarProps) {
   return (
@@ -56,18 +70,31 @@ export function VoiceComposerBar({
       aria-label="Voice session"
       className="flex items-center gap-3 px-2 pb-2"
     >
-      {/* pl-2 lines the mic up with the textarea's px-4 text inset. */}
-      <div className="flex shrink-0 items-center gap-2 pl-2">
-        <Mic
-          aria-hidden
-          className="h-4 w-4 text-[var(--content-secondary)]"
+      {/* pl-1 keeps the toggle roughly on the textarea's px-4 text inset. */}
+      <div className="flex shrink-0 items-center gap-2 pl-1">
+        <Button
+          variant="ghost"
+          iconOnly={
+            muted ? (
+              <MicOff className="h-4 w-4" />
+            ) : (
+              <Mic className="h-4 w-4" />
+            )
+          }
+          onClick={onToggleMute}
+          aria-label={muted ? "Unmute microphone" : "Mute microphone"}
+          aria-pressed={muted}
+          tooltip={muted ? "Unmute microphone" : "Mute microphone"}
+          className={
+            muted ? "[--vbtn-fg:var(--system-negative-strong)]" : undefined
+          }
         />
         {/* Muted placeholder styling — matches the textarea's placeholder. */}
         <span
           aria-live="polite"
           className="text-chat text-[var(--content-disabled)]"
         >
-          {LIVE_VOICE_STATE_LABELS[state]}
+          {muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]}
         </span>
       </div>
       <VoiceTimelineWaveform
@@ -83,6 +110,15 @@ export function VoiceComposerBar({
             onClick={onExpand}
             aria-label="Open voice room"
             tooltip="Open voice room"
+          />
+        ) : null}
+        {onStop && state === "speaking" ? (
+          <Button
+            variant="primary"
+            iconOnly={<Square className="h-3 w-3" fill="currentColor" />}
+            onClick={onStop}
+            aria-label="Stop assistant response"
+            tooltip="Stop assistant response"
           />
         ) : null}
         <Button

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -3,8 +3,7 @@
  * active the composer's action row is replaced by this bar — a mic mute
  * toggle and muted state label on the left, the dotted timeline waveform
  * filling the middle, and the session controls on the right: optional
- * expand (reopen the minimized room), optional ■ stop-response (while the
- * assistant speaks), end (✕), and send-now (↑).
+ * ■ stop-response (while the assistant speaks), end (✕), and send-now (↑).
  *
  * Purely presentational: the composer observes the live-voice store and
  * wires `state`, an amplitude poll function, and the callbacks. The green ↑
@@ -16,7 +15,7 @@
  * layout shift.
  */
 
-import { ArrowUp, Maximize2, Mic, MicOff, Square, X } from "lucide-react";
+import { ArrowUp, Mic, MicOff, Square, X } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
@@ -45,13 +44,6 @@ export interface VoiceComposerBarProps {
    * hands-free sessions, where the interrupt is turn-scoped.
    */
   onStop?: () => void;
-  /**
-   * Re-expand the minimized voice room. The composer passes this only while
-   * the room is actually minimized — the one case where this bar is visible
-   * AND the room could be reopened — so the control never dead-renders (e.g.
-   * in pop-outs, where the room never mounts). Absent → no expand button.
-   */
-  onExpand?: () => void;
 }
 
 export function VoiceComposerBar({
@@ -62,7 +54,6 @@ export function VoiceComposerBar({
   onEnd,
   onSend,
   onStop,
-  onExpand,
 }: VoiceComposerBarProps) {
   return (
     <div
@@ -103,15 +94,6 @@ export function VoiceComposerBar({
         className="min-w-0 flex-1"
       />
       <div className="flex shrink-0 items-center gap-1">
-        {onExpand ? (
-          <Button
-            variant="ghost"
-            iconOnly={<Maximize2 className="h-4 w-4" strokeWidth={2.5} />}
-            onClick={onExpand}
-            aria-label="Open voice room"
-            tooltip="Open voice room"
-          />
-        ) : null}
         {onStop && state === "speaking" ? (
           <Button
             variant="primary"

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -23,8 +23,12 @@ import { Button } from "@vellumai/design-library";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 interface LiveVoiceButtonProps {
-  /** Start a live-voice session (the composer binds assistant + conversation). */
-  onStart: () => void;
+  /**
+   * Start a live-voice session (the composer binds assistant + conversation).
+   * Receives the button's viewport-space center so the room can grow its
+   * entrance from where the user tapped.
+   */
+  onStart: (origin?: { x: number; y: number }) => void;
   /** Disable the control (e.g. while dictation is recording). */
   disabled?: boolean;
 }
@@ -41,7 +45,10 @@ export function LiveVoiceButton({
     <Button
       variant="ghost"
       iconOnly={<AudioLines strokeWidth={2} />}
-      onClick={onStart}
+      onClick={(event) => {
+        const rect = event.currentTarget.getBoundingClientRect();
+        onStart({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+      }}
       disabled={disabled}
       aria-label="Start voice mode"
       title="Start voice mode"

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -51,10 +51,11 @@
  * two error surfaces never double-render. Dismissing the chip resets the
  * store to idle, mirroring the composer Notice's dismiss.
  *
- * The ■ "stop response" control is deliberately not wired: V1's `interrupt()`
- * ends the whole session, contradicting the control's "without ending the
- * session" contract, so the pill offers only ✕ (end) until a turn-scoped
- * interrupt exists (engine plan, JARVIS-1240).
+ * The ■ "stop response" control is wired only for hands-free sessions, where
+ * the client interrupt is turn-scoped (the daemon cancels the turn and
+ * re-arms). A manual session's `interrupt()` ends the whole session,
+ * contradicting the control's "without ending the session" contract, so
+ * there the pill offers only ✕ (end).
  */
 
 import { useCallback } from "react";
@@ -76,6 +77,8 @@ import {
   getLiveVoiceInputAmplitude,
   isLiveVoiceSessionActive,
   releaseLiveVoiceTurn,
+  setLiveVoiceMuted,
+  stopLiveVoiceResponse,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useOwningComposerSurfaceVisible } from "@/domains/chat/voice/voice-room/use-is-voice-room-visible";
@@ -98,6 +101,11 @@ export function VoiceSessionPillHost({
   const error = useLiveVoiceStore.use.error();
   const sessionAssistantId = useLiveVoiceStore.use.assistantId();
   const sessionConversationId = useLiveVoiceStore.use.conversationId();
+  const muted = useLiveVoiceStore.use.muted();
+  // Turn-scoped ■ stop is hands-free-only: a manual (version-skew fallback)
+  // session's interrupt ends the whole session, contradicting the control's
+  // "without ending the session" contract — there the ✕ is the only stop.
+  const handsFree = useLiveVoiceStore.use.handsFree();
 
   const navigate = useNavigate();
 
@@ -144,12 +152,15 @@ export function VoiceSessionPillHost({
   } else if (visible) {
     content = (
       <VoiceSessionPill
-        primaryLabel={LIVE_VOICE_STATE_LABELS[state]}
+        primaryLabel={muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]}
         secondaryLabel={
           owningConversation ? (owningConversation.title ?? "Untitled") : undefined
         }
         state={state}
         getAmplitude={getLiveVoiceInputAmplitude}
+        muted={muted}
+        onToggleMute={() => setLiveVoiceMuted(!muted)}
+        onStop={handsFree ? stopLiveVoiceResponse : undefined}
         onEnd={endLiveVoiceSession}
         onSend={releaseLiveVoiceTurn}
         onNavigate={sessionConversationId ? handleNavigate : undefined}

--- a/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.test.tsx
@@ -25,6 +25,7 @@ afterEach(() => {
 
 function renderPill(overrides: Partial<VoiceSessionPillProps> = {}) {
   const handlers = {
+    onToggleMute: mock(() => {}),
     onStop: mock(() => {}),
     onEnd: mock(() => {}),
     onSend: mock(() => {}),
@@ -36,6 +37,7 @@ function renderPill(overrides: Partial<VoiceSessionPillProps> = {}) {
       secondaryLabel="Thread name here"
       state="listening"
       getAmplitude={() => 0.5}
+      muted={false}
       {...handlers}
       {...overrides}
     />,
@@ -102,11 +104,28 @@ describe("VoiceSessionPill — stop control", () => {
   });
 
   test("hidden even while speaking when onStop is not provided", () => {
-    // Hosts omit onStop while stopping a response would end the whole
-    // session (V1 interrupt); the ✕ stays the only destructive control.
+    // The host omits onStop for manual (version-skew fallback) sessions,
+    // where stopping a response would end the whole session; the ✕ stays
+    // the only destructive control there.
     renderPill({ state: "speaking", onStop: undefined });
     expect(stopButton()).toBeNull();
     expect(endButton()).toBeTruthy();
+  });
+});
+
+describe("VoiceSessionPill — mute toggle", () => {
+  test("live: offers mute and fires onToggleMute", () => {
+    const { onToggleMute } = renderPill();
+    fireEvent.click(screen.getByRole("button", { name: "Mute microphone" }));
+    expect(onToggleMute).toHaveBeenCalledTimes(1);
+  });
+
+  test("muted: offers unmute and freezes the waveform", () => {
+    const { onToggleMute } = renderPill({ muted: true });
+    const toggle = screen.getByRole("button", { name: "Unmute microphone" });
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(toggle);
+    expect(onToggleMute).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/clients/web/src/domains/chat/components/voice-session-pill.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill.tsx
@@ -18,7 +18,7 @@
  * 44px min-height with 32px controls, so the pill must never stretch it.
  */
 
-import { ArrowUp, Mic, Square, TriangleAlert, X } from "lucide-react";
+import { ArrowUp, Mic, MicOff, Square, TriangleAlert, X } from "lucide-react";
 
 import { Button, Tag, Typography, cn } from "@vellumai/design-library";
 
@@ -39,12 +39,16 @@ export interface VoiceSessionPillProps {
   state: LiveVoiceSessionState;
   /** Polled by the waveform at ~30 Hz; must not force parent re-renders. */
   getAmplitude: () => number;
+  /** Whether the mic is muted — drives the mic toggle beside the waveform. */
+  muted: boolean;
+  /** Toggle the mic mute without ending the session. */
+  onToggleMute: () => void;
   /**
    * Stop the in-flight assistant response without ending the session. The
-   * ■ control is hidden when absent — hosts must only wire this once a
-   * turn-scoped interrupt exists; the ✕ (`onEnd`) is the destructive control.
-   * Dormant until the turn-scoped interrupt lands (engine plan, JARVIS-1240):
-   * no host passes it yet, deliberately.
+   * ■ control is hidden when absent — the host wires it only for hands-free
+   * sessions, where the interrupt is turn-scoped; a manual session's
+   * interrupt ends the whole session, so there the ✕ (`onEnd`) is the only
+   * stop.
    */
   onStop?: () => void;
   /** End the voice session. */
@@ -60,6 +64,8 @@ export function VoiceSessionPill({
   secondaryLabel,
   state,
   getAmplitude,
+  muted,
+  onToggleMute,
   onStop,
   onEnd,
   onSend,
@@ -121,10 +127,29 @@ export function VoiceSessionPill({
         />
       ) : null}
       <div className="flex items-center gap-1">
-        <Mic aria-hidden className="size-3.5 shrink-0 text-[var(--content-default)]" />
+        {/* The mic glyph doubles as the mute toggle — the one control a hot
+            open mic must always offer, wherever the session surface is. */}
+        <Button
+          variant="ghost"
+          iconOnly={
+            muted ? (
+              <MicOff className="size-3.5" />
+            ) : (
+              <Mic className="size-3.5" />
+            )
+          }
+          expandOnMobile={false}
+          onClick={onToggleMute}
+          aria-label={muted ? "Unmute microphone" : "Mute microphone"}
+          aria-pressed={muted}
+          tooltip={muted ? "Unmute microphone" : "Mute microphone"}
+          className={
+            muted ? "[--vbtn-fg:var(--system-negative-strong)]" : undefined
+          }
+        />
         <VoiceTimelineWaveform
           compact
-          active={isLiveVoiceMicLive(state)}
+          active={isLiveVoiceMicLive(state) && !muted}
           getAmplitude={getAmplitude}
           className="w-24"
         />

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -136,6 +136,9 @@ export function useChatEmptyState({
           size={40}
           interactive
           isAssistantBusy={isAssistantBusy}
+          // The empty-state greeting avatar — the room's entrance grows from
+          // here on a fresh chat.
+          originAnchor
         />
       ) : null,
     greeting: editingApp ? buildEditAppGreeting(editingApp) : emptyStateGreeting,
@@ -182,6 +185,10 @@ export function useChatEmptyState({
               size={56}
               interactive
               isAssistantBusy={isAssistantBusy}
+              // The latest-turn avatar below the most recent assistant
+              // response — the room's entrance grows from here in a
+              // conversation.
+              originAnchor
             />
           )
         : undefined,

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -213,6 +213,7 @@ export function makeControlsSpies() {
     stop: mock(() => {}),
     release: mock(() => {}),
     interrupt: mock(() => {}),
+    setMuted: mock((_muted: boolean) => {}),
   } satisfies LiveVoiceSessionControls;
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -11,13 +11,11 @@ import { makeControlsSpies } from "@/domains/chat/voice/live-voice/live-voice-fa
 import {
   dismissLiveVoiceFailure,
   endLiveVoiceSession,
-  expandLiveVoiceRoom,
   getLiveVoiceInputAmplitude,
   isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
   liveVoiceStateLabel,
-  minimizeLiveVoiceRoom,
   releaseLiveVoiceTurn,
   setLiveVoiceMuted,
   stopLiveVoiceResponse,
@@ -111,31 +109,6 @@ describe("useLiveVoiceStore — reconnecting", () => {
     useLiveVoiceStore.getState().setReconnecting(true);
     useLiveVoiceStore.getState().reset();
     expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
-  });
-});
-
-describe("useLiveVoiceStore — room minimize", () => {
-  test("defaults to expanded", () => {
-    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
-  });
-
-  test("the module-level helpers minimize and re-expand the room", () => {
-    minimizeLiveVoiceRoom();
-    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
-    expandLiveVoiceRoom();
-    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
-  });
-
-  test("reset clears a minimized room", () => {
-    minimizeLiveVoiceRoom();
-    useLiveVoiceStore.getState().reset();
-    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
-  });
-
-  test("setSessionContext re-expands — a fresh session always opens with the room", () => {
-    minimizeLiveVoiceRoom();
-    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
-    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -19,6 +19,8 @@ import {
   liveVoiceStateLabel,
   minimizeLiveVoiceRoom,
   releaseLiveVoiceTurn,
+  setLiveVoiceMuted,
+  stopLiveVoiceResponse,
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -134,6 +136,48 @@ describe("useLiveVoiceStore — room minimize", () => {
     minimizeLiveVoiceRoom();
     useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
     expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
+  });
+});
+
+describe("useLiveVoiceStore — mute + handsFree", () => {
+  test("defaults: mic live, not hands-free", () => {
+    expect(useLiveVoiceStore.getState().muted).toBe(false);
+    expect(useLiveVoiceStore.getState().handsFree).toBe(false);
+  });
+
+  test("setLiveVoiceMuted drives the registered control", () => {
+    const controls = makeControlsSpies();
+    useLiveVoiceStore.getState().setControls(controls);
+    setLiveVoiceMuted(true);
+    expect(controls.setMuted).toHaveBeenCalledWith(true);
+    setLiveVoiceMuted(false);
+    expect(controls.setMuted).toHaveBeenCalledWith(false);
+  });
+
+  test("stopLiveVoiceResponse drives the registered interrupt control", () => {
+    const controls = makeControlsSpies();
+    useLiveVoiceStore.getState().setControls(controls);
+    stopLiveVoiceResponse();
+    expect(controls.interrupt).toHaveBeenCalledTimes(1);
+  });
+
+  test("helpers are no-ops with no registered controls", () => {
+    expect(() => {
+      setLiveVoiceMuted(true);
+      stopLiveVoiceResponse();
+    }).not.toThrow();
+  });
+
+  test("reset clears muted and handsFree; setSessionContext unmutes a fresh session", () => {
+    useLiveVoiceStore.getState().setMuted(true);
+    useLiveVoiceStore.getState().setHandsFree(true);
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().muted).toBe(false);
+    expect(useLiveVoiceStore.getState().handsFree).toBe(false);
+
+    useLiveVoiceStore.getState().setMuted(true);
+    useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+    expect(useLiveVoiceStore.getState().muted).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -221,11 +221,12 @@ export interface LiveVoiceState {
   handsFree: boolean;
   /**
    * Viewport-space center of the control the user tapped to start the session
-   * (the composer's voice button), captured at start. The color room grows its
-   * entrance from here — "the avatar on the screen" the user acted on — instead
-   * of a fixed screen-center point. `null` when a session started without a
-   * captured origin (falls back to center). Cleared on `reset`; NOT cleared by
-   * `setSessionContext`, which the start flow calls after this is set.
+   * (the composer's voice button). The color room grows its entrance from here
+   * — "the avatar on the screen" the user acted on — instead of a fixed
+   * screen-center point. `null` when a session started without a captured
+   * origin (falls back to center). The composer publishes it just before
+   * invoking the `starter`; the controller's `connectSession` carries it across
+   * its start-time `reset()` (like `muted`), so it survives to the room mount.
    */
   entryOrigin: LiveVoiceEntryOrigin | null;
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -145,6 +145,12 @@ export interface LiveVoiceTurnLatency {
   readonly clientHeardLatencyMs: number | null;
 }
 
+/** Viewport-space point (px) the color room's entrance grows from. */
+export interface LiveVoiceEntryOrigin {
+  readonly x: number;
+  readonly y: number;
+}
+
 /**
  * Starts a live-voice session for `assistantId`, attaching `conversationId`
  * when non-null. Registered into the store by the persistently mounted
@@ -214,6 +220,15 @@ export interface LiveVoiceState {
    */
   handsFree: boolean;
   /**
+   * Viewport-space center of the control the user tapped to start the session
+   * (the composer's voice button), captured at start. The color room grows its
+   * entrance from here — "the avatar on the screen" the user acted on — instead
+   * of a fixed screen-center point. `null` when a session started without a
+   * captured origin (falls back to center). Cleared on `reset`; NOT cleared by
+   * `setSessionContext`, which the start flow calls after this is set.
+   */
+  entryOrigin: LiveVoiceEntryOrigin | null;
+  /**
    * Latency measurements for the last turn, `null` until a turn is measured.
    * Debug surface only — per the minimal-treatment note on
    * {@link LIVE_VOICE_STATE_LABELS}, no surface renders this: the controller
@@ -274,6 +289,8 @@ export interface LiveVoiceActions {
   setMuted: (muted: boolean) => void;
   /** Record whether the active session runs hands-free (server-VAD). */
   setHandsFree: (handsFree: boolean) => void;
+  /** Record the entry origin (the tapped control's center) for the entrance. */
+  setEntryOrigin: (origin: LiveVoiceEntryOrigin | null) => void;
   /**
    * Replace the last turn's latency pair wholesale (never patch a member in
    * place) so subscribers of the atomic selector see one consistent object.
@@ -376,6 +393,7 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   inputAmplitude: 0,
   muted: false,
   handsFree: false,
+  entryOrigin: null,
   lastTurnLatency: null,
   outputAmplitudeProvider: null,
   error: null,
@@ -408,6 +426,7 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
   setMuted: (muted) => set({ muted }),
   setHandsFree: (handsFree) => set({ handsFree }),
+  setEntryOrigin: (entryOrigin) => set({ entryOrigin }),
   setLastTurnLatency: (lastTurnLatency) => set({ lastTurnLatency }),
   setOutputAmplitudeProvider: (outputAmplitudeProvider) =>
     set({ outputAmplitudeProvider }),
@@ -480,6 +499,18 @@ export function stopLiveVoiceResponse(): void {
  */
 export function setLiveVoiceMuted(muted: boolean): void {
   useLiveVoiceStore.getState().controls?.setMuted(muted);
+}
+
+/**
+ * Record the viewport-space center of the control that started the session, so
+ * the color room grows its entrance from there. Set by the composer just
+ * before it invokes the session `starter`. Module-level for the same
+ * stable-identity reasons as {@link endLiveVoiceSession}.
+ */
+export function setLiveVoiceEntryOrigin(
+  origin: LiveVoiceEntryOrigin | null,
+): void {
+  useLiveVoiceStore.getState().setEntryOrigin(origin);
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -102,19 +102,28 @@ export interface LiveVoiceSessionControls {
   /** End the voice session (release mic, socket, and audio). */
   stop: () => void;
   /**
-   * Force-end the current user turn — a manual push-to-talk release, identical
-   * to the automatic silence release (the green ↑ "send now" button). No-op
-   * unless the session is `listening`.
+   * Force-end the current user turn — a manual "send now", identical to the
+   * automatic release. In hands-free mode it forces the server VAD's
+   * utterance boundary (`ptt_release` is honored as a manual override); in
+   * manual mode it is the classic push-to-talk release. No-op unless the
+   * session is `listening`.
    */
   release: () => void;
   /**
-   * Stop in-flight assistant playback without the user having to speak. V1
-   * behavior: same path as barge-in interrupt, which ends the session (a later
-   * engine revision makes it turn-scoped). No-op unless the session is
-   * `speaking`. Dormant until the turn-scoped interrupt lands (engine plan,
-   * JARVIS-1240) — deliberately kept registered, but no surface wires it yet.
+   * Stop in-flight assistant playback without the user having to speak.
+   * Hands-free (server-VAD) sessions: turn-scoped — the daemon cancels the
+   * turn and re-arms, and the session returns to `listening`. Manual
+   * sessions keep the V1 barge-in semantics, which end the session. No-op
+   * unless the session is `speaking`.
    */
   interrupt: () => void;
+  /**
+   * Mute (or unmute) the mic without ending the session. While muted the
+   * capture graph keeps running but silence is streamed in place of the
+   * captured PCM (keeps the server VAD / STT stream healthy) and the
+   * published amplitude pins to 0.
+   */
+  setMuted: (muted: boolean) => void;
 }
 
 /**
@@ -199,6 +208,20 @@ export interface LiveVoiceState {
    */
   roomMinimized: boolean;
   /**
+   * True while the user muted the mic (see {@link LiveVoiceSessionControls.setMuted}).
+   * Written by the controller so surfaces render the muted state; cleared on
+   * `reset` and `setSessionContext` — a new session always starts live.
+   */
+  muted: boolean;
+  /**
+   * Whether the active session runs hands-free (server-VAD). Published by the
+   * controller at start and downgraded on the version-skew fallback (an older
+   * daemon that ignores `turnDetection`). Surfaces use it to gate hands-free-
+   * only affordances — e.g. the pill's turn-scoped ■ stop, which in a manual
+   * session would end the whole session.
+   */
+  handsFree: boolean;
+  /**
    * Latency measurements for the last turn, `null` until a turn is measured.
    * Debug surface only — per the minimal-treatment note on
    * {@link LIVE_VOICE_STATE_LABELS}, no surface renders this: the controller
@@ -257,6 +280,10 @@ export interface LiveVoiceActions {
   setInputAmplitude: (amplitude: number) => void;
   /** Minimize (or re-expand) the voice room for the active session. */
   setRoomMinimized: (minimized: boolean) => void;
+  /** Record the muted state published by the controller. */
+  setMuted: (muted: boolean) => void;
+  /** Record whether the active session runs hands-free (server-VAD). */
+  setHandsFree: (handsFree: boolean) => void;
   /**
    * Replace the last turn's latency pair wholesale (never patch a member in
    * place) so subscribers of the atomic selector see one consistent object.
@@ -358,6 +385,8 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   assistantTranscript: "",
   inputAmplitude: 0,
   roomMinimized: false,
+  muted: false,
+  handsFree: false,
   lastTurnLatency: null,
   outputAmplitudeProvider: null,
   error: null,
@@ -370,13 +399,14 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   setState: (state) => set({ state }),
   setReconnecting: (reconnecting) => set({ reconnecting }),
   setSessionContext: (assistantId, conversationId) =>
-    // A fresh session always opens with the room expanded, even if the
-    // controller starts it without an intervening `reset`.
+    // A fresh session always opens with the room expanded and the mic live,
+    // even if the controller starts it without an intervening `reset`.
     set({
       assistantId,
       conversationId,
       startedConversationId: conversationId,
       roomMinimized: false,
+      muted: false,
     }),
   setConversationId: (conversationId) => set({ conversationId }),
   setControls: (controls) => set({ controls }),
@@ -389,6 +419,8 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   clearUserTranscripts: () => set({ partialTranscript: "", finalTranscript: "" }),
   setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
   setRoomMinimized: (roomMinimized) => set({ roomMinimized }),
+  setMuted: (muted) => set({ muted }),
+  setHandsFree: (handsFree) => set({ handsFree }),
   setLastTurnLatency: (lastTurnLatency) => set({ lastTurnLatency }),
   setOutputAmplitudeProvider: (outputAmplitudeProvider) =>
     set({ outputAmplitudeProvider }),
@@ -440,6 +472,27 @@ export function endLiveVoiceSession(): void {
  */
 export function releaseLiveVoiceTurn(): void {
   useLiveVoiceStore.getState().controls?.release();
+}
+
+/**
+ * Stop the in-flight assistant response through the store-registered
+ * controls. Turn-scoped for hands-free sessions (the session returns to
+ * `listening`); ends a manual session (V1 barge-in semantics). No-op unless
+ * the session is `speaking`. See {@link endLiveVoiceSession} for why this is
+ * module-level.
+ */
+export function stopLiveVoiceResponse(): void {
+  useLiveVoiceStore.getState().controls?.interrupt();
+}
+
+/**
+ * Mute or unmute the active session's mic through the store-registered
+ * controls (the controller mirrors the state into `muted`). No-op when no
+ * session exists. See {@link endLiveVoiceSession} for why this is
+ * module-level.
+ */
+export function setLiveVoiceMuted(muted: boolean): void {
+  useLiveVoiceStore.getState().controls?.setMuted(muted);
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -200,14 +200,6 @@ export interface LiveVoiceState {
   /** Smoothed RMS mic amplitude in [0, 1] for UI / barge-in. */
   inputAmplitude: number;
   /**
-   * True while the user has minimized the voice room for the active session
-   * (Escape / the room's minimize control). The room hides but the session —
-   * and the owning composer's voice bar — stay live; expanding from the voice
-   * bar flips this back. Session-scoped: cleared on `reset` and on
-   * `setSessionContext`, so every new session opens with the room expanded.
-   */
-  roomMinimized: boolean;
-  /**
    * True while the user muted the mic (see {@link LiveVoiceSessionControls.setMuted}).
    * Written by the controller so surfaces render the muted state; cleared on
    * `reset` and `setSessionContext` — a new session always starts live.
@@ -278,8 +270,6 @@ export interface LiveVoiceActions {
    */
   clearUserTranscripts: () => void;
   setInputAmplitude: (amplitude: number) => void;
-  /** Minimize (or re-expand) the voice room for the active session. */
-  setRoomMinimized: (minimized: boolean) => void;
   /** Record the muted state published by the controller. */
   setMuted: (muted: boolean) => void;
   /** Record whether the active session runs hands-free (server-VAD). */
@@ -384,7 +374,6 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   finalTranscript: "",
   assistantTranscript: "",
   inputAmplitude: 0,
-  roomMinimized: false,
   muted: false,
   handsFree: false,
   lastTurnLatency: null,
@@ -399,13 +388,12 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   setState: (state) => set({ state }),
   setReconnecting: (reconnecting) => set({ reconnecting }),
   setSessionContext: (assistantId, conversationId) =>
-    // A fresh session always opens with the room expanded and the mic live,
-    // even if the controller starts it without an intervening `reset`.
+    // A fresh session always opens with the mic live, even if the controller
+    // starts it without an intervening `reset`.
     set({
       assistantId,
       conversationId,
       startedConversationId: conversationId,
-      roomMinimized: false,
       muted: false,
     }),
   setConversationId: (conversationId) => set({ conversationId }),
@@ -418,7 +406,6 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   clearAssistantTranscript: () => set({ assistantTranscript: "" }),
   clearUserTranscripts: () => set({ partialTranscript: "", finalTranscript: "" }),
   setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
-  setRoomMinimized: (roomMinimized) => set({ roomMinimized }),
   setMuted: (muted) => set({ muted }),
   setHandsFree: (handsFree) => set({ handsFree }),
   setLastTurnLatency: (lastTurnLatency) => set({ lastTurnLatency }),
@@ -493,20 +480,6 @@ export function stopLiveVoiceResponse(): void {
  */
 export function setLiveVoiceMuted(muted: boolean): void {
   useLiveVoiceStore.getState().controls?.setMuted(muted);
-}
-
-/**
- * Minimize the voice room without ending the session — the room hides and the
- * owning composer's voice bar becomes the session surface. Module-level for
- * the same stable-identity reasons as {@link endLiveVoiceSession}.
- */
-export function minimizeLiveVoiceRoom(): void {
-  useLiveVoiceStore.getState().setRoomMinimized(true);
-}
-
-/** Re-expand a minimized voice room. Counterpart to {@link minimizeLiveVoiceRoom}. */
-export function expandLiveVoiceRoom(): void {
-  useLiveVoiceStore.getState().setRoomMinimized(false);
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -806,6 +806,39 @@ describe("hands-free session controls (send now / stop response / mute)", () => 
     expect(h.view.result.current.state).toBe("speaking");
   });
 
+  test("straggler assistant_text_delta after a client interrupt is dropped until the next turn", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+    driveToSpeaking(h);
+
+    act(() => controls().interrupt());
+    expect(h.view.result.current.state).toBe("listening");
+    // A delta already in transit for the cancelled turn must not append its
+    // text or drag the flushed `listening` back to `thinking`.
+    act(() => {
+      h.client.emit("assistantTextDelta", {
+        type: "assistant_text_delta",
+        seq: 4,
+        text: "cancelled tail",
+      });
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(useLiveVoiceStore.getState().assistantTranscript).not.toContain(
+      "cancelled tail",
+    );
+
+    // The next turn lifts the guard: its deltas apply again.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 5, turnId: "t2" });
+      h.client.emit("assistantTextDelta", {
+        type: "assistant_text_delta",
+        seq: 6,
+        text: "next turn",
+      });
+    });
+    expect(useLiveVoiceStore.getState().assistantTranscript).toBe("next turn");
+  });
+
   test("stop response is a no-op while not speaking", async () => {
     const h = renderController();
     await startListening(h, { handsFree: true });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -686,30 +686,222 @@ describe("hands-free mode", () => {
     expect(h.view.result.current.state).toBe("speaking");
   });
 
-  test("controls.release is a no-op in hands-free (mic forwarding stays on)", async () => {
-    const h = renderController();
-    await startListening(h, { handsFree: true });
-
-    // The "send now" ↑ is manual-only. In hands-free the server VAD owns
-    // utterance boundaries, so release must not fire ptt_release or drop
-    // forwarding — otherwise the session strands (looks live, drops chunks).
-    act(() => {
-      useLiveVoiceStore.getState().controls?.release();
-    });
-    expect(h.client.pttReleaseCount).toBe(0);
-    expect(h.view.result.current.state).toBe("listening");
-
-    // Forwarding is untouched: the next mic chunk still streams to the server.
-    act(() => {
-      h.getCapture().pushChunk(pcmChunk(20));
-    });
-    expect(h.client.sentAudio).toHaveLength(1);
-  });
+  // controls.release in hands-free is covered by the dedicated
+  // "hands-free session controls" suite below: it sends ptt_release (the
+  // daemon honors it as a manual VAD override) while leaving forwarding and
+  // local state untouched.
 });
 
 // ---------------------------------------------------------------------------
 // Version skew: hands-free against an older daemon
 // ---------------------------------------------------------------------------
+
+describe("hands-free session controls (send now / stop response / mute)", () => {
+  function controls() {
+    const c = useLiveVoiceStore.getState().controls;
+    expect(c).not.toBeNull();
+    return c!;
+  }
+
+  /** Drive the session into `speaking` with one thinking + tts frame. */
+  function driveToSpeaking(h: ReturnType<typeof renderController>, turnId = "t1") {
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+  }
+
+  test("release while listening sends ptt_release and leaves forwarding on", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => controls().release());
+    expect(h.client.pttReleaseCount).toBe(1);
+    // The state transition is frame-driven — the daemon's utterance_end owns
+    // it — and forwarding must stay on (the hands-free listening return never
+    // re-enables it, so flipping it off would strand the session).
+    expect(h.view.result.current.state).toBe("listening");
+    act(() => {
+      h.getCapture().pushChunk(pcmChunk(20));
+    });
+    expect(h.client.sentAudio).toHaveLength(1);
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+    });
+    expect(h.view.result.current.state).toBe("transcribing");
+  });
+
+  test("release is a no-op outside listening", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+    driveToSpeaking(h);
+
+    act(() => controls().release());
+    expect(h.client.pttReleaseCount).toBe(0);
+  });
+
+  test("stop response while speaking is turn-scoped: playback flushes, session survives", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+    driveToSpeaking(h);
+
+    act(() => controls().interrupt());
+    expect(h.client.interruptCount).toBe(1);
+    expect(h.player.stopCount).toBeGreaterThan(0);
+    // NOT torn down: same socket, mic still open and streaming.
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.closed).toBe(false);
+    expect(h.getCapture().shutdownCount).toBe(0);
+    act(() => {
+      h.getCapture().pushChunk(pcmChunk(20));
+    });
+    expect(h.client.sentAudio).toHaveLength(1);
+  });
+
+  test("straggler tts_audio after a client interrupt is dropped until the next turn", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+    driveToSpeaking(h);
+    expect(h.player.enqueued).toHaveLength(1);
+
+    act(() => controls().interrupt());
+    // A frame already in transit when the interrupt was sent must not
+    // resurrect playback.
+    act(() => {
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 4,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.player.enqueued).toHaveLength(1);
+    expect(h.view.result.current.state).toBe("listening");
+
+    // The next turn lifts the guard.
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 5, turnId: "t2" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 6,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.player.enqueued).toHaveLength(2);
+    expect(h.view.result.current.state).toBe("speaking");
+  });
+
+  test("stop response is a no-op while not speaking", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => controls().interrupt());
+    expect(h.client.interruptCount).toBe(0);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("mute streams silence of equal length and pins amplitude to 0; unmute restores", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.getCapture().pushAmplitude(0.5);
+    });
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBeCloseTo(0.5);
+
+    act(() => controls().setMuted(true));
+    expect(useLiveVoiceStore.getState().muted).toBe(true);
+    // Muting zeroes the published amplitude immediately and pins later samples.
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0);
+    act(() => {
+      h.getCapture().pushAmplitude(0.7);
+    });
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBe(0);
+
+    // Chunks keep flowing (VAD/STT keepalive) but as silence, same length.
+    const loud = new Int16Array(320).fill(1234).buffer;
+    act(() => {
+      h.getCapture().pushChunk(loud);
+    });
+    expect(h.client.sentAudio).toHaveLength(1);
+    const sent = new Int16Array(h.client.sentAudio[0]!);
+    expect(sent).toHaveLength(320);
+    expect(sent.every((sample) => sample === 0)).toBe(true);
+
+    act(() => controls().setMuted(false));
+    act(() => {
+      h.getCapture().pushChunk(loud);
+      h.getCapture().pushAmplitude(0.4);
+    });
+    expect(new Int16Array(h.client.sentAudio[1]!)[0]).toBe(1234);
+    expect(useLiveVoiceStore.getState().inputAmplitude).toBeCloseTo(0.4);
+  });
+
+  test("muted survives a retryable reconnect — no hot mic after a blip", async () => {
+    const h = renderController({ reconnectBackoffMs: [10] });
+    await startListening(h, { handsFree: true });
+    act(() => controls().setMuted(true));
+
+    await act(async () => {
+      h.client.emit("closed", {
+        code: 1013,
+        reason: "assistant tunnel disconnected",
+      });
+    });
+    await act(async () => {
+      await sleep(40);
+    });
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s2",
+        conversationId: "conv-1",
+        turnDetection: "server_vad",
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(useLiveVoiceStore.getState().muted).toBe(true);
+  });
+
+  test("publishes handsFree to the store, downgraded on the version-skew fallback", async () => {
+    const h = renderController();
+    // Ready echoes manual — an older daemon ignored turnDetection.
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1", {
+        handsFree: true,
+      });
+    });
+    expect(useLiveVoiceStore.getState().handsFree).toBe(true);
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-1",
+        turnDetection: "manual",
+      });
+      await Promise.resolve();
+    });
+    expect(useLiveVoiceStore.getState().handsFree).toBe(false);
+  });
+});
 
 describe("hands-free fallback to manual (older daemon)", () => {
   test("ready without turnDetection re-enables auto-release, amplitude barge-in, and single-turn teardown", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -506,6 +506,10 @@ export function useLiveVoice(
       // below clears the flag, so carry it over (a fresh start() always
       // begins live: attempt 0 ⇒ wasMuted is not re-applied).
       const wasMuted = store.muted;
+      // The entry origin (the tapped control's position, published by the
+      // composer just before start) also lives in the session state the reset
+      // below clears — carry it across so the room's entrance grows from it.
+      const entryOrigin = store.entryOrigin;
       store.reset();
       store.setState("connecting");
       // A retry re-enters here via the backoff timer with `reconnectAttemptRef`
@@ -515,6 +519,7 @@ export function useLiveVoice(
       // to (re)assert true on the reconnect path.
       store.setReconnecting(isReconnect);
       store.setSessionContext(assistantId, conversationId ?? null);
+      store.setEntryOrigin(entryOrigin);
       if (isReconnect && wasMuted) store.setMuted(true);
       store.setHandsFree(startOptions.handsFree === true);
       // Registered here (not on `ready`) so a globally mounted surface can

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -428,33 +428,63 @@ export function useLiveVoice(
   }, [clearReconnectTimer]);
 
   /**
-   * Manual push-to-talk release — same internal path as the automatic silence
-   * release. Guarded to `listening` so a stray click (or the store-registered
-   * control firing late) can't disturb another phase.
+   * Manual turn release ("send now"). Guarded to `listening` so a stray click
+   * (or the store-registered control firing late) can't disturb another phase.
+   *
+   * Hands-free: the daemon honors `ptt_release` as a manual override of the
+   * server VAD — it forces the detector's utterance boundary and runs the
+   * standard release path (see `releaseFromClient` in
+   * `assistant/src/live-voice/live-voice-session.ts`). Send the frame ALONE:
+   * `forwardingAudio` must stay on (the hands-free return to `listening`
+   * never re-enables it — flipping it off strands the session), and the state
+   * transition is frame-driven — the daemon's `utterance_end` moves us to
+   * `transcribing` and stamps client-heard latency.
+   *
+   * Manual mode: the classic push-to-talk release (closes the forwarding
+   * gate; single-utterance semantics).
    */
   const release = useCallback(() => {
     const session = sessionRef.current;
     if (!session) return;
-    // Hands-free sessions have no manual push-to-talk to release: the server
-    // VAD owns utterance boundaries and mic forwarding stays on for the whole
-    // session. A release here would flip `forwardingAudio` off — which the
-    // hands-free `tts_done`/listening return never re-enables — so every later
-    // mic chunk is dropped and the session strands (looks live, accepts no
-    // turns). No-op instead; the "send now" affordance is manual-mode only.
-    if (session.handsFree) return;
     if (useLiveVoiceStore.getState().state !== "listening") return;
+    if (session.handsFree) {
+      session.client.pttRelease();
+      return;
+    }
     releasePushToTalk(session);
   }, []);
 
   /**
-   * Stop in-flight assistant playback — the barge-in interrupt path without
-   * the amplitude gate. `interruptIfSpeaking` itself guards to `speaking`.
+   * Stop in-flight assistant playback. Hands-free: turn-scoped — the daemon
+   * cancels the turn and re-arms the next utterance cycle, so the session
+   * survives and returns to `listening`. Manual mode: the barge-in interrupt
+   * path without the amplitude gate, which ends the session (V1 semantics —
+   * the interrupted manual session is terminal on the runtime).
    */
   const interrupt = useCallback(() => {
     const session = sessionRef.current;
     if (!session) return;
+    if (session.handsFree) {
+      interruptTurnHandsFree(session);
+      return;
+    }
     interruptIfSpeaking(session, teardown);
   }, [teardown]);
+
+  /**
+   * Mute/unmute the mic without ending the session. The capture graph keeps
+   * running; `handleChunk` substitutes silence for captured PCM while muted
+   * (an absent audio stream can starve the server VAD / STT keepalive, silence
+   * cannot) and `handleAmplitude` pins the published amplitude to 0. Store-
+   * backed rather than session-context state so the muted flag survives the
+   * hands-free reconnect gap (where no session context exists) — a user who
+   * muted must never come back from a transient reconnect with a hot mic.
+   */
+  const setMuted = useCallback((muted: boolean) => {
+    const s = useLiveVoiceStore.getState();
+    s.setMuted(muted);
+    if (muted) s.setInputAmplitude(0);
+  }, []);
 
   // The connect flow, shared by the user-facing `start()` and the hands-free
   // reconnect path. `start()` owns the "already active" guard and resets the
@@ -470,7 +500,12 @@ export function useLiveVoice(
       if (sessionRef.current) teardown();
       startGenerationRef.current += 1;
 
+      const isReconnect = reconnectAttemptRef.current > 0;
       const store = useLiveVoiceStore.getState();
+      // A muted user must stay muted across a transient reconnect — the reset
+      // below clears the flag, so carry it over (a fresh start() always
+      // begins live: attempt 0 ⇒ wasMuted is not re-applied).
+      const wasMuted = store.muted;
       store.reset();
       store.setState("connecting");
       // A retry re-enters here via the backoff timer with `reconnectAttemptRef`
@@ -478,12 +513,14 @@ export function useLiveVoice(
       // connect as a reconnect; a fresh `start()` (attempt 0) clears it. The
       // `store.reset()` above already cleared `reconnecting`, so this only needs
       // to (re)assert true on the reconnect path.
-      store.setReconnecting(reconnectAttemptRef.current > 0);
+      store.setReconnecting(isReconnect);
       store.setSessionContext(assistantId, conversationId ?? null);
+      if (isReconnect && wasMuted) store.setMuted(true);
+      store.setHandsFree(startOptions.handsFree === true);
       // Registered here (not on `ready`) so a globally mounted surface can
       // drive the session from the moment it exists; cleared by the store
       // reset in teardown()/stop().
-      store.setControls({ stop: () => void stop(), release, interrupt });
+      store.setControls({ stop: () => void stop(), release, interrupt, setMuted });
 
       const opts = optionsRef.current;
       const client = (opts.createClient ?? (() => new LiveVoiceChannelClient()))();
@@ -544,6 +581,9 @@ export function useLiveVoice(
           // single-turn teardown) so the session works instead of hanging.
           if (session.handsFree && frame.turnDetection !== "server_vad") {
             session.handsFree = false;
+            // Keep surfaces honest: hands-free-only affordances (the pill's
+            // turn-scoped ■ stop) must not render against a manual session.
+            useLiveVoiceStore.getState().setHandsFree(false);
           }
           // A `ready` means the (re)connection succeeded — clear the reconnect
           // budget so a later, unrelated tunnel drop gets its full retry set,
@@ -625,6 +665,10 @@ export function useLiveVoice(
             // server's `thinking` frame (which re-bumps; the guard only
             // checks inequality, so the double bump is harmless).
             session.responseEpoch += 1;
+            // A new turn also lifts the straggler-frame guard set by a
+            // client-initiated interrupt (normally `thinking` clears it, but
+            // this final may be the first frame of the next turn we see).
+            session.interruptSent = false;
           }
           s.setState("thinking");
         }),
@@ -659,6 +703,11 @@ export function useLiveVoice(
         }),
         client.on("ttsAudio", (frame) => {
           if (!live()) return;
+          // Frames already in transit when a client-initiated interrupt
+          // cancelled the turn must not resurrect playback after the local
+          // flush; the guard lifts on the next turn (`thinking` / hands-free
+          // stt-final reset `interruptSent`).
+          if (session.interruptSent) return;
           beginAssistantAudioIfNeeded(session);
           const chunk: TtsAudioChunk = {
             dataBase64: frame.dataBase64,
@@ -772,7 +821,7 @@ export function useLiveVoice(
             // timer re-enters `connectSession`) so the surface shows a
             // reconnect, not a fresh connect. Cleared on `ready`/teardown.
             s.setReconnecting(true);
-            s.setControls({ stop: () => void stop(), release, interrupt });
+            s.setControls({ stop: () => void stop(), release, interrupt, setMuted });
             console.warn(
               `live-voice: transport closed (code ${info.code}); reconnecting ` +
                 `(attempt ${attempt + 1}/${backoff.length})`,
@@ -796,7 +845,7 @@ export function useLiveVoice(
         ...(session.handsFree ? { turnDetection: "server_vad" as const } : {}),
       });
     },
-    [teardown, stop, release, interrupt],
+    [teardown, stop, release, interrupt, setMuted],
   );
 
   // Let the transport `closed` handler re-enter the connect flow for a
@@ -926,7 +975,11 @@ async function finishCaptureStartup(
  */
 function handleChunk(session: SessionContext, buf: ArrayBuffer): void {
   if (!session.captureRunning || !session.forwardingAudio) return;
-  session.client.sendAudio(buf);
+  // Muted: substitute silence rather than skipping the send — an absent audio
+  // stream can starve the server VAD / streaming-STT keepalive, silence
+  // cannot. A fresh ArrayBuffer is zero-filled, and Int16 zeros are silence.
+  const muted = useLiveVoiceStore.getState().muted;
+  session.client.sendAudio(muted ? new ArrayBuffer(buf.byteLength) : buf);
   if (!session.handsFree) {
     updateAutomaticRelease(session, buf);
   }
@@ -947,8 +1000,12 @@ function handleAmplitude(
   teardown: () => void,
 ): void {
   if (!session.captureRunning) return;
-  useLiveVoiceStore.getState().setInputAmplitude(amplitude);
-  if (!session.handsFree && amplitude >= BARGE_IN_AMPLITUDE_THRESHOLD) {
+  // Muted: the server hears silence (see handleChunk), so the UI and the
+  // manual-mode amplitude barge-in must too — a hot-looking waveform (or a
+  // barge-in) from a muted mic would contradict the substituted stream.
+  const muted = useLiveVoiceStore.getState().muted;
+  useLiveVoiceStore.getState().setInputAmplitude(muted ? 0 : amplitude);
+  if (!muted && !session.handsFree && amplitude >= BARGE_IN_AMPLITUDE_THRESHOLD) {
     interruptIfSpeaking(session, teardown);
   }
 }
@@ -999,10 +1056,11 @@ function releasePushToTalk(session: SessionContext): void {
 }
 
 /**
- * Barge-in: stop playback and interrupt the server once per response, then end
- * the session (→ idle). The interrupted session is terminal on the runtime — it
- * won't accept more audio — so we can't keep forwarding on it; the user starts a
- * fresh session to respond. (Seamless reconnect-on-barge-in is a follow-up.)
+ * Barge-in (manual mode): stop playback and interrupt the server once per
+ * response, then end the session (→ idle). The interrupted MANUAL session is
+ * terminal on the runtime — it won't accept more audio — so we can't keep
+ * forwarding on it; the user starts a fresh session to respond. (Seamless
+ * reconnect-on-barge-in is a follow-up.)
  */
 function interruptIfSpeaking(
   session: SessionContext,
@@ -1017,6 +1075,29 @@ function interruptIfSpeaking(
 }
 
 /**
+ * Turn-scoped stop for a hands-free session: cancel the in-flight response
+ * without ending the session. The daemon treats a client `interrupt` in
+ * server-VAD mode as turn-scoped — it cancels the assistant turn and re-arms
+ * the next utterance cycle — so locally we mirror the server-barge-in path:
+ * flush playback and return to `listening` on the same socket. `interruptSent`
+ * doubles as the straggler guard: `tts_audio` frames already in transit are
+ * dropped until the next turn lifts it (see the `ttsAudio` handler).
+ *
+ * Unlike the manual barge-in above this does not require `player.isPlaying`:
+ * `speaking` can hold between chunks with more audio still inbound, and the
+ * cancel must land regardless.
+ */
+function interruptTurnHandsFree(session: SessionContext): void {
+  if (useLiveVoiceStore.getState().state !== "speaking") return;
+  if (session.interruptSent) return;
+  session.interruptSent = true;
+  // The cancelled turn's latency stamp must not pair with a later response.
+  session.turnHeardStampMs = null;
+  session.client.interrupt();
+  flushPlaybackToListening(session);
+}
+
+/**
  * First TTS frame of a response: reset playback flags for the new utterance
  * and resolve the client-heard latency — the end-of-speech stamp → first
  * audio enqueue delta the user actually perceives (network + queueing
@@ -1026,7 +1107,10 @@ function interruptIfSpeaking(
 function beginAssistantAudioIfNeeded(session: SessionContext): void {
   if (session.responseAudioStarted) return;
   session.responseAudioStarted = true;
-  session.interruptSent = false;
+  // `interruptSent` is deliberately NOT reset here: it clears on the next
+  // turn (`thinking` / hands-free stt-final) so it can double as the
+  // straggler-frame guard after a client-initiated interrupt — a reset on
+  // first audio would let the second straggler frame through.
   if (session.turnHeardStampMs === null) return;
   session.clientHeardLatencyMs = performance.now() - session.turnHeardStampMs;
   session.turnHeardStampMs = null;

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -694,6 +694,11 @@ export function useLiveVoice(
         }),
         client.on("assistantTextDelta", (frame) => {
           if (!live() || frame.text.length === 0) return;
+          // Deltas already in transit when a client-initiated interrupt
+          // cancelled the turn must not append the cancelled response's text
+          // or drag the flushed `listening` back to `thinking`; like
+          // `ttsAudio` below, the guard lifts on the next turn.
+          if (session.interruptSent) return;
           const s = useLiveVoiceStore.getState();
           s.appendAssistantTranscript(frame.text);
           const phase = s.state;

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.ts
@@ -3,14 +3,14 @@
  * visible.
  *
  * The room is the owning-composer's voice surface: it shows exactly when a
- * session is active AND the composer currently on screen owns it AND the user
- * has not minimized it AND this is the main window (never a pop-out — see
- * below). Its popout-free core, {@link useOwningComposerSurfaceVisible}, is the
- * precise complement of the title-bar session pill, whose host consumes that
- * primitive's negation (`sessionActive && !owningSurfaceVisible`) so the two
- * surfaces can never both render — or both hide — for an active owned session.
- * (While minimized, the owning composer's voice bar — always rendered under
- * the room — is the visible session surface, so the pill stays hidden.)
+ * session is active AND the composer currently on screen owns it AND this is
+ * the main window (never a pop-out — see below). It is a full-app takeover —
+ * there is no minimize: the room stays up for the whole session and ending the
+ * session (the room's ✕) is the only way out. Its popout-free core,
+ * {@link useOwningComposerSurfaceVisible}, is the precise complement of the
+ * title-bar session pill, whose host consumes that primitive's negation
+ * (`sessionActive && !owningSurfaceVisible`) so the two surfaces can never
+ * both render — or both hide — for an active owned session.
  *
  * The inputs mirror {@link VoiceSessionPillHost} one-for-one:
  * - `composerOnScreen` — shared via {@link useComposerOnScreen}: a conversation
@@ -70,17 +70,9 @@ export function useOwningComposerSurfaceVisible(): boolean {
  * Whether the voice room should render. See the module docstring for the
  * complement contract with the title-bar session pill and the pop-out
  * exclusion.
- *
- * Also ANDs in `!roomMinimized`: minimizing (Escape / the room's minimize
- * control) hides the room while the session stays live. The owning composer's
- * voice bar — which always renders under the room for an owned session — then
- * becomes the visible session surface, so `useOwningComposerSurfaceVisible`
- * (and therefore the pill) deliberately ignores the flag: an owned, on-screen,
- * minimized session is controlled from the voice bar, not the pill.
  */
 export function useIsVoiceRoomVisible(): boolean {
   const owningSurfaceVisible = useOwningComposerSurfaceVisible();
-  const roomMinimized = useLiveVoiceStore.use.roomMinimized();
   const location = useLocation();
   // Capture pop-out mode once at mount: pop-out URLs carry `?popout=1` only on
   // the window's initial load (in-window navigation drops the query), and this
@@ -88,5 +80,5 @@ export function useIsVoiceRoomVisible(): boolean {
   // window's lifetime value — mirroring `ChatLayout`'s own capture.
   const [isPopout] = useState(() => isPopoutWindow(location.search));
 
-  return owningSurfaceVisible && !roomMinimized && !isPopout;
+  return owningSurfaceVisible && !isPopout;
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 // The `.voice-avatar-*` / `.voice-room-*` / `.voice-listening-waves` keyframes
 // are hand-written rules in the app's global stylesheet, not Tailwind utilities
@@ -12,14 +12,22 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import type { CharacterTraits } from "@/types/avatar";
 
+import { toneForBg } from "@/utils/surface-tone";
+
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import {
   VoiceListeningWaves,
   type VoiceWavePalette,
+  type VoiceWavePlacement,
   type VoiceWaveStyle,
 } from "./voice-listening-waves";
 import { VoiceAvatar } from "./voice-avatar";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
+import {
+  VoiceRoomColorLook,
+  resolveVoiceRoomLook,
+  type VoiceEyePlacement,
+} from "./voice-room-eyes";
 
 /**
  * Iteration harness for the live-voice room's avatar + state animations. Scrub
@@ -78,6 +86,12 @@ const VISUALS: VoiceAvatarVisual[] = [
   "responding",
   "reconnecting",
 ];
+
+// Bundled trait ids for the color-look knobs — the same palette the picker
+// draws from, so every avatar the app can render is scrubbable here.
+const COLOR_IDS = BUNDLED_COMPONENTS.colors.map((c) => c.id);
+const EYE_IDS = BUNDLED_COMPONENTS.eyeStyles.map((e) => e.id);
+const BODY_IDS = BUNDLED_COMPONENTS.bodyShapes.map((b) => b.id);
 
 /**
  * A stable `getAmplitude` backed by a ref: a static slider value, or a
@@ -168,18 +182,181 @@ function RoomScene({
   );
 }
 
-const meta: Meta<typeof RoomScene> = {
-  title: "Chat/Voice/VoiceAvatar",
-  component: RoomScene,
-  parameters: { layout: "fullscreen" },
-  args: {
-    amplitude: 0.5,
-    oscillate: true,
-    waveStyle: "fill",
-    palette: "accent",
-    realAvatar: true,
-    size: 200,
+/** Measure a box with a ResizeObserver — the color look sizes against it. */
+function useBoxSize() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => {
+      const r = el.getBoundingClientRect();
+      setSize({ w: r.width, h: r.height });
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return { ref, size };
+}
+
+interface ColorLookSceneProps {
+  visual: VoiceAvatarVisual;
+  amplitude: number;
+  oscillate: boolean;
+  eyePlacement: VoiceEyePlacement;
+  wavePlacement: VoiceWavePlacement;
+  waveStyle: VoiceWaveStyle;
+  wavePalette: VoiceWavePalette;
+  colorId: string;
+  eyeStyle: string;
+  bodyShape: string;
+  /** Bump to remount and replay the entrance animation. */
+  replay: number;
+  minHeight?: number;
+}
+
+/**
+ * The color-with-eyes look for one avatar: the Introduction-step grow entrance
+ * (body springs to fill, color fades in, eyes grow into place), the mic
+ * waveform behind the eyes while `listening`, all in a measured box so the
+ * geometry sizes against the story frame rather than the window. The whole
+ * look remounts (replaying the entrance) whenever `replay` or any trait knob
+ * changes.
+ */
+function ColorLookScene({
+  visual,
+  amplitude,
+  oscillate,
+  eyePlacement,
+  wavePlacement,
+  waveStyle,
+  wavePalette,
+  colorId,
+  eyeStyle,
+  bodyShape,
+  replay,
+  minHeight = 520,
+}: ColorLookSceneProps) {
+  const driveAmplitude = useAmplitudeDriver(amplitude, oscillate);
+  // Only `listening` has a live mic in the real app; silence the driver in the
+  // other states so e.g. `thinking` shows the eyes held steady-low, not bobbing.
+  const getAmplitude = useCallback(
+    () => (visual === "listening" ? driveAmplitude() : 0),
+    [driveAmplitude, visual],
+  );
+  const { ref, size } = useBoxSize();
+  const look = useMemo(
+    () =>
+      resolveVoiceRoomLook(
+        BUNDLED_COMPONENTS,
+        { bodyShape, eyeStyle, color: colorId },
+        null,
+      ),
+    [bodyShape, eyeStyle, colorId],
+  );
+  const tone = look ? toneForBg(look.bgHex) : null;
+  const toneVars = {
+    "--room-fg": tone?.fg ?? "#FFFFFF",
+    "--room-fg-muted": tone?.fgMuted ?? "rgba(255,255,255,0.7)",
+    "--room-wash": tone?.wash ?? "rgba(255,255,255,0.1)",
+    "--room-border": tone?.wash ?? "rgba(255,255,255,0.15)",
+  } as Record<string, string>;
+
+  return (
+    <div
+      ref={ref}
+      data-theme={tone?.isLight ? "light" : "dark"}
+      className="relative overflow-hidden rounded-lg"
+      style={{ minHeight, ...toneVars }}
+    >
+      {look && size.w > 0 ? (
+        <VoiceRoomColorLook
+          // Remount on any trait/replay change so the entrance plays again.
+          key={`${colorId}-${eyeStyle}-${bodyShape}-${eyePlacement}-${replay}`}
+          look={look}
+          visual={visual}
+          getAmplitude={getAmplitude}
+          eyePlacement={eyePlacement}
+          wavePlacement={wavePlacement}
+          waveStyle={waveStyle}
+          wavePalette={wavePalette}
+          viewport={size}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared + color-look controls (the color-with-eyes look is the app default).
+// ---------------------------------------------------------------------------
+
+const sharedArgTypes = {
+  visual: { options: VISUALS, control: { type: "select" as const } },
+  amplitude: {
+    control: { type: "range" as const, min: 0, max: 1, step: 0.01 },
+    description: "Static level (0–1). Ignored while Oscillate is on.",
   },
+  oscillate: { control: { type: "boolean" as const } },
+  waveStyle: {
+    options: ["fill", "line"] satisfies VoiceWaveStyle[],
+    control: { type: "inline-radio" as const },
+    description: "Waveform: filled water vs stroked ribbon.",
+  },
+};
+
+/** Defaults for the color-look stories. */
+const colorArgs = {
+  visual: "listening" as VoiceAvatarVisual,
+  amplitude: 0.5,
+  oscillate: true,
+  waveStyle: "fill" as VoiceWaveStyle,
+  eyePlacement: "center" as VoiceEyePlacement,
+  wavePlacement: "center" as VoiceWavePlacement,
+  wavePalette: "tone" as VoiceWavePalette,
+  colorId: SAMPLE_COLOR_ID,
+  eyeStyle: "grumpy",
+  bodyShape: "blob",
+  replay: 0,
+};
+
+const colorArgTypes = {
+  ...sharedArgTypes,
+  eyePlacement: {
+    options: ["center", "bottom"] satisfies VoiceEyePlacement[],
+    control: { type: "inline-radio" as const },
+    description: "Eyes rest centered, or cut off at the bottom edge.",
+  },
+  wavePlacement: {
+    options: ["center", "bottom"] satisfies VoiceWavePlacement[],
+    control: { type: "inline-radio" as const },
+    description: "Waveform: a centered band, or rising from the floor.",
+  },
+  wavePalette: {
+    options: ["tone", "accent", "aurora"] satisfies VoiceWavePalette[],
+    control: { type: "inline-radio" as const },
+    description: "tone follows the room fg; accent = avatar hue; aurora = cyan→indigo.",
+  },
+  colorId: { options: COLOR_IDS, control: { type: "select" as const } },
+  eyeStyle: { options: EYE_IDS, control: { type: "select" as const } },
+  bodyShape: {
+    options: BODY_IDS,
+    control: { type: "select" as const },
+    description: "Body shape that grows to fill on entrance.",
+  },
+  replay: {
+    control: { type: "range" as const, min: 0, max: 20, step: 1 },
+    description: "Bump to remount and replay the grow-in entrance.",
+  },
+};
+
+const meta: Meta<typeof ColorLookScene> = {
+  title: "Chat/Voice/VoiceAvatar",
+  component: ColorLookScene,
+  parameters: { layout: "fullscreen" },
+  args: colorArgs,
   decorators: [
     (Story) => (
       <QueryClientProvider client={queryClient}>
@@ -189,88 +366,112 @@ const meta: Meta<typeof RoomScene> = {
       </QueryClientProvider>
     ),
   ],
-  argTypes: {
-    visual: { options: VISUALS, control: { type: "select" } },
-    amplitude: {
-      control: { type: "range", min: 0, max: 1, step: 0.01 },
-      description: "Static level (0–1). Ignored while Oscillate is on.",
-    },
-    oscillate: { control: { type: "boolean" } },
-    waveStyle: {
-      options: ["fill", "line"] satisfies VoiceWaveStyle[],
-      control: { type: "inline-radio" },
-      description: "Listening waves: filled water vs stroked ribbon.",
-    },
-    palette: {
-      options: ["aurora", "accent"] satisfies VoiceWavePalette[],
-      control: { type: "inline-radio" },
-      description: "Fixed cyan→indigo vs tinted from the avatar accent.",
-    },
-    realAvatar: {
-      control: { type: "boolean" },
-      description: "Real bundled character vs the “V” fallback.",
-    },
-    size: { control: { type: "range", min: 80, max: 320, step: 4 } },
-  },
+  argTypes: colorArgTypes,
 };
 
 export default meta;
-type Story = StoryObj<typeof RoomScene>;
-
-/** Playground — every knob live. Defaults to the listening state so the waves + wave controls are visible. */
-export const Playground: Story = {
-  args: { visual: "listening" },
-};
+type Story = StoryObj<typeof ColorLookScene>;
+type VoidStory = StoryObj<typeof RoomScene>;
 
 /**
- * The two audio-reactive states side by side (aurora / fill): `listening` reads
- * as energy coming *in* (waves rising toward a still, receptive avatar),
- * `responding` as energy going *out* (the avatar's own outward pulse).
+ * Playground for the room's color-with-eyes look — every knob live. Change any
+ * trait (or bump Replay) to replay the entrance: the body springs to fill, the
+ * color fades in, and the eyes grow into place. In `listening`, the mic
+ * waveform swells in the center and the eyes sink toward the lower rest with
+ * the simulated-speech driver.
  */
-export const ListeningVsResponding: Story = {
+export const Playground: Story = {};
+
+/**
+ * Every session state, all sharing the simulated-speech driver. Wired so far:
+ * `idle` (eyes centered, no waveform) and `listening` (the centered waveform
+ * plus the eyes sinking toward the lower rest with the voice). The remaining
+ * states — `thinking`, `responding`, `reconnecting` — still show the resting
+ * centered eyes; their own treatments are the next thing to design.
+ */
+export const States: Story = {
   render: (args) => (
-    <div className="grid gap-4 sm:grid-cols-2">
-      {(["listening", "responding"] as const).map((visual) => (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {VISUALS.map((visual) => (
         <div key={visual} className="flex flex-col gap-2">
           <span className="text-[13px] font-medium text-white/60">{visual}</span>
-          <RoomScene {...args} visual={visual} size={180} />
+          <ColorLookScene
+            {...args}
+            visual={visual}
+            eyePlacement="center"
+            wavePlacement="center"
+            minHeight={280}
+          />
         </div>
       ))}
     </div>
   ),
 };
 
-/**
- * The four wave treatments to choose between — style (fill / line) × palette
- * (aurora / accent) — all in the listening state, sharing the simulated-speech
- * driver. The `accent` column is tinted from a sample avatar color.
- */
-export const WaveVariants: Story = {
+/** The look across every avatar color, entrance playing in each. */
+export const Colors: Story = {
   render: (args) => (
-    <div className="grid gap-4 sm:grid-cols-2">
-      {(["fill", "line"] as const).flatMap((waveStyle) =>
-        (["aurora", "accent"] as const).map((palette) => (
-          <div key={`${waveStyle}-${palette}`} className="flex flex-col gap-2">
-            <span className="text-[13px] font-medium text-white/60">
-              {waveStyle} · {palette}
-            </span>
-            <RoomScene
-              {...args}
-              visual="listening"
-              waveStyle={waveStyle}
-              palette={palette}
-              size={150}
-              minHeight={300}
-            />
-          </div>
-        )),
-      )}
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {COLOR_IDS.map((colorId) => (
+        <div key={colorId} className="flex flex-col gap-2">
+          <span className="text-[13px] font-medium text-white/60">{colorId}</span>
+          <ColorLookScene {...args} colorId={colorId} minHeight={300} />
+        </div>
+      ))}
     </div>
   ),
 };
 
-/** Every visual side by side, all driven by the same simulated-speech envelope. */
-export const AllStates: Story = {
+// ---------------------------------------------------------------------------
+// Void look — the deep-dark ambient fallback for custom-image / no-character
+// avatars (kept for reference; the color look above is the default).
+// ---------------------------------------------------------------------------
+
+const voidArgs = {
+  visual: "listening" as VoiceAvatarVisual,
+  amplitude: 0.5,
+  oscillate: true,
+  waveStyle: "fill" as VoiceWaveStyle,
+  palette: "accent" as VoiceWavePalette,
+  realAvatar: true,
+  size: 200,
+};
+
+const voidArgTypes = {
+  ...sharedArgTypes,
+  palette: {
+    options: ["aurora", "accent", "tone"] satisfies VoiceWavePalette[],
+    control: { type: "inline-radio" as const },
+    description: "Fixed cyan→indigo, tinted from the avatar accent, or room-fg tone.",
+  },
+  realAvatar: {
+    control: { type: "boolean" as const },
+    description: "Real bundled character vs the “V” fallback.",
+  },
+  size: { control: { type: "range" as const, min: 80, max: 320, step: 4 } },
+  // Color-look-only knobs — irrelevant to the void look.
+  eyePlacement: { table: { disable: true } },
+  wavePlacement: { table: { disable: true } },
+  wavePalette: { table: { disable: true } },
+  colorId: { table: { disable: true } },
+  eyeStyle: { table: { disable: true } },
+  bodyShape: { table: { disable: true } },
+  replay: { table: { disable: true } },
+};
+
+/** Void-look playground — the centered avatar, ambient void, and bottom waves. */
+export const VoidLookPlayground: VoidStory = {
+  name: "Void Look — Playground",
+  render: (args) => <RoomScene {...args} />,
+  args: voidArgs,
+  argTypes: voidArgTypes,
+};
+
+/** Every state in the void look, all driven by the same simulated-speech envelope. */
+export const VoidLookStates: VoidStory = {
+  name: "Void Look — States",
+  args: voidArgs,
+  argTypes: voidArgTypes,
   render: (args) => (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {VISUALS.map((visual) => (

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -27,6 +27,7 @@ import {
   VoiceRoomColorLook,
   resolveVoiceRoomLook,
   type VoiceEyePlacement,
+  type VoiceRespondingStyle,
 } from "./voice-room-eyes";
 
 /**
@@ -209,6 +210,7 @@ interface ColorLookSceneProps {
   wavePlacement: VoiceWavePlacement;
   waveStyle: VoiceWaveStyle;
   wavePalette: VoiceWavePalette;
+  respondingStyle: VoiceRespondingStyle;
   colorId: string;
   eyeStyle: string;
   bodyShape: string;
@@ -233,6 +235,7 @@ function ColorLookScene({
   wavePlacement,
   waveStyle,
   wavePalette,
+  respondingStyle,
   colorId,
   eyeStyle,
   bodyShape,
@@ -240,10 +243,14 @@ function ColorLookScene({
   minHeight = 520,
 }: ColorLookSceneProps) {
   const driveAmplitude = useAmplitudeDriver(amplitude, oscillate);
-  // Only `listening` has a live mic in the real app; silence the driver in the
-  // other states so e.g. `thinking` shows the eyes held steady-low, not bobbing.
+  // Only `listening` (mic) and `responding` (TTS) are audio-reactive in the
+  // real app; silence the driver in the other states so e.g. `thinking` shows
+  // the eyes held steady-low, not bobbing.
   const getAmplitude = useCallback(
-    () => (visual === "listening" ? driveAmplitude() : 0),
+    () =>
+      visual === "listening" || visual === "responding"
+        ? driveAmplitude()
+        : 0,
     [driveAmplitude, visual],
   );
   const { ref, size } = useBoxSize();
@@ -282,6 +289,7 @@ function ColorLookScene({
           wavePlacement={wavePlacement}
           waveStyle={waveStyle}
           wavePalette={wavePalette}
+          respondingStyle={respondingStyle}
           viewport={size}
         />
       ) : null}
@@ -316,6 +324,7 @@ const colorArgs = {
   eyePlacement: "center" as VoiceEyePlacement,
   wavePlacement: "center" as VoiceWavePlacement,
   wavePalette: "tone" as VoiceWavePalette,
+  respondingStyle: "rings" as VoiceRespondingStyle,
   colorId: SAMPLE_COLOR_ID,
   eyeStyle: "grumpy",
   bodyShape: "blob",
@@ -338,6 +347,11 @@ const colorArgTypes = {
     options: ["tone", "accent", "aurora"] satisfies VoiceWavePalette[],
     control: { type: "inline-radio" as const },
     description: "tone follows the room fg; accent = avatar hue; aurora = cyan→indigo.",
+  },
+  respondingStyle: {
+    options: ["rings", "halo", "waveform", "pulse"] satisfies VoiceRespondingStyle[],
+    control: { type: "inline-radio" as const },
+    description: "Responding treatment (visible in the responding state).",
   },
   colorId: { options: COLOR_IDS, control: { type: "select" as const } },
   eyeStyle: { options: EYE_IDS, control: { type: "select" as const } },
@@ -422,6 +436,35 @@ export const Colors: Story = {
   ),
 };
 
+/**
+ * Responding-state sketches, all in the responding state on the same
+ * simulated-TTS driver — the eyes back up at center (engaged), each option a
+ * different way of radiating the assistant's voice outward. Pick one; the rest
+ * come out.
+ */
+export const RespondingSketches: Story = {
+  name: "Responding — Sketches",
+  args: { ...colorArgs, visual: "responding" },
+  argTypes: colorArgTypes,
+  render: (args) => (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {(["rings", "halo", "waveform", "pulse"] as const).map((respondingStyle) => (
+        <div key={respondingStyle} className="flex flex-col gap-2">
+          <span className="text-[13px] font-medium text-white/60">
+            {respondingStyle}
+          </span>
+          <ColorLookScene
+            {...args}
+            visual="responding"
+            respondingStyle={respondingStyle}
+            minHeight={340}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
 // ---------------------------------------------------------------------------
 // Void look — the deep-dark ambient fallback for custom-image / no-character
 // avatars (kept for reference; the color look above is the default).
@@ -453,6 +496,7 @@ const voidArgTypes = {
   eyePlacement: { table: { disable: true } },
   wavePlacement: { table: { disable: true } },
   wavePalette: { table: { disable: true } },
+  respondingStyle: { table: { disable: true } },
   colorId: { table: { disable: true } },
   eyeStyle: { table: { disable: true } },
   bodyShape: { table: { disable: true } },

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -1,14 +1,14 @@
 /**
  * Tests for `VoiceFirstRunCard`.
  *
- * The card is exercised in isolation: `onStart` is a spy, and the real
- * persisted `voice-prefs` store backs the toggles (reset between tests). The
- * assistant-avatar hook is stubbed so the card renders without the React Query
- * graph — the avatar is chrome, not behavior.
+ * The card is exercised in isolation: `onStart` is a spy. The assistant-avatar
+ * hook is stubbed so the card renders without the React Query graph — the
+ * avatar is chrome, not behavior.
  *
  * Load-bearing behavior:
  *   - the card renders on first run and does NOT start on its own,
- *   - the toggles mutate the shared voice-prefs store (both default OFF),
+ *   - it carries no settings quiz — captions/prefs are in-session and in
+ *     Settings, not front-loaded here,
  *   - "Start" invokes the caller's `onStart`; wiring that `onStart` to
  *     `markFirstRunSeen` (as the composer does) consumes the first run so a
  *     second entry would skip the card.
@@ -49,34 +49,26 @@ beforeEach(() => {
 describe("VoiceFirstRunCard", () => {
   test("renders the card and does not start on its own", () => {
     const onStart = mock(() => {});
-    const { getByText, getByLabelText } = render(
+    const { getByText } = render(
       <VoiceFirstRunCard assistantId="asst_test" onStart={onStart} />,
     );
 
-    // Title + both toggles are present, and nothing has started yet.
     expect(getByText("Voice mode")).toBeTruthy();
-    expect(getByLabelText("Show the words you say")).toBeTruthy();
-    expect(getByLabelText("Show the words the assistant says")).toBeTruthy();
     expect(getByText("Start")).toBeTruthy();
     expect(onStart).not.toHaveBeenCalled();
   });
 
-  test("toggles are OFF by default and flip the shared voice-prefs store", () => {
-    const { getByLabelText } = render(
+  test("carries no settings quiz — no transcript toggles, prefs untouched", () => {
+    const { queryByLabelText } = render(
       <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
     );
 
-    // Defaults OFF.
+    // The old toggle pair is gone (captions moved in-session) and the card
+    // never writes the prefs store on its own.
+    expect(queryByLabelText("Show the words you say")).toBeNull();
+    expect(queryByLabelText("Show the words the assistant says")).toBeNull();
     expect(useVoicePrefsStore.getState().showUserTranscript).toBe(false);
     expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(false);
-
-    // Flipping each toggle writes through to the same store the settings
-    // page reads.
-    fireEvent.click(getByLabelText("Show the words you say"));
-    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(true);
-
-    fireEvent.click(getByLabelText("Show the words the assistant says"));
-    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(true);
   });
 
   test("Start invokes onStart", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -2,20 +2,17 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
-import { VoiceTranscriptToggles } from "@/components/voice-transcript-toggles";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
-import { VOICE_TRANSCRIPT_RECOMMENDATION } from "@/utils/voice-transcript-prefs";
 
 /**
- * One-time preferences card shown the first time a user enters voice mode,
- * before the live session starts.
+ * One-time welcome card shown the first time a user enters voice mode, before
+ * the live session starts.
  *
- * The two transcript toggles are bound to the SAME persisted `voice-prefs`
- * store as the Voice settings page (`settings/pages/voice-page.tsx`), so a
- * choice made here is the choice the settings screen shows — the card is just
- * an earlier, in-context surface for the same preferences. Both default OFF;
- * the "Recommended off" badge and the closing note nudge users to try the
- * hands-free, transcript-free experience first, matching the settings copy.
+ * Deliberately NOT a settings quiz (it once carried the two transcript
+ * toggles): captions are toggled in-session from the voice room, and the full
+ * preferences live in Settings → Voice — front-loading choices before the
+ * user has ever experienced voice mode was the wrong moment. The card now
+ * just sets expectations and starts.
  *
  * The card does NOT persist `firstRunSeen` itself: dismissing it (Escape /
  * backdrop / ✕) is a plain cancel and must leave the first run un-consumed so
@@ -74,13 +71,10 @@ export function VoiceFirstRunCard({
           </Modal.Description>
         </Modal.Header>
         <Modal.Body>
-          <div className="flex flex-col gap-1">
-            <VoiceTranscriptToggles showRecommendedBadge />
-            <p className="pt-2 text-body-small-default text-[var(--content-tertiary)]">
-              You can change these anytime in settings.{" "}
-              {VOICE_TRANSCRIPT_RECOMMENDATION}
-            </p>
-          </div>
+          <p className="text-body-small-default text-[var(--content-tertiary)]">
+            You can mute the mic or turn on captions anytime during the
+            session, and fine-tune everything in Settings.
+          </p>
         </Modal.Body>
         <Modal.Footer>
           <Button variant="primary" onClick={onStart}>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -1,3 +1,5 @@
+import { AudioLines, Captions, MicOff } from "lucide-react";
+
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 
@@ -66,15 +68,49 @@ export function VoiceFirstRunCard({
             <Modal.Title>Voice mode</Modal.Title>
           </div>
           <Modal.Description>
-            A hands-free, spoken conversation. Speak naturally and your
-            assistant listens, then replies out loud.
+            A hands-free, spoken conversation with your assistant.
           </Modal.Description>
         </Modal.Header>
         <Modal.Body>
-          <p className="text-body-small-default text-[var(--content-tertiary)]">
-            You can mute the mic or turn on captions anytime during the
-            session, and fine-tune everything in Settings.
-          </p>
+          <div className="flex flex-col gap-3">
+            {/* Each bullet's icon matches the in-session control it describes,
+                so the card doubles as a legend for the room. */}
+            <ul className="flex flex-col gap-2.5">
+              <li className="flex items-start gap-2.5">
+                <AudioLines
+                  aria-hidden
+                  className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
+                />
+                <span className="text-body-medium-default">
+                  Speak naturally — your assistant listens and replies out
+                  loud.
+                </span>
+              </li>
+              <li className="flex items-start gap-2.5">
+                <MicOff
+                  aria-hidden
+                  className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
+                />
+                <span className="text-body-medium-default">
+                  Mute the mic whenever you need to, without ending the
+                  session.
+                </span>
+              </li>
+              <li className="flex items-start gap-2.5">
+                <Captions
+                  aria-hidden
+                  className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
+                />
+                <span className="text-body-medium-default">
+                  Turn on live captions from the session controls.
+                </span>
+              </li>
+            </ul>
+            <p className="text-body-small-default text-[var(--content-tertiary)]">
+              You can change any of this anytime, in the session or in
+              Settings.
+            </p>
+          </div>
         </Modal.Body>
         <Modal.Footer>
           <Button variant="primary" onClick={onStart}>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -10,11 +10,10 @@ import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
  * One-time welcome card shown the first time a user enters voice mode, before
  * the live session starts.
  *
- * Deliberately NOT a settings quiz (it once carried the two transcript
- * toggles): captions are toggled in-session from the voice room, and the full
- * preferences live in Settings → Voice — front-loading choices before the
- * user has ever experienced voice mode was the wrong moment. The card now
- * just sets expectations and starts.
+ * Deliberately NOT a settings quiz: captions are toggled in-session from the
+ * voice room, and the full preferences live in Settings → Voice —
+ * front-loading choices before the user has ever experienced voice mode is
+ * the wrong moment. The card just sets expectations and starts.
  *
  * The card does NOT persist `firstRunSeen` itself: dismissing it (Escape /
  * backdrop / ✕) is a plain cancel and must leave the first run un-consumed so

--- a/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
@@ -1,8 +1,10 @@
 /**
- * Listening-state waves for the voice room: layered sine waves that rise from
- * the bottom edge of the screen as the user speaks — the visual language of
- * energy coming *in* (the user's voice arriving), the counterpart to the
- * assistant's outward `responding` pulse on the avatar.
+ * Listening-state waves for the voice room: layered sine waves that swell as
+ * the user speaks — the visual language of energy coming *in* (the user's
+ * voice arriving), the counterpart to the assistant's outward `responding`
+ * pulse on the avatar. `placement` anchors the band: `bottom` rises from the
+ * floor edge (the void look), `center` is a symmetric band around the middle
+ * (the color look, gathering behind the centered eyes).
  *
  * The waves always drift horizontally (a slow CSS loop); the user's live mic
  * amplitude drives how high they rise and how bright they are, written
@@ -64,19 +66,29 @@ export type VoiceWaveStyle = "fill" | "line";
 /**
  * Color language: `aurora` is the fixed cyan→indigo accent (matches the
  * listening sonar); `accent` tints the waves from the assistant's avatar color
- * (`--avatar-accent`).
+ * (`--avatar-accent`); `tone` follows the room foreground (`--room-fg`) so the
+ * waves read on any solid avatar-color background (the color look).
  */
-export type VoiceWavePalette = "aurora" | "accent";
+export type VoiceWavePalette = "aurora" | "accent" | "tone";
+
+/**
+ * Where the wave band sits: `bottom` rises from the floor edge (the void
+ * look), `center` swells symmetrically around the middle of the screen (the
+ * color look — the voice gathering around the centered eyes).
+ */
+export type VoiceWavePlacement = "bottom" | "center";
 
 export function VoiceListeningWaves({
   getAmplitude,
   waveStyle = "fill",
   palette = "aurora",
+  placement = "bottom",
 }: {
   /** Mic amplitude source (0–1), polled in a rAF loop. */
   getAmplitude: () => number;
   waveStyle?: VoiceWaveStyle;
   palette?: VoiceWavePalette;
+  placement?: VoiceWavePlacement;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
   const getAmplitudeRef = useRef(getAmplitude);
@@ -112,22 +124,40 @@ export function VoiceListeningWaves({
 
   const buildPath = waveStyle === "line" ? wavePathLine : wavePathFill;
 
+  const layers = () =>
+    WAVE_LAYERS.map((layer) => (
+      <svg
+        key={layer.modifier}
+        className={`voice-wave voice-wave--${layer.modifier}`}
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        preserveAspectRatio="none"
+      >
+        <path d={buildPath(layer.amplitude, layer.cycles, layer.phase)} />
+      </svg>
+    ));
+
+  const className = `voice-listening-waves voice-listening-waves--${waveStyle} voice-listening-waves--${palette} voice-listening-waves--${placement}`;
+
+  // Center: the wave fill hugs the bottom edge of its box, so a merely
+  // centered box would still read low. Mirror the band into two halves that
+  // meet at the midline — the fill hugs the center line from above and below,
+  // its wavy edges rippling outward — for a waveform that is visually centered.
+  if (placement === "center") {
+    return (
+      <div ref={ref} className={className} aria-hidden>
+        <div className="voice-listening-waves__half voice-listening-waves__half--top">
+          {layers()}
+        </div>
+        <div className="voice-listening-waves__half voice-listening-waves__half--bottom">
+          {layers()}
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div
-      ref={ref}
-      className={`voice-listening-waves voice-listening-waves--${waveStyle} voice-listening-waves--${palette}`}
-      aria-hidden
-    >
-      {WAVE_LAYERS.map((layer) => (
-        <svg
-          key={layer.modifier}
-          className={`voice-wave voice-wave--${layer.modifier}`}
-          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
-          preserveAspectRatio="none"
-        >
-          <path d={buildPath(layer.amplitude, layer.cycles, layer.phase)} />
-        </svg>
-      ))}
+    <div ref={ref} className={className} aria-hidden>
+      {layers()}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -12,9 +12,16 @@
  *    cover the viewport end to end,
  * 3. the matching color layer fades in behind it (covering the body shape's
  *    gaps/spikes),
- * 4. the giant eyes rise from the center into their bottom-edge rest —
- *    dipping a touch below rest first — then settle with a double blink and
- *    idle-blink from there (with a slight cursor parallax).
+ * 4. the giant eyes grow into their rest position (bottom-edge or centered,
+ *    per `eyePlacement`) with a settle dip, then a double blink and idle-blink
+ *    from there (with a slight cursor parallax).
+ *
+ * Per-state treatments (driven by `visual`): while the user speaks
+ * (`listening`) the mic-amplitude waveform swells behind the eyes — centered
+ * by default so it reads as the voice gathering around them rather than rising
+ * from the floor — and the eyes drop to a low hold. They stay held low through
+ * the `thinking` that follows (a quiet dot indicator works above them), then
+ * ride back up to center for the rest. `responding` is still to design.
  *
  * Geometry and timing mirror onboarding's `IntroductionScreen` +
  * `OnboardingPeekingEyes`. Traits default like `ChatAvatar` does (first
@@ -27,16 +34,28 @@
  * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe (no
  * entrance, no parallax; the blink is a discrete squish, kept). Sized against
  * the window — the room is a `fixed inset-0` overlay, so the window IS its
- * box.
+ * box — unless a `viewport` override is passed (Storybook renders in a box).
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 
 import { pathBBox, unionBBox, type BBox } from "@/components/avatar/eye-bbox";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 
-/** How much of the eyes sits below the bottom edge — at rest, and at the dip. */
+import {
+  VoiceListeningWaves,
+  type VoiceWavePalette,
+  type VoiceWavePlacement,
+  type VoiceWaveStyle,
+} from "./voice-listening-waves";
+import type { VoiceAvatarVisual } from "./voice-avatar-state";
+import { createAmplitudeSmoother } from "./voice-motion";
+
+/** Where the eyes come to rest: cut off at the bottom edge, or centered. */
+export type VoiceEyePlacement = "bottom" | "center";
+
+/** How much of the bottom-placed eyes sits below the edge — rest, and the dip. */
 const EYE_REST_CUTOFF = 0.25;
 const EYE_DIP_CUTOFF = 0.46;
 /** Eye sizing: height at most 30% of the smaller viewport dimension, capped
@@ -46,6 +65,13 @@ const EYE_MAX_WIDTH = 0.85;
 /** Slight whole-eye cursor parallax. */
 const CURSOR_MAX_X = 14;
 const CURSOR_MAX_Y = 8;
+/**
+ * How far down the centered eyes hold while listening, as a fraction of the
+ * sink travel to the bottom rest — they settle low (clear of the centered
+ * waveform) the moment the user starts, and the remaining fraction is the
+ * live bob driven by mic amplitude, so they never float back up between words.
+ */
+const EYE_LISTEN_SINK_BASE = 0.85;
 /** The entrance grows the body from this "avatar on the screen" size and the
  *  eyes from this vertical center — onboarding's picker geometry. */
 const ENTER_FROM_SIZE = 200;
@@ -130,12 +156,41 @@ function useViewportSize(): { w: number; h: number } {
 
 /**
  * The full color look: dark base, screen-covering body grow, color fade,
- * peeking eyes. Mount = session start (the room only mounts once per
- * session), so mounting plays the entrance.
+ * listening waves, peeking eyes. Mount = session start (the room only mounts
+ * once per session), so mounting plays the entrance.
  */
-export function VoiceRoomColorLook({ look }: { look: VoiceRoomLook }) {
+export function VoiceRoomColorLook({
+  look,
+  visual = "idle",
+  getAmplitude,
+  eyePlacement = "center",
+  wavePlacement = "center",
+  wavePalette = "tone",
+  waveStyle = "fill",
+  viewport,
+}: {
+  look: VoiceRoomLook;
+  /** Session phase — drives which per-state treatment the look shows. */
+  visual?: VoiceAvatarVisual;
+  /** Mic amplitude source (0–1), polled by the waveform's rAF loop. */
+  getAmplitude?: () => number;
+  eyePlacement?: VoiceEyePlacement;
+  wavePlacement?: VoiceWavePlacement;
+  wavePalette?: VoiceWavePalette;
+  waveStyle?: VoiceWaveStyle;
+  /** Override the room box (Storybook renders in a box, not the full window). */
+  viewport?: { w: number; h: number };
+}) {
   const reduce = useReducedMotion();
-  const { w, h } = useViewportSize();
+  const measured = useViewportSize();
+  const { w, h } = viewport ?? measured;
+
+  // Per-state treatments. The waveform is the user's live voice (listening
+  // only); the eyes hold low through the whole user-owned turn — listening AND
+  // the thinking that follows — so they don't bob back up to center the moment
+  // the user stops talking, then settle back to center for the rest.
+  const showWaves = visual === "listening";
+  const sinkEyes = visual === "listening" || visual === "thinking";
 
   // Body grows to cover the screen end to end, from the small avatar size —
   // onboarding's Introduction grow, verbatim.
@@ -200,18 +255,120 @@ export function VoiceRoomColorLook({ look }: { look: VoiceRoomLook }) {
         </motion.svg>
       ) : null}
 
-      <VoiceRoomEyes art={look.art} viewport={{ w, h }} />
+      {/* The user's voice, gathering behind the eyes while they speak. */}
+      {showWaves && getAmplitude ? (
+        <VoiceListeningWaves
+          getAmplitude={getAmplitude}
+          waveStyle={waveStyle}
+          palette={wavePalette}
+          placement={wavePlacement}
+        />
+      ) : null}
+
+      {/* Thinking: the eyes stay held low (looking down, pondering) while a
+          quiet indicator works away above them. */}
+      {visual === "thinking" ? <VoiceThinkingIndicator /> : null}
+
+      <VoiceRoomEyes
+        art={look.art}
+        placement={eyePlacement}
+        viewport={{ w, h }}
+        getAmplitude={getAmplitude}
+        // The centered eyes hold low through the user-owned turn (listening +
+        // thinking), sinking with the voice while listening (see `VoiceRoomEyes`).
+        sink={sinkEyes}
+      />
     </>
   );
+}
+
+/**
+ * Thinking indicator — a soft triad of dots pulsing in sequence above the
+ * held-low eyes, in the room's foreground tone so it reads on any avatar
+ * color. A first-pass "the assistant is working" motif; the responding-state
+ * treatment (and whether thinking wants something richer) is still open.
+ */
+function VoiceThinkingIndicator() {
+  const reduce = useReducedMotion();
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute left-1/2 z-[1] flex -translate-x-1/2 items-center gap-3"
+      style={{ top: "34%" }}
+    >
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          className="block size-3 rounded-full"
+          style={{ backgroundColor: "var(--room-fg, #ffffff)" }}
+          initial={reduce ? false : { opacity: 0.3, scale: 0.75 }}
+          animate={
+            reduce
+              ? { opacity: 0.6 }
+              : { opacity: [0.3, 1, 0.3], scale: [0.75, 1, 0.75] }
+          }
+          transition={
+            reduce
+              ? { duration: 0 }
+              : {
+                  duration: 1.1,
+                  repeat: Infinity,
+                  ease: "easeInOut",
+                  delay: i * 0.18,
+                }
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Rest position + entrance travel for the eyes, per placement, plus
+ * `sinkTravel`: how far the centered eyes can slide down toward the bottom
+ * rest while the user speaks (0 for the bottom placement — nowhere lower).
+ */
+function eyeLayout(
+  placement: VoiceEyePlacement,
+  eyesH: number,
+  h: number,
+): { restTop: number; startY: number; dipY: number; sinkTravel: number } {
+  const bottomRestTop = h - (1 - EYE_REST_CUTOFF) * eyesH;
+  if (placement === "center") {
+    const restTop = (h - eyesH) / 2;
+    return {
+      restTop,
+      // Grow in place with a small settle dip — no long travel from the floor.
+      startY: -eyesH * 0.22,
+      dipY: eyesH * 0.12,
+      // Full voice pulls the eyes all the way down to the bottom rest.
+      sinkTravel: Math.max(0, bottomRestTop - restTop),
+    };
+  }
+  return {
+    restTop: bottomRestTop,
+    // Rise from the picker's centered position (40vh), dipping below rest.
+    startY: (ENTER_FROM_CENTER_VH / 100) * h - (bottomRestTop + eyesH / 2),
+    dipY: (EYE_DIP_CUTOFF - EYE_REST_CUTOFF) * eyesH,
+    sinkTravel: 0,
+  };
 }
 
 export function VoiceRoomEyes({
   art,
   viewport,
+  placement = "center",
+  getAmplitude,
+  sink = false,
 }: {
   art: VoiceRoomEyeArt;
   /** The room box the eyes are framed in (the caller's live viewport size). */
   viewport: { w: number; h: number };
+  placement?: VoiceEyePlacement;
+  /** Mic amplitude source (0–1); drives the live bob while the eyes are sunk. */
+  getAmplitude?: () => number;
+  /** Hold the eyes at the low rest (the user-owned turn — listening + thinking). */
+  sink?: boolean;
 }) {
   const reduce = useReducedMotion();
   const { w, h } = viewport;
@@ -264,18 +421,70 @@ export function VoiceRoomEyes({
       (maxEyesW * art.bbox.h) / art.bbox.w,
     );
     const eyesW = (eyesH * art.bbox.w) / art.bbox.h;
-    const restTop = h - (1 - EYE_REST_CUTOFF) * eyesH;
+    const { restTop, startY, dipY, sinkTravel } = eyeLayout(placement, eyesH, h);
     return {
       eyesW,
       eyesH,
       left: (w - eyesW) / 2,
       restTop,
-      // Entrance: rise from the "avatar on the screen" center, dip a touch
-      // below rest, settle.
-      startY: (ENTER_FROM_CENTER_VH / 100) * h - (restTop + eyesH / 2),
-      dipY: (EYE_DIP_CUTOFF - EYE_REST_CUTOFF) * eyesH,
+      startY,
+      dipY,
+      sinkTravel,
     };
-  }, [art, w, h]);
+  }, [art, w, h, placement]);
+
+  // Sink: while the user owns the turn (listening + thinking) the centered eyes
+  // drop to a low hold near the bottom rest (`EYE_LISTEN_SINK_BASE` of the
+  // travel) so they sit clear of the centered waveform, then bob the remaining
+  // fraction with the mic amplitude — they don't float back up to center
+  // between words or when the user stops. Driven imperatively (never React
+  // state, matching the waveform / avatar) through a smoothed rAF loop writing
+  // `translateY` on a dedicated wrapper — kept off the entrance `y` and the
+  // cursor parallax so all three compose.
+  const sinkRef = useRef<HTMLDivElement | null>(null);
+  const getAmplitudeRef = useRef(getAmplitude);
+  const sinkActiveRef = useRef(sink);
+  const sinkTravelRef = useRef(geometry.sinkTravel);
+  useEffect(() => {
+    getAmplitudeRef.current = getAmplitude;
+  }, [getAmplitude]);
+  useEffect(() => {
+    sinkActiveRef.current = sink;
+  }, [sink]);
+  useEffect(() => {
+    sinkTravelRef.current = geometry.sinkTravel;
+  }, [geometry.sinkTravel]);
+  useEffect(() => {
+    if (reduce) return;
+    const node = sinkRef.current;
+    if (!node) return;
+    // Drop to the low hold when listening starts, ease back up to center when
+    // it ends — a touch slower than the waveform so the eyes settle, not
+    // jitter.
+    const smoother = createAmplitudeSmoother({ attackMs: 160, releaseMs: 380 });
+    let raf = 0;
+    let lastTime = performance.now();
+    let lastWritten = "";
+    const tick = (now: number) => {
+      const dt = now - lastTime;
+      lastTime = now;
+      const get = getAmplitudeRef.current;
+      // While sunk the eyes hold at `EYE_LISTEN_SINK_BASE` of the travel and
+      // bob the rest with amplitude; otherwise they return to center (0).
+      const amp = get ? Math.min(1, Math.max(0, get())) : 0;
+      const target = sinkActiveRef.current
+        ? EYE_LISTEN_SINK_BASE + (1 - EYE_LISTEN_SINK_BASE) * amp
+        : 0;
+      const shift = (smoother.step(target, dt) * sinkTravelRef.current).toFixed(1);
+      if (shift !== lastWritten) {
+        lastWritten = shift;
+        node.style.transform = `translateY(${shift}px)`;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [reduce]);
 
   const cx = art.bbox.x + art.bbox.w / 2;
   const cy = art.bbox.y + art.bbox.h / 2;
@@ -305,31 +514,34 @@ export function VoiceRoomEyes({
       }
       onAnimationComplete={() => setEntranceDone(true)}
     >
-      {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
-      <div
-        style={{
-          transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,
-          transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
-        }}
-      >
-        <svg
-          viewBox={`${art.bbox.x} ${art.bbox.y} ${art.bbox.w} ${art.bbox.h}`}
-          width={geometry.eyesW}
-          height={geometry.eyesH}
-          style={{ overflow: "visible", display: "block" }}
+      {/* Speak-to-sink: rAF writes translateY here as the voice rises. */}
+      <div ref={sinkRef}>
+        {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
+        <div
+          style={{
+            transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,
+            transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
+          }}
         >
-          <g
-            style={{
-              transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
-              transformOrigin: `${cx}px ${cy}px`,
-              transition: "transform 0.14s ease-in-out",
-            }}
+          <svg
+            viewBox={`${art.bbox.x} ${art.bbox.y} ${art.bbox.w} ${art.bbox.h}`}
+            width={geometry.eyesW}
+            height={geometry.eyesH}
+            style={{ overflow: "visible", display: "block" }}
           >
-            {art.paths.map((p, i) => (
-              <path key={i} d={p.svgPath} fill={p.color} />
-            ))}
-          </g>
-        </svg>
+            <g
+              style={{
+                transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
+                transformOrigin: `${cx}px ${cy}px`,
+                transition: "transform 0.14s ease-in-out",
+              }}
+            >
+              {art.paths.map((p, i) => (
+                <path key={i} d={p.svgPath} fill={p.color} />
+              ))}
+            </g>
+          </svg>
+        </div>
       </div>
     </motion.div>
   );

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -21,7 +21,9 @@
  * by default so it reads as the voice gathering around them rather than rising
  * from the floor — and the eyes drop to a low hold. They stay held low through
  * the `thinking` that follows (a quiet dot indicator works above them), then
- * ride back up to center for the rest. `responding` is still to design.
+ * ride back up to center to speak (`responding`, where the assistant's voice
+ * radiates outward from behind the eyes — see {@link VoiceRespondingStyle}).
+ * `reconnecting` fades the eyes back — presence dimmed while away.
  *
  * Geometry and timing mirror onboarding's `IntroductionScreen` +
  * `OnboardingPeekingEyes`. Traits default like `ChatAvatar` does (first
@@ -163,6 +165,8 @@ export function VoiceRoomColorLook({
   look,
   visual = "idle",
   getAmplitude,
+  getResponseAmplitude,
+  respondingStyle = "rings",
   eyePlacement = "center",
   wavePlacement = "center",
   wavePalette = "tone",
@@ -172,8 +176,13 @@ export function VoiceRoomColorLook({
   look: VoiceRoomLook;
   /** Session phase — drives which per-state treatment the look shows. */
   visual?: VoiceAvatarVisual;
-  /** Mic amplitude source (0–1), polled by the waveform's rAF loop. */
+  /** Mic (input) amplitude source (0–1) — the listening waveform + eye bob. */
   getAmplitude?: () => number;
+  /** TTS (output) amplitude source (0–1) — the responding treatment. Falls
+   *  back to {@link getAmplitude} when omitted. */
+  getResponseAmplitude?: () => number;
+  /** Which responding-state treatment to show (sketch knob). */
+  respondingStyle?: VoiceRespondingStyle;
   eyePlacement?: VoiceEyePlacement;
   wavePlacement?: VoiceWavePlacement;
   wavePalette?: VoiceWavePalette;
@@ -269,6 +278,19 @@ export function VoiceRoomColorLook({
           quiet indicator works away above them. */}
       {visual === "thinking" ? <VoiceThinkingIndicator /> : null}
 
+      {/* Responding: the eyes ride back up to center (engaged, addressing the
+          user) and the assistant's voice radiates outward from behind them,
+          driven by the TTS-output amplitude — energy going out, the mirror of
+          listening's incoming waves. */}
+      {visual === "responding" ? (
+        <VoiceRespondingTreatment
+          style={respondingStyle}
+          getAmplitude={getResponseAmplitude ?? getAmplitude}
+          waveStyle={waveStyle}
+          wavePlacement={wavePlacement}
+        />
+      ) : null}
+
       <VoiceRoomEyes
         art={look.art}
         placement={eyePlacement}
@@ -277,6 +299,8 @@ export function VoiceRoomColorLook({
         // The centered eyes hold low through the user-owned turn (listening +
         // thinking), sinking with the voice while listening (see `VoiceRoomEyes`).
         sink={sinkEyes}
+        // Reconnecting: fade the eyes back — presence dimmed while away.
+        dimmed={visual === "reconnecting"}
       />
     </>
   );
@@ -324,6 +348,154 @@ function VoiceThinkingIndicator() {
 }
 
 /**
+ * Candidate responding-state treatments (sketches to compare in Storybook):
+ * - `rings`    — concentric rings expanding outward from behind the eyes,
+ *                the mirror of listening's incoming waves (energy going out).
+ * - `halo`     — a soft radial bloom around the eyes that swells with speech.
+ * - `waveform` — the centered waveform again, now the assistant's own voice.
+ * - `pulse`    — the whole color field brightens gently on speech peaks.
+ * All ride the TTS-output amplitude and tint from the room foreground tone.
+ */
+export type VoiceRespondingStyle = "rings" | "halo" | "waveform" | "pulse";
+
+/**
+ * Smoothed output-amplitude → `--resp-amp` on a ref, for the responding
+ * treatments to read in CSS. Imperative rAF (never React state), mirroring the
+ * waveform / eye-sink loops.
+ */
+function useRespondingAmp(getAmplitude?: () => number) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const getRef = useRef(getAmplitude);
+  const reduce = useReducedMotion();
+  useEffect(() => {
+    getRef.current = getAmplitude;
+  }, [getAmplitude]);
+  useEffect(() => {
+    if (reduce) return;
+    const node = ref.current;
+    if (!node) return;
+    const smoother = createAmplitudeSmoother({ attackMs: 90, releaseMs: 260 });
+    let raf = 0;
+    let lastTime = performance.now();
+    let lastWritten = "";
+    const tick = (now: number) => {
+      const dt = now - lastTime;
+      lastTime = now;
+      const get = getRef.current;
+      const target = get ? Math.min(1, Math.max(0, get())) : 0;
+      const v = smoother.step(target, dt).toFixed(3);
+      if (v !== lastWritten) {
+        lastWritten = v;
+        node.style.setProperty("--resp-amp", v);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [reduce]);
+  return ref;
+}
+
+function VoiceRespondingTreatment({
+  style,
+  getAmplitude,
+  waveStyle,
+  wavePlacement,
+}: {
+  style: VoiceRespondingStyle;
+  getAmplitude?: () => number;
+  waveStyle: VoiceWaveStyle;
+  wavePlacement: VoiceWavePlacement;
+}) {
+  const ampRef = useRespondingAmp(getAmplitude);
+  const reduce = useReducedMotion();
+
+  if (style === "waveform") {
+    // The assistant's own voice — reuse the centered band, output-driven.
+    return getAmplitude ? (
+      <VoiceListeningWaves
+        getAmplitude={getAmplitude}
+        waveStyle={waveStyle}
+        palette="tone"
+        placement={wavePlacement}
+      />
+    ) : null;
+  }
+
+  if (style === "pulse") {
+    // The whole color field lightens gently on speech peaks.
+    return (
+      <div
+        ref={ampRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-0"
+        style={{
+          backgroundColor: "var(--room-fg, #ffffff)",
+          opacity: "calc(var(--resp-amp, 0) * 0.14)",
+        }}
+      />
+    );
+  }
+
+  if (style === "halo") {
+    // A soft radial bloom behind the eyes, swelling + brightening with speech.
+    return (
+      <div
+        ref={ampRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center"
+      >
+        <div
+          style={{
+            width: "min(70vh, 70vw)",
+            aspectRatio: "1 / 1",
+            borderRadius: "9999px",
+            background:
+              "radial-gradient(circle, color-mix(in srgb, var(--room-fg, #ffffff) 24%, transparent) 0%, transparent 66%)",
+            transform: "scale(calc(0.8 + var(--resp-amp, 0) * 0.5))",
+            opacity: "calc(0.35 + var(--resp-amp, 0) * 0.65)",
+            transformOrigin: "center",
+          }}
+        />
+      </div>
+    );
+  }
+
+  // `rings` — concentric rings expanding outward from the eyes; overall
+  // presence scales with the TTS amplitude.
+  return (
+    <div
+      ref={ampRef}
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center"
+      style={{ opacity: "calc(0.25 + var(--resp-amp, 0) * 0.75)" }}
+    >
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          className="absolute rounded-full border-2"
+          style={{
+            width: "min(38vh, 38vw)",
+            height: "min(38vh, 38vw)",
+            borderColor:
+              "color-mix(in srgb, var(--room-fg, #ffffff) 55%, transparent)",
+          }}
+          initial={reduce ? false : { scale: 0.4, opacity: 0.55 }}
+          animate={
+            reduce ? { opacity: 0.2 } : { scale: [0.4, 1.75], opacity: [0.55, 0] }
+          }
+          transition={
+            reduce
+              ? { duration: 0 }
+              : { duration: 2.4, repeat: Infinity, ease: "easeOut", delay: i * 0.8 }
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
  * Rest position + entrance travel for the eyes, per placement, plus
  * `sinkTravel`: how far the centered eyes can slide down toward the bottom
  * rest while the user speaks (0 for the bottom placement — nowhere lower).
@@ -360,6 +532,7 @@ export function VoiceRoomEyes({
   placement = "center",
   getAmplitude,
   sink = false,
+  dimmed = false,
 }: {
   art: VoiceRoomEyeArt;
   /** The room box the eyes are framed in (the caller's live viewport size). */
@@ -369,6 +542,8 @@ export function VoiceRoomEyes({
   getAmplitude?: () => number;
   /** Hold the eyes at the low rest (the user-owned turn — listening + thinking). */
   sink?: boolean;
+  /** Fade the eyes back (the reconnecting state — presence dimmed while away). */
+  dimmed?: boolean;
 }) {
   const reduce = useReducedMotion();
   const { w, h } = viewport;
@@ -514,8 +689,16 @@ export function VoiceRoomEyes({
       }
       onAnimationComplete={() => setEntranceDone(true)}
     >
-      {/* Speak-to-sink: rAF writes translateY here as the voice rises. */}
-      <div ref={sinkRef}>
+      {/* Speak-to-sink: rAF writes translateY here as the voice rises. The
+          opacity fades the eyes back while reconnecting (rAF only touches
+          `transform`, so it never clobbers this). */}
+      <div
+        ref={sinkRef}
+        style={{
+          opacity: dimmed ? 0.4 : 1,
+          transition: "opacity 0.5s ease",
+        }}
+      >
         {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
         <div
           style={{

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -1,31 +1,44 @@
 /**
- * The session assistant's eyes peeking up from the bottom of the voice room —
- * the onboarding "full-screen color with eyes" treatment reused as the room's
- * look for character avatars.
+ * The color look for the voice room — the onboarding "avatar is the screen"
+ * treatment reused for character avatars.
  *
- * `resolveVoiceRoomLook` maps the assistant's avatar data to the look: the
- * avatar color fills the room and the avatar's eye style renders giant at the
- * bottom edge, ~25% cut off, with an idle blink and a slight cursor parallax
- * (geometry and behavior mirror onboarding's `OnboardingPeekingEyes`). Traits
- * default like `ChatAvatar` does (first component of each type), so a
- * default-character assistant gets the same color and eyes the user sees in
- * its small avatar. Custom-image / no-character avatars resolve to `null` and
- * the room falls back to its ambient-void look — what that look should become
- * is an open design question.
+ * `resolveVoiceRoomLook` maps the assistant's avatar data to the look; the
+ * {@link VoiceRoomColorLook} component plays the onboarding Introduction
+ * step's entrance on mount, so opening the room reads as the avatar growing
+ * from "on the screen" to BEING the screen:
+ *
+ * 1. the room starts on a dark surface,
+ * 2. the avatar's body shape springs from its small on-screen size up to
+ *    cover the viewport end to end,
+ * 3. the matching color layer fades in behind it (covering the body shape's
+ *    gaps/spikes),
+ * 4. the giant eyes rise from the center into their bottom-edge rest —
+ *    dipping a touch below rest first — then settle with a double blink and
+ *    idle-blink from there (with a slight cursor parallax).
+ *
+ * Geometry and timing mirror onboarding's `IntroductionScreen` +
+ * `OnboardingPeekingEyes`. Traits default like `ChatAvatar` does (first
+ * component of each type), so a default-character assistant gets the same
+ * color and eyes the user sees in its small avatar. Custom-image /
+ * no-character avatars resolve to `null` and the room falls back to its
+ * ambient-void look — what that look should become is an open design
+ * question.
  *
  * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe (no
- * parallax; the blink is a discrete squish, kept). Sized against the window —
- * the room is a `fixed inset-0` overlay, so the window IS its box.
+ * entrance, no parallax; the blink is a discrete squish, kept). Sized against
+ * the window — the room is a `fixed inset-0` overlay, so the window IS its
+ * box.
  */
 
 import { useEffect, useMemo, useState } from "react";
-import { useReducedMotion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 
 import { pathBBox, unionBBox, type BBox } from "@/components/avatar/eye-bbox";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 
-/** How much of the eyes sits below the bottom edge. */
+/** How much of the eyes sits below the bottom edge — at rest, and at the dip. */
 const EYE_REST_CUTOFF = 0.25;
+const EYE_DIP_CUTOFF = 0.46;
 /** Eye sizing: height at most 30% of the smaller viewport dimension, capped
  *  so width stays on-screen. */
 const EYE_TARGET_HEIGHT = 0.3;
@@ -33,6 +46,13 @@ const EYE_MAX_WIDTH = 0.85;
 /** Slight whole-eye cursor parallax. */
 const CURSOR_MAX_X = 14;
 const CURSOR_MAX_Y = 8;
+/** The entrance grows the body from this "avatar on the screen" size and the
+ *  eyes from this vertical center — onboarding's picker geometry. */
+const ENTER_FROM_SIZE = 200;
+const ENTER_FROM_CENTER_VH = 40;
+/** The room's own dark base, under the color fade (matches the ambient look's
+ *  deep surface so the first frames read the same for both looks). */
+const DARK_SURFACE = "#17191C";
 
 export interface VoiceRoomEyeArt {
   paths: { svgPath: string; color: string }[];
@@ -44,6 +64,8 @@ export interface VoiceRoomLook {
   bgHex: string;
   /** The avatar's eye art, sized/framed by its union bounding box. */
   art: VoiceRoomEyeArt;
+  /** The avatar's body shape, grown to cover the screen on entrance. */
+  body: { svgPath: string; viewBox: { width: number; height: number } } | null;
 }
 
 /**
@@ -63,8 +85,12 @@ export function resolveVoiceRoomLook(
   if (!traits && customImageUrl) return null;
   const effectiveTraits =
     traits ??
-    (components.eyeStyles[0] && components.colors[0]
-      ? { eyeStyle: components.eyeStyles[0].id, color: components.colors[0].id }
+    (components.bodyShapes[0] && components.eyeStyles[0] && components.colors[0]
+      ? {
+          bodyShape: components.bodyShapes[0].id,
+          eyeStyle: components.eyeStyles[0].id,
+          color: components.colors[0].id,
+        }
       : null);
   if (!effectiveTraits) return null;
   const eyeDef = components.eyeStyles.find(
@@ -77,22 +103,119 @@ export function resolveVoiceRoomLook(
   const bbox = unionBBox(eyeDef.paths.map((p) => pathBBox(p.svgPath)));
   // Degenerate art (empty paths) would make the sizing math divide by zero.
   if (bbox.w <= 0 || bbox.h <= 0) return null;
-  return { bgHex, art: { paths: eyeDef.paths, bbox } };
+  const bodyDef = components.bodyShapes.find(
+    (b) => b.id === effectiveTraits.bodyShape,
+  );
+  const body =
+    bodyDef && bodyDef.viewBox.width > 0 && bodyDef.viewBox.height > 0
+      ? { svgPath: bodyDef.svgPath, viewBox: bodyDef.viewBox }
+      : null;
+  return { bgHex, art: { paths: eyeDef.paths, bbox }, body };
 }
 
 function windowSize(): { w: number; h: number } {
   return { w: window.innerWidth, h: window.innerHeight };
 }
 
-export function VoiceRoomEyes({ art }: { art: VoiceRoomEyeArt }) {
-  const reduce = useReducedMotion();
-  const [{ w, h }, setSize] = useState(windowSize);
-
+/** The window box, kept live on resize — the room is a full-viewport overlay. */
+function useViewportSize(): { w: number; h: number } {
+  const [size, setSize] = useState(windowSize);
   useEffect(() => {
     const onResize = () => setSize(windowSize());
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);
+  return size;
+}
+
+/**
+ * The full color look: dark base, screen-covering body grow, color fade,
+ * peeking eyes. Mount = session start (the room only mounts once per
+ * session), so mounting plays the entrance.
+ */
+export function VoiceRoomColorLook({ look }: { look: VoiceRoomLook }) {
+  const reduce = useReducedMotion();
+  const { w, h } = useViewportSize();
+
+  // Body grows to cover the screen end to end, from the small avatar size —
+  // onboarding's Introduction grow, verbatim.
+  const bodyGeometry = useMemo(() => {
+    if (!look.body) return null;
+    const coverSize = 1.25 * Math.max(w, h);
+    const coverH = (coverSize * look.body.viewBox.height) / look.body.viewBox.width;
+    return {
+      coverSize,
+      coverH,
+      left: (w - coverSize) / 2,
+      top: (h - coverH) / 2,
+      startScale: ENTER_FROM_SIZE / coverSize,
+      startY: (ENTER_FROM_CENTER_VH / 100 - 0.5) * h,
+    };
+  }, [look.body, w, h]);
+
+  return (
+    <>
+      {/* Dark base, so the grow has something to happen over. */}
+      <div
+        className="absolute inset-0"
+        style={{ backgroundColor: DARK_SURFACE }}
+      />
+
+      {/* The avatar color fills in behind the body so coverage is end-to-end
+          even where the body shape has gaps/spikes. */}
+      <motion.div
+        className="absolute inset-0"
+        style={{ backgroundColor: look.bgHex }}
+        initial={reduce ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.35 }}
+      />
+
+      {/* Body — springs from "avatar on the screen" to covering it. */}
+      {look.body && bodyGeometry ? (
+        <motion.svg
+          aria-hidden="true"
+          className="pointer-events-none absolute"
+          viewBox={`0 0 ${look.body.viewBox.width} ${look.body.viewBox.height}`}
+          width={bodyGeometry.coverSize}
+          height={bodyGeometry.coverH}
+          style={{
+            left: bodyGeometry.left,
+            top: bodyGeometry.top,
+            transformOrigin: "center",
+          }}
+          initial={
+            reduce
+              ? false
+              : { scale: bodyGeometry.startScale, y: bodyGeometry.startY }
+          }
+          animate={{ scale: 1, y: 0 }}
+          transition={
+            reduce
+              ? { duration: 0 }
+              : { type: "spring", stiffness: 78, damping: 18, mass: 1 }
+          }
+        >
+          <path d={look.body.svgPath} fill={look.bgHex} />
+        </motion.svg>
+      ) : null}
+
+      <VoiceRoomEyes art={look.art} viewport={{ w, h }} />
+    </>
+  );
+}
+
+export function VoiceRoomEyes({
+  art,
+  viewport,
+}: {
+  art: VoiceRoomEyeArt;
+  /** The room box the eyes are framed in (the caller's live viewport size). */
+  viewport: { w: number; h: number };
+}) {
+  const reduce = useReducedMotion();
+  const { w, h } = viewport;
+  const playEntrance = !reduce;
 
   const [pointer, setPointer] = useState({ x: 0, y: 0 });
   useEffect(() => {
@@ -107,29 +230,32 @@ export function VoiceRoomEyes({ art }: { art: VoiceRoomEyeArt }) {
     return () => window.removeEventListener("mousemove", onMove);
   }, [reduce]);
 
-  // Slow random idle blink (a 140ms squish), like the onboarding eyes at rest.
+  // Two settle blinks once the entrance lands, then a slow random idle blink —
+  // onboarding's entrance blink choreography.
   const [blinking, setBlinking] = useState(false);
+  const [entranceDone, setEntranceDone] = useState(!playEntrance);
   useEffect(() => {
-    if (reduce) return;
+    if (reduce || !entranceDone) return;
     let cancelled = false;
     let t: ReturnType<typeof setTimeout>;
-    const idle = () => {
+    const blink = (next: () => void) => {
+      if (cancelled) return;
+      setBlinking(true);
       t = setTimeout(() => {
         if (cancelled) return;
-        setBlinking(true);
-        t = setTimeout(() => {
-          if (cancelled) return;
-          setBlinking(false);
-          idle();
-        }, 140);
-      }, 2500 + Math.random() * 4000);
+        setBlinking(false);
+        t = setTimeout(next, 140);
+      }, 140);
     };
-    idle();
+    const idle = () => {
+      t = setTimeout(() => blink(idle), 2500 + Math.random() * 4000);
+    };
+    blink(() => blink(idle));
     return () => {
       cancelled = true;
       clearTimeout(t);
     };
-  }, [reduce]);
+  }, [reduce, entranceDone]);
 
   const geometry = useMemo(() => {
     const maxEyesW = w * EYE_MAX_WIDTH;
@@ -138,11 +264,16 @@ export function VoiceRoomEyes({ art }: { art: VoiceRoomEyeArt }) {
       (maxEyesW * art.bbox.h) / art.bbox.w,
     );
     const eyesW = (eyesH * art.bbox.w) / art.bbox.h;
+    const restTop = h - (1 - EYE_REST_CUTOFF) * eyesH;
     return {
       eyesW,
       eyesH,
       left: (w - eyesW) / 2,
-      top: h - (1 - EYE_REST_CUTOFF) * eyesH,
+      restTop,
+      // Entrance: rise from the "avatar on the screen" center, dip a touch
+      // below rest, settle.
+      startY: (ENTER_FROM_CENTER_VH / 100) * h - (restTop + eyesH / 2),
+      dipY: (EYE_DIP_CUTOFF - EYE_REST_CUTOFF) * eyesH,
     };
   }, [art, w, h]);
 
@@ -150,16 +281,29 @@ export function VoiceRoomEyes({ art }: { art: VoiceRoomEyeArt }) {
   const cy = art.bbox.y + art.bbox.h / 2;
 
   return (
-    <div
+    <motion.div
       aria-hidden="true"
       data-testid="voice-room-eyes"
-      className="pointer-events-none absolute z-0"
+      className="pointer-events-none absolute"
       style={{
         left: geometry.left,
-        top: geometry.top,
+        top: geometry.restTop,
         width: geometry.eyesW,
         height: geometry.eyesH,
+        transformOrigin: "center",
       }}
+      initial={playEntrance ? { y: geometry.startY, scale: 0.35 } : false}
+      animate={
+        playEntrance
+          ? { y: [geometry.startY, geometry.dipY, 0], scale: [0.35, 1, 1] }
+          : { y: 0, scale: 1 }
+      }
+      transition={
+        playEntrance
+          ? { duration: 1, times: [0, 0.7, 1], ease: "easeInOut" }
+          : { duration: 0 }
+      }
+      onAnimationComplete={() => setEntranceDone(true)}
     >
       {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
       <div
@@ -187,6 +331,6 @@ export function VoiceRoomEyes({ art }: { art: VoiceRoomEyeArt }) {
           </g>
         </svg>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -1,0 +1,192 @@
+/**
+ * The session assistant's eyes peeking up from the bottom of the voice room —
+ * the onboarding "full-screen color with eyes" treatment reused as the room's
+ * look for character avatars.
+ *
+ * `resolveVoiceRoomLook` maps the assistant's avatar data to the look: the
+ * avatar color fills the room and the avatar's eye style renders giant at the
+ * bottom edge, ~25% cut off, with an idle blink and a slight cursor parallax
+ * (geometry and behavior mirror onboarding's `OnboardingPeekingEyes`). Traits
+ * default like `ChatAvatar` does (first component of each type), so a
+ * default-character assistant gets the same color and eyes the user sees in
+ * its small avatar. Custom-image / no-character avatars resolve to `null` and
+ * the room falls back to its ambient-void look — what that look should become
+ * is an open design question.
+ *
+ * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe (no
+ * parallax; the blink is a discrete squish, kept). Sized against the window —
+ * the room is a `fixed inset-0` overlay, so the window IS its box.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useReducedMotion } from "motion/react";
+
+import { pathBBox, unionBBox, type BBox } from "@/components/avatar/eye-bbox";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+
+/** How much of the eyes sits below the bottom edge. */
+const EYE_REST_CUTOFF = 0.25;
+/** Eye sizing: height at most 30% of the smaller viewport dimension, capped
+ *  so width stays on-screen. */
+const EYE_TARGET_HEIGHT = 0.3;
+const EYE_MAX_WIDTH = 0.85;
+/** Slight whole-eye cursor parallax. */
+const CURSOR_MAX_X = 14;
+const CURSOR_MAX_Y = 8;
+
+export interface VoiceRoomEyeArt {
+  paths: { svgPath: string; color: string }[];
+  bbox: BBox;
+}
+
+export interface VoiceRoomLook {
+  /** The avatar color that fills the room. */
+  bgHex: string;
+  /** The avatar's eye art, sized/framed by its union bounding box. */
+  art: VoiceRoomEyeArt;
+}
+
+/**
+ * Resolve the room's color-with-eyes look from the session assistant's avatar
+ * data, or `null` when the assistant has no character to draw (custom-image /
+ * "none" avatars, or components/traits still loading) — the caller then keeps
+ * the ambient-void look.
+ */
+export function resolveVoiceRoomLook(
+  components: CharacterComponents | null,
+  traits: CharacterTraits | null,
+  customImageUrl: string | null,
+): VoiceRoomLook | null {
+  if (!components) return null;
+  // A custom uploaded image with no traits renders as the image avatar, not a
+  // character — same precedence as ChatAvatar's `preferCharacter`.
+  if (!traits && customImageUrl) return null;
+  const effectiveTraits =
+    traits ??
+    (components.eyeStyles[0] && components.colors[0]
+      ? { eyeStyle: components.eyeStyles[0].id, color: components.colors[0].id }
+      : null);
+  if (!effectiveTraits) return null;
+  const eyeDef = components.eyeStyles.find(
+    (e) => e.id === effectiveTraits.eyeStyle,
+  );
+  const bgHex = components.colors.find(
+    (c) => c.id === effectiveTraits.color,
+  )?.hex;
+  if (!eyeDef || eyeDef.paths.length === 0 || !bgHex) return null;
+  const bbox = unionBBox(eyeDef.paths.map((p) => pathBBox(p.svgPath)));
+  // Degenerate art (empty paths) would make the sizing math divide by zero.
+  if (bbox.w <= 0 || bbox.h <= 0) return null;
+  return { bgHex, art: { paths: eyeDef.paths, bbox } };
+}
+
+function windowSize(): { w: number; h: number } {
+  return { w: window.innerWidth, h: window.innerHeight };
+}
+
+export function VoiceRoomEyes({ art }: { art: VoiceRoomEyeArt }) {
+  const reduce = useReducedMotion();
+  const [{ w, h }, setSize] = useState(windowSize);
+
+  useEffect(() => {
+    const onResize = () => setSize(windowSize());
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  const [pointer, setPointer] = useState({ x: 0, y: 0 });
+  useEffect(() => {
+    if (reduce) return;
+    const onMove = (e: MouseEvent) => {
+      setPointer({
+        x: (e.clientX / window.innerWidth - 0.5) * 2,
+        y: (e.clientY / window.innerHeight - 0.5) * 2,
+      });
+    };
+    window.addEventListener("mousemove", onMove);
+    return () => window.removeEventListener("mousemove", onMove);
+  }, [reduce]);
+
+  // Slow random idle blink (a 140ms squish), like the onboarding eyes at rest.
+  const [blinking, setBlinking] = useState(false);
+  useEffect(() => {
+    if (reduce) return;
+    let cancelled = false;
+    let t: ReturnType<typeof setTimeout>;
+    const idle = () => {
+      t = setTimeout(() => {
+        if (cancelled) return;
+        setBlinking(true);
+        t = setTimeout(() => {
+          if (cancelled) return;
+          setBlinking(false);
+          idle();
+        }, 140);
+      }, 2500 + Math.random() * 4000);
+    };
+    idle();
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [reduce]);
+
+  const geometry = useMemo(() => {
+    const maxEyesW = w * EYE_MAX_WIDTH;
+    const eyesH = Math.min(
+      Math.min(w, h) * EYE_TARGET_HEIGHT,
+      (maxEyesW * art.bbox.h) / art.bbox.w,
+    );
+    const eyesW = (eyesH * art.bbox.w) / art.bbox.h;
+    return {
+      eyesW,
+      eyesH,
+      left: (w - eyesW) / 2,
+      top: h - (1 - EYE_REST_CUTOFF) * eyesH,
+    };
+  }, [art, w, h]);
+
+  const cx = art.bbox.x + art.bbox.w / 2;
+  const cy = art.bbox.y + art.bbox.h / 2;
+
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="voice-room-eyes"
+      className="pointer-events-none absolute z-0"
+      style={{
+        left: geometry.left,
+        top: geometry.top,
+        width: geometry.eyesW,
+        height: geometry.eyesH,
+      }}
+    >
+      {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
+      <div
+        style={{
+          transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,
+          transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
+        }}
+      >
+        <svg
+          viewBox={`${art.bbox.x} ${art.bbox.y} ${art.bbox.w} ${art.bbox.h}`}
+          width={geometry.eyesW}
+          height={geometry.eyesH}
+          style={{ overflow: "visible", display: "block" }}
+        >
+          <g
+            style={{
+              transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
+              transformOrigin: `${cx}px ${cy}px`,
+              transition: "transform 0.14s ease-in-out",
+            }}
+          >
+            {art.paths.map((p, i) => (
+              <path key={i} d={p.svgPath} fill={p.color} />
+            ))}
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -57,9 +57,8 @@ import { createAmplitudeSmoother } from "./voice-motion";
 /** Where the eyes come to rest: cut off at the bottom edge, or centered. */
 export type VoiceEyePlacement = "bottom" | "center";
 
-/** How much of the bottom-placed eyes sits below the edge — rest, and the dip. */
+/** How much of the bottom-placed eyes sits below the edge at rest. */
 const EYE_REST_CUTOFF = 0.25;
-const EYE_DIP_CUTOFF = 0.46;
 /** Eye sizing: height at most 30% of the smaller viewport dimension, capped
  *  so width stays on-screen. */
 const EYE_TARGET_HEIGHT = 0.3;
@@ -171,6 +170,7 @@ export function VoiceRoomColorLook({
   wavePlacement = "center",
   wavePalette = "tone",
   waveStyle = "fill",
+  entryOrigin = null,
   viewport,
 }: {
   look: VoiceRoomLook;
@@ -187,12 +187,19 @@ export function VoiceRoomColorLook({
   wavePlacement?: VoiceWavePlacement;
   wavePalette?: VoiceWavePalette;
   waveStyle?: VoiceWaveStyle;
+  /** Viewport point the entrance grows from (the tapped control). Null → the
+   *  fixed screen-center origin. */
+  entryOrigin?: { x: number; y: number } | null;
   /** Override the room box (Storybook renders in a box, not the full window). */
   viewport?: { w: number; h: number };
 }) {
   const reduce = useReducedMotion();
   const measured = useViewportSize();
   const { w, h } = viewport ?? measured;
+
+  // Where the entrance grows from: the tapped control's viewport point, or the
+  // fixed picker-height screen center when none was captured (or in Storybook).
+  const origin = entryOrigin ?? { x: w / 2, y: (ENTER_FROM_CENTER_VH / 100) * h };
 
   // Per-state treatments. The waveform is the user's live voice (listening
   // only); the eyes hold low through the whole user-owned turn — listening AND
@@ -201,8 +208,10 @@ export function VoiceRoomColorLook({
   const showWaves = visual === "listening";
   const sinkEyes = visual === "listening" || visual === "thinking";
 
-  // Body grows to cover the screen end to end, from the small avatar size —
-  // onboarding's Introduction grow, verbatim.
+  // Body grows to cover the screen end to end, from the small avatar size at
+  // the entry origin — onboarding's Introduction grow, re-anchored to where the
+  // user tapped. The body's rest center is the screen center (w/2, h/2), so it
+  // starts offset by (origin − center) and slides to 0.
   const bodyGeometry = useMemo(() => {
     if (!look.body) return null;
     const coverSize = 1.25 * Math.max(w, h);
@@ -213,9 +222,10 @@ export function VoiceRoomColorLook({
       left: (w - coverSize) / 2,
       top: (h - coverH) / 2,
       startScale: ENTER_FROM_SIZE / coverSize,
-      startY: (ENTER_FROM_CENTER_VH / 100 - 0.5) * h,
+      startX: origin.x - w / 2,
+      startY: origin.y - h / 2,
     };
-  }, [look.body, w, h]);
+  }, [look.body, w, h, origin.x, origin.y]);
 
   return (
     <>
@@ -251,9 +261,13 @@ export function VoiceRoomColorLook({
           initial={
             reduce
               ? false
-              : { scale: bodyGeometry.startScale, y: bodyGeometry.startY }
+              : {
+                  scale: bodyGeometry.startScale,
+                  x: bodyGeometry.startX,
+                  y: bodyGeometry.startY,
+                }
           }
-          animate={{ scale: 1, y: 0 }}
+          animate={{ scale: 1, x: 0, y: 0 }}
           transition={
             reduce
               ? { duration: 0 }
@@ -276,7 +290,9 @@ export function VoiceRoomColorLook({
 
       {/* Thinking: the eyes stay held low (looking down, pondering) while a
           quiet indicator works away above them. */}
-      {visual === "thinking" ? <VoiceThinkingIndicator /> : null}
+      {visual === "thinking" ? (
+        <VoiceThinkingIndicator viewport={{ w, h }} />
+      ) : null}
 
       {/* Responding: the eyes ride back up to center (engaged, addressing the
           user) and the assistant's voice radiates outward from behind them,
@@ -288,6 +304,7 @@ export function VoiceRoomColorLook({
           getAmplitude={getResponseAmplitude ?? getAmplitude}
           waveStyle={waveStyle}
           wavePlacement={wavePlacement}
+          viewport={{ w, h }}
         />
       ) : null}
 
@@ -295,6 +312,7 @@ export function VoiceRoomColorLook({
         art={look.art}
         placement={eyePlacement}
         viewport={{ w, h }}
+        entranceOrigin={origin}
         getAmplitude={getAmplitude}
         // The centered eyes hold low through the user-owned turn (listening +
         // thinking), sinking with the voice while listening (see `VoiceRoomEyes`).
@@ -312,19 +330,30 @@ export function VoiceRoomColorLook({
  * color. A first-pass "the assistant is working" motif; the responding-state
  * treatment (and whether thinking wants something richer) is still open.
  */
-function VoiceThinkingIndicator() {
+function VoiceThinkingIndicator({
+  viewport,
+}: {
+  viewport: { w: number; h: number };
+}) {
   const reduce = useReducedMotion();
+  // Size against the room box (not fixed px) so the dots keep the same
+  // proportion in a small Storybook frame and the full-window app.
+  const dot = Math.max(8, Math.round(0.04 * Math.min(viewport.w, viewport.h)));
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute left-1/2 z-[1] flex -translate-x-1/2 items-center gap-3"
-      style={{ top: "34%" }}
+      className="pointer-events-none absolute left-1/2 z-[1] flex -translate-x-1/2 items-center"
+      style={{ top: "34%", gap: dot }}
     >
       {[0, 1, 2].map((i) => (
         <motion.span
           key={i}
-          className="block size-3 rounded-full"
-          style={{ backgroundColor: "var(--room-fg, #ffffff)" }}
+          className="block rounded-full"
+          style={{
+            width: dot,
+            height: dot,
+            backgroundColor: "var(--room-fg, #ffffff)",
+          }}
           initial={reduce ? false : { opacity: 0.3, scale: 0.75 }}
           animate={
             reduce
@@ -401,14 +430,19 @@ function VoiceRespondingTreatment({
   getAmplitude,
   waveStyle,
   wavePlacement,
+  viewport,
 }: {
   style: VoiceRespondingStyle;
   getAmplitude?: () => number;
   waveStyle: VoiceWaveStyle;
   wavePlacement: VoiceWavePlacement;
+  viewport: { w: number; h: number };
 }) {
   const ampRef = useRespondingAmp(getAmplitude);
   const reduce = useReducedMotion();
+  // Size against the room box (not `vh`/`vw`, which ignore the Storybook frame
+  // and resolve against the window) so proportions match app and Storybook.
+  const M = Math.min(viewport.w, viewport.h);
 
   if (style === "waveform") {
     // The assistant's own voice — reuse the centered band, output-driven.
@@ -447,8 +481,8 @@ function VoiceRespondingTreatment({
       >
         <div
           style={{
-            width: "min(70vh, 70vw)",
-            aspectRatio: "1 / 1",
+            width: Math.round(0.9 * M),
+            height: Math.round(0.9 * M),
             borderRadius: "9999px",
             background:
               "radial-gradient(circle, color-mix(in srgb, var(--room-fg, #ffffff) 24%, transparent) 0%, transparent 66%)",
@@ -475,8 +509,8 @@ function VoiceRespondingTreatment({
           key={i}
           className="absolute rounded-full border-2"
           style={{
-            width: "min(38vh, 38vw)",
-            height: "min(38vh, 38vw)",
+            width: Math.round(0.5 * M),
+            height: Math.round(0.5 * M),
             borderColor:
               "color-mix(in srgb, var(--room-fg, #ffffff) 55%, transparent)",
           }}
@@ -496,33 +530,39 @@ function VoiceRespondingTreatment({
 }
 
 /**
- * Rest position + entrance travel for the eyes, per placement, plus
- * `sinkTravel`: how far the centered eyes can slide down toward the bottom
- * rest while the user speaks (0 for the bottom placement — nowhere lower).
+ * Rest position + entrance geometry for the eyes, per placement. The eyes grow
+ * from the entry origin (start offset by `origin − restCenter`, scaled down)
+ * and settle at rest with a small dip. `sinkTravel` is how far the centered
+ * eyes can slide toward the bottom rest while the user speaks (0 for the
+ * bottom placement — nowhere lower).
  */
 function eyeLayout(
   placement: VoiceEyePlacement,
+  eyesW: number,
   eyesH: number,
+  w: number,
   h: number,
-): { restTop: number; startY: number; dipY: number; sinkTravel: number } {
+  origin: { x: number; y: number },
+): {
+  restTop: number;
+  startX: number;
+  startY: number;
+  dipY: number;
+  sinkTravel: number;
+} {
   const bottomRestTop = h - (1 - EYE_REST_CUTOFF) * eyesH;
-  if (placement === "center") {
-    const restTop = (h - eyesH) / 2;
-    return {
-      restTop,
-      // Grow in place with a small settle dip — no long travel from the floor.
-      startY: -eyesH * 0.22,
-      dipY: eyesH * 0.12,
-      // Full voice pulls the eyes all the way down to the bottom rest.
-      sinkTravel: Math.max(0, bottomRestTop - restTop),
-    };
-  }
+  const restTop = placement === "center" ? (h - eyesH) / 2 : bottomRestTop;
+  // Rest center (the eyes are horizontally centered: left = (w − eyesW) / 2).
+  const restCenterX = w / 2;
+  const restCenterY = restTop + eyesH / 2;
   return {
-    restTop: bottomRestTop,
-    // Rise from the picker's centered position (40vh), dipping below rest.
-    startY: (ENTER_FROM_CENTER_VH / 100) * h - (bottomRestTop + eyesH / 2),
-    dipY: (EYE_DIP_CUTOFF - EYE_REST_CUTOFF) * eyesH,
-    sinkTravel: 0,
+    restTop,
+    startX: origin.x - restCenterX,
+    startY: origin.y - restCenterY,
+    // A small settle dip below rest as they land.
+    dipY: eyesH * 0.12,
+    sinkTravel:
+      placement === "center" ? Math.max(0, bottomRestTop - restTop) : 0,
   };
 }
 
@@ -530,6 +570,7 @@ export function VoiceRoomEyes({
   art,
   viewport,
   placement = "center",
+  entranceOrigin,
   getAmplitude,
   sink = false,
   dimmed = false,
@@ -538,6 +579,8 @@ export function VoiceRoomEyes({
   /** The room box the eyes are framed in (the caller's live viewport size). */
   viewport: { w: number; h: number };
   placement?: VoiceEyePlacement;
+  /** Viewport point the eyes grow from on entrance. Defaults to screen center. */
+  entranceOrigin?: { x: number; y: number };
   /** Mic amplitude source (0–1); drives the live bob while the eyes are sunk. */
   getAmplitude?: () => number;
   /** Hold the eyes at the low rest (the user-owned turn — listening + thinking). */
@@ -589,6 +632,8 @@ export function VoiceRoomEyes({
     };
   }, [reduce, entranceDone]);
 
+  const originX = entranceOrigin?.x ?? w / 2;
+  const originY = entranceOrigin?.y ?? (ENTER_FROM_CENTER_VH / 100) * h;
   const geometry = useMemo(() => {
     const maxEyesW = w * EYE_MAX_WIDTH;
     const eyesH = Math.min(
@@ -596,17 +641,25 @@ export function VoiceRoomEyes({
       (maxEyesW * art.bbox.h) / art.bbox.w,
     );
     const eyesW = (eyesH * art.bbox.w) / art.bbox.h;
-    const { restTop, startY, dipY, sinkTravel } = eyeLayout(placement, eyesH, h);
+    const { restTop, startX, startY, dipY, sinkTravel } = eyeLayout(
+      placement,
+      eyesW,
+      eyesH,
+      w,
+      h,
+      { x: originX, y: originY },
+    );
     return {
       eyesW,
       eyesH,
       left: (w - eyesW) / 2,
       restTop,
+      startX,
       startY,
       dipY,
       sinkTravel,
     };
-  }, [art, w, h, placement]);
+  }, [art, w, h, placement, originX, originY]);
 
   // Sink: while the user owns the turn (listening + thinking) the centered eyes
   // drop to a low hold near the bottom rest (`EYE_LISTEN_SINK_BASE` of the
@@ -676,11 +729,19 @@ export function VoiceRoomEyes({
         height: geometry.eyesH,
         transformOrigin: "center",
       }}
-      initial={playEntrance ? { y: geometry.startY, scale: 0.35 } : false}
+      initial={
+        playEntrance
+          ? { x: geometry.startX, y: geometry.startY, scale: 0.35 }
+          : false
+      }
       animate={
         playEntrance
-          ? { y: [geometry.startY, geometry.dipY, 0], scale: [0.35, 1, 1] }
-          : { y: 0, scale: 1 }
+          ? {
+              x: [geometry.startX, 0, 0],
+              y: [geometry.startY, geometry.dipY, 0],
+              scale: [0.35, 1, 1],
+            }
+          : { x: 0, y: 0, scale: 1 }
       }
       transition={
         playEntrance

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -397,11 +397,24 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     expect(eyes()).not.toBeNull();
-    // The eyes replace the void look's cast: no centered avatar, no waves.
+    // The eyes replace the void look's centered avatar; the mic waveform
+    // still shows while listening (centered, behind the eyes).
     expect(screen.queryByTestId("voice-avatar")).toBeNull();
-    expect(screen.queryByTestId("listening-waves")).toBeNull();
+    expect(screen.getByTestId("listening-waves")).toBeTruthy();
     // The exit control stays available regardless of look.
     expect(exitButton()).not.toBeNull();
+  });
+
+  test("the color look shows no waveform outside listening", () => {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
+      customImageUrl: null,
+    };
+    startOwnedSession("speaking");
+    render(<VoiceRoom />);
+    expect(eyes()).not.toBeNull();
+    expect(screen.queryByTestId("listening-waves")).toBeNull();
   });
 
   test("a default character (no traits) gets first-component eyes", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -10,9 +10,9 @@
  * so the exit control's independence from avatar readiness is testable).
  *
  * Exit is the load-bearing behavior: the room is a full-app takeover with no
- * minimize — the ✕ control (which ends the session) is the only way out, it
- * renders even with no assistant resolved, and Escape deliberately does
- * nothing (an accidental keypress must not end a live call).
+ * minimize — ending the session is the only way out, via the ✕ control (which
+ * renders even with no assistant resolved) or Escape, and the key listener is
+ * removed on unmount (no leaks).
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -92,7 +92,13 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
 
 /** Minimal character components: one body/eye/color of each. */
 const CHARACTER_COMPONENTS = {
-  bodyShapes: [{ id: "sprout", svgPath: "M0 0 L10 0 L10 10 Z" }],
+  bodyShapes: [
+    {
+      id: "sprout",
+      svgPath: "M0 0 L10 0 L10 10 Z",
+      viewBox: { width: 10, height: 10 },
+    },
+  ],
   eyeStyles: [
     {
       id: "curious",
@@ -241,13 +247,36 @@ describe("VoiceRoom — no way out but ending the session", () => {
     ).toBeNull();
   });
 
-  test("Escape neither dismisses the room nor ends the session", () => {
+  test("Escape ends the session, same as ✕", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     act(() => {
       window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     });
-    expect(roomDialog()).not.toBeNull();
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+  });
+
+  test("Escape ends the session even when an editable element holds focus (global key)", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    // The room can open while the composer textarea still owns focus; the key
+    // is global and must fire regardless of the editable target guard.
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+    expect(controls.stop).toHaveBeenCalledTimes(1);
+    input.remove();
+  });
+
+  test("the key listener is removed on unmount — no stray Escape handling", () => {
+    startOwnedSession("listening");
+    const { unmount } = render(<VoiceRoom />);
+    unmount();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(controls.stop).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -293,6 +293,54 @@ describe("VoiceRoom — captions toggle", () => {
   });
 });
 
+describe("VoiceRoom — mute toggle", () => {
+  test("mute drives the registered setMuted control", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    fireEvent.click(screen.getByRole("button", { name: "Mute microphone" }));
+    expect(controls.setMuted).toHaveBeenCalledWith(true);
+  });
+
+  test("muted: offers unmute", () => {
+    startOwnedSession("listening");
+    useLiveVoiceStore.setState({ muted: true });
+    render(<VoiceRoom />);
+    const toggle = screen.getByRole("button", { name: "Unmute microphone" });
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(toggle);
+    expect(controls.setMuted).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("VoiceRoom — stop response", () => {
+  const stopButton = () =>
+    screen.queryByRole("button", { name: "Stop assistant response" });
+
+  test("■ renders while speaking hands-free and drives the interrupt control", () => {
+    startOwnedSession("speaking");
+    useLiveVoiceStore.setState({ handsFree: true });
+    render(<VoiceRoom />);
+    fireEvent.click(stopButton()!);
+    expect(controls.interrupt).toHaveBeenCalledTimes(1);
+    expect(controls.stop).not.toHaveBeenCalled();
+  });
+
+  test("no ■ outside speaking, or for a manual (fallback) session", () => {
+    startOwnedSession("listening");
+    useLiveVoiceStore.setState({ handsFree: true });
+    const { unmount } = render(<VoiceRoom />);
+    expect(stopButton()).toBeNull();
+    unmount();
+
+    // Manual session (version-skew fallback): interrupt would end the whole
+    // session, so the room must not offer the turn-scoped control.
+    startOwnedSession("speaking");
+    useLiveVoiceStore.setState({ handsFree: false });
+    render(<VoiceRoom />);
+    expect(stopButton()).toBeNull();
+  });
+});
+
 describe("VoiceRoom — connect feedback", () => {
   test("shows the connecting label while the session connects", () => {
     startOwnedSession("connecting");

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -9,10 +9,10 @@
  * assistant-avatar React Query graph — irrelevant to room chrome, and stubbed
  * so the exit control's independence from avatar readiness is testable).
  *
- * Exit and minimize are the load-bearing behaviors: the ✕ control ends the
- * session, Escape / the minimize control collapse the room WITHOUT ending the
- * session (the composer's voice bar takes over), the ✕ renders even with no
- * assistant resolved, and the key listeners are removed on unmount (no leaks).
+ * Exit is the load-bearing behavior: the room is a full-app takeover with no
+ * minimize — the ✕ control (which ends the session) is the only way out, it
+ * renders even with no assistant resolved, and Escape deliberately does
+ * nothing (an accidental keypress must not end a live call).
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -76,17 +76,31 @@ mock.module("@/domains/chat/voice/voice-room/voice-listening-waves", () => ({
   VoiceListeningWaves: () => <div data-testid="listening-waves" />,
 }));
 
-// The room reads the session avatar to tint the waves to the assistant color;
-// stub the hook so these tests don't need the assistant-avatar React Query
-// graph (the room-chrome behavior is independent of avatar data).
+// The room resolves its look (color-with-eyes vs the ambient void) and the
+// wave accent from the session avatar; stub the hook — with mutable data so
+// look tests can exercise both — to avoid the assistant-avatar React Query
+// graph.
+let mockAvatarData: {
+  components: unknown;
+  traits: unknown;
+  customImageUrl: string | null;
+} = { components: null, traits: null, customImageUrl: null };
 mock.module("@/hooks/use-assistant-avatar", () => ({
-  useAssistantAvatar: () => ({
-    components: null,
-    traits: null,
-    customImageUrl: null,
-  }),
+  useAssistantAvatar: () => ({ ...mockAvatarData }),
   avatarQueryKey: (id: string) => ["assistantAvatar", id],
 }));
+
+/** Minimal character components: one body/eye/color of each. */
+const CHARACTER_COMPONENTS = {
+  bodyShapes: [{ id: "sprout", svgPath: "M0 0 L10 0 L10 10 Z" }],
+  eyeStyles: [
+    {
+      id: "curious",
+      paths: [{ svgPath: "M0 0 L10 0 L10 10 Z", color: "#FFFFFF" }],
+    },
+  ],
+  colors: [{ id: "green", hex: "#4C9B50" }],
+};
 
 // Imported after the mocks so the room picks up the mocked modules.
 const { VoiceRoom } = await import("@/domains/chat/voice/voice-room/voice-room");
@@ -107,6 +121,7 @@ beforeEach(() => {
   mockSearch = "";
   mockMainView = "chat";
   mockIsMobile = false;
+  mockAvatarData = { components: null, traits: null, customImageUrl: null };
   controls.stop.mockClear();
   controls.release.mockClear();
   controls.interrupt.mockClear();
@@ -215,60 +230,25 @@ describe("VoiceRoom — exit", () => {
     expect(screen.getByTestId("voice-avatar").textContent).toBe("no-assistant");
   });
 
-  test("key listeners are removed on unmount — no stray Escape handling", () => {
-    startOwnedSession("listening");
-    const { unmount } = render(<VoiceRoom />);
-    unmount();
-    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-    expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
-    expect(controls.stop).not.toHaveBeenCalled();
-  });
 });
 
-describe("VoiceRoom — minimize (session keeps running)", () => {
-  test("Escape minimizes the room without ending the session", () => {
+describe("VoiceRoom — no way out but ending the session", () => {
+  test("no minimize control renders", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
-    // act: minimizing flips the store flag, which re-renders (unmounts) the room.
+    expect(
+      screen.queryByRole("button", { name: "Minimize voice room" }),
+    ).toBeNull();
+  });
+
+  test("Escape neither dismisses the room nor ends the session", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
     act(() => {
       window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     });
-    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
+    expect(roomDialog()).not.toBeNull();
     expect(controls.stop).not.toHaveBeenCalled();
-  });
-
-  test("Escape minimizes even when an editable element holds focus (global key)", () => {
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    // The room can open while the composer textarea still owns focus; the key
-    // is global and must fire regardless of the editable target guard.
-    const input = document.createElement("input");
-    document.body.appendChild(input);
-    act(() => {
-      input.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
-      );
-    });
-    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
-    expect(controls.stop).not.toHaveBeenCalled();
-    input.remove();
-  });
-
-  test("the minimize control minimizes without ending the session", () => {
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    fireEvent.click(
-      screen.getByRole("button", { name: "Minimize voice room" }),
-    );
-    expect(useLiveVoiceStore.getState().roomMinimized).toBe(true);
-    expect(controls.stop).not.toHaveBeenCalled();
-  });
-
-  test("a minimized room does not render for an owned active session", () => {
-    startOwnedSession("listening");
-    useLiveVoiceStore.getState().setRoomMinimized(true);
-    render(<VoiceRoom />);
-    expect(roomDialog()).toBeNull();
   });
 });
 
@@ -366,17 +346,64 @@ describe("VoiceRoom — connect feedback", () => {
   });
 });
 
-describe("VoiceRoom — placement variants", () => {
-  test("the fullscreen (mobile) variant is modal", () => {
+describe("VoiceRoom — full-app takeover", () => {
+  test("the room is a modal full-viewport overlay", () => {
     startOwnedSession("listening");
-    render(<VoiceRoom variant="fullscreen" />);
-    expect(roomDialog()!.getAttribute("aria-modal")).toBe("true");
+    render(<VoiceRoom />);
+    const dialog = roomDialog()!;
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.className).toContain("fixed inset-0");
+  });
+});
+
+describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
+  const eyes = () => screen.queryByTestId("voice-room-eyes");
+
+  test("a character avatar gets the color-with-eyes look", () => {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
+      customImageUrl: null,
+    };
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(eyes()).not.toBeNull();
+    // The eyes replace the void look's cast: no centered avatar, no waves.
+    expect(screen.queryByTestId("voice-avatar")).toBeNull();
+    expect(screen.queryByTestId("listening-waves")).toBeNull();
+    // The exit control stays available regardless of look.
+    expect(exitButton()).not.toBeNull();
   });
 
-  test("the content (desktop) variant is not modal — surrounding chrome stays usable", () => {
+  test("a default character (no traits) gets first-component eyes", () => {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: null,
+      customImageUrl: null,
+    };
     startOwnedSession("listening");
-    render(<VoiceRoom variant="content" />);
-    expect(roomDialog()!.getAttribute("aria-modal")).toBeNull();
+    render(<VoiceRoom />);
+    expect(eyes()).not.toBeNull();
+  });
+
+  test("a custom-image avatar keeps the ambient-void look", () => {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: null,
+      customImageUrl: "blob:custom-avatar",
+    };
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(eyes()).toBeNull();
+    expect(screen.getByTestId("voice-avatar")).toBeTruthy();
+    expect(screen.getByTestId("listening-waves")).toBeTruthy();
+  });
+
+  test("an unresolved avatar (still loading) keeps the ambient-void look", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(eyes()).toBeNull();
+    expect(screen.getByTestId("voice-avatar")).toBeTruthy();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -1,41 +1,43 @@
 /**
- * "Voice room" — the owning-composer surface for a live-voice session. A
- * deep-dark ambient void with the assistant's state-driven avatar at its
- * center, mounted by `chat-layout.tsx` as a purely additive overlay: the
- * composer's voice bar and display transcript still render underneath, hidden
- * by this layer, so removing the room leaves the old UI intact.
+ * "Voice room" — the owning-composer surface for a live-voice session,
+ * mounted by `chat-layout.tsx` as a purely additive overlay: the composer's
+ * voice bar and display transcript still render underneath, hidden by this
+ * layer, so removing the room leaves the old UI intact.
  *
- * Two placement variants (see `chat-layout.tsx` for the mounts):
+ * Two looks, resolved per session assistant ({@link resolveVoiceRoomLook}):
  *
- * - `"fullscreen"` (mobile) — `fixed inset-0` over the whole viewport,
- *   modal, with safe-area padding for notched iOS shells.
- * - `"content"` (desktop) — `absolute inset-0` inside the layout's `<main>`,
- *   leaving the header and sidebar visible AND interactive so the user can
- *   keep navigating; any navigation away hands the session off to the
- *   title-bar pill. Deliberately not `aria-modal`: the surrounding chrome
- *   stays usable.
+ * - Character avatars get the onboarding "full-screen color with eyes"
+ *   treatment — the avatar color fills the room and the avatar's giant eyes
+ *   peek from the bottom edge, with the control chrome toned for contrast
+ *   against that color ({@link toneForBg}, via the `--room-*` CSS vars).
+ * - Custom-image / no-character avatars fall back to the deep-dark ambient
+ *   void with the state-driven avatar at its center and the listening waves —
+ *   what this look should become is an open design question.
+ *
+ * The room is a full-app takeover on every platform — `fixed inset-0`, modal,
+ * covering the header and sidebar, with safe-area padding for notched iOS
+ * shells. A voice session IS the room: there is no minimize and no way to
+ * leave it while the session runs — ending the session (the ✕ control) is the
+ * only way out.
  *
  * Visibility is a pure function of {@link useIsVoiceRoomVisible} — active
- * session, owned by the on-screen composer, not minimized, main window. Any
- * session end (user exit, `failed`, conversation timeout, stop from elsewhere)
- * flips that predicate false and unmounts the room; a `failed` session
- * surfaces through the existing composer Notice / pill failure chip, never a
- * dead room.
+ * session, owned by the on-screen composer, main window. Any session end
+ * (user exit, `failed`, conversation timeout, stop from elsewhere) flips that
+ * predicate false and unmounts the room; a `failed` session surfaces through
+ * the existing composer Notice / pill failure chip, never a dead room.
  *
  * Sessions are hands-free (server-VAD): the user just speaks, so there is no
  * push-to-talk control. Bottom-center carries the session controls in the
  * call-app idiom: a mic mute toggle (always) and, while the assistant speaks
  * hands-free, a turn-scoped ■ stop. Exit is first-class: a persistent
  * ✕ control (always rendered, even while the avatar/assistant data is loading
- * or failed) ends the session; Escape and the minimize control collapse the
- * room to the composer's voice bar WITHOUT ending the session (the bar's
- * expand control reopens it). The key handler attaches only while the room is
- * mounted.
+ * or failed) ends the session. Escape deliberately does nothing — an
+ * accidental keypress must not end a live call.
  */
 
+import type { CSSProperties } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useEffect } from "react";
-import { Captions, CaptionsOff, Mic, MicOff, Minimize2, Square, X } from "lucide-react";
+import { Captions, CaptionsOff, Mic, MicOff, Square, X } from "lucide-react";
 
 import { Tooltip, cn } from "@vellumai/design-library";
 
@@ -44,7 +46,6 @@ import {
   getLiveVoiceInputAmplitude,
   getLiveVoiceOutputAmplitude,
   liveVoiceStateLabel,
-  minimizeLiveVoiceRoom,
   setLiveVoiceMuted,
   stopLiveVoiceResponse,
   useLiveVoiceStore,
@@ -52,6 +53,7 @@ import {
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+import { toneForBg } from "@/utils/surface-tone";
 
 import { resolveWaveAccentHex } from "./wave-accent";
 
@@ -61,6 +63,7 @@ import { VoiceAvatar } from "./voice-avatar";
 import { VoiceListeningWaves } from "./voice-listening-waves";
 import { AVATAR_ENTER_SPRING } from "./voice-motion";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
+import { VoiceRoomEyes, resolveVoiceRoomLook } from "./voice-room-eyes";
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
 
 const AVATAR_SIZE = 220;
@@ -79,33 +82,36 @@ const SAFE_AREA_LEFT =
 const SAFE_AREA_RIGHT =
   "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))";
 
-/** Shared white-on-dark treatment for the room's icon controls. */
+/**
+ * Shared treatment for the room's top icon controls, toned to the active look
+ * via the `--room-*` vars set on the root (white-on-dark for the void look,
+ * tone-derived over an avatar color).
+ */
 const ROOM_CONTROL_CLASS =
-  "flex size-10 items-center justify-center rounded-full text-white/70 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60";
+  "flex size-10 items-center justify-center rounded-full text-[var(--room-fg-muted)] transition hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--room-fg-muted)]";
 
-export type VoiceRoomVariant = "fullscreen" | "content";
+/** Bottom-row circular session controls (mute / ■ stop), same toning. */
+const SESSION_CONTROL_CLASS =
+  "flex size-12 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--room-fg-muted)]";
+const SESSION_CONTROL_NEUTRAL_CLASS =
+  "border-[var(--room-border)] text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]";
 
-export interface VoiceRoomProps {
-  /** Placement variant — see the module docstring. Defaults to fullscreen. */
-  variant?: VoiceRoomVariant;
-}
-
-export function VoiceRoom({ variant = "fullscreen" }: VoiceRoomProps) {
+export function VoiceRoom() {
   const visible = useIsVoiceRoomVisible();
 
   return (
     <AnimatePresence>
-      {visible ? <VoiceRoomOverlay key="voice-room" variant={variant} /> : null}
+      {visible ? <VoiceRoomOverlay key="voice-room" /> : null}
     </AnimatePresence>
   );
 }
 
 /**
- * The mounted room. Split from {@link VoiceRoom} so its store subscriptions and
- * key handlers only exist while the room is actually visible and are torn
- * down cleanly on exit.
+ * The mounted room. Split from {@link VoiceRoom} so its store subscriptions
+ * only exist while the room is actually visible and are torn down cleanly on
+ * exit.
  */
-function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
+function VoiceRoomOverlay() {
   const state = useLiveVoiceStore.use.state();
   const reconnecting = useLiveVoiceStore.use.reconnecting();
   const assistantId = useLiveVoiceStore.use.assistantId();
@@ -132,60 +138,44 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
     prefs.setShowAssistantTranscript(!captionsOn);
   };
 
-  // Publish the session assistant's avatar accent on the room itself (not just
-  // the html-level var, which tracks the *active* assistant) so the listening
-  // waves tint to the avatar shown here even if a session outlives navigating
-  // away. Shares the cached avatar query with VoiceAvatar; null for
-  // custom-image / "none" / still-loading avatars, where the waves fall back to
-  // the aurora indigo via the CSS var fallback.
-  const { components, traits } = useAssistantAvatar(assistantId);
+  // Resolve the assistant's look: color-with-eyes for character avatars, the
+  // ambient void otherwise. The accent var is still published for the
+  // fallback look's listening waves (null for custom-image / "none" /
+  // still-loading avatars, where the waves keep their aurora fallback).
+  const { components, traits, customImageUrl } = useAssistantAvatar(assistantId);
+  const look = resolveVoiceRoomLook(components, traits, customImageUrl);
+  const tone = look ? toneForBg(look.bgHex) : null;
   const accentHex = resolveWaveAccentHex(components, traits);
 
-  // Global Escape, live only while the room is mounted: minimizes the room
-  // (the session keeps running; the composer's voice bar takes over as the
-  // control surface) — ending is reserved for the explicit ✕. It fires even
-  // when the composer textarea (or any other focused element) still holds
-  // focus as the room opens, so it is intentionally not guarded by the event
-  // target.
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        minimizeLiveVoiceRoom();
-      }
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, []);
+  // Control-chrome colors for the active look, consumed by the shared control
+  // classes. The fallbacks are the void look's white-on-dark values.
+  const toneVars = {
+    "--room-fg": tone?.fg ?? "#FFFFFF",
+    "--room-fg-muted": tone?.fgMuted ?? "rgba(255,255,255,0.7)",
+    "--room-wash": tone?.wash ?? "rgba(255,255,255,0.1)",
+    "--room-border": tone?.wash ?? "rgba(255,255,255,0.15)",
+  } as CSSProperties;
 
   return (
     <motion.div
-      className={cn(
-        "flex items-center justify-center overflow-hidden",
-        // Both variants sit at z-50: the highest tier used inside the chat
-        // content (e.g. the quote-reply bubble), with DOM order — the room
-        // mounts after the Outlet — breaking the tie in the room's favor.
-        variant === "fullscreen"
-          ? "fixed inset-0 z-50"
-          : "absolute inset-0 z-50 rounded-xl",
-      )}
-      data-theme="dark"
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden"
+      // Theme tokens (the connect label, the ambient transcript) follow the
+      // look: dark over the void and the dark avatar colors, light over the
+      // light one (yellow).
+      data-theme={tone?.isLight ? "light" : "dark"}
       role="dialog"
-      // Only the fullscreen room is modal: the content variant deliberately
-      // leaves the header and sidebar interactive so the user can navigate
-      // mid-session (the pill takes over as the control surface).
-      aria-modal={variant === "fullscreen" || undefined}
+      aria-modal
       aria-label="Voice session"
-      // The fullscreen overlay covers `ChatLayoutHeader`, so it loses the
-      // header's safe-area protection — pad the centered avatar inside the
-      // notch/home-indicator per docs/CAPACITOR.md. Inert for the desktop
-      // content variant. The ambient void is `absolute inset-0` and stays
-      // full-bleed behind the padding.
+      // The overlay covers `ChatLayoutHeader`, so it loses the header's
+      // safe-area protection — pad the centered avatar inside the
+      // notch/home-indicator per docs/CAPACITOR.md. The background layers are
+      // `absolute inset-0` and stay full-bleed behind the padding.
       style={{
         paddingTop: SAFE_AREA_TOP,
         paddingBottom: SAFE_AREA_BOTTOM,
         paddingLeft: SAFE_AREA_LEFT,
         paddingRight: SAFE_AREA_RIGHT,
+        ...toneVars,
         ...(accentHex ? { [AVATAR_ACCENT_CSS_VAR]: accentHex } : {}),
       }}
       initial={reduce ? false : { opacity: 0 }}
@@ -193,13 +183,25 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       exit={{ opacity: 0 }}
       transition={{ duration: reduce ? 0 : 0.4 }}
     >
-      <VoiceRoomAmbientBackground />
+      {look ? (
+        <div
+          className="absolute inset-0"
+          style={{ backgroundColor: look.bgHex }}
+        />
+      ) : (
+        <VoiceRoomAmbientBackground />
+      )}
+
+      {/* The assistant's giant eyes peeking from the bottom — the color look's
+          entire cast. The void look expresses the session through the centered
+          avatar and the listening waves instead. */}
+      {look ? <VoiceRoomEyes art={look.art} /> : null}
 
       {/* Listening waves: the user's voice arriving as energy coming in, rising
-          from the bottom edge with live mic amplitude. Only while listening;
-          responding expresses itself through the avatar's own emanation. Sits
-          above the void, behind the centered avatar (later in DOM, z-0). */}
-      {visual === "listening" ? (
+          from the bottom edge with live mic amplitude. Void look only, while
+          listening; responding expresses itself through the avatar's own
+          emanation. Sits above the void, behind the centered avatar. */}
+      {!look && visual === "listening" ? (
         <VoiceListeningWaves
           getAmplitude={getLiveVoiceInputAmplitude}
           palette="accent"
@@ -212,9 +214,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           avatar and stays absent by default. */}
       <VoiceAmbientTranscript />
 
-      {/* Room controls — captions toggle, minimize, and the persistent exit.
-          Rendered above all room chrome; ✕ is never gated behind avatar
-          readiness, so ending works even mid-load / on failure. */}
+      {/* Room controls — captions toggle and the persistent exit. Rendered
+          above all room chrome; ✕ is never gated behind avatar readiness, so
+          ending works even mid-load / on failure. */}
       <div
         // Absolute position is relative to the padding box, so the overlay's
         // safe-area padding does not shift this — inset it from the notch /
@@ -240,16 +242,6 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             )}
           </button>
         </Tooltip>
-        <Tooltip content="Minimize (Esc)">
-          <button
-            type="button"
-            onClick={minimizeLiveVoiceRoom}
-            aria-label="Minimize voice room"
-            className={ROOM_CONTROL_CLASS}
-          >
-            <Minimize2 className="size-5" />
-          </button>
-        </Tooltip>
         <Tooltip content="End voice session">
           <button
             type="button"
@@ -262,26 +254,29 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         </Tooltip>
       </div>
 
-      {/* The avatar springs to center once on entry (the wrapper owns the
-          one-time entry spring); per-state expression is the avatar's own CSS
-          loop, which cross-fades in place without re-popping. */}
-      <motion.div
-        className="relative z-0"
-        initial={reduce ? false : { scale: 0.8, y: 24, opacity: 0 }}
-        animate={{ scale: 1, y: 0, opacity: 1 }}
-        transition={reduce ? { duration: 0 } : AVATAR_ENTER_SPRING}
-      >
-        <VoiceAvatar
-          assistantId={assistantId}
-          visual={visual}
-          // Only the `responding` avatar is audio-reactive, and it always rides
-          // TTS output — so the output amplitude is the sole source here. The
-          // user's voice is expressed by the bottom waves in `listening`, not
-          // by the avatar.
-          getAmplitude={getLiveVoiceOutputAmplitude}
-          size={AVATAR_SIZE}
-        />
-      </motion.div>
+      {/* Void look: the avatar springs to center once on entry (the wrapper
+          owns the one-time entry spring); per-state expression is the avatar's
+          own CSS loop, which cross-fades in place without re-popping. The
+          color look has no centered figure — the bottom eyes are the cast. */}
+      {!look ? (
+        <motion.div
+          className="relative z-0"
+          initial={reduce ? false : { scale: 0.8, y: 24, opacity: 0 }}
+          animate={{ scale: 1, y: 0, opacity: 1 }}
+          transition={reduce ? { duration: 0 } : AVATAR_ENTER_SPRING}
+        >
+          <VoiceAvatar
+            assistantId={assistantId}
+            visual={visual}
+            // Only the `responding` avatar is audio-reactive, and it always
+            // rides TTS output — so the output amplitude is the sole source
+            // here. The user's voice is expressed by the bottom waves in
+            // `listening`, not by the avatar.
+            getAmplitude={getLiveVoiceOutputAmplitude}
+            size={AVATAR_SIZE}
+          />
+        </motion.div>
+      ) : null}
 
       {/* Connect feedback: until the session reaches `listening` the avatar
           shows the idle visual, which otherwise reads as dead air — surface
@@ -321,10 +316,12 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             aria-label={muted ? "Unmute microphone" : "Mute microphone"}
             aria-pressed={muted}
             className={cn(
-              "flex size-12 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60",
+              SESSION_CONTROL_CLASS,
               muted
-                ? "border-red-400/50 bg-red-500/20 text-red-300 hover:bg-red-500/30"
-                : "border-white/15 text-white/70 hover:bg-white/10 hover:text-white",
+                ? tone?.isLight
+                  ? "border-red-700/50 bg-red-600/15 text-red-800 hover:bg-red-600/25"
+                  : "border-red-400/50 bg-red-500/20 text-red-300 hover:bg-red-500/30"
+                : SESSION_CONTROL_NEUTRAL_CLASS,
             )}
           >
             {muted ? <MicOff className="size-5" /> : <Mic className="size-5" />}
@@ -344,7 +341,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                   type="button"
                   onClick={stopLiveVoiceResponse}
                   aria-label="Stop assistant response"
-                  className="flex size-12 items-center justify-center rounded-full border border-white/15 text-white/70 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+                  className={cn(
+                    SESSION_CONTROL_CLASS,
+                    SESSION_CONTROL_NEUTRAL_CLASS,
+                  )}
                 >
                   <Square className="size-4" fill="currentColor" />
                 </button>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -316,11 +316,12 @@ function VoiceRoomOverlay() {
           the response without ending the session (web barge-in by just
           talking is not reliable yet, so this is the room's only interrupt).
           Anchored bottom-right (the mic sits in the corner, the transient stop
-          to its left), clamped to the same insets as the top-right cluster. */}
+          to its left) with an equal corner gap on both edges, matching the
+          top-right cluster's 1.25rem inset. */}
       <div
         className="absolute z-10 flex items-center gap-3"
         style={{
-          bottom: `max(2.5rem, ${SAFE_AREA_BOTTOM})`,
+          bottom: `max(1.25rem, ${SAFE_AREA_BOTTOM})`,
           right: `max(1.25rem, ${SAFE_AREA_RIGHT})`,
         }}
       >

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -9,9 +9,10 @@
  * - Character avatars get the onboarding "full-screen color with eyes"
  *   treatment — entering the room plays the Introduction-step grow (the
  *   avatar's body springs from its on-screen size to BE the screen, the color
- *   fades in behind it, the giant eyes rise into their bottom-edge rest; see
- *   {@link VoiceRoomColorLook}), with the control chrome toned for contrast
- *   against that color ({@link toneForBg}, via the `--room-*` CSS vars).
+ *   fades in behind it, the giant eyes grow into the center; see
+ *   {@link VoiceRoomColorLook}), the mic waveform swells behind the eyes while
+ *   the user speaks, and the control chrome is toned for contrast against that
+ *   color ({@link toneForBg}, via the `--room-*` CSS vars).
  * - Custom-image / no-character avatars fall back to the deep-dark ambient
  *   void with the state-driven avatar at its center and the listening waves —
  *   what this look should become is an open design question.
@@ -202,21 +203,28 @@ function VoiceRoomOverlay() {
       exit={{ opacity: 0 }}
       transition={{ duration: reduce ? 0 : 0.4 }}
     >
-      {/* The color look (body grow entrance + color fade + peeking eyes) is
-          the entire cast; the void look expresses the session through the
-          centered avatar and the listening waves instead. */}
-      {look ? <VoiceRoomColorLook look={look} /> : <VoiceRoomAmbientBackground />}
-
-      {/* Listening waves: the user's voice arriving as energy coming in, rising
-          from the bottom edge with live mic amplitude. Void look only, while
-          listening; responding expresses itself through the avatar's own
-          emanation. Sits above the void, behind the centered avatar. */}
-      {!look && visual === "listening" ? (
-        <VoiceListeningWaves
+      {/* The color look (body grow entrance + color fade + centered waves +
+          centered eyes) is the entire cast; the void look expresses the
+          session through the centered avatar and the bottom listening waves
+          instead. Both draw the waves only while `listening`, from live mic
+          amplitude. */}
+      {look ? (
+        <VoiceRoomColorLook
+          look={look}
+          visual={visual}
           getAmplitude={getLiveVoiceInputAmplitude}
-          palette="accent"
         />
-      ) : null}
+      ) : (
+        <>
+          <VoiceRoomAmbientBackground />
+          {visual === "listening" ? (
+            <VoiceListeningWaves
+              getAmplitude={getLiveVoiceInputAmplitude}
+              palette="accent"
+            />
+          ) : null}
+        </>
+      )}
 
       {/* Optional muted echo of the live transcript, floating above (user) and
           below (assistant) the centered avatar. Pref-gated (the captions

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -23,9 +23,9 @@
  * dead room.
  *
  * Sessions are hands-free (server-VAD): the user just speaks, so there is no
- * push-to-talk control — and deliberately no manual "send now" either: the
- * controller's `release` seam is a no-op for hands-free sessions, so such a
- * control would be dead (PR #37913 review). Exit is first-class: a persistent
+ * push-to-talk control. Bottom-center carries the session controls in the
+ * call-app idiom: a mic mute toggle (always) and, while the assistant speaks
+ * hands-free, a turn-scoped ■ stop. Exit is first-class: a persistent
  * ✕ control (always rendered, even while the avatar/assistant data is loading
  * or failed) ends the session; Escape and the minimize control collapse the
  * room to the composer's voice bar WITHOUT ending the session (the bar's
@@ -35,7 +35,7 @@
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect } from "react";
-import { Captions, CaptionsOff, Minimize2, X } from "lucide-react";
+import { Captions, CaptionsOff, Mic, MicOff, Minimize2, Square, X } from "lucide-react";
 
 import { Tooltip, cn } from "@vellumai/design-library";
 
@@ -45,6 +45,8 @@ import {
   getLiveVoiceOutputAmplitude,
   liveVoiceStateLabel,
   minimizeLiveVoiceRoom,
+  setLiveVoiceMuted,
+  stopLiveVoiceResponse,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
@@ -107,6 +109,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const state = useLiveVoiceStore.use.state();
   const reconnecting = useLiveVoiceStore.use.reconnecting();
   const assistantId = useLiveVoiceStore.use.assistantId();
+  const muted = useLiveVoiceStore.use.muted();
+  // Turn-scoped ■ stop is hands-free-only (a manual session's interrupt ends
+  // the whole session); room sessions are hands-free except on the
+  // version-skew fallback against an older daemon.
+  const handsFree = useLiveVoiceStore.use.handsFree();
   const reduce = useReducedMotion();
 
   const visual = toVoiceAvatarVisual(state, reconnecting);
@@ -298,10 +305,59 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         ) : null}
       </AnimatePresence>
 
+      {/* Bottom-center session controls, the call-app idiom: the mic mute
+          toggle always (an open mic demands an always-reachable mute), and —
+          while the assistant speaks in a hands-free session — a ■ that stops
+          the response without ending the session (web barge-in by just
+          talking is not reliable yet, so this is the room's only interrupt). */}
+      <div
+        className="absolute left-1/2 z-10 flex -translate-x-1/2 items-center gap-3"
+        style={{ bottom: `max(2.5rem, ${SAFE_AREA_BOTTOM})` }}
+      >
+        <Tooltip content={muted ? "Unmute microphone" : "Mute microphone"}>
+          <button
+            type="button"
+            onClick={() => setLiveVoiceMuted(!muted)}
+            aria-label={muted ? "Unmute microphone" : "Mute microphone"}
+            aria-pressed={muted}
+            className={cn(
+              "flex size-12 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60",
+              muted
+                ? "border-red-400/50 bg-red-500/20 text-red-300 hover:bg-red-500/30"
+                : "border-white/15 text-white/70 hover:bg-white/10 hover:text-white",
+            )}
+          >
+            {muted ? <MicOff className="size-5" /> : <Mic className="size-5" />}
+          </button>
+        </Tooltip>
+        <AnimatePresence>
+          {handsFree && state === "speaking" ? (
+            <motion.div
+              key="stop-response"
+              initial={reduce ? false : { opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.9 }}
+              transition={{ duration: reduce ? 0 : 0.2 }}
+            >
+              <Tooltip content="Stop assistant response">
+                <button
+                  type="button"
+                  onClick={stopLiveVoiceResponse}
+                  aria-label="Stop assistant response"
+                  className="flex size-12 items-center justify-center rounded-full border border-white/15 text-white/70 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+                >
+                  <Square className="size-4" fill="currentColor" />
+                </button>
+              </Tooltip>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </div>
+
       {/* Screen readers get session-state changes here; the avatar is the
           visual channel, so this stays off-screen. */}
       <div aria-live="polite" className="sr-only">
-        {stateLabel}
+        {muted ? `Muted — ${stateLabel}` : stateLabel}
       </div>
     </motion.div>
   );

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -213,6 +213,7 @@ function VoiceRoomOverlay() {
           look={look}
           visual={visual}
           getAmplitude={getLiveVoiceInputAmplitude}
+          getResponseAmplitude={getLiveVoiceOutputAmplitude}
         />
       ) : (
         <>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -124,6 +124,9 @@ function VoiceRoomOverlay() {
   // the whole session); room sessions are hands-free except on the
   // version-skew fallback against an older daemon.
   const handsFree = useLiveVoiceStore.use.handsFree();
+  // Viewport point the entrance grows from (the tapped voice button); null →
+  // the color look falls back to its screen-center origin.
+  const entryOrigin = useLiveVoiceStore.use.entryOrigin();
   const reduce = useReducedMotion();
 
   const visual = toVoiceAvatarVisual(state, reconnecting);
@@ -214,6 +217,7 @@ function VoiceRoomOverlay() {
           visual={visual}
           getAmplitude={getLiveVoiceInputAmplitude}
           getResponseAmplitude={getLiveVoiceOutputAmplitude}
+          entryOrigin={entryOrigin}
         />
       ) : (
         <>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -7,8 +7,10 @@
  * Two looks, resolved per session assistant ({@link resolveVoiceRoomLook}):
  *
  * - Character avatars get the onboarding "full-screen color with eyes"
- *   treatment — the avatar color fills the room and the avatar's giant eyes
- *   peek from the bottom edge, with the control chrome toned for contrast
+ *   treatment — entering the room plays the Introduction-step grow (the
+ *   avatar's body springs from its on-screen size to BE the screen, the color
+ *   fades in behind it, the giant eyes rise into their bottom-edge rest; see
+ *   {@link VoiceRoomColorLook}), with the control chrome toned for contrast
  *   against that color ({@link toneForBg}, via the `--room-*` CSS vars).
  * - Custom-image / no-character avatars fall back to the deep-dark ambient
  *   void with the state-driven avatar at its center and the listening waves —
@@ -29,13 +31,14 @@
  * Sessions are hands-free (server-VAD): the user just speaks, so there is no
  * push-to-talk control. Bottom-center carries the session controls in the
  * call-app idiom: a mic mute toggle (always) and, while the assistant speaks
- * hands-free, a turn-scoped ■ stop. Exit is first-class: a persistent
+ * hands-free, a turn-scoped ■ stop. Exit is first-class: the persistent
  * ✕ control (always rendered, even while the avatar/assistant data is loading
- * or failed) ends the session. Escape deliberately does nothing — an
- * accidental keypress must not end a live call.
+ * or failed) and Escape both end the session — the room is modal with no
+ * lesser dismissal, so the platform "leave" key maps to the only exit there
+ * is. The key handler attaches only while the room is mounted.
  */
 
-import type { CSSProperties } from "react";
+import { useEffect, type CSSProperties } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Captions, CaptionsOff, Mic, MicOff, Square, X } from "lucide-react";
 
@@ -63,7 +66,7 @@ import { VoiceAvatar } from "./voice-avatar";
 import { VoiceListeningWaves } from "./voice-listening-waves";
 import { AVATAR_ENTER_SPRING } from "./voice-motion";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
-import { VoiceRoomEyes, resolveVoiceRoomLook } from "./voice-room-eyes";
+import { VoiceRoomColorLook, resolveVoiceRoomLook } from "./voice-room-eyes";
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
 
 const AVATAR_SIZE = 220;
@@ -156,6 +159,22 @@ function VoiceRoomOverlay() {
     "--room-border": tone?.wash ?? "rgba(255,255,255,0.15)",
   } as CSSProperties;
 
+  // Global Escape, live only while the room is mounted: ends the session,
+  // same as the ✕ — the room is modal with no lesser dismissal, so the
+  // platform "leave" key maps to the only exit there is. It fires even when
+  // the composer textarea (or any other focused element) still holds focus as
+  // the room opens, so it is intentionally not guarded by the event target.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        endLiveVoiceSession();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   return (
     <motion.div
       className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden"
@@ -183,19 +202,10 @@ function VoiceRoomOverlay() {
       exit={{ opacity: 0 }}
       transition={{ duration: reduce ? 0 : 0.4 }}
     >
-      {look ? (
-        <div
-          className="absolute inset-0"
-          style={{ backgroundColor: look.bgHex }}
-        />
-      ) : (
-        <VoiceRoomAmbientBackground />
-      )}
-
-      {/* The assistant's giant eyes peeking from the bottom — the color look's
-          entire cast. The void look expresses the session through the centered
-          avatar and the listening waves instead. */}
-      {look ? <VoiceRoomEyes art={look.art} /> : null}
+      {/* The color look (body grow entrance + color fade + peeking eyes) is
+          the entire cast; the void look expresses the session through the
+          centered avatar and the listening waves instead. */}
+      {look ? <VoiceRoomColorLook look={look} /> : <VoiceRoomAmbientBackground />}
 
       {/* Listening waves: the user's voice arriving as energy coming in, rising
           from the bottom edge with live mic amplitude. Void look only, while
@@ -242,7 +252,7 @@ function VoiceRoomOverlay() {
             )}
           </button>
         </Tooltip>
-        <Tooltip content="End voice session">
+        <Tooltip content="End voice session (Esc)">
           <button
             type="button"
             onClick={endLiveVoiceSession}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -310,33 +310,20 @@ function VoiceRoomOverlay() {
         ) : null}
       </AnimatePresence>
 
-      {/* Bottom-center session controls, the call-app idiom: the mic mute
+      {/* Bottom-right session controls, the call-app idiom: the mic mute
           toggle always (an open mic demands an always-reachable mute), and —
           while the assistant speaks in a hands-free session — a ■ that stops
           the response without ending the session (web barge-in by just
-          talking is not reliable yet, so this is the room's only interrupt). */}
+          talking is not reliable yet, so this is the room's only interrupt).
+          Anchored bottom-right (the mic sits in the corner, the transient stop
+          to its left), clamped to the same insets as the top-right cluster. */}
       <div
-        className="absolute left-1/2 z-10 flex -translate-x-1/2 items-center gap-3"
-        style={{ bottom: `max(2.5rem, ${SAFE_AREA_BOTTOM})` }}
+        className="absolute z-10 flex items-center gap-3"
+        style={{
+          bottom: `max(2.5rem, ${SAFE_AREA_BOTTOM})`,
+          right: `max(1.25rem, ${SAFE_AREA_RIGHT})`,
+        }}
       >
-        <Tooltip content={muted ? "Unmute microphone" : "Mute microphone"}>
-          <button
-            type="button"
-            onClick={() => setLiveVoiceMuted(!muted)}
-            aria-label={muted ? "Unmute microphone" : "Mute microphone"}
-            aria-pressed={muted}
-            className={cn(
-              SESSION_CONTROL_CLASS,
-              muted
-                ? tone?.isLight
-                  ? "border-red-700/50 bg-red-600/15 text-red-800 hover:bg-red-600/25"
-                  : "border-red-400/50 bg-red-500/20 text-red-300 hover:bg-red-500/30"
-                : SESSION_CONTROL_NEUTRAL_CLASS,
-            )}
-          >
-            {muted ? <MicOff className="size-5" /> : <Mic className="size-5" />}
-          </button>
-        </Tooltip>
         <AnimatePresence>
           {handsFree && state === "speaking" ? (
             <motion.div
@@ -362,6 +349,24 @@ function VoiceRoomOverlay() {
             </motion.div>
           ) : null}
         </AnimatePresence>
+        <Tooltip content={muted ? "Unmute microphone" : "Mute microphone"}>
+          <button
+            type="button"
+            onClick={() => setLiveVoiceMuted(!muted)}
+            aria-label={muted ? "Unmute microphone" : "Mute microphone"}
+            aria-pressed={muted}
+            className={cn(
+              SESSION_CONTROL_CLASS,
+              muted
+                ? tone?.isLight
+                  ? "border-red-700/50 bg-red-600/15 text-red-800 hover:bg-red-600/25"
+                  : "border-red-400/50 bg-red-500/20 text-red-300 hover:bg-red-500/30"
+                : SESSION_CONTROL_NEUTRAL_CLASS,
+            )}
+          >
+            {muted ? <MicOff className="size-5" /> : <Mic className="size-5" />}
+          </button>
+        </Tooltip>
       </div>
 
       {/* Screen readers get session-state changes here; the avatar is the

--- a/clients/web/src/domains/onboarding/components/onboarding-motion-eyes.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-motion-eyes.tsx
@@ -12,7 +12,7 @@
 import { useMemo } from "react";
 import { motion, useTransform, type MotionValue } from "motion/react";
 
-import { pathBBox, unionBBox, type BBox } from "@/domains/onboarding/components/eye-bbox";
+import { pathBBox, unionBBox, type BBox } from "@/components/avatar/eye-bbox";
 import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";

--- a/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-peeking-eyes.tsx
@@ -16,7 +16,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { motion, useAnimationControls, useReducedMotion } from "motion/react";
 
-import { pathBBox, unionBBox } from "@/domains/onboarding/components/eye-bbox";
+import { pathBBox, unionBBox } from "@/components/avatar/eye-bbox";
 import { useOnboardingStageSize } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";

--- a/clients/web/src/domains/onboarding/onboarding-tone.ts
+++ b/clients/web/src/domains/onboarding/onboarding-tone.ts
@@ -4,10 +4,9 @@
  * SPIKE — research-onboarding flow.
  *
  * Those steps paint the background with the chosen avatar's color, so UI drawn
- * on top (top bar, titles, labels) needs a foreground that contrasts: white on
- * the dark/saturated colors, black on the light one (yellow). This derives that
- * once from the chosen color's perceived brightness, so every surface can read
- * the same `fg`/`fgMuted` instead of hard-coding white.
+ * on top (top bar, titles, labels) needs a foreground that contrasts. The
+ * derivation itself is the shared `toneForBg` (see `@/utils/surface-tone`);
+ * this module binds it to the onboarding picker's chosen character.
  *
  * The picker / first form sit on the dark app surface (not an avatar color) and
  * should stay white regardless — they pass an explicit tone rather than using
@@ -17,63 +16,12 @@
 import { useMemo } from "react";
 
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { toneForBg, type SurfaceTone } from "@/utils/surface-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
-export interface OnboardingTone {
-  /** Background hex (the chosen avatar color), or the app surface fallback. */
-  bg: string;
-  /** True when the background is light enough to need dark foreground. */
-  isLight: boolean;
-  /** Foreground color: black on light bg, white otherwise. */
-  fg: string;
-  /**
-   * A deeper heading foreground: the background color itself, darkened. Shared
-   * by the "Hey {name}" greeting and the pitch setup line so they read as the
-   * same secondary tone.
-   */
-  fgDeep: string;
-  /** Muted/secondary foreground at the matching tone. */
-  fgMuted: string;
-  /** A subtle hover/fill wash at the matching tone. */
-  wash: string;
-}
+export type OnboardingTone = SurfaceTone;
 
-const FG_DARK = "#1A1A1A";
-const FG_LIGHT = "#FFFFFF";
-
-/** Perceived brightness (YIQ), 0–1. */
-function brightness(hex: string): number {
-  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
-  if (!m) return 0;
-  const n = parseInt(m[1]!, 16);
-  const r = (n >> 16) & 0xff;
-  const g = (n >> 8) & 0xff;
-  const b = n & 0xff;
-  return (r * 299 + g * 587 + b * 114) / 1000 / 255;
-}
-
-/** Multiply each channel of a #rrggbb hex by `factor` (clamped 0–255). */
-function darkenHex(hex: string, factor: number): string {
-  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
-  if (!m) return hex;
-  const n = parseInt(m[1]!, 16);
-  const ch = (shift: number) =>
-    Math.max(0, Math.min(255, Math.round(((n >> shift) & 0xff) * factor)));
-  return `#${((1 << 24) | (ch(16) << 16) | (ch(8) << 8) | ch(0)).toString(16).slice(1)}`;
-}
-
-/** Build a tone object from a background hex. */
-export function toneForBg(bg: string): OnboardingTone {
-  const isLight = brightness(bg) > 0.6;
-  return {
-    bg,
-    isLight,
-    fg: isLight ? FG_DARK : FG_LIGHT,
-    fgDeep: darkenHex(bg, 0.6),
-    fgMuted: isLight ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.65)",
-    wash: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)",
-  };
-}
+export { toneForBg };
 
 /** Tone derived from the currently-chosen avatar's color. */
 export function useOnboardingTone(): OnboardingTone {

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -713,6 +713,68 @@ body {
   stroke: color-mix(in srgb, var(--wave-accent) 82%, transparent);
 }
 
+/* Palette: tone = follows the room's foreground tone (--room-fg), so the waves
+ * read on any solid avatar-color background (white waves on the dark colors,
+ * near-black on the light one). Same rgba-then-color-mix fallback as accent. */
+.voice-listening-waves--tone {
+  --wave-tone: var(--room-fg, #ffffff);
+}
+.voice-listening-waves--tone.voice-listening-waves--fill .voice-wave--back path {
+  fill: rgba(255, 255, 255, 0.1);
+  fill: color-mix(in srgb, var(--wave-tone) 12%, transparent);
+}
+.voice-listening-waves--tone.voice-listening-waves--fill .voice-wave--mid path {
+  fill: rgba(255, 255, 255, 0.14);
+  fill: color-mix(in srgb, var(--wave-tone) 17%, transparent);
+}
+.voice-listening-waves--tone.voice-listening-waves--fill .voice-wave--front path {
+  fill: rgba(255, 255, 255, 0.2);
+  fill: color-mix(in srgb, var(--wave-tone) 24%, transparent);
+}
+.voice-listening-waves--tone.voice-listening-waves--line .voice-wave--back path {
+  stroke: rgba(255, 255, 255, 0.42);
+  stroke: color-mix(in srgb, var(--wave-tone) 45%, transparent);
+}
+.voice-listening-waves--tone.voice-listening-waves--line .voice-wave--mid path {
+  stroke: rgba(255, 255, 255, 0.55);
+  stroke: color-mix(in srgb, var(--wave-tone) 58%, transparent);
+}
+.voice-listening-waves--tone.voice-listening-waves--line .voice-wave--front path {
+  stroke: rgba(255, 255, 255, 0.72);
+  stroke: color-mix(in srgb, var(--wave-tone) 75%, transparent);
+}
+
+/* Placement: center = a symmetric band around the middle of the screen (the
+ * color look), swelling from its center as amplitude grows rather than rising
+ * from the floor. Overrides the base bottom anchoring + amplitude translate.
+ * The band is two mirrored halves whose wave fills meet at the midline, so the
+ * rippling edges open outward from the center (see voice-listening-waves.tsx). */
+.voice-listening-waves--center {
+  top: 50%;
+  bottom: auto;
+  height: 52%;
+  transform-origin: center;
+  transform: translateY(-50%) scaleY(calc(0.5 + var(--voice-amp) * 0.7));
+  opacity: calc(0.3 + var(--voice-amp) * 0.7);
+}
+.voice-listening-waves--center .voice-listening-waves__half {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 50%;
+  overflow: hidden;
+}
+/* Top half sits above the midline; its wave fill hugs the half's bottom edge
+ * (= the center line), rippling upward. */
+.voice-listening-waves--center .voice-listening-waves__half--top {
+  top: 0;
+}
+/* Bottom half is the vertical mirror below the midline. */
+.voice-listening-waves--center .voice-listening-waves__half--bottom {
+  bottom: 0;
+  transform: scaleY(-1);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .voice-listening-waves path {
     animation: none;
@@ -720,6 +782,11 @@ body {
   /* Hold a low, steady band rather than a moving swell. */
   .voice-listening-waves {
     transform: none;
+    opacity: 0.4;
+  }
+  /* Keep the centered band centered (transform: none would drop it by 50%). */
+  .voice-listening-waves--center {
+    transform: translateY(-50%);
     opacity: 0.4;
   }
 }

--- a/clients/web/src/utils/surface-tone.ts
+++ b/clients/web/src/utils/surface-tone.ts
@@ -1,0 +1,65 @@
+/**
+ * Foreground tone for surfaces painted with an avatar color.
+ *
+ * Screens that fill their background with an assistant's avatar color (the
+ * avatar-tinted onboarding steps, the voice room) need a foreground that
+ * contrasts: white on the dark/saturated palette colors, near-black on the
+ * light one (yellow). `toneForBg` derives that once from the background's
+ * perceived brightness so every surface reads the same `fg`/`fgMuted` instead
+ * of hard-coding white.
+ */
+
+export interface SurfaceTone {
+  /** Background hex the tone was derived for. */
+  bg: string;
+  /** True when the background is light enough to need dark foreground. */
+  isLight: boolean;
+  /** Foreground color: black on light bg, white otherwise. */
+  fg: string;
+  /**
+   * A deeper heading foreground: the background color itself, darkened.
+   * Reads as a secondary tone of the same hue.
+   */
+  fgDeep: string;
+  /** Muted/secondary foreground at the matching tone. */
+  fgMuted: string;
+  /** A subtle hover/fill wash at the matching tone. */
+  wash: string;
+}
+
+const FG_DARK = "#1A1A1A";
+const FG_LIGHT = "#FFFFFF";
+
+/** Perceived brightness (YIQ), 0–1. */
+function brightness(hex: string): number {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return 0;
+  const n = parseInt(m[1]!, 16);
+  const r = (n >> 16) & 0xff;
+  const g = (n >> 8) & 0xff;
+  const b = n & 0xff;
+  return (r * 299 + g * 587 + b * 114) / 1000 / 255;
+}
+
+/** Multiply each channel of a #rrggbb hex by `factor` (clamped 0–255). */
+function darkenHex(hex: string, factor: number): string {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return hex;
+  const n = parseInt(m[1]!, 16);
+  const ch = (shift: number) =>
+    Math.max(0, Math.min(255, Math.round(((n >> shift) & 0xff) * factor)));
+  return `#${((1 << 24) | (ch(16) << 16) | (ch(8) << 8) | ch(0)).toString(16).slice(1)}`;
+}
+
+/** Build a tone object from a background hex. */
+export function toneForBg(bg: string): SurfaceTone {
+  const isLight = brightness(bg) > 0.6;
+  return {
+    bg,
+    isLight,
+    fg: isLight ? FG_DARK : FG_LIGHT,
+    fgDeep: darkenHex(bg, 0.6),
+    fgMuted: isLight ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.65)",
+    wash: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)",
+  };
+}


### PR DESCRIPTION
Closes JARVIS-1270.

Second tranche of voice-mode UX after #37913 — all client-side; no daemon changes needed.

## Mic mute (new)

- `setMuted` joins the store-registered session controls. While muted the capture graph keeps running but `handleChunk` streams **silence of equal length** instead of the captured PCM — an absent audio stream can starve the server VAD / streaming-STT keepalive, silence cannot — and `handleAmplitude` pins the published amplitude to 0 (waveforms flatline, manual-mode amplitude barge-in can't fire from a muted mic).
- Muted state **survives a hands-free reconnect** (a user who muted must never come back from a transient tunnel blip with a hot mic); every fresh session starts live.
- Toggle on every session surface: bottom-center in the voice room (call-app idiom), the composer voice bar (state label reads "Muted"), and the title-bar pill (the mic glyph beside the waveform is now the toggle; primary label reads "Muted").

## Stop assistant response (■, was dormant)

- The daemon treats a client `interrupt` in a server-VAD session as **turn-scoped** — it cancels the assistant turn and re-arms the next utterance cycle. The controller now mirrors that: flush playback and return to `listening` on the same socket instead of tearing down. `tts_audio` frames already in transit are dropped until the next turn (`interruptSent` doubles as the straggler guard; it now clears only on the next turn's `thinking` / hands-free stt-final).
- Wired on the pill's dormant ■ plus new ■ controls in the room (while speaking) and the voice bar. **Hands-free only**: a manual (version-skew fallback) session's interrupt still ends the whole session, so those surfaces omit the control there (`handsFree` is now published to the store).
- This matters extra on web, where echo handling still blocks speak-over barge-in — this is the first reliable way to cut the assistant off.

## Send now un-deadened (follow-up to the #37913 review finding)

- Codex flagged (and Alex confirmed) the ↑ controls were dead in hands-free. Root cause: the client no-opped `release` to protect the forwarding gate. But the daemon honors `ptt_release` as a **manual override of the server VAD** (`releaseFromClient` forces the detector's utterance boundary) — so hands-free release now just sends the frame: forwarding untouched, state transitions frame-driven (`utterance_end` → `transcribing`). The composer bar and pill ↑ now genuinely work.

## First-run card

- Dropped the transcript-toggle quiz: captions are toggled in-session (voice room) and the full prefs live in Settings → Voice. The card now sets expectations and starts.

## Tests

New "hands-free session controls" suite in `use-live-voice.test.ts` (release passthrough, turn-scoped interrupt + straggler guard, mute silence substitution, mute-across-reconnect, handsFree publication/downgrade); updated store, room, voice-bar, pill, pill-host, and first-run suites. Full voice sweep green (340+ assertions across 15 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)