### PR TITLE
refactor(telemetry): record onboarding/activation events into the telemetry_events outbox

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -27,19 +27,27 @@ const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
 
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type { SurfaceType, UiSurfaceShow } from "../daemon/message-protocol.js";
-import { queryUnreportedOnboardingEvents } from "../onboarding/onboarding-events-store.js";
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
   activationSessions,
-  onboardingEvents,
+  telemetryEvents,
 } from "../persistence/schema/index.js";
 import {
   isActivationSession,
   markActivationSession,
 } from "../plugins/defaults/memory/activation-session-store.js";
+import { queryTelemetryOutboxBatch } from "../telemetry/telemetry-events-outbox.js";
+import type { OnboardingTelemetryEvent } from "../telemetry/types.js";
 
 await initializeDb();
+
+/** Pending onboarding outbox payloads, parsed, in `(created_at, id)` order. */
+function pendingOnboardingPayloads(): OnboardingTelemetryEvent[] {
+  return queryTelemetryOutboxBatch("onboarding", 10).map(
+    (row) => JSON.parse(row.payload) as OnboardingTelemetryEvent,
+  );
+}
 
 interface ProcessMessageCall {
   content: string;
@@ -84,7 +92,7 @@ function makeContext(
 }
 
 function resetTables(): void {
-  getTelemetryDb()!.delete(onboardingEvents).run();
+  getTelemetryDb()!.delete(telemetryEvents).run();
   getDb().delete(activationSessions).run();
 }
 
@@ -131,11 +139,11 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_2_complete");
-    expect(rows[0]!.stepIndex).toBe(2);
-    expect(rows[0]!.sessionId).toBe("conv-marked");
+    expect(rows[0]!.step_name).toBe("activation_moment_2_complete");
+    expect(rows[0]!.step_index).toBe(2);
+    expect(rows[0]!.session_id).toBe("conv-marked");
   });
 
   test("a queue-rejected commit does NOT emit; the tag survives for the retry", async () => {
@@ -156,7 +164,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       choiceId: "inbox",
       selectedIds: ["inbox"],
     });
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
 
     // Retry is accepted → records exactly one row.
     ctx.enqueueMessage = () => ({ queued: false, requestId: "req-ok" });
@@ -164,9 +172,9 @@ describe("activation moment emission from ui_show surface commits", () => {
       choiceId: "inbox",
       selectedIds: ["inbox"],
     });
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_2_complete");
+    expect(rows[0]!.step_name).toBe("activation_moment_2_complete");
   });
 
   test("first_wow_executed records at SHOW time (no commit) and never double-emits", async () => {
@@ -183,10 +191,10 @@ describe("activation moment emission from ui_show surface commits", () => {
     });
 
     // Recorded immediately on render — no handleSurfaceAction commit needed.
-    let rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    let rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_first_wow_executed");
-    expect(rows[0]!.stepIndex).toBe(4);
+    expect(rows[0]!.step_name).toBe("activation_first_wow_executed");
+    expect(rows[0]!.step_index).toBe(4);
 
     // If the card later receives a commit (e.g. it carried an action), it must
     // NOT double-emit — a show-timing tag is never stored for the commit path.
@@ -194,7 +202,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
     ) as UiSurfaceShow;
     await handleSurfaceAction(ctx, showMessage.surfaceId, "expand", {});
-    rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
   });
 
@@ -207,7 +215,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       data: { body: "x" },
       activation_moment: "first_wow_executed",
     });
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("does not forward the daemon-only tag to the client", async () => {
@@ -236,7 +244,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("tagged surface in an UNMARKED session writes no row", async () => {
@@ -249,7 +257,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("an invalid activation_moment token is ignored (no row)", async () => {
@@ -263,7 +271,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("FIX 1: launch_conversation commit on a tagged surface records exactly one row", async () => {
@@ -292,10 +300,10 @@ describe("activation moment emission from ui_show surface commits", () => {
       seedPrompt: "Write a draft",
     });
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_1_complete");
-    expect(rows[0]!.sessionId).toBe("conv-launch");
+    expect(rows[0]!.step_name).toBe("activation_moment_1_complete");
+    expect(rows[0]!.session_id).toBe("conv-launch");
   });
 
   test("FIX 2: commit-timing tag survives a surfaceState restore from history", async () => {
@@ -346,10 +354,10 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_2_complete");
-    expect(rows[0]!.sessionId).toBe("conv-restore");
+    expect(rows[0]!.step_name).toBe("activation_moment_2_complete");
+    expect(rows[0]!.session_id).toBe("conv-restore");
   });
 
   test("intermediate selection_changed does NOT emit; the terminal commit does", async () => {
@@ -381,12 +389,12 @@ describe("activation moment emission from ui_show surface commits", () => {
     await handleSurfaceAction(ctx, surfaceId, "selection_changed", {
       selectedIds: ["r1"],
     });
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
 
     // Terminal commit — emits exactly once.
     await handleSurfaceAction(ctx, surfaceId, "run", { selectedIds: ["r1"] });
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_3_complete");
+    expect(rows[0]!.step_name).toBe("activation_moment_3_complete");
   });
 });

--- a/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
@@ -12,9 +12,12 @@ import {
   getTelemetrySqlite,
 } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
-import { onboardingEvents } from "../../persistence/schema/index.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
+import { ACTIVATION_FUNNEL_VERSION } from "../../telemetry/activation-funnel.js";
+import { queryTelemetryOutboxBatch } from "../../telemetry/telemetry-events-outbox.js";
+import type { OnboardingTelemetryEvent } from "../../telemetry/types.js";
+import { APP_VERSION } from "../../version.js";
 import {
-  queryUnreportedOnboardingEvents,
   recordActivationEvent,
   recordOnboardingEvent,
 } from "../onboarding-events-store.js";
@@ -22,7 +25,14 @@ import {
 await initializeDb();
 
 function resetTable(): void {
-  getTelemetryDb()!.delete(onboardingEvents).run();
+  getTelemetryDb()!.delete(telemetryEvents).run();
+}
+
+/** Pending onboarding outbox payloads, parsed, in `(created_at, id)` order. */
+function pendingOnboardingPayloads(): OnboardingTelemetryEvent[] {
+  return queryTelemetryOutboxBatch("onboarding", 10).map(
+    (row) => JSON.parse(row.payload) as OnboardingTelemetryEvent,
+  );
 }
 
 /** Run `fn` with the dedicated telemetry connection reported as unavailable. */
@@ -41,26 +51,32 @@ describe("onboarding-events-store: recordActivationEvent", () => {
     resetTable();
   });
 
-  test("persists an activation funnel event that round-trips through the query", () => {
+  test("stores the full wire payload with the deterministic activation daemon_event_id", () => {
     const event = recordActivationEvent({
       stepName: "activation_moment_1_complete",
       sessionId: "conv-1",
     });
     expect(event).not.toBeNull();
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    const row = rows[0]!;
-    expect(row.stepName).toBe("activation_moment_1_complete");
-    expect(row.stepIndex).toBe(1);
-    expect(row.funnelVersion).toBe("activation_v1_2026_06");
-    expect(row.screen).toBe("activation_moment_1_complete");
-    expect(row.abVariant).toBe("variant-a");
-    expect(row.sessionId).toBe("conv-1");
-    expect(row.completedAt).toBe(new Date(row.createdAt).toISOString());
+    const payloads = pendingOnboardingPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toEqual({
+      type: "onboarding",
+      daemon_event_id: `${ACTIVATION_FUNNEL_VERSION}:conv-1:activation_moment_1_complete`,
+      recorded_at: event!.createdAt,
+      screen: "activation_moment_1_complete",
+      ab_variant: "variant-a",
+      session_id: "conv-1",
+      step_name: "activation_moment_1_complete",
+      step_index: 1,
+      completed_at: new Date(event!.createdAt).toISOString(),
+      funnel_version: ACTIVATION_FUNNEL_VERSION,
+      assistant_version: APP_VERSION,
+    });
+    expect(event!.completedAt).toBe(new Date(event!.createdAt).toISOString());
   });
 
-  test("writes the row into the dedicated telemetry database", () => {
+  test("outbox row id stays a UUID distinct from the payload daemon_event_id", () => {
     const event = recordActivationEvent({
       stepName: "activation_moment_1_complete",
       sessionId: "conv-telemetry",
@@ -68,9 +84,11 @@ describe("onboarding-events-store: recordActivationEvent", () => {
     expect(event).not.toBeNull();
 
     const raw = getTelemetrySqlite()!
-      .query(`SELECT id, session_id FROM onboarding_events`)
-      .all() as Array<{ id: string; session_id: string }>;
-    expect(raw).toEqual([{ id: event!.id, session_id: "conv-telemetry" }]);
+      .query(`SELECT id, name FROM telemetry_events`)
+      .all() as Array<{ id: string; name: string }>;
+    expect(raw).toEqual([{ id: event!.id, name: "onboarding" }]);
+    const payload = pendingOnboardingPayloads()[0]!;
+    expect(payload.daemon_event_id).not.toBe(event!.id);
   });
 
   test("honors an explicit abVariant override", () => {
@@ -80,10 +98,10 @@ describe("onboarding-events-store: recordActivationEvent", () => {
       abVariant: "variant-b",
     });
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.abVariant).toBe("variant-b");
-    expect(rows[0]!.stepIndex).toBe(2);
+    const payloads = pendingOnboardingPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]!.ab_variant).toBe("variant-b");
+    expect(payloads[0]!.step_index).toBe(2);
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
@@ -94,8 +112,7 @@ describe("onboarding-events-store: recordActivationEvent", () => {
     });
     expect(event).toBeNull();
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("returns null when the telemetry database is unavailable", () => {
@@ -105,10 +122,9 @@ describe("onboarding-events-store: recordActivationEvent", () => {
         sessionId: "conv-4",
       });
       expect(event).toBeNull();
-      expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 });
 
@@ -118,32 +134,45 @@ describe("onboarding-events-store: recordOnboardingEvent", () => {
     resetTable();
   });
 
-  test("persists a pre-chat onboarding event into the telemetry database", () => {
+  test("stores a pre-chat wire payload with daemon_event_id = row id and no funnel fields", () => {
     const event = recordOnboardingEvent({
       screen: "tools",
       tools: ["gmail", "calendar"],
       tone: "warm",
       googleConnected: true,
+      priorAssistants: ["siri"],
     });
     expect(event).not.toBeNull();
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.screen).toBe("tools");
-    expect(rows[0]!.toolsJson).toBe(JSON.stringify(["gmail", "calendar"]));
-    expect(rows[0]!.tone).toBe("warm");
-    expect(rows[0]!.googleConnected).toBe(true);
+    const payloads = pendingOnboardingPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toEqual({
+      type: "onboarding",
+      daemon_event_id: event!.id,
+      recorded_at: event!.createdAt,
+      screen: "tools",
+      tools: ["gmail", "calendar"],
+      tone: "warm",
+      google_connected: true,
+      assistant_version: APP_VERSION,
+    });
 
     const raw = getTelemetrySqlite()!
-      .query(`SELECT id FROM onboarding_events`)
-      .all() as Array<{ id: string }>;
-    expect(raw).toEqual([{ id: event!.id }]);
+      .query(`SELECT id, name, conversation_id FROM telemetry_events`)
+      .all() as Array<{
+      id: string;
+      name: string;
+      conversation_id: string | null;
+    }>;
+    expect(raw).toEqual([
+      { id: event!.id, name: "onboarding", conversation_id: null },
+    ]);
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
     shareAnalytics = false;
     expect(recordOnboardingEvent({ screen: "tools" })).toBeNull();
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("returns null when the telemetry database is unavailable", () => {
@@ -151,6 +180,6 @@ describe("onboarding-events-store: recordOnboardingEvent", () => {
       expect(recordOnboardingEvent({ screen: "tools" })).toBeNull();
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 });

--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -1,15 +1,16 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
-import { onboardingEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import {
   ACTIVATION_AB_VARIANT,
   ACTIVATION_FUNNEL_VERSION,
   activationStepIndex,
   type ActivationStepName,
+  buildActivationDaemonEventId,
 } from "../telemetry/activation-funnel.js";
+import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import type { OnboardingTelemetryEvent } from "../telemetry/types.js";
+import { APP_VERSION } from "../version.js";
 
 export interface OnboardingEvent {
   id: string;
@@ -20,7 +21,6 @@ export interface OnboardingEvent {
   tone: string | null;
   googleConnected: boolean | null;
   googleScopesJson: string | null;
-  priorAssistantsJson: string | null;
   abVariant: string | null;
   sessionId: string | null;
   stepName: string | null;
@@ -36,6 +36,7 @@ export interface RecordOnboardingEventParams {
   tone?: string;
   googleConnected?: boolean;
   googleScopes?: string[];
+  /** Accepted for caller compatibility; never shipped and no longer stored. */
   priorAssistants?: string[];
   abVariant?: string;
   sessionId?: string | null;
@@ -46,15 +47,89 @@ export interface RecordOnboardingEventParams {
 }
 
 /**
- * Insert a fully-built event row. Shared by all record* entry points.
- * Returns null when the telemetry database is unavailable — the event is
- * dropped, matching the degraded-mode behavior of the other telemetry stores.
+ * Build the wire event stored in the outbox payload at record time.
+ * `assistant_version` is therefore record-time: the binary that recorded the
+ * event, not the one that later flushes it.
  */
-function insertOnboardingEvent(event: OnboardingEvent): OnboardingEvent | null {
-  const db = getTelemetryDb();
-  if (!db) return null;
-  db.insert(onboardingEvents).values(event).run();
-  return event;
+function buildOnboardingTelemetryEvent(
+  id: string,
+  createdAt: number,
+  params: RecordOnboardingEventParams,
+): OnboardingTelemetryEvent {
+  return {
+    type: "onboarding",
+    // Wire-only override for activation rows: a deterministic id keyed on
+    // funnel_version/session/step lets dbt collapse a moment that fires more
+    // than once. Keyed on the params' funnelVersion (frozen into the payload
+    // now) so rows recorded under an older version — flushed offline or after
+    // an upgrade — keep a stable id and still collapse with already-ingested
+    // rows. The outbox row id stays `id`, so flush acks are unaffected.
+    daemon_event_id:
+      params.sessionId && params.stepName && params.funnelVersion
+        ? buildActivationDaemonEventId(
+            params.sessionId,
+            params.stepName as ActivationStepName,
+            params.funnelVersion,
+          )
+        : id,
+    recorded_at: createdAt,
+    screen: params.screen,
+    ...(params.tools ? { tools: params.tools } : {}),
+    ...(params.tasks ? { tasks: params.tasks } : {}),
+    ...(params.tone ? { tone: params.tone } : {}),
+    ...(params.googleConnected != null
+      ? { google_connected: params.googleConnected }
+      : {}),
+    ...(params.googleScopes ? { google_scopes: params.googleScopes } : {}),
+    ...(params.abVariant ? { ab_variant: params.abVariant } : {}),
+    // Activation funnel fields — only present on activation rows.
+    ...(params.sessionId ? { session_id: params.sessionId } : {}),
+    ...(params.stepName ? { step_name: params.stepName } : {}),
+    ...(params.stepIndex != null ? { step_index: params.stepIndex } : {}),
+    ...(params.completedAt ? { completed_at: params.completedAt } : {}),
+    ...(params.funnelVersion ? { funnel_version: params.funnelVersion } : {}),
+    assistant_version: APP_VERSION,
+  };
+}
+
+/**
+ * Build the wire payload and insert it into the `telemetry_events` outbox.
+ * Shared by all record* entry points. Returns null when the telemetry
+ * database is unavailable — the event is dropped, matching the degraded-mode
+ * behavior of the other telemetry stores.
+ */
+function insertOnboardingEvent(
+  id: string,
+  createdAt: number,
+  params: RecordOnboardingEventParams,
+): OnboardingEvent | null {
+  const inserted = insertTelemetryOutboxEvent({
+    id,
+    name: "onboarding",
+    createdAt,
+    event: buildOnboardingTelemetryEvent(id, createdAt, params),
+  });
+  if (!inserted) {
+    return null;
+  }
+  return {
+    id,
+    createdAt,
+    screen: params.screen,
+    toolsJson: params.tools ? JSON.stringify(params.tools) : null,
+    tasksJson: params.tasks ? JSON.stringify(params.tasks) : null,
+    tone: params.tone ?? null,
+    googleConnected: params.googleConnected ?? null,
+    googleScopesJson: params.googleScopes
+      ? JSON.stringify(params.googleScopes)
+      : null,
+    abVariant: params.abVariant ?? null,
+    sessionId: params.sessionId ?? null,
+    stepName: params.stepName ?? null,
+    stepIndex: params.stepIndex ?? null,
+    completedAt: params.completedAt ?? null,
+    funnelVersion: params.funnelVersion ?? null,
+  };
 }
 
 /**
@@ -68,34 +143,13 @@ export function recordOnboardingEvent(
   if (!getCachedShareAnalytics()) {
     return null;
   }
-  return insertOnboardingEvent({
-    id: uuid(),
-    createdAt: Date.now(),
-    screen: params.screen,
-    toolsJson: params.tools ? JSON.stringify(params.tools) : null,
-    tasksJson: params.tasks ? JSON.stringify(params.tasks) : null,
-    tone: params.tone ?? null,
-    googleConnected: params.googleConnected ?? null,
-    googleScopesJson: params.googleScopes
-      ? JSON.stringify(params.googleScopes)
-      : null,
-    priorAssistantsJson: params.priorAssistants
-      ? JSON.stringify(params.priorAssistants)
-      : null,
-    abVariant: params.abVariant ?? null,
-    sessionId: params.sessionId ?? null,
-    stepName: params.stepName ?? null,
-    stepIndex: params.stepIndex ?? null,
-    completedAt: params.completedAt ?? null,
-    funnelVersion: params.funnelVersion ?? null,
-  });
+  return insertOnboardingEvent(uuid(), Date.now(), params);
 }
 
 /**
  * Record an activation-funnel milestone event. Reuses the onboarding telemetry
- * substrate (`screen` carries the step name to satisfy the NOT NULL column).
- * Returns null when usage data collection is disabled or the telemetry
- * database is unavailable.
+ * substrate (`screen` carries the step name). Returns null when usage data
+ * collection is disabled or the telemetry database is unavailable.
  */
 export function recordActivationEvent(params: {
   stepName: ActivationStepName;
@@ -107,16 +161,8 @@ export function recordActivationEvent(params: {
     return null;
   }
   const createdAt = Date.now();
-  return insertOnboardingEvent({
-    id: uuid(),
-    createdAt,
+  return insertOnboardingEvent(uuid(), createdAt, {
     screen: params.stepName,
-    toolsJson: null,
-    tasksJson: null,
-    tone: null,
-    googleConnected: null,
-    googleScopesJson: null,
-    priorAssistantsJson: null,
     abVariant: params.abVariant ?? ACTIVATION_AB_VARIANT,
     sessionId: params.sessionId,
     stepName: params.stepName,
@@ -124,53 +170,4 @@ export function recordActivationEvent(params: {
     completedAt: new Date(createdAt).toISOString(),
     funnelVersion: ACTIVATION_FUNNEL_VERSION,
   });
-}
-
-/**
- * Query onboarding events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedOnboardingEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): OnboardingEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
-  }
-  const rows = db
-    .select({
-      id: onboardingEvents.id,
-      createdAt: onboardingEvents.createdAt,
-      screen: onboardingEvents.screen,
-      toolsJson: onboardingEvents.toolsJson,
-      tasksJson: onboardingEvents.tasksJson,
-      tone: onboardingEvents.tone,
-      googleConnected: onboardingEvents.googleConnected,
-      googleScopesJson: onboardingEvents.googleScopesJson,
-      priorAssistantsJson: onboardingEvents.priorAssistantsJson,
-      abVariant: onboardingEvents.abVariant,
-      sessionId: onboardingEvents.sessionId,
-      stepName: onboardingEvents.stepName,
-      stepIndex: onboardingEvents.stepIndex,
-      completedAt: onboardingEvents.completedAt,
-      funnelVersion: onboardingEvents.funnelVersion,
-    })
-    .from(onboardingEvents)
-    .where(
-      afterId
-        ? or(
-            gt(onboardingEvents.createdAt, afterCreatedAt),
-            and(
-              eq(onboardingEvents.createdAt, afterCreatedAt),
-              gt(onboardingEvents.id, afterId),
-            ),
-          )
-        : gt(onboardingEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(onboardingEvents.createdAt), asc(onboardingEvents.id))
-    .limit(limit)
-    .all();
-  return rows;
 }

--- a/assistant/src/persistence/migrations/329-move-onboarding-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/329-move-onboarding-events-to-telemetry-db.test.ts
@@ -13,8 +13,6 @@ import { describe, expect, test } from "bun:test";
 const { getDb, getSqlite, getTelemetrySqlite } =
   await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
-const { queryUnreportedOnboardingEvents } =
-  await import("../../onboarding/onboarding-events-store.js");
 const { migrateMoveOnboardingEventsToTelemetryDb } =
   await import("./329-move-onboarding-events-to-telemetry-db.js");
 
@@ -26,6 +24,24 @@ const SOURCE_COLUMNS = `
   google_scopes_json TEXT, prior_assistants_json TEXT, ab_variant TEXT,
   session_id TEXT, step_name TEXT, step_index INTEGER, completed_at TEXT,
   funnel_version TEXT`;
+
+/** Relocated rows in the telemetry-side table, in `(created_at, id)` order. */
+function telemetryOnboardingRows(): Array<{
+  id: string;
+  step_name: string | null;
+  step_index: number | null;
+}> {
+  return getTelemetrySqlite()!
+    .query(
+      `SELECT id, step_name, step_index FROM onboarding_events
+       ORDER BY created_at, id`,
+    )
+    .all() as Array<{
+    id: string;
+    step_name: string | null;
+    step_index: number | null;
+  }>;
+}
 
 function existsInMain(name: string): boolean {
   return (
@@ -82,11 +98,10 @@ describe("migration 329: move onboarding_events to the telemetry DB", () => {
       { id: "seed-dupe", screen: "tasks" },
     ]);
 
-    // The relocated rows are readable through the store's reporter query.
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = telemetryOnboardingRows();
     expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    expect(rows[1]!.stepName).toBe("activation_moment_1_complete");
-    expect(rows[1]!.stepIndex).toBe(1);
+    expect(rows[1]!.step_name).toBe("activation_moment_1_complete");
+    expect(rows[1]!.step_index).toBe(1);
   });
 
   test("re-running after a completed move is a no-op", async () => {
@@ -98,7 +113,7 @@ describe("migration 329: move onboarding_events to the telemetry DB", () => {
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetryOnboardingRows()).toHaveLength(3);
   });
 
   test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
@@ -120,7 +135,7 @@ describe("migration 329: move onboarding_events to the telemetry DB", () => {
       .query(`SELECT screen FROM onboarding_events WHERE id = 'seed-dupe'`)
       .get() as { screen: string };
     expect(dupe.screen).toBe("already-copied");
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetryOnboardingRows()).toHaveLength(3);
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -131,7 +146,7 @@ describe("migration 329: move onboarding_events to the telemetry DB", () => {
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(telemetryOnboardingRows()).toHaveLength(0);
   });
 
   test("telemetry-side schema has the reporter's compound cursor index", () => {

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -9,7 +9,6 @@
  * which sources its reporter instance is constructed with.
  */
 
-import { queryUnreportedOnboardingEvents } from "../onboarding/onboarding-events-store.js";
 import { queryUnreportedLifecycleEvents } from "../persistence/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../persistence/llm-usage-store.js";
 import {
@@ -20,10 +19,6 @@ import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-eve
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
-import {
-  type ActivationStepName,
-  buildActivationDaemonEventId,
-} from "./activation-funnel.js";
 import { queryUnreportedConfigSettingEvents } from "./config-setting-events-store.js";
 import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
 import {
@@ -457,52 +452,9 @@ const lifecycleSource = simpleSource(
   }),
 );
 
-const onboardingSource = simpleSource(
-  "onboarding",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedOnboardingEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "onboarding",
-    // Wire-only override for activation rows: a deterministic id keyed
-    // on funnel_version/session/step lets dbt collapse a moment that
-    // fires more than once. Key on the ROW's stored `funnelVersion`
-    // (not the binary's current constant) so rows recorded under an
-    // older version — flushed offline or after an upgrade — keep a
-    // stable id and still collapse with already-ingested rows. The
-    // SQLite watermark cursor still uses `e.id`/`e.createdAt`, so this
-    // override is checkpoint-safe.
-    daemon_event_id:
-      e.sessionId && e.stepName && e.funnelVersion
-        ? buildActivationDaemonEventId(
-            e.sessionId,
-            e.stepName as ActivationStepName,
-            e.funnelVersion,
-          )
-        : e.id,
-    recorded_at: e.createdAt,
-    screen: e.screen,
-    ...(e.toolsJson ? { tools: JSON.parse(e.toolsJson) } : {}),
-    ...(e.tasksJson ? { tasks: JSON.parse(e.tasksJson) } : {}),
-    ...(e.tone ? { tone: e.tone } : {}),
-    ...(e.googleConnected != null
-      ? { google_connected: e.googleConnected }
-      : {}),
-    ...(e.googleScopesJson
-      ? { google_scopes: JSON.parse(e.googleScopesJson) }
-      : {}),
-    ...(e.abVariant ? { ab_variant: e.abVariant } : {}),
-    // Activation funnel fields — only present on activation rows.
-    ...(e.sessionId ? { session_id: e.sessionId } : {}),
-    ...(e.stepName ? { step_name: e.stepName } : {}),
-    ...(e.stepIndex != null ? { step_index: e.stepIndex } : {}),
-    ...(e.completedAt ? { completed_at: e.completedAt } : {}),
-    ...(e.funnelVersion ? { funnel_version: e.funnelVersion } : {}),
-    // Onboarding events carry no record-time version column — stamp the
-    // running binary's `APP_VERSION`. Adding one (mirroring
-    // `llm_usage_events`) is a known follow-up.
-    assistant_version: APP_VERSION,
-  }),
-);
+// Onboarding/activation events are outbox-backed: the store builds the wire
+// event (including the activation daemon_event_id override) at record time.
+const onboardingSource = outboxSource("onboarding");
 
 const authFallbackSource = simpleSource(
   "auth_fallback",

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -184,36 +184,11 @@ mock.module("../persistence/lifecycle-events-store.js", () => ({
   queryUnreportedLifecycleEvents: mockQueryUnreportedLifecycleEvents,
 }));
 
-const mockQueryUnreportedOnboardingEvents = mock(
-  () =>
-    [] as {
-      id: string;
-      createdAt: number;
-      screen: string;
-      toolsJson: string | null;
-      tasksJson: string | null;
-      tone: string | null;
-      googleConnected: boolean | null;
-      googleScopesJson: string | null;
-      priorAssistantsJson: string | null;
-      abVariant: string | null;
-      sessionId: string | null;
-      stepName: string | null;
-      stepIndex: number | null;
-      completedAt: string | null;
-      funnelVersion: string | null;
-    }[],
-);
-
-mock.module("../onboarding/onboarding-events-store.js", () => ({
-  queryUnreportedOnboardingEvents: mockQueryUnreportedOnboardingEvents,
-}));
-
-// The auth-fallback, tool-executed, and skill-loaded stores are intentionally
-// NOT mocked — they have their own DB-backed tests, and Bun's `mock.module`
-// is process-global, so mocking them here would leak into those tests when
-// files share an invocation. We seed the real DB instead so every test stays
-// order-independent.
+// The onboarding, auth-fallback, tool-executed, and skill-loaded stores are
+// intentionally NOT mocked — they have their own DB-backed tests, and Bun's
+// `mock.module` is process-global, so mocking them here would leak into those
+// tests when files share an invocation. We seed the real DB instead so every
+// test stays order-independent.
 
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
@@ -224,6 +199,10 @@ import {
   TOOL_INVOCATION_PII_SENTINEL as TOOL_PII_SENTINEL,
   type ToolInvocationSeedSpec,
 } from "../__tests__/test-support/tool-invocation-seed.js";
+import {
+  recordActivationEvent,
+  recordOnboardingEvent,
+} from "../onboarding/onboarding-events-store.js";
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
@@ -319,34 +298,6 @@ function makeUsageEvent(
   };
 }
 
-type OnboardingEventFixture = ReturnType<
-  typeof mockQueryUnreportedOnboardingEvents
->[number];
-
-function makeOnboardingEvent(
-  overrides: Partial<OnboardingEventFixture> = {},
-): OnboardingEventFixture {
-  eventIdCounter += 1;
-  return {
-    id: `onb-${eventIdCounter}`,
-    createdAt: 1700000000000 + eventIdCounter * 1000,
-    screen: "tools",
-    toolsJson: null,
-    tasksJson: null,
-    tone: null,
-    googleConnected: null,
-    googleScopesJson: null,
-    priorAssistantsJson: null,
-    abVariant: null,
-    sessionId: null,
-    stepName: null,
-    stepIndex: null,
-    completedAt: null,
-    funnelVersion: null,
-    ...overrides,
-  };
-}
-
 const TOOL_CONVERSATION_ID = "conv-reporter-tool-executed";
 
 function seedToolInvocation(
@@ -410,8 +361,6 @@ beforeEach(() => {
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
   mockQueryUnreportedLifecycleEvents.mockReset();
   mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
-  mockQueryUnreportedOnboardingEvents.mockReset();
-  mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
   getTelemetryDb()!.delete(skillLoadedEvents).run();
   getTelemetryDb()!.delete(authFallbackEvents).run();
@@ -1651,11 +1600,13 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 9 timestamp watermarks should have been advanced, and all 9 ID
-    // watermarks pinned to the high-sorting sentinel (a truthy value keeps
-    // the compound-cursor branch active while closing its same-millisecond
-    // arm against opt-out rows).
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(18);
+    // All 8 watermark-mode timestamp watermarks should have been advanced,
+    // and their 8 ID watermarks pinned to the high-sorting sentinel (a truthy
+    // value keeps the compound-cursor branch active while closing its
+    // same-millisecond arm against opt-out rows). Ack-mode sources
+    // (onboarding) discard their pending outbox rows instead and never touch
+    // `flush_checkpoints`.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(16);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -1663,7 +1614,6 @@ describe("UsageTelemetryReporter", () => {
       "usage",
       "turns",
       "lifecycle",
-      "onboarding",
       "auth_fallback",
       "tool_executed",
       "skill_loaded",
@@ -1677,6 +1627,8 @@ describe("UsageTelemetryReporter", () => {
       );
       expect(idCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
     }
+    expect(keys).not.toContain("telemetry:onboarding:last_reported_at");
+    expect(keys).not.toContain("telemetry:onboarding:last_reported_id");
   });
 
   test("platform disabled takes precedence over consent off — watermarks NOT advanced", async () => {
@@ -1751,9 +1703,9 @@ describe("UsageTelemetryReporter", () => {
   //
   // The envelope's `assistant_version` is upload-time (always the current
   // binary). The per-event field is record-time (the binary that was running
-  // when the event was persisted to SQLite). In this PR only `llm_usage`
-  // events carry a true record-time value; turn events (and lifecycle /
-  // onboarding events, not asserted here) stamp the running binary's
+  // when the event was persisted to SQLite). `llm_usage` events and the
+  // outbox-backed types carry a true record-time value; turn events (and
+  // lifecycle events, not asserted here) stamp the running binary's
   // `APP_VERSION` directly until their respective follow-ups land.
   // Nullable llm_usage cases (legacy rows from before migration 267 ran)
   // fall back to the running binary's `APP_VERSION` rather than emitting
@@ -1968,22 +1920,12 @@ describe("UsageTelemetryReporter", () => {
   // Onboarding / activation funnel events
   // -------------------------------------------------------------------------
 
-  test("activation onboarding row serializes funnel fields + deterministic daemon_event_id", async () => {
+  test("activation onboarding row flushes with funnel fields + deterministic daemon_event_id, then acks", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     const sessionId = "sess-activation-1";
     const stepName = "activation_moment_1_complete";
-    mockQueryUnreportedOnboardingEvents.mockReturnValue([
-      makeOnboardingEvent({
-        id: "onb-activation-1",
-        screen: stepName,
-        abVariant: "variant-a",
-        sessionId,
-        stepName,
-        stepIndex: 1,
-        completedAt: "2026-06-06T00:00:00.000Z",
-        funnelVersion: ACTIVATION_FUNNEL_VERSION,
-      }),
-    ]);
+    const recorded = recordActivationEvent({ stepName, sessionId });
+    expect(recorded).not.toBeNull();
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
@@ -2001,31 +1943,41 @@ describe("UsageTelemetryReporter", () => {
       session_id: sessionId,
       step_name: stepName,
       step_index: 1,
-      completed_at: "2026-06-06T00:00:00.000Z",
-      funnel_version: "activation_v1_2026_06",
+      funnel_version: ACTIVATION_FUNNEL_VERSION,
       daemon_event_id: buildActivationDaemonEventId(sessionId, stepName),
     });
+    // The wire id is the deterministic activation id, distinct from the
+    // outbox row id (a UUID) the ack deletes by.
+    expect(body.events[0].daemon_event_id).not.toBe(recorded!.id);
+    expect(queryTelemetryOutboxBatch("onboarding", 10)).toHaveLength(0);
   });
 
-  test("activation daemon_event_id is keyed on the row's stored funnel_version, not the binary constant", async () => {
+  test("queued activation row recorded under an older funnel version ships its frozen payload verbatim", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    const sessionId = "sess-activation-old";
-    const stepName = "activation_moment_1_complete";
-    // A row recorded under an OLDER funnel version, queued across an upgrade.
+    // The payload (including the deterministic daemon_event_id keyed on the
+    // OLD funnel version) was frozen at record time; a flush after a version
+    // bump must not restamp it with the new binary's constant.
     const oldVersion = "activation_v0_2026_05";
     expect(oldVersion).not.toBe(ACTIVATION_FUNNEL_VERSION);
-    mockQueryUnreportedOnboardingEvents.mockReturnValue([
-      makeOnboardingEvent({
-        id: "onb-activation-old",
-        screen: stepName,
-        abVariant: "variant-a",
-        sessionId,
-        stepName,
-        stepIndex: 1,
-        completedAt: "2026-05-01T00:00:00.000Z",
-        funnelVersion: oldVersion,
-      }),
-    ]);
+    const frozen: TelemetryEvent = {
+      type: "onboarding",
+      daemon_event_id: `${oldVersion}:sess-activation-old:activation_moment_1_complete`,
+      recorded_at: 1700000100000,
+      screen: "activation_moment_1_complete",
+      ab_variant: "variant-a",
+      session_id: "sess-activation-old",
+      step_name: "activation_moment_1_complete",
+      step_index: 1,
+      completed_at: "2026-05-01T00:00:00.000Z",
+      funnel_version: oldVersion,
+      assistant_version: "0.9.0-old",
+    };
+    insertTelemetryOutboxEvent({
+      id: "row-activation-old",
+      name: "onboarding",
+      createdAt: 1700000100000,
+      event: frozen,
+    });
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
@@ -2036,29 +1988,16 @@ describe("UsageTelemetryReporter", () => {
     const body = JSON.parse(
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
-    expect(body.events[0]).toMatchObject({
-      funnel_version: oldVersion,
-      daemon_event_id: buildActivationDaemonEventId(
-        sessionId,
-        stepName,
-        oldVersion,
-      ),
-    });
-    // Guard: the id must carry the row's version, not the binary constant.
-    expect(body.events[0].daemon_event_id).toBe(
-      `${oldVersion}:${sessionId}:${stepName}`,
-    );
+    expect(body.events).toEqual([frozen]);
   });
 
-  test("legacy onboarding row keeps daemon_event_id: e.id and omits funnel fields", async () => {
+  test("legacy onboarding row keeps daemon_event_id = row id and omits funnel fields", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    mockQueryUnreportedOnboardingEvents.mockReturnValue([
-      makeOnboardingEvent({
-        id: "onb-legacy-1",
-        screen: "tools",
-        toolsJson: JSON.stringify(["calendar"]),
-      }),
-    ]);
+    const recorded = recordOnboardingEvent({
+      screen: "tools",
+      tools: ["calendar"],
+    });
+    expect(recorded).not.toBeNull();
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
@@ -2073,7 +2012,8 @@ describe("UsageTelemetryReporter", () => {
     expect(body.events.length).toBe(1);
     const e = body.events[0];
     expect(e.type).toBe("onboarding");
-    expect(e.daemon_event_id).toBe("onb-legacy-1");
+    expect(e.daemon_event_id).toBe(recorded!.id);
+    expect(e.tools).toEqual(["calendar"]);
     expect(e.session_id).toBeUndefined();
     expect(e.step_name).toBeUndefined();
     expect(e.step_index).toBeUndefined();


### PR DESCRIPTION
## Summary
- recordOnboardingEvent/recordActivationEvent build wire payloads at record time (incl. activation daemon_event_id override) and write the outbox (name=onboarding)
- onboardingSource is now outboxSource("onboarding") — delete-on-flush
- prior_assistants persistence dropped: stored today but never shipped on the wire and never read locally (param still accepted)

Part of plan: telemetry-outbox-consolidation.md (PR 5 of 9)