### PR TITLE
feat(gateway): m0017 coerces stale contact_channels.policy='escalate' to 'deny'

### DIFF
--- a/gateway/src/__tests__/data-migration-m0017-coerce-escalate-policy.test.ts
+++ b/gateway/src/__tests__/data-migration-m0017-coerce-escalate-policy.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for m0017-coerce-escalate-policy.
+ *
+ * Verifies that only contact_channels rows with policy='escalate' are
+ * coerced to 'deny' (allow/deny rows untouched byte-for-byte, updated_at
+ * included), that coerced rows get a fresh updated_at stamp, that a re-run
+ * coerces zero rows (idempotent), that the migration is registered after
+ * m0016, and that down() is a no-op. Uses the real in-memory gateway DB;
+ * this migration never touches the assistant DB.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+
+import "./test-preload.js";
+
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+import { MIGRATIONS } from "../db/data-migrations/index.js";
+import {
+  up as m0017Up,
+  down as m0017Down,
+} from "../db/data-migrations/m0017-coerce-escalate-policy.js";
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function seedChannel(id: string, policy: string, updatedAt: number): void {
+  const db = getGatewayDb();
+  db.insert(contacts)
+    .values({
+      id: `contact-${id}`,
+      displayName: `Contact ${id}`,
+      createdAt: 100,
+      updatedAt: 100,
+    })
+    .run();
+  db.insert(contactChannels)
+    .values({
+      id,
+      contactId: `contact-${id}`,
+      type: "telegram",
+      address: `addr-${id}`,
+      status: "active",
+      policy,
+      createdAt: 100,
+      updatedAt,
+    })
+    .run();
+}
+
+function channelRow(id: string): Record<string, unknown> {
+  return getGatewayDb()
+    .$client.prepare("SELECT * FROM contact_channels WHERE id = ?")
+    .get(id) as Record<string, unknown>;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("m0017-coerce-escalate-policy", () => {
+  test("coerces only escalate rows to deny and stamps their updated_at", () => {
+    seedChannel("ch-allow", "allow", 111);
+    seedChannel("ch-deny", "deny", 222);
+    seedChannel("ch-escalate", "escalate", 333);
+    const allowBefore = channelRow("ch-allow");
+    const denyBefore = channelRow("ch-deny");
+    const before = Date.now();
+
+    expect(m0017Up()).toBe("done");
+
+    const coerced = channelRow("ch-escalate");
+    expect(coerced.policy).toBe("deny");
+    expect(coerced.updated_at as number).toBeGreaterThanOrEqual(before);
+
+    // allow/deny rows are byte-for-byte untouched, updated_at included.
+    expect(channelRow("ch-allow")).toEqual(allowBefore);
+    expect(channelRow("ch-deny")).toEqual(denyBefore);
+  });
+
+  test("idempotent: a re-run coerces zero rows", () => {
+    seedChannel("ch-escalate", "escalate", 333);
+
+    expect(m0017Up()).toBe("done");
+    const afterFirst = channelRow("ch-escalate");
+
+    expect(m0017Up()).toBe("done");
+    expect(channelRow("ch-escalate")).toEqual(afterFirst);
+  });
+
+  test("no-op on a DB with no escalate rows", () => {
+    seedChannel("ch-allow", "allow", 111);
+    const allowBefore = channelRow("ch-allow");
+
+    expect(m0017Up()).toBe("done");
+    expect(channelRow("ch-allow")).toEqual(allowBefore);
+  });
+
+  test("is registered directly after m0016", () => {
+    const keys = MIGRATIONS.map((m) => m.key);
+    const m0016Index = keys.indexOf("m0016-drop-assistant-guardian-tables");
+    const m0017Index = keys.indexOf("m0017-coerce-escalate-policy");
+
+    expect(m0016Index).toBeGreaterThanOrEqual(0);
+    expect(m0017Index).toBe(m0016Index + 1);
+  });
+
+  test("down is a no-op (returns done)", () => {
+    expect(m0017Down()).toBe("done");
+  });
+});

--- a/gateway/src/db/data-migrations/index.ts
+++ b/gateway/src/db/data-migrations/index.ts
@@ -35,6 +35,7 @@ import * as m0013 from "./m0013-verification-sessions-backfill.js";
 import * as m0014 from "./m0014-drop-assistant-verification-tables.js";
 import * as m0015 from "./m0015-guardian-requests-backfill.js";
 import * as m0016 from "./m0016-drop-assistant-guardian-tables.js";
+import * as m0017 from "./m0017-coerce-escalate-policy.js";
 
 const log = getLogger("data-migrations");
 
@@ -66,6 +67,7 @@ export const MIGRATIONS: { key: string; mod: MigrationModule }[] = [
   { key: "m0015-guardian-requests-backfill", mod: m0015 },
   // m0016 must stay after m0015: it drops the assistant tables m0015 reads.
   { key: "m0016-drop-assistant-guardian-tables", mod: m0016 },
+  { key: "m0017-coerce-escalate-policy", mod: m0017 },
 ];
 
 /**

--- a/gateway/src/db/data-migrations/m0017-coerce-escalate-policy.ts
+++ b/gateway/src/db/data-migrations/m0017-coerce-escalate-policy.ts
@@ -1,0 +1,57 @@
+/**
+ * One-time migration: coerce stale contact_channels.policy = 'escalate'
+ * rows to 'deny'.
+ *
+ * The escalate channel policy is removed; the column has no CHECK, so rows
+ * written before the vocabulary shrank to allow|deny can persist. 'deny'
+ * preserves the fail-closed posture and the feature's observed behavior
+ * (escalated messages were never delivered), and the guardian can flip the
+ * row to allow.
+ *
+ * Idempotent: on a DB with no escalate rows, the UPDATE is a no-op.
+ */
+
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../logger.js";
+import { getGatewayDb } from "../connection.js";
+
+import type { MigrationResult } from "./index.js";
+
+const log = getLogger("m0017-coerce-escalate-policy");
+
+function getRawGatewayDb(): Database {
+  return (getGatewayDb() as unknown as { $client: Database }).$client;
+}
+
+export function up(): MigrationResult {
+  try {
+    const { changes } = getRawGatewayDb()
+      .prepare(
+        /*sql*/ `
+          UPDATE contact_channels
+             SET policy = 'deny', updated_at = ?
+           WHERE policy = 'escalate'
+        `,
+      )
+      .run(Date.now());
+
+    if (changes > 0) {
+      log.info(
+        { coerced: changes },
+        "Coerced stale escalate channel policies to deny",
+      );
+    }
+    return "done";
+  } catch (err) {
+    log.error(
+      { err },
+      "Escalate-policy coercion failed — will retry on next startup",
+    );
+    return "skip";
+  }
+}
+
+export function down(): MigrationResult {
+  return "done";
+}


### PR DESCRIPTION
## Summary
- One-time m0017 data migration rewrites any stale contact_channels.policy='escalate' to 'deny' (logged count, idempotent, skip-on-failure)
- deny preserves the fail-closed posture and the removed feature's observed behavior (escalated messages were never delivered); guardians can flip the row to allow
- Without this, a stale row would read as an unresolvable member after the vocabulary shrink — a silent lockout instead of a visible deny

Part of plan: remove-escalate-policy.md (PR 4 of 5)