### PR TITLE
feat(telemetry): add generic telemetry_events outbox table and store

### DIFF
--- a/assistant/src/persistence/migrations/333-create-telemetry-events-table.test.ts
+++ b/assistant/src/persistence/migrations/333-create-telemetry-events-table.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, test } from "bun:test";
 
-const { getTelemetrySqlite } = await import("../db-connection.js");
+const { getDb, getTelemetrySqlite } = await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
 const { migrateCreateTelemetryEventsTable } =
   await import("./333-create-telemetry-events-table.js");
@@ -47,7 +47,7 @@ describe("migration 333: create telemetry_events on the telemetry DB", () => {
        VALUES ('row-1', 'lifecycle', 1000, NULL, '{"type":"lifecycle"}')`,
     );
 
-    migrateCreateTelemetryEventsTable();
+    migrateCreateTelemetryEventsTable(getDb());
 
     expect(telemetryTableExists("telemetry_events")).toBe(true);
     const indexes = telemetryIndexNames();

--- a/assistant/src/persistence/migrations/333-create-telemetry-events-table.test.ts
+++ b/assistant/src/persistence/migrations/333-create-telemetry-events-table.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for migration 333: creating the generic `telemetry_events` outbox
+ * table on the dedicated telemetry database (`assistant-telemetry.db`).
+ *
+ * Runs against real workspace databases (`initializeDb()` already ran the
+ * step once), so the tests assert the resulting telemetry-side schema and
+ * that re-running the step is idempotent.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getTelemetrySqlite } = await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { migrateCreateTelemetryEventsTable } =
+  await import("./333-create-telemetry-events-table.js");
+
+await initializeDb();
+
+function telemetryTableExists(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
+function telemetryIndexNames(): string[] {
+  return (
+    getTelemetrySqlite()!
+      .query(`PRAGMA index_list(telemetry_events)`)
+      .all() as Array<{ name: string }>
+  ).map((i) => i.name);
+}
+
+describe("migration 333: create telemetry_events on the telemetry DB", () => {
+  test("initializeDb created the table with both indexes", () => {
+    expect(telemetryTableExists("telemetry_events")).toBe(true);
+    const indexes = telemetryIndexNames();
+    expect(indexes).toContain("idx_telemetry_events_name_created_at_id");
+    expect(indexes).toContain("idx_telemetry_events_conversation_id");
+  });
+
+  test("re-running the step is idempotent and preserves existing rows", () => {
+    const telemetry = getTelemetrySqlite()!;
+    telemetry.exec(`DELETE FROM telemetry_events`);
+    telemetry.exec(
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('row-1', 'lifecycle', 1000, NULL, '{"type":"lifecycle"}')`,
+    );
+
+    migrateCreateTelemetryEventsTable();
+
+    expect(telemetryTableExists("telemetry_events")).toBe(true);
+    const indexes = telemetryIndexNames();
+    expect(indexes).toContain("idx_telemetry_events_name_created_at_id");
+    expect(indexes).toContain("idx_telemetry_events_conversation_id");
+    const row = telemetry
+      .query(`SELECT id, name, payload FROM telemetry_events`)
+      .get();
+    expect(row).toEqual({
+      id: "row-1",
+      name: "lifecycle",
+      payload: '{"type":"lifecycle"}',
+    });
+    telemetry.exec(`DELETE FROM telemetry_events`);
+  });
+});

--- a/assistant/src/persistence/migrations/333-create-telemetry-events-table.ts
+++ b/assistant/src/persistence/migrations/333-create-telemetry-events-table.ts
@@ -1,0 +1,42 @@
+import { getTelemetrySqlite } from "../db-connection.js";
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS telemetry_events (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    conversation_id TEXT,
+    payload TEXT NOT NULL
+  )
+`;
+
+/**
+ * Create `telemetry_events` — the generic telemetry outbox — on the dedicated
+ * telemetry database (`assistant-telemetry.db`). Each row's `payload` holds
+ * the wire `TelemetryEvent` JSON built at record time; the usage telemetry
+ * reporter deletes rows after a successful flush. The `(name, created_at,
+ * id)` index backs the per-source ordered batch reads; the `conversation_id`
+ * index keeps conversation redaction an indexed delete. Idempotent
+ * (`IF NOT EXISTS`); no main-DB work.
+ *
+ * Throws (rather than returning) if the telemetry database cannot be opened,
+ * so the runner records the step as failed instead of applied and retries it
+ * on a later boot. The throw is caught per-step by the runner, so startup is
+ * not aborted.
+ */
+export function migrateCreateTelemetryEventsTable(): void {
+  const telemetryRaw = getTelemetrySqlite();
+  if (!telemetryRaw) {
+    throw new Error(
+      "telemetry database unavailable — deferring telemetry_events creation",
+    );
+  }
+
+  telemetryRaw.exec(CREATE_TABLE);
+  telemetryRaw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_telemetry_events_name_created_at_id ON telemetry_events (name, created_at, id)`,
+  );
+  telemetryRaw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_telemetry_events_conversation_id ON telemetry_events (conversation_id)`,
+  );
+}

--- a/assistant/src/persistence/migrations/333-create-telemetry-events-table.ts
+++ b/assistant/src/persistence/migrations/333-create-telemetry-events-table.ts
@@ -1,42 +1,43 @@
-import { getTelemetrySqlite } from "../db-connection.js";
+import { Database } from "bun:sqlite";
 
-const CREATE_TABLE = /*sql*/ `
-  CREATE TABLE IF NOT EXISTS telemetry_events (
-    id TEXT PRIMARY KEY,
-    name TEXT NOT NULL,
-    created_at INTEGER NOT NULL,
-    conversation_id TEXT,
-    payload TEXT NOT NULL
-  )
-`;
+import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
+import { type DrizzleDb, getTelemetrySqlite } from "../db-connection.js";
 
 /**
  * Create `telemetry_events` — the generic telemetry outbox — on the dedicated
- * telemetry database (`assistant-telemetry.db`). Each row's `payload` holds
- * the wire `TelemetryEvent` JSON built at record time; the usage telemetry
- * reporter deletes rows after a successful flush. The `(name, created_at,
- * id)` index backs the per-source ordered batch reads; the `conversation_id`
- * index keeps conversation redaction an indexed delete. Idempotent
- * (`IF NOT EXISTS`); no main-DB work.
+ * telemetry database (`assistant-telemetry.db`), not the main DB. Each row's
+ * `payload` holds the wire `TelemetryEvent` JSON built at record time; the
+ * usage telemetry reporter deletes rows after a successful flush.
  *
- * Throws (rather than returning) if the telemetry database cannot be opened,
- * so the runner records the step as failed instead of applied and retries it
- * on a later boot. The throw is caught per-step by the runner, so startup is
- * not aborted.
+ * Idempotent (`IF NOT EXISTS`). The `(name, created_at, id)` index backs the
+ * per-source ordered batch reads; the `conversation_id` index keeps
+ * conversation redaction an indexed delete.
+ *
+ * The `mainDb` parameter is accepted to satisfy the migration-step signature but
+ * is not used — this migration operates exclusively on the telemetry DB.
  */
-export function migrateCreateTelemetryEventsTable(): void {
-  const telemetryRaw = getTelemetrySqlite();
-  if (!telemetryRaw) {
-    throw new Error(
-      "telemetry database unavailable — deferring telemetry_events creation",
-    );
+export function migrateCreateTelemetryEventsTable(_mainDb: DrizzleDb): void {
+  let raw: Database | null = getTelemetrySqlite();
+  if (!raw) {
+    // The dedicated connection failed to open (logged by openDedicatedDb).
+    // Fall back to opening the file directly so the migration still runs —
+    // the singleton will pick it up on a later access. This mirrors the
+    // fail-soft pattern of the other dedicated-DB migrations.
+    raw = new Database(getTelemetryDbPath());
   }
-
-  telemetryRaw.exec(CREATE_TABLE);
-  telemetryRaw.exec(
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS telemetry_events (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      conversation_id TEXT,
+      payload TEXT NOT NULL
+    )
+  `);
+  raw.exec(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_telemetry_events_name_created_at_id ON telemetry_events (name, created_at, id)`,
   );
-  telemetryRaw.exec(
+  raw.exec(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_telemetry_events_conversation_id ON telemetry_events (conversation_id)`,
   );
 }

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -406,3 +406,28 @@ export const configSettingEvents = sqliteTable(
     ),
   ],
 );
+
+// Generic telemetry outbox. Lives on the dedicated telemetry database
+// (assistant-telemetry.db). Each row's `payload` is the wire `TelemetryEvent`
+// JSON built at record time; `name` is the telemetry source id (e.g.
+// 'lifecycle'). Rows are deleted on successful flush by the usage telemetry
+// reporter. `conversation_id` is populated only for conversation-scoped
+// events so redaction stays an indexed column delete.
+export const telemetryEvents = sqliteTable(
+  "telemetry_events",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    createdAt: integer("created_at").notNull(),
+    conversationId: text("conversation_id"),
+    payload: text("payload").notNull(),
+  },
+  (table) => [
+    index("idx_telemetry_events_name_created_at_id").on(
+      table.name,
+      table.createdAt,
+      table.id,
+    ),
+    index("idx_telemetry_events_conversation_id").on(table.conversationId),
+  ],
+);

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -440,6 +440,7 @@ import { migrateMoveOnboardingEventsToTelemetryDb } from "./migrations/329-move-
 import { migrateMoveAuthFallbackEventsToTelemetryDb } from "./migrations/330-move-auth-fallback-events-to-telemetry-db.js";
 import { migrateMoveLifecycleEventsToTelemetryDb } from "./migrations/331-move-lifecycle-events-to-telemetry-db.js";
 import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/332-move-skill-loaded-events-to-telemetry-db.js";
+import { migrateCreateTelemetryEventsTable } from "./migrations/333-create-telemetry-events-table.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1351,4 +1352,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateMoveAuthFallbackEventsToTelemetryDb,
   migrateMoveLifecycleEventsToTelemetryDb,
   migrateMoveSkillLoadedEventsToTelemetryDb,
+  migrateCreateTelemetryEventsTable,
 ];

--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getTelemetryDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
+import {
+  deleteTelemetryOutboxEvents,
+  discardPendingTelemetryOutboxEvents,
+  insertTelemetryOutboxEvent,
+  queryTelemetryOutboxBatch,
+} from "./telemetry-events-outbox.js";
+import type { LifecycleTelemetryEvent } from "./types.js";
+
+await initializeDb();
+
+function lifecycleEvent(
+  id: string,
+  createdAt: number,
+): LifecycleTelemetryEvent {
+  return {
+    type: "lifecycle",
+    daemon_event_id: id,
+    event_name: "app_open",
+    recorded_at: createdAt,
+    assistant_version: "1.2.3",
+  };
+}
+
+function insert(
+  id: string,
+  createdAt: number,
+  name = "lifecycle",
+  conversationId?: string | null,
+): boolean {
+  return insertTelemetryOutboxEvent({
+    id,
+    name,
+    createdAt,
+    conversationId,
+    event: lifecycleEvent(id, createdAt),
+  });
+}
+
+function allIds(): string[] {
+  return queryTelemetryOutboxBatch("lifecycle", 10_000).map((r) => r.id);
+}
+
+describe("telemetry-events-outbox", () => {
+  beforeEach(() => {
+    getTelemetryDb()!.delete(telemetryEvents).run();
+  });
+
+  test("insert + query round-trips the wire payload", () => {
+    expect(insert("evt-1", 1000)).toBe(true);
+
+    const rows = queryTelemetryOutboxBatch("lifecycle", 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: "evt-1", createdAt: 1000 });
+    expect(JSON.parse(rows[0]!.payload)).toEqual(lifecycleEvent("evt-1", 1000));
+  });
+
+  test("conversation_id persists in its dedicated column", () => {
+    insert("evt-conv", 1000, "lifecycle", "conv-1");
+    insert("evt-null", 2000, "lifecycle");
+
+    const rows = getTelemetryDb()!
+      .select({
+        id: telemetryEvents.id,
+        conversationId: telemetryEvents.conversationId,
+      })
+      .from(telemetryEvents)
+      .all()
+      .sort((a, b) => a.id.localeCompare(b.id));
+    expect(rows).toEqual([
+      { id: "evt-conv", conversationId: "conv-1" },
+      { id: "evt-null", conversationId: null },
+    ]);
+  });
+
+  test("orders by (created_at, id) with id as tiebreaker", () => {
+    insert("evt-b", 2000);
+    insert("evt-c", 1000);
+    insert("evt-a", 1000);
+
+    expect(allIds()).toEqual(["evt-a", "evt-c", "evt-b"]);
+  });
+
+  test("honors the limit", () => {
+    insert("evt-1", 1000);
+    insert("evt-2", 2000);
+    insert("evt-3", 3000);
+
+    const rows = queryTelemetryOutboxBatch("lifecycle", 2);
+    expect(rows.map((r) => r.id)).toEqual(["evt-1", "evt-2"]);
+  });
+
+  test("queries are isolated per event name", () => {
+    insert("evt-life", 1000, "lifecycle");
+    insert("evt-watch", 1000, "watchdog");
+
+    expect(allIds()).toEqual(["evt-life"]);
+    expect(queryTelemetryOutboxBatch("watchdog", 10).map((r) => r.id)).toEqual([
+      "evt-watch",
+    ]);
+    expect(queryTelemetryOutboxBatch("onboarding", 10)).toEqual([]);
+  });
+
+  test("deletes rows by id", () => {
+    insert("evt-1", 1000);
+    insert("evt-2", 2000);
+    insert("evt-3", 3000);
+
+    deleteTelemetryOutboxEvents(["evt-1", "evt-3"]);
+
+    expect(allIds()).toEqual(["evt-2"]);
+  });
+
+  test("delete with an empty id list is a no-op", () => {
+    insert("evt-1", 1000);
+
+    deleteTelemetryOutboxEvents([]);
+
+    expect(allIds()).toEqual(["evt-1"]);
+  });
+
+  test("deletes more than one chunk of ids", () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 501; i++) {
+      const id = `evt-${String(i).padStart(4, "0")}`;
+      ids.push(id);
+      insert(id, i);
+    }
+    insert("evt-keep", 9999);
+
+    deleteTelemetryOutboxEvents(ids);
+
+    expect(allIds()).toEqual(["evt-keep"]);
+  });
+
+  test("discards all pending rows for one name only", () => {
+    insert("evt-1", 1000, "lifecycle");
+    insert("evt-2", 2000, "lifecycle");
+    insert("evt-other", 1000, "watchdog");
+
+    discardPendingTelemetryOutboxEvents("lifecycle");
+
+    expect(allIds()).toEqual([]);
+    expect(queryTelemetryOutboxBatch("watchdog", 10).map((r) => r.id)).toEqual([
+      "evt-other",
+    ]);
+  });
+});

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -1,0 +1,95 @@
+/**
+ * Storage seam for the generic `telemetry_events` outbox on the dedicated
+ * telemetry database (`assistant-telemetry.db`). Rows carry the full wire
+ * `TelemetryEvent` built at record time and are deleted after a successful
+ * flush. No consent logic lives here — call sites own gating.
+ */
+import { asc, eq, inArray } from "drizzle-orm";
+
+import { getTelemetryDb } from "../persistence/db-connection.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
+import type { TelemetryEvent } from "./types.js";
+
+/** Ids per DELETE chunk — stays under SQLite's bound-variable limit. */
+const DELETE_CHUNK_SIZE = 500;
+
+/** One pending outbox row; `payload` is the wire `TelemetryEvent` JSON. */
+export interface TelemetryOutboxRow {
+  id: string;
+  createdAt: number;
+  payload: string;
+}
+
+/**
+ * Insert one pending telemetry event. Returns false when the telemetry DB is
+ * unavailable (degraded mode), true once the row is inserted.
+ */
+export function insertTelemetryOutboxEvent(row: {
+  id: string;
+  name: string;
+  createdAt: number;
+  conversationId?: string | null;
+  event: TelemetryEvent;
+}): boolean {
+  const db = getTelemetryDb();
+  if (!db) {
+    return false;
+  }
+  db.insert(telemetryEvents)
+    .values({
+      id: row.id,
+      name: row.name,
+      createdAt: row.createdAt,
+      conversationId: row.conversationId ?? null,
+      payload: JSON.stringify(row.event),
+    })
+    .run();
+  return true;
+}
+
+/**
+ * Read the oldest pending rows for one event name in `(created_at, id)`
+ * order. Empty when the telemetry DB is unavailable.
+ */
+export function queryTelemetryOutboxBatch(
+  name: string,
+  limit: number,
+): TelemetryOutboxRow[] {
+  const db = getTelemetryDb();
+  if (!db) {
+    return [];
+  }
+  return db
+    .select({
+      id: telemetryEvents.id,
+      createdAt: telemetryEvents.createdAt,
+      payload: telemetryEvents.payload,
+    })
+    .from(telemetryEvents)
+    .where(eq(telemetryEvents.name, name))
+    .orderBy(asc(telemetryEvents.createdAt), asc(telemetryEvents.id))
+    .limit(limit)
+    .all();
+}
+
+/** Delete flushed rows by id, in chunks. No-op when db null or ids empty. */
+export function deleteTelemetryOutboxEvents(ids: string[]): void {
+  const db = getTelemetryDb();
+  if (!db || ids.length === 0) {
+    return;
+  }
+  for (let i = 0; i < ids.length; i += DELETE_CHUNK_SIZE) {
+    db.delete(telemetryEvents)
+      .where(inArray(telemetryEvents.id, ids.slice(i, i + DELETE_CHUNK_SIZE)))
+      .run();
+  }
+}
+
+/** Drop all pending rows for one event name (telemetry opt-out). */
+export function discardPendingTelemetryOutboxEvents(name: string): void {
+  const db = getTelemetryDb();
+  if (!db) {
+    return;
+  }
+  db.delete(telemetryEvents).where(eq(telemetryEvents.name, name)).run();
+}


### PR DESCRIPTION
## Summary
- New telemetry_events table on assistant-telemetry.db: (id, name, created_at, conversation_id, payload) + (name, created_at, id) and conversation_id indexes (migration 333)
- New telemetry-events-outbox store module: insert/query-batch/delete-by-ids/discard-by-name, degraded-mode tolerant
- Inert scaffolding — no production caller yet

Part of plan: telemetry-outbox-consolidation.md (PR 1 of 9)