### PR TITLE
fix(runtime): report run_error when a wake's agent loop dies before producing output

### DIFF
--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -863,7 +863,11 @@ describe("wakeAgentForOpportunity", () => {
       { resolveTarget: async () => conversation },
     );
 
-    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "run_error",
+    });
     expect(conversation.personaOverrideSets).toEqual([override, undefined]);
   });
 
@@ -1536,11 +1540,86 @@ describe("wakeAgentForOpportunity", () => {
       { resolveTarget: async () => conversation },
     );
 
-    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    // A throw before anything went live is a failed run, not a silent
+    // no-op — callers like the memory retrospective advance their
+    // processed-message watermark on `invoked: true`, so a phantom
+    // success would permanently consume their trigger window.
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "run_error",
+    });
     // Critical: the finally block must have released the flag despite
     // the thrown error, otherwise the next user turn would hang.
     expect(conversation.processingToggles).toEqual([true, false]);
     expect(conversation.isProcessing()).toBe(false);
+  });
+
+  test("reports run_error when the loop throws before any output", async () => {
+    const conversation = makeWakeConversation({
+      conversationId: "conv-err-turn0",
+      runImpl: async () => {
+        throw new Error("provider 402: insufficient balance");
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      { conversationId: "conv-err-turn0", hint: "boom", source: "t" },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "run_error",
+    });
+    // No checkpoint fired and nothing was flushed: the failed run must
+    // not have pushed or persisted anything.
+    expect(conversation.pushedMessages).toEqual([]);
+    expect(conversation.persistedTailCalls).toEqual([]);
+  });
+
+  test("keeps invoked true when the loop throws after a checkpoint went live", async () => {
+    // A completed tool turn (checkpoint) means side effects have already
+    // landed and partial output was pushed + persisted — a later throw
+    // must NOT read as "the wake never ran", or callers would re-run a
+    // pass whose side effects already fired.
+    const assistantToolMsg: Message = {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "tu-1", name: "remember", input: {} }],
+    };
+    const toolResultMsg: Message = {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "tu-1", content: "saved" }],
+    };
+    const conversation = makeWakeConversation({
+      conversationId: "conv-err-after-checkpoint",
+      runImpl: async (input, _onEvent, runOptions) => {
+        const history = [...input, assistantToolMsg, toolResultMsg];
+        await runOptions?.onCheckpoint?.({
+          turnIndex: 0,
+          toolCount: 1,
+          hasToolUse: true,
+          history,
+        });
+        throw new Error("provider died mid-run");
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: "conv-err-after-checkpoint",
+        hint: "boom",
+        source: "t",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    // The checkpoint's flush pushed + persisted the partial tail before
+    // the throw.
+    expect(conversation.pushedMessages.length).toBeGreaterThan(0);
+    expect(conversation.persistedTailCalls.length).toBeGreaterThan(0);
   });
 
   test("elevates the turn's trust context before the agent loop runs", async () => {
@@ -2014,7 +2093,7 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.runCalls).toHaveLength(0);
   });
 
-  test("agent loop error is treated as a no-op", async () => {
+  test("agent loop error before any output is reported as run_error", async () => {
     const conversation = makeWakeConversation({
       conversationId: "conv-err",
       runImpl: async () => {
@@ -2027,7 +2106,11 @@ describe("wakeAgentForOpportunity", () => {
       { resolveTarget: async () => conversation },
     );
 
-    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "run_error",
+    });
     expect(conversation.persistedTailCalls).toHaveLength(0);
   });
 
@@ -2083,7 +2166,11 @@ describe("wakeAgentForOpportunity", () => {
       { resolveTarget: async () => conversation },
     );
 
-    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "run_error",
+    });
     // Drain ran AFTER setProcessing(false), satisfying the
     // enqueueMessage gate invariant. Snapshot proves the flag was
     // false at the moment drain ran.
@@ -3159,7 +3246,7 @@ describe("wakeAgentForOpportunity", () => {
       expect(conversation.drainQueueCalls).toBe(1);
     });
 
-    test("suppressed wake treats an unrelated rewrapped error as a generic no-op, not an overflow", async () => {
+    test("suppressed wake treats an unrelated rewrapped error as a run_error, not an overflow", async () => {
       const conversation = makeWakeConversation({
         estimatedInputTokens: 0,
         runImpl: async () => {
@@ -3177,7 +3264,13 @@ describe("wakeAgentForOpportunity", () => {
         { resolveTarget: async () => conversation },
       );
 
-      expect(result).toEqual({ invoked: true, producedToolCalls: false });
+      // Not mapped to "context_overflow" (the error is unrelated), but the
+      // run still died before producing output — reported as run_error.
+      expect(result).toEqual({
+        invoked: false,
+        producedToolCalls: false,
+        reason: "run_error",
+      });
     });
 
     test("the compaction gate is sized with the wake's call site and forced profile", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -37,6 +37,11 @@
  *   - Tool calls produced → normal tool execution runs (the conversation's
  *     `AgentLoop` has its tool executor already wired). Returns
  *     `{ invoked: true, producedToolCalls: true }`.
+ *   - Loop threw before ANY output went live or was persisted → the wake did
+ *     no work. Returns `{ invoked: false, reason: "run_error" }` so callers
+ *     that advance state on success (memory retrospective watermark,
+ *     scheduler feed events) can retry instead of recording a phantom pass.
+ *     A throw after output went live still returns `invoked: true`.
  *
  * Concurrency:
  *   - If a user turn (or another wake) is currently in flight on the same
@@ -369,7 +374,18 @@ export type WakeSkipReason =
    * run cannot proceed without the compaction it was told not to perform.
    * Only possible on suppressed wakes.
    */
-  | "context_overflow";
+  | "context_overflow"
+  /**
+   * The agent loop threw before producing ANY output — no checkpoint fired
+   * and no tail message was emitted or persisted (typically a provider
+   * failure on the run's first LLM call). The wake did no work, so callers
+   * that treat `invoked: true` as "the pass ran" (e.g. the memory
+   * retrospective, which advances its processed-message watermark and
+   * finalizes on success) must see a retryable failure rather than a
+   * silent no-op. A throw AFTER output went live keeps `invoked: true` —
+   * side effects have already landed and the run must not read as skipped.
+   */
+  | "run_error";
 
 export interface WakeResult {
   invoked: boolean;
@@ -1245,6 +1261,11 @@ export async function wakeAgentForOpportunity(
     // block skips its generic outcome log for this path — the failure
     // already logged its own dedicated warn line.
     let failedContextOverflow = false;
+    // Set when a mid-run throw was reported as `invoked: false` (reason
+    // "run_error") because nothing had gone live or been persisted. The
+    // finally's error log names the reported outcome so the line matches
+    // what the caller actually saw.
+    let reportedRunErrorAsFailure = false;
     // Shared failure path for an over-window condition on a
     // compaction-suppressed wake (reached from the pre-flight estimate, from
     // the run's catch when the rejection escaped as a throw, or post-run when
@@ -1381,6 +1402,25 @@ export async function wakeAgentForOpportunity(
         // run threw mid-flight. The outer finally still runs to release
         // `processing` and drain the queue.
         runError = err instanceof Error ? err : new Error(String(err));
+        // Nothing went live and nothing was persisted: no checkpoint fired
+        // (mode never left "buffering") and no tail message was flushed.
+        // The run died before doing any work — typically a provider error
+        // on the first LLM call — so report a failure instead of a silent
+        // no-op. Callers gate real state transitions on `invoked` (the
+        // memory retrospective advances its processed-message watermark
+        // and finalizes on success; the scheduler emits a success feed
+        // event), and a no-op result here permanently consumes their
+        // trigger without a run ever happening. A throw after output went
+        // live keeps `invoked: true`: side effects have already landed,
+        // and the run must not read as skipped.
+        if (mode === "buffering" && persistedTailIndex === 0) {
+          reportedRunErrorAsFailure = true;
+          return {
+            invoked: false,
+            producedToolCalls: false,
+            reason: "run_error" as const,
+          };
+        }
         return { invoked: true, producedToolCalls: false };
       } finally {
         // Restore the pre-wake values so a queued user turn or background read
@@ -1515,7 +1555,9 @@ export async function wakeAgentForOpportunity(
             hintRole,
             err: runError,
           },
-          "agent-wake: agent loop threw; treating as no-op",
+          reportedRunErrorAsFailure
+            ? "agent-wake: agent loop threw before producing output; reported as run_error"
+            : "agent-wake: agent loop threw after output went live; treating as no-op",
         );
       } else if (tailMessageCount === 0) {
         log.info(


### PR DESCRIPTION
## Problem

`wakeAgentForOpportunity` catches a mid-run agent-loop throw and returns `{ invoked: true, producedToolCalls: false }` ("silent no-op") — even when the loop died on its **first LLM call** and the wake did literally nothing. Callers that advance state on `invoked: true` record a phantom pass:

- **Memory retrospective** (sharpest edge): finalizes the run, bumps `lastProcessedMessageId` past the window, keeps the fork. The trigger for those messages is **permanently consumed** — no retry ever re-covers them, and no skill/remember pass ran.
- **Scheduler**: records a `wake-ok` run + success feed event for a wake that never fired.

Observed live on 2026-07-13: the managed-inference Fireworks account hit 402 `insufficient_balance`, and every retrospective on the install "completed" in ~70 ms — fork created, instruction appended, zero model calls, watermark burned. The only trace was an `[agent-loop]` error line followed by `agent-wake: no output; silent no-op`.

## Fix

A throw now returns `{ invoked: false, reason: "run_error" }` **iff nothing went live and nothing was persisted** (no checkpoint fired — `mode` never left `"buffering"` — and no tail message was flushed). A throw after output went live keeps `invoked: true`: side effects have already landed, and the run must not read as skipped (callers would otherwise blindly re-run a pass whose side effects fired).

Callers already handle `invoked: false` correctly today:
- the retrospective takes its `wake_failed` path — watermark untouched, orphan fork deleted, retried on the next trigger;
- the scheduler logs `Wake not invoked; skipping feed event` (one-shots complete without a phantom success run, same policy as `archived`/`not_found`);
- other callers (`background-tool-registry`, shell notify-wakes, v2 consolidation) gate feed/notify effects on `invoked` and now skip them truthfully.

The finally's error log now names the reported outcome (`reported as run_error` vs `treating as no-op`) so the line matches what the caller saw.

## Tests

- Updated the five tests that pinned the old phantom-success contract (turn-0 throw → now `run_error`).
- New: `reports run_error when the loop throws before any output` — asserts nothing was pushed/persisted.
- New: `keeps invoked true when the loop throws after a checkpoint went live` — checkpoint flushes partial tail, then throws; result stays `invoked: true`.
- `bun test src/runtime/__tests__/agent-wake.test.ts` → 73 pass. Consumer files (`memory-retrospective-job.test.ts`, `wake-conversation-routes.test.ts`) green. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)