### PR TITLE
refactor(assistant): merge_contacts relays to the gateway; local assistant-DB merge deleted (ATL-987)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5822,6 +5822,7 @@ paths:
                   ok:
                     type: boolean
                   contact:
+                    description: Merged (surviving) contact
                     type: object
                     properties:
                       id:
@@ -5926,10 +5927,8 @@ paths:
                       - updatedAt
                       - channels
                     additionalProperties: false
-                    description: Merged contact
                 required:
                   - ok
-                  - contact
                 additionalProperties: false
   /v1/contacts/prompt:
     post:

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -25,8 +25,9 @@ mock.module("../config/env.js", () => ({
 let searchContactsOverride: unknown[] | null = null;
 
 // Skill tools call cliIpcCall instead of the gateway HTTP.
-// Mock the IPC client to dispatch contact reads/merge to the real store
-// (backed by the test DB) without needing a running IPC server.
+// Mock the IPC client to dispatch contact reads to the real store (backed by
+// the test DB) and serve `merge_contacts` as a fake gateway relay, without
+// needing a running IPC server.
 mock.module("../ipc/cli-client.js", () => ({
   cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
     const store = await import("../contacts/contact-store.js");
@@ -45,9 +46,26 @@ mock.module("../ipc/cli-client.js", () => ({
       return { ok: true, result: { ok: true, contact } };
     }
     if (method === "merge_contacts") {
+      // Fake gateway relay: the daemon route relays merges to the gateway
+      // merge core, which validates and mirrors back into the assistant DB.
+      // Emulate that against the fixture DB via the mirror write path.
       const { keepId, mergeId } = body as { keepId: string; mergeId: string };
-      const contact = store.mergeContacts(keepId, mergeId);
-      return { ok: true, result: { ok: true, contact } };
+      const keep = store.getContact(keepId);
+      if (!keep) {
+        return { ok: false, error: `Contact "${keepId}" not found` };
+      }
+      if (!store.getContact(mergeId)) {
+        return { ok: false, error: `Contact "${mergeId}" not found` };
+      }
+      store.mergeContactMirror({
+        keepContactId: keepId,
+        mergeContactId: mergeId,
+        keepDisplayName: keep.displayName,
+      });
+      return {
+        ok: true,
+        result: { ok: true, contact: store.getContact(keepId) },
+      };
     }
     return { ok: false, error: `Unknown IPC method: ${method}` };
   },
@@ -80,14 +98,6 @@ beforeAll(() => {
       const path = url.pathname;
 
       try {
-        if (path === "/v1/contacts/merge" && req.method === "POST") {
-          const mergeRoute = ROUTES.find(
-            (r) => r.operationId === "merge_contacts",
-          )!;
-          const body = (await req.json()) as Record<string, unknown>;
-          const result = mergeRoute.handler({ body });
-          return Response.json(result);
-        }
         if (path === "/v1/contacts" && req.method === "GET") {
           const listRoute = ROUTES.find(
             (r) => r.operationId === "listContacts",

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -59,14 +59,13 @@ function concatMergedNotes(
 /**
  * Move donor channels onto the survivor, skipping any the survivor already
  * holds by logical (type, address) key. COLLATE NOCASE catches legacy
- * lowercased rows. `touchUpdatedAt` stamps updated_at on moved rows (the
- * mirror op does; the local merge historically does not).
+ * lowercased rows. `touchUpdatedAt` stamps updated_at on moved rows.
  */
 function reparentDonorChannels(
   tx: DbOrTx,
   keepId: string,
   mergeId: string,
-  touchUpdatedAt?: number,
+  touchUpdatedAt: number,
 ): void {
   const donorChannels = tx
     .select()
@@ -89,12 +88,7 @@ function reparentDonorChannels(
 
     if (!exists) {
       tx.update(contactChannels)
-        .set({
-          contactId: keepId,
-          ...(touchUpdatedAt !== undefined
-            ? { updatedAt: touchUpdatedAt }
-            : {}),
-        })
+        .set({ contactId: keepId, updatedAt: touchUpdatedAt })
         .where(eq(contactChannels.id, ch.id))
         .run();
     }
@@ -669,55 +663,6 @@ export function listContacts(
     .limit(effectiveLimit)
     .all();
   return rows.map((r) => withChannels(parseContact(r)));
-}
-
-/**
- * Merge two contacts into one. The surviving contact keeps the
- * more recent interaction timestamp, concatenated notes, and all channels
- * from both contacts. The donor contact is deleted after merging.
- */
-export function mergeContacts(
-  keepId: string,
-  mergeId: string,
-): ContactWithChannels {
-  const db = getDb();
-
-  if (keepId === mergeId) throw new Error("Cannot merge a contact with itself");
-
-  db.transaction((tx) => {
-    const now = Date.now();
-
-    const keep = tx
-      .select()
-      .from(contacts)
-      .where(eq(contacts.id, keepId))
-      .get();
-    if (!keep) throw new Error(`Contact "${keepId}" not found`);
-
-    const merge = tx
-      .select()
-      .from(contacts)
-      .where(eq(contacts.id, mergeId))
-      .get();
-    if (!merge) throw new Error(`Contact "${mergeId}" not found`);
-
-    tx.update(contacts)
-      .set({
-        notes: concatMergedNotes(keep.notes, merge.notes),
-        updatedAt: now,
-      })
-      .where(eq(contacts.id, keepId))
-      .run();
-
-    // Move channels from donor to survivor, skipping duplicates
-    reparentDonorChannels(tx, keepId, mergeId);
-
-    // Delete the donor contact (cascading deletes remaining channels)
-    tx.delete(contacts).where(eq(contacts.id, mergeId)).run();
-  });
-
-  notifyContactsChanged();
-  return getContact(keepId)!;
 }
 
 /**

--- a/assistant/src/runtime/routes/__tests__/contact-routes-merge-relay.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes-merge-relay.test.ts
@@ -73,10 +73,15 @@ describe("merge contacts relay", () => {
     contactStoreWriteGuard.mockClear();
   });
 
-  test("forwards { keepId, mergeId } unchanged and returns the gateway response verbatim", async () => {
+  test("forwards { keepId, mergeId } unchanged and returns the gateway contact", async () => {
     const gatewayResponse = {
       ok: true as const,
-      contact: { id: "ct_keep", displayName: "Alice", channels: [] },
+      contact: {
+        id: "ct_keep",
+        displayName: "Alice",
+        contactType: "human",
+        channels: [],
+      },
     };
     ipcResult = gatewayResponse;
 
@@ -91,9 +96,29 @@ describe("merge contacts relay", () => {
         timeoutMs: undefined,
       },
     ]);
-    expect(result).toEqual(gatewayResponse);
+    expect(result as unknown).toEqual(gatewayResponse);
     // Must NOT write the assistant DB directly.
     expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("coerces degraded assistant-owned fields to the contact schema (null contactType → human)", async () => {
+    ipcResult = {
+      ok: true as const,
+      // A mirror soft-fail on the gateway leaves assistant-owned info fields
+      // null; the relay must still satisfy the route's non-null contactType.
+      contact: {
+        id: "ct_keep",
+        displayName: "Alice",
+        contactType: null,
+        channels: [{ id: "ch_1", type: "telegram", address: "alice" }],
+      },
+    };
+
+    const result = (await handleMergeContactsRoute({
+      body: { keepId: "ct_keep", mergeId: "ct_merge" },
+    })) as { ok: boolean; contact?: { contactType?: string } };
+
+    expect(result.contact?.contactType).toBe("human");
   });
 
   test("missing keepId/mergeId is rejected before any relay call", async () => {

--- a/assistant/src/runtime/routes/__tests__/contact-routes-merge-relay.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes-merge-relay.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the daemon merge_contacts relay.
+ *
+ * `handleMergeContactsRoute` is a thin relay to the gateway IPC method
+ * `merge_contacts` via `ipcCallPersistent`. The gateway DB is the source of
+ * truth: it owns validation, the merge transaction, and the assistant-DB
+ * mirror — the daemon writes NOTHING to the assistant DB directly. These tests
+ * assert the handler forwards `{ keepId, mergeId }` unchanged, returns the
+ * gateway response verbatim, never touches the assistant contact store, and
+ * propagates a relay failure (no local-merge fallback).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+type IpcCall = {
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+};
+
+let ipcCalls: IpcCall[] = [];
+let ipcResult: unknown = { ok: true };
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCalls.push({ method, params, timeoutMs });
+    if (ipcError) {
+      throw ipcError;
+    }
+    return ipcResult;
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Guard: fail loudly if the relay still writes the assistant contact store
+// directly. The assistant DB only changes via the gateway's
+// `contacts_mirror_merge_contact` mirror op, never on this route.
+const actualContactStore = await import("../../../contacts/contact-store.js");
+
+const contactStoreWriteGuard = mock(() => {
+  throw new Error(
+    "assistant contact-store write must not happen on the relayed merge path",
+  );
+});
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  ...actualContactStore,
+  mergeContactMirror: contactStoreWriteGuard,
+}));
+
+const { handleMergeContactsRoute, ROUTES } =
+  await import("../contact-routes.js");
+
+describe("merge contacts relay", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcResult = { ok: true };
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
+    contactStoreWriteGuard.mockClear();
+  });
+
+  test("forwards { keepId, mergeId } unchanged and returns the gateway response verbatim", async () => {
+    const gatewayResponse = {
+      ok: true as const,
+      contact: { id: "ct_keep", displayName: "Alice", channels: [] },
+    };
+    ipcResult = gatewayResponse;
+
+    const result = await handleMergeContactsRoute({
+      body: { keepId: "ct_keep", mergeId: "ct_merge" },
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "merge_contacts",
+        params: { keepId: "ct_keep", mergeId: "ct_merge" },
+        timeoutMs: undefined,
+      },
+    ]);
+    expect(result).toEqual(gatewayResponse);
+    // Must NOT write the assistant DB directly.
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("missing keepId/mergeId is rejected before any relay call", async () => {
+    for (const body of [
+      {},
+      { keepId: "ct_keep" },
+      { mergeId: "ct_merge" },
+      { keepId: "", mergeId: "ct_merge" },
+    ]) {
+      try {
+        await handleMergeContactsRoute({ body });
+        throw new Error("expected handler to throw");
+      } catch (err) {
+        const e = err as { statusCode?: number; message: string };
+        expect(e.message).toBe("keepId and mergeId are required");
+        expect(e.statusCode).toBe(400);
+      }
+    }
+    expect(ipcCalls).toHaveLength(0);
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("relayed IpcCallError surfaces with its statusCode/errorCode", async () => {
+    ipcError = new IpcCallError("Cannot merge a contact with itself", {
+      statusCode: 400,
+      errorCode: "MERGE_CONTACTS_INVALID",
+    });
+
+    try {
+      await handleMergeContactsRoute({
+        body: { keepId: "ct_same", mergeId: "ct_same" },
+      });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      const e = err as { statusCode?: number; code?: string; message: string };
+      expect(e.message).toBe("Cannot merge a contact with itself");
+      expect(e.statusCode).toBe(400);
+      expect(e.code).toBe("MERGE_CONTACTS_INVALID");
+    }
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("gateway unreachable: the rejection propagates and the assistant DB is untouched (no local merge)", async () => {
+    ipcError = new Error("ipc transport exploded");
+
+    try {
+      await handleMergeContactsRoute({
+        body: { keepId: "ct_keep", mergeId: "ct_merge" },
+      });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      expect((err as Error).message).toBe("ipc transport exploded");
+    }
+    // No daemon-side fallback write.
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+    expect(ipcCalls).toHaveLength(1);
+  });
+
+  test("the merge_contacts route is registered and wired to the relay", () => {
+    const route = ROUTES.find((r) => r.operationId === "merge_contacts");
+    expect(route).toBeDefined();
+    expect(route?.endpoint).toBe("contacts/merge");
+    expect(route?.method).toBe("POST");
+  });
+});

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -17,6 +17,7 @@ import type { ContactRead } from "@vellumai/gateway-client/gateway-ipc-contracts
 import {
   GetContactIpcResponseSchema,
   ListContactsIpcResponseSchema,
+  MergeContactsIpcResponseSchema,
   UpdateContactChannelIpcResponseSchema,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
@@ -30,11 +31,7 @@ import {
   redeemInviteByVoiceCode,
   revokeInvite,
 } from "../../channels/gateway-invites.js";
-import {
-  listContacts,
-  mergeContacts,
-  searchContacts,
-} from "../../contacts/contact-store.js";
+import { listContacts, searchContacts } from "../../contacts/contact-store.js";
 import { getGuardianContactIds } from "../../contacts/guardian-contact-reader.js";
 import type {
   ContactChannel,
@@ -950,7 +947,7 @@ export const ROUTES: RouteDefinition[] = [
     }),
     responseBody: z.object({
       ok: z.boolean(),
-      contact: contactSchema.describe("Merged contact"),
+      contact: contactSchema.optional().describe("Merged (surviving) contact"),
     }),
     handler: (args: RouteHandlerArgs) => handleMergeContactsRoute(args),
   },
@@ -985,49 +982,32 @@ export const ROUTES: RouteDefinition[] = [
 // ---------------------------------------------------------------------------
 
 /**
- * DIVERGENCE RISK — daemon-local merge, NOT the canonical path.
+ * Relay the contact merge to the gateway-native handler.
  *
- * This executes the LOCAL `mergeContacts` (assistant DB only). The canonical
- * merge is the gateway control plane (POST /v1/contacts/merge →
- * contacts-control-plane-proxy.handleMergeContacts), which merges the gateway
- * DB — the ACL source of truth — and mirrors here via
- * `contacts_mirror_merge_contact`. A merge through THIS route leaves the
- * gateway DB untouched: the donor contact and its ACL channel rows survive
- * gateway-side while the assistant mirror deletes them. Gateway-fronted
- * clients never reach this route (the control-plane route-match intercepts
- * the path), but direct daemon callers — notably the bundled `contact_merge`
- * tool — do.
- *
- * Not converted to a relay yet because no gateway IPC/SDK merge surface
- * exists (unlike `update_contact_channel` below); relaying requires new
- * gateway-client contracts + a gateway IPC route + a core extraction of the
- * HTTP handler. Until then, prefer the gateway route wherever reachable.
+ * The gateway DB is the source of truth: it owns validation (self-merge,
+ * not-found, guardian donor), the merge transaction, the assistant-DB mirror
+ * (`contacts_mirror_merge_contact`), and the `contacts_changed` emit. This
+ * daemon handler writes NOTHING to the assistant DB directly — it forwards
+ * `{ keepId, mergeId }` and returns the gateway response verbatim. No
+ * fallback: an unexpected relay failure surfaces as an error (never a silent
+ * second write).
  */
-async function handleMergeContactsRoute(args: RouteHandlerArgs) {
-  const { body } = args;
-  const keepId = body?.keepId as string | undefined;
-  const mergeId = body?.mergeId as string | undefined;
+export async function handleMergeContactsRoute(args: RouteHandlerArgs) {
+  const keepId = args.body?.keepId as string | undefined;
+  const mergeId = args.body?.mergeId as string | undefined;
 
   if (!keepId || !mergeId) {
     throw new BadRequestError("keepId and mergeId are required");
   }
 
   try {
-    const contact = mergeContacts(keepId, mergeId);
-    // Daemon-native read (assistant DB): telemetry is gateway-owned, so overlay
-    // it (fail-soft to null) and derive role from the guardian-id set. Both hit
-    // the gateway and are independent — run them concurrently.
-    const [[hydrated], guardianIds] = await Promise.all([
-      hydrateTelemetryFromGateway([contact]),
-      getGuardianContactIds(),
-    ]);
-    return {
-      ok: true,
-      contact: prepareContactResponse(hydrated, guardianIds),
-    };
+    const result = await ipcCallPersistent("merge_contacts", {
+      keepId,
+      mergeId,
+    });
+    return MergeContactsIpcResponseSchema.parse(result);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new BadRequestError(message);
+    rethrowGatewayError(err);
   }
 }
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -460,9 +460,7 @@ export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
       note: body.note as string | undefined,
       maxUses: body.maxUses as number | undefined,
       expiresInMs: body.expiresInMs as number | undefined,
-      expectedExternalUserId: body.expectedExternalUserId as
-        | string
-        | undefined,
+      expectedExternalUserId: body.expectedExternalUserId as string | undefined,
       ...(guardianName ? { guardianName } : {}),
       ...(typeof body.sourceConversationId === "string"
         ? { sourceConversationId: body.sourceConversationId }
@@ -743,7 +741,10 @@ export const ROUTES: RouteDefinition[] = [
         .string()
         .optional()
         .describe("Invite token (token-based redemption)"),
-      code: z.string().optional().describe("Voice code (voice-code redemption)"),
+      code: z
+        .string()
+        .optional()
+        .describe("Voice code (voice-code redemption)"),
       callerExternalUserId: z
         .string()
         .optional()
@@ -1005,7 +1006,18 @@ export async function handleMergeContactsRoute(args: RouteHandlerArgs) {
       keepId,
       mergeId,
     });
-    return MergeContactsIpcResponseSchema.parse(result);
+    const parsed = MergeContactsIpcResponseSchema.parse(result);
+    // Relayed write: coerce degraded assistant-owned fields (a null
+    // contactType under a mirror soft-fail) back to the route's contact
+    // schema, like the list/get relays.
+    return {
+      ok: parsed.ok,
+      contact: parsed.contact
+        ? prepareContactResponse(
+            parsed.contact as unknown as PreparableContact & { role: string },
+          )
+        : undefined,
+    };
   } catch (err) {
     rethrowGatewayError(err);
   }


### PR DESCRIPTION
## Summary
- handleMergeContactsRoute is now a pure gateway relay (ipcCallPersistent merge_contacts + schema parse + rethrowGatewayError) — no local fallback, closing the ATL-987 divergence where the daemon merged the assistant DB while the gateway kept the donor + ACL rows
- The dead local mergeContacts is deleted; mergeContactMirror (the daemon's write path for gateway-driven merges) and the shared helpers stay
- The bundled contact_merge tool inherits the source-of-truth path unchanged

Part of plan: contact-merge-relay.md (PR 2 of 2)