### PR TITLE
refactor(telemetry): record watchdog and config_setting events into the telemetry_events outbox

### DIFF
--- a/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
@@ -8,22 +8,17 @@ mock.module("../../platform/consent-cache.js", () => ({
 
 import { getTelemetryDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
-import { configSettingEvents } from "../../persistence/schema/index.js";
-import {
-  queryUnreportedConfigSettingEvents,
-  recordConfigSettingEvent,
-} from "../config-setting-events-store.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
+import { APP_VERSION } from "../../version.js";
+import { recordConfigSettingEvent } from "../config-setting-events-store.js";
+import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
 
 await initializeDb();
 
-function insertEvent(id: string, createdAt: number): void {
-  const db = getTelemetryDb();
-  if (!db) {
-    throw new Error("telemetry DB unavailable in test");
-  }
-  db.insert(configSettingEvents)
-    .values({ id, createdAt, configKey: "memory.enabled", configValue: "true" })
-    .run();
+function pendingConfigSettingPayloads(): Array<Record<string, unknown>> {
+  return queryTelemetryOutboxBatch("config_setting", 100).map(
+    (row) => JSON.parse(row.payload) as Record<string, unknown>,
+  );
 }
 
 function clearEvents(): void {
@@ -31,7 +26,7 @@ function clearEvents(): void {
   if (!db) {
     throw new Error("telemetry DB unavailable in test");
   }
-  db.delete(configSettingEvents).run();
+  db.delete(telemetryEvents).run();
 }
 
 describe("config-setting-events-store", () => {
@@ -40,7 +35,7 @@ describe("config-setting-events-store", () => {
     clearEvents();
   });
 
-  test("honors the share_analytics opt-out (records nothing)", () => {
+  test("honors the share_analytics opt-out (records nothing, returns false)", () => {
     shareAnalytics = false;
     expect(
       recordConfigSettingEvent({
@@ -48,12 +43,10 @@ describe("config-setting-events-store", () => {
         configValue: "true",
       }),
     ).toBe(false);
-    expect(queryUnreportedConfigSettingEvents(0, undefined, 10)).toHaveLength(
-      0,
-    );
+    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(0);
   });
 
-  test("record + query round-trips the key/value pair", () => {
+  test("records the full wire event and returns true", () => {
     expect(
       recordConfigSettingEvent({
         configKey: "memory.v2.enabled",
@@ -61,13 +54,19 @@ describe("config-setting-events-store", () => {
       }),
     ).toBe(true);
 
-    const rows = queryUnreportedConfigSettingEvents(0, undefined, 10);
+    const rows = queryTelemetryOutboxBatch("config_setting", 10);
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
     expect(row.id).toBeString();
     expect(row.createdAt).toBeGreaterThan(0);
-    expect(row.configKey).toBe("memory.v2.enabled");
-    expect(row.configValue).toBe("false");
+    expect(JSON.parse(row.payload)).toEqual({
+      type: "config_setting",
+      daemon_event_id: row.id,
+      recorded_at: row.createdAt,
+      config_key: "memory.v2.enabled",
+      config_value: "false",
+      assistant_version: APP_VERSION,
+    });
   });
 
   test("clamps oversize key and value to the platform bounds", () => {
@@ -76,55 +75,9 @@ describe("config-setting-events-store", () => {
       configValue: "v".repeat(300),
     });
 
-    const rows = queryUnreportedConfigSettingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.configKey).toBe("k".repeat(128));
-    expect(rows[0]!.configValue).toBe("v".repeat(256));
-  });
-
-  test("returns rows in (createdAt, id) order", () => {
-    insertEvent("cs-b", 2000);
-    insertEvent("cs-a", 1000);
-
-    const rows = queryUnreportedConfigSettingEvents(0, undefined, 100);
-    expect(rows.map((r) => r.id)).toEqual(["cs-a", "cs-b"]);
-  });
-
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    // Two rows in the same millisecond: pagination must use the id
-    // tiebreaker to make forward progress, not loop.
-    insertEvent("cs-1", 5000);
-    insertEvent("cs-2", 5000);
-    insertEvent("cs-3", 6000);
-
-    const first = queryUnreportedConfigSettingEvents(0, undefined, 1);
-    expect(first.map((r) => r.id)).toEqual(["cs-1"]);
-
-    const second = queryUnreportedConfigSettingEvents(
-      first[0]!.createdAt,
-      first[0]!.id,
-      100,
-    );
-    expect(second.map((r) => r.id)).toEqual(["cs-2", "cs-3"]);
-
-    // Without an id cursor the timestamp-only branch is used.
-    expect(
-      queryUnreportedConfigSettingEvents(5000, undefined, 100).map((r) => r.id),
-    ).toEqual(["cs-3"]);
-
-    // Cursor past the last row returns nothing.
-    const last = second[second.length - 1]!;
-    expect(
-      queryUnreportedConfigSettingEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
-  });
-
-  test("honors the limit", () => {
-    insertEvent("cs-l1", 1000);
-    insertEvent("cs-l2", 2000);
-    insertEvent("cs-l3", 3000);
-
-    const rows = queryUnreportedConfigSettingEvents(0, undefined, 2);
-    expect(rows.map((r) => r.id)).toEqual(["cs-l1", "cs-l2"]);
+    const payloads = pendingConfigSettingPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]!.config_key).toBe("k".repeat(128));
+    expect(payloads[0]!.config_value).toBe("v".repeat(256));
   });
 });

--- a/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
@@ -9,12 +9,12 @@ mock.module("../../platform/consent-cache.js", () => ({
 import type { AssistantConfig } from "../../config/schema.js";
 import { getTelemetryDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
-import { configSettingEvents } from "../../persistence/schema/index.js";
-import { queryUnreportedConfigSettingEvents } from "../config-setting-events-store.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
 import {
   recordConfigSettingSnapshot,
   resetConfigSettingSnapshotForTesting,
 } from "../config-setting-snapshot.js";
+import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
 
 await initializeDb();
 
@@ -28,10 +28,13 @@ function makeConfig(
 }
 
 function recordedPairs(): Array<[string, string]> {
-  return queryUnreportedConfigSettingEvents(0, undefined, 100).map((r) => [
-    r.configKey,
-    r.configValue,
-  ]);
+  return queryTelemetryOutboxBatch("config_setting", 100).map((row) => {
+    const event = JSON.parse(row.payload) as {
+      config_key: string;
+      config_value: string;
+    };
+    return [event.config_key, event.config_value];
+  });
 }
 
 function clearEvents(): void {
@@ -39,7 +42,7 @@ function clearEvents(): void {
   if (!db) {
     throw new Error("telemetry DB unavailable in test");
   }
-  db.delete(configSettingEvents).run();
+  db.delete(telemetryEvents).run();
 }
 
 describe("config-setting-snapshot", () => {

--- a/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
@@ -8,28 +8,25 @@ mock.module("../../platform/consent-cache.js", () => ({
 
 import { getTelemetryDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
-import { watchdogEvents } from "../../persistence/schema/index.js";
-import {
-  queryUnreportedWatchdogEvents,
-  recordWatchdogEvent,
-} from "../watchdog-events-store.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
+import { APP_VERSION } from "../../version.js";
+import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
+import { recordWatchdogEvent } from "../watchdog-events-store.js";
 
 await initializeDb();
 
-function insertEvent(
-  id: string,
-  createdAt: number,
-  checkName = "event_loop_blocked",
-): void {
-  const db = getTelemetryDb();
-  if (!db) throw new Error("telemetry DB unavailable in test");
-  db.insert(watchdogEvents).values({ id, createdAt, checkName }).run();
+function pendingWatchdogPayloads(): Array<Record<string, unknown>> {
+  return queryTelemetryOutboxBatch("watchdog", 100).map(
+    (row) => JSON.parse(row.payload) as Record<string, unknown>,
+  );
 }
 
 function clearEvents(): void {
   const db = getTelemetryDb();
-  if (!db) throw new Error("telemetry DB unavailable in test");
-  db.delete(watchdogEvents).run();
+  if (!db) {
+    throw new Error("telemetry DB unavailable in test");
+  }
+  db.delete(telemetryEvents).run();
 }
 
 describe("watchdog-events-store", () => {
@@ -41,35 +38,39 @@ describe("watchdog-events-store", () => {
   test("honors the share_analytics opt-out (records nothing)", () => {
     shareAnalytics = false;
     recordWatchdogEvent({ checkName: "event_loop_blocked", value: 60000 });
-    expect(queryUnreportedWatchdogEvents(0, undefined, 10)).toHaveLength(0);
+    expect(queryTelemetryOutboxBatch("watchdog", 10)).toHaveLength(0);
   });
 
-  test("record + query round-trips all fields", () => {
+  test("records the full wire event, with detail as a nested object", () => {
     recordWatchdogEvent({
       checkName: "event_loop_blocked",
       value: 12345,
       detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
     });
 
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 10);
+    const rows = queryTelemetryOutboxBatch("watchdog", 10);
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
     expect(row.id).toBeString();
     expect(row.createdAt).toBeGreaterThan(0);
-    expect(row.checkName).toBe("event_loop_blocked");
-    expect(row.value).toBe(12345);
-    expect(row.detail).toBe(
-      JSON.stringify({ reason: "no_bytes_60s", threshold_ms: 5000 }),
-    );
+    expect(JSON.parse(row.payload)).toEqual({
+      type: "watchdog",
+      daemon_event_id: row.id,
+      recorded_at: row.createdAt,
+      check_name: "event_loop_blocked",
+      value: 12345,
+      detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
+      assistant_version: APP_VERSION,
+    });
   });
 
-  test("optional fields persist as null", () => {
+  test("omitted value and detail persist as null", () => {
     recordWatchdogEvent({ checkName: "stream_idle" });
 
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      checkName: "stream_idle",
+    const payloads = pendingWatchdogPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      check_name: "stream_idle",
       value: null,
       detail: null,
     });
@@ -82,72 +83,9 @@ describe("watchdog-events-store", () => {
       detail: null,
     });
 
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.value).toBeNull();
-    expect(rows[0]?.detail).toBeNull();
-  });
-
-  test("returns rows in (createdAt, id) order", () => {
-    insertEvent("wd-b", 2000);
-    insertEvent("wd-a", 1000);
-
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 100);
-    expect(rows.map((r) => r.id)).toEqual(["wd-a", "wd-b"]);
-  });
-
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    // Two rows in the same millisecond: pagination must use the id
-    // tiebreaker to make forward progress, not loop.
-    insertEvent("wd-1", 5000);
-    insertEvent("wd-2", 5000);
-    insertEvent("wd-3", 6000);
-
-    const first = queryUnreportedWatchdogEvents(0, undefined, 1);
-    expect(first.map((r) => r.id)).toEqual(["wd-1"]);
-
-    const second = queryUnreportedWatchdogEvents(
-      first[0]!.createdAt,
-      first[0]!.id,
-      100,
-    );
-    expect(second.map((r) => r.id)).toEqual(["wd-2", "wd-3"]);
-
-    // Without an id cursor the timestamp-only branch is used.
-    expect(
-      queryUnreportedWatchdogEvents(5000, undefined, 100).map((r) => r.id),
-    ).toEqual(["wd-3"]);
-
-    // Cursor past the last row returns nothing.
-    const last = second[second.length - 1]!;
-    expect(
-      queryUnreportedWatchdogEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
-  });
-
-  test("resumes from a persisted watermark without re-reporting", () => {
-    insertEvent("wd-w1", 1000);
-    insertEvent("wd-w2", 2000);
-
-    const batch = queryUnreportedWatchdogEvents(0, undefined, 100);
-    const watermark = batch[batch.length - 1]!;
-
-    insertEvent("wd-w3", 3000);
-
-    const resumed = queryUnreportedWatchdogEvents(
-      watermark.createdAt,
-      watermark.id,
-      100,
-    );
-    expect(resumed.map((r) => r.id)).toEqual(["wd-w3"]);
-  });
-
-  test("honors the limit", () => {
-    insertEvent("wd-l1", 1000);
-    insertEvent("wd-l2", 2000);
-    insertEvent("wd-l3", 3000);
-
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 2);
-    expect(rows.map((r) => r.id)).toEqual(["wd-l1", "wd-l2"]);
+    const payloads = pendingWatchdogPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.value).toBeNull();
+    expect(payloads[0]?.detail).toBeNull();
   });
 });

--- a/assistant/src/telemetry/config-setting-events-store.ts
+++ b/assistant/src/telemetry/config-setting-events-store.ts
@@ -1,9 +1,9 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
-import { configSettingEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { APP_VERSION } from "../version.js";
+import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import type { ConfigSettingTelemetryEvent } from "./types.js";
 
 /**
  * Server-side bounds from the platform `ConfigSettingTelemetryEventSerializer`.
@@ -25,22 +25,14 @@ export interface ConfigSettingEventRecord {
   configValue: string;
 }
 
-/** A persisted config_setting event row. */
-export interface ConfigSettingEvent {
-  id: string;
-  createdAt: number;
-  configKey: string;
-  configValue: string;
-}
-
 /**
- * Record a `config_setting` telemetry event. No-ops when usage data
+ * Record a `config_setting` telemetry event. Builds the full wire event and
+ * enqueues it on the `telemetry_events` outbox. No-ops when usage data
  * collection is disabled (the event is dropped to honor the opt-out,
- * matching the rest of telemetry) — so opt-out rows never exist and the
- * reporter's standard 0 watermark default is safe. Returns whether a row
- * was persisted, so a caller with its own dedupe memo
- * (config-setting-snapshot.ts) only advances the memo on a real write and
- * keeps retrying while consent is off or the telemetry DB is unavailable.
+ * matching the rest of telemetry). Returns whether the event was persisted,
+ * so a caller with its own dedupe memo (config-setting-snapshot.ts) only
+ * advances the memo on a real write and keeps retrying while consent is off
+ * or the telemetry DB is unavailable.
  */
 export function recordConfigSettingEvent(
   record: ConfigSettingEventRecord,
@@ -48,54 +40,20 @@ export function recordConfigSettingEvent(
   if (!getCachedShareAnalytics()) {
     return false;
   }
-  const db = getTelemetryDb();
-  if (!db) {
-    return false;
-  }
-  db.insert(configSettingEvents)
-    .values({
-      id: uuid(),
-      createdAt: Date.now(),
-      configKey: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
-      configValue: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
-    })
-    .run();
-  return true;
-}
-
-/**
- * Query config_setting events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedConfigSettingEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): ConfigSettingEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
-  }
-  return db
-    .select({
-      id: configSettingEvents.id,
-      createdAt: configSettingEvents.createdAt,
-      configKey: configSettingEvents.configKey,
-      configValue: configSettingEvents.configValue,
-    })
-    .from(configSettingEvents)
-    .where(
-      afterId
-        ? or(
-            gt(configSettingEvents.createdAt, afterCreatedAt),
-            and(
-              eq(configSettingEvents.createdAt, afterCreatedAt),
-              gt(configSettingEvents.id, afterId),
-            ),
-          )
-        : gt(configSettingEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(configSettingEvents.createdAt), asc(configSettingEvents.id))
-    .limit(limit)
-    .all();
+  const id = uuid();
+  const createdAt = Date.now();
+  const event: ConfigSettingTelemetryEvent = {
+    type: "config_setting",
+    daemon_event_id: id,
+    recorded_at: createdAt,
+    config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
+    config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
+    assistant_version: APP_VERSION,
+  };
+  return insertTelemetryOutboxEvent({
+    id,
+    name: "config_setting",
+    createdAt,
+    event,
+  });
 }

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -24,7 +24,6 @@ import {
   type ActivationStepName,
   buildActivationDaemonEventId,
 } from "./activation-funnel.js";
-import { queryUnreportedConfigSettingEvents } from "./config-setting-events-store.js";
 import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
 import {
   deleteTelemetryOutboxEvents,
@@ -36,7 +35,6 @@ import { isDiagnosticsConsentVersionEligible } from "./trace-collection-policy.j
 import { queryUnreportedTurnEvents } from "./turn-events-store.js";
 import { assembleBoundedTurnTrace, isTurnSettled } from "./turn-trace-store.js";
 import type { TelemetryEvent, TurnTelemetryClientInfo } from "./types.js";
-import { queryUnreportedWatchdogEvents } from "./watchdog-events-store.js";
 
 const log = getLogger("usage-telemetry");
 
@@ -188,39 +186,6 @@ export function outboxSource(name: string): TelemetryEventSource {
       discardPending: () => discardPendingTelemetryOutboxEvents(name),
     },
   };
-}
-
-// ---------------------------------------------------------------------------
-// Wire-mapping helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Parse a stored `watchdog_events.detail` JSON text column into the object the
- * platform expects. Returns null for a null column or an unparseable/corrupted
- * blob (mirroring the turn `client` metadata parse: a bad blob emits null
- * rather than failing the batch). A non-object (e.g. a bare number or string)
- * also resolves to null, since the platform serializer treats `detail` as a
- * JSON object bag.
- */
-function parseWatchdogDetail(
-  raw: string | null,
-): Record<string, unknown> | null {
-  if (!raw) {
-    return null;
-  }
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-    return null;
-  } catch {
-    log.warn(
-      { rawDetail: raw.slice(0, 200) },
-      "Telemetry watchdog: failed to parse detail; emitting null",
-    );
-    return null;
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -579,43 +544,9 @@ const skillLoadedSource = simpleSource(
   }),
 );
 
-const watchdogSource = simpleSource(
-  "watchdog",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedWatchdogEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "watchdog",
-    daemon_event_id: e.id,
-    recorded_at: e.createdAt,
-    check_name: e.checkName,
-    value: e.value,
-    // `detail` is stored as JSON text; parse defensively so a
-    // corrupted blob never fails the batch flush. A parse failure
-    // emits null rather than dropping the event.
-    detail: parseWatchdogDetail(e.detail),
-    // `watchdog_events` has no record-time version column — same
-    // upload-time APP_VERSION stamping as the other non-llm_usage
-    // event types.
-    assistant_version: APP_VERSION,
-  }),
-);
+const watchdogSource = outboxSource("watchdog");
 
-const configSettingSource = simpleSource(
-  "config_setting",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedConfigSettingEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "config_setting",
-    daemon_event_id: e.id,
-    recorded_at: e.createdAt,
-    config_key: e.configKey,
-    config_value: e.configValue,
-    // `config_setting_events` has no record-time version column —
-    // same upload-time APP_VERSION stamping as the other
-    // non-llm_usage event types.
-    assistant_version: APP_VERSION,
-  }),
-);
+const configSettingSource = outboxSource("config_setting");
 
 /**
  * Watermark key namespace of the tool_executed source — referenced by the

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -228,7 +228,6 @@ import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
   authFallbackEvents,
-  configSettingEvents,
   conversations,
   skillLoadedEvents,
   telemetryEvents,
@@ -258,6 +257,7 @@ import {
   initToolExecutedWatermarkIfAbsent,
   UsageTelemetryReporter,
 } from "./usage-telemetry-reporter.js";
+import { recordWatchdogEvent } from "./watchdog-events-store.js";
 
 /**
  * Construct a reporter wired to the in-memory checkpoint fake. All tests go
@@ -415,7 +415,6 @@ beforeEach(() => {
   getDb().delete(toolInvocations).run();
   getTelemetryDb()!.delete(skillLoadedEvents).run();
   getTelemetryDb()!.delete(authFallbackEvents).run();
-  getTelemetryDb()!.delete(configSettingEvents).run();
   getTelemetryDb()!.delete(telemetryEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
   delete process.env.IS_PLATFORM;
@@ -1651,11 +1650,13 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 9 timestamp watermarks should have been advanced, and all 9 ID
-    // watermarks pinned to the high-sorting sentinel (a truthy value keeps
-    // the compound-cursor branch active while closing its same-millisecond
-    // arm against opt-out rows).
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(18);
+    // Every watermark-mode source's timestamp watermark should have been
+    // advanced, and its ID watermark pinned to the high-sorting sentinel (a
+    // truthy value keeps the compound-cursor branch active while closing its
+    // same-millisecond arm against opt-out rows). Ack-mode sources (watchdog,
+    // config_setting) discard pending outbox rows instead and never touch
+    // `flush_checkpoints`.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(14);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -1667,8 +1668,6 @@ describe("UsageTelemetryReporter", () => {
       "auth_fallback",
       "tool_executed",
       "skill_loaded",
-      "watchdog",
-      "config_setting",
     ];
     for (const eventType of eventTypes) {
       expect(keys).toContain(`telemetry:${eventType}:last_reported_at`);
@@ -2639,7 +2638,7 @@ describe("UsageTelemetryReporter", () => {
     });
   });
 
-  test("config_setting watermark advances to the last reported row on success", async () => {
+  test("config_setting rows are deleted on success and no watermark is written", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     recordConfigSettingEvent({
       configKey: "memory.enabled",
@@ -2649,35 +2648,72 @@ describe("UsageTelemetryReporter", () => {
       configKey: "memory.v2.enabled",
       configValue: "true",
     });
+    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(2);
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    // The last row by the reporter's (createdAt, id) cursor order is the one
-    // whose watermark should be persisted after a successful upload.
-    const rows = getTelemetryDb()!
-      .select()
-      .from(configSettingEvents)
-      .orderBy(configSettingEvents.createdAt, configSettingEvents.id)
-      .all();
-    const lastRow = rows[rows.length - 1];
+    const reporter = makeReporter();
+    await reporter.flush();
+
+    // Ack-mode: acknowledged rows are deleted from the outbox instead of
+    // advancing a `flush_checkpoints` watermark.
+    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(0);
+    const watermarkKeys = mockSetFlushCheckpoint.mock.calls
+      .map((c) => c[0] as string)
+      .filter((key) => key.startsWith("telemetry:config_setting:"));
+    expect(watermarkKeys).toHaveLength(0);
+  });
+
+  test("config_setting rows survive a failed POST for the next flush", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordConfigSettingEvent({
+      configKey: "memory.enabled",
+      configValue: "true",
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("error", { status: 500 })),
+    );
 
     const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:config_setting:last_reported_at",
-    );
-    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
-    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
-      String(lastRow.createdAt),
+    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Watchdog events
+  // -------------------------------------------------------------------------
+
+  test("watchdog events ship the record-time payload with nested detail, then delete", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordWatchdogEvent({
+      checkName: "event_loop_blocked",
+      value: 60000,
+      detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:config_setting:last_reported_id",
+    const reporter = makeReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
-    expect(idCalls.length).toBeGreaterThanOrEqual(1);
-    expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0]).toMatchObject({
+      type: "watchdog",
+      check_name: "event_loop_blocked",
+      value: 60000,
+      detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
+      assistant_version: "1.2.3-test",
+    });
+    expect(typeof body.events[0].daemon_event_id).toBe("string");
+    expect(typeof body.events[0].recorded_at).toBe("number");
+    expect(queryTelemetryOutboxBatch("watchdog", 10)).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/watchdog-events-store.ts
+++ b/assistant/src/telemetry/watchdog-events-store.ts
@@ -1,15 +1,15 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
-import { watchdogEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { APP_VERSION } from "../version.js";
+import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import type { WatchdogTelemetryEvent } from "./types.js";
 
 /**
  * Input for one `watchdog` telemetry event. Metadata only — never conversation
  * content. `value` and `detail` are optional; omitting both yields the minimal
- * event (check_name only). `detail` is a JSON bag serialized to text on persist
- * and forwarded verbatim on flush.
+ * event (check_name only). `detail` is an open JSON bag carried verbatim in
+ * the event payload.
  */
 export interface WatchdogEventRecord {
   checkName: string;
@@ -19,69 +19,27 @@ export interface WatchdogEventRecord {
   detail?: Record<string, unknown> | null;
 }
 
-/** A persisted watchdog event row. */
-export interface WatchdogEvent {
-  id: string;
-  createdAt: number;
-  checkName: string;
-  value: number | null;
-  /** Raw `detail` JSON text from the row, or null. Parsed by the reporter on flush. */
-  detail: string | null;
-}
-
 /**
- * Record a `watchdog` telemetry event for a watchdog check firing. No-ops when
- * usage data collection is disabled (the event is dropped to honor the opt-out,
- * matching the rest of telemetry) — so opt-out rows never exist and the
- * reporter's standard 0 watermark default is safe.
+ * Record a `watchdog` telemetry event for a watchdog check firing. Builds the
+ * full wire event and enqueues it on the `telemetry_events` outbox. No-ops
+ * when usage data collection is disabled (the event is dropped to honor the
+ * opt-out, matching the rest of telemetry) or when the telemetry DB is
+ * unavailable.
  */
 export function recordWatchdogEvent(record: WatchdogEventRecord): void {
-  if (!getCachedShareAnalytics()) return;
-  const db = getTelemetryDb();
-  if (!db) return;
-  db.insert(watchdogEvents)
-    .values({
-      id: uuid(),
-      createdAt: Date.now(),
-      checkName: record.checkName,
-      value: record.value ?? null,
-      detail: record.detail != null ? JSON.stringify(record.detail) : null,
-    })
-    .run();
-}
-
-/**
- * Query watchdog events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedWatchdogEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): WatchdogEvent[] {
-  const db = getTelemetryDb();
-  if (!db) return [];
-  return db
-    .select({
-      id: watchdogEvents.id,
-      createdAt: watchdogEvents.createdAt,
-      checkName: watchdogEvents.checkName,
-      value: watchdogEvents.value,
-      detail: watchdogEvents.detail,
-    })
-    .from(watchdogEvents)
-    .where(
-      afterId
-        ? or(
-            gt(watchdogEvents.createdAt, afterCreatedAt),
-            and(
-              eq(watchdogEvents.createdAt, afterCreatedAt),
-              gt(watchdogEvents.id, afterId),
-            ),
-          )
-        : gt(watchdogEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(watchdogEvents.createdAt), asc(watchdogEvents.id))
-    .limit(limit)
-    .all();
+  if (!getCachedShareAnalytics()) {
+    return;
+  }
+  const id = uuid();
+  const createdAt = Date.now();
+  const event: WatchdogTelemetryEvent = {
+    type: "watchdog",
+    daemon_event_id: id,
+    recorded_at: createdAt,
+    check_name: record.checkName,
+    value: record.value ?? null,
+    detail: record.detail ?? null,
+    assistant_version: APP_VERSION,
+  };
+  insertTelemetryOutboxEvent({ id, name: "watchdog", createdAt, event });
 }


### PR DESCRIPTION
## Summary
- recordWatchdogEvent/recordConfigSettingEvent build wire payloads at record time and write the outbox (names watchdog / config_setting)
- Both sources are now outboxSource(...) — delete-on-flush; flush-time parseWatchdogDetail removed (detail is a native payload object now)
- Contracts preserved: watchdog void, config_setting boolean (snapshot memo)

Part of plan: telemetry-outbox-consolidation.md (PR 8 of 9)