### PR TITLE
fix(cli): provider-inference drift for openai/gpt-5.6 models

### DIFF
--- a/cli/src/lib/provider-secrets.ts
+++ b/cli/src/lib/provider-secrets.ts
@@ -176,6 +176,11 @@ export function inferProviderFromModel(model: string): string | undefined {
   if (model.startsWith("accounts/fireworks/models/")) {
     return "fireworks";
   }
+  if (model.startsWith("openai/gpt-5.6")) {
+    // Listed by OpenRouter (#37856), the earlier catalog entry; the Vercel
+    // AI Gateway does not carry these IDs.
+    return "openrouter";
+  }
   if (model.startsWith("openai/") || model.startsWith("xai/")) {
     return "vercel-ai-gateway";
   }


### PR DESCRIPTION
Pre-existing breakage on main, extracted from #37921 so it doesn't wait on speech review: #37856 listed `openai/gpt-5.6-*` under OpenRouter (the earlier catalog entry) without updating the CLI's `inferProviderFromModel` heuristic. The parity drift-guard (`cli/src/__tests__/provider-inference-parity.test.ts`) catches this, but the CLI-scoped CI job only runs when `cli/` changes — #37856 didn't touch `cli/`, so main's CLI job has been silently red since. Any PR touching `cli/` currently fails CI on it.

Fix mirrors first-catalog-provider semantics: `openai/gpt-5.6*` resolves to `openrouter`; all other `openai/*` and `xai/*` IDs stay on `vercel-ai-gateway` (which does not carry the gpt-5.6 IDs).

Once this merges, #37921 will be rebased to drop its copy of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->