### PR TITLE
ATL-987 — Daemon contact merge relays to the gateway

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5822,6 +5822,7 @@ paths:
                   ok:
                     type: boolean
                   contact:
+                    description: Merged (surviving) contact
                     type: object
                     properties:
                       id:
@@ -5926,10 +5927,8 @@ paths:
                       - updatedAt
                       - channels
                     additionalProperties: false
-                    description: Merged contact
                 required:
                   - ok
-                  - contact
                 additionalProperties: false
   /v1/contacts/prompt:
     post:

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -25,8 +25,9 @@ mock.module("../config/env.js", () => ({
 let searchContactsOverride: unknown[] | null = null;
 
 // Skill tools call cliIpcCall instead of the gateway HTTP.
-// Mock the IPC client to dispatch contact reads/merge to the real store
-// (backed by the test DB) without needing a running IPC server.
+// Mock the IPC client to dispatch contact reads to the real store (backed by
+// the test DB) and serve `merge_contacts` as a fake gateway relay, without
+// needing a running IPC server.
 mock.module("../ipc/cli-client.js", () => ({
   cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
     const store = await import("../contacts/contact-store.js");
@@ -45,9 +46,26 @@ mock.module("../ipc/cli-client.js", () => ({
       return { ok: true, result: { ok: true, contact } };
     }
     if (method === "merge_contacts") {
+      // Fake gateway relay: the daemon route relays merges to the gateway
+      // merge core, which validates and mirrors back into the assistant DB.
+      // Emulate that against the fixture DB via the mirror write path.
       const { keepId, mergeId } = body as { keepId: string; mergeId: string };
-      const contact = store.mergeContacts(keepId, mergeId);
-      return { ok: true, result: { ok: true, contact } };
+      const keep = store.getContact(keepId);
+      if (!keep) {
+        return { ok: false, error: `Contact "${keepId}" not found` };
+      }
+      if (!store.getContact(mergeId)) {
+        return { ok: false, error: `Contact "${mergeId}" not found` };
+      }
+      store.mergeContactMirror({
+        keepContactId: keepId,
+        mergeContactId: mergeId,
+        keepDisplayName: keep.displayName,
+      });
+      return {
+        ok: true,
+        result: { ok: true, contact: store.getContact(keepId) },
+      };
     }
     return { ok: false, error: `Unknown IPC method: ${method}` };
   },
@@ -80,14 +98,6 @@ beforeAll(() => {
       const path = url.pathname;
 
       try {
-        if (path === "/v1/contacts/merge" && req.method === "POST") {
-          const mergeRoute = ROUTES.find(
-            (r) => r.operationId === "merge_contacts",
-          )!;
-          const body = (await req.json()) as Record<string, unknown>;
-          const result = mergeRoute.handler({ body });
-          return Response.json(result);
-        }
         if (path === "/v1/contacts" && req.method === "GET") {
           const listRoute = ROUTES.find(
             (r) => r.operationId === "listContacts",

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -50,12 +50,11 @@ mock.module("../ipc/cli-client.js", () => ({
       // merge core, which validates and mirrors back into the assistant DB.
       // Emulate that against the fixture DB via the mirror write path.
       const { keepId, mergeId } = body as { keepId: string; mergeId: string };
+      // The tool pre-validates both contacts via getContact, so the fake only
+      // needs the survivor row (for keepDisplayName).
       const keep = store.getContact(keepId);
       if (!keep) {
         return { ok: false, error: `Contact "${keepId}" not found` };
-      }
-      if (!store.getContact(mergeId)) {
-        return { ok: false, error: `Contact "${mergeId}" not found` };
       }
       store.mergeContactMirror({
         keepContactId: keepId,

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
@@ -49,7 +49,7 @@ export async function executeContactMerge(
 
   const mergeResult = await cliIpcCall<{
     ok: boolean;
-    contact: ContactRead;
+    contact?: ContactRead;
   }>("merge_contacts", {
     body: { keepId, mergeId },
   });
@@ -58,7 +58,9 @@ export async function executeContactMerge(
     return { content: `Error: ${mergeResult.error}`, isError: true };
   }
 
-  const mergedId = mergeResult.result!.contact.id;
+  // The merge response may omit the survivor (post-merge read-back can
+  // degrade); the id we asked to keep is authoritative either way.
+  const mergedId = mergeResult.result?.contact?.id ?? keepId;
 
   // Re-read the surviving contact through the gateway-relayed read so role and
   // interactionCount come from the gateway ContactRead.

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -59,14 +59,13 @@ function concatMergedNotes(
 /**
  * Move donor channels onto the survivor, skipping any the survivor already
  * holds by logical (type, address) key. COLLATE NOCASE catches legacy
- * lowercased rows. `touchUpdatedAt` stamps updated_at on moved rows (the
- * mirror op does; the local merge historically does not).
+ * lowercased rows. `touchUpdatedAt` stamps updated_at on moved rows.
  */
 function reparentDonorChannels(
   tx: DbOrTx,
   keepId: string,
   mergeId: string,
-  touchUpdatedAt?: number,
+  touchUpdatedAt: number,
 ): void {
   const donorChannels = tx
     .select()
@@ -89,12 +88,7 @@ function reparentDonorChannels(
 
     if (!exists) {
       tx.update(contactChannels)
-        .set({
-          contactId: keepId,
-          ...(touchUpdatedAt !== undefined
-            ? { updatedAt: touchUpdatedAt }
-            : {}),
-        })
+        .set({ contactId: keepId, updatedAt: touchUpdatedAt })
         .where(eq(contactChannels.id, ch.id))
         .run();
     }
@@ -669,55 +663,6 @@ export function listContacts(
     .limit(effectiveLimit)
     .all();
   return rows.map((r) => withChannels(parseContact(r)));
-}
-
-/**
- * Merge two contacts into one. The surviving contact keeps the
- * more recent interaction timestamp, concatenated notes, and all channels
- * from both contacts. The donor contact is deleted after merging.
- */
-export function mergeContacts(
-  keepId: string,
-  mergeId: string,
-): ContactWithChannels {
-  const db = getDb();
-
-  if (keepId === mergeId) throw new Error("Cannot merge a contact with itself");
-
-  db.transaction((tx) => {
-    const now = Date.now();
-
-    const keep = tx
-      .select()
-      .from(contacts)
-      .where(eq(contacts.id, keepId))
-      .get();
-    if (!keep) throw new Error(`Contact "${keepId}" not found`);
-
-    const merge = tx
-      .select()
-      .from(contacts)
-      .where(eq(contacts.id, mergeId))
-      .get();
-    if (!merge) throw new Error(`Contact "${mergeId}" not found`);
-
-    tx.update(contacts)
-      .set({
-        notes: concatMergedNotes(keep.notes, merge.notes),
-        updatedAt: now,
-      })
-      .where(eq(contacts.id, keepId))
-      .run();
-
-    // Move channels from donor to survivor, skipping duplicates
-    reparentDonorChannels(tx, keepId, mergeId);
-
-    // Delete the donor contact (cascading deletes remaining channels)
-    tx.delete(contacts).where(eq(contacts.id, mergeId)).run();
-  });
-
-  notifyContactsChanged();
-  return getContact(keepId)!;
 }
 
 /**

--- a/assistant/src/runtime/routes/__tests__/contact-routes-merge-relay.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes-merge-relay.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for the daemon merge_contacts relay.
+ *
+ * `handleMergeContactsRoute` is a thin relay to the gateway IPC method
+ * `merge_contacts` via `ipcCallPersistent`. The gateway DB is the source of
+ * truth: it owns validation, the merge transaction, and the assistant-DB
+ * mirror — the daemon writes NOTHING to the assistant DB directly. These tests
+ * assert the handler forwards `{ keepId, mergeId }` unchanged, returns the
+ * gateway response verbatim, never touches the assistant contact store, and
+ * propagates a relay failure (no local-merge fallback).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+type IpcCall = {
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+};
+
+let ipcCalls: IpcCall[] = [];
+let ipcResult: unknown = { ok: true };
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCalls.push({ method, params, timeoutMs });
+    if (ipcError) {
+      throw ipcError;
+    }
+    return ipcResult;
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Guard: fail loudly if the relay still writes the assistant contact store
+// directly. The assistant DB only changes via the gateway's
+// `contacts_mirror_merge_contact` mirror op, never on this route.
+const actualContactStore = await import("../../../contacts/contact-store.js");
+
+const contactStoreWriteGuard = mock(() => {
+  throw new Error(
+    "assistant contact-store write must not happen on the relayed merge path",
+  );
+});
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  ...actualContactStore,
+  mergeContactMirror: contactStoreWriteGuard,
+}));
+
+const { handleMergeContactsRoute, ROUTES } =
+  await import("../contact-routes.js");
+
+describe("merge contacts relay", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcResult = { ok: true };
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
+    contactStoreWriteGuard.mockClear();
+  });
+
+  test("forwards { keepId, mergeId } unchanged and returns the gateway contact", async () => {
+    const gatewayResponse = {
+      ok: true as const,
+      contact: {
+        id: "ct_keep",
+        displayName: "Alice",
+        contactType: "human",
+        channels: [],
+      },
+    };
+    ipcResult = gatewayResponse;
+
+    const result = await handleMergeContactsRoute({
+      body: { keepId: "ct_keep", mergeId: "ct_merge" },
+    });
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "merge_contacts",
+        params: { keepId: "ct_keep", mergeId: "ct_merge" },
+        timeoutMs: undefined,
+      },
+    ]);
+    expect(result as unknown).toEqual(gatewayResponse);
+    // Must NOT write the assistant DB directly.
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("coerces degraded assistant-owned fields to the contact schema (null contactType → human)", async () => {
+    ipcResult = {
+      ok: true as const,
+      // A mirror soft-fail on the gateway leaves assistant-owned info fields
+      // null; the relay must still satisfy the route's non-null contactType.
+      contact: {
+        id: "ct_keep",
+        displayName: "Alice",
+        contactType: null,
+        channels: [{ id: "ch_1", type: "telegram", address: "alice" }],
+      },
+    };
+
+    const result = (await handleMergeContactsRoute({
+      body: { keepId: "ct_keep", mergeId: "ct_merge" },
+    })) as { ok: boolean; contact?: { contactType?: string } };
+
+    expect(result.contact?.contactType).toBe("human");
+  });
+
+  test("missing keepId/mergeId is rejected before any relay call", async () => {
+    for (const body of [
+      {},
+      { keepId: "ct_keep" },
+      { mergeId: "ct_merge" },
+      { keepId: "", mergeId: "ct_merge" },
+    ]) {
+      try {
+        await handleMergeContactsRoute({ body });
+        throw new Error("expected handler to throw");
+      } catch (err) {
+        const e = err as { statusCode?: number; message: string };
+        expect(e.message).toBe("keepId and mergeId are required");
+        expect(e.statusCode).toBe(400);
+      }
+    }
+    expect(ipcCalls).toHaveLength(0);
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("relayed IpcCallError surfaces with its statusCode/errorCode", async () => {
+    ipcError = new IpcCallError("Cannot merge a contact with itself", {
+      statusCode: 400,
+      errorCode: "MERGE_CONTACTS_INVALID",
+    });
+
+    try {
+      await handleMergeContactsRoute({
+        body: { keepId: "ct_same", mergeId: "ct_same" },
+      });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      const e = err as { statusCode?: number; code?: string; message: string };
+      expect(e.message).toBe("Cannot merge a contact with itself");
+      expect(e.statusCode).toBe(400);
+      expect(e.code).toBe("MERGE_CONTACTS_INVALID");
+    }
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+  });
+
+  test("gateway unreachable: the rejection propagates and the assistant DB is untouched (no local merge)", async () => {
+    ipcError = new Error("ipc transport exploded");
+
+    try {
+      await handleMergeContactsRoute({
+        body: { keepId: "ct_keep", mergeId: "ct_merge" },
+      });
+      throw new Error("expected handler to throw");
+    } catch (err) {
+      expect((err as Error).message).toBe("ipc transport exploded");
+    }
+    // No daemon-side fallback write.
+    expect(contactStoreWriteGuard).not.toHaveBeenCalled();
+    expect(ipcCalls).toHaveLength(1);
+  });
+
+  test("the merge_contacts route is registered and wired to the relay", () => {
+    const route = ROUTES.find((r) => r.operationId === "merge_contacts");
+    expect(route).toBeDefined();
+    expect(route?.endpoint).toBe("contacts/merge");
+    expect(route?.method).toBe("POST");
+  });
+});

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -17,6 +17,7 @@ import type { ContactRead } from "@vellumai/gateway-client/gateway-ipc-contracts
 import {
   GetContactIpcResponseSchema,
   ListContactsIpcResponseSchema,
+  MergeContactsIpcResponseSchema,
   UpdateContactChannelIpcResponseSchema,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
@@ -30,11 +31,7 @@ import {
   redeemInviteByVoiceCode,
   revokeInvite,
 } from "../../channels/gateway-invites.js";
-import {
-  listContacts,
-  mergeContacts,
-  searchContacts,
-} from "../../contacts/contact-store.js";
+import { listContacts, searchContacts } from "../../contacts/contact-store.js";
 import { getGuardianContactIds } from "../../contacts/guardian-contact-reader.js";
 import type {
   ContactChannel,
@@ -463,9 +460,7 @@ export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
       note: body.note as string | undefined,
       maxUses: body.maxUses as number | undefined,
       expiresInMs: body.expiresInMs as number | undefined,
-      expectedExternalUserId: body.expectedExternalUserId as
-        | string
-        | undefined,
+      expectedExternalUserId: body.expectedExternalUserId as string | undefined,
       ...(guardianName ? { guardianName } : {}),
       ...(typeof body.sourceConversationId === "string"
         ? { sourceConversationId: body.sourceConversationId }
@@ -746,7 +741,10 @@ export const ROUTES: RouteDefinition[] = [
         .string()
         .optional()
         .describe("Invite token (token-based redemption)"),
-      code: z.string().optional().describe("Voice code (voice-code redemption)"),
+      code: z
+        .string()
+        .optional()
+        .describe("Voice code (voice-code redemption)"),
       callerExternalUserId: z
         .string()
         .optional()
@@ -950,7 +948,7 @@ export const ROUTES: RouteDefinition[] = [
     }),
     responseBody: z.object({
       ok: z.boolean(),
-      contact: contactSchema.describe("Merged contact"),
+      contact: contactSchema.optional().describe("Merged (surviving) contact"),
     }),
     handler: (args: RouteHandlerArgs) => handleMergeContactsRoute(args),
   },
@@ -985,49 +983,43 @@ export const ROUTES: RouteDefinition[] = [
 // ---------------------------------------------------------------------------
 
 /**
- * DIVERGENCE RISK — daemon-local merge, NOT the canonical path.
+ * Relay the contact merge to the gateway-native handler.
  *
- * This executes the LOCAL `mergeContacts` (assistant DB only). The canonical
- * merge is the gateway control plane (POST /v1/contacts/merge →
- * contacts-control-plane-proxy.handleMergeContacts), which merges the gateway
- * DB — the ACL source of truth — and mirrors here via
- * `contacts_mirror_merge_contact`. A merge through THIS route leaves the
- * gateway DB untouched: the donor contact and its ACL channel rows survive
- * gateway-side while the assistant mirror deletes them. Gateway-fronted
- * clients never reach this route (the control-plane route-match intercepts
- * the path), but direct daemon callers — notably the bundled `contact_merge`
- * tool — do.
- *
- * Not converted to a relay yet because no gateway IPC/SDK merge surface
- * exists (unlike `update_contact_channel` below); relaying requires new
- * gateway-client contracts + a gateway IPC route + a core extraction of the
- * HTTP handler. Until then, prefer the gateway route wherever reachable.
+ * The gateway DB is the source of truth: it owns validation (self-merge,
+ * not-found, guardian donor), the merge transaction, the assistant-DB mirror
+ * (`contacts_mirror_merge_contact`), and the `contacts_changed` emit. This
+ * daemon handler writes NOTHING to the assistant DB directly — it forwards
+ * `{ keepId, mergeId }` and returns the gateway response verbatim. No
+ * fallback: an unexpected relay failure surfaces as an error (never a silent
+ * second write).
  */
-async function handleMergeContactsRoute(args: RouteHandlerArgs) {
-  const { body } = args;
-  const keepId = body?.keepId as string | undefined;
-  const mergeId = body?.mergeId as string | undefined;
+export async function handleMergeContactsRoute(args: RouteHandlerArgs) {
+  const keepId = args.body?.keepId as string | undefined;
+  const mergeId = args.body?.mergeId as string | undefined;
 
   if (!keepId || !mergeId) {
     throw new BadRequestError("keepId and mergeId are required");
   }
 
   try {
-    const contact = mergeContacts(keepId, mergeId);
-    // Daemon-native read (assistant DB): telemetry is gateway-owned, so overlay
-    // it (fail-soft to null) and derive role from the guardian-id set. Both hit
-    // the gateway and are independent — run them concurrently.
-    const [[hydrated], guardianIds] = await Promise.all([
-      hydrateTelemetryFromGateway([contact]),
-      getGuardianContactIds(),
-    ]);
+    const result = await ipcCallPersistent("merge_contacts", {
+      keepId,
+      mergeId,
+    });
+    const parsed = MergeContactsIpcResponseSchema.parse(result);
+    // Relayed write: coerce degraded assistant-owned fields (a null
+    // contactType under a mirror soft-fail) back to the route's contact
+    // schema, like the list/get relays.
     return {
-      ok: true,
-      contact: prepareContactResponse(hydrated, guardianIds),
+      ok: parsed.ok,
+      contact: parsed.contact
+        ? prepareContactResponse(
+            parsed.contact as unknown as PreparableContact & { role: string },
+          )
+        : undefined,
     };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new BadRequestError(message);
+    rethrowGatewayError(err);
   }
 }
 

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -988,6 +988,207 @@ describe("IPC contact routes", () => {
     });
   });
 
+  // ── merge_contacts (gateway-native merge over IPC) ─────────────────────
+  describe("merge_contacts", () => {
+    /**
+     * Insert a donor contact with one channel duplicating the survivor's
+     * (by (type, address COLLATE NOCASE)) and one unique channel.
+     */
+    function seedDonor(): void {
+      const db = getGatewayDb();
+      const now = Date.now();
+      db.insert(contacts)
+        .values({
+          id: "c3",
+          displayName: "Donor Contact",
+          role: "contact",
+          principalId: null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+      db.insert(contactChannels)
+        .values([
+          {
+            // Case-variant duplicate of c2's ch3 (email test@example.com):
+            // must be dup-skipped, then cascade-deleted with the donor.
+            id: "ch_dup",
+            contactId: "c3",
+            type: "email",
+            address: "TEST@Example.com",
+            isPrimary: true,
+            externalChatId: null,
+            status: "active",
+            policy: "allow",
+            interactionCount: 2,
+            createdAt: now,
+          },
+          {
+            id: "ch_uniq",
+            contactId: "c3",
+            type: "telegram",
+            address: "tg-donor-001",
+            isPrimary: false,
+            externalChatId: "chat-donor-001",
+            status: "active",
+            policy: "allow",
+            interactionCount: 4,
+            createdAt: now,
+          },
+        ])
+        .run();
+    }
+
+    test("merges over the socket: donor deleted, channels reparented with NOCASE dup-skip", async () => {
+      seedTestData();
+      seedDonor();
+
+      const ipcCalls: { method: string; body?: Record<string, unknown> }[] = [];
+      ipcCallAssistantMock = mock(async (method, params) => {
+        ipcCalls.push({
+          method,
+          body: params?.body as Record<string, unknown> | undefined,
+        });
+        return {};
+      });
+
+      await startServerAndConnect();
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "c2",
+        mergeId: "c3",
+      });
+
+      expect(res.error).toBeUndefined();
+      const body = res.result as {
+        ok: boolean;
+        contact: {
+          id: string;
+          displayName: string;
+          channels: { id: string; address: string; externalUserId: string }[];
+        };
+      };
+      expect(body.ok).toBe(true);
+      // Survivor payload matches the HTTP handler's toContactPayload shape,
+      // including the externalUserId = address channel compat field.
+      expect(body.contact.id).toBe("c2");
+      expect(body.contact.displayName).toBe("Test Contact");
+      expect(body.contact.channels.map((ch) => ch.id).sort()).toEqual([
+        "ch3",
+        "ch_uniq",
+      ]);
+      for (const ch of body.contact.channels) {
+        expect(ch.externalUserId).toBe(ch.address);
+      }
+
+      // Gateway DB: donor row gone, unique channel reparented, duplicate
+      // channel cascade-deleted with the donor.
+      const db = getGatewayDb();
+      const store = new ContactStore(db);
+      expect(store.getContact("c3")).toBeUndefined();
+      const uniq = db
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch_uniq"))
+        .get();
+      expect(uniq?.contactId).toBe("c2");
+      const dup = db
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch_dup"))
+        .get();
+      expect(dup).toBeUndefined();
+      // The survivor keeps its original casing of the shared address.
+      const kept = db
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(kept?.contactId).toBe("c2");
+      expect(kept?.address).toBe("test@example.com");
+
+      // Exactly one assistant mirror op, plus the contacts_changed emit.
+      const mirror = ipcCalls.filter(
+        (c) => c.method === "contacts_mirror_merge_contact",
+      );
+      expect(mirror).toHaveLength(1);
+      expect(mirror[0].body!.keepContactId).toBe("c2");
+      expect(mirror[0].body!.mergeContactId).toBe("c3");
+      const emits = ipcCalls.filter((c) => c.method === "emit_event");
+      expect(emits).toHaveLength(1);
+      expect(emits[0].body!.kind).toBe("contacts_changed");
+    });
+
+    test("self-merge is rejected with the 400-shaped wire error", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "c2",
+        mergeId: "c2",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("MERGE_CONTACTS_INVALID");
+      expect(res.error).toMatch(/itself/);
+    });
+
+    test("unknown contact is rejected with the 400-shaped wire error", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "does-not-exist",
+        mergeId: "c2",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("MERGE_CONTACTS_INVALID");
+      expect(res.error).toMatch(/not found/);
+    });
+
+    test("guardian donor is rejected and left untouched", async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "c2",
+        mergeId: "c1",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("MERGE_CONTACTS_INVALID");
+      expect(res.error).toMatch(/guardian/);
+
+      const store = new ContactStore(getGatewayDb());
+      expect(store.getContact("c1")).toBeDefined();
+      expect(store.getChannelsForContact("c1")).toHaveLength(2);
+    });
+
+    test("missing params are rejected by the schema", async () => {
+      await startServerAndConnect();
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "c2",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.error).toContain("Invalid params");
+    });
+
+    test("empty-string params are rejected by the schema", async () => {
+      await startServerAndConnect();
+      const res = await sendRequest(client, "merge_contacts", {
+        keepId: "",
+        mergeId: "c2",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.error).toContain("Invalid params");
+    });
+  });
+
   // ── Rich reads (contacts_list_rich / contacts_get_rich) ─────────────────
   //
   // The assistant DB proxy is not available in this test harness, so the rich

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1817,9 +1817,13 @@ export class CannotDowngradeGuardianError extends Error {
 
 /**
  * Thrown by `mergeContacts` for validation errors (self-merge, contact not
- * found). The caller maps this to HTTP 400.
+ * found, guardian donor). The HTTP handler maps this to a 400; the gateway
+ * IPC server mirrors `statusCode`/`code` into the wire envelope.
  */
 export class MergeContactsError extends Error {
+  readonly statusCode = 400;
+  readonly code = "MERGE_CONTACTS_INVALID";
+
   constructor(message: string) {
     super(message);
     this.name = "MergeContactsError";

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -764,6 +764,40 @@ export async function updateContactChannelCore(params: {
 }
 
 /**
+ * Transport-agnostic contact merge.
+ *
+ * Shared by the HTTP `handleMergeContacts` and the gateway IPC
+ * `merge_contacts` route. Runs `ContactStore.mergeContacts` (gateway DB
+ * transaction + best-effort assistant mirror), emits `contacts_changed`, and
+ * returns the survivor contact payload.
+ *
+ * Throws `MergeContactsError` (statusCode 400, code MERGE_CONTACTS_INVALID)
+ * for validation failures (self-merge, contact not found, guardian donor).
+ * The HTTP handler maps it to a 400; the IPC server mirrors `statusCode`/
+ * `code` into the wire envelope. Unexpected errors propagate so each
+ * transport surfaces a 500-equivalent — never a silent fallback.
+ */
+export async function mergeContactsCore(params: {
+  keepId: string;
+  mergeId: string;
+}): Promise<{ ok: true; contact?: Record<string, unknown> }> {
+  const { keepId, mergeId } = params;
+  const store = new ContactStore();
+  const contact = await store.mergeContacts(keepId, mergeId);
+
+  // Emit contacts_changed so connected clients refresh.
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
+
+  log.info({ keepId, mergeId }, "merge_contacts: handled natively");
+  return {
+    ok: true,
+    contact: contact ? toContactPayload(contact) : undefined,
+  };
+}
+
+/**
  * Validate that metadata matches the expected shape for the given species.
  * Mirrors `validateSpeciesMetadata` in `assistant/src/contacts/contact-store.ts`.
  */
@@ -1544,19 +1578,8 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       }
 
       try {
-        const store = new ContactStore();
-        const contact = await store.mergeContacts(keepId, mergeId);
-
-        // Emit contacts_changed so connected clients refresh.
-        void ipcCallAssistant("emit_event", {
-          body: { kind: "contacts_changed" },
-        } as unknown as Record<string, unknown>).catch(() => {});
-
-        log.info({ keepId, mergeId }, "merge_contacts: handled natively");
-        return Response.json({
-          ok: true,
-          contact: contact ? toContactPayload(contact) : undefined,
-        });
+        const result = await mergeContactsCore({ keepId, mergeId });
+        return Response.json(result);
       } catch (err) {
         if (err instanceof MergeContactsError) {
           return Response.json(

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -771,11 +771,9 @@ export async function updateContactChannelCore(params: {
  * transaction + best-effort assistant mirror), emits `contacts_changed`, and
  * returns the survivor contact payload.
  *
- * Throws `MergeContactsError` (statusCode 400, code MERGE_CONTACTS_INVALID)
- * for validation failures (self-merge, contact not found, guardian donor).
- * The HTTP handler maps it to a 400; the IPC server mirrors `statusCode`/
- * `code` into the wire envelope. Unexpected errors propagate so each
- * transport surfaces a 500-equivalent — never a silent fallback.
+ * Throws `MergeContactsError` for validation failures; unexpected errors
+ * propagate so each transport surfaces a 500-equivalent — never a silent
+ * fallback.
  */
 export async function mergeContactsCore(params: {
   keepId: string;
@@ -1211,8 +1209,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       }
 
       const assistantMeta = body.assistantMetadata as
-        | { species?: unknown; metadata?: unknown }
-        | undefined;
+        { species?: unknown; metadata?: unknown } | undefined;
 
       if (body.contactType === "assistant") {
         if (!assistantMeta) {
@@ -1368,9 +1365,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
                 species: assistantMeta.species as string,
                 metadata:
                   (assistantMeta.metadata as
-                    | Record<string, unknown>
-                    | null
-                    | undefined) ?? null,
+                    Record<string, unknown> | null | undefined) ?? null,
               }
             : undefined,
         channels: channelInputs?.map((ch) => ({

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -14,6 +14,7 @@ import {
   ListContactsIpcParamsSchema,
   MarkChannelRevokedIpcParamsSchema,
   MarkChannelRevokedIpcResponseSchema,
+  MergeContactsIpcParamsSchema,
   UpdateContactChannelIpcParamsSchema,
   UpsertVerifiedChannelIpcParamsSchema,
   UpsertVerifiedChannelIpcResponseSchema,
@@ -21,7 +22,10 @@ import {
 import { z } from "zod";
 
 import { ContactStore } from "../db/contact-store.js";
-import { updateContactChannelCore } from "../http/routes/contacts-control-plane-proxy.js";
+import {
+  mergeContactsCore,
+  updateContactChannelCore,
+} from "../http/routes/contacts-control-plane-proxy.js";
 import { getLogger } from "../logger.js";
 import {
   getGatewayChannelByKey,
@@ -204,6 +208,17 @@ export const contactRoutes: IpcRoute[] = [
       // server's buildErrorResponse mirrors into the wire envelope; unexpected
       // errors propagate as a generic IPC error (no fallback).
       return updateContactChannelCore(parsed);
+    },
+  },
+  {
+    method: "merge_contacts",
+    schema: MergeContactsIpcParamsSchema,
+    handler: (params?: Record<string, unknown>) => {
+      const parsed = MergeContactsIpcParamsSchema.parse(params);
+      // Thrown MergeContactsError carries statusCode/code, which the IPC
+      // server's buildErrorResponse mirrors into the wire envelope; unexpected
+      // errors propagate as a generic IPC error (no fallback).
+      return mergeContactsCore(parsed);
     },
   },
   {

--- a/gateway/src/ipc/contact-handlers.ts
+++ b/gateway/src/ipc/contact-handlers.ts
@@ -215,9 +215,6 @@ export const contactRoutes: IpcRoute[] = [
     schema: MergeContactsIpcParamsSchema,
     handler: (params?: Record<string, unknown>) => {
       const parsed = MergeContactsIpcParamsSchema.parse(params);
-      // Thrown MergeContactsError carries statusCode/code, which the IPC
-      // server's buildErrorResponse mirrors into the wire envelope; unexpected
-      // errors propagate as a generic IPC error (no fallback).
       return mergeContactsCore(parsed);
     },
   },

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -108,6 +108,26 @@ export type UpdateContactChannelIpcResponse = z.infer<
   typeof UpdateContactChannelIpcResponseSchema
 >;
 
+export const MergeContactsIpcParamsSchema = z.object({
+  keepId: z.string().min(1),
+  mergeId: z.string().min(1),
+});
+
+export type MergeContactsIpcParams = z.infer<
+  typeof MergeContactsIpcParamsSchema
+>;
+
+export const MergeContactsIpcResponseSchema = z.object({
+  ok: z.literal(true),
+  // The gateway-native handler owns the full contact payload shape; pass it
+  // through verbatim rather than re-declaring channel fields here.
+  contact: z.object({}).passthrough().optional(),
+});
+
+export type MergeContactsIpcResponse = z.infer<
+  typeof MergeContactsIpcResponseSchema
+>;
+
 export const MarkChannelVerifiedIpcParamsSchema = z.object({
   contactChannelId: z.string().min(1),
   // Audit source for the verification. CLI/session-driven verifications


### PR DESCRIPTION
## Summary
Closes ATL-987 (LUM-2756): the daemon's `merge_contacts` route — and therefore the bundled `contact_merge` tool — merged the assistant DB only, leaving the gateway (the ACL source of truth) with the donor contact and its ACL channel rows alive: a permanent, unreconciled divergence. The gateway merge core (`ContactStore.mergeContacts`) is now exposed over IPC via a shared `mergeContactsCore` (the `updateContactChannelCore` pattern, so HTTP/IPC parity is by construction), and the daemon route is a pure relay with no local fallback — the dead local merge is deleted while `mergeContactMirror` (the daemon's write path for gateway-driven merges) and its helpers stay. Relayed responses run through `prepareContactResponse` so a gateway info-join soft-fail can't violate the route's contact schema.

## Self-review result
4-pass self-review (external-feedback, plan-faithfulness, repo-integration, slop/reuse): Passes 1–2 clean; passes 3–4 flagged 3 actionable minor items (tool deref on a now-optional contact, duplicated envelope comments, a dead test-fake branch) — fixed in #37953 and verified on the tip. Triaged-accepted with rationale: the `"MergeContactsError: "` wire-message prefix (existing relay-wide envelope pattern shared with `update_contact_channel`), the doubled `contacts_changed` on daemon merges (identical to the gateway-HTTP path), and transport-level error-test overlap.

## PRs merged into feature branch
- #37933: feat(gateway): merge_contacts IPC route over the existing gateway merge core
- #37941: refactor(assistant): merge_contacts relays to the gateway; local assistant-DB merge deleted (ATL-987)

### Fix PRs
- #37953: fix: self-review batch — guard optional merge contact in the tool; comment/test trims

Part of plan: contact-merge-relay.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)