### PR TITLE
feat(plugins): add gated catalog resolvers for install source and detail lookup

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the gated catalog resolvers.
+ *
+ * `resolveSourceFromMatch` is exercised as a pure function. The catalog-backed
+ * resolvers run against the bundled manifest with platform features disabled
+ * (`VELLUM_DISABLE_PLATFORM`, zero network), plus a platform-enabled case that
+ * asserts a rejecting catalog fetch propagates rather than resolving to `null`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { FetchLike } from "../fetch-like.js";
+import { invalidatePluginCatalogCache } from "../plugin-catalog-cache.js";
+import {
+  findCatalogEntry,
+  resolvePluginSourceFromCatalog,
+  resolveSourceFromMatch,
+} from "../plugin-catalog-resolve.js";
+import type { PluginSearchMatch, SearchPluginsDeps } from "../search-plugins.js";
+import { PluginCatalogUnavailableError } from "../search-plugins.js";
+
+const FULL_SHA = "63a91ecadbf4c4719a4602a5abb00883f9966034";
+
+/** A synthetic catalog match with an overridable source. */
+function match(
+  source: Partial<PluginSearchMatch["source"]> = {},
+): PluginSearchMatch {
+  return {
+    name: "example",
+    path: "github:acme/example@ref",
+    category: null,
+    source: { kind: "github", repo: "acme/example", ref: FULL_SHA, ...source },
+  };
+}
+
+describe("resolveSourceFromMatch", () => {
+  test("returns owner/repo/path/ref for a full-SHA match", () => {
+    expect(
+      resolveSourceFromMatch(match({ repo: "acme/widget", path: "pkg/plugin" })),
+    ).toEqual({
+      owner: "acme",
+      repo: "widget",
+      path: "pkg/plugin",
+      ref: FULL_SHA,
+    });
+  });
+
+  test("defaults path to \"\" when the source declares none", () => {
+    expect(resolveSourceFromMatch(match())).toEqual({
+      owner: "acme",
+      repo: "example",
+      path: "",
+      ref: FULL_SHA,
+    });
+  });
+
+  test.each([
+    ["a branch", "main"],
+    ["a tag", "v1.2.3"],
+    ["a short SHA", "63a91ec"],
+  ])("throws on %s ref", (_label, ref) => {
+    expect(() => resolveSourceFromMatch(match({ ref }))).toThrow();
+  });
+});
+
+describe("catalog-backed resolvers (bundled, offline)", () => {
+  const ORIGINAL_ENV = {
+    IS_PLATFORM: process.env.IS_PLATFORM,
+    VELLUM_DISABLE_PLATFORM: process.env.VELLUM_DISABLE_PLATFORM,
+  };
+
+  beforeEach(() => {
+    invalidatePluginCatalogCache();
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    delete process.env.IS_PLATFORM;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+      if (value === undefined) {delete process.env[key];}
+      else {process.env[key] = value;}
+    }
+  });
+
+  // A rejecting fetch proves the bundled path never touches the network.
+  const rejectingDeps: SearchPluginsDeps = {
+    fetch: (async () => {
+      throw new Error("network must not be used");
+    }) as FetchLike,
+  };
+
+  test("findCatalogEntry returns the bundled entry for a known name", async () => {
+    const entry = await findCatalogEntry("caveman", rejectingDeps);
+    expect(entry?.name).toBe("caveman");
+    expect(entry?.source).toEqual({
+      kind: "github",
+      repo: "JuliusBrussee/caveman",
+      path: undefined,
+      ref: FULL_SHA,
+    });
+  });
+
+  test("resolvePluginSourceFromCatalog resolves a known name to its pinned source", async () => {
+    expect(
+      await resolvePluginSourceFromCatalog("caveman", rejectingDeps),
+    ).toEqual({
+      owner: "JuliusBrussee",
+      repo: "caveman",
+      path: "",
+      ref: FULL_SHA,
+    });
+  });
+
+  test("resolvePluginSourceFromCatalog returns null for an unknown name", async () => {
+    expect(
+      await resolvePluginSourceFromCatalog("no-such-plugin", rejectingDeps),
+    ).toBeNull();
+  });
+});
+
+describe("catalog-backed resolvers (platform enabled)", () => {
+  const ORIGINAL_ENV = {
+    IS_PLATFORM: process.env.IS_PLATFORM,
+    VELLUM_DISABLE_PLATFORM: process.env.VELLUM_DISABLE_PLATFORM,
+  };
+
+  beforeEach(() => {
+    invalidatePluginCatalogCache();
+    delete process.env.IS_PLATFORM;
+    delete process.env.VELLUM_DISABLE_PLATFORM;
+  });
+
+  afterEach(() => {
+    invalidatePluginCatalogCache();
+    for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+      if (value === undefined) {delete process.env[key];}
+      else {process.env[key] = value;}
+    }
+  });
+
+  test("propagates PluginCatalogUnavailableError instead of resolving to null", async () => {
+    const deps: SearchPluginsDeps = {
+      fetch: (async () => {
+        throw new Error("network down");
+      }) as FetchLike,
+    };
+    const promise = resolvePluginSourceFromCatalog("caveman", deps);
+    await expect(promise).rejects.toBeInstanceOf(PluginCatalogUnavailableError);
+  });
+});

--- a/assistant/src/cli/lib/plugin-catalog-resolve.ts
+++ b/assistant/src/cli/lib/plugin-catalog-resolve.ts
@@ -1,0 +1,58 @@
+/**
+ * Gated catalog resolvers for install-by-name and the plugin detail view.
+ *
+ * The gated analogues of {@link ./plugin-marketplace}'s `resolveMarketplaceSource`
+ * / GitHub `findMarketplaceEntry`: install-by-name and the detail lookup resolve
+ * the SAME catalog `search` uses (platform-first via {@link ./plugin-catalog-cache}'s
+ * `getPluginCatalog`, bundled offline) instead of a direct GitHub
+ * `plugins/marketplace.json` fetch — so search, install, and details read one source.
+ */
+
+import { isFullCommitSha } from "./install-from-github.js";
+import { getPluginCatalog } from "./plugin-catalog-cache.js";
+import { DEFAULT_PLUGIN_REF } from "./plugin-constants.js";
+import type { ResolvedPluginSource } from "./plugin-marketplace.js";
+import type {
+  PluginSearchMatch,
+  SearchPluginsDeps,
+} from "./search-plugins.js";
+
+/** Find the catalog entry claiming {@link name}, or `null` when none does. */
+export async function findCatalogEntry(
+  name: string,
+  deps: SearchPluginsDeps,
+): Promise<PluginSearchMatch | null> {
+  const catalog = await getPluginCatalog(DEFAULT_PLUGIN_REF, deps);
+  return catalog.matches.find((m) => m.name === name) ?? null;
+}
+
+/**
+ * Project a catalog match onto concrete GitHub install coordinates.
+ *
+ * Re-asserts the install-pinning invariant the GitHub path enforces via schema:
+ * a curated install MUST pin to an immutable full commit SHA, so a non-SHA ref
+ * from an upstream catalog is a config defect and throws rather than installing
+ * mutable code. Pure — unit-testable without a catalog.
+ */
+export function resolveSourceFromMatch(
+  match: PluginSearchMatch,
+): ResolvedPluginSource {
+  const { repo, path, ref } = match.source;
+  if (!isFullCommitSha(ref)) {
+    throw new Error(
+      `Catalog entry "${match.name}" pins ref "${ref}", which is not a full commit SHA; ` +
+        `a curated install must pin to an immutable full commit SHA (tags and branches are mutable).`,
+    );
+  }
+  const [owner, repoName] = repo.split("/", 2) as [string, string];
+  return { owner, repo: repoName, path: path ?? "", ref };
+}
+
+/** Resolve {@link name} to install coordinates from the catalog, or `null`. */
+export async function resolvePluginSourceFromCatalog(
+  name: string,
+  deps: SearchPluginsDeps,
+): Promise<ResolvedPluginSource | null> {
+  const match = await findCatalogEntry(name, deps);
+  return match ? resolveSourceFromMatch(match) : null;
+}


### PR DESCRIPTION
## Summary
- Add plugin-catalog-resolve.ts: findCatalogEntry + resolveSourceFromMatch (full-SHA enforced) + resolvePluginSourceFromCatalog, the gated analogues of the GitHub marketplace resolution used by install and details.

Part of plan: catalog-source-consistency.md (PR 2 of 4)