### PR TITLE
telemetry: shared outbox test harness for consent + telemetry-DB scaffolding

### DIFF
--- a/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
@@ -1,14 +1,13 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { APP_VERSION } from "../../version.js";
+import { recordConfigSettingEvent } from "../config-setting-events-store.js";
 import {
   pendingOutboxPayloads,
   pendingOutboxRows,
   resetOutboxTable,
   setShareAnalytics,
 } from "./outbox-test-harness.js";
-
-import { beforeEach, describe, expect, test } from "bun:test";
-
-import { APP_VERSION } from "../../version.js";
-import { recordConfigSettingEvent } from "../config-setting-events-store.js";
 
 describe("config-setting-events-store", () => {
   beforeEach(() => {

--- a/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
@@ -1,49 +1,30 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  pendingOutboxPayloads,
+  pendingOutboxRows,
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./outbox-test-harness.js";
 
-let shareAnalytics = true;
+import { beforeEach, describe, expect, test } from "bun:test";
 
-mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
-import { getTelemetryDb } from "../../persistence/db-connection.js";
-import { initializeDb } from "../../persistence/db-init.js";
-import { telemetryEvents } from "../../persistence/schema/index.js";
 import { APP_VERSION } from "../../version.js";
 import { recordConfigSettingEvent } from "../config-setting-events-store.js";
-import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
-
-await initializeDb();
-
-function pendingConfigSettingPayloads(): Array<Record<string, unknown>> {
-  return queryTelemetryOutboxBatch("config_setting", 100).map(
-    (row) => JSON.parse(row.payload) as Record<string, unknown>,
-  );
-}
-
-function clearEvents(): void {
-  const db = getTelemetryDb();
-  if (!db) {
-    throw new Error("telemetry DB unavailable in test");
-  }
-  db.delete(telemetryEvents).run();
-}
 
 describe("config-setting-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    clearEvents();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("honors the share_analytics opt-out (records nothing, returns false)", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     expect(
       recordConfigSettingEvent({
         configKey: "memory.enabled",
         configValue: "true",
       }),
     ).toBe(false);
-    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(0);
+    expect(pendingOutboxRows("config_setting", 10)).toHaveLength(0);
   });
 
   test("records the full wire event and returns true", () => {
@@ -54,7 +35,7 @@ describe("config-setting-events-store", () => {
       }),
     ).toBe(true);
 
-    const rows = queryTelemetryOutboxBatch("config_setting", 10);
+    const rows = pendingOutboxRows("config_setting", 10);
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
     expect(row.id).toBeString();
@@ -75,7 +56,7 @@ describe("config-setting-events-store", () => {
       configValue: "v".repeat(300),
     });
 
-    const payloads = pendingConfigSettingPayloads();
+    const payloads = pendingOutboxPayloads("config_setting");
     expect(payloads).toHaveLength(1);
     expect(payloads[0]!.config_key).toBe("k".repeat(128));
     expect(payloads[0]!.config_value).toBe("v".repeat(256));

--- a/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
@@ -1,9 +1,3 @@
-import {
-  pendingOutboxPayloads,
-  resetOutboxTable,
-  setShareAnalytics,
-} from "./outbox-test-harness.js";
-
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../../config/schema.js";
@@ -11,6 +5,11 @@ import {
   recordConfigSettingSnapshot,
   resetConfigSettingSnapshotForTesting,
 } from "../config-setting-snapshot.js";
+import {
+  pendingOutboxPayloads,
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./outbox-test-harness.js";
 
 function makeConfig(
   memoryEnabled: boolean,

--- a/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
@@ -1,22 +1,16 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  pendingOutboxPayloads,
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./outbox-test-harness.js";
 
-let shareAnalytics = true;
-
-mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../../config/schema.js";
-import { getTelemetryDb } from "../../persistence/db-connection.js";
-import { initializeDb } from "../../persistence/db-init.js";
-import { telemetryEvents } from "../../persistence/schema/index.js";
 import {
   recordConfigSettingSnapshot,
   resetConfigSettingSnapshotForTesting,
 } from "../config-setting-snapshot.js";
-import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
-
-await initializeDb();
 
 function makeConfig(
   memoryEnabled: boolean,
@@ -28,27 +22,16 @@ function makeConfig(
 }
 
 function recordedPairs(): Array<[string, string]> {
-  return queryTelemetryOutboxBatch("config_setting", 100).map((row) => {
-    const event = JSON.parse(row.payload) as {
-      config_key: string;
-      config_value: string;
-    };
-    return [event.config_key, event.config_value];
-  });
-}
-
-function clearEvents(): void {
-  const db = getTelemetryDb();
-  if (!db) {
-    throw new Error("telemetry DB unavailable in test");
-  }
-  db.delete(telemetryEvents).run();
+  return pendingOutboxPayloads<{
+    config_key: string;
+    config_value: string;
+  }>("config_setting").map((event) => [event.config_key, event.config_value]);
 }
 
 describe("config-setting-snapshot", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    clearEvents();
+    setShareAnalytics(true);
+    resetOutboxTable();
     resetConfigSettingSnapshotForTesting();
   });
 
@@ -71,7 +54,7 @@ describe("config-setting-snapshot", () => {
 
   test("a changed value records only the changed key", () => {
     recordConfigSettingSnapshot(makeConfig(true, true));
-    clearEvents();
+    resetOutboxTable();
 
     recordConfigSettingSnapshot(makeConfig(true, false));
 
@@ -79,14 +62,14 @@ describe("config-setting-snapshot", () => {
   });
 
   test("consent off drops the snapshot without poisoning the memo", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs()).toHaveLength(0);
 
     // A later opted-in snapshot records the full set — the opted-out attempt
     // must not have memoized the values (mirrors the reporter's flush retry
     // once consent resolves).
-    shareAnalytics = true;
+    setShareAnalytics(true);
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs()).toHaveLength(2);
   });
@@ -95,17 +78,17 @@ describe("config-setting-snapshot", () => {
     // Recorded while opted in.
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs()).toHaveLength(2);
-    clearEvents();
+    resetOutboxTable();
 
     // Opt out: the reporter's opt-out flush discards any pending rows, so the
     // memo must be cleared here too.
-    shareAnalytics = false;
+    setShareAnalytics(false);
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs()).toHaveLength(0);
 
     // Re-opt-in with the SAME config: the full snapshot re-records rather than
     // being skipped by a stale memo.
-    shareAnalytics = true;
+    setShareAnalytics(true);
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs().sort()).toEqual([
       ["memory.enabled", "true"],

--- a/assistant/src/telemetry/__tests__/outbox-test-harness.ts
+++ b/assistant/src/telemetry/__tests__/outbox-test-harness.ts
@@ -2,8 +2,8 @@ import { mock, spyOn } from "bun:test";
 
 let shareAnalytics = true;
 
-// Installed at import time — import this harness BEFORE the module under
-// test so the mock wins the module-registry race.
+// Installed when this harness is imported. bun's mock.module patches
+// retroactively (live bindings), so importers need no special import order.
 mock.module("../../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));

--- a/assistant/src/telemetry/__tests__/outbox-test-harness.ts
+++ b/assistant/src/telemetry/__tests__/outbox-test-harness.ts
@@ -4,6 +4,10 @@ let shareAnalytics = true;
 
 // Installed when this harness is imported. bun's mock.module patches
 // retroactively (live bindings), so importers need no special import order.
+// This harness is imported by *.test.ts files only — never by the test
+// preload — so it runs after the per-test workspace override, where src/
+// imports are as safe as in the test files themselves (AGENTS.md "Test
+// machinery isolation" scopes its no-src/ rule to preload-time machinery).
 mock.module("../../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
 }));

--- a/assistant/src/telemetry/__tests__/outbox-test-harness.ts
+++ b/assistant/src/telemetry/__tests__/outbox-test-harness.ts
@@ -1,0 +1,56 @@
+import { mock, spyOn } from "bun:test";
+
+let shareAnalytics = true;
+
+// Installed at import time — import this harness BEFORE the module under
+// test so the mock wins the module-registry race.
+mock.module("../../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
+}));
+
+import * as dbConnection from "../../persistence/db-connection.js";
+import { getTelemetryDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
+import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
+
+await initializeDb();
+
+/** Flip the mocked share_analytics consent; call with true in beforeEach. */
+export function setShareAnalytics(value: boolean): void {
+  shareAnalytics = value;
+}
+
+/** Delete every telemetry_events row. */
+export function resetOutboxTable(): void {
+  const db = getTelemetryDb();
+  if (!db) {
+    throw new Error("telemetry DB unavailable in test");
+  }
+  db.delete(telemetryEvents).run();
+}
+
+/** Pending rows for one event name in (created_at, id) order. */
+export function pendingOutboxRows(name: string, limit = 100) {
+  return queryTelemetryOutboxBatch(name, limit);
+}
+
+/** Pending payloads for one event name, JSON-parsed, in flush order. */
+export function pendingOutboxPayloads<T = Record<string, unknown>>(
+  name: string,
+  limit = 100,
+): T[] {
+  return pendingOutboxRows(name, limit).map(
+    (row) => JSON.parse(row.payload) as T,
+  );
+}
+
+/** Run `fn` with the telemetry connection reported as unavailable. */
+export function withTelemetryDbUnavailable(fn: () => void): void {
+  const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+}

--- a/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
@@ -1,14 +1,13 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { APP_VERSION } from "../../version.js";
+import { recordWatchdogEvent } from "../watchdog-events-store.js";
 import {
   pendingOutboxPayloads,
   pendingOutboxRows,
   resetOutboxTable,
   setShareAnalytics,
 } from "./outbox-test-harness.js";
-
-import { beforeEach, describe, expect, test } from "bun:test";
-
-import { APP_VERSION } from "../../version.js";
-import { recordWatchdogEvent } from "../watchdog-events-store.js";
 
 describe("watchdog-events-store", () => {
   beforeEach(() => {

--- a/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
@@ -1,44 +1,25 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  pendingOutboxPayloads,
+  pendingOutboxRows,
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./outbox-test-harness.js";
 
-let shareAnalytics = true;
+import { beforeEach, describe, expect, test } from "bun:test";
 
-mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
-import { getTelemetryDb } from "../../persistence/db-connection.js";
-import { initializeDb } from "../../persistence/db-init.js";
-import { telemetryEvents } from "../../persistence/schema/index.js";
 import { APP_VERSION } from "../../version.js";
-import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
 import { recordWatchdogEvent } from "../watchdog-events-store.js";
-
-await initializeDb();
-
-function pendingWatchdogPayloads(): Array<Record<string, unknown>> {
-  return queryTelemetryOutboxBatch("watchdog", 100).map(
-    (row) => JSON.parse(row.payload) as Record<string, unknown>,
-  );
-}
-
-function clearEvents(): void {
-  const db = getTelemetryDb();
-  if (!db) {
-    throw new Error("telemetry DB unavailable in test");
-  }
-  db.delete(telemetryEvents).run();
-}
 
 describe("watchdog-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    clearEvents();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("honors the share_analytics opt-out (records nothing)", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     recordWatchdogEvent({ checkName: "event_loop_blocked", value: 60000 });
-    expect(queryTelemetryOutboxBatch("watchdog", 10)).toHaveLength(0);
+    expect(pendingOutboxRows("watchdog", 10)).toHaveLength(0);
   });
 
   test("records the full wire event, with detail as a nested object", () => {
@@ -48,7 +29,7 @@ describe("watchdog-events-store", () => {
       detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
     });
 
-    const rows = queryTelemetryOutboxBatch("watchdog", 10);
+    const rows = pendingOutboxRows("watchdog", 10);
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
     expect(row.id).toBeString();
@@ -67,7 +48,7 @@ describe("watchdog-events-store", () => {
   test("omitted value and detail persist as null", () => {
     recordWatchdogEvent({ checkName: "stream_idle" });
 
-    const payloads = pendingWatchdogPayloads();
+    const payloads = pendingOutboxPayloads("watchdog");
     expect(payloads).toHaveLength(1);
     expect(payloads[0]).toMatchObject({
       check_name: "stream_idle",
@@ -83,7 +64,7 @@ describe("watchdog-events-store", () => {
       detail: null,
     });
 
-    const payloads = pendingWatchdogPayloads();
+    const payloads = pendingOutboxPayloads("watchdog");
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.value).toBeNull();
     expect(payloads[0]?.detail).toBeNull();

--- a/assistant/src/telemetry/skill-loaded-events-store.test.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.test.ts
@@ -1,13 +1,12 @@
-import {
-  resetOutboxTable,
-  setShareAnalytics,
-} from "./__tests__/outbox-test-harness.js";
-
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
 import { APP_VERSION } from "../version.js";
+import {
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./__tests__/outbox-test-harness.js";
 import { recordSkillLoadedEvent } from "./skill-loaded-events-store.js";
 
 function pendingRows(): Array<{

--- a/assistant/src/telemetry/skill-loaded-events-store.test.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.test.ts
@@ -1,18 +1,14 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./__tests__/outbox-test-harness.js";
 
-let shareAnalytics = true;
-
-mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import { getTelemetryDb } from "../persistence/db-connection.js";
-import { initializeDb } from "../persistence/db-init.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
 import { APP_VERSION } from "../version.js";
 import { recordSkillLoadedEvent } from "./skill-loaded-events-store.js";
-
-await initializeDb();
 
 function pendingRows(): Array<{
   id: string;
@@ -33,12 +29,12 @@ function pendingRows(): Array<{
 
 describe("skill-loaded-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    getTelemetryDb()!.delete(telemetryEvents).run();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("honors the share_analytics opt-out (records nothing)", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     recordSkillLoadedEvent({ skillName: "web-research" });
     expect(pendingRows()).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- New outbox-test-harness.ts centralizing the consent mock, initializeDb, table reset, payload readers, and degraded-mode spy
- Migrates watchdog, config-setting, config-setting-snapshot, and skill-loaded store tests to the harness
- Test bodies and assertion strength unchanged

Part of plan: telemetry-outbox-ergonomics.md (PR 3 of 5)