### PR TITLE
feat(telemetry): backfill telemetry_events from legacy tables, drop them, purge their watermarks

### DIFF
--- a/assistant/src/persistence/__tests__/main-db-readonly-probe.ts
+++ b/assistant/src/persistence/__tests__/main-db-readonly-probe.ts
@@ -22,7 +22,7 @@ import {
 } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
 import { queryUnreportedUsageEvents } from "../llm-usage-store.js";
-import { configSettingEvents, memoryCheckpoints } from "../schema/index.js";
+import { memoryCheckpoints, telemetryEvents } from "../schema/index.js";
 
 // Create the schema over the normal read-write connections, then reopen
 // with the monitor's posture: telemetry main-DB reads go through the
@@ -67,12 +67,13 @@ if (!telemetryDb) {
   throw new Error("telemetry DB unavailable");
 }
 telemetryDb
-  .insert(configSettingEvents)
+  .insert(telemetryEvents)
   .values({
     id: "readonly-probe-row",
+    name: "config_setting",
     createdAt: Date.now(),
-    configKey: "memory.enabled",
-    configValue: "true",
+    conversationId: null,
+    payload: '{"type":"config_setting"}',
   })
   .run();
 

--- a/assistant/src/persistence/db-connection.ts
+++ b/assistant/src/persistence/db-connection.ts
@@ -278,8 +278,9 @@ export function getMemorySqlite(): Database | null {
 
 /**
  * The telemetry database (`assistant-telemetry.db`), opened lazily as its own
- * connection. Houses the telemetry-only event tables (see
- * `util/telemetry-db-path.ts` for the list).
+ * connection. Houses the `telemetry_events` outbox (wire payloads recorded at
+ * emit time, deleted on successful flush) and `flush_checkpoints` (watermark
+ * cursors for the main-DB-backed telemetry sources).
  * Returns `null` if the file cannot be opened (logged; the daemon stays up).
  */
 export function getTelemetryDb(): DrizzleDb | null {

--- a/assistant/src/persistence/migrations/329-move-onboarding-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/329-move-onboarding-events-to-telemetry-db.test.ts
@@ -1,12 +1,15 @@
 /**
  * Tests for migration 329: relocating `onboarding_events` from the main DB
- * into the dedicated telemetry database (`assistant-telemetry.db`).
+ * into the dedicated telemetry database (`assistant-telemetry.db`), covered
+ * as the head of the full pipeline — migration 334 then backfills the
+ * relocated rows into the generic `telemetry_events` outbox and drops the
+ * telemetry-side table.
  *
  * Runs against real workspace databases (`initializeDb()`) because the drain
  * engine dispatches batches via `runAsyncSqlite` against the workspace's main
- * DB file. `initializeDb()` already ran migration 329 once (dropping the empty
- * main-side table created by migration 248), so each test recreates the
- * pre-move source table in `main` to simulate an upgrading install.
+ * DB file. `initializeDb()` already ran the pipeline once, so each test
+ * recreates the pre-move source table in `main` to simulate an upgrading
+ * install, then runs 329 + 334 directly.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -15,6 +18,8 @@ const { getDb, getSqlite, getTelemetrySqlite } =
 const { initializeDb } = await import("../db-init.js");
 const { migrateMoveOnboardingEventsToTelemetryDb } =
   await import("./329-move-onboarding-events-to-telemetry-db.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
 
 await initializeDb();
 
@@ -25,22 +30,19 @@ const SOURCE_COLUMNS = `
   session_id TEXT, step_name TEXT, step_index INTEGER, completed_at TEXT,
   funnel_version TEXT`;
 
-/** Relocated rows in the telemetry-side table, in `(created_at, id)` order. */
-function telemetryOnboardingRows(): Array<{
+/** Backfilled outbox rows for the onboarding source, in `(created_at, id)` order. */
+function outboxOnboardingRows(): Array<{
   id: string;
-  step_name: string | null;
-  step_index: number | null;
+  payload: Record<string, unknown>;
 }> {
-  return getTelemetrySqlite()!
-    .query(
-      `SELECT id, step_name, step_index FROM onboarding_events
-       ORDER BY created_at, id`,
-    )
-    .all() as Array<{
-    id: string;
-    step_name: string | null;
-    step_index: number | null;
-  }>;
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id, payload FROM telemetry_events
+         WHERE name = 'onboarding' ORDER BY created_at, id`,
+      )
+      .all() as Array<{ id: string; payload: string }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
 }
 
 function existsInMain(name: string): boolean {
@@ -53,8 +55,22 @@ function existsInMain(name: string): boolean {
   );
 }
 
+function existsInTelemetry(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
 function resetState(): void {
-  getTelemetrySqlite()!.exec(`DELETE FROM onboarding_events`);
+  getTelemetrySqlite()!.exec(`DROP TABLE IF EXISTS onboarding_events`);
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM telemetry_events WHERE name = 'onboarding'`,
+  );
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM flush_checkpoints WHERE key LIKE 'telemetry:onboarding:%'`,
+  );
   getSqlite().exec(`DROP TABLE IF EXISTS main.onboarding_events`);
   getSqlite().exec(`DROP TABLE IF EXISTS main."onboarding_events__relocating"`);
 }
@@ -64,10 +80,10 @@ function seedSourceTable(): void {
   sqlite.exec(`CREATE TABLE main.onboarding_events (${SOURCE_COLUMNS})`);
   const insert = sqlite.prepare(
     `INSERT INTO main.onboarding_events
-       (id, created_at, screen, session_id, step_name, step_index)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+       (id, created_at, screen, session_id, step_name, step_index, funnel_version)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   );
-  insert.run("seed-1", 1000, "tools", "conv-1", null, null);
+  insert.run("seed-1", 1000, "tools", "conv-1", null, null, null);
   insert.run(
     "seed-2",
     2000,
@@ -75,86 +91,89 @@ function seedSourceTable(): void {
     "conv-2",
     "activation_moment_1_complete",
     1,
+    "v2",
   );
-  insert.run("seed-dupe", 3000, "tasks", "conv-3", null, null);
+  insert.run("seed-dupe", 3000, "tasks", "conv-3", null, null, null);
+}
+
+async function runPipeline(): Promise<void> {
+  await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+  migrateBackfillTelemetryEventsOutbox(getDb());
 }
 
 describe("migration 329: move onboarding_events to the telemetry DB", () => {
-  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+  test("pre-move rows land in telemetry_events and both legacy tables are gone", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
+    expect(existsInTelemetry("onboarding_events")).toBe(false);
 
-    const moved = getTelemetrySqlite()!
-      .query(`SELECT id, screen FROM onboarding_events ORDER BY id`)
-      .all();
-    expect(moved).toEqual([
-      { id: "seed-1", screen: "tools" },
-      { id: "seed-2", screen: "activation_moment_1_complete" },
-      { id: "seed-dupe", screen: "tasks" },
-    ]);
-
-    const rows = telemetryOnboardingRows();
+    const rows = outboxOnboardingRows();
     expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    expect(rows[1]!.step_name).toBe("activation_moment_1_complete");
-    expect(rows[1]!.step_index).toBe(1);
+    expect(rows[0]!.payload).toMatchObject({
+      type: "onboarding",
+      daemon_event_id: "seed-1",
+      recorded_at: 1000,
+      screen: "tools",
+      session_id: "conv-1",
+    });
+    // Activation rows carry the deterministic wire id; the outbox row id
+    // stays the original row id.
+    expect(rows[1]!.payload).toMatchObject({
+      daemon_event_id: "v2:conv-2:activation_moment_1_complete",
+      step_name: "activation_moment_1_complete",
+      step_index: 1,
+      funnel_version: "v2",
+    });
   });
 
-  test("re-running after a completed move is a no-op", async () => {
+  test("re-running the pipeline after a completed move is a no-op", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+    await runPipeline();
+    await runPipeline();
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    expect(telemetryOnboardingRows()).toHaveLength(3);
+    expect(existsInTelemetry("onboarding_events")).toBe(false);
+    expect(outboxOnboardingRows()).toHaveLength(3);
   });
 
-  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+  test("a pre-existing duplicate id in the outbox does not fail the pipeline", async () => {
     resetState();
     seedSourceTable();
 
-    // A crash between a drain batch's copy and delete re-copies the same rows
-    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    // A crash between a drain/backfill batch's copy and delete re-copies the
+    // same rows next boot; INSERT OR IGNORE must keep the already-copied row.
     getTelemetrySqlite()!.exec(
-      `INSERT INTO onboarding_events (id, created_at, screen)
-       VALUES ('seed-dupe', 3000, 'already-copied')`,
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('seed-dupe', 'onboarding', 3000, NULL, '{"type":"onboarding","screen":"already-copied"}')`,
     );
 
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    const dupe = getTelemetrySqlite()!
-      .query(`SELECT screen FROM onboarding_events WHERE id = 'seed-dupe'`)
-      .get() as { screen: string };
-    expect(dupe.screen).toBe("already-copied");
-    expect(telemetryOnboardingRows()).toHaveLength(3);
+    const rows = outboxOnboardingRows();
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === "seed-dupe")!.payload.screen).toBe(
+      "already-copied",
+    );
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
     resetState();
     getSqlite().exec(`CREATE TABLE main.onboarding_events (${SOURCE_COLUMNS})`);
 
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    expect(telemetryOnboardingRows()).toHaveLength(0);
-  });
-
-  test("telemetry-side schema has the reporter's compound cursor index", () => {
-    const indexes = (
-      getTelemetrySqlite()!
-        .query(`PRAGMA index_list(onboarding_events)`)
-        .all() as Array<{ name: string }>
-    ).map((i) => i.name);
-    expect(indexes).toContain("idx_onboarding_events_created_at_id");
+    expect(outboxOnboardingRows()).toHaveLength(0);
   });
 });

--- a/assistant/src/persistence/migrations/330-move-auth-fallback-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/330-move-auth-fallback-events-to-telemetry-db.test.ts
@@ -1,12 +1,15 @@
 /**
  * Tests for migration 330: relocating `auth_fallback_events` from the main DB
- * into the dedicated telemetry database (`assistant-telemetry.db`).
+ * into the dedicated telemetry database (`assistant-telemetry.db`), covered
+ * as the head of the full pipeline — migration 334 then backfills the
+ * relocated rows into the generic `telemetry_events` outbox and drops the
+ * telemetry-side table.
  *
  * Runs against real workspace databases (`initializeDb()`) because the drain
  * engine dispatches batches via `runAsyncSqlite` against the workspace's main
- * DB file. `initializeDb()` already ran migration 330 once (dropping the empty
- * main-side table created by migration 271), so each test recreates the
- * pre-move source table in `main` to simulate an upgrading install.
+ * DB file. `initializeDb()` already ran the pipeline once, so each test
+ * recreates the pre-move source table in `main` to simulate an upgrading
+ * install, then runs 330 + 334 directly.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -15,6 +18,8 @@ const { getDb, getSqlite, getTelemetrySqlite } =
 const { initializeDb } = await import("../db-init.js");
 const { migrateMoveAuthFallbackEventsToTelemetryDb } =
   await import("./330-move-auth-fallback-events-to-telemetry-db.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
 
 await initializeDb();
 
@@ -23,13 +28,19 @@ const SOURCE_COLUMNS = `
   path TEXT NOT NULL, failure_kind TEXT NOT NULL, count INTEGER NOT NULL,
   window_start INTEGER NOT NULL, window_end INTEGER NOT NULL`;
 
-function relocatedRows(): Array<Record<string, unknown>> {
-  return getTelemetrySqlite()!
-    .query(
-      `SELECT id, guard, path, failure_kind, count, window_start, window_end
-         FROM auth_fallback_events ORDER BY created_at, id`,
-    )
-    .all() as Array<Record<string, unknown>>;
+/** Backfilled outbox rows for the auth_fallback source, in `(created_at, id)` order. */
+function outboxAuthFallbackRows(): Array<{
+  id: string;
+  payload: Record<string, unknown>;
+}> {
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id, payload FROM telemetry_events
+         WHERE name = 'auth_fallback' ORDER BY created_at, id`,
+      )
+      .all() as Array<{ id: string; payload: string }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
 }
 
 function existsInMain(name: string): boolean {
@@ -42,8 +53,22 @@ function existsInMain(name: string): boolean {
   );
 }
 
+function existsInTelemetry(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
 function resetState(): void {
-  getTelemetrySqlite()!.exec(`DELETE FROM auth_fallback_events`);
+  getTelemetrySqlite()!.exec(`DROP TABLE IF EXISTS auth_fallback_events`);
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM telemetry_events WHERE name = 'auth_fallback'`,
+  );
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM flush_checkpoints WHERE key LIKE 'telemetry:auth_fallback:%'`,
+  );
   getSqlite().exec(`DROP TABLE IF EXISTS main.auth_fallback_events`);
   getSqlite().exec(
     `DROP TABLE IF EXISTS main."auth_fallback_events__relocating"`,
@@ -90,28 +115,28 @@ function seedSourceTable(): void {
   );
 }
 
+async function runPipeline(): Promise<void> {
+  await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+  migrateBackfillTelemetryEventsOutbox(getDb());
+}
+
 describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
-  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+  test("pre-move rows land in telemetry_events and both legacy tables are gone", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
+    expect(existsInTelemetry("auth_fallback_events")).toBe(false);
 
-    const moved = getTelemetrySqlite()!
-      .query(`SELECT id, guard FROM auth_fallback_events ORDER BY id`)
-      .all();
-    expect(moved).toEqual([
-      { id: "seed-1", guard: "edge" },
-      { id: "seed-2", guard: "edge-scoped" },
-      { id: "seed-dupe", guard: "edge-guardian" },
-    ]);
-
-    const rows = relocatedRows();
+    const rows = outboxAuthFallbackRows();
     expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    expect(rows[0]!).toMatchObject({
+    expect(rows[0]!.payload).toMatchObject({
+      type: "auth_fallback",
+      daemon_event_id: "seed-1",
+      recorded_at: 1000,
       guard: "edge",
       path: "/v1/messages",
       failure_kind: "missing_authorization",
@@ -119,41 +144,42 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
       window_start: 900,
       window_end: 1000,
     });
+    expect(rows[2]!.payload.guard).toBe("edge-guardian");
   });
 
-  test("re-running after a completed move is a no-op", async () => {
+  test("re-running the pipeline after a completed move is a no-op", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+    await runPipeline();
+    await runPipeline();
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    expect(relocatedRows()).toHaveLength(3);
+    expect(existsInTelemetry("auth_fallback_events")).toBe(false);
+    expect(outboxAuthFallbackRows()).toHaveLength(3);
   });
 
-  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+  test("a pre-existing duplicate id in the outbox does not fail the pipeline", async () => {
     resetState();
     seedSourceTable();
 
-    // A crash between a drain batch's copy and delete re-copies the same rows
-    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    // A crash between a drain/backfill batch's copy and delete re-copies the
+    // same rows next boot; INSERT OR IGNORE must keep the already-copied row.
     getTelemetrySqlite()!.exec(
-      `INSERT INTO auth_fallback_events
-         (id, created_at, guard, path, failure_kind, count, window_start, window_end)
-       VALUES ('seed-dupe', 3000, 'already-copied', '/v1/pair', 'guardian_mismatch', 1, 2900, 3000)`,
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('seed-dupe', 'auth_fallback', 3000, NULL, '{"type":"auth_fallback","guard":"already-copied"}')`,
     );
 
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    const dupe = getTelemetrySqlite()!
-      .query(`SELECT guard FROM auth_fallback_events WHERE id = 'seed-dupe'`)
-      .get() as { guard: string };
-    expect(dupe.guard).toBe("already-copied");
-    expect(relocatedRows()).toHaveLength(3);
+    const rows = outboxAuthFallbackRows();
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === "seed-dupe")!.payload.guard).toBe(
+      "already-copied",
+    );
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -162,19 +188,10 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
       `CREATE TABLE main.auth_fallback_events (${SOURCE_COLUMNS})`,
     );
 
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    expect(relocatedRows()).toHaveLength(0);
-  });
-
-  test("telemetry-side schema has the reporter's compound cursor index", () => {
-    const indexes = (
-      getTelemetrySqlite()!
-        .query(`PRAGMA index_list(auth_fallback_events)`)
-        .all() as Array<{ name: string }>
-    ).map((i) => i.name);
-    expect(indexes).toContain("idx_auth_fallback_events_created_at_id");
+    expect(outboxAuthFallbackRows()).toHaveLength(0);
   });
 });

--- a/assistant/src/persistence/migrations/331-move-lifecycle-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/331-move-lifecycle-events-to-telemetry-db.test.ts
@@ -1,12 +1,15 @@
 /**
  * Tests for migration 331: relocating `lifecycle_events` from the main DB
- * into the dedicated telemetry database (`assistant-telemetry.db`).
+ * into the dedicated telemetry database (`assistant-telemetry.db`), covered
+ * as the head of the full pipeline — migration 334 then backfills the
+ * relocated rows into the generic `telemetry_events` outbox and drops the
+ * telemetry-side table.
  *
  * Runs against real workspace databases (`initializeDb()`) because the drain
  * engine dispatches batches via `runAsyncSqlite` against the workspace's main
- * DB file. `initializeDb()` already ran migration 331 once (dropping the empty
- * main-side table created by migration 175), so each test recreates the
- * pre-move source table in `main` to simulate an upgrading install.
+ * DB file. `initializeDb()` already ran the pipeline once, so each test
+ * recreates the pre-move source table in `main` to simulate an upgrading
+ * install, then runs 331 + 334 directly.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -15,20 +18,25 @@ const { getDb, getSqlite, getTelemetrySqlite } =
 const { initializeDb } = await import("../db-init.js");
 const { migrateMoveLifecycleEventsToTelemetryDb } =
   await import("./331-move-lifecycle-events-to-telemetry-db.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
 
 await initializeDb();
 
-function telemetryLifecycleRows(): Array<{
+/** Backfilled outbox rows for the lifecycle source, in `(created_at, id)` order. */
+function outboxLifecycleRows(): Array<{
   id: string;
-  event_name: string;
   created_at: number;
+  payload: Record<string, unknown>;
 }> {
-  return getTelemetrySqlite()!
-    .query(
-      `SELECT id, event_name, created_at FROM lifecycle_events
-       ORDER BY created_at, id`,
-    )
-    .all() as Array<{ id: string; event_name: string; created_at: number }>;
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id, created_at, payload FROM telemetry_events
+         WHERE name = 'lifecycle' ORDER BY created_at, id`,
+      )
+      .all() as Array<{ id: string; created_at: number; payload: string }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
 }
 
 const SOURCE_COLUMNS = `
@@ -44,8 +52,22 @@ function existsInMain(name: string): boolean {
   );
 }
 
+function existsInTelemetry(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
 function resetState(): void {
-  getTelemetrySqlite()!.exec(`DELETE FROM lifecycle_events`);
+  getTelemetrySqlite()!.exec(`DROP TABLE IF EXISTS lifecycle_events`);
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM telemetry_events WHERE name = 'lifecycle'`,
+  );
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM flush_checkpoints WHERE key LIKE 'telemetry:lifecycle:%'`,
+  );
   getSqlite().exec(`DROP TABLE IF EXISTS main.lifecycle_events`);
   getSqlite().exec(`DROP TABLE IF EXISTS main."lifecycle_events__relocating"`);
 }
@@ -62,78 +84,76 @@ function seedSourceTable(): void {
   insert.run("seed-dupe", "conversations_clear_all", 3000);
 }
 
+async function runPipeline(): Promise<void> {
+  await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+  migrateBackfillTelemetryEventsOutbox(getDb());
+}
+
 describe("migration 331: move lifecycle_events to the telemetry DB", () => {
-  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+  test("pre-move rows land in telemetry_events and both legacy tables are gone", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
+    expect(existsInTelemetry("lifecycle_events")).toBe(false);
 
-    expect(telemetryLifecycleRows()).toEqual([
-      { id: "seed-1", event_name: "app_open", created_at: 1000 },
-      { id: "seed-2", event_name: "hatch", created_at: 2000 },
-      {
-        id: "seed-dupe",
-        event_name: "conversations_clear_all",
-        created_at: 3000,
-      },
-    ]);
+    const rows = outboxLifecycleRows();
+    expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
+    expect(rows[0]!.payload).toMatchObject({
+      type: "lifecycle",
+      daemon_event_id: "seed-1",
+      event_name: "app_open",
+      recorded_at: 1000,
+    });
+    expect(rows[2]!.payload.event_name).toBe("conversations_clear_all");
   });
 
-  test("re-running after a completed move is a no-op", async () => {
+  test("re-running the pipeline after a completed move is a no-op", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+    await runPipeline();
+    await runPipeline();
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    expect(telemetryLifecycleRows()).toHaveLength(3);
+    expect(existsInTelemetry("lifecycle_events")).toBe(false);
+    expect(outboxLifecycleRows()).toHaveLength(3);
   });
 
-  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+  test("a pre-existing duplicate id in the outbox does not fail the pipeline", async () => {
     resetState();
     seedSourceTable();
 
-    // A crash between a drain batch's copy and delete re-copies the same rows
-    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    // A crash between a drain/backfill batch's copy and delete re-copies the
+    // same rows next boot; INSERT OR IGNORE must keep the already-copied row.
     getTelemetrySqlite()!.exec(
-      `INSERT INTO lifecycle_events (id, event_name, created_at)
-       VALUES ('seed-dupe', 'already-copied', 3000)`,
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('seed-dupe', 'lifecycle', 3000, NULL, '{"type":"lifecycle","event_name":"already-copied"}')`,
     );
 
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    const dupe = getTelemetrySqlite()!
-      .query(`SELECT event_name FROM lifecycle_events WHERE id = 'seed-dupe'`)
-      .get() as { event_name: string };
-    expect(dupe.event_name).toBe("already-copied");
-    expect(telemetryLifecycleRows()).toHaveLength(3);
+    const rows = outboxLifecycleRows();
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === "seed-dupe")!.payload.event_name).toBe(
+      "already-copied",
+    );
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
     resetState();
     getSqlite().exec(`CREATE TABLE main.lifecycle_events (${SOURCE_COLUMNS})`);
 
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    expect(telemetryLifecycleRows()).toHaveLength(0);
-  });
-
-  test("telemetry-side schema has the reporter's compound cursor index", () => {
-    const indexes = (
-      getTelemetrySqlite()!
-        .query(`PRAGMA index_list(lifecycle_events)`)
-        .all() as Array<{ name: string }>
-    ).map((i) => i.name);
-    expect(indexes).toContain("idx_lifecycle_events_created_at_id");
+    expect(outboxLifecycleRows()).toHaveLength(0);
   });
 });

--- a/assistant/src/persistence/migrations/332-move-skill-loaded-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/332-move-skill-loaded-events-to-telemetry-db.test.ts
@@ -1,12 +1,16 @@
 /**
  * Tests for migration 332: relocating `skill_loaded_events` from the main DB
- * into the dedicated telemetry database (`assistant-telemetry.db`).
+ * into the dedicated telemetry database (`assistant-telemetry.db`), covered
+ * as the head of the full pipeline — migration 334 then backfills the
+ * relocated rows into the generic `telemetry_events` outbox (with the
+ * conversation id in its dedicated column) and drops the telemetry-side
+ * table.
  *
  * Runs against real workspace databases (`initializeDb()`) because the drain
  * engine dispatches batches via `runAsyncSqlite` against the workspace's main
- * DB file. `initializeDb()` already ran migration 332 once (dropping the empty
- * main-side table created by migration 279), so each test recreates the
- * pre-move source table in `main` to simulate an upgrading install.
+ * DB file. `initializeDb()` already ran the pipeline once, so each test
+ * recreates the pre-move source table in `main` to simulate an upgrading
+ * install, then runs 332 + 334 directly.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -15,24 +19,35 @@ const { getDb, getSqlite, getTelemetrySqlite } =
 const { initializeDb } = await import("../db-init.js");
 const { migrateMoveSkillLoadedEventsToTelemetryDb } =
   await import("./332-move-skill-loaded-events-to-telemetry-db.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
 
 await initializeDb();
-
-/** Telemetry-side rows in the reporter's `(created_at, id)` order. */
-function telemetrySkillRowIds(): string[] {
-  return (
-    getTelemetrySqlite()!
-      .query(
-        `SELECT id FROM skill_loaded_events ORDER BY created_at ASC, id ASC`,
-      )
-      .all() as Array<{ id: string }>
-  ).map((r) => r.id);
-}
 
 const SOURCE_COLUMNS = `
   id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, conversation_id TEXT,
   skill_name TEXT NOT NULL, skill_updated_at TEXT, provider TEXT, model TEXT,
   inference_profile TEXT, inference_profile_source TEXT`;
+
+/** Backfilled outbox rows for the skill_loaded source, in `(created_at, id)` order. */
+function outboxSkillRows(): Array<{
+  id: string;
+  conversation_id: string | null;
+  payload: Record<string, unknown>;
+}> {
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id, conversation_id, payload FROM telemetry_events
+         WHERE name = 'skill_loaded' ORDER BY created_at, id`,
+      )
+      .all() as Array<{
+      id: string;
+      conversation_id: string | null;
+      payload: string;
+    }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
+}
 
 function existsInMain(name: string): boolean {
   return (
@@ -44,8 +59,22 @@ function existsInMain(name: string): boolean {
   );
 }
 
+function existsInTelemetry(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
 function resetState(): void {
-  getTelemetrySqlite()!.exec(`DELETE FROM skill_loaded_events`);
+  getTelemetrySqlite()!.exec(`DROP TABLE IF EXISTS skill_loaded_events`);
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM telemetry_events WHERE name = 'skill_loaded'`,
+  );
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM flush_checkpoints WHERE key LIKE 'telemetry:skill_loaded:%'`,
+  );
   getSqlite().exec(`DROP TABLE IF EXISTS main.skill_loaded_events`);
   getSqlite().exec(
     `DROP TABLE IF EXISTS main."skill_loaded_events__relocating"`,
@@ -78,38 +107,37 @@ function seedSourceTable(): void {
   insert.run("seed-dupe", 3000, "conv-b", "calendar");
 }
 
+async function runPipeline(): Promise<void> {
+  await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+  migrateBackfillTelemetryEventsOutbox(getDb());
+}
+
 describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
-  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+  test("pre-move rows land in telemetry_events with the conversation id column; both legacy tables are gone", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
+    expect(existsInTelemetry("skill_loaded_events")).toBe(false);
 
-    const moved = getTelemetrySqlite()!
-      .query(
-        `SELECT id, skill_name, conversation_id FROM skill_loaded_events ORDER BY id`,
-      )
-      .all();
-    expect(moved).toEqual([
-      { id: "seed-1", skill_name: "web-research", conversation_id: "conv-a" },
-      { id: "seed-2", skill_name: "tasks", conversation_id: null },
-      { id: "seed-dupe", skill_name: "calendar", conversation_id: "conv-b" },
+    const rows = outboxSkillRows();
+    expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
+    expect(rows.map((r) => r.conversation_id)).toEqual([
+      "conv-a",
+      null,
+      "conv-b",
     ]);
-
-    // Every column relocates intact.
-    expect(telemetrySkillRowIds()).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    const first = getTelemetrySqlite()!
-      .query(`SELECT * FROM skill_loaded_events WHERE id = 'seed-1'`)
-      .get();
-    expect(first).toEqual({
-      id: "seed-1",
-      created_at: 1000,
-      conversation_id: "conv-a",
+    // Every column reaches the wire payload intact.
+    expect(rows[0]!.payload).toMatchObject({
+      type: "skill_loaded",
+      daemon_event_id: "seed-1",
+      recorded_at: 1000,
       skill_name: "web-research",
       skill_updated_at: null,
+      conversation_id: "conv-a",
       provider: null,
       model: null,
       inference_profile: null,
@@ -117,40 +145,39 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
     });
   });
 
-  test("re-running after a completed move is a no-op", async () => {
+  test("re-running the pipeline after a completed move is a no-op", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    expect(telemetrySkillRowIds()).toHaveLength(3);
+    expect(existsInTelemetry("skill_loaded_events")).toBe(false);
+    expect(outboxSkillRows()).toHaveLength(3);
   });
 
-  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+  test("a pre-existing duplicate id in the outbox does not fail the pipeline", async () => {
     resetState();
     seedSourceTable();
 
-    // A crash between a drain batch's copy and delete re-copies the same rows
-    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    // A crash between a drain/backfill batch's copy and delete re-copies the
+    // same rows next boot; INSERT OR IGNORE must keep the already-copied row.
     getTelemetrySqlite()!.exec(
-      `INSERT INTO skill_loaded_events (id, created_at, skill_name)
-       VALUES ('seed-dupe', 3000, 'already-copied')`,
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('seed-dupe', 'skill_loaded', 3000, 'conv-b', '{"type":"skill_loaded","skill_name":"already-copied"}')`,
     );
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    const dupe = getTelemetrySqlite()!
-      .query(
-        `SELECT skill_name FROM skill_loaded_events WHERE id = 'seed-dupe'`,
-      )
-      .get() as { skill_name: string };
-    expect(dupe.skill_name).toBe("already-copied");
-    expect(telemetrySkillRowIds()).toHaveLength(3);
+    const rows = outboxSkillRows();
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === "seed-dupe")!.payload.skill_name).toBe(
+      "already-copied",
+    );
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -159,11 +186,11 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
       `CREATE TABLE main.skill_loaded_events (${SOURCE_COLUMNS})`,
     );
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    expect(telemetrySkillRowIds()).toHaveLength(0);
+    expect(outboxSkillRows()).toHaveLength(0);
   });
 
   test("the drain purges rows whose conversation no longer exists (redaction across boots)", async () => {
@@ -182,24 +209,11 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
     // itself must purge this row rather than resurrect it.
     insert.run("dead-1", 3000, "conv-deleted", "calendar");
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
 
-    expect(telemetrySkillRowIds()).toEqual(["live-1", "null-1"]);
-    const dead = getTelemetrySqlite()!
-      .query(`SELECT 1 FROM skill_loaded_events WHERE id = 'dead-1'`)
-      .get();
-    expect(dead).toBeNull();
-  });
-
-  test("telemetry-side schema has the compound cursor index", () => {
-    const indexes = (
-      getTelemetrySqlite()!
-        .query(`PRAGMA index_list(skill_loaded_events)`)
-        .all() as Array<{ name: string }>
-    ).map((i) => i.name);
-    expect(indexes).toContain("idx_skill_loaded_events_created_at_id");
+    expect(outboxSkillRows().map((r) => r.id)).toEqual(["live-1", "null-1"]);
   });
 });

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.test.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.test.ts
@@ -11,7 +11,8 @@
  */
 import { describe, expect, test } from "bun:test";
 
-const { getDb, getTelemetrySqlite } = await import("../db-connection.js");
+const { getDb, getSqlite, getTelemetrySqlite } =
+  await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
 const { migrateBackfillTelemetryEventsOutbox } =
   await import("./334-backfill-telemetry-events-outbox.js");
@@ -394,9 +395,19 @@ describe("migration 334: backfill telemetry_events from the legacy tables", () =
     });
   });
 
-  test("skill_loaded rows carry conversation_id in the dedicated column", () => {
+  test("skill_loaded: live/NULL-conversation rows backfill with conversation_id; redacted-conversation rows do not", () => {
     resetState();
     createLegacyTable("skill_loaded_events");
+    // Live conversation in the main DB; "conv-redacted" deliberately absent —
+    // its rows must not be resurrected by the backfill.
+    getSqlite().exec(
+      `DELETE FROM conversations WHERE id IN ('conv-a', 'conv-redacted')`,
+    );
+    getSqlite()
+      .prepare(
+        `INSERT INTO conversations (id, created_at, updated_at) VALUES (?, 0, 0)`,
+      )
+      .run("conv-a");
     const insert = telemetry().prepare(
       `INSERT INTO skill_loaded_events
          (id, created_at, conversation_id, skill_name, skill_updated_at,
@@ -415,11 +426,24 @@ describe("migration 334: backfill telemetry_events from the legacy tables", () =
       "mix",
     );
     insert.run("sk-2", 2000, null, "tasks", null, null, null, null, null);
+    insert.run(
+      "sk-dead",
+      3000,
+      "conv-redacted",
+      "calendar",
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
 
     migrateBackfillTelemetryEventsOutbox(getDb());
 
     const rows = outboxRows("skill_loaded");
+    expect(rows.map((r) => r.id)).toEqual(["sk-1", "sk-2"]);
     expect(rows.map((r) => r.conversation_id)).toEqual(["conv-a", null]);
+    expect(tableExists("skill_loaded_events")).toBe(false);
     expect(rows[0]!.payload).toEqual({
       type: "skill_loaded",
       daemon_event_id: "sk-1",

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.test.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.test.ts
@@ -514,6 +514,56 @@ describe("migration 334: backfill telemetry_events from the legacy tables", () =
     expect(watermarkKeyCount()).toBe(0);
   });
 
+  test("a main-side __relocating staging table defers the backfill: throws, drops nothing, purges no watermarks", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    telemetry().exec(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES ('l-1', 'hatch', 1000)`,
+    );
+    setWatermark("lifecycle", 500);
+    getSqlite().exec(
+      `CREATE TABLE main."skill_loaded_events__relocating" (id TEXT PRIMARY KEY)`,
+    );
+
+    try {
+      expect(() => migrateBackfillTelemetryEventsOutbox(getDb())).toThrow(
+        "legacy telemetry relocations incomplete",
+      );
+      expect(tableExists("lifecycle_events")).toBe(true);
+      expect(outboxRows("lifecycle")).toHaveLength(0);
+      expect(watermarkKeyCount()).toBe(1);
+    } finally {
+      getSqlite().exec(
+        `DROP TABLE IF EXISTS main."skill_loaded_events__relocating"`,
+      );
+    }
+
+    // Staging table gone (relocation completed) → the retried step succeeds.
+    migrateBackfillTelemetryEventsOutbox(getDb());
+    expect(tableExists("lifecycle_events")).toBe(false);
+    expect(outboxRows("lifecycle")).toHaveLength(1);
+    expect(watermarkKeyCount()).toBe(0);
+  });
+
+  test("a main-side legacy table (relocation not yet run) defers the backfill", () => {
+    resetState();
+    createLegacyTable("watchdog_events");
+    setWatermark("watchdog", 500);
+    getSqlite().exec(
+      `CREATE TABLE main.onboarding_events (id TEXT PRIMARY KEY)`,
+    );
+
+    try {
+      expect(() => migrateBackfillTelemetryEventsOutbox(getDb())).toThrow(
+        "legacy telemetry relocations incomplete",
+      );
+      expect(tableExists("watchdog_events")).toBe(true);
+      expect(watermarkKeyCount()).toBe(1);
+    } finally {
+      getSqlite().exec(`DROP TABLE IF EXISTS main.onboarding_events`);
+    }
+  });
+
   test("a pre-existing outbox row with the same id survives (INSERT OR IGNORE)", () => {
     resetState();
     createLegacyTable("lifecycle_events");

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.test.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Tests for migration 334: backfilling unshipped rows from the six legacy
+ * per-type telemetry tables into the generic `telemetry_events` outbox,
+ * dropping the legacy tables, and purging their `flush_checkpoints`
+ * watermarks.
+ *
+ * Runs against real workspace databases (`initializeDb()` already ran the
+ * step once, dropping the empty legacy tables), so each test recreates the
+ * legacy tables via raw SQL to simulate an upgrading install with pending
+ * rows.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getDb, getTelemetrySqlite } = await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
+const { APP_VERSION } = await import("../../version.js");
+
+await initializeDb();
+
+const OPT_OUT_SENTINEL = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+const LEGACY_TABLES: Record<string, string> = {
+  lifecycle_events: /*sql*/ `
+    id TEXT PRIMARY KEY, event_name TEXT NOT NULL, created_at INTEGER NOT NULL`,
+  onboarding_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, screen TEXT NOT NULL,
+    tools_json TEXT, tasks_json TEXT, tone TEXT, google_connected INTEGER,
+    google_scopes_json TEXT, prior_assistants_json TEXT, ab_variant TEXT,
+    session_id TEXT, step_name TEXT, step_index INTEGER, completed_at TEXT,
+    funnel_version TEXT`,
+  auth_fallback_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, guard TEXT NOT NULL,
+    path TEXT NOT NULL, failure_kind TEXT NOT NULL, count INTEGER NOT NULL,
+    window_start INTEGER NOT NULL, window_end INTEGER NOT NULL`,
+  skill_loaded_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, conversation_id TEXT,
+    skill_name TEXT NOT NULL, skill_updated_at TEXT, provider TEXT, model TEXT,
+    inference_profile TEXT, inference_profile_source TEXT`,
+  watchdog_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, check_name TEXT NOT NULL,
+    value REAL, detail TEXT`,
+  config_setting_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, config_key TEXT NOT NULL,
+    config_value TEXT NOT NULL`,
+};
+
+const SOURCE_IDS = [
+  "lifecycle",
+  "onboarding",
+  "auth_fallback",
+  "skill_loaded",
+  "watchdog",
+  "config_setting",
+];
+
+const WATERMARK_KEYS = SOURCE_IDS.flatMap((sourceId) => [
+  `telemetry:${sourceId}:last_reported_at`,
+  `telemetry:${sourceId}:last_reported_id`,
+]);
+
+function telemetry() {
+  return getTelemetrySqlite()!;
+}
+
+function resetState(): void {
+  for (const table of Object.keys(LEGACY_TABLES)) {
+    telemetry().exec(`DROP TABLE IF EXISTS ${table}`);
+  }
+  telemetry().exec(`DELETE FROM telemetry_events`);
+  telemetry()
+    .query(
+      `DELETE FROM flush_checkpoints WHERE key IN (${WATERMARK_KEYS.map(() => "?").join(", ")})`,
+    )
+    .run(...WATERMARK_KEYS);
+}
+
+function createLegacyTable(table: string): void {
+  telemetry().exec(`CREATE TABLE ${table} (${LEGACY_TABLES[table]})`);
+}
+
+function setWatermark(sourceId: string, at: number, id?: string): void {
+  const insert = telemetry().prepare(
+    `INSERT INTO flush_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+  );
+  insert.run(`telemetry:${sourceId}:last_reported_at`, String(at), Date.now());
+  if (id !== undefined) {
+    insert.run(`telemetry:${sourceId}:last_reported_id`, id, Date.now());
+  }
+}
+
+function tableExists(table: string): boolean {
+  return (
+    telemetry()
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(table) != null
+  );
+}
+
+function outboxRows(name: string): Array<{
+  id: string;
+  created_at: number;
+  conversation_id: string | null;
+  payload: Record<string, unknown>;
+}> {
+  return (
+    telemetry()
+      .query(
+        `SELECT id, created_at, conversation_id, payload FROM telemetry_events
+         WHERE name = ? ORDER BY created_at, id`,
+      )
+      .all(name) as Array<{
+      id: string;
+      created_at: number;
+      conversation_id: string | null;
+      payload: string;
+    }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
+}
+
+function watermarkKeyCount(): number {
+  return (
+    telemetry()
+      .query(
+        `SELECT COUNT(*) AS n FROM flush_checkpoints
+         WHERE key IN (${WATERMARK_KEYS.map(() => "?").join(", ")})`,
+      )
+      .get(...WATERMARK_KEYS) as { n: number }
+  ).n;
+}
+
+describe("migration 334: backfill telemetry_events from the legacy tables", () => {
+  test("initializeDb leaves telemetry_events and none of the legacy tables", () => {
+    expect(tableExists("telemetry_events")).toBe(true);
+    for (const table of Object.keys(LEGACY_TABLES)) {
+      expect(tableExists(table)).toBe(false);
+    }
+  });
+
+  test("compound watermark: only rows past (at, id) backfill; payload is the frozen wire shape", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
+    );
+    insert.run("shipped-1", "app_open", 1000);
+    insert.run("aaa-at-watermark", "hatch", 2000); // id <= watermark id at equal timestamp
+    insert.run("zzz-at-watermark", "app_open", 2000); // id > watermark id at equal timestamp
+    insert.run("unshipped-1", "conversations_clear_all", 3000);
+    setWatermark("lifecycle", 2000, "aaa-at-watermark");
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("lifecycle");
+    expect(rows.map((r) => r.id)).toEqual(["zzz-at-watermark", "unshipped-1"]);
+    expect(rows[0]!.created_at).toBe(2000);
+    expect(rows[0]!.conversation_id).toBeNull();
+    expect(rows[0]!.payload).toEqual({
+      type: "lifecycle",
+      daemon_event_id: "zzz-at-watermark",
+      event_name: "app_open",
+      recorded_at: 2000,
+      assistant_version: APP_VERSION,
+    });
+    expect(tableExists("lifecycle_events")).toBe(false);
+  });
+
+  test("opt-out id sentinel: rows at the pinned timestamp stay shipped, later rows backfill", () => {
+    resetState();
+    createLegacyTable("config_setting_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO config_setting_events (id, created_at, config_key, config_value)
+       VALUES (?, ?, ?, ?)`,
+    );
+    // Hex UUID-shaped ids: every real row id sorts below the ffffffff-… sentinel.
+    insert.run("ab12cd34-pinned", 2000, "memory.enabled", "true");
+    insert.run("ef56ab78-after-optout", 2001, "memory.enabled", "false");
+    setWatermark("config_setting", 2000, OPT_OUT_SENTINEL);
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("config_setting");
+    expect(rows.map((r) => r.id)).toEqual(["ef56ab78-after-optout"]);
+    expect(rows[0]!.payload).toEqual({
+      type: "config_setting",
+      daemon_event_id: "ef56ab78-after-optout",
+      recorded_at: 2001,
+      config_key: "memory.enabled",
+      config_value: "false",
+      assistant_version: APP_VERSION,
+    });
+  });
+
+  test("timestamp-only watermark (no id key) filters on created_at alone", () => {
+    resetState();
+    createLegacyTable("auth_fallback_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO auth_fallback_events
+         (id, created_at, guard, path, failure_kind, count, window_start, window_end)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      "shipped-1",
+      1000,
+      "edge",
+      "/v1/messages",
+      "missing_authorization",
+      7,
+      900,
+      1000,
+    );
+    insert.run(
+      "at-watermark",
+      2000,
+      "edge-scoped",
+      "/v1/files",
+      "insufficient_scope",
+      2,
+      1900,
+      2000,
+    );
+    insert.run(
+      "unshipped-1",
+      3000,
+      "edge-guardian",
+      "/v1/pair",
+      "guardian_mismatch",
+      1,
+      2900,
+      3000,
+    );
+    setWatermark("auth_fallback", 2000);
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("auth_fallback");
+    expect(rows.map((r) => r.id)).toEqual(["unshipped-1"]);
+    expect(rows[0]!.payload).toEqual({
+      type: "auth_fallback",
+      daemon_event_id: "unshipped-1",
+      recorded_at: 3000,
+      guard: "edge-guardian",
+      path: "/v1/pair",
+      failure_kind: "guardian_mismatch",
+      count: 1,
+      window_start: 2900,
+      window_end: 3000,
+      assistant_version: APP_VERSION,
+    });
+  });
+
+  test("absent watermark backfills ALL rows; corrupt watchdog detail becomes null", () => {
+    resetState();
+    createLegacyTable("watchdog_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO watchdog_events (id, created_at, check_name, value, detail)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      "wd-1",
+      1000,
+      "event_loop_block",
+      250.5,
+      '{"reason":"gc","secondary":2}',
+    );
+    insert.run("wd-corrupt", 2000, "stream_idle", null, "{not json");
+    insert.run("wd-nonobject", 3000, "restart", 1, "42");
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("watchdog");
+    expect(rows.map((r) => r.id)).toEqual([
+      "wd-1",
+      "wd-corrupt",
+      "wd-nonobject",
+    ]);
+    expect(rows[0]!.payload).toEqual({
+      type: "watchdog",
+      daemon_event_id: "wd-1",
+      recorded_at: 1000,
+      check_name: "event_loop_block",
+      value: 250.5,
+      detail: { reason: "gc", secondary: 2 },
+      assistant_version: APP_VERSION,
+    });
+    expect(rows[1]!.payload.detail).toBeNull();
+    expect(rows[2]!.payload.detail).toBeNull();
+  });
+
+  test("onboarding: activation daemon_event_id override, omit-when-absent fields, corrupt JSON column omitted", () => {
+    resetState();
+    createLegacyTable("onboarding_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO onboarding_events
+         (id, created_at, screen, tools_json, tasks_json, tone, google_connected,
+          google_scopes_json, prior_assistants_json, ab_variant, session_id,
+          step_name, step_index, completed_at, funnel_version)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      "ob-full",
+      1000,
+      "tools",
+      '["calendar","email"]',
+      '["plan-day"]',
+      "warm",
+      0,
+      '["scope-a"]',
+      '["other"]',
+      "variant-b",
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
+    insert.run(
+      "ob-activation",
+      2000,
+      "activation_moment_1_complete",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      "sess-1",
+      "activation_moment_1_complete",
+      1,
+      "2026-07-01T00:00:00.000Z",
+      "v2",
+    );
+    insert.run(
+      "ob-corrupt",
+      3000,
+      "tasks",
+      "{not json",
+      null,
+      null,
+      1,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("onboarding");
+    expect(rows.map((r) => r.id)).toEqual([
+      "ob-full",
+      "ob-activation",
+      "ob-corrupt",
+    ]);
+    expect(rows[0]!.payload).toEqual({
+      type: "onboarding",
+      daemon_event_id: "ob-full",
+      recorded_at: 1000,
+      screen: "tools",
+      tools: ["calendar", "email"],
+      tasks: ["plan-day"],
+      tone: "warm",
+      google_connected: false,
+      google_scopes: ["scope-a"],
+      ab_variant: "variant-b",
+      assistant_version: APP_VERSION,
+    });
+    expect(rows[1]!.payload).toEqual({
+      type: "onboarding",
+      daemon_event_id: "v2:sess-1:activation_moment_1_complete",
+      recorded_at: 2000,
+      screen: "activation_moment_1_complete",
+      session_id: "sess-1",
+      step_name: "activation_moment_1_complete",
+      step_index: 1,
+      completed_at: "2026-07-01T00:00:00.000Z",
+      funnel_version: "v2",
+      assistant_version: APP_VERSION,
+    });
+    // Corrupt tools_json: the field is omitted, the row still backfills.
+    expect(rows[2]!.payload).toEqual({
+      type: "onboarding",
+      daemon_event_id: "ob-corrupt",
+      recorded_at: 3000,
+      screen: "tasks",
+      google_connected: true,
+      assistant_version: APP_VERSION,
+    });
+  });
+
+  test("skill_loaded rows carry conversation_id in the dedicated column", () => {
+    resetState();
+    createLegacyTable("skill_loaded_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO skill_loaded_events
+         (id, created_at, conversation_id, skill_name, skill_updated_at,
+          provider, model, inference_profile, inference_profile_source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      "sk-1",
+      1000,
+      "conv-a",
+      "web-research",
+      "2026-06-01T00:00:00Z",
+      "anthropic",
+      "claude-1",
+      "profile-x",
+      "mix",
+    );
+    insert.run("sk-2", 2000, null, "tasks", null, null, null, null, null);
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("skill_loaded");
+    expect(rows.map((r) => r.conversation_id)).toEqual(["conv-a", null]);
+    expect(rows[0]!.payload).toEqual({
+      type: "skill_loaded",
+      daemon_event_id: "sk-1",
+      recorded_at: 1000,
+      skill_name: "web-research",
+      skill_updated_at: "2026-06-01T00:00:00Z",
+      conversation_id: "conv-a",
+      provider: "anthropic",
+      model: "claude-1",
+      inference_profile: "profile-x",
+      inference_profile_source: "mix",
+      assistant_version: APP_VERSION,
+    });
+    expect(rows[1]!.payload).toMatchObject({
+      skill_updated_at: null,
+      conversation_id: null,
+      provider: null,
+    });
+  });
+
+  test("drops every legacy table, purges all 12 watermark keys, and skips absent tables", () => {
+    resetState();
+    // Only two of the six tables exist — the rest must be skipped cleanly.
+    createLegacyTable("lifecycle_events");
+    createLegacyTable("watchdog_events");
+    telemetry().exec(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES ('l-1', 'app_open', 1000)`,
+    );
+    setWatermark("onboarding", 5000, "some-id"); // watermark for an absent table
+    setWatermark("lifecycle", 500);
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    for (const table of Object.keys(LEGACY_TABLES)) {
+      expect(tableExists(table)).toBe(false);
+    }
+    expect(watermarkKeyCount()).toBe(0);
+    expect(outboxRows("lifecycle")).toHaveLength(1);
+    expect(outboxRows("watchdog")).toHaveLength(0);
+  });
+
+  test("backfills in chunks past 500 rows", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
+    );
+    for (let i = 0; i < 501; i++) {
+      insert.run(`bulk-${String(i).padStart(4, "0")}`, "app_open", 1000 + i);
+    }
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    expect(outboxRows("lifecycle")).toHaveLength(501);
+  });
+
+  test("re-running after completion is a safe no-op", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    telemetry().exec(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES ('l-1', 'hatch', 1000)`,
+    );
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    expect(outboxRows("lifecycle")).toHaveLength(1);
+    expect(watermarkKeyCount()).toBe(0);
+  });
+
+  test("a pre-existing outbox row with the same id survives (INSERT OR IGNORE)", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    telemetry().exec(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES ('dupe-1', 'app_open', 1000)`,
+    );
+    telemetry().exec(
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('dupe-1', 'lifecycle', 1000, NULL, '{"type":"lifecycle","already":"queued"}')`,
+    );
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("lifecycle");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.payload).toEqual({ type: "lifecycle", already: "queued" });
+  });
+});

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
@@ -3,7 +3,11 @@ import { Database } from "bun:sqlite";
 import { getLogger } from "../../util/logger.js";
 import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
 import { APP_VERSION } from "../../version.js";
-import { type DrizzleDb, getTelemetrySqlite } from "../db-connection.js";
+import {
+  type DrizzleDb,
+  getSqliteFrom,
+  getTelemetrySqlite,
+} from "../db-connection.js";
 
 const log = getLogger("migration-334");
 
@@ -218,6 +222,47 @@ function selectUnshippedRows(
     .all(at) as LegacyRow[];
 }
 
+/**
+ * Drop rows whose conversation no longer exists in the main DB. The redaction
+ * paths delete from `telemetry_events` only, so a backfill selecting purely by
+ * watermark would resurrect rows for already-deleted conversations — the same
+ * liveness filter migration 332 applies via `copyWhere`. NULL-conversation
+ * rows always backfill. No-op for specs without conversation scoping.
+ */
+function dropRedactedConversationRows(
+  mainRaw: Database,
+  spec: LegacyBackfillSpec,
+  rows: LegacyRow[],
+): LegacyRow[] {
+  const column = spec.conversationIdColumn;
+  if (!column) {
+    return rows;
+  }
+  const ids = [
+    ...new Set(
+      rows
+        .map((row) => row[column])
+        .filter((value): value is string => typeof value === "string"),
+    ),
+  ];
+  const live = new Set<string>();
+  for (let i = 0; i < ids.length; i += INSERT_CHUNK_SIZE) {
+    const chunk = ids.slice(i, i + INSERT_CHUNK_SIZE);
+    const found = mainRaw
+      .query(
+        /*sql*/ `SELECT id FROM conversations WHERE id IN (${chunk.map(() => "?").join(", ")})`,
+      )
+      .all(...chunk) as Array<{ id: string }>;
+    for (const row of found) {
+      live.add(row.id);
+    }
+  }
+  return rows.filter((row) => {
+    const conversationId = row[column];
+    return conversationId == null || live.has(String(conversationId));
+  });
+}
+
 function insertOutboxRows(
   raw: Database,
   spec: LegacyBackfillSpec,
@@ -257,16 +302,16 @@ function insertOutboxRows(
  * mapping would have produced), `INSERT OR IGNORE` them into
  * `telemetry_events` (idempotent under a re-run after a partial crash), and
  * drop the legacy table. `conversation_id` is populated only from
- * `skill_loaded_events`, keeping conversation redaction an indexed delete.
+ * `skill_loaded_events`, keeping conversation redaction an indexed delete —
+ * and its rows are first checked against the main DB's `conversations` table
+ * (see {@link dropRedactedConversationRows}) so already-redacted
+ * conversations are never resurrected, mirroring migration 332's `copyWhere`.
  * Finally the six sources' now-meaningless watermark keys are purged from
  * `flush_checkpoints` (ack-mode sources delete rows instead of advancing
  * cursors); the table itself survives for the main-DB-backed watermark
  * sources (`usage`, `turns`, `tool_executed`).
- *
- * The `mainDb` parameter is accepted to satisfy the migration-step signature
- * but is not used — this migration operates exclusively on the telemetry DB.
  */
-export function migrateBackfillTelemetryEventsOutbox(_mainDb: DrizzleDb): void {
+export function migrateBackfillTelemetryEventsOutbox(mainDb: DrizzleDb): void {
   let raw: Database | null = getTelemetrySqlite();
   if (!raw) {
     // The dedicated connection failed to open (logged by openDedicatedDb).
@@ -276,12 +321,17 @@ export function migrateBackfillTelemetryEventsOutbox(_mainDb: DrizzleDb): void {
     raw = new Database(getTelemetryDbPath());
   }
 
+  const mainRaw = getSqliteFrom(mainDb);
   const backfilled: Record<string, number> = {};
   for (const spec of LEGACY_BACKFILL_SPECS) {
     if (!tableExists(raw, spec.table)) {
       continue;
     }
-    const rows = selectUnshippedRows(raw, spec);
+    const rows = dropRedactedConversationRows(
+      mainRaw,
+      spec,
+      selectUnshippedRows(raw, spec),
+    );
     insertOutboxRows(raw, spec, rows);
     raw.exec(/*sql*/ `DROP TABLE ${spec.table}`);
     backfilled[spec.table] = rows.length;

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
@@ -8,6 +8,7 @@ import {
   getSqliteFrom,
   getTelemetrySqlite,
 } from "../db-connection.js";
+import { RELOCATING_SUFFIX } from "./helpers/relocation.js";
 
 const log = getLogger("migration-334");
 
@@ -171,6 +172,33 @@ const LEGACY_BACKFILL_SPECS: readonly LegacyBackfillSpec[] = [
   },
 ];
 
+/**
+ * Throw unless the legacy relocations (329–332) have fully completed. The
+ * migration runner catches a failed step and still runs later ones, so
+ * without this gate a mid-drain relocation failure would let 334 backfill,
+ * drop the telemetry-side tables, and checkpoint — then the relocation's
+ * next-boot rerun drains rows into a legacy table nothing reads anymore.
+ * Throwing leaves 334 uncheckpointed so it retries after the relocations.
+ */
+function assertLegacyRelocationsComplete(mainRaw: Database): void {
+  const names = LEGACY_BACKFILL_SPECS.flatMap((spec) => [
+    spec.table,
+    `${spec.table}${RELOCATING_SUFFIX}`,
+  ]);
+  const pending = (
+    mainRaw
+      .query(
+        /*sql*/ `SELECT name FROM main.sqlite_master WHERE type='table' AND name IN (${names.map(() => "?").join(", ")})`,
+      )
+      .all(...names) as Array<{ name: string }>
+  ).map((row) => row.name);
+  if (pending.length > 0) {
+    throw new Error(
+      `legacy telemetry relocations incomplete (${pending.join(", ")}) — deferring outbox backfill`,
+    );
+  }
+}
+
 function tableExists(raw: Database, table: string): boolean {
   return (
     raw
@@ -312,6 +340,9 @@ function insertOutboxRows(
  * sources (`usage`, `turns`, `tool_executed`).
  */
 export function migrateBackfillTelemetryEventsOutbox(mainDb: DrizzleDb): void {
+  const mainRaw = getSqliteFrom(mainDb);
+  assertLegacyRelocationsComplete(mainRaw);
+
   let raw: Database | null = getTelemetrySqlite();
   if (!raw) {
     // The dedicated connection failed to open (logged by openDedicatedDb).
@@ -321,7 +352,6 @@ export function migrateBackfillTelemetryEventsOutbox(mainDb: DrizzleDb): void {
     raw = new Database(getTelemetryDbPath());
   }
 
-  const mainRaw = getSqliteFrom(mainDb);
   const backfilled: Record<string, number> = {};
   for (const spec of LEGACY_BACKFILL_SPECS) {
     if (!tableExists(raw, spec.table)) {

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
@@ -1,0 +1,304 @@
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../util/logger.js";
+import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
+import { APP_VERSION } from "../../version.js";
+import { type DrizzleDb, getTelemetrySqlite } from "../db-connection.js";
+
+const log = getLogger("migration-334");
+
+/** Rows per multi-row INSERT — stays under SQLite's bound-variable limit. */
+const INSERT_CHUNK_SIZE = 500;
+
+type LegacyRow = Record<string, string | number | null>;
+
+/**
+ * One legacy per-type telemetry table to fold into the `telemetry_events`
+ * outbox. `sourceId` is the reporter watermark namespace
+ * (`telemetry:<sourceId>:last_reported_{at,id}` in `flush_checkpoints`);
+ * `toPayload` is a frozen copy of the source's pre-outbox flush-time wire
+ * mapper (deliberately NOT shared with the live store code, so later store
+ * changes cannot rewrite what this migration produces).
+ */
+interface LegacyBackfillSpec {
+  table: string;
+  sourceId: string;
+  /** Column copied into `telemetry_events.conversation_id` (redaction index). */
+  conversationIdColumn?: string;
+  toPayload(row: LegacyRow): Record<string, unknown>;
+}
+
+/** `{ [key]: JSON.parse(raw) }` when `raw` is parseable JSON text; else `{}`. */
+function jsonField(
+  key: string,
+  raw: string | number | null,
+): Record<string, unknown> {
+  if (typeof raw !== "string" || raw === "") {
+    return {};
+  }
+  try {
+    return { [key]: JSON.parse(raw) };
+  } catch {
+    return {};
+  }
+}
+
+/** Stored watchdog `detail` JSON text → object bag; null/corrupt/non-object → null. */
+function parseWatchdogDetail(
+  raw: string | number | null,
+): Record<string, unknown> | null {
+  if (typeof raw !== "string" || raw === "") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const LEGACY_BACKFILL_SPECS: readonly LegacyBackfillSpec[] = [
+  {
+    table: "lifecycle_events",
+    sourceId: "lifecycle",
+    toPayload: (row) => ({
+      type: "lifecycle",
+      daemon_event_id: row.id,
+      event_name: row.event_name,
+      recorded_at: row.created_at,
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "onboarding_events",
+    sourceId: "onboarding",
+    toPayload: (row) => ({
+      type: "onboarding",
+      // Activation rows carry a deterministic wire id keyed on the row's own
+      // funnel_version/session/step so dbt collapses a moment that fires more
+      // than once; every other row uses the row id.
+      daemon_event_id:
+        row.session_id && row.step_name && row.funnel_version
+          ? `${row.funnel_version}:${row.session_id}:${row.step_name}`
+          : row.id,
+      recorded_at: row.created_at,
+      screen: row.screen,
+      // Optional fields are omit-when-absent; a corrupt stored JSON column
+      // omits just that field (the row still backfills). The never-shipped
+      // `prior_assistants_json` column is dropped here.
+      ...jsonField("tools", row.tools_json),
+      ...jsonField("tasks", row.tasks_json),
+      ...(row.tone ? { tone: row.tone } : {}),
+      ...(row.google_connected != null
+        ? { google_connected: row.google_connected !== 0 }
+        : {}),
+      ...jsonField("google_scopes", row.google_scopes_json),
+      ...(row.ab_variant ? { ab_variant: row.ab_variant } : {}),
+      ...(row.session_id ? { session_id: row.session_id } : {}),
+      ...(row.step_name ? { step_name: row.step_name } : {}),
+      ...(row.step_index != null ? { step_index: row.step_index } : {}),
+      ...(row.completed_at ? { completed_at: row.completed_at } : {}),
+      ...(row.funnel_version ? { funnel_version: row.funnel_version } : {}),
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "auth_fallback_events",
+    sourceId: "auth_fallback",
+    toPayload: (row) => ({
+      type: "auth_fallback",
+      daemon_event_id: row.id,
+      recorded_at: row.created_at,
+      guard: row.guard,
+      path: row.path,
+      failure_kind: row.failure_kind,
+      count: row.count,
+      window_start: row.window_start,
+      window_end: row.window_end,
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "skill_loaded_events",
+    sourceId: "skill_loaded",
+    conversationIdColumn: "conversation_id",
+    toPayload: (row) => ({
+      type: "skill_loaded",
+      daemon_event_id: row.id,
+      recorded_at: row.created_at,
+      skill_name: row.skill_name,
+      skill_updated_at: row.skill_updated_at,
+      conversation_id: row.conversation_id,
+      provider: row.provider,
+      model: row.model,
+      inference_profile: row.inference_profile,
+      inference_profile_source: row.inference_profile_source,
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "watchdog_events",
+    sourceId: "watchdog",
+    toPayload: (row) => ({
+      type: "watchdog",
+      daemon_event_id: row.id,
+      recorded_at: row.created_at,
+      check_name: row.check_name,
+      value: row.value,
+      detail: parseWatchdogDetail(row.detail),
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "config_setting_events",
+    sourceId: "config_setting",
+    toPayload: (row) => ({
+      type: "config_setting",
+      daemon_event_id: row.id,
+      recorded_at: row.created_at,
+      config_key: row.config_key,
+      config_value: row.config_value,
+      assistant_version: APP_VERSION,
+    }),
+  },
+];
+
+function tableExists(raw: Database, table: string): boolean {
+  return (
+    raw
+      .query(
+        /*sql*/ `SELECT name FROM sqlite_master WHERE type='table' AND name = ?`,
+      )
+      .get(table) != null
+  );
+}
+
+/**
+ * Rows the reporter has NOT yet shipped, per the source's `flush_checkpoints`
+ * watermark: the standard compound cursor when both keys exist (the opt-out
+ * `ffffffff-…` id sentinel composes correctly — nothing at the pinned
+ * timestamp sorts above it), timestamp-only when only `at` exists, and ALL
+ * rows when the watermark is absent or unreadable (never-flushed installs).
+ */
+function selectUnshippedRows(
+  raw: Database,
+  spec: LegacyBackfillSpec,
+): LegacyRow[] {
+  const keyPrefix = `telemetry:${spec.sourceId}:last_reported`;
+  const checkpoint = raw.query(
+    /*sql*/ `SELECT value FROM flush_checkpoints WHERE key = ?`,
+  );
+  const atValue = (
+    checkpoint.get(`${keyPrefix}_at`) as { value: string } | null
+  )?.value;
+  const at = atValue != null ? Number(atValue) : null;
+  const id = (checkpoint.get(`${keyPrefix}_id`) as { value: string } | null)
+    ?.value;
+
+  const base = /*sql*/ `SELECT * FROM ${spec.table}`;
+  const order = /*sql*/ ` ORDER BY created_at, id`;
+  if (at == null || !Number.isFinite(at)) {
+    return raw.query(base + order).all() as LegacyRow[];
+  }
+  if (id != null) {
+    return raw
+      .query(
+        base +
+          /*sql*/ ` WHERE created_at > ? OR (created_at = ? AND id > ?)` +
+          order,
+      )
+      .all(at, at, id) as LegacyRow[];
+  }
+  return raw
+    .query(base + /*sql*/ ` WHERE created_at > ?` + order)
+    .all(at) as LegacyRow[];
+}
+
+function insertOutboxRows(
+  raw: Database,
+  spec: LegacyBackfillSpec,
+  rows: LegacyRow[],
+): void {
+  for (let i = 0; i < rows.length; i += INSERT_CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + INSERT_CHUNK_SIZE);
+    const placeholders = chunk.map(() => "(?, ?, ?, ?, ?)").join(", ");
+    const params = chunk.flatMap((row) => [
+      row.id,
+      spec.sourceId,
+      row.created_at,
+      spec.conversationIdColumn
+        ? (row[spec.conversationIdColumn] ?? null)
+        : null,
+      JSON.stringify(spec.toPayload(row)),
+    ]);
+    raw
+      .query(
+        /*sql*/ `INSERT OR IGNORE INTO telemetry_events (id, name, created_at, conversation_id, payload) VALUES ${placeholders}`,
+      )
+      .run(...params);
+  }
+}
+
+/**
+ * Fold the six legacy per-type telemetry tables (`lifecycle_events`,
+ * `onboarding_events`, `auth_fallback_events`, `skill_loaded_events`,
+ * `watchdog_events`, `config_setting_events`) into the generic
+ * `telemetry_events` outbox (migration 333) and drop them, entirely on the
+ * telemetry database (`assistant-telemetry.db`).
+ *
+ * For each table (skipping any absent from `sqlite_master`): select the rows
+ * the reporter's `flush_checkpoints` watermark marks as unshipped, map each to
+ * its wire `TelemetryEvent` with the frozen mappers above (record-time
+ * payloads, `assistant_version: APP_VERSION` — the same stamp flush-time
+ * mapping would have produced), `INSERT OR IGNORE` them into
+ * `telemetry_events` (idempotent under a re-run after a partial crash), and
+ * drop the legacy table. `conversation_id` is populated only from
+ * `skill_loaded_events`, keeping conversation redaction an indexed delete.
+ * Finally the six sources' now-meaningless watermark keys are purged from
+ * `flush_checkpoints` (ack-mode sources delete rows instead of advancing
+ * cursors); the table itself survives for the main-DB-backed watermark
+ * sources (`usage`, `turns`, `tool_executed`).
+ *
+ * The `mainDb` parameter is accepted to satisfy the migration-step signature
+ * but is not used — this migration operates exclusively on the telemetry DB.
+ */
+export function migrateBackfillTelemetryEventsOutbox(_mainDb: DrizzleDb): void {
+  let raw: Database | null = getTelemetrySqlite();
+  if (!raw) {
+    // The dedicated connection failed to open (logged by openDedicatedDb).
+    // Fall back to opening the file directly so the migration still runs —
+    // the singleton will pick it up on a later access. This mirrors the
+    // fail-soft pattern of the other dedicated-DB migrations.
+    raw = new Database(getTelemetryDbPath());
+  }
+
+  const backfilled: Record<string, number> = {};
+  for (const spec of LEGACY_BACKFILL_SPECS) {
+    if (!tableExists(raw, spec.table)) {
+      continue;
+    }
+    const rows = selectUnshippedRows(raw, spec);
+    insertOutboxRows(raw, spec, rows);
+    raw.exec(/*sql*/ `DROP TABLE ${spec.table}`);
+    backfilled[spec.table] = rows.length;
+  }
+
+  const watermarkKeys = LEGACY_BACKFILL_SPECS.flatMap((spec) => [
+    `telemetry:${spec.sourceId}:last_reported_at`,
+    `telemetry:${spec.sourceId}:last_reported_id`,
+  ]);
+  raw
+    .query(
+      /*sql*/ `DELETE FROM flush_checkpoints WHERE key IN (${watermarkKeys.map(() => "?").join(", ")})`,
+    )
+    .run(...watermarkKeys);
+
+  log.info(
+    { backfilled },
+    "Backfilled unshipped legacy telemetry rows into telemetry_events and dropped the legacy tables",
+  );
+}

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -274,51 +274,6 @@ export const llmUsageEvents = sqliteTable(
   ],
 );
 
-// Lives on the dedicated telemetry database (assistant-telemetry.db)
-// alongside watchdog_events.
-export const lifecycleEvents = sqliteTable("lifecycle_events", {
-  id: text("id").primaryKey(),
-  eventName: text("event_name").notNull(), // 'app_open' | 'hatch'
-  createdAt: integer("created_at").notNull(),
-});
-
-// Lives on the dedicated telemetry database (assistant-telemetry.db)
-// alongside watchdog_events.
-export const onboardingEvents = sqliteTable("onboarding_events", {
-  id: text("id").primaryKey(),
-  createdAt: integer("created_at").notNull(),
-  screen: text("screen").notNull(),
-  toolsJson: text("tools_json"),
-  tasksJson: text("tasks_json"),
-  tone: text("tone"),
-  googleConnected: integer("google_connected", { mode: "boolean" }),
-  googleScopesJson: text("google_scopes_json"),
-  priorAssistantsJson: text("prior_assistants_json"),
-  abVariant: text("ab_variant"),
-  sessionId: text("session_id"),
-  stepName: text("step_name"),
-  stepIndex: integer("step_index"),
-  completedAt: text("completed_at"),
-  funnelVersion: text("funnel_version"),
-});
-
-// Aggregated legacy-loopback auth-fallback counts forwarded by the gateway.
-// One row per (guard, path, failure_kind) per flush window; `count` is how many
-// requests fell back to the loopback exemption in that window. Flushed to the
-// platform telemetry endpoint by the usage telemetry reporter. Lives on the
-// dedicated telemetry database (assistant-telemetry.db) alongside
-// watchdog_events.
-export const authFallbackEvents = sqliteTable("auth_fallback_events", {
-  id: text("id").primaryKey(),
-  createdAt: integer("created_at").notNull(),
-  guard: text("guard").notNull(), // 'edge' | 'edge-scoped' | 'edge-guardian'
-  path: text("path").notNull(),
-  failureKind: text("failure_kind").notNull(),
-  count: integer("count").notNull(),
-  windowStart: integer("window_start").notNull(),
-  windowEnd: integer("window_end").notNull(),
-});
-
 // One row per conversation started on the activation-rail bootstrap template.
 // Lets the activation funnel telemetry scope its events to activation
 // conversations without inspecting the bootstrap template at emit time.
@@ -326,53 +281,6 @@ export const activationSessions = sqliteTable("activation_sessions", {
   conversationId: text("conversation_id").primaryKey(),
   createdAt: integer("created_at").notNull(),
 });
-
-// One row per `skill_loaded` telemetry event, emitted when a Vellum-produced
-// skill is activated in a conversation — see skill-loaded-events-store.ts for
-// the data contract. Flushed by the usage telemetry reporter. Lives on the
-// dedicated telemetry database (assistant-telemetry.db) alongside
-// watchdog_events.
-export const skillLoadedEvents = sqliteTable(
-  "skill_loaded_events",
-  {
-    id: text("id").primaryKey(),
-    createdAt: integer("created_at").notNull(),
-    conversationId: text("conversation_id"),
-    skillName: text("skill_name").notNull(),
-    // ISO 8601 timestamp from the merged skill catalog, when known.
-    skillUpdatedAt: text("skill_updated_at"),
-    provider: text("provider"),
-    model: text("model"),
-    inferenceProfile: text("inference_profile"),
-    inferenceProfileSource: text("inference_profile_source"),
-  },
-  (table) => [
-    index("idx_skill_loaded_events_created_at_id").on(
-      table.createdAt,
-      table.id,
-    ),
-  ],
-);
-
-// One row per `watchdog` telemetry event, emitted when a daemon watchdog
-// check fires (event-loop block, stream-idle stall, restart, ...) — see
-// watchdog-events-store.ts for the data contract. Flushed by the usage
-// telemetry reporter. `value` is a REAL (BQ FLOAT) so the daemon need not
-// distinguish int vs float; the platform serializer coerces ints to float.
-// `detail` is a JSON bag stored as text and forwarded verbatim.
-export const watchdogEvents = sqliteTable(
-  "watchdog_events",
-  {
-    id: text("id").primaryKey(),
-    createdAt: integer("created_at").notNull(),
-    checkName: text("check_name").notNull(),
-    value: real("value"),
-    detail: text("detail"),
-  },
-  (table) => [
-    index("idx_watchdog_events_created_at_id").on(table.createdAt, table.id),
-  ],
-);
 
 // Key/value store for telemetry flush state — the per-event-type
 // `(last_reported_at, last_reported_id)` watermark cursors advanced by the
@@ -385,27 +293,6 @@ export const flushCheckpoints = sqliteTable("flush_checkpoints", {
   value: text("value").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });
-
-// One row per `config_setting` telemetry event — a tracked config key's
-// effective value; see config-setting-events-store.ts for the data
-// contract. Lives on the dedicated telemetry database
-// (assistant-telemetry.db) alongside watchdog_events. Flushed by the usage
-// telemetry reporter.
-export const configSettingEvents = sqliteTable(
-  "config_setting_events",
-  {
-    id: text("id").primaryKey(),
-    createdAt: integer("created_at").notNull(),
-    configKey: text("config_key").notNull(),
-    configValue: text("config_value").notNull(),
-  },
-  (table) => [
-    index("idx_config_setting_events_created_at_id").on(
-      table.createdAt,
-      table.id,
-    ),
-  ],
-);
 
 // Generic telemetry outbox. Lives on the dedicated telemetry database
 // (assistant-telemetry.db). Each row's `payload` is the wire `TelemetryEvent`

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -441,6 +441,7 @@ import { migrateMoveAuthFallbackEventsToTelemetryDb } from "./migrations/330-mov
 import { migrateMoveLifecycleEventsToTelemetryDb } from "./migrations/331-move-lifecycle-events-to-telemetry-db.js";
 import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/332-move-skill-loaded-events-to-telemetry-db.js";
 import { migrateCreateTelemetryEventsTable } from "./migrations/333-create-telemetry-events-table.js";
+import { migrateBackfillTelemetryEventsOutbox } from "./migrations/334-backfill-telemetry-events-outbox.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1353,4 +1354,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateMoveLifecycleEventsToTelemetryDb,
   migrateMoveSkillLoadedEventsToTelemetryDb,
   migrateCreateTelemetryEventsTable,
+  migrateBackfillTelemetryEventsOutbox,
 ];

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -18,18 +18,17 @@ export interface TelemetryEventBase {
    * `null`) it wins. When the field is omitted on the event entirely
    * (old assistant), the envelope value is the back-compat fallback.
    *
-   * Daemon-side, this field is always non-null — the reporter stamps
-   * the running binary's `APP_VERSION` when the underlying SQLite row
-   * has no record-time value. In this PR only `llm_usage` events
-   * carry a true record-time value (legacy llm_usage rows from before
-   * migration 267 fall back to `APP_VERSION`); turn, lifecycle, and
-   * onboarding events all stamp `APP_VERSION` directly until the
-   * follow-ups that add the column to `messages` / `lifecycle_events`
-   * (#18112) / `onboarding_events` (#30733) land. Stamping
-   * `APP_VERSION` instead of emitting explicit `null` preserves
-   * envelope-equivalent behavior under the per-event-wins contract.
-   * The type allows `null` for parity with the platform contract;
-   * in practice the daemon never sends it.
+   * Daemon-side, this field is always non-null. The outbox-backed
+   * event types store the full wire payload at record time, so their
+   * `APP_VERSION` stamp is genuinely record-time; `llm_usage` carries
+   * a record-time column (legacy rows from before migration 267 fall
+   * back to the flushing binary's `APP_VERSION`); `turn` and
+   * `tool_executed` derive from tables without a version column and
+   * stamp the flushing binary's `APP_VERSION`. Stamping `APP_VERSION`
+   * instead of emitting explicit `null` preserves envelope-equivalent
+   * behavior under the per-event-wins contract. The type allows
+   * `null` for parity with the platform contract; in practice the
+   * daemon never sends it.
    */
   assistant_version: string | null;
 }

--- a/assistant/src/telemetry/watchdog-direct-emit.ts
+++ b/assistant/src/telemetry/watchdog-direct-emit.ts
@@ -1,7 +1,7 @@
 /**
  * Direct (unbuffered) emit of a single `watchdog` telemetry event.
  *
- * The usual watchdog path persists to the SQLite `watchdog_events` table and
+ * The usual watchdog path persists to the SQLite `telemetry_events` outbox and
  * lets {@link ./usage-telemetry-reporter} batch and upload it later. That
  * durable buffer is the right default — it survives restarts and dedupes on
  * `daemon_event_id`. But it is the wrong tool for a check that fires *because*

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -54,8 +54,8 @@ export interface UsageAttributionSnapshot {
 }
 
 /**
- * The four nullable attribution columns shared by telemetry event rows
- * (`tool_invocations`, `skill_loaded_events`).
+ * The four nullable attribution columns shared by telemetry events
+ * (`tool_invocations` rows, `skill_loaded` outbox payloads).
  */
 export interface UsageAttributionColumns {
   provider: string | null;

--- a/assistant/src/util/telemetry-db-path.ts
+++ b/assistant/src/util/telemetry-db-path.ts
@@ -3,14 +3,15 @@ import { join } from "node:path";
 import { getDataDir } from "./platform.js";
 
 /**
- * Path to the dedicated SQLite file that houses the telemetry-only event
- * tables: `watchdog_events`, `config_setting_events`, `onboarding_events`,
- * `auth_fallback_events`, `lifecycle_events`, and `skill_loaded_events`. It
- * lives in the same `data/db` directory as the main DB and is opened on its
- * own connection (see `getTelemetryDb()` in `persistence/db-connection.ts`).
- * Splitting telemetry tables into their own file keeps the main DB — and its
- * WAL — small and lets the two files VACUUM/checkpoint independently, so a
- * burst of telemetry events cannot bloat the main database.
+ * Path to the dedicated SQLite file that houses the telemetry-only tables:
+ * `telemetry_events` (the generic outbox of wire `TelemetryEvent` payloads,
+ * deleted on successful flush) and `flush_checkpoints` (watermark cursors for
+ * the main-DB-backed sources: usage, turns, tool_executed). It lives in the
+ * same `data/db` directory as the main DB and is opened on its own connection
+ * (see `getTelemetryDb()` in `persistence/db-connection.ts`). Splitting
+ * telemetry tables into their own file keeps the main DB — and its WAL —
+ * small and lets the two files VACUUM/checkpoint independently, so a burst of
+ * telemetry events cannot bloat the main database.
  *
  * Kept in its own leaf module rather than alongside `getDbPath()` in
  * `platform.ts`: `platform.ts` is imported very early and widely, and adding an


### PR DESCRIPTION
## Summary
- Migration 334: watermark-filtered backfill of unshipped legacy rows into telemetry_events (frozen embedded mappers incl. activation id override + defensive JSON parses), then drops the six legacy tables and purges their 12 flush_checkpoints keys
- Removes the six legacy drizzle table defs; docs updated (telemetry-db-path, db-connection)
- Historical migration tests 329-332 re-scoped to the full relocate-then-backfill pipeline

Part of plan: telemetry-outbox-consolidation.md (PR 9 of 9)