### PR TITLE
fix(plugins): resolve daemon install-by-name from the gated catalog, not GitHub

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
@@ -55,6 +55,20 @@ describe("resolveSourceFromMatch", () => {
   });
 
   test.each([
+    ["absent", undefined],
+    ["empty", ""],
+  ])("resolves a repo-root %s path to \"\"", (_label, path) => {
+    // A repo-root entry (`path: ""` or absent) is valid — the clean-path gate
+    // only applies to a non-empty path, so it must not be rejected.
+    expect(resolveSourceFromMatch(match({ path }))).toEqual({
+      owner: "acme",
+      repo: "example",
+      path: "",
+      ref: FULL_SHA,
+    });
+  });
+
+  test.each([
     ["a branch", "main"],
     ["a tag", "v1.2.3"],
     ["a short SHA", "63a91ec"],

--- a/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
@@ -69,11 +69,22 @@ describe("resolveSourceFromMatch", () => {
   });
 
   test.each([
+    ["too many segments", "owner/repo/extra"],
+    ["a slashless name", "justname"],
+  ])("throws on an invalid repo slug with %s", (_label, repo) => {
+    expect(() => resolveSourceFromMatch(match({ repo }))).toThrow(
+      /invalid source/,
+    );
+  });
+
+  test.each([
     ["a branch", "main"],
     ["a tag", "v1.2.3"],
     ["a short SHA", "63a91ec"],
   ])("throws on %s ref", (_label, ref) => {
-    expect(() => resolveSourceFromMatch(match({ ref }))).toThrow();
+    expect(() => resolveSourceFromMatch(match({ ref }))).toThrow(
+      /invalid source/,
+    );
   });
 
   test("resolves a clean nested path", () => {
@@ -94,7 +105,7 @@ describe("resolveSourceFromMatch", () => {
     ["an empty segment", "a//b"],
   ])("throws on an unsafe path with %s", (_label, path) => {
     expect(() => resolveSourceFromMatch(match({ path }))).toThrow(
-      /unsafe plugin path/,
+      /invalid source/,
     );
   });
 });

--- a/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
@@ -61,6 +61,28 @@ describe("resolveSourceFromMatch", () => {
   ])("throws on %s ref", (_label, ref) => {
     expect(() => resolveSourceFromMatch(match({ ref }))).toThrow();
   });
+
+  test("resolves a clean nested path", () => {
+    expect(
+      resolveSourceFromMatch(match({ path: "packages/plugin" })),
+    ).toEqual({
+      owner: "acme",
+      repo: "example",
+      path: "packages/plugin",
+      ref: FULL_SHA,
+    });
+  });
+
+  test.each([
+    ["a leading `..` segment", "../evil"],
+    ["an interior `..` segment", "a/../b"],
+    ["a backslash `..` segment", "a\\..\\b"],
+    ["an empty segment", "a//b"],
+  ])("throws on an unsafe path with %s", (_label, path) => {
+    expect(() => resolveSourceFromMatch(match({ path }))).toThrow(
+      /unsafe plugin path/,
+    );
+  });
 });
 
 describe("catalog-backed resolvers (bundled, offline)", () => {

--- a/assistant/src/cli/lib/plugin-catalog-resolve.ts
+++ b/assistant/src/cli/lib/plugin-catalog-resolve.ts
@@ -8,10 +8,12 @@
  * `plugins/marketplace.json` fetch — so search, install, and details read one source.
  */
 
-import { isFullCommitSha } from "./install-from-github.js";
 import { getPluginCatalog } from "./plugin-catalog-cache.js";
 import { DEFAULT_PLUGIN_REF } from "./plugin-constants.js";
-import type { ResolvedPluginSource } from "./plugin-marketplace.js";
+import {
+  githubSourceSchema,
+  type ResolvedPluginSource,
+} from "./plugin-marketplace.js";
 import type {
   PluginSearchMatch,
   SearchPluginsDeps,
@@ -27,47 +29,37 @@ export async function findCatalogEntry(
 }
 
 /**
- * A NON-EMPTY repo-relative path is clean when no `/`-or-`\`-split segment
- * escapes (`..`) or is interior-empty (`a//b`). Mirrors the marketplace
- * schema's `path` refine so the gated resolver rejects the same paths the
- * GitHub manifest does — platform catalog rows accept `path` as any string, so
- * this is the install-side gate. An empty/absent path is repo root, not passed
- * here.
- */
-function isCleanRepoRelativePath(path: string): boolean {
-  return !path.split(/[/\\]/).some((seg) => seg === ".." || seg === "");
-}
-
-/**
  * Project a catalog match onto concrete GitHub install coordinates.
  *
- * Re-asserts the install-pinning invariant the GitHub path enforces via schema:
- * a curated install MUST pin to an immutable full commit SHA, so a non-SHA ref
- * from an upstream catalog is a config defect and throws rather than installing
- * mutable code. Likewise re-asserts the schema's clean-path rule: a platform
- * catalog row does not validate `path`, so an escaping/empty segment reaching
- * `trustedSource.rootPath` is rejected here rather than copying the wrong tree.
+ * Validates the reconstructed source against the canonical marketplace
+ * GitHub-source schema (`owner/repo` slug, clean repo-relative path, full commit
+ * SHA) — the exact rules the GitHub manifest enforces. Platform catalog rows
+ * validate none of these (`repo`/`path` are any string), so a malformed
+ * coordinate — an over-segmented or slashless repo, an escaping/empty path, a
+ * mutable non-SHA ref — is rejected here before it reaches `trustedSource`
+ * rather than installing the wrong tree or a repointable revision.
  * Pure — unit-testable without a catalog.
  */
 export function resolveSourceFromMatch(
   match: PluginSearchMatch,
 ): ResolvedPluginSource {
-  const { repo, path, ref } = match.source;
-  if (!isFullCommitSha(ref)) {
+  // Repo-root `""` maps to `undefined` (omitted = root) so the schema's
+  // non-empty path refine does not reject a valid repo-root entry.
+  const path = match.source.path || undefined;
+  const parsed = githubSourceSchema.safeParse({
+    source: "github" as const,
+    repo: match.source.repo,
+    ...(path ? { path } : {}),
+    ref: match.source.ref,
+  });
+  if (!parsed.success) {
     throw new Error(
-      `Catalog entry "${match.name}" pins ref "${ref}", which is not a full commit SHA; ` +
-        `a curated install must pin to an immutable full commit SHA (tags and branches are mutable).`,
+      `Catalog entry "${match.name}" (${match.source.repo}) has an invalid source: ` +
+        parsed.error.issues.map((i) => i.message).join("; "),
     );
   }
-  // An empty/absent path is repo root (valid); only gate a non-empty path.
-  if (path && !isCleanRepoRelativePath(path)) {
-    throw new Error(
-      `Catalog entry "${match.name}" has an unsafe plugin path "${path}"; ` +
-        `a curated install path must be a clean repo-relative directory (no ".." or empty segments).`,
-    );
-  }
-  const [owner, repoName] = repo.split("/", 2) as [string, string];
-  return { owner, repo: repoName, path: path ?? "", ref };
+  const [owner, repoName] = parsed.data.repo.split("/", 2) as [string, string];
+  return { owner, repo: repoName, path: match.source.path ?? "", ref: match.source.ref };
 }
 
 /** Resolve {@link name} to install coordinates from the catalog, or `null`. */

--- a/assistant/src/cli/lib/plugin-catalog-resolve.ts
+++ b/assistant/src/cli/lib/plugin-catalog-resolve.ts
@@ -27,10 +27,12 @@ export async function findCatalogEntry(
 }
 
 /**
- * A repo-relative path is clean when no `/`-or-`\`-split segment escapes (`..`)
- * or is empty (`""`). Mirrors the marketplace schema's `path` refine so the
- * gated resolver rejects the same paths the GitHub manifest does — platform
- * catalog rows accept `path` as any string, so this is the install-side gate.
+ * A NON-EMPTY repo-relative path is clean when no `/`-or-`\`-split segment
+ * escapes (`..`) or is interior-empty (`a//b`). Mirrors the marketplace
+ * schema's `path` refine so the gated resolver rejects the same paths the
+ * GitHub manifest does — platform catalog rows accept `path` as any string, so
+ * this is the install-side gate. An empty/absent path is repo root, not passed
+ * here.
  */
 function isCleanRepoRelativePath(path: string): boolean {
   return !path.split(/[/\\]/).some((seg) => seg === ".." || seg === "");
@@ -57,7 +59,8 @@ export function resolveSourceFromMatch(
         `a curated install must pin to an immutable full commit SHA (tags and branches are mutable).`,
     );
   }
-  if (path !== undefined && !isCleanRepoRelativePath(path)) {
+  // An empty/absent path is repo root (valid); only gate a non-empty path.
+  if (path && !isCleanRepoRelativePath(path)) {
     throw new Error(
       `Catalog entry "${match.name}" has an unsafe plugin path "${path}"; ` +
         `a curated install path must be a clean repo-relative directory (no ".." or empty segments).`,

--- a/assistant/src/cli/lib/plugin-catalog-resolve.ts
+++ b/assistant/src/cli/lib/plugin-catalog-resolve.ts
@@ -27,12 +27,25 @@ export async function findCatalogEntry(
 }
 
 /**
+ * A repo-relative path is clean when no `/`-or-`\`-split segment escapes (`..`)
+ * or is empty (`""`). Mirrors the marketplace schema's `path` refine so the
+ * gated resolver rejects the same paths the GitHub manifest does — platform
+ * catalog rows accept `path` as any string, so this is the install-side gate.
+ */
+function isCleanRepoRelativePath(path: string): boolean {
+  return !path.split(/[/\\]/).some((seg) => seg === ".." || seg === "");
+}
+
+/**
  * Project a catalog match onto concrete GitHub install coordinates.
  *
  * Re-asserts the install-pinning invariant the GitHub path enforces via schema:
  * a curated install MUST pin to an immutable full commit SHA, so a non-SHA ref
  * from an upstream catalog is a config defect and throws rather than installing
- * mutable code. Pure — unit-testable without a catalog.
+ * mutable code. Likewise re-asserts the schema's clean-path rule: a platform
+ * catalog row does not validate `path`, so an escaping/empty segment reaching
+ * `trustedSource.rootPath` is rejected here rather than copying the wrong tree.
+ * Pure — unit-testable without a catalog.
  */
 export function resolveSourceFromMatch(
   match: PluginSearchMatch,
@@ -42,6 +55,12 @@ export function resolveSourceFromMatch(
     throw new Error(
       `Catalog entry "${match.name}" pins ref "${ref}", which is not a full commit SHA; ` +
         `a curated install must pin to an immutable full commit SHA (tags and branches are mutable).`,
+    );
+  }
+  if (path !== undefined && !isCleanRepoRelativePath(path)) {
+    throw new Error(
+      `Catalog entry "${match.name}" has an unsafe plugin path "${path}"; ` +
+        `a curated install path must be a clean repo-relative directory (no ".." or empty segments).`,
     );
   }
   const [owner, repoName] = repo.split("/", 2) as [string, string];

--- a/assistant/src/cli/lib/plugin-marketplace.ts
+++ b/assistant/src/cli/lib/plugin-marketplace.ts
@@ -59,7 +59,7 @@ const PLUGIN_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
  */
 const COMMIT_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 
-const githubSourceSchema = z.object({
+export const githubSourceSchema = z.object({
   /** Discriminator. Only GitHub sources are resolved today. */
   source: z.literal("github"),
   /** `owner/repo` of the external plugin repository. */

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -70,6 +70,7 @@ import {
   type InstallPluginOptions,
   type InstallPluginResult,
   InvalidPluginNameError,
+  isFullCommitSha,
   PluginAlreadyInstalledError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
@@ -181,6 +182,9 @@ mock.module("../../../cli/lib/install-from-github.js", () => ({
   // path from `:name` rather than delegating to a lib that sanitizes), so pass
   // the real `sanitizePluginName` through — a traversal name must still 400.
   sanitizePluginName,
+  // The (unmocked) catalog resolver enforces the full-SHA pin invariant via the
+  // real `isFullCommitSha`, so pass it through rather than the default undefined.
+  isFullCommitSha,
   installPlugin: installSpy,
 }));
 
@@ -1394,50 +1398,91 @@ async function invokeInstall(args: RouteHandlerArgs = {}): Promise<{
   };
 }
 
+// A gated-catalog match for `caveman` pinned to an immutable full commit SHA —
+// the shape the resolver projects onto trusted install coordinates. Mirrors the
+// bundled manifest: platform-first live, or the bundled pin when platform
+// features are off.
+const CAVEMAN_PIN = "63a91ecadbf4c4719a4602a5abb00883f9966034";
+const CAVEMAN_CATALOG_MATCH: PluginSearchMatch = {
+  name: "caveman",
+  path: `github:JuliusBrussee/caveman@${CAVEMAN_PIN}`,
+  description: "Ultra-compressed communication mode.",
+  category: null,
+  source: { kind: "github", repo: "JuliusBrussee/caveman", ref: CAVEMAN_PIN },
+};
+
+// installPlugin result for a trustedSource install: the returned `ref` is the
+// trusted pin (the external content commit), not the default branch.
+function trustedInstallResult(opts: InstallPluginOptions): InstallPluginResult {
+  return {
+    name: opts.name,
+    target: `/workspace/.vellum/plugins/${opts.name}`,
+    fileCount: 7,
+    ref: opts.trustedSource?.ref ?? opts.ref ?? "main",
+    commit: opts.trustedSource?.ref ?? null,
+    committedAt: null,
+  };
+}
+
 describe("POST /v1/plugins/install", () => {
   beforeEach(() => {
     installSpy.mockReset();
     resolvePinSpy.mockReset();
     broadcastMessageSpy.mockReset();
+    getCatalogSpy.mockReset();
+    // Default: the gated catalog resolves `caveman` to its bundled full-SHA pin.
+    getCatalogSpy.mockImplementation(async (ref) =>
+      catalog(ref, [CAVEMAN_CATALOG_MATCH]),
+    );
   });
 
-  test("forwards name/force and shapes the result, pinning ref to the default", async () => {
-    installSpy.mockImplementation(async (opts) => ({
-      name: opts.name,
-      target: `/workspace/.vellum/plugins/${opts.name}`,
-      fileCount: 7,
-      ref: opts.ref ?? "main",
-      commit: null,
-      committedAt: null,
-    }));
+  test("no-pin install resolves from the gated catalog and installs via trustedSource", async () => {
+    // The default (no-pin) path reads the same gated catalog `search`
+    // advertises and installs from a trusted pre-resolved source — no direct
+    // `plugins/marketplace.json` fetch (the pin/marketplace path is untouched).
+    const prev = process.env.VELLUM_DISABLE_PLATFORM;
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    try {
+      installSpy.mockImplementation(async (opts) => trustedInstallResult(opts));
 
-    const result = await invokeInstall({
-      body: { name: "caveman", force: true },
-    });
+      const result = await invokeInstall({
+        body: { name: "caveman", force: true },
+      });
 
-    expect(result).toEqual({
-      ok: true,
-      name: "caveman",
-      target: "/workspace/.vellum/plugins/caveman",
-      fileCount: 7,
-      ref: "main",
-    });
-    expect(installSpy.mock.calls[0]?.[0]).toEqual({
-      name: "caveman",
-      ref: "main",
-      force: true,
-    });
+      // Resolved through the gated catalog, not the pin/marketplace path.
+      expect(getCatalogSpy).toHaveBeenCalledTimes(1);
+      expect(resolvePinSpy).not.toHaveBeenCalled();
+      // installPlugin receives the pre-resolved trusted coordinates (owner/repo
+      // split from the catalog `repo`, `rootPath` from its path, the full-SHA
+      // pin as `ref`) — no caller-supplied `ref`.
+      expect(installSpy.mock.calls[0]?.[0]).toEqual({
+        name: "caveman",
+        force: true,
+        trustedSource: {
+          owner: "JuliusBrussee",
+          repo: "caveman",
+          rootPath: "",
+          ref: CAVEMAN_PIN,
+        },
+      });
+      expect(result).toEqual({
+        ok: true,
+        name: "caveman",
+        target: "/workspace/.vellum/plugins/caveman",
+        fileCount: 7,
+        ref: CAVEMAN_PIN,
+      });
+    } finally {
+      if (prev === undefined) {
+        delete process.env.VELLUM_DISABLE_PLATFORM;
+      } else {
+        process.env.VELLUM_DISABLE_PLATFORM = prev;
+      }
+    }
   });
 
   test("publishes sync_changed(plugins:list) on a successful install", async () => {
-    installSpy.mockImplementation(async (opts) => ({
-      name: opts.name,
-      target: `/workspace/.vellum/plugins/${opts.name}`,
-      fileCount: 7,
-      ref: opts.ref ?? "main",
-      commit: null,
-      committedAt: null,
-    }));
+    installSpy.mockImplementation(async (opts) => trustedInstallResult(opts));
 
     await invokeInstall({ body: { name: "caveman" } });
 
@@ -1445,14 +1490,7 @@ describe("POST /v1/plugins/install", () => {
   });
 
   test("threads x-vellum-client-id into the published event's originClientId", async () => {
-    installSpy.mockImplementation(async (opts) => ({
-      name: opts.name,
-      target: `/workspace/.vellum/plugins/${opts.name}`,
-      fileCount: 7,
-      ref: opts.ref ?? "main",
-      commit: null,
-      committedAt: null,
-    }));
+    installSpy.mockImplementation(async (opts) => trustedInstallResult(opts));
 
     await invokeInstall({
       body: { name: "caveman" },
@@ -1466,30 +1504,51 @@ describe("POST /v1/plugins/install", () => {
     });
   });
 
-  test("ignores a caller-supplied ref and pins to the curated default", async () => {
+  test("ignores a caller-supplied ref and installs from the catalog-resolved source", async () => {
     // Security boundary: installing from an unreviewed ref (a PR branch,
-    // fork ref, ...) could load attacker-controlled marketplace code, so the
-    // HTTP route never honors a body `ref` — it always resolves
-    // against the curated default ref.
-    installSpy.mockImplementation(async (opts) => ({
-      name: opts.name,
-      target: `/workspace/.vellum/plugins/${opts.name}`,
-      fileCount: 7,
-      ref: opts.ref ?? "main",
-      commit: null,
-      committedAt: null,
-    }));
+    // fork ref, ...) could load attacker-controlled code, so the HTTP route
+    // never honors a body `ref` — the no-pin source comes only from the gated
+    // catalog.
+    installSpy.mockImplementation(async (opts) => trustedInstallResult(opts));
 
     const result = await invokeInstall({
       body: { name: "caveman", ref: "attacker-pr-branch" },
     });
 
-    expect(result.ref).toBe("main");
+    expect(result.ref).toBe(CAVEMAN_PIN);
     expect(installSpy.mock.calls[0]?.[0]).toEqual({
       name: "caveman",
-      ref: "main",
       force: undefined,
+      trustedSource: {
+        owner: "JuliusBrussee",
+        repo: "caveman",
+        rootPath: "",
+        ref: CAVEMAN_PIN,
+      },
     });
+  });
+
+  test("an unknown name (no pin) → NotFoundError (404), no install", async () => {
+    // The catalog claims no such plugin, so the resolver returns null.
+    getCatalogSpy.mockImplementation(async (ref) => catalog(ref, []));
+
+    await expect(
+      invokeInstall({ body: { name: "ghost" } }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+    expect(installSpy).not.toHaveBeenCalled();
+  });
+
+  test("a catalog outage on the no-pin path → ServiceUnavailableError (503)", async () => {
+    // A rate-limited or unavailable platform catalog (no stale fallback) is
+    // transient — the route surfaces it as retryable, not a misleading 500.
+    getCatalogSpy.mockImplementation(async () => {
+      throw new PluginCatalogUnavailableError("HTTP 403", 403);
+    });
+
+    await expect(
+      invokeInstall({ body: { name: "caveman" } }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+    expect(installSpy).not.toHaveBeenCalled();
   });
 
   test("a missing name short-circuits to BadRequestError without calling the lib", async () => {
@@ -1497,15 +1556,16 @@ describe("POST /v1/plugins/install", () => {
       BadRequestError,
     );
     expect(installSpy).not.toHaveBeenCalled();
+    expect(getCatalogSpy).not.toHaveBeenCalled();
   });
 
   test("InvalidPluginNameError → BadRequestError (400)", async () => {
     installSpy.mockImplementation(async () => {
-      throw new InvalidPluginNameError("../escape");
+      throw new InvalidPluginNameError("bad plugin name");
     });
 
     await expect(
-      invokeInstall({ body: { name: "../escape" } }),
+      invokeInstall({ body: { name: "caveman" } }),
     ).rejects.toBeInstanceOf(BadRequestError);
   });
 
@@ -1528,7 +1588,7 @@ describe("POST /v1/plugins/install", () => {
     });
 
     await expect(
-      invokeInstall({ body: { name: "ghost" } }),
+      invokeInstall({ body: { name: "caveman" } }),
     ).rejects.toBeInstanceOf(NotFoundError);
     // A failed install must not fan out a spurious invalidation.
     expect(broadcastMessageSpy).not.toHaveBeenCalled();
@@ -1587,7 +1647,9 @@ describe("POST /v1/plugins/install", () => {
     });
 
     // THEN the install reads the manifest at the resolving marketplace commit,
-    // not the default branch
+    // not the default branch, and the gated catalog resolver is bypassed — the
+    // pin path stays on the reviewed pin-history/GitHub route.
+    expect(getCatalogSpy).not.toHaveBeenCalled();
     expect(installSpy.mock.calls[0]?.[0]).toEqual({
       name: "caveman",
       ref: "f".repeat(40),

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -1559,6 +1559,16 @@ describe("POST /v1/plugins/install", () => {
     expect(getCatalogSpy).not.toHaveBeenCalled();
   });
 
+  test("an invalid name (no pin) → BadRequestError before the catalog lookup", async () => {
+    // A malformed install name is validated up front via `sanitizePluginName`,
+    // so it's a deterministic 400 — never a 404/503 from resolving the catalog.
+    await expect(
+      invokeInstall({ body: { name: "../escape" } }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(getCatalogSpy).not.toHaveBeenCalled();
+    expect(installSpy).not.toHaveBeenCalled();
+  });
+
   test("InvalidPluginNameError → BadRequestError (400)", async () => {
     installSpy.mockImplementation(async () => {
       throw new InvalidPluginNameError("bad plugin name");

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1103,8 +1103,8 @@ async function resolveInstallMarketplaceRef(
 }
 
 async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
-  const name = typeof body.name === "string" ? body.name : "";
-  if (!name) {
+  const rawName = typeof body.name === "string" ? body.name : "";
+  if (!rawName) {
     throw new BadRequestError("`name` is required");
   }
   const force = typeof body.force === "boolean" ? body.force : undefined;
@@ -1123,6 +1123,11 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
   // SHA is refused. Operators who need an unreviewed revision use the local
   // CLI's `assistant plugins install --pin <sha> --allow-unreviewed`.
   try {
+    // Validate the name up front — before any catalog/pin/network work — so a
+    // malformed name (`../escape`) is a deterministic 400 rather than a 404/503
+    // from the catalog lookup. `installPlugin` sanitizes too; this restores the
+    // advertised 400 across both the no-pin and pin paths.
+    const name = sanitizePluginName(rawName);
     let result;
     if (pin) {
       const marketplaceRef = await resolveInstallMarketplaceRef(name, pin);

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -49,6 +49,7 @@ import {
   listInstalledPlugins,
 } from "../../cli/lib/list-installed-plugins.js";
 import { getPluginCatalog } from "../../cli/lib/plugin-catalog-cache.js";
+import { resolvePluginSourceFromCatalog } from "../../cli/lib/plugin-catalog-resolve.js";
 import {
   DEFAULT_PIN_HISTORY_LIMIT,
   DEFAULT_PLUGIN_REF,
@@ -1109,22 +1110,47 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
   const force = typeof body.force === "boolean" ? body.force : undefined;
   const pin = typeof body.pin === "string" ? body.pin : undefined;
 
-  // The marketplace ref is never taken raw from the request: a caller-supplied
+  // The install source is never taken raw from the request: a caller-supplied
   // ref would let any `settings.write` principal install from an unreviewed
   // revision (a PR branch, fork ref, ...) whose manifest could carry attacker
-  // code the loader then dynamically imports. Installs over HTTP therefore
-  // resolve only against reviewed history. A `pin` is honored by mapping it —
-  // server-side — to the marketplace commit that introduced it, but only if it
-  // appears in the plugin's reviewed pin history; an unreviewed SHA is refused.
-  // The default install reads the current catalog on `DEFAULT_PLUGIN_REF`.
-  // Operators who need an unreviewed revision use the local CLI's
-  // `assistant plugins install --pin <sha> --allow-unreviewed`.
+  // code the loader then dynamically imports. The default (no-pin) install
+  // resolves owner/repo/ref from the gated catalog — platform-first, or the
+  // bundled manifest when platform features are disabled — which is the same
+  // reviewed source of truth `handleSearchPlugins` advertises, and installs via
+  // a trusted pre-resolved source (no direct `plugins/marketplace.json` fetch).
+  // A `pin` is honored by mapping it — server-side — to the marketplace commit
+  // that introduced it through the plugin's reviewed pin history; an unreviewed
+  // SHA is refused. Operators who need an unreviewed revision use the local
+  // CLI's `assistant plugins install --pin <sha> --allow-unreviewed`.
   try {
-    const marketplaceRef = await resolveInstallMarketplaceRef(name, pin);
-    const result = await installPlugin(
-      { name, ref: marketplaceRef, force },
-      { fetch: globalThis.fetch.bind(globalThis) },
-    );
+    let result;
+    if (pin) {
+      const marketplaceRef = await resolveInstallMarketplaceRef(name, pin);
+      result = await installPlugin(
+        { name, ref: marketplaceRef, force },
+        { fetch: globalThis.fetch.bind(globalThis) },
+      );
+    } else {
+      const source = await resolvePluginSourceFromCatalog(name, {
+        fetch: globalThis.fetch.bind(globalThis),
+      });
+      if (!source) {
+        throw new NotFoundError(`No plugin named "${name}" in the catalog.`);
+      }
+      result = await installPlugin(
+        {
+          name,
+          force,
+          trustedSource: {
+            owner: source.owner,
+            repo: source.repo,
+            rootPath: source.path,
+            ref: source.ref,
+          },
+        },
+        { fetch: globalThis.fetch.bind(globalThis) },
+      );
+    }
     publishPluginsChanged(getOriginClientId(headers));
     return {
       ok: true as const,
@@ -1134,7 +1160,7 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
       ref: result.ref,
     };
   } catch (err) {
-    // Pin resolution already maps unreviewed/bad-pin cases to a RouteError;
+    // Pin resolution and the not-in-catalog case already map to a RouteError;
     // re-throw those verbatim rather than masking them as a 500.
     if (err instanceof RouteError) {
       throw err;
@@ -1155,6 +1181,11 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
     }
     // The pin-history read hits GitHub too; treat its failures as retryable.
     if (err instanceof PluginPinHistoryError) {
+      throw new ServiceUnavailableError(err.message);
+    }
+    // A rate-limited or unavailable platform catalog (no stale fallback) is
+    // transient — surface it as retryable rather than a misleading 500.
+    if (err instanceof PluginCatalogUnavailableError) {
       throw new ServiceUnavailableError(err.message);
     }
     throw new InternalError(


### PR DESCRIPTION
## Summary
- Daemon install-by-name (no pin) now resolves owner/repo/ref from the gated catalog (platform-first, bundled offline) and installs via trustedSource — the same source search advertises. --pin path unchanged (reviewed pin history). Catalog outage → 503.

Part of plan: catalog-source-consistency.md (PR 3 of 4)