### PR TITLE
fix: drop dead onboarding telemetry plumbing (priorAssistants forward, completedAt return, userId param)

### DIFF
--- a/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
@@ -73,7 +73,6 @@ describe("onboarding-events-store: recordActivationEvent", () => {
       funnel_version: ACTIVATION_FUNNEL_VERSION,
       assistant_version: APP_VERSION,
     });
-    expect(event!.completedAt).toBe(new Date(event!.createdAt).toISOString());
   });
 
   test("outbox row id stays a UUID distinct from the payload daemon_event_id", () => {
@@ -140,7 +139,6 @@ describe("onboarding-events-store: recordOnboardingEvent", () => {
       tools: ["gmail", "calendar"],
       tone: "warm",
       googleConnected: true,
-      priorAssistants: ["siri"],
     });
     expect(event).not.toBeNull();
 

--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -13,7 +13,6 @@ import { APP_VERSION } from "../version.js";
 export interface OnboardingEvent {
   id: string;
   createdAt: number;
-  completedAt: string | null;
 }
 
 export interface RecordOnboardingEventParams {
@@ -23,8 +22,6 @@ export interface RecordOnboardingEventParams {
   tone?: string;
   googleConnected?: boolean;
   googleScopes?: string[];
-  /** Accepted for caller compatibility; never shipped and no longer stored. */
-  priorAssistants?: string[];
   abVariant?: string;
   sessionId?: string | null;
   stepName?: string | null;
@@ -87,12 +84,9 @@ function buildOnboardingTelemetryEvent(
 export function recordOnboardingEvent(
   params: RecordOnboardingEventParams,
 ): OnboardingEvent | null {
-  const recorded = recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
+  return recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
     buildOnboardingTelemetryEvent(id, createdAt, params),
   );
-  return recorded
-    ? { ...recorded, completedAt: params.completedAt ?? null }
-    : null;
 }
 
 /**
@@ -103,10 +97,9 @@ export function recordOnboardingEvent(
 export function recordActivationEvent(params: {
   stepName: ActivationStepName;
   sessionId: string;
-  userId?: string | null;
   abVariant?: string;
 }): OnboardingEvent | null {
-  const recorded = recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
+  return recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
     buildOnboardingTelemetryEvent(id, createdAt, {
       screen: params.stepName,
       abVariant: params.abVariant ?? ACTIVATION_AB_VARIANT,
@@ -117,7 +110,4 @@ export function recordActivationEvent(params: {
       funnelVersion: ACTIVATION_FUNNEL_VERSION,
     }),
   );
-  return recorded
-    ? { ...recorded, completedAt: new Date(recorded.createdAt).toISOString() }
-    : null;
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1920,7 +1920,6 @@ export async function handleSendMessage(
             tone: body.onboarding!.tone,
             googleConnected: body.onboarding!.googleConnected,
             googleScopes: body.onboarding!.googleScopes,
-            priorAssistants: body.onboarding!.priorAssistants,
           });
         } catch (err) {
           log.warn({ err }, "Failed to record onboarding telemetry event");
@@ -1983,7 +1982,6 @@ export async function handleSendMessage(
         tone: body.onboarding!.tone,
         googleConnected: body.onboarding!.googleConnected,
         googleScopes: body.onboarding!.googleScopes,
-        priorAssistants: body.onboarding!.priorAssistants,
       });
     } catch (err) {
       log.warn({ err }, "Failed to record onboarding telemetry event");


### PR DESCRIPTION
## Summary
Fixes residual gaps from plan review for telemetry-outbox-consolidation.md.

- priorAssistants: no-op record param deleted along with its two conversation-routes forwards (request-body field untouched — it feeds prompt personalization, not telemetry)
- Record functions now return the outbox identity directly; unread completedAt return field and dead userId param removed