### PR TITLE
fix: consolidate record-time outbox boilerplate across the six stores

### DIFF
--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -1,6 +1,3 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import {
   ACTIVATION_AB_VARIANT,
   ACTIVATION_FUNNEL_VERSION,
@@ -8,25 +5,15 @@ import {
   type ActivationStepName,
   buildActivationDaemonEventId,
 } from "../telemetry/activation-funnel.js";
-import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
 import type { OnboardingTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
 
+/** Identity of a recorded outbox row; the full payload lives in the outbox. */
 export interface OnboardingEvent {
   id: string;
   createdAt: number;
-  screen: string;
-  toolsJson: string | null;
-  tasksJson: string | null;
-  tone: string | null;
-  googleConnected: boolean | null;
-  googleScopesJson: string | null;
-  abVariant: string | null;
-  sessionId: string | null;
-  stepName: string | null;
-  stepIndex: number | null;
   completedAt: string | null;
-  funnelVersion: string | null;
 }
 
 export interface RecordOnboardingEventParams {
@@ -93,46 +80,6 @@ function buildOnboardingTelemetryEvent(
 }
 
 /**
- * Build the wire payload and insert it into the `telemetry_events` outbox.
- * Shared by all record* entry points. Returns null when the telemetry
- * database is unavailable — the event is dropped, matching the degraded-mode
- * behavior of the other telemetry stores.
- */
-function insertOnboardingEvent(
-  id: string,
-  createdAt: number,
-  params: RecordOnboardingEventParams,
-): OnboardingEvent | null {
-  const inserted = insertTelemetryOutboxEvent({
-    id,
-    name: "onboarding",
-    createdAt,
-    event: buildOnboardingTelemetryEvent(id, createdAt, params),
-  });
-  if (!inserted) {
-    return null;
-  }
-  return {
-    id,
-    createdAt,
-    screen: params.screen,
-    toolsJson: params.tools ? JSON.stringify(params.tools) : null,
-    tasksJson: params.tasks ? JSON.stringify(params.tasks) : null,
-    tone: params.tone ?? null,
-    googleConnected: params.googleConnected ?? null,
-    googleScopesJson: params.googleScopes
-      ? JSON.stringify(params.googleScopes)
-      : null,
-    abVariant: params.abVariant ?? null,
-    sessionId: params.sessionId ?? null,
-    stepName: params.stepName ?? null,
-    stepIndex: params.stepIndex ?? null,
-    completedAt: params.completedAt ?? null,
-    funnelVersion: params.funnelVersion ?? null,
-  };
-}
-
-/**
  * Record an onboarding event (pre-chat selections and Google connect status).
  * Returns null when usage data collection is disabled or the telemetry
  * database is unavailable.
@@ -140,10 +87,12 @@ function insertOnboardingEvent(
 export function recordOnboardingEvent(
   params: RecordOnboardingEventParams,
 ): OnboardingEvent | null {
-  if (!getCachedShareAnalytics()) {
-    return null;
-  }
-  return insertOnboardingEvent(uuid(), Date.now(), params);
+  const recorded = recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
+    buildOnboardingTelemetryEvent(id, createdAt, params),
+  );
+  return recorded
+    ? { ...recorded, completedAt: params.completedAt ?? null }
+    : null;
 }
 
 /**
@@ -157,17 +106,18 @@ export function recordActivationEvent(params: {
   userId?: string | null;
   abVariant?: string;
 }): OnboardingEvent | null {
-  if (!getCachedShareAnalytics()) {
-    return null;
-  }
-  const createdAt = Date.now();
-  return insertOnboardingEvent(uuid(), createdAt, {
-    screen: params.stepName,
-    abVariant: params.abVariant ?? ACTIVATION_AB_VARIANT,
-    sessionId: params.sessionId,
-    stepName: params.stepName,
-    stepIndex: activationStepIndex(params.stepName),
-    completedAt: new Date(createdAt).toISOString(),
-    funnelVersion: ACTIVATION_FUNNEL_VERSION,
-  });
+  const recorded = recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
+    buildOnboardingTelemetryEvent(id, createdAt, {
+      screen: params.stepName,
+      abVariant: params.abVariant ?? ACTIVATION_AB_VARIANT,
+      sessionId: params.sessionId,
+      stepName: params.stepName,
+      stepIndex: activationStepIndex(params.stepName),
+      completedAt: new Date(createdAt).toISOString(),
+      funnelVersion: ACTIVATION_FUNNEL_VERSION,
+    }),
+  );
+  return recorded
+    ? { ...recorded, completedAt: new Date(recorded.createdAt).toISOString() }
+    : null;
 }

--- a/assistant/src/persistence/lifecycle-events-store.ts
+++ b/assistant/src/persistence/lifecycle-events-store.ts
@@ -1,7 +1,4 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
-import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
 import type { LifecycleTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
 
@@ -35,19 +32,8 @@ export function buildLifecycleTelemetryEvent(
  * telemetry database is unavailable (degraded mode).
  */
 export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
-  if (!getCachedShareAnalytics()) {
-    return null;
-  }
-  const event: LifecycleEvent = {
-    id: uuid(),
-    eventName,
-    createdAt: Date.now(),
-  };
-  const inserted = insertTelemetryOutboxEvent({
-    id: event.id,
-    name: "lifecycle",
-    createdAt: event.createdAt,
-    event: buildLifecycleTelemetryEvent(event.id, eventName, event.createdAt),
-  });
-  return inserted ? event : null;
+  const recorded = recordTelemetryOutboxEvent("lifecycle", (id, createdAt) =>
+    buildLifecycleTelemetryEvent(id, eventName, createdAt),
+  );
+  return recorded ? { ...recorded, eventName } : null;
 }

--- a/assistant/src/telemetry/config-setting-events-store.ts
+++ b/assistant/src/telemetry/config-setting-events-store.ts
@@ -1,8 +1,5 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { APP_VERSION } from "../version.js";
-import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
 import type { ConfigSettingTelemetryEvent } from "./types.js";
 
 /**
@@ -37,23 +34,17 @@ export interface ConfigSettingEventRecord {
 export function recordConfigSettingEvent(
   record: ConfigSettingEventRecord,
 ): boolean {
-  if (!getCachedShareAnalytics()) {
-    return false;
-  }
-  const id = uuid();
-  const createdAt = Date.now();
-  const event: ConfigSettingTelemetryEvent = {
-    type: "config_setting",
-    daemon_event_id: id,
-    recorded_at: createdAt,
-    config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
-    config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
-    assistant_version: APP_VERSION,
-  };
-  return insertTelemetryOutboxEvent({
-    id,
-    name: "config_setting",
-    createdAt,
-    event,
-  });
+  return (
+    recordTelemetryOutboxEvent(
+      "config_setting",
+      (id, createdAt): ConfigSettingTelemetryEvent => ({
+        type: "config_setting",
+        daemon_event_id: id,
+        recorded_at: createdAt,
+        config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
+        config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
+        assistant_version: APP_VERSION,
+      }),
+    ) !== null
+  );
 }

--- a/assistant/src/telemetry/skill-loaded-events-store.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.ts
@@ -1,10 +1,7 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import type { UsageAttributionColumns } from "../usage/attribution.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { APP_VERSION } from "../version.js";
-import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
 import type { SkillLoadedTelemetryEvent } from "./types.js";
 
 /**
@@ -30,30 +27,22 @@ export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns>
  * telemetry DB is unavailable.
  */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
-  if (!getCachedShareAnalytics()) {
-    return;
-  }
-  const id = uuid();
-  const createdAt = Date.now();
-  const event: SkillLoadedTelemetryEvent = {
-    type: "skill_loaded",
-    daemon_event_id: id,
-    recorded_at: createdAt,
-    skill_name: record.skillName,
-    skill_updated_at: record.skillUpdatedAt ?? null,
-    conversation_id: record.conversationId ?? null,
-    provider: record.provider ?? null,
-    model: record.model ?? null,
-    inference_profile: record.inferenceProfile ?? null,
-    inference_profile_source: (record.inferenceProfileSource ??
-      null) as UsageAttributionProfileSource | null,
-    assistant_version: APP_VERSION,
-  };
-  insertTelemetryOutboxEvent({
-    id,
-    name: "skill_loaded",
-    createdAt,
-    conversationId: record.conversationId ?? null,
-    event,
-  });
+  recordTelemetryOutboxEvent(
+    "skill_loaded",
+    (id, createdAt): SkillLoadedTelemetryEvent => ({
+      type: "skill_loaded",
+      daemon_event_id: id,
+      recorded_at: createdAt,
+      skill_name: record.skillName,
+      skill_updated_at: record.skillUpdatedAt ?? null,
+      conversation_id: record.conversationId ?? null,
+      provider: record.provider ?? null,
+      model: record.model ?? null,
+      inference_profile: record.inferenceProfile ?? null,
+      inference_profile_source: (record.inferenceProfileSource ??
+        null) as UsageAttributionProfileSource | null,
+      assistant_version: APP_VERSION,
+    }),
+    { conversationId: record.conversationId ?? null },
+  );
 }

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -1,13 +1,17 @@
 /**
- * Storage seam for the generic `telemetry_events` outbox on the dedicated
- * telemetry database (`assistant-telemetry.db`). Rows carry the full wire
- * `TelemetryEvent` built at record time and are deleted after a successful
- * flush. No consent logic lives here — call sites own gating.
+ * Generic `telemetry_events` outbox on the dedicated telemetry database
+ * (`assistant-telemetry.db`). Rows carry the full wire `TelemetryEvent` built
+ * at record time and are deleted after a successful flush.
+ * `recordTelemetryOutboxEvent` is the consent-owning record layer; the
+ * storage seam functions carry no consent logic — their call sites own
+ * gating.
  */
 import { asc, eq, inArray } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
 
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import type { TelemetryEvent } from "./types.js";
 
 /** Ids per DELETE chunk — stays under SQLite's bound-variable limit. */
@@ -67,6 +71,34 @@ export function insertTelemetryOutboxEvent(
   row: TelemetryOutboxInsert,
 ): boolean {
   return insertTelemetryOutboxEvents([row]);
+}
+
+/**
+ * Record one telemetry event: gate on usage-data consent, generate the outbox
+ * row id and record-time timestamp, build the wire payload via `buildEvent`
+ * (which owns per-type stamping, e.g. `daemon_event_id` overrides), and
+ * insert. Returns the generated row identity, or null when usage data
+ * collection is disabled (the event is dropped to honor the opt-out) or the
+ * telemetry DB is unavailable (degraded mode).
+ */
+export function recordTelemetryOutboxEvent(
+  name: string,
+  buildEvent: (id: string, createdAt: number) => TelemetryEvent,
+  opts?: { conversationId?: string | null },
+): { id: string; createdAt: number } | null {
+  if (!getCachedShareAnalytics()) {
+    return null;
+  }
+  const id = uuid();
+  const createdAt = Date.now();
+  const inserted = insertTelemetryOutboxEvent({
+    id,
+    name,
+    createdAt,
+    conversationId: opts?.conversationId ?? null,
+    event: buildEvent(id, createdAt),
+  });
+  return inserted ? { id, createdAt } : null;
 }
 
 /**

--- a/assistant/src/telemetry/watchdog-events-store.ts
+++ b/assistant/src/telemetry/watchdog-events-store.ts
@@ -1,8 +1,5 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { APP_VERSION } from "../version.js";
-import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
 import type { WatchdogTelemetryEvent } from "./types.js";
 
 /**
@@ -27,19 +24,16 @@ export interface WatchdogEventRecord {
  * unavailable.
  */
 export function recordWatchdogEvent(record: WatchdogEventRecord): void {
-  if (!getCachedShareAnalytics()) {
-    return;
-  }
-  const id = uuid();
-  const createdAt = Date.now();
-  const event: WatchdogTelemetryEvent = {
-    type: "watchdog",
-    daemon_event_id: id,
-    recorded_at: createdAt,
-    check_name: record.checkName,
-    value: record.value ?? null,
-    detail: record.detail ?? null,
-    assistant_version: APP_VERSION,
-  };
-  insertTelemetryOutboxEvent({ id, name: "watchdog", createdAt, event });
+  recordTelemetryOutboxEvent(
+    "watchdog",
+    (id, createdAt): WatchdogTelemetryEvent => ({
+      type: "watchdog",
+      daemon_event_id: id,
+      recorded_at: createdAt,
+      check_name: record.checkName,
+      value: record.value ?? null,
+      detail: record.detail ?? null,
+      assistant_version: APP_VERSION,
+    }),
+  );
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for telemetry-outbox-consolidation.md.

**Gap 1:** six stores duplicated the consent-gate/uuid/timestamp/stamp/insert boilerplate — now one recordTelemetryOutboxEvent helper owns it; stores are payload mappings.
**Gap 2:** onboarding store rebuilt a 14-field legacy row shape nobody reads (with redundant re-serialization) — return slimmed to the fields tests actually use.