### PR TITLE
fix: stale telemetry docs and accurate migration-334 backfill counts

### DIFF
--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -29,9 +29,11 @@ and a custom daemon turn-counting hook are not needed.
 
 Flow, end to end:
 
-1. **Daemon records** an activation event into the SQLite `onboarding_events`
-   table via `recordActivationEvent()` in
-   `assistant/src/memory/onboarding-events-store.ts`:
+1. **Daemon records** an activation event into the SQLite `telemetry_events`
+   outbox — the row stores the record-time wire payload, including the
+   deterministic activation `daemon_event_id` (§3) — via
+   `recordActivationEvent()` in
+   `assistant/src/onboarding/onboarding-events-store.ts`:
    - emission is **deterministic, tied to a `ui_show` surface** — there is no
      model-facing tool. The model tags the surface it is already rendering for a
      rail move with an optional `activation_moment` parameter on `ui_show`; the
@@ -55,9 +57,9 @@ Flow, end to end:
      user has not consented; default-off when there is no platform session).
 2. **Reporter flushes** every ~5 min: `usage-telemetry-reporter.ts`
    (`REPORT_INTERVAL_MS = 5 * 60 * 1000`, with a one-time
-   `INITIAL_FLUSH_DELAY_MS = 30_000` after startup) POSTs unreported onboarding
-   rows to `/v1/telemetry/ingest/` as `type: "onboarding"` events, mapping the
-   funnel columns onto the wire shape.
+   `INITIAL_FLUSH_DELAY_MS = 30_000` after startup) POSTs queued onboarding
+   rows to `/v1/telemetry/ingest/` as `type: "onboarding"` events — the stored
+   record-time payloads as-is — and deletes the rows after a successful upload.
 3. **Platform ingests** the onboarding events and writes GCS NDJSON.
 4. **BigQuery** exposes them via the external table
    `vellum-ai-prod.telemetry.onboarding_raw`, which already carries the
@@ -93,9 +95,9 @@ All five steps are recorded deterministically on surface commit. The north star
 (≥5 user messages) is derived downstream from the existing `turn` telemetry, not
 a materialized activation event (see §1).
 
-On the wire, each onboarding event also sets `screen = step_name` (to satisfy the
-SQLite `screen TEXT NOT NULL` column and the platform's legacy-path validation),
-and `completed_at` is the ISO-8601 record time.
+On the wire, each onboarding event also sets `screen = step_name` (to satisfy
+the platform's legacy-path validation), and `completed_at` is the ISO-8601
+record time.
 
 ---
 
@@ -108,21 +110,21 @@ daemon_event_id = `${funnel_version}:${session_id}:${step_name}`
 ```
 
 Built by `buildActivationDaemonEventId()` in
-`assistant/src/telemetry/activation-funnel.ts`. The reporter overrides
-`daemon_event_id` for activation rows (where `session_id && step_name &&
-funnel_version` are all present) and keys it on the **row's stored
-`funnel_version`**, NOT the running binary's current constant. This keeps the id
-stable across a version bump so rows queued offline / flushed after an upgrade
-still collapse with already-ingested rows from the same session.
+`assistant/src/telemetry/activation-funnel.ts`. The store freezes the id into
+the outbox payload **at record time**, keyed on the **funnel version the row was
+recorded under**, NOT whatever constant the binary that later flushes it carries.
+This keeps the id stable across a version bump so rows queued offline / flushed
+after an upgrade still collapse with already-ingested rows from the same session.
 
 A moment that fires more than once (e.g. a model double-emit) therefore lands
 with the same `daemon_event_id` and is collapsed downstream by the existing dbt
 earliest-wins dedup on `daemon_event_id`. For boolean "moment complete"
 semantics, earliest-wins is correct.
 
-**Checkpoint safety:** the SQLite watermark cursor in the reporter advances on the
-row `id` / `createdAt`, NOT on `daemon_event_id`. The deterministic id is a
-wire-only override, so overriding it never affects flush checkpointing.
+**Flush safety:** each outbox row keeps its own random row `id`, and the reporter
+acknowledges (deletes) shipped rows by that row id, NOT by `daemon_event_id`. The
+deterministic id lives only in the wire payload, so it never affects flush
+bookkeeping.
 
 ---
 

--- a/assistant/scripts/build-test-fixtures.ts
+++ b/assistant/scripts/build-test-fixtures.ts
@@ -69,8 +69,9 @@ async function buildMigratedFixture(outWorkspaceDir: string): Promise<void> {
   mkdirSync(destDbDir, { recursive: true });
 
   // The four DBs are captured together: the migrated state spans them (e.g.
-  // llm_request_logs in `logs`, memory_jobs in `memory`, watchdog_events in
-  // `telemetry`), so a partial capture would leave a test with missing tables.
+  // llm_request_logs in `logs`, memory_jobs in `memory`, telemetry_events +
+  // flush_checkpoints in `telemetry`), so a partial capture would leave a test
+  // with missing tables.
   const captures = [
     [getSqlite(), getDbPath()],
     [getLogsSqlite(), getLogsDbPath()],

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
@@ -291,11 +291,13 @@ function dropRedactedConversationRows(
   });
 }
 
+/** Returns the number of rows actually inserted (dupes IGNOREd don't count). */
 function insertOutboxRows(
   raw: Database,
   spec: LegacyBackfillSpec,
   rows: LegacyRow[],
-): void {
+): number {
+  let inserted = 0;
   for (let i = 0; i < rows.length; i += INSERT_CHUNK_SIZE) {
     const chunk = rows.slice(i, i + INSERT_CHUNK_SIZE);
     const placeholders = chunk.map(() => "(?, ?, ?, ?, ?)").join(", ");
@@ -308,12 +310,13 @@ function insertOutboxRows(
         : null,
       JSON.stringify(spec.toPayload(row)),
     ]);
-    raw
+    inserted += raw
       .query(
         /*sql*/ `INSERT OR IGNORE INTO telemetry_events (id, name, created_at, conversation_id, payload) VALUES ${placeholders}`,
       )
-      .run(...params);
+      .run(...params).changes;
   }
+  return inserted;
 }
 
 /**
@@ -362,9 +365,8 @@ export function migrateBackfillTelemetryEventsOutbox(mainDb: DrizzleDb): void {
       spec,
       selectUnshippedRows(raw, spec),
     );
-    insertOutboxRows(raw, spec, rows);
+    backfilled[spec.table] = insertOutboxRows(raw, spec, rows);
     raw.exec(/*sql*/ `DROP TABLE ${spec.table}`);
-    backfilled[spec.table] = rows.length;
   }
 
   const watermarkKeys = LEGACY_BACKFILL_SPECS.flatMap((spec) => [


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for telemetry-outbox-consolidation.md.

**Gap A:** activation-funnel doc still described the dropped onboarding_events table — now describes the telemetry_events outbox.
**Gap B:** build-test-fixtures comment cited the dropped watchdog_events table.
**Gap C:** migration 334's summary log counted attempted rows, over-counting on crash-retry re-runs — now sums actual INSERT changes.