### PR TITLE
feat(plugins): carry homepage/license through the catalog projection

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-catalog-local.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-local.test.ts
@@ -35,6 +35,8 @@ describe("buildBundledPluginCatalog", () => {
       description:
         "Ultra-compressed communication mode that strips filler words to cut token usage.",
       category: "productivity",
+      homepage: "https://github.com/JuliusBrussee/caveman",
+      license: "MIT",
       source: {
         kind: "github",
         repo: "JuliusBrussee/caveman",

--- a/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
@@ -38,12 +38,12 @@ describe("fetchPluginCatalogFromPlatform", () => {
             path: "packages/plugin",
             description: "graph memory",
             category: "productivity",
+            homepage: "https://example.com",
+            license: "MIT",
             // dropped keys
             id: "abc",
             display_name: "Memory Graph",
             icon: "🧠",
-            homepage: "https://example.com",
-            license: "MIT",
           },
           {
             name: "alpha-tool",
@@ -66,6 +66,8 @@ describe("fetchPluginCatalogFromPlatform", () => {
       path: `github:acme/memory-graph/packages/plugin@${SHA_B}`,
       description: "graph memory",
       category: "productivity",
+      homepage: "https://example.com",
+      license: "MIT",
       source: {
         kind: "github",
         repo: "acme/memory-graph",
@@ -76,6 +78,8 @@ describe("fetchPluginCatalogFromPlatform", () => {
 
     const alpha = catalog.matches[0];
     expect(alpha.category).toBeNull();
+    expect(alpha.homepage).toBeUndefined();
+    expect(alpha.license).toBeUndefined();
     expect(alpha.source).toEqual({
       kind: "github",
       repo: "vellum-ai/alpha-tool",

--- a/assistant/src/cli/lib/__tests__/search-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/search-plugins.test.ts
@@ -30,7 +30,13 @@ function entry(
   name: string,
   repo: string,
   ref: string,
-  extra?: { path?: string; description?: string; category?: string },
+  extra?: {
+    path?: string;
+    description?: string;
+    category?: string;
+    homepage?: string;
+    license?: string;
+  },
 ): MarketplaceEntry {
   return {
     name,
@@ -42,6 +48,8 @@ function entry(
     },
     ...(extra?.description ? { description: extra.description } : {}),
     ...(extra?.category ? { category: extra.category } : {}),
+    ...(extra?.homepage ? { homepage: extra.homepage } : {}),
+    ...(extra?.license ? { license: extra.license } : {}),
   };
 }
 
@@ -146,6 +154,8 @@ describe("marketplaceMatch", () => {
       path: `github:vellum-ai/simple-memory@${SHA_A}`,
       description: undefined,
       category: null,
+      homepage: undefined,
+      license: undefined,
       source: {
         kind: "github",
         repo: "vellum-ai/simple-memory",
@@ -168,6 +178,8 @@ describe("marketplaceMatch", () => {
       path: `github:acme/monorepo/packages/nested@${SHA_B}`,
       description: "A nested plugin.",
       category: null,
+      homepage: undefined,
+      license: undefined,
       source: {
         kind: "github",
         repo: "acme/monorepo",
@@ -189,6 +201,25 @@ describe("marketplaceMatch", () => {
       marketplaceMatch(entry("plain-plugin", "acme/plain-plugin", SHA_B))
         .category,
     ).toBeNull();
+  });
+
+  test("carries homepage/license when the entry declares them", () => {
+    const match = marketplaceMatch(
+      entry("calendar-sync", "acme/calendar-sync", SHA_A, {
+        homepage: "https://example.com/calendar-sync",
+        license: "MIT",
+      }),
+    );
+    expect(match.homepage).toBe("https://example.com/calendar-sync");
+    expect(match.license).toBe("MIT");
+  });
+
+  test("leaves homepage/license undefined when the entry omits them", () => {
+    const match = marketplaceMatch(
+      entry("plain-plugin", "acme/plain-plugin", SHA_B),
+    );
+    expect(match.homepage).toBeUndefined();
+    expect(match.license).toBeUndefined();
   });
 });
 
@@ -215,5 +246,21 @@ describe("projectMarketplaceEntries", () => {
 
   test("returns an empty list for no entries", () => {
     expect(projectMarketplaceEntries([])).toEqual([]);
+  });
+
+  test("carries homepage/license through, undefined when the entry omits them", () => {
+    const [withMeta, without] = projectMarketplaceEntries([
+      entry("calendar-sync", "acme/calendar-sync", SHA_A, {
+        homepage: "https://example.com/calendar-sync",
+        license: "MIT",
+      }),
+      entry("plain-plugin", "acme/plain-plugin", SHA_B),
+    ]);
+    expect(withMeta).toMatchObject({
+      homepage: "https://example.com/calendar-sync",
+      license: "MIT",
+    });
+    expect(without!.homepage).toBeUndefined();
+    expect(without!.license).toBeUndefined();
   });
 });

--- a/assistant/src/cli/lib/plugin-catalog-platform.ts
+++ b/assistant/src/cli/lib/plugin-catalog-platform.ts
@@ -26,8 +26,8 @@ import {
 
 /**
  * One flattened row from the platform catalog. Unknown keys (`id`,
- * `display_name`, `icon`, `homepage`, `license`) are accepted and dropped —
- * zod strips them by default.
+ * `display_name`, `icon`) are accepted and dropped — zod strips them by
+ * default.
  */
 const platformPluginRowSchema = z.object({
   name: z.string(),
@@ -36,6 +36,8 @@ const platformPluginRowSchema = z.object({
   path: z.string().nullable().optional(),
   description: z.string().optional(),
   category: z.string().nullable().optional(),
+  homepage: z.string().nullable().optional(),
+  license: z.string().nullable().optional(),
 });
 
 const platformCatalogSchema = z.object({
@@ -105,6 +107,8 @@ export async function fetchPluginCatalogFromPlatform(
       },
       description: row.description ?? undefined,
       category: row.category ?? undefined,
+      homepage: row.homepage ?? undefined,
+      license: row.license ?? undefined,
     });
   }
 

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -48,6 +48,10 @@ export interface PluginSearchMatch {
    * `productivity`), or `null` when the entry declares none.
    */
   readonly category: string | null;
+  /** Homepage URL, from the curated marketplace entry when present. */
+  readonly homepage?: string;
+  /** License identifier, from the curated marketplace entry when present. */
+  readonly license?: string;
   /** Discriminated origin, so callers can render/install accordingly. */
   readonly source: PluginMatchSource;
 }
@@ -125,6 +129,8 @@ export function marketplaceMatch(entry: MarketplaceEntry): PluginSearchMatch {
     path: locator,
     description: entry.description,
     category: entry.category ?? null,
+    homepage: entry.homepage,
+    license: entry.license,
     source: { kind: "github", repo, path, ref },
   };
 }


### PR DESCRIPTION
## Summary
- Add optional homepage/license to PluginSearchMatch and project them in marketplaceMatch.
- Capture homepage/license in the platform row schema + mapping (previously dropped); bundled reader carries them via the shared projection.

Part of plan: catalog-source-consistency.md (PR 1 of 4)