### PR TITLE
Consolidate telemetry-only tables into a generic telemetry_events outbox

### DIFF
--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -29,9 +29,11 @@ and a custom daemon turn-counting hook are not needed.
 
 Flow, end to end:
 
-1. **Daemon records** an activation event into the SQLite `onboarding_events`
-   table via `recordActivationEvent()` in
-   `assistant/src/memory/onboarding-events-store.ts`:
+1. **Daemon records** an activation event into the SQLite `telemetry_events`
+   outbox — the row stores the record-time wire payload, including the
+   deterministic activation `daemon_event_id` (§3) — via
+   `recordActivationEvent()` in
+   `assistant/src/onboarding/onboarding-events-store.ts`:
    - emission is **deterministic, tied to a `ui_show` surface** — there is no
      model-facing tool. The model tags the surface it is already rendering for a
      rail move with an optional `activation_moment` parameter on `ui_show`; the
@@ -55,9 +57,9 @@ Flow, end to end:
      user has not consented; default-off when there is no platform session).
 2. **Reporter flushes** every ~5 min: `usage-telemetry-reporter.ts`
    (`REPORT_INTERVAL_MS = 5 * 60 * 1000`, with a one-time
-   `INITIAL_FLUSH_DELAY_MS = 30_000` after startup) POSTs unreported onboarding
-   rows to `/v1/telemetry/ingest/` as `type: "onboarding"` events, mapping the
-   funnel columns onto the wire shape.
+   `INITIAL_FLUSH_DELAY_MS = 30_000` after startup) POSTs queued onboarding
+   rows to `/v1/telemetry/ingest/` as `type: "onboarding"` events — the stored
+   record-time payloads as-is — and deletes the rows after a successful upload.
 3. **Platform ingests** the onboarding events and writes GCS NDJSON.
 4. **BigQuery** exposes them via the external table
    `vellum-ai-prod.telemetry.onboarding_raw`, which already carries the
@@ -93,9 +95,9 @@ All five steps are recorded deterministically on surface commit. The north star
 (≥5 user messages) is derived downstream from the existing `turn` telemetry, not
 a materialized activation event (see §1).
 
-On the wire, each onboarding event also sets `screen = step_name` (to satisfy the
-SQLite `screen TEXT NOT NULL` column and the platform's legacy-path validation),
-and `completed_at` is the ISO-8601 record time.
+On the wire, each onboarding event also sets `screen = step_name` (to satisfy
+the platform's legacy-path validation), and `completed_at` is the ISO-8601
+record time.
 
 ---
 
@@ -108,21 +110,21 @@ daemon_event_id = `${funnel_version}:${session_id}:${step_name}`
 ```
 
 Built by `buildActivationDaemonEventId()` in
-`assistant/src/telemetry/activation-funnel.ts`. The reporter overrides
-`daemon_event_id` for activation rows (where `session_id && step_name &&
-funnel_version` are all present) and keys it on the **row's stored
-`funnel_version`**, NOT the running binary's current constant. This keeps the id
-stable across a version bump so rows queued offline / flushed after an upgrade
-still collapse with already-ingested rows from the same session.
+`assistant/src/telemetry/activation-funnel.ts`. The store freezes the id into
+the outbox payload **at record time**, keyed on the **funnel version the row was
+recorded under**, NOT whatever constant the binary that later flushes it carries.
+This keeps the id stable across a version bump so rows queued offline / flushed
+after an upgrade still collapse with already-ingested rows from the same session.
 
 A moment that fires more than once (e.g. a model double-emit) therefore lands
 with the same `daemon_event_id` and is collapsed downstream by the existing dbt
 earliest-wins dedup on `daemon_event_id`. For boolean "moment complete"
 semantics, earliest-wins is correct.
 
-**Checkpoint safety:** the SQLite watermark cursor in the reporter advances on the
-row `id` / `createdAt`, NOT on `daemon_event_id`. The deterministic id is a
-wire-only override, so overriding it never affects flush checkpointing.
+**Flush safety:** each outbox row keeps its own random row `id`, and the reporter
+acknowledges (deletes) shipped rows by that row id, NOT by `daemon_event_id`. The
+deterministic id lives only in the wire payload, so it never affects flush
+bookkeeping.
 
 ---
 

--- a/assistant/scripts/build-test-fixtures.ts
+++ b/assistant/scripts/build-test-fixtures.ts
@@ -69,8 +69,9 @@ async function buildMigratedFixture(outWorkspaceDir: string): Promise<void> {
   mkdirSync(destDbDir, { recursive: true });
 
   // The four DBs are captured together: the migrated state spans them (e.g.
-  // llm_request_logs in `logs`, memory_jobs in `memory`, watchdog_events in
-  // `telemetry`), so a partial capture would leave a test with missing tables.
+  // llm_request_logs in `logs`, memory_jobs in `memory`, telemetry_events +
+  // flush_checkpoints in `telemetry`), so a partial capture would leave a test
+  // with missing tables.
   const captures = [
     [getSqlite(), getDbPath()],
     [getLogsSqlite(), getLogsDbPath()],

--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 let shareAnalytics = true;
 
@@ -6,19 +6,23 @@ mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
+import * as dbConnection from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { authFallbackEvents } from "../persistence/schema/index.js";
 import {
   type AuthFallbackCount,
-  queryUnreportedAuthFallbackEvents,
   recordAuthFallbackCounts,
 } from "../security/auth-fallback-events-store.js";
+import {
+  discardPendingTelemetryOutboxEvents,
+  queryTelemetryOutboxBatch,
+} from "../telemetry/telemetry-events-outbox.js";
+import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
+import { APP_VERSION } from "../version.js";
 
 await initializeDb();
 
-function resetTable(): void {
-  getTelemetryDb()!.delete(authFallbackEvents).run();
+function pendingRows() {
+  return queryTelemetryOutboxBatch("auth_fallback", 100);
 }
 
 const SAMPLE: AuthFallbackCount[] = [
@@ -39,27 +43,41 @@ const SAMPLE: AuthFallbackCount[] = [
 describe("auth-fallback-events-store", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    resetTable();
+    discardPendingTelemetryOutboxEvents("auth_fallback");
   });
 
-  test("records one row per count entry and they are queryable", () => {
+  test("records one outbox row per count entry with the full wire payload", () => {
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(2);
 
-    const rows = queryUnreportedAuthFallbackEvents(0, undefined, 100);
+    const rows = pendingRows();
     expect(rows.length).toBe(2);
-    const byGuard = Object.fromEntries(rows.map((r) => [r.guard, r]));
-    expect(byGuard["edge"]).toMatchObject({
+    const payloads = rows.map(
+      (r) => JSON.parse(r.payload) as AuthFallbackTelemetryEvent,
+    );
+    const byGuard = Object.fromEntries(payloads.map((p) => [p.guard, p]));
+    expect(byGuard["edge"]).toEqual({
+      type: "auth_fallback",
+      daemon_event_id: expect.any(String),
+      recorded_at: expect.any(Number),
+      guard: "edge",
       path: "/v1/messages",
-      failureKind: "missing_authorization",
+      failure_kind: "missing_authorization",
       count: 7,
-      windowStart: 1000,
-      windowEnd: 2000,
+      window_start: 1000,
+      window_end: 2000,
+      assistant_version: APP_VERSION,
     });
     expect(byGuard["edge-scoped"]).toMatchObject({
       path: "/v1/files",
-      failureKind: "insufficient_scope",
+      failure_kind: "insufficient_scope",
       count: 2,
+    });
+    // The wire daemon_event_id matches the outbox row id, and recorded_at
+    // matches the row's created_at (record-time stamping).
+    rows.forEach((row, i) => {
+      expect(payloads[i].daemon_event_id).toBe(row.id);
+      expect(payloads[i].recorded_at).toBe(row.createdAt);
     });
   });
 
@@ -67,35 +85,23 @@ describe("auth-fallback-events-store", () => {
     shareAnalytics = false;
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(0);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingRows().length).toBe(0);
   });
 
   test("empty counts batch is a no-op", () => {
     expect(recordAuthFallbackCounts(1000, 2000, [])).toBe(0);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingRows().length).toBe(0);
   });
 
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    recordAuthFallbackCounts(1000, 2000, SAMPLE);
-    const all = queryUnreportedAuthFallbackEvents(0, undefined, 100);
-    expect(all.length).toBe(2);
-
-    // All rows share the same createdAt (one insert batch). Paginating with a
-    // limit of 1 must use the id tiebreaker to make forward progress, not loop.
-    const first = queryUnreportedAuthFallbackEvents(0, undefined, 1);
-    expect(first.length).toBe(1);
-    const second = queryUnreportedAuthFallbackEvents(
-      first[0].createdAt,
-      first[0].id,
-      1,
-    );
-    expect(second.length).toBe(1);
-    expect(second[0].id).not.toBe(first[0].id);
-
-    // Cursor past the last row returns nothing.
-    const last = all[all.length - 1];
-    expect(
-      queryUnreportedAuthFallbackEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
+  test("records all-or-nothing: db unavailable returns 0 with no rows", () => {
+    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+    try {
+      expect(recordAuthFallbackCounts(1000, 2000, SAMPLE)).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+    // No partial batch: the gateway's `recorded === 0` retry contract means
+    // any committed remnant would later double-count.
+    expect(pendingRows().length).toBe(0);
   });
 });

--- a/assistant/src/__tests__/conversation-clear-safety.test.ts
+++ b/assistant/src/__tests__/conversation-clear-safety.test.ts
@@ -6,7 +6,7 @@
  * - Missing X-Confirm-Destructive header returns BadRequestError
  * - Wrong header value returns BadRequestError
  * - Correct header clears data
- * - lifecycle_events contains `conversations_clear_all` audit entry after clear
+ * - telemetry_events contains the `conversations_clear_all` audit entry after clear
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -170,20 +170,31 @@ describe("DELETE /v1/conversations — route handler", () => {
     expect(getConversation(conv.id)).toBeNull();
   });
 
-  test("lifecycle_events contains conversations_clear_all after successful clear", async () => {
+  test("telemetry_events contains conversations_clear_all after successful clear", async () => {
     await clearRoute.handler({
       pathParams: {},
       body: {},
       headers: { "x-confirm-destructive": "clear-all-conversations" },
     });
 
-    // The audit row lives in the dedicated telemetry DB (migration 329).
+    // The audit row lands in the telemetry_events outbox on the dedicated
+    // telemetry DB; the durable trail persists platform-side once flushed.
     const rows = getTelemetrySqlite()!
       .query(
-        "SELECT event_name FROM lifecycle_events WHERE event_name = 'conversations_clear_all'",
+        "SELECT id, payload FROM telemetry_events WHERE name = 'lifecycle'",
       )
-      .all() as Array<{ event_name: string }>;
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-    expect(rows[0].event_name).toBe("conversations_clear_all");
+      .all() as Array<{ id: string; payload: string }>;
+    const audits = rows
+      .map((r) => ({
+        id: r.id,
+        payload: JSON.parse(r.payload) as Record<string, unknown>,
+      }))
+      .filter((r) => r.payload.event_name === "conversations_clear_all");
+    expect(audits.length).toBeGreaterThanOrEqual(1);
+    expect(audits[0].payload).toMatchObject({
+      type: "lifecycle",
+      daemon_event_id: audits[0].id,
+      event_name: "conversations_clear_all",
+    });
   });
 });

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -19,9 +19,31 @@ import {
 import { isLastUserMessageToolResult } from "../persistence/conversation-queries.js";
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { skillLoadedEvents } from "../persistence/schema/index.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
 // Initialize db once before all tests
 await initializeDb();
+
+/** Seed a pending telemetry outbox row (default name: skill_loaded). */
+function seedTelemetryEvent(
+  id: string,
+  createdAt: number,
+  conversationId: string | null,
+  name = "skill_loaded",
+): void {
+  getTelemetryDb()!
+    .insert(telemetryEvents)
+    .values({ id, name, createdAt, conversationId, payload: "{}" })
+    .run();
+}
+
+function pendingTelemetryEventIds(): string[] {
+  return getTelemetryDb()!
+    .select()
+    .from(telemetryEvents)
+    .all()
+    .map((r) => r.id)
+    .sort();
+}
 
 describe("deleteLastExchange", () => {
   beforeEach(() => {
@@ -351,109 +373,62 @@ describe("attachment orphan cleanup", () => {
     expect(linkCount.c).toBe(0);
   });
 
-  test("clearAll removes skill_loaded_events", async () => {
-    // Privacy posture: Clear All wins over unflushed telemetry — the
-    // skill_loaded_events rows (conversation id, skill name, model
-    // attribution) must not survive the wipe and ship later.
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+  test("clearAll removes pending skill_loaded telemetry_events rows", async () => {
+    // Privacy posture: Clear All wins over unflushed telemetry — the pending
+    // skill_loaded rows (conversation id, skill name, model attribution)
+    // must not survive the wipe and ship later.
+    getTelemetryDb()!.delete(telemetryEvents).run();
     const conv = createConversation("test");
-    getTelemetryDb()!
-      .insert(skillLoadedEvents)
-      .values([
-        {
-          id: "sle-clear-1",
-          createdAt: 1000,
-          conversationId: conv.id,
-          skillName: "web-research",
-        },
-        // Rows without a conversation are wiped too.
-        { id: "sle-clear-2", createdAt: 2000, skillName: "tasks" },
-      ])
-      .run();
+    seedTelemetryEvent("sle-clear-1", 1000, conv.id);
+    // Rows without a conversation are wiped too.
+    seedTelemetryEvent("sle-clear-2", 2000, null);
 
     await clearAll();
 
-    expect(
-      getTelemetryDb()!.select().from(skillLoadedEvents).all(),
-    ).toHaveLength(0);
+    const skillRows = getTelemetryDb()!
+      .select()
+      .from(telemetryEvents)
+      .all()
+      .filter((r) => r.name === "skill_loaded");
+    expect(skillRows).toHaveLength(0);
   });
 
-  test("deleteConversation removes that conversation's skill_loaded_events", async () => {
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+  test("deleteConversation removes that conversation's telemetry_events rows", async () => {
+    getTelemetryDb()!.delete(telemetryEvents).run();
     const conv = createConversation("doomed");
     await addMessage(conv.id, "user", "hello");
     const other = createConversation("kept");
-    getTelemetryDb()!
-      .insert(skillLoadedEvents)
-      .values([
-        {
-          id: "sle-del-1",
-          createdAt: 1000,
-          conversationId: conv.id,
-          skillName: "web-research",
-        },
-        {
-          id: "sle-del-2",
-          createdAt: 2000,
-          conversationId: other.id,
-          skillName: "tasks",
-        },
-      ])
-      .run();
+    seedTelemetryEvent("te-del-1", 1000, conv.id);
+    seedTelemetryEvent("te-del-2", 2000, other.id);
+    // Redaction keys on conversation_id regardless of event name.
+    seedTelemetryEvent("te-del-3", 3000, conv.id, "future_event");
 
     deleteConversation(conv.id);
 
-    const remaining = getTelemetryDb()!.select().from(skillLoadedEvents).all();
-    expect(remaining.map((r) => r.id)).toEqual(["sle-del-2"]);
+    expect(pendingTelemetryEventIds()).toEqual(["te-del-2"]);
   });
 
-  test("deleteConversation removes skill_loaded_events when the conversation has no messages", () => {
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+  test("deleteConversation removes telemetry_events rows when the conversation has no messages", () => {
+    getTelemetryDb()!.delete(telemetryEvents).run();
     const conv = createConversation("empty");
-    getTelemetryDb()!
-      .insert(skillLoadedEvents)
-      .values({
-        id: "sle-del-empty",
-        createdAt: 1000,
-        conversationId: conv.id,
-        skillName: "web-research",
-      })
-      .run();
+    seedTelemetryEvent("te-del-empty", 1000, conv.id);
 
     deleteConversation(conv.id);
 
-    expect(
-      getTelemetryDb()!.select().from(skillLoadedEvents).all(),
-    ).toHaveLength(0);
+    expect(pendingTelemetryEventIds()).toHaveLength(0);
   });
 
-  test("deleteConversationGently removes that conversation's skill_loaded_events", async () => {
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+  test("deleteConversationGently removes that conversation's telemetry_events rows", async () => {
+    getTelemetryDb()!.delete(telemetryEvents).run();
     const conv = createConversation("doomed");
     await addMessage(conv.id, "user", "hello");
     const other = createConversation("kept");
-    getTelemetryDb()!
-      .insert(skillLoadedEvents)
-      .values([
-        {
-          id: "sle-gentle-1",
-          createdAt: 1000,
-          conversationId: conv.id,
-          skillName: "web-research",
-        },
-        {
-          id: "sle-gentle-2",
-          createdAt: 2000,
-          conversationId: other.id,
-          skillName: "tasks",
-        },
-      ])
-      .run();
+    seedTelemetryEvent("te-gentle-1", 1000, conv.id);
+    seedTelemetryEvent("te-gentle-2", 2000, other.id);
 
     await deleteConversationGently(conv.id);
 
-    const remaining = getTelemetryDb()!.select().from(skillLoadedEvents).all();
-    expect(remaining.map((r) => r.id)).toEqual(["sle-gentle-2"]);
+    expect(pendingTelemetryEventIds()).toEqual(["te-gentle-2"]);
   });
 
   test("deleteLastExchange does not delete unlinked user uploads", async () => {

--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -27,19 +27,27 @@ const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
 
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type { SurfaceType, UiSurfaceShow } from "../daemon/message-protocol.js";
-import { queryUnreportedOnboardingEvents } from "../onboarding/onboarding-events-store.js";
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
   activationSessions,
-  onboardingEvents,
+  telemetryEvents,
 } from "../persistence/schema/index.js";
 import {
   isActivationSession,
   markActivationSession,
 } from "../plugins/defaults/memory/activation-session-store.js";
+import { queryTelemetryOutboxBatch } from "../telemetry/telemetry-events-outbox.js";
+import type { OnboardingTelemetryEvent } from "../telemetry/types.js";
 
 await initializeDb();
+
+/** Pending onboarding outbox payloads, parsed, in `(created_at, id)` order. */
+function pendingOnboardingPayloads(): OnboardingTelemetryEvent[] {
+  return queryTelemetryOutboxBatch("onboarding", 10).map(
+    (row) => JSON.parse(row.payload) as OnboardingTelemetryEvent,
+  );
+}
 
 interface ProcessMessageCall {
   content: string;
@@ -84,7 +92,7 @@ function makeContext(
 }
 
 function resetTables(): void {
-  getTelemetryDb()!.delete(onboardingEvents).run();
+  getTelemetryDb()!.delete(telemetryEvents).run();
   getDb().delete(activationSessions).run();
 }
 
@@ -131,11 +139,11 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_2_complete");
-    expect(rows[0]!.stepIndex).toBe(2);
-    expect(rows[0]!.sessionId).toBe("conv-marked");
+    expect(rows[0]!.step_name).toBe("activation_moment_2_complete");
+    expect(rows[0]!.step_index).toBe(2);
+    expect(rows[0]!.session_id).toBe("conv-marked");
   });
 
   test("a queue-rejected commit does NOT emit; the tag survives for the retry", async () => {
@@ -156,7 +164,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       choiceId: "inbox",
       selectedIds: ["inbox"],
     });
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
 
     // Retry is accepted → records exactly one row.
     ctx.enqueueMessage = () => ({ queued: false, requestId: "req-ok" });
@@ -164,9 +172,9 @@ describe("activation moment emission from ui_show surface commits", () => {
       choiceId: "inbox",
       selectedIds: ["inbox"],
     });
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_2_complete");
+    expect(rows[0]!.step_name).toBe("activation_moment_2_complete");
   });
 
   test("first_wow_executed records at SHOW time (no commit) and never double-emits", async () => {
@@ -183,10 +191,10 @@ describe("activation moment emission from ui_show surface commits", () => {
     });
 
     // Recorded immediately on render — no handleSurfaceAction commit needed.
-    let rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    let rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_first_wow_executed");
-    expect(rows[0]!.stepIndex).toBe(4);
+    expect(rows[0]!.step_name).toBe("activation_first_wow_executed");
+    expect(rows[0]!.step_index).toBe(4);
 
     // If the card later receives a commit (e.g. it carried an action), it must
     // NOT double-emit — a show-timing tag is never stored for the commit path.
@@ -194,7 +202,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
     ) as UiSurfaceShow;
     await handleSurfaceAction(ctx, showMessage.surfaceId, "expand", {});
-    rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
   });
 
@@ -207,7 +215,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       data: { body: "x" },
       activation_moment: "first_wow_executed",
     });
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("does not forward the daemon-only tag to the client", async () => {
@@ -236,7 +244,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("tagged surface in an UNMARKED session writes no row", async () => {
@@ -249,7 +257,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("an invalid activation_moment token is ignored (no row)", async () => {
@@ -263,7 +271,7 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("FIX 1: launch_conversation commit on a tagged surface records exactly one row", async () => {
@@ -292,10 +300,10 @@ describe("activation moment emission from ui_show surface commits", () => {
       seedPrompt: "Write a draft",
     });
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_1_complete");
-    expect(rows[0]!.sessionId).toBe("conv-launch");
+    expect(rows[0]!.step_name).toBe("activation_moment_1_complete");
+    expect(rows[0]!.session_id).toBe("conv-launch");
   });
 
   test("FIX 2: commit-timing tag survives a surfaceState restore from history", async () => {
@@ -346,10 +354,10 @@ describe("activation moment emission from ui_show surface commits", () => {
       selectedIds: ["inbox"],
     });
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_2_complete");
-    expect(rows[0]!.sessionId).toBe("conv-restore");
+    expect(rows[0]!.step_name).toBe("activation_moment_2_complete");
+    expect(rows[0]!.session_id).toBe("conv-restore");
   });
 
   test("intermediate selection_changed does NOT emit; the terminal commit does", async () => {
@@ -381,12 +389,12 @@ describe("activation moment emission from ui_show surface commits", () => {
     await handleSurfaceAction(ctx, surfaceId, "selection_changed", {
       selectedIds: ["r1"],
     });
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
 
     // Terminal commit — emits exactly once.
     await handleSurfaceAction(ctx, surfaceId, "run", { selectedIds: ["r1"] });
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = pendingOnboardingPayloads();
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.stepName).toBe("activation_moment_3_complete");
+    expect(rows[0]!.step_name).toBe("activation_moment_3_complete");
   });
 });

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -30,7 +30,6 @@ mock.module("../telemetry/watchdog-direct-emit.js", () => ({
 
 import * as dbConnection from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { authFallbackEvents } from "../persistence/schema/index.js";
 import { GATEWAY_PRINCIPALS } from "../runtime/auth/route-policy.js";
 import {
   RouteError,
@@ -38,9 +37,19 @@ import {
 } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/internal-telemetry-routes.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
-import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-events-store.js";
+import {
+  discardPendingTelemetryOutboxEvents,
+  queryTelemetryOutboxBatch,
+} from "../telemetry/telemetry-events-outbox.js";
+import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
 
 await initializeDb();
+
+function pendingAuthFallbackPayloads(): AuthFallbackTelemetryEvent[] {
+  return queryTelemetryOutboxBatch("auth_fallback", 100).map(
+    (r) => JSON.parse(r.payload) as AuthFallbackTelemetryEvent,
+  );
+}
 
 const route = ROUTES.find(
   (r) => r.operationId === "internal_telemetry_auth_fallback",
@@ -67,7 +76,7 @@ const VALID_BODY = {
 describe("internal-telemetry-routes: auth-fallback", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    dbConnection.getTelemetryDb()!.delete(authFallbackEvents).run();
+    discardPendingTelemetryOutboxEvents("auth_fallback");
   });
 
   test("route is locked to service-token callers (GATEWAY_PRINCIPALS + internal.write)", () => {
@@ -78,26 +87,27 @@ describe("internal-telemetry-routes: auth-fallback", () => {
     expect(route?.policy?.requiredScopes).toEqual(["internal.write"]);
   });
 
-  test("valid batch is persisted with snake_case → camelCase mapping", () => {
+  test("valid batch is persisted to the outbox as a wire auth_fallback event", () => {
     const result = call(VALID_BODY);
     expect(result).toEqual({ recorded: 1 });
 
-    const rows = queryUnreportedAuthFallbackEvents(0, undefined, 100);
-    expect(rows.length).toBe(1);
-    expect(rows[0]).toMatchObject({
+    const payloads = pendingAuthFallbackPayloads();
+    expect(payloads.length).toBe(1);
+    expect(payloads[0]).toMatchObject({
+      type: "auth_fallback",
       guard: "edge",
       path: "/v1/messages",
-      failureKind: "missing_authorization",
+      failure_kind: "missing_authorization",
       count: 5,
-      windowStart: 1000,
-      windowEnd: 2000,
+      window_start: 1000,
+      window_end: 2000,
     });
   });
 
   test("returns skipped and persists nothing under the opt-out", () => {
     shareAnalytics = false;
     expect(call(VALID_BODY)).toEqual({ skipped: true });
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingAuthFallbackPayloads().length).toBe(0);
   });
 
   test("throws 503 when consent is on but the telemetry DB is unavailable, so the gateway re-queues", () => {
@@ -107,7 +117,7 @@ describe("internal-telemetry-routes: auth-fallback", () => {
     } finally {
       spy.mockRestore();
     }
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingAuthFallbackPayloads().length).toBe(0);
 
     // Once the DB is back the same batch records normally.
     expect(call(VALID_BODY)).toEqual({ recorded: 1 });
@@ -122,7 +132,7 @@ describe("internal-telemetry-routes: auth-fallback", () => {
         counts: [{ guard: "edge", path: "/x", failure_kind: "y", count: 0 }],
       }),
     ).toThrow(RouteError);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
+    expect(pendingAuthFallbackPayloads().length).toBe(0);
   });
 });
 

--- a/assistant/src/__tests__/prune-old-conversations-job.test.ts
+++ b/assistant/src/__tests__/prune-old-conversations-job.test.ts
@@ -7,7 +7,7 @@ import { pruneOldConversationsJob } from "../persistence/job-handlers/cleanup.js
 import type { MemoryJob } from "../persistence/jobs-store.js";
 import {
   conversations,
-  skillLoadedEvents,
+  telemetryEvents,
   toolInvocations,
 } from "../persistence/schema/index.js";
 
@@ -39,21 +39,23 @@ function seedConversation(id: string, updatedAt: number): void {
       createdAt: updatedAt,
     })
     .run();
-  // skill_loaded_events lives in the dedicated telemetry DB.
+  // Pending conversation-scoped telemetry rows live in the telemetry_events
+  // outbox on the dedicated telemetry DB.
   getTelemetryDb()!
-    .insert(skillLoadedEvents)
+    .insert(telemetryEvents)
     .values({
-      id: `sl-${id}`,
+      id: `te-${id}`,
+      name: "skill_loaded",
       createdAt: updatedAt,
       conversationId: id,
-      skillName: "test-skill",
+      payload: "{}",
     })
     .run();
 }
 
 function countRows(conversationId: string): {
   invocations: number;
-  skillLoads: number;
+  telemetryRows: number;
 } {
   const db = getDb();
   return {
@@ -62,9 +64,9 @@ function countRows(conversationId: string): {
       .from(toolInvocations)
       .all()
       .filter((r) => r.conversationId === conversationId).length,
-    skillLoads: getTelemetryDb()!
+    telemetryRows: getTelemetryDb()!
       .select()
-      .from(skillLoadedEvents)
+      .from(telemetryEvents)
       .all()
       .filter((r) => r.conversationId === conversationId).length,
   };
@@ -73,20 +75,20 @@ function countRows(conversationId: string): {
 describe("pruneOldConversationsJob", () => {
   beforeEach(() => {
     const db = getDb();
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+    getTelemetryDb()!.delete(telemetryEvents).run();
     db.delete(toolInvocations).run();
     db.delete(conversations).run();
   });
 
-  test("deletes non-cascading rows — including skill_loaded_events — for pruned conversations only", () => {
+  test("deletes non-cascading rows — including pending telemetry_events — for pruned conversations only", () => {
     const staleUpdatedAt = Date.now() - 60 * 86_400_000;
     seedConversation(STALE_ID, staleUpdatedAt);
     seedConversation(FRESH_ID, Date.now());
 
     pruneOldConversationsJob(JOB, CONFIG);
 
-    expect(countRows(STALE_ID)).toEqual({ invocations: 0, skillLoads: 0 });
-    expect(countRows(FRESH_ID)).toEqual({ invocations: 1, skillLoads: 1 });
+    expect(countRows(STALE_ID)).toEqual({ invocations: 0, telemetryRows: 0 });
+    expect(countRows(FRESH_ID)).toEqual({ invocations: 1, telemetryRows: 1 });
     const remaining = getDb().select().from(conversations).all();
     expect(remaining.map((c) => c.id)).toEqual([FRESH_ID]);
   });

--- a/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
@@ -12,9 +12,12 @@ import {
   getTelemetrySqlite,
 } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
-import { onboardingEvents } from "../../persistence/schema/index.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
+import { ACTIVATION_FUNNEL_VERSION } from "../../telemetry/activation-funnel.js";
+import { queryTelemetryOutboxBatch } from "../../telemetry/telemetry-events-outbox.js";
+import type { OnboardingTelemetryEvent } from "../../telemetry/types.js";
+import { APP_VERSION } from "../../version.js";
 import {
-  queryUnreportedOnboardingEvents,
   recordActivationEvent,
   recordOnboardingEvent,
 } from "../onboarding-events-store.js";
@@ -22,7 +25,14 @@ import {
 await initializeDb();
 
 function resetTable(): void {
-  getTelemetryDb()!.delete(onboardingEvents).run();
+  getTelemetryDb()!.delete(telemetryEvents).run();
+}
+
+/** Pending onboarding outbox payloads, parsed, in `(created_at, id)` order. */
+function pendingOnboardingPayloads(): OnboardingTelemetryEvent[] {
+  return queryTelemetryOutboxBatch("onboarding", 10).map(
+    (row) => JSON.parse(row.payload) as OnboardingTelemetryEvent,
+  );
 }
 
 /** Run `fn` with the dedicated telemetry connection reported as unavailable. */
@@ -41,26 +51,32 @@ describe("onboarding-events-store: recordActivationEvent", () => {
     resetTable();
   });
 
-  test("persists an activation funnel event that round-trips through the query", () => {
+  test("stores the full wire payload with the deterministic activation daemon_event_id", () => {
     const event = recordActivationEvent({
       stepName: "activation_moment_1_complete",
       sessionId: "conv-1",
     });
     expect(event).not.toBeNull();
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    const row = rows[0]!;
-    expect(row.stepName).toBe("activation_moment_1_complete");
-    expect(row.stepIndex).toBe(1);
-    expect(row.funnelVersion).toBe("activation_v1_2026_06");
-    expect(row.screen).toBe("activation_moment_1_complete");
-    expect(row.abVariant).toBe("variant-a");
-    expect(row.sessionId).toBe("conv-1");
-    expect(row.completedAt).toBe(new Date(row.createdAt).toISOString());
+    const payloads = pendingOnboardingPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toEqual({
+      type: "onboarding",
+      daemon_event_id: `${ACTIVATION_FUNNEL_VERSION}:conv-1:activation_moment_1_complete`,
+      recorded_at: event!.createdAt,
+      screen: "activation_moment_1_complete",
+      ab_variant: "variant-a",
+      session_id: "conv-1",
+      step_name: "activation_moment_1_complete",
+      step_index: 1,
+      completed_at: new Date(event!.createdAt).toISOString(),
+      funnel_version: ACTIVATION_FUNNEL_VERSION,
+      assistant_version: APP_VERSION,
+    });
+    expect(event!.completedAt).toBe(new Date(event!.createdAt).toISOString());
   });
 
-  test("writes the row into the dedicated telemetry database", () => {
+  test("outbox row id stays a UUID distinct from the payload daemon_event_id", () => {
     const event = recordActivationEvent({
       stepName: "activation_moment_1_complete",
       sessionId: "conv-telemetry",
@@ -68,9 +84,11 @@ describe("onboarding-events-store: recordActivationEvent", () => {
     expect(event).not.toBeNull();
 
     const raw = getTelemetrySqlite()!
-      .query(`SELECT id, session_id FROM onboarding_events`)
-      .all() as Array<{ id: string; session_id: string }>;
-    expect(raw).toEqual([{ id: event!.id, session_id: "conv-telemetry" }]);
+      .query(`SELECT id, name FROM telemetry_events`)
+      .all() as Array<{ id: string; name: string }>;
+    expect(raw).toEqual([{ id: event!.id, name: "onboarding" }]);
+    const payload = pendingOnboardingPayloads()[0]!;
+    expect(payload.daemon_event_id).not.toBe(event!.id);
   });
 
   test("honors an explicit abVariant override", () => {
@@ -80,10 +98,10 @@ describe("onboarding-events-store: recordActivationEvent", () => {
       abVariant: "variant-b",
     });
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.abVariant).toBe("variant-b");
-    expect(rows[0]!.stepIndex).toBe(2);
+    const payloads = pendingOnboardingPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]!.ab_variant).toBe("variant-b");
+    expect(payloads[0]!.step_index).toBe(2);
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
@@ -94,8 +112,7 @@ describe("onboarding-events-store: recordActivationEvent", () => {
     });
     expect(event).toBeNull();
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("returns null when the telemetry database is unavailable", () => {
@@ -105,10 +122,9 @@ describe("onboarding-events-store: recordActivationEvent", () => {
         sessionId: "conv-4",
       });
       expect(event).toBeNull();
-      expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 });
 
@@ -118,32 +134,45 @@ describe("onboarding-events-store: recordOnboardingEvent", () => {
     resetTable();
   });
 
-  test("persists a pre-chat onboarding event into the telemetry database", () => {
+  test("stores a pre-chat wire payload with daemon_event_id = row id and no funnel fields", () => {
     const event = recordOnboardingEvent({
       screen: "tools",
       tools: ["gmail", "calendar"],
       tone: "warm",
       googleConnected: true,
+      priorAssistants: ["siri"],
     });
     expect(event).not.toBeNull();
 
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.screen).toBe("tools");
-    expect(rows[0]!.toolsJson).toBe(JSON.stringify(["gmail", "calendar"]));
-    expect(rows[0]!.tone).toBe("warm");
-    expect(rows[0]!.googleConnected).toBe(true);
+    const payloads = pendingOnboardingPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toEqual({
+      type: "onboarding",
+      daemon_event_id: event!.id,
+      recorded_at: event!.createdAt,
+      screen: "tools",
+      tools: ["gmail", "calendar"],
+      tone: "warm",
+      google_connected: true,
+      assistant_version: APP_VERSION,
+    });
 
     const raw = getTelemetrySqlite()!
-      .query(`SELECT id FROM onboarding_events`)
-      .all() as Array<{ id: string }>;
-    expect(raw).toEqual([{ id: event!.id }]);
+      .query(`SELECT id, name, conversation_id FROM telemetry_events`)
+      .all() as Array<{
+      id: string;
+      name: string;
+      conversation_id: string | null;
+    }>;
+    expect(raw).toEqual([
+      { id: event!.id, name: "onboarding", conversation_id: null },
+    ]);
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
     shareAnalytics = false;
     expect(recordOnboardingEvent({ screen: "tools" })).toBeNull();
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 
   test("returns null when the telemetry database is unavailable", () => {
@@ -151,6 +180,6 @@ describe("onboarding-events-store: recordOnboardingEvent", () => {
       expect(recordOnboardingEvent({ screen: "tools" })).toBeNull();
     });
 
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingOnboardingPayloads()).toHaveLength(0);
   });
 });

--- a/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
@@ -73,7 +73,6 @@ describe("onboarding-events-store: recordActivationEvent", () => {
       funnel_version: ACTIVATION_FUNNEL_VERSION,
       assistant_version: APP_VERSION,
     });
-    expect(event!.completedAt).toBe(new Date(event!.createdAt).toISOString());
   });
 
   test("outbox row id stays a UUID distinct from the payload daemon_event_id", () => {
@@ -140,7 +139,6 @@ describe("onboarding-events-store: recordOnboardingEvent", () => {
       tools: ["gmail", "calendar"],
       tone: "warm",
       googleConnected: true,
-      priorAssistants: ["siri"],
     });
     expect(event).not.toBeNull();
 

--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -13,7 +13,6 @@ import { APP_VERSION } from "../version.js";
 export interface OnboardingEvent {
   id: string;
   createdAt: number;
-  completedAt: string | null;
 }
 
 export interface RecordOnboardingEventParams {
@@ -23,8 +22,6 @@ export interface RecordOnboardingEventParams {
   tone?: string;
   googleConnected?: boolean;
   googleScopes?: string[];
-  /** Accepted for caller compatibility; never shipped and no longer stored. */
-  priorAssistants?: string[];
   abVariant?: string;
   sessionId?: string | null;
   stepName?: string | null;
@@ -87,12 +84,9 @@ function buildOnboardingTelemetryEvent(
 export function recordOnboardingEvent(
   params: RecordOnboardingEventParams,
 ): OnboardingEvent | null {
-  const recorded = recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
+  return recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
     buildOnboardingTelemetryEvent(id, createdAt, params),
   );
-  return recorded
-    ? { ...recorded, completedAt: params.completedAt ?? null }
-    : null;
 }
 
 /**
@@ -103,10 +97,9 @@ export function recordOnboardingEvent(
 export function recordActivationEvent(params: {
   stepName: ActivationStepName;
   sessionId: string;
-  userId?: string | null;
   abVariant?: string;
 }): OnboardingEvent | null {
-  const recorded = recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
+  return recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
     buildOnboardingTelemetryEvent(id, createdAt, {
       screen: params.stepName,
       abVariant: params.abVariant ?? ACTIVATION_AB_VARIANT,
@@ -117,7 +110,4 @@ export function recordActivationEvent(params: {
       funnelVersion: ACTIVATION_FUNNEL_VERSION,
     }),
   );
-  return recorded
-    ? { ...recorded, completedAt: new Date(recorded.createdAt).toISOString() }
-    : null;
 }

--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -1,6 +1,3 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import {
   ACTIVATION_AB_VARIANT,
   ACTIVATION_FUNNEL_VERSION,
@@ -8,25 +5,15 @@ import {
   type ActivationStepName,
   buildActivationDaemonEventId,
 } from "../telemetry/activation-funnel.js";
-import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
 import type { OnboardingTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
 
+/** Identity of a recorded outbox row; the full payload lives in the outbox. */
 export interface OnboardingEvent {
   id: string;
   createdAt: number;
-  screen: string;
-  toolsJson: string | null;
-  tasksJson: string | null;
-  tone: string | null;
-  googleConnected: boolean | null;
-  googleScopesJson: string | null;
-  abVariant: string | null;
-  sessionId: string | null;
-  stepName: string | null;
-  stepIndex: number | null;
   completedAt: string | null;
-  funnelVersion: string | null;
 }
 
 export interface RecordOnboardingEventParams {
@@ -93,46 +80,6 @@ function buildOnboardingTelemetryEvent(
 }
 
 /**
- * Build the wire payload and insert it into the `telemetry_events` outbox.
- * Shared by all record* entry points. Returns null when the telemetry
- * database is unavailable — the event is dropped, matching the degraded-mode
- * behavior of the other telemetry stores.
- */
-function insertOnboardingEvent(
-  id: string,
-  createdAt: number,
-  params: RecordOnboardingEventParams,
-): OnboardingEvent | null {
-  const inserted = insertTelemetryOutboxEvent({
-    id,
-    name: "onboarding",
-    createdAt,
-    event: buildOnboardingTelemetryEvent(id, createdAt, params),
-  });
-  if (!inserted) {
-    return null;
-  }
-  return {
-    id,
-    createdAt,
-    screen: params.screen,
-    toolsJson: params.tools ? JSON.stringify(params.tools) : null,
-    tasksJson: params.tasks ? JSON.stringify(params.tasks) : null,
-    tone: params.tone ?? null,
-    googleConnected: params.googleConnected ?? null,
-    googleScopesJson: params.googleScopes
-      ? JSON.stringify(params.googleScopes)
-      : null,
-    abVariant: params.abVariant ?? null,
-    sessionId: params.sessionId ?? null,
-    stepName: params.stepName ?? null,
-    stepIndex: params.stepIndex ?? null,
-    completedAt: params.completedAt ?? null,
-    funnelVersion: params.funnelVersion ?? null,
-  };
-}
-
-/**
  * Record an onboarding event (pre-chat selections and Google connect status).
  * Returns null when usage data collection is disabled or the telemetry
  * database is unavailable.
@@ -140,10 +87,12 @@ function insertOnboardingEvent(
 export function recordOnboardingEvent(
   params: RecordOnboardingEventParams,
 ): OnboardingEvent | null {
-  if (!getCachedShareAnalytics()) {
-    return null;
-  }
-  return insertOnboardingEvent(uuid(), Date.now(), params);
+  const recorded = recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
+    buildOnboardingTelemetryEvent(id, createdAt, params),
+  );
+  return recorded
+    ? { ...recorded, completedAt: params.completedAt ?? null }
+    : null;
 }
 
 /**
@@ -157,17 +106,18 @@ export function recordActivationEvent(params: {
   userId?: string | null;
   abVariant?: string;
 }): OnboardingEvent | null {
-  if (!getCachedShareAnalytics()) {
-    return null;
-  }
-  const createdAt = Date.now();
-  return insertOnboardingEvent(uuid(), createdAt, {
-    screen: params.stepName,
-    abVariant: params.abVariant ?? ACTIVATION_AB_VARIANT,
-    sessionId: params.sessionId,
-    stepName: params.stepName,
-    stepIndex: activationStepIndex(params.stepName),
-    completedAt: new Date(createdAt).toISOString(),
-    funnelVersion: ACTIVATION_FUNNEL_VERSION,
-  });
+  const recorded = recordTelemetryOutboxEvent("onboarding", (id, createdAt) =>
+    buildOnboardingTelemetryEvent(id, createdAt, {
+      screen: params.stepName,
+      abVariant: params.abVariant ?? ACTIVATION_AB_VARIANT,
+      sessionId: params.sessionId,
+      stepName: params.stepName,
+      stepIndex: activationStepIndex(params.stepName),
+      completedAt: new Date(createdAt).toISOString(),
+      funnelVersion: ACTIVATION_FUNNEL_VERSION,
+    }),
+  );
+  return recorded
+    ? { ...recorded, completedAt: new Date(recorded.createdAt).toISOString() }
+    : null;
 }

--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -1,15 +1,16 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
-import { onboardingEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import {
   ACTIVATION_AB_VARIANT,
   ACTIVATION_FUNNEL_VERSION,
   activationStepIndex,
   type ActivationStepName,
+  buildActivationDaemonEventId,
 } from "../telemetry/activation-funnel.js";
+import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import type { OnboardingTelemetryEvent } from "../telemetry/types.js";
+import { APP_VERSION } from "../version.js";
 
 export interface OnboardingEvent {
   id: string;
@@ -20,7 +21,6 @@ export interface OnboardingEvent {
   tone: string | null;
   googleConnected: boolean | null;
   googleScopesJson: string | null;
-  priorAssistantsJson: string | null;
   abVariant: string | null;
   sessionId: string | null;
   stepName: string | null;
@@ -36,6 +36,7 @@ export interface RecordOnboardingEventParams {
   tone?: string;
   googleConnected?: boolean;
   googleScopes?: string[];
+  /** Accepted for caller compatibility; never shipped and no longer stored. */
   priorAssistants?: string[];
   abVariant?: string;
   sessionId?: string | null;
@@ -46,15 +47,89 @@ export interface RecordOnboardingEventParams {
 }
 
 /**
- * Insert a fully-built event row. Shared by all record* entry points.
- * Returns null when the telemetry database is unavailable — the event is
- * dropped, matching the degraded-mode behavior of the other telemetry stores.
+ * Build the wire event stored in the outbox payload at record time.
+ * `assistant_version` is therefore record-time: the binary that recorded the
+ * event, not the one that later flushes it.
  */
-function insertOnboardingEvent(event: OnboardingEvent): OnboardingEvent | null {
-  const db = getTelemetryDb();
-  if (!db) return null;
-  db.insert(onboardingEvents).values(event).run();
-  return event;
+function buildOnboardingTelemetryEvent(
+  id: string,
+  createdAt: number,
+  params: RecordOnboardingEventParams,
+): OnboardingTelemetryEvent {
+  return {
+    type: "onboarding",
+    // Wire-only override for activation rows: a deterministic id keyed on
+    // funnel_version/session/step lets dbt collapse a moment that fires more
+    // than once. Keyed on the params' funnelVersion (frozen into the payload
+    // now) so rows recorded under an older version — flushed offline or after
+    // an upgrade — keep a stable id and still collapse with already-ingested
+    // rows. The outbox row id stays `id`, so flush acks are unaffected.
+    daemon_event_id:
+      params.sessionId && params.stepName && params.funnelVersion
+        ? buildActivationDaemonEventId(
+            params.sessionId,
+            params.stepName as ActivationStepName,
+            params.funnelVersion,
+          )
+        : id,
+    recorded_at: createdAt,
+    screen: params.screen,
+    ...(params.tools ? { tools: params.tools } : {}),
+    ...(params.tasks ? { tasks: params.tasks } : {}),
+    ...(params.tone ? { tone: params.tone } : {}),
+    ...(params.googleConnected != null
+      ? { google_connected: params.googleConnected }
+      : {}),
+    ...(params.googleScopes ? { google_scopes: params.googleScopes } : {}),
+    ...(params.abVariant ? { ab_variant: params.abVariant } : {}),
+    // Activation funnel fields — only present on activation rows.
+    ...(params.sessionId ? { session_id: params.sessionId } : {}),
+    ...(params.stepName ? { step_name: params.stepName } : {}),
+    ...(params.stepIndex != null ? { step_index: params.stepIndex } : {}),
+    ...(params.completedAt ? { completed_at: params.completedAt } : {}),
+    ...(params.funnelVersion ? { funnel_version: params.funnelVersion } : {}),
+    assistant_version: APP_VERSION,
+  };
+}
+
+/**
+ * Build the wire payload and insert it into the `telemetry_events` outbox.
+ * Shared by all record* entry points. Returns null when the telemetry
+ * database is unavailable — the event is dropped, matching the degraded-mode
+ * behavior of the other telemetry stores.
+ */
+function insertOnboardingEvent(
+  id: string,
+  createdAt: number,
+  params: RecordOnboardingEventParams,
+): OnboardingEvent | null {
+  const inserted = insertTelemetryOutboxEvent({
+    id,
+    name: "onboarding",
+    createdAt,
+    event: buildOnboardingTelemetryEvent(id, createdAt, params),
+  });
+  if (!inserted) {
+    return null;
+  }
+  return {
+    id,
+    createdAt,
+    screen: params.screen,
+    toolsJson: params.tools ? JSON.stringify(params.tools) : null,
+    tasksJson: params.tasks ? JSON.stringify(params.tasks) : null,
+    tone: params.tone ?? null,
+    googleConnected: params.googleConnected ?? null,
+    googleScopesJson: params.googleScopes
+      ? JSON.stringify(params.googleScopes)
+      : null,
+    abVariant: params.abVariant ?? null,
+    sessionId: params.sessionId ?? null,
+    stepName: params.stepName ?? null,
+    stepIndex: params.stepIndex ?? null,
+    completedAt: params.completedAt ?? null,
+    funnelVersion: params.funnelVersion ?? null,
+  };
 }
 
 /**
@@ -68,34 +143,13 @@ export function recordOnboardingEvent(
   if (!getCachedShareAnalytics()) {
     return null;
   }
-  return insertOnboardingEvent({
-    id: uuid(),
-    createdAt: Date.now(),
-    screen: params.screen,
-    toolsJson: params.tools ? JSON.stringify(params.tools) : null,
-    tasksJson: params.tasks ? JSON.stringify(params.tasks) : null,
-    tone: params.tone ?? null,
-    googleConnected: params.googleConnected ?? null,
-    googleScopesJson: params.googleScopes
-      ? JSON.stringify(params.googleScopes)
-      : null,
-    priorAssistantsJson: params.priorAssistants
-      ? JSON.stringify(params.priorAssistants)
-      : null,
-    abVariant: params.abVariant ?? null,
-    sessionId: params.sessionId ?? null,
-    stepName: params.stepName ?? null,
-    stepIndex: params.stepIndex ?? null,
-    completedAt: params.completedAt ?? null,
-    funnelVersion: params.funnelVersion ?? null,
-  });
+  return insertOnboardingEvent(uuid(), Date.now(), params);
 }
 
 /**
  * Record an activation-funnel milestone event. Reuses the onboarding telemetry
- * substrate (`screen` carries the step name to satisfy the NOT NULL column).
- * Returns null when usage data collection is disabled or the telemetry
- * database is unavailable.
+ * substrate (`screen` carries the step name). Returns null when usage data
+ * collection is disabled or the telemetry database is unavailable.
  */
 export function recordActivationEvent(params: {
   stepName: ActivationStepName;
@@ -107,16 +161,8 @@ export function recordActivationEvent(params: {
     return null;
   }
   const createdAt = Date.now();
-  return insertOnboardingEvent({
-    id: uuid(),
-    createdAt,
+  return insertOnboardingEvent(uuid(), createdAt, {
     screen: params.stepName,
-    toolsJson: null,
-    tasksJson: null,
-    tone: null,
-    googleConnected: null,
-    googleScopesJson: null,
-    priorAssistantsJson: null,
     abVariant: params.abVariant ?? ACTIVATION_AB_VARIANT,
     sessionId: params.sessionId,
     stepName: params.stepName,
@@ -124,53 +170,4 @@ export function recordActivationEvent(params: {
     completedAt: new Date(createdAt).toISOString(),
     funnelVersion: ACTIVATION_FUNNEL_VERSION,
   });
-}
-
-/**
- * Query onboarding events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedOnboardingEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): OnboardingEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
-  }
-  const rows = db
-    .select({
-      id: onboardingEvents.id,
-      createdAt: onboardingEvents.createdAt,
-      screen: onboardingEvents.screen,
-      toolsJson: onboardingEvents.toolsJson,
-      tasksJson: onboardingEvents.tasksJson,
-      tone: onboardingEvents.tone,
-      googleConnected: onboardingEvents.googleConnected,
-      googleScopesJson: onboardingEvents.googleScopesJson,
-      priorAssistantsJson: onboardingEvents.priorAssistantsJson,
-      abVariant: onboardingEvents.abVariant,
-      sessionId: onboardingEvents.sessionId,
-      stepName: onboardingEvents.stepName,
-      stepIndex: onboardingEvents.stepIndex,
-      completedAt: onboardingEvents.completedAt,
-      funnelVersion: onboardingEvents.funnelVersion,
-    })
-    .from(onboardingEvents)
-    .where(
-      afterId
-        ? or(
-            gt(onboardingEvents.createdAt, afterCreatedAt),
-            and(
-              eq(onboardingEvents.createdAt, afterCreatedAt),
-              gt(onboardingEvents.id, afterId),
-            ),
-          )
-        : gt(onboardingEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(onboardingEvents.createdAt), asc(onboardingEvents.id))
-    .limit(limit)
-    .all();
-  return rows;
 }

--- a/assistant/src/persistence/__tests__/main-db-readonly-probe.ts
+++ b/assistant/src/persistence/__tests__/main-db-readonly-probe.ts
@@ -22,7 +22,7 @@ import {
 } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
 import { queryUnreportedUsageEvents } from "../llm-usage-store.js";
-import { configSettingEvents, memoryCheckpoints } from "../schema/index.js";
+import { memoryCheckpoints, telemetryEvents } from "../schema/index.js";
 
 // Create the schema over the normal read-write connections, then reopen
 // with the monitor's posture: telemetry main-DB reads go through the
@@ -67,12 +67,13 @@ if (!telemetryDb) {
   throw new Error("telemetry DB unavailable");
 }
 telemetryDb
-  .insert(configSettingEvents)
+  .insert(telemetryEvents)
   .values({
     id: "readonly-probe-row",
+    name: "config_setting",
     createdAt: Date.now(),
-    configKey: "memory.enabled",
-    configValue: "true",
+    conversationId: null,
+    payload: '{"type":"config_setting"}',
   })
   .run();
 

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -90,6 +90,7 @@ import {
   enqueueLexicalIndexForMessage,
   enqueuePurgeConversationLexical,
 } from "./job-handlers/message-lexical.js";
+import { buildLifecycleTelemetryEvent } from "./lifecycle-events-store.js";
 import { resolveMessageContentBlocks } from "./message-content-file.js";
 import {
   rawAll,
@@ -3008,18 +3009,25 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM messages");
   await runOrThrow("DELETE FROM conversations");
 
-  // Record audit event — lifecycle_events lives in the telemetry DB and is
-  // NOT deleted by clearAll(), so this survives the wipe as a permanent trail.
-  // Best-effort: the destructive deletes above already completed, so telemetry
-  // degradation must not turn a finished wipe into a failure or skip the
-  // cleanup below.
+  // Record audit event into the telemetry_events outbox (consent-bypassing);
+  // the trail persists platform-side once flushed. Best-effort: the
+  // destructive deletes above already completed, so telemetry degradation
+  // must not turn a finished wipe into a failure or skip the cleanup below.
   try {
+    const auditEventId = uuid();
+    const auditEventAt = Date.now();
     rawTelemetryRun(
       "conversation:clearAll:auditEvent",
-      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
-      uuid(),
-      "conversations_clear_all",
-      Date.now(),
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload) VALUES (?, 'lifecycle', ?, NULL, ?)`,
+      auditEventId,
+      auditEventAt,
+      JSON.stringify(
+        buildLifecycleTelemetryEvent(
+          auditEventId,
+          "conversations_clear_all",
+          auditEventAt,
+        ),
+      ),
     );
   } catch (err) {
     log.warn({ err }, "clearAll: failed to record audit event");

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -109,7 +109,7 @@ import {
   memorySegments,
   messageAttachments,
   messages,
-  skillLoadedEvents,
+  telemetryEvents,
   toolInvocations,
 } from "./schema/index.js";
 import { timeSyncSection } from "./slow-sync-log.js";
@@ -130,10 +130,10 @@ function logsDb(): DrizzleDb {
 }
 
 /**
- * The telemetry connection (`assistant-telemetry.db`), where
- * `skill_loaded_events` lives. Throws if the file cannot be opened — the
+ * The telemetry connection (`assistant-telemetry.db`), where the
+ * `telemetry_events` outbox lives. Throws if the file cannot be opened — the
  * conversation-delete call sites must not report success while unshipped
- * skill events referencing the deleted conversation survive to be flushed.
+ * events referencing the deleted conversation survive to be flushed.
  */
 function telemetryDb(): DrizzleDb {
   const db = getTelemetryDb();
@@ -1656,17 +1656,19 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   const convBeforeDelete = getConversation(id);
   const createdAtForDiskCleanup = convBeforeDelete?.createdAt;
 
-  // llm_request_logs and skill_loaded_events live in the dedicated logs and
-  // telemetry connections, so they are deleted there — separately from (and
-  // before) the main-DB transaction below, so a failure leaves the
-  // conversation intact for a retried delete.
+  // llm_request_logs and pending telemetry_events rows live in the dedicated
+  // logs and telemetry connections, so they are deleted there — separately
+  // from (and before) the main-DB transaction below, so a failure leaves the
+  // conversation intact for a retried delete. Telemetry redaction keys on
+  // conversation_id regardless of event name, so every conversation-scoped
+  // pending event is covered.
   logsDb()
     .delete(llmRequestLogs)
     .where(eq(llmRequestLogs.conversationId, id))
     .run();
   telemetryDb()
-    .delete(skillLoadedEvents)
-    .where(eq(skillLoadedEvents.conversationId, id))
+    .delete(telemetryEvents)
+    .where(eq(telemetryEvents.conversationId, id))
     .run();
 
   db.transaction((tx) => {
@@ -1785,13 +1787,14 @@ export async function deleteConversationGently(
     .all()
     .map((r) => r.id);
 
-  // skill_loaded_events lives in the dedicated telemetry connection; delete
-  // it there before ANY destructive work so a telemetry failure leaves the
-  // conversation fully intact for a retried delete — a throw after the bulk
-  // drains below would strand unredacted rows that could still flush.
+  // Pending telemetry_events rows live in the dedicated telemetry connection;
+  // delete them there (by conversation_id, regardless of event name) before
+  // ANY destructive work so a telemetry failure leaves the conversation fully
+  // intact for a retried delete — a throw after the bulk drains below would
+  // strand unredacted rows that could still flush.
   telemetryDb()
-    .delete(skillLoadedEvents)
-    .where(eq(skillLoadedEvents.conversationId, id))
+    .delete(telemetryEvents)
+    .where(eq(telemetryEvents.conversationId, id))
     .run();
 
   // llm_request_logs lives in the dedicated logs connection, and each row is
@@ -2977,14 +2980,15 @@ export async function clearAll(): Promise<{
     }
   };
 
-  // skill_loaded_events lives in the dedicated telemetry connection. Redact
-  // it FIRST, before any destructive delete: unshipped skill events reference
-  // conversations this wipe must redact, so a telemetry failure must abort
-  // the clear-all while the workspace is still fully intact — never after
-  // memory state is already gone.
+  // Pending skill_loaded rows live in the telemetry_events outbox on the
+  // dedicated telemetry connection. Redact them FIRST, before any destructive
+  // delete: unshipped skill events reference conversations this wipe must
+  // redact, so a telemetry failure must abort the clear-all while the
+  // workspace is still fully intact — never after memory state is already
+  // gone.
   rawTelemetryRun(
     "conversation:clearAll:skillLoadedEvents",
-    "DELETE FROM skill_loaded_events",
+    "DELETE FROM telemetry_events WHERE name = 'skill_loaded'",
   );
 
   // Delete in dependency order. Cascades handle memory_segments and

--- a/assistant/src/persistence/db-connection.ts
+++ b/assistant/src/persistence/db-connection.ts
@@ -278,8 +278,9 @@ export function getMemorySqlite(): Database | null {
 
 /**
  * The telemetry database (`assistant-telemetry.db`), opened lazily as its own
- * connection. Houses the telemetry-only event tables (see
- * `util/telemetry-db-path.ts` for the list).
+ * connection. Houses the `telemetry_events` outbox (wire payloads recorded at
+ * emit time, deleted on successful flush) and `flush_checkpoints` (watermark
+ * cursors for the main-DB-backed telemetry sources).
  * Returns `null` if the file cannot be opened (logged; the daemon stays up).
  */
 export function getTelemetryDb(): DrizzleDb | null {

--- a/assistant/src/persistence/job-handlers/cleanup.ts
+++ b/assistant/src/persistence/job-handlers/cleanup.ts
@@ -144,8 +144,8 @@ function parseDeletedCount(stdout: string | undefined): number {
  * conversation_keys, channel_inbound_events, message_runs, call_sessions,
  * external_conversation_bindings) are handled automatically. Tables without
  * cascade (messages, tool_invocations, plus llm_request_logs and
- * skill_loaded_events on their dedicated connections) are deleted explicitly
- * before removing the conversation row.
+ * conversation-scoped telemetry_events rows on their dedicated connections)
+ * are deleted explicitly before removing the conversation row.
  */
 export function pruneOldConversationsJob(
   job: MemoryJob,
@@ -185,20 +185,21 @@ export function pruneOldConversationsJob(
       );
       if (still.length === 0) return;
 
-      // Non-cascading tables. llm_request_logs and skill_loaded_events live in
-      // the dedicated logs/telemetry connections, so they are deleted there
-      // (outside this main-DB transaction). Both run before the main-DB
-      // deletes: a failure leaves the conversation row in place so the prune
-      // retries — unshipped skill events must never outlive their pruned
-      // conversation and flush later.
+      // Non-cascading tables. llm_request_logs and conversation-scoped
+      // telemetry_events rows live in the dedicated logs/telemetry
+      // connections, so they are deleted there (outside this main-DB
+      // transaction). Both run before the main-DB deletes: a failure leaves
+      // the conversation row in place so the prune retries — unshipped
+      // telemetry events must never outlive their pruned conversation and
+      // flush later.
       rawLogsRun(
         "cleanup:pruneOldConversations:logs",
         `DELETE FROM llm_request_logs WHERE conversation_id = ?`,
         id,
       );
       rawTelemetryRun(
-        "cleanup:pruneOldConversations:skills",
-        `DELETE FROM skill_loaded_events WHERE conversation_id = ?`,
+        "cleanup:pruneOldConversations:telemetry",
+        `DELETE FROM telemetry_events WHERE conversation_id = ?`,
         id,
       );
       rawRun(

--- a/assistant/src/persistence/lifecycle-events-store.test.ts
+++ b/assistant/src/persistence/lifecycle-events-store.test.ts
@@ -6,22 +6,33 @@ mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));
 
+import { APP_VERSION } from "../version.js";
 import * as dbConnection from "./db-connection.js";
 import { getTelemetryDb, getTelemetrySqlite } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
 import {
-  queryUnreportedLifecycleEvents,
+  buildLifecycleTelemetryEvent,
   recordLifecycleEvent,
 } from "./lifecycle-events-store.js";
-import { lifecycleEvents } from "./schema.js";
+import { telemetryEvents } from "./schema.js";
 
 await initializeDb();
 
-function insertEvent(id: string, createdAt: number, eventName = "hatch"): void {
-  getTelemetryDb()!
-    .insert(lifecycleEvents)
-    .values({ id, eventName, createdAt })
-    .run();
+interface RawOutboxRow {
+  id: string;
+  name: string;
+  created_at: number;
+  conversation_id: string | null;
+  payload: string;
+}
+
+function outboxRows(): RawOutboxRow[] {
+  return getTelemetrySqlite()!
+    .query(
+      `SELECT id, name, created_at, conversation_id, payload
+       FROM telemetry_events ORDER BY created_at, id`,
+    )
+    .all() as RawOutboxRow[];
 }
 
 /** Run `fn` with the dedicated telemetry connection reported as unavailable. */
@@ -37,82 +48,53 @@ function withTelemetryDbUnavailable(fn: () => void): void {
 describe("lifecycle-events-store", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    getTelemetryDb()!.delete(lifecycleEvents).run();
+    getTelemetryDb()!.delete(telemetryEvents).run();
   });
 
-  test("record + query round-trips and writes into the telemetry database", () => {
+  test("record writes a telemetry_events outbox row carrying the wire payload", () => {
     const event = recordLifecycleEvent("app_open");
     expect(event).not.toBeNull();
     expect(event!.eventName).toBe("app_open");
     expect(event!.createdAt).toBeGreaterThan(0);
 
-    const rows = queryUnreportedLifecycleEvents(0, undefined, 10);
-    expect(rows).toEqual([event!]);
+    const rows = outboxRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: event!.id,
+      name: "lifecycle",
+      created_at: event!.createdAt,
+      conversation_id: null,
+    });
+    expect(JSON.parse(rows[0]!.payload)).toEqual({
+      type: "lifecycle",
+      daemon_event_id: event!.id,
+      event_name: "app_open",
+      recorded_at: event!.createdAt,
+      assistant_version: APP_VERSION,
+    });
+  });
 
-    const raw = getTelemetrySqlite()!
-      .query(`SELECT id, event_name FROM lifecycle_events`)
-      .all() as Array<{ id: string; event_name: string }>;
-    expect(raw).toEqual([{ id: event!.id, event_name: "app_open" }]);
+  test("buildLifecycleTelemetryEvent stamps the record-time binary version", () => {
+    expect(buildLifecycleTelemetryEvent("id-1", "hatch", 1234)).toEqual({
+      type: "lifecycle",
+      daemon_event_id: "id-1",
+      event_name: "hatch",
+      recorded_at: 1234,
+      assistant_version: APP_VERSION,
+    });
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
     shareAnalytics = false;
     expect(recordLifecycleEvent("app_open")).toBeNull();
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(0);
+    expect(outboxRows()).toHaveLength(0);
   });
 
   test("degrades when the telemetry database is unavailable", () => {
     withTelemetryDbUnavailable(() => {
       expect(recordLifecycleEvent("app_open")).toBeNull();
-      expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toEqual([]);
     });
 
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(0);
-  });
-
-  test("returns rows in (createdAt, id) order", () => {
-    insertEvent("le-b", 2000);
-    insertEvent("le-a", 1000);
-
-    const rows = queryUnreportedLifecycleEvents(0, undefined, 100);
-    expect(rows.map((r) => r.id)).toEqual(["le-a", "le-b"]);
-  });
-
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    // Two rows in the same millisecond: pagination must use the id
-    // tiebreaker to make forward progress, not loop.
-    insertEvent("le-1", 5000);
-    insertEvent("le-2", 5000);
-    insertEvent("le-3", 6000);
-
-    const first = queryUnreportedLifecycleEvents(0, undefined, 1);
-    expect(first.map((r) => r.id)).toEqual(["le-1"]);
-
-    const second = queryUnreportedLifecycleEvents(
-      first[0]!.createdAt,
-      first[0]!.id,
-      100,
-    );
-    expect(second.map((r) => r.id)).toEqual(["le-2", "le-3"]);
-
-    // Without an id cursor the timestamp-only branch is used.
-    expect(
-      queryUnreportedLifecycleEvents(5000, undefined, 100).map((r) => r.id),
-    ).toEqual(["le-3"]);
-
-    // Cursor past the last row returns nothing.
-    const last = second[second.length - 1]!;
-    expect(
-      queryUnreportedLifecycleEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
-  });
-
-  test("honors the limit", () => {
-    insertEvent("le-l1", 1000);
-    insertEvent("le-l2", 2000);
-    insertEvent("le-l3", 3000);
-
-    const rows = queryUnreportedLifecycleEvents(0, undefined, 2);
-    expect(rows.map((r) => r.id)).toEqual(["le-l1", "le-l2"]);
+    expect(outboxRows()).toHaveLength(0);
   });
 });

--- a/assistant/src/persistence/lifecycle-events-store.ts
+++ b/assistant/src/persistence/lifecycle-events-store.ts
@@ -1,7 +1,4 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
-import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
 import type { LifecycleTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
 
@@ -35,19 +32,8 @@ export function buildLifecycleTelemetryEvent(
  * telemetry database is unavailable (degraded mode).
  */
 export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
-  if (!getCachedShareAnalytics()) {
-    return null;
-  }
-  const event: LifecycleEvent = {
-    id: uuid(),
-    eventName,
-    createdAt: Date.now(),
-  };
-  const inserted = insertTelemetryOutboxEvent({
-    id: event.id,
-    name: "lifecycle",
-    createdAt: event.createdAt,
-    event: buildLifecycleTelemetryEvent(event.id, eventName, event.createdAt),
-  });
-  return inserted ? event : null;
+  const recorded = recordTelemetryOutboxEvent("lifecycle", (id, createdAt) =>
+    buildLifecycleTelemetryEvent(id, eventName, createdAt),
+  );
+  return recorded ? { ...recorded, eventName } : null;
 }

--- a/assistant/src/persistence/lifecycle-events-store.ts
+++ b/assistant/src/persistence/lifecycle-events-store.ts
@@ -1,9 +1,9 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
-import { getTelemetryDb } from "./db-connection.js";
-import { lifecycleEvents } from "./schema.js";
+import { insertTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import type { LifecycleTelemetryEvent } from "../telemetry/types.js";
+import { APP_VERSION } from "../version.js";
 
 export interface LifecycleEvent {
   id: string;
@@ -12,16 +12,30 @@ export interface LifecycleEvent {
 }
 
 /**
- * Record a lifecycle event (e.g. app_open, hatch). Returns null when usage
- * data collection is disabled or the telemetry database is unavailable
- * (degraded mode).
+ * Wire shape of one lifecycle event, stamped with the record-time binary's
+ * `APP_VERSION` (the outbox stores the full wire payload at record time).
+ */
+export function buildLifecycleTelemetryEvent(
+  id: string,
+  eventName: string,
+  createdAt: number,
+): LifecycleTelemetryEvent {
+  return {
+    type: "lifecycle",
+    daemon_event_id: id,
+    event_name: eventName,
+    recorded_at: createdAt,
+    assistant_version: APP_VERSION,
+  };
+}
+
+/**
+ * Record a lifecycle event (e.g. app_open, hatch) into the `telemetry_events`
+ * outbox. Returns null when usage data collection is disabled or the
+ * telemetry database is unavailable (degraded mode).
  */
 export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
   if (!getCachedShareAnalytics()) {
-    return null;
-  }
-  const db = getTelemetryDb();
-  if (!db) {
     return null;
   }
   const event: LifecycleEvent = {
@@ -29,49 +43,11 @@ export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
     eventName,
     createdAt: Date.now(),
   };
-  db.insert(lifecycleEvents)
-    .values({
-      id: event.id,
-      eventName: event.eventName,
-      createdAt: event.createdAt,
-    })
-    .run();
-  return event;
-}
-
-/**
- * Query lifecycle events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedLifecycleEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): LifecycleEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
-  }
-  const rows = db
-    .select({
-      id: lifecycleEvents.id,
-      eventName: lifecycleEvents.eventName,
-      createdAt: lifecycleEvents.createdAt,
-    })
-    .from(lifecycleEvents)
-    .where(
-      afterId
-        ? or(
-            gt(lifecycleEvents.createdAt, afterCreatedAt),
-            and(
-              eq(lifecycleEvents.createdAt, afterCreatedAt),
-              gt(lifecycleEvents.id, afterId),
-            ),
-          )
-        : gt(lifecycleEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(lifecycleEvents.createdAt), asc(lifecycleEvents.id))
-    .limit(limit)
-    .all();
-  return rows;
+  const inserted = insertTelemetryOutboxEvent({
+    id: event.id,
+    name: "lifecycle",
+    createdAt: event.createdAt,
+    event: buildLifecycleTelemetryEvent(event.id, eventName, event.createdAt),
+  });
+  return inserted ? event : null;
 }

--- a/assistant/src/persistence/migrations/329-move-onboarding-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/329-move-onboarding-events-to-telemetry-db.test.ts
@@ -1,12 +1,15 @@
 /**
  * Tests for migration 329: relocating `onboarding_events` from the main DB
- * into the dedicated telemetry database (`assistant-telemetry.db`).
+ * into the dedicated telemetry database (`assistant-telemetry.db`), covered
+ * as the head of the full pipeline — migration 334 then backfills the
+ * relocated rows into the generic `telemetry_events` outbox and drops the
+ * telemetry-side table.
  *
  * Runs against real workspace databases (`initializeDb()`) because the drain
  * engine dispatches batches via `runAsyncSqlite` against the workspace's main
- * DB file. `initializeDb()` already ran migration 329 once (dropping the empty
- * main-side table created by migration 248), so each test recreates the
- * pre-move source table in `main` to simulate an upgrading install.
+ * DB file. `initializeDb()` already ran the pipeline once, so each test
+ * recreates the pre-move source table in `main` to simulate an upgrading
+ * install, then runs 329 + 334 directly.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -15,6 +18,8 @@ const { getDb, getSqlite, getTelemetrySqlite } =
 const { initializeDb } = await import("../db-init.js");
 const { migrateMoveOnboardingEventsToTelemetryDb } =
   await import("./329-move-onboarding-events-to-telemetry-db.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
 
 await initializeDb();
 
@@ -25,22 +30,19 @@ const SOURCE_COLUMNS = `
   session_id TEXT, step_name TEXT, step_index INTEGER, completed_at TEXT,
   funnel_version TEXT`;
 
-/** Relocated rows in the telemetry-side table, in `(created_at, id)` order. */
-function telemetryOnboardingRows(): Array<{
+/** Backfilled outbox rows for the onboarding source, in `(created_at, id)` order. */
+function outboxOnboardingRows(): Array<{
   id: string;
-  step_name: string | null;
-  step_index: number | null;
+  payload: Record<string, unknown>;
 }> {
-  return getTelemetrySqlite()!
-    .query(
-      `SELECT id, step_name, step_index FROM onboarding_events
-       ORDER BY created_at, id`,
-    )
-    .all() as Array<{
-    id: string;
-    step_name: string | null;
-    step_index: number | null;
-  }>;
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id, payload FROM telemetry_events
+         WHERE name = 'onboarding' ORDER BY created_at, id`,
+      )
+      .all() as Array<{ id: string; payload: string }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
 }
 
 function existsInMain(name: string): boolean {
@@ -53,8 +55,22 @@ function existsInMain(name: string): boolean {
   );
 }
 
+function existsInTelemetry(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
 function resetState(): void {
-  getTelemetrySqlite()!.exec(`DELETE FROM onboarding_events`);
+  getTelemetrySqlite()!.exec(`DROP TABLE IF EXISTS onboarding_events`);
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM telemetry_events WHERE name = 'onboarding'`,
+  );
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM flush_checkpoints WHERE key LIKE 'telemetry:onboarding:%'`,
+  );
   getSqlite().exec(`DROP TABLE IF EXISTS main.onboarding_events`);
   getSqlite().exec(`DROP TABLE IF EXISTS main."onboarding_events__relocating"`);
 }
@@ -64,10 +80,10 @@ function seedSourceTable(): void {
   sqlite.exec(`CREATE TABLE main.onboarding_events (${SOURCE_COLUMNS})`);
   const insert = sqlite.prepare(
     `INSERT INTO main.onboarding_events
-       (id, created_at, screen, session_id, step_name, step_index)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+       (id, created_at, screen, session_id, step_name, step_index, funnel_version)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   );
-  insert.run("seed-1", 1000, "tools", "conv-1", null, null);
+  insert.run("seed-1", 1000, "tools", "conv-1", null, null, null);
   insert.run(
     "seed-2",
     2000,
@@ -75,86 +91,89 @@ function seedSourceTable(): void {
     "conv-2",
     "activation_moment_1_complete",
     1,
+    "v2",
   );
-  insert.run("seed-dupe", 3000, "tasks", "conv-3", null, null);
+  insert.run("seed-dupe", 3000, "tasks", "conv-3", null, null, null);
+}
+
+async function runPipeline(): Promise<void> {
+  await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+  migrateBackfillTelemetryEventsOutbox(getDb());
 }
 
 describe("migration 329: move onboarding_events to the telemetry DB", () => {
-  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+  test("pre-move rows land in telemetry_events and both legacy tables are gone", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
+    expect(existsInTelemetry("onboarding_events")).toBe(false);
 
-    const moved = getTelemetrySqlite()!
-      .query(`SELECT id, screen FROM onboarding_events ORDER BY id`)
-      .all();
-    expect(moved).toEqual([
-      { id: "seed-1", screen: "tools" },
-      { id: "seed-2", screen: "activation_moment_1_complete" },
-      { id: "seed-dupe", screen: "tasks" },
-    ]);
-
-    const rows = telemetryOnboardingRows();
+    const rows = outboxOnboardingRows();
     expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    expect(rows[1]!.step_name).toBe("activation_moment_1_complete");
-    expect(rows[1]!.step_index).toBe(1);
+    expect(rows[0]!.payload).toMatchObject({
+      type: "onboarding",
+      daemon_event_id: "seed-1",
+      recorded_at: 1000,
+      screen: "tools",
+      session_id: "conv-1",
+    });
+    // Activation rows carry the deterministic wire id; the outbox row id
+    // stays the original row id.
+    expect(rows[1]!.payload).toMatchObject({
+      daemon_event_id: "v2:conv-2:activation_moment_1_complete",
+      step_name: "activation_moment_1_complete",
+      step_index: 1,
+      funnel_version: "v2",
+    });
   });
 
-  test("re-running after a completed move is a no-op", async () => {
+  test("re-running the pipeline after a completed move is a no-op", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+    await runPipeline();
+    await runPipeline();
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    expect(telemetryOnboardingRows()).toHaveLength(3);
+    expect(existsInTelemetry("onboarding_events")).toBe(false);
+    expect(outboxOnboardingRows()).toHaveLength(3);
   });
 
-  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+  test("a pre-existing duplicate id in the outbox does not fail the pipeline", async () => {
     resetState();
     seedSourceTable();
 
-    // A crash between a drain batch's copy and delete re-copies the same rows
-    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    // A crash between a drain/backfill batch's copy and delete re-copies the
+    // same rows next boot; INSERT OR IGNORE must keep the already-copied row.
     getTelemetrySqlite()!.exec(
-      `INSERT INTO onboarding_events (id, created_at, screen)
-       VALUES ('seed-dupe', 3000, 'already-copied')`,
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('seed-dupe', 'onboarding', 3000, NULL, '{"type":"onboarding","screen":"already-copied"}')`,
     );
 
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    const dupe = getTelemetrySqlite()!
-      .query(`SELECT screen FROM onboarding_events WHERE id = 'seed-dupe'`)
-      .get() as { screen: string };
-    expect(dupe.screen).toBe("already-copied");
-    expect(telemetryOnboardingRows()).toHaveLength(3);
+    const rows = outboxOnboardingRows();
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === "seed-dupe")!.payload.screen).toBe(
+      "already-copied",
+    );
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
     resetState();
     getSqlite().exec(`CREATE TABLE main.onboarding_events (${SOURCE_COLUMNS})`);
 
-    await migrateMoveOnboardingEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    expect(telemetryOnboardingRows()).toHaveLength(0);
-  });
-
-  test("telemetry-side schema has the reporter's compound cursor index", () => {
-    const indexes = (
-      getTelemetrySqlite()!
-        .query(`PRAGMA index_list(onboarding_events)`)
-        .all() as Array<{ name: string }>
-    ).map((i) => i.name);
-    expect(indexes).toContain("idx_onboarding_events_created_at_id");
+    expect(outboxOnboardingRows()).toHaveLength(0);
   });
 });

--- a/assistant/src/persistence/migrations/329-move-onboarding-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/329-move-onboarding-events-to-telemetry-db.test.ts
@@ -13,8 +13,6 @@ import { describe, expect, test } from "bun:test";
 const { getDb, getSqlite, getTelemetrySqlite } =
   await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
-const { queryUnreportedOnboardingEvents } =
-  await import("../../onboarding/onboarding-events-store.js");
 const { migrateMoveOnboardingEventsToTelemetryDb } =
   await import("./329-move-onboarding-events-to-telemetry-db.js");
 
@@ -26,6 +24,24 @@ const SOURCE_COLUMNS = `
   google_scopes_json TEXT, prior_assistants_json TEXT, ab_variant TEXT,
   session_id TEXT, step_name TEXT, step_index INTEGER, completed_at TEXT,
   funnel_version TEXT`;
+
+/** Relocated rows in the telemetry-side table, in `(created_at, id)` order. */
+function telemetryOnboardingRows(): Array<{
+  id: string;
+  step_name: string | null;
+  step_index: number | null;
+}> {
+  return getTelemetrySqlite()!
+    .query(
+      `SELECT id, step_name, step_index FROM onboarding_events
+       ORDER BY created_at, id`,
+    )
+    .all() as Array<{
+    id: string;
+    step_name: string | null;
+    step_index: number | null;
+  }>;
+}
 
 function existsInMain(name: string): boolean {
   return (
@@ -82,11 +98,10 @@ describe("migration 329: move onboarding_events to the telemetry DB", () => {
       { id: "seed-dupe", screen: "tasks" },
     ]);
 
-    // The relocated rows are readable through the store's reporter query.
-    const rows = queryUnreportedOnboardingEvents(0, undefined, 10);
+    const rows = telemetryOnboardingRows();
     expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    expect(rows[1]!.stepName).toBe("activation_moment_1_complete");
-    expect(rows[1]!.stepIndex).toBe(1);
+    expect(rows[1]!.step_name).toBe("activation_moment_1_complete");
+    expect(rows[1]!.step_index).toBe(1);
   });
 
   test("re-running after a completed move is a no-op", async () => {
@@ -98,7 +113,7 @@ describe("migration 329: move onboarding_events to the telemetry DB", () => {
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetryOnboardingRows()).toHaveLength(3);
   });
 
   test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
@@ -120,7 +135,7 @@ describe("migration 329: move onboarding_events to the telemetry DB", () => {
       .query(`SELECT screen FROM onboarding_events WHERE id = 'seed-dupe'`)
       .get() as { screen: string };
     expect(dupe.screen).toBe("already-copied");
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetryOnboardingRows()).toHaveLength(3);
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -131,7 +146,7 @@ describe("migration 329: move onboarding_events to the telemetry DB", () => {
 
     expect(existsInMain("onboarding_events")).toBe(false);
     expect(existsInMain("onboarding_events__relocating")).toBe(false);
-    expect(queryUnreportedOnboardingEvents(0, undefined, 10)).toHaveLength(0);
+    expect(telemetryOnboardingRows()).toHaveLength(0);
   });
 
   test("telemetry-side schema has the reporter's compound cursor index", () => {

--- a/assistant/src/persistence/migrations/330-move-auth-fallback-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/330-move-auth-fallback-events-to-telemetry-db.test.ts
@@ -1,12 +1,15 @@
 /**
  * Tests for migration 330: relocating `auth_fallback_events` from the main DB
- * into the dedicated telemetry database (`assistant-telemetry.db`).
+ * into the dedicated telemetry database (`assistant-telemetry.db`), covered
+ * as the head of the full pipeline — migration 334 then backfills the
+ * relocated rows into the generic `telemetry_events` outbox and drops the
+ * telemetry-side table.
  *
  * Runs against real workspace databases (`initializeDb()`) because the drain
  * engine dispatches batches via `runAsyncSqlite` against the workspace's main
- * DB file. `initializeDb()` already ran migration 330 once (dropping the empty
- * main-side table created by migration 271), so each test recreates the
- * pre-move source table in `main` to simulate an upgrading install.
+ * DB file. `initializeDb()` already ran the pipeline once, so each test
+ * recreates the pre-move source table in `main` to simulate an upgrading
+ * install, then runs 330 + 334 directly.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -15,6 +18,8 @@ const { getDb, getSqlite, getTelemetrySqlite } =
 const { initializeDb } = await import("../db-init.js");
 const { migrateMoveAuthFallbackEventsToTelemetryDb } =
   await import("./330-move-auth-fallback-events-to-telemetry-db.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
 
 await initializeDb();
 
@@ -23,13 +28,19 @@ const SOURCE_COLUMNS = `
   path TEXT NOT NULL, failure_kind TEXT NOT NULL, count INTEGER NOT NULL,
   window_start INTEGER NOT NULL, window_end INTEGER NOT NULL`;
 
-function relocatedRows(): Array<Record<string, unknown>> {
-  return getTelemetrySqlite()!
-    .query(
-      `SELECT id, guard, path, failure_kind, count, window_start, window_end
-         FROM auth_fallback_events ORDER BY created_at, id`,
-    )
-    .all() as Array<Record<string, unknown>>;
+/** Backfilled outbox rows for the auth_fallback source, in `(created_at, id)` order. */
+function outboxAuthFallbackRows(): Array<{
+  id: string;
+  payload: Record<string, unknown>;
+}> {
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id, payload FROM telemetry_events
+         WHERE name = 'auth_fallback' ORDER BY created_at, id`,
+      )
+      .all() as Array<{ id: string; payload: string }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
 }
 
 function existsInMain(name: string): boolean {
@@ -42,8 +53,22 @@ function existsInMain(name: string): boolean {
   );
 }
 
+function existsInTelemetry(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
 function resetState(): void {
-  getTelemetrySqlite()!.exec(`DELETE FROM auth_fallback_events`);
+  getTelemetrySqlite()!.exec(`DROP TABLE IF EXISTS auth_fallback_events`);
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM telemetry_events WHERE name = 'auth_fallback'`,
+  );
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM flush_checkpoints WHERE key LIKE 'telemetry:auth_fallback:%'`,
+  );
   getSqlite().exec(`DROP TABLE IF EXISTS main.auth_fallback_events`);
   getSqlite().exec(
     `DROP TABLE IF EXISTS main."auth_fallback_events__relocating"`,
@@ -90,28 +115,28 @@ function seedSourceTable(): void {
   );
 }
 
+async function runPipeline(): Promise<void> {
+  await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+  migrateBackfillTelemetryEventsOutbox(getDb());
+}
+
 describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
-  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+  test("pre-move rows land in telemetry_events and both legacy tables are gone", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
+    expect(existsInTelemetry("auth_fallback_events")).toBe(false);
 
-    const moved = getTelemetrySqlite()!
-      .query(`SELECT id, guard FROM auth_fallback_events ORDER BY id`)
-      .all();
-    expect(moved).toEqual([
-      { id: "seed-1", guard: "edge" },
-      { id: "seed-2", guard: "edge-scoped" },
-      { id: "seed-dupe", guard: "edge-guardian" },
-    ]);
-
-    const rows = relocatedRows();
+    const rows = outboxAuthFallbackRows();
     expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    expect(rows[0]!).toMatchObject({
+    expect(rows[0]!.payload).toMatchObject({
+      type: "auth_fallback",
+      daemon_event_id: "seed-1",
+      recorded_at: 1000,
       guard: "edge",
       path: "/v1/messages",
       failure_kind: "missing_authorization",
@@ -119,41 +144,42 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
       window_start: 900,
       window_end: 1000,
     });
+    expect(rows[2]!.payload.guard).toBe("edge-guardian");
   });
 
-  test("re-running after a completed move is a no-op", async () => {
+  test("re-running the pipeline after a completed move is a no-op", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+    await runPipeline();
+    await runPipeline();
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    expect(relocatedRows()).toHaveLength(3);
+    expect(existsInTelemetry("auth_fallback_events")).toBe(false);
+    expect(outboxAuthFallbackRows()).toHaveLength(3);
   });
 
-  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+  test("a pre-existing duplicate id in the outbox does not fail the pipeline", async () => {
     resetState();
     seedSourceTable();
 
-    // A crash between a drain batch's copy and delete re-copies the same rows
-    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    // A crash between a drain/backfill batch's copy and delete re-copies the
+    // same rows next boot; INSERT OR IGNORE must keep the already-copied row.
     getTelemetrySqlite()!.exec(
-      `INSERT INTO auth_fallback_events
-         (id, created_at, guard, path, failure_kind, count, window_start, window_end)
-       VALUES ('seed-dupe', 3000, 'already-copied', '/v1/pair', 'guardian_mismatch', 1, 2900, 3000)`,
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('seed-dupe', 'auth_fallback', 3000, NULL, '{"type":"auth_fallback","guard":"already-copied"}')`,
     );
 
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    const dupe = getTelemetrySqlite()!
-      .query(`SELECT guard FROM auth_fallback_events WHERE id = 'seed-dupe'`)
-      .get() as { guard: string };
-    expect(dupe.guard).toBe("already-copied");
-    expect(relocatedRows()).toHaveLength(3);
+    const rows = outboxAuthFallbackRows();
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === "seed-dupe")!.payload.guard).toBe(
+      "already-copied",
+    );
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -162,19 +188,10 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
       `CREATE TABLE main.auth_fallback_events (${SOURCE_COLUMNS})`,
     );
 
-    await migrateMoveAuthFallbackEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    expect(relocatedRows()).toHaveLength(0);
-  });
-
-  test("telemetry-side schema has the reporter's compound cursor index", () => {
-    const indexes = (
-      getTelemetrySqlite()!
-        .query(`PRAGMA index_list(auth_fallback_events)`)
-        .all() as Array<{ name: string }>
-    ).map((i) => i.name);
-    expect(indexes).toContain("idx_auth_fallback_events_created_at_id");
+    expect(outboxAuthFallbackRows()).toHaveLength(0);
   });
 });

--- a/assistant/src/persistence/migrations/330-move-auth-fallback-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/330-move-auth-fallback-events-to-telemetry-db.test.ts
@@ -13,8 +13,6 @@ import { describe, expect, test } from "bun:test";
 const { getDb, getSqlite, getTelemetrySqlite } =
   await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
-const { queryUnreportedAuthFallbackEvents } =
-  await import("../../security/auth-fallback-events-store.js");
 const { migrateMoveAuthFallbackEventsToTelemetryDb } =
   await import("./330-move-auth-fallback-events-to-telemetry-db.js");
 
@@ -24,6 +22,15 @@ const SOURCE_COLUMNS = `
   id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, guard TEXT NOT NULL,
   path TEXT NOT NULL, failure_kind TEXT NOT NULL, count INTEGER NOT NULL,
   window_start INTEGER NOT NULL, window_end INTEGER NOT NULL`;
+
+function relocatedRows(): Array<Record<string, unknown>> {
+  return getTelemetrySqlite()!
+    .query(
+      `SELECT id, guard, path, failure_kind, count, window_start, window_end
+         FROM auth_fallback_events ORDER BY created_at, id`,
+    )
+    .all() as Array<Record<string, unknown>>;
+}
 
 function existsInMain(name: string): boolean {
   return (
@@ -102,16 +109,15 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
       { id: "seed-dupe", guard: "edge-guardian" },
     ]);
 
-    // The relocated rows are readable through the store's reporter query.
-    const rows = queryUnreportedAuthFallbackEvents(0, undefined, 10);
+    const rows = relocatedRows();
     expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
     expect(rows[0]!).toMatchObject({
       guard: "edge",
       path: "/v1/messages",
-      failureKind: "missing_authorization",
+      failure_kind: "missing_authorization",
       count: 7,
-      windowStart: 900,
-      windowEnd: 1000,
+      window_start: 900,
+      window_end: 1000,
     });
   });
 
@@ -124,7 +130,7 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 10)).toHaveLength(3);
+    expect(relocatedRows()).toHaveLength(3);
   });
 
   test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
@@ -147,7 +153,7 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
       .query(`SELECT guard FROM auth_fallback_events WHERE id = 'seed-dupe'`)
       .get() as { guard: string };
     expect(dupe.guard).toBe("already-copied");
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 10)).toHaveLength(3);
+    expect(relocatedRows()).toHaveLength(3);
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -160,7 +166,7 @@ describe("migration 330: move auth_fallback_events to the telemetry DB", () => {
 
     expect(existsInMain("auth_fallback_events")).toBe(false);
     expect(existsInMain("auth_fallback_events__relocating")).toBe(false);
-    expect(queryUnreportedAuthFallbackEvents(0, undefined, 10)).toHaveLength(0);
+    expect(relocatedRows()).toHaveLength(0);
   });
 
   test("telemetry-side schema has the reporter's compound cursor index", () => {

--- a/assistant/src/persistence/migrations/331-move-lifecycle-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/331-move-lifecycle-events-to-telemetry-db.test.ts
@@ -1,12 +1,15 @@
 /**
  * Tests for migration 331: relocating `lifecycle_events` from the main DB
- * into the dedicated telemetry database (`assistant-telemetry.db`).
+ * into the dedicated telemetry database (`assistant-telemetry.db`), covered
+ * as the head of the full pipeline — migration 334 then backfills the
+ * relocated rows into the generic `telemetry_events` outbox and drops the
+ * telemetry-side table.
  *
  * Runs against real workspace databases (`initializeDb()`) because the drain
  * engine dispatches batches via `runAsyncSqlite` against the workspace's main
- * DB file. `initializeDb()` already ran migration 331 once (dropping the empty
- * main-side table created by migration 175), so each test recreates the
- * pre-move source table in `main` to simulate an upgrading install.
+ * DB file. `initializeDb()` already ran the pipeline once, so each test
+ * recreates the pre-move source table in `main` to simulate an upgrading
+ * install, then runs 331 + 334 directly.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -15,20 +18,25 @@ const { getDb, getSqlite, getTelemetrySqlite } =
 const { initializeDb } = await import("../db-init.js");
 const { migrateMoveLifecycleEventsToTelemetryDb } =
   await import("./331-move-lifecycle-events-to-telemetry-db.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
 
 await initializeDb();
 
-function telemetryLifecycleRows(): Array<{
+/** Backfilled outbox rows for the lifecycle source, in `(created_at, id)` order. */
+function outboxLifecycleRows(): Array<{
   id: string;
-  event_name: string;
   created_at: number;
+  payload: Record<string, unknown>;
 }> {
-  return getTelemetrySqlite()!
-    .query(
-      `SELECT id, event_name, created_at FROM lifecycle_events
-       ORDER BY created_at, id`,
-    )
-    .all() as Array<{ id: string; event_name: string; created_at: number }>;
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id, created_at, payload FROM telemetry_events
+         WHERE name = 'lifecycle' ORDER BY created_at, id`,
+      )
+      .all() as Array<{ id: string; created_at: number; payload: string }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
 }
 
 const SOURCE_COLUMNS = `
@@ -44,8 +52,22 @@ function existsInMain(name: string): boolean {
   );
 }
 
+function existsInTelemetry(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
 function resetState(): void {
-  getTelemetrySqlite()!.exec(`DELETE FROM lifecycle_events`);
+  getTelemetrySqlite()!.exec(`DROP TABLE IF EXISTS lifecycle_events`);
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM telemetry_events WHERE name = 'lifecycle'`,
+  );
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM flush_checkpoints WHERE key LIKE 'telemetry:lifecycle:%'`,
+  );
   getSqlite().exec(`DROP TABLE IF EXISTS main.lifecycle_events`);
   getSqlite().exec(`DROP TABLE IF EXISTS main."lifecycle_events__relocating"`);
 }
@@ -62,78 +84,76 @@ function seedSourceTable(): void {
   insert.run("seed-dupe", "conversations_clear_all", 3000);
 }
 
+async function runPipeline(): Promise<void> {
+  await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+  migrateBackfillTelemetryEventsOutbox(getDb());
+}
+
 describe("migration 331: move lifecycle_events to the telemetry DB", () => {
-  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+  test("pre-move rows land in telemetry_events and both legacy tables are gone", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
+    expect(existsInTelemetry("lifecycle_events")).toBe(false);
 
-    expect(telemetryLifecycleRows()).toEqual([
-      { id: "seed-1", event_name: "app_open", created_at: 1000 },
-      { id: "seed-2", event_name: "hatch", created_at: 2000 },
-      {
-        id: "seed-dupe",
-        event_name: "conversations_clear_all",
-        created_at: 3000,
-      },
-    ]);
+    const rows = outboxLifecycleRows();
+    expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
+    expect(rows[0]!.payload).toMatchObject({
+      type: "lifecycle",
+      daemon_event_id: "seed-1",
+      event_name: "app_open",
+      recorded_at: 1000,
+    });
+    expect(rows[2]!.payload.event_name).toBe("conversations_clear_all");
   });
 
-  test("re-running after a completed move is a no-op", async () => {
+  test("re-running the pipeline after a completed move is a no-op", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+    await runPipeline();
+    await runPipeline();
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    expect(telemetryLifecycleRows()).toHaveLength(3);
+    expect(existsInTelemetry("lifecycle_events")).toBe(false);
+    expect(outboxLifecycleRows()).toHaveLength(3);
   });
 
-  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+  test("a pre-existing duplicate id in the outbox does not fail the pipeline", async () => {
     resetState();
     seedSourceTable();
 
-    // A crash between a drain batch's copy and delete re-copies the same rows
-    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    // A crash between a drain/backfill batch's copy and delete re-copies the
+    // same rows next boot; INSERT OR IGNORE must keep the already-copied row.
     getTelemetrySqlite()!.exec(
-      `INSERT INTO lifecycle_events (id, event_name, created_at)
-       VALUES ('seed-dupe', 'already-copied', 3000)`,
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('seed-dupe', 'lifecycle', 3000, NULL, '{"type":"lifecycle","event_name":"already-copied"}')`,
     );
 
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    const dupe = getTelemetrySqlite()!
-      .query(`SELECT event_name FROM lifecycle_events WHERE id = 'seed-dupe'`)
-      .get() as { event_name: string };
-    expect(dupe.event_name).toBe("already-copied");
-    expect(telemetryLifecycleRows()).toHaveLength(3);
+    const rows = outboxLifecycleRows();
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === "seed-dupe")!.payload.event_name).toBe(
+      "already-copied",
+    );
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
     resetState();
     getSqlite().exec(`CREATE TABLE main.lifecycle_events (${SOURCE_COLUMNS})`);
 
-    await migrateMoveLifecycleEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    expect(telemetryLifecycleRows()).toHaveLength(0);
-  });
-
-  test("telemetry-side schema has the reporter's compound cursor index", () => {
-    const indexes = (
-      getTelemetrySqlite()!
-        .query(`PRAGMA index_list(lifecycle_events)`)
-        .all() as Array<{ name: string }>
-    ).map((i) => i.name);
-    expect(indexes).toContain("idx_lifecycle_events_created_at_id");
+    expect(outboxLifecycleRows()).toHaveLength(0);
   });
 });

--- a/assistant/src/persistence/migrations/331-move-lifecycle-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/331-move-lifecycle-events-to-telemetry-db.test.ts
@@ -13,12 +13,23 @@ import { describe, expect, test } from "bun:test";
 const { getDb, getSqlite, getTelemetrySqlite } =
   await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
-const { queryUnreportedLifecycleEvents } =
-  await import("../lifecycle-events-store.js");
 const { migrateMoveLifecycleEventsToTelemetryDb } =
   await import("./331-move-lifecycle-events-to-telemetry-db.js");
 
 await initializeDb();
+
+function telemetryLifecycleRows(): Array<{
+  id: string;
+  event_name: string;
+  created_at: number;
+}> {
+  return getTelemetrySqlite()!
+    .query(
+      `SELECT id, event_name, created_at FROM lifecycle_events
+       ORDER BY created_at, id`,
+    )
+    .all() as Array<{ id: string; event_name: string; created_at: number }>;
+}
 
 const SOURCE_COLUMNS = `
   id TEXT PRIMARY KEY, event_name TEXT NOT NULL, created_at INTEGER NOT NULL`;
@@ -61,24 +72,13 @@ describe("migration 331: move lifecycle_events to the telemetry DB", () => {
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
 
-    const moved = getTelemetrySqlite()!
-      .query(`SELECT id, event_name FROM lifecycle_events ORDER BY id`)
-      .all();
-    expect(moved).toEqual([
-      { id: "seed-1", event_name: "app_open" },
-      { id: "seed-2", event_name: "hatch" },
-      { id: "seed-dupe", event_name: "conversations_clear_all" },
-    ]);
-
-    // The relocated rows are readable through the store's reporter query.
-    const rows = queryUnreportedLifecycleEvents(0, undefined, 10);
-    expect(rows).toEqual([
-      { id: "seed-1", eventName: "app_open", createdAt: 1000 },
-      { id: "seed-2", eventName: "hatch", createdAt: 2000 },
+    expect(telemetryLifecycleRows()).toEqual([
+      { id: "seed-1", event_name: "app_open", created_at: 1000 },
+      { id: "seed-2", event_name: "hatch", created_at: 2000 },
       {
         id: "seed-dupe",
-        eventName: "conversations_clear_all",
-        createdAt: 3000,
+        event_name: "conversations_clear_all",
+        created_at: 3000,
       },
     ]);
   });
@@ -92,7 +92,7 @@ describe("migration 331: move lifecycle_events to the telemetry DB", () => {
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetryLifecycleRows()).toHaveLength(3);
   });
 
   test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
@@ -114,7 +114,7 @@ describe("migration 331: move lifecycle_events to the telemetry DB", () => {
       .query(`SELECT event_name FROM lifecycle_events WHERE id = 'seed-dupe'`)
       .get() as { event_name: string };
     expect(dupe.event_name).toBe("already-copied");
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetryLifecycleRows()).toHaveLength(3);
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -125,7 +125,7 @@ describe("migration 331: move lifecycle_events to the telemetry DB", () => {
 
     expect(existsInMain("lifecycle_events")).toBe(false);
     expect(existsInMain("lifecycle_events__relocating")).toBe(false);
-    expect(queryUnreportedLifecycleEvents(0, undefined, 10)).toHaveLength(0);
+    expect(telemetryLifecycleRows()).toHaveLength(0);
   });
 
   test("telemetry-side schema has the reporter's compound cursor index", () => {

--- a/assistant/src/persistence/migrations/332-move-skill-loaded-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/332-move-skill-loaded-events-to-telemetry-db.test.ts
@@ -1,12 +1,16 @@
 /**
  * Tests for migration 332: relocating `skill_loaded_events` from the main DB
- * into the dedicated telemetry database (`assistant-telemetry.db`).
+ * into the dedicated telemetry database (`assistant-telemetry.db`), covered
+ * as the head of the full pipeline — migration 334 then backfills the
+ * relocated rows into the generic `telemetry_events` outbox (with the
+ * conversation id in its dedicated column) and drops the telemetry-side
+ * table.
  *
  * Runs against real workspace databases (`initializeDb()`) because the drain
  * engine dispatches batches via `runAsyncSqlite` against the workspace's main
- * DB file. `initializeDb()` already ran migration 332 once (dropping the empty
- * main-side table created by migration 279), so each test recreates the
- * pre-move source table in `main` to simulate an upgrading install.
+ * DB file. `initializeDb()` already ran the pipeline once, so each test
+ * recreates the pre-move source table in `main` to simulate an upgrading
+ * install, then runs 332 + 334 directly.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -15,24 +19,35 @@ const { getDb, getSqlite, getTelemetrySqlite } =
 const { initializeDb } = await import("../db-init.js");
 const { migrateMoveSkillLoadedEventsToTelemetryDb } =
   await import("./332-move-skill-loaded-events-to-telemetry-db.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
 
 await initializeDb();
-
-/** Telemetry-side rows in the reporter's `(created_at, id)` order. */
-function telemetrySkillRowIds(): string[] {
-  return (
-    getTelemetrySqlite()!
-      .query(
-        `SELECT id FROM skill_loaded_events ORDER BY created_at ASC, id ASC`,
-      )
-      .all() as Array<{ id: string }>
-  ).map((r) => r.id);
-}
 
 const SOURCE_COLUMNS = `
   id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, conversation_id TEXT,
   skill_name TEXT NOT NULL, skill_updated_at TEXT, provider TEXT, model TEXT,
   inference_profile TEXT, inference_profile_source TEXT`;
+
+/** Backfilled outbox rows for the skill_loaded source, in `(created_at, id)` order. */
+function outboxSkillRows(): Array<{
+  id: string;
+  conversation_id: string | null;
+  payload: Record<string, unknown>;
+}> {
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id, conversation_id, payload FROM telemetry_events
+         WHERE name = 'skill_loaded' ORDER BY created_at, id`,
+      )
+      .all() as Array<{
+      id: string;
+      conversation_id: string | null;
+      payload: string;
+    }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
+}
 
 function existsInMain(name: string): boolean {
   return (
@@ -44,8 +59,22 @@ function existsInMain(name: string): boolean {
   );
 }
 
+function existsInTelemetry(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
 function resetState(): void {
-  getTelemetrySqlite()!.exec(`DELETE FROM skill_loaded_events`);
+  getTelemetrySqlite()!.exec(`DROP TABLE IF EXISTS skill_loaded_events`);
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM telemetry_events WHERE name = 'skill_loaded'`,
+  );
+  getTelemetrySqlite()!.exec(
+    `DELETE FROM flush_checkpoints WHERE key LIKE 'telemetry:skill_loaded:%'`,
+  );
   getSqlite().exec(`DROP TABLE IF EXISTS main.skill_loaded_events`);
   getSqlite().exec(
     `DROP TABLE IF EXISTS main."skill_loaded_events__relocating"`,
@@ -78,38 +107,37 @@ function seedSourceTable(): void {
   insert.run("seed-dupe", 3000, "conv-b", "calendar");
 }
 
+async function runPipeline(): Promise<void> {
+  await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+  migrateBackfillTelemetryEventsOutbox(getDb());
+}
+
 describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
-  test("drains pre-move rows into the telemetry DB and drops the main-side table", async () => {
+  test("pre-move rows land in telemetry_events with the conversation id column; both legacy tables are gone", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
+    expect(existsInTelemetry("skill_loaded_events")).toBe(false);
 
-    const moved = getTelemetrySqlite()!
-      .query(
-        `SELECT id, skill_name, conversation_id FROM skill_loaded_events ORDER BY id`,
-      )
-      .all();
-    expect(moved).toEqual([
-      { id: "seed-1", skill_name: "web-research", conversation_id: "conv-a" },
-      { id: "seed-2", skill_name: "tasks", conversation_id: null },
-      { id: "seed-dupe", skill_name: "calendar", conversation_id: "conv-b" },
+    const rows = outboxSkillRows();
+    expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
+    expect(rows.map((r) => r.conversation_id)).toEqual([
+      "conv-a",
+      null,
+      "conv-b",
     ]);
-
-    // Every column relocates intact.
-    expect(telemetrySkillRowIds()).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    const first = getTelemetrySqlite()!
-      .query(`SELECT * FROM skill_loaded_events WHERE id = 'seed-1'`)
-      .get();
-    expect(first).toEqual({
-      id: "seed-1",
-      created_at: 1000,
-      conversation_id: "conv-a",
+    // Every column reaches the wire payload intact.
+    expect(rows[0]!.payload).toMatchObject({
+      type: "skill_loaded",
+      daemon_event_id: "seed-1",
+      recorded_at: 1000,
       skill_name: "web-research",
       skill_updated_at: null,
+      conversation_id: "conv-a",
       provider: null,
       model: null,
       inference_profile: null,
@@ -117,40 +145,39 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
     });
   });
 
-  test("re-running after a completed move is a no-op", async () => {
+  test("re-running the pipeline after a completed move is a no-op", async () => {
     resetState();
     seedSourceTable();
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    expect(telemetrySkillRowIds()).toHaveLength(3);
+    expect(existsInTelemetry("skill_loaded_events")).toBe(false);
+    expect(outboxSkillRows()).toHaveLength(3);
   });
 
-  test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
+  test("a pre-existing duplicate id in the outbox does not fail the pipeline", async () => {
     resetState();
     seedSourceTable();
 
-    // A crash between a drain batch's copy and delete re-copies the same rows
-    // next boot; INSERT OR IGNORE must keep the already-copied row and finish.
+    // A crash between a drain/backfill batch's copy and delete re-copies the
+    // same rows next boot; INSERT OR IGNORE must keep the already-copied row.
     getTelemetrySqlite()!.exec(
-      `INSERT INTO skill_loaded_events (id, created_at, skill_name)
-       VALUES ('seed-dupe', 3000, 'already-copied')`,
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('seed-dupe', 'skill_loaded', 3000, 'conv-b', '{"type":"skill_loaded","skill_name":"already-copied"}')`,
     );
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    const dupe = getTelemetrySqlite()!
-      .query(
-        `SELECT skill_name FROM skill_loaded_events WHERE id = 'seed-dupe'`,
-      )
-      .get() as { skill_name: string };
-    expect(dupe.skill_name).toBe("already-copied");
-    expect(telemetrySkillRowIds()).toHaveLength(3);
+    const rows = outboxSkillRows();
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.id === "seed-dupe")!.payload.skill_name).toBe(
+      "already-copied",
+    );
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -159,11 +186,11 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
       `CREATE TABLE main.skill_loaded_events (${SOURCE_COLUMNS})`,
     );
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    expect(telemetrySkillRowIds()).toHaveLength(0);
+    expect(outboxSkillRows()).toHaveLength(0);
   });
 
   test("the drain purges rows whose conversation no longer exists (redaction across boots)", async () => {
@@ -182,24 +209,11 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
     // itself must purge this row rather than resurrect it.
     insert.run("dead-1", 3000, "conv-deleted", "calendar");
 
-    await migrateMoveSkillLoadedEventsToTelemetryDb(getDb());
+    await runPipeline();
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
 
-    expect(telemetrySkillRowIds()).toEqual(["live-1", "null-1"]);
-    const dead = getTelemetrySqlite()!
-      .query(`SELECT 1 FROM skill_loaded_events WHERE id = 'dead-1'`)
-      .get();
-    expect(dead).toBeNull();
-  });
-
-  test("telemetry-side schema has the compound cursor index", () => {
-    const indexes = (
-      getTelemetrySqlite()!
-        .query(`PRAGMA index_list(skill_loaded_events)`)
-        .all() as Array<{ name: string }>
-    ).map((i) => i.name);
-    expect(indexes).toContain("idx_skill_loaded_events_created_at_id");
+    expect(outboxSkillRows().map((r) => r.id)).toEqual(["live-1", "null-1"]);
   });
 });

--- a/assistant/src/persistence/migrations/332-move-skill-loaded-events-to-telemetry-db.test.ts
+++ b/assistant/src/persistence/migrations/332-move-skill-loaded-events-to-telemetry-db.test.ts
@@ -13,13 +13,21 @@ import { describe, expect, test } from "bun:test";
 const { getDb, getSqlite, getTelemetrySqlite } =
   await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
-const { queryUnreportedSkillLoadedEvents } =
-  await import("../../telemetry/skill-loaded-events-store.js");
 const { migrateMoveSkillLoadedEventsToTelemetryDb } =
   await import("./332-move-skill-loaded-events-to-telemetry-db.js");
-const { rawTelemetryRun } = await import("../raw-query.js");
 
 await initializeDb();
+
+/** Telemetry-side rows in the reporter's `(created_at, id)` order. */
+function telemetrySkillRowIds(): string[] {
+  return (
+    getTelemetrySqlite()!
+      .query(
+        `SELECT id FROM skill_loaded_events ORDER BY created_at ASC, id ASC`,
+      )
+      .all() as Array<{ id: string }>
+  ).map((r) => r.id);
+}
 
 const SOURCE_COLUMNS = `
   id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, conversation_id TEXT,
@@ -91,19 +99,21 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
       { id: "seed-dupe", skill_name: "calendar", conversation_id: "conv-b" },
     ]);
 
-    // The relocated rows are readable through the store's reporter query.
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
-    expect(rows.map((r) => r.id)).toEqual(["seed-1", "seed-2", "seed-dupe"]);
-    expect(rows[0]).toEqual({
+    // Every column relocates intact.
+    expect(telemetrySkillRowIds()).toEqual(["seed-1", "seed-2", "seed-dupe"]);
+    const first = getTelemetrySqlite()!
+      .query(`SELECT * FROM skill_loaded_events WHERE id = 'seed-1'`)
+      .get();
+    expect(first).toEqual({
       id: "seed-1",
-      createdAt: 1000,
-      conversationId: "conv-a",
-      skillName: "web-research",
-      skillUpdatedAt: null,
+      created_at: 1000,
+      conversation_id: "conv-a",
+      skill_name: "web-research",
+      skill_updated_at: null,
       provider: null,
       model: null,
-      inferenceProfile: null,
-      inferenceProfileSource: null,
+      inference_profile: null,
+      inference_profile_source: null,
     });
   });
 
@@ -116,7 +126,7 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetrySkillRowIds()).toHaveLength(3);
   });
 
   test("a pre-existing duplicate id in the telemetry copy does not fail the drain", async () => {
@@ -140,7 +150,7 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
       )
       .get() as { skill_name: string };
     expect(dupe.skill_name).toBe("already-copied");
-    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(3);
+    expect(telemetrySkillRowIds()).toHaveLength(3);
   });
 
   test("an empty main-side table (fresh install) is dropped without a drain", async () => {
@@ -153,7 +163,7 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
 
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
-    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
+    expect(telemetrySkillRowIds()).toHaveLength(0);
   });
 
   test("the drain purges rows whose conversation no longer exists (redaction across boots)", async () => {
@@ -177,34 +187,14 @@ describe("migration 332: move skill_loaded_events to the telemetry DB", () => {
     expect(existsInMain("skill_loaded_events")).toBe(false);
     expect(existsInMain("skill_loaded_events__relocating")).toBe(false);
 
-    const moved = queryUnreportedSkillLoadedEvents(0, undefined, 10);
-    expect(moved.map((r) => r.id)).toEqual(["live-1", "null-1"]);
+    expect(telemetrySkillRowIds()).toEqual(["live-1", "null-1"]);
     const dead = getTelemetrySqlite()!
       .query(`SELECT 1 FROM skill_loaded_events WHERE id = 'dead-1'`)
       .get();
     expect(dead).toBeNull();
   });
 
-  test("per-conversation redaction deletes rows on the telemetry connection", () => {
-    resetState();
-    getTelemetrySqlite()!.exec(
-      `INSERT INTO skill_loaded_events (id, created_at, conversation_id, skill_name)
-       VALUES ('red-1', 1000, 'conv-pruned', 'web-research'),
-              ('red-2', 2000, 'conv-kept', 'tasks')`,
-    );
-
-    // The exact delete the conversation prune runs (job-handlers/cleanup.ts).
-    rawTelemetryRun(
-      "test:prune-redaction",
-      `DELETE FROM skill_loaded_events WHERE conversation_id = ?`,
-      "conv-pruned",
-    );
-
-    const remaining = queryUnreportedSkillLoadedEvents(0, undefined, 10);
-    expect(remaining.map((r) => r.id)).toEqual(["red-2"]);
-  });
-
-  test("telemetry-side schema has the reporter's compound cursor index", () => {
+  test("telemetry-side schema has the compound cursor index", () => {
     const indexes = (
       getTelemetrySqlite()!
         .query(`PRAGMA index_list(skill_loaded_events)`)

--- a/assistant/src/persistence/migrations/333-create-telemetry-events-table.test.ts
+++ b/assistant/src/persistence/migrations/333-create-telemetry-events-table.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for migration 333: creating the generic `telemetry_events` outbox
+ * table on the dedicated telemetry database (`assistant-telemetry.db`).
+ *
+ * Runs against real workspace databases (`initializeDb()` already ran the
+ * step once), so the tests assert the resulting telemetry-side schema and
+ * that re-running the step is idempotent.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getDb, getTelemetrySqlite } = await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { migrateCreateTelemetryEventsTable } =
+  await import("./333-create-telemetry-events-table.js");
+
+await initializeDb();
+
+function telemetryTableExists(name: string): boolean {
+  return (
+    getTelemetrySqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
+function telemetryIndexNames(): string[] {
+  return (
+    getTelemetrySqlite()!
+      .query(`PRAGMA index_list(telemetry_events)`)
+      .all() as Array<{ name: string }>
+  ).map((i) => i.name);
+}
+
+describe("migration 333: create telemetry_events on the telemetry DB", () => {
+  test("initializeDb created the table with both indexes", () => {
+    expect(telemetryTableExists("telemetry_events")).toBe(true);
+    const indexes = telemetryIndexNames();
+    expect(indexes).toContain("idx_telemetry_events_name_created_at_id");
+    expect(indexes).toContain("idx_telemetry_events_conversation_id");
+  });
+
+  test("re-running the step is idempotent and preserves existing rows", () => {
+    const telemetry = getTelemetrySqlite()!;
+    telemetry.exec(`DELETE FROM telemetry_events`);
+    telemetry.exec(
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('row-1', 'lifecycle', 1000, NULL, '{"type":"lifecycle"}')`,
+    );
+
+    migrateCreateTelemetryEventsTable(getDb());
+
+    expect(telemetryTableExists("telemetry_events")).toBe(true);
+    const indexes = telemetryIndexNames();
+    expect(indexes).toContain("idx_telemetry_events_name_created_at_id");
+    expect(indexes).toContain("idx_telemetry_events_conversation_id");
+    const row = telemetry
+      .query(`SELECT id, name, payload FROM telemetry_events`)
+      .get();
+    expect(row).toEqual({
+      id: "row-1",
+      name: "lifecycle",
+      payload: '{"type":"lifecycle"}',
+    });
+    telemetry.exec(`DELETE FROM telemetry_events`);
+  });
+});

--- a/assistant/src/persistence/migrations/333-create-telemetry-events-table.ts
+++ b/assistant/src/persistence/migrations/333-create-telemetry-events-table.ts
@@ -1,0 +1,43 @@
+import { Database } from "bun:sqlite";
+
+import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
+import { type DrizzleDb, getTelemetrySqlite } from "../db-connection.js";
+
+/**
+ * Create `telemetry_events` — the generic telemetry outbox — on the dedicated
+ * telemetry database (`assistant-telemetry.db`), not the main DB. Each row's
+ * `payload` holds the wire `TelemetryEvent` JSON built at record time; the
+ * usage telemetry reporter deletes rows after a successful flush.
+ *
+ * Idempotent (`IF NOT EXISTS`). The `(name, created_at, id)` index backs the
+ * per-source ordered batch reads; the `conversation_id` index keeps
+ * conversation redaction an indexed delete.
+ *
+ * The `mainDb` parameter is accepted to satisfy the migration-step signature but
+ * is not used — this migration operates exclusively on the telemetry DB.
+ */
+export function migrateCreateTelemetryEventsTable(_mainDb: DrizzleDb): void {
+  let raw: Database | null = getTelemetrySqlite();
+  if (!raw) {
+    // The dedicated connection failed to open (logged by openDedicatedDb).
+    // Fall back to opening the file directly so the migration still runs —
+    // the singleton will pick it up on a later access. This mirrors the
+    // fail-soft pattern of the other dedicated-DB migrations.
+    raw = new Database(getTelemetryDbPath());
+  }
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS telemetry_events (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      conversation_id TEXT,
+      payload TEXT NOT NULL
+    )
+  `);
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_telemetry_events_name_created_at_id ON telemetry_events (name, created_at, id)`,
+  );
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_telemetry_events_conversation_id ON telemetry_events (conversation_id)`,
+  );
+}

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.test.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Tests for migration 334: backfilling unshipped rows from the six legacy
+ * per-type telemetry tables into the generic `telemetry_events` outbox,
+ * dropping the legacy tables, and purging their `flush_checkpoints`
+ * watermarks.
+ *
+ * Runs against real workspace databases (`initializeDb()` already ran the
+ * step once, dropping the empty legacy tables), so each test recreates the
+ * legacy tables via raw SQL to simulate an upgrading install with pending
+ * rows.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getDb, getSqlite, getTelemetrySqlite } =
+  await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { migrateBackfillTelemetryEventsOutbox } =
+  await import("./334-backfill-telemetry-events-outbox.js");
+const { APP_VERSION } = await import("../../version.js");
+
+await initializeDb();
+
+const OPT_OUT_SENTINEL = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+const LEGACY_TABLES: Record<string, string> = {
+  lifecycle_events: /*sql*/ `
+    id TEXT PRIMARY KEY, event_name TEXT NOT NULL, created_at INTEGER NOT NULL`,
+  onboarding_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, screen TEXT NOT NULL,
+    tools_json TEXT, tasks_json TEXT, tone TEXT, google_connected INTEGER,
+    google_scopes_json TEXT, prior_assistants_json TEXT, ab_variant TEXT,
+    session_id TEXT, step_name TEXT, step_index INTEGER, completed_at TEXT,
+    funnel_version TEXT`,
+  auth_fallback_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, guard TEXT NOT NULL,
+    path TEXT NOT NULL, failure_kind TEXT NOT NULL, count INTEGER NOT NULL,
+    window_start INTEGER NOT NULL, window_end INTEGER NOT NULL`,
+  skill_loaded_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, conversation_id TEXT,
+    skill_name TEXT NOT NULL, skill_updated_at TEXT, provider TEXT, model TEXT,
+    inference_profile TEXT, inference_profile_source TEXT`,
+  watchdog_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, check_name TEXT NOT NULL,
+    value REAL, detail TEXT`,
+  config_setting_events: /*sql*/ `
+    id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, config_key TEXT NOT NULL,
+    config_value TEXT NOT NULL`,
+};
+
+const SOURCE_IDS = [
+  "lifecycle",
+  "onboarding",
+  "auth_fallback",
+  "skill_loaded",
+  "watchdog",
+  "config_setting",
+];
+
+const WATERMARK_KEYS = SOURCE_IDS.flatMap((sourceId) => [
+  `telemetry:${sourceId}:last_reported_at`,
+  `telemetry:${sourceId}:last_reported_id`,
+]);
+
+function telemetry() {
+  return getTelemetrySqlite()!;
+}
+
+function resetState(): void {
+  for (const table of Object.keys(LEGACY_TABLES)) {
+    telemetry().exec(`DROP TABLE IF EXISTS ${table}`);
+  }
+  telemetry().exec(`DELETE FROM telemetry_events`);
+  telemetry()
+    .query(
+      `DELETE FROM flush_checkpoints WHERE key IN (${WATERMARK_KEYS.map(() => "?").join(", ")})`,
+    )
+    .run(...WATERMARK_KEYS);
+}
+
+function createLegacyTable(table: string): void {
+  telemetry().exec(`CREATE TABLE ${table} (${LEGACY_TABLES[table]})`);
+}
+
+function setWatermark(sourceId: string, at: number, id?: string): void {
+  const insert = telemetry().prepare(
+    `INSERT INTO flush_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+  );
+  insert.run(`telemetry:${sourceId}:last_reported_at`, String(at), Date.now());
+  if (id !== undefined) {
+    insert.run(`telemetry:${sourceId}:last_reported_id`, id, Date.now());
+  }
+}
+
+function tableExists(table: string): boolean {
+  return (
+    telemetry()
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(table) != null
+  );
+}
+
+function outboxRows(name: string): Array<{
+  id: string;
+  created_at: number;
+  conversation_id: string | null;
+  payload: Record<string, unknown>;
+}> {
+  return (
+    telemetry()
+      .query(
+        `SELECT id, created_at, conversation_id, payload FROM telemetry_events
+         WHERE name = ? ORDER BY created_at, id`,
+      )
+      .all(name) as Array<{
+      id: string;
+      created_at: number;
+      conversation_id: string | null;
+      payload: string;
+    }>
+  ).map((row) => ({ ...row, payload: JSON.parse(row.payload) }));
+}
+
+function watermarkKeyCount(): number {
+  return (
+    telemetry()
+      .query(
+        `SELECT COUNT(*) AS n FROM flush_checkpoints
+         WHERE key IN (${WATERMARK_KEYS.map(() => "?").join(", ")})`,
+      )
+      .get(...WATERMARK_KEYS) as { n: number }
+  ).n;
+}
+
+describe("migration 334: backfill telemetry_events from the legacy tables", () => {
+  test("initializeDb leaves telemetry_events and none of the legacy tables", () => {
+    expect(tableExists("telemetry_events")).toBe(true);
+    for (const table of Object.keys(LEGACY_TABLES)) {
+      expect(tableExists(table)).toBe(false);
+    }
+  });
+
+  test("compound watermark: only rows past (at, id) backfill; payload is the frozen wire shape", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
+    );
+    insert.run("shipped-1", "app_open", 1000);
+    insert.run("aaa-at-watermark", "hatch", 2000); // id <= watermark id at equal timestamp
+    insert.run("zzz-at-watermark", "app_open", 2000); // id > watermark id at equal timestamp
+    insert.run("unshipped-1", "conversations_clear_all", 3000);
+    setWatermark("lifecycle", 2000, "aaa-at-watermark");
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("lifecycle");
+    expect(rows.map((r) => r.id)).toEqual(["zzz-at-watermark", "unshipped-1"]);
+    expect(rows[0]!.created_at).toBe(2000);
+    expect(rows[0]!.conversation_id).toBeNull();
+    expect(rows[0]!.payload).toEqual({
+      type: "lifecycle",
+      daemon_event_id: "zzz-at-watermark",
+      event_name: "app_open",
+      recorded_at: 2000,
+      assistant_version: APP_VERSION,
+    });
+    expect(tableExists("lifecycle_events")).toBe(false);
+  });
+
+  test("opt-out id sentinel: rows at the pinned timestamp stay shipped, later rows backfill", () => {
+    resetState();
+    createLegacyTable("config_setting_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO config_setting_events (id, created_at, config_key, config_value)
+       VALUES (?, ?, ?, ?)`,
+    );
+    // Hex UUID-shaped ids: every real row id sorts below the ffffffff-… sentinel.
+    insert.run("ab12cd34-pinned", 2000, "memory.enabled", "true");
+    insert.run("ef56ab78-after-optout", 2001, "memory.enabled", "false");
+    setWatermark("config_setting", 2000, OPT_OUT_SENTINEL);
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("config_setting");
+    expect(rows.map((r) => r.id)).toEqual(["ef56ab78-after-optout"]);
+    expect(rows[0]!.payload).toEqual({
+      type: "config_setting",
+      daemon_event_id: "ef56ab78-after-optout",
+      recorded_at: 2001,
+      config_key: "memory.enabled",
+      config_value: "false",
+      assistant_version: APP_VERSION,
+    });
+  });
+
+  test("timestamp-only watermark (no id key) filters on created_at alone", () => {
+    resetState();
+    createLegacyTable("auth_fallback_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO auth_fallback_events
+         (id, created_at, guard, path, failure_kind, count, window_start, window_end)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      "shipped-1",
+      1000,
+      "edge",
+      "/v1/messages",
+      "missing_authorization",
+      7,
+      900,
+      1000,
+    );
+    insert.run(
+      "at-watermark",
+      2000,
+      "edge-scoped",
+      "/v1/files",
+      "insufficient_scope",
+      2,
+      1900,
+      2000,
+    );
+    insert.run(
+      "unshipped-1",
+      3000,
+      "edge-guardian",
+      "/v1/pair",
+      "guardian_mismatch",
+      1,
+      2900,
+      3000,
+    );
+    setWatermark("auth_fallback", 2000);
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("auth_fallback");
+    expect(rows.map((r) => r.id)).toEqual(["unshipped-1"]);
+    expect(rows[0]!.payload).toEqual({
+      type: "auth_fallback",
+      daemon_event_id: "unshipped-1",
+      recorded_at: 3000,
+      guard: "edge-guardian",
+      path: "/v1/pair",
+      failure_kind: "guardian_mismatch",
+      count: 1,
+      window_start: 2900,
+      window_end: 3000,
+      assistant_version: APP_VERSION,
+    });
+  });
+
+  test("absent watermark backfills ALL rows; corrupt watchdog detail becomes null", () => {
+    resetState();
+    createLegacyTable("watchdog_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO watchdog_events (id, created_at, check_name, value, detail)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      "wd-1",
+      1000,
+      "event_loop_block",
+      250.5,
+      '{"reason":"gc","secondary":2}',
+    );
+    insert.run("wd-corrupt", 2000, "stream_idle", null, "{not json");
+    insert.run("wd-nonobject", 3000, "restart", 1, "42");
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("watchdog");
+    expect(rows.map((r) => r.id)).toEqual([
+      "wd-1",
+      "wd-corrupt",
+      "wd-nonobject",
+    ]);
+    expect(rows[0]!.payload).toEqual({
+      type: "watchdog",
+      daemon_event_id: "wd-1",
+      recorded_at: 1000,
+      check_name: "event_loop_block",
+      value: 250.5,
+      detail: { reason: "gc", secondary: 2 },
+      assistant_version: APP_VERSION,
+    });
+    expect(rows[1]!.payload.detail).toBeNull();
+    expect(rows[2]!.payload.detail).toBeNull();
+  });
+
+  test("onboarding: activation daemon_event_id override, omit-when-absent fields, corrupt JSON column omitted", () => {
+    resetState();
+    createLegacyTable("onboarding_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO onboarding_events
+         (id, created_at, screen, tools_json, tasks_json, tone, google_connected,
+          google_scopes_json, prior_assistants_json, ab_variant, session_id,
+          step_name, step_index, completed_at, funnel_version)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      "ob-full",
+      1000,
+      "tools",
+      '["calendar","email"]',
+      '["plan-day"]',
+      "warm",
+      0,
+      '["scope-a"]',
+      '["other"]',
+      "variant-b",
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
+    insert.run(
+      "ob-activation",
+      2000,
+      "activation_moment_1_complete",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      "sess-1",
+      "activation_moment_1_complete",
+      1,
+      "2026-07-01T00:00:00.000Z",
+      "v2",
+    );
+    insert.run(
+      "ob-corrupt",
+      3000,
+      "tasks",
+      "{not json",
+      null,
+      null,
+      1,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("onboarding");
+    expect(rows.map((r) => r.id)).toEqual([
+      "ob-full",
+      "ob-activation",
+      "ob-corrupt",
+    ]);
+    expect(rows[0]!.payload).toEqual({
+      type: "onboarding",
+      daemon_event_id: "ob-full",
+      recorded_at: 1000,
+      screen: "tools",
+      tools: ["calendar", "email"],
+      tasks: ["plan-day"],
+      tone: "warm",
+      google_connected: false,
+      google_scopes: ["scope-a"],
+      ab_variant: "variant-b",
+      assistant_version: APP_VERSION,
+    });
+    expect(rows[1]!.payload).toEqual({
+      type: "onboarding",
+      daemon_event_id: "v2:sess-1:activation_moment_1_complete",
+      recorded_at: 2000,
+      screen: "activation_moment_1_complete",
+      session_id: "sess-1",
+      step_name: "activation_moment_1_complete",
+      step_index: 1,
+      completed_at: "2026-07-01T00:00:00.000Z",
+      funnel_version: "v2",
+      assistant_version: APP_VERSION,
+    });
+    // Corrupt tools_json: the field is omitted, the row still backfills.
+    expect(rows[2]!.payload).toEqual({
+      type: "onboarding",
+      daemon_event_id: "ob-corrupt",
+      recorded_at: 3000,
+      screen: "tasks",
+      google_connected: true,
+      assistant_version: APP_VERSION,
+    });
+  });
+
+  test("skill_loaded: live/NULL-conversation rows backfill with conversation_id; redacted-conversation rows do not", () => {
+    resetState();
+    createLegacyTable("skill_loaded_events");
+    // Live conversation in the main DB; "conv-redacted" deliberately absent —
+    // its rows must not be resurrected by the backfill.
+    getSqlite().exec(
+      `DELETE FROM conversations WHERE id IN ('conv-a', 'conv-redacted')`,
+    );
+    getSqlite()
+      .prepare(
+        `INSERT INTO conversations (id, created_at, updated_at) VALUES (?, 0, 0)`,
+      )
+      .run("conv-a");
+    const insert = telemetry().prepare(
+      `INSERT INTO skill_loaded_events
+         (id, created_at, conversation_id, skill_name, skill_updated_at,
+          provider, model, inference_profile, inference_profile_source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      "sk-1",
+      1000,
+      "conv-a",
+      "web-research",
+      "2026-06-01T00:00:00Z",
+      "anthropic",
+      "claude-1",
+      "profile-x",
+      "mix",
+    );
+    insert.run("sk-2", 2000, null, "tasks", null, null, null, null, null);
+    insert.run(
+      "sk-dead",
+      3000,
+      "conv-redacted",
+      "calendar",
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("skill_loaded");
+    expect(rows.map((r) => r.id)).toEqual(["sk-1", "sk-2"]);
+    expect(rows.map((r) => r.conversation_id)).toEqual(["conv-a", null]);
+    expect(tableExists("skill_loaded_events")).toBe(false);
+    expect(rows[0]!.payload).toEqual({
+      type: "skill_loaded",
+      daemon_event_id: "sk-1",
+      recorded_at: 1000,
+      skill_name: "web-research",
+      skill_updated_at: "2026-06-01T00:00:00Z",
+      conversation_id: "conv-a",
+      provider: "anthropic",
+      model: "claude-1",
+      inference_profile: "profile-x",
+      inference_profile_source: "mix",
+      assistant_version: APP_VERSION,
+    });
+    expect(rows[1]!.payload).toMatchObject({
+      skill_updated_at: null,
+      conversation_id: null,
+      provider: null,
+    });
+  });
+
+  test("drops every legacy table, purges all 12 watermark keys, and skips absent tables", () => {
+    resetState();
+    // Only two of the six tables exist — the rest must be skipped cleanly.
+    createLegacyTable("lifecycle_events");
+    createLegacyTable("watchdog_events");
+    telemetry().exec(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES ('l-1', 'app_open', 1000)`,
+    );
+    setWatermark("onboarding", 5000, "some-id"); // watermark for an absent table
+    setWatermark("lifecycle", 500);
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    for (const table of Object.keys(LEGACY_TABLES)) {
+      expect(tableExists(table)).toBe(false);
+    }
+    expect(watermarkKeyCount()).toBe(0);
+    expect(outboxRows("lifecycle")).toHaveLength(1);
+    expect(outboxRows("watchdog")).toHaveLength(0);
+  });
+
+  test("backfills in chunks past 500 rows", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    const insert = telemetry().prepare(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES (?, ?, ?)`,
+    );
+    for (let i = 0; i < 501; i++) {
+      insert.run(`bulk-${String(i).padStart(4, "0")}`, "app_open", 1000 + i);
+    }
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    expect(outboxRows("lifecycle")).toHaveLength(501);
+  });
+
+  test("re-running after completion is a safe no-op", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    telemetry().exec(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES ('l-1', 'hatch', 1000)`,
+    );
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    expect(outboxRows("lifecycle")).toHaveLength(1);
+    expect(watermarkKeyCount()).toBe(0);
+  });
+
+  test("a main-side __relocating staging table defers the backfill: throws, drops nothing, purges no watermarks", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    telemetry().exec(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES ('l-1', 'hatch', 1000)`,
+    );
+    setWatermark("lifecycle", 500);
+    getSqlite().exec(
+      `CREATE TABLE main."skill_loaded_events__relocating" (id TEXT PRIMARY KEY)`,
+    );
+
+    try {
+      expect(() => migrateBackfillTelemetryEventsOutbox(getDb())).toThrow(
+        "legacy telemetry relocations incomplete",
+      );
+      expect(tableExists("lifecycle_events")).toBe(true);
+      expect(outboxRows("lifecycle")).toHaveLength(0);
+      expect(watermarkKeyCount()).toBe(1);
+    } finally {
+      getSqlite().exec(
+        `DROP TABLE IF EXISTS main."skill_loaded_events__relocating"`,
+      );
+    }
+
+    // Staging table gone (relocation completed) → the retried step succeeds.
+    migrateBackfillTelemetryEventsOutbox(getDb());
+    expect(tableExists("lifecycle_events")).toBe(false);
+    expect(outboxRows("lifecycle")).toHaveLength(1);
+    expect(watermarkKeyCount()).toBe(0);
+  });
+
+  test("a main-side legacy table (relocation not yet run) defers the backfill", () => {
+    resetState();
+    createLegacyTable("watchdog_events");
+    setWatermark("watchdog", 500);
+    getSqlite().exec(
+      `CREATE TABLE main.onboarding_events (id TEXT PRIMARY KEY)`,
+    );
+
+    try {
+      expect(() => migrateBackfillTelemetryEventsOutbox(getDb())).toThrow(
+        "legacy telemetry relocations incomplete",
+      );
+      expect(tableExists("watchdog_events")).toBe(true);
+      expect(watermarkKeyCount()).toBe(1);
+    } finally {
+      getSqlite().exec(`DROP TABLE IF EXISTS main.onboarding_events`);
+    }
+  });
+
+  test("a pre-existing outbox row with the same id survives (INSERT OR IGNORE)", () => {
+    resetState();
+    createLegacyTable("lifecycle_events");
+    telemetry().exec(
+      `INSERT INTO lifecycle_events (id, event_name, created_at) VALUES ('dupe-1', 'app_open', 1000)`,
+    );
+    telemetry().exec(
+      `INSERT INTO telemetry_events (id, name, created_at, conversation_id, payload)
+       VALUES ('dupe-1', 'lifecycle', 1000, NULL, '{"type":"lifecycle","already":"queued"}')`,
+    );
+
+    migrateBackfillTelemetryEventsOutbox(getDb());
+
+    const rows = outboxRows("lifecycle");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.payload).toEqual({ type: "lifecycle", already: "queued" });
+  });
+});

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
@@ -1,0 +1,384 @@
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../util/logger.js";
+import { getTelemetryDbPath } from "../../util/telemetry-db-path.js";
+import { APP_VERSION } from "../../version.js";
+import {
+  type DrizzleDb,
+  getSqliteFrom,
+  getTelemetrySqlite,
+} from "../db-connection.js";
+import { RELOCATING_SUFFIX } from "./helpers/relocation.js";
+
+const log = getLogger("migration-334");
+
+/** Rows per multi-row INSERT — stays under SQLite's bound-variable limit. */
+const INSERT_CHUNK_SIZE = 500;
+
+type LegacyRow = Record<string, string | number | null>;
+
+/**
+ * One legacy per-type telemetry table to fold into the `telemetry_events`
+ * outbox. `sourceId` is the reporter watermark namespace
+ * (`telemetry:<sourceId>:last_reported_{at,id}` in `flush_checkpoints`);
+ * `toPayload` is a frozen copy of the source's pre-outbox flush-time wire
+ * mapper (deliberately NOT shared with the live store code, so later store
+ * changes cannot rewrite what this migration produces).
+ */
+interface LegacyBackfillSpec {
+  table: string;
+  sourceId: string;
+  /** Column copied into `telemetry_events.conversation_id` (redaction index). */
+  conversationIdColumn?: string;
+  toPayload(row: LegacyRow): Record<string, unknown>;
+}
+
+/** `{ [key]: JSON.parse(raw) }` when `raw` is parseable JSON text; else `{}`. */
+function jsonField(
+  key: string,
+  raw: string | number | null,
+): Record<string, unknown> {
+  if (typeof raw !== "string" || raw === "") {
+    return {};
+  }
+  try {
+    return { [key]: JSON.parse(raw) };
+  } catch {
+    return {};
+  }
+}
+
+/** Stored watchdog `detail` JSON text → object bag; null/corrupt/non-object → null. */
+function parseWatchdogDetail(
+  raw: string | number | null,
+): Record<string, unknown> | null {
+  if (typeof raw !== "string" || raw === "") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const LEGACY_BACKFILL_SPECS: readonly LegacyBackfillSpec[] = [
+  {
+    table: "lifecycle_events",
+    sourceId: "lifecycle",
+    toPayload: (row) => ({
+      type: "lifecycle",
+      daemon_event_id: row.id,
+      event_name: row.event_name,
+      recorded_at: row.created_at,
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "onboarding_events",
+    sourceId: "onboarding",
+    toPayload: (row) => ({
+      type: "onboarding",
+      // Activation rows carry a deterministic wire id keyed on the row's own
+      // funnel_version/session/step so dbt collapses a moment that fires more
+      // than once; every other row uses the row id.
+      daemon_event_id:
+        row.session_id && row.step_name && row.funnel_version
+          ? `${row.funnel_version}:${row.session_id}:${row.step_name}`
+          : row.id,
+      recorded_at: row.created_at,
+      screen: row.screen,
+      // Optional fields are omit-when-absent; a corrupt stored JSON column
+      // omits just that field (the row still backfills). The never-shipped
+      // `prior_assistants_json` column is dropped here.
+      ...jsonField("tools", row.tools_json),
+      ...jsonField("tasks", row.tasks_json),
+      ...(row.tone ? { tone: row.tone } : {}),
+      ...(row.google_connected != null
+        ? { google_connected: row.google_connected !== 0 }
+        : {}),
+      ...jsonField("google_scopes", row.google_scopes_json),
+      ...(row.ab_variant ? { ab_variant: row.ab_variant } : {}),
+      ...(row.session_id ? { session_id: row.session_id } : {}),
+      ...(row.step_name ? { step_name: row.step_name } : {}),
+      ...(row.step_index != null ? { step_index: row.step_index } : {}),
+      ...(row.completed_at ? { completed_at: row.completed_at } : {}),
+      ...(row.funnel_version ? { funnel_version: row.funnel_version } : {}),
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "auth_fallback_events",
+    sourceId: "auth_fallback",
+    toPayload: (row) => ({
+      type: "auth_fallback",
+      daemon_event_id: row.id,
+      recorded_at: row.created_at,
+      guard: row.guard,
+      path: row.path,
+      failure_kind: row.failure_kind,
+      count: row.count,
+      window_start: row.window_start,
+      window_end: row.window_end,
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "skill_loaded_events",
+    sourceId: "skill_loaded",
+    conversationIdColumn: "conversation_id",
+    toPayload: (row) => ({
+      type: "skill_loaded",
+      daemon_event_id: row.id,
+      recorded_at: row.created_at,
+      skill_name: row.skill_name,
+      skill_updated_at: row.skill_updated_at,
+      conversation_id: row.conversation_id,
+      provider: row.provider,
+      model: row.model,
+      inference_profile: row.inference_profile,
+      inference_profile_source: row.inference_profile_source,
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "watchdog_events",
+    sourceId: "watchdog",
+    toPayload: (row) => ({
+      type: "watchdog",
+      daemon_event_id: row.id,
+      recorded_at: row.created_at,
+      check_name: row.check_name,
+      value: row.value,
+      detail: parseWatchdogDetail(row.detail),
+      assistant_version: APP_VERSION,
+    }),
+  },
+  {
+    table: "config_setting_events",
+    sourceId: "config_setting",
+    toPayload: (row) => ({
+      type: "config_setting",
+      daemon_event_id: row.id,
+      recorded_at: row.created_at,
+      config_key: row.config_key,
+      config_value: row.config_value,
+      assistant_version: APP_VERSION,
+    }),
+  },
+];
+
+/**
+ * Throw unless the legacy relocations (329–332) have fully completed. The
+ * migration runner catches a failed step and still runs later ones, so
+ * without this gate a mid-drain relocation failure would let 334 backfill,
+ * drop the telemetry-side tables, and checkpoint — then the relocation's
+ * next-boot rerun drains rows into a legacy table nothing reads anymore.
+ * Throwing leaves 334 uncheckpointed so it retries after the relocations.
+ */
+function assertLegacyRelocationsComplete(mainRaw: Database): void {
+  const names = LEGACY_BACKFILL_SPECS.flatMap((spec) => [
+    spec.table,
+    `${spec.table}${RELOCATING_SUFFIX}`,
+  ]);
+  const pending = (
+    mainRaw
+      .query(
+        /*sql*/ `SELECT name FROM main.sqlite_master WHERE type='table' AND name IN (${names.map(() => "?").join(", ")})`,
+      )
+      .all(...names) as Array<{ name: string }>
+  ).map((row) => row.name);
+  if (pending.length > 0) {
+    throw new Error(
+      `legacy telemetry relocations incomplete (${pending.join(", ")}) — deferring outbox backfill`,
+    );
+  }
+}
+
+function tableExists(raw: Database, table: string): boolean {
+  return (
+    raw
+      .query(
+        /*sql*/ `SELECT name FROM sqlite_master WHERE type='table' AND name = ?`,
+      )
+      .get(table) != null
+  );
+}
+
+/**
+ * Rows the reporter has NOT yet shipped, per the source's `flush_checkpoints`
+ * watermark: the standard compound cursor when both keys exist (the opt-out
+ * `ffffffff-…` id sentinel composes correctly — nothing at the pinned
+ * timestamp sorts above it), timestamp-only when only `at` exists, and ALL
+ * rows when the watermark is absent or unreadable (never-flushed installs).
+ */
+function selectUnshippedRows(
+  raw: Database,
+  spec: LegacyBackfillSpec,
+): LegacyRow[] {
+  const keyPrefix = `telemetry:${spec.sourceId}:last_reported`;
+  const checkpoint = raw.query(
+    /*sql*/ `SELECT value FROM flush_checkpoints WHERE key = ?`,
+  );
+  const atValue = (
+    checkpoint.get(`${keyPrefix}_at`) as { value: string } | null
+  )?.value;
+  const at = atValue != null ? Number(atValue) : null;
+  const id = (checkpoint.get(`${keyPrefix}_id`) as { value: string } | null)
+    ?.value;
+
+  const base = /*sql*/ `SELECT * FROM ${spec.table}`;
+  const order = /*sql*/ ` ORDER BY created_at, id`;
+  if (at == null || !Number.isFinite(at)) {
+    return raw.query(base + order).all() as LegacyRow[];
+  }
+  if (id != null) {
+    return raw
+      .query(
+        base +
+          /*sql*/ ` WHERE created_at > ? OR (created_at = ? AND id > ?)` +
+          order,
+      )
+      .all(at, at, id) as LegacyRow[];
+  }
+  return raw
+    .query(base + /*sql*/ ` WHERE created_at > ?` + order)
+    .all(at) as LegacyRow[];
+}
+
+/**
+ * Drop rows whose conversation no longer exists in the main DB. The redaction
+ * paths delete from `telemetry_events` only, so a backfill selecting purely by
+ * watermark would resurrect rows for already-deleted conversations — the same
+ * liveness filter migration 332 applies via `copyWhere`. NULL-conversation
+ * rows always backfill. No-op for specs without conversation scoping.
+ */
+function dropRedactedConversationRows(
+  mainRaw: Database,
+  spec: LegacyBackfillSpec,
+  rows: LegacyRow[],
+): LegacyRow[] {
+  const column = spec.conversationIdColumn;
+  if (!column) {
+    return rows;
+  }
+  const ids = [
+    ...new Set(
+      rows
+        .map((row) => row[column])
+        .filter((value): value is string => typeof value === "string"),
+    ),
+  ];
+  const live = new Set<string>();
+  for (let i = 0; i < ids.length; i += INSERT_CHUNK_SIZE) {
+    const chunk = ids.slice(i, i + INSERT_CHUNK_SIZE);
+    const found = mainRaw
+      .query(
+        /*sql*/ `SELECT id FROM conversations WHERE id IN (${chunk.map(() => "?").join(", ")})`,
+      )
+      .all(...chunk) as Array<{ id: string }>;
+    for (const row of found) {
+      live.add(row.id);
+    }
+  }
+  return rows.filter((row) => {
+    const conversationId = row[column];
+    return conversationId == null || live.has(String(conversationId));
+  });
+}
+
+function insertOutboxRows(
+  raw: Database,
+  spec: LegacyBackfillSpec,
+  rows: LegacyRow[],
+): void {
+  for (let i = 0; i < rows.length; i += INSERT_CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + INSERT_CHUNK_SIZE);
+    const placeholders = chunk.map(() => "(?, ?, ?, ?, ?)").join(", ");
+    const params = chunk.flatMap((row) => [
+      row.id,
+      spec.sourceId,
+      row.created_at,
+      spec.conversationIdColumn
+        ? (row[spec.conversationIdColumn] ?? null)
+        : null,
+      JSON.stringify(spec.toPayload(row)),
+    ]);
+    raw
+      .query(
+        /*sql*/ `INSERT OR IGNORE INTO telemetry_events (id, name, created_at, conversation_id, payload) VALUES ${placeholders}`,
+      )
+      .run(...params);
+  }
+}
+
+/**
+ * Fold the six legacy per-type telemetry tables (`lifecycle_events`,
+ * `onboarding_events`, `auth_fallback_events`, `skill_loaded_events`,
+ * `watchdog_events`, `config_setting_events`) into the generic
+ * `telemetry_events` outbox (migration 333) and drop them, entirely on the
+ * telemetry database (`assistant-telemetry.db`).
+ *
+ * For each table (skipping any absent from `sqlite_master`): select the rows
+ * the reporter's `flush_checkpoints` watermark marks as unshipped, map each to
+ * its wire `TelemetryEvent` with the frozen mappers above (record-time
+ * payloads, `assistant_version: APP_VERSION` — the same stamp flush-time
+ * mapping would have produced), `INSERT OR IGNORE` them into
+ * `telemetry_events` (idempotent under a re-run after a partial crash), and
+ * drop the legacy table. `conversation_id` is populated only from
+ * `skill_loaded_events`, keeping conversation redaction an indexed delete —
+ * and its rows are first checked against the main DB's `conversations` table
+ * (see {@link dropRedactedConversationRows}) so already-redacted
+ * conversations are never resurrected, mirroring migration 332's `copyWhere`.
+ * Finally the six sources' now-meaningless watermark keys are purged from
+ * `flush_checkpoints` (ack-mode sources delete rows instead of advancing
+ * cursors); the table itself survives for the main-DB-backed watermark
+ * sources (`usage`, `turns`, `tool_executed`).
+ */
+export function migrateBackfillTelemetryEventsOutbox(mainDb: DrizzleDb): void {
+  const mainRaw = getSqliteFrom(mainDb);
+  assertLegacyRelocationsComplete(mainRaw);
+
+  let raw: Database | null = getTelemetrySqlite();
+  if (!raw) {
+    // The dedicated connection failed to open (logged by openDedicatedDb).
+    // Fall back to opening the file directly so the migration still runs —
+    // the singleton will pick it up on a later access. This mirrors the
+    // fail-soft pattern of the other dedicated-DB migrations.
+    raw = new Database(getTelemetryDbPath());
+  }
+
+  const backfilled: Record<string, number> = {};
+  for (const spec of LEGACY_BACKFILL_SPECS) {
+    if (!tableExists(raw, spec.table)) {
+      continue;
+    }
+    const rows = dropRedactedConversationRows(
+      mainRaw,
+      spec,
+      selectUnshippedRows(raw, spec),
+    );
+    insertOutboxRows(raw, spec, rows);
+    raw.exec(/*sql*/ `DROP TABLE ${spec.table}`);
+    backfilled[spec.table] = rows.length;
+  }
+
+  const watermarkKeys = LEGACY_BACKFILL_SPECS.flatMap((spec) => [
+    `telemetry:${spec.sourceId}:last_reported_at`,
+    `telemetry:${spec.sourceId}:last_reported_id`,
+  ]);
+  raw
+    .query(
+      /*sql*/ `DELETE FROM flush_checkpoints WHERE key IN (${watermarkKeys.map(() => "?").join(", ")})`,
+    )
+    .run(...watermarkKeys);
+
+  log.info(
+    { backfilled },
+    "Backfilled unshipped legacy telemetry rows into telemetry_events and dropped the legacy tables",
+  );
+}

--- a/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
+++ b/assistant/src/persistence/migrations/334-backfill-telemetry-events-outbox.ts
@@ -291,11 +291,13 @@ function dropRedactedConversationRows(
   });
 }
 
+/** Returns the number of rows actually inserted (dupes IGNOREd don't count). */
 function insertOutboxRows(
   raw: Database,
   spec: LegacyBackfillSpec,
   rows: LegacyRow[],
-): void {
+): number {
+  let inserted = 0;
   for (let i = 0; i < rows.length; i += INSERT_CHUNK_SIZE) {
     const chunk = rows.slice(i, i + INSERT_CHUNK_SIZE);
     const placeholders = chunk.map(() => "(?, ?, ?, ?, ?)").join(", ");
@@ -308,12 +310,13 @@ function insertOutboxRows(
         : null,
       JSON.stringify(spec.toPayload(row)),
     ]);
-    raw
+    inserted += raw
       .query(
         /*sql*/ `INSERT OR IGNORE INTO telemetry_events (id, name, created_at, conversation_id, payload) VALUES ${placeholders}`,
       )
-      .run(...params);
+      .run(...params).changes;
   }
+  return inserted;
 }
 
 /**
@@ -362,9 +365,8 @@ export function migrateBackfillTelemetryEventsOutbox(mainDb: DrizzleDb): void {
       spec,
       selectUnshippedRows(raw, spec),
     );
-    insertOutboxRows(raw, spec, rows);
+    backfilled[spec.table] = insertOutboxRows(raw, spec, rows);
     raw.exec(/*sql*/ `DROP TABLE ${spec.table}`);
-    backfilled[spec.table] = rows.length;
   }
 
   const watermarkKeys = LEGACY_BACKFILL_SPECS.flatMap((spec) => [

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -274,51 +274,6 @@ export const llmUsageEvents = sqliteTable(
   ],
 );
 
-// Lives on the dedicated telemetry database (assistant-telemetry.db)
-// alongside watchdog_events.
-export const lifecycleEvents = sqliteTable("lifecycle_events", {
-  id: text("id").primaryKey(),
-  eventName: text("event_name").notNull(), // 'app_open' | 'hatch'
-  createdAt: integer("created_at").notNull(),
-});
-
-// Lives on the dedicated telemetry database (assistant-telemetry.db)
-// alongside watchdog_events.
-export const onboardingEvents = sqliteTable("onboarding_events", {
-  id: text("id").primaryKey(),
-  createdAt: integer("created_at").notNull(),
-  screen: text("screen").notNull(),
-  toolsJson: text("tools_json"),
-  tasksJson: text("tasks_json"),
-  tone: text("tone"),
-  googleConnected: integer("google_connected", { mode: "boolean" }),
-  googleScopesJson: text("google_scopes_json"),
-  priorAssistantsJson: text("prior_assistants_json"),
-  abVariant: text("ab_variant"),
-  sessionId: text("session_id"),
-  stepName: text("step_name"),
-  stepIndex: integer("step_index"),
-  completedAt: text("completed_at"),
-  funnelVersion: text("funnel_version"),
-});
-
-// Aggregated legacy-loopback auth-fallback counts forwarded by the gateway.
-// One row per (guard, path, failure_kind) per flush window; `count` is how many
-// requests fell back to the loopback exemption in that window. Flushed to the
-// platform telemetry endpoint by the usage telemetry reporter. Lives on the
-// dedicated telemetry database (assistant-telemetry.db) alongside
-// watchdog_events.
-export const authFallbackEvents = sqliteTable("auth_fallback_events", {
-  id: text("id").primaryKey(),
-  createdAt: integer("created_at").notNull(),
-  guard: text("guard").notNull(), // 'edge' | 'edge-scoped' | 'edge-guardian'
-  path: text("path").notNull(),
-  failureKind: text("failure_kind").notNull(),
-  count: integer("count").notNull(),
-  windowStart: integer("window_start").notNull(),
-  windowEnd: integer("window_end").notNull(),
-});
-
 // One row per conversation started on the activation-rail bootstrap template.
 // Lets the activation funnel telemetry scope its events to activation
 // conversations without inspecting the bootstrap template at emit time.
@@ -326,53 +281,6 @@ export const activationSessions = sqliteTable("activation_sessions", {
   conversationId: text("conversation_id").primaryKey(),
   createdAt: integer("created_at").notNull(),
 });
-
-// One row per `skill_loaded` telemetry event, emitted when a Vellum-produced
-// skill is activated in a conversation — see skill-loaded-events-store.ts for
-// the data contract. Flushed by the usage telemetry reporter. Lives on the
-// dedicated telemetry database (assistant-telemetry.db) alongside
-// watchdog_events.
-export const skillLoadedEvents = sqliteTable(
-  "skill_loaded_events",
-  {
-    id: text("id").primaryKey(),
-    createdAt: integer("created_at").notNull(),
-    conversationId: text("conversation_id"),
-    skillName: text("skill_name").notNull(),
-    // ISO 8601 timestamp from the merged skill catalog, when known.
-    skillUpdatedAt: text("skill_updated_at"),
-    provider: text("provider"),
-    model: text("model"),
-    inferenceProfile: text("inference_profile"),
-    inferenceProfileSource: text("inference_profile_source"),
-  },
-  (table) => [
-    index("idx_skill_loaded_events_created_at_id").on(
-      table.createdAt,
-      table.id,
-    ),
-  ],
-);
-
-// One row per `watchdog` telemetry event, emitted when a daemon watchdog
-// check fires (event-loop block, stream-idle stall, restart, ...) — see
-// watchdog-events-store.ts for the data contract. Flushed by the usage
-// telemetry reporter. `value` is a REAL (BQ FLOAT) so the daemon need not
-// distinguish int vs float; the platform serializer coerces ints to float.
-// `detail` is a JSON bag stored as text and forwarded verbatim.
-export const watchdogEvents = sqliteTable(
-  "watchdog_events",
-  {
-    id: text("id").primaryKey(),
-    createdAt: integer("created_at").notNull(),
-    checkName: text("check_name").notNull(),
-    value: real("value"),
-    detail: text("detail"),
-  },
-  (table) => [
-    index("idx_watchdog_events_created_at_id").on(table.createdAt, table.id),
-  ],
-);
 
 // Key/value store for telemetry flush state — the per-event-type
 // `(last_reported_at, last_reported_id)` watermark cursors advanced by the
@@ -385,27 +293,6 @@ export const flushCheckpoints = sqliteTable("flush_checkpoints", {
   value: text("value").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });
-
-// One row per `config_setting` telemetry event — a tracked config key's
-// effective value; see config-setting-events-store.ts for the data
-// contract. Lives on the dedicated telemetry database
-// (assistant-telemetry.db) alongside watchdog_events. Flushed by the usage
-// telemetry reporter.
-export const configSettingEvents = sqliteTable(
-  "config_setting_events",
-  {
-    id: text("id").primaryKey(),
-    createdAt: integer("created_at").notNull(),
-    configKey: text("config_key").notNull(),
-    configValue: text("config_value").notNull(),
-  },
-  (table) => [
-    index("idx_config_setting_events_created_at_id").on(
-      table.createdAt,
-      table.id,
-    ),
-  ],
-);
 
 // Generic telemetry outbox. Lives on the dedicated telemetry database
 // (assistant-telemetry.db). Each row's `payload` is the wire `TelemetryEvent`

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -406,3 +406,28 @@ export const configSettingEvents = sqliteTable(
     ),
   ],
 );
+
+// Generic telemetry outbox. Lives on the dedicated telemetry database
+// (assistant-telemetry.db). Each row's `payload` is the wire `TelemetryEvent`
+// JSON built at record time; `name` is the telemetry source id (e.g.
+// 'lifecycle'). Rows are deleted on successful flush by the usage telemetry
+// reporter. `conversation_id` is populated only for conversation-scoped
+// events so redaction stays an indexed column delete.
+export const telemetryEvents = sqliteTable(
+  "telemetry_events",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    createdAt: integer("created_at").notNull(),
+    conversationId: text("conversation_id"),
+    payload: text("payload").notNull(),
+  },
+  (table) => [
+    index("idx_telemetry_events_name_created_at_id").on(
+      table.name,
+      table.createdAt,
+      table.id,
+    ),
+    index("idx_telemetry_events_conversation_id").on(table.conversationId),
+  ],
+);

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -441,6 +441,7 @@ import { migrateMoveAuthFallbackEventsToTelemetryDb } from "./migrations/330-mov
 import { migrateMoveLifecycleEventsToTelemetryDb } from "./migrations/331-move-lifecycle-events-to-telemetry-db.js";
 import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/332-move-skill-loaded-events-to-telemetry-db.js";
 import { migrateCreateTelemetryEventsTable } from "./migrations/333-create-telemetry-events-table.js";
+import { migrateBackfillTelemetryEventsOutbox } from "./migrations/334-backfill-telemetry-events-outbox.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1353,4 +1354,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateMoveLifecycleEventsToTelemetryDb,
   migrateMoveSkillLoadedEventsToTelemetryDb,
   migrateCreateTelemetryEventsTable,
+  migrateBackfillTelemetryEventsOutbox,
 ];

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -440,6 +440,7 @@ import { migrateMoveOnboardingEventsToTelemetryDb } from "./migrations/329-move-
 import { migrateMoveAuthFallbackEventsToTelemetryDb } from "./migrations/330-move-auth-fallback-events-to-telemetry-db.js";
 import { migrateMoveLifecycleEventsToTelemetryDb } from "./migrations/331-move-lifecycle-events-to-telemetry-db.js";
 import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/332-move-skill-loaded-events-to-telemetry-db.js";
+import { migrateCreateTelemetryEventsTable } from "./migrations/333-create-telemetry-events-table.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1351,4 +1352,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateMoveAuthFallbackEventsToTelemetryDb,
   migrateMoveLifecycleEventsToTelemetryDb,
   migrateMoveSkillLoadedEventsToTelemetryDb,
+  migrateCreateTelemetryEventsTable,
 ];

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1920,7 +1920,6 @@ export async function handleSendMessage(
             tone: body.onboarding!.tone,
             googleConnected: body.onboarding!.googleConnected,
             googleScopes: body.onboarding!.googleScopes,
-            priorAssistants: body.onboarding!.priorAssistants,
           });
         } catch (err) {
           log.warn({ err }, "Failed to record onboarding telemetry event");
@@ -1983,7 +1982,6 @@ export async function handleSendMessage(
         tone: body.onboarding!.tone,
         googleConnected: body.onboarding!.googleConnected,
         googleScopes: body.onboarding!.googleScopes,
-        priorAssistants: body.onboarding!.priorAssistants,
       });
     } catch (err) {
       log.warn({ err }, "Failed to record onboarding telemetry event");

--- a/assistant/src/security/auth-fallback-events-store.ts
+++ b/assistant/src/security/auth-fallback-events-store.ts
@@ -1,9 +1,9 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
-import { authFallbackEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { insertTelemetryOutboxEvents } from "../telemetry/telemetry-events-outbox.js";
+import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
+import { APP_VERSION } from "../version.js";
 
 /** A single aggregated auth-fallback count for one (guard, path, failure_kind). */
 export interface AuthFallbackCount {
@@ -13,25 +13,16 @@ export interface AuthFallbackCount {
   count: number;
 }
 
-/** A persisted auth-fallback event row. */
-export interface AuthFallbackEvent {
-  id: string;
-  createdAt: number;
-  guard: string;
-  path: string;
-  failureKind: string;
-  count: number;
-  windowStart: number;
-  windowEnd: number;
-}
-
 /**
  * Record a batch of aggregated auth-fallback counts forwarded by the gateway —
- * one row per count entry, all sharing the same flush window. Returns the
- * number of rows recorded, or 0 when usage data collection is disabled (the
- * counts are dropped to honor the opt-out, matching the rest of telemetry) or
- * the telemetry database is unavailable (degraded mode). Callers that must
- * tell those apart check `getCachedShareAnalytics()` themselves.
+ * one `telemetry_events` outbox row per count entry, all sharing the same
+ * flush window, each carrying its full wire event built at record time. The
+ * whole batch inserts atomically, so a failure never leaves a partial batch
+ * committed (the gateway retries the full batch on `recorded === 0`). Returns
+ * the number of rows recorded, or 0 when usage data collection is disabled
+ * (the counts are dropped to honor the opt-out, matching the rest of
+ * telemetry) or the telemetry database is unavailable (degraded mode). Callers
+ * that must tell those apart check `getCachedShareAnalytics()` themselves.
  */
 export function recordAuthFallbackCounts(
   windowStart: number,
@@ -44,63 +35,22 @@ export function recordAuthFallbackCounts(
   if (counts.length === 0) {
     return 0;
   }
-  const db = getTelemetryDb();
-  if (!db) {
-    return 0;
-  }
   const createdAt = Date.now();
-  const rows = counts.map((c) => ({
-    id: uuid(),
-    createdAt,
-    guard: c.guard,
-    path: c.path,
-    failureKind: c.failureKind,
-    count: c.count,
-    windowStart,
-    windowEnd,
-  }));
-  db.insert(authFallbackEvents).values(rows).run();
-  return rows.length;
-}
-
-/**
- * Query auth-fallback events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedAuthFallbackEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): AuthFallbackEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
-  }
-  const rows = db
-    .select({
-      id: authFallbackEvents.id,
-      createdAt: authFallbackEvents.createdAt,
-      guard: authFallbackEvents.guard,
-      path: authFallbackEvents.path,
-      failureKind: authFallbackEvents.failureKind,
-      count: authFallbackEvents.count,
-      windowStart: authFallbackEvents.windowStart,
-      windowEnd: authFallbackEvents.windowEnd,
-    })
-    .from(authFallbackEvents)
-    .where(
-      afterId
-        ? or(
-            gt(authFallbackEvents.createdAt, afterCreatedAt),
-            and(
-              eq(authFallbackEvents.createdAt, afterCreatedAt),
-              gt(authFallbackEvents.id, afterId),
-            ),
-          )
-        : gt(authFallbackEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(authFallbackEvents.createdAt), asc(authFallbackEvents.id))
-    .limit(limit)
-    .all();
-  return rows;
+  const rows = counts.map((c) => {
+    const id = uuid();
+    const event: AuthFallbackTelemetryEvent = {
+      type: "auth_fallback",
+      daemon_event_id: id,
+      recorded_at: createdAt,
+      guard: c.guard,
+      path: c.path,
+      failure_kind: c.failureKind,
+      count: c.count,
+      window_start: windowStart,
+      window_end: windowEnd,
+      assistant_version: APP_VERSION,
+    };
+    return { id, name: "auth_fallback", createdAt, event };
+  });
+  return insertTelemetryOutboxEvents(rows) ? rows.length : 0;
 }

--- a/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
@@ -8,22 +8,17 @@ mock.module("../../platform/consent-cache.js", () => ({
 
 import { getTelemetryDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
-import { configSettingEvents } from "../../persistence/schema/index.js";
-import {
-  queryUnreportedConfigSettingEvents,
-  recordConfigSettingEvent,
-} from "../config-setting-events-store.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
+import { APP_VERSION } from "../../version.js";
+import { recordConfigSettingEvent } from "../config-setting-events-store.js";
+import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
 
 await initializeDb();
 
-function insertEvent(id: string, createdAt: number): void {
-  const db = getTelemetryDb();
-  if (!db) {
-    throw new Error("telemetry DB unavailable in test");
-  }
-  db.insert(configSettingEvents)
-    .values({ id, createdAt, configKey: "memory.enabled", configValue: "true" })
-    .run();
+function pendingConfigSettingPayloads(): Array<Record<string, unknown>> {
+  return queryTelemetryOutboxBatch("config_setting", 100).map(
+    (row) => JSON.parse(row.payload) as Record<string, unknown>,
+  );
 }
 
 function clearEvents(): void {
@@ -31,7 +26,7 @@ function clearEvents(): void {
   if (!db) {
     throw new Error("telemetry DB unavailable in test");
   }
-  db.delete(configSettingEvents).run();
+  db.delete(telemetryEvents).run();
 }
 
 describe("config-setting-events-store", () => {
@@ -40,7 +35,7 @@ describe("config-setting-events-store", () => {
     clearEvents();
   });
 
-  test("honors the share_analytics opt-out (records nothing)", () => {
+  test("honors the share_analytics opt-out (records nothing, returns false)", () => {
     shareAnalytics = false;
     expect(
       recordConfigSettingEvent({
@@ -48,12 +43,10 @@ describe("config-setting-events-store", () => {
         configValue: "true",
       }),
     ).toBe(false);
-    expect(queryUnreportedConfigSettingEvents(0, undefined, 10)).toHaveLength(
-      0,
-    );
+    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(0);
   });
 
-  test("record + query round-trips the key/value pair", () => {
+  test("records the full wire event and returns true", () => {
     expect(
       recordConfigSettingEvent({
         configKey: "memory.v2.enabled",
@@ -61,13 +54,19 @@ describe("config-setting-events-store", () => {
       }),
     ).toBe(true);
 
-    const rows = queryUnreportedConfigSettingEvents(0, undefined, 10);
+    const rows = queryTelemetryOutboxBatch("config_setting", 10);
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
     expect(row.id).toBeString();
     expect(row.createdAt).toBeGreaterThan(0);
-    expect(row.configKey).toBe("memory.v2.enabled");
-    expect(row.configValue).toBe("false");
+    expect(JSON.parse(row.payload)).toEqual({
+      type: "config_setting",
+      daemon_event_id: row.id,
+      recorded_at: row.createdAt,
+      config_key: "memory.v2.enabled",
+      config_value: "false",
+      assistant_version: APP_VERSION,
+    });
   });
 
   test("clamps oversize key and value to the platform bounds", () => {
@@ -76,55 +75,9 @@ describe("config-setting-events-store", () => {
       configValue: "v".repeat(300),
     });
 
-    const rows = queryUnreportedConfigSettingEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.configKey).toBe("k".repeat(128));
-    expect(rows[0]!.configValue).toBe("v".repeat(256));
-  });
-
-  test("returns rows in (createdAt, id) order", () => {
-    insertEvent("cs-b", 2000);
-    insertEvent("cs-a", 1000);
-
-    const rows = queryUnreportedConfigSettingEvents(0, undefined, 100);
-    expect(rows.map((r) => r.id)).toEqual(["cs-a", "cs-b"]);
-  });
-
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    // Two rows in the same millisecond: pagination must use the id
-    // tiebreaker to make forward progress, not loop.
-    insertEvent("cs-1", 5000);
-    insertEvent("cs-2", 5000);
-    insertEvent("cs-3", 6000);
-
-    const first = queryUnreportedConfigSettingEvents(0, undefined, 1);
-    expect(first.map((r) => r.id)).toEqual(["cs-1"]);
-
-    const second = queryUnreportedConfigSettingEvents(
-      first[0]!.createdAt,
-      first[0]!.id,
-      100,
-    );
-    expect(second.map((r) => r.id)).toEqual(["cs-2", "cs-3"]);
-
-    // Without an id cursor the timestamp-only branch is used.
-    expect(
-      queryUnreportedConfigSettingEvents(5000, undefined, 100).map((r) => r.id),
-    ).toEqual(["cs-3"]);
-
-    // Cursor past the last row returns nothing.
-    const last = second[second.length - 1]!;
-    expect(
-      queryUnreportedConfigSettingEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
-  });
-
-  test("honors the limit", () => {
-    insertEvent("cs-l1", 1000);
-    insertEvent("cs-l2", 2000);
-    insertEvent("cs-l3", 3000);
-
-    const rows = queryUnreportedConfigSettingEvents(0, undefined, 2);
-    expect(rows.map((r) => r.id)).toEqual(["cs-l1", "cs-l2"]);
+    const payloads = pendingConfigSettingPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]!.config_key).toBe("k".repeat(128));
+    expect(payloads[0]!.config_value).toBe("v".repeat(256));
   });
 });

--- a/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
@@ -9,12 +9,12 @@ mock.module("../../platform/consent-cache.js", () => ({
 import type { AssistantConfig } from "../../config/schema.js";
 import { getTelemetryDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
-import { configSettingEvents } from "../../persistence/schema/index.js";
-import { queryUnreportedConfigSettingEvents } from "../config-setting-events-store.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
 import {
   recordConfigSettingSnapshot,
   resetConfigSettingSnapshotForTesting,
 } from "../config-setting-snapshot.js";
+import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
 
 await initializeDb();
 
@@ -28,10 +28,13 @@ function makeConfig(
 }
 
 function recordedPairs(): Array<[string, string]> {
-  return queryUnreportedConfigSettingEvents(0, undefined, 100).map((r) => [
-    r.configKey,
-    r.configValue,
-  ]);
+  return queryTelemetryOutboxBatch("config_setting", 100).map((row) => {
+    const event = JSON.parse(row.payload) as {
+      config_key: string;
+      config_value: string;
+    };
+    return [event.config_key, event.config_value];
+  });
 }
 
 function clearEvents(): void {
@@ -39,7 +42,7 @@ function clearEvents(): void {
   if (!db) {
     throw new Error("telemetry DB unavailable in test");
   }
-  db.delete(configSettingEvents).run();
+  db.delete(telemetryEvents).run();
 }
 
 describe("config-setting-snapshot", () => {

--- a/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
@@ -8,28 +8,25 @@ mock.module("../../platform/consent-cache.js", () => ({
 
 import { getTelemetryDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
-import { watchdogEvents } from "../../persistence/schema/index.js";
-import {
-  queryUnreportedWatchdogEvents,
-  recordWatchdogEvent,
-} from "../watchdog-events-store.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
+import { APP_VERSION } from "../../version.js";
+import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
+import { recordWatchdogEvent } from "../watchdog-events-store.js";
 
 await initializeDb();
 
-function insertEvent(
-  id: string,
-  createdAt: number,
-  checkName = "event_loop_blocked",
-): void {
-  const db = getTelemetryDb();
-  if (!db) throw new Error("telemetry DB unavailable in test");
-  db.insert(watchdogEvents).values({ id, createdAt, checkName }).run();
+function pendingWatchdogPayloads(): Array<Record<string, unknown>> {
+  return queryTelemetryOutboxBatch("watchdog", 100).map(
+    (row) => JSON.parse(row.payload) as Record<string, unknown>,
+  );
 }
 
 function clearEvents(): void {
   const db = getTelemetryDb();
-  if (!db) throw new Error("telemetry DB unavailable in test");
-  db.delete(watchdogEvents).run();
+  if (!db) {
+    throw new Error("telemetry DB unavailable in test");
+  }
+  db.delete(telemetryEvents).run();
 }
 
 describe("watchdog-events-store", () => {
@@ -41,35 +38,39 @@ describe("watchdog-events-store", () => {
   test("honors the share_analytics opt-out (records nothing)", () => {
     shareAnalytics = false;
     recordWatchdogEvent({ checkName: "event_loop_blocked", value: 60000 });
-    expect(queryUnreportedWatchdogEvents(0, undefined, 10)).toHaveLength(0);
+    expect(queryTelemetryOutboxBatch("watchdog", 10)).toHaveLength(0);
   });
 
-  test("record + query round-trips all fields", () => {
+  test("records the full wire event, with detail as a nested object", () => {
     recordWatchdogEvent({
       checkName: "event_loop_blocked",
       value: 12345,
       detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
     });
 
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 10);
+    const rows = queryTelemetryOutboxBatch("watchdog", 10);
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
     expect(row.id).toBeString();
     expect(row.createdAt).toBeGreaterThan(0);
-    expect(row.checkName).toBe("event_loop_blocked");
-    expect(row.value).toBe(12345);
-    expect(row.detail).toBe(
-      JSON.stringify({ reason: "no_bytes_60s", threshold_ms: 5000 }),
-    );
+    expect(JSON.parse(row.payload)).toEqual({
+      type: "watchdog",
+      daemon_event_id: row.id,
+      recorded_at: row.createdAt,
+      check_name: "event_loop_blocked",
+      value: 12345,
+      detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
+      assistant_version: APP_VERSION,
+    });
   });
 
-  test("optional fields persist as null", () => {
+  test("omitted value and detail persist as null", () => {
     recordWatchdogEvent({ checkName: "stream_idle" });
 
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      checkName: "stream_idle",
+    const payloads = pendingWatchdogPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      check_name: "stream_idle",
       value: null,
       detail: null,
     });
@@ -82,72 +83,9 @@ describe("watchdog-events-store", () => {
       detail: null,
     });
 
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 10);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.value).toBeNull();
-    expect(rows[0]?.detail).toBeNull();
-  });
-
-  test("returns rows in (createdAt, id) order", () => {
-    insertEvent("wd-b", 2000);
-    insertEvent("wd-a", 1000);
-
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 100);
-    expect(rows.map((r) => r.id)).toEqual(["wd-a", "wd-b"]);
-  });
-
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    // Two rows in the same millisecond: pagination must use the id
-    // tiebreaker to make forward progress, not loop.
-    insertEvent("wd-1", 5000);
-    insertEvent("wd-2", 5000);
-    insertEvent("wd-3", 6000);
-
-    const first = queryUnreportedWatchdogEvents(0, undefined, 1);
-    expect(first.map((r) => r.id)).toEqual(["wd-1"]);
-
-    const second = queryUnreportedWatchdogEvents(
-      first[0]!.createdAt,
-      first[0]!.id,
-      100,
-    );
-    expect(second.map((r) => r.id)).toEqual(["wd-2", "wd-3"]);
-
-    // Without an id cursor the timestamp-only branch is used.
-    expect(
-      queryUnreportedWatchdogEvents(5000, undefined, 100).map((r) => r.id),
-    ).toEqual(["wd-3"]);
-
-    // Cursor past the last row returns nothing.
-    const last = second[second.length - 1]!;
-    expect(
-      queryUnreportedWatchdogEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
-  });
-
-  test("resumes from a persisted watermark without re-reporting", () => {
-    insertEvent("wd-w1", 1000);
-    insertEvent("wd-w2", 2000);
-
-    const batch = queryUnreportedWatchdogEvents(0, undefined, 100);
-    const watermark = batch[batch.length - 1]!;
-
-    insertEvent("wd-w3", 3000);
-
-    const resumed = queryUnreportedWatchdogEvents(
-      watermark.createdAt,
-      watermark.id,
-      100,
-    );
-    expect(resumed.map((r) => r.id)).toEqual(["wd-w3"]);
-  });
-
-  test("honors the limit", () => {
-    insertEvent("wd-l1", 1000);
-    insertEvent("wd-l2", 2000);
-    insertEvent("wd-l3", 3000);
-
-    const rows = queryUnreportedWatchdogEvents(0, undefined, 2);
-    expect(rows.map((r) => r.id)).toEqual(["wd-l1", "wd-l2"]);
+    const payloads = pendingWatchdogPayloads();
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.value).toBeNull();
+    expect(payloads[0]?.detail).toBeNull();
   });
 });

--- a/assistant/src/telemetry/config-setting-events-store.ts
+++ b/assistant/src/telemetry/config-setting-events-store.ts
@@ -1,9 +1,9 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
-import { configSettingEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { APP_VERSION } from "../version.js";
+import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import type { ConfigSettingTelemetryEvent } from "./types.js";
 
 /**
  * Server-side bounds from the platform `ConfigSettingTelemetryEventSerializer`.
@@ -25,22 +25,14 @@ export interface ConfigSettingEventRecord {
   configValue: string;
 }
 
-/** A persisted config_setting event row. */
-export interface ConfigSettingEvent {
-  id: string;
-  createdAt: number;
-  configKey: string;
-  configValue: string;
-}
-
 /**
- * Record a `config_setting` telemetry event. No-ops when usage data
+ * Record a `config_setting` telemetry event. Builds the full wire event and
+ * enqueues it on the `telemetry_events` outbox. No-ops when usage data
  * collection is disabled (the event is dropped to honor the opt-out,
- * matching the rest of telemetry) — so opt-out rows never exist and the
- * reporter's standard 0 watermark default is safe. Returns whether a row
- * was persisted, so a caller with its own dedupe memo
- * (config-setting-snapshot.ts) only advances the memo on a real write and
- * keeps retrying while consent is off or the telemetry DB is unavailable.
+ * matching the rest of telemetry). Returns whether the event was persisted,
+ * so a caller with its own dedupe memo (config-setting-snapshot.ts) only
+ * advances the memo on a real write and keeps retrying while consent is off
+ * or the telemetry DB is unavailable.
  */
 export function recordConfigSettingEvent(
   record: ConfigSettingEventRecord,
@@ -48,54 +40,20 @@ export function recordConfigSettingEvent(
   if (!getCachedShareAnalytics()) {
     return false;
   }
-  const db = getTelemetryDb();
-  if (!db) {
-    return false;
-  }
-  db.insert(configSettingEvents)
-    .values({
-      id: uuid(),
-      createdAt: Date.now(),
-      configKey: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
-      configValue: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
-    })
-    .run();
-  return true;
-}
-
-/**
- * Query config_setting events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedConfigSettingEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): ConfigSettingEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
-  }
-  return db
-    .select({
-      id: configSettingEvents.id,
-      createdAt: configSettingEvents.createdAt,
-      configKey: configSettingEvents.configKey,
-      configValue: configSettingEvents.configValue,
-    })
-    .from(configSettingEvents)
-    .where(
-      afterId
-        ? or(
-            gt(configSettingEvents.createdAt, afterCreatedAt),
-            and(
-              eq(configSettingEvents.createdAt, afterCreatedAt),
-              gt(configSettingEvents.id, afterId),
-            ),
-          )
-        : gt(configSettingEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(configSettingEvents.createdAt), asc(configSettingEvents.id))
-    .limit(limit)
-    .all();
+  const id = uuid();
+  const createdAt = Date.now();
+  const event: ConfigSettingTelemetryEvent = {
+    type: "config_setting",
+    daemon_event_id: id,
+    recorded_at: createdAt,
+    config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
+    config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
+    assistant_version: APP_VERSION,
+  };
+  return insertTelemetryOutboxEvent({
+    id,
+    name: "config_setting",
+    createdAt,
+    event,
+  });
 }

--- a/assistant/src/telemetry/config-setting-events-store.ts
+++ b/assistant/src/telemetry/config-setting-events-store.ts
@@ -1,8 +1,5 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { APP_VERSION } from "../version.js";
-import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
 import type { ConfigSettingTelemetryEvent } from "./types.js";
 
 /**
@@ -37,23 +34,17 @@ export interface ConfigSettingEventRecord {
 export function recordConfigSettingEvent(
   record: ConfigSettingEventRecord,
 ): boolean {
-  if (!getCachedShareAnalytics()) {
-    return false;
-  }
-  const id = uuid();
-  const createdAt = Date.now();
-  const event: ConfigSettingTelemetryEvent = {
-    type: "config_setting",
-    daemon_event_id: id,
-    recorded_at: createdAt,
-    config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
-    config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
-    assistant_version: APP_VERSION,
-  };
-  return insertTelemetryOutboxEvent({
-    id,
-    name: "config_setting",
-    createdAt,
-    event,
-  });
+  return (
+    recordTelemetryOutboxEvent(
+      "config_setting",
+      (id, createdAt): ConfigSettingTelemetryEvent => ({
+        type: "config_setting",
+        daemon_event_id: id,
+        recorded_at: createdAt,
+        config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
+        config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
+        assistant_version: APP_VERSION,
+      }),
+    ) !== null
+  );
 }

--- a/assistant/src/telemetry/skill-loaded-events-store.test.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.test.ts
@@ -8,38 +8,42 @@ mock.module("../platform/consent-cache.js", () => ({
 
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { skillLoadedEvents } from "../persistence/schema/index.js";
-import {
-  queryUnreportedSkillLoadedEvents,
-  recordSkillLoadedEvent,
-} from "./skill-loaded-events-store.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
+import { APP_VERSION } from "../version.js";
+import { recordSkillLoadedEvent } from "./skill-loaded-events-store.js";
 
 await initializeDb();
 
-function insertEvent(
-  id: string,
-  createdAt: number,
-  skillName = "web-research",
-): void {
-  getTelemetryDb()!
-    .insert(skillLoadedEvents)
-    .values({ id, createdAt, skillName })
-    .run();
+function pendingRows(): Array<{
+  id: string;
+  name: string;
+  createdAt: number;
+  conversationId: string | null;
+  payload: Record<string, unknown>;
+}> {
+  return getTelemetryDb()!
+    .select()
+    .from(telemetryEvents)
+    .all()
+    .map((row) => ({
+      ...row,
+      payload: JSON.parse(row.payload) as Record<string, unknown>,
+    }));
 }
 
 describe("skill-loaded-events-store", () => {
   beforeEach(() => {
     shareAnalytics = true;
-    getTelemetryDb()!.delete(skillLoadedEvents).run();
+    getTelemetryDb()!.delete(telemetryEvents).run();
   });
 
   test("honors the share_analytics opt-out (records nothing)", () => {
     shareAnalytics = false;
     recordSkillLoadedEvent({ skillName: "web-research" });
-    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
+    expect(pendingRows()).toHaveLength(0);
   });
 
-  test("record + query round-trips all fields", () => {
+  test("record writes the full wire payload into the outbox", () => {
     recordSkillLoadedEvent({
       conversationId: "conv-xyz",
       skillName: "web-research",
@@ -50,98 +54,45 @@ describe("skill-loaded-events-store", () => {
       inferenceProfileSource: "active-profile",
     });
 
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    const rows = pendingRows();
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
+    expect(row.name).toBe("skill_loaded");
     expect(row.id).toBeString();
     expect(row.createdAt).toBeGreaterThan(0);
-    expect(row).toMatchObject({
-      conversationId: "conv-xyz",
-      skillName: "web-research",
-      skillUpdatedAt: "2026-06-01T00:00:00.000Z",
+    // Dedicated column, so conversation deletion redacts pending rows via an
+    // indexed delete.
+    expect(row.conversationId).toBe("conv-xyz");
+    expect(row.payload).toEqual({
+      type: "skill_loaded",
+      daemon_event_id: row.id,
+      recorded_at: row.createdAt,
+      skill_name: "web-research",
+      skill_updated_at: "2026-06-01T00:00:00.000Z",
+      conversation_id: "conv-xyz",
       provider: "anthropic",
       model: "model-a",
-      inferenceProfile: "balanced",
-      inferenceProfileSource: "active-profile",
+      inference_profile: "balanced",
+      inference_profile_source: "active-profile",
+      assistant_version: APP_VERSION,
     });
   });
 
-  test("optional fields persist as null", () => {
+  test("optional fields ship as null and leave the conversation column null", () => {
     recordSkillLoadedEvent({ skillName: "tasks" });
 
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    const rows = pendingRows();
     expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      skillName: "tasks",
-      conversationId: null,
-      skillUpdatedAt: null,
+    expect(rows[0]!.conversationId).toBeNull();
+    expect(rows[0]!.payload).toMatchObject({
+      type: "skill_loaded",
+      skill_name: "tasks",
+      skill_updated_at: null,
+      conversation_id: null,
       provider: null,
       model: null,
-      inferenceProfile: null,
-      inferenceProfileSource: null,
+      inference_profile: null,
+      inference_profile_source: null,
     });
-  });
-
-  test("returns rows in (createdAt, id) order", () => {
-    insertEvent("sle-b", 2000);
-    insertEvent("sle-a", 1000);
-
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 100);
-    expect(rows.map((r) => r.id)).toEqual(["sle-a", "sle-b"]);
-  });
-
-  test("query advances past the compound (createdAt, id) cursor", () => {
-    // Two rows in the same millisecond: pagination must use the id
-    // tiebreaker to make forward progress, not loop.
-    insertEvent("sle-1", 5000);
-    insertEvent("sle-2", 5000);
-    insertEvent("sle-3", 6000);
-
-    const first = queryUnreportedSkillLoadedEvents(0, undefined, 1);
-    expect(first.map((r) => r.id)).toEqual(["sle-1"]);
-
-    const second = queryUnreportedSkillLoadedEvents(
-      first[0]!.createdAt,
-      first[0]!.id,
-      100,
-    );
-    expect(second.map((r) => r.id)).toEqual(["sle-2", "sle-3"]);
-
-    // Without an id cursor the timestamp-only branch is used.
-    expect(
-      queryUnreportedSkillLoadedEvents(5000, undefined, 100).map((r) => r.id),
-    ).toEqual(["sle-3"]);
-
-    // Cursor past the last row returns nothing.
-    const last = second[second.length - 1]!;
-    expect(
-      queryUnreportedSkillLoadedEvents(last.createdAt, last.id, 100).length,
-    ).toBe(0);
-  });
-
-  test("resumes from a persisted watermark without re-reporting", () => {
-    insertEvent("sle-w1", 1000);
-    insertEvent("sle-w2", 2000);
-
-    const batch = queryUnreportedSkillLoadedEvents(0, undefined, 100);
-    const watermark = batch[batch.length - 1]!;
-
-    insertEvent("sle-w3", 3000);
-
-    const resumed = queryUnreportedSkillLoadedEvents(
-      watermark.createdAt,
-      watermark.id,
-      100,
-    );
-    expect(resumed.map((r) => r.id)).toEqual(["sle-w3"]);
-  });
-
-  test("honors the limit", () => {
-    insertEvent("sle-l1", 1000);
-    insertEvent("sle-l2", 2000);
-    insertEvent("sle-l3", 3000);
-
-    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 2);
-    expect(rows.map((r) => r.id)).toEqual(["sle-l1", "sle-l2"]);
   });
 });

--- a/assistant/src/telemetry/skill-loaded-events-store.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.ts
@@ -1,16 +1,17 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
-import { skillLoadedEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import type { UsageAttributionColumns } from "../usage/attribution.js";
+import type { UsageAttributionProfileSource } from "../usage/types.js";
+import { APP_VERSION } from "../version.js";
+import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import type { SkillLoadedTelemetryEvent } from "./types.js";
 
 /**
  * Input for one `skill_loaded` telemetry event. Metadata only — never skill
  * output or conversation content. The attribution columns reuse the shared
  * nullable shape from `toAttributionColumns` so producers can spread it
- * directly; null and absent both persist as NULL.
+ * directly; null and absent both ship as null.
  */
 export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns> {
   conversationId?: string;
@@ -19,85 +20,40 @@ export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns>
   skillUpdatedAt?: string;
 }
 
-/** A persisted skill_loaded event row. */
-export interface SkillLoadedEvent {
-  id: string;
-  createdAt: number;
-  conversationId: string | null;
-  skillName: string;
-  skillUpdatedAt: string | null;
-  provider: string | null;
-  model: string | null;
-  inferenceProfile: string | null;
-  inferenceProfileSource: string | null;
-}
-
 /**
- * Record a `skill_loaded` telemetry event for a skill activation. No-ops when
- * usage data collection is disabled (the event is dropped to honor the
- * opt-out, matching the rest of telemetry).
+ * Record a `skill_loaded` telemetry event for a skill activation. The full
+ * wire event (record-time `assistant_version` included) goes into the
+ * `telemetry_events` outbox, with the conversation id in its dedicated
+ * column so conversation deletion redacts pending rows via an indexed
+ * delete. No-ops when usage data collection is disabled (the event is
+ * dropped to honor the opt-out, matching the rest of telemetry) or when the
+ * telemetry DB is unavailable.
  */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
   if (!getCachedShareAnalytics()) {
     return;
   }
-  const db = getTelemetryDb();
-  if (!db) {
-    return;
-  }
-  db.insert(skillLoadedEvents)
-    .values({
-      id: uuid(),
-      createdAt: Date.now(),
-      conversationId: record.conversationId,
-      skillName: record.skillName,
-      skillUpdatedAt: record.skillUpdatedAt,
-      provider: record.provider,
-      model: record.model,
-      inferenceProfile: record.inferenceProfile,
-      inferenceProfileSource: record.inferenceProfileSource,
-    })
-    .run();
-}
-
-/**
- * Query skill_loaded events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedSkillLoadedEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): SkillLoadedEvent[] {
-  const db = getTelemetryDb();
-  if (!db) {
-    return [];
-  }
-  return db
-    .select({
-      id: skillLoadedEvents.id,
-      createdAt: skillLoadedEvents.createdAt,
-      conversationId: skillLoadedEvents.conversationId,
-      skillName: skillLoadedEvents.skillName,
-      skillUpdatedAt: skillLoadedEvents.skillUpdatedAt,
-      provider: skillLoadedEvents.provider,
-      model: skillLoadedEvents.model,
-      inferenceProfile: skillLoadedEvents.inferenceProfile,
-      inferenceProfileSource: skillLoadedEvents.inferenceProfileSource,
-    })
-    .from(skillLoadedEvents)
-    .where(
-      afterId
-        ? or(
-            gt(skillLoadedEvents.createdAt, afterCreatedAt),
-            and(
-              eq(skillLoadedEvents.createdAt, afterCreatedAt),
-              gt(skillLoadedEvents.id, afterId),
-            ),
-          )
-        : gt(skillLoadedEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(skillLoadedEvents.createdAt), asc(skillLoadedEvents.id))
-    .limit(limit)
-    .all();
+  const id = uuid();
+  const createdAt = Date.now();
+  const event: SkillLoadedTelemetryEvent = {
+    type: "skill_loaded",
+    daemon_event_id: id,
+    recorded_at: createdAt,
+    skill_name: record.skillName,
+    skill_updated_at: record.skillUpdatedAt ?? null,
+    conversation_id: record.conversationId ?? null,
+    provider: record.provider ?? null,
+    model: record.model ?? null,
+    inference_profile: record.inferenceProfile ?? null,
+    inference_profile_source: (record.inferenceProfileSource ??
+      null) as UsageAttributionProfileSource | null,
+    assistant_version: APP_VERSION,
+  };
+  insertTelemetryOutboxEvent({
+    id,
+    name: "skill_loaded",
+    createdAt,
+    conversationId: record.conversationId ?? null,
+    event,
+  });
 }

--- a/assistant/src/telemetry/skill-loaded-events-store.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.ts
@@ -1,10 +1,7 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import type { UsageAttributionColumns } from "../usage/attribution.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { APP_VERSION } from "../version.js";
-import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
 import type { SkillLoadedTelemetryEvent } from "./types.js";
 
 /**
@@ -30,30 +27,22 @@ export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns>
  * telemetry DB is unavailable.
  */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
-  if (!getCachedShareAnalytics()) {
-    return;
-  }
-  const id = uuid();
-  const createdAt = Date.now();
-  const event: SkillLoadedTelemetryEvent = {
-    type: "skill_loaded",
-    daemon_event_id: id,
-    recorded_at: createdAt,
-    skill_name: record.skillName,
-    skill_updated_at: record.skillUpdatedAt ?? null,
-    conversation_id: record.conversationId ?? null,
-    provider: record.provider ?? null,
-    model: record.model ?? null,
-    inference_profile: record.inferenceProfile ?? null,
-    inference_profile_source: (record.inferenceProfileSource ??
-      null) as UsageAttributionProfileSource | null,
-    assistant_version: APP_VERSION,
-  };
-  insertTelemetryOutboxEvent({
-    id,
-    name: "skill_loaded",
-    createdAt,
-    conversationId: record.conversationId ?? null,
-    event,
-  });
+  recordTelemetryOutboxEvent(
+    "skill_loaded",
+    (id, createdAt): SkillLoadedTelemetryEvent => ({
+      type: "skill_loaded",
+      daemon_event_id: id,
+      recorded_at: createdAt,
+      skill_name: record.skillName,
+      skill_updated_at: record.skillUpdatedAt ?? null,
+      conversation_id: record.conversationId ?? null,
+      provider: record.provider ?? null,
+      model: record.model ?? null,
+      inference_profile: record.inferenceProfile ?? null,
+      inference_profile_source: (record.inferenceProfileSource ??
+        null) as UsageAttributionProfileSource | null,
+      assistant_version: APP_VERSION,
+    }),
+    { conversationId: record.conversationId ?? null },
+  );
 }

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -9,7 +9,6 @@
  * which sources its reporter instance is constructed with.
  */
 
-import { queryUnreportedOnboardingEvents } from "../onboarding/onboarding-events-store.js";
 import { queryUnreportedLifecycleEvents } from "../persistence/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../persistence/llm-usage-store.js";
 import {
@@ -20,10 +19,6 @@ import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-eve
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
-import {
-  type ActivationStepName,
-  buildActivationDaemonEventId,
-} from "./activation-funnel.js";
 import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
 import {
   deleteTelemetryOutboxEvents,
@@ -422,52 +417,9 @@ const lifecycleSource = simpleSource(
   }),
 );
 
-const onboardingSource = simpleSource(
-  "onboarding",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedOnboardingEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "onboarding",
-    // Wire-only override for activation rows: a deterministic id keyed
-    // on funnel_version/session/step lets dbt collapse a moment that
-    // fires more than once. Key on the ROW's stored `funnelVersion`
-    // (not the binary's current constant) so rows recorded under an
-    // older version — flushed offline or after an upgrade — keep a
-    // stable id and still collapse with already-ingested rows. The
-    // SQLite watermark cursor still uses `e.id`/`e.createdAt`, so this
-    // override is checkpoint-safe.
-    daemon_event_id:
-      e.sessionId && e.stepName && e.funnelVersion
-        ? buildActivationDaemonEventId(
-            e.sessionId,
-            e.stepName as ActivationStepName,
-            e.funnelVersion,
-          )
-        : e.id,
-    recorded_at: e.createdAt,
-    screen: e.screen,
-    ...(e.toolsJson ? { tools: JSON.parse(e.toolsJson) } : {}),
-    ...(e.tasksJson ? { tasks: JSON.parse(e.tasksJson) } : {}),
-    ...(e.tone ? { tone: e.tone } : {}),
-    ...(e.googleConnected != null
-      ? { google_connected: e.googleConnected }
-      : {}),
-    ...(e.googleScopesJson
-      ? { google_scopes: JSON.parse(e.googleScopesJson) }
-      : {}),
-    ...(e.abVariant ? { ab_variant: e.abVariant } : {}),
-    // Activation funnel fields — only present on activation rows.
-    ...(e.sessionId ? { session_id: e.sessionId } : {}),
-    ...(e.stepName ? { step_name: e.stepName } : {}),
-    ...(e.stepIndex != null ? { step_index: e.stepIndex } : {}),
-    ...(e.completedAt ? { completed_at: e.completedAt } : {}),
-    ...(e.funnelVersion ? { funnel_version: e.funnelVersion } : {}),
-    // Onboarding events carry no record-time version column — stamp the
-    // running binary's `APP_VERSION`. Adding one (mirroring
-    // `llm_usage_events`) is a known follow-up.
-    assistant_version: APP_VERSION,
-  }),
-);
+// Onboarding/activation events are outbox-backed: the store builds the wire
+// event (including the activation daemon_event_id override) at record time.
+const onboardingSource = outboxSource("onboarding");
 
 const authFallbackSource = simpleSource(
   "auth_fallback",

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -45,6 +45,13 @@ export interface TelemetryCursor {
 export interface TelemetryEventSourceBatch {
   /** Wire events for the rows reportable this cycle, in cursor order. */
   events: TelemetryEvent[];
+  /**
+   * Row ids backing `events`, set by ack-mode sources so the reporter can
+   * acknowledge (delete) exactly the shipped rows. These are ROW ids, not
+   * wire `daemon_event_id`s — the onboarding source overrides
+   * `daemon_event_id` for activation rows, so the two can differ.
+   */
+  rowIds?: string[];
   /** Cursor of the last reportable row; null when nothing is reportable. */
   lastCursor: TelemetryCursor | null;
   /**
@@ -72,6 +79,17 @@ export interface TelemetryEventSource {
     afterId: string | undefined,
     limit: number,
   ): TelemetryEventSourceBatch;
+  /**
+   * Delete-on-flush mode. Both operations are required together: `acknowledge`
+   * deletes the rows behind {@link TelemetryEventSourceBatch.rowIds} after a
+   * 2xx from the ingest endpoint, and `discardPending` drops all pending rows
+   * on an opted-out flush (watermark writes are meaningless for ack-mode
+   * sources, so they never touch `flush_checkpoints`).
+   */
+  ack?: {
+    acknowledge(rowIds: string[]): void;
+    discardPending(): void;
+  };
 }
 
 /** The `flush_checkpoints` keys holding a source's compound cursor. */

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -14,7 +14,6 @@ import {
   getCachedShareDiagnostics,
   getCachedShareDiagnosticsVersion,
 } from "../platform/consent-cache.js";
-import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-events-store.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
@@ -404,28 +403,7 @@ const lifecycleSource = outboxSource("lifecycle");
 // event (including the activation daemon_event_id override) at record time.
 const onboardingSource = outboxSource("onboarding");
 
-const authFallbackSource = simpleSource(
-  "auth_fallback",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedAuthFallbackEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "auth_fallback",
-    daemon_event_id: e.id,
-    recorded_at: e.createdAt,
-    guard: e.guard,
-    path: e.path,
-    failure_kind: e.failureKind,
-    count: e.count,
-    window_start: e.windowStart,
-    window_end: e.windowEnd,
-    // Aggregated counts forwarded by the gateway carry no record-time
-    // binary version; stamp the running binary's `APP_VERSION` so the
-    // wire value is concrete rather than an explicit null that would
-    // override the envelope under the platform's per-event-wins
-    // contract.
-    assistant_version: APP_VERSION,
-  }),
-);
+const authFallbackSource = outboxSource("auth_fallback");
 
 const toolExecutedSource = simpleSource(
   "tool_executed",

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -26,6 +26,11 @@ import {
 } from "./activation-funnel.js";
 import { queryUnreportedConfigSettingEvents } from "./config-setting-events-store.js";
 import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
+import {
+  deleteTelemetryOutboxEvents,
+  discardPendingTelemetryOutboxEvents,
+  queryTelemetryOutboxBatch,
+} from "./telemetry-events-outbox.js";
 import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
 import { isDiagnosticsConsentVersionEligible } from "./trace-collection-policy.js";
 import { queryUnreportedTurnEvents } from "./turn-events-store.js";
@@ -127,6 +132,60 @@ function simpleSource<Row extends { id: string; createdAt: number }>(
         lastCursor: last ? { createdAt: last.createdAt, id: last.id } : null,
         fullBatch: rows.length === limit,
       };
+    },
+  };
+}
+
+/**
+ * Build an ack-mode source over the generic `telemetry_events` outbox for one
+ * event name. `collect` ignores the cursor args — acknowledged rows are
+ * deleted, so the head of the queue is always the next batch — and parses
+ * each stored payload into its wire event. A row whose payload does not parse
+ * to an object is purged immediately with a warn: an early empty-batch return
+ * in the reporter would otherwise strand it at the head of the queue forever.
+ */
+export function outboxSource(name: string): TelemetryEventSource {
+  return {
+    id: name,
+    collect(_afterCreatedAt, _afterId, limit) {
+      const rows = queryTelemetryOutboxBatch(name, limit);
+      const events: TelemetryEvent[] = [];
+      const rowIds: string[] = [];
+      const corruptIds: string[] = [];
+      for (const row of rows) {
+        let event: TelemetryEvent | null = null;
+        try {
+          const parsed = JSON.parse(row.payload) as unknown;
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            event = parsed as TelemetryEvent;
+          }
+        } catch {
+          // Fall through to the purge below.
+        }
+        if (event) {
+          events.push(event);
+          rowIds.push(row.id);
+        } else {
+          corruptIds.push(row.id);
+          log.warn(
+            { name, rowId: row.id, payloadLength: row.payload.length },
+            "Telemetry outbox: unparseable payload — purging row",
+          );
+        }
+      }
+      if (corruptIds.length > 0) {
+        deleteTelemetryOutboxEvents(corruptIds);
+      }
+      return {
+        events,
+        rowIds,
+        lastCursor: null,
+        fullBatch: rows.length === limit,
+      };
+    },
+    ack: {
+      acknowledge: (rowIds) => deleteTelemetryOutboxEvents(rowIds),
+      discardPending: () => discardPendingTelemetryOutboxEvents(name),
     },
   };
 }

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -24,7 +24,6 @@ import {
   type ActivationStepName,
   buildActivationDaemonEventId,
 } from "./activation-funnel.js";
-import { queryUnreportedConfigSettingEvents } from "./config-setting-events-store.js";
 import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
 import {
   deleteTelemetryOutboxEvents,
@@ -36,7 +35,6 @@ import { isDiagnosticsConsentVersionEligible } from "./trace-collection-policy.j
 import { queryUnreportedTurnEvents } from "./turn-events-store.js";
 import { assembleBoundedTurnTrace, isTurnSettled } from "./turn-trace-store.js";
 import type { TelemetryEvent, TurnTelemetryClientInfo } from "./types.js";
-import { queryUnreportedWatchdogEvents } from "./watchdog-events-store.js";
 
 const log = getLogger("usage-telemetry");
 
@@ -188,39 +186,6 @@ export function outboxSource(name: string): TelemetryEventSource {
       discardPending: () => discardPendingTelemetryOutboxEvents(name),
     },
   };
-}
-
-// ---------------------------------------------------------------------------
-// Wire-mapping helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Parse a stored `watchdog_events.detail` JSON text column into the object the
- * platform expects. Returns null for a null column or an unparseable/corrupted
- * blob (mirroring the turn `client` metadata parse: a bad blob emits null
- * rather than failing the batch). A non-object (e.g. a bare number or string)
- * also resolves to null, since the platform serializer treats `detail` as a
- * JSON object bag.
- */
-function parseWatchdogDetail(
-  raw: string | null,
-): Record<string, unknown> | null {
-  if (!raw) {
-    return null;
-  }
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-    return null;
-  } catch {
-    log.warn(
-      { rawDetail: raw.slice(0, 200) },
-      "Telemetry watchdog: failed to parse detail; emitting null",
-    );
-    return null;
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -579,43 +544,9 @@ const skillLoadedSource = simpleSource(
   }),
 );
 
-const watchdogSource = simpleSource(
-  "watchdog",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedWatchdogEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "watchdog",
-    daemon_event_id: e.id,
-    recorded_at: e.createdAt,
-    check_name: e.checkName,
-    value: e.value,
-    // `detail` is stored as JSON text; parse defensively so a
-    // corrupted blob never fails the batch flush. A parse failure
-    // emits null rather than dropping the event.
-    detail: parseWatchdogDetail(e.detail),
-    // `watchdog_events` has no record-time version column — same
-    // upload-time APP_VERSION stamping as the other non-llm_usage
-    // event types.
-    assistant_version: APP_VERSION,
-  }),
-);
+const watchdogSource = outboxSource("watchdog");
 
-const configSettingSource = simpleSource(
-  "config_setting",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedConfigSettingEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "config_setting",
-    daemon_event_id: e.id,
-    recorded_at: e.createdAt,
-    config_key: e.configKey,
-    config_value: e.configValue,
-    // `config_setting_events` has no record-time version column —
-    // same upload-time APP_VERSION stamping as the other
-    // non-llm_usage event types.
-    assistant_version: APP_VERSION,
-  }),
-);
+const configSettingSource = outboxSource("config_setting");
 
 /**
  * Watermark key namespace of the tool_executed source — referenced by the

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -18,7 +18,6 @@ import { queryUnreportedAuthFallbackEvents } from "../security/auth-fallback-eve
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
-import { queryUnreportedSkillLoadedEvents } from "./skill-loaded-events-store.js";
 import {
   deleteTelemetryOutboxEvents,
   discardPendingTelemetryOutboxEvents,
@@ -457,28 +456,7 @@ const toolExecutedSource = simpleSource(
   }),
 );
 
-const skillLoadedSource = simpleSource(
-  "skill_loaded",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedSkillLoadedEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "skill_loaded",
-    daemon_event_id: e.id,
-    recorded_at: e.createdAt,
-    skill_name: e.skillName,
-    skill_updated_at: e.skillUpdatedAt,
-    conversation_id: e.conversationId,
-    provider: e.provider,
-    model: e.model,
-    inference_profile: e.inferenceProfile,
-    inference_profile_source:
-      e.inferenceProfileSource as UsageAttributionProfileSource | null,
-    // `skill_loaded_events` has no record-time version column — same
-    // upload-time APP_VERSION stamping as the other non-llm_usage
-    // event types.
-    assistant_version: APP_VERSION,
-  }),
-);
+const skillLoadedSource = outboxSource("skill_loaded");
 
 const watchdogSource = outboxSource("watchdog");
 

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -9,7 +9,6 @@
  * which sources its reporter instance is constructed with.
  */
 
-import { queryUnreportedLifecycleEvents } from "../persistence/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../persistence/llm-usage-store.js";
 import {
   getCachedShareDiagnostics,
@@ -400,22 +399,7 @@ const turnSource: TelemetryEventSource = {
   },
 };
 
-const lifecycleSource = simpleSource(
-  "lifecycle",
-  (afterCreatedAt, afterId, limit) =>
-    queryUnreportedLifecycleEvents(afterCreatedAt, afterId, limit),
-  (e): TelemetryEvent => ({
-    type: "lifecycle",
-    daemon_event_id: e.id,
-    event_name: e.eventName,
-    recorded_at: e.createdAt,
-    // Lifecycle events carry no record-time version column — stamp the
-    // running binary's `APP_VERSION`. Adding the record-time column to
-    // `lifecycle_events` (#18112) is a separate follow-up that mirrors
-    // `llm_usage_events`.
-    assistant_version: APP_VERSION,
-  }),
-);
+const lifecycleSource = outboxSource("lifecycle");
 
 // Onboarding/activation events are outbox-backed: the store builds the wire
 // event (including the activation daemon_event_id override) at record time.

--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getTelemetryDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
+import {
+  deleteTelemetryOutboxEvents,
+  discardPendingTelemetryOutboxEvents,
+  insertTelemetryOutboxEvent,
+  queryTelemetryOutboxBatch,
+} from "./telemetry-events-outbox.js";
+import type { LifecycleTelemetryEvent } from "./types.js";
+
+await initializeDb();
+
+function lifecycleEvent(
+  id: string,
+  createdAt: number,
+): LifecycleTelemetryEvent {
+  return {
+    type: "lifecycle",
+    daemon_event_id: id,
+    event_name: "app_open",
+    recorded_at: createdAt,
+    assistant_version: "1.2.3",
+  };
+}
+
+function insert(
+  id: string,
+  createdAt: number,
+  name = "lifecycle",
+  conversationId?: string | null,
+): boolean {
+  return insertTelemetryOutboxEvent({
+    id,
+    name,
+    createdAt,
+    conversationId,
+    event: lifecycleEvent(id, createdAt),
+  });
+}
+
+function allIds(): string[] {
+  return queryTelemetryOutboxBatch("lifecycle", 10_000).map((r) => r.id);
+}
+
+describe("telemetry-events-outbox", () => {
+  beforeEach(() => {
+    getTelemetryDb()!.delete(telemetryEvents).run();
+  });
+
+  test("insert + query round-trips the wire payload", () => {
+    expect(insert("evt-1", 1000)).toBe(true);
+
+    const rows = queryTelemetryOutboxBatch("lifecycle", 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: "evt-1", createdAt: 1000 });
+    expect(JSON.parse(rows[0]!.payload)).toEqual(lifecycleEvent("evt-1", 1000));
+  });
+
+  test("conversation_id persists in its dedicated column", () => {
+    insert("evt-conv", 1000, "lifecycle", "conv-1");
+    insert("evt-null", 2000, "lifecycle");
+
+    const rows = getTelemetryDb()!
+      .select({
+        id: telemetryEvents.id,
+        conversationId: telemetryEvents.conversationId,
+      })
+      .from(telemetryEvents)
+      .all()
+      .sort((a, b) => a.id.localeCompare(b.id));
+    expect(rows).toEqual([
+      { id: "evt-conv", conversationId: "conv-1" },
+      { id: "evt-null", conversationId: null },
+    ]);
+  });
+
+  test("orders by (created_at, id) with id as tiebreaker", () => {
+    insert("evt-b", 2000);
+    insert("evt-c", 1000);
+    insert("evt-a", 1000);
+
+    expect(allIds()).toEqual(["evt-a", "evt-c", "evt-b"]);
+  });
+
+  test("honors the limit", () => {
+    insert("evt-1", 1000);
+    insert("evt-2", 2000);
+    insert("evt-3", 3000);
+
+    const rows = queryTelemetryOutboxBatch("lifecycle", 2);
+    expect(rows.map((r) => r.id)).toEqual(["evt-1", "evt-2"]);
+  });
+
+  test("queries are isolated per event name", () => {
+    insert("evt-life", 1000, "lifecycle");
+    insert("evt-watch", 1000, "watchdog");
+
+    expect(allIds()).toEqual(["evt-life"]);
+    expect(queryTelemetryOutboxBatch("watchdog", 10).map((r) => r.id)).toEqual([
+      "evt-watch",
+    ]);
+    expect(queryTelemetryOutboxBatch("onboarding", 10)).toEqual([]);
+  });
+
+  test("deletes rows by id", () => {
+    insert("evt-1", 1000);
+    insert("evt-2", 2000);
+    insert("evt-3", 3000);
+
+    deleteTelemetryOutboxEvents(["evt-1", "evt-3"]);
+
+    expect(allIds()).toEqual(["evt-2"]);
+  });
+
+  test("delete with an empty id list is a no-op", () => {
+    insert("evt-1", 1000);
+
+    deleteTelemetryOutboxEvents([]);
+
+    expect(allIds()).toEqual(["evt-1"]);
+  });
+
+  test("deletes more than one chunk of ids", () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 501; i++) {
+      const id = `evt-${String(i).padStart(4, "0")}`;
+      ids.push(id);
+      insert(id, i);
+    }
+    insert("evt-keep", 9999);
+
+    deleteTelemetryOutboxEvents(ids);
+
+    expect(allIds()).toEqual(["evt-keep"]);
+  });
+
+  test("discards all pending rows for one name only", () => {
+    insert("evt-1", 1000, "lifecycle");
+    insert("evt-2", 2000, "lifecycle");
+    insert("evt-other", 1000, "watchdog");
+
+    discardPendingTelemetryOutboxEvents("lifecycle");
+
+    expect(allIds()).toEqual([]);
+    expect(queryTelemetryOutboxBatch("watchdog", 10).map((r) => r.id)).toEqual([
+      "evt-other",
+    ]);
+  });
+});

--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 
+import * as dbConnection from "../persistence/db-connection.js";
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
@@ -7,6 +8,7 @@ import {
   deleteTelemetryOutboxEvents,
   discardPendingTelemetryOutboxEvents,
   insertTelemetryOutboxEvent,
+  insertTelemetryOutboxEvents,
   queryTelemetryOutboxBatch,
 } from "./telemetry-events-outbox.js";
 import type { LifecycleTelemetryEvent } from "./types.js";
@@ -57,6 +59,85 @@ describe("telemetry-events-outbox", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ id: "evt-1", createdAt: 1000 });
     expect(JSON.parse(rows[0]!.payload)).toEqual(lifecycleEvent("evt-1", 1000));
+  });
+
+  test("batch insert lands every row", () => {
+    const inserted = insertTelemetryOutboxEvents([
+      {
+        id: "evt-1",
+        name: "lifecycle",
+        createdAt: 1000,
+        event: lifecycleEvent("evt-1", 1000),
+      },
+      {
+        id: "evt-2",
+        name: "lifecycle",
+        createdAt: 2000,
+        event: lifecycleEvent("evt-2", 2000),
+      },
+      {
+        id: "evt-3",
+        name: "lifecycle",
+        createdAt: 3000,
+        event: lifecycleEvent("evt-3", 3000),
+      },
+    ]);
+    expect(inserted).toBe(true);
+    expect(allIds()).toEqual(["evt-1", "evt-2", "evt-3"]);
+  });
+
+  test("batch insert is all-or-nothing on a mid-batch failure", () => {
+    insert("evt-dup", 500);
+
+    expect(() =>
+      insertTelemetryOutboxEvents([
+        {
+          id: "evt-new-1",
+          name: "lifecycle",
+          createdAt: 1000,
+          event: lifecycleEvent("evt-new-1", 1000),
+        },
+        {
+          id: "evt-dup",
+          name: "lifecycle",
+          createdAt: 2000,
+          event: lifecycleEvent("evt-dup", 2000),
+        },
+        {
+          id: "evt-new-2",
+          name: "lifecycle",
+          createdAt: 3000,
+          event: lifecycleEvent("evt-new-2", 3000),
+        },
+      ]),
+    ).toThrow();
+
+    // The primary-key conflict aborts the whole statement — no partial batch.
+    expect(allIds()).toEqual(["evt-dup"]);
+  });
+
+  test("batch insert returns false when the telemetry DB is unavailable", () => {
+    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+    try {
+      expect(
+        insertTelemetryOutboxEvents([
+          {
+            id: "evt-1",
+            name: "lifecycle",
+            createdAt: 1000,
+            event: lifecycleEvent("evt-1", 1000),
+          },
+        ]),
+      ).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(allIds()).toEqual([]);
+  });
+
+  test("empty batch is a successful no-op", () => {
+    expect(insertTelemetryOutboxEvents([])).toBe(true);
+    expect(allIds()).toEqual([]);
   });
 
   test("conversation_id persists in its dedicated column", () => {

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -1,13 +1,17 @@
 /**
- * Storage seam for the generic `telemetry_events` outbox on the dedicated
- * telemetry database (`assistant-telemetry.db`). Rows carry the full wire
- * `TelemetryEvent` built at record time and are deleted after a successful
- * flush. No consent logic lives here — call sites own gating.
+ * Generic `telemetry_events` outbox on the dedicated telemetry database
+ * (`assistant-telemetry.db`). Rows carry the full wire `TelemetryEvent` built
+ * at record time and are deleted after a successful flush.
+ * `recordTelemetryOutboxEvent` is the consent-owning record layer; the
+ * storage seam functions carry no consent logic — their call sites own
+ * gating.
  */
 import { asc, eq, inArray } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
 
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import type { TelemetryEvent } from "./types.js";
 
 /** Ids per DELETE chunk — stays under SQLite's bound-variable limit. */
@@ -67,6 +71,34 @@ export function insertTelemetryOutboxEvent(
   row: TelemetryOutboxInsert,
 ): boolean {
   return insertTelemetryOutboxEvents([row]);
+}
+
+/**
+ * Record one telemetry event: gate on usage-data consent, generate the outbox
+ * row id and record-time timestamp, build the wire payload via `buildEvent`
+ * (which owns per-type stamping, e.g. `daemon_event_id` overrides), and
+ * insert. Returns the generated row identity, or null when usage data
+ * collection is disabled (the event is dropped to honor the opt-out) or the
+ * telemetry DB is unavailable (degraded mode).
+ */
+export function recordTelemetryOutboxEvent(
+  name: string,
+  buildEvent: (id: string, createdAt: number) => TelemetryEvent,
+  opts?: { conversationId?: string | null },
+): { id: string; createdAt: number } | null {
+  if (!getCachedShareAnalytics()) {
+    return null;
+  }
+  const id = uuid();
+  const createdAt = Date.now();
+  const inserted = insertTelemetryOutboxEvent({
+    id,
+    name,
+    createdAt,
+    conversationId: opts?.conversationId ?? null,
+    event: buildEvent(id, createdAt),
+  });
+  return inserted ? { id, createdAt } : null;
 }
 
 /**

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -1,0 +1,95 @@
+/**
+ * Storage seam for the generic `telemetry_events` outbox on the dedicated
+ * telemetry database (`assistant-telemetry.db`). Rows carry the full wire
+ * `TelemetryEvent` built at record time and are deleted after a successful
+ * flush. No consent logic lives here — call sites own gating.
+ */
+import { asc, eq, inArray } from "drizzle-orm";
+
+import { getTelemetryDb } from "../persistence/db-connection.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
+import type { TelemetryEvent } from "./types.js";
+
+/** Ids per DELETE chunk — stays under SQLite's bound-variable limit. */
+const DELETE_CHUNK_SIZE = 500;
+
+/** One pending outbox row; `payload` is the wire `TelemetryEvent` JSON. */
+export interface TelemetryOutboxRow {
+  id: string;
+  createdAt: number;
+  payload: string;
+}
+
+/**
+ * Insert one pending telemetry event. Returns false when the telemetry DB is
+ * unavailable (degraded mode), true once the row is inserted.
+ */
+export function insertTelemetryOutboxEvent(row: {
+  id: string;
+  name: string;
+  createdAt: number;
+  conversationId?: string | null;
+  event: TelemetryEvent;
+}): boolean {
+  const db = getTelemetryDb();
+  if (!db) {
+    return false;
+  }
+  db.insert(telemetryEvents)
+    .values({
+      id: row.id,
+      name: row.name,
+      createdAt: row.createdAt,
+      conversationId: row.conversationId ?? null,
+      payload: JSON.stringify(row.event),
+    })
+    .run();
+  return true;
+}
+
+/**
+ * Read the oldest pending rows for one event name in `(created_at, id)`
+ * order. Empty when the telemetry DB is unavailable.
+ */
+export function queryTelemetryOutboxBatch(
+  name: string,
+  limit: number,
+): TelemetryOutboxRow[] {
+  const db = getTelemetryDb();
+  if (!db) {
+    return [];
+  }
+  return db
+    .select({
+      id: telemetryEvents.id,
+      createdAt: telemetryEvents.createdAt,
+      payload: telemetryEvents.payload,
+    })
+    .from(telemetryEvents)
+    .where(eq(telemetryEvents.name, name))
+    .orderBy(asc(telemetryEvents.createdAt), asc(telemetryEvents.id))
+    .limit(limit)
+    .all();
+}
+
+/** Delete flushed rows by id, in chunks. No-op when db null or ids empty. */
+export function deleteTelemetryOutboxEvents(ids: string[]): void {
+  const db = getTelemetryDb();
+  if (!db || ids.length === 0) {
+    return;
+  }
+  for (let i = 0; i < ids.length; i += DELETE_CHUNK_SIZE) {
+    db.delete(telemetryEvents)
+      .where(inArray(telemetryEvents.id, ids.slice(i, i + DELETE_CHUNK_SIZE)))
+      .run();
+  }
+}
+
+/** Drop all pending rows for one event name (telemetry opt-out). */
+export function discardPendingTelemetryOutboxEvents(name: string): void {
+  const db = getTelemetryDb();
+  if (!db) {
+    return;
+  }
+  db.delete(telemetryEvents).where(eq(telemetryEvents.name, name)).run();
+}

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -20,31 +20,53 @@ export interface TelemetryOutboxRow {
   payload: string;
 }
 
-/**
- * Insert one pending telemetry event. Returns false when the telemetry DB is
- * unavailable (degraded mode), true once the row is inserted.
- */
-export function insertTelemetryOutboxEvent(row: {
+/** One pending telemetry event to insert; `event` is the wire payload. */
+export interface TelemetryOutboxInsert {
   id: string;
   name: string;
   createdAt: number;
   conversationId?: string | null;
   event: TelemetryEvent;
-}): boolean {
+}
+
+/**
+ * Insert a batch of pending telemetry events as one multi-row INSERT —
+ * all-or-nothing, so a mid-batch failure never leaves a partial batch
+ * committed. Returns false when the telemetry DB is unavailable (degraded
+ * mode), true once every row is inserted (or the batch is empty).
+ */
+export function insertTelemetryOutboxEvents(
+  rows: TelemetryOutboxInsert[],
+): boolean {
   const db = getTelemetryDb();
   if (!db) {
     return false;
   }
+  if (rows.length === 0) {
+    return true;
+  }
   db.insert(telemetryEvents)
-    .values({
-      id: row.id,
-      name: row.name,
-      createdAt: row.createdAt,
-      conversationId: row.conversationId ?? null,
-      payload: JSON.stringify(row.event),
-    })
+    .values(
+      rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        createdAt: row.createdAt,
+        conversationId: row.conversationId ?? null,
+        payload: JSON.stringify(row.event),
+      })),
+    )
     .run();
   return true;
+}
+
+/**
+ * Insert one pending telemetry event. Returns false when the telemetry DB is
+ * unavailable (degraded mode), true once the row is inserted.
+ */
+export function insertTelemetryOutboxEvent(
+  row: TelemetryOutboxInsert,
+): boolean {
+  return insertTelemetryOutboxEvents([row]);
 }
 
 /**

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -18,18 +18,17 @@ export interface TelemetryEventBase {
    * `null`) it wins. When the field is omitted on the event entirely
    * (old assistant), the envelope value is the back-compat fallback.
    *
-   * Daemon-side, this field is always non-null — the reporter stamps
-   * the running binary's `APP_VERSION` when the underlying SQLite row
-   * has no record-time value. In this PR only `llm_usage` events
-   * carry a true record-time value (legacy llm_usage rows from before
-   * migration 267 fall back to `APP_VERSION`); turn, lifecycle, and
-   * onboarding events all stamp `APP_VERSION` directly until the
-   * follow-ups that add the column to `messages` / `lifecycle_events`
-   * (#18112) / `onboarding_events` (#30733) land. Stamping
-   * `APP_VERSION` instead of emitting explicit `null` preserves
-   * envelope-equivalent behavior under the per-event-wins contract.
-   * The type allows `null` for parity with the platform contract;
-   * in practice the daemon never sends it.
+   * Daemon-side, this field is always non-null. The outbox-backed
+   * event types store the full wire payload at record time, so their
+   * `APP_VERSION` stamp is genuinely record-time; `llm_usage` carries
+   * a record-time column (legacy rows from before migration 267 fall
+   * back to the flushing binary's `APP_VERSION`); `turn` and
+   * `tool_executed` derive from tables without a version column and
+   * stamp the flushing binary's `APP_VERSION`. Stamping `APP_VERSION`
+   * instead of emitting explicit `null` preserves envelope-equivalent
+   * behavior under the per-event-wins contract. The type allows
+   * `null` for parity with the platform contract; in practice the
+   * daemon never sends it.
    */
   assistant_version: string | null;
 }

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -228,7 +228,6 @@ import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
   authFallbackEvents,
-  configSettingEvents,
   conversations,
   skillLoadedEvents,
   telemetryEvents,
@@ -258,6 +257,7 @@ import {
   initToolExecutedWatermarkIfAbsent,
   UsageTelemetryReporter,
 } from "./usage-telemetry-reporter.js";
+import { recordWatchdogEvent } from "./watchdog-events-store.js";
 
 /**
  * Construct a reporter wired to the in-memory checkpoint fake. All tests go
@@ -415,7 +415,6 @@ beforeEach(() => {
   getDb().delete(toolInvocations).run();
   getTelemetryDb()!.delete(skillLoadedEvents).run();
   getTelemetryDb()!.delete(authFallbackEvents).run();
-  getTelemetryDb()!.delete(configSettingEvents).run();
   getTelemetryDb()!.delete(telemetryEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
   delete process.env.IS_PLATFORM;
@@ -1651,11 +1650,13 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 9 timestamp watermarks should have been advanced, and all 9 ID
-    // watermarks pinned to the high-sorting sentinel (a truthy value keeps
-    // the compound-cursor branch active while closing its same-millisecond
-    // arm against opt-out rows).
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(18);
+    // Every watermark-mode source's timestamp watermark should have been
+    // advanced, and its ID watermark pinned to the high-sorting sentinel (a
+    // truthy value keeps the compound-cursor branch active while closing its
+    // same-millisecond arm against opt-out rows). Ack-mode sources (watchdog,
+    // config_setting) discard pending outbox rows instead and never touch
+    // `flush_checkpoints`.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(14);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -1667,8 +1668,6 @@ describe("UsageTelemetryReporter", () => {
       "auth_fallback",
       "tool_executed",
       "skill_loaded",
-      "watchdog",
-      "config_setting",
     ];
     for (const eventType of eventTypes) {
       expect(keys).toContain(`telemetry:${eventType}:last_reported_at`);
@@ -2639,7 +2638,7 @@ describe("UsageTelemetryReporter", () => {
     });
   });
 
-  test("config_setting watermark advances to the last reported row on success", async () => {
+  test("config_setting rows are deleted on success and no watermark is written", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     recordConfigSettingEvent({
       configKey: "memory.enabled",
@@ -2649,35 +2648,72 @@ describe("UsageTelemetryReporter", () => {
       configKey: "memory.v2.enabled",
       configValue: "true",
     });
+    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(2);
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    // The last row by the reporter's (createdAt, id) cursor order is the one
-    // whose watermark should be persisted after a successful upload.
-    const rows = getTelemetryDb()!
-      .select()
-      .from(configSettingEvents)
-      .orderBy(configSettingEvents.createdAt, configSettingEvents.id)
-      .all();
-    const lastRow = rows[rows.length - 1];
+    const reporter = makeReporter();
+    await reporter.flush();
+
+    // Ack-mode: acknowledged rows are deleted from the outbox instead of
+    // advancing a `flush_checkpoints` watermark.
+    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(0);
+    const watermarkKeys = mockSetFlushCheckpoint.mock.calls
+      .map((c) => c[0] as string)
+      .filter((key) => key.startsWith("telemetry:config_setting:"));
+    expect(watermarkKeys).toHaveLength(0);
+  });
+
+  test("config_setting rows survive a failed POST for the next flush", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordConfigSettingEvent({
+      configKey: "memory.enabled",
+      configValue: "true",
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("error", { status: 500 })),
+    );
 
     const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:config_setting:last_reported_at",
-    );
-    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
-    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
-      String(lastRow.createdAt),
+    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Watchdog events
+  // -------------------------------------------------------------------------
+
+  test("watchdog events ship the record-time payload with nested detail, then delete", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordWatchdogEvent({
+      checkName: "event_loop_blocked",
+      value: 60000,
+      detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
 
-    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:config_setting:last_reported_id",
+    const reporter = makeReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
-    expect(idCalls.length).toBeGreaterThanOrEqual(1);
-    expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0]).toMatchObject({
+      type: "watchdog",
+      check_name: "event_loop_blocked",
+      value: 60000,
+      detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
+      assistant_version: "1.2.3-test",
+    });
+    expect(typeof body.events[0].daemon_event_id).toBe("string");
+    expect(typeof body.events[0].recorded_at).toBe("number");
+    expect(queryTelemetryOutboxBatch("watchdog", 10)).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -171,20 +171,7 @@ mock.module("./turn-trace-store.js", () => ({
   isTurnSettled: mockIsTurnSettled,
 }));
 
-const mockQueryUnreportedLifecycleEvents = mock(
-  () =>
-    [] as {
-      id: string;
-      eventName: string;
-      createdAt: number;
-    }[],
-);
-
-mock.module("../persistence/lifecycle-events-store.js", () => ({
-  queryUnreportedLifecycleEvents: mockQueryUnreportedLifecycleEvents,
-}));
-
-// The onboarding, auth-fallback, tool-executed, and skill-loaded stores are
+// The auth-fallback, tool-executed, and skill-loaded stores are
 // intentionally NOT mocked — they have their own DB-backed tests, and Bun's
 // `mock.module` is process-global, so mocking them here would leak into those
 // tests when files share an invocation. We seed the real DB instead so every
@@ -205,6 +192,7 @@ import {
 } from "../onboarding/onboarding-events-store.js";
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import { recordLifecycleEvent } from "../persistence/lifecycle-events-store.js";
 import {
   authFallbackEvents,
   conversations,
@@ -359,8 +347,6 @@ beforeEach(() => {
   mockQueryUnreportedUsageEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
-  mockQueryUnreportedLifecycleEvents.mockReset();
-  mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
   getTelemetryDb()!.delete(skillLoadedEvents).run();
   getTelemetryDb()!.delete(authFallbackEvents).run();
@@ -1599,20 +1585,19 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-// All 6 watermark-mode timestamp watermarks should have been advanced,
-    // and their 6 ID watermarks pinned to the high-sorting sentinel (a truthy
+    // All 5 watermark-mode timestamp watermarks should have been advanced,
+    // and their 5 ID watermarks pinned to the high-sorting sentinel (a truthy
     // value keeps the compound-cursor branch active while closing its
     // same-millisecond arm against opt-out rows). Ack-mode sources
-    // (onboarding, watchdog, config_setting) discard their pending outbox
-    // rows instead and never touch `flush_checkpoints`.
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(12);
+    // (lifecycle, onboarding, watchdog, config_setting) discard their pending
+    // outbox rows instead and never touch `flush_checkpoints`.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(10);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
     const eventTypes = [
       "usage",
       "turns",
-      "lifecycle",
       "auth_fallback",
       "tool_executed",
       "skill_loaded",
@@ -1624,6 +1609,7 @@ describe("UsageTelemetryReporter", () => {
       );
       expect(idCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
     }
+    expect(keys.some((k) => k.includes(":lifecycle:"))).toBe(false);
     expect(keys).not.toContain("telemetry:onboarding:last_reported_at");
     expect(keys).not.toContain("telemetry:onboarding:last_reported_id");
   });
@@ -1701,8 +1687,8 @@ describe("UsageTelemetryReporter", () => {
   // The envelope's `assistant_version` is upload-time (always the current
   // binary). The per-event field is record-time (the binary that was running
   // when the event was persisted to SQLite). `llm_usage` events and the
-  // outbox-backed types carry a true record-time value; turn events (and
-  // lifecycle events, not asserted here) stamp the running binary's
+  // outbox-backed types carry a true record-time value; turn events
+  // (not asserted here) stamp the running binary's
   // `APP_VERSION` directly until their respective follow-ups land.
   // Nullable llm_usage cases (legacy rows from before migration 267 ran)
   // fall back to the running binary's `APP_VERSION` rather than emitting
@@ -3076,5 +3062,48 @@ describe("UsageTelemetryReporter", () => {
     );
     expect(secondBody.events).toHaveLength(1);
     expect(pendingOutboxIds()).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Lifecycle events (outbox-backed)
+  // -------------------------------------------------------------------------
+
+  test("a recorded lifecycle event flushes once and its outbox row is deleted", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    const recorded = recordLifecycleEvent("app_open");
+    expect(recorded).not.toBeNull();
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = makeReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events).toHaveLength(1);
+    // The stored payload IS the wire event — record-time version included.
+    expect(body.events[0]).toEqual({
+      type: "lifecycle",
+      daemon_event_id: recorded!.id,
+      event_name: "app_open",
+      recorded_at: recorded!.createdAt,
+      assistant_version: "1.2.3-test",
+    });
+    // Delete-on-flush: the outbox row is gone, and lifecycle (ack-mode)
+    // never touches flush_checkpoints.
+    expect(queryTelemetryOutboxBatch("lifecycle", 10)).toEqual([]);
+    expect(
+      mockSetFlushCheckpoint.mock.calls.some((c) =>
+        c[0].includes(":lifecycle:"),
+      ),
+    ).toBe(false);
+
+    // A second flush finds nothing pending — the event never re-ships.
+    mockFetch.mockClear();
+    await reporter.flush();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -245,7 +245,9 @@ import {
   ALL_TELEMETRY_EVENT_SOURCES,
   DAEMON_TELEMETRY_EVENT_SOURCES,
   MONITOR_TELEMETRY_EVENT_SOURCES,
+  type TelemetryEventSource,
 } from "./telemetry-event-sources.js";
+import type { TelemetryEvent } from "./types.js";
 import {
   initToolExecutedWatermarkIfAbsent,
   UsageTelemetryReporter,
@@ -2669,5 +2671,299 @@ describe("UsageTelemetryReporter", () => {
     );
     expect(idCalls.length).toBeGreaterThanOrEqual(1);
     expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+  });
+
+  // -------------------------------------------------------------------------
+  // Ack-mode sources (grouped `ack` field: acknowledge + discardPending)
+  // -------------------------------------------------------------------------
+
+  // Wire id deliberately differs from the row id: acknowledge must receive
+  // ROW ids, never wire daemon_event_ids.
+  function fakeWireEvent(rowId: string, createdAt: number): TelemetryEvent {
+    return {
+      type: "lifecycle",
+      daemon_event_id: `wire-${rowId}`,
+      event_name: "fake_event",
+      recorded_at: createdAt,
+      assistant_version: "1.2.3-test",
+    };
+  }
+
+  /**
+   * Ack-mode fake backed by a mutable in-memory row array: `collect` ignores
+   * the cursor args, `acknowledge` deletes the acknowledged rows, and
+   * `discardPending` drops everything — mirroring the outbox-store contract.
+   */
+  function makeAckSource(id: string, rowIds: string[] = []) {
+    let rows = rowIds.map((rowId, i) => ({
+      rowId,
+      createdAt: 1700000000000 + i,
+    }));
+    const acknowledge = mock((acked: string[]) => {
+      rows = rows.filter((r) => !acked.includes(r.rowId));
+    });
+    const discardPending = mock(() => {
+      rows = [];
+    });
+    const source: TelemetryEventSource = {
+      id,
+      collect(_afterCreatedAt, _afterId, limit) {
+        const batch = rows.slice(0, limit);
+        return {
+          events: batch.map((r) => fakeWireEvent(r.rowId, r.createdAt)),
+          rowIds: batch.map((r) => r.rowId),
+          lastCursor: null,
+          fullBatch: batch.length === limit,
+        };
+      },
+      ack: { acknowledge, discardPending },
+    };
+    return { source, acknowledge, discardPending, pending: () => rows.length };
+  }
+
+  function makeWatermarkSource(
+    id: string,
+    rowIds: string[] = [],
+  ): TelemetryEventSource {
+    const rows = rowIds.map((rowId, i) => ({
+      rowId,
+      createdAt: 1700000000000 + i,
+    }));
+    return {
+      id,
+      collect(_afterCreatedAt, _afterId, limit) {
+        const batch = rows.slice(0, limit);
+        const last = batch.length > 0 ? batch[batch.length - 1] : null;
+        return {
+          events: batch.map((r) => fakeWireEvent(r.rowId, r.createdAt)),
+          lastCursor: last
+            ? { createdAt: last.createdAt, id: last.rowId }
+            : null,
+          fullBatch: batch.length === limit,
+        };
+      },
+    };
+  }
+
+  test("ack-mode source: acknowledge receives ROW ids after a 2xx and no watermark keys are written", async () => {
+    const { source, acknowledge } = makeAckSource("fake_ack", [
+      "row-1",
+      "row-2",
+    ]);
+    const reporter = new UsageTelemetryReporter(
+      [source],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-row-1", "wire-row-2"]);
+    expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(acknowledge.mock.calls[0][0]).toEqual(["row-1", "row-2"]);
+    // Ack-mode sources never touch flush_checkpoints.
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("acknowledge is NOT called when the POST fails", async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("error", { status: 500 })),
+    );
+    const { source, acknowledge, pending } = makeAckSource("fake_ack", [
+      "row-1",
+    ]);
+    const reporter = new UsageTelemetryReporter(
+      [source],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(acknowledge).not.toHaveBeenCalled();
+    expect(pending()).toBe(1);
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("acknowledge is NOT called when platform credentials are missing", async () => {
+    mockPlatformClient = null;
+    const { source, acknowledge, pending } = makeAckSource("fake_ack", [
+      "row-1",
+    ]);
+    const reporter = new UsageTelemetryReporter(
+      [source],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(acknowledge).not.toHaveBeenCalled();
+    expect(pending()).toBe(1);
+  });
+
+  test("acknowledge is skipped for an empty ack batch shipped alongside a watermark source", async () => {
+    const { source: ackSource, acknowledge } = makeAckSource("fake_ack");
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1"]);
+    const reporter = new UsageTelemetryReporter(
+      [wmSource, ackSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(acknowledge).not.toHaveBeenCalled();
+  });
+
+  test("opt-out: discardPending drops ack-mode rows while watermark sources get the sentinel pin", async () => {
+    mockGetCachedShareAnalytics.mockReturnValue(false);
+    const {
+      source: ackSource,
+      discardPending,
+      pending,
+    } = makeAckSource("fake_ack", ["row-1"]);
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1"]);
+    const reporter = new UsageTelemetryReporter(
+      [wmSource, ackSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(discardPending).toHaveBeenCalledTimes(1);
+    expect(pending()).toBe(0);
+
+    const keys = mockSetFlushCheckpoint.mock.calls.map((c) => c[0]);
+    expect(keys).toContain("telemetry:fake_wm:last_reported_at");
+    const wmIdCall = mockSetFlushCheckpoint.mock.calls.find(
+      (c) => c[0] === "telemetry:fake_wm:last_reported_id",
+    );
+    expect(wmIdCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    expect(keys.some((k) => k.includes("fake_ack"))).toBe(false);
+  });
+
+  test("mixed watermark+ack sources flush in construction order, each acknowledged in its own mode", async () => {
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1", "wm-2"]);
+    const { source: ackSource, acknowledge } = makeAckSource("fake_ack", [
+      "row-1",
+    ]);
+    const reporter = new UsageTelemetryReporter(
+      [wmSource, ackSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-wm-1", "wire-wm-2", "wire-row-1"]);
+
+    expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(acknowledge.mock.calls[0][0]).toEqual(["row-1"]);
+
+    const wmAtCalls = mockSetFlushCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:fake_wm:last_reported_at",
+    );
+    expect(wmAtCalls[wmAtCalls.length - 1][1]).toBe(String(1700000000001));
+    const wmIdCalls = mockSetFlushCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:fake_wm:last_reported_id",
+    );
+    expect(wmIdCalls[wmIdCalls.length - 1][1]).toBe("wm-2");
+    expect(
+      mockSetFlushCheckpoint.mock.calls.some((c) => c[0].includes("fake_ack")),
+    ).toBe(false);
+  });
+
+  test("an ack-mode full batch drives recursion until the backlog drains", async () => {
+    // 501 rows: the first collect fills BATCH_SIZE (500), acknowledge drains
+    // them, and the fullBatch recursion ships the remaining row.
+    const rowIds = Array.from({ length: 501 }, (_, i) => `row-${i}`);
+    const { source, acknowledge, pending } = makeAckSource("fake_ack", rowIds);
+    const reporter = new UsageTelemetryReporter(
+      [source],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(acknowledge).toHaveBeenCalledTimes(2);
+    expect(acknowledge.mock.calls[0][0]).toHaveLength(500);
+    expect(acknowledge.mock.calls[1][0]).toEqual(["row-500"]);
+    expect(pending()).toBe(0);
+  });
+
+  /** Ack source whose collect returns events with broken rowIds. */
+  function makeBrokenAckSource(id: string, rowIds: string[] | undefined) {
+    const acknowledge = mock((_acked: string[]) => {});
+    const discardPending = mock(() => {});
+    const source: TelemetryEventSource = {
+      id,
+      collect() {
+        return {
+          events: [
+            fakeWireEvent("row-1", 1700000000000),
+            fakeWireEvent("row-2", 1700000000001),
+          ],
+          ...(rowIds ? { rowIds } : {}),
+          lastCursor: null,
+          fullBatch: false,
+        };
+      },
+      ack: { acknowledge, discardPending },
+    };
+    return { source, acknowledge };
+  }
+
+  test("an ack batch omitting rowIds ships nothing while other sources still ship", async () => {
+    const { source: brokenSource, acknowledge } = makeBrokenAckSource(
+      "fake_broken_ack",
+      undefined,
+    );
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1"]);
+    const reporter = new UsageTelemetryReporter(
+      [brokenSource, wmSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-wm-1"]);
+    expect(acknowledge).not.toHaveBeenCalled();
+    expect(
+      mockSetFlushCheckpoint.mock.calls.some((c) =>
+        c[0].includes("fake_broken_ack"),
+      ),
+    ).toBe(false);
+  });
+
+  test("an ack batch with mismatched rowIds ships nothing while other sources still ship", async () => {
+    const { source: brokenSource, acknowledge } = makeBrokenAckSource(
+      "fake_broken_ack",
+      ["row-1"],
+    );
+    const wmSource = makeWatermarkSource("fake_wm", ["wm-1"]);
+    const reporter = new UsageTelemetryReporter(
+      [brokenSource, wmSource],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-wm-1"]);
+    expect(acknowledge).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -194,7 +194,6 @@ import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { recordLifecycleEvent } from "../persistence/lifecycle-events-store.js";
 import {
-  authFallbackEvents,
   conversations,
   telemetryEvents,
   toolInvocations,
@@ -347,7 +346,6 @@ beforeEach(() => {
   mockQueryUnreportedTurnEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
-  getTelemetryDb()!.delete(authFallbackEvents).run();
   getTelemetryDb()!.delete(telemetryEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
   delete process.env.IS_PLATFORM;
@@ -1583,18 +1581,19 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 4 watermark-mode timestamp watermarks should have been advanced,
-    // and their 4 ID watermarks pinned to the high-sorting sentinel (a truthy
+    // All 3 watermark-mode timestamp watermarks should have been advanced,
+    // and their 3 ID watermarks pinned to the high-sorting sentinel (a truthy
     // value keeps the compound-cursor branch active while closing its
     // same-millisecond arm against opt-out rows). Ack-mode sources
-    // (lifecycle, onboarding, skill_loaded, watchdog, config_setting) discard
-    // their pending outbox rows instead and never touch `flush_checkpoints`.
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(8);
+    // (lifecycle, onboarding, auth_fallback, skill_loaded, watchdog,
+    // config_setting) discard their pending outbox rows instead and never
+    // touch `flush_checkpoints`.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(6);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
     expect(keys.some((k) => k.includes("skill_loaded"))).toBe(false);
-    const eventTypes = ["usage", "turns", "auth_fallback", "tool_executed"];
+    const eventTypes = ["usage", "turns", "tool_executed"];
     for (const eventType of eventTypes) {
       expect(keys).toContain(`telemetry:${eventType}:last_reported_at`);
       const idCall = calls.find(
@@ -1602,6 +1601,8 @@ describe("UsageTelemetryReporter", () => {
       );
       expect(idCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
     }
+    expect(keys).not.toContain("telemetry:auth_fallback:last_reported_at");
+    expect(keys).not.toContain("telemetry:auth_fallback:last_reported_id");
     expect(keys.some((k) => k.includes(":lifecycle:"))).toBe(false);
     expect(keys).not.toContain("telemetry:onboarding:last_reported_at");
     expect(keys).not.toContain("telemetry:onboarding:last_reported_id");
@@ -1845,7 +1846,7 @@ describe("UsageTelemetryReporter", () => {
     expect(typeof body.events[0].daemon_event_id).toBe("string");
   });
 
-  test("auth_fallback watermark advances to the last reported row on success", async () => {
+  test("auth_fallback rows are deleted on success and never watermarked (ack mode)", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     recordAuthFallbackCounts(1700000000000, 1700000001000, [
       {
@@ -1864,32 +1865,49 @@ describe("UsageTelemetryReporter", () => {
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
-
-    // The last row by the reporter's (createdAt, id) cursor order is the one
-    // whose watermark should be persisted after a successful upload.
-    const rows = getTelemetryDb()!
-      .select()
-      .from(authFallbackEvents)
-      .orderBy(authFallbackEvents.createdAt, authFallbackEvents.id)
-      .all();
-    const lastRow = rows[rows.length - 1];
+    expect(queryTelemetryOutboxBatch("auth_fallback", 10)).toHaveLength(2);
 
     const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:auth_fallback:last_reported_at",
+    // Both rows shipped, were acknowledged (deleted), and no auth_fallback
+    // watermark was ever written — ack-mode sources bypass flush_checkpoints.
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
-    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
-    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
-      String(lastRow.createdAt),
+    expect(
+      body.events.filter((e: { type: string }) => e.type === "auth_fallback"),
+    ).toHaveLength(2);
+    expect(queryTelemetryOutboxBatch("auth_fallback", 10)).toHaveLength(0);
+    const authFallbackKeys = mockSetFlushCheckpoint.mock.calls.filter((c) =>
+      String(c[0]).startsWith("telemetry:auth_fallback:"),
+    );
+    expect(authFallbackKeys).toHaveLength(0);
+  });
+
+  test("auth_fallback rows survive a failed POST and re-ship on the next flush", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordAuthFallbackCounts(1700000000000, 1700000001000, [
+      {
+        guard: "edge",
+        path: "/v1/messages",
+        failureKind: "missing_authorization",
+        count: 9,
+      },
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("server error", { status: 500 })),
     );
 
-    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:auth_fallback:last_reported_id",
+    const reporter = makeReporter();
+    await reporter.flush();
+    expect(queryTelemetryOutboxBatch("auth_fallback", 10)).toHaveLength(1);
+
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
-    expect(idCalls.length).toBeGreaterThanOrEqual(1);
-    expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+    await reporter.flush();
+    expect(queryTelemetryOutboxBatch("auth_fallback", 10)).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -231,6 +231,7 @@ import {
   configSettingEvents,
   conversations,
   skillLoadedEvents,
+  telemetryEvents,
   toolInvocations,
 } from "../persistence/schema/index.js";
 import { recordAuthFallbackCounts } from "../security/auth-fallback-events-store.js";
@@ -245,8 +246,13 @@ import {
   ALL_TELEMETRY_EVENT_SOURCES,
   DAEMON_TELEMETRY_EVENT_SOURCES,
   MONITOR_TELEMETRY_EVENT_SOURCES,
+  outboxSource,
   type TelemetryEventSource,
 } from "./telemetry-event-sources.js";
+import {
+  insertTelemetryOutboxEvent,
+  queryTelemetryOutboxBatch,
+} from "./telemetry-events-outbox.js";
 import type { TelemetryEvent } from "./types.js";
 import {
   initToolExecutedWatermarkIfAbsent,
@@ -410,6 +416,7 @@ beforeEach(() => {
   getTelemetryDb()!.delete(skillLoadedEvents).run();
   getTelemetryDb()!.delete(authFallbackEvents).run();
   getTelemetryDb()!.delete(configSettingEvents).run();
+  getTelemetryDb()!.delete(telemetryEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
   delete process.env.IS_PLATFORM;
   mockGetPlatformBaseUrl.mockReset();
@@ -2965,5 +2972,135 @@ describe("UsageTelemetryReporter", () => {
       body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
     ).toEqual(["wire-wm-1"]);
     expect(acknowledge).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // outboxSource (real telemetry_events outbox behind an ack-mode source)
+  // -------------------------------------------------------------------------
+
+  const OUTBOX_NAME = "test_outbox";
+
+  function seedOutboxRow(id: string, createdAt: number): void {
+    insertTelemetryOutboxEvent({
+      id,
+      name: OUTBOX_NAME,
+      createdAt,
+      event: fakeWireEvent(id, createdAt),
+    });
+  }
+
+  function pendingOutboxIds(): string[] {
+    return queryTelemetryOutboxBatch(OUTBOX_NAME, 1000).map((r) => r.id);
+  }
+
+  test("outboxSource ships pending rows and deletes them after a 2xx", async () => {
+    seedOutboxRow("ob-1", 1700000001000);
+    seedOutboxRow("ob-2", 1700000002000);
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-ob-1", "wire-ob-2"]);
+    expect(pendingOutboxIds()).toEqual([]);
+    // Ack-mode: flush_checkpoints untouched.
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("outboxSource leaves rows intact when the POST fails", async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("error", { status: 500 })),
+    );
+    seedOutboxRow("ob-1", 1700000001000);
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(pendingOutboxIds()).toEqual(["ob-1"]);
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("outboxSource opt-out discards all pending rows for the name", async () => {
+    mockGetCachedShareAnalytics.mockReturnValue(false);
+    seedOutboxRow("ob-1", 1700000001000);
+    seedOutboxRow("ob-2", 1700000002000);
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(pendingOutboxIds()).toEqual([]);
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("outboxSource purges corrupt-payload rows at collect while valid siblings ship", async () => {
+    // Raw inserts: the store API only writes JSON.stringify-ed events, so
+    // corrupt payloads (invalid JSON, non-object JSON) go in directly.
+    getTelemetryDb()!
+      .insert(telemetryEvents)
+      .values([
+        {
+          id: "ob-corrupt-json",
+          name: OUTBOX_NAME,
+          createdAt: 1700000001000,
+          conversationId: null,
+          payload: "{not json",
+        },
+        {
+          id: "ob-non-object",
+          name: OUTBOX_NAME,
+          createdAt: 1700000002000,
+          conversationId: null,
+          payload: "42",
+        },
+      ])
+      .run();
+    seedOutboxRow("ob-valid", 1700000003000);
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-ob-valid"]);
+    // Corrupt rows are gone (purged at collect), the valid row via ack.
+    expect(pendingOutboxIds()).toEqual([]);
+  });
+
+  test("a full outbox batch drives recursion until the backlog drains", async () => {
+    // 501 rows: the first collect fills BATCH_SIZE (500) and the fullBatch
+    // recursion ships the remaining row.
+    for (let i = 0; i < 501; i++) {
+      seedOutboxRow(`ob-${String(i).padStart(3, "0")}`, 1700000000000 + i);
+    }
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(
+      (mockFetch.mock.calls[1] as [string, RequestInit])[1].body as string,
+    );
+    expect(secondBody.events).toHaveLength(1);
+    expect(pendingOutboxIds()).toEqual([]);
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -196,7 +196,6 @@ import { recordLifecycleEvent } from "../persistence/lifecycle-events-store.js";
 import {
   authFallbackEvents,
   conversations,
-  skillLoadedEvents,
   telemetryEvents,
   toolInvocations,
 } from "../persistence/schema/index.js";
@@ -348,7 +347,6 @@ beforeEach(() => {
   mockQueryUnreportedTurnEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
-  getTelemetryDb()!.delete(skillLoadedEvents).run();
   getTelemetryDb()!.delete(authFallbackEvents).run();
   getTelemetryDb()!.delete(telemetryEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
@@ -1585,23 +1583,18 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 5 watermark-mode timestamp watermarks should have been advanced,
-    // and their 5 ID watermarks pinned to the high-sorting sentinel (a truthy
+    // All 4 watermark-mode timestamp watermarks should have been advanced,
+    // and their 4 ID watermarks pinned to the high-sorting sentinel (a truthy
     // value keeps the compound-cursor branch active while closing its
     // same-millisecond arm against opt-out rows). Ack-mode sources
-    // (lifecycle, onboarding, watchdog, config_setting) discard their pending
-    // outbox rows instead and never touch `flush_checkpoints`.
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(10);
+    // (lifecycle, onboarding, skill_loaded, watchdog, config_setting) discard
+    // their pending outbox rows instead and never touch `flush_checkpoints`.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(8);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
-    const eventTypes = [
-      "usage",
-      "turns",
-      "auth_fallback",
-      "tool_executed",
-      "skill_loaded",
-    ];
+    expect(keys.some((k) => k.includes("skill_loaded"))).toBe(false);
+    const eventTypes = ["usage", "turns", "auth_fallback", "tool_executed"];
     for (const eventType of eventTypes) {
       expect(keys).toContain(`telemetry:${eventType}:last_reported_at`);
       const idCall = calls.find(
@@ -2459,51 +2452,35 @@ describe("UsageTelemetryReporter", () => {
     });
   });
 
-  test("skill_loaded watermark advances to the last reported row on success", async () => {
+  test("skill_loaded rows are deleted from the outbox after a 2xx, never via watermarks", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     recordSkillLoadedEvent({ skillName: "web-research" });
     recordSkillLoadedEvent({ skillName: "tasks" });
+    expect(queryTelemetryOutboxBatch("skill_loaded", 10)).toHaveLength(2);
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
     );
 
-    // The last row by the reporter's (createdAt, id) cursor order is the one
-    // whose watermark should be persisted after a successful upload.
-    const rows = getTelemetryDb()!
-      .select()
-      .from(skillLoadedEvents)
-      .orderBy(skillLoadedEvents.createdAt, skillLoadedEvents.id)
-      .all();
-    const lastRow = rows[rows.length - 1];
-
     const reporter = makeReporter();
     await reporter.flush();
 
-    const watermarkCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:skill_loaded:last_reported_at",
-    );
-    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
-    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
-      String(lastRow.createdAt),
-    );
-
-    const idCalls = mockSetFlushCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:skill_loaded:last_reported_id",
-    );
-    expect(idCalls.length).toBeGreaterThanOrEqual(1);
-    expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(queryTelemetryOutboxBatch("skill_loaded", 10)).toHaveLength(0);
+    // Ack-mode: the skill_loaded source never touches flush_checkpoints.
+    expect(
+      mockSetFlushCheckpoint.mock.calls.some((c) =>
+        c[0].includes("skill_loaded"),
+      ),
+    ).toBe(false);
   });
 
-  test("batch recursion when skill_loaded returns a full batch, capped at 10", async () => {
+  test("a full skill_loaded batch drives recursion until the outbox drains", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // Exactly BATCH_SIZE rows; the mocked checkpoints never persist, so each
-    // recursion re-reads the same full batch until the cap.
-    const fullBatch = Array.from({ length: 500 }, (_, i) => ({
-      id: `sle-batch-${String(i).padStart(3, "0")}`,
-      createdAt: 1700000000000 + i,
-      skillName: "web-research",
-    }));
-    getTelemetryDb()!.insert(skillLoadedEvents).values(fullBatch).run();
+    // BATCH_SIZE (500) + 1 rows: the first flush ships and deletes a full
+    // batch, and the fullBatch recursion ships the remaining row.
+    for (let i = 0; i < 501; i++) {
+      recordSkillLoadedEvent({ skillName: `skill-${i}` });
+    }
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":500}', { status: 200 })),
     );
@@ -2511,8 +2488,8 @@ describe("UsageTelemetryReporter", () => {
     const reporter = makeReporter();
     await reporter.flush();
 
-    // MAX_CONSECUTIVE_BATCHES = 10
-    expect(mockFetch).toHaveBeenCalledTimes(10);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(queryTelemetryOutboxBatch("skill_loaded", 1000)).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -184,36 +184,11 @@ mock.module("../persistence/lifecycle-events-store.js", () => ({
   queryUnreportedLifecycleEvents: mockQueryUnreportedLifecycleEvents,
 }));
 
-const mockQueryUnreportedOnboardingEvents = mock(
-  () =>
-    [] as {
-      id: string;
-      createdAt: number;
-      screen: string;
-      toolsJson: string | null;
-      tasksJson: string | null;
-      tone: string | null;
-      googleConnected: boolean | null;
-      googleScopesJson: string | null;
-      priorAssistantsJson: string | null;
-      abVariant: string | null;
-      sessionId: string | null;
-      stepName: string | null;
-      stepIndex: number | null;
-      completedAt: string | null;
-      funnelVersion: string | null;
-    }[],
-);
-
-mock.module("../onboarding/onboarding-events-store.js", () => ({
-  queryUnreportedOnboardingEvents: mockQueryUnreportedOnboardingEvents,
-}));
-
-// The auth-fallback, tool-executed, and skill-loaded stores are intentionally
-// NOT mocked — they have their own DB-backed tests, and Bun's `mock.module`
-// is process-global, so mocking them here would leak into those tests when
-// files share an invocation. We seed the real DB instead so every test stays
-// order-independent.
+// The onboarding, auth-fallback, tool-executed, and skill-loaded stores are
+// intentionally NOT mocked — they have their own DB-backed tests, and Bun's
+// `mock.module` is process-global, so mocking them here would leak into those
+// tests when files share an invocation. We seed the real DB instead so every
+// test stays order-independent.
 
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
@@ -224,6 +199,10 @@ import {
   TOOL_INVOCATION_PII_SENTINEL as TOOL_PII_SENTINEL,
   type ToolInvocationSeedSpec,
 } from "../__tests__/test-support/tool-invocation-seed.js";
+import {
+  recordActivationEvent,
+  recordOnboardingEvent,
+} from "../onboarding/onboarding-events-store.js";
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
@@ -319,34 +298,6 @@ function makeUsageEvent(
   };
 }
 
-type OnboardingEventFixture = ReturnType<
-  typeof mockQueryUnreportedOnboardingEvents
->[number];
-
-function makeOnboardingEvent(
-  overrides: Partial<OnboardingEventFixture> = {},
-): OnboardingEventFixture {
-  eventIdCounter += 1;
-  return {
-    id: `onb-${eventIdCounter}`,
-    createdAt: 1700000000000 + eventIdCounter * 1000,
-    screen: "tools",
-    toolsJson: null,
-    tasksJson: null,
-    tone: null,
-    googleConnected: null,
-    googleScopesJson: null,
-    priorAssistantsJson: null,
-    abVariant: null,
-    sessionId: null,
-    stepName: null,
-    stepIndex: null,
-    completedAt: null,
-    funnelVersion: null,
-    ...overrides,
-  };
-}
-
 const TOOL_CONVERSATION_ID = "conv-reporter-tool-executed";
 
 function seedToolInvocation(
@@ -410,8 +361,6 @@ beforeEach(() => {
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
   mockQueryUnreportedLifecycleEvents.mockReset();
   mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
-  mockQueryUnreportedOnboardingEvents.mockReset();
-  mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(toolInvocations).run();
   getTelemetryDb()!.delete(skillLoadedEvents).run();
   getTelemetryDb()!.delete(authFallbackEvents).run();
@@ -1650,13 +1599,13 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // Every watermark-mode source's timestamp watermark should have been
-    // advanced, and its ID watermark pinned to the high-sorting sentinel (a
-    // truthy value keeps the compound-cursor branch active while closing its
-    // same-millisecond arm against opt-out rows). Ack-mode sources (watchdog,
-    // config_setting) discard pending outbox rows instead and never touch
-    // `flush_checkpoints`.
-    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(14);
+// All 6 watermark-mode timestamp watermarks should have been advanced,
+    // and their 6 ID watermarks pinned to the high-sorting sentinel (a truthy
+    // value keeps the compound-cursor branch active while closing its
+    // same-millisecond arm against opt-out rows). Ack-mode sources
+    // (onboarding, watchdog, config_setting) discard their pending outbox
+    // rows instead and never touch `flush_checkpoints`.
+    expect(mockSetFlushCheckpoint).toHaveBeenCalledTimes(12);
 
     const calls = mockSetFlushCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -1664,7 +1613,6 @@ describe("UsageTelemetryReporter", () => {
       "usage",
       "turns",
       "lifecycle",
-      "onboarding",
       "auth_fallback",
       "tool_executed",
       "skill_loaded",
@@ -1676,6 +1624,8 @@ describe("UsageTelemetryReporter", () => {
       );
       expect(idCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
     }
+    expect(keys).not.toContain("telemetry:onboarding:last_reported_at");
+    expect(keys).not.toContain("telemetry:onboarding:last_reported_id");
   });
 
   test("platform disabled takes precedence over consent off — watermarks NOT advanced", async () => {
@@ -1750,9 +1700,9 @@ describe("UsageTelemetryReporter", () => {
   //
   // The envelope's `assistant_version` is upload-time (always the current
   // binary). The per-event field is record-time (the binary that was running
-  // when the event was persisted to SQLite). In this PR only `llm_usage`
-  // events carry a true record-time value; turn events (and lifecycle /
-  // onboarding events, not asserted here) stamp the running binary's
+  // when the event was persisted to SQLite). `llm_usage` events and the
+  // outbox-backed types carry a true record-time value; turn events (and
+  // lifecycle events, not asserted here) stamp the running binary's
   // `APP_VERSION` directly until their respective follow-ups land.
   // Nullable llm_usage cases (legacy rows from before migration 267 ran)
   // fall back to the running binary's `APP_VERSION` rather than emitting
@@ -1967,22 +1917,12 @@ describe("UsageTelemetryReporter", () => {
   // Onboarding / activation funnel events
   // -------------------------------------------------------------------------
 
-  test("activation onboarding row serializes funnel fields + deterministic daemon_event_id", async () => {
+  test("activation onboarding row flushes with funnel fields + deterministic daemon_event_id, then acks", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     const sessionId = "sess-activation-1";
     const stepName = "activation_moment_1_complete";
-    mockQueryUnreportedOnboardingEvents.mockReturnValue([
-      makeOnboardingEvent({
-        id: "onb-activation-1",
-        screen: stepName,
-        abVariant: "variant-a",
-        sessionId,
-        stepName,
-        stepIndex: 1,
-        completedAt: "2026-06-06T00:00:00.000Z",
-        funnelVersion: ACTIVATION_FUNNEL_VERSION,
-      }),
-    ]);
+    const recorded = recordActivationEvent({ stepName, sessionId });
+    expect(recorded).not.toBeNull();
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
@@ -2000,31 +1940,41 @@ describe("UsageTelemetryReporter", () => {
       session_id: sessionId,
       step_name: stepName,
       step_index: 1,
-      completed_at: "2026-06-06T00:00:00.000Z",
-      funnel_version: "activation_v1_2026_06",
+      funnel_version: ACTIVATION_FUNNEL_VERSION,
       daemon_event_id: buildActivationDaemonEventId(sessionId, stepName),
     });
+    // The wire id is the deterministic activation id, distinct from the
+    // outbox row id (a UUID) the ack deletes by.
+    expect(body.events[0].daemon_event_id).not.toBe(recorded!.id);
+    expect(queryTelemetryOutboxBatch("onboarding", 10)).toHaveLength(0);
   });
 
-  test("activation daemon_event_id is keyed on the row's stored funnel_version, not the binary constant", async () => {
+  test("queued activation row recorded under an older funnel version ships its frozen payload verbatim", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    const sessionId = "sess-activation-old";
-    const stepName = "activation_moment_1_complete";
-    // A row recorded under an OLDER funnel version, queued across an upgrade.
+    // The payload (including the deterministic daemon_event_id keyed on the
+    // OLD funnel version) was frozen at record time; a flush after a version
+    // bump must not restamp it with the new binary's constant.
     const oldVersion = "activation_v0_2026_05";
     expect(oldVersion).not.toBe(ACTIVATION_FUNNEL_VERSION);
-    mockQueryUnreportedOnboardingEvents.mockReturnValue([
-      makeOnboardingEvent({
-        id: "onb-activation-old",
-        screen: stepName,
-        abVariant: "variant-a",
-        sessionId,
-        stepName,
-        stepIndex: 1,
-        completedAt: "2026-05-01T00:00:00.000Z",
-        funnelVersion: oldVersion,
-      }),
-    ]);
+    const frozen: TelemetryEvent = {
+      type: "onboarding",
+      daemon_event_id: `${oldVersion}:sess-activation-old:activation_moment_1_complete`,
+      recorded_at: 1700000100000,
+      screen: "activation_moment_1_complete",
+      ab_variant: "variant-a",
+      session_id: "sess-activation-old",
+      step_name: "activation_moment_1_complete",
+      step_index: 1,
+      completed_at: "2026-05-01T00:00:00.000Z",
+      funnel_version: oldVersion,
+      assistant_version: "0.9.0-old",
+    };
+    insertTelemetryOutboxEvent({
+      id: "row-activation-old",
+      name: "onboarding",
+      createdAt: 1700000100000,
+      event: frozen,
+    });
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
@@ -2035,29 +1985,16 @@ describe("UsageTelemetryReporter", () => {
     const body = JSON.parse(
       (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
     );
-    expect(body.events[0]).toMatchObject({
-      funnel_version: oldVersion,
-      daemon_event_id: buildActivationDaemonEventId(
-        sessionId,
-        stepName,
-        oldVersion,
-      ),
-    });
-    // Guard: the id must carry the row's version, not the binary constant.
-    expect(body.events[0].daemon_event_id).toBe(
-      `${oldVersion}:${sessionId}:${stepName}`,
-    );
+    expect(body.events).toEqual([frozen]);
   });
 
-  test("legacy onboarding row keeps daemon_event_id: e.id and omits funnel fields", async () => {
+  test("legacy onboarding row keeps daemon_event_id = row id and omits funnel fields", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    mockQueryUnreportedOnboardingEvents.mockReturnValue([
-      makeOnboardingEvent({
-        id: "onb-legacy-1",
-        screen: "tools",
-        toolsJson: JSON.stringify(["calendar"]),
-      }),
-    ]);
+    const recorded = recordOnboardingEvent({
+      screen: "tools",
+      tools: ["calendar"],
+    });
+    expect(recorded).not.toBeNull();
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
     );
@@ -2072,7 +2009,8 @@ describe("UsageTelemetryReporter", () => {
     expect(body.events.length).toBe(1);
     const e = body.events[0];
     expect(e.type).toBe("onboarding");
-    expect(e.daemon_event_id).toBe("onb-legacy-1");
+    expect(e.daemon_event_id).toBe(recorded!.id);
+    expect(e.tools).toEqual(["calendar"]);
     expect(e.session_id).toBeUndefined();
     expect(e.step_name).toBeUndefined();
     expect(e.step_index).toBeUndefined();

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -5,9 +5,11 @@
  * lifecycle, ...) from the local SQLite databases and POSTs them to the
  * platform telemetry endpoint. Each event type is a
  * {@link TelemetryEventSource}; the reporter is a generic engine over the
- * source list it is constructed with, advancing one compound
- * `(createdAt, id)` watermark cursor per source in the telemetry DB's
- * `flush_checkpoints` table after each successful upload.
+ * source list it is constructed with, acknowledging each source after a
+ * successful upload in one of two modes: watermark-mode sources advance a
+ * compound `(createdAt, id)` cursor in the telemetry DB's
+ * `flush_checkpoints` table, and ack-mode sources (those defining `ack`)
+ * delete their shipped rows instead.
  *
  * Flushing is split across two processes, each running its own reporter
  * instance over a disjoint source partition: the daemon flushes turn events
@@ -300,9 +302,10 @@ export class UsageTelemetryReporter {
       // opted-out tool_invocations rows persist NULL telemetry columns and
       // are unreportable by construction regardless of watermark timing.
       if (!getCachedShareAnalytics()) {
-        // Advance the timestamp watermarks and pin the ID watermarks to a
-        // sentinel that sorts above any real UUID. The sentinel (rather than
-        // "") keeps the compound-cursor branch active — a falsy ID would
+        // Ack-mode sources drop their pending rows outright. Watermark-mode
+        // sources advance the timestamp watermarks and pin the ID watermarks
+        // to a sentinel that sorts above any real UUID. The sentinel (rather
+        // than "") keeps the compound-cursor branch active — a falsy ID would
         // downgrade the query to a timestamp-only `gt(createdAt, watermark)`
         // — while making its same-millisecond arm unsatisfiable, so a row
         // written in the same millisecond as this flush's Date.now() can
@@ -310,6 +313,10 @@ export class UsageTelemetryReporter {
         // ships events overwrites the sentinel with a real row ID.
         const now = String(Date.now());
         for (const source of this.sources) {
+          if (source.ack) {
+            source.ack.discardPending();
+            continue;
+          }
           const keys = watermarkKeysForSource(source.id);
           this.checkpoints.set(keys.at, now);
           this.checkpoints.set(keys.id, OPT_OUT_WATERMARK_ID_SENTINEL);
@@ -334,6 +341,33 @@ export class UsageTelemetryReporter {
           batch: source.collect(afterCreatedAt, afterId, BATCH_SIZE),
         };
       });
+
+      // Ack-mode batches must carry a row id per event: without them nothing
+      // can be acknowledged post-2xx, so shipping would re-send the same rows
+      // on every flush. Exclude such a batch from the POST instead.
+      for (const entry of batches) {
+        const { source, batch } = entry;
+        if (
+          source.ack &&
+          batch.events.length > 0 &&
+          (batch.rowIds ?? []).length !== batch.events.length
+        ) {
+          log.warn(
+            {
+              sourceId: source.id,
+              eventCount: batch.events.length,
+              rowIdCount: batch.rowIds?.length ?? 0,
+            },
+            "Telemetry flush: ack-mode batch missing/mismatched rowIds — excluding from POST",
+          );
+          entry.batch = {
+            events: [],
+            rowIds: [],
+            lastCursor: null,
+            fullBatch: false,
+          };
+        }
+      }
 
       if (batches.every(({ batch }) => batch.events.length === 0)) {
         return;
@@ -402,9 +436,15 @@ export class UsageTelemetryReporter {
       }
       await resp.text(); // consume body to release connection
 
-      // Advance each source's watermark to its last reported row.
+      // Acknowledge each source's shipped rows: ack-mode sources delete them
+      // (never touching flush_checkpoints), watermark-mode sources advance
+      // their compound cursor to the last reported row.
       for (const { source, batch } of batches) {
-        if (batch.lastCursor) {
+        if (source.ack) {
+          if (batch.events.length > 0) {
+            source.ack.acknowledge(batch.rowIds ?? []);
+          }
+        } else if (batch.lastCursor) {
           const keys = watermarkKeysForSource(source.id);
           this.checkpoints.set(keys.at, String(batch.lastCursor.createdAt));
           this.checkpoints.set(keys.id, batch.lastCursor.id);

--- a/assistant/src/telemetry/watchdog-direct-emit.ts
+++ b/assistant/src/telemetry/watchdog-direct-emit.ts
@@ -1,7 +1,7 @@
 /**
  * Direct (unbuffered) emit of a single `watchdog` telemetry event.
  *
- * The usual watchdog path persists to the SQLite `watchdog_events` table and
+ * The usual watchdog path persists to the SQLite `telemetry_events` outbox and
  * lets {@link ./usage-telemetry-reporter} batch and upload it later. That
  * durable buffer is the right default — it survives restarts and dedupes on
  * `daemon_event_id`. But it is the wrong tool for a check that fires *because*

--- a/assistant/src/telemetry/watchdog-events-store.ts
+++ b/assistant/src/telemetry/watchdog-events-store.ts
@@ -1,15 +1,15 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
-import { watchdogEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { APP_VERSION } from "../version.js";
+import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import type { WatchdogTelemetryEvent } from "./types.js";
 
 /**
  * Input for one `watchdog` telemetry event. Metadata only — never conversation
  * content. `value` and `detail` are optional; omitting both yields the minimal
- * event (check_name only). `detail` is a JSON bag serialized to text on persist
- * and forwarded verbatim on flush.
+ * event (check_name only). `detail` is an open JSON bag carried verbatim in
+ * the event payload.
  */
 export interface WatchdogEventRecord {
   checkName: string;
@@ -19,69 +19,27 @@ export interface WatchdogEventRecord {
   detail?: Record<string, unknown> | null;
 }
 
-/** A persisted watchdog event row. */
-export interface WatchdogEvent {
-  id: string;
-  createdAt: number;
-  checkName: string;
-  value: number | null;
-  /** Raw `detail` JSON text from the row, or null. Parsed by the reporter on flush. */
-  detail: string | null;
-}
-
 /**
- * Record a `watchdog` telemetry event for a watchdog check firing. No-ops when
- * usage data collection is disabled (the event is dropped to honor the opt-out,
- * matching the rest of telemetry) — so opt-out rows never exist and the
- * reporter's standard 0 watermark default is safe.
+ * Record a `watchdog` telemetry event for a watchdog check firing. Builds the
+ * full wire event and enqueues it on the `telemetry_events` outbox. No-ops
+ * when usage data collection is disabled (the event is dropped to honor the
+ * opt-out, matching the rest of telemetry) or when the telemetry DB is
+ * unavailable.
  */
 export function recordWatchdogEvent(record: WatchdogEventRecord): void {
-  if (!getCachedShareAnalytics()) return;
-  const db = getTelemetryDb();
-  if (!db) return;
-  db.insert(watchdogEvents)
-    .values({
-      id: uuid(),
-      createdAt: Date.now(),
-      checkName: record.checkName,
-      value: record.value ?? null,
-      detail: record.detail != null ? JSON.stringify(record.detail) : null,
-    })
-    .run();
-}
-
-/**
- * Query watchdog events that haven't been reported to telemetry yet.
- * Uses a compound cursor (createdAt + id) for reliable watermarking.
- */
-export function queryUnreportedWatchdogEvents(
-  afterCreatedAt: number,
-  afterId: string | undefined,
-  limit: number,
-): WatchdogEvent[] {
-  const db = getTelemetryDb();
-  if (!db) return [];
-  return db
-    .select({
-      id: watchdogEvents.id,
-      createdAt: watchdogEvents.createdAt,
-      checkName: watchdogEvents.checkName,
-      value: watchdogEvents.value,
-      detail: watchdogEvents.detail,
-    })
-    .from(watchdogEvents)
-    .where(
-      afterId
-        ? or(
-            gt(watchdogEvents.createdAt, afterCreatedAt),
-            and(
-              eq(watchdogEvents.createdAt, afterCreatedAt),
-              gt(watchdogEvents.id, afterId),
-            ),
-          )
-        : gt(watchdogEvents.createdAt, afterCreatedAt),
-    )
-    .orderBy(asc(watchdogEvents.createdAt), asc(watchdogEvents.id))
-    .limit(limit)
-    .all();
+  if (!getCachedShareAnalytics()) {
+    return;
+  }
+  const id = uuid();
+  const createdAt = Date.now();
+  const event: WatchdogTelemetryEvent = {
+    type: "watchdog",
+    daemon_event_id: id,
+    recorded_at: createdAt,
+    check_name: record.checkName,
+    value: record.value ?? null,
+    detail: record.detail ?? null,
+    assistant_version: APP_VERSION,
+  };
+  insertTelemetryOutboxEvent({ id, name: "watchdog", createdAt, event });
 }

--- a/assistant/src/telemetry/watchdog-events-store.ts
+++ b/assistant/src/telemetry/watchdog-events-store.ts
@@ -1,8 +1,5 @@
-import { v4 as uuid } from "uuid";
-
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { APP_VERSION } from "../version.js";
-import { insertTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
 import type { WatchdogTelemetryEvent } from "./types.js";
 
 /**
@@ -27,19 +24,16 @@ export interface WatchdogEventRecord {
  * unavailable.
  */
 export function recordWatchdogEvent(record: WatchdogEventRecord): void {
-  if (!getCachedShareAnalytics()) {
-    return;
-  }
-  const id = uuid();
-  const createdAt = Date.now();
-  const event: WatchdogTelemetryEvent = {
-    type: "watchdog",
-    daemon_event_id: id,
-    recorded_at: createdAt,
-    check_name: record.checkName,
-    value: record.value ?? null,
-    detail: record.detail ?? null,
-    assistant_version: APP_VERSION,
-  };
-  insertTelemetryOutboxEvent({ id, name: "watchdog", createdAt, event });
+  recordTelemetryOutboxEvent(
+    "watchdog",
+    (id, createdAt): WatchdogTelemetryEvent => ({
+      type: "watchdog",
+      daemon_event_id: id,
+      recorded_at: createdAt,
+      check_name: record.checkName,
+      value: record.value ?? null,
+      detail: record.detail ?? null,
+      assistant_version: APP_VERSION,
+    }),
+  );
 }

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -54,8 +54,8 @@ export interface UsageAttributionSnapshot {
 }
 
 /**
- * The four nullable attribution columns shared by telemetry event rows
- * (`tool_invocations`, `skill_loaded_events`).
+ * The four nullable attribution columns shared by telemetry events
+ * (`tool_invocations` rows, `skill_loaded` outbox payloads).
  */
 export interface UsageAttributionColumns {
   provider: string | null;

--- a/assistant/src/util/telemetry-db-path.ts
+++ b/assistant/src/util/telemetry-db-path.ts
@@ -3,14 +3,15 @@ import { join } from "node:path";
 import { getDataDir } from "./platform.js";
 
 /**
- * Path to the dedicated SQLite file that houses the telemetry-only event
- * tables: `watchdog_events`, `config_setting_events`, `onboarding_events`,
- * `auth_fallback_events`, `lifecycle_events`, and `skill_loaded_events`. It
- * lives in the same `data/db` directory as the main DB and is opened on its
- * own connection (see `getTelemetryDb()` in `persistence/db-connection.ts`).
- * Splitting telemetry tables into their own file keeps the main DB — and its
- * WAL — small and lets the two files VACUUM/checkpoint independently, so a
- * burst of telemetry events cannot bloat the main database.
+ * Path to the dedicated SQLite file that houses the telemetry-only tables:
+ * `telemetry_events` (the generic outbox of wire `TelemetryEvent` payloads,
+ * deleted on successful flush) and `flush_checkpoints` (watermark cursors for
+ * the main-DB-backed sources: usage, turns, tool_executed). It lives in the
+ * same `data/db` directory as the main DB and is opened on its own connection
+ * (see `getTelemetryDb()` in `persistence/db-connection.ts`). Splitting
+ * telemetry tables into their own file keeps the main DB — and its WAL —
+ * small and lets the two files VACUUM/checkpoint independently, so a burst of
+ * telemetry events cannot bloat the main database.
  *
  * Kept in its own leaf module rather than alongside `getDbPath()` in
  * `platform.ts`: `platform.ts` is imported very early and widely, and adding an


### PR DESCRIPTION
## Summary
Replaces the six telemetry-only tables in `assistant-telemetry.db` (`lifecycle_events`, `onboarding_events`, `auth_fallback_events`, `skill_loaded_events`, `watchdog_events`, `config_setting_events`) with one generic `telemetry_events` outbox: common columns (`id`, `name`, `created_at`, nullable indexed `conversation_id`) plus a `payload` column holding the exact wire `TelemetryEvent`, built at record time by a shared consent-owning helper. Flush acknowledgment switches from watermark cursors to **delete-on-flush** (rows deleted after a 2xx; at-least-once preserved by server-side `daemon_event_id` dedup). New event types / schema changes no longer need a SQLite migration. The main-DB sources (`llm_usage`, `turns`, `tool_executed`) are untouched and stay watermark-based; `flush_checkpoints` survives for them.

Migration 333 creates the table; migration 334 backfills **unshipped** legacy rows (watermark-filtered, frozen embedded mappers, conversation-liveness filter for skill_loaded, gated on completed relocations), drops the six tables, and purges their 12 watermark keys.

## Accepted behavior changes (flagged for review judgment)
1. **`conversations_clear_all` audit rows now ship-and-delete** like any outbox row — the durable trail lives platform-side once flushed; while opted out, the opt-out discard removes it locally without shipping (previously it sat locally forever, unshipped and unread).
2. **`prior_assistants` telemetry persistence dropped** — it was stored but never shipped on the wire and never read locally. The request-body field still feeds prompt personalization.
3. **`assistant_version` is now record-time** for the six types (previously flush-time) — the direction existing code comments already called the desired follow-up.
4. **Corrupt stored payloads are purged at collect with a metadata-only warn** — previously a corrupt JSON column could wedge the flush retry loop forever.

## Self-review result
GAPS FOUND → fixed. 3 rounds, 4 passes each (external feedback, plan faithfulness, repo integration, slop audit): 7 gaps fixed across 3 fix PRs; 13 Codex inline findings across the milestone PRs all fixed or verified deferred-by-design into PR 9. Round 3 clean.

## PRs merged into feature branch
- #37918: telemetry_events table (migration 333) + outbox store
- #37919: reporter acknowledge/discard (ack-mode) plumbing
- #37920: outboxSource factory
- #37926: lifecycle → outbox (+ clearAll audit switch)
- #37924: onboarding/activation → outbox
- #37923: auth_fallback → outbox (atomic batch; gateway 503 contract preserved)
- #37925: skill_loaded → outbox (+ conversation redaction on telemetry_events)
- #37922: watchdog + config_setting → outbox
- #37934: migration 334 backfill + drop + watermark purge + docs

### Fix PRs
- #37943: shared consent-owning recordTelemetryOutboxEvent helper; slim onboarding return
- #37944: stale docs; migration-334 counts sum actual INSERT changes
- #37947: drop dead onboarding plumbing (priorAssistants forward, completedAt return, userId param)

Part of plan: telemetry-outbox-consolidation.md