### PR TITLE
Plugin catalog source consistency (search ⟷ install ⟷ details)

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-catalog-local.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-local.test.ts
@@ -35,6 +35,8 @@ describe("buildBundledPluginCatalog", () => {
       description:
         "Ultra-compressed communication mode that strips filler words to cut token usage.",
       category: "productivity",
+      homepage: "https://github.com/JuliusBrussee/caveman",
+      license: "MIT",
       source: {
         kind: "github",
         repo: "JuliusBrussee/caveman",

--- a/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
@@ -38,12 +38,12 @@ describe("fetchPluginCatalogFromPlatform", () => {
             path: "packages/plugin",
             description: "graph memory",
             category: "productivity",
+            homepage: "https://example.com",
+            license: "MIT",
             // dropped keys
             id: "abc",
             display_name: "Memory Graph",
             icon: "🧠",
-            homepage: "https://example.com",
-            license: "MIT",
           },
           {
             name: "alpha-tool",
@@ -66,6 +66,8 @@ describe("fetchPluginCatalogFromPlatform", () => {
       path: `github:acme/memory-graph/packages/plugin@${SHA_B}`,
       description: "graph memory",
       category: "productivity",
+      homepage: "https://example.com",
+      license: "MIT",
       source: {
         kind: "github",
         repo: "acme/memory-graph",
@@ -76,6 +78,8 @@ describe("fetchPluginCatalogFromPlatform", () => {
 
     const alpha = catalog.matches[0];
     expect(alpha.category).toBeNull();
+    expect(alpha.homepage).toBeUndefined();
+    expect(alpha.license).toBeUndefined();
     expect(alpha.source).toEqual({
       kind: "github",
       repo: "vellum-ai/alpha-tool",

--- a/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the gated catalog resolvers.
+ *
+ * `resolveSourceFromMatch` is exercised as a pure function. The catalog-backed
+ * resolvers run against the bundled manifest with platform features disabled
+ * (`VELLUM_DISABLE_PLATFORM`, zero network), plus a platform-enabled case that
+ * asserts a rejecting catalog fetch propagates rather than resolving to `null`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { FetchLike } from "../fetch-like.js";
+import { invalidatePluginCatalogCache } from "../plugin-catalog-cache.js";
+import {
+  findCatalogEntry,
+  resolvePluginSourceFromCatalog,
+  resolveSourceFromMatch,
+} from "../plugin-catalog-resolve.js";
+import type { PluginSearchMatch, SearchPluginsDeps } from "../search-plugins.js";
+import { PluginCatalogUnavailableError } from "../search-plugins.js";
+
+const FULL_SHA = "63a91ecadbf4c4719a4602a5abb00883f9966034";
+
+/** A synthetic catalog match with an overridable source. */
+function match(
+  source: Partial<PluginSearchMatch["source"]> = {},
+): PluginSearchMatch {
+  return {
+    name: "example",
+    path: "github:acme/example@ref",
+    category: null,
+    source: { kind: "github", repo: "acme/example", ref: FULL_SHA, ...source },
+  };
+}
+
+describe("resolveSourceFromMatch", () => {
+  test("returns owner/repo/path/ref for a full-SHA match", () => {
+    expect(
+      resolveSourceFromMatch(match({ repo: "acme/widget", path: "pkg/plugin" })),
+    ).toEqual({
+      owner: "acme",
+      repo: "widget",
+      path: "pkg/plugin",
+      ref: FULL_SHA,
+    });
+  });
+
+  test("defaults path to \"\" when the source declares none", () => {
+    expect(resolveSourceFromMatch(match())).toEqual({
+      owner: "acme",
+      repo: "example",
+      path: "",
+      ref: FULL_SHA,
+    });
+  });
+
+  test.each([
+    ["a branch", "main"],
+    ["a tag", "v1.2.3"],
+    ["a short SHA", "63a91ec"],
+  ])("throws on %s ref", (_label, ref) => {
+    expect(() => resolveSourceFromMatch(match({ ref }))).toThrow();
+  });
+});
+
+describe("catalog-backed resolvers (bundled, offline)", () => {
+  const ORIGINAL_ENV = {
+    IS_PLATFORM: process.env.IS_PLATFORM,
+    VELLUM_DISABLE_PLATFORM: process.env.VELLUM_DISABLE_PLATFORM,
+  };
+
+  beforeEach(() => {
+    invalidatePluginCatalogCache();
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    delete process.env.IS_PLATFORM;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+      if (value === undefined) {delete process.env[key];}
+      else {process.env[key] = value;}
+    }
+  });
+
+  // A rejecting fetch proves the bundled path never touches the network.
+  const rejectingDeps: SearchPluginsDeps = {
+    fetch: (async () => {
+      throw new Error("network must not be used");
+    }) as FetchLike,
+  };
+
+  test("findCatalogEntry returns the bundled entry for a known name", async () => {
+    const entry = await findCatalogEntry("caveman", rejectingDeps);
+    expect(entry?.name).toBe("caveman");
+    expect(entry?.source).toEqual({
+      kind: "github",
+      repo: "JuliusBrussee/caveman",
+      path: undefined,
+      ref: FULL_SHA,
+    });
+  });
+
+  test("resolvePluginSourceFromCatalog resolves a known name to its pinned source", async () => {
+    expect(
+      await resolvePluginSourceFromCatalog("caveman", rejectingDeps),
+    ).toEqual({
+      owner: "JuliusBrussee",
+      repo: "caveman",
+      path: "",
+      ref: FULL_SHA,
+    });
+  });
+
+  test("resolvePluginSourceFromCatalog returns null for an unknown name", async () => {
+    expect(
+      await resolvePluginSourceFromCatalog("no-such-plugin", rejectingDeps),
+    ).toBeNull();
+  });
+});
+
+describe("catalog-backed resolvers (platform enabled)", () => {
+  const ORIGINAL_ENV = {
+    IS_PLATFORM: process.env.IS_PLATFORM,
+    VELLUM_DISABLE_PLATFORM: process.env.VELLUM_DISABLE_PLATFORM,
+  };
+
+  beforeEach(() => {
+    invalidatePluginCatalogCache();
+    delete process.env.IS_PLATFORM;
+    delete process.env.VELLUM_DISABLE_PLATFORM;
+  });
+
+  afterEach(() => {
+    invalidatePluginCatalogCache();
+    for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+      if (value === undefined) {delete process.env[key];}
+      else {process.env[key] = value;}
+    }
+  });
+
+  test("propagates PluginCatalogUnavailableError instead of resolving to null", async () => {
+    const deps: SearchPluginsDeps = {
+      fetch: (async () => {
+        throw new Error("network down");
+      }) as FetchLike,
+    };
+    const promise = resolvePluginSourceFromCatalog("caveman", deps);
+    await expect(promise).rejects.toBeInstanceOf(PluginCatalogUnavailableError);
+  });
+});

--- a/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-resolve.test.ts
@@ -55,11 +55,58 @@ describe("resolveSourceFromMatch", () => {
   });
 
   test.each([
+    ["absent", undefined],
+    ["empty", ""],
+  ])("resolves a repo-root %s path to \"\"", (_label, path) => {
+    // A repo-root entry (`path: ""` or absent) is valid — the clean-path gate
+    // only applies to a non-empty path, so it must not be rejected.
+    expect(resolveSourceFromMatch(match({ path }))).toEqual({
+      owner: "acme",
+      repo: "example",
+      path: "",
+      ref: FULL_SHA,
+    });
+  });
+
+  test.each([
+    ["too many segments", "owner/repo/extra"],
+    ["a slashless name", "justname"],
+  ])("throws on an invalid repo slug with %s", (_label, repo) => {
+    expect(() => resolveSourceFromMatch(match({ repo }))).toThrow(
+      /invalid source/,
+    );
+  });
+
+  test.each([
     ["a branch", "main"],
     ["a tag", "v1.2.3"],
     ["a short SHA", "63a91ec"],
   ])("throws on %s ref", (_label, ref) => {
-    expect(() => resolveSourceFromMatch(match({ ref }))).toThrow();
+    expect(() => resolveSourceFromMatch(match({ ref }))).toThrow(
+      /invalid source/,
+    );
+  });
+
+  test("resolves a clean nested path", () => {
+    expect(
+      resolveSourceFromMatch(match({ path: "packages/plugin" })),
+    ).toEqual({
+      owner: "acme",
+      repo: "example",
+      path: "packages/plugin",
+      ref: FULL_SHA,
+    });
+  });
+
+  test.each([
+    ["a leading `..` segment", "../evil"],
+    ["an interior `..` segment", "a/../b"],
+    ["a backslash `..` segment", "a\\..\\b"],
+    ["an empty segment", "a//b"],
+  ])("throws on an unsafe path with %s", (_label, path) => {
+    expect(() => resolveSourceFromMatch(match({ path }))).toThrow(
+      /invalid source/,
+    );
   });
 });
 

--- a/assistant/src/cli/lib/__tests__/plugin-details.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-details.test.ts
@@ -1,13 +1,22 @@
 /**
  * Tests for {@link getPluginDetails}.
  *
- * Network is replaced with an in-memory GitHub Contents API fixture passed via
- * the `fetch` dependency, and the installed-copy path is exercised against a
- * real temp directory passed via `workspacePluginsDir` — no globals are
- * monkey-patched. The fixture answers three URL shapes:
- *   - the marketplace manifest file (raw JSON body),
+ * At the default ref, the catalog entry is resolved from the gated plugin
+ * catalog (the same source search and install-by-name use): these tests run
+ * with platform features disabled (`VELLUM_DISABLE_PLATFORM`) so the catalog is
+ * the bundled manifest — real plugin names / pinned SHAs, zero network. An
+ * explicit historical `ref` instead reads the GitHub `plugins/marketplace.json`
+ * at that revision (a git lookup, matching pin history / inspect). GitHub is
+ * replaced with an
+ * in-memory Contents API fixture passed via the `fetch` dependency, and the
+ * installed-copy path is exercised against a real temp directory passed via
+ * `workspacePluginsDir` — no globals are monkey-patched. The fixture answers two
+ * URL shapes:
  *   - directory listings (`/contents/<path>` → entry array or 404),
  *   - raw file downloads (a listing entry's `download_url`).
+ *
+ * A separate suite drives the platform-enabled path with a failing catalog
+ * fetch to prove the detail view degrades (local + repo fallback) on an outage.
  */
 
 import { createHash } from "node:crypto";
@@ -17,10 +26,16 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { FetchLike } from "../fetch-like.js";
+import { invalidatePluginCatalogCache } from "../plugin-catalog-cache.js";
+import { readBundledPluginCatalog } from "../plugin-catalog-local.js";
 import {
   getPluginDetails,
   PluginDetailsNotFoundError,
 } from "../plugin-details.js";
+import {
+  PluginCatalogUnavailableError,
+  type PluginSearchMatch,
+} from "../search-plugins.js";
 
 interface ContentEntry {
   name: string;
@@ -34,8 +49,6 @@ function fileEntry(name: string, downloadUrl: string): ContentEntry {
 }
 
 interface FixtureConfig {
-  /** Manifest object served at `plugins/marketplace.json`. Omit for 404. */
-  marketplace?: unknown;
   /** Directory listings keyed by `<owner>/<repo>[/<path>]`. Missing key → 404. */
   listings?: Record<string, ContentEntry[]>;
   /** Raw file bodies keyed by `download_url`. Missing key → 404. */
@@ -54,13 +67,6 @@ function makeFetch(config: FixtureConfig): FetchLike {
 
     for (const needle of config.failOn ?? []) {
       if (url.includes(needle)) throw new Error(`network down: ${needle}`);
-    }
-
-    if (url.includes("marketplace.json")) {
-      if (config.marketplace === undefined) {
-        return new Response("not found", { status: 404 });
-      }
-      return new Response(JSON.stringify(config.marketplace), { status: 200 });
     }
 
     if (config.raw && url in config.raw) {
@@ -95,6 +101,13 @@ function splitOnce(s: string, sep: string): [string, string] {
   return [s.slice(0, i), s.slice(i + sep.length)];
 }
 
+/** The bundled catalog entry for {@link name} — the source under test. */
+function bundledMatch(name: string): PluginSearchMatch {
+  const match = readBundledPluginCatalog().matches.find((m) => m.name === name);
+  if (!match) throw new Error(`bundled catalog has no entry for "${name}"`);
+  return match;
+}
+
 const PNG_SIGNATURE = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
 ]);
@@ -114,39 +127,43 @@ function sha16(buf: Buffer): string {
   return createHash("sha256").update(buf).digest("hex").slice(0, 16);
 }
 
+const ORIGINAL_ENV = {
+  IS_PLATFORM: process.env.IS_PLATFORM,
+  VELLUM_DISABLE_PLATFORM: process.env.VELLUM_DISABLE_PLATFORM,
+};
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
 let workspace: string;
 
-beforeEach(() => {
-  workspace = mkdtempSync(join(tmpdir(), "plugin-details-"));
-});
+describe("getPluginDetails (bundled catalog, offline)", () => {
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "plugin-details-"));
+    invalidatePluginCatalogCache();
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    delete process.env.IS_PLATFORM;
+  });
 
-afterEach(() => {
-  rmSync(workspace, { recursive: true, force: true });
-});
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+    restoreEnv();
+  });
 
-describe("getPluginDetails", () => {
-  test("resolves an external plugin: manifest metadata + repo README/package.json", async () => {
-    // GIVEN a marketplace entry for an external, not-installed plugin
+  test("resolves an external plugin: catalog metadata + repo README/package.json", async () => {
+    // GIVEN a known bundled catalog plugin, not installed locally
+    const caveman = bundledMatch("caveman");
     const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [
-          {
-            name: "caveman",
-            source: {
-              source: "github",
-              repo: "example-org/caveman",
-              ref: "1111111111111111111111111111111111111111",
-            },
-            description: "manifest description",
-            homepage: "https://example.com/caveman",
-            license: "MIT",
-          },
-        ],
-      },
-      // AND the external repo root lists a README and package.json
+      // AND its external repo root lists a README and package.json
       listings: {
-        "example-org/caveman": [
+        [caveman.source.repo]: [
           fileEntry("README.md", "raw://caveman/readme"),
           fileEntry("package.json", "raw://caveman/pkg"),
         ],
@@ -161,55 +178,35 @@ describe("getPluginDetails", () => {
       },
     });
 
-    // WHEN we resolve the detail view at a ref
+    // WHEN we resolve the detail view at the default ref (gated catalog path)
     const details = await getPluginDetails(
-      { name: "caveman", ref: "v1" },
+      { name: "caveman" },
       { fetch, workspacePluginsDir: workspace },
     );
 
-    // THEN the source is the external repo and the README comes from it
-    expect(details.source).toEqual({
-      kind: "github",
-      repo: "example-org/caveman",
-      ref: "1111111111111111111111111111111111111111",
-    });
+    // THEN the source is the catalog's pinned origin and the README comes from it
+    expect(details.source).toEqual(caveman.source);
     expect(details.installed).toBe(false);
     expect(details.readme).toContain("Grug brain plugin");
-    // AND manifest fields win over the repo package.json for description/homepage
-    expect(details.description).toBe("manifest description");
-    expect(details.homepage).toBe("https://example.com/caveman");
-    expect(details.license).toBe("MIT");
-    // AND version falls back to the repo package.json (manifest has none)
+    // AND catalog fields win over the repo package.json for description/homepage
+    expect(details.description).toBe(caveman.description ?? null);
+    expect(details.homepage).toBe(caveman.homepage ?? null);
+    expect(details.license).toBe(caveman.license ?? null);
+    // AND version falls back to the repo package.json (the catalog carries none)
     expect(details.version).toBe("1.8.2");
-    expect(details.ref).toBe("v1");
+    expect(details.ref).toBe("main");
   });
 
   test("reads an external plugin at its pinned source ref, not the catalog ref", async () => {
-    // GIVEN a marketplace entry pinned to a ref that differs from the catalog
-    // ref the detail view is resolved at
-    const marketplace = {
-      name: "vellum",
-      plugins: [
-        {
-          name: "caveman",
-          source: {
-            source: "github",
-            repo: "example-org/caveman",
-            ref: "2222222222222222222222222222222222222222",
-          },
-        },
-      ],
-    };
+    // GIVEN a bundled catalog entry pinned to a full-SHA source ref
+    const caveman = bundledMatch("caveman");
     // AND a fetch that records the ref query param of every contents request
     const contentsRefs = new Map<string, string>();
     const fetch = (async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("marketplace.json")) {
-        return new Response(JSON.stringify(marketplace), { status: 200 });
-      }
       if (url.includes("/contents")) {
         const ref = new URL(url).searchParams.get("ref") ?? "";
-        const key = url.includes("example-org/caveman") ? "external" : "other";
+        const key = url.includes(caveman.source.repo) ? "external" : "other";
         contentsRefs.set(key, ref);
         if (key === "external") {
           return new Response(
@@ -225,41 +222,26 @@ describe("getPluginDetails", () => {
       return new Response("unexpected url: " + url, { status: 500 });
     }) as FetchLike;
 
-    // WHEN we resolve the detail view at the catalog ref `main`
+    // WHEN we resolve the detail view at a catalog ref that isn't the pin
     const details = await getPluginDetails(
       { name: "caveman", ref: "main" },
       { fetch, workspacePluginsDir: workspace },
     );
 
-    // THEN the external repo is read at the plugin's pinned ref, not `main`
-    expect(contentsRefs.get("external")).toBe(
-      "2222222222222222222222222222222222222222",
-    );
-    // AND the pinned external repo is the only contents request — no other
-    // GitHub lookups are made for the name
+    // THEN the external repo is read at the plugin's pinned SHA, not the ref
+    expect(contentsRefs.get("external")).toBe(caveman.source.ref);
+    // AND the pinned external repo is the only contents request
     expect(contentsRefs.has("other")).toBe(false);
     // AND the README from the pinned ref is surfaced
     expect(details.readme).toContain("Caveman");
   });
 
-  test("resolves the external marketplace source for an uninstalled plugin", async () => {
-    // GIVEN a marketplace entry for "simple-memory" and no installed copy
+  test("resolves the external catalog source for an uninstalled plugin", async () => {
+    // GIVEN a bundled catalog entry and no installed copy
+    const simpleMemory = bundledMatch("simple-memory");
     const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [
-          {
-            name: "simple-memory",
-            source: {
-              source: "github",
-              repo: "example-org/simple-memory",
-              ref: "9999999999999999999999999999999999999999",
-            },
-          },
-        ],
-      },
       listings: {
-        "example-org/simple-memory": [
+        [simpleMemory.source.repo]: [
           fileEntry("README.md", "raw://ext/readme"),
         ],
       },
@@ -272,17 +254,14 @@ describe("getPluginDetails", () => {
       { fetch, workspacePluginsDir: workspace },
     );
 
-    // THEN the external marketplace source is used
-    expect(details.source).toEqual({
-      kind: "github",
-      repo: "example-org/simple-memory",
-      ref: "9999999999999999999999999999999999999999",
-    });
+    // THEN the external catalog source is used
+    expect(details.source).toEqual(simpleMemory.source);
     expect(details.readme).toContain("external");
   });
 
   test("prefers an installed copy's README and package.json over the repo", async () => {
     // GIVEN an installed copy on disk with its own README + package.json
+    const caveman = bundledMatch("caveman");
     const target = join(workspace, "caveman");
     mkdirSync(target, { recursive: true });
     writeFileSync(join(target, "README.md"), "# Installed Caveman");
@@ -291,24 +270,12 @@ describe("getPluginDetails", () => {
       JSON.stringify({ version: "2.0.0", license: "Apache-2.0" }),
     );
 
-    // AND a marketplace entry + external repo that would otherwise be used
+    // AND an external repo that would otherwise be used
     const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [
-          {
-            name: "caveman",
-            source: {
-              source: "github",
-              repo: "example-org/caveman",
-              ref: "1111111111111111111111111111111111111111",
-            },
-            description: "manifest description",
-          },
-        ],
-      },
       listings: {
-        "example-org/caveman": [fileEntry("README.md", "raw://caveman/readme")],
+        [caveman.source.repo]: [
+          fileEntry("README.md", "raw://caveman/readme"),
+        ],
       },
       raw: { "raw://caveman/readme": "# Remote Caveman" },
     });
@@ -319,12 +286,12 @@ describe("getPluginDetails", () => {
       { fetch, workspacePluginsDir: workspace },
     );
 
-    // THEN the installed README + version/license win; manifest fills the gap
+    // THEN the installed README + version/license win; the catalog fills the gap
     expect(details.installed).toBe(true);
     expect(details.readme).toBe("# Installed Caveman");
     expect(details.version).toBe("2.0.0");
     expect(details.license).toBe("Apache-2.0");
-    expect(details.description).toBe("manifest description");
+    expect(details.description).toBe(caveman.description ?? null);
     // AND a package.json without vellum.icon surfaces icon as null
     expect(details.icon).toBeNull();
   });
@@ -338,14 +305,7 @@ describe("getPluginDetails", () => {
       JSON.stringify({ version: "2.0.0", vellum: { icon: "🦴" } }),
     );
 
-    const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [{ name: "caveman", description: "d" }],
-      },
-      listings: {},
-      raw: {},
-    });
+    const fetch = makeFetch({});
 
     const details = await getPluginDetails(
       { name: "caveman" },
@@ -368,12 +328,7 @@ describe("getPluginDetails", () => {
     const png = makePng(64, 64);
     writeFileSync(join(target, "icon.png"), png);
 
-    const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [{ name: "caveman", description: "d" }],
-      },
-    });
+    const fetch = makeFetch({});
 
     // WHEN we resolve the detail view
     const details = await getPluginDetails(
@@ -396,12 +351,7 @@ describe("getPluginDetails", () => {
       JSON.stringify({ version: "2.0.0" }),
     );
 
-    const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [{ name: "caveman", description: "d" }],
-      },
-    });
+    const fetch = makeFetch({});
 
     const details = await getPluginDetails(
       { name: "caveman" },
@@ -414,23 +364,9 @@ describe("getPluginDetails", () => {
   });
 
   test("reports hasIcon false + null iconVersion for an uninstalled plugin", async () => {
-    // GIVEN a marketplace-only plugin with no installed copy
-    const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [
-          {
-            name: "simple-memory",
-            source: {
-              source: "github",
-              repo: "example-org/simple-memory",
-              ref: "9999999999999999999999999999999999999999",
-            },
-          },
-        ],
-      },
-      listings: { "example-org/simple-memory": [] },
-    });
+    // GIVEN a catalog-only plugin with no installed copy
+    const simpleMemory = bundledMatch("simple-memory");
+    const fetch = makeFetch({ listings: { [simpleMemory.source.repo]: [] } });
 
     const details = await getPluginDetails(
       { name: "simple-memory" },
@@ -444,61 +380,129 @@ describe("getPluginDetails", () => {
   });
 
   test("throws PluginDetailsNotFoundError when nothing claims the name", async () => {
-    // GIVEN no installed copy and an empty marketplace
-    const fetch = makeFetch({
-      marketplace: { name: "vellum", plugins: [] },
-    });
+    // GIVEN no installed copy and a name absent from the bundled catalog
+    const fetch = makeFetch({});
 
     // WHEN / THEN resolving an unknown name rejects with the not-found error
     await expect(
       getPluginDetails(
-        { name: "ghost" },
+        { name: "no-such-ghost-plugin" },
         { fetch, workspacePluginsDir: workspace },
       ),
     ).rejects.toBeInstanceOf(PluginDetailsNotFoundError);
   });
 
-  test("degrades to manifest metadata when the repo listing fails", async () => {
-    // GIVEN a marketplace entry whose external repo listing errors out
-    const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [
-          {
-            name: "caveman",
-            source: {
-              source: "github",
-              repo: "example-org/caveman",
-              ref: "1111111111111111111111111111111111111111",
-            },
-            description: "manifest description",
-            license: "MIT",
-          },
-        ],
-      },
-      failOn: ["example-org/caveman"],
-    });
+  test("degrades to catalog metadata when the repo listing fails", async () => {
+    // GIVEN a catalog entry whose external repo listing errors out
+    const caveman = bundledMatch("caveman");
+    const fetch = makeFetch({ failOn: [caveman.source.repo] });
 
-    // WHEN we resolve the detail view
+    // WHEN we resolve the detail view at the default ref
     const details = await getPluginDetails(
-      { name: "caveman", ref: "v1" },
+      { name: "caveman" },
       { fetch, workspacePluginsDir: workspace },
     );
 
-    // THEN it still renders manifest metadata with a null README rather than throwing
+    // THEN it still renders catalog metadata with a null README rather than throwing
     expect(details.readme).toBeNull();
-    expect(details.description).toBe("manifest description");
-    expect(details.license).toBe("MIT");
+    expect(details.description).toBe(caveman.description ?? null);
+    expect(details.license).toBe(caveman.license ?? null);
+    expect(details.source).toEqual(caveman.source);
+  });
+
+  test("resolves an explicit historical ref via the GitHub marketplace, not the gated catalog", async () => {
+    // GIVEN an explicit historical ref and a name absent from the gated catalog
+    const historicalRef = "a".repeat(40);
+    const historicalRepo = "octo/time-machine";
+    const marketplaceRefs: string[] = [];
+    const fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      // The marketplace manifest, read at the requested historical ref
+      if (url.includes("/contents/plugins/marketplace.json")) {
+        marketplaceRefs.push(new URL(url).searchParams.get("ref") ?? "");
+        return new Response(
+          JSON.stringify({
+            name: "vellum",
+            plugins: [
+              {
+                name: "time-traveler",
+                source: {
+                  source: "github",
+                  repo: historicalRepo,
+                  ref: "b".repeat(40),
+                },
+                description: "historical description",
+                homepage: "https://historical.example.com",
+                license: "MIT",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      // The entry's own external repo, read at its pinned source ref
+      if (url.includes("/contents") && url.includes(historicalRepo)) {
+        return new Response(
+          JSON.stringify([fileEntry("README.md", "raw://hist/readme")]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url === "raw://hist/readme") {
+        return new Response("# Time Traveler (historical)", { status: 200 });
+      }
+      return new Response("unexpected url: " + url, { status: 500 });
+    }) as FetchLike;
+
+    // WHEN we resolve the detail view at the historical ref
+    const details = await getPluginDetails(
+      { name: "time-traveler", ref: historicalRef },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN the marketplace manifest was read at the requested historical ref
+    expect(marketplaceRefs).toContain(historicalRef);
+    // AND source + metadata come from that historical entry, not the gated catalog
     expect(details.source).toEqual({
       kind: "github",
-      repo: "example-org/caveman",
-      ref: "1111111111111111111111111111111111111111",
+      repo: historicalRepo,
+      ref: "b".repeat(40),
     });
+    expect(details.description).toBe("historical description");
+    expect(details.homepage).toBe("https://historical.example.com");
+    expect(details.license).toBe("MIT");
+    expect(details.readme).toContain("historical");
+    expect(details.ref).toBe(historicalRef);
+  });
+
+  test("degrades gracefully when the historical marketplace fetch fails", async () => {
+    // GIVEN an installed copy and a historical ref whose marketplace fetch errors
+    const historicalRef = "a".repeat(40);
+    const target = join(workspace, "caveman");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "README.md"), "# Installed Caveman");
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ version: "2.0.0" }),
+    );
+    const fetch = makeFetch({ failOn: ["plugins/marketplace.json"] });
+
+    // WHEN we resolve the detail view at the historical ref
+    const details = await getPluginDetails(
+      { name: "caveman", ref: historicalRef },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN it renders from disk with no advertised source rather than throwing
+    expect(details.installed).toBe(true);
+    expect(details.readme).toBe("# Installed Caveman");
+    expect(details.version).toBe("2.0.0");
+    expect(details.source).toBeNull();
+    expect(details.ref).toBe(historicalRef);
   });
 
   test("rejects an invalid (path-traversal) plugin name", async () => {
     // GIVEN a name that fails the install-name sanitizer
-    const fetch = makeFetch({ marketplace: { name: "vellum", plugins: [] } });
+    const fetch = makeFetch({});
 
     // WHEN / THEN resolution throws before any lookup
     await expect(
@@ -512,25 +516,11 @@ describe("getPluginDetails", () => {
   test("surfaces a well-formed vellum.artifact from the repo package.json", async () => {
     // GIVEN an external plugin whose repo package.json declares a complete
     // vellum.artifact (https url + 64-hex sha256)
+    const notch = bundledMatch("dynamic-notch");
     const sha = "a".repeat(64);
     const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [
-          {
-            name: "dynamic-notch",
-            source: {
-              source: "github",
-              repo: "example-org/dynamic-notch",
-              ref: "1111111111111111111111111111111111111111",
-            },
-          },
-        ],
-      },
       listings: {
-        "example-org/dynamic-notch": [
-          fileEntry("package.json", "raw://notch/pkg"),
-        ],
+        [notch.source.repo]: [fileEntry("package.json", "raw://notch/pkg")],
       },
       raw: {
         "raw://notch/pkg": JSON.stringify({
@@ -562,6 +552,7 @@ describe("getPluginDetails", () => {
 
   test("an installed copy's artifact wins over the repo's", async () => {
     // GIVEN an installed copy whose package.json declares its own artifact
+    const notch = bundledMatch("dynamic-notch");
     const localSha = "b".repeat(64);
     const remoteSha = "c".repeat(64);
     const target = join(workspace, "dynamic-notch");
@@ -578,25 +569,10 @@ describe("getPluginDetails", () => {
       }),
     );
 
-    // AND a marketplace entry + repo package.json declaring a different artifact
+    // AND a repo package.json declaring a different artifact
     const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [
-          {
-            name: "dynamic-notch",
-            source: {
-              source: "github",
-              repo: "example-org/dynamic-notch",
-              ref: "1111111111111111111111111111111111111111",
-            },
-          },
-        ],
-      },
       listings: {
-        "example-org/dynamic-notch": [
-          fileEntry("package.json", "raw://notch/pkg"),
-        ],
+        [notch.source.repo]: [fileEntry("package.json", "raw://notch/pkg")],
       },
       raw: {
         "raw://notch/pkg": JSON.stringify({
@@ -626,24 +602,10 @@ describe("getPluginDetails", () => {
   test("treats a placeholder sha256 as no artifact yet", async () => {
     // GIVEN a repo package.json with a url but an empty (placeholder) sha256 —
     // the bootstrap state before a release workflow fills the digest in
+    const notch = bundledMatch("dynamic-notch");
     const fetch = makeFetch({
-      marketplace: {
-        name: "vellum",
-        plugins: [
-          {
-            name: "dynamic-notch",
-            source: {
-              source: "github",
-              repo: "example-org/dynamic-notch",
-              ref: "1111111111111111111111111111111111111111",
-            },
-          },
-        ],
-      },
       listings: {
-        "example-org/dynamic-notch": [
-          fileEntry("package.json", "raw://notch/pkg"),
-        ],
+        [notch.source.repo]: [fileEntry("package.json", "raw://notch/pkg")],
       },
       raw: {
         "raw://notch/pkg": JSON.stringify({
@@ -665,5 +627,87 @@ describe("getPluginDetails", () => {
 
     // THEN no artifact is surfaced (a client must not offer an unverifiable download)
     expect(details.artifact).toBeNull();
+  });
+});
+
+describe("getPluginDetails (catalog unavailable, platform enabled)", () => {
+  // A fetch that always rejects — the platform catalog fetch fails, and no
+  // GitHub enrichment should be attempted for the degraded cases below.
+  const failingFetch = (async () => {
+    throw new Error("network down");
+  }) as FetchLike;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "plugin-details-"));
+    invalidatePluginCatalogCache();
+    delete process.env.IS_PLATFORM;
+    delete process.env.VELLUM_DISABLE_PLATFORM;
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+    invalidatePluginCatalogCache();
+    restoreEnv();
+  });
+
+  test("an installed copy still renders from disk when the catalog is down", async () => {
+    // GIVEN an installed copy on disk and a catalog that fails to resolve
+    const target = join(workspace, "caveman");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "README.md"), "# Installed Caveman");
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({
+        version: "2.0.0",
+        description: "local description",
+        license: "Apache-2.0",
+      }),
+    );
+
+    // WHEN we resolve the detail view
+    const details = await getPluginDetails(
+      { name: "caveman" },
+      { fetch: failingFetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN it degrades to the on-disk metadata rather than throwing; with no
+    // catalog entry there is no advertised source to enrich from
+    expect(details.installed).toBe(true);
+    expect(details.readme).toBe("# Installed Caveman");
+    expect(details.version).toBe("2.0.0");
+    expect(details.description).toBe("local description");
+    expect(details.license).toBe("Apache-2.0");
+    expect(details.source).toBeNull();
+  });
+
+  test("a not-installed plugin propagates PluginCatalogUnavailableError on an outage", async () => {
+    // GIVEN no installed copy and a gated catalog that fails to resolve
+    // WHEN / THEN there is nothing on disk to render, so the transient outage
+    // propagates (mapped to a retryable 503 upstream) rather than degrading to
+    // a misleading not-found.
+    await expect(
+      getPluginDetails(
+        { name: "caveman" },
+        { fetch: failingFetch, workspacePluginsDir: workspace },
+      ),
+    ).rejects.toBeInstanceOf(PluginCatalogUnavailableError);
+  });
+
+  test("a successful catalog lookup with no match still throws PluginDetailsNotFoundError", async () => {
+    // GIVEN a catalog that resolves successfully but has no entry for the name,
+    // and no installed copy — a real not-found, not an outage
+    const emptyCatalogFetch = (async () =>
+      new Response(JSON.stringify({ plugins: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as FetchLike;
+
+    // WHEN / THEN the missing name is a permanent 404, unchanged by the outage rule
+    await expect(
+      getPluginDetails(
+        { name: "no-such-ghost-plugin" },
+        { fetch: emptyCatalogFetch, workspacePluginsDir: workspace },
+      ),
+    ).rejects.toBeInstanceOf(PluginDetailsNotFoundError);
   });
 });

--- a/assistant/src/cli/lib/__tests__/plugin-details.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-details.test.ts
@@ -693,6 +693,71 @@ describe("getPluginDetails (catalog unavailable, platform enabled)", () => {
     ).rejects.toBeInstanceOf(PluginCatalogUnavailableError);
   });
 
+  /** A platform `/v1/plugins/` fetch serving a single row (unvalidated source). */
+  function platformCatalogFetch(row: Record<string, unknown>): FetchLike {
+    return (async () =>
+      new Response(JSON.stringify({ plugins: [row] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as FetchLike;
+  }
+
+  test("404s a not-installed plugin whose only catalog row has a malformed source", async () => {
+    // GIVEN a platform catalog row pinned to a mutable ref (not a full SHA) —
+    // platform rows are not source-validated, so this reaches the detail view;
+    // install-by-name would refuse it
+    const fetch = platformCatalogFetch({
+      name: "time-traveler",
+      repo: "octo/time-machine",
+      ref: "main",
+      description: "malformed row description",
+    });
+
+    // WHEN / THEN with nothing installed, the row install would refuse must not
+    // be presented as a valid source: it resolves to a 404
+    await expect(
+      getPluginDetails(
+        { name: "time-traveler" },
+        { fetch, workspacePluginsDir: workspace },
+      ),
+    ).rejects.toBeInstanceOf(PluginDetailsNotFoundError);
+  });
+
+  test("renders an installed plugin from disk with no source when its catalog row is malformed", async () => {
+    // GIVEN an installed copy AND a malformed platform row (over-segmented repo)
+    const target = join(workspace, "time-traveler");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "README.md"), "# Installed Time Traveler");
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ version: "3.0.0" }),
+    );
+    const fetch = platformCatalogFetch({
+      name: "time-traveler",
+      repo: "octo/time-machine/extra",
+      ref: "b".repeat(40),
+      description: "malformed row description",
+      homepage: "https://malformed.example.com",
+      license: "MIT",
+    });
+
+    // WHEN we resolve the detail view
+    const details = await getPluginDetails(
+      { name: "time-traveler" },
+      { fetch, workspacePluginsDir: workspace },
+    );
+
+    // THEN it renders from disk with no advertised source, and the untrusted
+    // row contributes no description/homepage/license
+    expect(details.installed).toBe(true);
+    expect(details.readme).toBe("# Installed Time Traveler");
+    expect(details.version).toBe("3.0.0");
+    expect(details.source).toBeNull();
+    expect(details.description).toBeNull();
+    expect(details.homepage).toBeNull();
+    expect(details.license).toBeNull();
+  });
+
   test("a successful catalog lookup with no match still throws PluginDetailsNotFoundError", async () => {
     // GIVEN a catalog that resolves successfully but has no entry for the name,
     // and no installed copy — a real not-found, not an outage

--- a/assistant/src/cli/lib/__tests__/search-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/search-plugins.test.ts
@@ -30,7 +30,13 @@ function entry(
   name: string,
   repo: string,
   ref: string,
-  extra?: { path?: string; description?: string; category?: string },
+  extra?: {
+    path?: string;
+    description?: string;
+    category?: string;
+    homepage?: string;
+    license?: string;
+  },
 ): MarketplaceEntry {
   return {
     name,
@@ -42,6 +48,8 @@ function entry(
     },
     ...(extra?.description ? { description: extra.description } : {}),
     ...(extra?.category ? { category: extra.category } : {}),
+    ...(extra?.homepage ? { homepage: extra.homepage } : {}),
+    ...(extra?.license ? { license: extra.license } : {}),
   };
 }
 
@@ -146,6 +154,8 @@ describe("marketplaceMatch", () => {
       path: `github:vellum-ai/simple-memory@${SHA_A}`,
       description: undefined,
       category: null,
+      homepage: undefined,
+      license: undefined,
       source: {
         kind: "github",
         repo: "vellum-ai/simple-memory",
@@ -168,6 +178,8 @@ describe("marketplaceMatch", () => {
       path: `github:acme/monorepo/packages/nested@${SHA_B}`,
       description: "A nested plugin.",
       category: null,
+      homepage: undefined,
+      license: undefined,
       source: {
         kind: "github",
         repo: "acme/monorepo",
@@ -189,6 +201,25 @@ describe("marketplaceMatch", () => {
       marketplaceMatch(entry("plain-plugin", "acme/plain-plugin", SHA_B))
         .category,
     ).toBeNull();
+  });
+
+  test("carries homepage/license when the entry declares them", () => {
+    const match = marketplaceMatch(
+      entry("calendar-sync", "acme/calendar-sync", SHA_A, {
+        homepage: "https://example.com/calendar-sync",
+        license: "MIT",
+      }),
+    );
+    expect(match.homepage).toBe("https://example.com/calendar-sync");
+    expect(match.license).toBe("MIT");
+  });
+
+  test("leaves homepage/license undefined when the entry omits them", () => {
+    const match = marketplaceMatch(
+      entry("plain-plugin", "acme/plain-plugin", SHA_B),
+    );
+    expect(match.homepage).toBeUndefined();
+    expect(match.license).toBeUndefined();
   });
 });
 
@@ -215,5 +246,21 @@ describe("projectMarketplaceEntries", () => {
 
   test("returns an empty list for no entries", () => {
     expect(projectMarketplaceEntries([])).toEqual([]);
+  });
+
+  test("carries homepage/license through, undefined when the entry omits them", () => {
+    const [withMeta, without] = projectMarketplaceEntries([
+      entry("calendar-sync", "acme/calendar-sync", SHA_A, {
+        homepage: "https://example.com/calendar-sync",
+        license: "MIT",
+      }),
+      entry("plain-plugin", "acme/plain-plugin", SHA_B),
+    ]);
+    expect(withMeta).toMatchObject({
+      homepage: "https://example.com/calendar-sync",
+      license: "MIT",
+    });
+    expect(without!.homepage).toBeUndefined();
+    expect(without!.license).toBeUndefined();
   });
 });

--- a/assistant/src/cli/lib/plugin-catalog-platform.ts
+++ b/assistant/src/cli/lib/plugin-catalog-platform.ts
@@ -26,8 +26,8 @@ import {
 
 /**
  * One flattened row from the platform catalog. Unknown keys (`id`,
- * `display_name`, `icon`, `homepage`, `license`) are accepted and dropped —
- * zod strips them by default.
+ * `display_name`, `icon`) are accepted and dropped — zod strips them by
+ * default.
  */
 const platformPluginRowSchema = z.object({
   name: z.string(),
@@ -36,6 +36,8 @@ const platformPluginRowSchema = z.object({
   path: z.string().nullable().optional(),
   description: z.string().optional(),
   category: z.string().nullable().optional(),
+  homepage: z.string().nullable().optional(),
+  license: z.string().nullable().optional(),
 });
 
 const platformCatalogSchema = z.object({
@@ -105,6 +107,8 @@ export async function fetchPluginCatalogFromPlatform(
       },
       description: row.description ?? undefined,
       category: row.category ?? undefined,
+      homepage: row.homepage ?? undefined,
+      license: row.license ?? undefined,
     });
   }
 

--- a/assistant/src/cli/lib/plugin-catalog-resolve.ts
+++ b/assistant/src/cli/lib/plugin-catalog-resolve.ts
@@ -8,10 +8,12 @@
  * `plugins/marketplace.json` fetch — so search, install, and details read one source.
  */
 
-import { isFullCommitSha } from "./install-from-github.js";
 import { getPluginCatalog } from "./plugin-catalog-cache.js";
 import { DEFAULT_PLUGIN_REF } from "./plugin-constants.js";
-import type { ResolvedPluginSource } from "./plugin-marketplace.js";
+import {
+  githubSourceSchema,
+  type ResolvedPluginSource,
+} from "./plugin-marketplace.js";
 import type {
   PluginSearchMatch,
   SearchPluginsDeps,
@@ -29,23 +31,35 @@ export async function findCatalogEntry(
 /**
  * Project a catalog match onto concrete GitHub install coordinates.
  *
- * Re-asserts the install-pinning invariant the GitHub path enforces via schema:
- * a curated install MUST pin to an immutable full commit SHA, so a non-SHA ref
- * from an upstream catalog is a config defect and throws rather than installing
- * mutable code. Pure — unit-testable without a catalog.
+ * Validates the reconstructed source against the canonical marketplace
+ * GitHub-source schema (`owner/repo` slug, clean repo-relative path, full commit
+ * SHA) — the exact rules the GitHub manifest enforces. Platform catalog rows
+ * validate none of these (`repo`/`path` are any string), so a malformed
+ * coordinate — an over-segmented or slashless repo, an escaping/empty path, a
+ * mutable non-SHA ref — is rejected here before it reaches `trustedSource`
+ * rather than installing the wrong tree or a repointable revision.
+ * Pure — unit-testable without a catalog.
  */
 export function resolveSourceFromMatch(
   match: PluginSearchMatch,
 ): ResolvedPluginSource {
-  const { repo, path, ref } = match.source;
-  if (!isFullCommitSha(ref)) {
+  // Repo-root `""` maps to `undefined` (omitted = root) so the schema's
+  // non-empty path refine does not reject a valid repo-root entry.
+  const path = match.source.path || undefined;
+  const parsed = githubSourceSchema.safeParse({
+    source: "github" as const,
+    repo: match.source.repo,
+    ...(path ? { path } : {}),
+    ref: match.source.ref,
+  });
+  if (!parsed.success) {
     throw new Error(
-      `Catalog entry "${match.name}" pins ref "${ref}", which is not a full commit SHA; ` +
-        `a curated install must pin to an immutable full commit SHA (tags and branches are mutable).`,
+      `Catalog entry "${match.name}" (${match.source.repo}) has an invalid source: ` +
+        parsed.error.issues.map((i) => i.message).join("; "),
     );
   }
-  const [owner, repoName] = repo.split("/", 2) as [string, string];
-  return { owner, repo: repoName, path: path ?? "", ref };
+  const [owner, repoName] = parsed.data.repo.split("/", 2) as [string, string];
+  return { owner, repo: repoName, path: match.source.path ?? "", ref: match.source.ref };
 }
 
 /** Resolve {@link name} to install coordinates from the catalog, or `null`. */

--- a/assistant/src/cli/lib/plugin-catalog-resolve.ts
+++ b/assistant/src/cli/lib/plugin-catalog-resolve.ts
@@ -1,0 +1,58 @@
+/**
+ * Gated catalog resolvers for install-by-name and the plugin detail view.
+ *
+ * The gated analogues of {@link ./plugin-marketplace}'s `resolveMarketplaceSource`
+ * / GitHub `findMarketplaceEntry`: install-by-name and the detail lookup resolve
+ * the SAME catalog `search` uses (platform-first via {@link ./plugin-catalog-cache}'s
+ * `getPluginCatalog`, bundled offline) instead of a direct GitHub
+ * `plugins/marketplace.json` fetch — so search, install, and details read one source.
+ */
+
+import { isFullCommitSha } from "./install-from-github.js";
+import { getPluginCatalog } from "./plugin-catalog-cache.js";
+import { DEFAULT_PLUGIN_REF } from "./plugin-constants.js";
+import type { ResolvedPluginSource } from "./plugin-marketplace.js";
+import type {
+  PluginSearchMatch,
+  SearchPluginsDeps,
+} from "./search-plugins.js";
+
+/** Find the catalog entry claiming {@link name}, or `null` when none does. */
+export async function findCatalogEntry(
+  name: string,
+  deps: SearchPluginsDeps,
+): Promise<PluginSearchMatch | null> {
+  const catalog = await getPluginCatalog(DEFAULT_PLUGIN_REF, deps);
+  return catalog.matches.find((m) => m.name === name) ?? null;
+}
+
+/**
+ * Project a catalog match onto concrete GitHub install coordinates.
+ *
+ * Re-asserts the install-pinning invariant the GitHub path enforces via schema:
+ * a curated install MUST pin to an immutable full commit SHA, so a non-SHA ref
+ * from an upstream catalog is a config defect and throws rather than installing
+ * mutable code. Pure — unit-testable without a catalog.
+ */
+export function resolveSourceFromMatch(
+  match: PluginSearchMatch,
+): ResolvedPluginSource {
+  const { repo, path, ref } = match.source;
+  if (!isFullCommitSha(ref)) {
+    throw new Error(
+      `Catalog entry "${match.name}" pins ref "${ref}", which is not a full commit SHA; ` +
+        `a curated install must pin to an immutable full commit SHA (tags and branches are mutable).`,
+    );
+  }
+  const [owner, repoName] = repo.split("/", 2) as [string, string];
+  return { owner, repo: repoName, path: path ?? "", ref };
+}
+
+/** Resolve {@link name} to install coordinates from the catalog, or `null`. */
+export async function resolvePluginSourceFromCatalog(
+  name: string,
+  deps: SearchPluginsDeps,
+): Promise<ResolvedPluginSource | null> {
+  const match = await findCatalogEntry(name, deps);
+  return match ? resolveSourceFromMatch(match) : null;
+}

--- a/assistant/src/cli/lib/plugin-details.ts
+++ b/assistant/src/cli/lib/plugin-details.ts
@@ -43,13 +43,12 @@ import {
 import { findCatalogEntry } from "./plugin-catalog-resolve.js";
 import { DEFAULT_PLUGIN_REF } from "./plugin-constants.js";
 import { readValidatedPluginIcon } from "./plugin-icon-file.js";
+import { fetchMarketplaceEntries } from "./plugin-marketplace.js";
 import {
-  fetchMarketplaceEntries,
-  type MarketplaceEntry,
-} from "./plugin-marketplace.js";
-import {
+  marketplaceMatch,
   PluginCatalogUnavailableError,
   type PluginMatchSource,
+  type PluginSearchMatch,
 } from "./search-plugins.js";
 
 /** Recognised README filenames, matched case-insensitively against a listing. */
@@ -370,14 +369,6 @@ async function fetchRawFile(
   }
 }
 
-/** Normalized catalog metadata both resolution branches project onto. */
-interface CatalogMatch {
-  readonly source: PluginMatchSource;
-  readonly description?: string;
-  readonly homepage?: string;
-  readonly license?: string;
-}
-
 /**
  * Resolve the external catalog entry claiming {@link name}.
  *
@@ -400,7 +391,7 @@ async function resolveCatalogEntry(
   ref: string,
   fetchFn: FetchLike,
   installed: boolean,
-): Promise<CatalogMatch | null> {
+): Promise<PluginSearchMatch | null> {
   try {
     return ref === DEFAULT_PLUGIN_REF
       ? await findCatalogEntry(name, { fetch: fetchFn })
@@ -413,28 +404,15 @@ async function resolveCatalogEntry(
   }
 }
 
-/** Read the GitHub marketplace at {@link ref} and normalize the named entry. */
+/** Read the GitHub marketplace at {@link ref} and project the named entry. */
 async function findMarketplaceMatch(
   name: string,
   ref: string,
   fetchFn: FetchLike,
-): Promise<CatalogMatch | null> {
+): Promise<PluginSearchMatch | null> {
   const entries = await fetchMarketplaceEntries({ fetch: fetchFn }, { ref });
   const entry = entries.find((e) => e.name === name);
-  return entry ? marketplaceEntryToMatch(entry) : null;
-}
-
-/** Project a raw marketplace entry onto the normalized {@link CatalogMatch}. */
-function marketplaceEntryToMatch(entry: MarketplaceEntry): CatalogMatch {
-  const { repo, path, ref } = entry.source;
-  return {
-    source: { kind: "github", repo, ref, ...(path ? { path } : {}) },
-    ...(entry.description !== undefined
-      ? { description: entry.description }
-      : {}),
-    ...(entry.homepage !== undefined ? { homepage: entry.homepage } : {}),
-    ...(entry.license !== undefined ? { license: entry.license } : {}),
-  };
+  return entry ? marketplaceMatch(entry) : null;
 }
 
 function githubFetch(

--- a/assistant/src/cli/lib/plugin-details.ts
+++ b/assistant/src/cli/lib/plugin-details.ts
@@ -6,16 +6,21 @@
  * most authoritative for each field:
  *   1. The locally installed copy under `<workspacePluginsDir>/<name>/`, when
  *      present — its `package.json` and `README.md` are read straight off disk.
- *   2. The curated `plugins/marketplace.json` entry, for external
- *      ecosystem plugins (description / homepage / license / pinned source).
+ *   2. The catalog metadata for external ecosystem plugins (description /
+ *      homepage / license / pinned source). At the default ref, the gated
+ *      plugin catalog (platform-first, bundled offline) — the same source
+ *      `assistant plugins search` and install-by-name resolve. At an explicit
+ *      historical `ref`, the GitHub `plugins/marketplace.json` at that revision,
+ *      so a reviewed/rolled-back marketplace entry is inspected at the ref
+ *      requested (inherently a git operation, matching pin history / inspect).
  *   3. The plugin's own external repository at the pinned `owner/repo[/path]`,
  *      fetched via the GitHub Contents API for the README and any
  *      `package.json` fields the manifest doesn't carry.
  *
- * The `source` field is the marketplace entry's pinned origin when one claims
- * the name, otherwise `null` — an installed copy with no catalog entry has no
+ * The `source` field is the catalog entry's pinned origin when one claims the
+ * name, otherwise `null` — an installed copy with no catalog entry has no
  * advertised origin. Name-collision precedence matches {@link ./search-plugins}
- * and {@link ./install-from-github}: a marketplace entry owns its name, so the
+ * and {@link ./install-from-github}: a catalog entry owns its name, so the
  * detail page advertises the external source the catalog and installer use. A
  * same-named `plugins/<name>/` directory is that plugin's adapter stub, not a
  * standalone plugin, so it does not override the claim.
@@ -35,13 +40,17 @@ import {
   parsePluginIcon,
   type PluginArtifact,
 } from "./plugin-artifact.js";
+import { findCatalogEntry } from "./plugin-catalog-resolve.js";
 import { DEFAULT_PLUGIN_REF } from "./plugin-constants.js";
 import { readValidatedPluginIcon } from "./plugin-icon-file.js";
 import {
   fetchMarketplaceEntries,
   type MarketplaceEntry,
 } from "./plugin-marketplace.js";
-import type { PluginMatchSource } from "./search-plugins.js";
+import {
+  PluginCatalogUnavailableError,
+  type PluginMatchSource,
+} from "./search-plugins.js";
 
 /** Recognised README filenames, matched case-insensitively against a listing. */
 const README_RE = /^readme(\.md|\.markdown)?$/i;
@@ -96,7 +105,7 @@ export interface PluginDetails {
   readonly version: string | null;
   /**
    * Pinned origin, mirroring the catalog's {@link PluginMatchSource}; `null`
-   * when an installed copy has no marketplace entry to advertise an origin.
+   * when an installed copy has no catalog entry to advertise an origin.
    */
   readonly source: PluginMatchSource | null;
   /** README markdown, or `null` when the plugin ships none. */
@@ -143,9 +152,12 @@ export class PluginDetailsNotFoundError extends Error {
  * Resolve the detail view for {@link opts.name}.
  *
  * Throws {@link PluginDetailsNotFoundError} when the name is neither installed
- * locally nor present in the marketplace catalog. Network failures while
- * enriching from GitHub degrade to the fields
- * already known from disk / the manifest rather than failing the whole view —
+ * locally nor present in the catalog (gated at the default ref, the GitHub
+ * marketplace at an explicit historical ref). A gated-catalog outage
+ * ({@link PluginCatalogUnavailableError}) degrades to the on-disk fields only
+ * when a local copy exists; with nothing installed to render it propagates so
+ * the caller can map the transient failure to a retryable 503 rather than a
+ * misleading 404. Network failures while enriching from GitHub always degrade —
  * a detail page that renders metadata without a README beats a hard error.
  */
 export async function getPluginDetails(
@@ -162,22 +174,18 @@ export async function getPluginDetails(
   // invalid icon — including a not-installed plugin — resolves to no icon).
   const localIcon = readValidatedPluginIcon(join(pluginsDir, name));
 
-  const marketplaceEntry = await findMarketplaceEntry(name, ref, fetchFn);
+  const catalogMatch = await resolveCatalogEntry(
+    name,
+    ref,
+    fetchFn,
+    local.installed,
+  );
 
-  if (!local.installed && !marketplaceEntry) {
+  if (!local.installed && !catalogMatch) {
     throw new PluginDetailsNotFoundError(name, ref);
   }
 
-  const source: PluginMatchSource | null = marketplaceEntry
-    ? {
-        kind: "github",
-        repo: marketplaceEntry.source.repo,
-        ref: marketplaceEntry.source.ref,
-        ...(marketplaceEntry.source.path
-          ? { path: marketplaceEntry.source.path }
-          : {}),
-      }
-    : null;
+  const source: PluginMatchSource | null = catalogMatch?.source ?? null;
 
   const remote = source
     ? await readRemotePlugin(source, fetchFn)
@@ -190,17 +198,17 @@ export async function getPluginDetails(
     installed: local.installed,
     description:
       local.manifest.description ??
-      marketplaceEntry?.description ??
+      catalogMatch?.description ??
       remote.manifest.description ??
       null,
     homepage:
       local.manifest.homepage ??
-      marketplaceEntry?.homepage ??
+      catalogMatch?.homepage ??
       remote.manifest.homepage ??
       null,
     license:
       local.manifest.license ??
-      marketplaceEntry?.license ??
+      catalogMatch?.license ??
       remote.manifest.license ??
       null,
     version: local.manifest.version ?? remote.manifest.version ?? null,
@@ -362,19 +370,71 @@ async function fetchRawFile(
   }
 }
 
-async function findMarketplaceEntry(
+/** Normalized catalog metadata both resolution branches project onto. */
+interface CatalogMatch {
+  readonly source: PluginMatchSource;
+  readonly description?: string;
+  readonly homepage?: string;
+  readonly license?: string;
+}
+
+/**
+ * Resolve the external catalog entry claiming {@link name}.
+ *
+ * The default ref reads the gated catalog (the same source search / install
+ * use). An explicit historical {@link ref} reads the GitHub marketplace
+ * manifest at that revision — the gated catalog is ref-agnostic, so honoring a
+ * reviewed/rolled-back revision is inherently a git lookup, matching the pin
+ * history / inspect carve-out.
+ *
+ * A gated-catalog outage (fail-hard {@link PluginCatalogUnavailableError})
+ * propagates when nothing is installed — there is nothing to render and the
+ * failure is transient, so the caller maps it to a retryable 503 instead of a
+ * misleading not-found. When a local copy exists ({@link installed}) that same
+ * outage degrades to `null` so the view still renders from disk. A marketplace
+ * fetch/parse failure or a malformed entry always degrades to `null`: that
+ * metadata is supplementary, never required to render a detail view.
+ */
+async function resolveCatalogEntry(
   name: string,
   ref: string,
   fetchFn: FetchLike,
-): Promise<MarketplaceEntry | null> {
+  installed: boolean,
+): Promise<CatalogMatch | null> {
   try {
-    const entries = await fetchMarketplaceEntries({ fetch: fetchFn }, { ref });
-    return entries.find((e) => e.name === name) ?? null;
-  } catch {
-    // A missing or malformed manifest degrades to "no external entry" — the
-    // marketplace is supplementary, never required to render a detail view.
+    return ref === DEFAULT_PLUGIN_REF
+      ? await findCatalogEntry(name, { fetch: fetchFn })
+      : await findMarketplaceMatch(name, ref, fetchFn);
+  } catch (err) {
+    if (err instanceof PluginCatalogUnavailableError && !installed) {
+      throw err;
+    }
     return null;
   }
+}
+
+/** Read the GitHub marketplace at {@link ref} and normalize the named entry. */
+async function findMarketplaceMatch(
+  name: string,
+  ref: string,
+  fetchFn: FetchLike,
+): Promise<CatalogMatch | null> {
+  const entries = await fetchMarketplaceEntries({ fetch: fetchFn }, { ref });
+  const entry = entries.find((e) => e.name === name);
+  return entry ? marketplaceEntryToMatch(entry) : null;
+}
+
+/** Project a raw marketplace entry onto the normalized {@link CatalogMatch}. */
+function marketplaceEntryToMatch(entry: MarketplaceEntry): CatalogMatch {
+  const { repo, path, ref } = entry.source;
+  return {
+    source: { kind: "github", repo, ref, ...(path ? { path } : {}) },
+    ...(entry.description !== undefined
+      ? { description: entry.description }
+      : {}),
+    ...(entry.homepage !== undefined ? { homepage: entry.homepage } : {}),
+    ...(entry.license !== undefined ? { license: entry.license } : {}),
+  };
 }
 
 function githubFetch(

--- a/assistant/src/cli/lib/plugin-details.ts
+++ b/assistant/src/cli/lib/plugin-details.ts
@@ -40,7 +40,10 @@ import {
   parsePluginIcon,
   type PluginArtifact,
 } from "./plugin-artifact.js";
-import { findCatalogEntry } from "./plugin-catalog-resolve.js";
+import {
+  findCatalogEntry,
+  resolveSourceFromMatch,
+} from "./plugin-catalog-resolve.js";
 import { DEFAULT_PLUGIN_REF } from "./plugin-constants.js";
 import { readValidatedPluginIcon } from "./plugin-icon-file.js";
 import { fetchMarketplaceEntries } from "./plugin-marketplace.js";
@@ -393,13 +396,38 @@ async function resolveCatalogEntry(
   installed: boolean,
 ): Promise<PluginSearchMatch | null> {
   try {
-    return ref === DEFAULT_PLUGIN_REF
-      ? await findCatalogEntry(name, { fetch: fetchFn })
-      : await findMarketplaceMatch(name, ref, fetchFn);
+    const match =
+      ref === DEFAULT_PLUGIN_REF
+        ? await findCatalogEntry(name, { fetch: fetchFn })
+        : await findMarketplaceMatch(name, ref, fetchFn);
+    return validateCatalogMatchSource(match);
   } catch (err) {
     if (err instanceof PluginCatalogUnavailableError && !installed) {
       throw err;
     }
+    return null;
+  }
+}
+
+/**
+ * Guard a resolved catalog match through the installer's source validation.
+ *
+ * Returns the match only when {@link resolveSourceFromMatch} accepts its source
+ * (valid `owner/repo` slug, clean path, full commit SHA). A malformed row — the
+ * exact coordinate install-by-name refuses — resolves to `null`, so the detail
+ * view neither advertises its source nor enriches from it (metadata included):
+ * the whole row is untrusted, mirroring install rejecting it.
+ */
+function validateCatalogMatchSource(
+  match: PluginSearchMatch | null,
+): PluginSearchMatch | null {
+  if (!match) {
+    return null;
+  }
+  try {
+    resolveSourceFromMatch(match);
+    return match;
+  } catch {
     return null;
   }
 }

--- a/assistant/src/cli/lib/plugin-marketplace.ts
+++ b/assistant/src/cli/lib/plugin-marketplace.ts
@@ -59,7 +59,7 @@ const PLUGIN_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
  */
 const COMMIT_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 
-const githubSourceSchema = z.object({
+export const githubSourceSchema = z.object({
   /** Discriminator. Only GitHub sources are resolved today. */
   source: z.literal("github"),
   /** `owner/repo` of the external plugin repository. */

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -48,6 +48,10 @@ export interface PluginSearchMatch {
    * `productivity`), or `null` when the entry declares none.
    */
   readonly category: string | null;
+  /** Homepage URL, from the curated marketplace entry when present. */
+  readonly homepage?: string;
+  /** License identifier, from the curated marketplace entry when present. */
+  readonly license?: string;
   /** Discriminated origin, so callers can render/install accordingly. */
   readonly source: PluginMatchSource;
 }
@@ -125,6 +129,8 @@ export function marketplaceMatch(entry: MarketplaceEntry): PluginSearchMatch {
     path: locator,
     description: entry.description,
     category: entry.category ?? null,
+    homepage: entry.homepage,
+    license: entry.license,
     source: { kind: "github", repo, path, ref },
   };
 }

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -1366,6 +1366,18 @@ describe("GET /v1/plugins/:name", () => {
     ).rejects.toBeInstanceOf(NotFoundError);
   });
 
+  test("PluginCatalogUnavailableError → ServiceUnavailableError (503)", async () => {
+    // A catalog outage blocking a remote-only detail view is transient — the
+    // handler surfaces it as retryable rather than a misleading 404/500.
+    detailsSpy.mockImplementation(async () => {
+      throw new PluginCatalogUnavailableError("HTTP 503", 503);
+    });
+
+    await expect(
+      invokeGet({ pathParams: { name: "caveman" } }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+  });
+
   test("unknown errors → InternalError with original message preserved", async () => {
     detailsSpy.mockImplementation(async () => {
       throw new Error("ENOTFOUND api.github.com");

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -70,6 +70,7 @@ import {
   type InstallPluginOptions,
   type InstallPluginResult,
   InvalidPluginNameError,
+  isFullCommitSha,
   PluginAlreadyInstalledError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
@@ -181,6 +182,9 @@ mock.module("../../../cli/lib/install-from-github.js", () => ({
   // path from `:name` rather than delegating to a lib that sanitizes), so pass
   // the real `sanitizePluginName` through — a traversal name must still 400.
   sanitizePluginName,
+  // The (unmocked) catalog resolver enforces the full-SHA pin invariant via the
+  // real `isFullCommitSha`, so pass it through rather than the default undefined.
+  isFullCommitSha,
   installPlugin: installSpy,
 }));
 
@@ -1394,50 +1398,91 @@ async function invokeInstall(args: RouteHandlerArgs = {}): Promise<{
   };
 }
 
+// A gated-catalog match for `caveman` pinned to an immutable full commit SHA —
+// the shape the resolver projects onto trusted install coordinates. Mirrors the
+// bundled manifest: platform-first live, or the bundled pin when platform
+// features are off.
+const CAVEMAN_PIN = "63a91ecadbf4c4719a4602a5abb00883f9966034";
+const CAVEMAN_CATALOG_MATCH: PluginSearchMatch = {
+  name: "caveman",
+  path: `github:JuliusBrussee/caveman@${CAVEMAN_PIN}`,
+  description: "Ultra-compressed communication mode.",
+  category: null,
+  source: { kind: "github", repo: "JuliusBrussee/caveman", ref: CAVEMAN_PIN },
+};
+
+// installPlugin result for a trustedSource install: the returned `ref` is the
+// trusted pin (the external content commit), not the default branch.
+function trustedInstallResult(opts: InstallPluginOptions): InstallPluginResult {
+  return {
+    name: opts.name,
+    target: `/workspace/.vellum/plugins/${opts.name}`,
+    fileCount: 7,
+    ref: opts.trustedSource?.ref ?? opts.ref ?? "main",
+    commit: opts.trustedSource?.ref ?? null,
+    committedAt: null,
+  };
+}
+
 describe("POST /v1/plugins/install", () => {
   beforeEach(() => {
     installSpy.mockReset();
     resolvePinSpy.mockReset();
     broadcastMessageSpy.mockReset();
+    getCatalogSpy.mockReset();
+    // Default: the gated catalog resolves `caveman` to its bundled full-SHA pin.
+    getCatalogSpy.mockImplementation(async (ref) =>
+      catalog(ref, [CAVEMAN_CATALOG_MATCH]),
+    );
   });
 
-  test("forwards name/force and shapes the result, pinning ref to the default", async () => {
-    installSpy.mockImplementation(async (opts) => ({
-      name: opts.name,
-      target: `/workspace/.vellum/plugins/${opts.name}`,
-      fileCount: 7,
-      ref: opts.ref ?? "main",
-      commit: null,
-      committedAt: null,
-    }));
+  test("no-pin install resolves from the gated catalog and installs via trustedSource", async () => {
+    // The default (no-pin) path reads the same gated catalog `search`
+    // advertises and installs from a trusted pre-resolved source — no direct
+    // `plugins/marketplace.json` fetch (the pin/marketplace path is untouched).
+    const prev = process.env.VELLUM_DISABLE_PLATFORM;
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    try {
+      installSpy.mockImplementation(async (opts) => trustedInstallResult(opts));
 
-    const result = await invokeInstall({
-      body: { name: "caveman", force: true },
-    });
+      const result = await invokeInstall({
+        body: { name: "caveman", force: true },
+      });
 
-    expect(result).toEqual({
-      ok: true,
-      name: "caveman",
-      target: "/workspace/.vellum/plugins/caveman",
-      fileCount: 7,
-      ref: "main",
-    });
-    expect(installSpy.mock.calls[0]?.[0]).toEqual({
-      name: "caveman",
-      ref: "main",
-      force: true,
-    });
+      // Resolved through the gated catalog, not the pin/marketplace path.
+      expect(getCatalogSpy).toHaveBeenCalledTimes(1);
+      expect(resolvePinSpy).not.toHaveBeenCalled();
+      // installPlugin receives the pre-resolved trusted coordinates (owner/repo
+      // split from the catalog `repo`, `rootPath` from its path, the full-SHA
+      // pin as `ref`) — no caller-supplied `ref`.
+      expect(installSpy.mock.calls[0]?.[0]).toEqual({
+        name: "caveman",
+        force: true,
+        trustedSource: {
+          owner: "JuliusBrussee",
+          repo: "caveman",
+          rootPath: "",
+          ref: CAVEMAN_PIN,
+        },
+      });
+      expect(result).toEqual({
+        ok: true,
+        name: "caveman",
+        target: "/workspace/.vellum/plugins/caveman",
+        fileCount: 7,
+        ref: CAVEMAN_PIN,
+      });
+    } finally {
+      if (prev === undefined) {
+        delete process.env.VELLUM_DISABLE_PLATFORM;
+      } else {
+        process.env.VELLUM_DISABLE_PLATFORM = prev;
+      }
+    }
   });
 
   test("publishes sync_changed(plugins:list) on a successful install", async () => {
-    installSpy.mockImplementation(async (opts) => ({
-      name: opts.name,
-      target: `/workspace/.vellum/plugins/${opts.name}`,
-      fileCount: 7,
-      ref: opts.ref ?? "main",
-      commit: null,
-      committedAt: null,
-    }));
+    installSpy.mockImplementation(async (opts) => trustedInstallResult(opts));
 
     await invokeInstall({ body: { name: "caveman" } });
 
@@ -1445,14 +1490,7 @@ describe("POST /v1/plugins/install", () => {
   });
 
   test("threads x-vellum-client-id into the published event's originClientId", async () => {
-    installSpy.mockImplementation(async (opts) => ({
-      name: opts.name,
-      target: `/workspace/.vellum/plugins/${opts.name}`,
-      fileCount: 7,
-      ref: opts.ref ?? "main",
-      commit: null,
-      committedAt: null,
-    }));
+    installSpy.mockImplementation(async (opts) => trustedInstallResult(opts));
 
     await invokeInstall({
       body: { name: "caveman" },
@@ -1466,30 +1504,51 @@ describe("POST /v1/plugins/install", () => {
     });
   });
 
-  test("ignores a caller-supplied ref and pins to the curated default", async () => {
+  test("ignores a caller-supplied ref and installs from the catalog-resolved source", async () => {
     // Security boundary: installing from an unreviewed ref (a PR branch,
-    // fork ref, ...) could load attacker-controlled marketplace code, so the
-    // HTTP route never honors a body `ref` — it always resolves
-    // against the curated default ref.
-    installSpy.mockImplementation(async (opts) => ({
-      name: opts.name,
-      target: `/workspace/.vellum/plugins/${opts.name}`,
-      fileCount: 7,
-      ref: opts.ref ?? "main",
-      commit: null,
-      committedAt: null,
-    }));
+    // fork ref, ...) could load attacker-controlled code, so the HTTP route
+    // never honors a body `ref` — the no-pin source comes only from the gated
+    // catalog.
+    installSpy.mockImplementation(async (opts) => trustedInstallResult(opts));
 
     const result = await invokeInstall({
       body: { name: "caveman", ref: "attacker-pr-branch" },
     });
 
-    expect(result.ref).toBe("main");
+    expect(result.ref).toBe(CAVEMAN_PIN);
     expect(installSpy.mock.calls[0]?.[0]).toEqual({
       name: "caveman",
-      ref: "main",
       force: undefined,
+      trustedSource: {
+        owner: "JuliusBrussee",
+        repo: "caveman",
+        rootPath: "",
+        ref: CAVEMAN_PIN,
+      },
     });
+  });
+
+  test("an unknown name (no pin) → NotFoundError (404), no install", async () => {
+    // The catalog claims no such plugin, so the resolver returns null.
+    getCatalogSpy.mockImplementation(async (ref) => catalog(ref, []));
+
+    await expect(
+      invokeInstall({ body: { name: "ghost" } }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+    expect(installSpy).not.toHaveBeenCalled();
+  });
+
+  test("a catalog outage on the no-pin path → ServiceUnavailableError (503)", async () => {
+    // A rate-limited or unavailable platform catalog (no stale fallback) is
+    // transient — the route surfaces it as retryable, not a misleading 500.
+    getCatalogSpy.mockImplementation(async () => {
+      throw new PluginCatalogUnavailableError("HTTP 403", 403);
+    });
+
+    await expect(
+      invokeInstall({ body: { name: "caveman" } }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+    expect(installSpy).not.toHaveBeenCalled();
   });
 
   test("a missing name short-circuits to BadRequestError without calling the lib", async () => {
@@ -1497,15 +1556,26 @@ describe("POST /v1/plugins/install", () => {
       BadRequestError,
     );
     expect(installSpy).not.toHaveBeenCalled();
+    expect(getCatalogSpy).not.toHaveBeenCalled();
+  });
+
+  test("an invalid name (no pin) → BadRequestError before the catalog lookup", async () => {
+    // A malformed install name is validated up front via `sanitizePluginName`,
+    // so it's a deterministic 400 — never a 404/503 from resolving the catalog.
+    await expect(
+      invokeInstall({ body: { name: "../escape" } }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(getCatalogSpy).not.toHaveBeenCalled();
+    expect(installSpy).not.toHaveBeenCalled();
   });
 
   test("InvalidPluginNameError → BadRequestError (400)", async () => {
     installSpy.mockImplementation(async () => {
-      throw new InvalidPluginNameError("../escape");
+      throw new InvalidPluginNameError("bad plugin name");
     });
 
     await expect(
-      invokeInstall({ body: { name: "../escape" } }),
+      invokeInstall({ body: { name: "caveman" } }),
     ).rejects.toBeInstanceOf(BadRequestError);
   });
 
@@ -1528,7 +1598,7 @@ describe("POST /v1/plugins/install", () => {
     });
 
     await expect(
-      invokeInstall({ body: { name: "ghost" } }),
+      invokeInstall({ body: { name: "caveman" } }),
     ).rejects.toBeInstanceOf(NotFoundError);
     // A failed install must not fan out a spurious invalidation.
     expect(broadcastMessageSpy).not.toHaveBeenCalled();
@@ -1587,7 +1657,9 @@ describe("POST /v1/plugins/install", () => {
     });
 
     // THEN the install reads the manifest at the resolving marketplace commit,
-    // not the default branch
+    // not the default branch, and the gated catalog resolver is bypassed — the
+    // pin path stays on the reviewed pin-history/GitHub route.
+    expect(getCatalogSpy).not.toHaveBeenCalled();
     expect(installSpy.mock.calls[0]?.[0]).toEqual({
       name: "caveman",
       ref: "f".repeat(40),

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1066,6 +1066,12 @@ async function handleGetPluginDetails({
     if (err instanceof PluginDetailsNotFoundError) {
       throw new NotFoundError(err.message);
     }
+    // A catalog outage blocking a remote-only (not-installed) detail view is
+    // transient — surface it as retryable rather than a misleading 404/500 so
+    // clients retry instead of treating the plugin as permanently gone.
+    if (err instanceof PluginCatalogUnavailableError) {
+      throw new ServiceUnavailableError(err.message);
+    }
     throw new InternalError(
       err instanceof Error ? err.message : "plugin detail lookup failed",
     );

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -49,6 +49,7 @@ import {
   listInstalledPlugins,
 } from "../../cli/lib/list-installed-plugins.js";
 import { getPluginCatalog } from "../../cli/lib/plugin-catalog-cache.js";
+import { resolvePluginSourceFromCatalog } from "../../cli/lib/plugin-catalog-resolve.js";
 import {
   DEFAULT_PIN_HISTORY_LIMIT,
   DEFAULT_PLUGIN_REF,
@@ -1102,29 +1103,59 @@ async function resolveInstallMarketplaceRef(
 }
 
 async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
-  const name = typeof body.name === "string" ? body.name : "";
-  if (!name) {
+  const rawName = typeof body.name === "string" ? body.name : "";
+  if (!rawName) {
     throw new BadRequestError("`name` is required");
   }
   const force = typeof body.force === "boolean" ? body.force : undefined;
   const pin = typeof body.pin === "string" ? body.pin : undefined;
 
-  // The marketplace ref is never taken raw from the request: a caller-supplied
+  // The install source is never taken raw from the request: a caller-supplied
   // ref would let any `settings.write` principal install from an unreviewed
   // revision (a PR branch, fork ref, ...) whose manifest could carry attacker
-  // code the loader then dynamically imports. Installs over HTTP therefore
-  // resolve only against reviewed history. A `pin` is honored by mapping it —
-  // server-side — to the marketplace commit that introduced it, but only if it
-  // appears in the plugin's reviewed pin history; an unreviewed SHA is refused.
-  // The default install reads the current catalog on `DEFAULT_PLUGIN_REF`.
-  // Operators who need an unreviewed revision use the local CLI's
-  // `assistant plugins install --pin <sha> --allow-unreviewed`.
+  // code the loader then dynamically imports. The default (no-pin) install
+  // resolves owner/repo/ref from the gated catalog — platform-first, or the
+  // bundled manifest when platform features are disabled — which is the same
+  // reviewed source of truth `handleSearchPlugins` advertises, and installs via
+  // a trusted pre-resolved source (no direct `plugins/marketplace.json` fetch).
+  // A `pin` is honored by mapping it — server-side — to the marketplace commit
+  // that introduced it through the plugin's reviewed pin history; an unreviewed
+  // SHA is refused. Operators who need an unreviewed revision use the local
+  // CLI's `assistant plugins install --pin <sha> --allow-unreviewed`.
   try {
-    const marketplaceRef = await resolveInstallMarketplaceRef(name, pin);
-    const result = await installPlugin(
-      { name, ref: marketplaceRef, force },
-      { fetch: globalThis.fetch.bind(globalThis) },
-    );
+    // Validate the name up front — before any catalog/pin/network work — so a
+    // malformed name (`../escape`) is a deterministic 400 rather than a 404/503
+    // from the catalog lookup. `installPlugin` sanitizes too; this restores the
+    // advertised 400 across both the no-pin and pin paths.
+    const name = sanitizePluginName(rawName);
+    let result;
+    if (pin) {
+      const marketplaceRef = await resolveInstallMarketplaceRef(name, pin);
+      result = await installPlugin(
+        { name, ref: marketplaceRef, force },
+        { fetch: globalThis.fetch.bind(globalThis) },
+      );
+    } else {
+      const source = await resolvePluginSourceFromCatalog(name, {
+        fetch: globalThis.fetch.bind(globalThis),
+      });
+      if (!source) {
+        throw new NotFoundError(`No plugin named "${name}" in the catalog.`);
+      }
+      result = await installPlugin(
+        {
+          name,
+          force,
+          trustedSource: {
+            owner: source.owner,
+            repo: source.repo,
+            rootPath: source.path,
+            ref: source.ref,
+          },
+        },
+        { fetch: globalThis.fetch.bind(globalThis) },
+      );
+    }
     publishPluginsChanged(getOriginClientId(headers));
     return {
       ok: true as const,
@@ -1134,7 +1165,7 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
       ref: result.ref,
     };
   } catch (err) {
-    // Pin resolution already maps unreviewed/bad-pin cases to a RouteError;
+    // Pin resolution and the not-in-catalog case already map to a RouteError;
     // re-throw those verbatim rather than masking them as a 500.
     if (err instanceof RouteError) {
       throw err;
@@ -1155,6 +1186,11 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
     }
     // The pin-history read hits GitHub too; treat its failures as retryable.
     if (err instanceof PluginPinHistoryError) {
+      throw new ServiceUnavailableError(err.message);
+    }
+    // A rate-limited or unavailable platform catalog (no stale fallback) is
+    // transient — surface it as retryable rather than a misleading 500.
+    if (err instanceof PluginCatalogUnavailableError) {
       throw new ServiceUnavailableError(err.message);
     }
     throw new InternalError(


### PR DESCRIPTION
## Summary
Routes plugin **install-by-name** and the **detail view** through the same gated `getPluginCatalog` that **search** already uses (platform-first, with a bundled offline fallback), instead of each fetching GitHub `plugins/marketplace.json` independently. This closes the drift/404 risk where the web "Available" list (search) could advertise entries that then 404 or install at a different pin than detail/install resolved. Closes the P2 left open on #37806.

## Self-review result
GAPS FOUND → all fixed. 1 remediation PR (reuse cleanup); final re-review PASS.

## PRs merged into feature branch
- #37927 — feat(plugins): carry homepage/license through the catalog projection (PR 1)
- #37928 — feat(plugins): add gated catalog resolvers for install source and detail lookup (PR 2)
- #37935 — fix(plugins): resolve daemon install-by-name from the gated catalog, not GitHub (PR 3)
- #37936 — fix(plugins): resolve the detail view's catalog entry from the gated catalog (PR 4)

### Fix PR (self-review remediation)
- #37948 — refactor(plugins): reuse marketplaceMatch in the detail view, drop duplicate projection

## Notable hardening from the Codex review gates
- Catalog-derived install coordinates are re-validated against the canonical `githubSourceSchema` (owner/repo slug + clean repo-relative path + full commit SHA) before constructing a `trustedSource` — the platform row schema alone doesn't enforce these.
- Install name is validated up front (`sanitizePluginName`) so a malformed name returns a deterministic 400.
- A catalog **outage** on a not-installed plugin's detail view returns a retryable **503** (not a misleading 404); installed plugins still degrade to disk.
- `GET /v1/plugins/:name?ref=<historical>` still honors an explicit historical ref via the GitHub marketplace path (the "inherently git" carve-out, matching pin-history/inspect); the default ref uses the gated catalog.

## Scope
`--pin` install, pin-history, inspect, and direct-URL installs remain on GitHub (inherently git) — unchanged. Bonus: under `VELLUM_DISABLE_PLATFORM`, the daemon default install-by-name and default details no longer make a GitHub `marketplace.json` metadata fetch (bundled catalog).

Part of plan: catalog-source-consistency.md