### PR TITLE
Daemon: accept null share_analytics in owner-consent (fail closed)

### DIFF
--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -265,6 +265,28 @@ describe("VellumPlatformClient", () => {
       expect(await client!.getOwnerConsent()).toBeNull();
     });
 
+    test("null share_analytics (owner never chose) maps to false, keeping diagnostics intact", async () => {
+      globalThis.fetch = mock(
+        async () =>
+          new Response(
+            JSON.stringify({
+              share_analytics: null,
+              share_diagnostics: true,
+              share_diagnostics_accepted_version: "2026-06-18",
+            }),
+            { status: 200 },
+          ),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      const consent = await client!.getOwnerConsent();
+      expect(consent).toEqual({
+        shareAnalytics: false,
+        shareDiagnostics: true,
+        shareDiagnosticsAcceptedVersion: "2026-06-18",
+      });
+    });
+
     test("returns null on malformed body (non-boolean fields)", async () => {
       globalThis.fetch = mock(
         async () =>

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -17,6 +17,11 @@ const log = getLogger("platform-client");
 let _missingPrereqsWarned = false;
 
 export interface OwnerConsent {
+  /**
+   * The platform returns null when the owner never made an explicit
+   * analytics choice (onboarding doesn't ask); that maps to `false` here —
+   * no consent, fail closed.
+   */
   shareAnalytics: boolean;
   shareDiagnostics: boolean;
   /**
@@ -152,7 +157,8 @@ export class VellumPlatformClient {
         share_diagnostics_accepted_version?: unknown;
       };
       if (
-        typeof body.share_analytics !== "boolean" ||
+        (typeof body.share_analytics !== "boolean" &&
+          body.share_analytics !== null) ||
         typeof body.share_diagnostics !== "boolean"
       ) {
         log.debug("owner-consent body malformed — treating as unknown");
@@ -160,7 +166,7 @@ export class VellumPlatformClient {
       }
 
       return {
-        shareAnalytics: body.share_analytics,
+        shareAnalytics: body.share_analytics === true,
         shareDiagnostics: body.share_diagnostics,
         // Back-compat: an older platform that doesn't return this field yields
         // "" → fails the trace-collection version gate → fail-closed (no trace).


### PR DESCRIPTION
## Summary
- The owner-consent parser in `assistant/src/platform/client.ts` required `share_analytics` to be a boolean; a null value marked the whole body malformed, which also discarded `share_diagnostics` and silently fail-closed the diagnostics/trace gate.
- Null now parses as "owner never chose" and maps to `shareAnalytics: false` (no consent → fail closed), leaving the diagnostics fields intact.
- Companion to platform PR vellum-ai/vellum-assistant-platform#9032. After review feedback there, the owner-consent endpoint keeps `share_analytics` as a strict boolean (null coerced to false server-side, plus an additive `share_analytics_chosen` field), so this PR is now **defensive hardening** rather than release-order-critical: no released daemon will actually receive null from that endpoint.

## Original prompt
Part of the onboarding-analytics-consent work (web PR #37912): onboarding no longer asks for analytics consent, so the platform keeps `share_analytics` null until the user makes an explicit choice. The daemon should tolerate a null wire value instead of rejecting the entire owner-consent body.

Release order requirement lives between the other two PRs: platform #9032 must deploy before web #37912.