### PR TITLE
fix: self-review batch — guard optional merge contact in the tool; comment/test trims

### DIFF
--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -50,12 +50,11 @@ mock.module("../ipc/cli-client.js", () => ({
       // merge core, which validates and mirrors back into the assistant DB.
       // Emulate that against the fixture DB via the mirror write path.
       const { keepId, mergeId } = body as { keepId: string; mergeId: string };
+      // The tool pre-validates both contacts via getContact, so the fake only
+      // needs the survivor row (for keepDisplayName).
       const keep = store.getContact(keepId);
       if (!keep) {
         return { ok: false, error: `Contact "${keepId}" not found` };
-      }
-      if (!store.getContact(mergeId)) {
-        return { ok: false, error: `Contact "${mergeId}" not found` };
       }
       store.mergeContactMirror({
         keepContactId: keepId,

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
@@ -49,7 +49,7 @@ export async function executeContactMerge(
 
   const mergeResult = await cliIpcCall<{
     ok: boolean;
-    contact: ContactRead;
+    contact?: ContactRead;
   }>("merge_contacts", {
     body: { keepId, mergeId },
   });
@@ -58,7 +58,9 @@ export async function executeContactMerge(
     return { content: `Error: ${mergeResult.error}`, isError: true };
   }
 
-  const mergedId = mergeResult.result!.contact.id;
+  // The merge response may omit the survivor (post-merge read-back can
+  // degrade); the id we asked to keep is authoritative either way.
+  const mergedId = mergeResult.result?.contact?.id ?? keepId;
 
   // Re-read the surviving contact through the gateway-relayed read so role and
   // interactionCount come from the gateway ContactRead.

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -771,11 +771,9 @@ export async function updateContactChannelCore(params: {
  * transaction + best-effort assistant mirror), emits `contacts_changed`, and
  * returns the survivor contact payload.
  *
- * Throws `MergeContactsError` (statusCode 400, code MERGE_CONTACTS_INVALID)
- * for validation failures (self-merge, contact not found, guardian donor).
- * The HTTP handler maps it to a 400; the IPC server mirrors `statusCode`/
- * `code` into the wire envelope. Unexpected errors propagate so each
- * transport surfaces a 500-equivalent — never a silent fallback.
+ * Throws `MergeContactsError` for validation failures; unexpected errors
+ * propagate so each transport surfaces a 500-equivalent — never a silent
+ * fallback.
  */
 export async function mergeContactsCore(params: {
   keepId: string;
@@ -1211,8 +1209,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       }
 
       const assistantMeta = body.assistantMetadata as
-        | { species?: unknown; metadata?: unknown }
-        | undefined;
+        { species?: unknown; metadata?: unknown } | undefined;
 
       if (body.contactType === "assistant") {
         if (!assistantMeta) {
@@ -1368,9 +1365,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
                 species: assistantMeta.species as string,
                 metadata:
                   (assistantMeta.metadata as
-                    | Record<string, unknown>
-                    | null
-                    | undefined) ?? null,
+                    Record<string, unknown> | null | undefined) ?? null,
               }
             : undefined,
         channels: channelInputs?.map((ch) => ({

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -215,9 +215,6 @@ export const contactRoutes: IpcRoute[] = [
     schema: MergeContactsIpcParamsSchema,
     handler: (params?: Record<string, unknown>) => {
       const parsed = MergeContactsIpcParamsSchema.parse(params);
-      // Thrown MergeContactsError carries statusCode/code, which the IPC
-      // server's buildErrorResponse mirrors into the wire envelope; unexpected
-      // errors propagate as a generic IPC error (no fallback).
       return mergeContactsCore(parsed);
     },
   },


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for contact-merge-relay.md.

- The bundled contact_merge tool no longer non-null-asserts the merge response's now-optional contact (falls back to keepId, which it re-reads anyway)
- The IPC error-envelope mechanism is documented once (on MergeContactsError) instead of three times
- The contacts-tools test fake drops its unreachable mergeId not-found branch