### PR TITLE
feat(doctor): inline user-outcome prompt — did the Doctor solve your problem?

### DIFF
--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -836,6 +836,79 @@ paths:
           description: ''
       x-vellum-api-clients:
       - platform
+  /v1/assistants/{assistant_id}/doctor/sessions/{session_id}/user-outcome/:
+    post:
+      operationId: assistants_doctor_sessions_user_outcome_create
+      description: |-
+        Record whether the Doctor solved the user's problem.
+
+        Writes only to the persisted Django row (no upstream Doctor call),
+        so it works for live sessions and for sessions that already ended.
+        Idempotent: the latest answer wins.
+      parameters:
+      - in: header
+        name: Vellum-Organization-Id
+        schema:
+          type: string
+          format: uuid
+        description: Required if using Cookie-based or X-Session-Token authentication
+          methods.
+      - in: path
+        name: assistant_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: session_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - assistants
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DoctorSessionUserOutcomeRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DoctorSessionUserOutcomeRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DoctorSessionUserOutcomeRequestRequest'
+        required: true
+      security:
+      - VellumAPIKey: []
+      - cookieAuth: []
+      - XSessionTokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DoctorSessionUserOutcomeResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
+          description: ''
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
+          description: ''
+      x-vellum-api-clients:
+      - platform
   /v1/assistants/{assistant_id}/domains/:
     get:
       operationId: assistants_domains_list
@@ -6423,6 +6496,17 @@ components:
             * `active` - Active
             * `completed` - Completed
             * `error` - Error
+        user_outcome:
+          readOnly: true
+          nullable: true
+          description: |-
+            User-reported outcome: whether the Doctor solved their problem. Null until the user answers the outcome prompt.
+
+            * `resolved` - Resolved
+            * `not_resolved` - Not resolved
+          oneOf:
+          - $ref: '#/components/schemas/UserOutcomeEnum'
+          - $ref: '#/components/schemas/NullEnum'
         last_message_at:
           type: string
           format: date-time
@@ -6486,6 +6570,7 @@ components:
       - total_estimated_cost_usd
       - total_input_tokens
       - total_output_tokens
+      - user_outcome
     DoctorSessionList:
       type: object
       description: |-
@@ -6509,6 +6594,17 @@ components:
             * `active` - Active
             * `completed` - Completed
             * `error` - Error
+        user_outcome:
+          readOnly: true
+          nullable: true
+          description: |-
+            User-reported outcome: whether the Doctor solved their problem. Null until the user answers the outcome prompt.
+
+            * `resolved` - Resolved
+            * `not_resolved` - Not resolved
+          oneOf:
+          - $ref: '#/components/schemas/UserOutcomeEnum'
+          - $ref: '#/components/schemas/NullEnum'
         last_message_at:
           type: string
           format: date-time
@@ -6566,6 +6662,7 @@ components:
       - total_estimated_cost_usd
       - total_input_tokens
       - total_output_tokens
+      - user_outcome
     DoctorSessionMessageRequestRequest:
       type: object
       description: Request body for sending a message to a Doctor session.
@@ -6589,6 +6686,23 @@ components:
         * `active` - Active
         * `completed` - Completed
         * `error` - Error
+    DoctorSessionUserOutcomeRequestRequest:
+      type: object
+      description: Request body for recording whether the Doctor solved the user's
+        problem.
+      properties:
+        resolved:
+          type: boolean
+      required:
+      - resolved
+    DoctorSessionUserOutcomeResponse:
+      type: object
+      description: Response after recording a Doctor session user outcome.
+      properties:
+        user_outcome:
+          type: string
+      required:
+      - user_outcome
     DomainVerificationStatus:
       type: object
       properties:
@@ -8763,6 +8877,14 @@ components:
       required:
       - event_count
       - total_usd
+    UserOutcomeEnum:
+      enum:
+      - resolved
+      - not_resolved
+      type: string
+      description: |-
+        * `resolved` - Resolved
+        * `not_resolved` - Not resolved
   securitySchemes:
     AssistantAPIKey:
       type: apiKey

--- a/clients/web/src/domains/settings/components/panels/doctor-chat-blocks.tsx
+++ b/clients/web/src/domains/settings/components/panels/doctor-chat-blocks.tsx
@@ -10,6 +10,8 @@ import {
   Loader2,
   MessageSquareText,
   Shield,
+  ThumbsDown,
+  ThumbsUp,
   Wrench,
   XCircle,
 } from "lucide-react";
@@ -396,6 +398,66 @@ export function FeedbackPromptBlock({
             Share Feedback
           </Button>
         </div>
+      </div>
+    </div>
+  );
+}
+
+export function UserOutcomePromptBlock({
+  question,
+  answer,
+  onRespond,
+  disabled,
+}: {
+  question: string;
+  answer?: "resolved" | "not_resolved";
+  onRespond: (resolved: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 flex-1 items-start gap-2">
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[var(--content-disabled)]" />
+          <span className="text-body-medium-default text-[var(--content-default)]">
+            {question}
+          </span>
+        </div>
+
+        {answer ? (
+          <span className="flex shrink-0 items-center gap-1.5 text-body-small-default text-[var(--content-tertiary)]">
+            {answer === "resolved" ? (
+              <>
+                <ThumbsUp className="h-4 w-4 text-[var(--system-positive-strong)]" />
+                Glad it&apos;s solved!
+              </>
+            ) : (
+              <>
+                <ThumbsDown className="h-4 w-4" />
+                Not solved
+              </>
+            )}
+          </span>
+        ) : (
+          <div className="flex shrink-0 gap-2">
+            <Button
+              variant="outlined"
+              onClick={() => onRespond(true)}
+              disabled={disabled}
+              iconOnly={<ThumbsUp />}
+              aria-label="Yes, my problem is solved"
+              title="Yes, my problem is solved"
+            />
+            <Button
+              variant="outlined"
+              onClick={() => onRespond(false)}
+              disabled={disabled}
+              iconOnly={<ThumbsDown />}
+              aria-label="No, my problem is not solved"
+              title="No, my problem is not solved"
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/clients/web/src/domains/settings/components/panels/doctor-event-handlers.ts
+++ b/clients/web/src/domains/settings/components/panels/doctor-event-handlers.ts
@@ -9,7 +9,10 @@
  */
 
 import type { DoctorPanelContext } from "@/domains/settings/components/panels/doctor-panel-store";
-import { hasDoctorFeedbackPromptSinceLastUser } from "@/domains/settings/components/panels/doctor-history";
+import {
+  USER_OUTCOME_PROMPT_QUESTION,
+  hasDoctorFeedbackPromptSinceLastUser,
+} from "@/domains/settings/components/panels/doctor-history";
 import type { FeedbackReason } from "@/components/share-feedback-types";
 
 // ---------------------------------------------------------------------------
@@ -150,6 +153,14 @@ export function handleFeedbackPrompt(
     kind: "feedback_prompt",
     content: summary || "Share feedback",
     ...(reason ? { meta: { reason } } : {}),
+  });
+}
+
+export function handleUserOutcomePrompt(ctx: DoctorPanelContext): void {
+  ctx.setThinking(false);
+  ctx.appendEntry({
+    kind: "user_outcome_prompt",
+    content: USER_OUTCOME_PROMPT_QUESTION,
   });
 }
 

--- a/clients/web/src/domains/settings/components/panels/doctor-event-schema.ts
+++ b/clients/web/src/domains/settings/components/panels/doctor-event-schema.ts
@@ -59,6 +59,10 @@ export const DoctorEventSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     ...DoctorSourceEventFields,
+    type: z.literal("user_outcome_prompt"),
+  }),
+  z.object({
+    ...DoctorSourceEventFields,
     type: z.literal("status"),
     status: z.union([
       z.literal("active"),

--- a/clients/web/src/domains/settings/components/panels/doctor-history.test.ts
+++ b/clients/web/src/domains/settings/components/panels/doctor-history.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from "bun:test";
 import type { DoctorMessage } from "@/generated/api/types.gen";
 
 import {
+  USER_OUTCOME_PROMPT_QUESTION,
+  applySessionUserOutcome,
   hasPendingApproval,
   hasPendingBackup,
   isReplayableDoctorSourceEventId,
@@ -258,6 +260,20 @@ describe("mapPersistedMessagesToEntries", () => {
       msg({ kind: "status", content: "active" }),
     ]);
     expect(entries).toHaveLength(0);
+  });
+
+  test("maps status 'user_outcome_prompt' to a user-outcome prompt entry", () => {
+    const entries = mapPersistedMessagesToEntries([
+      msg({ kind: "status", content: "user_outcome_prompt" }),
+    ]);
+    expect(entries).toEqual([
+      {
+        id: "msg-1",
+        kind: "user_outcome_prompt",
+        content: USER_OUTCOME_PROMPT_QUESTION,
+        timestamp: Date.parse("2026-01-01T00:00:00Z"),
+      },
+    ]);
   });
 
   test("maps error message", () => {
@@ -682,5 +698,43 @@ describe("selectLatestHistorySession", () => {
 
   test("returns null for empty list", () => {
     expect(selectLatestHistorySession([])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applySessionUserOutcome
+// ---------------------------------------------------------------------------
+
+describe("applySessionUserOutcome", () => {
+  const promptEntry: ChatEntry = {
+    id: "e1",
+    kind: "user_outcome_prompt",
+    content: USER_OUTCOME_PROMPT_QUESTION,
+    timestamp: 0,
+  };
+
+  test("marks user-outcome prompts answered from the session field", () => {
+    const entries = applySessionUserOutcome([promptEntry], "resolved");
+    expect(entries[0]).toMatchObject({
+      kind: "user_outcome_prompt",
+      meta: { answer: "resolved" },
+    });
+  });
+
+  test("supports not_resolved", () => {
+    const entries = applySessionUserOutcome([promptEntry], "not_resolved");
+    expect(entries[0]).toMatchObject({ meta: { answer: "not_resolved" } });
+  });
+
+  test("returns entries unchanged when user outcome is null or unknown", () => {
+    expect(applySessionUserOutcome([promptEntry], null)).toEqual([promptEntry]);
+    expect(applySessionUserOutcome([promptEntry], undefined)).toEqual([promptEntry]);
+    expect(applySessionUserOutcome([promptEntry], "bogus")).toEqual([promptEntry]);
+  });
+
+  test("leaves other entry kinds untouched", () => {
+    const user: ChatEntry = { id: "u1", kind: "user", content: "hi", timestamp: 0 };
+    const entries = applySessionUserOutcome([user, promptEntry], "resolved");
+    expect(entries[0]).toEqual(user);
   });
 });

--- a/clients/web/src/domains/settings/components/panels/doctor-history.ts
+++ b/clients/web/src/domains/settings/components/panels/doctor-history.ts
@@ -38,10 +38,17 @@ export interface FeedbackPromptMeta {
   reason?: FeedbackReason;
 }
 
+export type DoctorUserOutcomeAnswer = "resolved" | "not_resolved";
+
+export interface UserOutcomePromptMeta {
+  answer?: DoctorUserOutcomeAnswer;
+}
+
 export type ChatEntry =
   | (ChatEntryBase & { kind: "user" })
   | (ChatEntryBase & { kind: "assistant" })
   | (ChatEntryBase & { kind: "feedback_prompt"; meta?: FeedbackPromptMeta })
+  | (ChatEntryBase & { kind: "user_outcome_prompt"; meta?: UserOutcomePromptMeta })
   | (ChatEntryBase & { kind: "tool_call"; meta: ToolCallMeta })
   | (ChatEntryBase & { kind: "approval"; meta: ApprovalMeta })
   | (ChatEntryBase & { kind: "backup_prompt"; meta: BackupPromptMeta })
@@ -53,11 +60,14 @@ export type NewChatEntry =
   | { kind: "user"; content: string }
   | { kind: "assistant"; content: string }
   | { kind: "feedback_prompt"; content: string; meta?: FeedbackPromptMeta }
+  | { kind: "user_outcome_prompt"; content: string; meta?: UserOutcomePromptMeta }
   | { kind: "tool_call"; content: string; meta: ToolCallMeta }
   | { kind: "approval"; content: string; meta: ApprovalMeta }
   | { kind: "backup_prompt"; content: string; meta: BackupPromptMeta }
   | { kind: "error"; content: string }
   | { kind: "status"; content: string };
+
+export const USER_OUTCOME_PROMPT_QUESTION = "Did the Doctor solve your problem?";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -240,6 +250,13 @@ export function mapPersistedMessagesToEntries(
             ...(reason ? { meta: { reason } } : {}),
             timestamp,
           });
+        } else if (message.content === "user_outcome_prompt") {
+          entries.push({
+            id: message.id,
+            kind: "user_outcome_prompt",
+            content: USER_OUTCOME_PROMPT_QUESTION,
+            timestamp,
+          });
         }
         break;
       }
@@ -274,13 +291,37 @@ export function mapPersistedStatusToPanelStatus(
   }
 }
 
+/**
+ * Mark user-outcome prompts as answered from the persisted session-level
+ * `user_outcome` field, so a rebuilt transcript doesn't re-offer Yes/No
+ * buttons the user already clicked. The answer is stored on the session
+ * row (not the message ledger), so it's applied here after mapping.
+ */
+export function applySessionUserOutcome(
+  entries: ChatEntry[],
+  userOutcome: string | null | undefined,
+): ChatEntry[] {
+  if (userOutcome !== "resolved" && userOutcome !== "not_resolved") {
+    return entries;
+  }
+  return entries.map((entry) =>
+    entry.kind === "user_outcome_prompt"
+      ? { ...entry, meta: { ...entry.meta, answer: userOutcome } }
+      : entry,
+  );
+}
+
 export function hasPendingApproval(entries: ChatEntry[]): boolean {
   for (let i = entries.length - 1; i >= 0; i -= 1) {
     const entry = entries[i];
     if (!entry) {
       continue;
     }
-    if (entry.kind === "status" || entry.kind === "feedback_prompt") {
+    if (
+      entry.kind === "status" ||
+      entry.kind === "feedback_prompt" ||
+      entry.kind === "user_outcome_prompt"
+    ) {
       continue;
     }
     return entry.kind === "approval";
@@ -294,7 +335,11 @@ export function hasPendingBackup(entries: ChatEntry[]): boolean {
     if (!entry) {
       continue;
     }
-    if (entry.kind === "status" || entry.kind === "feedback_prompt") {
+    if (
+      entry.kind === "status" ||
+      entry.kind === "feedback_prompt" ||
+      entry.kind === "user_outcome_prompt"
+    ) {
       continue;
     }
     return entry.kind === "backup_prompt";
@@ -315,6 +360,15 @@ export function serializeSessionToText(entries: ChatEntry[]): string {
         break;
       case "feedback_prompt":
         lines.push(`Feedback Prompt: ${entry.content}`);
+        break;
+      case "user_outcome_prompt":
+        lines.push(
+          `User Outcome Prompt: ${entry.content}${
+            entry.meta?.answer
+              ? ` (answered: ${entry.meta.answer === "resolved" ? "Yes" : "No"})`
+              : ""
+          }`,
+        );
         break;
       case "tool_call": {
         const { toolName, input, result, isError } = entry.meta;

--- a/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -14,6 +14,7 @@ import {
   BackupPromptBlock,
   ErrorMessage,
   FeedbackPromptBlock,
+  UserOutcomePromptBlock,
   StatusMessage,
   ToolCallBlock,
   UserMessage,
@@ -21,6 +22,7 @@ import {
 import { DoctorAvatar } from "@/domains/settings/components/panels/doctor-avatar";
 import {
   type ChatEntry,
+  applySessionUserOutcome,
   hasPendingApproval,
   hasPendingBackup,
   latestReplayableDoctorSourceEventId,
@@ -43,7 +45,11 @@ import {
   assistantsDoctorHistoryRetrieveOptions,
   useAssistantsDoctorSessionsMessagesCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
-import { type Options, assistantsDoctorSessionsCreate } from "@/generated/api/sdk.gen";
+import {
+  type Options,
+  assistantsDoctorSessionsCreate,
+  assistantsDoctorSessionsUserOutcomeCreate,
+} from "@/generated/api/sdk.gen";
 import type { AssistantsDoctorSessionsCreateData } from "@/generated/api/types.gen";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { captureError } from "@/lib/sentry/capture-error";
@@ -178,7 +184,10 @@ export function DoctorPanel() {
   const historyEntries = useMemo(
     () =>
       historyDetail
-        ? mapPersistedMessagesToEntries(historyDetail.messages ?? [])
+        ? applySessionUserOutcome(
+            mapPersistedMessagesToEntries(historyDetail.messages ?? []),
+            historyDetail.user_outcome,
+          )
         : [],
     [historyDetail],
   );
@@ -205,7 +214,10 @@ export function DoctorPanel() {
 
     const store = useDoctorPanelStore.getState();
     const messages = historyDetail.messages ?? [];
-    const resumedEntries = mapPersistedMessagesToEntries(messages);
+    const resumedEntries = applySessionUserOutcome(
+      mapPersistedMessagesToEntries(messages),
+      historyDetail.user_outcome,
+    );
     store.setEntries(resumedEntries);
     store.setPendingApproval(hasPendingApproval(resumedEntries));
     store.setPendingBackup(hasPendingBackup(resumedEntries));
@@ -346,6 +358,52 @@ export function DoctorPanel() {
     setFeedbackOpen(false);
     setFeedbackDraft(null);
   }, []);
+
+  const refetchHistoryDetail = historyDetailQuery.refetch;
+  const handleUserOutcomeRespond = useCallback(
+    (entryId: string, resolved: boolean) => {
+      const store = useDoctorPanelStore.getState();
+      const isHistoryView = store.sessionId === null;
+      const targetSessionId = store.sessionId ?? latestHistorySessionId;
+      if (!assistantId || !targetSessionId) {
+        return;
+      }
+      // Optimistic answer for the live-session view (store-backed entries).
+      store.updateEntries((entries) =>
+        entries.map((entry) =>
+          entry.id === entryId && entry.kind === "user_outcome_prompt"
+            ? {
+                ...entry,
+                meta: {
+                  ...entry.meta,
+                  answer: resolved ? "resolved" : "not_resolved",
+                },
+              }
+            : entry,
+        ),
+      );
+      assistantsDoctorSessionsUserOutcomeCreate({
+        path: { assistant_id: assistantId, session_id: targetSessionId },
+        body: { resolved },
+        throwOnError: false,
+      }).then(({ error }) => {
+        if (error) {
+          captureError(error, { context: "doctor_session_user_outcome" });
+        } else if (isHistoryView) {
+          // History-view entries render from the query cache, not the
+          // store — refetch so the answered state comes back via
+          // applySessionUserOutcome.
+          void refetchHistoryDetail();
+        }
+      });
+      if (!resolved) {
+        handleOpenFeedback({
+          message: "The Doctor wasn't able to solve my problem: ",
+        });
+      }
+    },
+    [assistantId, latestHistorySessionId, handleOpenFeedback, refetchHistoryDetail],
+  );
 
   const handleEndSession = () => {
     abort();
@@ -642,6 +700,18 @@ export function DoctorPanel() {
                                   : entry.content,
                               reason: entry.meta?.reason,
                             })
+                          }
+                        />
+                      </div>
+                    );
+                  case "user_outcome_prompt":
+                    return (
+                      <div key={entry.id} className="max-w-[90%]">
+                        <UserOutcomePromptBlock
+                          question={entry.content}
+                          answer={entry.meta?.answer}
+                          onRespond={(resolved) =>
+                            handleUserOutcomeRespond(entry.id, resolved)
                           }
                         />
                       </div>

--- a/clients/web/src/domains/settings/components/panels/use-doctor-sse.ts
+++ b/clients/web/src/domains/settings/components/panels/use-doctor-sse.ts
@@ -31,6 +31,7 @@ import {
   handleFeedbackPrompt,
   handleMessageComplete,
   handleMessageDelta,
+  handleUserOutcomePrompt,
   handleStatus,
   handleToolCall,
   handleToolResult,
@@ -235,6 +236,9 @@ export function useDoctorSSE() {
             break;
           case "feedback_prompt":
             handleFeedbackPrompt(ctx, event);
+            break;
+          case "user_outcome_prompt":
+            handleUserOutcomePrompt(ctx);
             break;
           case "status":
             if (handleStatus(ctx, event)) {


### PR DESCRIPTION
## What

Web half of the Doctor resolution-rate KPI measurement (platform half: vellum-ai/vellum-assistant-platform#9034).

When the Doctor believes it fixed the issue (or concludes it can't), it now emits a `user_outcome_prompt` SSE event. This PR renders that as an inline "Did the Doctor solve your problem?" block with thumbs-up / thumbs-down buttons in the doctor panel:

- **Yes** → `POST .../doctor/sessions/{id}/user-outcome/` with `{resolved: true}`; block shows the recorded answer.
- **No** → records `{resolved: false}` and opens the existing Share Feedback modal (prefilled) so we capture why.
- Works in both the live session and the completed-history view (the endpoint intentionally accepts answers after the session ends). Live view updates optimistically via the store; history view refetches the detail query since its entries render from the query cache, and `applySessionUserOutcome` marks prompts answered from the session-level `user_outcome` field so refreshes don't re-offer already-clicked buttons.

## Changes

- `doctor-event-schema.ts` — accept `user_outcome_prompt` (unknown types were already dropped, so this is purely additive)
- `doctor-history.ts` — new `user_outcome_prompt` ChatEntry kind, ledger mapping, `applySessionUserOutcome`, pending-approval/backup skip rules
- `doctor-event-handlers.ts` / `use-doctor-sse.ts` — event handler + dispatch
- `doctor-chat-blocks.tsx` — `UserOutcomePromptBlock`
- `doctor-panel.tsx` — render + respond handler
- `openapi-schemas/platform.yaml` — synced from the platform repo (adds `assistantsDoctorSessionsUserOutcomeCreate`)

## Merge order

**Merge and deploy vellum-ai/vellum-assistant-platform#9034 first** — this UI calls the endpoint that PR adds. (The reverse order is harmless to old clients but would 404 the new buttons.)

## Checks

- `bunx tsc --noEmit` clean
- `bun run test:ci` — 601 test files passed, 0 failed
- targeted eslint on changed files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)