### PR TITLE
refactor(telemetry): record lifecycle events into the telemetry_events outbox

### DIFF
--- a/assistant/src/__tests__/conversation-clear-safety.test.ts
+++ b/assistant/src/__tests__/conversation-clear-safety.test.ts
@@ -6,7 +6,7 @@
  * - Missing X-Confirm-Destructive header returns BadRequestError
  * - Wrong header value returns BadRequestError
  * - Correct header clears data
- * - lifecycle_events contains `conversations_clear_all` audit entry after clear
+ * - telemetry_events contains the `conversations_clear_all` audit entry after clear
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -170,20 +170,31 @@ describe("DELETE /v1/conversations — route handler", () => {
     expect(getConversation(conv.id)).toBeNull();
   });
 
-  test("lifecycle_events contains conversations_clear_all after successful clear", async () => {
+  test("telemetry_events contains conversations_clear_all after successful clear", async () => {
     await clearRoute.handler({
       pathParams: {},
       body: {},
       headers: { "x-confirm-destructive": "clear-all-conversations" },
     });
 
-    // The audit row lives in the dedicated telemetry DB (migration 329).
+    // The audit row lands in the telemetry_events outbox on the dedicated
+    // telemetry DB; the durable trail persists platform-side once flushed.
     const rows = getTelemetrySqlite()!
       .query(
-        "SELECT event_name FROM lifecycle_events WHERE event_name = 'conversations_clear_all'",
+        "SELECT id, payload FROM telemetry_events WHERE name = 'lifecycle'",
       )
-      .all() as Array<{ event_name: string }>;
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-    expect(rows[0].event_name).toBe("conversations_clear_all");
+      .all() as Array<{ id: string; payload: string }>;
+    const audits = rows
+      .map((r) => ({
+        id: r.id,
+        payload: JSON.parse(r.payload) as Record<string, unknown>,
+      }))
+      .filter((r) => r.payload.event_name === "conversations_clear_all");
+    expect(audits.length).toBeGreaterThanOrEqual(1);
+    expect(audits[0].payload).toMatchObject({
+      type: "lifecycle",
+      daemon_event_id: audits[0].id,
+      event_name: "conversations_clear_all",
+    });
   });
 });

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -90,6 +90,7 @@ import {
   enqueueLexicalIndexForMessage,
   enqueuePurgeConversationLexical,
 } from "./job-handlers/message-lexical.js";
+import { buildLifecycleTelemetryEvent } from "./lifecycle-events-store.js";
 import { resolveMessageContentBlocks } from "./message-content-file.js";
 import {
   rawAll,
@@ -3008,18 +3009,25 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM messages");
   await runOrThrow("DELETE FROM conversations");
 
-  // Record audit event — lifecycle_events lives in the telemetry DB and is
-  // NOT deleted by clearAll(), so this survives the wipe as a permanent trail.
-  // Best-effort: the destructive deletes above already completed, so telemetry
-  // degradation must not turn a finished wipe into a failure or skip the
-  // cleanup below.
+  // Record audit event into the telemetry_events outbox (consent-bypassing);
+  // the trail persists platform-side once flushed. Best-effort: the
+  // destructive deletes above already completed, so telemetry degradation
+  // must not turn a finished wipe into a failure or skip the cleanup below.
   try {
+    const auditEventId = uuid();
+    const auditEventAt = Date.now();
     rawTelemetryRun(
       "conversation:clearAll:auditEvent",
-      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
-      uuid(),
-      "conversations_clear_all",
-      Date.now(),
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload) VALUES (?, 'lifecycle', ?, NULL, ?)`,
+      auditEventId,
+      auditEventAt,
+      JSON.stringify(
+        buildLifecycleTelemetryEvent(
+          auditEventId,
+          "conversations_clear_all",
+          auditEventAt,
+        ),
+      ),
     );
   } catch (err) {
     log.warn({ err }, "clearAll: failed to record audit event");

--- a/assistant/src/persistence/lifecycle-events-store.test.ts
+++ b/assistant/src/persistence/lifecycle-events-store.test.ts
@@ -6,22 +6,33 @@ mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));
 
+import { APP_VERSION } from "../version.js";
 import * as dbConnection from "./db-connection.js";
 import { getTelemetryDb, getTelemetrySqlite } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
 import {
-  queryUnreportedLifecycleEvents,
+  buildLifecycleTelemetryEvent,
   recordLifecycleEvent,
 } from "./lifecycle-events-store.js";
-import { lifecycleEvents } from "./schema.js";
+import { telemetryEvents } from "./schema.js";
 
 await initializeDb();
 
-function insertEvent(id: string, createdAt: number, eventName = "hatch"): void {
-  getTelemetryDb()!
-    .insert(lifecycleEvents)
-    .values({ id, eventName, createdAt })
-    .run();
+interface RawOutboxRow {
+  id: string;
+  name: string;
+  created_at: number;
+  conversation_id: string | null;
+  payload: string;
+}
+
+function outboxRows(): RawOutboxRow[] {
+  return getTelemetrySqlite()!
+    .query(
+      `SELECT id, name, created_at, conversation_id, payload
+       FROM telemetry_events ORDER BY created_at, id`,
+    )
+    .all() as RawOutboxRow[];
 }
 
 /** Run `fn` with the dedicated telemetry connection reported as unavailable. */
@@ -37,82 +48,53 @@ function withTelemetryDbUnavailable(fn: () => void): void {
 describe("lifecycle-events-store", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    getTelemetryDb()!.delete(lifecycleEvents).run();
+    getTelemetryDb()!.delete(telemetryEvents).run();
   });
 
-  test("record + query round-trips and writes into the telemetry database", () => {
+  test("record writes a telemetry_events outbox row carrying the wire payload", () => {
     const event = recordLifecycleEvent("app_open");
     expect(event).not.toBeNull();
     expect(event!.eventName).toBe("app_open");
     expect(event!.createdAt).toBeGreaterThan(0);
 
-    const rows = queryUnreportedLifecycleEvents(0, undefined, 10);
-    expect(rows).toEqual([event!]);
+    const rows = outboxRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: event!.id,
+      name: "lifecycle",
+      created_at: event!.createdAt,
+      conversation_id: null,
+    });
+    expect(JSON.parse(rows[0]!.payload)).toEqual({
+      type: "lifecycle",
+      daemon_event_id: event!.id,
+      event_name: "app_open",
+      recorded_at: event!.createdAt,
+      assistant_version: APP_VERSION,
+    });
+  });
 
-    const raw = getTelemetrySqlite()!
-      .query(`SELECT id, event_name FROM lifecycle_events`)
-      .all() as Array<{ id: string; event_name: string }>;
-    expect(raw).toEqual([{ id: event!.id, event_name: "app_open" }]);
+  test("buildLifecycleTelemetryEvent stamps the record-time binary version", () => {
+    expect(buildLifecycleTelemetryEvent("id-1", "hatch", 1234)).toEqual({
+      type: "lifecycle",
+      daemon_event_id: "id-1",
+      event_name: "hatch",
+      recorded_at: 1234,
+      assistant_version: APP_VERSION,
+    });
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
     shareAnalytics = false;
     expect(recordLifecycleEvent("app_open")).toBeNull();
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(0);
+    expect(outboxRows()).toHaveLength(0);
   });
 
   test("degrades when the telemetry database is unavailable", () => {
     withTelemetryDbUnavailable(() => {
       expect(recordLifecycleEvent("app_open")).toBeNull();
-      expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toEqual([]);
     });
 
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(0);
-  });
-
-  test("returns rows in (createdAt, id) order", () => {
-    insertEvent("le-b", 2000);
-    insertEvent("le-a", 1000);
-
-    const rows = queryUnreportedLifecycleEvents(0, undefined, 100);
-    expect(rows.map((r) => r.id)).toEqual(["le-a", "le-b"]);
-  });
-
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    // Two rows in the same millisecond: pagination must use the id
-    // tiebreaker to make forward progress, not loop.
-    insertEvent("le-1", 5000);
-    insertEvent("le-2", 5000);
-    insertEvent("le-3", 6000);
-
-    const first = queryUnreportedLifecycleEvents(0, undefined, 1);
-    expect(first.map((r) => r.id)).toEqual(["le-1"]);
-
-    const second = queryUnreportedLifecycleEvents(
-      first[0]!.createdAt,
-      first[0]!.id,
-      100,
-    );
-    expect(second.map((r) => r.id)).toEqual(["le-2", "le-3"]);
-
-    // Without an id cursor the timestamp-only branch is used.
-    expect(
-      queryUnreportedLifecycleEvents(5000, undefined, 100).map((r) => r.id),
-    ).toEqual(["le-3"]);
-
-    // Cursor past the last row returns nothing.
-    const last = second[second.length - 1]!;
-    expect(
-      queryUnreportedLifecycleEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
-  });
-
-  test("honors the limit", () => {
-    insertEvent("le-l1", 1000);
-    insertEvent("le-l2", 2000);
-    insertEvent("le-l3", 3000);
-
-    const rows = queryUnreportedLifecycleEvents(0, undefined, 2);
-    expect(rows.map((r) => r.id)).toEqual(["le-l1", "le-l2"]);
+    expect(outboxRows()).toHaveLength(0);
   });
 });

--- a/assistant/src/persistence/lifecycle-events-store.ts
+++ b/assistant/src/persistence/lifecycle-events-store.ts
@@ -1,9 +1,9 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
-import { getTelemetryDb } from "./db-connection.js";
-import { lifecycleEvents } from "./schema.js";
+import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import type { LifecycleTelemetryEvent } from "../telemetry/types.js";
+import { APP_VERSION } from "../version.js";
 
 export interface LifecycleEvent {
   id: string;
@@ -12,16 +12,30 @@ export interface LifecycleEvent {
 }
 
 /**
- * Record a lifecycle event (e.g. app_open, hatch). Returns null when usage
- * data collection is disabled or the telemetry database is unavailable
- * (degraded mode).
+ * Wire shape of one lifecycle event, stamped with the record-time binary's
+ * `APP_VERSION` (the outbox stores the full wire payload at record time).
+ */
+export function buildLifecycleTelemetryEvent(
+  id: string,
+  eventName: string,
+  createdAt: number,
+): LifecycleTelemetryEvent {
+  return {
+    type: "lifecycle",
+    daemon_event_id: id,
+    event_name: eventName,
+    recorded_at: createdAt,
+    assistant_version: APP_VERSION,
+  };
+}
+
+/**
+ * Record a lifecycle event (e.g. app_open, hatch) into the `telemetry_events`
+ * outbox. Returns null when usage data collection is disabled or the
+ * telemetry database is unavailable (degraded mode).
  */
 export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
   if (!getCachedShareAnalytics()) {
-    return null;
-  }
-  const db = getTelemetryDb();
-  if (!db) {
     return null;
   }
   const event: LifecycleEvent = {
@@ -29,49 +43,11 @@ export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
     eventName,
     createdAt: Date.now(),
   };
-  db.insert(lifecycleEvents)
-    .values({
-      id: event.id,
-      eventName: event.eventName,
-      createdAt: event.createdAt,
-    })
-    .run();
-  return event;
-}
-
-/**
- * Query lifecycle events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedLifecycleEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): LifecycleEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
-  }
-  const rows = db
-    .select({
-      id: lifecycleEvents.id,
-      eventName: lifecycleEvents.eventName,
-      createdAt: lifecycleEvents.createdAt,
-    })
-    .from(lifecycleEvents)
-    .where(
-      afterId
-        ? or(
-            gt(lifecycleEvents.createdAt, afterCreatedAt),
-            and(
-              eq(lifecycleEvents.createdAt, afterCreatedAt),
-              gt(lifecycleEvents.id, afterId),
-            ),
-          )
-        : gt(lifecycleEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(lifecycleEvents.createdAt), asc(lifecycleEvents.id))
-    .limit(limit)
-    .all();
-  return rows;
+  const inserted = insertTelemetryOutboxEvent({
+    id: event.id,
+    name: "lifecycle",
+    createdAt: event.createdAt,
+    event: buildLifecycleTelemetryEvent(event.id, eventName, event.createdAt),
+  });
+  return inserted ? event : null;
 }

--- a/assistant/src/persistence/migrations/331-move-lifecycle-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/331-move-lifecycle-events-to-telemetry-db.test.ts
@@ -13,12 +13,23 @@ import { describe, expect, test } from "bun:test";
 const { getDb, getSqlite, getTelemetrySqlite } =
   await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
-const { queryUnreportedLifecycleEvents } =
-  await import("../lifecycle-events-store.js");
 const { migrateMoveLifecycleEventsToTelemetryDb } =
   await import("./331-move-lifecycle-events-to-telemetry-db.js");
 
 await initializeDb();
+
+function telemetryLifecycleRows(): Array<{
+  id: string;
+  event_name: string;
+  created_at: number;
+}> {
+  return getTelemetrySqlite()!
+    .query(
+      `SELECT id, event_name, created_at FROM lifecycle_events
+       ORDER BY created_at, id`,
+    )
+    .all() as Array<{ id: string; event_name: string; created_at: number }>;
+}
 
 const SOURCE_COLUMNS = `
   id TEXT PRIMARY KEY, event_name TEXT NOT NULL, created_at INTEGER NOT NULL`;
@@ -61,24 +72,13 @@ describe("migration 331: move lifecycle_events to the telemetry DB", () => {
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
 
-    const moved = getTelemetrySqlite()!
-      .query(`SELECT id, event_name FROM lifecycle_events ORDER BY id`)
-      .all();
-    expect(moved).toEqual([
-      { id: "seed-1", event_name: "app_open" },
-      { id: "seed-2", event_name: "hatch" },
-      { id: "seed-dupe", event_name: "conversations_clear_all" },
-    ]);
-
-    // The relocated rows are readable through the store's reporter query.
-    const rows = queryUnreportedLifecycleEvents(0, undefined, 10);
-    expect(rows).toEqual([
-      { id: "seed-1", eventName: "app_open", createdAt: 1000 },
-      { id: "seed-2", eventName: "hatch", createdAt: 2000 },
+    expect(telemetryLifecycleRows()).toEqual([
+      { id: "seed-1", event_name: "app_open", created_at: 1000 },
+      { id: "seed-2", event_name: "hatch", created_at: 2000 },
       {
         id: "seed-dupe",
-        eventName: "conversations_clear_all",
-        createdAt: 3000,
+        event_name: "conversations_clear_all",
+        created_at: 3000,
       },
     ]);
   });
@@ -92,7 +92,7 @@ describe("migration 331: move lifecycle_events to the telemetry DB", () => {
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetryLifecycleRows()).toHaveLength(3);
   });
 
   test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
@@ -114,7 +114,7 @@ describe("migration 331: move lifecycle_events to the telemetry DB", () => {
       .query(`SELECT event_name FROM lifecycle_events WHERE id = 'seed-dupe'`)
       .get() as { event_name: string };
     expect(dupe.event_name).toBe("already-copied");
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetryLifecycleRows()).toHaveLength(3);
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -125,7 +125,7 @@ describe("migration 331: move lifecycle_events to the telemetry DB", () => {
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(0);
+    expect(telemetryLifecycleRows()).toHaveLength(0);
   });
 
   test("telemetry-side schema has the reporter's compound cursor index", () => {

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -10,7 +10,6 @@
  */
 
 import { queryUnreportedOnboardingEvents } from "../onboarding/onboarding-events-store.js";
-import { queryUnreportedLifecycleEvents } from "../persistence/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../persistence/llm-usage-store.js";
 import {
   getCachedShareDiagnostics,
@@ -440,22 +439,7 @@ const turnSource: TelemetryEventSource = {
   },
 };
 
-const lifecycleSource = simpleSource(
-  "lifecycle",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedLifecycleEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "lifecycle",
-    daemon_event_id: e.id,
-    event_name: e.eventName,
-    recorded_at: e.createdAt,
-    // Lifecycle events carry no record-time version column — stamp the
-    // running binary's `APP_VERSION`. Adding the record-time column to
-    // `lifecycle_events` (#18112) is a separate follow-up that mirrors
-    // `llm_usage_events`.
-    assistant_version: APP_VERSION,
-  }),
-);
+const lifecycleSource = outboxSource("lifecycle");
 
 const onboardingSource = simpleSource(
   "onboarding",

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -171,19 +171,6 @@ mock.module("./turn-trace-store.js", () => ({
   isTurnSettled: mockIsTurnSettled,
 }));
 
-const mockQueryUnreportedLifecycleEvents = mock(
-  () =>
-    [] as {
-      id: string;
-      eventName: string;
-      createdAt: number;
-    }[],
-);
-
-mock.module("../persistence/lifecycle-events-store.js", () => ({
-  queryUnreportedLifecycleEvents: mockQueryUnreportedLifecycleEvents,
-}));
-
 const mockQueryUnreportedOnboardingEvents = mock(
   () =>
     [] as {
@@ -209,11 +196,11 @@ mock.module("../onboarding/onboarding-events-store.js", () => ({
   queryUnreportedOnboardingEvents: mockQueryUnreportedOnboardingEvents,
 }));
 
-// The auth-fallback, tool-executed, and skill-loaded stores are intentionally
-// NOT mocked — they have their own DB-backed tests, and Bun's `mock.module`
-// is process-global, so mocking them here would leak into those tests when
-// files share an invocation. We seed the real DB instead so every test stays
-// order-independent.
+// The auth-fallback, tool-executed, skill-loaded, and lifecycle stores are
+// intentionally NOT mocked — they have their own DB-backed tests, and Bun's
+// `mock.module` is process-global, so mocking them here would leak into those
+// tests when files share an invocation. We seed the real DB instead so every
+// test stays order-independent.
 
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
@@ -226,6 +213,7 @@ import {
 } from "../__tests__/test-support/tool-invocation-seed.js";
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { recordLifecycleEvent } from "../persistence/lifecycle-events-store.js";
 import {
   authFallbackEvents,
   configSettingEvents,
@@ -408,8 +396,6 @@ beforeEach(() => {
   mockQueryUnreportedUsageEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
-  mockQueryUnreportedLifecycleEvents.mockReset();
-  mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
@@ -1651,18 +1637,18 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 9 timestamp watermarks should have been advanced, and all 9 ID
-    // watermarks pinned to the high-sorting sentinel (a truthy value keeps
-    // the compound-cursor branch active while closing its same-millisecond
-    // arm against opt-out rows).
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(18);
+    // All 8 watermark sources' timestamp watermarks should have been
+    // advanced, and their ID watermarks pinned to the high-sorting sentinel
+    // (a truthy value keeps the compound-cursor branch active while closing
+    // its same-millisecond arm against opt-out rows). Ack-mode sources
+    // (lifecycle) discard pending rows instead of touching watermarks.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(16);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
     const eventTypes = [
       "usage",
       "turns",
-      "lifecycle",
       "onboarding",
       "auth_fallback",
       "tool_executed",
@@ -1677,6 +1663,7 @@ describe("UsageTelemetryReporter", () => {
       );
       expect(idCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
     }
+    expect(keys.some((k) => k.includes(":lifecycle:"))).toBe(false);
   });
 
   test("platform disabled takes precedence over consent off — watermarks NOT advanced", async () => {
@@ -1751,8 +1738,9 @@ describe("UsageTelemetryReporter", () => {
   //
   // The envelope's `assistant_version` is upload-time (always the current
   // binary). The per-event field is record-time (the binary that was running
-  // when the event was persisted to SQLite). In this PR only `llm_usage`
-  // events carry a true record-time value; turn events (and lifecycle /
+  // when the event was persisted to SQLite). Outbox-backed sources
+  // (lifecycle) stamp record-time versions into their stored payloads;
+  // `llm_usage` carries a true record-time column; turn events (and
   // onboarding events, not asserted here) stamp the running binary's
   // `APP_VERSION` directly until their respective follow-ups land.
   // Nullable llm_usage cases (legacy rows from before migration 267 ran)
@@ -3102,5 +3090,48 @@ describe("UsageTelemetryReporter", () => {
     );
     expect(secondBody.events).toHaveLength(1);
     expect(pendingOutboxIds()).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Lifecycle events (outbox-backed)
+  // -------------------------------------------------------------------------
+
+  test("a recorded lifecycle event flushes once and its outbox row is deleted", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    const recorded = recordLifecycleEvent("app_open");
+    expect(recorded).not.toBeNull();
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = makeReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events).toHaveLength(1);
+    // The stored payload IS the wire event — record-time version included.
+    expect(body.events[0]).toEqual({
+      type: "lifecycle",
+      daemon_event_id: recorded!.id,
+      event_name: "app_open",
+      recorded_at: recorded!.createdAt,
+      assistant_version: "1.2.3-test",
+    });
+    // Delete-on-flush: the outbox row is gone, and lifecycle (ack-mode)
+    // never touches flush_checkpoints.
+    expect(queryTelemetryOutboxBatch("lifecycle", 10)).toEqual([]);
+    expect(
+      mockSetFlushCheckpoint.mock.calls.some((c) =>
+        c[0].includes(":lifecycle:"),
+      ),
+    ).toBe(false);
+
+    // A second flush finds nothing pending — the event never re-ships.
+    mockFetch.mockClear();
+    await reporter.flush();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- recordLifecycleEvent builds the wire payload at record time and writes the telemetry_events outbox (name=lifecycle)
- lifecycleSource is now outboxSource("lifecycle") — delete-on-flush
- clearAll audit event writes the outbox via buildLifecycleTelemetryEvent (best-effort, consent-bypassing as before)

Part of plan: telemetry-outbox-consolidation.md (PR 4 of 9)