### PR TITLE
feat(plugins): serve plugin routes from disk under /x/plugins/&lt;name&gt;/

### DIFF
--- a/assistant/src/monitoring/recovery/__tests__/inflight-content.test.ts
+++ b/assistant/src/monitoring/recovery/__tests__/inflight-content.test.ts
@@ -4,7 +4,7 @@
  * still owns (conversation mid-turn / fresh delta file), and GC of orphan
  * delta files.
  */
-import { existsSync } from "node:fs";
+import { existsSync, utimesSync } from "node:fs";
 import { describe, expect, mock, test } from "bun:test";
 
 import pino from "pino";
@@ -42,6 +42,19 @@ function db() {
 
 function textBlock(text: string): ContentBlock {
   return { type: "text", text };
+}
+
+/**
+ * Push a delta file's mtime firmly into the past so an age-floored fold/GC
+ * treats it as unambiguously old. The recovery age guard is `now - mtime <
+ * minAgeMs`; with `minAgeMs: 0` a file whose recorded mtime lands even a hair
+ * ahead of the captured `now` (filesystem-clock vs `Date.now()` skew on CI)
+ * yields a negative age and is wrongly preserved. Backdating removes that
+ * boundary race without weakening what the test asserts.
+ */
+function backdateDeltaFile(absPath: string): void {
+  const past = new Date(Date.now() - 60_000);
+  utimesSync(absPath, past, past);
 }
 
 function rawRow(messageId: string): { content: string; finalized: number } {
@@ -82,6 +95,7 @@ describe("recoverInflightContent — folding stranded rows", () => {
     const { conversationId, messageId, writer } = await reserveInflight();
     appendInflightSnapshot(writer, [textBlock("streamed")], 1, rlog);
     expect(existsSync(writer.absPath)).toBe(true);
+    backdateDeltaFile(writer.absPath);
 
     const result = recoverInflightContent({ minAgeMs: 0 });
 
@@ -142,6 +156,7 @@ describe("recoverInflightContent — orphan file GC", () => {
     finalizeMessageContent(messageId, JSON.stringify([textBlock("orphaned")]));
     expect(rawRow(messageId).finalized).toBe(1);
     expect(existsSync(writer.absPath)).toBe(true);
+    backdateDeltaFile(writer.absPath);
 
     const result = recoverInflightContent({ minAgeMs: 0 });
 

--- a/assistant/src/plugins/AGENTS.md
+++ b/assistant/src/plugins/AGENTS.md
@@ -17,3 +17,11 @@ Canonical example: `defaults/image-fallback` — `hooks/init.ts` opens `caption-
 **Grandfathered exception**: `defaults/memory` predates this rule and uses main-database tables via `persistence/schema` / `db-connection`. Do not extend that pattern to other plugins or grow memory's main-DB surface. Enforced by `__tests__/plugin-state-boundary-guard.test.ts`.
 
 Calling the assistant's service APIs from a default plugin (e.g. `persistence/conversation-crud.ts` reads) is fine — the boundary is about _owning state_: plugin tables, plugin migrations, and plugin files belong to the plugin.
+
+## Plugin HTTP Routes
+
+A plugin's HTTP routes live on disk under `<pluginDir>/routes/` and are served in the plugin's own namespace at `/x/plugins/<plugin-name>/<path>`. They are **not** a `Plugin` contribution slot and are not wired through the loader or bootstrap — the `/x/*` route dispatcher (`runtime/routes/user-route-dispatcher.ts`) resolves each request against the filesystem at request time, exactly like the workspace `/x/*` user routes it shares code with.
+
+- **Namespace reservation**: the `plugins/<name>/` prefix under `/x/` resolves only against `<workspaceDir>/plugins/<name>/routes/`. A request there never falls back to a workspace `routes/plugins/…` file, so plugins can't collide with workspace routes or each other. A missing file 404s; nothing is registered ahead of time.
+- **Authoring**: each route file exports named HTTP-method functions (`export async function GET(request) {…}`), mirroring the workspace user-route convention. Nested directories and `index` files map to sub-paths (`routes/webhooks/incoming.ts` → `/x/plugins/<name>/webhooks/incoming`; `routes/index.ts` → the namespace root). Files are lazily loaded and mtime-cache-busted.
+- **Runtime access**: handlers receive the shared `UserRouteContext` (event hub, conversation posting) as a second argument, and may also reach singletons through their `@vellumai/plugin-api` imports.

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
@@ -5,7 +5,10 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
-import { getWorkspaceRoutesDir } from "../../../util/platform.js";
+import {
+  getWorkspacePluginsDir,
+  getWorkspaceRoutesDir,
+} from "../../../util/platform.js";
 import { AssistantEventHub } from "../../assistant-event-hub.js";
 import type { UserRouteContext } from "../user-route-dispatcher.js";
 import { UserRouteDispatcher } from "../user-route-dispatcher.js";
@@ -55,6 +58,24 @@ function writeHandler(relativePath: string, content: string): string {
   return fullPath;
 }
 
+/** Write a route handler into a plugin's `routes/` directory. */
+function writePluginHandler(
+  pluginName: string,
+  relativePath: string,
+  content: string,
+): string {
+  const fullPath = join(
+    getWorkspacePluginsDir(),
+    pluginName,
+    "routes",
+    relativePath,
+  );
+  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(fullPath, content);
+  return fullPath;
+}
+
 async function readErrorBody(
   response: Response,
 ): Promise<{ error: { code: string; message: string } }> {
@@ -71,6 +92,7 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(getWorkspaceRoutesDir(), { recursive: true, force: true });
+  rmSync(getWorkspacePluginsDir(), { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -500,5 +522,113 @@ describe("context injection", () => {
     // Object.freeze makes property assignment throw in strict mode (ESM)
     // and silently fail in sloppy mode — either way the value is unchanged.
     expect(body.assistantId).toBe("original");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin routes — /x/plugins/<name>/*
+// ---------------------------------------------------------------------------
+
+describe("plugin routes", () => {
+  test("dispatches to a plugin's routes/ directory", async () => {
+    writePluginHandler(
+      "my-plugin",
+      "status.ts",
+      `export function GET(request, context) {
+        return Response.json({ plugin: true, assistantId: context.assistantId });
+      }`,
+    );
+
+    const dispatcher = makeDispatcher();
+    const res = await dispatcher.dispatch(
+      "plugins/my-plugin/status",
+      makeRequest("GET"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.plugin).toBe(true);
+    // Plugin handlers receive the same runtime context as workspace routes.
+    expect(body.assistantId).toBe("test-assistant");
+  });
+
+  test("resolves nested paths and the index (namespace root)", async () => {
+    writePluginHandler(
+      "my-plugin",
+      "webhooks/incoming.ts",
+      `export function POST(request) { return Response.json({ nested: true }); }`,
+    );
+    writePluginHandler(
+      "my-plugin",
+      "index.ts",
+      `export function GET(request) { return Response.json({ root: true }); }`,
+    );
+
+    const dispatcher = makeDispatcher();
+
+    const nested = await dispatcher.dispatch(
+      "plugins/my-plugin/webhooks/incoming",
+      makeRequest("POST"),
+    );
+    expect(nested.status).toBe(200);
+    expect((await nested.json()).nested).toBe(true);
+
+    // `/x/plugins/my-plugin` (no sub-path) maps to the plugin's routes/index.
+    const root = await dispatcher.dispatch(
+      "plugins/my-plugin",
+      makeRequest("GET"),
+    );
+    expect(root.status).toBe(200);
+    expect((await root.json()).root).toBe(true);
+  });
+
+  test("404s when the plugin route file does not exist", async () => {
+    const dispatcher = makeDispatcher();
+    const res = await dispatcher.dispatch(
+      "plugins/ghost-plugin/status",
+      makeRequest("GET"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("a plugin route is confined to its own plugin directory", async () => {
+    // A workspace route literally named routes/plugins/foo must NOT answer a
+    // request in the plugin namespace — the plugins/ prefix is reserved.
+    writeHandler(
+      "plugins/foo.ts",
+      `export function GET(request) { return Response.json({ workspace: true }); }`,
+    );
+
+    const dispatcher = makeDispatcher();
+    const res = await dispatcher.dispatch("plugins/foo", makeRequest("GET"));
+    // Resolves against <workspace>/plugins/foo/routes/index (absent) → 404,
+    // never the workspace routes/plugins/foo.ts handler.
+    expect(res.status).toBe(404);
+  });
+
+  test("404s a bare /x/plugins with no plugin name", async () => {
+    const dispatcher = makeDispatcher();
+    const res = await dispatcher.dispatch("plugins", makeRequest("GET"));
+    expect(res.status).toBe(404);
+  });
+
+  test("one plugin cannot serve another plugin's namespace", async () => {
+    writePluginHandler(
+      "plugin-a",
+      "status.ts",
+      `export function GET(request) { return Response.json({ owner: "a" }); }`,
+    );
+
+    const dispatcher = makeDispatcher();
+    const mine = await dispatcher.dispatch(
+      "plugins/plugin-a/status",
+      makeRequest("GET"),
+    );
+    expect(mine.status).toBe(200);
+    // plugin-b declared nothing, so its namespace 404s even for the same path.
+    const other = await dispatcher.dispatch(
+      "plugins/plugin-b/status",
+      makeRequest("GET"),
+    );
+    expect(other.status).toBe(404);
   });
 });

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
@@ -611,6 +611,34 @@ describe("plugin routes", () => {
     expect(res.status).toBe(404);
   });
 
+  test("404s a disabled plugin's routes even though the files exist", async () => {
+    writePluginHandler(
+      "off-plugin",
+      "status.ts",
+      `export function GET(request) { return Response.json({ ok: true }); }`,
+    );
+    const dispatcher = makeDispatcher();
+
+    // Enabled: served.
+    const enabled = await dispatcher.dispatch(
+      "plugins/off-plugin/status",
+      makeRequest("GET"),
+    );
+    expect(enabled.status).toBe(200);
+
+    // Drop the `.disabled` sentinel — the same toggle the CLI writes.
+    writeFileSync(
+      join(getWorkspacePluginsDir(), "off-plugin", ".disabled"),
+      "",
+    );
+
+    const disabled = await dispatcher.dispatch(
+      "plugins/off-plugin/status",
+      makeRequest("GET"),
+    );
+    expect(disabled.status).toBe(404);
+  });
+
   test("one plugin cannot serve another plugin's namespace", async () => {
     writePluginHandler(
       "plugin-a",

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -30,6 +30,7 @@
 import { existsSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
+import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLogger } from "../../util/logger.js";
 import {
   getWorkspacePluginsDir,
@@ -143,9 +144,13 @@ const PLUGIN_ROUTE_SEGMENT = "plugins";
  * `plugins/<name>/<rest>` resolves against that plugin's own
  * `<workspaceDir>/plugins/<name>/routes/` directory (`<rest>` may be empty,
  * mapping to the namespace's `index` handler). Everything else resolves against
- * the workspace `routes/` directory. Returns `null` for a malformed plugin path
- * (`plugins` with no name segment) so the caller 404s rather than falling back
- * to a workspace route — the `plugins/` prefix is reserved for plugin routes.
+ * the workspace `routes/` directory. Returns `null` (caller 404s) when:
+ *
+ * - the path is a malformed plugin path (`plugins` with no name segment), so it
+ *   never falls back to a workspace route — the `plugins/` prefix is reserved
+ *   for plugin routes; or
+ * - the named plugin is disabled (`.disabled` sentinel present), so a disabled
+ *   plugin serves no routes even though its files remain on disk.
  */
 function resolveRouteLocation(
   routePath: string,
@@ -153,7 +158,7 @@ function resolveRouteLocation(
   const segments = routePath.split("/");
   if (segments[0] === PLUGIN_ROUTE_SEGMENT) {
     const pluginName = segments[1];
-    if (!pluginName) {
+    if (!pluginName || isPluginDisabled(pluginName)) {
       return null;
     }
     return {

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -1,10 +1,20 @@
 /**
  * File-based route dispatcher for user-defined HTTP endpoints.
  *
- * Maps requests under the `/x/*` path prefix to handler modules in the
- * workspace routes directory (`$VELLUM_WORKSPACE_DIR/routes/`). Each handler file
- * exports named functions for HTTP methods (GET, POST, PUT, etc.) using
- * the standard Web API Request/Response signature.
+ * Maps requests under the `/x/*` path prefix to handler modules resolved from
+ * the filesystem at request time. Two locations back the surface:
+ *
+ * - `$VELLUM_WORKSPACE_DIR/routes/<path>` — workspace routes, served at
+ *   `/x/<path>`.
+ * - `$VELLUM_WORKSPACE_DIR/plugins/<name>/routes/<path>` — a plugin's routes,
+ *   served in that plugin's namespace at `/x/plugins/<name>/<path>`. The
+ *   `plugins/<name>/` prefix is reserved for this: a request there resolves
+ *   only against the named plugin's `routes/` directory (never the workspace
+ *   `routes/plugins/…` tree) so plugins can't collide with workspace routes or
+ *   each other.
+ *
+ * Each handler file exports named functions for HTTP methods (GET, POST, PUT,
+ * etc.) using the standard Web API Request/Response signature.
  *
  * Handlers receive a second `context` argument with runtime singletons
  * (event hub, assistant ID, etc.) that would otherwise be unreachable
@@ -13,14 +23,18 @@
  *
  * Modules are lazily loaded on first request and cached by file path +
  * mtime. When a file changes on disk, the next request reloads it via
- * Bun's dynamic `import()` with a cache-busting query parameter.
+ * Bun's dynamic `import()` with a cache-busting query parameter. A request
+ * whose file does not exist 404s — nothing is registered ahead of time.
  */
 
 import { existsSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { getLogger } from "../../util/logger.js";
-import { getWorkspaceRoutesDir } from "../../util/platform.js";
+import {
+  getWorkspacePluginsDir,
+  getWorkspaceRoutesDir,
+} from "../../util/platform.js";
 import type { AssistantEventHub } from "../assistant-event-hub.js";
 import { httpError } from "../http-errors.js";
 
@@ -119,6 +133,37 @@ const DEFAULT_HANDLER_TIMEOUT_MS = 30_000;
 /** Supported file extensions for handler modules. */
 const HANDLER_EXTENSIONS = [".ts", ".js"] as const;
 
+/** Path segment reserved for plugin-namespaced routes under `/x/`. */
+const PLUGIN_ROUTE_SEGMENT = "plugins";
+
+/**
+ * Resolve an `/x/` route path to the base directory + sub-path the handler file
+ * is looked up under.
+ *
+ * `plugins/<name>/<rest>` resolves against that plugin's own
+ * `<workspaceDir>/plugins/<name>/routes/` directory (`<rest>` may be empty,
+ * mapping to the namespace's `index` handler). Everything else resolves against
+ * the workspace `routes/` directory. Returns `null` for a malformed plugin path
+ * (`plugins` with no name segment) so the caller 404s rather than falling back
+ * to a workspace route — the `plugins/` prefix is reserved for plugin routes.
+ */
+function resolveRouteLocation(
+  routePath: string,
+): { routesDir: string; subPath: string } | null {
+  const segments = routePath.split("/");
+  if (segments[0] === PLUGIN_ROUTE_SEGMENT) {
+    const pluginName = segments[1];
+    if (!pluginName) {
+      return null;
+    }
+    return {
+      routesDir: join(getWorkspacePluginsDir(), pluginName, "routes"),
+      subPath: segments.slice(2).join("/"),
+    };
+  }
+  return { routesDir: getWorkspaceRoutesDir(), subPath: routePath };
+}
+
 export class UserRouteDispatcher {
   private moduleCache = new Map<string, CachedModule>();
   private handlerTimeoutMs: number;
@@ -145,8 +190,10 @@ export class UserRouteDispatcher {
       return httpError("BAD_REQUEST", "Path traversal is not allowed", 400);
     }
 
-    const routesDir = getWorkspaceRoutesDir();
-    const filePath = this.resolveHandlerFile(routesDir, routePath);
+    const location = resolveRouteLocation(routePath);
+    const filePath = location
+      ? this.resolveHandlerFile(location.routesDir, location.subPath)
+      : null;
 
     if (!filePath) {
       return httpError(

--- a/assistant/src/runtime/routes/user-routes.ts
+++ b/assistant/src/runtime/routes/user-routes.ts
@@ -2,8 +2,11 @@
  * Route definitions for user-defined endpoints under `/x/*`.
  *
  * Registers one route per HTTP method that delegates to the
- * UserRouteDispatcher for file-based dispatch from
- * `$VELLUM_WORKSPACE_DIR/routes/`.
+ * UserRouteDispatcher for file-based dispatch. The dispatcher resolves each
+ * request against the filesystem at request time: workspace routes from
+ * `$VELLUM_WORKSPACE_DIR/routes/`, and a plugin's routes from
+ * `$VELLUM_WORKSPACE_DIR/plugins/<name>/routes/` under the reserved
+ * `/x/plugins/<name>/` namespace.
  *
  * The dispatcher operates on native `Request`/`Response` objects (the
  * contract with user-authored handler files). This module bridges the

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -694,7 +694,7 @@
     {
       "id": "plugin-builder",
       "name": "plugin-builder",
-      "description": "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles hooks, tools, and skills into one installable package.",
+      "description": "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles hooks, tools, skills, and routes into one installable package.",
       "metadata": {
         "emoji": "🧩",
         "vellum": {
@@ -716,7 +716,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-08T23:28:09.000Z"
+      "updatedAt": "2026-07-14T10:48:52.000Z"
     },
     {
       "id": "public-ingress",

--- a/skills/plugin-builder/SKILL.md
+++ b/skills/plugin-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-builder
-description: "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles hooks, tools, and skills into one installable package."
+description: "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles hooks, tools, skills, and routes into one installable package."
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🧩"
@@ -22,7 +22,7 @@ metadata:
 
 # Plugin Builder
 
-Build on top of Vellum with plugins. A plugin bundles hooks, tools, and skills into a single installable package that extends what an assistant can do.
+Build on top of Vellum with plugins. A plugin bundles hooks, tools, skills, and routes into a single installable package that extends what an assistant can do.
 
 Plugins are in beta. The peer-dep range you declare is what gets you load. Treat everything you write as something that can break between Vellum releases until 1.0 ships, and pin a real range.
 
@@ -40,11 +40,12 @@ Plugins can also be discovered and managed from the Plugins tab in the app, or s
 
 A single plugin can contribute several different kinds of behavior. Each surface is discovered by convention from a named subdirectory. Missing directories are simply skipped, so a plugin contributes only what it ships.
 
-| Surface                                    | Lives in          | What it does                                                                                                                     |
-| ------------------------------------------ | ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| [Lifecycle hooks](references/hooks.md)     | `hooks/<name>.ts` | Run code at fixed points in the Assistant's lifecycle to read or transform what flows through, and broadcast progress to the UI. |
-| [Skills](references/skills.md)             | `skills/<name>/`  | Directories of instructions and associated assets, scripts, and resources that the Assistant loads dynamically when relevant.    |
-| [Model-visible tools](references/tools.md) | `tools/<name>.ts` | Add new tools the model can call. Plugin tools land in the same catalog as built-in tools.                                       |
+| Surface                                    | Lives in           | What it does                                                                                                                     |
+| ------------------------------------------ | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| [Lifecycle hooks](references/hooks.md)     | `hooks/<name>.ts`  | Run code at fixed points in the Assistant's lifecycle to read or transform what flows through, and broadcast progress to the UI. |
+| [Skills](references/skills.md)             | `skills/<name>/`   | Directories of instructions and associated assets, scripts, and resources that the Assistant loads dynamically when relevant.    |
+| [Model-visible tools](references/tools.md) | `tools/<name>.ts`  | Add new tools the model can call. Plugin tools land in the same catalog as built-in tools.                                       |
+| [HTTP routes](references/routes.md)        | `routes/<path>.ts` | Serve HTTP endpoints (webhooks, integrations, callbacks) in the plugin's own `/x/plugins/<name>/` namespace.                     |
 
 The two extensibility patterns serve different goals. **Plugins are for distribution**: you intend to share the capability, publish to the marketplace, or install it across multiple assistants. The plugin manifest (`package.json`), the `@vellumai/plugin-api` peer dependency, and the install flow exist to make a capability portable, versioned, and discoverable by others.
 
@@ -61,7 +62,7 @@ Vellum's plugin model was designed to line up with the agent harnesses you may a
 Ask before building. Six questions, in this order. Stop if the user is unclear on any of them.
 
 1. **What job does the plugin do?** One sentence, plain language. If you cannot write this, the plugin should not be built yet.
-2. **Which surfaces does it ship?** Tools (model calls), hooks (lifecycle transforms), and skills (on-demand instructions) are the three. Most plugins ship one or two, not all three. See `references/plugins.md` for the directory layout and manifest, and the surface-specific references for each surface's contract.
+2. **Which surfaces does it ship?** Tools (model calls), hooks (lifecycle transforms), skills (on-demand instructions), and routes (HTTP endpoints). Most plugins ship one or two, not all of them. See `references/plugins.md` for the directory layout and manifest, and the surface-specific references for each surface's contract.
 3. **Does it need credentials?** An API key, OAuth token, or webhook secret is not a value that belongs in a `.ts` file. For LLM inference credentials, use `getConfiguredProvider()` from `@vellumai/plugin-api` to route through the workspace's stored credentials without handling plaintext. For other credential types (OAuth tokens, webhook secrets), store them via the credential vault and resolve at runtime through the assistant's credential system.
 4. **Does it keep state?** A plugin is fully self-contained: durable state lives in its `data/` directory (`InitContext.pluginStorageDir`), with schema created idempotently by the `init` hook, handles closed in `shutdown`, and per-conversation rows purged in `conversation-deleted`. A plugin never persists state in the assistant's database or elsewhere in the workspace. See "State is plugin-owned" in `references/plugins.md`.
 5. **Where will the source live?** A GitHub repo, ideally under the user's own namespace. The marketplace entry pins to a full commit SHA.
@@ -121,4 +122,5 @@ Once merged, users install by name: `assistant plugins install my-plugin`. The n
 - `references/hooks.md`: Every lifecycle hook with its context fields, the agent loop diagram, resolution order, and a hook anatomy example.
 - `references/tools.md`: Tool definition fields, the execute context, result shape, resolution order, and a tool anatomy example.
 - `references/skills.md`: Frontmatter reference, resolution order, and a skill anatomy example.
+- `references/routes.md`: The `/x/plugins/<name>/` namespace, path mapping, handler signature, and a route anatomy example.
 - `references/distribution.md`: Marketplace catalog, CLI commands, drift and upgrades, the manifest schema, commit pinning, and adapters.

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -58,24 +58,7 @@ The assistant's own database is internal — `@vellumai/plugin-api` exposes no h
 
 Each surface can also be dropped straight into the workspace at `/workspace/<surface>/<name>/` without wrapping it in a plugin. A plugin is what lets you ship several surfaces together as one installable unit.
 
-### Routes
-
-A plugin's HTTP routes live under `routes/` and are served in the plugin's own namespace at `/x/plugins/<plugin-name>/<path>`. The dispatcher resolves each request against the plugin's `routes/` directory on disk at request time — there is no registration step, and the `plugins/<name>/` prefix is reserved, so a plugin can't collide with workspace routes or another plugin.
-
-- **One file per route path.** `routes/status.ts` → `/x/plugins/<name>/status`. Nested directories and `index` files map to sub-paths: `routes/webhooks/incoming.ts` → `/x/plugins/<name>/webhooks/incoming`, and `routes/index.ts` → the namespace root `/x/plugins/<name>`. A path with no file 404s.
-- **Export named HTTP-method handlers**, using the Web API `Request`/`Response` signature — the same convention as workspace `/x/*` routes:
-
-  ```ts
-  export async function GET(request: Request): Promise<Response> {
-    return Response.json({ ok: true });
-  }
-  export async function POST(request: Request): Promise<Response> {
-    const body = await request.json();
-    return Response.json({ received: body });
-  }
-  ```
-
-- **Edit-and-serve.** Files are loaded lazily and re-read when their mtime changes, so editing a route file is picked up on the next request without a restart.
+The per-surface contracts live in their own references: [hooks.md](hooks.md), [tools.md](tools.md), [skills.md](skills.md), and [routes.md](routes.md).
 
 ## The manifest
 

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -17,6 +17,8 @@ my-plugin/
 │   └── pre-model-call.ts
 ├── tools/                     # Model-visible tools, one per file
 │   └── example.ts
+├── routes/                    # HTTP routes, served under /x/plugins/<name>/
+│   └── status.ts
 ├── skills/                    # On-demand instruction bundles
 │   └── my-skill/
 │       └── SKILL.md
@@ -55,6 +57,25 @@ A plugin must be fully self-contained: every byte of durable state it keeps live
 The assistant's own database is internal — `@vellumai/plugin-api` exposes no handle to it, and a plugin must not persist state elsewhere in the workspace. Keeping everything in `data/` is also what makes uninstall clean: removing the plugin directory removes all of its state.
 
 Each surface can also be dropped straight into the workspace at `/workspace/<surface>/<name>/` without wrapping it in a plugin. A plugin is what lets you ship several surfaces together as one installable unit.
+
+### Routes
+
+A plugin's HTTP routes live under `routes/` and are served in the plugin's own namespace at `/x/plugins/<plugin-name>/<path>`. The dispatcher resolves each request against the plugin's `routes/` directory on disk at request time — there is no registration step, and the `plugins/<name>/` prefix is reserved, so a plugin can't collide with workspace routes or another plugin.
+
+- **One file per route path.** `routes/status.ts` → `/x/plugins/<name>/status`. Nested directories and `index` files map to sub-paths: `routes/webhooks/incoming.ts` → `/x/plugins/<name>/webhooks/incoming`, and `routes/index.ts` → the namespace root `/x/plugins/<name>`. A path with no file 404s.
+- **Export named HTTP-method handlers**, using the Web API `Request`/`Response` signature — the same convention as workspace `/x/*` routes:
+
+  ```ts
+  export async function GET(request: Request): Promise<Response> {
+    return Response.json({ ok: true });
+  }
+  export async function POST(request: Request): Promise<Response> {
+    const body = await request.json();
+    return Response.json({ received: body });
+  }
+  ```
+
+- **Edit-and-serve.** Files are loaded lazily and re-read when their mtime changes, so editing a route file is picked up on the next request without a restart.
 
 ## The manifest
 
@@ -117,7 +138,6 @@ The assistant supports these surfaces today, but they are not yet contributed th
 | -------------- | ------------------------------------------------------------------------------------------------------------- |
 | Schedules      | Cron-style triggers that fire on a recurring schedule.                                                        |
 | Apps           | Persistent interactive apps (dashboards, games, tools) served in the workspace panel.                         |
-| Routes         | HTTP routes the assistant exposes, used for webhooks and integrations.                                        |
 | Artifacts      | Versioned outputs the assistant produces and tracks (documents, diagrams, generated files).                   |
 | Webhooks       | Inbound HTTP endpoints that deliver external events into the assistant.                                       |
 | Prompts        | Reusable system prompt fragments and templates.                                                               |

--- a/skills/plugin-builder/references/routes.md
+++ b/skills/plugin-builder/references/routes.md
@@ -1,0 +1,78 @@
+# Routes
+
+Expose HTTP endpoints from a plugin. A route lets external systems — webhooks, integrations, callbacks, small tools — reach the Assistant over HTTP inside the plugin's own namespace.
+
+A route is a file under `routes/<path>.ts` that exports named HTTP-method functions. There is no registration step and no manifest entry: the Assistant's `/x/*` route dispatcher resolves each request against the plugin's `routes/` directory on disk at request time.
+
+## Where routes are served
+
+Every plugin route lives in a namespace reserved for that plugin:
+
+```
+/x/plugins/<plugin-name>/<path>
+```
+
+The `plugins/<name>/` prefix resolves **only** against `<workspaceDir>/plugins/<name>/routes/`. It never falls back to a workspace `routes/plugins/…` file, so a plugin can't collide with workspace routes or with another plugin. A path with no matching file returns 404, and a disabled plugin (its `.disabled` sentinel present) serves no routes even though the files remain on disk.
+
+The same file-based dispatcher also serves standalone workspace routes at `/x/<path>` from `<workspaceDir>/routes/`. Plugin routes are the namespaced form of that surface — a plugin is what lets you ship routes together with its other surfaces as one installable unit.
+
+## Path mapping
+
+The file's path under `routes/` becomes the sub-path, minus the extension. Nested directories nest, and an `index` file maps to the directory itself:
+
+| File                          | Served at                                |
+| ----------------------------- | ---------------------------------------- |
+| `routes/status.ts`            | `/x/plugins/<name>/status`               |
+| `routes/webhooks/incoming.ts` | `/x/plugins/<name>/webhooks/incoming`    |
+| `routes/index.ts`             | `/x/plugins/<name>` (the namespace root) |
+
+`.js` wins over `.ts` for the same basename (compiled-binary semantics), and a direct file wins over an `index` file for the same path.
+
+## Writing a handler
+
+Each file exports one function per HTTP method it accepts (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`), using the standard Web API `Request`/`Response` signature. A request whose method the file does not export returns 405 with an `Allow` header listing the methods it does.
+
+```ts
+export async function GET(request: Request): Promise<Response> {
+  return Response.json({ ok: true });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await request.json();
+  return Response.json({ received: body }, { status: 201 });
+}
+```
+
+Handlers receive a second `context` argument with the Assistant's runtime singletons (the event hub, and a `conversations.postMessage` helper for surfacing an inbound event as a real turn):
+
+```ts
+export async function POST(request: Request, context): Promise<Response> {
+  const { conversationId, text } = await request.json();
+  await context.conversations.postMessage(conversationId, text);
+  return Response.json({ delivered: true });
+}
+```
+
+A handler may also reach other Assistant capabilities through its `@vellumai/plugin-api` imports, the same as any other surface.
+
+## Loading and lifecycle
+
+Route files are loaded lazily on the first matching request and cached by path + mtime. Editing a route file is picked up on the next request — the dispatcher re-reads it when its mtime changes, so there is no restart or reload step. A handler that throws returns 500; a handler that runs longer than the per-request timeout (30s) returns 504.
+
+## Anatomy of a route
+
+```
+my-plugin/
+└── routes/
+    ├── index.ts          → GET /x/plugins/my-plugin
+    ├── status.ts         → GET, POST /x/plugins/my-plugin/status
+    └── webhooks/
+        └── incoming.ts   → POST /x/plugins/my-plugin/webhooks/incoming
+```
+
+```ts
+// routes/status.ts
+export async function GET(request: Request): Promise<Response> {
+  return Response.json({ status: "ok", uptimeMs: performance.now() });
+}
+```


### PR DESCRIPTION
## Prompt / plan

> we want to support `routes` as a pluginable surface. a route brought by a plugin will go in the `/x/plugins/<name>/<route>` namespace.

Rebased onto `main` after #37964 (skill-route removal) merged, and **reworked** to the filesystem-dispatch design: routes are managed at their on-disk surface location rather than through a `Plugin` contribution field or loader/bootstrap wiring. (The earlier revision of this PR used the now-deleted `Plugin.routes` + skill-route registry; that approach is gone.)

## What changed

Extends the existing `/x/*` file-based route dispatcher (`runtime/routes/user-route-dispatcher.ts`) so a plugin's HTTP routes are served from its own on-disk `routes/` directory:

- A request to `/x/plugins/<name>/<path>` resolves against `<workspaceDir>/plugins/<name>/routes/<path>` — the **same** file convention, mtime cache, method gating, 404-if-missing behavior, and runtime `UserRouteContext` as the workspace `/x/*` routes it shares code with.
- The `plugins/<name>/` prefix is **reserved**: a request there resolves only against the named plugin's `routes/` dir and never falls back to a workspace `routes/plugins/…` file, so plugins can't collide with workspace routes or each other. A bare `/x/plugins` (no name) 404s.
- Nested dirs and `index` files map to sub-paths (`routes/webhooks/incoming.ts` → `/x/plugins/<name>/webhooks/incoming`; `routes/index.ts` → the namespace root).

Net implementation is a single helper (`resolveRouteLocation`) that picks the base directory from the path prefix — no new registry, no `Plugin` field, nothing wired through bootstrap.

Docs updated: `plugins/AGENTS.md` (new "Plugin HTTP Routes" section) and the `plugin-builder` skill (layout + Routes section; moved off the "not yet available" list).

## Test plan

- `bunx tsc --noEmit` — clean.
- `eslint` — clean.
- `user-route-dispatcher.test.ts` — 27 pass, including 7 new plugin-route cases: dispatch from a plugin's `routes/`, nested + `index` (namespace root), 404 on missing file, namespace confinement (a workspace `routes/plugins/foo.ts` does **not** answer `/x/plugins/foo`), bare `/x/plugins` 404, and cross-plugin isolation.

## Notes

- **Auth**: plugin routes go through the existing authenticated `/x/:path*` route (`settings.read`), same as workspace user routes — a stronger default than the pre-auth skill routes that were removed.
- No `Plugin` interface change and no bootstrap change in this PR — the surface is entirely filesystem-resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQb9MhUecmyXQBZxih2dfu