### PR TITLE
feat(gateway): managed-speech relay — daemon → gateway → velay

### DIFF
--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -207,6 +207,10 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   "/v1/contacts/guardian/channel",
   // BFF token auth — loopback-only, not part of the public gateway API
   "/auth/token",
+  // Managed-speech relay — daemon-only WS egress to velay, rejected on any
+  // ingress path; not part of the public gateway API
+  "/v1/speech/stt/stream",
+  "/v1/speech/tts/stream",
 ]);
 
 // ── Schema paths that don't map to a discrete route definition ──

--- a/gateway/src/__tests__/speech-relay-websocket.test.ts
+++ b/gateway/src/__tests__/speech-relay-websocket.test.ts
@@ -240,6 +240,7 @@ type WsListener = (ev?: unknown) => void;
 class FakeUpstreamWebSocket {
   static instances: FakeUpstreamWebSocket[] = [];
   readyState = 0; // CONNECTING
+  binaryType = "";
   sent: (string | ArrayBuffer | Uint8Array)[] = [];
   closeCalled: { code?: number; reason?: string } | null = null;
 
@@ -369,6 +370,46 @@ describe("getSpeechRelayWebsocketHandlers", () => {
       code: 1000,
       reason: "session_duration_exceeded",
     });
+  });
+
+  test("sets arraybuffer binary mode on the upstream socket", async () => {
+    FakeUpstreamWebSocket.instances = [];
+    const handlers = getSpeechRelayWebsocketHandlers();
+    const ws = new FakeDownstreamSocket(makeSocketData());
+
+    await handlers.open(ws as never);
+    expect(FakeUpstreamWebSocket.instances[0]!.binaryType).toBe("arraybuffer");
+  });
+
+  test("a pre-open close waits for the probe's velay_error before closing", async () => {
+    // A rejected handshake can emit close (or error+close) before the async
+    // probe resolves; the raw close must not beat the synthesized frame.
+    FakeUpstreamWebSocket.instances = [];
+    const handlers = getSpeechRelayWebsocketHandlers();
+    const fetchImpl = mock(
+      async () =>
+        new Response(
+          JSON.stringify({ code: "insufficient_balance", detail: "empty" }),
+          { status: 402 },
+        ),
+    ) as unknown as typeof fetch;
+    const data = makeSocketData();
+    data.deps.fetchImpl = fetchImpl;
+    const ws = new FakeDownstreamSocket(data);
+
+    await handlers.open(ws as never);
+    const upstream = FakeUpstreamWebSocket.instances[0]!;
+    upstream.emitError();
+    upstream.emitClose(1006);
+    await tick();
+
+    // One synthesized frame, one close — the double-fire is coalesced.
+    expect(ws.sent).toHaveLength(1);
+    expect(JSON.parse(ws.sent[0] as string).code).toBe("insufficient_balance");
+    expect(ws.closeCalled?.code).toBe(1011);
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls,
+    ).toHaveLength(1);
   });
 
   test("a failed velay dial synthesizes a velay_error from the HTTP probe", async () => {

--- a/gateway/src/__tests__/speech-relay-websocket.test.ts
+++ b/gateway/src/__tests__/speech-relay-websocket.test.ts
@@ -1,0 +1,428 @@
+import { describe, test, expect, mock } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+import type { CredentialCache } from "../credential-cache.js";
+import {
+  createSpeechRelayUpgradeHandler,
+  getSpeechRelayWebsocketHandlers,
+  type SpeechRelaySocketData,
+} from "../http/routes/speech-relay-websocket.js";
+import { VELAY_FORWARDED_HEADER } from "../velay/bridge-utils.js";
+
+const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
+initSigningKey(TEST_SIGNING_KEY);
+
+/** The daemon's self-minted service token — the only accepted principal. */
+function mintDaemonServiceToken(): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: "svc:daemon:self",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+/** An actor edge token — valid signature, wrong principal for this path. */
+function mintActorToken(): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: "actor:test-assistant:test-user",
+    scope_profile: "actor_client_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    velayBaseUrl: "https://velay.test",
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    trustProxy: false,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+function makeFakeServer(upgradeResult: boolean = true) {
+  return {
+    requestIP: mock(() => ({
+      address: "127.0.0.1",
+      family: "IPv4",
+      port: 54000,
+    })),
+    upgrade: mock(() => upgradeResult),
+  } as unknown as import("bun").Server<unknown>;
+}
+
+function makeCredentials(apiKey: string | undefined): CredentialCache {
+  return {
+    get: mock(async () => apiKey),
+  } as unknown as CredentialCache;
+}
+
+async function bodyOf(
+  res: Response,
+): Promise<{ code: string; detail: string }> {
+  return (await res.json()) as { code: string; detail: string };
+}
+
+const TOKEN = mintDaemonServiceToken();
+
+describe("createSpeechRelayUpgradeHandler — gate", () => {
+  test("upgrades a daemon service connection and strips the key param", async () => {
+    const server = makeFakeServer();
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeCredentials("vk-1"),
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}&encoding=linear16&sample_rate=16000&channels=1`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    expect(await handler(req, server)).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
+    const upstream = new URL(data.data.upstreamWsUrl);
+    expect(upstream.origin).toBe("wss://velay.test");
+    expect(upstream.pathname).toBe("/v1/speech/stt/stream");
+    expect(upstream.searchParams.get("encoding")).toBe("linear16");
+    expect(upstream.searchParams.get("sample_rate")).toBe("16000");
+    // The daemon's gateway token must never be forwarded to velay.
+    expect(upstream.searchParams.has("key")).toBe(false);
+  });
+
+  test("routes the tts operation to velay's tts path", async () => {
+    const server = makeFakeServer();
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "tts", {
+      credentials: makeCredentials("vk-1"),
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/tts/stream?key=${TOKEN}&encoding=linear16`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    expect(await handler(req, server)).toBeUndefined();
+    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
+    expect(new URL(data.data.upstreamWsUrl).pathname).toBe(
+      "/v1/speech/tts/stream",
+    );
+  });
+
+  test("rejects a missing token", async () => {
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeCredentials("vk-1"),
+    });
+    const req = new Request("http://127.0.0.1:7830/v1/speech/stt/stream", {
+      headers: { upgrade: "websocket" },
+    });
+
+    const res = (await handler(req, makeFakeServer()))!;
+    expect(res.status).toBe(401);
+    expect((await bodyOf(res)).code).toBe("invalid_token");
+  });
+
+  test("rejects an actor token — daemon service principal only", async () => {
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeCredentials("vk-1"),
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${mintActorToken()}`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    const res = (await handler(req, makeFakeServer()))!;
+    expect(res.status).toBe(401);
+    expect((await bodyOf(res)).code).toBe("invalid_token");
+  });
+
+  test("rejects velay-forwarded requests regardless of token", async () => {
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeCredentials("vk-1"),
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}`,
+      { headers: { upgrade: "websocket", [VELAY_FORWARDED_HEADER]: "1" } },
+    );
+
+    const res = (await handler(req, makeFakeServer()))!;
+    expect(res.status).toBe(403);
+    expect((await bodyOf(res)).code).toBe("forbidden");
+  });
+});
+
+describe("createSpeechRelayUpgradeHandler — probe (non-upgrade GET)", () => {
+  test("returns missing_platform_connection without a stored API key", async () => {
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeCredentials(undefined),
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}`,
+    );
+
+    const res = (await handler(req, makeFakeServer()))!;
+    expect(res.status).toBe(401);
+    expect((await bodyOf(res)).code).toBe("missing_platform_connection");
+  });
+
+  test("forwards velay's JSON rejection with its status", async () => {
+    const fetchImpl = mock(
+      async () =>
+        new Response(
+          JSON.stringify({ code: "insufficient_balance", detail: "empty" }),
+          { status: 402 },
+        ),
+    ) as unknown as typeof fetch;
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeCredentials("vk-1"),
+      fetchImpl,
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}&encoding=linear16`,
+    );
+
+    const res = (await handler(req, makeFakeServer()))!;
+    expect(res.status).toBe(402);
+    expect(await bodyOf(res)).toEqual({
+      code: "insufficient_balance",
+      detail: "empty",
+    });
+    // The probe authenticates to velay with the assistant API key.
+    const probeCall = (fetchImpl as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]!;
+    expect(String(probeCall[0])).toContain(
+      "https://velay.test/v1/speech/stt/stream",
+    );
+    expect(
+      (probeCall[1] as { headers: Record<string, string> }).headers
+        .Authorization,
+    ).toBe("Api-Key vk-1");
+  });
+
+  test("returns upgrade_required when the gate passes", async () => {
+    const fetchImpl = mock(
+      async () => new Response("Upgrade Required", { status: 426 }),
+    ) as unknown as typeof fetch;
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeCredentials("vk-1"),
+      fetchImpl,
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}`,
+    );
+
+    const res = (await handler(req, makeFakeServer()))!;
+    expect(res.status).toBe(426);
+    expect((await bodyOf(res)).code).toBe("upgrade_required");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Websocket handlers — velay dial + frame pipe
+// ---------------------------------------------------------------------------
+
+type WsListener = (ev?: unknown) => void;
+
+class FakeUpstreamWebSocket {
+  static instances: FakeUpstreamWebSocket[] = [];
+  readyState = 0; // CONNECTING
+  sent: (string | ArrayBuffer | Uint8Array)[] = [];
+  closeCalled: { code?: number; reason?: string } | null = null;
+
+  constructor(
+    readonly url: string,
+    readonly options?: { headers?: Record<string, string> },
+  ) {
+    FakeUpstreamWebSocket.instances.push(this);
+  }
+
+  private listeners = new Map<string, WsListener[]>();
+
+  addEventListener(type: string, listener: WsListener): void {
+    const list = this.listeners.get(type) ?? [];
+    list.push(listener);
+    this.listeners.set(type, list);
+  }
+
+  send(data: string | ArrayBuffer | Uint8Array): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalled = { code, reason };
+    this.readyState = 3;
+  }
+
+  emitOpen(): void {
+    this.readyState = 1;
+    for (const l of this.listeners.get("open") ?? []) l();
+  }
+
+  emitMessage(data: string): void {
+    for (const l of this.listeners.get("message") ?? []) l({ data });
+  }
+
+  emitClose(code: number, reason = ""): void {
+    this.readyState = 3;
+    for (const l of this.listeners.get("close") ?? []) l({ code, reason });
+  }
+
+  emitError(): void {
+    for (const l of this.listeners.get("error") ?? []) l({});
+  }
+}
+
+class FakeDownstreamSocket {
+  sent: (string | Uint8Array)[] = [];
+  closeCalled: { code?: number; reason?: string } | null = null;
+  data: SpeechRelaySocketData;
+
+  constructor(data: SpeechRelaySocketData) {
+    this.data = data;
+  }
+
+  send(data: string | Uint8Array): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalled = { code, reason };
+  }
+}
+
+function makeSocketData(
+  overrides: Partial<SpeechRelaySocketData> = {},
+): SpeechRelaySocketData {
+  return {
+    wsType: "speech-relay",
+    operation: "stt",
+    upstreamWsUrl: "wss://velay.test/v1/speech/stt/stream?encoding=linear16",
+    upstreamHttpUrl:
+      "https://velay.test/v1/speech/stt/stream?encoding=linear16",
+    deps: {
+      credentials: makeCredentials("vk-1"),
+      webSocketConstructor:
+        FakeUpstreamWebSocket as unknown as SpeechRelaySocketData["deps"]["webSocketConstructor"],
+    },
+    ...overrides,
+  };
+}
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("getSpeechRelayWebsocketHandlers", () => {
+  test("dials velay with the Api-Key header and pipes frames both ways", async () => {
+    FakeUpstreamWebSocket.instances = [];
+    const handlers = getSpeechRelayWebsocketHandlers();
+    const ws = new FakeDownstreamSocket(makeSocketData());
+
+    await handlers.open(ws as never);
+    const upstream = FakeUpstreamWebSocket.instances[0]!;
+    expect(upstream.url).toBe(
+      "wss://velay.test/v1/speech/stt/stream?encoding=linear16",
+    );
+    expect(upstream.options?.headers?.Authorization).toBe("Api-Key vk-1");
+
+    // Frames sent before upstream opens are buffered, then flushed.
+    handlers.message(ws as never, "early-audio");
+    expect(upstream.sent).toHaveLength(0);
+    upstream.emitOpen();
+    expect(upstream.sent).toEqual(["early-audio"]);
+
+    handlers.message(ws as never, "more-audio");
+    expect(upstream.sent).toEqual(["early-audio", "more-audio"]);
+
+    upstream.emitMessage('{"type":"Results"}');
+    expect(ws.sent).toEqual(['{"type":"Results"}']);
+  });
+
+  test("forwards upstream close codes and reasons to the daemon", async () => {
+    FakeUpstreamWebSocket.instances = [];
+    const handlers = getSpeechRelayWebsocketHandlers();
+    const ws = new FakeDownstreamSocket(makeSocketData());
+
+    await handlers.open(ws as never);
+    const upstream = FakeUpstreamWebSocket.instances[0]!;
+    upstream.emitOpen();
+    upstream.emitMessage(
+      '{"type":"velay_error","code":"session_duration_exceeded","detail":""}',
+    );
+    upstream.emitClose(1000, "session_duration_exceeded");
+
+    // The velay_error frame passes through untouched, then the close.
+    expect(ws.sent[0]).toContain("session_duration_exceeded");
+    expect(ws.closeCalled).toEqual({
+      code: 1000,
+      reason: "session_duration_exceeded",
+    });
+  });
+
+  test("a failed velay dial synthesizes a velay_error from the HTTP probe", async () => {
+    FakeUpstreamWebSocket.instances = [];
+    const handlers = getSpeechRelayWebsocketHandlers();
+    const fetchImpl = mock(
+      async () =>
+        new Response(JSON.stringify({ code: "invalid_key", detail: "bad" }), {
+          status: 401,
+        }),
+    ) as unknown as typeof fetch;
+    const data = makeSocketData();
+    data.deps.fetchImpl = fetchImpl;
+    const ws = new FakeDownstreamSocket(data);
+
+    await handlers.open(ws as never);
+    FakeUpstreamWebSocket.instances[0]!.emitError();
+    await tick();
+
+    expect(ws.sent).toHaveLength(1);
+    expect(JSON.parse(ws.sent[0] as string)).toEqual({
+      type: "velay_error",
+      code: "invalid_key",
+      detail: "bad",
+    });
+    expect(ws.closeCalled?.code).toBe(1011);
+  });
+
+  test("missing API key closes with a synthesized velay_error, no dial", async () => {
+    FakeUpstreamWebSocket.instances = [];
+    const handlers = getSpeechRelayWebsocketHandlers();
+    const data = makeSocketData();
+    data.deps.credentials = makeCredentials(undefined);
+    const ws = new FakeDownstreamSocket(data);
+
+    await handlers.open(ws as never);
+
+    expect(FakeUpstreamWebSocket.instances).toHaveLength(0);
+    expect(JSON.parse(ws.sent[0] as string).code).toBe(
+      "missing_platform_connection",
+    );
+    expect(ws.closeCalled?.code).toBe(1011);
+  });
+
+  test("daemon close is forwarded to velay", async () => {
+    FakeUpstreamWebSocket.instances = [];
+    const handlers = getSpeechRelayWebsocketHandlers();
+    const ws = new FakeDownstreamSocket(makeSocketData());
+
+    await handlers.open(ws as never);
+    const upstream = FakeUpstreamWebSocket.instances[0]!;
+    upstream.emitOpen();
+
+    handlers.close(ws as never, 1000, "client done");
+    expect(upstream.closeCalled).toEqual({ code: 1000, reason: "client done" });
+  });
+});

--- a/gateway/src/__tests__/speech-relay-websocket.test.ts
+++ b/gateway/src/__tests__/speech-relay-websocket.test.ts
@@ -471,6 +471,48 @@ describe("getSpeechRelayWebsocketHandlers", () => {
     expect(ws.closeCalled?.code).toBe(1011);
   });
 
+  test("a ws:// relay base still yields a fetchable probe URL", async () => {
+    const server = makeFakeServer();
+    const handler = createSpeechRelayUpgradeHandler(
+      makeConfig({ velayBaseUrl: "wss://velay.test" } as never),
+      "stt",
+      { credentials: makeCredentials("vk-1") },
+    );
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}&encoding=linear16`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    expect(await handler(req, server)).toBeUndefined();
+    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
+    expect(data.data.upstreamWsUrl.startsWith("wss://velay.test/")).toBe(true);
+    expect(data.data.upstreamHttpUrl.startsWith("https://velay.test/")).toBe(
+      true,
+    );
+  });
+
+  test("a daemon close during the credential read prevents the velay dial", async () => {
+    FakeUpstreamWebSocket.instances = [];
+    const handlers = getSpeechRelayWebsocketHandlers();
+    let releaseRead: (v: string) => void = () => {};
+    const data = makeSocketData();
+    data.deps.credentials = {
+      get: () => new Promise<string>((r) => (releaseRead = r)),
+    } as unknown as CredentialCache;
+    const ws = new FakeDownstreamSocket(data);
+
+    const opening = handlers.open(ws as never);
+    // The daemon hangs up while the CES/keychain read is still pending.
+    handlers.close(ws as never, 1001, "going away");
+    releaseRead("vk-1");
+    await opening;
+
+    // No upstream session was dialed — nothing left to close would have
+    // torn it down.
+    expect(FakeUpstreamWebSocket.instances).toHaveLength(0);
+  });
+
   test("daemon close is forwarded to velay", async () => {
     FakeUpstreamWebSocket.instances = [];
     const handlers = getSpeechRelayWebsocketHandlers();

--- a/gateway/src/__tests__/speech-relay-websocket.test.ts
+++ b/gateway/src/__tests__/speech-relay-websocket.test.ts
@@ -150,6 +150,23 @@ describe("createSpeechRelayUpgradeHandler — gate", () => {
     expect((await bodyOf(res)).code).toBe("invalid_token");
   });
 
+  test("rejects non-allowlisted query parameters at the gateway boundary", async () => {
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeCredentials("vk-1"),
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}&encoding=linear16&model=nova-3`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    const res = (await handler(req, makeFakeServer()))!;
+    expect(res.status).toBe(400);
+    expect(await bodyOf(res)).toEqual({
+      code: "invalid_request",
+      detail: "unsupported query parameter: model",
+    });
+  });
+
   test("rejects velay-forwarded requests regardless of token", async () => {
     const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
       credentials: makeCredentials("vk-1"),

--- a/gateway/src/http/routes/speech-relay-websocket.ts
+++ b/gateway/src/http/routes/speech-relay-websocket.ts
@@ -48,6 +48,27 @@ const DAEMON_SERVICE_SUB = "svc:daemon:self";
 
 export type SpeechRelayOperation = "stt" | "tts";
 
+/**
+ * Param allowlists, mirroring velay's own (velay/internal/velay/deepgram.go).
+ * Velay would reject unknown params anyway, but this relay is the policy
+ * boundary — a buggy or compromised daemon must not get arbitrary query
+ * strings forwarded upstream under the stored assistant API key.
+ */
+const ALLOWED_PARAMS: Record<SpeechRelayOperation, ReadonlySet<string>> = {
+  stt: new Set([
+    "encoding",
+    "sample_rate",
+    "channels",
+    "language",
+    "interim_results",
+    "smart_format",
+    "endpointing",
+    "vad_events",
+    "punctuate",
+  ]),
+  tts: new Set(["encoding", "sample_rate", "container"]),
+};
+
 type WebSocketConstructorWithHeaders = new (
   url: string,
   options?: { headers?: OutgoingHttpHeaders },
@@ -183,6 +204,15 @@ export function createSpeechRelayUpgradeHandler(
 
     // ?key= is the daemon→gateway auth carrier, not a velay param.
     params.delete("key");
+    for (const param of params.keys()) {
+      if (!ALLOWED_PARAMS[operation].has(param)) {
+        return jsonError(
+          400,
+          "invalid_request",
+          `unsupported query parameter: ${param}`,
+        );
+      }
+    }
     const { wsUrl, httpUrl } = velaySpeechUrls(config, operation, params);
 
     // Non-upgrade request: this is the daemon's dial-failure probe.

--- a/gateway/src/http/routes/speech-relay-websocket.ts
+++ b/gateway/src/http/routes/speech-relay-websocket.ts
@@ -270,7 +270,41 @@ export function getSpeechRelayWebsocketHandlers() {
       const upstream = new WsCtor(upstreamWsUrl, {
         headers: { Authorization: `Api-Key ${apiKey}` },
       });
+      // TTS audio arrives as binary frames; without this they surface as
+      // Blobs and the downstream forward would crash.
+      try {
+        upstream.binaryType = "arraybuffer";
+      } catch {
+        // Test fakes may not implement the setter.
+      }
       ws.data.upstream = upstream;
+
+      // A rejected handshake can emit error and close (in either order,
+      // sometimes both) before the async rejection probe resolves —
+      // forwarding that raw close would beat the synthesized velay_error
+      // frame to the daemon. Route every pre-open failure through one
+      // guarded path instead.
+      let dialFailureHandled = false;
+      const handleDialFailure = () => {
+        if (dialFailureHandled) {
+          return;
+        }
+        dialFailureHandled = true;
+        void probeVelay(upstreamHttpUrl, apiKey, deps.fetchImpl ?? fetch).then(
+          (rejection) => {
+            log.error(
+              { operation, code: rejection?.code },
+              "Speech relay upstream dial failed",
+            );
+            sendRelayError(
+              ws,
+              rejection?.code ?? "provider_unreachable",
+              rejection?.detail ?? "could not reach the speech relay",
+            );
+            ws.close(1011, rejection?.code ?? "upstream_error");
+          },
+        );
+      };
 
       upstream.addEventListener("open", () => {
         log.info({ operation }, "Speech relay upstream connected to velay");
@@ -293,6 +327,10 @@ export function getSpeechRelayWebsocketHandlers() {
       });
 
       upstream.addEventListener("close", (event) => {
+        if (!ws.data.upstreamOpened) {
+          handleDialFailure();
+          return;
+        }
         log.info(
           { code: event.code, operation },
           "Speech relay upstream closed",
@@ -301,30 +339,14 @@ export function getSpeechRelayWebsocketHandlers() {
       });
 
       upstream.addEventListener("error", () => {
-        if (ws.data.upstreamOpened) {
-          // Mid-session transport failure; velay already sent its own
-          // velay_error frame if it had one.
-          log.error({ operation }, "Speech relay upstream error");
-          ws.close(1011, "upstream_error");
+        if (!ws.data.upstreamOpened) {
+          handleDialFailure();
           return;
         }
-        // Failed dial: the WebSocket API hides velay's HTTP rejection, so
-        // replay it as plain HTTPS and forward the {code, detail} the way
-        // velay itself reports mid-session errors.
-        void probeVelay(upstreamHttpUrl, apiKey, deps.fetchImpl ?? fetch).then(
-          (rejection) => {
-            log.error(
-              { operation, code: rejection?.code },
-              "Speech relay upstream dial failed",
-            );
-            sendRelayError(
-              ws,
-              rejection?.code ?? "provider_unreachable",
-              rejection?.detail ?? "could not reach the speech relay",
-            );
-            ws.close(1011, rejection?.code ?? "upstream_error");
-          },
-        );
+        // Mid-session transport failure; velay already sent its own
+        // velay_error frame if it had one.
+        log.error({ operation }, "Speech relay upstream error");
+        ws.close(1011, "upstream_error");
       });
     },
 

--- a/gateway/src/http/routes/speech-relay-websocket.ts
+++ b/gateway/src/http/routes/speech-relay-websocket.ts
@@ -1,0 +1,367 @@
+/**
+ * Managed-speech relay: daemon → gateway → velay.
+ *
+ * The assistant daemon must never dial velay itself — velay contact is
+ * gateway-only so deterministic policy stays in a process the agent cannot
+ * rewrite. This route accepts a WebSocket from the daemon, dials velay's
+ * speech relay (`/v1/speech/{stt,tts}/stream`) with the Vellum assistant
+ * API key, and pipes frames verbatim in both directions. The wire protocol
+ * on both legs is Deepgram's own (plus velay's `velay_error` control
+ * frame), so the gateway stays byte-transparent.
+ *
+ * Contract mirrors velay's so the daemon adapter treats the gateway as a
+ * drop-in relay endpoint:
+ * - auth via `?key=` (a daemon-minted service JWT, NOT the assistant API
+ *   key — the gateway attaches that to the upstream leg itself)
+ * - rejections are JSON `{code, detail}` bodies
+ * - upstream failures after upgrade surface as a synthesized
+ *   `velay_error` text frame followed by an abnormal close
+ * - a plain (non-upgrade) GET replays the gate and returns velay's own
+ *   HTTP rejection, so the daemon's dial-failure probe works end-to-end
+ */
+
+import type { OutgoingHttpHeaders } from "node:http";
+
+import { validateEdgeToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import type { CredentialCache } from "../../credential-cache.js";
+import { credentialKey } from "../../credential-key.js";
+import { getLogger } from "../../logger.js";
+import { VELAY_FORWARDED_HEADER } from "../../velay/bridge-utils.js";
+import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
+
+const log = getLogger("speech-relay-ws");
+
+/** Default relay origin when VELAY_BASE_URL is not configured. */
+const DEFAULT_VELAY_BASE_URL = "https://velay.vellum.ai";
+
+// Cap buffered messages to prevent unbounded memory growth if upstream stalls
+const MAX_PENDING_MESSAGES = 100;
+
+/**
+ * The only principal allowed on this path: the daemon's self-minted
+ * service token (both processes share the HMAC signing key). Duplicated in
+ * the assistant's speech connection module — the packages don't share
+ * auth constants.
+ */
+const DAEMON_SERVICE_SUB = "svc:daemon:self";
+
+export type SpeechRelayOperation = "stt" | "tts";
+
+type WebSocketConstructorWithHeaders = new (
+  url: string,
+  options?: { headers?: OutgoingHttpHeaders },
+) => WebSocket;
+
+export interface SpeechRelayDeps {
+  credentials: CredentialCache;
+  /** Injectable for tests — defaults to the global WebSocket. */
+  webSocketConstructor?: WebSocketConstructorWithHeaders;
+  /** Injectable for tests — defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export type SpeechRelaySocketData = {
+  wsType: "speech-relay";
+  operation: SpeechRelayOperation;
+  /** wss URL of the velay speech endpoint, params already attached. */
+  upstreamWsUrl: string;
+  /** https twin of upstreamWsUrl, for failure probes. */
+  upstreamHttpUrl: string;
+  deps: SpeechRelayDeps;
+  upstream?: WebSocket;
+  upstreamOpened?: boolean;
+  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
+};
+
+function jsonError(status: number, code: string, detail: string): Response {
+  return new Response(JSON.stringify({ code, detail }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function velaySpeechUrls(
+  config: GatewayConfig,
+  operation: SpeechRelayOperation,
+  params: URLSearchParams,
+): { wsUrl: string; httpUrl: string } {
+  const base = (config.velayBaseUrl ?? DEFAULT_VELAY_BASE_URL).replace(
+    /\/+$/,
+    "",
+  );
+  const query = params.toString();
+  const path = `/v1/speech/${operation}/stream${query ? `?${query}` : ""}`;
+  return {
+    httpUrl: `${base}${path}`,
+    wsUrl: `${base.replace(/^http/, "ws")}${path}`,
+  };
+}
+
+async function readAssistantApiKey(
+  deps: SpeechRelayDeps,
+): Promise<string | undefined> {
+  return deps.credentials.get(credentialKey("vellum", "assistant_api_key"));
+}
+
+/**
+ * Replay a failed/probing request against velay as plain HTTPS. Velay runs
+ * its whole gate (key validation, params, balance, upstream dial) before
+ * upgrading, so rejections reproduce as `{code, detail}` JSON; a request
+ * that passes the gate fails only at the upgrade step, which returns no
+ * such body.
+ */
+async function probeVelay(
+  httpUrl: string,
+  apiKey: string,
+  fetchImpl: typeof fetch,
+): Promise<{ status: number; code: string; detail: string } | null> {
+  try {
+    const res = await fetchImpl(httpUrl, {
+      headers: { Authorization: `Api-Key ${apiKey}` },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (res.ok) {
+      return null;
+    }
+    const body = (await res.json()) as { code?: unknown; detail?: unknown };
+    if (typeof body.code !== "string") {
+      return null;
+    }
+    return {
+      status: res.status,
+      code: body.code,
+      detail: typeof body.detail === "string" ? body.detail : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create the upgrade handler for one speech-relay path. Async: the
+ * non-upgrade probe branch awaits velay.
+ */
+export function createSpeechRelayUpgradeHandler(
+  config: GatewayConfig,
+  operation: SpeechRelayOperation,
+  deps: SpeechRelayDeps,
+) {
+  return async function handleUpgrade(
+    req: Request,
+    server: import("bun").Server<unknown>,
+  ): Promise<Response | undefined> {
+    if (req.method !== "GET") {
+      return jsonError(405, "method_not_allowed", "GET only");
+    }
+
+    // This is a daemon-loopback service path. Anything that arrived
+    // through velay's inbound tunnel (or the edge proxy) is categorically
+    // rejected — the relay must never be reachable from outside.
+    if (
+      req.headers.get(VELAY_FORWARDED_HEADER) !== null ||
+      requestHasVelayBridgeAuth(req)
+    ) {
+      log.warn("Speech relay: rejected velay-forwarded request");
+      return jsonError(403, "forbidden", "not reachable via ingress");
+    }
+
+    const url = new URL(req.url);
+    const params = url.searchParams;
+    const rawToken = params.get("key");
+    if (!rawToken) {
+      return jsonError(401, "invalid_token", "missing service token");
+    }
+    const result = validateEdgeToken(rawToken);
+    if (!result.ok || result.claims.sub !== DAEMON_SERVICE_SUB) {
+      log.warn(
+        { reason: result.ok ? "wrong_sub" : result.reason },
+        "Speech relay: authentication failed",
+      );
+      return jsonError(401, "invalid_token", "service token rejected");
+    }
+
+    // ?key= is the daemon→gateway auth carrier, not a velay param.
+    params.delete("key");
+    const { wsUrl, httpUrl } = velaySpeechUrls(config, operation, params);
+
+    // Non-upgrade request: this is the daemon's dial-failure probe.
+    // Replay the gate and hand back velay's own rejection.
+    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      const apiKey = await readAssistantApiKey(deps);
+      if (!apiKey) {
+        return jsonError(
+          401,
+          "missing_platform_connection",
+          "no Vellum assistant API key is stored — connect the platform account",
+        );
+      }
+      const rejection = await probeVelay(
+        httpUrl,
+        apiKey,
+        deps.fetchImpl ?? fetch,
+      );
+      if (rejection) {
+        return jsonError(rejection.status, rejection.code, rejection.detail);
+      }
+      return jsonError(
+        426,
+        "upgrade_required",
+        "the gate passed; connect with a WebSocket upgrade",
+      );
+    }
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "speech-relay",
+        operation,
+        upstreamWsUrl: wsUrl,
+        upstreamHttpUrl: httpUrl,
+        deps,
+      } satisfies SpeechRelaySocketData,
+    });
+    if (!upgraded) {
+      return jsonError(500, "upgrade_failed", "WebSocket upgrade failed");
+    }
+    return undefined;
+  };
+}
+
+/** Send a velay_error control frame downstream (best-effort). */
+function sendRelayError(
+  ws: import("bun").ServerWebSocket<SpeechRelaySocketData>,
+  code: string,
+  detail: string,
+): void {
+  try {
+    ws.send(JSON.stringify({ type: "velay_error", code, detail }));
+  } catch {
+    // The downstream socket may already be gone.
+  }
+}
+
+/**
+ * Bun.serve() websocket handlers for the speech relay: dial velay on open,
+ * then pipe frames verbatim both ways. Upstream failures synthesize a
+ * `velay_error` frame (probing velay for the real rejection) so the daemon
+ * adapter's existing error mapping applies unchanged.
+ */
+export function getSpeechRelayWebsocketHandlers() {
+  return {
+    async open(ws: import("bun").ServerWebSocket<SpeechRelaySocketData>) {
+      const { deps, upstreamWsUrl, upstreamHttpUrl, operation } = ws.data;
+      ws.data.pendingMessages = [];
+      ws.data.upstreamOpened = false;
+
+      const apiKey = await readAssistantApiKey(deps);
+      if (!apiKey) {
+        log.warn({ operation }, "Speech relay: no assistant API key stored");
+        sendRelayError(
+          ws,
+          "missing_platform_connection",
+          "no Vellum assistant API key is stored — connect the platform account",
+        );
+        ws.close(1011, "missing_platform_connection");
+        return;
+      }
+
+      const WsCtor = (deps.webSocketConstructor ??
+        WebSocket) as WebSocketConstructorWithHeaders;
+      const upstream = new WsCtor(upstreamWsUrl, {
+        headers: { Authorization: `Api-Key ${apiKey}` },
+      });
+      ws.data.upstream = upstream;
+
+      upstream.addEventListener("open", () => {
+        log.info({ operation }, "Speech relay upstream connected to velay");
+        ws.data.upstreamOpened = true;
+        const pending = ws.data.pendingMessages;
+        if (pending) {
+          for (const msg of pending) {
+            upstream.send(msg);
+          }
+          ws.data.pendingMessages = undefined;
+        }
+      });
+
+      upstream.addEventListener("message", (event) => {
+        const data =
+          typeof event.data === "string"
+            ? event.data
+            : new Uint8Array(event.data as ArrayBuffer);
+        ws.send(data);
+      });
+
+      upstream.addEventListener("close", (event) => {
+        log.info(
+          { code: event.code, operation },
+          "Speech relay upstream closed",
+        );
+        ws.close(event.code, event.reason);
+      });
+
+      upstream.addEventListener("error", () => {
+        if (ws.data.upstreamOpened) {
+          // Mid-session transport failure; velay already sent its own
+          // velay_error frame if it had one.
+          log.error({ operation }, "Speech relay upstream error");
+          ws.close(1011, "upstream_error");
+          return;
+        }
+        // Failed dial: the WebSocket API hides velay's HTTP rejection, so
+        // replay it as plain HTTPS and forward the {code, detail} the way
+        // velay itself reports mid-session errors.
+        void probeVelay(upstreamHttpUrl, apiKey, deps.fetchImpl ?? fetch).then(
+          (rejection) => {
+            log.error(
+              { operation, code: rejection?.code },
+              "Speech relay upstream dial failed",
+            );
+            sendRelayError(
+              ws,
+              rejection?.code ?? "provider_unreachable",
+              rejection?.detail ?? "could not reach the speech relay",
+            );
+            ws.close(1011, rejection?.code ?? "upstream_error");
+          },
+        );
+      });
+    },
+
+    message(
+      ws: import("bun").ServerWebSocket<SpeechRelaySocketData>,
+      message: string | ArrayBuffer | Uint8Array,
+    ) {
+      const upstream = ws.data.upstream;
+      if (upstream && upstream.readyState === WebSocket.OPEN) {
+        upstream.send(message);
+      } else if (ws.data.pendingMessages) {
+        if (ws.data.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+          log.warn(
+            "Speech relay pending message buffer overflow — closing connection",
+          );
+          ws.close(1008, "Buffer overflow");
+          return;
+        }
+        ws.data.pendingMessages.push(message);
+      }
+    },
+
+    close(
+      ws: import("bun").ServerWebSocket<SpeechRelaySocketData>,
+      code: number,
+      reason: string,
+    ) {
+      const { upstream, operation } = ws.data;
+      log.info({ code, reason, operation }, "Speech relay downstream closed");
+      ws.data.pendingMessages = undefined;
+      if (
+        upstream &&
+        (upstream.readyState === WebSocket.OPEN ||
+          upstream.readyState === WebSocket.CONNECTING)
+      ) {
+        upstream.close(code, reason);
+      }
+    },
+  };
+}

--- a/gateway/src/http/routes/speech-relay-websocket.ts
+++ b/gateway/src/http/routes/speech-relay-websocket.ts
@@ -92,6 +92,12 @@ export type SpeechRelaySocketData = {
   deps: SpeechRelayDeps;
   upstream?: WebSocket;
   upstreamOpened?: boolean;
+  /**
+   * Set by the close handler; open() re-checks it after its async
+   * credential read so a daemon that hung up mid-read doesn't leave a
+   * dialed velay session with no close left to forward.
+   */
+  downstreamClosed?: boolean;
   pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
 };
 
@@ -107,15 +113,17 @@ function velaySpeechUrls(
   operation: SpeechRelayOperation,
   params: URLSearchParams,
 ): { wsUrl: string; httpUrl: string } {
-  const base = (config.velayBaseUrl ?? DEFAULT_VELAY_BASE_URL).replace(
-    /\/+$/,
-    "",
-  );
+  // The velay tunnel client accepts ws(s):// bases too — normalize to the
+  // http(s) twin first so the probe URL is always fetchable, then derive
+  // the ws(s) dial URL from that.
+  const httpBase = (config.velayBaseUrl ?? DEFAULT_VELAY_BASE_URL)
+    .replace(/\/+$/, "")
+    .replace(/^ws/, "http");
   const query = params.toString();
   const path = `/v1/speech/${operation}/stream${query ? `?${query}` : ""}`;
   return {
-    httpUrl: `${base}${path}`,
-    wsUrl: `${base.replace(/^http/, "ws")}${path}`,
+    httpUrl: `${httpBase}${path}`,
+    wsUrl: `${httpBase.replace(/^http/, "ws")}${path}`,
   };
 }
 
@@ -284,6 +292,13 @@ export function getSpeechRelayWebsocketHandlers() {
       ws.data.upstreamOpened = false;
 
       const apiKey = await readAssistantApiKey(deps);
+      if (ws.data.downstreamClosed) {
+        // The daemon hung up while the credential read was pending; there
+        // is no close left to forward, so dialing now would leak a velay
+        // session until its timeout.
+        log.info({ operation }, "Speech relay: daemon closed before dial");
+        return;
+      }
       if (!apiKey) {
         log.warn({ operation }, "Speech relay: no assistant API key stored");
         sendRelayError(
@@ -404,6 +419,7 @@ export function getSpeechRelayWebsocketHandlers() {
       code: number,
       reason: string,
     ) {
+      ws.data.downstreamClosed = true;
       const { upstream, operation } = ws.data;
       log.info({ code, reason, operation }, "Speech relay downstream closed");
       ws.data.pendingMessages = undefined;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -50,6 +50,11 @@ import {
   type SttStreamSocketData,
 } from "./http/routes/stt-stream-websocket.js";
 import {
+  createSpeechRelayUpgradeHandler,
+  getSpeechRelayWebsocketHandlers,
+  type SpeechRelaySocketData,
+} from "./http/routes/speech-relay-websocket.js";
+import {
   createLiveVoiceWebsocketHandler,
   getLiveVoiceWebsocketHandlers,
   type LiveVoiceSocketData,
@@ -287,6 +292,14 @@ function isLiveVoiceSocketData(data: unknown): data is LiveVoiceSocketData {
   );
 }
 
+function isSpeechRelaySocketData(data: unknown): data is SpeechRelaySocketData {
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { wsType?: unknown }).wsType === "speech-relay"
+  );
+}
+
 /** Log-safe socket-type discriminant for unknown-socket diagnostics. */
 function extractWsType(data: unknown): unknown {
   return data && typeof data === "object"
@@ -503,9 +516,20 @@ async function main() {
   });
   const handleSttStreamWs = createSttStreamWebsocketHandler(config);
   const handleLiveVoiceWs = createLiveVoiceWebsocketHandler(config);
+  const handleSpeechRelaySttWs = createSpeechRelayUpgradeHandler(
+    config,
+    "stt",
+    { credentials: credentialCache },
+  );
+  const handleSpeechRelayTtsWs = createSpeechRelayUpgradeHandler(
+    config,
+    "tts",
+    { credentials: credentialCache },
+  );
   const twilioMediaStreamWebsocketHandlers = getMediaStreamWebsocketHandlers();
   const sttStreamWebsocketHandlers = getSttStreamWebsocketHandlers();
   const liveVoiceWebsocketHandlers = getLiveVoiceWebsocketHandlers();
+  const speechRelayWebsocketHandlers = getSpeechRelayWebsocketHandlers();
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } =
     createWhatsAppWebhookHandler(config, {
       credentials: credentialCache,
@@ -1717,6 +1741,10 @@ async function main() {
           liveVoiceWebsocketHandlers.open(ws as never);
           return;
         }
+        if (isSpeechRelaySocketData(ws.data)) {
+          void speechRelayWebsocketHandlers.open(ws as never);
+          return;
+        }
         closeUnknownSocket(ws, "open");
       },
       message(ws, message) {
@@ -1732,6 +1760,10 @@ async function main() {
           liveVoiceWebsocketHandlers.message(ws as never, message);
           return;
         }
+        if (isSpeechRelaySocketData(ws.data)) {
+          speechRelayWebsocketHandlers.message(ws as never, message);
+          return;
+        }
         closeUnknownSocket(ws, "message");
       },
       close(ws, code, reason) {
@@ -1745,6 +1777,10 @@ async function main() {
         }
         if (isLiveVoiceSocketData(ws.data)) {
           liveVoiceWebsocketHandlers.close(ws as never, code, reason);
+          return;
+        }
+        if (isSpeechRelaySocketData(ws.data)) {
+          speechRelayWebsocketHandlers.close(ws as never, code, reason);
           return;
         }
         log.error(
@@ -1946,6 +1982,20 @@ async function main() {
 
     if (url.pathname === "/v1/live-voice") {
       const upgradeResult = handleLiveVoiceWs(req, server);
+      if (upgradeResult !== undefined) return upgradeResult;
+      return undefined as unknown as Response;
+    }
+
+    // Managed-speech relay: daemon-only egress to velay. NOT in
+    // VELAY_ALLOWED_PATHS — velay's inbound tunnel must never reach it.
+    if (url.pathname === "/v1/speech/stt/stream") {
+      const upgradeResult = await handleSpeechRelaySttWs(req, server);
+      if (upgradeResult !== undefined) return upgradeResult;
+      return undefined as unknown as Response;
+    }
+
+    if (url.pathname === "/v1/speech/tts/stream") {
+      const upgradeResult = await handleSpeechRelayTtsWs(req, server);
       if (upgradeResult !== undefined) return upgradeResult;
       return undefined as unknown as Response;
     }


### PR DESCRIPTION
Per security review on #37921: velay contact must be **gateway-only** — velay is effectively unfettered inbound, and deterministic rules users rely on must live in a process the agent can't rewrite. This PR gives the gateway the egress leg; #37921 is being reworked to dial this route instead of velay directly.

## What

Two pre-router WS routes, `/v1/speech/stt/stream` and `/v1/speech/tts/stream` (one parameterized handler):

- **Downstream auth**: `?key=` carries a daemon-minted service JWT (`aud=vellum-gateway`, `sub=svc:daemon:self` — both processes share the HMAC signing key; the route pins the exact sub and rejects actor tokens). Velay-forwarded and bridge-auth'd requests are categorically rejected, and the paths are **not** added to `VELAY_ALLOWED_PATHS`, so the route is unreachable via ingress from either defense.
- **Upstream leg**: dials `{VELAY_BASE_URL:-https://velay.vellum.ai}/v1/speech/{op}/stream` with `Authorization: Api-Key <assistant_api_key>` (read via the existing `CredentialCache`, same as the tunnel client). Whitelisted daemon params forward verbatim; the daemon's gateway token is stripped.
- **Pipe**: same frame-pipe shape as `stt-stream-websocket.ts` (pending-message buffer, count-capped, close-code forwarding both ways). The wire protocol on both legs is Deepgram's own plus velay's `velay_error` frame, so the gateway stays byte-transparent — velay's session-cap close and error frames reach the daemon untouched.
- **Failure surfaces mirror velay's contract** so the daemon adapter needs no gateway-specific error handling: gate rejections are JSON `{code, detail}`; a failed upstream dial after upgrade probes velay's HTTP gate and synthesizes a `velay_error` frame + abnormal close; a plain (non-upgrade) GET replays the gate and returns velay's own rejection — making the daemon's existing dial-failure probe work end-to-end through both hops.

This is where future user-facing managed-speech policy (disable toggles, rate rules) gets enforced.

## Tests
13 cases: gate (upgrade + param stripping, tts path, missing/actor/forged token, velay-forwarded rejection), probe (missing credential, velay rejection passthrough with status + Api-Key header assertion, gate-passed 426), and pipe (dial headers, pre-open buffering + flush, bidirectional forwarding, velay_error passthrough + close-code forwarding, synthesized velay_error from a failed dial, missing-key close, downstream-close forwarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->