### PR TITLE
telemetry: typed recordTelemetryEvent helper stamps the outbox base fields

### DIFF
--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -1,15 +1,23 @@
-import { beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+let shareAnalytics = true;
+
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
+}));
 
 import * as dbConnection from "../persistence/db-connection.js";
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
+import { APP_VERSION } from "../version.js";
 import {
   deleteTelemetryOutboxEvents,
   discardPendingTelemetryOutboxEvents,
   insertTelemetryOutboxEvent,
   insertTelemetryOutboxEvents,
   queryTelemetryOutboxBatch,
+  recordTelemetryEvent,
 } from "./telemetry-events-outbox.js";
 import type { LifecycleTelemetryEvent } from "./types.js";
 
@@ -49,6 +57,7 @@ function allIds(): string[] {
 
 describe("telemetry-events-outbox", () => {
   beforeEach(() => {
+    shareAnalytics = true;
     getTelemetryDb()!.delete(telemetryEvents).run();
   });
 
@@ -216,6 +225,83 @@ describe("telemetry-events-outbox", () => {
     deleteTelemetryOutboxEvents(ids);
 
     expect(allIds()).toEqual(["evt-keep"]);
+  });
+
+  test("recordTelemetryEvent stamps the base fields", () => {
+    const fields = {
+      check_name: "db_size",
+      value: 42,
+      detail: { table: "messages" },
+    };
+    const recorded = recordTelemetryEvent("watchdog", fields);
+    expect(recorded).not.toBeNull();
+
+    const rows = queryTelemetryOutboxBatch("watchdog", 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe(recorded!.id);
+    expect(JSON.parse(rows[0]!.payload)).toEqual({
+      type: "watchdog",
+      daemon_event_id: recorded!.id,
+      recorded_at: recorded!.createdAt,
+      assistant_version: APP_VERSION,
+      ...fields,
+    });
+  });
+
+  test("recordTelemetryEvent persists conversation_id in its column", () => {
+    const withConv = recordTelemetryEvent(
+      "watchdog",
+      { check_name: "c1", value: null, detail: null },
+      { conversationId: "conv-1" },
+    );
+    const withoutConv = recordTelemetryEvent("watchdog", {
+      check_name: "c2",
+      value: null,
+      detail: null,
+    });
+
+    const rows = getTelemetryDb()!
+      .select({
+        id: telemetryEvents.id,
+        conversationId: telemetryEvents.conversationId,
+      })
+      .from(telemetryEvents)
+      .all();
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.id === withConv!.id)!.conversationId).toBe(
+      "conv-1",
+    );
+    expect(rows.find((r) => r.id === withoutConv!.id)!.conversationId).toBe(
+      null,
+    );
+  });
+
+  test("recordTelemetryEvent honors the share_analytics opt-out", () => {
+    shareAnalytics = false;
+    expect(
+      recordTelemetryEvent("watchdog", {
+        check_name: "c",
+        value: null,
+        detail: null,
+      }),
+    ).toBeNull();
+    expect(queryTelemetryOutboxBatch("watchdog", 10)).toEqual([]);
+  });
+
+  test("recordTelemetryEvent returns null when the telemetry DB is unavailable", () => {
+    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+    try {
+      expect(
+        recordTelemetryEvent("watchdog", {
+          check_name: "c",
+          value: null,
+          detail: null,
+        }),
+      ).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+    expect(queryTelemetryOutboxBatch("watchdog", 10)).toEqual([]);
   });
 
   test("discards all pending rows for one name only", () => {

--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -248,6 +248,28 @@ describe("telemetry-events-outbox", () => {
     });
   });
 
+  test("recordTelemetryEvent stamps win over base keys smuggled in via a widened fields value", () => {
+    // A variable (not a literal) skips excess-property checking, so base
+    // keys can reach the helper structurally. The stamps must still win.
+    const widened = {
+      check_name: "db_size",
+      value: null,
+      detail: null,
+      daemon_event_id: "spoofed-id",
+      recorded_at: 1,
+      assistant_version: "0.0.0-spoof",
+    };
+    const recorded = recordTelemetryEvent("watchdog", widened);
+    expect(recorded).not.toBeNull();
+
+    const payload = JSON.parse(
+      queryTelemetryOutboxBatch("watchdog", 10)[0]!.payload,
+    ) as Record<string, unknown>;
+    expect(payload.daemon_event_id).toBe(recorded!.id);
+    expect(payload.recorded_at).toBe(recorded!.createdAt);
+    expect(payload.assistant_version).toBe(APP_VERSION);
+  });
+
   test("recordTelemetryEvent persists conversation_id in its column", () => {
     const withConv = recordTelemetryEvent(
       "watchdog",

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -125,12 +125,14 @@ export function recordTelemetryEvent<N extends OutboxTelemetryEventName>(
     (id, createdAt) =>
       // Cast: TS cannot re-associate the `Omit<...>` spread with the stamped
       // base fields across a generic; `fields`' type guarantees the shape.
+      // Base fields are stamped after the spread so a widened `fields` value
+      // carrying base keys can never override them.
       ({
+        ...fields,
         type: name,
         daemon_event_id: id,
         recorded_at: createdAt,
         assistant_version: APP_VERSION,
-        ...fields,
       }) as OutboxTelemetryEventOf<N>,
     opts,
   );

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -12,7 +12,13 @@ import { v4 as uuid } from "uuid";
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
-import type { TelemetryEvent } from "./types.js";
+import { APP_VERSION } from "../version.js";
+import type {
+  OutboxTelemetryEventName,
+  OutboxTelemetryEventOf,
+  TelemetryEvent,
+  TelemetryEventBase,
+} from "./types.js";
 
 /** Ids per DELETE chunk — stays under SQLite's bound-variable limit. */
 const DELETE_CHUNK_SIZE = 500;
@@ -74,12 +80,14 @@ export function insertTelemetryOutboxEvent(
 }
 
 /**
- * Record one telemetry event: gate on usage-data consent, generate the outbox
- * row id and record-time timestamp, build the wire payload via `buildEvent`
- * (which owns per-type stamping, e.g. `daemon_event_id` overrides), and
- * insert. Returns the generated row identity, or null when usage data
- * collection is disabled (the event is dropped to honor the opt-out) or the
- * telemetry DB is unavailable (degraded mode).
+ * Lower-level record escape hatch: for payloads that need the record-time
+ * `(id, createdAt)` inside type-specific fields (onboarding's activation
+ * `daemon_event_id` override and `completed_at`). Gates on usage-data
+ * consent, generates the outbox row identity, builds the wire payload via
+ * `buildEvent` (which owns all stamping), and inserts. Returns the generated
+ * row identity, or null when usage data collection is disabled (the event is
+ * dropped to honor the opt-out) or the telemetry DB is unavailable (degraded
+ * mode). Prefer `recordTelemetryEvent` when the payload doesn't need them.
  */
 export function recordTelemetryOutboxEvent(
   name: string,
@@ -99,6 +107,33 @@ export function recordTelemetryOutboxEvent(
     event: buildEvent(id, createdAt),
   });
   return inserted ? { id, createdAt } : null;
+}
+
+/**
+ * Preferred record API for outbox events whose payload does not depend on
+ * the record-time `(id, createdAt)`: stamps the `TelemetryEventBase` fields
+ * (record-time `assistant_version` included) and inherits
+ * `recordTelemetryOutboxEvent`'s consent gate and degraded-mode `null`.
+ */
+export function recordTelemetryEvent<N extends OutboxTelemetryEventName>(
+  name: N,
+  fields: Omit<OutboxTelemetryEventOf<N>, keyof TelemetryEventBase>,
+  opts?: { conversationId?: string | null },
+): { id: string; createdAt: number } | null {
+  return recordTelemetryOutboxEvent(
+    name,
+    (id, createdAt) =>
+      // Cast: TS cannot re-associate the `Omit<...>` spread with the stamped
+      // base fields across a generic; `fields`' type guarantees the shape.
+      ({
+        type: name,
+        daemon_event_id: id,
+        recorded_at: createdAt,
+        assistant_version: APP_VERSION,
+        ...fields,
+      }) as OutboxTelemetryEventOf<N>,
+    opts,
+  );
 }
 
 /**

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -522,3 +522,21 @@ export type TelemetryEvent =
   | SkillLoadedTelemetryEvent
   | WatchdogTelemetryEvent
   | ConfigSettingTelemetryEvent;
+
+/**
+ * Event names backed by the `telemetry_events` outbox. Each name doubles as
+ * the wire `type` discriminant and the flush-group key, so names must never
+ * change once shipped. The watermark-flushed types (`llm_usage`, `turn`,
+ * `tool_executed`) live on their own tables and are deliberately excluded.
+ */
+export type OutboxTelemetryEventName =
+  | "lifecycle"
+  | "onboarding"
+  | "auth_fallback"
+  | "skill_loaded"
+  | "watchdog"
+  | "config_setting";
+
+/** Wire event type for one outbox event name. */
+export type OutboxTelemetryEventOf<N extends OutboxTelemetryEventName> =
+  Extract<TelemetryEvent, { type: N }>;


### PR DESCRIPTION
## Summary
- Adds OutboxTelemetryEventName/OutboxTelemetryEventOf types derived from the TelemetryEvent union
- Adds typed recordTelemetryEvent helper that stamps the TelemetryEventBase fields; recordTelemetryOutboxEvent becomes the documented escape hatch
- Test coverage for base-field stamping, conversationId column, consent gate, degraded mode

Part of plan: telemetry-outbox-ergonomics.md (PR 1 of 5)