### PR TITLE
feat(gateway): merge_contacts IPC route over the existing gateway merge core

### DIFF
--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -988,6 +988,207 @@ describe("IPC contact routes", () => {
     });
   });
 
+  // ── merge_contacts (gateway-native merge over IPC) ─────────────────────
+  describe("merge_contacts", () => {
+    /**
+     * Insert a donor contact with one channel duplicating the survivor's
+     * (by (type, address COLLATE NOCASE)) and one unique channel.
+     */
+    function seedDonor(): void {
+      const db = getGatewayDb();
+      const now = Date.now();
+      db.insert(contacts)
+        .values({
+          id: "c3",
+          displayName: "Donor Contact",
+          role: "contact",
+          principalId: null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+      db.insert(contactChannels)
+        .values([
+          {
+            // Case-variant duplicate of c2's ch3 (email test@example.com):
+            // must be dup-skipped, then cascade-deleted with the donor.
+            id: "ch_dup",
+            contactId: "c3",
+            type: "email",
+            address: "TEST@Example.com",
+            isPrimary: true,
+            externalChatId: null,
+            status: "active",
+            policy: "allow",
+            interactionCount: 2,
+            createdAt: now,
+          },
+          {
+            id: "ch_uniq",
+            contactId: "c3",
+            type: "telegram",
+            address: "tg-donor-001",
+            isPrimary: false,
+            externalChatId: "chat-donor-001",
+            status: "active",
+            policy: "allow",
+            interactionCount: 4,
+            createdAt: now,
+          },
+        ])
+        .run();
+    }
+
+    test("merges over the socket: donor deleted, channels reparented with NOCASE dup-skip", async () => {
+      seedTestData();
+      seedDonor();
+
+      const ipcCalls: { method: string; body?: Record<string, unknown> }[] = [];
+      ipcCallAssistantMock = mock(async (method, params) => {
+        ipcCalls.push({
+          method,
+          body: params?.body as Record<string, unknown> | undefined,
+        });
+        return {};
+      });
+
+      await startServerAndConnect();
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "c2",
+        mergeId: "c3",
+      });
+
+      expect(res.error).toBeUndefined();
+      const body = res.result as {
+        ok: boolean;
+        contact: {
+          id: string;
+          displayName: string;
+          channels: { id: string; address: string; externalUserId: string }[];
+        };
+      };
+      expect(body.ok).toBe(true);
+      // Survivor payload matches the HTTP handler's toContactPayload shape,
+      // including the externalUserId = address channel compat field.
+      expect(body.contact.id).toBe("c2");
+      expect(body.contact.displayName).toBe("Test Contact");
+      expect(body.contact.channels.map((ch) => ch.id).sort()).toEqual([
+        "ch3",
+        "ch_uniq",
+      ]);
+      for (const ch of body.contact.channels) {
+        expect(ch.externalUserId).toBe(ch.address);
+      }
+
+      // Gateway DB: donor row gone, unique channel reparented, duplicate
+      // channel cascade-deleted with the donor.
+      const db = getGatewayDb();
+      const store = new ContactStore(db);
+      expect(store.getContact("c3")).toBeUndefined();
+      const uniq = db
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch_uniq"))
+        .get();
+      expect(uniq?.contactId).toBe("c2");
+      const dup = db
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch_dup"))
+        .get();
+      expect(dup).toBeUndefined();
+      // The survivor keeps its original casing of the shared address.
+      const kept = db
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(kept?.contactId).toBe("c2");
+      expect(kept?.address).toBe("test@example.com");
+
+      // Exactly one assistant mirror op, plus the contacts_changed emit.
+      const mirror = ipcCalls.filter(
+        (c) => c.method === "contacts_mirror_merge_contact",
+      );
+      expect(mirror).toHaveLength(1);
+      expect(mirror[0].body!.keepContactId).toBe("c2");
+      expect(mirror[0].body!.mergeContactId).toBe("c3");
+      const emits = ipcCalls.filter((c) => c.method === "emit_event");
+      expect(emits).toHaveLength(1);
+      expect(emits[0].body!.kind).toBe("contacts_changed");
+    });
+
+    test("self-merge is rejected with the 400-shaped wire error", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "c2",
+        mergeId: "c2",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("MERGE_CONTACTS_INVALID");
+      expect(res.error).toMatch(/itself/);
+    });
+
+    test("unknown contact is rejected with the 400-shaped wire error", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "does-not-exist",
+        mergeId: "c2",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("MERGE_CONTACTS_INVALID");
+      expect(res.error).toMatch(/not found/);
+    });
+
+    test("guardian donor is rejected and left untouched", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "c2",
+        mergeId: "c1",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("MERGE_CONTACTS_INVALID");
+      expect(res.error).toMatch(/guardian/);
+
+      const store = new ContactStore(getGatewayDb());
+      expect(store.getContact("c1")).toBeDefined();
+      expect(store.getChannelsForContact("c1")).toHaveLength(2);
+    });
+
+    test("missing params are rejected by the schema", async () => {
+      await startServerAndConnect();
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "c2",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.error).toContain("Invalid params");
+    });
+
+    test("empty-string params are rejected by the schema", async () => {
+      await startServerAndConnect();
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "",
+        mergeId: "c2",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.error).toContain("Invalid params");
+    });
+  });
+
   // ── Rich reads (contacts_list_rich / contacts_get_rich) ─────────────────
   //
   // The assistant DB proxy is not available in this test harness, so the rich

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1817,9 +1817,13 @@ export class CannotDowngradeGuardianError extends Error {
 
 /**
  * Thrown by `mergeContacts` for validation errors (self-merge, contact not
- * found). The caller maps this to HTTP 400.
+ * found, guardian donor). The HTTP handler maps this to a 400; the gateway
+ * IPC server mirrors `statusCode`/`code` into the wire envelope.
  */
 export class MergeContactsError extends Error {
+  readonly statusCode = 400;
+  readonly code = "MERGE_CONTACTS_INVALID";
+
   constructor(message: string) {
     super(message);
     this.name = "MergeContactsError";

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -764,6 +764,40 @@ export async function updateContactChannelCore(params: {
 }
 
 /**
+ * Transport-agnostic contact merge.
+ *
+ * Shared by the HTTP `handleMergeContacts` and the gateway IPC
+ * `merge_contacts` route. Runs `ContactStore.mergeContacts` (gateway DB
+ * transaction + best-effort assistant mirror), emits `contacts_changed`, and
+ * returns the survivor contact payload.
+ *
+ * Throws `MergeContactsError` (statusCode 400, code MERGE_CONTACTS_INVALID)
+ * for validation failures (self-merge, contact not found, guardian donor).
+ * The HTTP handler maps it to a 400; the IPC server mirrors `statusCode`/
+ * `code` into the wire envelope. Unexpected errors propagate so each
+ * transport surfaces a 500-equivalent — never a silent fallback.
+ */
+export async function mergeContactsCore(params: {
+  keepId: string;
+  mergeId: string;
+}): Promise<{ ok: true; contact?: Record<string, unknown> }> {
+  const { keepId, mergeId } = params;
+  const store = new ContactStore();
+  const contact = await store.mergeContacts(keepId, mergeId);
+
+  // Emit contacts_changed so connected clients refresh.
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
+
+  log.info({ keepId, mergeId }, "merge_contacts: handled natively");
+  return {
+    ok: true,
+    contact: contact ? toContactPayload(contact) : undefined,
+  };
+}
+
+/**
  * Validate that metadata matches the expected shape for the given species.
  * Mirrors `validateSpeciesMetadata` in `assistant/src/contacts/contact-store.ts`.
  */
@@ -1544,19 +1578,8 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       }
 
       try {
-        const store = new ContactStore();
-        const contact = await store.mergeContacts(keepId, mergeId);
-
-        // Emit contacts_changed so connected clients refresh.
-        void ipcCallAssistant("emit_event", {
-          body: { kind: "contacts_changed" },
-        } as unknown as Record<string, unknown>).catch(() => {});
-
-        log.info({ keepId, mergeId }, "merge_contacts: handled natively");
-        return Response.json({
-          ok: true,
-          contact: contact ? toContactPayload(contact) : undefined,
-        });
+        const result = await mergeContactsCore({ keepId, mergeId });
+        return Response.json(result);
       } catch (err) {
         if (err instanceof MergeContactsError) {
           return Response.json(

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -14,6 +14,7 @@ import {
   ListContactsIpcParamsSchema,
   MarkChannelRevokedIpcParamsSchema,
   MarkChannelRevokedIpcResponseSchema,
+  MergeContactsIpcParamsSchema,
   UpdateContactChannelIpcParamsSchema,
   UpsertVerifiedChannelIpcParamsSchema,
   UpsertVerifiedChannelIpcResponseSchema,
@@ -21,7 +22,10 @@ import {
 import { z } from "zod";
 
 import { ContactStore } from "../db/contact-store.js";
-import { updateContactChannelCore } from "../http/routes/contacts-control-plane-proxy.js";
+import {
+  mergeContactsCore,
+  updateContactChannelCore,
+} from "../http/routes/contacts-control-plane-proxy.js";
 import { getLogger } from "../logger.js";
 import {
   getGatewayChannelByKey,
@@ -204,6 +208,17 @@ export const contactRoutes: IpcRoute[] = [
       // server's buildErrorResponse mirrors into the wire envelope; unexpected
       // errors propagate as a generic IPC error (no fallback).
       return updateContactChannelCore(parsed);
+    },
+  },
+  {
+    method: "merge_contacts",
+    schema: MergeContactsIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const parsed = MergeContactsIpcParamsSchema.parse(params);
+      // Thrown MergeContactsError carries statusCode/code, which the IPC
+      // server's buildErrorResponse mirrors into the wire envelope; unexpected
+      // errors propagate as a generic IPC error (no fallback).
+      return mergeContactsCore(parsed);
     },
   },
   {

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -108,6 +108,26 @@ export type UpdateContactChannelIpcResponse = z.infer<
   typeof UpdateContactChannelIpcResponseSchema
 >;
 
+export const MergeContactsIpcParamsSchema = z.object({
+  keepId: z.string().min(1),
+  mergeId: z.string().min(1),
+});
+
+export type MergeContactsIpcParams = z.infer<
+  typeof MergeContactsIpcParamsSchema
+>;
+
+export const MergeContactsIpcResponseSchema = z.object({
+  ok: z.literal(true),
+  // The gateway-native handler owns the full contact payload shape; pass it
+  // through verbatim rather than re-declaring channel fields here.
+  contact: z.object({}).passthrough().optional(),
+});
+
+export type MergeContactsIpcResponse = z.infer<
+  typeof MergeContactsIpcResponseSchema
+>;
+
 export const MarkChannelVerifiedIpcParamsSchema = z.object({
   contactChannelId: z.string().min(1),
   // Audit source for the verification. CLI/session-driven verifications


### PR DESCRIPTION
## Summary
- Adds MergeContacts IPC contract schemas to packages/gateway-client (modeled on UpdateContactChannel)
- MergeContactsError now carries statusCode 400 + code MERGE_CONTACTS_INVALID so IPC and HTTP surface it identically
- New merge_contacts route in gateway/src/ipc/contact-handlers.ts over the existing ContactStore.mergeContacts core (transaction + assistant mirror + skew telemetry unchanged)

Part of plan: contact-merge-relay.md (PR 1 of 2)