### PR TITLE
refactor(telemetry): record auth-fallback counts into the telemetry_events outbox

### DIFF
--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 let shareAnalytics = true;
 
@@ -6,19 +6,29 @@ mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
+import * as dbConnection from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { authFallbackEvents } from "../persistence/schema/index.js";
 import {
   type AuthFallbackCount,
-  queryUnreportedAuthFallbackEvents,
   recordAuthFallbackCounts,
 } from "../security/auth-fallback-events-store.js";
+import {
+  discardPendingTelemetryOutboxEvents,
+  queryTelemetryOutboxBatch,
+} from "../telemetry/telemetry-events-outbox.js";
+import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
+import { APP_VERSION } from "../version.js";
 
 await initializeDb();
 
-function resetTable(): void {
-  getTelemetryDb()!.delete(authFallbackEvents).run();
+function pendingRows() {
+  return queryTelemetryOutboxBatch("auth_fallback", 100);
+}
+
+function pendingPayloads(): AuthFallbackTelemetryEvent[] {
+  return pendingRows().map(
+    (r) => JSON.parse(r.payload) as AuthFallbackTelemetryEvent,
+  );
 }
 
 const SAMPLE: AuthFallbackCount[] = [
@@ -39,27 +49,41 @@ const SAMPLE: AuthFallbackCount[] = [
 describe("auth-fallback-events-store", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    resetTable();
+    discardPendingTelemetryOutboxEvents("auth_fallback");
   });
 
-  test("records one row per count entry and they are queryable", () => {
+  test("records one outbox row per count entry with the full wire payload", () => {
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(2);
 
-    const rows = queryUnreportedAuthFallbackEvents(0, undefined, 100);
+    const rows = pendingRows();
     expect(rows.length).toBe(2);
-    const byGuard = Object.fromEntries(rows.map((r) => [r.guard, r]));
-    expect(byGuard["edge"]).toMatchObject({
+    const payloads = rows.map(
+      (r) => JSON.parse(r.payload) as AuthFallbackTelemetryEvent,
+    );
+    const byGuard = Object.fromEntries(payloads.map((p) => [p.guard, p]));
+    expect(byGuard["edge"]).toEqual({
+      type: "auth_fallback",
+      daemon_event_id: expect.any(String),
+      recorded_at: expect.any(Number),
+      guard: "edge",
       path: "/v1/messages",
-      failureKind: "missing_authorization",
+      failure_kind: "missing_authorization",
       count: 7,
-      windowStart: 1000,
-      windowEnd: 2000,
+      window_start: 1000,
+      window_end: 2000,
+      assistant_version: APP_VERSION,
     });
     expect(byGuard["edge-scoped"]).toMatchObject({
       path: "/v1/files",
-      failureKind: "insufficient_scope",
+      failure_kind: "insufficient_scope",
       count: 2,
+    });
+    // The wire daemon_event_id matches the outbox row id, and recorded_at
+    // matches the row's created_at (record-time stamping).
+    rows.forEach((row, i) => {
+      expect(payloads[i].daemon_event_id).toBe(row.id);
+      expect(payloads[i].recorded_at).toBe(row.createdAt);
     });
   });
 
@@ -67,35 +91,39 @@ describe("auth-fallback-events-store", () => {
     shareAnalytics = false;
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(0);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingRows().length).toBe(0);
   });
 
   test("empty counts batch is a no-op", () => {
     expect(recordAuthFallbackCounts(1000, 2000, [])).toBe(0);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingRows().length).toBe(0);
   });
 
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    recordAuthFallbackCounts(1000, 2000, SAMPLE);
-    const all = queryUnreportedAuthFallbackEvents(0, undefined, 100);
-    expect(all.length).toBe(2);
+  test("returns 0 when the telemetry DB is unavailable", () => {
+    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+    try {
+      expect(recordAuthFallbackCounts(1000, 2000, SAMPLE)).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(pendingRows().length).toBe(0);
+  });
 
-    // All rows share the same createdAt (one insert batch). Paginating with a
-    // limit of 1 must use the id tiebreaker to make forward progress, not loop.
-    const first = queryUnreportedAuthFallbackEvents(0, undefined, 1);
-    expect(first.length).toBe(1);
-    const second = queryUnreportedAuthFallbackEvents(
-      first[0].createdAt,
-      first[0].id,
-      1,
-    );
-    expect(second.length).toBe(1);
-    expect(second[0].id).not.toBe(first[0].id);
-
-    // Cursor past the last row returns nothing.
-    const last = all[all.length - 1];
-    expect(
-      queryUnreportedAuthFallbackEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
+  test("returns the partial count when the telemetry DB vanishes mid-batch", () => {
+    const realDb = dbConnection.getTelemetryDb();
+    // Call order: the store's own upfront check, then one call per insert.
+    // Let the check and the first insert see the DB, then lose it.
+    const spy = spyOn(dbConnection, "getTelemetryDb")
+      .mockReturnValueOnce(realDb)
+      .mockReturnValueOnce(realDb)
+      .mockReturnValue(null);
+    try {
+      expect(recordAuthFallbackCounts(1000, 2000, SAMPLE)).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+    const payloads = pendingPayloads();
+    expect(payloads.length).toBe(1);
+    expect(payloads[0].guard).toBe("edge");
   });
 });

--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -25,12 +25,6 @@ function pendingRows() {
   return queryTelemetryOutboxBatch("auth_fallback", 100);
 }
 
-function pendingPayloads(): AuthFallbackTelemetryEvent[] {
-  return pendingRows().map(
-    (r) => JSON.parse(r.payload) as AuthFallbackTelemetryEvent,
-  );
-}
-
 const SAMPLE: AuthFallbackCount[] = [
   {
     guard: "edge",
@@ -99,31 +93,15 @@ describe("auth-fallback-events-store", () => {
     expect(pendingRows().length).toBe(0);
   });
 
-  test("returns 0 when the telemetry DB is unavailable", () => {
+  test("records all-or-nothing: db unavailable returns 0 with no rows", () => {
     const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
     try {
       expect(recordAuthFallbackCounts(1000, 2000, SAMPLE)).toBe(0);
     } finally {
       spy.mockRestore();
     }
+    // No partial batch: the gateway's `recorded === 0` retry contract means
+    // any committed remnant would later double-count.
     expect(pendingRows().length).toBe(0);
-  });
-
-  test("returns the partial count when the telemetry DB vanishes mid-batch", () => {
-    const realDb = dbConnection.getTelemetryDb();
-    // Call order: the store's own upfront check, then one call per insert.
-    // Let the check and the first insert see the DB, then lose it.
-    const spy = spyOn(dbConnection, "getTelemetryDb")
-      .mockReturnValueOnce(realDb)
-      .mockReturnValueOnce(realDb)
-      .mockReturnValue(null);
-    try {
-      expect(recordAuthFallbackCounts(1000, 2000, SAMPLE)).toBe(1);
-    } finally {
-      spy.mockRestore();
-    }
-    const payloads = pendingPayloads();
-    expect(payloads.length).toBe(1);
-    expect(payloads[0].guard).toBe("edge");
   });
 });

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -30,7 +30,6 @@ mock.module("../telemetry/watchdog-direct-emit.js", () => ({
 
 import * as dbConnection from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { authFallbackEvents } from "../persistence/schema/index.js";
 import { GATEWAY_PRINCIPALS } from "../runtime/auth/route-policy.js";
 import {
   RouteError,
@@ -38,9 +37,19 @@ import {
 } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/internal-telemetry-routes.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
-import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-events-store.js";
+import {
+  discardPendingTelemetryOutboxEvents,
+  queryTelemetryOutboxBatch,
+} from "../telemetry/telemetry-events-outbox.js";
+import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
 
 await initializeDb();
+
+function pendingAuthFallbackPayloads(): AuthFallbackTelemetryEvent[] {
+  return queryTelemetryOutboxBatch("auth_fallback", 100).map(
+    (r) => JSON.parse(r.payload) as AuthFallbackTelemetryEvent,
+  );
+}
 
 const route = ROUTES.find(
   (r) => r.operationId === "internal_telemetry_auth_fallback",
@@ -67,7 +76,7 @@ const VALID_BODY = {
 describe("internal-telemetry-routes: auth-fallback", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    dbConnection.getTelemetryDb()!.delete(authFallbackEvents).run();
+    discardPendingTelemetryOutboxEvents("auth_fallback");
   });
 
   test("route is locked to service-token callers (GATEWAY_PRINCIPALS + internal.write)", () => {
@@ -78,26 +87,27 @@ describe("internal-telemetry-routes: auth-fallback", () => {
     expect(route?.policy?.requiredScopes).toEqual(["internal.write"]);
   });
 
-  test("valid batch is persisted with snake_case → camelCase mapping", () => {
+  test("valid batch is persisted to the outbox as a wire auth_fallback event", () => {
     const result = call(VALID_BODY);
     expect(result).toEqual({ recorded: 1 });
 
-    const rows = queryUnreportedAuthFallbackEvents(0, undefined, 100);
-    expect(rows.length).toBe(1);
-    expect(rows[0]).toMatchObject({
+    const payloads = pendingAuthFallbackPayloads();
+    expect(payloads.length).toBe(1);
+    expect(payloads[0]).toMatchObject({
+      type: "auth_fallback",
       guard: "edge",
       path: "/v1/messages",
-      failureKind: "missing_authorization",
+      failure_kind: "missing_authorization",
       count: 5,
-      windowStart: 1000,
-      windowEnd: 2000,
+      window_start: 1000,
+      window_end: 2000,
     });
   });
 
   test("returns skipped and persists nothing under the opt-out", () => {
     shareAnalytics = false;
     expect(call(VALID_BODY)).toEqual({ skipped: true });
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingAuthFallbackPayloads().length).toBe(0);
   });
 
   test("throws 503 when consent is on but the telemetry DB is unavailable, so the gateway re-queues", () => {
@@ -107,7 +117,7 @@ describe("internal-telemetry-routes: auth-fallback", () => {
     } finally {
       spy.mockRestore();
     }
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingAuthFallbackPayloads().length).toBe(0);
 
     // Once the DB is back the same batch records normally.
     expect(call(VALID_BODY)).toEqual({ recorded: 1 });
@@ -122,7 +132,7 @@ describe("internal-telemetry-routes: auth-fallback", () => {
         counts: [{ guard: "edge", path: "/x", failure_kind: "y", count: 0 }],
       }),
     ).toThrow(RouteError);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingAuthFallbackPayloads().length).toBe(0);
   });
 });
 

--- a/assistant/src/persistence/migrations/330-move-auth-fallback-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/330-move-auth-fallback-events-to-telemetry-db.test.ts
@@ -13,8 +13,6 @@ import { describe, expect, test } from "bun:test";
 const { getDb, getSqlite, getTelemetrySqlite } =
   await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
-const { queryUnreportedAuthFallbackEvents } =
-  await import("../../security/auth-fallback-events-store.js");
 const { migrateMoveAuthFallbackEventsToTelemetryDb } =
   await import("./330-move-auth-fallback-events-to-telemetry-db.js");
 
@@ -24,6 +22,15 @@ const SOURCE_COLUMNS = `
   id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, guard TEXT NOT NULL,
   path TEXT NOT NULL, failure_kind TEXT NOT NULL, count INTEGER NOT NULL,
   window_start INTEGER NOT NULL, window_end INTEGER NOT NULL`;
+
+function relocatedRows(): Array<Record<string, unknown>> {
+  return getTelemetrySqlite()!
+    .query(
+      `SELECT id, guard, path, failure_kind, count, window_start, window_end
+         FROM auth_fallback_events ORDER BY created_at, id`,
+    )
+    .all() as Array<Record<string, unknown>>;
+}
 
 function existsInMain(name: string): boolean {
   return (
@@ -102,16 +109,15 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
       { id: "seed-dupe", guard: "edge-guardian" },
     ]);
 
-    // The relocated rows are readable through the store's reporter query.
-    const rows = queryUnreportedAuthFallbackEvents(0, undefined, 10);
+    const rows = relocatedRows();
     expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
     expect(rows[0]!).toMatchObject({
       guard: "edge",
       path: "/v1/messages",
-      failureKind: "missing_authorization",
+      failure_kind: "missing_authorization",
       count: 7,
-      windowStart: 900,
-      windowEnd: 1000,
+      window_start: 900,
+      window_end: 1000,
     });
   });
 
@@ -124,7 +130,7 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 10)).toHaveLength(3);
+    expect(relocatedRows()).toHaveLength(3);
   });
 
   test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
@@ -147,7 +153,7 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
       .query(`SELECT guard FROM auth_fallback_events WHERE id = 'seed-dupe'`)
       .get() as { guard: string };
     expect(dupe.guard).toBe("already-copied");
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 10)).toHaveLength(3);
+    expect(relocatedRows()).toHaveLength(3);
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -160,7 +166,7 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 10)).toHaveLength(0);
+    expect(relocatedRows()).toHaveLength(0);
   });
 
   test("telemetry-side schema has the reporter's compound cursor index", () => {

--- a/assistant/src/security/auth-fallback-events-store.ts
+++ b/assistant/src/security/auth-fallback-events-store.ts
@@ -1,8 +1,7 @@
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
-import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import { insertTelemetryOutboxEvents } from "../telemetry/telemetry-events-outbox.js";
 import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
 
@@ -17,9 +16,11 @@ export interface AuthFallbackCount {
 /**
  * Record a batch of aggregated auth-fallback counts forwarded by the gateway —
  * one `telemetry_events` outbox row per count entry, all sharing the same
- * flush window, each carrying its full wire event built at record time.
- * Returns the number of rows recorded, or 0 when usage data collection is
- * disabled (the counts are dropped to honor the opt-out, matching the rest of
+ * flush window, each carrying its full wire event built at record time. The
+ * whole batch inserts atomically, so a failure never leaves a partial batch
+ * committed (the gateway retries the full batch on `recorded === 0`). Returns
+ * the number of rows recorded, or 0 when usage data collection is disabled
+ * (the counts are dropped to honor the opt-out, matching the rest of
  * telemetry) or the telemetry database is unavailable (degraded mode). Callers
  * that must tell those apart check `getCachedShareAnalytics()` themselves.
  */
@@ -34,12 +35,8 @@ export function recordAuthFallbackCounts(
   if (counts.length === 0) {
     return 0;
   }
-  if (!getTelemetryDb()) {
-    return 0;
-  }
   const createdAt = Date.now();
-  let recorded = 0;
-  for (const c of counts) {
+  const rows = counts.map((c) => {
     const id = uuid();
     const event: AuthFallbackTelemetryEvent = {
       type: "auth_fallback",
@@ -53,19 +50,7 @@ export function recordAuthFallbackCounts(
       window_end: windowEnd,
       assistant_version: APP_VERSION,
     };
-    if (
-      !insertTelemetryOutboxEvent({
-        id,
-        name: "auth_fallback",
-        createdAt,
-        event,
-      })
-    ) {
-      // Telemetry DB went away mid-batch; report what actually landed so the
-      // gateway's `recorded === 0` retry contract stays meaningful.
-      return recorded;
-    }
-    recorded += 1;
-  }
-  return recorded;
+    return { id, name: "auth_fallback", createdAt, event };
+  });
+  return insertTelemetryOutboxEvents(rows) ? rows.length : 0;
 }

--- a/assistant/src/security/auth-fallback-events-store.ts
+++ b/assistant/src/security/auth-fallback-events-store.ts
@@ -1,9 +1,10 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getTelemetryDb } from "../persistence/db-connection.js";
-import { authFallbackEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
+import { APP_VERSION } from "../version.js";
 
 /** A single aggregated auth-fallback count for one (guard, path, failure_kind). */
 export interface AuthFallbackCount {
@@ -13,25 +14,14 @@ export interface AuthFallbackCount {
   count: number;
 }
 
-/** A persisted auth-fallback event row. */
-export interface AuthFallbackEvent {
-  id: string;
-  createdAt: number;
-  guard: string;
-  path: string;
-  failureKind: string;
-  count: number;
-  windowStart: number;
-  windowEnd: number;
-}
-
 /**
  * Record a batch of aggregated auth-fallback counts forwarded by the gateway —
- * one row per count entry, all sharing the same flush window. Returns the
- * number of rows recorded, or 0 when usage data collection is disabled (the
- * counts are dropped to honor the opt-out, matching the rest of telemetry) or
- * the telemetry database is unavailable (degraded mode). Callers that must
- * tell those apart check `getCachedShareAnalytics()` themselves.
+ * one `telemetry_events` outbox row per count entry, all sharing the same
+ * flush window, each carrying its full wire event built at record time.
+ * Returns the number of rows recorded, or 0 when usage data collection is
+ * disabled (the counts are dropped to honor the opt-out, matching the rest of
+ * telemetry) or the telemetry database is unavailable (degraded mode). Callers
+ * that must tell those apart check `getCachedShareAnalytics()` themselves.
  */
 export function recordAuthFallbackCounts(
   windowStart: number,
@@ -44,63 +34,38 @@ export function recordAuthFallbackCounts(
   if (counts.length === 0) {
     return 0;
   }
-  const db = getTelemetryDb();
-  if (!db) {
+  if (!getTelemetryDb()) {
     return 0;
   }
   const createdAt = Date.now();
-  const rows = counts.map((c) => ({
-    id: uuid(),
-    createdAt,
-    guard: c.guard,
-    path: c.path,
-    failureKind: c.failureKind,
-    count: c.count,
-    windowStart,
-    windowEnd,
-  }));
-  db.insert(authFallbackEvents).values(rows).run();
-  return rows.length;
-}
-
-/**
- * Query auth-fallback events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedAuthFallbackEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): AuthFallbackEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
+  let recorded = 0;
+  for (const c of counts) {
+    const id = uuid();
+    const event: AuthFallbackTelemetryEvent = {
+      type: "auth_fallback",
+      daemon_event_id: id,
+      recorded_at: createdAt,
+      guard: c.guard,
+      path: c.path,
+      failure_kind: c.failureKind,
+      count: c.count,
+      window_start: windowStart,
+      window_end: windowEnd,
+      assistant_version: APP_VERSION,
+    };
+    if (
+      !insertTelemetryOutboxEvent({
+        id,
+        name: "auth_fallback",
+        createdAt,
+        event,
+      })
+    ) {
+      // Telemetry DB went away mid-batch; report what actually landed so the
+      // gateway's `recorded === 0` retry contract stays meaningful.
+      return recorded;
+    }
+    recorded += 1;
   }
-  const rows = db
-    .select({
-      id: authFallbackEvents.id,
-      createdAt: authFallbackEvents.createdAt,
-      guard: authFallbackEvents.guard,
-      path: authFallbackEvents.path,
-      failureKind: authFallbackEvents.failureKind,
-      count: authFallbackEvents.count,
-      windowStart: authFallbackEvents.windowStart,
-      windowEnd: authFallbackEvents.windowEnd,
-    })
-    .from(authFallbackEvents)
-    .where(
-      afterId
-        ? or(
-            gt(authFallbackEvents.createdAt, afterCreatedAt),
-            and(
-              eq(authFallbackEvents.createdAt, afterCreatedAt),
-              gt(authFallbackEvents.id, afterId),
-            ),
-          )
-        : gt(authFallbackEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(authFallbackEvents.createdAt), asc(authFallbackEvents.id))
-    .limit(limit)
-    .all();
-  return rows;
+  return recorded;
 }

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -16,7 +16,6 @@ import {
   getCachedShareDiagnostics,
   getCachedShareDiagnosticsVersion,
 } from "../platform/consent-cache.js";
-import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-events-store.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
@@ -504,28 +503,7 @@ const onboardingSource = simpleSource(
   }),
 );
 
-const authFallbackSource = simpleSource(
-  "auth_fallback",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedAuthFallbackEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "auth_fallback",
-    daemon_event_id: e.id,
-    recorded_at: e.createdAt,
-    guard: e.guard,
-    path: e.path,
-    failure_kind: e.failureKind,
-    count: e.count,
-    window_start: e.windowStart,
-    window_end: e.windowEnd,
-    // Aggregated counts forwarded by the gateway carry no record-time
-    // binary version; stamp the running binary's `APP_VERSION` so the
-    // wire value is concrete rather than an explicit null that would
-    // override the envelope under the platform's per-event-wins
-    // contract.
-    assistant_version: APP_VERSION,
-  }),
-);
+const authFallbackSource = outboxSource("auth_fallback");
 
 const toolExecutedSource = simpleSource(
   "tool_executed",

--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 
+import * as dbConnection from "../persistence/db-connection.js";
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
@@ -7,6 +8,7 @@ import {
   deleteTelemetryOutboxEvents,
   discardPendingTelemetryOutboxEvents,
   insertTelemetryOutboxEvent,
+  insertTelemetryOutboxEvents,
   queryTelemetryOutboxBatch,
 } from "./telemetry-events-outbox.js";
 import type { LifecycleTelemetryEvent } from "./types.js";
@@ -57,6 +59,85 @@ describe("telemetry-events-outbox", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ id: "evt-1", createdAt: 1000 });
     expect(JSON.parse(rows[0]!.payload)).toEqual(lifecycleEvent("evt-1", 1000));
+  });
+
+  test("batch insert lands every row", () => {
+    const inserted = insertTelemetryOutboxEvents([
+      {
+        id: "evt-1",
+        name: "lifecycle",
+        createdAt: 1000,
+        event: lifecycleEvent("evt-1", 1000),
+      },
+      {
+        id: "evt-2",
+        name: "lifecycle",
+        createdAt: 2000,
+        event: lifecycleEvent("evt-2", 2000),
+      },
+      {
+        id: "evt-3",
+        name: "lifecycle",
+        createdAt: 3000,
+        event: lifecycleEvent("evt-3", 3000),
+      },
+    ]);
+    expect(inserted).toBe(true);
+    expect(allIds()).toEqual(["evt-1", "evt-2", "evt-3"]);
+  });
+
+  test("batch insert is all-or-nothing on a mid-batch failure", () => {
+    insert("evt-dup", 500);
+
+    expect(() =>
+      insertTelemetryOutboxEvents([
+        {
+          id: "evt-new-1",
+          name: "lifecycle",
+          createdAt: 1000,
+          event: lifecycleEvent("evt-new-1", 1000),
+        },
+        {
+          id: "evt-dup",
+          name: "lifecycle",
+          createdAt: 2000,
+          event: lifecycleEvent("evt-dup", 2000),
+        },
+        {
+          id: "evt-new-2",
+          name: "lifecycle",
+          createdAt: 3000,
+          event: lifecycleEvent("evt-new-2", 3000),
+        },
+      ]),
+    ).toThrow();
+
+    // The primary-key conflict aborts the whole statement — no partial batch.
+    expect(allIds()).toEqual(["evt-dup"]);
+  });
+
+  test("batch insert returns false when the telemetry DB is unavailable", () => {
+    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+    try {
+      expect(
+        insertTelemetryOutboxEvents([
+          {
+            id: "evt-1",
+            name: "lifecycle",
+            createdAt: 1000,
+            event: lifecycleEvent("evt-1", 1000),
+          },
+        ]),
+      ).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(allIds()).toEqual([]);
+  });
+
+  test("empty batch is a successful no-op", () => {
+    expect(insertTelemetryOutboxEvents([])).toBe(true);
+    expect(allIds()).toEqual([]);
   });
 
   test("conversation_id persists in its dedicated column", () => {

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -20,31 +20,53 @@ export interface TelemetryOutboxRow {
   payload: string;
 }
 
-/**
- * Insert one pending telemetry event. Returns false when the telemetry DB is
- * unavailable (degraded mode), true once the row is inserted.
- */
-export function insertTelemetryOutboxEvent(row: {
+/** One pending telemetry event to insert; `event` is the wire payload. */
+export interface TelemetryOutboxInsert {
   id: string;
   name: string;
   createdAt: number;
   conversationId?: string | null;
   event: TelemetryEvent;
-}): boolean {
+}
+
+/**
+ * Insert a batch of pending telemetry events as one multi-row INSERT —
+ * all-or-nothing, so a mid-batch failure never leaves a partial batch
+ * committed. Returns false when the telemetry DB is unavailable (degraded
+ * mode), true once every row is inserted (or the batch is empty).
+ */
+export function insertTelemetryOutboxEvents(
+  rows: TelemetryOutboxInsert[],
+): boolean {
   const db = getTelemetryDb();
   if (!db) {
     return false;
   }
+  if (rows.length === 0) {
+    return true;
+  }
   db.insert(telemetryEvents)
-    .values({
-      id: row.id,
-      name: row.name,
-      createdAt: row.createdAt,
-      conversationId: row.conversationId ?? null,
-      payload: JSON.stringify(row.event),
-    })
+    .values(
+      rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        createdAt: row.createdAt,
+        conversationId: row.conversationId ?? null,
+        payload: JSON.stringify(row.event),
+      })),
+    )
     .run();
   return true;
+}
+
+/**
+ * Insert one pending telemetry event. Returns false when the telemetry DB is
+ * unavailable (degraded mode), true once the row is inserted.
+ */
+export function insertTelemetryOutboxEvent(
+  row: TelemetryOutboxInsert,
+): boolean {
+  return insertTelemetryOutboxEvents([row]);
 }
 
 /**

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -227,7 +227,6 @@ import {
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
-  authFallbackEvents,
   configSettingEvents,
   conversations,
   skillLoadedEvents,
@@ -414,7 +413,6 @@ beforeEach(() => {
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
   getTelemetryDb()!.delete(skillLoadedEvents).run();
-  getTelemetryDb()!.delete(authFallbackEvents).run();
   getTelemetryDb()!.delete(configSettingEvents).run();
   getTelemetryDb()!.delete(telemetryEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
@@ -1651,11 +1649,13 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 9 timestamp watermarks should have been advanced, and all 9 ID
-    // watermarks pinned to the high-sorting sentinel (a truthy value keeps
-    // the compound-cursor branch active while closing its same-millisecond
-    // arm against opt-out rows).
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(18);
+    // Every watermark-mode source's timestamp watermark should have been
+    // advanced, and its ID watermark pinned to the high-sorting sentinel (a
+    // truthy value keeps the compound-cursor branch active while closing its
+    // same-millisecond arm against opt-out rows). Ack-mode sources
+    // (auth_fallback) discard their pending rows instead and never touch
+    // `flush_checkpoints`.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(16);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -1664,7 +1664,6 @@ describe("UsageTelemetryReporter", () => {
       "turns",
       "lifecycle",
       "onboarding",
-      "auth_fallback",
       "tool_executed",
       "skill_loaded",
       "watchdog",
@@ -1677,6 +1676,8 @@ describe("UsageTelemetryReporter", () => {
       );
       expect(idCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
     }
+    expect(keys).not.toContain("telemetry:auth_fallback:last_reported_at");
+    expect(keys).not.toContain("telemetry:auth_fallback:last_reported_id");
   });
 
   test("platform disabled takes precedence over consent off — watermarks NOT advanced", async () => {
@@ -1917,7 +1918,7 @@ describe("UsageTelemetryReporter", () => {
     expect(typeof body.events[0].daemon_event_id).toBe("string");
   });
 
-  test("auth_fallback watermark advances to the last reported row on success", async () => {
+  test("auth_fallback rows are deleted on success and never watermarked (ack mode)", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     recordAuthFallbackCounts(1700000000000, 1700000001000, [
       {
@@ -1936,32 +1937,49 @@ describe("UsageTelemetryReporter", () => {
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
-
-    // The last row by the reporter's (createdAt, id) cursor order is the one
-    // whose watermark should be persisted after a successful upload.
-    const rows = getTelemetryDb()!
-      .select()
-      .from(authFallbackEvents)
-      .orderBy(authFallbackEvents.createdAt, authFallbackEvents.id)
-      .all();
-    const lastRow = rows[rows.length - 1];
+    expect(queryTelemetryOutboxBatch("auth_fallback", 10)).toHaveLength(2);
 
     const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:auth_fallback:last_reported_at",
+    // Both rows shipped, were acknowledged (deleted), and no auth_fallback
+    // watermark was ever written — ack-mode sources bypass flush_checkpoints.
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
-    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
-    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
-      String(lastRow.createdAt),
+    expect(
+      body.events.filter((e: { type: string }) => e.type === "auth_fallback"),
+    ).toHaveLength(2);
+    expect(queryTelemetryOutboxBatch("auth_fallback", 10)).toHaveLength(0);
+    const authFallbackKeys = mockSetFlushCheckpoint.mock.calls.filter((c) =>
+      String(c[0]).startsWith("telemetry:auth_fallback:"),
+    );
+    expect(authFallbackKeys).toHaveLength(0);
+  });
+
+  test("auth_fallback rows survive a failed POST and re-ship on the next flush", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordAuthFallbackCounts(1700000000000, 1700000001000, [
+      {
+        guard: "edge",
+        path: "/v1/messages",
+        failureKind: "missing_authorization",
+        count: 9,
+      },
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("server error", { status: 500 })),
     );
 
-    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:auth_fallback:last_reported_id",
+    const reporter = makeReporter();
+    await reporter.flush();
+    expect(queryTelemetryOutboxBatch("auth_fallback", 10)).toHaveLength(1);
+
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
-    expect(idCalls.length).toBeGreaterThanOrEqual(1);
-    expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+    await reporter.flush();
+    expect(queryTelemetryOutboxBatch("auth_fallback", 10)).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- recordAuthFallbackCounts builds wire payloads at record time and writes the outbox (name=auth_fallback), one row per count entry
- authFallbackSource is now outboxSource("auth_fallback") — delete-on-flush
- Gateway 503 retry contract preserved: consent-off/db-null still return 0

Part of plan: telemetry-outbox-consolidation.md (PR 6 of 9)