### PR TITLE
feat(telemetry): outboxSource factory bridging the outbox store to the reporter

### DIFF
--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -26,6 +26,11 @@ import {
 } from "./activation-funnel.js";
 import { queryUnreportedConfigSettingEvents } from "./config-setting-events-store.js";
 import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
+import {
+  deleteTelemetryOutboxEvents,
+  discardPendingTelemetryOutboxEvents,
+  queryTelemetryOutboxBatch,
+} from "./telemetry-events-outbox.js";
 import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
 import { isDiagnosticsConsentVersionEligible } from "./trace-collection-policy.js";
 import { queryUnreportedTurnEvents } from "./turn-events-store.js";
@@ -127,6 +132,60 @@ function simpleSource<Row extends { id: string; createdAt: number }>(
         lastCursor: last ? { createdAt: last.createdAt, id: last.id } : null,
         fullBatch: rows.length === limit,
       };
+    },
+  };
+}
+
+/**
+ * Build an ack-mode source over the generic `telemetry_events` outbox for one
+ * event name. `collect` ignores the cursor args — acknowledged rows are
+ * deleted, so the head of the queue is always the next batch — and parses
+ * each stored payload into its wire event. A row whose payload does not parse
+ * to an object is purged immediately with a warn: an early empty-batch return
+ * in the reporter would otherwise strand it at the head of the queue forever.
+ */
+export function outboxSource(name: string): TelemetryEventSource {
+  return {
+    id: name,
+    collect(_afterCreatedAt, _afterId, limit) {
+      const rows = queryTelemetryOutboxBatch(name, limit);
+      const events: TelemetryEvent[] = [];
+      const rowIds: string[] = [];
+      const corruptIds: string[] = [];
+      for (const row of rows) {
+        let event: TelemetryEvent | null = null;
+        try {
+          const parsed = JSON.parse(row.payload) as unknown;
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            event = parsed as TelemetryEvent;
+          }
+        } catch {
+          // Fall through to the purge below.
+        }
+        if (event) {
+          events.push(event);
+          rowIds.push(row.id);
+        } else {
+          corruptIds.push(row.id);
+          log.warn(
+            { name, rowId: row.id, payload: row.payload.slice(0, 200) },
+            "Telemetry outbox: unparseable payload — purging row",
+          );
+        }
+      }
+      if (corruptIds.length > 0) {
+        deleteTelemetryOutboxEvents(corruptIds);
+      }
+      return {
+        events,
+        rowIds,
+        lastCursor: null,
+        fullBatch: rows.length === limit,
+      };
+    },
+    ack: {
+      acknowledge: (rowIds) => deleteTelemetryOutboxEvents(rowIds),
+      discardPending: () => discardPendingTelemetryOutboxEvents(name),
     },
   };
 }

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -168,7 +168,7 @@ export function outboxSource(name: string): TelemetryEventSource {
         } else {
           corruptIds.push(row.id);
           log.warn(
-            { name, rowId: row.id, payload: row.payload.slice(0, 200) },
+            { name, rowId: row.id, payloadLength: row.payload.length },
             "Telemetry outbox: unparseable payload — purging row",
           );
         }

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -231,6 +231,7 @@ import {
   configSettingEvents,
   conversations,
   skillLoadedEvents,
+  telemetryEvents,
   toolInvocations,
 } from "../persistence/schema/index.js";
 import { recordAuthFallbackCounts } from "../security/auth-fallback-events-store.js";
@@ -245,8 +246,13 @@ import {
   ALL_TELEMETRY_EVENT_SOURCES,
   DAEMON_TELEMETRY_EVENT_SOURCES,
   MONITOR_TELEMETRY_EVENT_SOURCES,
+  outboxSource,
   type TelemetryEventSource,
 } from "./telemetry-event-sources.js";
+import {
+  insertTelemetryOutboxEvent,
+  queryTelemetryOutboxBatch,
+} from "./telemetry-events-outbox.js";
 import type { TelemetryEvent } from "./types.js";
 import {
   initToolExecutedWatermarkIfAbsent,
@@ -410,6 +416,7 @@ beforeEach(() => {
   getTelemetryDb()!.delete(skillLoadedEvents).run();
   getTelemetryDb()!.delete(authFallbackEvents).run();
   getTelemetryDb()!.delete(configSettingEvents).run();
+  getTelemetryDb()!.delete(telemetryEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
   delete process.env.IS_PLATFORM;
   mockGetPlatformBaseUrl.mockReset();
@@ -2965,5 +2972,135 @@ describe("UsageTelemetryReporter", () => {
       body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
     ).toEqual(["wire-wm-1"]);
     expect(acknowledge).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // outboxSource (real telemetry_events outbox behind an ack-mode source)
+  // -------------------------------------------------------------------------
+
+  const OUTBOX_NAME = "test_outbox";
+
+  function seedOutboxRow(id: string, createdAt: number): void {
+    insertTelemetryOutboxEvent({
+      id,
+      name: OUTBOX_NAME,
+      createdAt,
+      event: fakeWireEvent(id, createdAt),
+    });
+  }
+
+  function pendingOutboxIds(): string[] {
+    return queryTelemetryOutboxBatch(OUTBOX_NAME, 1000).map((r) => r.id);
+  }
+
+  test("outboxSource ships pending rows and deletes them after a 2xx", async () => {
+    seedOutboxRow("ob-1", 1700000001000);
+    seedOutboxRow("ob-2", 1700000002000);
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-ob-1", "wire-ob-2"]);
+    expect(pendingOutboxIds()).toEqual([]);
+    // Ack-mode: flush_checkpoints untouched.
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("outboxSource leaves rows intact when the POST fails", async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("error", { status: 500 })),
+    );
+    seedOutboxRow("ob-1", 1700000001000);
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(pendingOutboxIds()).toEqual(["ob-1"]);
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("outboxSource opt-out discards all pending rows for the name", async () => {
+    mockGetCachedShareAnalytics.mockReturnValue(false);
+    seedOutboxRow("ob-1", 1700000001000);
+    seedOutboxRow("ob-2", 1700000002000);
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(pendingOutboxIds()).toEqual([]);
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("outboxSource purges corrupt-payload rows at collect while valid siblings ship", async () => {
+    // Raw inserts: the store API only writes JSON.stringify-ed events, so
+    // corrupt payloads (invalid JSON, non-object JSON) go in directly.
+    getTelemetryDb()!
+      .insert(telemetryEvents)
+      .values([
+        {
+          id: "ob-corrupt-json",
+          name: OUTBOX_NAME,
+          createdAt: 1700000001000,
+          conversationId: null,
+          payload: "{not json",
+        },
+        {
+          id: "ob-non-object",
+          name: OUTBOX_NAME,
+          createdAt: 1700000002000,
+          conversationId: null,
+          payload: "42",
+        },
+      ])
+      .run();
+    seedOutboxRow("ob-valid", 1700000003000);
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-ob-valid"]);
+    // Corrupt rows are gone (purged at collect), the valid row via ack.
+    expect(pendingOutboxIds()).toEqual([]);
+  });
+
+  test("a full outbox batch drives recursion until the backlog drains", async () => {
+    // 501 rows: the first collect fills BATCH_SIZE (500) and the fullBatch
+    // recursion ships the remaining row.
+    for (let i = 0; i < 501; i++) {
+      seedOutboxRow(`ob-${String(i).padStart(3, "0")}`, 1700000000000 + i);
+    }
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(
+      (mockFetch.mock.calls[1] as [string, RequestInit])[1].body as string,
+    );
+    expect(secondBody.events).toHaveLength(1);
+    expect(pendingOutboxIds()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- outboxSource(name): ack-mode TelemetryEventSource over the telemetry_events outbox (collect ignores cursors; delete-on-flush ack; opt-out discard)
- Corrupt payload rows are purged at collect time with a warn instead of poisoning the flush
- Covered end-to-end through the reporter with a real telemetry DB

Part of plan: telemetry-outbox-consolidation.md (PR 3 of 9)