### PR TITLE
fix(runtime): serve out-of-band surfaces from persisted history in GET /v1/surfaces

### DIFF
--- a/assistant/src/daemon/message-provenance.ts
+++ b/assistant/src/daemon/message-provenance.ts
@@ -35,15 +35,24 @@ export function parseProvenanceTrustClass(
   return undefined;
 }
 
+/**
+ * Per-row form of {@link filterMessagesForUntrustedActor}: whether a single
+ * persisted row's provenance is visible to an untrusted (non-guardian)
+ * actor view. Exported so consumers that scan raw rows outside a full
+ * history load (e.g. the persisted-surface fallback in the surface routes)
+ * apply the identical predicate instead of duplicating the allowlist.
+ */
+export function isRowVisibleToUntrustedActor(metadata: string | null): boolean {
+  const provenanceTrustClass = parseProvenanceTrustClass(metadata);
+  return (
+    provenanceTrustClass === "trusted_contact" ||
+    provenanceTrustClass === "unverified_contact" ||
+    provenanceTrustClass === "unknown"
+  );
+}
+
 export function filterMessagesForUntrustedActor(
   messages: MessageRow[],
 ): MessageRow[] {
-  return messages.filter((m) => {
-    const provenanceTrustClass = parseProvenanceTrustClass(m.metadata);
-    return (
-      provenanceTrustClass === "trusted_contact" ||
-      provenanceTrustClass === "unverified_contact" ||
-      provenanceTrustClass === "unknown"
-    );
-  });
+  return messages.filter((m) => isRowVisibleToUntrustedActor(m.metadata));
 }

--- a/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/channel-verification-routes.test.ts
@@ -20,7 +20,10 @@ const updateChannelStatusCalls: unknown[] = [];
 const ipcCalls: Array<[string, unknown]> = [];
 
 mock.module("../../../daemon/handlers/config-channels.js", () => ({
-  verifyTrustedContact: async (contactChannelId: string, assistantId: string) => {
+  verifyTrustedContact: async (
+    contactChannelId: string,
+    assistantId: string,
+  ) => {
     verifyTrustedContactCalls.push([contactChannelId, assistantId]);
     return verifyTrustedContactImpl(contactChannelId, assistantId);
   },

--- a/assistant/src/runtime/routes/__tests__/contact-routes-update-channel-relay.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes-update-channel-relay.test.ts
@@ -57,9 +57,8 @@ mock.module("../../../contacts/contact-store.js", () => ({
   updateChannelStatus: contactStoreWriteGuard,
 }));
 
-const { handleUpdateContactChannelRoute, ROUTES } = await import(
-  "../contact-routes.js"
-);
+const { handleUpdateContactChannelRoute, ROUTES } =
+  await import("../contact-routes.js");
 
 describe("update contact channel relay", () => {
   beforeEach(() => {

--- a/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/llm-call-sites-routes.test.ts
@@ -23,7 +23,12 @@ describe("llm-call-sites-routes", () => {
 
   test("all call site IDs match LLMCallSiteEnum", async () => {
     const result = (await route.handler({})) as {
-      callSites: Array<{ id: string; displayName: string; description: string; domain: string }>;
+      callSites: Array<{
+        id: string;
+        displayName: string;
+        description: string;
+        domain: string;
+      }>;
     };
     const validIds = new Set(LLMCallSiteEnum.options);
     for (const site of result.callSites) {

--- a/assistant/src/runtime/routes/__tests__/question-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/question-routes.test.ts
@@ -76,10 +76,8 @@ afterEach(() => {
 describe("POST /v1/question-response", () => {
   test("submit: resolves a one-question batch with an option entry", async () => {
     const resolved: QuestionPromptResult[] = [];
-    registerQuestion(
-      "req-1",
-      [{ id: "q1", options: ["yes", "no"] }],
-      (v) => resolved.push(v as QuestionPromptResult),
+    registerQuestion("req-1", [{ id: "q1", options: ["yes", "no"] }], (v) =>
+      resolved.push(v as QuestionPromptResult),
     );
 
     const result = await call({

--- a/assistant/src/runtime/routes/__tests__/schedule-routes-create.test.ts
+++ b/assistant/src/runtime/routes/__tests__/schedule-routes-create.test.ts
@@ -35,7 +35,8 @@ describe("createSchedule route — script mode", () => {
     const { schedule } = await create({
       name: "wt-script-create",
       mode: "script",
-      script: 'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts',
+      script:
+        'cd "$VELLUM_WORKSPACE_DIR/schedules/$__SCHEDULE_ID" && bun poll.ts',
       expression: "*/15 * * * *",
       description: "polls github",
       timeoutMs: 120000,

--- a/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-action-routes.test.ts
@@ -114,6 +114,11 @@ mock.module("../../../persistence/raw-query.js", () => ({
     rawGetCalls.push({ sql, params });
     return rawGetReturn;
   },
+  // Consumed by the resolver module's persisted-history fallback
+  // (`findPersistedSurfaceState`); the action routes never reach it, but
+  // the mocked module must still provide every export the resolver
+  // imports or the import itself fails.
+  rawAll: () => [],
 }));
 
 // Mock guardian-action-service to cut off its deep transitive dependency chain.

--- a/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
@@ -35,6 +35,7 @@ interface StubConversation {
   id: string;
   surfaceState: Map<string, StoredSurface>;
   contextCompactedMessageCount: number;
+  loadedHistoryTrustClass: string;
   currentTurnSurfaces?: Array<{
     surfaceId: string;
     surfaceType: string;
@@ -46,7 +47,7 @@ interface StubConversation {
 let memoryById: StubConversation | null = null;
 let rehydrated: StubConversation | null = null;
 let rawGetReturn: { conversation_id: string } | null = null;
-let rawAllReturn: Array<{ content: string }> = [];
+let rawAllReturn: Array<{ content: string; metadata?: string | null }> = [];
 
 const findConvCalls: string[] = [];
 const findBySurfaceCalls: string[] = [];
@@ -100,7 +101,12 @@ function findHandler(operationId: string): RouteDefinition["handler"] {
 }
 
 function makeStub(id: string): StubConversation {
-  return { id, surfaceState: new Map(), contextCompactedMessageCount: 0 };
+  return {
+    id,
+    surfaceState: new Map(),
+    contextCompactedMessageCount: 0,
+    loadedHistoryTrustClass: "guardian",
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -304,6 +310,91 @@ describe("surfaces_get_content handler", () => {
       42,
       `%"surfaceId":"surf-old"%`,
     ]);
+  });
+
+  test("actor-scoped view never serves a surface the provenance filter dropped", async () => {
+    // `loadFromDb` builds an untrusted actor's history (and surfaceState)
+    // through `filterMessagesForUntrustedActor`, so guardian-authored and
+    // provenance-less rows are deliberately absent from that view. The
+    // fallback must apply the same per-row predicate — naming a hidden
+    // surface id must 404, not expose (and memoize) the dropped payload.
+    const conv = makeStub("conv-actor");
+    conv.loadedHistoryTrustClass = "unknown";
+    memoryById = conv;
+    rawAllReturn = [
+      {
+        content: JSON.stringify([
+          {
+            type: "ui_surface",
+            surfaceId: "surf-hidden",
+            surfaceType: "card",
+            title: "Guardian only",
+            data: { secret: true },
+          },
+        ]),
+        metadata: JSON.stringify({ provenanceTrustClass: "guardian" }),
+      },
+      {
+        content: JSON.stringify([
+          {
+            type: "ui_surface",
+            surfaceId: "surf-hidden",
+            surfaceType: "card",
+            title: "No provenance",
+            data: { secret: true },
+          },
+        ]),
+        metadata: null,
+      },
+    ];
+
+    const handler = findHandler("surfaces_get_content");
+
+    let caught: unknown;
+    try {
+      await handler({
+        pathParams: { surfaceId: "surf-hidden" },
+        queryParams: { conversationId: "conv-actor" },
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(NotFoundError);
+    expect(conv.surfaceState.has("surf-hidden")).toBe(false);
+  });
+
+  test("actor-scoped view still serves actor-visible provenance rows", async () => {
+    const conv = makeStub("conv-actor-ok");
+    conv.loadedHistoryTrustClass = "unknown";
+    memoryById = conv;
+    rawAllReturn = [
+      {
+        content: JSON.stringify([
+          {
+            type: "ui_surface",
+            surfaceId: "surf-visible",
+            surfaceType: "card",
+            title: "Contact-authored",
+            data: { ok: true },
+          },
+        ]),
+        metadata: JSON.stringify({ provenanceTrustClass: "trusted_contact" }),
+      },
+    ];
+
+    const handler = findHandler("surfaces_get_content");
+    const result = await handler({
+      pathParams: { surfaceId: "surf-visible" },
+      queryParams: { conversationId: "conv-actor-ok" },
+    });
+
+    expect(result).toEqual({
+      surfaceId: "surf-visible",
+      surfaceType: "card",
+      title: "Contact-authored",
+      data: { ok: true },
+    });
   });
 
   test("persisted-history fallback skips rows that merely quote the surfaceId", async () => {

--- a/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
@@ -35,7 +35,6 @@ interface StubConversation {
   id: string;
   surfaceState: Map<string, StoredSurface>;
   contextCompactedMessageCount: number;
-  loadedHistoryTrustClass: string;
   currentTurnSurfaces?: Array<{
     surfaceId: string;
     surfaceType: string;
@@ -108,13 +107,18 @@ function findHandler(operationId: string): RouteDefinition["handler"] {
   return route.handler;
 }
 
+/**
+ * Headers for a request from the guardian actor. The fallback fails closed
+ * without a verified actor id or local principal, so every test that means
+ * to exercise it as the guardian must send these.
+ */
+const GUARDIAN_HEADERS = {
+  "x-vellum-principal-type": "actor",
+  "x-vellum-actor-principal-id": "vellum-principal-guardian",
+};
+
 function makeStub(id: string): StubConversation {
-  return {
-    id,
-    surfaceState: new Map(),
-    contextCompactedMessageCount: 0,
-    loadedHistoryTrustClass: "guardian",
-  };
+  return { id, surfaceState: new Map(), contextCompactedMessageCount: 0 };
 }
 
 // ---------------------------------------------------------------------------
@@ -234,7 +238,7 @@ describe("surfaces_get_content handler", () => {
   // predates a surface appended straight to the messages table (`addMessage`
   // on a loaded conversation — the memory retrospective's skill card).
   // -------------------------------------------------------------------------
-  test("serves an out-of-band surface from persisted history and memoizes it", async () => {
+  test("serves an out-of-band surface from persisted history without memoizing", async () => {
     const conv = makeStub("conv-live"); // loaded, but surfaceState predates the insert
     memoryById = conv;
     rawAllReturn = [
@@ -261,6 +265,7 @@ describe("surfaces_get_content handler", () => {
     const result = await handler({
       pathParams: { surfaceId: "surf-oob" },
       queryParams: { conversationId: "conv-live" },
+      headers: GUARDIAN_HEADERS,
     });
 
     expect(result).toEqual({
@@ -277,13 +282,9 @@ describe("surfaces_get_content handler", () => {
       0,
       `%"surfaceId":"surf-oob"%`,
     ]);
-    // Memoized into the live conversation so the next fetch (and action
-    // routing / findConversationBySurfaceId) hits surfaceState directly.
-    expect(conv.surfaceState.get("surf-oob")).toMatchObject({
-      surfaceType: "skill_card",
-      title: "New skill learned",
-      data: { skills: [{ skillId: "standup-drafter" }] },
-    });
+    // Never memoized: a cached hit would let a later request skip the
+    // requester filter via the unscoped surfaceState fast path.
+    expect(conv.surfaceState.has("surf-oob")).toBe(false);
     // Never rehydrated — the conversation was already live.
     expect(getOrCreateCalls).toEqual([]);
   });
@@ -306,6 +307,7 @@ describe("surfaces_get_content handler", () => {
       await handler({
         pathParams: { surfaceId: "surf-old" },
         queryParams: { conversationId: "conv-compacted" },
+        headers: GUARDIAN_HEADERS,
       });
     } catch (err) {
       caught = err;
@@ -366,6 +368,10 @@ describe("surfaces_get_content handler", () => {
       await handler({
         pathParams: { surfaceId: "surf-hidden" },
         queryParams: { conversationId: "conv-actor" },
+        headers: {
+          "x-vellum-principal-type": "actor",
+          "x-vellum-actor-principal-id": "vellum-principal-contact",
+        },
       });
     } catch (err) {
       caught = err;
@@ -398,6 +404,10 @@ describe("surfaces_get_content handler", () => {
     const result = await handler({
       pathParams: { surfaceId: "surf-visible" },
       queryParams: { conversationId: "conv-actor-ok" },
+      headers: {
+        "x-vellum-principal-type": "actor",
+        "x-vellum-actor-principal-id": "vellum-principal-contact",
+      },
     });
 
     expect(result).toEqual({
@@ -408,13 +418,13 @@ describe("surfaces_get_content handler", () => {
     });
   });
 
-  test("guardian fetch on an actor-scoped view serves but never widens the cached map", async () => {
-    // The requester (guardian) may see the payload, but the conversation's
-    // cached surfaceState reflects an actor-scoped load — memoizing a
-    // guardian-only row into it would let a later untrusted fetch read the
-    // payload straight off the fast path.
-    const conv = makeStub("conv-actor-view");
-    conv.loadedHistoryTrustClass = "unknown";
+  test("service principals without a forwarded actor id fail closed", async () => {
+    // The route policy admits svc_gateway / svc_daemon with chat.read, and
+    // those AuthContexts carry no actor principal. Only local/IPC callers
+    // are the guardian by construction — a service token naming a
+    // guardian-provenance surface must be scoped to the untrusted filter,
+    // not defaulted to guardian.
+    const conv = makeStub("conv-svc");
     memoryById = conv;
     rawAllReturn = [
       {
@@ -432,18 +442,56 @@ describe("surfaces_get_content handler", () => {
     ];
 
     const handler = findHandler("surfaces_get_content");
+
+    let caught: unknown;
+    try {
+      await handler({
+        pathParams: { surfaceId: "surf-g" },
+        queryParams: { conversationId: "conv-svc" },
+        headers: { "x-vellum-principal-type": "svc_gateway" },
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(NotFoundError);
+    expect(conv.surfaceState.has("surf-g")).toBe(false);
+  });
+
+  test("local principals without an actor id resolve as the guardian", async () => {
+    // IPC/CLI callers get the injected local principal header and no actor
+    // id — they ARE the guardian and must not be fail-closed like service
+    // tokens.
+    const conv = makeStub("conv-local");
+    memoryById = conv;
+    rawAllReturn = [
+      {
+        content: JSON.stringify([
+          {
+            type: "ui_surface",
+            surfaceId: "surf-l",
+            surfaceType: "card",
+            title: "Guardian payload",
+            data: { ok: true },
+          },
+        ]),
+        metadata: JSON.stringify({ provenanceTrustClass: "guardian" }),
+      },
+    ];
+
+    const handler = findHandler("surfaces_get_content");
     const result = await handler({
-      pathParams: { surfaceId: "surf-g" },
-      queryParams: { conversationId: "conv-actor-view" },
+      pathParams: { surfaceId: "surf-l" },
+      queryParams: { conversationId: "conv-local" },
+      headers: { "x-vellum-principal-type": "local" },
     });
 
     expect(result).toEqual({
-      surfaceId: "surf-g",
+      surfaceId: "surf-l",
       surfaceType: "card",
       title: "Guardian payload",
-      data: { secret: true },
+      data: { ok: true },
     });
-    expect(conv.surfaceState.has("surf-g")).toBe(false);
   });
 
   test("persisted-history fallback skips rows that merely quote the surfaceId", async () => {
@@ -475,6 +523,7 @@ describe("surfaces_get_content handler", () => {
     const result = await handler({
       pathParams: { surfaceId: "surf-quoted" },
       queryParams: { conversationId: "conv-live" },
+      headers: GUARDIAN_HEADERS,
     });
 
     expect(result).toEqual({
@@ -498,6 +547,7 @@ describe("surfaces_get_content handler", () => {
       await handler({
         pathParams: { surfaceId: "surf-nope" },
         queryParams: { conversationId: "conv-live" },
+        headers: GUARDIAN_HEADERS,
       });
     } catch (err) {
       caught = err;

--- a/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
@@ -78,6 +78,14 @@ mock.module("../../../daemon/conversation-store.js", () => ({
   },
 }));
 
+let requesterTrustClass = "guardian";
+mock.module("../vellum-actor-trust.js", () => ({
+  resolveVellumActorTrustContext: async () => ({
+    trustClass: requesterTrustClass,
+    sourceChannel: "vellum",
+  }),
+}));
+
 mock.module("../../../persistence/raw-query.js", () => ({
   rawGet: (_label: string, sql: string, ...params: unknown[]) => {
     rawGetCalls.push({ sql, params });
@@ -114,6 +122,7 @@ function makeStub(id: string): StubConversation {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  requesterTrustClass = "guardian";
   memoryById = null;
   rehydrated = null;
   rawGetReturn = null;
@@ -313,13 +322,15 @@ describe("surfaces_get_content handler", () => {
   });
 
   test("actor-scoped view never serves a surface the provenance filter dropped", async () => {
-    // `loadFromDb` builds an untrusted actor's history (and surfaceState)
-    // through `filterMessagesForUntrustedActor`, so guardian-authored and
-    // provenance-less rows are deliberately absent from that view. The
-    // fallback must apply the same per-row predicate — naming a hidden
-    // surface id must 404, not expose (and memoize) the dropped payload.
-    const conv = makeStub("conv-actor");
-    conv.loadedHistoryTrustClass = "unknown";
+    // Untrusted-actor views are built through
+    // `filterMessagesForUntrustedActor`, so guardian-authored and
+    // provenance-less rows are deliberately hidden from non-guardian
+    // actors. The fallback keys the same per-row predicate on the
+    // REQUESTER's trust (not the cached view's — a guardian-loaded
+    // conversation must not leak to a non-guardian caller): naming a
+    // hidden surface id must 404, not expose (and memoize) the payload.
+    const conv = makeStub("conv-actor"); // loaded under guardian view
+    requesterTrustClass = "unknown";
     memoryById = conv;
     rawAllReturn = [
       {
@@ -366,7 +377,7 @@ describe("surfaces_get_content handler", () => {
 
   test("actor-scoped view still serves actor-visible provenance rows", async () => {
     const conv = makeStub("conv-actor-ok");
-    conv.loadedHistoryTrustClass = "unknown";
+    requesterTrustClass = "unknown";
     memoryById = conv;
     rawAllReturn = [
       {
@@ -395,6 +406,44 @@ describe("surfaces_get_content handler", () => {
       title: "Contact-authored",
       data: { ok: true },
     });
+  });
+
+  test("guardian fetch on an actor-scoped view serves but never widens the cached map", async () => {
+    // The requester (guardian) may see the payload, but the conversation's
+    // cached surfaceState reflects an actor-scoped load — memoizing a
+    // guardian-only row into it would let a later untrusted fetch read the
+    // payload straight off the fast path.
+    const conv = makeStub("conv-actor-view");
+    conv.loadedHistoryTrustClass = "unknown";
+    memoryById = conv;
+    rawAllReturn = [
+      {
+        content: JSON.stringify([
+          {
+            type: "ui_surface",
+            surfaceId: "surf-g",
+            surfaceType: "card",
+            title: "Guardian payload",
+            data: { secret: true },
+          },
+        ]),
+        metadata: JSON.stringify({ provenanceTrustClass: "guardian" }),
+      },
+    ];
+
+    const handler = findHandler("surfaces_get_content");
+    const result = await handler({
+      pathParams: { surfaceId: "surf-g" },
+      queryParams: { conversationId: "conv-actor-view" },
+    });
+
+    expect(result).toEqual({
+      surfaceId: "surf-g",
+      surfaceType: "card",
+      title: "Guardian payload",
+      data: { secret: true },
+    });
+    expect(conv.surfaceState.has("surf-g")).toBe(false);
   });
 
   test("persisted-history fallback skips rows that merely quote the surfaceId", async () => {

--- a/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
@@ -45,11 +45,13 @@ interface StubConversation {
 let memoryById: StubConversation | null = null;
 let rehydrated: StubConversation | null = null;
 let rawGetReturn: { conversation_id: string } | null = null;
+let rawAllReturn: Array<{ content: string }> = [];
 
 const findConvCalls: string[] = [];
 const findBySurfaceCalls: string[] = [];
 const getOrCreateCalls: string[] = [];
 const rawGetCalls: Array<{ sql: string; params: unknown[] }> = [];
+const rawAllCalls: Array<{ sql: string; params: unknown[] }> = [];
 
 mock.module("../../../daemon/conversation-registry.js", () => ({
   findConversation: (id: string) => {
@@ -79,6 +81,10 @@ mock.module("../../../persistence/raw-query.js", () => ({
     rawGetCalls.push({ sql, params });
     return rawGetReturn;
   },
+  rawAll: (_label: string, sql: string, ...params: unknown[]) => {
+    rawAllCalls.push({ sql, params });
+    return rawAllReturn;
+  },
 }));
 
 // Defer route import until after mocks are installed.
@@ -104,10 +110,12 @@ beforeEach(() => {
   memoryById = null;
   rehydrated = null;
   rawGetReturn = null;
+  rawAllReturn = [];
   findConvCalls.length = 0;
   findBySurfaceCalls.length = 0;
   getOrCreateCalls.length = 0;
   rawGetCalls.length = 0;
+  rawAllCalls.length = 0;
 });
 
 // ---------------------------------------------------------------------------
@@ -203,6 +211,125 @@ describe("surfaces_get_content handler", () => {
     expect(rawGetCalls).toHaveLength(1);
     expect(rawGetCalls[0]!.params[0]).toBe(`%"surfaceId":"surf-restored"%`);
     expect(getOrCreateCalls).toEqual(["conv-evicted"]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Out-of-band inserts: the conversation IS in memory but its surfaceState
+  // predates a surface appended straight to the messages table (`addMessage`
+  // on a loaded conversation — the memory retrospective's skill card).
+  // -------------------------------------------------------------------------
+  test("serves an out-of-band surface from persisted history and memoizes it", async () => {
+    const conv = makeStub("conv-live"); // loaded, but surfaceState predates the insert
+    memoryById = conv;
+    rawAllReturn = [
+      {
+        content: JSON.stringify([
+          {
+            type: "ui_surface",
+            surfaceId: "surf-oob",
+            surfaceType: "skill_card",
+            title: "New skill learned",
+            display: "inline",
+            data: { skills: [{ skillId: "standup-drafter" }] },
+          },
+          {
+            type: "text",
+            text: "New skill learned: Standup",
+            _surfaceFallback: true,
+          },
+        ]),
+      },
+    ];
+
+    const handler = findHandler("surfaces_get_content");
+    const result = await handler({
+      pathParams: { surfaceId: "surf-oob" },
+      queryParams: { conversationId: "conv-live" },
+    });
+
+    expect(result).toEqual({
+      surfaceId: "surf-oob",
+      surfaceType: "skill_card",
+      title: "New skill learned",
+      data: { skills: [{ skillId: "standup-drafter" }] },
+    });
+    // The history scan is scoped to the caller's (validated) conversation.
+    expect(rawAllCalls).toHaveLength(1);
+    expect(rawAllCalls[0]!.params).toEqual([
+      "conv-live",
+      `%"surfaceId":"surf-oob"%`,
+    ]);
+    // Memoized into the live conversation so the next fetch (and action
+    // routing / findConversationBySurfaceId) hits surfaceState directly.
+    expect(conv.surfaceState.get("surf-oob")).toMatchObject({
+      surfaceType: "skill_card",
+      title: "New skill learned",
+      data: { skills: [{ skillId: "standup-drafter" }] },
+    });
+    // Never rehydrated — the conversation was already live.
+    expect(getOrCreateCalls).toEqual([]);
+  });
+
+  test("persisted-history fallback skips rows that merely quote the surfaceId", async () => {
+    // The LIKE probe is a candidate filter, not the match: a message whose
+    // TEXT quotes the surfaceId (e.g. a tool_result echoing JSON) parses to
+    // no ui_surface block and the scan moves to the next candidate row.
+    const conv = makeStub("conv-live");
+    memoryById = conv;
+    rawAllReturn = [
+      {
+        content: JSON.stringify([
+          { type: "text", text: 'log line: {"surfaceId":"surf-quoted"} seen' },
+        ]),
+      },
+      {
+        content: JSON.stringify([
+          {
+            type: "ui_surface",
+            surfaceId: "surf-quoted",
+            surfaceType: "card",
+            title: "Real",
+            data: { ok: true },
+          },
+        ]),
+      },
+    ];
+
+    const handler = findHandler("surfaces_get_content");
+    const result = await handler({
+      pathParams: { surfaceId: "surf-quoted" },
+      queryParams: { conversationId: "conv-live" },
+    });
+
+    expect(result).toEqual({
+      surfaceId: "surf-quoted",
+      surfaceType: "card",
+      title: "Real",
+      data: { ok: true },
+    });
+  });
+
+  test("404s when the conversation is live and no persisted block matches", async () => {
+    // Live conversation, empty surfaceState, no ui_surface row in history:
+    // the fallback must not invent a surface (nor rehydrate).
+    memoryById = makeStub("conv-live");
+    rawAllReturn = [];
+
+    const handler = findHandler("surfaces_get_content");
+
+    let caught: unknown;
+    try {
+      await handler({
+        pathParams: { surfaceId: "surf-nope" },
+        queryParams: { conversationId: "conv-live" },
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(NotFoundError);
+    expect(rawAllCalls).toHaveLength(1);
+    expect(getOrCreateCalls).toEqual([]);
   });
 
   test("400s when conversationId is missing", async () => {

--- a/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/surface-content-routes.test.ts
@@ -34,6 +34,7 @@ interface StoredSurface {
 interface StubConversation {
   id: string;
   surfaceState: Map<string, StoredSurface>;
+  contextCompactedMessageCount: number;
   currentTurnSurfaces?: Array<{
     surfaceId: string;
     surfaceType: string;
@@ -99,7 +100,7 @@ function findHandler(operationId: string): RouteDefinition["handler"] {
 }
 
 function makeStub(id: string): StubConversation {
-  return { id, surfaceState: new Map() };
+  return { id, surfaceState: new Map(), contextCompactedMessageCount: 0 };
 }
 
 // ---------------------------------------------------------------------------
@@ -253,10 +254,12 @@ describe("surfaces_get_content handler", () => {
       title: "New skill learned",
       data: { skills: [{ skillId: "standup-drafter" }] },
     });
-    // The history scan is scoped to the caller's (validated) conversation.
+    // The history scan is scoped to the caller's (validated) conversation
+    // and starts past the compaction boundary (0 here — nothing compacted).
     expect(rawAllCalls).toHaveLength(1);
     expect(rawAllCalls[0]!.params).toEqual([
       "conv-live",
+      0,
       `%"surfaceId":"surf-oob"%`,
     ]);
     // Memoized into the live conversation so the next fetch (and action
@@ -268,6 +271,39 @@ describe("surfaces_get_content handler", () => {
     });
     // Never rehydrated — the conversation was already live.
     expect(getOrCreateCalls).toEqual([]);
+  });
+
+  test("persisted-history scan starts past the conversation's compaction boundary", async () => {
+    // `restoreSurfaceStateFromHistory` never sees the compacted-away prefix
+    // (live history = rows.slice(contextCompactedMessageCount)), so the
+    // fallback must not resurrect a surface only that prefix owned — stale
+    // surface ids are not globally unique, and memoizing one would let
+    // later surface-action routing operate on state compaction dropped.
+    const conv = makeStub("conv-compacted");
+    conv.contextCompactedMessageCount = 42;
+    memoryById = conv;
+    rawAllReturn = [];
+
+    const handler = findHandler("surfaces_get_content");
+
+    let caught: unknown;
+    try {
+      await handler({
+        pathParams: { surfaceId: "surf-old" },
+        queryParams: { conversationId: "conv-compacted" },
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(NotFoundError);
+    // The boundary is threaded into the scan as its row offset.
+    expect(rawAllCalls).toHaveLength(1);
+    expect(rawAllCalls[0]!.params).toEqual([
+      "conv-compacted",
+      42,
+      `%"surfaceId":"surf-old"%`,
+    ]);
   });
 
   test("persisted-history fallback skips rows that merely quote the surfaceId", async () => {

--- a/assistant/src/runtime/routes/assets/vellum-design-system.css
+++ b/assistant/src/runtime/routes/assets/vellum-design-system.css
@@ -8,1952 +8,2229 @@
    ============================================================ */
 
 @layer vellum-design-system {
+  /* ─── Reset ──────────────────────────────────────────────────── */
 
-/* ─── Reset ──────────────────────────────────────────────────── */
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
+  /* ─── Layer 1: Tokens ────────────────────────────────────────── */
 
-/* ─── Layer 1: Tokens ────────────────────────────────────────── */
-
-:root {
-  /* ── Semantic Colors (Light Mode — default) ─────────────────── */
-  --v-primary-disabled: #D4D1C1;
-  --v-primary-base: #516748;
-  --v-primary-hover: #657D5B;
-  --v-primary-active: #7A8B6F;
-  --v-surface-base: #E8E6DA;
-  --v-surface-overlay: #F5F3EB;
-  --v-surface-active: #D4D1C1;
-  --v-surface-lift: #FFFFFF;
-  --v-border-disabled: #D4D1C1;
-  --v-border-base: #BDB9A9;
-  --v-border-hover: #A1A096;
-  --v-border-active: #7A8B6F;
-  --v-content-emphasized: #20201E;
-  --v-content-default: #2A2A28;
-  --v-content-secondary: #4A4A46;
-  --v-content-tertiary: #A1A096;
-  --v-content-disabled: #BDB9A9;
-  --v-content-background: #D4D1C1;
-  --v-content-inset: #FFFFFF;
-  --v-system-positive-strong: #516748;
-  --v-system-positive-weak: #D4DFD0;
-  --v-system-negative-strong: #DA491A;
-  --v-system-negative-hover: #E86B40;
-  --v-system-negative-weak: #F7DAC9;
-  --v-system-mid-strong: #F1B21E;
-  --v-system-mid-weak: #FCF3DD;
-  --v-aux-white: #FFFFFF;
-
-  /* ── Shorthand Aliases (referenced by app-builder SKILL.md) ── */
-  --v-bg: var(--v-surface-overlay);
-  --v-surface: var(--v-surface-base);
-  --v-surface-border: var(--v-border-base);
-  --v-text: var(--v-content-default);
-  --v-text-secondary: var(--v-content-secondary);
-  --v-text-muted: var(--v-content-tertiary);
-  --v-accent: var(--v-primary-base);
-  --v-accent-hover: var(--v-primary-hover);
-  --v-success: var(--v-system-positive-strong);
-  --v-danger: var(--v-system-negative-strong);
-  --v-warning: var(--v-system-mid-strong);
-
-  /* ── Palette Scales (Tailwind-style, referenced by SKILL.md) ─ */
-  --v-slate-50:  #F8FAFC; --v-slate-100: #F1F5F9; --v-slate-200: #E2E8F0;
-  --v-slate-300: #CBD5E1; --v-slate-400: #94A3B8; --v-slate-500: #64748B;
-  --v-slate-600: #475569; --v-slate-700: #334155; --v-slate-800: #1E293B;
-  --v-slate-900: #0F172A; --v-slate-950: #020617;
-  --v-emerald-50:  #ECFDF5; --v-emerald-100: #D1FAE5; --v-emerald-200: #A7F3D0;
-  --v-emerald-300: #6EE7B7; --v-emerald-400: #34D399; --v-emerald-500: #10B981;
-  --v-emerald-600: #059669; --v-emerald-700: #047857; --v-emerald-800: #065F46;
-  --v-emerald-900: #064E3B; --v-emerald-950: #022C22;
-  --v-violet-50:  #F5F3FF; --v-violet-100: #EDE9FE; --v-violet-200: #DDD6FE;
-  --v-violet-300: #C4B5FD; --v-violet-400: #A78BFA; --v-violet-500: #8B5CF6;
-  --v-violet-600: #7C3AED; --v-violet-700: #6D28D9; --v-violet-800: #5B21B6;
-  --v-violet-900: #4C1D95; --v-violet-950: #2E1065;
-  --v-indigo-50:  #EEF2FF; --v-indigo-100: #E0E7FF; --v-indigo-200: #C7D2FE;
-  --v-indigo-300: #A5B4FC; --v-indigo-400: #818CF8; --v-indigo-500: #6366F1;
-  --v-indigo-600: #4F46E5; --v-indigo-700: #4338CA; --v-indigo-800: #3730A3;
-  --v-indigo-900: #312E81; --v-indigo-950: #1E1B4B;
-  --v-rose-50:  #FFF1F2; --v-rose-100: #FFE4E6; --v-rose-200: #FECDD3;
-  --v-rose-300: #FDA4AF; --v-rose-400: #FB7185; --v-rose-500: #F43F5E;
-  --v-rose-600: #E11D48; --v-rose-700: #BE123C; --v-rose-800: #9F1239;
-  --v-rose-900: #881337; --v-rose-950: #4C0519;
-  --v-amber-50:  #FFFBEB; --v-amber-100: #FEF3C7; --v-amber-200: #FDE68A;
-  --v-amber-300: #FCD34D; --v-amber-400: #FBBF24; --v-amber-500: #F59E0B;
-  --v-amber-600: #D97706; --v-amber-700: #B45309; --v-amber-800: #92400E;
-  --v-amber-900: #78350F; --v-amber-950: #451A03;
-
-  /* ── Spacing (4pt grid) ─────────────────────────────────────── */
-  --v-spacing-xxs:  2px;
-  --v-spacing-xs:   4px;
-  --v-spacing-sm:   8px;
-  --v-spacing-md:   12px;
-  --v-spacing-lg:   16px;
-  --v-spacing-xl:   24px;
-  --v-spacing-xxl:  32px;
-  --v-spacing-xxxl: 48px;
-
-  /* ── Radius ─────────────────────────────────────────────────── */
-  --v-radius-xs:   2px;
-  --v-radius-sm:   4px;
-  --v-radius-md:   8px;
-  --v-radius-lg:   12px;
-  --v-radius-xl:   16px;
-  --v-radius-pill: 999px;
-
-  /* ── Shadows ────────────────────────────────────────────────── */
-  --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.08);
-  --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.12);
-  --v-shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.16);
-
-  /* ── Animation ──────────────────────────────────────────────── */
-  --v-duration-fast:     0.15s;
-  --v-duration-standard: 0.25s;
-  --v-duration-slow:     0.4s;
-
-  /* ── Typography ─────────────────────────────────────────────── */
-  --v-font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text",
-    "Helvetica Neue", sans-serif;
-  --v-font-mono: "SF Mono", SFMono-Regular, ui-monospace, Menlo,
-    Monaco, monospace;
-  --v-font-size-xs:   10px;
-  --v-font-size-sm:   11px;
-  --v-font-size-base: 14px;
-  --v-font-size-lg:   17px;
-  --v-font-size-xl:   22px;
-  --v-font-size-2xl:  26px;
-  --v-line-height:    1.5;
-}
-
-/* ── Dark Mode (matches SwiftUI VColor semantic values) ───────── */
-
-@media (prefers-color-scheme: dark) {
   :root {
-    --v-primary-disabled: #3A3A37;
-    --v-primary-base: #657D5B;
-    --v-primary-hover: #516748;
-    --v-primary-active: #7A8B6F;
-    --v-surface-base: #2A2A28;
-    --v-surface-overlay: #20201E;
-    --v-surface-active: #3A3A37;
-    --v-surface-lift: #000000;
-    --v-border-disabled: #3A3A37;
-    --v-border-base: #4A4A46;
-    --v-border-hover: #6B6B65;
-    --v-border-active: #7A8B6F;
-    --v-content-emphasized: #F5F3EB;
-    --v-content-default: #E8E6DA;
-    --v-content-secondary: #BDB9A9;
-    --v-content-tertiary: #A1A096;
-    --v-content-disabled: #6B6B65;
-    --v-content-background: #3A3A37;
-    --v-content-inset: #000000;
+    /* ── Semantic Colors (Light Mode — default) ─────────────────── */
+    --v-primary-disabled: #d4d1c1;
+    --v-primary-base: #516748;
+    --v-primary-hover: #657d5b;
+    --v-primary-active: #7a8b6f;
+    --v-surface-base: #e8e6da;
+    --v-surface-overlay: #f5f3eb;
+    --v-surface-active: #d4d1c1;
+    --v-surface-lift: #ffffff;
+    --v-border-disabled: #d4d1c1;
+    --v-border-base: #bdb9a9;
+    --v-border-hover: #a1a096;
+    --v-border-active: #7a8b6f;
+    --v-content-emphasized: #20201e;
+    --v-content-default: #2a2a28;
+    --v-content-secondary: #4a4a46;
+    --v-content-tertiary: #a1a096;
+    --v-content-disabled: #bdb9a9;
+    --v-content-background: #d4d1c1;
+    --v-content-inset: #ffffff;
     --v-system-positive-strong: #516748;
-    --v-system-positive-weak: #1A2316;
-    --v-system-negative-strong: #DA491A;
-    --v-system-negative-hover: #AB3F1C;
-    --v-system-negative-weak: #4E281D;
-    --v-system-mid-strong: #F1B21E;
-    --v-system-mid-weak: #4B3D1E;
-    --v-aux-white: #FFFFFF;
+    --v-system-positive-weak: #d4dfd0;
+    --v-system-negative-strong: #da491a;
+    --v-system-negative-hover: #e86b40;
+    --v-system-negative-weak: #f7dac9;
+    --v-system-mid-strong: #f1b21e;
+    --v-system-mid-weak: #fcf3dd;
+    --v-aux-white: #ffffff;
 
-    --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
-    --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
-    --v-shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.5);
+    /* ── Shorthand Aliases (referenced by app-builder SKILL.md) ── */
+    --v-bg: var(--v-surface-overlay);
+    --v-surface: var(--v-surface-base);
+    --v-surface-border: var(--v-border-base);
+    --v-text: var(--v-content-default);
+    --v-text-secondary: var(--v-content-secondary);
+    --v-text-muted: var(--v-content-tertiary);
+    --v-accent: var(--v-primary-base);
+    --v-accent-hover: var(--v-primary-hover);
+    --v-success: var(--v-system-positive-strong);
+    --v-danger: var(--v-system-negative-strong);
+    --v-warning: var(--v-system-mid-strong);
+
+    /* ── Palette Scales (Tailwind-style, referenced by SKILL.md) ─ */
+    --v-slate-50: #f8fafc;
+    --v-slate-100: #f1f5f9;
+    --v-slate-200: #e2e8f0;
+    --v-slate-300: #cbd5e1;
+    --v-slate-400: #94a3b8;
+    --v-slate-500: #64748b;
+    --v-slate-600: #475569;
+    --v-slate-700: #334155;
+    --v-slate-800: #1e293b;
+    --v-slate-900: #0f172a;
+    --v-slate-950: #020617;
+    --v-emerald-50: #ecfdf5;
+    --v-emerald-100: #d1fae5;
+    --v-emerald-200: #a7f3d0;
+    --v-emerald-300: #6ee7b7;
+    --v-emerald-400: #34d399;
+    --v-emerald-500: #10b981;
+    --v-emerald-600: #059669;
+    --v-emerald-700: #047857;
+    --v-emerald-800: #065f46;
+    --v-emerald-900: #064e3b;
+    --v-emerald-950: #022c22;
+    --v-violet-50: #f5f3ff;
+    --v-violet-100: #ede9fe;
+    --v-violet-200: #ddd6fe;
+    --v-violet-300: #c4b5fd;
+    --v-violet-400: #a78bfa;
+    --v-violet-500: #8b5cf6;
+    --v-violet-600: #7c3aed;
+    --v-violet-700: #6d28d9;
+    --v-violet-800: #5b21b6;
+    --v-violet-900: #4c1d95;
+    --v-violet-950: #2e1065;
+    --v-indigo-50: #eef2ff;
+    --v-indigo-100: #e0e7ff;
+    --v-indigo-200: #c7d2fe;
+    --v-indigo-300: #a5b4fc;
+    --v-indigo-400: #818cf8;
+    --v-indigo-500: #6366f1;
+    --v-indigo-600: #4f46e5;
+    --v-indigo-700: #4338ca;
+    --v-indigo-800: #3730a3;
+    --v-indigo-900: #312e81;
+    --v-indigo-950: #1e1b4b;
+    --v-rose-50: #fff1f2;
+    --v-rose-100: #ffe4e6;
+    --v-rose-200: #fecdd3;
+    --v-rose-300: #fda4af;
+    --v-rose-400: #fb7185;
+    --v-rose-500: #f43f5e;
+    --v-rose-600: #e11d48;
+    --v-rose-700: #be123c;
+    --v-rose-800: #9f1239;
+    --v-rose-900: #881337;
+    --v-rose-950: #4c0519;
+    --v-amber-50: #fffbeb;
+    --v-amber-100: #fef3c7;
+    --v-amber-200: #fde68a;
+    --v-amber-300: #fcd34d;
+    --v-amber-400: #fbbf24;
+    --v-amber-500: #f59e0b;
+    --v-amber-600: #d97706;
+    --v-amber-700: #b45309;
+    --v-amber-800: #92400e;
+    --v-amber-900: #78350f;
+    --v-amber-950: #451a03;
+
+    /* ── Spacing (4pt grid) ─────────────────────────────────────── */
+    --v-spacing-xxs: 2px;
+    --v-spacing-xs: 4px;
+    --v-spacing-sm: 8px;
+    --v-spacing-md: 12px;
+    --v-spacing-lg: 16px;
+    --v-spacing-xl: 24px;
+    --v-spacing-xxl: 32px;
+    --v-spacing-xxxl: 48px;
+
+    /* ── Radius ─────────────────────────────────────────────────── */
+    --v-radius-xs: 2px;
+    --v-radius-sm: 4px;
+    --v-radius-md: 8px;
+    --v-radius-lg: 12px;
+    --v-radius-xl: 16px;
+    --v-radius-pill: 999px;
+
+    /* ── Shadows ────────────────────────────────────────────────── */
+    --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.08);
+    --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.12);
+    --v-shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.16);
+
+    /* ── Animation ──────────────────────────────────────────────── */
+    --v-duration-fast: 0.15s;
+    --v-duration-standard: 0.25s;
+    --v-duration-slow: 0.4s;
+
+    /* ── Typography ─────────────────────────────────────────────── */
+    --v-font-family:
+      -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue",
+      sans-serif;
+    --v-font-mono:
+      "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, monospace;
+    --v-font-size-xs: 10px;
+    --v-font-size-sm: 11px;
+    --v-font-size-base: 14px;
+    --v-font-size-lg: 17px;
+    --v-font-size-xl: 22px;
+    --v-font-size-2xl: 26px;
+    --v-line-height: 1.5;
   }
-}
 
-/* ─── Layer 2: Element Defaults ──────────────────────────────── */
+  /* ── Dark Mode (matches SwiftUI VColor semantic values) ───────── */
 
-body {
-  margin: 0;
-  font-family: var(--v-font-family);
-  font-size: var(--v-font-size-base);
-  line-height: var(--v-line-height);
-  color: var(--v-content-default);
-  background: var(--v-surface-overlay);
-  padding: var(--v-spacing-xl);
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  -webkit-font-smoothing: antialiased;
-}
-body > *:not(#vellum-bottom-fade):not(#v-toast-container) {
-  width: 100%;
-}
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --v-primary-disabled: #3a3a37;
+      --v-primary-base: #657d5b;
+      --v-primary-hover: #516748;
+      --v-primary-active: #7a8b6f;
+      --v-surface-base: #2a2a28;
+      --v-surface-overlay: #20201e;
+      --v-surface-active: #3a3a37;
+      --v-surface-lift: #000000;
+      --v-border-disabled: #3a3a37;
+      --v-border-base: #4a4a46;
+      --v-border-hover: #6b6b65;
+      --v-border-active: #7a8b6f;
+      --v-content-emphasized: #f5f3eb;
+      --v-content-default: #e8e6da;
+      --v-content-secondary: #bdb9a9;
+      --v-content-tertiary: #a1a096;
+      --v-content-disabled: #6b6b65;
+      --v-content-background: #3a3a37;
+      --v-content-inset: #000000;
+      --v-system-positive-strong: #516748;
+      --v-system-positive-weak: #1a2316;
+      --v-system-negative-strong: #da491a;
+      --v-system-negative-hover: #ab3f1c;
+      --v-system-negative-weak: #4e281d;
+      --v-system-mid-strong: #f1b21e;
+      --v-system-mid-weak: #4b3d1e;
+      --v-aux-white: #ffffff;
 
-@media (prefers-color-scheme: dark) {
+      --v-shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
+      --v-shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
+      --v-shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.5);
+    }
+  }
+
+  /* ─── Layer 2: Element Defaults ──────────────────────────────── */
+
   body {
-    background:
-      radial-gradient(ellipse at 50% 0%, var(--v-surface-base) 0%, transparent 50%),
-      var(--v-surface-overlay);
+    margin: 0;
+    font-family: var(--v-font-family);
+    font-size: var(--v-font-size-base);
+    line-height: var(--v-line-height);
+    color: var(--v-content-default);
+    background: var(--v-surface-overlay);
+    padding: var(--v-spacing-xl);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    -webkit-font-smoothing: antialiased;
   }
-}
+  body > *:not(#vellum-bottom-fade):not(#v-toast-container) {
+    width: 100%;
+  }
 
-h1, h2, h3, h4, h5, h6 {
-  line-height: 1.2;
-  margin: 0 0 var(--v-spacing-md) 0;
-  color: var(--v-content-default);
-}
+  @media (prefers-color-scheme: dark) {
+    body {
+      background:
+        radial-gradient(
+          ellipse at 50% 0%,
+          var(--v-surface-base) 0%,
+          transparent 50%
+        ),
+        var(--v-surface-overlay);
+    }
+  }
 
-h1 { font-size: var(--v-font-size-2xl); font-weight: 700; }
-h2 { font-size: var(--v-font-size-xl); font-weight: 600; }
-h3 { font-size: var(--v-font-size-lg); font-weight: 600; }
-h4 { font-size: var(--v-font-size-base); font-weight: 600; }
-h5 { font-size: var(--v-font-size-sm); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
-h6 { font-size: var(--v-font-size-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    line-height: 1.2;
+    margin: 0 0 var(--v-spacing-md) 0;
+    color: var(--v-content-default);
+  }
 
-p { margin: 0 0 var(--v-spacing-md) 0; }
+  h1 {
+    font-size: var(--v-font-size-2xl);
+    font-weight: 700;
+  }
+  h2 {
+    font-size: var(--v-font-size-xl);
+    font-weight: 600;
+  }
+  h3 {
+    font-size: var(--v-font-size-lg);
+    font-weight: 600;
+  }
+  h4 {
+    font-size: var(--v-font-size-base);
+    font-weight: 600;
+  }
+  h5 {
+    font-size: var(--v-font-size-sm);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  h6 {
+    font-size: var(--v-font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
 
-a {
-  color: var(--v-primary-base);
-  text-decoration: none;
-}
-a:hover { text-decoration: underline; }
+  p {
+    margin: 0 0 var(--v-spacing-md) 0;
+  }
 
-button {
-  font-family: var(--v-font-family);
-  font-size: var(--v-font-size-base);
-  border: none;
-  background: none;
-  cursor: pointer;
-  color: inherit;
-}
+  a {
+    color: var(--v-primary-base);
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
 
-input, textarea, select {
-  font-family: var(--v-font-family);
-  font-size: var(--v-font-size-base);
-  padding: var(--v-spacing-sm) var(--v-spacing-md);
-  background: var(--v-surface-overlay);
-  color: var(--v-content-default);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-md);
-  outline: none;
-  transition: border-color var(--v-duration-fast) ease-out;
-}
-select {
-  -webkit-appearance: none;
-  appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2386868B' d='M6 8.5L1.5 4h9z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right var(--v-spacing-md) center;
-  padding-right: calc(var(--v-spacing-md) + 20px);
-}
-input:focus, textarea:focus, select:focus {
-  border-color: var(--v-primary-base);
-}
+  button {
+    font-family: var(--v-font-family);
+    font-size: var(--v-font-size-base);
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: inherit;
+  }
 
-textarea { resize: vertical; }
+  input,
+  textarea,
+  select {
+    font-family: var(--v-font-family);
+    font-size: var(--v-font-size-base);
+    padding: var(--v-spacing-sm) var(--v-spacing-md);
+    background: var(--v-surface-overlay);
+    color: var(--v-content-default);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-md);
+    outline: none;
+    transition: border-color var(--v-duration-fast) ease-out;
+  }
+  select {
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2386868B' d='M6 8.5L1.5 4h9z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right var(--v-spacing-md) center;
+    padding-right: calc(var(--v-spacing-md) + 20px);
+  }
+  input:focus,
+  textarea:focus,
+  select:focus {
+    border-color: var(--v-primary-base);
+  }
 
-code {
-  font-family: var(--v-font-mono);
-  font-size: 0.9em;
-  background: var(--v-surface-base);
-  padding: var(--v-spacing-xxs) var(--v-spacing-xs);
-  border-radius: var(--v-radius-sm);
-}
+  textarea {
+    resize: vertical;
+  }
 
-pre {
-  font-family: var(--v-font-mono);
-  font-size: var(--v-font-size-sm);
-  background: var(--v-surface-base);
-  padding: var(--v-spacing-lg);
-  border-radius: var(--v-radius-md);
-  overflow-x: auto;
-  margin: 0 0 var(--v-spacing-md) 0;
-}
-pre code {
-  background: none;
-  padding: 0;
-}
+  code {
+    font-family: var(--v-font-mono);
+    font-size: 0.9em;
+    background: var(--v-surface-base);
+    padding: var(--v-spacing-xxs) var(--v-spacing-xs);
+    border-radius: var(--v-radius-sm);
+  }
 
-hr {
-  border: none;
-  border-top: 1px solid var(--v-border-base);
-  margin: var(--v-spacing-xl) 0;
-}
+  pre {
+    font-family: var(--v-font-mono);
+    font-size: var(--v-font-size-sm);
+    background: var(--v-surface-base);
+    padding: var(--v-spacing-lg);
+    border-radius: var(--v-radius-md);
+    overflow-x: auto;
+    margin: 0 0 var(--v-spacing-md) 0;
+  }
+  pre code {
+    background: none;
+    padding: 0;
+  }
 
-ul, ol { padding-left: var(--v-spacing-xl); margin: 0 0 var(--v-spacing-md) 0; }
+  hr {
+    border: none;
+    border-top: 1px solid var(--v-border-base);
+    margin: var(--v-spacing-xl) 0;
+  }
 
-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 0 0 var(--v-spacing-md) 0;
-}
-th, td {
-  text-align: left;
-  padding: var(--v-spacing-sm) var(--v-spacing-md);
-  border-bottom: 1px solid var(--v-border-base);
-}
-th { font-weight: 600; color: var(--v-content-secondary); font-size: var(--v-font-size-sm); }
+  ul,
+  ol {
+    padding-left: var(--v-spacing-xl);
+    margin: 0 0 var(--v-spacing-md) 0;
+  }
 
-/* ─── Layer 3: Component Classes ─────────────────────────────── */
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 var(--v-spacing-md) 0;
+  }
+  th,
+  td {
+    text-align: left;
+    padding: var(--v-spacing-sm) var(--v-spacing-md);
+    border-bottom: 1px solid var(--v-border-base);
+  }
+  th {
+    font-weight: 600;
+    color: var(--v-content-secondary);
+    font-size: var(--v-font-size-sm);
+  }
 
-/* Button variants */
-.v-button {
-  font-family: var(--v-font-family);
-  font-size: var(--v-font-size-base);
-  font-weight: 500;
-  padding: var(--v-spacing-sm) var(--v-spacing-lg);
-  background: var(--v-primary-base);
-  color: var(--v-aux-white);
-  border: none;
-  border-radius: var(--v-radius-md);
-  cursor: pointer;
-  transition: filter var(--v-duration-fast) ease-out,
-              transform var(--v-duration-fast) ease-out;
-}
-.v-button:hover { filter: brightness(1.1); }
-.v-button:active { transform: scale(0.97); }
-.v-button:disabled { opacity: 0.4; cursor: not-allowed; filter: none; transform: none; }
-.v-button.secondary {
-  background: var(--v-surface-base);
-  color: var(--v-content-default);
-  border: 1px solid var(--v-border-base);
-}
-.v-button.secondary:hover { filter: brightness(0.95); }
-.v-button.danger {
-  background: var(--v-system-negative-strong);
-}
-.v-button.ghost {
-  background: transparent;
-  color: var(--v-primary-base);
-}
-.v-button.ghost:hover { background: var(--v-surface-base); filter: none; }
+  /* ─── Layer 3: Component Classes ─────────────────────────────── */
 
-/* Focus-visible for keyboard accessibility */
-.v-button:focus-visible {
-  outline: 2px solid var(--v-primary-base);
-  outline-offset: 2px;
-}
-input:focus-visible, textarea:focus-visible, select:focus-visible {
-  border-color: var(--v-primary-base);
-  outline: 2px solid var(--v-primary-base);
-  outline-offset: -1px;
-}
+  /* Button variants */
+  .v-button {
+    font-family: var(--v-font-family);
+    font-size: var(--v-font-size-base);
+    font-weight: 500;
+    padding: var(--v-spacing-sm) var(--v-spacing-lg);
+    background: var(--v-primary-base);
+    color: var(--v-aux-white);
+    border: none;
+    border-radius: var(--v-radius-md);
+    cursor: pointer;
+    transition:
+      filter var(--v-duration-fast) ease-out,
+      transform var(--v-duration-fast) ease-out;
+  }
+  .v-button:hover {
+    filter: brightness(1.1);
+  }
+  .v-button:active {
+    transform: scale(0.97);
+  }
+  .v-button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    filter: none;
+    transform: none;
+  }
+  .v-button.secondary {
+    background: var(--v-surface-base);
+    color: var(--v-content-default);
+    border: 1px solid var(--v-border-base);
+  }
+  .v-button.secondary:hover {
+    filter: brightness(0.95);
+  }
+  .v-button.danger {
+    background: var(--v-system-negative-strong);
+  }
+  .v-button.ghost {
+    background: transparent;
+    color: var(--v-primary-base);
+  }
+  .v-button.ghost:hover {
+    background: var(--v-surface-base);
+    filter: none;
+  }
 
-/* Card */
-.v-card {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-lg);
-  box-shadow: var(--v-shadow-sm);
-}
+  /* Focus-visible for keyboard accessibility */
+  .v-button:focus-visible {
+    outline: 2px solid var(--v-primary-base);
+    outline-offset: 2px;
+  }
+  input:focus-visible,
+  textarea:focus-visible,
+  select:focus-visible {
+    border-color: var(--v-primary-base);
+    outline: 2px solid var(--v-primary-base);
+    outline-offset: -1px;
+  }
 
-/* Badge */
-.v-badge {
-  display: inline-flex;
-  align-items: center;
-  font-size: var(--v-font-size-xs);
-  font-weight: 600;
-  padding: var(--v-spacing-xxs) var(--v-spacing-sm);
-  border-radius: var(--v-radius-pill);
-  background: var(--v-surface-base);
-  color: var(--v-content-secondary);
-}
-.v-badge.success { background: color-mix(in srgb, var(--v-system-positive-strong) 15%, transparent); color: var(--v-system-positive-strong); }
-.v-badge.danger  { background: color-mix(in srgb, var(--v-system-negative-strong) 15%, transparent);  color: var(--v-system-negative-strong); }
-.v-badge.warning { background: color-mix(in srgb, var(--v-system-mid-strong) 15%, transparent); color: var(--v-system-mid-strong); }
+  /* Card */
+  .v-card {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-lg);
+    box-shadow: var(--v-shadow-sm);
+  }
 
-/* List */
-.v-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.v-list-item {
-  padding: var(--v-spacing-md) var(--v-spacing-lg);
-  border-radius: var(--v-radius-md);
-  transition: background var(--v-duration-fast) ease-out;
-}
-.v-list-item:hover { background: var(--v-surface-base); }
-.v-list-item:focus-visible {
-  outline: 2px solid var(--v-primary-base);
-  outline-offset: -2px;
-}
+  /* Badge */
+  .v-badge {
+    display: inline-flex;
+    align-items: center;
+    font-size: var(--v-font-size-xs);
+    font-weight: 600;
+    padding: var(--v-spacing-xxs) var(--v-spacing-sm);
+    border-radius: var(--v-radius-pill);
+    background: var(--v-surface-base);
+    color: var(--v-content-secondary);
+  }
+  .v-badge.success {
+    background: color-mix(
+      in srgb,
+      var(--v-system-positive-strong) 15%,
+      transparent
+    );
+    color: var(--v-system-positive-strong);
+  }
+  .v-badge.danger {
+    background: color-mix(
+      in srgb,
+      var(--v-system-negative-strong) 15%,
+      transparent
+    );
+    color: var(--v-system-negative-strong);
+  }
+  .v-badge.warning {
+    background: color-mix(in srgb, var(--v-system-mid-strong) 15%, transparent);
+    color: var(--v-system-mid-strong);
+  }
 
-/* Toggle switch */
-.v-toggle {
-  position: relative;
-  display: inline-block;
-  width: 40px;
-  height: 22px;
-}
-.v-toggle input {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  opacity: 0;
-  margin: 0;
-  cursor: pointer;
-}
-.v-toggle-track {
-  position: absolute;
-  inset: 0;
-  background: var(--v-border-base);
-  border-radius: var(--v-radius-pill);
-  cursor: pointer;
-  transition: background var(--v-duration-fast) ease-out;
-}
-.v-toggle-track::after {
-  content: "";
-  position: absolute;
-  top: 2px; left: 2px;
-  width: 18px; height: 18px;
-  background: white;
-  border-radius: 50%;
-  transition: transform var(--v-duration-fast) ease-out;
-}
-.v-toggle input:checked + .v-toggle-track {
-  background: var(--v-primary-base);
-}
-.v-toggle input:checked + .v-toggle-track::after {
-  transform: translateX(18px);
-}
-.v-toggle input:focus-visible + .v-toggle-track {
-  outline: 2px solid var(--v-primary-base);
-  outline-offset: 2px;
-}
+  /* List */
+  .v-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .v-list-item {
+    padding: var(--v-spacing-md) var(--v-spacing-lg);
+    border-radius: var(--v-radius-md);
+    transition: background var(--v-duration-fast) ease-out;
+  }
+  .v-list-item:hover {
+    background: var(--v-surface-base);
+  }
+  .v-list-item:focus-visible {
+    outline: 2px solid var(--v-primary-base);
+    outline-offset: -2px;
+  }
 
-/* Input row (input + button combo) */
-.v-input-row {
-  display: flex;
-  gap: var(--v-spacing-sm);
-}
-.v-input-row input,
-.v-input-row .v-input {
-  flex: 1;
-}
-
-/* ─── Layer 4: Utility Classes ───────────────────────────────── */
-
-/* Flexbox */
-.v-flex       { display: flex; }
-.v-flex-col   { display: flex; flex-direction: column; }
-.v-flex-wrap  { flex-wrap: wrap; }
-.v-items-center    { align-items: center; }
-.v-justify-between { justify-content: space-between; }
-.v-justify-center  { justify-content: center; }
-
-/* Gap */
-.v-gap-xs  { gap: var(--v-spacing-xs); }
-.v-gap-sm  { gap: var(--v-spacing-sm); }
-.v-gap-md  { gap: var(--v-spacing-md); }
-.v-gap-lg  { gap: var(--v-spacing-lg); }
-.v-gap-xl  { gap: var(--v-spacing-xl); }
-
-/* Text */
-.v-text-secondary { color: var(--v-content-secondary); }
-.v-text-muted     { color: var(--v-content-tertiary); }
-.v-text-accent    { color: var(--v-primary-base); }
-.v-text-xs  { font-size: var(--v-font-size-xs); }
-.v-text-sm  { font-size: var(--v-font-size-sm); }
-.v-text-lg  { font-size: var(--v-font-size-lg); }
-.v-font-mono { font-family: var(--v-font-mono); }
-
-/* Layout */
-.v-truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.v-w-full { width: 100%; }
-
-/* Accessibility */
-.v-sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
-/* ─── Layer 5: Widget Components ────────────────────────────── */
-
-/* ── Tier 1: Layout & Data Primitives ───────────────────────── */
-
-/* Metric Card — single big number with label and trend arrow */
-.v-metric-card {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-xs);
-}
-.v-metric-card .v-metric-value {
-  font-size: var(--v-font-size-2xl);
-  font-weight: 700;
-  line-height: 1.1;
-  color: var(--v-content-default);
-}
-.v-metric-card .v-metric-label {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-.v-metric-card .v-metric-trend {
-  font-size: var(--v-font-size-sm);
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--v-spacing-xxs);
-}
-.v-metric-card .v-metric-trend.up   { color: var(--v-system-positive-strong); }
-.v-metric-card .v-metric-trend.down { color: var(--v-system-negative-strong); }
-.v-metric-card .v-metric-trend.neutral { color: var(--v-content-tertiary); }
-
-/* Metric Grid — responsive grid of metric cards */
-.v-metric-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: var(--v-spacing-lg);
-}
-
-/* Data Table — sortable, hoverable, sticky header */
-.v-data-table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  overflow: hidden;
-}
-.v-data-table thead th {
-  position: sticky;
-  top: 0;
-  background: var(--v-surface-overlay);
-  font-size: var(--v-font-size-sm);
-  font-weight: 600;
-  color: var(--v-content-secondary);
-  text-align: left;
-  padding: var(--v-spacing-sm) var(--v-spacing-md);
-  border-bottom: 1px solid var(--v-border-base);
-  cursor: default;
-  user-select: none;
-  white-space: nowrap;
-}
-.v-data-table thead th[data-sortable] {
-  cursor: pointer;
-}
-.v-data-table thead th[data-sortable]:hover {
-  color: var(--v-content-default);
-}
-.v-data-table tbody td {
-  padding: var(--v-spacing-sm) var(--v-spacing-md);
-  border-bottom: 1px solid var(--v-border-base);
-  font-size: var(--v-font-size-base);
-  color: var(--v-content-default);
-}
-.v-data-table tbody tr:last-child td {
-  border-bottom: none;
-}
-.v-data-table tbody tr:hover {
-  background: color-mix(in srgb, var(--v-primary-base) 5%, transparent);
-}
-.v-data-table tbody tr.selected {
-  background: color-mix(in srgb, var(--v-primary-base) 10%, transparent);
-}
-.v-data-table input[type="checkbox"] {
-  accent-color: var(--v-primary-base);
-}
-
-/* Timeline — vertical timeline with entries */
-.v-timeline {
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  padding-left: var(--v-spacing-xl);
-}
-.v-timeline::before {
-  content: "";
-  position: absolute;
-  left: 7px;
-  top: var(--v-spacing-xs);
-  bottom: var(--v-spacing-xs);
-  width: 2px;
-  background: var(--v-border-base);
-}
-.v-timeline-entry {
-  position: relative;
-  padding-bottom: var(--v-spacing-lg);
-}
-.v-timeline-entry::before {
-  content: "";
-  position: absolute;
-  left: calc(-1 * var(--v-spacing-xl) + 3px);
-  top: 6px;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--v-border-base);
-  border: 2px solid var(--v-surface-overlay);
-}
-.v-timeline-entry.active::before {
-  background: var(--v-primary-base);
-}
-.v-timeline-entry.success::before {
-  background: var(--v-system-positive-strong);
-}
-.v-timeline-entry.error::before {
-  background: var(--v-system-negative-strong);
-}
-.v-timeline-entry .v-timeline-time {
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-tertiary);
-  margin-bottom: var(--v-spacing-xxs);
-}
-.v-timeline-entry .v-timeline-title {
-  font-size: var(--v-font-size-base);
-  font-weight: 600;
-  color: var(--v-content-default);
-}
-.v-timeline-entry .v-timeline-desc {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-  margin-top: var(--v-spacing-xxs);
-}
-
-/* Action List — rows with per-item action buttons */
-.v-action-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-}
-.v-action-list-item {
-  display: flex;
-  align-items: center;
-  gap: var(--v-spacing-md);
-  padding: var(--v-spacing-md) var(--v-spacing-lg);
-  border-bottom: 1px solid var(--v-border-base);
-  transition: background var(--v-duration-fast) ease-out;
-}
-.v-action-list-item:last-child {
-  border-bottom: none;
-}
-.v-action-list-item:hover {
-  background: var(--v-surface-base);
-}
-.v-action-list-item .v-action-content {
-  flex: 1;
-  min-width: 0;
-}
-.v-action-list-item .v-action-title {
-  font-weight: 500;
-  color: var(--v-content-default);
-}
-.v-action-list-item .v-action-subtitle {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-  margin-top: var(--v-spacing-xxs);
-}
-.v-action-list-item .v-action-buttons {
-  display: flex;
-  gap: var(--v-spacing-xs);
-  flex-shrink: 0;
-}
-
-/* Tabs — tab bar + tab panels */
-.v-tabs {
-  display: flex;
-  flex-direction: column;
-}
-.v-tab-bar {
-  display: flex;
-  gap: 0;
-  border-bottom: 1px solid var(--v-border-base);
-}
-.v-tab {
-  padding: var(--v-spacing-sm) var(--v-spacing-lg);
-  font-size: var(--v-font-size-base);
-  font-weight: 500;
-  color: var(--v-content-secondary);
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  cursor: pointer;
-  transition: color var(--v-duration-fast) ease-out,
-              border-color var(--v-duration-fast) ease-out;
-}
-.v-tab:hover {
-  color: var(--v-content-default);
-}
-.v-tab[aria-selected="true"],
-.v-tab.active {
-  color: var(--v-primary-base);
-  border-bottom-color: var(--v-primary-base);
-}
-.v-tab:focus-visible {
-  outline: 2px solid var(--v-primary-base);
-  outline-offset: -2px;
-}
-.v-tab-panel {
-  padding: var(--v-spacing-lg) 0;
-}
-.v-tab-panel[hidden] {
-  display: none;
-}
-
-/* Accordion — collapsible sections */
-.v-accordion {
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  overflow: hidden;
-}
-.v-accordion-item {
-  border-bottom: 1px solid var(--v-border-base);
-}
-.v-accordion-item:last-child {
-  border-bottom: none;
-}
-.v-accordion-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: var(--v-spacing-md) var(--v-spacing-lg);
-  background: var(--v-surface-base);
-  border: none;
-  cursor: pointer;
-  font-size: var(--v-font-size-base);
-  font-weight: 500;
-  color: var(--v-content-default);
-  text-align: left;
-  transition: background var(--v-duration-fast) ease-out;
-}
-.v-accordion-header:hover {
-  background: color-mix(in srgb, var(--v-surface-base) 80%, var(--v-surface-overlay));
-}
-.v-accordion-header::after {
-  content: "\203A";
-  font-size: var(--v-font-size-lg);
-  color: var(--v-content-tertiary);
-  transform: rotate(90deg);
-  transition: transform var(--v-duration-standard) ease-in-out;
-}
-.v-accordion-item[open] .v-accordion-header::after,
-.v-accordion-header[aria-expanded="true"]::after {
-  transform: rotate(270deg);
-}
-.v-accordion-body {
-  padding: var(--v-spacing-lg);
-  background: var(--v-surface-overlay);
-}
-.v-accordion-header:focus-visible {
-  outline: 2px solid var(--v-primary-base);
-  outline-offset: -2px;
-}
-
-/* Search Bar — input with icon and clear button */
-.v-search-bar {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-.v-search-bar input {
-  width: 100%;
-  padding-left: var(--v-spacing-xxl);
-  padding-right: var(--v-spacing-xxl);
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-pill);
-}
-.v-search-bar input:focus {
-  border-color: var(--v-primary-base);
-}
-.v-search-bar::before {
-  content: "\1F50D";
-  position: absolute;
-  left: var(--v-spacing-md);
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-tertiary);
-  pointer-events: none;
-}
-.v-search-bar .v-search-clear {
-  position: absolute;
-  right: var(--v-spacing-sm);
-  background: none;
-  border: none;
-  color: var(--v-content-tertiary);
-  cursor: pointer;
-  font-size: var(--v-font-size-sm);
-  padding: var(--v-spacing-xs);
-  border-radius: 50%;
-}
-.v-search-bar .v-search-clear:hover {
-  color: var(--v-content-default);
-  background: var(--v-border-base);
-}
-
-/* Card Grid — responsive grid of cards */
-.v-card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: var(--v-spacing-lg);
-}
-
-/* Progress Bar — horizontal fill bar with label */
-.v-progress-bar {
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-xs);
-}
-.v-progress-bar .v-progress-header {
-  display: flex;
-  justify-content: space-between;
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-}
-.v-progress-bar .v-progress-track {
-  height: 8px;
-  background: var(--v-border-base);
-  border-radius: var(--v-radius-pill);
-  overflow: hidden;
-}
-.v-progress-bar .v-progress-fill {
-  height: 100%;
-  background: var(--v-primary-base);
-  border-radius: var(--v-radius-pill);
-  transition: width var(--v-duration-standard) ease-in-out;
-}
-.v-progress-bar .v-progress-fill.success { background: var(--v-system-positive-strong); }
-.v-progress-bar .v-progress-fill.warning { background: var(--v-system-mid-strong); }
-.v-progress-bar .v-progress-fill.danger  { background: var(--v-system-negative-strong); }
-
-/* Status Badge — colored pill with dot indicator */
-.v-status-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--v-spacing-xs);
-  font-size: var(--v-font-size-xs);
-  font-weight: 600;
-  padding: var(--v-spacing-xxs) var(--v-spacing-sm);
-  border-radius: var(--v-radius-pill);
-  background: var(--v-surface-base);
-  color: var(--v-content-secondary);
-}
-.v-status-badge::before {
-  content: "";
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-  flex-shrink: 0;
-}
-.v-status-badge.success {
-  background: color-mix(in srgb, var(--v-system-positive-strong) 15%, transparent);
-  color: var(--v-system-positive-strong);
-}
-.v-status-badge.warning {
-  background: color-mix(in srgb, var(--v-system-mid-strong) 15%, transparent);
-  color: var(--v-system-mid-strong);
-}
-.v-status-badge.error {
-  background: color-mix(in srgb, var(--v-system-negative-strong) 15%, transparent);
-  color: var(--v-system-negative-strong);
-}
-.v-status-badge.info {
-  background: color-mix(in srgb, var(--v-primary-base) 15%, transparent);
-  color: var(--v-primary-base);
-}
-
-/* Stat Row — horizontal strip of label-value pairs */
-.v-stat-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--v-spacing-lg);
-  padding: var(--v-spacing-md) 0;
-}
-.v-stat-row .v-stat {
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-xxs);
-}
-.v-stat-row .v-stat:not(:last-child) {
-  padding-right: var(--v-spacing-lg);
-  border-right: 1px solid var(--v-border-base);
-}
-.v-stat-row .v-stat-label {
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-tertiary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-weight: 500;
-}
-.v-stat-row .v-stat-value {
-  font-size: var(--v-font-size-lg);
-  font-weight: 700;
-  color: var(--v-content-default);
-}
-
-/* Toast — dismissible notification banner */
-.v-toast {
-  display: flex;
-  align-items: center;
-  gap: var(--v-spacing-md);
-  padding: var(--v-spacing-md) var(--v-spacing-lg);
-  border-radius: var(--v-radius-md);
-  font-size: var(--v-font-size-sm);
-  font-weight: 500;
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  box-shadow: var(--v-shadow-md);
-}
-.v-toast.success {
-  background: color-mix(in srgb, var(--v-system-positive-strong) 10%, var(--v-surface-base));
-  border-color: color-mix(in srgb, var(--v-system-positive-strong) 30%, var(--v-border-base));
-  color: var(--v-system-positive-strong);
-}
-.v-toast.error {
-  background: color-mix(in srgb, var(--v-system-negative-strong) 10%, var(--v-surface-base));
-  border-color: color-mix(in srgb, var(--v-system-negative-strong) 30%, var(--v-border-base));
-  color: var(--v-system-negative-strong);
-}
-.v-toast.warning {
-  background: color-mix(in srgb, var(--v-system-mid-strong) 10%, var(--v-surface-base));
-  border-color: color-mix(in srgb, var(--v-system-mid-strong) 30%, var(--v-border-base));
-  color: var(--v-system-mid-strong);
-}
-.v-toast.info {
-  background: color-mix(in srgb, var(--v-primary-base) 10%, var(--v-surface-base));
-  border-color: color-mix(in srgb, var(--v-primary-base) 30%, var(--v-border-base));
-  color: var(--v-primary-base);
-}
-.v-toast .v-toast-dismiss {
-  margin-left: auto;
-  background: none;
-  border: none;
-  color: inherit;
-  opacity: 0.6;
-  cursor: pointer;
-  font-size: var(--v-font-size-lg);
-  padding: 0 var(--v-spacing-xs);
-}
-.v-toast .v-toast-dismiss:hover {
-  opacity: 1;
-}
-
-/* Empty State — enhanced version with icon + CTA */
-.v-empty-state {
-  text-align: center;
-  color: var(--v-content-tertiary);
-  padding: var(--v-spacing-xxxl) var(--v-spacing-xl);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--v-spacing-md);
-}
-.v-empty-state .v-empty-icon {
-  font-size: 48px;
-  line-height: 1;
-  opacity: 0.5;
-}
-.v-empty-state .v-empty-title {
-  font-size: var(--v-font-size-lg);
-  font-weight: 600;
-  color: var(--v-content-secondary);
-  margin: 0;
-}
-.v-empty-state .v-empty-desc {
-  font-size: var(--v-font-size-base);
-  color: var(--v-content-tertiary);
-  max-width: 360px;
-}
-
-/* Divider — horizontal rule with optional label */
-.v-divider {
-  display: flex;
-  align-items: center;
-  gap: var(--v-spacing-md);
-  margin: var(--v-spacing-xl) 0;
-  color: var(--v-content-tertiary);
-  font-size: var(--v-font-size-xs);
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-.v-divider::before,
-.v-divider::after {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: var(--v-border-base);
-}
-.v-divider:empty::after {
-  display: none;
-}
-
-/* Avatar Row — circular avatar + name + subtitle */
-.v-avatar-row {
-  display: flex;
-  align-items: center;
-  gap: var(--v-spacing-md);
-}
-.v-avatar-row .v-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: var(--v-primary-base);
-  color: var(--v-content-inset);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  font-size: var(--v-font-size-sm);
-  flex-shrink: 0;
-  overflow: hidden;
-}
-.v-avatar-row .v-avatar img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-.v-avatar-row .v-avatar-info {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
-.v-avatar-row .v-avatar-name {
-  font-weight: 500;
-  color: var(--v-content-default);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.v-avatar-row .v-avatar-subtitle {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-}
-
-/* Tag / Chip Group — wrapping row of badges */
-.v-tag-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--v-spacing-xs);
-}
-
-/* ── Tier 2: Domain-Specific Widgets ────────────────────────── */
-
-/* Weather Card */
-.v-weather-card {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-md);
-}
-.v-weather-card .v-weather-main {
-  display: flex;
-  align-items: center;
-  gap: var(--v-spacing-lg);
-}
-.v-weather-card .v-weather-temp {
-  font-size: 48px;
-  font-weight: 700;
-  line-height: 1;
-  color: var(--v-content-default);
-}
-.v-weather-card .v-weather-condition {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-}
-.v-weather-card .v-weather-icon {
-  font-size: 48px;
-  line-height: 1;
-}
-.v-weather-card .v-weather-details {
-  display: flex;
-  gap: var(--v-spacing-lg);
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-}
-.v-weather-card .v-weather-forecast {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
-  gap: var(--v-spacing-sm);
-  text-align: center;
-}
-.v-weather-card .v-weather-forecast-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--v-spacing-xxs);
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-secondary);
-  padding: var(--v-spacing-sm);
-  border-radius: var(--v-radius-md);
-  background: color-mix(in srgb, var(--v-border-base) 30%, transparent);
-}
-
-/* Stock Ticker */
-.v-stock-ticker {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-md);
-}
-.v-stock-ticker .v-stock-header {
-  display: flex;
-  align-items: baseline;
-  gap: var(--v-spacing-md);
-}
-.v-stock-ticker .v-stock-symbol {
-  font-size: var(--v-font-size-lg);
-  font-weight: 700;
-  color: var(--v-content-default);
-}
-.v-stock-ticker .v-stock-price {
-  font-size: var(--v-font-size-2xl);
-  font-weight: 700;
-  color: var(--v-content-default);
-}
-.v-stock-ticker .v-stock-change {
-  font-size: var(--v-font-size-sm);
-  font-weight: 600;
-}
-.v-stock-ticker .v-stock-change.up   { color: var(--v-system-positive-strong); }
-.v-stock-ticker .v-stock-change.down { color: var(--v-system-negative-strong); }
-.v-stock-ticker .v-stock-chart {
-  width: 100%;
-  height: 120px;
-  border-radius: var(--v-radius-md);
-  overflow: hidden;
-}
-.v-stock-ticker .v-stock-meta {
-  display: flex;
-  gap: var(--v-spacing-lg);
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-tertiary);
-}
-
-/* Flight Card */
-.v-flight-card {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-md);
-}
-.v-flight-card .v-flight-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.v-flight-card .v-flight-airline {
-  font-weight: 600;
-  color: var(--v-content-default);
-}
-.v-flight-card .v-flight-price {
-  font-size: var(--v-font-size-lg);
-  font-weight: 700;
-  color: var(--v-primary-base);
-}
-.v-flight-card .v-flight-route {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--v-spacing-md);
-}
-.v-flight-card .v-flight-endpoint {
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-xxs);
-}
-.v-flight-card .v-flight-time {
-  font-size: var(--v-font-size-xl);
-  font-weight: 700;
-  color: var(--v-content-default);
-}
-.v-flight-card .v-flight-code {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-  font-weight: 500;
-}
-.v-flight-card .v-flight-duration {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--v-spacing-xxs);
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-tertiary);
-}
-.v-flight-card .v-flight-line {
-  width: 80px;
-  height: 1px;
-  background: var(--v-border-base);
-  position: relative;
-}
-.v-flight-card .v-flight-line::after {
-  content: "\2708";
-  position: absolute;
-  right: -4px;
-  top: -8px;
-  font-size: var(--v-font-size-base);
-  color: var(--v-content-tertiary);
-}
-.v-flight-card .v-flight-meta {
-  display: flex;
-  gap: var(--v-spacing-lg);
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-tertiary);
-}
-
-/* Billing Chart */
-.v-billing-chart {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-md);
-}
-.v-billing-chart .v-billing-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-}
-.v-billing-chart .v-billing-total {
-  font-size: var(--v-font-size-2xl);
-  font-weight: 700;
-  color: var(--v-content-default);
-}
-.v-billing-chart .v-billing-period {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-}
-.v-billing-chart .v-billing-canvas {
-  width: 100%;
-  height: 160px;
-  border-radius: var(--v-radius-md);
-  overflow: hidden;
-}
-.v-billing-chart .v-billing-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--v-spacing-md);
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-secondary);
-}
-.v-billing-chart .v-billing-legend-item {
-  display: flex;
-  align-items: center;
-  gap: var(--v-spacing-xs);
-}
-.v-billing-chart .v-billing-legend-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-}
-
-/* Boarding Pass */
-.v-boarding-pass {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-lg);
-  position: relative;
-  overflow: hidden;
-}
-.v-boarding-pass::before {
-  content: "";
-  position: absolute;
-  left: -8px;
-  top: 50%;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--v-surface-overlay);
-}
-.v-boarding-pass::after {
-  content: "";
-  position: absolute;
-  right: -8px;
-  top: 50%;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--v-surface-overlay);
-}
-.v-boarding-pass .v-bp-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-weight: 600;
-  color: var(--v-content-default);
-}
-.v-boarding-pass .v-bp-route {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.v-boarding-pass .v-bp-city {
-  font-size: var(--v-font-size-2xl);
-  font-weight: 700;
-  color: var(--v-content-default);
-}
-.v-boarding-pass .v-bp-details {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-  gap: var(--v-spacing-md);
-  padding-top: var(--v-spacing-md);
-  border-top: 1px dashed var(--v-border-base);
-}
-.v-boarding-pass .v-bp-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-xxs);
-}
-.v-boarding-pass .v-bp-field-label {
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-tertiary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-.v-boarding-pass .v-bp-field-value {
-  font-size: var(--v-font-size-lg);
-  font-weight: 700;
-  color: var(--v-content-default);
-}
-
-/* Itinerary */
-.v-itinerary {
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-lg);
-}
-.v-itinerary .v-itinerary-day {
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-sm);
-}
-.v-itinerary .v-itinerary-date {
-  font-size: var(--v-font-size-sm);
-  font-weight: 600;
-  color: var(--v-primary-base);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-.v-itinerary .v-itinerary-item {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-md);
-  padding: var(--v-spacing-md) var(--v-spacing-lg);
-  display: flex;
-  align-items: center;
-  gap: var(--v-spacing-md);
-}
-.v-itinerary .v-itinerary-time {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-tertiary);
-  font-weight: 500;
-  white-space: nowrap;
-}
-.v-itinerary .v-itinerary-content {
-  flex: 1;
-}
-.v-itinerary .v-itinerary-title {
-  font-weight: 500;
-  color: var(--v-content-default);
-}
-.v-itinerary .v-itinerary-location {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-}
-
-/* Receipt */
-.v-receipt {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-xl);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-md);
-  max-width: 400px;
-  font-family: var(--v-font-mono);
-}
-.v-receipt .v-receipt-header {
-  text-align: center;
-  padding-bottom: var(--v-spacing-md);
-  border-bottom: 1px dashed var(--v-border-base);
-}
-.v-receipt .v-receipt-store {
-  font-size: var(--v-font-size-lg);
-  font-weight: 700;
-  color: var(--v-content-default);
-  font-family: var(--v-font-family);
-}
-.v-receipt .v-receipt-items {
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-xs);
-}
-.v-receipt .v-receipt-line {
-  display: flex;
-  justify-content: space-between;
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-default);
-}
-.v-receipt .v-receipt-divider {
-  border: none;
-  border-top: 1px dashed var(--v-border-base);
-  margin: var(--v-spacing-sm) 0;
-}
-.v-receipt .v-receipt-total {
-  display: flex;
-  justify-content: space-between;
-  font-weight: 700;
-  font-size: var(--v-font-size-base);
-  color: var(--v-content-default);
-  padding-top: var(--v-spacing-sm);
-  border-top: 2px solid var(--v-border-base);
-}
-
-/* Invoice */
-.v-invoice {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-xl);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-lg);
-}
-.v-invoice .v-invoice-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-}
-.v-invoice .v-invoice-title {
-  font-size: var(--v-font-size-xl);
-  font-weight: 700;
-  color: var(--v-content-default);
-}
-.v-invoice .v-invoice-number {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-  font-family: var(--v-font-mono);
-}
-.v-invoice .v-invoice-parties {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--v-spacing-xl);
-}
-.v-invoice .v-invoice-party-label {
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-tertiary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin-bottom: var(--v-spacing-xs);
-}
-.v-invoice .v-invoice-party-name {
-  font-weight: 600;
-  color: var(--v-content-default);
-}
-.v-invoice .v-invoice-party-detail {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-}
-.v-invoice .v-invoice-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-.v-invoice .v-invoice-table th {
-  text-align: left;
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-tertiary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: var(--v-spacing-sm) var(--v-spacing-md);
-  border-bottom: 2px solid var(--v-border-base);
-}
-.v-invoice .v-invoice-table td {
-  padding: var(--v-spacing-sm) var(--v-spacing-md);
-  border-bottom: 1px solid var(--v-border-base);
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-default);
-}
-.v-invoice .v-invoice-table td:last-child,
-.v-invoice .v-invoice-table th:last-child {
-  text-align: right;
-}
-.v-invoice .v-invoice-totals {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: var(--v-spacing-xs);
-}
-.v-invoice .v-invoice-totals .v-invoice-line {
-  display: flex;
-  gap: var(--v-spacing-xxl);
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-}
-.v-invoice .v-invoice-totals .v-invoice-line.total {
-  font-weight: 700;
-  font-size: var(--v-font-size-lg);
-  color: var(--v-content-default);
-  padding-top: var(--v-spacing-sm);
-  border-top: 2px solid var(--v-border-base);
-}
-.v-invoice .v-invoice-footer {
-  font-size: var(--v-font-size-xs);
-  color: var(--v-content-tertiary);
-  padding-top: var(--v-spacing-md);
-  border-top: 1px solid var(--v-border-base);
-}
-
-/* ── Tier 3: Content & Landing Page Components ─────────────── */
-
-/* Page — centered content container for landing pages */
-.v-page {
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-xxl);
-  width: 100%;
-}
-
-/* Hero — top-of-page banner with gradient background */
-.v-hero {
-  position: relative;
-  background: linear-gradient(135deg, var(--v-system-positive-weak) 0%, var(--v-border-active) 100%);
-  border-radius: var(--v-radius-xl);
-  padding: var(--v-spacing-xxxl) var(--v-spacing-xl);
-  text-align: center;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--v-spacing-md);
-}
-.v-hero::before {
-  content: "";
-  position: absolute;
-  top: -40%;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 120%;
-  height: 80%;
-  background: radial-gradient(ellipse, color-mix(in srgb, var(--v-primary-base) 30%, transparent) 0%, transparent 70%);
-  pointer-events: none;
-}
-.v-hero-badge {
-  display: inline-block;
-  padding: var(--v-spacing-xs) var(--v-spacing-lg);
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: var(--v-radius-pill);
-  font-size: var(--v-font-size-xs);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--v-content-disabled);
-  position: relative;
-}
-.v-hero h1 {
-  font-size: 2.5rem;
-  font-weight: 800;
-  background: linear-gradient(180deg, #fff 30%, var(--v-content-background) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin: 0;
-  position: relative;
-  line-height: 1.15;
-}
-.v-hero-subtitle {
-  font-size: var(--v-font-size-base);
-  color: var(--v-content-tertiary);
-  max-width: 500px;
-  margin: 0 auto;
-  line-height: 1.5;
-  position: relative;
-}
-
-/* Section Header — labeled section intro */
-.v-section-header {
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-xs);
-  margin-bottom: var(--v-spacing-lg);
-}
-.v-section-label {
-  font-size: var(--v-font-size-xs);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--v-primary-base);
-}
-.v-section-header h2 {
-  margin: 0;
-}
-.v-section-desc {
-  font-size: var(--v-font-size-base);
-  color: var(--v-content-secondary);
-  margin: 0;
-}
-
-/* Pullquote — dramatic blockquote with glassmorphism */
-.v-pullquote {
-  position: relative;
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-xl);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-md);
-}
-.v-pullquote::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: var(--v-spacing-lg);
-  bottom: var(--v-spacing-lg);
-  width: 3px;
-  background: linear-gradient(180deg, var(--v-primary-hover) 0%, var(--v-primary-active) 100%);
-  border-radius: var(--v-radius-pill);
-}
-.v-pullquote-text {
-  font-size: var(--v-font-size-lg);
-  font-style: italic;
-  color: var(--v-content-default);
-  line-height: 1.5;
-  margin: 0;
-  padding-left: var(--v-spacing-lg);
-}
-.v-pullquote-points {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-sm);
-  padding-left: var(--v-spacing-lg);
-}
-.v-pullquote-points li {
-  position: relative;
-  padding-left: var(--v-spacing-lg);
-  font-size: var(--v-font-size-base);
-  color: var(--v-content-secondary);
-}
-.v-pullquote-points li::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0.55em;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--v-primary-base);
-}
-
-/* Comparison — before/after or contrasting ideas */
-.v-comparison {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  gap: var(--v-spacing-md);
-  align-items: center;
-}
-.v-comparison-card {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-sm);
-}
-.v-comparison-card.before {
-  background: color-mix(in srgb, var(--v-surface-base) 60%, var(--v-surface-overlay));
-}
-.v-comparison-card.before .v-comparison-label {
-  color: var(--v-content-tertiary);
-}
-.v-comparison-card.after {
-  background: color-mix(in srgb, var(--v-primary-base) 8%, var(--v-surface-base));
-  border-color: color-mix(in srgb, var(--v-primary-base) 25%, var(--v-border-base));
-}
-.v-comparison-card.after .v-comparison-label {
-  color: var(--v-primary-base);
-}
-.v-comparison-label {
-  font-size: var(--v-font-size-xs);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-.v-comparison-arrow {
-  font-size: var(--v-font-size-xl);
-  color: var(--v-content-tertiary);
-  text-align: center;
-}
-
-/* Feature Grid — auto-fit grid of feature cards */
-.v-feature-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: var(--v-spacing-lg);
-}
-.v-feature-card {
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-lg);
-  padding: var(--v-spacing-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--v-spacing-sm);
-  transition: transform var(--v-duration-fast) ease-out,
-              box-shadow var(--v-duration-fast) ease-out;
-}
-.v-feature-card:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--v-shadow-md);
-}
-.v-feature-card .v-feature-icon {
-  font-size: 24px;
-  line-height: 1;
-}
-.v-feature-card .v-feature-title {
-  font-size: var(--v-font-size-base);
-  font-weight: 600;
-  color: var(--v-content-default);
-}
-.v-feature-card .v-feature-desc {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-  line-height: 1.4;
-}
-
-/* Gradient Text — forest gradient text fill */
-.v-gradient-text {
-  background: linear-gradient(135deg, var(--v-primary-active) 0%, var(--v-system-positive-weak) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-/* Staggered Fade-In Animation */
-@keyframes v-fade-in {
-  from {
+  /* Toggle switch */
+  .v-toggle {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 22px;
+  }
+  .v-toggle input {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     opacity: 0;
-    transform: translateY(12px);
+    margin: 0;
+    cursor: pointer;
   }
-  to {
+  .v-toggle-track {
+    position: absolute;
+    inset: 0;
+    background: var(--v-border-base);
+    border-radius: var(--v-radius-pill);
+    cursor: pointer;
+    transition: background var(--v-duration-fast) ease-out;
+  }
+  .v-toggle-track::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    background: white;
+    border-radius: 50%;
+    transition: transform var(--v-duration-fast) ease-out;
+  }
+  .v-toggle input:checked + .v-toggle-track {
+    background: var(--v-primary-base);
+  }
+  .v-toggle input:checked + .v-toggle-track::after {
+    transform: translateX(18px);
+  }
+  .v-toggle input:focus-visible + .v-toggle-track {
+    outline: 2px solid var(--v-primary-base);
+    outline-offset: 2px;
+  }
+
+  /* Input row (input + button combo) */
+  .v-input-row {
+    display: flex;
+    gap: var(--v-spacing-sm);
+  }
+  .v-input-row input,
+  .v-input-row .v-input {
+    flex: 1;
+  }
+
+  /* ─── Layer 4: Utility Classes ───────────────────────────────── */
+
+  /* Flexbox */
+  .v-flex {
+    display: flex;
+  }
+  .v-flex-col {
+    display: flex;
+    flex-direction: column;
+  }
+  .v-flex-wrap {
+    flex-wrap: wrap;
+  }
+  .v-items-center {
+    align-items: center;
+  }
+  .v-justify-between {
+    justify-content: space-between;
+  }
+  .v-justify-center {
+    justify-content: center;
+  }
+
+  /* Gap */
+  .v-gap-xs {
+    gap: var(--v-spacing-xs);
+  }
+  .v-gap-sm {
+    gap: var(--v-spacing-sm);
+  }
+  .v-gap-md {
+    gap: var(--v-spacing-md);
+  }
+  .v-gap-lg {
+    gap: var(--v-spacing-lg);
+  }
+  .v-gap-xl {
+    gap: var(--v-spacing-xl);
+  }
+
+  /* Text */
+  .v-text-secondary {
+    color: var(--v-content-secondary);
+  }
+  .v-text-muted {
+    color: var(--v-content-tertiary);
+  }
+  .v-text-accent {
+    color: var(--v-primary-base);
+  }
+  .v-text-xs {
+    font-size: var(--v-font-size-xs);
+  }
+  .v-text-sm {
+    font-size: var(--v-font-size-sm);
+  }
+  .v-text-lg {
+    font-size: var(--v-font-size-lg);
+  }
+  .v-font-mono {
+    font-family: var(--v-font-mono);
+  }
+
+  /* Layout */
+  .v-truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .v-w-full {
+    width: 100%;
+  }
+
+  /* Accessibility */
+  .v-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+
+  /* ─── Layer 5: Widget Components ────────────────────────────── */
+
+  /* ── Tier 1: Layout & Data Primitives ───────────────────────── */
+
+  /* Metric Card — single big number with label and trend arrow */
+  .v-metric-card {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-xs);
+  }
+  .v-metric-card .v-metric-value {
+    font-size: var(--v-font-size-2xl);
+    font-weight: 700;
+    line-height: 1.1;
+    color: var(--v-content-default);
+  }
+  .v-metric-card .v-metric-label {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .v-metric-card .v-metric-trend {
+    font-size: var(--v-font-size-sm);
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--v-spacing-xxs);
+  }
+  .v-metric-card .v-metric-trend.up {
+    color: var(--v-system-positive-strong);
+  }
+  .v-metric-card .v-metric-trend.down {
+    color: var(--v-system-negative-strong);
+  }
+  .v-metric-card .v-metric-trend.neutral {
+    color: var(--v-content-tertiary);
+  }
+
+  /* Metric Grid — responsive grid of metric cards */
+  .v-metric-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--v-spacing-lg);
+  }
+
+  /* Data Table — sortable, hoverable, sticky header */
+  .v-data-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    overflow: hidden;
+  }
+  .v-data-table thead th {
+    position: sticky;
+    top: 0;
+    background: var(--v-surface-overlay);
+    font-size: var(--v-font-size-sm);
+    font-weight: 600;
+    color: var(--v-content-secondary);
+    text-align: left;
+    padding: var(--v-spacing-sm) var(--v-spacing-md);
+    border-bottom: 1px solid var(--v-border-base);
+    cursor: default;
+    user-select: none;
+    white-space: nowrap;
+  }
+  .v-data-table thead th[data-sortable] {
+    cursor: pointer;
+  }
+  .v-data-table thead th[data-sortable]:hover {
+    color: var(--v-content-default);
+  }
+  .v-data-table tbody td {
+    padding: var(--v-spacing-sm) var(--v-spacing-md);
+    border-bottom: 1px solid var(--v-border-base);
+    font-size: var(--v-font-size-base);
+    color: var(--v-content-default);
+  }
+  .v-data-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+  .v-data-table tbody tr:hover {
+    background: color-mix(in srgb, var(--v-primary-base) 5%, transparent);
+  }
+  .v-data-table tbody tr.selected {
+    background: color-mix(in srgb, var(--v-primary-base) 10%, transparent);
+  }
+  .v-data-table input[type="checkbox"] {
+    accent-color: var(--v-primary-base);
+  }
+
+  /* Timeline — vertical timeline with entries */
+  .v-timeline {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding-left: var(--v-spacing-xl);
+  }
+  .v-timeline::before {
+    content: "";
+    position: absolute;
+    left: 7px;
+    top: var(--v-spacing-xs);
+    bottom: var(--v-spacing-xs);
+    width: 2px;
+    background: var(--v-border-base);
+  }
+  .v-timeline-entry {
+    position: relative;
+    padding-bottom: var(--v-spacing-lg);
+  }
+  .v-timeline-entry::before {
+    content: "";
+    position: absolute;
+    left: calc(-1 * var(--v-spacing-xl) + 3px);
+    top: 6px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--v-border-base);
+    border: 2px solid var(--v-surface-overlay);
+  }
+  .v-timeline-entry.active::before {
+    background: var(--v-primary-base);
+  }
+  .v-timeline-entry.success::before {
+    background: var(--v-system-positive-strong);
+  }
+  .v-timeline-entry.error::before {
+    background: var(--v-system-negative-strong);
+  }
+  .v-timeline-entry .v-timeline-time {
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-tertiary);
+    margin-bottom: var(--v-spacing-xxs);
+  }
+  .v-timeline-entry .v-timeline-title {
+    font-size: var(--v-font-size-base);
+    font-weight: 600;
+    color: var(--v-content-default);
+  }
+  .v-timeline-entry .v-timeline-desc {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+    margin-top: var(--v-spacing-xxs);
+  }
+
+  /* Action List — rows with per-item action buttons */
+  .v-action-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .v-action-list-item {
+    display: flex;
+    align-items: center;
+    gap: var(--v-spacing-md);
+    padding: var(--v-spacing-md) var(--v-spacing-lg);
+    border-bottom: 1px solid var(--v-border-base);
+    transition: background var(--v-duration-fast) ease-out;
+  }
+  .v-action-list-item:last-child {
+    border-bottom: none;
+  }
+  .v-action-list-item:hover {
+    background: var(--v-surface-base);
+  }
+  .v-action-list-item .v-action-content {
+    flex: 1;
+    min-width: 0;
+  }
+  .v-action-list-item .v-action-title {
+    font-weight: 500;
+    color: var(--v-content-default);
+  }
+  .v-action-list-item .v-action-subtitle {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+    margin-top: var(--v-spacing-xxs);
+  }
+  .v-action-list-item .v-action-buttons {
+    display: flex;
+    gap: var(--v-spacing-xs);
+    flex-shrink: 0;
+  }
+
+  /* Tabs — tab bar + tab panels */
+  .v-tabs {
+    display: flex;
+    flex-direction: column;
+  }
+  .v-tab-bar {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--v-border-base);
+  }
+  .v-tab {
+    padding: var(--v-spacing-sm) var(--v-spacing-lg);
+    font-size: var(--v-font-size-base);
+    font-weight: 500;
+    color: var(--v-content-secondary);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    transition:
+      color var(--v-duration-fast) ease-out,
+      border-color var(--v-duration-fast) ease-out;
+  }
+  .v-tab:hover {
+    color: var(--v-content-default);
+  }
+  .v-tab[aria-selected="true"],
+  .v-tab.active {
+    color: var(--v-primary-base);
+    border-bottom-color: var(--v-primary-base);
+  }
+  .v-tab:focus-visible {
+    outline: 2px solid var(--v-primary-base);
+    outline-offset: -2px;
+  }
+  .v-tab-panel {
+    padding: var(--v-spacing-lg) 0;
+  }
+  .v-tab-panel[hidden] {
+    display: none;
+  }
+
+  /* Accordion — collapsible sections */
+  .v-accordion {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    overflow: hidden;
+  }
+  .v-accordion-item {
+    border-bottom: 1px solid var(--v-border-base);
+  }
+  .v-accordion-item:last-child {
+    border-bottom: none;
+  }
+  .v-accordion-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: var(--v-spacing-md) var(--v-spacing-lg);
+    background: var(--v-surface-base);
+    border: none;
+    cursor: pointer;
+    font-size: var(--v-font-size-base);
+    font-weight: 500;
+    color: var(--v-content-default);
+    text-align: left;
+    transition: background var(--v-duration-fast) ease-out;
+  }
+  .v-accordion-header:hover {
+    background: color-mix(
+      in srgb,
+      var(--v-surface-base) 80%,
+      var(--v-surface-overlay)
+    );
+  }
+  .v-accordion-header::after {
+    content: "\203A";
+    font-size: var(--v-font-size-lg);
+    color: var(--v-content-tertiary);
+    transform: rotate(90deg);
+    transition: transform var(--v-duration-standard) ease-in-out;
+  }
+  .v-accordion-item[open] .v-accordion-header::after,
+  .v-accordion-header[aria-expanded="true"]::after {
+    transform: rotate(270deg);
+  }
+  .v-accordion-body {
+    padding: var(--v-spacing-lg);
+    background: var(--v-surface-overlay);
+  }
+  .v-accordion-header:focus-visible {
+    outline: 2px solid var(--v-primary-base);
+    outline-offset: -2px;
+  }
+
+  /* Search Bar — input with icon and clear button */
+  .v-search-bar {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+  .v-search-bar input {
+    width: 100%;
+    padding-left: var(--v-spacing-xxl);
+    padding-right: var(--v-spacing-xxl);
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-pill);
+  }
+  .v-search-bar input:focus {
+    border-color: var(--v-primary-base);
+  }
+  .v-search-bar::before {
+    content: "\1F50D";
+    position: absolute;
+    left: var(--v-spacing-md);
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-tertiary);
+    pointer-events: none;
+  }
+  .v-search-bar .v-search-clear {
+    position: absolute;
+    right: var(--v-spacing-sm);
+    background: none;
+    border: none;
+    color: var(--v-content-tertiary);
+    cursor: pointer;
+    font-size: var(--v-font-size-sm);
+    padding: var(--v-spacing-xs);
+    border-radius: 50%;
+  }
+  .v-search-bar .v-search-clear:hover {
+    color: var(--v-content-default);
+    background: var(--v-border-base);
+  }
+
+  /* Card Grid — responsive grid of cards */
+  .v-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: var(--v-spacing-lg);
+  }
+
+  /* Progress Bar — horizontal fill bar with label */
+  .v-progress-bar {
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-xs);
+  }
+  .v-progress-bar .v-progress-header {
+    display: flex;
+    justify-content: space-between;
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+  }
+  .v-progress-bar .v-progress-track {
+    height: 8px;
+    background: var(--v-border-base);
+    border-radius: var(--v-radius-pill);
+    overflow: hidden;
+  }
+  .v-progress-bar .v-progress-fill {
+    height: 100%;
+    background: var(--v-primary-base);
+    border-radius: var(--v-radius-pill);
+    transition: width var(--v-duration-standard) ease-in-out;
+  }
+  .v-progress-bar .v-progress-fill.success {
+    background: var(--v-system-positive-strong);
+  }
+  .v-progress-bar .v-progress-fill.warning {
+    background: var(--v-system-mid-strong);
+  }
+  .v-progress-bar .v-progress-fill.danger {
+    background: var(--v-system-negative-strong);
+  }
+
+  /* Status Badge — colored pill with dot indicator */
+  .v-status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--v-spacing-xs);
+    font-size: var(--v-font-size-xs);
+    font-weight: 600;
+    padding: var(--v-spacing-xxs) var(--v-spacing-sm);
+    border-radius: var(--v-radius-pill);
+    background: var(--v-surface-base);
+    color: var(--v-content-secondary);
+  }
+  .v-status-badge::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    flex-shrink: 0;
+  }
+  .v-status-badge.success {
+    background: color-mix(
+      in srgb,
+      var(--v-system-positive-strong) 15%,
+      transparent
+    );
+    color: var(--v-system-positive-strong);
+  }
+  .v-status-badge.warning {
+    background: color-mix(in srgb, var(--v-system-mid-strong) 15%, transparent);
+    color: var(--v-system-mid-strong);
+  }
+  .v-status-badge.error {
+    background: color-mix(
+      in srgb,
+      var(--v-system-negative-strong) 15%,
+      transparent
+    );
+    color: var(--v-system-negative-strong);
+  }
+  .v-status-badge.info {
+    background: color-mix(in srgb, var(--v-primary-base) 15%, transparent);
+    color: var(--v-primary-base);
+  }
+
+  /* Stat Row — horizontal strip of label-value pairs */
+  .v-stat-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--v-spacing-lg);
+    padding: var(--v-spacing-md) 0;
+  }
+  .v-stat-row .v-stat {
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-xxs);
+  }
+  .v-stat-row .v-stat:not(:last-child) {
+    padding-right: var(--v-spacing-lg);
+    border-right: 1px solid var(--v-border-base);
+  }
+  .v-stat-row .v-stat-label {
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 500;
+  }
+  .v-stat-row .v-stat-value {
+    font-size: var(--v-font-size-lg);
+    font-weight: 700;
+    color: var(--v-content-default);
+  }
+
+  /* Toast — dismissible notification banner */
+  .v-toast {
+    display: flex;
+    align-items: center;
+    gap: var(--v-spacing-md);
+    padding: var(--v-spacing-md) var(--v-spacing-lg);
+    border-radius: var(--v-radius-md);
+    font-size: var(--v-font-size-sm);
+    font-weight: 500;
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    box-shadow: var(--v-shadow-md);
+  }
+  .v-toast.success {
+    background: color-mix(
+      in srgb,
+      var(--v-system-positive-strong) 10%,
+      var(--v-surface-base)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--v-system-positive-strong) 30%,
+      var(--v-border-base)
+    );
+    color: var(--v-system-positive-strong);
+  }
+  .v-toast.error {
+    background: color-mix(
+      in srgb,
+      var(--v-system-negative-strong) 10%,
+      var(--v-surface-base)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--v-system-negative-strong) 30%,
+      var(--v-border-base)
+    );
+    color: var(--v-system-negative-strong);
+  }
+  .v-toast.warning {
+    background: color-mix(
+      in srgb,
+      var(--v-system-mid-strong) 10%,
+      var(--v-surface-base)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--v-system-mid-strong) 30%,
+      var(--v-border-base)
+    );
+    color: var(--v-system-mid-strong);
+  }
+  .v-toast.info {
+    background: color-mix(
+      in srgb,
+      var(--v-primary-base) 10%,
+      var(--v-surface-base)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--v-primary-base) 30%,
+      var(--v-border-base)
+    );
+    color: var(--v-primary-base);
+  }
+  .v-toast .v-toast-dismiss {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: inherit;
+    opacity: 0.6;
+    cursor: pointer;
+    font-size: var(--v-font-size-lg);
+    padding: 0 var(--v-spacing-xs);
+  }
+  .v-toast .v-toast-dismiss:hover {
     opacity: 1;
-    transform: translateY(0);
   }
-}
-.v-animate-in {
-  animation: v-fade-in var(--v-duration-slow) ease-out both;
-}
-.v-animate-in:nth-child(1) { animation-delay: 0s; }
-.v-animate-in:nth-child(2) { animation-delay: 0.1s; }
-.v-animate-in:nth-child(3) { animation-delay: 0.2s; }
-.v-animate-in:nth-child(4) { animation-delay: 0.3s; }
-.v-animate-in:nth-child(5) { animation-delay: 0.4s; }
-.v-animate-in:nth-child(6) { animation-delay: 0.5s; }
 
-/* ── Pill Toggles — time range / filter toggle group ────────── */
-.v-pill-toggles {
-  display: inline-flex;
-  gap: var(--v-spacing-xxs);
-  background: var(--v-surface-base);
-  border: 1px solid var(--v-border-base);
-  border-radius: var(--v-radius-md);
-  padding: var(--v-spacing-xxs);
-}
-.v-pill-toggle {
-  padding: var(--v-spacing-xs) var(--v-spacing-md);
-  border-radius: var(--v-radius-md);
-  border: none;
-  background: none;
-  font-size: var(--v-font-size-sm);
-  font-weight: 500;
-  color: var(--v-content-secondary);
-  cursor: pointer;
-  transition: all var(--v-duration-fast) ease-out;
-}
-.v-pill-toggle:hover {
-  color: var(--v-content-default);
-}
-.v-pill-toggle.active {
-  background: var(--v-primary-base);
-  color: var(--v-aux-white);
-  font-weight: 600;
-  box-shadow: var(--v-shadow-sm);
-}
+  /* Empty State — enhanced version with icon + CTA */
+  .v-empty-state {
+    text-align: center;
+    color: var(--v-content-tertiary);
+    padding: var(--v-spacing-xxxl) var(--v-spacing-xl);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--v-spacing-md);
+  }
+  .v-empty-state .v-empty-icon {
+    font-size: 48px;
+    line-height: 1;
+    opacity: 0.5;
+  }
+  .v-empty-state .v-empty-title {
+    font-size: var(--v-font-size-lg);
+    font-weight: 600;
+    color: var(--v-content-secondary);
+    margin: 0;
+  }
+  .v-empty-state .v-empty-desc {
+    font-size: var(--v-font-size-base);
+    color: var(--v-content-tertiary);
+    max-width: 360px;
+  }
 
-/* ── Chip Group — suggestion / filter chip row ─────────────── */
-.v-chip-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--v-spacing-xs);
-}
-.v-chip {
-  padding: var(--v-spacing-xs) var(--v-spacing-md);
-  border-radius: var(--v-radius-md);
-  border: 1px solid var(--v-border-base);
-  background: var(--v-surface-base);
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-secondary);
-  cursor: pointer;
-  transition: all var(--v-duration-fast) ease-out;
-}
-.v-chip:hover {
-  border-color: var(--v-primary-base);
-  color: var(--v-content-default);
-}
-.v-chip.active {
-  background: color-mix(in srgb, var(--v-primary-base) 12%, transparent);
-  border-color: var(--v-primary-base);
-  color: var(--v-primary-base);
-  font-weight: 600;
-}
+  /* Divider — horizontal rule with optional label */
+  .v-divider {
+    display: flex;
+    align-items: center;
+    gap: var(--v-spacing-md);
+    margin: var(--v-spacing-xl) 0;
+    color: var(--v-content-tertiary);
+    font-size: var(--v-font-size-xs);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .v-divider::before,
+  .v-divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--v-border-base);
+  }
+  .v-divider:empty::after {
+    display: none;
+  }
 
-/* ── Metric Icon — emoji icon for metric cards ─────────────── */
-.v-metric-card .v-metric-icon {
-  font-size: 28px;
-  line-height: 1;
-}
+  /* Avatar Row — circular avatar + name + subtitle */
+  .v-avatar-row {
+    display: flex;
+    align-items: center;
+    gap: var(--v-spacing-md);
+  }
+  .v-avatar-row .v-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--v-primary-base);
+    color: var(--v-content-inset);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: var(--v-font-size-sm);
+    flex-shrink: 0;
+    overflow: hidden;
+  }
+  .v-avatar-row .v-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .v-avatar-row .v-avatar-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  .v-avatar-row .v-avatar-name {
+    font-weight: 500;
+    color: var(--v-content-default);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .v-avatar-row .v-avatar-subtitle {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+  }
 
-/* ── Action Bar — sticky bulk-action bar for multi-select UIs ── */
-.v-action-bar {
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  display: none;
-  align-items: center;
-  gap: var(--v-spacing-md);
-  padding: var(--v-spacing-sm) var(--v-spacing-lg);
-  background: var(--v-surface-base);
-  border-bottom: 1px solid var(--v-border-base);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-}
-.v-action-bar.visible {
-  display: flex;
-}
-.v-action-bar-count {
-  font-size: var(--v-font-size-sm);
-  font-weight: 600;
-  color: var(--v-primary-base);
-  white-space: nowrap;
-}
-.v-action-bar-buttons {
-  display: flex;
-  gap: var(--v-spacing-sm);
-  margin-left: auto;
-}
+  /* Tag / Chip Group — wrapping row of badges */
+  .v-tag-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--v-spacing-xs);
+  }
 
-/* ── Action Progress — inline progress bar during bulk ops ───── */
-.v-action-progress {
-  width: 100%;
-  height: 4px;
-  border-radius: var(--v-radius-pill);
-  background: var(--v-border-base);
-  overflow: hidden;
-}
-.v-action-progress::after {
-  content: '';
-  display: block;
-  height: 100%;
-  width: var(--progress, 0%);
-  background: var(--v-primary-base);
-  border-radius: var(--v-radius-pill);
-  transition: width 0.3s ease-out;
-}
+  /* ── Tier 2: Domain-Specific Widgets ────────────────────────── */
 
-/* ── Group Header — collapsible section with checkbox + chevron ─ */
-.v-group-header {
-  display: flex;
-  align-items: center;
-  gap: var(--v-spacing-sm);
-  padding: var(--v-spacing-sm) var(--v-spacing-md);
-  background: color-mix(in srgb, var(--v-surface-base) 60%, transparent);
-  border-radius: var(--v-radius-md);
-  cursor: pointer;
-  user-select: none;
-  -webkit-user-select: none;
-  transition: background var(--v-duration-fast) ease-out;
-}
-.v-group-header:hover {
-  background: var(--v-surface-base);
-}
-.v-group-header .v-group-title {
-  flex: 1;
-  font-weight: 600;
-  font-size: var(--v-font-size-base);
-  color: var(--v-content-default);
-}
-.v-group-header .v-group-count {
-  font-size: var(--v-font-size-sm);
-  color: var(--v-content-tertiary);
-}
-.v-group-header .v-group-chevron {
-  font-size: 12px;
-  color: var(--v-content-tertiary);
-  transition: transform var(--v-duration-fast) ease-out;
-}
-.v-group-header[aria-expanded="true"] .v-group-chevron {
-  transform: rotate(90deg);
-}
+  /* Weather Card */
+  .v-weather-card {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-md);
+  }
+  .v-weather-card .v-weather-main {
+    display: flex;
+    align-items: center;
+    gap: var(--v-spacing-lg);
+  }
+  .v-weather-card .v-weather-temp {
+    font-size: 48px;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--v-content-default);
+  }
+  .v-weather-card .v-weather-condition {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+  }
+  .v-weather-card .v-weather-icon {
+    font-size: 48px;
+    line-height: 1;
+  }
+  .v-weather-card .v-weather-details {
+    display: flex;
+    gap: var(--v-spacing-lg);
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+  }
+  .v-weather-card .v-weather-forecast {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+    gap: var(--v-spacing-sm);
+    text-align: center;
+  }
+  .v-weather-card .v-weather-forecast-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--v-spacing-xxs);
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-secondary);
+    padding: var(--v-spacing-sm);
+    border-radius: var(--v-radius-md);
+    background: color-mix(in srgb, var(--v-border-base) 30%, transparent);
+  }
 
-/* ── Group Body — indented container for group items ─────────── */
-.v-group-body {
-  padding-left: var(--v-spacing-xl);
-  overflow: hidden;
-}
+  /* Stock Ticker */
+  .v-stock-ticker {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-md);
+  }
+  .v-stock-ticker .v-stock-header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--v-spacing-md);
+  }
+  .v-stock-ticker .v-stock-symbol {
+    font-size: var(--v-font-size-lg);
+    font-weight: 700;
+    color: var(--v-content-default);
+  }
+  .v-stock-ticker .v-stock-price {
+    font-size: var(--v-font-size-2xl);
+    font-weight: 700;
+    color: var(--v-content-default);
+  }
+  .v-stock-ticker .v-stock-change {
+    font-size: var(--v-font-size-sm);
+    font-weight: 600;
+  }
+  .v-stock-ticker .v-stock-change.up {
+    color: var(--v-system-positive-strong);
+  }
+  .v-stock-ticker .v-stock-change.down {
+    color: var(--v-system-negative-strong);
+  }
+  .v-stock-ticker .v-stock-chart {
+    width: 100%;
+    height: 120px;
+    border-radius: var(--v-radius-md);
+    overflow: hidden;
+  }
+  .v-stock-ticker .v-stock-meta {
+    display: flex;
+    gap: var(--v-spacing-lg);
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-tertiary);
+  }
 
-/* ── Row Removing — fade-out + slide animation for processed items */
-.v-row-removing {
-  opacity: 0;
-  transform: translateX(20px);
-  max-height: 0;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-  overflow: hidden;
-  transition: opacity 0.25s ease-out,
-              transform 0.25s ease-out,
-              max-height 0.3s 0.1s ease-out,
-              padding 0.3s 0.1s ease-out,
-              margin 0.3s 0.1s ease-out;
-}
+  /* Flight Card */
+  .v-flight-card {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-md);
+  }
+  .v-flight-card .v-flight-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .v-flight-card .v-flight-airline {
+    font-weight: 600;
+    color: var(--v-content-default);
+  }
+  .v-flight-card .v-flight-price {
+    font-size: var(--v-font-size-lg);
+    font-weight: 700;
+    color: var(--v-primary-base);
+  }
+  .v-flight-card .v-flight-route {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--v-spacing-md);
+  }
+  .v-flight-card .v-flight-endpoint {
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-xxs);
+  }
+  .v-flight-card .v-flight-time {
+    font-size: var(--v-font-size-xl);
+    font-weight: 700;
+    color: var(--v-content-default);
+  }
+  .v-flight-card .v-flight-code {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+    font-weight: 500;
+  }
+  .v-flight-card .v-flight-duration {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--v-spacing-xxs);
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-tertiary);
+  }
+  .v-flight-card .v-flight-line {
+    width: 80px;
+    height: 1px;
+    background: var(--v-border-base);
+    position: relative;
+  }
+  .v-flight-card .v-flight-line::after {
+    content: "\2708";
+    position: absolute;
+    right: -4px;
+    top: -8px;
+    font-size: var(--v-font-size-base);
+    color: var(--v-content-tertiary);
+  }
+  .v-flight-card .v-flight-meta {
+    display: flex;
+    gap: var(--v-spacing-lg);
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-tertiary);
+  }
 
+  /* Billing Chart */
+  .v-billing-chart {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-md);
+  }
+  .v-billing-chart .v-billing-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+  .v-billing-chart .v-billing-total {
+    font-size: var(--v-font-size-2xl);
+    font-weight: 700;
+    color: var(--v-content-default);
+  }
+  .v-billing-chart .v-billing-period {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+  }
+  .v-billing-chart .v-billing-canvas {
+    width: 100%;
+    height: 160px;
+    border-radius: var(--v-radius-md);
+    overflow: hidden;
+  }
+  .v-billing-chart .v-billing-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--v-spacing-md);
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-secondary);
+  }
+  .v-billing-chart .v-billing-legend-item {
+    display: flex;
+    align-items: center;
+    gap: var(--v-spacing-xs);
+  }
+  .v-billing-chart .v-billing-legend-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+
+  /* Boarding Pass */
+  .v-boarding-pass {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-lg);
+    position: relative;
+    overflow: hidden;
+  }
+  .v-boarding-pass::before {
+    content: "";
+    position: absolute;
+    left: -8px;
+    top: 50%;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--v-surface-overlay);
+  }
+  .v-boarding-pass::after {
+    content: "";
+    position: absolute;
+    right: -8px;
+    top: 50%;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--v-surface-overlay);
+  }
+  .v-boarding-pass .v-bp-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 600;
+    color: var(--v-content-default);
+  }
+  .v-boarding-pass .v-bp-route {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .v-boarding-pass .v-bp-city {
+    font-size: var(--v-font-size-2xl);
+    font-weight: 700;
+    color: var(--v-content-default);
+  }
+  .v-boarding-pass .v-bp-details {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+    gap: var(--v-spacing-md);
+    padding-top: var(--v-spacing-md);
+    border-top: 1px dashed var(--v-border-base);
+  }
+  .v-boarding-pass .v-bp-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-xxs);
+  }
+  .v-boarding-pass .v-bp-field-label {
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .v-boarding-pass .v-bp-field-value {
+    font-size: var(--v-font-size-lg);
+    font-weight: 700;
+    color: var(--v-content-default);
+  }
+
+  /* Itinerary */
+  .v-itinerary {
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-lg);
+  }
+  .v-itinerary .v-itinerary-day {
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-sm);
+  }
+  .v-itinerary .v-itinerary-date {
+    font-size: var(--v-font-size-sm);
+    font-weight: 600;
+    color: var(--v-primary-base);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .v-itinerary .v-itinerary-item {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-md);
+    padding: var(--v-spacing-md) var(--v-spacing-lg);
+    display: flex;
+    align-items: center;
+    gap: var(--v-spacing-md);
+  }
+  .v-itinerary .v-itinerary-time {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-tertiary);
+    font-weight: 500;
+    white-space: nowrap;
+  }
+  .v-itinerary .v-itinerary-content {
+    flex: 1;
+  }
+  .v-itinerary .v-itinerary-title {
+    font-weight: 500;
+    color: var(--v-content-default);
+  }
+  .v-itinerary .v-itinerary-location {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+  }
+
+  /* Receipt */
+  .v-receipt {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-md);
+    max-width: 400px;
+    font-family: var(--v-font-mono);
+  }
+  .v-receipt .v-receipt-header {
+    text-align: center;
+    padding-bottom: var(--v-spacing-md);
+    border-bottom: 1px dashed var(--v-border-base);
+  }
+  .v-receipt .v-receipt-store {
+    font-size: var(--v-font-size-lg);
+    font-weight: 700;
+    color: var(--v-content-default);
+    font-family: var(--v-font-family);
+  }
+  .v-receipt .v-receipt-items {
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-xs);
+  }
+  .v-receipt .v-receipt-line {
+    display: flex;
+    justify-content: space-between;
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-default);
+  }
+  .v-receipt .v-receipt-divider {
+    border: none;
+    border-top: 1px dashed var(--v-border-base);
+    margin: var(--v-spacing-sm) 0;
+  }
+  .v-receipt .v-receipt-total {
+    display: flex;
+    justify-content: space-between;
+    font-weight: 700;
+    font-size: var(--v-font-size-base);
+    color: var(--v-content-default);
+    padding-top: var(--v-spacing-sm);
+    border-top: 2px solid var(--v-border-base);
+  }
+
+  /* Invoice */
+  .v-invoice {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-lg);
+  }
+  .v-invoice .v-invoice-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+  .v-invoice .v-invoice-title {
+    font-size: var(--v-font-size-xl);
+    font-weight: 700;
+    color: var(--v-content-default);
+  }
+  .v-invoice .v-invoice-number {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+    font-family: var(--v-font-mono);
+  }
+  .v-invoice .v-invoice-parties {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--v-spacing-xl);
+  }
+  .v-invoice .v-invoice-party-label {
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: var(--v-spacing-xs);
+  }
+  .v-invoice .v-invoice-party-name {
+    font-weight: 600;
+    color: var(--v-content-default);
+  }
+  .v-invoice .v-invoice-party-detail {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+  }
+  .v-invoice .v-invoice-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .v-invoice .v-invoice-table th {
+    text-align: left;
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: var(--v-spacing-sm) var(--v-spacing-md);
+    border-bottom: 2px solid var(--v-border-base);
+  }
+  .v-invoice .v-invoice-table td {
+    padding: var(--v-spacing-sm) var(--v-spacing-md);
+    border-bottom: 1px solid var(--v-border-base);
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-default);
+  }
+  .v-invoice .v-invoice-table td:last-child,
+  .v-invoice .v-invoice-table th:last-child {
+    text-align: right;
+  }
+  .v-invoice .v-invoice-totals {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: var(--v-spacing-xs);
+  }
+  .v-invoice .v-invoice-totals .v-invoice-line {
+    display: flex;
+    gap: var(--v-spacing-xxl);
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+  }
+  .v-invoice .v-invoice-totals .v-invoice-line.total {
+    font-weight: 700;
+    font-size: var(--v-font-size-lg);
+    color: var(--v-content-default);
+    padding-top: var(--v-spacing-sm);
+    border-top: 2px solid var(--v-border-base);
+  }
+  .v-invoice .v-invoice-footer {
+    font-size: var(--v-font-size-xs);
+    color: var(--v-content-tertiary);
+    padding-top: var(--v-spacing-md);
+    border-top: 1px solid var(--v-border-base);
+  }
+
+  /* ── Tier 3: Content & Landing Page Components ─────────────── */
+
+  /* Page — centered content container for landing pages */
+  .v-page {
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-xxl);
+    width: 100%;
+  }
+
+  /* Hero — top-of-page banner with gradient background */
+  .v-hero {
+    position: relative;
+    background: linear-gradient(
+      135deg,
+      var(--v-system-positive-weak) 0%,
+      var(--v-border-active) 100%
+    );
+    border-radius: var(--v-radius-xl);
+    padding: var(--v-spacing-xxxl) var(--v-spacing-xl);
+    text-align: center;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--v-spacing-md);
+  }
+  .v-hero::before {
+    content: "";
+    position: absolute;
+    top: -40%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 120%;
+    height: 80%;
+    background: radial-gradient(
+      ellipse,
+      color-mix(in srgb, var(--v-primary-base) 30%, transparent) 0%,
+      transparent 70%
+    );
+    pointer-events: none;
+  }
+  .v-hero-badge {
+    display: inline-block;
+    padding: var(--v-spacing-xs) var(--v-spacing-lg);
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: var(--v-radius-pill);
+    font-size: var(--v-font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--v-content-disabled);
+    position: relative;
+  }
+  .v-hero h1 {
+    font-size: 2.5rem;
+    font-weight: 800;
+    background: linear-gradient(
+      180deg,
+      #fff 30%,
+      var(--v-content-background) 100%
+    );
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin: 0;
+    position: relative;
+    line-height: 1.15;
+  }
+  .v-hero-subtitle {
+    font-size: var(--v-font-size-base);
+    color: var(--v-content-tertiary);
+    max-width: 500px;
+    margin: 0 auto;
+    line-height: 1.5;
+    position: relative;
+  }
+
+  /* Section Header — labeled section intro */
+  .v-section-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-xs);
+    margin-bottom: var(--v-spacing-lg);
+  }
+  .v-section-label {
+    font-size: var(--v-font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--v-primary-base);
+  }
+  .v-section-header h2 {
+    margin: 0;
+  }
+  .v-section-desc {
+    font-size: var(--v-font-size-base);
+    color: var(--v-content-secondary);
+    margin: 0;
+  }
+
+  /* Pullquote — dramatic blockquote with glassmorphism */
+  .v-pullquote {
+    position: relative;
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-md);
+  }
+  .v-pullquote::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: var(--v-spacing-lg);
+    bottom: var(--v-spacing-lg);
+    width: 3px;
+    background: linear-gradient(
+      180deg,
+      var(--v-primary-hover) 0%,
+      var(--v-primary-active) 100%
+    );
+    border-radius: var(--v-radius-pill);
+  }
+  .v-pullquote-text {
+    font-size: var(--v-font-size-lg);
+    font-style: italic;
+    color: var(--v-content-default);
+    line-height: 1.5;
+    margin: 0;
+    padding-left: var(--v-spacing-lg);
+  }
+  .v-pullquote-points {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-sm);
+    padding-left: var(--v-spacing-lg);
+  }
+  .v-pullquote-points li {
+    position: relative;
+    padding-left: var(--v-spacing-lg);
+    font-size: var(--v-font-size-base);
+    color: var(--v-content-secondary);
+  }
+  .v-pullquote-points li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.55em;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--v-primary-base);
+  }
+
+  /* Comparison — before/after or contrasting ideas */
+  .v-comparison {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: var(--v-spacing-md);
+    align-items: center;
+  }
+  .v-comparison-card {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-sm);
+  }
+  .v-comparison-card.before {
+    background: color-mix(
+      in srgb,
+      var(--v-surface-base) 60%,
+      var(--v-surface-overlay)
+    );
+  }
+  .v-comparison-card.before .v-comparison-label {
+    color: var(--v-content-tertiary);
+  }
+  .v-comparison-card.after {
+    background: color-mix(
+      in srgb,
+      var(--v-primary-base) 8%,
+      var(--v-surface-base)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--v-primary-base) 25%,
+      var(--v-border-base)
+    );
+  }
+  .v-comparison-card.after .v-comparison-label {
+    color: var(--v-primary-base);
+  }
+  .v-comparison-label {
+    font-size: var(--v-font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .v-comparison-arrow {
+    font-size: var(--v-font-size-xl);
+    color: var(--v-content-tertiary);
+    text-align: center;
+  }
+
+  /* Feature Grid — auto-fit grid of feature cards */
+  .v-feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--v-spacing-lg);
+  }
+  .v-feature-card {
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-lg);
+    padding: var(--v-spacing-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--v-spacing-sm);
+    transition:
+      transform var(--v-duration-fast) ease-out,
+      box-shadow var(--v-duration-fast) ease-out;
+  }
+  .v-feature-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--v-shadow-md);
+  }
+  .v-feature-card .v-feature-icon {
+    font-size: 24px;
+    line-height: 1;
+  }
+  .v-feature-card .v-feature-title {
+    font-size: var(--v-font-size-base);
+    font-weight: 600;
+    color: var(--v-content-default);
+  }
+  .v-feature-card .v-feature-desc {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+    line-height: 1.4;
+  }
+
+  /* Gradient Text — forest gradient text fill */
+  .v-gradient-text {
+    background: linear-gradient(
+      135deg,
+      var(--v-primary-active) 0%,
+      var(--v-system-positive-weak) 100%
+    );
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  /* Staggered Fade-In Animation */
+  @keyframes v-fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .v-animate-in {
+    animation: v-fade-in var(--v-duration-slow) ease-out both;
+  }
+  .v-animate-in:nth-child(1) {
+    animation-delay: 0s;
+  }
+  .v-animate-in:nth-child(2) {
+    animation-delay: 0.1s;
+  }
+  .v-animate-in:nth-child(3) {
+    animation-delay: 0.2s;
+  }
+  .v-animate-in:nth-child(4) {
+    animation-delay: 0.3s;
+  }
+  .v-animate-in:nth-child(5) {
+    animation-delay: 0.4s;
+  }
+  .v-animate-in:nth-child(6) {
+    animation-delay: 0.5s;
+  }
+
+  /* ── Pill Toggles — time range / filter toggle group ────────── */
+  .v-pill-toggles {
+    display: inline-flex;
+    gap: var(--v-spacing-xxs);
+    background: var(--v-surface-base);
+    border: 1px solid var(--v-border-base);
+    border-radius: var(--v-radius-md);
+    padding: var(--v-spacing-xxs);
+  }
+  .v-pill-toggle {
+    padding: var(--v-spacing-xs) var(--v-spacing-md);
+    border-radius: var(--v-radius-md);
+    border: none;
+    background: none;
+    font-size: var(--v-font-size-sm);
+    font-weight: 500;
+    color: var(--v-content-secondary);
+    cursor: pointer;
+    transition: all var(--v-duration-fast) ease-out;
+  }
+  .v-pill-toggle:hover {
+    color: var(--v-content-default);
+  }
+  .v-pill-toggle.active {
+    background: var(--v-primary-base);
+    color: var(--v-aux-white);
+    font-weight: 600;
+    box-shadow: var(--v-shadow-sm);
+  }
+
+  /* ── Chip Group — suggestion / filter chip row ─────────────── */
+  .v-chip-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--v-spacing-xs);
+  }
+  .v-chip {
+    padding: var(--v-spacing-xs) var(--v-spacing-md);
+    border-radius: var(--v-radius-md);
+    border: 1px solid var(--v-border-base);
+    background: var(--v-surface-base);
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-secondary);
+    cursor: pointer;
+    transition: all var(--v-duration-fast) ease-out;
+  }
+  .v-chip:hover {
+    border-color: var(--v-primary-base);
+    color: var(--v-content-default);
+  }
+  .v-chip.active {
+    background: color-mix(in srgb, var(--v-primary-base) 12%, transparent);
+    border-color: var(--v-primary-base);
+    color: var(--v-primary-base);
+    font-weight: 600;
+  }
+
+  /* ── Metric Icon — emoji icon for metric cards ─────────────── */
+  .v-metric-card .v-metric-icon {
+    font-size: 28px;
+    line-height: 1;
+  }
+
+  /* ── Action Bar — sticky bulk-action bar for multi-select UIs ── */
+  .v-action-bar {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: none;
+    align-items: center;
+    gap: var(--v-spacing-md);
+    padding: var(--v-spacing-sm) var(--v-spacing-lg);
+    background: var(--v-surface-base);
+    border-bottom: 1px solid var(--v-border-base);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+  .v-action-bar.visible {
+    display: flex;
+  }
+  .v-action-bar-count {
+    font-size: var(--v-font-size-sm);
+    font-weight: 600;
+    color: var(--v-primary-base);
+    white-space: nowrap;
+  }
+  .v-action-bar-buttons {
+    display: flex;
+    gap: var(--v-spacing-sm);
+    margin-left: auto;
+  }
+
+  /* ── Action Progress — inline progress bar during bulk ops ───── */
+  .v-action-progress {
+    width: 100%;
+    height: 4px;
+    border-radius: var(--v-radius-pill);
+    background: var(--v-border-base);
+    overflow: hidden;
+  }
+  .v-action-progress::after {
+    content: "";
+    display: block;
+    height: 100%;
+    width: var(--progress, 0%);
+    background: var(--v-primary-base);
+    border-radius: var(--v-radius-pill);
+    transition: width 0.3s ease-out;
+  }
+
+  /* ── Group Header — collapsible section with checkbox + chevron ─ */
+  .v-group-header {
+    display: flex;
+    align-items: center;
+    gap: var(--v-spacing-sm);
+    padding: var(--v-spacing-sm) var(--v-spacing-md);
+    background: color-mix(in srgb, var(--v-surface-base) 60%, transparent);
+    border-radius: var(--v-radius-md);
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    transition: background var(--v-duration-fast) ease-out;
+  }
+  .v-group-header:hover {
+    background: var(--v-surface-base);
+  }
+  .v-group-header .v-group-title {
+    flex: 1;
+    font-weight: 600;
+    font-size: var(--v-font-size-base);
+    color: var(--v-content-default);
+  }
+  .v-group-header .v-group-count {
+    font-size: var(--v-font-size-sm);
+    color: var(--v-content-tertiary);
+  }
+  .v-group-header .v-group-chevron {
+    font-size: 12px;
+    color: var(--v-content-tertiary);
+    transition: transform var(--v-duration-fast) ease-out;
+  }
+  .v-group-header[aria-expanded="true"] .v-group-chevron {
+    transform: rotate(90deg);
+  }
+
+  /* ── Group Body — indented container for group items ─────────── */
+  .v-group-body {
+    padding-left: var(--v-spacing-xl);
+    overflow: hidden;
+  }
+
+  /* ── Row Removing — fade-out + slide animation for processed items */
+  .v-row-removing {
+    opacity: 0;
+    transform: translateX(20px);
+    max-height: 0;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    overflow: hidden;
+    transition:
+      opacity 0.25s ease-out,
+      transform 0.25s ease-out,
+      max-height 0.3s 0.1s ease-out,
+      padding 0.3s 0.1s ease-out,
+      margin 0.3s 0.1s ease-out;
+  }
 } /* end @layer vellum-design-system */

--- a/assistant/src/runtime/routes/auth-routes.ts
+++ b/assistant/src/runtime/routes/auth-routes.ts
@@ -25,7 +25,9 @@ interface AuthInfoResult {
   message?: string;
 }
 
-async function handleAuthInfo(_args: RouteHandlerArgs): Promise<AuthInfoResult> {
+async function handleAuthInfo(
+  _args: RouteHandlerArgs,
+): Promise<AuthInfoResult> {
   const ctx = await resolveManagedProxyContext();
 
   const platformUrl = getPlatformBaseUrl();

--- a/assistant/src/runtime/routes/cache-routes.ts
+++ b/assistant/src/runtime/routes/cache-routes.ts
@@ -34,9 +34,9 @@ function handleCacheSet({ body = {} }: RouteHandlerArgs): { key: string } {
   return setCacheEntry(data, { key, ttlMs: ttl_ms });
 }
 
-function handleCacheGet(
-  { body = {} }: RouteHandlerArgs,
-): { data: unknown } | null {
+function handleCacheGet({
+  body = {},
+}: RouteHandlerArgs): { data: unknown } | null {
   const { key } = CacheKeyParams.parse(body);
   return getCacheEntry(key);
 }

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -59,7 +59,11 @@ const STATUS_CODE_MAP: Record<number, string> = {
 };
 
 function throwDomainError(error: string, status: number): never {
-  throw new RouteError(error, STATUS_CODE_MAP[status] ?? "INTERNAL_ERROR", status);
+  throw new RouteError(
+    error,
+    STATUS_CODE_MAP[status] ?? "INTERNAL_ERROR",
+    status,
+  );
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -197,7 +197,8 @@ async function handleGetVerificationStatus({
   queryParams = {},
   body = {},
 }: RouteHandlerArgs) {
-  const channel = (queryParams.channel ?? (body as Record<string, unknown>).channel) as ChannelId | undefined;
+  const channel = (queryParams.channel ??
+    (body as Record<string, unknown>).channel) as ChannelId | undefined;
   return await getVerificationStatus(channel);
 }
 

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -52,9 +52,9 @@ const pendingContactPrompts = new Map<string, PendingContactPrompt>();
  * Called by the gateway after it writes the contact and channel.
  * Resolves the pending promise so the CLI's `contacts/prompt` IPC call returns.
  */
-function resolveContactPrompt({
-  body = {},
-}: RouteHandlerArgs): { resolved: boolean } {
+function resolveContactPrompt({ body = {} }: RouteHandlerArgs): {
+  resolved: boolean;
+} {
   const { requestId, contactId, channelId, channelType, address, error } =
     body as {
       requestId: string;
@@ -104,8 +104,14 @@ const ContactPromptParams = z.object({
     .string()
     .optional()
     .describe("Placeholder text for the address input field."),
-  label: z.string().optional().describe("Display label shown in the prompt UI."),
-  description: z.string().optional().describe("Longer description for the prompt UI."),
+  label: z
+    .string()
+    .optional()
+    .describe("Display label shown in the prompt UI."),
+  description: z
+    .string()
+    .optional()
+    .describe("Longer description for the prompt UI."),
   role: z
     .enum(["guardian", "trusted-contact", "unknown"])
     .default("unknown")

--- a/assistant/src/runtime/routes/inbound-stages/admission-policy.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/admission-policy.test.ts
@@ -6,12 +6,14 @@
  * `handle-inbound-admission.test.ts` and in the full inbound-message
  * handler integration tests.
  */
-import { describe, expect,test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import type { AdmissionPolicyInput } from "./admission-policy.js";
 import { enforceAdmissionPolicy } from "./admission-policy.js";
 
-function makeInput(overrides: Partial<AdmissionPolicyInput>): AdmissionPolicyInput {
+function makeInput(
+  overrides: Partial<AdmissionPolicyInput>,
+): AdmissionPolicyInput {
   return {
     sourceChannel: "telegram",
     trustClass: "unknown",
@@ -28,7 +30,11 @@ function makeInput(overrides: Partial<AdmissionPolicyInput>): AdmissionPolicyInp
 describe("enforceAdmissionPolicy — exempt channels", () => {
   test("a2a short-circuits to admitted regardless of policy", () => {
     const result = enforceAdmissionPolicy(
-      makeInput({ sourceChannel: "a2a", trustClass: "unknown", policy: "no_one" }),
+      makeInput({
+        sourceChannel: "a2a",
+        trustClass: "unknown",
+        policy: "no_one",
+      }),
     );
     expect(result.admitted).toBe(true);
   });
@@ -37,7 +43,11 @@ describe("enforceAdmissionPolicy — exempt channels", () => {
     // Voice ingress is wired, so `phone` is no longer exempt — an `unknown`
     // caller is denied under `no_one`.
     const result = enforceAdmissionPolicy(
-      makeInput({ sourceChannel: "phone", trustClass: "unknown", policy: "no_one" }),
+      makeInput({
+        sourceChannel: "phone",
+        trustClass: "unknown",
+        policy: "no_one",
+      }),
     );
     expect(result.admitted).toBe(false);
   });
@@ -133,7 +143,11 @@ describe("enforceAdmissionPolicy — rank vs floor", () => {
 
   test("unknown (non-member) admitted under strangers floor", () => {
     const result = enforceAdmissionPolicy(
-      makeInput({ trustClass: "unknown", memberStatus: undefined, policy: "strangers" }),
+      makeInput({
+        trustClass: "unknown",
+        memberStatus: undefined,
+        policy: "strangers",
+      }),
     );
     expect(result.admitted).toBe(true);
   });
@@ -147,7 +161,11 @@ describe("enforceAdmissionPolicy — rank vs floor", () => {
 
   test("pending member (unverified_contact) admitted under strangers floor", () => {
     const result = enforceAdmissionPolicy(
-      makeInput({ trustClass: "unverified_contact", memberStatus: "pending", policy: "strangers" }),
+      makeInput({
+        trustClass: "unverified_contact",
+        memberStatus: "pending",
+        policy: "strangers",
+      }),
     );
     expect(result.admitted).toBe(true);
   });

--- a/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
@@ -65,7 +65,10 @@ async function respondBootstrapUnavailable(
   eventId: string,
 ): Promise<Record<string, unknown>> {
   try {
-    await sendTelegramReply(conversationExternalId, BOOTSTRAP_UNAVAILABLE_REPLY);
+    await sendTelegramReply(
+      conversationExternalId,
+      BOOTSTRAP_UNAVAILABLE_REPLY,
+    );
   } catch (err) {
     log.error(
       { err, chatId: conversationExternalId },
@@ -224,12 +227,12 @@ export async function handleBootstrapIntercept(
     );
   }
 
-  return ({
+  return {
     accepted: true,
     duplicate: false,
     eventId,
     verificationOutcome: "bootstrap_bound",
-  });
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -99,7 +99,10 @@ export async function handleGuardianActivationIntercept(
   const guardianList = await getGuardianDeliveryFresh({
     channelTypes: [sourceChannel],
   });
-  if (guardianList === null || guardianForChannel(guardianList, sourceChannel)) {
+  if (
+    guardianList === null ||
+    guardianForChannel(guardianList, sourceChannel)
+  ) {
     return null;
   }
 

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -231,7 +231,10 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
 
   test("contact verdict records the reaction; the decision pipeline self-gate ignores it", async () => {
     const result = await handleSlackReactionIntercept(
-      buildParams({ rawSenderId: MEMBER_USER_ID, trustVerdict: MEMBER_VERDICT }),
+      buildParams({
+        rawSenderId: MEMBER_USER_ID,
+        trustVerdict: MEMBER_VERDICT,
+      }),
     );
 
     // Dispatched with the contact class (guardian-reply-intercept self-gates
@@ -291,7 +294,10 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
       }),
     );
     await handleSlackReactionIntercept(
-      buildParams({ rawSenderId: MEMBER_USER_ID, trustVerdict: MEMBER_VERDICT }),
+      buildParams({
+        rawSenderId: MEMBER_USER_ID,
+        trustVerdict: MEMBER_VERDICT,
+      }),
     );
 
     expect(ipcCalls).toEqual([]);

--- a/assistant/src/runtime/routes/oauth-connect-routes.ts
+++ b/assistant/src/runtime/routes/oauth-connect-routes.ts
@@ -128,9 +128,18 @@ async function handleOAuthConnectStart({
       onDeferredComplete: (r) => {
         if (!resolvedState) return;
         if (r.success) {
-          setOAuthConnectComplete(resolvedState, r.service, r.accountInfo, r.grantedScopes);
+          setOAuthConnectComplete(
+            resolvedState,
+            r.service,
+            r.accountInfo,
+            r.grantedScopes,
+          );
         } else {
-          setOAuthConnectError(resolvedState, r.service, r.error ?? "OAuth connect failed");
+          setOAuthConnectError(
+            resolvedState,
+            r.service,
+            r.error ?? "OAuth connect failed",
+          );
         }
       },
     });
@@ -166,19 +175,28 @@ function handleOAuthConnectStatus({
   const flowState = getOAuthConnectState(state);
 
   if (flowState === null) {
-    throw new NotFoundError(`No active OAuth connect flow for state "${state}"`);
+    throw new NotFoundError(
+      `No active OAuth connect flow for state "${state}"`,
+    );
   }
 
-  if (flowState.status === "pending") return { status: "pending", service: flowState.service };
+  if (flowState.status === "pending")
+    return { status: "pending", service: flowState.service };
   if (flowState.status === "complete") {
     return {
       status: "complete",
       service: flowState.service,
       ...(flowState.accountInfo ? { account_info: flowState.accountInfo } : {}),
-      ...(flowState.grantedScopes ? { granted_scopes: flowState.grantedScopes } : {}),
+      ...(flowState.grantedScopes
+        ? { granted_scopes: flowState.grantedScopes }
+        : {}),
     };
   }
-  return { status: "error", service: flowState.service, error: flowState.error };
+  return {
+    status: "error",
+    service: flowState.service,
+    error: flowState.error,
+  };
 }
 
 export const ROUTES: RouteDefinition[] = [
@@ -217,7 +235,9 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["internal"],
     pathParams: [{ name: "state" }],
     additionalResponses: {
-      "404": { description: "No active OAuth connect flow for the given state token" },
+      "404": {
+        description: "No active OAuth connect flow for the given state token",
+      },
     },
     handler: handleOAuthConnectStatus,
   },

--- a/assistant/src/runtime/routes/playground/seed-conversation.ts
+++ b/assistant/src/runtime/routes/playground/seed-conversation.ts
@@ -16,7 +16,10 @@ import type { Message } from "../../../providers/types.js";
 import { BadRequestError } from "../errors.js";
 import type { RouteDefinition } from "../types.js";
 import { assertPlaygroundEnabled } from "./guard.js";
-import { addPlaygroundMessage, createPlaygroundConversation } from "./helpers.js";
+import {
+  addPlaygroundMessage,
+  createPlaygroundConversation,
+} from "./helpers.js";
 
 /**
  * Title prefix applied to every seeded-playground conversation. Exported so
@@ -89,9 +92,7 @@ export const ROUTES: RouteDefinition[] = [
       }
 
       for (const msg of messages) {
-        const contentJson = JSON.stringify([
-          { type: "text", text: msg.text },
-        ]);
+        const contentJson = JSON.stringify([{ type: "text", text: msg.text }]);
         await addPlaygroundMessage(conversationId, msg.role, contentJson, {
           skipIndexing: true,
         });

--- a/assistant/src/runtime/routes/playground/seeded-conversations.ts
+++ b/assistant/src/runtime/routes/playground/seeded-conversations.ts
@@ -42,8 +42,9 @@ export const ROUTES: RouteDefinition[] = [
       assertPlaygroundEnabled();
 
       const id = pathParams!.id;
-      const seeded = listConversationsByTitlePrefix(PLAYGROUND_TITLE_PREFIX)
-        .find((c) => c.id === id);
+      const seeded = listConversationsByTitlePrefix(
+        PLAYGROUND_TITLE_PREFIX,
+      ).find((c) => c.id === id);
       if (!seeded) {
         throw new ForbiddenError("Not a playground conversation");
       }

--- a/assistant/src/runtime/routes/profiler-routes.ts
+++ b/assistant/src/runtime/routes/profiler-routes.ts
@@ -79,8 +79,7 @@ const DEFAULT_MAX_BYTES = 500 * 1024 * 1024;
 function handleListRuns() {
   const manifests = rescanRuns({ readOnly: true });
   manifests.sort(
-    (a, b) =>
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
   );
 
   return {
@@ -124,9 +123,7 @@ function handleGetRun({ pathParams = {} }: RouteHandlerArgs) {
   };
 }
 
-function handleExportRun({
-  pathParams = {},
-}: RouteHandlerArgs): Uint8Array {
+function handleExportRun({ pathParams = {} }: RouteHandlerArgs): Uint8Array {
   const runId = validateRunId(pathParams.runId);
 
   const runDir = getProfilerRunDir(runId);

--- a/assistant/src/runtime/routes/question-routes.ts
+++ b/assistant/src/runtime/routes/question-routes.ts
@@ -163,9 +163,11 @@ function handleQuestionResponse({ body }: RouteHandlerArgs) {
     "Question resolved",
   );
 
-  (interaction.rpcResolve as
-    | ((value: QuestionPromptResult) => void)
-    | undefined)?.(result);
+  (
+    interaction.rpcResolve as
+      | ((value: QuestionPromptResult) => void)
+      | undefined
+  )?.(result);
 
   return { success: true };
 }
@@ -233,7 +235,9 @@ function buildCompletedResult(
 function readBatchMetadata(
   interaction: ReturnType<typeof pendingInteractions.get>,
 ): QuestionBatchMetadata {
-  const meta = interaction?.metadata as Partial<QuestionBatchMetadata> | undefined;
+  const meta = interaction?.metadata as
+    | Partial<QuestionBatchMetadata>
+    | undefined;
   return {
     orderedIds: meta?.orderedIds ?? [],
     optionsById: meta?.optionsById ?? {},

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -14,12 +14,10 @@ import type { TrustContext } from "../../daemon/trust-context-types.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
-import { reResolveTrustOnResetDrift } from "../guardian-vellum-migration.js";
 import {
   findLocalGuardianPrincipalId,
   resolveActorPrincipalIdForLocalGuardian,
 } from "../local-actor-identity.js";
-import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
 import { parseCallbackData } from "./channel-route-shared.js";
 import {
   BadRequestError,
@@ -29,6 +27,7 @@ import {
 } from "./errors.js";
 import { resolveSurfaceConversation } from "./surface-conversation-resolver.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+import { resolveVellumActorTrustContext } from "./vellum-actor-trust.js";
 
 const log = getLogger("surface-action-routes");
 
@@ -39,7 +38,10 @@ const log = getLogger("surface-action-routes");
 /**
  * Resolve trust context for the actor principal from the gateway guardian
  * binding and set it on the conversation. A vellum principal is the guardian or
- * nobody, so the mapper yields guardian or unknown.
+ * nobody, so the mapper yields guardian or unknown. Resolution (including the
+ * dev-bypass principal translation and the mutating reset-drift repair) lives
+ * in the shared {@link resolveVellumActorTrustContext} so the surface content
+ * route's read-only requester scoping cannot drift from it.
  */
 async function applyTrustContext(
   conversation: {
@@ -50,40 +52,11 @@ async function applyTrustContext(
   if (!conversation.setTrustContext) {
     return;
   }
-
-  const sourceChannel = "vellum";
-
-  if (!actorPrincipalId) {
-    conversation.setTrustContext({ trustClass: "guardian", sourceChannel });
-    return;
-  }
-
-  // Dev-bypass injects a synthetic principal that won't match the real
-  // guardian binding, so resolve the actual guardian principalId (gateway
-  // first, local store fallback) before mapping trust.
-  let principalId = actorPrincipalId;
-  if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
-    principalId = (await findLocalGuardianPrincipalId()) ?? actorPrincipalId;
-  }
-
-  let trustCtx = await resolveLocalPrincipalTrustContext({
-    actorPrincipalId: principalId,
-    sourceChannel,
-    conversationExternalId: "local",
-  });
-  if (trustCtx.trustClass === "unknown") {
-    const healed = await reResolveTrustOnResetDrift(principalId, sourceChannel);
-    if (healed) {
-      trustCtx = healed;
-      if (healed.trustClass !== "unknown") {
-        log.info(
-          { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
-          "Trust re-resolved from local mirror after gateway reset drift (surface action)",
-        );
-      }
-    }
-  }
-  conversation.setTrustContext(trustCtx);
+  conversation.setTrustContext(
+    await resolveVellumActorTrustContext(actorPrincipalId, {
+      healResetDrift: true,
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/surface-content-routes.ts
+++ b/assistant/src/runtime/routes/surface-content-routes.ts
@@ -12,7 +12,10 @@ import { z } from "zod";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
-import { resolveSurfaceConversation } from "./surface-conversation-resolver.js";
+import {
+  findPersistedSurfaceState,
+  resolveSurfaceConversation,
+} from "./surface-conversation-resolver.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("surface-content-routes");
@@ -80,6 +83,30 @@ async function handleGetSurfaceContent({
       surfaceType: turnSurface.surfaceType,
       title: turnSurface.title ?? null,
       data: turnSurface.data,
+    };
+  }
+
+  // Fall back to persisted history. A surface appended out-of-band
+  // (`addMessage` against an already-loaded conversation — the memory
+  // retrospective's skill card) lands in the messages table without
+  // touching the live object's `surfaceState`, which is only rebuilt on
+  // construction. Without this rung the lookup 404s exactly while the
+  // conversation is loaded and works again after eviction. Memoize the hit
+  // so later fetches, action routing, and `findConversationBySurfaceId`
+  // resolve in-memory — the same O(1) registration that helper already
+  // performs; no DB state is written on this GET.
+  const persisted = findPersistedSurfaceState(conversationId, surfaceId);
+  if (persisted) {
+    conversation.surfaceState.set(surfaceId, persisted);
+    log.info(
+      { conversationId, surfaceId },
+      "Surface content served from persisted history",
+    );
+    return {
+      surfaceId,
+      surfaceType: persisted.surfaceType,
+      title: persisted.title ?? null,
+      data: persisted.data,
     };
   }
 

--- a/assistant/src/runtime/routes/surface-content-routes.ts
+++ b/assistant/src/runtime/routes/surface-content-routes.ts
@@ -101,38 +101,43 @@ async function handleGetSurfaceContent({
   // Provenance is scoped to the REQUESTER, not to whatever trust class the
   // cached conversation happens to be loaded under — a guardian-loaded view
   // must not leak a guardian-provenance row to a non-guardian actor who
-  // names its surface id. Resolved read-only (no reset-drift repair): safe
-  // methods stay side-effect-free, and an unhealed drift just fail-closes
-  // to the untrusted filter until a mutating route heals it.
-  const requesterTrust = await resolveVellumActorTrustContext(
-    headers["x-vellum-actor-principal-id"],
-  );
+  // names its surface id. The verified principal type gates the guardian
+  // default: only local/IPC callers are the guardian by construction;
+  // service principals without a forwarded actor id fail closed to the
+  // untrusted filter. Trust is resolved read-only (no reset-drift repair):
+  // safe methods stay side-effect-free, and an unhealed drift just
+  // fail-closes the same way until a mutating route heals it.
+  const actorPrincipalId = headers["x-vellum-actor-principal-id"];
+  const principalType = headers["x-vellum-principal-type"];
+  let requesterCanAccessMemory = false;
+  if (actorPrincipalId || principalType === "local") {
+    const requesterTrust =
+      await resolveVellumActorTrustContext(actorPrincipalId);
+    requesterCanAccessMemory = resolveCapabilities(
+      requesterTrust.trustClass,
+    ).canAccessMemory;
+  }
+  // Serve WITHOUT memoizing. Writing the hit into the shared
+  // `conversation.surfaceState` would let a later request skip this rung's
+  // requester filter via the unscoped fast path above — the exposure the
+  // filter exists to prevent. Re-scanning per fetch keeps the GET fully
+  // side-effect-free; the scan is LIKE-bounded and per-conversation.
   const persisted = findPersistedSurfaceState(conversationId, surfaceId, {
     // Share the live window's compaction boundary so the scan can never
-    // resurrect (and memoize) a surface the compacted-away prefix owned.
+    // resurrect a surface the compacted-away prefix owned.
     liveHistoryStartRow: conversation.contextCompactedMessageCount,
-    requesterCanAccessMemory: resolveCapabilities(requesterTrust.trustClass)
-      .canAccessMemory,
+    requesterCanAccessMemory,
   });
   if (persisted) {
-    // Memoize only when the row belongs in the LOADED view's scope: writing
-    // a guardian-only payload into an actor-scoped `surfaceState` would let
-    // a later untrusted fetch read it straight off the fast path.
-    const viewCanAccessMemory = resolveCapabilities(
-      conversation.loadedHistoryTrustClass,
-    ).canAccessMemory;
-    if (viewCanAccessMemory || persisted.visibleToUntrustedActor) {
-      conversation.surfaceState.set(surfaceId, persisted.state);
-    }
     log.info(
       { conversationId, surfaceId },
       "Surface content served from persisted history",
     );
     return {
       surfaceId,
-      surfaceType: persisted.state.surfaceType,
-      title: persisted.state.title ?? null,
-      data: persisted.state.data,
+      surfaceType: persisted.surfaceType,
+      title: persisted.title ?? null,
+      data: persisted.data,
     };
   }
 

--- a/assistant/src/runtime/routes/surface-content-routes.ts
+++ b/assistant/src/runtime/routes/surface-content-routes.ts
@@ -18,6 +18,7 @@ import {
   resolveSurfaceConversation,
 } from "./surface-conversation-resolver.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+import { resolveVellumActorTrustContext } from "./vellum-actor-trust.js";
 
 const log = getLogger("surface-content-routes");
 
@@ -28,6 +29,7 @@ const log = getLogger("surface-content-routes");
 async function handleGetSurfaceContent({
   pathParams = {},
   queryParams = {},
+  headers = {},
 }: RouteHandlerArgs) {
   const conversationId = queryParams.conversationId;
   if (!conversationId) {
@@ -96,28 +98,41 @@ async function handleGetSurfaceContent({
   // so later fetches, action routing, and `findConversationBySurfaceId`
   // resolve in-memory — the same O(1) registration that helper already
   // performs; no DB state is written on this GET.
+  // Provenance is scoped to the REQUESTER, not to whatever trust class the
+  // cached conversation happens to be loaded under — a guardian-loaded view
+  // must not leak a guardian-provenance row to a non-guardian actor who
+  // names its surface id. Resolved read-only (no reset-drift repair): safe
+  // methods stay side-effect-free, and an unhealed drift just fail-closes
+  // to the untrusted filter until a mutating route heals it.
+  const requesterTrust = await resolveVellumActorTrustContext(
+    headers["x-vellum-actor-principal-id"],
+  );
   const persisted = findPersistedSurfaceState(conversationId, surfaceId, {
     // Share the live window's compaction boundary so the scan can never
     // resurrect (and memoize) a surface the compacted-away prefix owned.
     liveHistoryStartRow: conversation.contextCompactedMessageCount,
-    // Mirror the loaded view's trust scope (`loadFromDb` resolves the same
-    // capability from the trust class it loaded under) so an actor-scoped
-    // view can't name a guardian-provenance surface the history filter
-    // deliberately dropped.
-    canAccessMemory: resolveCapabilities(conversation.loadedHistoryTrustClass)
+    requesterCanAccessMemory: resolveCapabilities(requesterTrust.trustClass)
       .canAccessMemory,
   });
   if (persisted) {
-    conversation.surfaceState.set(surfaceId, persisted);
+    // Memoize only when the row belongs in the LOADED view's scope: writing
+    // a guardian-only payload into an actor-scoped `surfaceState` would let
+    // a later untrusted fetch read it straight off the fast path.
+    const viewCanAccessMemory = resolveCapabilities(
+      conversation.loadedHistoryTrustClass,
+    ).canAccessMemory;
+    if (viewCanAccessMemory || persisted.visibleToUntrustedActor) {
+      conversation.surfaceState.set(surfaceId, persisted.state);
+    }
     log.info(
       { conversationId, surfaceId },
       "Surface content served from persisted history",
     );
     return {
       surfaceId,
-      surfaceType: persisted.surfaceType,
-      title: persisted.title ?? null,
-      data: persisted.data,
+      surfaceType: persisted.state.surfaceType,
+      title: persisted.state.title ?? null,
+      data: persisted.state.data,
     };
   }
 

--- a/assistant/src/runtime/routes/surface-content-routes.ts
+++ b/assistant/src/runtime/routes/surface-content-routes.ts
@@ -95,7 +95,13 @@ async function handleGetSurfaceContent({
   // so later fetches, action routing, and `findConversationBySurfaceId`
   // resolve in-memory — the same O(1) registration that helper already
   // performs; no DB state is written on this GET.
-  const persisted = findPersistedSurfaceState(conversationId, surfaceId);
+  const persisted = findPersistedSurfaceState(
+    conversationId,
+    surfaceId,
+    // Share the live window's compaction boundary so the scan can never
+    // resurrect (and memoize) a surface the compacted-away prefix owned.
+    conversation.contextCompactedMessageCount,
+  );
   if (persisted) {
     conversation.surfaceState.set(surfaceId, persisted);
     log.info(

--- a/assistant/src/runtime/routes/surface-content-routes.ts
+++ b/assistant/src/runtime/routes/surface-content-routes.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { resolveCapabilities } from "../capabilities.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
 import {
   findPersistedSurfaceState,
@@ -95,13 +96,17 @@ async function handleGetSurfaceContent({
   // so later fetches, action routing, and `findConversationBySurfaceId`
   // resolve in-memory — the same O(1) registration that helper already
   // performs; no DB state is written on this GET.
-  const persisted = findPersistedSurfaceState(
-    conversationId,
-    surfaceId,
+  const persisted = findPersistedSurfaceState(conversationId, surfaceId, {
     // Share the live window's compaction boundary so the scan can never
     // resurrect (and memoize) a surface the compacted-away prefix owned.
-    conversation.contextCompactedMessageCount,
-  );
+    liveHistoryStartRow: conversation.contextCompactedMessageCount,
+    // Mirror the loaded view's trust scope (`loadFromDb` resolves the same
+    // capability from the trust class it loaded under) so an actor-scoped
+    // view can't name a guardian-provenance surface the history filter
+    // deliberately dropped.
+    canAccessMemory: resolveCapabilities(conversation.loadedHistoryTrustClass)
+      .canAccessMemory,
+  });
   if (persisted) {
     conversation.surfaceState.set(surfaceId, persisted);
     log.info(

--- a/assistant/src/runtime/routes/surface-conversation-resolver.ts
+++ b/assistant/src/runtime/routes/surface-conversation-resolver.ts
@@ -20,6 +20,7 @@ import {
   findConversationBySurfaceId,
 } from "../../daemon/conversation-registry.js";
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
+import { isRowVisibleToUntrustedActor } from "../../daemon/message-provenance.js";
 import type {
   SurfaceData,
   SurfaceType,
@@ -55,7 +56,9 @@ export async function resolveSurfaceConversation(
   const found = conversationId
     ? findConversation(conversationId)
     : findConversationBySurfaceId(surfaceId);
-  if (found) return found;
+  if (found) {
+    return found;
+  }
 
   // Escape LIKE wildcards so a `surfaceId` like "%" or "_" can't match
   // unrelated rows.
@@ -68,9 +71,12 @@ export async function resolveSurfaceConversation(
      LIMIT 1`,
     `%"surfaceId":"${escaped}"%`,
   );
-  if (!row) return undefined;
-  if (conversationId && conversationId !== row.conversation_id)
+  if (!row) {
     return undefined;
+  }
+  if (conversationId && conversationId !== row.conversation_id) {
+    return undefined;
+  }
   return await getOrCreateConversation(row.conversation_id);
 }
 
@@ -118,19 +124,31 @@ export interface PersistedSurfaceState {
  * resurrecting one here would let later surface-action routing operate on
  * state the compaction dropped. The scan skips that same prefix (rows are
  * numbered in the store's `created_at ASC` order).
+ *
+ * `canAccessMemory` preserves actor provenance: when the live view was
+ * loaded for an untrusted actor, `loadFromDb` builds history (and therefore
+ * `surfaceState`) from `filterMessagesForUntrustedActor(...)`, so a
+ * guardian-authored or provenance-less row is deliberately absent from the
+ * actor-scoped view. The scan applies the identical per-row predicate
+ * before parsing, serving, or memoizing — otherwise naming a hidden
+ * surface id would expose the payload the trust filter dropped.
  */
 export function findPersistedSurfaceState(
   conversationId: string,
   surfaceId: string,
-  liveHistoryStartRow: number,
+  opts: {
+    liveHistoryStartRow: number;
+    canAccessMemory: boolean;
+  },
 ): PersistedSurfaceState | undefined {
   // Escape LIKE wildcards so a `surfaceId` like "%" or "_" can't match
   // unrelated rows.
   const escaped = surfaceId.replace(/[\\%_]/g, "\\$&");
-  const rows = rawAll<{ content: string }>(
+  const rows = rawAll<{ content: string; metadata: string | null }>(
     "surfaceResolver:findPersistedSurface",
-    `SELECT content FROM (
-       SELECT content, ROW_NUMBER() OVER (ORDER BY created_at ASC) AS rn
+    `SELECT content, metadata FROM (
+       SELECT content, metadata,
+              ROW_NUMBER() OVER (ORDER BY created_at ASC) AS rn
        FROM messages
        WHERE conversation_id = ?
      )
@@ -138,20 +156,27 @@ export function findPersistedSurfaceState(
      ORDER BY rn DESC
      LIMIT 10`,
     conversationId,
-    Math.max(0, Math.floor(liveHistoryStartRow)),
+    Math.max(0, Math.floor(opts.liveHistoryStartRow)),
     `%"surfaceId":"${escaped}"%`,
   );
   for (const row of rows) {
+    if (!opts.canAccessMemory && !isRowVisibleToUntrustedActor(row.metadata)) {
+      continue;
+    }
     let blocks: unknown;
     try {
       blocks = JSON.parse(row.content);
     } catch {
       continue;
     }
-    if (!Array.isArray(blocks)) continue;
+    if (!Array.isArray(blocks)) {
+      continue;
+    }
     for (const block of blocks) {
       const b = block as Record<string, unknown>;
-      if (b.type !== "ui_surface" || b.surfaceId !== surfaceId) continue;
+      if (b.type !== "ui_surface" || b.surfaceId !== surfaceId) {
+        continue;
+      }
       // Same field mapping and validation as
       // `restoreSurfaceStateFromHistory` — a malformed daemon-only
       // `activationMoment` is dropped, never served or memoized.

--- a/assistant/src/runtime/routes/surface-conversation-resolver.ts
+++ b/assistant/src/runtime/routes/surface-conversation-resolver.ts
@@ -110,22 +110,35 @@ export interface PersistedSurfaceState {
  * index-friendly candidate probe only — the parsed block is what confirms
  * the exact `surfaceId` (a message merely quoting the id in text parses to
  * no matching block and the scan moves on).
+ *
+ * `liveHistoryStartRow` preserves the compaction boundary: the live history
+ * is `getMessages(...).slice(contextCompactedMessageCount)` (`loadFromDb`),
+ * and `restoreSurfaceStateFromHistory` deliberately never sees the
+ * compacted-away prefix — stale surface ids are not globally unique, so
+ * resurrecting one here would let later surface-action routing operate on
+ * state the compaction dropped. The scan skips that same prefix (rows are
+ * numbered in the store's `created_at ASC` order).
  */
 export function findPersistedSurfaceState(
   conversationId: string,
   surfaceId: string,
+  liveHistoryStartRow: number,
 ): PersistedSurfaceState | undefined {
   // Escape LIKE wildcards so a `surfaceId` like "%" or "_" can't match
   // unrelated rows.
   const escaped = surfaceId.replace(/[\\%_]/g, "\\$&");
   const rows = rawAll<{ content: string }>(
     "surfaceResolver:findPersistedSurface",
-    `SELECT content FROM messages
-     WHERE conversation_id = ?
-       AND content LIKE ? ESCAPE '\\'
-     ORDER BY created_at DESC
+    `SELECT content FROM (
+       SELECT content, ROW_NUMBER() OVER (ORDER BY created_at ASC) AS rn
+       FROM messages
+       WHERE conversation_id = ?
+     )
+     WHERE rn > ? AND content LIKE ? ESCAPE '\\'
+     ORDER BY rn DESC
      LIMIT 10`,
     conversationId,
+    Math.max(0, Math.floor(liveHistoryStartRow)),
     `%"surfaceId":"${escaped}"%`,
   );
   for (const row of rows) {

--- a/assistant/src/runtime/routes/surface-conversation-resolver.ts
+++ b/assistant/src/runtime/routes/surface-conversation-resolver.ts
@@ -20,7 +20,15 @@ import {
   findConversationBySurfaceId,
 } from "../../daemon/conversation-registry.js";
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
-import { rawGet } from "../../persistence/raw-query.js";
+import type {
+  SurfaceData,
+  SurfaceType,
+} from "../../daemon/message-types/surfaces.js";
+import { rawAll, rawGet } from "../../persistence/raw-query.js";
+import {
+  type ActivationMomentParam,
+  isActivationMomentParam,
+} from "../../telemetry/activation-funnel.js";
 
 /**
  * Resolve the {@link Conversation} that owns the given surface.
@@ -64,4 +72,91 @@ export async function resolveSurfaceConversation(
   if (conversationId && conversationId !== row.conversation_id)
     return undefined;
   return await getOrCreateConversation(row.conversation_id);
+}
+
+/**
+ * A `ui_surface` block extracted from persisted history, in the shape of a
+ * `Conversation.surfaceState` entry so callers can memoize it directly.
+ */
+export interface PersistedSurfaceState {
+  surfaceType: SurfaceType;
+  data: SurfaceData;
+  title?: string;
+  actions?: Array<{
+    id: string;
+    label: string;
+    style?: string;
+    data?: Record<string, unknown>;
+  }>;
+  activationMoment?: ActivationMomentParam;
+}
+
+/**
+ * Find the `ui_surface` block for `surfaceId` in the conversation's
+ * PERSISTED message history and map it to the `surfaceState` entry shape.
+ *
+ * Why this exists: `surfaceState` is only rebuilt from history when a
+ * Conversation is constructed (`restoreSurfaceStateFromHistory`). A surface
+ * appended out-of-band — `addMessage` against an already-loaded
+ * conversation, as the memory retrospective's skill card does — lands in
+ * the messages table without ever touching the live object's map, so an
+ * in-memory registry hit resolves a conversation whose `surfaceState`
+ * predates the insert and the content lookup 404s. (An evicted
+ * conversation works: rehydration rescans history.)
+ *
+ * The newest matching message wins, mirroring
+ * `restoreSurfaceStateFromHistory`'s forward scan where a later write to
+ * the same `surfaceId` overwrites an earlier one. The LIKE pre-filter is an
+ * index-friendly candidate probe only — the parsed block is what confirms
+ * the exact `surfaceId` (a message merely quoting the id in text parses to
+ * no matching block and the scan moves on).
+ */
+export function findPersistedSurfaceState(
+  conversationId: string,
+  surfaceId: string,
+): PersistedSurfaceState | undefined {
+  // Escape LIKE wildcards so a `surfaceId` like "%" or "_" can't match
+  // unrelated rows.
+  const escaped = surfaceId.replace(/[\\%_]/g, "\\$&");
+  const rows = rawAll<{ content: string }>(
+    "surfaceResolver:findPersistedSurface",
+    `SELECT content FROM messages
+     WHERE conversation_id = ?
+       AND content LIKE ? ESCAPE '\\'
+     ORDER BY created_at DESC
+     LIMIT 10`,
+    conversationId,
+    `%"surfaceId":"${escaped}"%`,
+  );
+  for (const row of rows) {
+    let blocks: unknown;
+    try {
+      blocks = JSON.parse(row.content);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(blocks)) continue;
+    for (const block of blocks) {
+      const b = block as Record<string, unknown>;
+      if (b.type !== "ui_surface" || b.surfaceId !== surfaceId) continue;
+      // Same field mapping and validation as
+      // `restoreSurfaceStateFromHistory` — a malformed daemon-only
+      // `activationMoment` is dropped, never served or memoized.
+      const activationMoment =
+        typeof b.activationMoment === "string" &&
+        isActivationMomentParam(b.activationMoment)
+          ? b.activationMoment
+          : undefined;
+      return {
+        surfaceType: (b.surfaceType ?? "dynamic_page") as SurfaceType,
+        data: (b.data ?? {}) as SurfaceData,
+        title: b.title as string | undefined,
+        actions: Array.isArray(b.actions)
+          ? (b.actions as PersistedSurfaceState["actions"])
+          : undefined,
+        ...(activationMoment ? { activationMoment } : {}),
+      };
+    }
+  }
+  return undefined;
 }

--- a/assistant/src/runtime/routes/surface-conversation-resolver.ts
+++ b/assistant/src/runtime/routes/surface-conversation-resolver.ts
@@ -82,20 +82,8 @@ export async function resolveSurfaceConversation(
 
 /**
  * A `ui_surface` block extracted from persisted history, in the shape of a
- * `Conversation.surfaceState` entry so callers can memoize it directly.
+ * `Conversation.surfaceState` entry.
  */
-export interface PersistedSurfaceHit {
-  state: PersistedSurfaceState;
-  /**
-   * Whether the owning row's provenance passes
-   * `isRowVisibleToUntrustedActor` — i.e. whether an actor-scoped history
-   * view would contain this row at all. Callers use it to keep memoization
-   * within the loaded view's scope (never widen a cached actor-scoped
-   * `surfaceState` with guardian-only payloads).
-   */
-  visibleToUntrustedActor: boolean;
-}
-
 export interface PersistedSurfaceState {
   surfaceType: SurfaceType;
   data: SurfaceData;
@@ -154,10 +142,15 @@ export function findPersistedSurfaceState(
     liveHistoryStartRow: number;
     requesterCanAccessMemory: boolean;
   },
-): PersistedSurfaceHit | undefined {
+): PersistedSurfaceState | undefined {
   // Escape LIKE wildcards so a `surfaceId` like "%" or "_" can't match
   // unrelated rows.
   const escaped = surfaceId.replace(/[\\%_]/g, "\\$&");
+  // No fixed row cap: rows that merely QUOTE the surfaceId (tool results,
+  // log echoes) are skipped by the parse-confirm loop below, and a cap
+  // would let enough of them starve out the real block entirely. The
+  // second LIKE clause keeps the candidate set to rows that can plausibly
+  // hold a ui_surface block at all, so the unbounded scan stays tiny.
   const rows = rawAll<{ content: string; metadata: string | null }>(
     "surfaceResolver:findPersistedSurface",
     `SELECT content, metadata FROM (
@@ -166,16 +159,19 @@ export function findPersistedSurfaceState(
        FROM messages
        WHERE conversation_id = ?
      )
-     WHERE rn > ? AND content LIKE ? ESCAPE '\\'
-     ORDER BY rn DESC
-     LIMIT 10`,
+     WHERE rn > ?
+       AND content LIKE ? ESCAPE '\\'
+       AND content LIKE '%"type":"ui_surface"%'
+     ORDER BY rn DESC`,
     conversationId,
     Math.max(0, Math.floor(opts.liveHistoryStartRow)),
     `%"surfaceId":"${escaped}"%`,
   );
   for (const row of rows) {
-    const visibleToUntrustedActor = isRowVisibleToUntrustedActor(row.metadata);
-    if (!opts.requesterCanAccessMemory && !visibleToUntrustedActor) {
+    if (
+      !opts.requesterCanAccessMemory &&
+      !isRowVisibleToUntrustedActor(row.metadata)
+    ) {
       continue;
     }
     let blocks: unknown;
@@ -201,16 +197,13 @@ export function findPersistedSurfaceState(
           ? b.activationMoment
           : undefined;
       return {
-        state: {
-          surfaceType: (b.surfaceType ?? "dynamic_page") as SurfaceType,
-          data: (b.data ?? {}) as SurfaceData,
-          title: b.title as string | undefined,
-          actions: Array.isArray(b.actions)
-            ? (b.actions as PersistedSurfaceState["actions"])
-            : undefined,
-          ...(activationMoment ? { activationMoment } : {}),
-        },
-        visibleToUntrustedActor,
+        surfaceType: (b.surfaceType ?? "dynamic_page") as SurfaceType,
+        data: (b.data ?? {}) as SurfaceData,
+        title: b.title as string | undefined,
+        actions: Array.isArray(b.actions)
+          ? (b.actions as PersistedSurfaceState["actions"])
+          : undefined,
+        ...(activationMoment ? { activationMoment } : {}),
       };
     }
   }

--- a/assistant/src/runtime/routes/surface-conversation-resolver.ts
+++ b/assistant/src/runtime/routes/surface-conversation-resolver.ts
@@ -84,6 +84,18 @@ export async function resolveSurfaceConversation(
  * A `ui_surface` block extracted from persisted history, in the shape of a
  * `Conversation.surfaceState` entry so callers can memoize it directly.
  */
+export interface PersistedSurfaceHit {
+  state: PersistedSurfaceState;
+  /**
+   * Whether the owning row's provenance passes
+   * `isRowVisibleToUntrustedActor` — i.e. whether an actor-scoped history
+   * view would contain this row at all. Callers use it to keep memoization
+   * within the loaded view's scope (never widen a cached actor-scoped
+   * `surfaceState` with guardian-only payloads).
+   */
+  visibleToUntrustedActor: boolean;
+}
+
 export interface PersistedSurfaceState {
   surfaceType: SurfaceType;
   data: SurfaceData;
@@ -125,22 +137,24 @@ export interface PersistedSurfaceState {
  * state the compaction dropped. The scan skips that same prefix (rows are
  * numbered in the store's `created_at ASC` order).
  *
- * `canAccessMemory` preserves actor provenance: when the live view was
- * loaded for an untrusted actor, `loadFromDb` builds history (and therefore
- * `surfaceState`) from `filterMessagesForUntrustedActor(...)`, so a
- * guardian-authored or provenance-less row is deliberately absent from the
- * actor-scoped view. The scan applies the identical per-row predicate
- * before parsing, serving, or memoizing — otherwise naming a hidden
- * surface id would expose the payload the trust filter dropped.
+ * `requesterCanAccessMemory` preserves actor provenance for the CALLER:
+ * untrusted-actor views are built from `filterMessagesForUntrustedActor(...)`
+ * (`loadFromDb`), so guardian-authored and provenance-less rows are
+ * deliberately hidden from non-guardian actors. The scan applies the
+ * identical per-row predicate before parsing or serving — otherwise a
+ * non-guardian requester naming a hidden surface id would be handed the
+ * payload the trust filter dropped. This is the trust of the REQUESTER
+ * (resolved from the verified actor principal), not of whatever view the
+ * cached conversation happens to be loaded under.
  */
 export function findPersistedSurfaceState(
   conversationId: string,
   surfaceId: string,
   opts: {
     liveHistoryStartRow: number;
-    canAccessMemory: boolean;
+    requesterCanAccessMemory: boolean;
   },
-): PersistedSurfaceState | undefined {
+): PersistedSurfaceHit | undefined {
   // Escape LIKE wildcards so a `surfaceId` like "%" or "_" can't match
   // unrelated rows.
   const escaped = surfaceId.replace(/[\\%_]/g, "\\$&");
@@ -160,7 +174,8 @@ export function findPersistedSurfaceState(
     `%"surfaceId":"${escaped}"%`,
   );
   for (const row of rows) {
-    if (!opts.canAccessMemory && !isRowVisibleToUntrustedActor(row.metadata)) {
+    const visibleToUntrustedActor = isRowVisibleToUntrustedActor(row.metadata);
+    if (!opts.requesterCanAccessMemory && !visibleToUntrustedActor) {
       continue;
     }
     let blocks: unknown;
@@ -186,13 +201,16 @@ export function findPersistedSurfaceState(
           ? b.activationMoment
           : undefined;
       return {
-        surfaceType: (b.surfaceType ?? "dynamic_page") as SurfaceType,
-        data: (b.data ?? {}) as SurfaceData,
-        title: b.title as string | undefined,
-        actions: Array.isArray(b.actions)
-          ? (b.actions as PersistedSurfaceState["actions"])
-          : undefined,
-        ...(activationMoment ? { activationMoment } : {}),
+        state: {
+          surfaceType: (b.surfaceType ?? "dynamic_page") as SurfaceType,
+          data: (b.data ?? {}) as SurfaceData,
+          title: b.title as string | undefined,
+          actions: Array.isArray(b.actions)
+            ? (b.actions as PersistedSurfaceState["actions"])
+            : undefined,
+          ...(activationMoment ? { activationMoment } : {}),
+        },
+        visibleToUntrustedActor,
       };
     }
   }

--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -161,12 +161,14 @@ async function handleSynthesizeCliTts({ body }: RouteHandlerArgs) {
   const useCase: TtsUseCase =
     (body.useCase as TtsUseCase | undefined) ?? "message-playback";
   const voiceId =
-    body.voiceId && typeof body.voiceId === "string"
-      ? body.voiceId
-      : undefined;
+    body.voiceId && typeof body.voiceId === "string" ? body.voiceId : undefined;
 
   try {
-    const result = await synthesizeText({ text: sanitizedText, useCase, voiceId });
+    const result = await synthesizeText({
+      text: sanitizedText,
+      useCase,
+      voiceId,
+    });
     return {
       audioBase64: Buffer.from(result.audio).toString("base64"),
       contentType: result.contentType,
@@ -273,7 +275,9 @@ export const ROUTES: RouteDefinition[] = [
     }),
     responseBody: z.object({
       audioBase64: z.string().describe("Base64-encoded audio bytes"),
-      contentType: z.string().describe("MIME type of the audio (e.g. audio/mpeg)"),
+      contentType: z
+        .string()
+        .describe("MIME type of the audio (e.g. audio/mpeg)"),
     }),
     handler: handleSynthesizeCliTts,
   },

--- a/assistant/src/runtime/routes/vellum-actor-trust.ts
+++ b/assistant/src/runtime/routes/vellum-actor-trust.ts
@@ -1,0 +1,67 @@
+/**
+ * Requester trust resolution for vellum-channel surface routes.
+ *
+ * Maps the verified `x-vellum-actor-principal-id` header to a
+ * {@link TrustContext} via the gateway guardian binding: a vellum principal
+ * is the guardian or nobody, so the mapper yields guardian or unknown. No
+ * header means a local/IPC caller, which is the guardian by construction.
+ *
+ * Shared by `surface-action-routes` (which additionally stamps the result
+ * onto the conversation) and `surface-content-routes` (which only reads it
+ * to scope the persisted-surface fallback) so the two routes cannot drift.
+ */
+import { isHttpAuthDisabled } from "../../config/env.js";
+import type { TrustContext } from "../../daemon/trust-context-types.js";
+import { getLogger } from "../../util/logger.js";
+import { reResolveTrustOnResetDrift } from "../guardian-vellum-migration.js";
+import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
+import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
+
+const log = getLogger("vellum-actor-trust");
+
+export async function resolveVellumActorTrustContext(
+  actorPrincipalId: string | undefined,
+  opts?: {
+    /**
+     * Whether an "unknown" verdict may attempt the reset-drift repair
+     * (`reResolveTrustOnResetDrift`). The repair WRITES to the local
+     * principal mirror, so GET handlers must leave this off (safe methods
+     * are side-effect-free); an unhealed drift then simply resolves as
+     * "unknown" and the caller fail-closes until a mutating route heals it.
+     */
+    healResetDrift?: boolean;
+  },
+): Promise<TrustContext> {
+  const sourceChannel = "vellum" as const;
+
+  if (!actorPrincipalId) {
+    return { trustClass: "guardian", sourceChannel };
+  }
+
+  // Dev-bypass injects a synthetic principal that won't match the real
+  // guardian binding, so resolve the actual guardian principalId before
+  // mapping trust.
+  let principalId = actorPrincipalId;
+  if (isHttpAuthDisabled() && actorPrincipalId === "dev-bypass") {
+    principalId = (await findLocalGuardianPrincipalId()) ?? actorPrincipalId;
+  }
+
+  let trustCtx = await resolveLocalPrincipalTrustContext({
+    actorPrincipalId: principalId,
+    sourceChannel,
+    conversationExternalId: "local",
+  });
+  if (trustCtx.trustClass === "unknown" && opts?.healResetDrift) {
+    const healed = await reResolveTrustOnResetDrift(principalId, sourceChannel);
+    if (healed) {
+      trustCtx = healed;
+      if (healed.trustClass !== "unknown") {
+        log.info(
+          { actorPrincipalId: principalId, trustClass: trustCtx.trustClass },
+          "Trust re-resolved from local mirror after gateway reset drift",
+        );
+      }
+    }
+  }
+  return trustCtx;
+}


### PR DESCRIPTION
## Problem

`GET /v1/surfaces/:surfaceId` serves from the conversation's in-memory `surfaceState`, which is only rebuilt from message history when a `Conversation` is constructed (`restoreSurfaceStateFromHistory`). A surface appended **out-of-band** — `addMessage` against an already-loaded conversation, as the memory retrospective's skill card (#37897) does — lands in the messages table without ever touching the live object's map.

Result: the endpoint 404s **exactly while the conversation is loaded** and works again after eviction (rehydration rescans history). Observed live 2026-07-13 with a skill-authored card: the card rendered fine from its inline block data, but the web client's surface-refresh hook re-hit the 404 on every history refetch (a WARN-log retry loop), and a post-compaction rehydration of the stripped surface would have failed outright.

## Fix

Add a third lookup rung to the content route, after `surfaceState` and `currentTurnSurfaces` both miss:

- `findPersistedSurfaceState(conversationId, surfaceId)` (new, in `surface-conversation-resolver.ts`, next to the existing LIKE-escape + `rawGet` scan): scan the conversation's persisted messages for the `ui_surface` block. The LIKE probe is a candidate pre-filter scoped to the **validated** conversationId; the parsed block is what confirms the exact `surfaceId` (a message merely quoting the id in text is skipped). Newest match wins, mirroring `restoreSurfaceStateFromHistory`'s last-write-wins scan, with the same field mapping/validation (including dropping a malformed daemon-only `activationMoment`).
- The route memoizes the hit into `conversation.surfaceState` so later fetches, action routing, and `findConversationBySurfaceId` resolve in-memory — the same O(1) registration `findConversationBySurfaceId` already performs for app-open surfaces. No DB state is written on the GET (per the runtime GET-idempotency rule).

## Tests

`surface-content-routes.test.ts`:
- new: out-of-band surface served from persisted history + memoized into the live conversation's `surfaceState` (and no rehydration call);
- new: rows that merely quote the surfaceId in text are skipped in favor of the real block;
- new: live conversation + no persisted block still 404s (fallback can't invent surfaces or trigger rehydration).

`surface-action-routes.test.ts`: its whole-module `raw-query` mock gained a `rawAll` no-op (the resolver module now imports it; the action path never calls it).

`bun test` per-file: content-routes 10 pass, action-routes 19 pass, conversation-surface-routes 14 pass. `tsc --noEmit` clean.

Companion to #37959 (both found while field-testing the skill-creation card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)