### PR TITLE
feat(voice): state-transition polish + live-caption word reveal (JARVIS-1273)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -13,7 +13,10 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { act, cleanup, render, screen } from "@testing-library/react";
 
-import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  type LiveVoiceSessionState,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 import { VoiceAmbientTranscript } from "@/domains/chat/voice/voice-room/voice-ambient-transcript";
@@ -36,6 +39,12 @@ function setPrefs({ user, assistant }: { user: boolean; assistant: boolean }) {
   act(() => {
     useVoicePrefsStore.getState().setShowUserTranscript(user);
     useVoicePrefsStore.getState().setShowAssistantTranscript(assistant);
+  });
+}
+
+function setSessionState(state: LiveVoiceSessionState) {
+  act(() => {
+    useLiveVoiceStore.getState().setState(state);
   });
 }
 
@@ -86,6 +95,34 @@ describe("VoiceAmbientTranscript — pref gating", () => {
     setPrefs({ user: true, assistant: true });
     const { container } = render(<VoiceAmbientTranscript />);
     expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("VoiceAmbientTranscript — listening gate", () => {
+  test("hides the lingering assistant transcript while listening", () => {
+    // A finished response lingers in the store until the next turn thinks; the
+    // following `listening` turn must not paint it under the low-sunk eyes.
+    seedAssistant("my previous answer");
+    setPrefs({ user: false, assistant: true });
+    setSessionState("listening");
+    render(<VoiceAmbientTranscript />);
+    expect(assistantText()).toBeNull();
+  });
+
+  test("shows the assistant transcript while the assistant is speaking", () => {
+    seedAssistant("here's my answer");
+    setPrefs({ user: false, assistant: true });
+    setSessionState("speaking");
+    render(<VoiceAmbientTranscript />);
+    expect(assistantText()?.textContent).toContain("here's my answer");
+  });
+
+  test("still shows the user transcript while listening", () => {
+    seedUser("what I'm saying now");
+    setPrefs({ user: true, assistant: false });
+    setSessionState("listening");
+    render(<VoiceAmbientTranscript />);
+    expect(userText()?.textContent).toContain("what I'm saying now");
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -6,30 +6,50 @@
  * - USER speech ABOVE the avatar — `partialTranscript || finalTranscript` from
  *   the live-voice store, shown only when `showUserTranscript` is on.
  * - ASSISTANT speech BELOW the avatar — `assistantTranscript`, shown only when
- *   `showAssistantTranscript` is on.
+ *   `showAssistantTranscript` is on AND the assistant isn't idle behind a new
+ *   `listening` turn (the transcript lingers until the next response starts, so
+ *   without this it would sit under the low-sunk listening eyes).
  *
  * Both prefs default OFF, so by default this renders nothing and the room stays
  * text-free. The avatar (centered by the room) is the primary anchor; each half
  * is absolutely positioned relative to the room overlay so text appearing or
- * clearing never shifts the avatar.
+ * clearing never shifts the avatar. Words reveal one at a time via
+ * {@link VoiceTranscriptText}, with a per-half clearance that keeps the text off
+ * the centered eyes at any window size.
  *
- * Subscriptions are deliberately narrow — only the three transcript fields and
- * the two prefs — so the high-frequency `inputAmplitude` (and `state`) churn on
- * the live-voice store never re-renders this component. The full transcript
- * still lands in the chat thread on exit via the engine path; this is a live,
- * ambient echo only.
+ * Subscriptions are deliberately narrow — the three transcript fields, the two
+ * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
+ * listening gate) — so the high-frequency `inputAmplitude` churn on the
+ * live-voice store never re-renders this component. The full transcript still
+ * lands in the chat thread on exit via the engine path; this is a live, ambient
+ * echo only.
  */
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
-import { cn } from "@vellumai/design-library";
-
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
-/** Shared muted, constrained-width, centered treatment for both halves. */
+import { toVoiceAvatarVisual } from "./voice-avatar-state";
+import { VoiceTranscriptText } from "./voice-transcript-text";
+
+/**
+ * Shared constrained-width, centered treatment for both halves. Base tone comes
+ * from the per-word {@link VoiceTranscriptText} (room-fg-muted, leading word
+ * brighter); this only owns layout + wrapping.
+ */
 const AMBIENT_TEXT_CLASS =
-  "pointer-events-none absolute left-1/2 z-0 max-w-[32rem] -translate-x-1/2 px-6 text-center text-sm text-balance whitespace-pre-wrap break-words text-[var(--content-tertiary)]";
+  "pointer-events-none absolute left-1/2 z-0 max-w-[38rem] -translate-x-1/2 px-6 text-center text-[clamp(19px,2.6vmin,30px)] leading-relaxed text-balance whitespace-pre-wrap break-words";
+
+/**
+ * Vertical clearance from the room center to each transcript half. The centered
+ * eyes reach up to `EYE_TARGET_HEIGHT` (30%) of the smaller viewport dimension
+ * tall — i.e. 15vmin above and below center — so anchoring the text past
+ * `15vmin` plus a gap keeps it clear of the eyes (color look) and the centered
+ * avatar (void look) at every window size, where the old fixed rem offset let
+ * the big eyes ride into the text.
+ */
+const TRANSCRIPT_CLEARANCE = "calc(50% + 15vmin + 2.5rem)";
 
 export function VoiceAmbientTranscript() {
   const showUser = useVoicePrefsStore.use.showUserTranscript();
@@ -38,14 +58,26 @@ export function VoiceAmbientTranscript() {
   const partialTranscript = useLiveVoiceStore.use.partialTranscript();
   const finalTranscript = useLiveVoiceStore.use.finalTranscript();
   const assistantTranscript = useLiveVoiceStore.use.assistantTranscript();
+  // Low-frequency (per-turn) fields — safe to subscribe to without the
+  // `inputAmplitude` churn the narrow subscriptions above avoid.
+  const state = useLiveVoiceStore.use.state();
+  const reconnecting = useLiveVoiceStore.use.reconnecting();
   const reduce = useReducedMotion();
 
   // In-flight partial wins over the last finalized transcript — same precedence
   // as the underneath composer transcript (`VoiceLiveTranscript`).
   const userText = partialTranscript || finalTranscript;
 
+  // The assistant transcript is only cleared when the NEXT response starts
+  // thinking, so a finished response lingers in the store through the following
+  // `listening` turn — where the eyes sink low, right onto the below-center
+  // assistant caption. Hide that half while listening (the assistant isn't
+  // speaking then anyway); in thinking/responding the eyes are centered and the
+  // clearance clears them.
+  const visual = toVoiceAvatarVisual(state, reconnecting);
   const showUserHalf = showUser && userText.length > 0;
-  const showAssistantHalf = showAssistant && assistantTranscript.length > 0;
+  const showAssistantHalf =
+    showAssistant && assistantTranscript.length > 0 && visual !== "listening";
 
   const fade = {
     initial: reduce ? false : { opacity: 0 },
@@ -63,10 +95,11 @@ export function VoiceAmbientTranscript() {
           aria-live="polite"
           // Above the centered avatar; bottom-anchored so it grows upward and
           // never creeps toward the orb.
-          className={cn(AMBIENT_TEXT_CLASS, "bottom-[calc(50%+8.5rem)]")}
+          className={AMBIENT_TEXT_CLASS}
+          style={{ bottom: TRANSCRIPT_CLEARANCE }}
           {...fade}
         >
-          {userText}
+          <VoiceTranscriptText text={userText} />
         </motion.p>
       ) : null}
 
@@ -76,10 +109,11 @@ export function VoiceAmbientTranscript() {
           data-testid="voice-ambient-assistant"
           aria-live="polite"
           // Below the centered avatar; top-anchored so it grows downward.
-          className={cn(AMBIENT_TEXT_CLASS, "top-[calc(50%+8.5rem)]")}
+          className={AMBIENT_TEXT_CLASS}
+          style={{ top: TRANSCRIPT_CLEARANCE }}
           {...fade}
         >
-          {assistantTranscript}
+          <VoiceTranscriptText text={assistantTranscript} />
         </motion.p>
       ) : null}
     </AnimatePresence>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -397,11 +397,16 @@ type VoidStory = StoryObj<typeof RoomScene>;
 export const Playground: Story = {};
 
 /**
- * Every session state, all sharing the simulated-speech driver. Wired so far:
- * `idle` (eyes centered, no waveform) and `listening` (the centered waveform
- * plus the eyes sinking toward the lower rest with the voice). The remaining
- * states — `thinking`, `responding`, `reconnecting` — still show the resting
- * centered eyes; their own treatments are the next thing to design.
+ * Every session state, all sharing the simulated-speech driver:
+ * - `idle` — eyes centered, no treatment.
+ * - `listening` — centered waveform, eyes sunk toward the lower rest with the
+ *   voice.
+ * - `thinking` — eyes ride back up to center, the dot triad hangs just above
+ *   them (the listening→thinking hand-off cross-fades the waves out / dots in).
+ * - `responding` — eyes centered, the responding treatment radiates outward.
+ * - `reconnecting` — eyes centered but dimmed.
+ *
+ * Scrub `visual` in the Playground to watch the transitions between them.
  */
 export const States: Story = {
   render: (args) => (

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -16,14 +16,15 @@
  *    per `eyePlacement`) with a settle dip, then a double blink and idle-blink
  *    from there (with a slight cursor parallax).
  *
- * Per-state treatments (driven by `visual`): while the user speaks
- * (`listening`) the mic-amplitude waveform swells behind the eyes — centered
- * by default so it reads as the voice gathering around them rather than rising
- * from the floor — and the eyes drop to a low hold. They stay held low through
- * the `thinking` that follows (a quiet dot indicator works above them), then
- * ride back up to center to speak (`responding`, where the assistant's voice
- * radiates outward from behind the eyes — see {@link VoiceRespondingStyle}).
- * `reconnecting` fades the eyes back — presence dimmed while away.
+ * Per-state treatments (driven by `visual`, cross-faded so nothing pops):
+ * while the user speaks (`listening`) the mic-amplitude waveform swells behind
+ * the eyes — centered by default so it reads as the voice gathering around them
+ * rather than rising from the floor — and the eyes drop to a low hold. When the
+ * turn passes to the assistant they ride back up to center: `thinking`
+ * dissolves the waves out and a quiet dot triad in just above the eyes, then
+ * `responding` keeps them centered while the assistant's voice radiates outward
+ * from behind them (see {@link VoiceRespondingStyle}). `reconnecting` fades the
+ * eyes back — presence dimmed while away.
  *
  * Geometry and timing mirror onboarding's `IntroductionScreen` +
  * `OnboardingPeekingEyes`. Traits default like `ChatAvatar` does (first
@@ -40,7 +41,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { motion, useReducedMotion } from "motion/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { pathBBox, unionBBox, type BBox } from "@/components/avatar/eye-bbox";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
@@ -73,6 +74,14 @@ const CURSOR_MAX_Y = 8;
  * live bob driven by mic amplitude, so they never float back up between words.
  */
 const EYE_LISTEN_SINK_BASE = 0.85;
+/**
+ * How long the eyes travel between center and the low listening hold — a
+ * motion tween on the hold wrapper (the same animation system as the entrance
+ * keyframes; see {@link VoiceRoomEyes}). The drop is quicker than the rise:
+ * getting out of the waveform's way is urgent, coming back up is composed.
+ */
+const EYE_SINK_MS = 450;
+const EYE_RISE_MS = 700;
 /** The entrance grows the body from this "avatar on the screen" size and the
  *  eyes from this vertical center — onboarding's picker geometry. */
 const ENTER_FROM_SIZE = 200;
@@ -140,6 +149,20 @@ export function resolveVoiceRoomLook(
   return { bgHex, art: { paths: eyeDef.paths, bbox }, body };
 }
 
+/**
+ * The on-screen height of the eyes in a `w`×`h` room — capped at
+ * `EYE_TARGET_HEIGHT` of the smaller dimension, then clamped so the width stays
+ * within `EYE_MAX_WIDTH`. Shared so the thinking dots can sit just above the
+ * centered eyes without re-deriving the sizing from the art bbox.
+ */
+function eyeDisplayHeight(art: VoiceRoomEyeArt, w: number, h: number): number {
+  const maxEyesW = w * EYE_MAX_WIDTH;
+  return Math.min(
+    Math.min(w, h) * EYE_TARGET_HEIGHT,
+    (maxEyesW * art.bbox.h) / art.bbox.w,
+  );
+}
+
 function windowSize(): { w: number; h: number } {
   return { w: window.innerWidth, h: window.innerHeight };
 }
@@ -202,11 +225,16 @@ export function VoiceRoomColorLook({
   const origin = entryOrigin ?? { x: w / 2, y: (ENTER_FROM_CENTER_VH / 100) * h };
 
   // Per-state treatments. The waveform is the user's live voice (listening
-  // only); the eyes hold low through the whole user-owned turn — listening AND
-  // the thinking that follows — so they don't bob back up to center the moment
-  // the user stops talking, then settle back to center for the rest.
+  // only); the eyes sink low only while listening, then ride back up to center
+  // the moment the turn passes to the assistant (thinking + responding), so the
+  // rise doubles as the "over to you" beat. The centered eye top is where they
+  // come to rest — the thinking dots hang just above it.
   const showWaves = visual === "listening";
-  const sinkEyes = visual === "listening" || visual === "thinking";
+  const sinkEyes = visual === "listening";
+  const centeredEyeTop = useMemo(
+    () => (h - eyeDisplayHeight(look.art, w, h)) / 2,
+    [look.art, w, h],
+  );
 
   // Body grows to cover the screen end to end, from the small avatar size at
   // the entry origin — onboarding's Introduction grow, re-anchored to where the
@@ -278,35 +306,72 @@ export function VoiceRoomColorLook({
         </motion.svg>
       ) : null}
 
-      {/* The user's voice, gathering behind the eyes while they speak. */}
-      {showWaves && getAmplitude ? (
-        <VoiceListeningWaves
-          getAmplitude={getAmplitude}
-          waveStyle={waveStyle}
-          palette={wavePalette}
-          placement={wavePlacement}
-        />
-      ) : null}
+      {/* Per-state treatment layer — the listening waves, the thinking dots,
+          and the responding treatment cross-fade as the session moves between
+          states (only one is live at a time), so nothing pops in or vanishes
+          hard. The listening→thinking hand-off in particular reads as the waves
+          dissolving out and the dots dissolving in while the eyes ride up. */}
+      <AnimatePresence>
+        {/* The user's voice, gathering behind the eyes while they speak. */}
+        {showWaves && getAmplitude ? (
+          <motion.div
+            key="listening"
+            className="pointer-events-none absolute inset-0"
+            initial={reduce ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: reduce ? 0 : 0.3 }}
+          >
+            <VoiceListeningWaves
+              getAmplitude={getAmplitude}
+              waveStyle={waveStyle}
+              palette={wavePalette}
+              placement={wavePlacement}
+            />
+          </motion.div>
+        ) : null}
 
-      {/* Thinking: the eyes stay held low (looking down, pondering) while a
-          quiet indicator works away above them. */}
-      {visual === "thinking" ? (
-        <VoiceThinkingIndicator viewport={{ w, h }} />
-      ) : null}
+        {/* Thinking: the eyes have ridden back up to center; a quiet dot triad
+            works away just above them. */}
+        {visual === "thinking" ? (
+          <motion.div
+            key="thinking"
+            className="pointer-events-none absolute inset-0"
+            initial={reduce ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: reduce ? 0 : 0.3 }}
+          >
+            <VoiceThinkingIndicator
+              viewport={{ w, h }}
+              eyesTop={centeredEyeTop}
+            />
+          </motion.div>
+        ) : null}
 
-      {/* Responding: the eyes ride back up to center (engaged, addressing the
-          user) and the assistant's voice radiates outward from behind them,
-          driven by the TTS-output amplitude — energy going out, the mirror of
-          listening's incoming waves. */}
-      {visual === "responding" ? (
-        <VoiceRespondingTreatment
-          style={respondingStyle}
-          getAmplitude={getResponseAmplitude ?? getAmplitude}
-          waveStyle={waveStyle}
-          wavePlacement={wavePlacement}
-          viewport={{ w, h }}
-        />
-      ) : null}
+        {/* Responding: the eyes stay centered (engaged, addressing the user)
+            and the assistant's voice radiates outward from behind them, driven
+            by the TTS-output amplitude — energy going out, the mirror of
+            listening's incoming waves. */}
+        {visual === "responding" ? (
+          <motion.div
+            key="responding"
+            className="pointer-events-none absolute inset-0"
+            initial={reduce ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: reduce ? 0 : 0.3 }}
+          >
+            <VoiceRespondingTreatment
+              style={respondingStyle}
+              getAmplitude={getResponseAmplitude ?? getAmplitude}
+              waveStyle={waveStyle}
+              wavePlacement={wavePlacement}
+              viewport={{ w, h }}
+            />
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
 
       <VoiceRoomEyes
         art={look.art}
@@ -314,8 +379,9 @@ export function VoiceRoomColorLook({
         viewport={{ w, h }}
         entranceOrigin={origin}
         getAmplitude={getAmplitude}
-        // The centered eyes hold low through the user-owned turn (listening +
-        // thinking), sinking with the voice while listening (see `VoiceRoomEyes`).
+        // The centered eyes drop low only while the user speaks (`listening`),
+        // sinking with the voice, then ride back up to center for the
+        // assistant's turn (see `VoiceRoomEyes`).
         sink={sinkEyes}
         // Reconnecting: fade the eyes back — presence dimmed while away.
         dimmed={visual === "reconnecting"}
@@ -325,25 +391,32 @@ export function VoiceRoomColorLook({
 }
 
 /**
- * Thinking indicator — a soft triad of dots pulsing in sequence above the
- * held-low eyes, in the room's foreground tone so it reads on any avatar
- * color. A first-pass "the assistant is working" motif; the responding-state
- * treatment (and whether thinking wants something richer) is still open.
+ * Thinking indicator — a soft triad of dots pulsing in sequence just above the
+ * centered eyes, in the room's foreground tone so it reads on any avatar color.
+ * `eyesTop` is the top of the centered eyes; the triad hangs a short gap above
+ * it (both scaled against the room box) so it stays clear of the eyes in any
+ * frame. A first-pass "the assistant is working" motif.
  */
 function VoiceThinkingIndicator({
   viewport,
+  eyesTop,
 }: {
   viewport: { w: number; h: number };
+  /** Top edge (px) of the centered eyes — the triad hangs above this. */
+  eyesTop: number;
 }) {
   const reduce = useReducedMotion();
   // Size against the room box (not fixed px) so the dots keep the same
   // proportion in a small Storybook frame and the full-window app.
   const dot = Math.max(8, Math.round(0.04 * Math.min(viewport.w, viewport.h)));
+  // Hang the triad's center a short gap above the eyes' top edge, clamped so it
+  // never rides off the top of a short frame.
+  const top = Math.max(dot * 1.5, eyesTop - dot * 2.5);
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute left-1/2 z-[1] flex -translate-x-1/2 items-center"
-      style={{ top: "34%", gap: dot }}
+      className="pointer-events-none absolute left-1/2 z-[1] flex -translate-x-1/2 -translate-y-1/2 items-center"
+      style={{ top, gap: dot }}
     >
       {[0, 1, 2].map((i) => (
         <motion.span
@@ -583,7 +656,7 @@ export function VoiceRoomEyes({
   entranceOrigin?: { x: number; y: number };
   /** Mic amplitude source (0–1); drives the live bob while the eyes are sunk. */
   getAmplitude?: () => number;
-  /** Hold the eyes at the low rest (the user-owned turn — listening + thinking). */
+  /** Hold the eyes at the low rest (while the user speaks — `listening`). */
   sink?: boolean;
   /** Fade the eyes back (the reconnecting state — presence dimmed while away). */
   dimmed?: boolean;
@@ -635,11 +708,7 @@ export function VoiceRoomEyes({
   const originX = entranceOrigin?.x ?? w / 2;
   const originY = entranceOrigin?.y ?? (ENTER_FROM_CENTER_VH / 100) * h;
   const geometry = useMemo(() => {
-    const maxEyesW = w * EYE_MAX_WIDTH;
-    const eyesH = Math.min(
-      Math.min(w, h) * EYE_TARGET_HEIGHT,
-      (maxEyesW * art.bbox.h) / art.bbox.w,
-    );
+    const eyesH = eyeDisplayHeight(art, w, h);
     const eyesW = (eyesH * art.bbox.w) / art.bbox.h;
     const { restTop, startX, startY, dipY, sinkTravel } = eyeLayout(
       placement,
@@ -661,14 +730,19 @@ export function VoiceRoomEyes({
     };
   }, [art, w, h, placement, originX, originY]);
 
-  // Sink: while the user owns the turn (listening + thinking) the centered eyes
-  // drop to a low hold near the bottom rest (`EYE_LISTEN_SINK_BASE` of the
-  // travel) so they sit clear of the centered waveform, then bob the remaining
-  // fraction with the mic amplitude — they don't float back up to center
-  // between words or when the user stops. Driven imperatively (never React
-  // state, matching the waveform / avatar) through a smoothed rAF loop writing
-  // `translateY` on a dedicated wrapper — kept off the entrance `y` and the
-  // cursor parallax so all three compose.
+  // Sink: while the user speaks (`listening`) the centered eyes drop to a low
+  // hold near the bottom rest (`EYE_LISTEN_SINK_BASE` of the travel) so they
+  // sit clear of the centered waveform; when the turn passes to the assistant
+  // they sweep back up to center. Two nested wrappers so the parts compose:
+  // - The big center↔low-hold travel is a motion tween on the hold wrapper
+  //   below — the same animation system as the entrance keyframes (per-frame
+  //   imperative writes of the full travel fought the entrance's transforms
+  //   and read as stutter). `sink` retargets the tween; a mid-flight reversal
+  //   continues from wherever the eyes are.
+  // - The residual mic bob (≤15% of the travel) stays an imperative smoothed
+  //   rAF writing `translateY` on the inner wrapper — a live noisy signal has
+  //   no place in React state or tween retargets. It releases to 0 the moment
+  //   the sink lifts, so the rise is the motion tween alone.
   const sinkRef = useRef<HTMLDivElement | null>(null);
   const getAmplitudeRef = useRef(getAmplitude);
   const sinkActiveRef = useRef(sink);
@@ -686,10 +760,7 @@ export function VoiceRoomEyes({
     if (reduce) return;
     const node = sinkRef.current;
     if (!node) return;
-    // Drop to the low hold when listening starts, ease back up to center when
-    // it ends — a touch slower than the waveform so the eyes settle, not
-    // jitter.
-    const smoother = createAmplitudeSmoother({ attackMs: 160, releaseMs: 380 });
+    const bobSmoother = createAmplitudeSmoother({ attackMs: 160, releaseMs: 380 });
     let raf = 0;
     let lastTime = performance.now();
     let lastWritten = "";
@@ -697,13 +768,9 @@ export function VoiceRoomEyes({
       const dt = now - lastTime;
       lastTime = now;
       const get = getAmplitudeRef.current;
-      // While sunk the eyes hold at `EYE_LISTEN_SINK_BASE` of the travel and
-      // bob the rest with amplitude; otherwise they return to center (0).
       const amp = get ? Math.min(1, Math.max(0, get())) : 0;
-      const target = sinkActiveRef.current
-        ? EYE_LISTEN_SINK_BASE + (1 - EYE_LISTEN_SINK_BASE) * amp
-        : 0;
-      const shift = (smoother.step(target, dt) * sinkTravelRef.current).toFixed(1);
+      const bob = bobSmoother.step(sinkActiveRef.current ? amp : 0, dt);
+      const shift = (bob * (1 - EYE_LISTEN_SINK_BASE) * sinkTravelRef.current).toFixed(1);
       if (shift !== lastWritten) {
         lastWritten = shift;
         node.style.transform = `translateY(${shift}px)`;
@@ -713,6 +780,10 @@ export function VoiceRoomEyes({
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
   }, [reduce]);
+
+  // The low-hold offset the hold wrapper tweens to while sunk (0 for the
+  // bottom placement — nowhere lower to go).
+  const holdY = geometry.sinkTravel * EYE_LISTEN_SINK_BASE;
 
   const cx = art.bbox.x + art.bbox.w / 2;
   const cy = art.bbox.y + art.bbox.h / 2;
@@ -734,8 +805,13 @@ export function VoiceRoomEyes({
           ? { x: geometry.startX, y: geometry.startY, scale: 0.35 }
           : false
       }
+      // Play the grow-in keyframes only until the entrance lands, then hold a
+      // stable static target. Otherwise every re-render (a `visual`/`sink`
+      // change) hands Motion a fresh keyframe array and it replays part of the
+      // entrance — the eyes lurch toward the origin and snap back, fighting the
+      // smooth sink-rise on the listening→thinking hand-off.
       animate={
-        playEntrance
+        playEntrance && !entranceDone
           ? {
               x: [geometry.startX, 0, 0],
               y: [geometry.startY, geometry.dipY, 0],
@@ -744,49 +820,64 @@ export function VoiceRoomEyes({
           : { x: 0, y: 0, scale: 1 }
       }
       transition={
-        playEntrance
+        playEntrance && !entranceDone
           ? { duration: 1, times: [0, 0.7, 1], ease: "easeInOut" }
           : { duration: 0 }
       }
       onAnimationComplete={() => setEntranceDone(true)}
     >
-      {/* Speak-to-sink: rAF writes translateY here as the voice rises. The
-          opacity fades the eyes back while reconnecting (rAF only touches
-          `transform`, so it never clobbers this). */}
-      <div
-        ref={sinkRef}
-        style={{
-          opacity: dimmed ? 0.4 : 1,
-          transition: "opacity 0.5s ease",
-        }}
+      {/* Turn hold: the big center↔low-hold travel, on the same motion tween
+          system as the entrance. `sink` retargets `y`; a mid-flight reversal
+          continues smoothly from wherever the eyes are. */}
+      <motion.div
+        animate={reduce ? { y: 0 } : { y: sink ? holdY : 0 }}
+        transition={
+          reduce
+            ? { duration: 0 }
+            : {
+                duration: (sink ? EYE_SINK_MS : EYE_RISE_MS) / 1000,
+                ease: "easeInOut",
+              }
+        }
       >
-        {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
+        {/* Speak-to-sink bob: rAF writes translateY here as the voice rises.
+            The opacity fades the eyes back while reconnecting (rAF only
+            touches `transform`, so it never clobbers this). */}
         <div
+          ref={sinkRef}
           style={{
-            transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,
-            transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
+            opacity: dimmed ? 0.4 : 1,
+            transition: "opacity 0.5s ease",
           }}
         >
-          <svg
-            viewBox={`${art.bbox.x} ${art.bbox.y} ${art.bbox.w} ${art.bbox.h}`}
-            width={geometry.eyesW}
-            height={geometry.eyesH}
-            style={{ overflow: "visible", display: "block" }}
+          {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
+          <div
+            style={{
+              transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,
+              transition: "transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)",
+            }}
           >
-            <g
-              style={{
-                transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
-                transformOrigin: `${cx}px ${cy}px`,
-                transition: "transform 0.14s ease-in-out",
-              }}
+            <svg
+              viewBox={`${art.bbox.x} ${art.bbox.y} ${art.bbox.w} ${art.bbox.h}`}
+              width={geometry.eyesW}
+              height={geometry.eyesH}
+              style={{ overflow: "visible", display: "block" }}
             >
-              {art.paths.map((p, i) => (
-                <path key={i} d={p.svgPath} fill={p.color} />
-              ))}
-            </g>
-          </svg>
+              <g
+                style={{
+                  transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
+                  transformOrigin: `${cx}px ${cy}px`,
+                  transition: "transform 0.14s ease-in-out",
+                }}
+              >
+                {art.paths.map((p, i) => (
+                  <path key={i} d={p.svgPath} fill={p.color} />
+                ))}
+              </g>
+            </svg>
+          </div>
         </div>
-      </div>
+      </motion.div>
     </motion.div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -1,0 +1,62 @@
+/**
+ * Word-by-word reveal for the voice room's live captions.
+ *
+ * The live transcript streams in a word (or few) at a time; rendering it as one
+ * flat string makes each update land as a hard text swap. This splits the text
+ * into words keyed by position so that, as the string grows, only the newly
+ * arrived words mount — each fading + rising + de-blurring into place — while
+ * the words already on screen stay put. The most recent word carries a brighter
+ * "leading edge" tone that cools to the muted base as the next word arrives, so
+ * the caption reads as speech flowing forward rather than a block appearing.
+ *
+ * Index keys (not content) are deliberate: a streaming append leaves earlier
+ * indices unchanged so they never re-animate, and a partial-transcript revision
+ * (STT rewriting the tail) just updates those words in place. Colors follow the
+ * room tone (`--room-fg` / `--room-fg-muted`) with the theme content tokens as
+ * the fallback, so captions match the room chrome over any avatar color.
+ *
+ * Decorative: the caller owns the `aria-live` region; this is `aria-hidden`
+ * visuals only. Reduced motion drops the per-word entrance (words appear
+ * immediately) but keeps the leading-edge tone.
+ */
+
+import { Fragment, useMemo } from "react";
+import { motion, useReducedMotion } from "motion/react";
+
+export function VoiceTranscriptText({ text }: { text: string }) {
+  const reduce = useReducedMotion();
+  // Collapse runs of whitespace to single spaces — the words are laid out with
+  // real space text nodes between them (so they wrap and select naturally, and
+  // `textContent` reads back as the plain sentence).
+  const words = useMemo(() => text.split(/\s+/).filter(Boolean), [text]);
+  const lastIndex = words.length - 1;
+
+  return (
+    <span aria-hidden="true">
+      {words.map((word, i) => {
+        const leading = i === lastIndex;
+        return (
+          <Fragment key={i}>
+            <motion.span
+              className="inline-block"
+              style={{
+                color: leading
+                  ? "var(--room-fg, var(--content-secondary))"
+                  : "var(--room-fg-muted, var(--content-tertiary))",
+                // The leading-edge tone eases back to the base as the next word
+                // takes over (the motion entrance below owns transform/opacity).
+                transition: "color 0.45s ease",
+              }}
+              initial={reduce ? false : { opacity: 0, y: 5, filter: "blur(2px)" }}
+              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+              transition={{ duration: reduce ? 0 : 0.32, ease: "easeOut" }}
+            >
+              {word}
+            </motion.span>
+            {i < lastIndex ? " " : null}
+          </Fragment>
+        );
+      })}
+    </span>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -15,9 +15,12 @@
  * room tone (`--room-fg` / `--room-fg-muted`) with the theme content tokens as
  * the fallback, so captions match the room chrome over any avatar color.
  *
- * Decorative: the caller owns the `aria-live` region; this is `aria-hidden`
- * visuals only. Reduced motion drops the per-word entrance (words appear
- * immediately) but keeps the leading-edge tone.
+ * Accessibility: the words stay in the accessibility tree (NOT `aria-hidden`) —
+ * the caller wraps this in the `aria-live` region, and the plain sentence is
+ * exactly its `textContent`, so screen readers announce the transcript as it
+ * streams. The per-word animation is purely visual (transform/opacity/color)
+ * and doesn't change what's read. Reduced motion drops the per-word entrance
+ * (words appear immediately) but keeps the leading-edge tone.
  */
 
 import { Fragment, useMemo } from "react";
@@ -32,7 +35,7 @@ export function VoiceTranscriptText({ text }: { text: string }) {
   const lastIndex = words.length - 1;
 
   return (
-    <span aria-hidden="true">
+    <>
       {words.map((word, i) => {
         const leading = i === lastIndex;
         return (
@@ -57,6 +60,6 @@ export function VoiceTranscriptText({ text }: { text: string }) {
           </Fragment>
         );
       })}
-    </span>
+    </>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
@@ -1,0 +1,228 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// The transcript reveal leans on the app's global CSS (content tokens, the
+// `--room-*` vars) — Storybook's preview.css only pulls Tailwind, so import the
+// app stylesheet to get them.
+import "@/index.css";
+
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+import { toneForBg } from "@/utils/surface-tone";
+
+import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
+import { VoiceTranscriptText } from "./voice-transcript-text";
+
+/**
+ * Iteration harness for the voice room's live captions — the ambient,
+ * word-by-word transcript that floats above (user) and below (assistant) the
+ * centered avatar without ever becoming a chat bubble.
+ *
+ * The scenes simulate a live session by streaming a canned utterance into the
+ * real live-voice store one word at a time (no mic / STT / TTS), so the reveal,
+ * leading-edge tone, and partial→final hand-off all behave exactly as in the
+ * app. Scrub `wordMs` for the pace of speech and bump `replay` to run the
+ * utterance again.
+ */
+
+// A sample avatar color so the room tone (and the `--room-*` caption vars)
+// resolve as they would over a real character look.
+const SAMPLE_COLOR_ID = "purple";
+const SAMPLE_HEX =
+  BUNDLED_COMPONENTS.colors.find((c) => c.id === SAMPLE_COLOR_ID)?.hex ??
+  "#A665C9";
+
+const USER_LINE =
+  "hey can you help me draft a quick note to the team about tomorrow's launch";
+const ASSISTANT_LINE =
+  "Of course — here's a short note you can send: the launch is on track for tomorrow morning, and I'll share the final checklist tonight so everyone's ready.";
+
+type Role = "user" | "assistant" | "both";
+
+/**
+ * Stream `text` into a setter one word at a time, restarting whenever `replay`
+ * or the pace changes. Returns nothing — it drives the store the component under
+ * test reads from.
+ */
+function useWordStream(
+  words: string[],
+  wordMs: number,
+  replay: number,
+  onWord: (soFar: string) => void,
+  onReset: () => void,
+) {
+  const onWordRef = useRef(onWord);
+  const onResetRef = useRef(onReset);
+  useEffect(() => {
+    onWordRef.current = onWord;
+    onResetRef.current = onReset;
+  });
+  useEffect(() => {
+    onResetRef.current();
+    let i = 0;
+    const id = setInterval(() => {
+      i += 1;
+      onWordRef.current(words.slice(0, i).join(" "));
+      if (i >= words.length) {
+        clearInterval(id);
+      }
+    }, wordMs);
+    return () => clearInterval(id);
+  }, [wordMs, replay, words]);
+}
+
+interface SceneProps {
+  role: Role;
+  wordMs: number;
+  replay: number;
+  minHeight?: number;
+}
+
+/** The real ambient transcript, over a toned room, fed by a simulated stream. */
+function AmbientTranscriptScene({
+  role,
+  wordMs,
+  replay,
+  minHeight = 520,
+}: SceneProps) {
+  const tone = toneForBg(SAMPLE_HEX);
+  const toneVars = {
+    "--room-fg": tone.fg,
+    "--room-fg-muted": tone.fgMuted,
+  } as Record<string, string>;
+
+  // Prefs gate each half; turn on whichever role this scene streams.
+  useEffect(() => {
+    const prefs = useVoicePrefsStore.getState();
+    prefs.setShowUserTranscript(role === "user" || role === "both");
+    prefs.setShowAssistantTranscript(role === "assistant" || role === "both");
+    return () => {
+      prefs.setShowUserTranscript(false);
+      prefs.setShowAssistantTranscript(false);
+    };
+  }, [role]);
+
+  const userWords = USER_LINE.split(" ");
+  const assistantWords = ASSISTANT_LINE.split(" ");
+
+  useWordStream(
+    role === "assistant" ? [] : userWords,
+    wordMs,
+    replay,
+    useCallback((soFar: string) => {
+      useLiveVoiceStore.getState().setPartialTranscript(soFar);
+    }, []),
+    useCallback(() => {
+      useLiveVoiceStore.getState().setPartialTranscript("");
+      useLiveVoiceStore.getState().setFinalTranscript("");
+    }, []),
+  );
+  useWordStream(
+    role === "user" ? [] : assistantWords,
+    wordMs,
+    replay,
+    useCallback((soFar: string) => {
+      const store = useLiveVoiceStore.getState();
+      store.clearAssistantTranscript();
+      store.appendAssistantTranscript(soFar);
+    }, []),
+    useCallback(() => {
+      useLiveVoiceStore.getState().clearAssistantTranscript();
+    }, []),
+  );
+
+  return (
+    <div
+      data-theme={tone.isLight ? "light" : "dark"}
+      className="relative flex items-center justify-center overflow-hidden rounded-lg"
+      style={{ minHeight, backgroundColor: SAMPLE_HEX, ...toneVars }}
+    >
+      {/* Stand-in for the centered avatar so the above/below anchoring reads. */}
+      <div
+        className="size-40 rounded-full"
+        style={{ backgroundColor: "var(--room-fg)", opacity: 0.12 }}
+      />
+      <VoiceAmbientTranscript />
+    </div>
+  );
+}
+
+const meta: Meta<typeof AmbientTranscriptScene> = {
+  title: "Chat/Voice/Transcript",
+  component: AmbientTranscriptScene,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: 24 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: { role: "both", wordMs: 260, replay: 0 },
+  argTypes: {
+    role: {
+      options: ["user", "assistant", "both"] satisfies Role[],
+      control: { type: "inline-radio" },
+      description: "Which half streams — user (above), assistant (below), or both.",
+    },
+    wordMs: {
+      control: { type: "range", min: 80, max: 600, step: 20 },
+      description: "Milliseconds between words — the pace of speech.",
+    },
+    replay: {
+      control: { type: "range", min: 0, max: 20, step: 1 },
+      description: "Bump to stream the utterance again.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AmbientTranscriptScene>;
+
+/**
+ * The ambient captions over a live-streamed turn: each word fades + rises +
+ * de-blurs in, the newest word carries the brighter leading-edge tone, and the
+ * text stays anchored clear of the avatar. Scrub `role` and `wordMs`.
+ */
+export const Playground: Story = {};
+
+/**
+ * The reveal mechanics in isolation — `VoiceTranscriptText` fed a plain growing
+ * string, no store, on a neutral surface. Useful for tuning the per-word
+ * entrance and the leading-edge tone without the room plumbing.
+ */
+export const Reveal: Story = {
+  argTypes: {
+    role: { table: { disable: true } },
+    wordMs: {
+      control: { type: "range", min: 80, max: 600, step: 20 },
+    },
+    replay: { control: { type: "range", min: 0, max: 20, step: 1 } },
+  },
+  args: { wordMs: 260, replay: 0 },
+  render: (args) => <RevealScene wordMs={args.wordMs} replay={args.replay} />,
+};
+
+function RevealScene({ wordMs, replay }: { wordMs: number; replay: number }) {
+  const [text, setText] = useState("");
+  const words = ASSISTANT_LINE.split(" ");
+  useWordStream(
+    words,
+    wordMs,
+    replay,
+    useCallback((soFar: string) => setText(soFar), []),
+    useCallback(() => setText(""), []),
+  );
+  return (
+    <div
+      data-theme="dark"
+      className="flex min-h-[240px] items-center justify-center rounded-lg p-10"
+      style={{ backgroundColor: "#17191C" }}
+    >
+      <p className="max-w-[36rem] text-center text-[15px] leading-relaxed text-balance">
+        <VoiceTranscriptText text={text} />
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Follow-on polish to the live-voice room (post JARVIS-1270). All changes are in `clients/web` and confined to the voice room; both looks and every prior test stay green.

## Eyes — listening → thinking hand-off
- The eyes now ride **back up to center** for the assistant's turn (they were held low through `thinking`). Listening is the only state that sinks them.
- The listening waves, thinking dots, and responding rings now **cross-fade** (`AnimatePresence`) instead of hard-swapping, so the hand-off reads as the waves dissolving out and the dots dissolving in while the eyes lift.
- Thinking dots reposition to hang just above the centered eyes (shared `eyeDisplayHeight` helper so dots + eyes agree on "center" in any frame).

## Eyes — smoother travel
- The big center↔low-hold travel now runs on the **motion tween system** — the same one that plays the entrance. The prior hand-rolled rAF wrote the full travel to `style.transform` every frame and fought the entrance's transforms, which read as stutter. The rAF now only carries the small mic-driven bob while sunk.
- Stopped the entrance keyframe array from **replaying on every re-render** (dropped once the entrance lands), which had been lurching the eyes back toward the origin on state changes.
- Known-imperfect: the rise can still show a slight pause-then-settle in some cases; the drop is smooth. Deprioritized per discussion.

## Live captions (`VoiceTranscriptText`, new)
- Word-by-word reveal: each newly-streamed word fades + rises + de-blurs in; the newest word carries a brighter leading-edge tone that cools as the next arrives. Index-keyed so only new words animate and partial-transcript rewrites update in place.
- Bigger, viewport-scaled text (`clamp(19px, 2.6vmin, 30px)`) and a per-half clearance (`15vmin`) that keeps captions off the centered eyes at any window size.
- The lingering **assistant caption is hidden during `listening`** — it's only cleared on the next response's `thinking` (`use-live-voice.ts`), so it otherwise sat right under the low-sunk listening eyes.

## Storybook
- Updated **Chat / Voice / VoiceAvatar** for the transitions (scrub `visual` listening→thinking).
- Added **Chat / Voice / Transcript** — streams a canned turn word-by-word into the real store to tune the reveal.

## Tests
- `voice-ambient-transcript.test.tsx`: added the listening-gate cases (assistant hidden while listening, shown while speaking, user unaffected).
- All 71 voice-room tests pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)