### PR TITLE
refactor(telemetry): record skill-loaded events into the telemetry_events outbox with conversation redaction

### DIFF
--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -19,9 +19,31 @@ import {
 import { isLastUserMessageToolResult } from "../persistence/conversation-queries.js";
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { skillLoadedEvents } from "../persistence/schema/index.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
 // Initialize db once before all tests
 await initializeDb();
+
+/** Seed a pending telemetry outbox row (default name: skill_loaded). */
+function seedTelemetryEvent(
+  id: string,
+  createdAt: number,
+  conversationId: string | null,
+  name = "skill_loaded",
+): void {
+  getTelemetryDb()!
+    .insert(telemetryEvents)
+    .values({ id, name, createdAt, conversationId, payload: "{}" })
+    .run();
+}
+
+function pendingTelemetryEventIds(): string[] {
+  return getTelemetryDb()!
+    .select()
+    .from(telemetryEvents)
+    .all()
+    .map((r) => r.id)
+    .sort();
+}
 
 describe("deleteLastExchange", () => {
   beforeEach(() => {
@@ -351,109 +373,62 @@ describe("attachment orphan cleanup", () => {
     expect(linkCount.c).toBe(0);
   });
 
-  test("clearAll removes skill_loaded_events", async () => {
-    // Privacy posture: Clear All wins over unflushed telemetry — the
-    // skill_loaded_events rows (conversation id, skill name, model
-    // attribution) must not survive the wipe and ship later.
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+  test("clearAll removes pending skill_loaded telemetry_events rows", async () => {
+    // Privacy posture: Clear All wins over unflushed telemetry — the pending
+    // skill_loaded rows (conversation id, skill name, model attribution)
+    // must not survive the wipe and ship later.
+    getTelemetryDb()!.delete(telemetryEvents).run();
     const conv = createConversation("test");
-    getTelemetryDb()!
-      .insert(skillLoadedEvents)
-      .values([
-        {
-          id: "sle-clear-1",
-          createdAt: 1000,
-          conversationId: conv.id,
-          skillName: "web-research",
-        },
-        // Rows without a conversation are wiped too.
-        { id: "sle-clear-2", createdAt: 2000, skillName: "tasks" },
-      ])
-      .run();
+    seedTelemetryEvent("sle-clear-1", 1000, conv.id);
+    // Rows without a conversation are wiped too.
+    seedTelemetryEvent("sle-clear-2", 2000, null);
 
     await clearAll();
 
-    expect(
-      getTelemetryDb()!.select().from(skillLoadedEvents).all(),
-    ).toHaveLength(0);
+    const skillRows = getTelemetryDb()!
+      .select()
+      .from(telemetryEvents)
+      .all()
+      .filter((r) => r.name === "skill_loaded");
+    expect(skillRows).toHaveLength(0);
   });
 
-  test("deleteConversation removes that conversation's skill_loaded_events", async () => {
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+  test("deleteConversation removes that conversation's telemetry_events rows", async () => {
+    getTelemetryDb()!.delete(telemetryEvents).run();
     const conv = createConversation("doomed");
     await addMessage(conv.id, "user", "hello");
     const other = createConversation("kept");
-    getTelemetryDb()!
-      .insert(skillLoadedEvents)
-      .values([
-        {
-          id: "sle-del-1",
-          createdAt: 1000,
-          conversationId: conv.id,
-          skillName: "web-research",
-        },
-        {
-          id: "sle-del-2",
-          createdAt: 2000,
-          conversationId: other.id,
-          skillName: "tasks",
-        },
-      ])
-      .run();
+    seedTelemetryEvent("te-del-1", 1000, conv.id);
+    seedTelemetryEvent("te-del-2", 2000, other.id);
+    // Redaction keys on conversation_id regardless of event name.
+    seedTelemetryEvent("te-del-3", 3000, conv.id, "future_event");
 
     deleteConversation(conv.id);
 
-    const remaining = getTelemetryDb()!.select().from(skillLoadedEvents).all();
-    expect(remaining.map((r) => r.id)).toEqual(["sle-del-2"]);
+    expect(pendingTelemetryEventIds()).toEqual(["te-del-2"]);
   });
 
-  test("deleteConversation removes skill_loaded_events when the conversation has no messages", () => {
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+  test("deleteConversation removes telemetry_events rows when the conversation has no messages", () => {
+    getTelemetryDb()!.delete(telemetryEvents).run();
     const conv = createConversation("empty");
-    getTelemetryDb()!
-      .insert(skillLoadedEvents)
-      .values({
-        id: "sle-del-empty",
-        createdAt: 1000,
-        conversationId: conv.id,
-        skillName: "web-research",
-      })
-      .run();
+    seedTelemetryEvent("te-del-empty", 1000, conv.id);
 
     deleteConversation(conv.id);
 
-    expect(
-      getTelemetryDb()!.select().from(skillLoadedEvents).all(),
-    ).toHaveLength(0);
+    expect(pendingTelemetryEventIds()).toHaveLength(0);
   });
 
-  test("deleteConversationGently removes that conversation's skill_loaded_events", async () => {
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+  test("deleteConversationGently removes that conversation's telemetry_events rows", async () => {
+    getTelemetryDb()!.delete(telemetryEvents).run();
     const conv = createConversation("doomed");
     await addMessage(conv.id, "user", "hello");
     const other = createConversation("kept");
-    getTelemetryDb()!
-      .insert(skillLoadedEvents)
-      .values([
-        {
-          id: "sle-gentle-1",
-          createdAt: 1000,
-          conversationId: conv.id,
-          skillName: "web-research",
-        },
-        {
-          id: "sle-gentle-2",
-          createdAt: 2000,
-          conversationId: other.id,
-          skillName: "tasks",
-        },
-      ])
-      .run();
+    seedTelemetryEvent("te-gentle-1", 1000, conv.id);
+    seedTelemetryEvent("te-gentle-2", 2000, other.id);
 
     await deleteConversationGently(conv.id);
 
-    const remaining = getTelemetryDb()!.select().from(skillLoadedEvents).all();
-    expect(remaining.map((r) => r.id)).toEqual(["sle-gentle-2"]);
+    expect(pendingTelemetryEventIds()).toEqual(["te-gentle-2"]);
   });
 
   test("deleteLastExchange does not delete unlinked user uploads", async () => {

--- a/assistant/src/__tests__/prune-old-conversations-job.test.ts
+++ b/assistant/src/__tests__/prune-old-conversations-job.test.ts
@@ -7,7 +7,7 @@ import { pruneOldConversationsJob } from "../persistence/job-handlers/cleanup.js
 import type { MemoryJob } from "../persistence/jobs-store.js";
 import {
   conversations,
-  skillLoadedEvents,
+  telemetryEvents,
   toolInvocations,
 } from "../persistence/schema/index.js";
 
@@ -39,21 +39,23 @@ function seedConversation(id: string, updatedAt: number): void {
       createdAt: updatedAt,
     })
     .run();
-  // skill_loaded_events lives in the dedicated telemetry DB.
+  // Pending conversation-scoped telemetry rows live in the telemetry_events
+  // outbox on the dedicated telemetry DB.
   getTelemetryDb()!
-    .insert(skillLoadedEvents)
+    .insert(telemetryEvents)
     .values({
-      id: `sl-${id}`,
+      id: `te-${id}`,
+      name: "skill_loaded",
       createdAt: updatedAt,
       conversationId: id,
-      skillName: "test-skill",
+      payload: "{}",
     })
     .run();
 }
 
 function countRows(conversationId: string): {
   invocations: number;
-  skillLoads: number;
+  telemetryRows: number;
 } {
   const db = getDb();
   return {
@@ -62,9 +64,9 @@ function countRows(conversationId: string): {
       .from(toolInvocations)
       .all()
       .filter((r) => r.conversationId === conversationId).length,
-    skillLoads: getTelemetryDb()!
+    telemetryRows: getTelemetryDb()!
       .select()
-      .from(skillLoadedEvents)
+      .from(telemetryEvents)
       .all()
       .filter((r) => r.conversationId === conversationId).length,
   };
@@ -73,20 +75,20 @@ function countRows(conversationId: string): {
 describe("pruneOldConversationsJob", () => {
   beforeEach(() => {
     const db = getDb();
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+    getTelemetryDb()!.delete(telemetryEvents).run();
     db.delete(toolInvocations).run();
     db.delete(conversations).run();
   });
 
-  test("deletes non-cascading rows — including skill_loaded_events — for pruned conversations only", () => {
+  test("deletes non-cascading rows — including pending telemetry_events — for pruned conversations only", () => {
     const staleUpdatedAt = Date.now() - 60 * 86_400_000;
     seedConversation(STALE_ID, staleUpdatedAt);
     seedConversation(FRESH_ID, Date.now());
 
     pruneOldConversationsJob(JOB, CONFIG);
 
-    expect(countRows(STALE_ID)).toEqual({ invocations: 0, skillLoads: 0 });
-    expect(countRows(FRESH_ID)).toEqual({ invocations: 1, skillLoads: 1 });
+    expect(countRows(STALE_ID)).toEqual({ invocations: 0, telemetryRows: 0 });
+    expect(countRows(FRESH_ID)).toEqual({ invocations: 1, telemetryRows: 1 });
     const remaining = getDb().select().from(conversations).all();
     expect(remaining.map((c) => c.id)).toEqual([FRESH_ID]);
   });

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -108,7 +108,7 @@ import {
   memorySegments,
   messageAttachments,
   messages,
-  skillLoadedEvents,
+  telemetryEvents,
   toolInvocations,
 } from "./schema/index.js";
 import { timeSyncSection } from "./slow-sync-log.js";
@@ -129,10 +129,10 @@ function logsDb(): DrizzleDb {
 }
 
 /**
- * The telemetry connection (`assistant-telemetry.db`), where
- * `skill_loaded_events` lives. Throws if the file cannot be opened — the
+ * The telemetry connection (`assistant-telemetry.db`), where the
+ * `telemetry_events` outbox lives. Throws if the file cannot be opened — the
  * conversation-delete call sites must not report success while unshipped
- * skill events referencing the deleted conversation survive to be flushed.
+ * events referencing the deleted conversation survive to be flushed.
  */
 function telemetryDb(): DrizzleDb {
   const db = getTelemetryDb();
@@ -1655,17 +1655,19 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   const convBeforeDelete = getConversation(id);
   const createdAtForDiskCleanup = convBeforeDelete?.createdAt;
 
-  // llm_request_logs and skill_loaded_events live in the dedicated logs and
-  // telemetry connections, so they are deleted there — separately from (and
-  // before) the main-DB transaction below, so a failure leaves the
-  // conversation intact for a retried delete.
+  // llm_request_logs and pending telemetry_events rows live in the dedicated
+  // logs and telemetry connections, so they are deleted there — separately
+  // from (and before) the main-DB transaction below, so a failure leaves the
+  // conversation intact for a retried delete. Telemetry redaction keys on
+  // conversation_id regardless of event name, so every conversation-scoped
+  // pending event is covered.
   logsDb()
     .delete(llmRequestLogs)
     .where(eq(llmRequestLogs.conversationId, id))
     .run();
   telemetryDb()
-    .delete(skillLoadedEvents)
-    .where(eq(skillLoadedEvents.conversationId, id))
+    .delete(telemetryEvents)
+    .where(eq(telemetryEvents.conversationId, id))
     .run();
 
   db.transaction((tx) => {
@@ -1784,13 +1786,14 @@ export async function deleteConversationGently(
     .all()
     .map((r) => r.id);
 
-  // skill_loaded_events lives in the dedicated telemetry connection; delete
-  // it there before ANY destructive work so a telemetry failure leaves the
-  // conversation fully intact for a retried delete — a throw after the bulk
-  // drains below would strand unredacted rows that could still flush.
+  // Pending telemetry_events rows live in the dedicated telemetry connection;
+  // delete them there (by conversation_id, regardless of event name) before
+  // ANY destructive work so a telemetry failure leaves the conversation fully
+  // intact for a retried delete — a throw after the bulk drains below would
+  // strand unredacted rows that could still flush.
   telemetryDb()
-    .delete(skillLoadedEvents)
-    .where(eq(skillLoadedEvents.conversationId, id))
+    .delete(telemetryEvents)
+    .where(eq(telemetryEvents.conversationId, id))
     .run();
 
   // llm_request_logs lives in the dedicated logs connection, and each row is
@@ -2976,14 +2979,15 @@ export async function clearAll(): Promise<{
     }
   };
 
-  // skill_loaded_events lives in the dedicated telemetry connection. Redact
-  // it FIRST, before any destructive delete: unshipped skill events reference
-  // conversations this wipe must redact, so a telemetry failure must abort
-  // the clear-all while the workspace is still fully intact — never after
-  // memory state is already gone.
+  // Pending skill_loaded rows live in the telemetry_events outbox on the
+  // dedicated telemetry connection. Redact them FIRST, before any destructive
+  // delete: unshipped skill events reference conversations this wipe must
+  // redact, so a telemetry failure must abort the clear-all while the
+  // workspace is still fully intact — never after memory state is already
+  // gone.
   rawTelemetryRun(
     "conversation:clearAll:skillLoadedEvents",
-    "DELETE FROM skill_loaded_events",
+    "DELETE FROM telemetry_events WHERE name = 'skill_loaded'",
   );
 
   // Delete in dependency order. Cascades handle memory_segments and

--- a/assistant/src/persistence/job-handlers/cleanup.ts
+++ b/assistant/src/persistence/job-handlers/cleanup.ts
@@ -144,8 +144,8 @@ function parseDeletedCount(stdout: string | undefined): number {
  * conversation_keys, channel_inbound_events, message_runs, call_sessions,
  * external_conversation_bindings) are handled automatically. Tables without
  * cascade (messages, tool_invocations, plus llm_request_logs and
- * skill_loaded_events on their dedicated connections) are deleted explicitly
- * before removing the conversation row.
+ * conversation-scoped telemetry_events rows on their dedicated connections)
+ * are deleted explicitly before removing the conversation row.
  */
 export function pruneOldConversationsJob(
   job: MemoryJob,
@@ -185,20 +185,21 @@ export function pruneOldConversationsJob(
       );
       if (still.length === 0) return;
 
-      // Non-cascading tables. llm_request_logs and skill_loaded_events live in
-      // the dedicated logs/telemetry connections, so they are deleted there
-      // (outside this main-DB transaction). Both run before the main-DB
-      // deletes: a failure leaves the conversation row in place so the prune
-      // retries — unshipped skill events must never outlive their pruned
-      // conversation and flush later.
+      // Non-cascading tables. llm_request_logs and conversation-scoped
+      // telemetry_events rows live in the dedicated logs/telemetry
+      // connections, so they are deleted there (outside this main-DB
+      // transaction). Both run before the main-DB deletes: a failure leaves
+      // the conversation row in place so the prune retries — unshipped
+      // telemetry events must never outlive their pruned conversation and
+      // flush later.
       rawLogsRun(
         "cleanup:pruneOldConversations:logs",
         `DELETE FROM llm_request_logs WHERE conversation_id = ?`,
         id,
       );
       rawTelemetryRun(
-        "cleanup:pruneOldConversations:skills",
-        `DELETE FROM skill_loaded_events WHERE conversation_id = ?`,
+        "cleanup:pruneOldConversations:telemetry",
+        `DELETE FROM telemetry_events WHERE conversation_id = ?`,
         id,
       );
       rawRun(

--- a/assistant/src/persistence/migrations/332-move-skill-loaded-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/332-move-skill-loaded-events-to-telemetry-db.test.ts
@@ -13,13 +13,21 @@ import { describe, expect, test } from "bun:test";
 const { getDb, getSqlite, getTelemetrySqlite } =
   await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
-const { queryUnreportedSkillLoadedEvents } =
-  await import("../../telemetry/skill-loaded-events-store.js");
 const { migrateMoveSkillLoadedEventsToTelemetryDb } =
   await import("./332-move-skill-loaded-events-to-telemetry-db.js");
-const { rawTelemetryRun } = await import("../raw-query.js");
 
 await initializeDb();
+
+/** Telemetry-side rows in the reporter's `(created_at, id)` order. */
+function telemetrySkillRowIds(): string[] {
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id FROM skill_loaded_events ORDER BY created_at ASC, id ASC`,
+      )
+      .all() as Array<{ id: string }>
+  ).map((r) => r.id);
+}
 
 const SOURCE_COLUMNS = `
   id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, conversation_id TEXT,
@@ -91,19 +99,21 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
       { id: "seed-dupe", skill_name: "calendar", conversation_id: "conv-b" },
     ]);
 
-    // The relocated rows are readable through the store's reporter query.
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
-    expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    expect(rows[0]).toEqual({
+    // Every column relocates intact.
+    expect(telemetrySkillRowIds()).toEqual(["seed-1", "seed-2", "seed-dupe"]);
+    const first = getTelemetrySqlite()!
+      .query(`SELECT * FROM skill_loaded_events WHERE id = 'seed-1'`)
+      .get();
+    expect(first).toEqual({
       id: "seed-1",
-      createdAt: 1000,
-      conversationId: "conv-a",
-      skillName: "web-research",
-      skillUpdatedAt: null,
+      created_at: 1000,
+      conversation_id: "conv-a",
+      skill_name: "web-research",
+      skill_updated_at: null,
       provider: null,
       model: null,
-      inferenceProfile: null,
-      inferenceProfileSource: null,
+      inference_profile: null,
+      inference_profile_source: null,
     });
   });
 
@@ -116,7 +126,7 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetrySkillRowIds()).toHaveLength(3);
   });
 
   test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
@@ -140,7 +150,7 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
       )
       .get() as { skill_name: string };
     expect(dupe.skill_name).toBe("already-copied");
-    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetrySkillRowIds()).toHaveLength(3);
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -153,7 +163,7 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
+    expect(telemetrySkillRowIds()).toHaveLength(0);
   });
 
   test("the drain purges rows whose conversation no longer exists (redaction across boots)", async () => {
@@ -177,34 +187,14 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
 
-    const moved = queryUnreportedSkillLoadedEvents(0, undefined, 10);
-    expect(moved.map((r) => r.id)).toEqual(["live-1", "null-1"]);
+    expect(telemetrySkillRowIds()).toEqual(["live-1", "null-1"]);
     const dead = getTelemetrySqlite()!
       .query(`SELECT 1 FROM skill_loaded_events WHERE id = 'dead-1'`)
       .get();
     expect(dead).toBeNull();
   });
 
-  test("per-conversation redaction deletes rows on the telemetry connection", () => {
-    resetState();
-    getTelemetrySqlite()!.exec(
-      `INSERT INTO skill_loaded_events (id, created_at, conversation_id, skill_name)
-       VALUES ('red-1', 1000, 'conv-pruned', 'web-research'),
-              ('red-2', 2000, 'conv-kept', 'tasks')`,
-    );
-
-    // The exact delete the conversation prune runs (job-handlers/cleanup.ts).
-    rawTelemetryRun(
-      "test:prune-redaction",
-      `DELETE FROM skill_loaded_events WHERE conversation_id = ?`,
-      "conv-pruned",
-    );
-
-    const remaining = queryUnreportedSkillLoadedEvents(0, undefined, 10);
-    expect(remaining.map((r) => r.id)).toEqual(["red-2"]);
-  });
-
-  test("telemetry-side schema has the reporter's compound cursor index", () => {
+  test("telemetry-side schema has the compound cursor index", () => {
     const indexes = (
       getTelemetrySqlite()!
         .query(`PRAGMA index_list(skill_loaded_events)`)

--- a/assistant/src/telemetry/skill-loaded-events-store.test.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.test.ts
@@ -8,38 +8,42 @@ mock.module("../platform/consent-cache.js", () => ({
 
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { skillLoadedEvents } from "../persistence/schema/index.js";
-import {
-  queryUnreportedSkillLoadedEvents,
-  recordSkillLoadedEvent,
-} from "./skill-loaded-events-store.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
+import { APP_VERSION } from "../version.js";
+import { recordSkillLoadedEvent } from "./skill-loaded-events-store.js";
 
 await initializeDb();
 
-function insertEvent(
-  id: string,
-  createdAt: number,
-  skillName = "web-research",
-): void {
-  getTelemetryDb()!
-    .insert(skillLoadedEvents)
-    .values({ id, createdAt, skillName })
-    .run();
+function pendingRows(): Array<{
+  id: string;
+  name: string;
+  createdAt: number;
+  conversationId: string | null;
+  payload: Record<string, unknown>;
+}> {
+  return getTelemetryDb()!
+    .select()
+    .from(telemetryEvents)
+    .all()
+    .map((row) => ({
+      ...row,
+      payload: JSON.parse(row.payload) as Record<string, unknown>,
+    }));
 }
 
 describe("skill-loaded-events-store", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+    getTelemetryDb()!.delete(telemetryEvents).run();
   });
 
   test("honors the share_analytics opt-out (records nothing)", () => {
     shareAnalytics = false;
     recordSkillLoadedEvent({ skillName: "web-research" });
-    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingRows()).toHaveLength(0);
   });
 
-  test("record + query round-trips all fields", () => {
+  test("record writes the full wire payload into the outbox", () => {
     recordSkillLoadedEvent({
       conversationId: "conv-xyz",
       skillName: "web-research",
@@ -50,98 +54,45 @@ describe("skill-loaded-events-store", () => {
       inferenceProfileSource: "active-profile",
     });
 
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    const rows = pendingRows();
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
+    expect(row.name).toBe("skill_loaded");
     expect(row.id).toBeString();
     expect(row.createdAt).toBeGreaterThan(0);
-    expect(row).toMatchObject({
-      conversationId: "conv-xyz",
-      skillName: "web-research",
-      skillUpdatedAt: "2026-06-01T00:00:00.000Z",
+    // Dedicated column, so conversation deletion redacts pending rows via an
+    // indexed delete.
+    expect(row.conversationId).toBe("conv-xyz");
+    expect(row.payload).toEqual({
+      type: "skill_loaded",
+      daemon_event_id: row.id,
+      recorded_at: row.createdAt,
+      skill_name: "web-research",
+      skill_updated_at: "2026-06-01T00:00:00.000Z",
+      conversation_id: "conv-xyz",
       provider: "anthropic",
       model: "model-a",
-      inferenceProfile: "balanced",
-      inferenceProfileSource: "active-profile",
+      inference_profile: "balanced",
+      inference_profile_source: "active-profile",
+      assistant_version: APP_VERSION,
     });
   });
 
-  test("optional fields persist as null", () => {
+  test("optional fields ship as null and leave the conversation column null", () => {
     recordSkillLoadedEvent({ skillName: "tasks" });
 
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    const rows = pendingRows();
     expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      skillName: "tasks",
-      conversationId: null,
-      skillUpdatedAt: null,
+    expect(rows[0]!.conversationId).toBeNull();
+    expect(rows[0]!.payload).toMatchObject({
+      type: "skill_loaded",
+      skill_name: "tasks",
+      skill_updated_at: null,
+      conversation_id: null,
       provider: null,
       model: null,
-      inferenceProfile: null,
-      inferenceProfileSource: null,
+      inference_profile: null,
+      inference_profile_source: null,
     });
-  });
-
-  test("returns rows in (createdAt, id) order", () => {
-    insertEvent("sle-b", 2000);
-    insertEvent("sle-a", 1000);
-
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 100);
-    expect(rows.map((r) => r.id)).toEqual(["sle-a", "sle-b"]);
-  });
-
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    // Two rows in the same millisecond: pagination must use the id
-    // tiebreaker to make forward progress, not loop.
-    insertEvent("sle-1", 5000);
-    insertEvent("sle-2", 5000);
-    insertEvent("sle-3", 6000);
-
-    const first = queryUnreportedSkillLoadedEvents(0, undefined, 1);
-    expect(first.map((r) => r.id)).toEqual(["sle-1"]);
-
-    const second = queryUnreportedSkillLoadedEvents(
-      first[0]!.createdAt,
-      first[0]!.id,
-      100,
-    );
-    expect(second.map((r) => r.id)).toEqual(["sle-2", "sle-3"]);
-
-    // Without an id cursor the timestamp-only branch is used.
-    expect(
-      queryUnreportedSkillLoadedEvents(5000, undefined, 100).map((r) => r.id),
-    ).toEqual(["sle-3"]);
-
-    // Cursor past the last row returns nothing.
-    const last = second[second.length - 1]!;
-    expect(
-      queryUnreportedSkillLoadedEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
-  });
-
-  test("resumes from a persisted watermark without re-reporting", () => {
-    insertEvent("sle-w1", 1000);
-    insertEvent("sle-w2", 2000);
-
-    const batch = queryUnreportedSkillLoadedEvents(0, undefined, 100);
-    const watermark = batch[batch.length - 1]!;
-
-    insertEvent("sle-w3", 3000);
-
-    const resumed = queryUnreportedSkillLoadedEvents(
-      watermark.createdAt,
-      watermark.id,
-      100,
-    );
-    expect(resumed.map((r) => r.id)).toEqual(["sle-w3"]);
-  });
-
-  test("honors the limit", () => {
-    insertEvent("sle-l1", 1000);
-    insertEvent("sle-l2", 2000);
-    insertEvent("sle-l3", 3000);
-
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 2);
-    expect(rows.map((r) => r.id)).toEqual(["sle-l1", "sle-l2"]);
   });
 });

--- a/assistant/src/telemetry/skill-loaded-events-store.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.ts
@@ -1,16 +1,17 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
-import { skillLoadedEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import type { UsageAttributionColumns } from "../usage/attribution.js";
+import type { UsageAttributionProfileSource } from "../usage/types.js";
+import { APP_VERSION } from "../version.js";
+import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import type { SkillLoadedTelemetryEvent } from "./types.js";
 
 /**
  * Input for one `skill_loaded` telemetry event. Metadata only — never skill
  * output or conversation content. The attribution columns reuse the shared
  * nullable shape from `toAttributionColumns` so producers can spread it
- * directly; null and absent both persist as NULL.
+ * directly; null and absent both ship as null.
  */
 export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns> {
   conversationId?: string;
@@ -19,85 +20,40 @@ export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns>
   skillUpdatedAt?: string;
 }
 
-/** A persisted skill_loaded event row. */
-export interface SkillLoadedEvent {
-  id: string;
-  createdAt: number;
-  conversationId: string | null;
-  skillName: string;
-  skillUpdatedAt: string | null;
-  provider: string | null;
-  model: string | null;
-  inferenceProfile: string | null;
-  inferenceProfileSource: string | null;
-}
-
 /**
- * Record a `skill_loaded` telemetry event for a skill activation. No-ops when
- * usage data collection is disabled (the event is dropped to honor the
- * opt-out, matching the rest of telemetry).
+ * Record a `skill_loaded` telemetry event for a skill activation. The full
+ * wire event (record-time `assistant_version` included) goes into the
+ * `telemetry_events` outbox, with the conversation id in its dedicated
+ * column so conversation deletion redacts pending rows via an indexed
+ * delete. No-ops when usage data collection is disabled (the event is
+ * dropped to honor the opt-out, matching the rest of telemetry) or when the
+ * telemetry DB is unavailable.
  */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
   if (!getCachedShareAnalytics()) {
     return;
   }
-  const db = getTelemetryDb();
-  if (!db) {
-    return;
-  }
-  db.insert(skillLoadedEvents)
-    .values({
-      id: uuid(),
-      createdAt: Date.now(),
-      conversationId: record.conversationId,
-      skillName: record.skillName,
-      skillUpdatedAt: record.skillUpdatedAt,
-      provider: record.provider,
-      model: record.model,
-      inferenceProfile: record.inferenceProfile,
-      inferenceProfileSource: record.inferenceProfileSource,
-    })
-    .run();
-}
-
-/**
- * Query skill_loaded events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedSkillLoadedEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): SkillLoadedEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
-  }
-  return db
-    .select({
-      id: skillLoadedEvents.id,
-      createdAt: skillLoadedEvents.createdAt,
-      conversationId: skillLoadedEvents.conversationId,
-      skillName: skillLoadedEvents.skillName,
-      skillUpdatedAt: skillLoadedEvents.skillUpdatedAt,
-      provider: skillLoadedEvents.provider,
-      model: skillLoadedEvents.model,
-      inferenceProfile: skillLoadedEvents.inferenceProfile,
-      inferenceProfileSource: skillLoadedEvents.inferenceProfileSource,
-    })
-    .from(skillLoadedEvents)
-    .where(
-      afterId
-        ? or(
-            gt(skillLoadedEvents.createdAt, afterCreatedAt),
-            and(
-              eq(skillLoadedEvents.createdAt, afterCreatedAt),
-              gt(skillLoadedEvents.id, afterId),
-            ),
-          )
-        : gt(skillLoadedEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(skillLoadedEvents.createdAt), asc(skillLoadedEvents.id))
-    .limit(limit)
-    .all();
+  const id = uuid();
+  const createdAt = Date.now();
+  const event: SkillLoadedTelemetryEvent = {
+    type: "skill_loaded",
+    daemon_event_id: id,
+    recorded_at: createdAt,
+    skill_name: record.skillName,
+    skill_updated_at: record.skillUpdatedAt ?? null,
+    conversation_id: record.conversationId ?? null,
+    provider: record.provider ?? null,
+    model: record.model ?? null,
+    inference_profile: record.inferenceProfile ?? null,
+    inference_profile_source: (record.inferenceProfileSource ??
+      null) as UsageAttributionProfileSource | null,
+    assistant_version: APP_VERSION,
+  };
+  insertTelemetryOutboxEvent({
+    id,
+    name: "skill_loaded",
+    createdAt,
+    conversationId: record.conversationId ?? null,
+    event,
+  });
 }

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -25,7 +25,6 @@ import {
   buildActivationDaemonEventId,
 } from "./activation-funnel.js";
 import { queryUnreportedConfigSettingEvents } from "./config-setting-events-store.js";
-import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
 import {
   deleteTelemetryOutboxEvents,
   discardPendingTelemetryOutboxEvents,
@@ -556,28 +555,7 @@ const toolExecutedSource = simpleSource(
   }),
 );
 
-const skillLoadedSource = simpleSource(
-  "skill_loaded",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedSkillLoadedEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "skill_loaded",
-    daemon_event_id: e.id,
-    recorded_at: e.createdAt,
-    skill_name: e.skillName,
-    skill_updated_at: e.skillUpdatedAt,
-    conversation_id: e.conversationId,
-    provider: e.provider,
-    model: e.model,
-    inference_profile: e.inferenceProfile,
-    inference_profile_source:
-      e.inferenceProfileSource as UsageAttributionProfileSource | null,
-    // `skill_loaded_events` has no record-time version column — same
-    // upload-time APP_VERSION stamping as the other non-llm_usage
-    // event types.
-    assistant_version: APP_VERSION,
-  }),
-);
+const skillLoadedSource = outboxSource("skill_loaded");
 
 const watchdogSource = simpleSource(
   "watchdog",

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -230,7 +230,6 @@ import {
   authFallbackEvents,
   configSettingEvents,
   conversations,
-  skillLoadedEvents,
   telemetryEvents,
   toolInvocations,
 } from "../persistence/schema/index.js";
@@ -413,7 +412,6 @@ beforeEach(() => {
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
-  getTelemetryDb()!.delete(skillLoadedEvents).run();
   getTelemetryDb()!.delete(authFallbackEvents).run();
   getTelemetryDb()!.delete(configSettingEvents).run();
   getTelemetryDb()!.delete(telemetryEvents).run();
@@ -1651,14 +1649,16 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 9 timestamp watermarks should have been advanced, and all 9 ID
-    // watermarks pinned to the high-sorting sentinel (a truthy value keeps
-    // the compound-cursor branch active while closing its same-millisecond
-    // arm against opt-out rows).
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(18);
+    // All 8 watermark-mode timestamp watermarks should have been advanced,
+    // and all 8 ID watermarks pinned to the high-sorting sentinel (a truthy
+    // value keeps the compound-cursor branch active while closing its
+    // same-millisecond arm against opt-out rows). The ack-mode skill_loaded
+    // source discards its pending outbox rows instead.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(16);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
+    expect(keys.some((k) => k.includes("skill_loaded"))).toBe(false);
     const eventTypes = [
       "usage",
       "turns",
@@ -1666,7 +1666,6 @@ describe("UsageTelemetryReporter", () => {
       "onboarding",
       "auth_fallback",
       "tool_executed",
-      "skill_loaded",
       "watchdog",
       "config_setting",
     ];
@@ -2536,51 +2535,35 @@ describe("UsageTelemetryReporter", () => {
     });
   });
 
-  test("skill_loaded watermark advances to the last reported row on success", async () => {
+  test("skill_loaded rows are deleted from the outbox after a 2xx, never via watermarks", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     recordSkillLoadedEvent({ skillName: "web-research" });
     recordSkillLoadedEvent({ skillName: "tasks" });
+    expect(queryTelemetryOutboxBatch("skill_loaded", 10)).toHaveLength(2);
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    // The last row by the reporter's (createdAt, id) cursor order is the one
-    // whose watermark should be persisted after a successful upload.
-    const rows = getTelemetryDb()!
-      .select()
-      .from(skillLoadedEvents)
-      .orderBy(skillLoadedEvents.createdAt, skillLoadedEvents.id)
-      .all();
-    const lastRow = rows[rows.length - 1];
-
     const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:skill_loaded:last_reported_at",
-    );
-    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
-    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
-      String(lastRow.createdAt),
-    );
-
-    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:skill_loaded:last_reported_id",
-    );
-    expect(idCalls.length).toBeGreaterThanOrEqual(1);
-    expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(queryTelemetryOutboxBatch("skill_loaded", 10)).toHaveLength(0);
+    // Ack-mode: the skill_loaded source never touches flush_checkpoints.
+    expect(
+      mockSetFlushCheckpoint.mock.calls.some((c) =>
+        c[0].includes("skill_loaded"),
+      ),
+    ).toBe(false);
   });
 
-  test("batch recursion when skill_loaded returns a full batch, capped at 10", async () => {
+  test("a full skill_loaded batch drives recursion until the outbox drains", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // Exactly BATCH_SIZE rows; the mocked checkpoints never persist, so each
-    // recursion re-reads the same full batch until the cap.
-    const fullBatch = Array.from({ length: 500 }, (_, i) => ({
-      id: `sle-batch-${String(i).padStart(3, "0")}`,
-      createdAt: 1700000000000 + i,
-      skillName: "web-research",
-    }));
-    getTelemetryDb()!.insert(skillLoadedEvents).values(fullBatch).run();
+    // BATCH_SIZE (500) + 1 rows: the first flush ships and deletes a full
+    // batch, and the fullBatch recursion ships the remaining row.
+    for (let i = 0; i < 501; i++) {
+      recordSkillLoadedEvent({ skillName: `skill-${i}` });
+    }
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":500}', { status: 200 })),
     );
@@ -2588,8 +2571,8 @@ describe("UsageTelemetryReporter", () => {
     const reporter = makeReporter();
     await reporter.flush();
 
-    // MAX_CONSECUTIVE_BATCHES = 10
-    expect(mockFetch).toHaveBeenCalledTimes(10);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(queryTelemetryOutboxBatch("skill_loaded", 1000)).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- recordSkillLoadedEvent builds the wire payload at record time and writes the outbox (name=skill_loaded, conversation_id column populated)
- skillLoadedSource is now outboxSource("skill_loaded") — delete-on-flush
- Conversation redaction (deleteConversation ×2, clearAll preflight, prune job) now targets telemetry_events, same fail-fast ordering

Part of plan: telemetry-outbox-consolidation.md (PR 7 of 9)