### PR TITLE
feat(telemetry): per-source acknowledge/discard hooks in the usage telemetry reporter

### DIFF
--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -45,6 +45,13 @@ export interface TelemetryCursor {
 export interface TelemetryEventSourceBatch {
   /** Wire events for the rows reportable this cycle, in cursor order. */
   events: TelemetryEvent[];
+  /**
+   * Row ids backing `events`, set by ack-mode sources so the reporter can
+   * acknowledge (delete) exactly the shipped rows. These are ROW ids, not
+   * wire `daemon_event_id`s — the onboarding source overrides
+   * `daemon_event_id` for activation rows, so the two can differ.
+   */
+  rowIds?: string[];
   /** Cursor of the last reportable row; null when nothing is reportable. */
   lastCursor: TelemetryCursor | null;
   /**
@@ -72,6 +79,19 @@ export interface TelemetryEventSource {
     afterId: string | undefined,
     limit: number,
   ): TelemetryEventSourceBatch;
+  /**
+   * Ack-mode (delete-on-flush) acknowledgment: delete the rows behind
+   * `rowIds` (the batch's {@link TelemetryEventSourceBatch.rowIds}). Called
+   * only after a 2xx from the ingest endpoint. Sources that define this
+   * never get watermark writes in `flush_checkpoints`.
+   */
+  acknowledge?(rowIds: string[]): void;
+  /**
+   * Opt-out handling for ack-mode sources: drop all pending rows so events
+   * recorded during the opt-out window are never sent, replacing the
+   * watermark-mode sentinel pin.
+   */
+  discardPending?(): void;
 }
 
 /** The `flush_checkpoints` keys holding a source's compound cursor. */

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -80,18 +80,16 @@ export interface TelemetryEventSource {
     limit: number,
   ): TelemetryEventSourceBatch;
   /**
-   * Ack-mode (delete-on-flush) acknowledgment: delete the rows behind
-   * `rowIds` (the batch's {@link TelemetryEventSourceBatch.rowIds}). Called
-   * only after a 2xx from the ingest endpoint. Sources that define this
-   * never get watermark writes in `flush_checkpoints`.
+   * Delete-on-flush mode. Both operations are required together: `acknowledge`
+   * deletes the rows behind {@link TelemetryEventSourceBatch.rowIds} after a
+   * 2xx from the ingest endpoint, and `discardPending` drops all pending rows
+   * on an opted-out flush (watermark writes are meaningless for ack-mode
+   * sources, so they never touch `flush_checkpoints`).
    */
-  acknowledge?(rowIds: string[]): void;
-  /**
-   * Opt-out handling for ack-mode sources: drop all pending rows so events
-   * recorded during the opt-out window are never sent, replacing the
-   * watermark-mode sentinel pin.
-   */
-  discardPending?(): void;
+  ack?: {
+    acknowledge(rowIds: string[]): void;
+    discardPending(): void;
+  };
 }
 
 /** The `flush_checkpoints` keys holding a source's compound cursor. */

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -245,7 +245,9 @@ import {
   ALL_TELEMETRY_EVENT_SOURCES,
   DAEMON_TELEMETRY_EVENT_SOURCES,
   MONITOR_TELEMETRY_EVENT_SOURCES,
+  type TelemetryEventSource,
 } from "./telemetry-event-sources.js";
+import type { TelemetryEvent } from "./types.js";
 import {
   initToolExecutedWatermarkIfAbsent,
   UsageTelemetryReporter,
@@ -2669,5 +2671,229 @@ describe("UsageTelemetryReporter", () => {
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);
     expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+  });
+
+  // -------------------------------------------------------------------------
+  // Ack-mode sources (acknowledge / discardPending hooks)
+  // -------------------------------------------------------------------------
+
+  // Wire id deliberately differs from the row id: acknowledge must receive
+  // ROW ids, never wire daemon_event_ids.
+  function fakeWireEvent(rowId: string, createdAt: number): TelemetryEvent {
+    return {
+      type: "lifecycle",
+      daemon_event_id: `wire-${rowId}`,
+      event_name: "fake_event",
+      recorded_at: createdAt,
+      assistant_version: "1.2.3-test",
+    };
+  }
+
+  /**
+   * Ack-mode fake backed by a mutable in-memory row array: `collect` ignores
+   * the cursor args, `acknowledge` deletes the acknowledged rows, and
+   * `discardPending` drops everything — mirroring the outbox-store contract.
+   */
+  function makeAckSource(id: string, rowIds: string[] = []) {
+    let rows = rowIds.map((rowId, i) => ({
+      rowId,
+      createdAt: 1700000000000 + i,
+    }));
+    const acknowledge = mock((acked: string[]) => {
+      rows = rows.filter((r) => !acked.includes(r.rowId));
+    });
+    const discardPending = mock(() => {
+      rows = [];
+    });
+    const source: TelemetryEventSource = {
+      id,
+      collect(_afterCreatedAt, _afterId, limit) {
+        const batch = rows.slice(0, limit);
+        return {
+          events: batch.map((r) => fakeWireEvent(r.rowId, r.createdAt)),
+          rowIds: batch.map((r) => r.rowId),
+          lastCursor: null,
+          fullBatch: batch.length === limit,
+        };
+      },
+      acknowledge,
+      discardPending,
+    };
+    return { source, acknowledge, discardPending, pending: () => rows.length };
+  }
+
+  function makeWatermarkSource(
+    id: string,
+    rowIds: string[] = [],
+  ): TelemetryEventSource {
+    const rows = rowIds.map((rowId, i) => ({
+      rowId,
+      createdAt: 1700000000000 + i,
+    }));
+    return {
+      id,
+      collect(_afterCreatedAt, _afterId, limit) {
+        const batch = rows.slice(0, limit);
+        const last = batch.length > 0 ? batch[batch.length - 1] : null;
+        return {
+          events: batch.map((r) => fakeWireEvent(r.rowId, r.createdAt)),
+          lastCursor: last
+            ? { createdAt: last.createdAt, id: last.rowId }
+            : null,
+          fullBatch: batch.length === limit,
+        };
+      },
+    };
+  }
+
+  test("ack-mode source: acknowledge receives ROW ids after a 2xx and no watermark keys are written", async () => {
+    const { source, acknowledge } = makeAckSource("fake_ack", [
+      "row-1",
+      "row-2",
+    ]);
+    const reporter = new UsageTelemetryReporter(
+      [source],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-row-1", "wire-row-2"]);
+    expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(acknowledge.mock.calls[0][0]).toEqual(["row-1", "row-2"]);
+    // Ack-mode sources never touch flush_checkpoints.
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("acknowledge is NOT called when the POST fails", async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("error", { status: 500 })),
+    );
+    const { source, acknowledge, pending } = makeAckSource("fake_ack", [
+      "row-1",
+    ]);
+    const reporter = new UsageTelemetryReporter(
+      [source],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(acknowledge).not.toHaveBeenCalled();
+    expect(pending()).toBe(1);
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("acknowledge is NOT called when platform credentials are missing", async () => {
+    mockPlatformClient = null;
+    const { source, acknowledge, pending } = makeAckSource("fake_ack", [
+      "row-1",
+    ]);
+    const reporter = new UsageTelemetryReporter(
+      [source],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(acknowledge).not.toHaveBeenCalled();
+    expect(pending()).toBe(1);
+  });
+
+  test("acknowledge is skipped for an empty ack batch shipped alongside a watermark source", async () => {
+    const { source: ackSource, acknowledge } = makeAckSource("fake_ack");
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1"]);
+    const reporter = new UsageTelemetryReporter(
+      [wmSource, ackSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(acknowledge).not.toHaveBeenCalled();
+  });
+
+  test("opt-out: discardPending drops ack-mode rows while watermark sources get the sentinel pin", async () => {
+    mockGetCachedShareAnalytics.mockReturnValue(false);
+    const {
+      source: ackSource,
+      discardPending,
+      pending,
+    } = makeAckSource("fake_ack", ["row-1"]);
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1"]);
+    const reporter = new UsageTelemetryReporter(
+      [wmSource, ackSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(discardPending).toHaveBeenCalledTimes(1);
+    expect(pending()).toBe(0);
+
+    const keys = mockSetFlushCheckpoint.mock.calls.map((c) => c[0]);
+    expect(keys).toContain("telemetry:fake_wm:last_reported_at");
+    const wmIdCall = mockSetFlushCheckpoint.mock.calls.find(
+      (c) => c[0] === "telemetry:fake_wm:last_reported_id",
+    );
+    expect(wmIdCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    expect(keys.some((k) => k.includes("fake_ack"))).toBe(false);
+  });
+
+  test("mixed watermark+ack sources flush in construction order, each acknowledged in its own mode", async () => {
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1", "wm-2"]);
+    const { source: ackSource, acknowledge } = makeAckSource("fake_ack", [
+      "row-1",
+    ]);
+    const reporter = new UsageTelemetryReporter(
+      [wmSource, ackSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-wm-1", "wire-wm-2", "wire-row-1"]);
+
+    expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(acknowledge.mock.calls[0][0]).toEqual(["row-1"]);
+
+    const wmAtCalls = mockSetFlushCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:fake_wm:last_reported_at",
+    );
+    expect(wmAtCalls[wmAtCalls.length - 1][1]).toBe(String(1700000000001));
+    const wmIdCalls = mockSetFlushCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:fake_wm:last_reported_id",
+    );
+    expect(wmIdCalls[wmIdCalls.length - 1][1]).toBe("wm-2");
+    expect(
+      mockSetFlushCheckpoint.mock.calls.some((c) => c[0].includes("fake_ack")),
+    ).toBe(false);
+  });
+
+  test("an ack-mode full batch drives recursion until the backlog drains", async () => {
+    // 501 rows: the first collect fills BATCH_SIZE (500), acknowledge drains
+    // them, and the fullBatch recursion ships the remaining row.
+    const rowIds = Array.from({ length: 501 }, (_, i) => `row-${i}`);
+    const { source, acknowledge, pending } = makeAckSource("fake_ack", rowIds);
+    const reporter = new UsageTelemetryReporter(
+      [source],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(acknowledge).toHaveBeenCalledTimes(2);
+    expect(acknowledge.mock.calls[0][0]).toHaveLength(500);
+    expect(acknowledge.mock.calls[1][0]).toEqual(["row-500"]);
+    expect(pending()).toBe(0);
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -2674,7 +2674,7 @@ describe("UsageTelemetryReporter", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Ack-mode sources (acknowledge / discardPending hooks)
+  // Ack-mode sources (grouped `ack` field: acknowledge + discardPending)
   // -------------------------------------------------------------------------
 
   // Wire id deliberately differs from the row id: acknowledge must receive
@@ -2716,8 +2716,7 @@ describe("UsageTelemetryReporter", () => {
           fullBatch: batch.length === limit,
         };
       },
-      acknowledge,
-      discardPending,
+      ack: { acknowledge, discardPending },
     };
     return { source, acknowledge, discardPending, pending: () => rows.length };
   }
@@ -2895,5 +2894,76 @@ describe("UsageTelemetryReporter", () => {
     expect(acknowledge.mock.calls[0][0]).toHaveLength(500);
     expect(acknowledge.mock.calls[1][0]).toEqual(["row-500"]);
     expect(pending()).toBe(0);
+  });
+
+  /** Ack source whose collect returns events with broken rowIds. */
+  function makeBrokenAckSource(id: string, rowIds: string[] | undefined) {
+    const acknowledge = mock((_acked: string[]) => {});
+    const discardPending = mock(() => {});
+    const source: TelemetryEventSource = {
+      id,
+      collect() {
+        return {
+          events: [
+            fakeWireEvent("row-1", 1700000000000),
+            fakeWireEvent("row-2", 1700000000001),
+          ],
+          ...(rowIds ? { rowIds } : {}),
+          lastCursor: null,
+          fullBatch: false,
+        };
+      },
+      ack: { acknowledge, discardPending },
+    };
+    return { source, acknowledge };
+  }
+
+  test("an ack batch omitting rowIds ships nothing while other sources still ship", async () => {
+    const { source: brokenSource, acknowledge } = makeBrokenAckSource(
+      "fake_broken_ack",
+      undefined,
+    );
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1"]);
+    const reporter = new UsageTelemetryReporter(
+      [brokenSource, wmSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-wm-1"]);
+    expect(acknowledge).not.toHaveBeenCalled();
+    expect(
+      mockSetFlushCheckpoint.mock.calls.some((c) =>
+        c[0].includes("fake_broken_ack"),
+      ),
+    ).toBe(false);
+  });
+
+  test("an ack batch with mismatched rowIds ships nothing while other sources still ship", async () => {
+    const { source: brokenSource, acknowledge } = makeBrokenAckSource(
+      "fake_broken_ack",
+      ["row-1"],
+    );
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1"]);
+    const reporter = new UsageTelemetryReporter(
+      [brokenSource, wmSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-wm-1"]);
+    expect(acknowledge).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -5,9 +5,11 @@
  * lifecycle, ...) from the local SQLite databases and POSTs them to the
  * platform telemetry endpoint. Each event type is a
  * {@link TelemetryEventSource}; the reporter is a generic engine over the
- * source list it is constructed with, advancing one compound
- * `(createdAt, id)` watermark cursor per source in the telemetry DB's
- * `flush_checkpoints` table after each successful upload.
+ * source list it is constructed with, acknowledging each source after a
+ * successful upload in one of two modes: watermark-mode sources advance a
+ * compound `(createdAt, id)` cursor in the telemetry DB's
+ * `flush_checkpoints` table, and ack-mode sources (those defining
+ * `acknowledge`) delete their shipped rows instead.
  *
  * Flushing is split across two processes, each running its own reporter
  * instance over a disjoint source partition: the daemon flushes turn events
@@ -300,9 +302,10 @@ export class UsageTelemetryReporter {
       // opted-out tool_invocations rows persist NULL telemetry columns and
       // are unreportable by construction regardless of watermark timing.
       if (!getCachedShareAnalytics()) {
-        // Advance the timestamp watermarks and pin the ID watermarks to a
-        // sentinel that sorts above any real UUID. The sentinel (rather than
-        // "") keeps the compound-cursor branch active — a falsy ID would
+        // Ack-mode sources drop their pending rows outright. Watermark-mode
+        // sources advance the timestamp watermarks and pin the ID watermarks
+        // to a sentinel that sorts above any real UUID. The sentinel (rather
+        // than "") keeps the compound-cursor branch active — a falsy ID would
         // downgrade the query to a timestamp-only `gt(createdAt, watermark)`
         // — while making its same-millisecond arm unsatisfiable, so a row
         // written in the same millisecond as this flush's Date.now() can
@@ -310,6 +313,10 @@ export class UsageTelemetryReporter {
         // ships events overwrites the sentinel with a real row ID.
         const now = String(Date.now());
         for (const source of this.sources) {
+          if (source.discardPending) {
+            source.discardPending();
+            continue;
+          }
           const keys = watermarkKeysForSource(source.id);
           this.checkpoints.set(keys.at, now);
           this.checkpoints.set(keys.id, OPT_OUT_WATERMARK_ID_SENTINEL);
@@ -402,9 +409,16 @@ export class UsageTelemetryReporter {
       }
       await resp.text(); // consume body to release connection
 
-      // Advance each source's watermark to its last reported row.
+      // Acknowledge each source's shipped rows: ack-mode sources delete them
+      // (never touching flush_checkpoints), watermark-mode sources advance
+      // their compound cursor to the last reported row.
       for (const { source, batch } of batches) {
-        if (batch.lastCursor) {
+        if (source.acknowledge) {
+          const rowIds = batch.rowIds ?? [];
+          if (rowIds.length > 0) {
+            source.acknowledge(rowIds);
+          }
+        } else if (batch.lastCursor) {
           const keys = watermarkKeysForSource(source.id);
           this.checkpoints.set(keys.at, String(batch.lastCursor.createdAt));
           this.checkpoints.set(keys.id, batch.lastCursor.id);

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -8,8 +8,8 @@
  * source list it is constructed with, acknowledging each source after a
  * successful upload in one of two modes: watermark-mode sources advance a
  * compound `(createdAt, id)` cursor in the telemetry DB's
- * `flush_checkpoints` table, and ack-mode sources (those defining
- * `acknowledge`) delete their shipped rows instead.
+ * `flush_checkpoints` table, and ack-mode sources (those defining `ack`)
+ * delete their shipped rows instead.
  *
  * Flushing is split across two processes, each running its own reporter
  * instance over a disjoint source partition: the daemon flushes turn events
@@ -313,8 +313,8 @@ export class UsageTelemetryReporter {
         // ships events overwrites the sentinel with a real row ID.
         const now = String(Date.now());
         for (const source of this.sources) {
-          if (source.discardPending) {
-            source.discardPending();
+          if (source.ack) {
+            source.ack.discardPending();
             continue;
           }
           const keys = watermarkKeysForSource(source.id);
@@ -341,6 +341,33 @@ export class UsageTelemetryReporter {
           batch: source.collect(afterCreatedAt, afterId, BATCH_SIZE),
         };
       });
+
+      // Ack-mode batches must carry a row id per event: without them nothing
+      // can be acknowledged post-2xx, so shipping would re-send the same rows
+      // on every flush. Exclude such a batch from the POST instead.
+      for (const entry of batches) {
+        const { source, batch } = entry;
+        if (
+          source.ack &&
+          batch.events.length > 0 &&
+          (batch.rowIds ?? []).length !== batch.events.length
+        ) {
+          log.warn(
+            {
+              sourceId: source.id,
+              eventCount: batch.events.length,
+              rowIdCount: batch.rowIds?.length ?? 0,
+            },
+            "Telemetry flush: ack-mode batch missing/mismatched rowIds — excluding from POST",
+          );
+          entry.batch = {
+            events: [],
+            rowIds: [],
+            lastCursor: null,
+            fullBatch: false,
+          };
+        }
+      }
 
       if (batches.every(({ batch }) => batch.events.length === 0)) {
         return;
@@ -413,10 +440,9 @@ export class UsageTelemetryReporter {
       // (never touching flush_checkpoints), watermark-mode sources advance
       // their compound cursor to the last reported row.
       for (const { source, batch } of batches) {
-        if (source.acknowledge) {
-          const rowIds = batch.rowIds ?? [];
-          if (rowIds.length > 0) {
-            source.acknowledge(rowIds);
+        if (source.ack) {
+          if (batch.events.length > 0) {
+            source.ack.acknowledge(batch.rowIds ?? []);
           }
         } else if (batch.lastCursor) {
           const keys = watermarkKeysForSource(source.id);


### PR DESCRIPTION
## Summary
- TelemetryEventSource gains optional acknowledge(rowIds)/discardPending() hooks; batches gain rowIds
- Reporter: ack-mode sources delete-on-flush after 2xx (no watermark writes); opt-out branch discards pending rows for ack-mode sources
- Watermark-mode sources byte-identical; covered by new fake-source tests

Part of plan: telemetry-outbox-consolidation.md (PR 2 of 9)