### PR TITLE
refactor(meta): move sync-bundled-copies.ts out of feature-flags/

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -46,7 +46,7 @@ jobs:
         run: bun install --frozen-lockfile --filter=@vellumai/assistant --filter=@vellumai/vellum-gateway
 
       - name: Sync feature flag registry
-        run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
+        run: cd .. && bun run meta/sync-bundled-copies.ts
 
       - name: Lint
         run: bun run lint
@@ -79,7 +79,7 @@ jobs:
         run: bun install --frozen-lockfile --filter=@vellumai/assistant --filter=@vellumai/vellum-gateway
 
       - name: Sync feature flag registry
-        run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
+        run: cd .. && bun run meta/sync-bundled-copies.ts
 
       - name: Type check
         run: bunx tsc --noEmit
@@ -112,7 +112,7 @@ jobs:
         run: bun install --frozen-lockfile --filter=@vellumai/assistant --filter=@vellumai/vellum-gateway
 
       - name: Sync feature flag registry
-        run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
+        run: cd .. && bun run meta/sync-bundled-copies.ts
 
       - name: Restore test durations cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -12,6 +12,7 @@ on:
       - 'credential-executor/**'
       - 'packages/**'
       - 'meta/feature-flags/**'
+      - 'meta/sync-bundled-copies.ts'
       # The daemon LLM catalog parity test reads these files, so hand edits to
       # either catalog JSON must run the assistant tests too.
       - 'meta/llm-provider-catalog.json'

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -35,7 +35,7 @@ jobs:
         run: bun install --frozen-lockfile --filter=@vellumai/vellum-gateway
 
       - name: Sync feature flag registry
-        run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
+        run: cd .. && bun run meta/sync-bundled-copies.ts
 
       - name: Lint
         run: bun run lint

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -11,6 +11,7 @@ on:
       - 'gateway/**'
       - 'packages/**'
       - 'meta/feature-flags/**'
+      - 'meta/sync-bundled-copies.ts'
       - '.github/workflows/ci-main-gateway.yaml'
 
 jobs:

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -154,7 +154,7 @@ jobs:
           done
 
       - name: Sync feature flag registry
-        run: bun run meta/feature-flags/sync-bundled-copies.ts
+        run: bun run meta/sync-bundled-copies.ts
 
       - name: Lint
         run: bun run lint
@@ -188,7 +188,7 @@ jobs:
         working-directory: gateway
 
       - name: Sync feature flag registry
-        run: bun run meta/feature-flags/sync-bundled-copies.ts
+        run: bun run meta/sync-bundled-copies.ts
 
       - name: Lint
         run: bun run lint
@@ -1899,7 +1899,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Sync feature flag registry
-        run: bun run meta/feature-flags/sync-bundled-copies.ts
+        run: bun run meta/sync-bundled-copies.ts
       - name: Stamp dev version
         run: jq --arg v "${{ needs.compute-version.outputs.version }}" '.version = $v' ${{ matrix.package }}/package.json > ${{ matrix.package }}/package.json.tmp && mv ${{ matrix.package }}/package.json.tmp ${{ matrix.package }}/package.json
       - name: Install package dependencies

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -13,6 +13,7 @@ on:
       - 'packages/**'
       - 'scripts/skills/**'
       - 'meta/feature-flags/**'
+      - 'meta/sync-bundled-copies.ts'
       # The daemon LLM catalog parity test reads these files, so hand edits to
       # either catalog JSON must run the assistant tests on the PR that
       # introduces drift.

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -52,7 +52,7 @@ jobs:
         run: bun install --frozen-lockfile --filter=@vellumai/assistant --filter=@vellumai/vellum-gateway
 
       - name: Sync feature flag registry
-        run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
+        run: cd .. && bun run meta/sync-bundled-copies.ts
 
       - name: Lint
         run: bun run lint
@@ -88,7 +88,7 @@ jobs:
         run: bun install --frozen-lockfile --filter=@vellumai/assistant --filter=@vellumai/vellum-gateway
 
       - name: Sync feature flag registry
-        run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
+        run: cd .. && bun run meta/sync-bundled-copies.ts
 
       - name: Type check
         run: bunx tsc --noEmit
@@ -121,7 +121,7 @@ jobs:
         run: bun install --frozen-lockfile --filter=@vellumai/assistant --filter=@vellumai/vellum-gateway
 
       - name: Sync feature flag registry
-        run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
+        run: cd .. && bun run meta/sync-bundled-copies.ts
 
       - name: Test
         run: bun run test
@@ -206,7 +206,7 @@ jobs:
         run: bun install --frozen-lockfile --filter=@vellumai/assistant --filter=@vellumai/vellum-gateway
 
       - name: Sync feature flag registry
-        run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
+        run: cd .. && bun run meta/sync-bundled-copies.ts
 
       - name: Check OpenAPI spec is up to date
         run: bun run generate:openapi -- --check

--- a/.github/workflows/pr-gateway.yaml
+++ b/.github/workflows/pr-gateway.yaml
@@ -37,7 +37,7 @@ jobs:
         run: bun install --frozen-lockfile --filter=@vellumai/vellum-gateway
 
       - name: Sync feature flag registry
-        run: cd .. && bun run meta/feature-flags/sync-bundled-copies.ts
+        run: cd .. && bun run meta/sync-bundled-copies.ts
 
       - name: Lint
         run: bun run lint

--- a/.github/workflows/pr-gateway.yaml
+++ b/.github/workflows/pr-gateway.yaml
@@ -10,6 +10,7 @@ on:
       - 'gateway/**'
       - 'packages/**'
       - 'meta/feature-flags/**'
+      - 'meta/sync-bundled-copies.ts'
       - '.github/workflows/pr-gateway.yaml'
 
 concurrency:

--- a/.github/workflows/pr-marketplace.yaml
+++ b/.github/workflows/pr-marketplace.yaml
@@ -7,7 +7,7 @@ on:
       - 'plugins/marketplace.json'
       - 'scripts/check-marketplace-prefix.mjs'
       - 'meta/feature-flags/feature-flag-registry.json'
-      - 'meta/feature-flags/sync-bundled-copies.ts'
+      - 'meta/sync-bundled-copies.ts'
       - 'assistant/src/cli/lib/bundled-marketplace.json'
       - 'clients/web/src/lib/feature-flags/feature-flag-registry.json'
       - '.github/workflows/pr-marketplace.yaml'
@@ -47,4 +47,4 @@ jobs:
           bun-version: '1.3.11'
 
       - name: Verify bundled copies match canonical sources
-        run: bun run meta/feature-flags/sync-bundled-copies.ts --check
+        run: bun run meta/sync-bundled-copies.ts --check

--- a/.github/workflows/pr-skills.yaml
+++ b/.github/workflows/pr-skills.yaml
@@ -145,7 +145,7 @@ jobs:
             # test-preload.ts guard blocks `bun test` invocations there.
             REPO_ROOT="$(pwd)"
             bun install --frozen-lockfile --filter=@vellumai/assistant
-            (cd assistant && bun run -b ../meta/feature-flags/sync-bundled-copies.ts || true)
+            (cd assistant && bun run -b ../meta/sync-bundled-copies.ts || true)
             TEST_FILES=$(find "$SKILL_DIR" \
               -path "$SKILL_DIR/bot" -prune -o \
               -path "$SKILL_DIR/meet-controller-ext" -prune -o \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1281,7 +1281,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Sync feature flag registry for publish
-        run: bun run meta/feature-flags/sync-bundled-copies.ts
+        run: bun run meta/sync-bundled-copies.ts
 
       - name: Install package dependencies
         run: |
@@ -1514,7 +1514,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Sync feature flag registry
-        run: bun run meta/feature-flags/sync-bundled-copies.ts
+        run: bun run meta/sync-bundled-copies.ts
       - name: Stamp staging version
         run: jq --arg v "${{ needs.extract-version.outputs.version }}" '.version = $v' ${{ matrix.package }}/package.json > ${{ matrix.package }}/package.json.tmp && mv ${{ matrix.package }}/package.json.tmp ${{ matrix.package }}/package.json
       - name: Install package dependencies

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -30,7 +30,7 @@
     "test:stable": "EXCLUDE_EXPERIMENTAL=true bun run scripts/test.ts",
     "test:bench": "find src -type f -name '*.benchmark.test.ts' -print0 | xargs -0 -P 1 -I {} bun test {}",
     "test:filesystem-tools": "bash scripts/test-filesystem-tools.sh",
-    "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/feature-flags/sync-bundled-copies.ts ] && bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
+    "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/sync-bundled-copies.ts ] && bun run meta/sync-bundled-copies.ts 2>/dev/null || true)"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.25.0",

--- a/assistant/scripts/test.ts
+++ b/assistant/scripts/test.ts
@@ -73,16 +73,11 @@ const KNOWN_BROKEN_FILES = new Set<string>([]);
 // and feature-flag-registry-bundled.test.ts fails. Running the sync here is
 // idempotent and cheap (two file copies).
 function syncFeatureFlagRegistry(): void {
-  const syncScript = join(
-    "..",
-    "meta",
-    "feature-flags",
-    "sync-bundled-copies.ts",
-  );
+  const syncScript = join("..", "meta", "sync-bundled-copies.ts");
   if (!existsSync(syncScript)) {
     return;
   }
-  Bun.spawnSync(["bun", "run", "meta/feature-flags/sync-bundled-copies.ts"], {
+  Bun.spawnSync(["bun", "run", "meta/sync-bundled-copies.ts"], {
     cwd: join(process.cwd(), ".."),
     stdout: "ignore",
     stderr: "ignore",

--- a/assistant/src/cli/lib/plugin-catalog-local.ts
+++ b/assistant/src/cli/lib/plugin-catalog-local.ts
@@ -1,6 +1,6 @@
 /**
  * Offline plugin catalog reader backed by the manifest bundled into the
- * package at build time (see meta/feature-flags/sync-bundled-copies.ts).
+ * package at build time (see meta/sync-bundled-copies.ts).
  *
  * `getPluginCatalog` selects this reader only when platform features are
  * disabled (air-gapped / self-hosted, `VELLUM_DISABLE_PLATFORM=true`). Importing

--- a/assistant/src/config/__tests__/feature-flag-registry-bundled.test.ts
+++ b/assistant/src/config/__tests__/feature-flag-registry-bundled.test.ts
@@ -2,7 +2,7 @@
  * Smoke test: verifies that the bundled feature-flag-registry.json exists
  * in the assistant source tree and is a valid, non-empty registry.
  *
- * The bundled copy is created by `meta/feature-flags/sync-bundled-copies.ts`
+ * The bundled copy is created by `meta/sync-bundled-copies.ts`
  * (run via postinstall or CI sync step). This test catches cases where the
  * sync was skipped — e.g. Docker builds that forget to copy the registry.
  */
@@ -21,7 +21,7 @@ describe("bundled feature-flag-registry.json", () => {
   test("file exists", () => {
     expect(
       existsSync(BUNDLED_PATH),
-      `Expected bundled registry at ${BUNDLED_PATH}. Run: bun run meta/feature-flags/sync-bundled-copies.ts`,
+      `Expected bundled registry at ${BUNDLED_PATH}. Run: bun run meta/sync-bundled-copies.ts`,
     ).toBe(true);
   });
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -21,8 +21,8 @@
     "lint": "eslint",
     "lint:unused": "knip --include files,dependencies,unlisted",
     "typecheck": "bunx tsc --noEmit",
-    "prebuild": "cd .. && bun run meta/feature-flags/sync-bundled-copies.ts",
-    "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/feature-flags/sync-bundled-copies.ts ] && bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
+    "prebuild": "cd .. && bun run meta/sync-bundled-copies.ts",
+    "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/sync-bundled-copies.ts ] && bun run meta/sync-bundled-copies.ts 2>/dev/null || true)"
   },
   "dependencies": {
     "@slack/types": "2.21.1",

--- a/meta/feature-flags/AGENTS.md
+++ b/meta/feature-flags/AGENTS.md
@@ -41,7 +41,7 @@ The `id` and `key` fields in `feature-flag-registry.json` **must match** and bot
 2. Run the sync script to copy the registry into bundled locations:
 
    ```bash
-   bun run meta/feature-flags/sync-bundled-copies.ts
+   bun run meta/sync-bundled-copies.ts
    ```
 
 3. **Create the flag via Terraform in `vellum-assistant-platform`** so it exists on the platform for remote sync.

--- a/meta/sync-bundled-copies.ts
+++ b/meta/sync-bundled-copies.ts
@@ -6,8 +6,8 @@
  *   - plugins/marketplace.json    → the assistant plugin catalog (offline reader)
  *
  * Usage:
- *   bun run meta/feature-flags/sync-bundled-copies.ts          # write copies
- *   bun run meta/feature-flags/sync-bundled-copies.ts --check  # fail on drift
+ *   bun run meta/sync-bundled-copies.ts          # write copies
+ *   bun run meta/sync-bundled-copies.ts --check  # fail on drift
  */
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
@@ -17,17 +17,17 @@ const ROOT = resolve(import.meta.dir);
 
 const PAIRS: { canonical: string; targets: string[] }[] = [
   {
-    canonical: join(ROOT, "feature-flag-registry.json"),
+    canonical: join(ROOT, "feature-flags", "feature-flag-registry.json"),
     targets: [
-      join(ROOT, "..", "..", "assistant", "src", "config", "feature-flag-registry.json"),
-      join(ROOT, "..", "..", "gateway", "src", "feature-flag-registry.json"),
-      join(ROOT, "..", "..", "clients", "web", "src", "lib", "feature-flags", "feature-flag-registry.json"),
+      join(ROOT, "..", "assistant", "src", "config", "feature-flag-registry.json"),
+      join(ROOT, "..", "gateway", "src", "feature-flag-registry.json"),
+      join(ROOT, "..", "clients", "web", "src", "lib", "feature-flags", "feature-flag-registry.json"),
     ],
   },
   {
-    canonical: join(ROOT, "..", "..", "plugins", "marketplace.json"),
+    canonical: join(ROOT, "..", "plugins", "marketplace.json"),
     targets: [
-      join(ROOT, "..", "..", "assistant", "src", "cli", "lib", "bundled-marketplace.json"),
+      join(ROOT, "..", "assistant", "src", "cli", "lib", "bundled-marketplace.json"),
     ],
   },
 ];
@@ -74,7 +74,7 @@ if (CHECK) {
   if (drifted.length > 0) {
     console.error(
       "✗ Bundled copies are out of sync with their canonical sources. " +
-        "Run `bun run meta/feature-flags/sync-bundled-copies.ts` and commit:",
+        "Run `bun run meta/sync-bundled-copies.ts` and commit:",
     );
     for (const target of drifted) console.error(`  - ${target}`);
     process.exit(1);

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -84,7 +84,7 @@
         }
       },
       "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Requires an Unstructured account to authorize during the OAuth step.",
-      "updatedAt": "2026-07-10T22:52:42.000Z"
+      "updatedAt": "2026-07-13T20:48:26.000Z"
     },
     {
       "id": "chatgpt-import",


### PR DESCRIPTION
## Summary
- `meta/feature-flags/sync-bundled-copies.ts` was a misnomer: it's a general canonical→bundled-copy sync — it copies **both** the feature-flag registry **and** `plugins/marketplace.json` → `bundled-marketplace.json` (added in #37806). Moved it up to `meta/sync-bundled-copies.ts` to match its actual scope.
- Fixed the tool's internal `ROOT`-relative paths (`ROOT` is now `meta/`: repo-root targets drop one `..`, the FF-registry canonical gains a `feature-flags/` segment) and updated every reference — CI/release workflows, `assistant`/`gateway` `package.json` scripts, tests, and docs.
- Verified from the new location: `bun run meta/sync-bundled-copies.ts --check` passes (2 bundled copies match) and write mode is idempotent.

## Original prompt
While planning plugin-icon work we noticed `sync-bundled-copies.ts` lives under `meta/feature-flags/` even though it's a general bundled-copy sync (feature flags + plugin marketplace) — a leftover from when it only handled the FF registry. This is a quick reorg to move it to a location matching its scope and fix the misnomer, updating all call sites.