### PR TITLE
feat(web): opt-out diagnostics consent — nullable ledger, on-screen-only persistence (mirror of #37912)

### DIFF
--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -15,7 +15,8 @@ export interface UserConsent {
   ai_data_sharing_accepted_at: string | null;
   /** Null until the user makes an explicit choice (settings or review-terms). */
   share_analytics: boolean | null;
-  share_diagnostics: boolean;
+  /** Null until the user makes an explicit choice (settings or review-terms). */
+  share_diagnostics: boolean | null;
   share_analytics_accepted_version: string;
   share_analytics_accepted_at: string | null;
   share_diagnostics_accepted_version: string;

--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -249,31 +249,37 @@ describe("onboarding funnel events", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("does not emit telemetry until analytics sharing is explicitly opted in", () => {
+  test("emits by default (opt-out) but honors an explicit analytics opt-out", () => {
     const fetchMock = mock(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>
         new Response("{}", { status: 200 }),
     );
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
+    // Never-asked: no device preference on record — analytics is opt-out, so
+    // the event emits.
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
+    // An explicit device opt-out stops uploads.
     localStorage.setItem("device:share_analytics", "false");
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
+    // The in-memory store must agree: a failed opt-out write cannot leave an
+    // older stored opt-in authorizing a new event.
     localStorage.setItem("device:share_analytics", "true");
     useOnboardingStore.setState({ shareAnalytics: false });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.nameVibe, {
       userId: "user-123",
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
-
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -1,10 +1,7 @@
 import { useCallback, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
-import {
-    AgreementsCard,
-    PrivacyPreferencesCard,
-} from "@/domains/onboarding/components/consent-controls";
+import { AgreementsCard } from "@/domains/onboarding/components/consent-controls";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { StepIndicatorDots } from "@/domains/onboarding/components/step-indicator-dots";
 import {
@@ -16,11 +13,7 @@ import {
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { isLocalMode } from "@/lib/local-mode";
-import {
-    usePrivacyConsent,
-    useShareDiagnostics,
-    useTosAccepted,
-} from "@/domains/onboarding/prefs";
+import { usePrivacyConsent, useTosAccepted } from "@/domains/onboarding/prefs";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
@@ -39,7 +32,6 @@ export function PrivacyScreen() {
     useClientFeatureFlagStore.use.stringFlags().preChatOnboardingExperiment20260606 ?? "control";
   const preferredFunnelVariant =
     onboardingFunnelVariantFromExperiment(preChatExperimentArm);
-  const [shareDiagnostics, setShareDiagnosticsReal] = useShareDiagnostics();
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
   const [privacyConsent, setPrivacyConsentReal] = usePrivacyConsent();
   const hasPlatformSession = useHasPlatformSession();
@@ -52,7 +44,6 @@ export function PrivacyScreen() {
 
   const isPreview = searchParams.get("preview") === "true";
   const noop = useCallback((_next: boolean) => {}, []);
-  const setShareDiagnostics = isPreview ? noop : setShareDiagnosticsReal;
   const setTosAccepted = isPreview ? noop : setTosAcceptedReal;
   const setPrivacyConsent = isPreview ? noop : setPrivacyConsentReal;
 
@@ -66,9 +57,9 @@ export function PrivacyScreen() {
       return;
     }
 
-    // Analytics isn't asked here — the server keeps share_analytics null
-    // until the user opts in via settings or review-terms.
-    saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics: null, shareDiagnostics, hasPlatformSession });
+    // Neither share toggle is asked here — the server keeps both null until
+    // the user makes an explicit choice via settings or review-terms.
+    saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics: null, shareDiagnostics: null, hasPlatformSession });
     if (!isNative) {
       const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
@@ -100,7 +91,6 @@ export function PrivacyScreen() {
     navigate,
     preferredFunnelVariant,
     searchParams,
-    shareDiagnostics,
     tosAccepted,
     userId,
   ]);
@@ -128,20 +118,9 @@ export function PrivacyScreen() {
           className={`text-center text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-4"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          Choose your privacy preferences. You can update these anytime in the
-          Settings.
+          Review and accept our terms to get started. You can manage your
+          privacy preferences anytime in the Settings.
         </p>
-
-        <PrivacyPreferencesCard
-          electron={electron}
-          showAnalytics={false}
-          shareAnalytics={false}
-          shareDiagnostics={shareDiagnostics}
-          onShareAnalyticsChange={noop}
-          onShareDiagnosticsChange={setShareDiagnostics}
-          className="mt-8 w-full"
-          style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
-        />
 
         <AgreementsCard
           electron={electron}
@@ -149,8 +128,8 @@ export function PrivacyScreen() {
           tosAccepted={tosAccepted}
           onPrivacyChange={setPrivacyConsent}
           onTosChange={setTosAccepted}
-          className="mt-6 w-full"
-          style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+          className="mt-8 w-full"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
         />
 
         <div

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -81,15 +81,17 @@ export function ReviewTermsScreen() {
       : "We've updated our terms. Please review and accept to continue.";
 
   const onContinue = useCallback(() => {
-    // Only persist analytics when its toggle was actually on screen — a user
+    // Only persist a share toggle when it was actually on screen — a user
     // routed here for other stale sections must not silently grant (or
-    // re-stamp) analytics consent; the server keeps null until they choose.
+    // re-stamp) consent for a toggle they never saw; the server keeps null
+    // until they choose. A toggle that WAS on screen persists on Continue
+    // even if untouched — shown + acknowledged is an explicit choice.
     saveConsent({
       userId,
       tos: tosAccepted,
       privacy: privacyConsent,
       shareAnalytics: showAnalytics ? shareAnalytics : null,
-      shareDiagnostics,
+      shareDiagnostics: showDiagnostics ? shareDiagnostics : null,
       hasPlatformSession,
     });
 
@@ -103,6 +105,7 @@ export function ReviewTermsScreen() {
     shareAnalytics,
     shareDiagnostics,
     showAnalytics,
+    showDiagnostics,
     tosAccepted,
     userId,
   ]);

--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -169,16 +169,15 @@ export function readConsentHydrated(): boolean {
 /**
  * SSR-safe, non-hook read for telemetry emitters.
  *
- * Unlike the onboarding UI, this treats an absent preference as no consent:
- * direct analytics uploads should only run after the privacy screen or
- * settings page has persisted an explicit opt-in. The in-memory store must
- * also agree so a failed opt-out write cannot leave an older stored opt-in
- * authorizing a new event.
+ * Analytics is opt-out: an absent preference (never asked) authorizes uploads;
+ * only an explicit opt-out stops them. The in-memory store must also agree so
+ * a failed opt-out write cannot leave an older stored opt-in authorizing a new
+ * event.
  */
 export function readShareAnalytics(): boolean {
   return (
     useOnboardingStore.getState().shareAnalytics &&
-    getDeviceBool("shareAnalytics", false)
+    getDeviceBool("shareAnalytics", true)
   );
 }
 

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -34,7 +34,6 @@ const FLOOR_CLEAR_MS = 5 * 60_000;
 
 type Resolved = {
   shareDiagnostics: boolean | null;
-  diagnosticsVersionCurrent: boolean;
   hasServerRecord: boolean;
 };
 const applyResolvedDiagnosticsConsent = mock(
@@ -117,7 +116,6 @@ describe("refreshDiagnosticsConsent", () => {
     const resolved = applyResolvedDiagnosticsConsent.mock.calls[0]![0];
     expect(resolved).toMatchObject({
       shareDiagnostics: false,
-      diagnosticsVersionCurrent: true,
       hasServerRecord: true,
     });
   });

--- a/clients/web/src/lib/consent/consent-refresh.ts
+++ b/clients/web/src/lib/consent/consent-refresh.ts
@@ -3,8 +3,8 @@
  * backstop, so a platform-side revoke is picked up without a fresh login.
  *
  * Everything routes through {@link applyResolvedDiagnosticsConsent} — the single
- * version-aware, direction-asymmetric chokepoint that writes the saved
- * preference, the effective Sentry gate, and the Electron main-process mirror.
+ * direction-asymmetric chokepoint that writes the saved preference, the
+ * effective Sentry gate, and the Electron main-process mirror.
  * A failed/timed-out fetch is swallowed and leaves all diagnostics state
  * unchanged (never flips the gate on or off).
  */
@@ -42,16 +42,13 @@ export async function refreshDiagnosticsConsent(): Promise<void> {
     if (useAuthStore.getState().user?.id !== userIdBefore) return;
     const resolved = resolveServerConsent(consent);
     // An empty server record is not authoritative: a platform-side revoke
-    // always arrives as a real record (share_diagnostics=false or a stale
-    // version). Closing the gate here would disable Sentry for a device-
-    // confirmed opted-in user whose server record is just missing (backfill
-    // pending/failed) until a full auth resync. Leave state unchanged, matching
-    // the failed-fetch posture; the auth resync owns the device-fallback reopen.
+    // always arrives as a real record (share_diagnostics=false). Leave state
+    // unchanged, matching the failed-fetch posture; the auth resync owns the
+    // no-record path.
     if (!resolved.hasServerRecord) return;
     applyResolvedDiagnosticsConsent(
       {
         shareDiagnostics: resolved.shareDiagnostics,
-        diagnosticsVersionCurrent: resolved.diagnosticsCurrent,
         hasServerRecord: resolved.hasServerRecord,
       },
       useOnboardingStore.getState().setShareDiagnostics,

--- a/clients/web/src/lib/consent/diagnostics-consent.test.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.test.ts
@@ -111,6 +111,21 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
     expectGate(true);
   });
 
+  // KEY REGRESSION: a no-row response materializes the old platform's API
+  // default `true` — not a user choice. It must not reopen the gate over an
+  // explicit local opt-out whose backfill hasn't landed.
+  test("no-record API-default true + local opt-out preference → gate stays closed", () => {
+    devicePreference = false;
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      { shareDiagnostics: true, hasServerRecord: false },
+      setShareDiagnostics,
+    );
+    expect(result).toBeNull();
+    expect(setShareDiagnostics).not.toHaveBeenCalled();
+    expectGate(false);
+  });
+
   // KEY REGRESSION: a local explicit opt-out whose patchConsent write hasn't
   // landed (server still null) must stay closed — null never overrides an
   // explicit device preference.

--- a/clients/web/src/lib/consent/diagnostics-consent.test.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.test.ts
@@ -5,7 +5,8 @@
  * (`device:share_diagnostics`, applied via the `setShareDiagnostics` mock) and
  * the EFFECTIVE GATE (`device:diagnostics_reporting` + the main-process sync,
  * written by `setDiagnosticsReportingGate`). The preference tracks the server's
- * share value direction-asymmetrically; the gate is `preference && version`.
+ * share value direction-asymmetrically; the gate is opt-out — closed only for
+ * an explicit revoke.
  *
  * `@/runtime/diagnostics` and `@/utils/device-settings` are mocked so the gate
  * writes are observable without a DOM/localStorage.
@@ -45,14 +46,10 @@ function expectGate(value: boolean): void {
 }
 
 describe("applyResolvedDiagnosticsConsent — saved preference", () => {
-  test("real record + true + current → preference true, gate true", () => {
+  test("real record + true → preference true, gate true", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      {
-        shareDiagnostics: true,
-        diagnosticsVersionCurrent: true,
-        hasServerRecord: true,
-      },
+      { shareDiagnostics: true, hasServerRecord: true },
       setShareDiagnostics,
     );
     expect(result).toBe(true);
@@ -60,33 +57,10 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
     expectGate(true);
   });
 
-  // KEY REGRESSION: a stale-version opt-in must PRESERVE the preference as
-  // `true` (so the re-consent UI can't silently drop it) while turning the
-  // effective gate OFF.
-  test("real record + true + STALE version → preference PRESERVED true, gate false", () => {
-    const setShareDiagnostics = mock((_: boolean) => {});
-    const result = applyResolvedDiagnosticsConsent(
-      {
-        shareDiagnostics: true,
-        diagnosticsVersionCurrent: false,
-        hasServerRecord: true,
-      },
-      setShareDiagnostics,
-    );
-    expect(result).toBe(true);
-    expect(setShareDiagnostics).toHaveBeenCalledWith(true);
-    expect(setShareDiagnostics).not.toHaveBeenCalledWith(false);
-    expectGate(false);
-  });
-
   test("real record + false → preference false, gate false", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      {
-        shareDiagnostics: false,
-        diagnosticsVersionCurrent: true,
-        hasServerRecord: true,
-      },
+      { shareDiagnostics: false, hasServerRecord: true },
       setShareDiagnostics,
     );
     expect(result).toBe(false);
@@ -94,59 +68,45 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
     expectGate(false);
   });
 
-  test("null + no record → preference unchanged, gate not forced on", () => {
+  // KEY OPT-OUT CASES: never-asked (null) must keep reporting ON — a user who
+  // was never shown the toggle has telemetry enabled by default.
+  test("null + no record → preference unchanged, gate open (opt-out default)", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      {
-        shareDiagnostics: null,
-        diagnosticsVersionCurrent: false,
-        hasServerRecord: false,
-      },
+      { shareDiagnostics: null, hasServerRecord: false },
       setShareDiagnostics,
     );
     expect(result).toBeNull();
     expect(setShareDiagnostics).not.toHaveBeenCalled();
-    expectGate(false);
+    expectGate(true);
   });
 
-  test("null grant with a server record → preference unchanged, gate false", () => {
+  test("null grant with a server record → preference unchanged, gate open", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      {
-        shareDiagnostics: null,
-        diagnosticsVersionCurrent: true,
-        hasServerRecord: true,
-      },
+      { shareDiagnostics: null, hasServerRecord: true },
       setShareDiagnostics,
     );
     expect(result).toBeNull();
     expect(setShareDiagnostics).not.toHaveBeenCalled();
-    expectGate(false);
+    expectGate(true);
   });
 
-  test("true grant but no server record → preference unchanged, gate false", () => {
+  test("true grant but no server record → preference unchanged, gate open", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      {
-        shareDiagnostics: true,
-        diagnosticsVersionCurrent: true,
-        hasServerRecord: false,
-      },
+      { shareDiagnostics: true, hasServerRecord: false },
       setShareDiagnostics,
     );
     expect(result).toBeNull();
     expect(setShareDiagnostics).not.toHaveBeenCalled();
-    expectGate(false);
+    expectGate(true);
   });
 
   test("explicit false with no prior record → preference false (eager revoke), gate false", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      {
-        shareDiagnostics: false,
-        diagnosticsVersionCurrent: false,
-        hasServerRecord: false,
-      },
+      { shareDiagnostics: false, hasServerRecord: false },
       setShareDiagnostics,
     );
     expect(result).toBe(false);

--- a/clients/web/src/lib/consent/diagnostics-consent.test.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.test.ts
@@ -5,8 +5,9 @@
  * (`device:share_diagnostics`, applied via the `setShareDiagnostics` mock) and
  * the EFFECTIVE GATE (`device:diagnostics_reporting` + the main-process sync,
  * written by `setDiagnosticsReportingGate`). The preference tracks the server's
- * share value direction-asymmetrically; the gate is opt-out — closed only for
- * an explicit revoke.
+ * share value direction-asymmetrically; the gate applies an explicit server
+ * value directly and follows the saved device preference on an unknown one
+ * (absent reads open — opt-out default).
  *
  * `@/runtime/diagnostics` and `@/utils/device-settings` are mocked so the gate
  * writes are observable without a DOM/localStorage.
@@ -19,9 +20,14 @@ const syncDiagnosticsToMain = mock((_enabled: boolean) => {});
 
 // Mock the full surface this module touches; `mock.module` is process-global,
 // so a partial mock would strip exports other test files import.
+// The saved device preference (`device:share_diagnostics`); null models
+// "never written", which resolves to the opt-out default via the fallback.
+let devicePreference: boolean | null = null;
+
 mock.module("@/utils/device-settings", () => ({
   setDeviceBool,
-  getDeviceBool: (_name: string, fallback: boolean) => fallback,
+  getDeviceBool: (_name: string, fallback: boolean) =>
+    devicePreference ?? fallback,
   watchDeviceSetting: () => () => {},
 }));
 mock.module("@/runtime/diagnostics", () => ({ syncDiagnosticsToMain }));
@@ -32,6 +38,7 @@ const { applyResolvedDiagnosticsConsent, setDiagnosticsReportingGate } =
 beforeEach(() => {
   setDeviceBool.mockClear();
   syncDiagnosticsToMain.mockClear();
+  devicePreference = null;
 });
 
 /**
@@ -68,8 +75,9 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
     expectGate(false);
   });
 
-  // KEY OPT-OUT CASES: never-asked (null) must keep reporting ON — a user who
-  // was never shown the toggle has telemetry enabled by default.
+  // KEY OPT-OUT CASES: never-asked (null) follows the saved device
+  // preference — absent reads open, so a user who was never shown the toggle
+  // has telemetry enabled by default.
   test("null + no record → preference unchanged, gate open (opt-out default)", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
@@ -100,6 +108,32 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
     );
     expect(result).toBeNull();
     expect(setShareDiagnostics).not.toHaveBeenCalled();
+    expectGate(true);
+  });
+
+  // KEY REGRESSION: a local explicit opt-out whose patchConsent write hasn't
+  // landed (server still null) must stay closed — null never overrides an
+  // explicit device preference.
+  test("null server value + local opt-out preference → gate stays closed", () => {
+    devicePreference = false;
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      { shareDiagnostics: null, hasServerRecord: true },
+      setShareDiagnostics,
+    );
+    expect(result).toBeNull();
+    expect(setShareDiagnostics).not.toHaveBeenCalled();
+    expectGate(false);
+  });
+
+  test("explicit server true overrides a local opt-out preference", () => {
+    devicePreference = false;
+    const setShareDiagnostics = mock((_: boolean) => {});
+    applyResolvedDiagnosticsConsent(
+      { shareDiagnostics: true, hasServerRecord: true },
+      setShareDiagnostics,
+    );
+    expect(setShareDiagnostics).toHaveBeenCalledWith(true);
     expectGate(true);
   });
 

--- a/clients/web/src/lib/consent/diagnostics-consent.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.ts
@@ -7,15 +7,17 @@
  *   server's `share_diagnostics` value (direction-asymmetric writes), so a
  *   stale-version record can't silently lose a prior explicit choice.
  * - **Effective reporting gate** (`device:diagnostics_reporting`) — what
- *   actually turns Sentry on. Diagnostics is opt-out: an explicit server
- *   value sets the gate directly (even a stale-version grant keeps reporting
- *   on — the review-terms re-confirmation is driven by the consent-currency
- *   flags, not this gate), while an unknown server value (null / no record)
- *   makes the gate follow the saved device preference, absent reading open.
- *   Following the preference — rather than forcing open — keeps an explicit
- *   local opt-out closed while its `patchConsent` write is still in flight
- *   (or failed), yet heals gates stuck closed by earlier strict-opt-in
- *   builds for users who never opted out.
+ *   actually turns Sentry on. Diagnostics is opt-out, and the gate always
+ *   equals the effective saved preference: an authoritative server signal
+ *   (the same rules the preference uses — a grant needs a real record, a
+ *   revoke is always honored) applies directly, while an unknown input
+ *   (null, or a non-false value on a no-row API default) leaves the device
+ *   preference in charge, absent reading open. Following the preference —
+ *   rather than forcing open — keeps an explicit local opt-out closed while
+ *   its `patchConsent` write is still in flight (or failed), yet heals gates
+ *   stuck closed by earlier strict-opt-in builds for users who never opted
+ *   out. A stale-version grant keeps reporting on — the review-terms
+ *   re-confirmation is driven by the consent-currency flags, not this gate.
  *
  * Every non-onboarding path that learns a diagnostics-consent value from the
  * server routes through {@link applyResolvedDiagnosticsConsent} so this policy
@@ -26,8 +28,8 @@
  *   stale version; an explicit revoke (`shareDiagnostics === false`) writes
  *   `false`; an unknown input (`null` / no record) leaves the preference
  *   untouched.
- * - **Gate** — an explicit server value applies directly; an unknown input
- *   follows the saved device preference (absent reads open).
+ * - **Gate** — always the effective preference: the authoritative value just
+ *   applied, or the saved device preference when unknown (absent reads open).
  */
 
 import { getDeviceBool, setDeviceBool } from "@/utils/device-settings";
@@ -57,8 +59,9 @@ export function setDiagnosticsReportingGate(enabled: boolean): void {
  * 1. The saved preference, via `setShareDiagnostics` — written only for a
  *    confident grant or explicit revoke; an unknown input leaves it untouched.
  * 2. The effective reporting gate, via {@link setDiagnosticsReportingGate} —
- *    an explicit server value directly; an unknown server value follows the
- *    saved device preference (absent reads open — opt-out default).
+ *    always the effective preference: the just-applied authoritative value,
+ *    or the existing device preference when the input is unknown (absent
+ *    reads open — opt-out default).
  *
  * @returns the saved-preference decision: `true`/`false` when the preference was
  * written to that value, or `null` when the input is an unknown grant and the
@@ -72,7 +75,7 @@ export function applyResolvedDiagnosticsConsent(
   if (preference !== null) setShareDiagnostics(preference);
 
   setDiagnosticsReportingGate(
-    resolved.shareDiagnostics ?? getDeviceBool("shareDiagnostics", true),
+    preference ?? getDeviceBool("shareDiagnostics", true),
   );
 
   return preference;

--- a/clients/web/src/lib/consent/diagnostics-consent.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.ts
@@ -1,15 +1,18 @@
 /**
- * The single, version-aware, direction-asymmetric decision point for the two
+ * The single, direction-asymmetric decision point for the two
  * diagnostics-consent values:
  *
  * - **Saved preference** (`device:share_diagnostics`) — the user's opt-in/out,
  *   shown and re-submitted by the re-consent screen. It always tracks the
- *   server's `share_diagnostics` value (direction-asymmetric writes), never the
- *   privacy-consent version, so a stale-version record can't silently lose a
- *   prior opt-in.
+ *   server's `share_diagnostics` value (direction-asymmetric writes), so a
+ *   stale-version record can't silently lose a prior explicit choice.
  * - **Effective reporting gate** (`device:diagnostics_reporting`) — what
- *   actually turns Sentry on. It is `preference && versionCurrent`, so a
- *   stale-version acceptance stops reporting until the user re-accepts.
+ *   actually turns Sentry on. Diagnostics is opt-out: the gate is open unless
+ *   the user explicitly opted out (`shareDiagnostics === false`). Never-asked
+ *   (null / no record) and explicit grants — even under a stale version —
+ *   keep reporting on; a stale explicit choice still owes a review-terms
+ *   re-confirmation, but that flow is driven by the consent-currency flags,
+ *   not this gate.
  *
  * Every non-onboarding path that learns a diagnostics-consent value from the
  * server routes through {@link applyResolvedDiagnosticsConsent} so this policy
@@ -20,8 +23,7 @@
  *   stale version; an explicit revoke (`shareDiagnostics === false`) writes
  *   `false`; an unknown input (`null` / no record) leaves the preference
  *   untouched.
- * - **Gate** — opens only for a confident, current grant
- *   (`hasServerRecord && shareDiagnostics === true && diagnosticsVersionCurrent`).
+ * - **Gate** — closes only for an explicit revoke (`shareDiagnostics === false`).
  */
 
 import { setDeviceBool } from "@/utils/device-settings";
@@ -29,8 +31,6 @@ import { setDeviceBool } from "@/utils/device-settings";
 export interface ResolvedDiagnosticsConsent {
   /** The server's `share_diagnostics` value; `null` when unknown/absent. */
   shareDiagnostics: boolean | null;
-  /** Whether the server's accepted version is at least `DIAGNOSTICS_CONSENT_VERSION`. */
-  diagnosticsVersionCurrent: boolean;
   /** Whether the server returned a real consent record (not API defaults). */
   hasServerRecord: boolean;
 }
@@ -53,7 +53,7 @@ export function setDiagnosticsReportingGate(enabled: boolean): void {
  * 1. The saved preference, via `setShareDiagnostics` — written only for a
  *    confident grant or explicit revoke; an unknown input leaves it untouched.
  * 2. The effective reporting gate, via {@link setDiagnosticsReportingGate} —
- *    always set to `preference && versionCurrent`.
+ *    opt-out: closed only for an explicit revoke.
  *
  * @returns the saved-preference decision: `true`/`false` when the preference was
  * written to that value, or `null` when the input is an unknown grant and the
@@ -66,11 +66,7 @@ export function applyResolvedDiagnosticsConsent(
   const preference = resolvePreference(resolved);
   if (preference !== null) setShareDiagnostics(preference);
 
-  const { shareDiagnostics, diagnosticsVersionCurrent, hasServerRecord } =
-    resolved;
-  setDiagnosticsReportingGate(
-    hasServerRecord && shareDiagnostics === true && diagnosticsVersionCurrent,
-  );
+  setDiagnosticsReportingGate(resolved.shareDiagnostics !== false);
 
   return preference;
 }

--- a/clients/web/src/lib/consent/diagnostics-consent.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.ts
@@ -7,12 +7,15 @@
  *   server's `share_diagnostics` value (direction-asymmetric writes), so a
  *   stale-version record can't silently lose a prior explicit choice.
  * - **Effective reporting gate** (`device:diagnostics_reporting`) — what
- *   actually turns Sentry on. Diagnostics is opt-out: the gate is open unless
- *   the user explicitly opted out (`shareDiagnostics === false`). Never-asked
- *   (null / no record) and explicit grants — even under a stale version —
- *   keep reporting on; a stale explicit choice still owes a review-terms
- *   re-confirmation, but that flow is driven by the consent-currency flags,
- *   not this gate.
+ *   actually turns Sentry on. Diagnostics is opt-out: an explicit server
+ *   value sets the gate directly (even a stale-version grant keeps reporting
+ *   on — the review-terms re-confirmation is driven by the consent-currency
+ *   flags, not this gate), while an unknown server value (null / no record)
+ *   makes the gate follow the saved device preference, absent reading open.
+ *   Following the preference — rather than forcing open — keeps an explicit
+ *   local opt-out closed while its `patchConsent` write is still in flight
+ *   (or failed), yet heals gates stuck closed by earlier strict-opt-in
+ *   builds for users who never opted out.
  *
  * Every non-onboarding path that learns a diagnostics-consent value from the
  * server routes through {@link applyResolvedDiagnosticsConsent} so this policy
@@ -23,10 +26,11 @@
  *   stale version; an explicit revoke (`shareDiagnostics === false`) writes
  *   `false`; an unknown input (`null` / no record) leaves the preference
  *   untouched.
- * - **Gate** — closes only for an explicit revoke (`shareDiagnostics === false`).
+ * - **Gate** — an explicit server value applies directly; an unknown input
+ *   follows the saved device preference (absent reads open).
  */
 
-import { setDeviceBool } from "@/utils/device-settings";
+import { getDeviceBool, setDeviceBool } from "@/utils/device-settings";
 
 export interface ResolvedDiagnosticsConsent {
   /** The server's `share_diagnostics` value; `null` when unknown/absent. */
@@ -53,7 +57,8 @@ export function setDiagnosticsReportingGate(enabled: boolean): void {
  * 1. The saved preference, via `setShareDiagnostics` — written only for a
  *    confident grant or explicit revoke; an unknown input leaves it untouched.
  * 2. The effective reporting gate, via {@link setDiagnosticsReportingGate} —
- *    opt-out: closed only for an explicit revoke.
+ *    an explicit server value directly; an unknown server value follows the
+ *    saved device preference (absent reads open — opt-out default).
  *
  * @returns the saved-preference decision: `true`/`false` when the preference was
  * written to that value, or `null` when the input is an unknown grant and the
@@ -66,7 +71,9 @@ export function applyResolvedDiagnosticsConsent(
   const preference = resolvePreference(resolved);
   if (preference !== null) setShareDiagnostics(preference);
 
-  setDiagnosticsReportingGate(resolved.shareDiagnostics !== false);
+  setDiagnosticsReportingGate(
+    resolved.shareDiagnostics ?? getDeviceBool("shareDiagnostics", true),
+  );
 
   return preference;
 }

--- a/clients/web/src/lib/sentry/consent-gate.ts
+++ b/clients/web/src/lib/sentry/consent-gate.ts
@@ -1,4 +1,5 @@
-import { getDeviceBool } from "@/utils/device-settings";
+import { getDeviceSetting } from "@/utils/device-settings";
+import { readConsentHydrated } from "@/domains/onboarding/prefs";
 import { useAuthStore } from "@/stores/auth-store";
 import { isConfirmedPlatformSession } from "@/stores/session-status";
 
@@ -10,8 +11,13 @@ import { isConfirmedPlatformSession } from "@/stores/session-status";
  *
  * Grants only on a probe-confirmed live platform session AND the effective
  * diagnostics-reporting gate. Diagnostics is opt-out, so an absent device gate
- * (never resolved) reads as open — only an explicit opt-out closes it. See
- * `sentry-control.ts` for the full rationale.
+ * (never written) reads as open — but only once consent state has hydrated:
+ * some session-confirmation paths (e.g. the local/gateway probe) publish a
+ * live session before any consent sync, and a fresh device must not upload
+ * ahead of learning about a server-side explicit opt-out. Every
+ * consent-resolution path writes the gate key, so the hydration guard only
+ * governs the pre-first-sync window. See `sentry-control.ts` for the full
+ * rationale.
  */
 export function diagnosticsConsentGranted(): boolean {
   const { platformSession, platformSessionRestoredOffline } =
@@ -21,5 +27,7 @@ export function diagnosticsConsentGranted(): boolean {
   ) {
     return false;
   }
-  return getDeviceBool("diagnosticsReporting", true);
+  const stored = getDeviceSetting("diagnosticsReporting", "");
+  if (stored !== "") return stored === "true";
+  return readConsentHydrated();
 }

--- a/clients/web/src/lib/sentry/consent-gate.ts
+++ b/clients/web/src/lib/sentry/consent-gate.ts
@@ -9,7 +9,8 @@ import { isConfirmedPlatformSession } from "@/stores/session-status";
  * `sentry-control`, which imports the flavor — that would be a cycle.
  *
  * Grants only on a probe-confirmed live platform session AND the effective
- * diagnostics-reporting gate (preference && version-current). See
+ * diagnostics-reporting gate. Diagnostics is opt-out, so an absent device gate
+ * (never resolved) reads as open — only an explicit opt-out closes it. See
  * `sentry-control.ts` for the full rationale.
  */
 export function diagnosticsConsentGranted(): boolean {
@@ -20,5 +21,5 @@ export function diagnosticsConsentGranted(): boolean {
   ) {
     return false;
   }
-  return getDeviceBool("diagnosticsReporting", false);
+  return getDeviceBool("diagnosticsReporting", true);
 }

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -27,7 +27,9 @@ mock.module("@/lib/sentry/flavor", () => ({
 // Controllable mock state for the composed gate inputs
 // ---------------------------------------------------------------------------
 
-let deviceDiagnostics = false; // device:diagnostics_reporting (effective gate)
+// device:diagnostics_reporting (effective gate); null models "never written",
+// which resolves to the opt-out default (open) via the read fallback.
+let deviceDiagnostics: boolean | null = null;
 let platformSession = "absent";
 let restoredOffline = false;
 
@@ -46,7 +48,7 @@ const syncDiagnosticsToMainMock = mock((_enabled: boolean) => {});
 mock.module("@/utils/device-settings", () => ({
   getDeviceBool: (name: string, fallback: boolean) => {
     readNames.push(name);
-    return deviceDiagnostics ? true : fallback;
+    return deviceDiagnostics ?? fallback;
   },
   watchDeviceSetting: (name: string, cb: () => void) => {
     watchedNames.push(name);
@@ -92,7 +94,7 @@ beforeEach(() => {
   watchedNames.length = 0;
   deviceWatchCallback = null;
   authSubscriber = null;
-  deviceDiagnostics = false;
+  deviceDiagnostics = null;
   platformSession = "absent";
   restoredOffline = false;
   clientEnabled = false;
@@ -122,13 +124,20 @@ describe("diagnosticsConsentGranted (composed gate)", () => {
     expect(diagnosticsConsentGranted()).toBe(false);
   });
 
-  test("true only with a confirmed-live session AND the reporting gate on", () => {
+  test("true only with a confirmed-live session AND the reporting gate not opted out", () => {
     platformSession = "present";
     restoredOffline = false;
     deviceDiagnostics = true;
     expect(diagnosticsConsentGranted()).toBe(true);
     deviceDiagnostics = false;
     expect(diagnosticsConsentGranted()).toBe(false);
+  });
+
+  test("an absent gate (never written) grants with a live session — opt-out default", () => {
+    platformSession = "present";
+    restoredOffline = false;
+    deviceDiagnostics = null;
+    expect(diagnosticsConsentGranted()).toBe(true);
   });
 });
 
@@ -174,7 +183,7 @@ describe("syncSentryClient", () => {
     expect(closeMock).toHaveBeenCalledTimes(1);
   });
 
-  test("live session + gate off: closes the flavor", () => {
+  test("live session + explicit opt-out: closes the flavor", () => {
     deviceDiagnostics = false;
     platformSession = "present";
     syncSentryClient(OPTIONS);

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -50,6 +50,10 @@ mock.module("@/utils/device-settings", () => ({
     readNames.push(name);
     return deviceDiagnostics ?? fallback;
   },
+  getDeviceSetting: (name: string, fallback: string) => {
+    readNames.push(name);
+    return deviceDiagnostics === null ? fallback : String(deviceDiagnostics);
+  },
   watchDeviceSetting: (name: string, cb: () => void) => {
     watchedNames.push(name);
     deviceWatchCallback = cb;
@@ -61,6 +65,13 @@ mock.module("@/utils/device-settings", () => ({
 
 mock.module("@/runtime/diagnostics", () => ({
   syncDiagnosticsToMain: syncDiagnosticsToMainMock,
+}));
+
+// Whether a consent sync (or explicit acceptance) has hydrated the flags —
+// gates the opt-out default for a never-written device key.
+let consentHydrated = true;
+mock.module("@/domains/onboarding/prefs", () => ({
+  readConsentHydrated: () => consentHydrated,
 }));
 
 mock.module("@/stores/auth-store", () => ({
@@ -98,6 +109,7 @@ beforeEach(() => {
   platformSession = "absent";
   restoredOffline = false;
   clientEnabled = false;
+  consentHydrated = true;
 });
 
 describe("diagnosticsConsentGranted (composed gate)", () => {
@@ -138,6 +150,24 @@ describe("diagnosticsConsentGranted (composed gate)", () => {
     restoredOffline = false;
     deviceDiagnostics = null;
     expect(diagnosticsConsentGranted()).toBe(true);
+  });
+
+  test("an absent gate stays closed before consent hydrates — a probe-confirmed session must not upload ahead of the first consent sync", () => {
+    platformSession = "present";
+    restoredOffline = false;
+    deviceDiagnostics = null;
+    consentHydrated = false;
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
+
+  test("an explicitly written gate applies even before hydration", () => {
+    platformSession = "present";
+    restoredOffline = false;
+    consentHydrated = false;
+    deviceDiagnostics = true;
+    expect(diagnosticsConsentGranted()).toBe(true);
+    deviceDiagnostics = false;
+    expect(diagnosticsConsentGranted()).toBe(false);
   });
 });
 

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -3,10 +3,9 @@
  * reporting gate (`device:diagnostics_reporting`) AND a probe-confirmed live
  * platform session.
  *
- * The reporting gate is the saved Share Diagnostics preference AND a current
- * privacy-consent version, so a stale-version record stops reporting until
- * re-accept without losing the saved opt-in. It is written by the consent-
- * resolution paths (`setDiagnosticsReportingGate`).
+ * The reporting gate tracks the saved Share Diagnostics preference with
+ * opt-out semantics: it closes only for an explicit opt-out. It is written by
+ * the consent-resolution paths (`setDiagnosticsReportingGate`).
  *
  * Diagnostics are recorded against a platform account, so an offline /
  * self-hosted client — including a believed offline restore (LUM-2412) that no
@@ -14,10 +13,10 @@
  * gate, matching the daemon's consent posture. The same composed gate drives
  * the browser client and, via `syncDiagnosticsToMain`, the Electron main client.
  *
- * Strict opt-in semantics for the reporting gate (when a session is live):
- *   - stored "true"  → Sentry ON  (current consent)
- *   - stored "false" → Sentry OFF (opt-out or stale version)
- *   - absent         → Sentry OFF (no consent on record yet)
+ * Opt-out semantics for the reporting gate (when a session is live):
+ *   - stored "true"  → Sentry ON  (explicit or default-on consent)
+ *   - stored "false" → Sentry OFF (explicit opt-out)
+ *   - absent         → Sentry ON  (never asked — telemetry is opt-out)
  *
  * SDK access is dispatched through `selectSentryFlavor()` so each surface
  * (web/electron renderer, capacitor) can supply its own implementation. The

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -79,6 +79,8 @@ const resolveServerConsentMock = mock(
     shareDiagnostics: boolean | null;
     analyticsCurrent: boolean;
     diagnosticsCurrent: boolean;
+    analyticsVersionCurrent: boolean;
+    diagnosticsVersionCurrent: boolean;
     hasServerRecord: boolean;
   } => ({
     tos: false,
@@ -87,6 +89,8 @@ const resolveServerConsentMock = mock(
     shareDiagnostics: null,
     analyticsCurrent: false,
     diagnosticsCurrent: false,
+    analyticsVersionCurrent: false,
+    diagnosticsVersionCurrent: false,
     hasServerRecord: false,
   }),
 );
@@ -563,6 +567,8 @@ describe("auth store onboarding flag reconciliation", () => {
       shareDiagnostics: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
+      analyticsVersionCurrent: true,
+      diagnosticsVersionCurrent: true,
       hasServerRecord: true,
     });
 
@@ -591,6 +597,8 @@ describe("auth store onboarding flag reconciliation", () => {
       // The resolver reads a null share_analytics as "nothing to re-review".
       analyticsCurrent: true,
       diagnosticsCurrent: true,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: true,
       hasServerRecord: true,
     });
 
@@ -642,6 +650,8 @@ describe("auth store onboarding flag reconciliation", () => {
       analyticsCurrent: true,
       // The resolver reads a null share_diagnostics as "nothing to re-review".
       diagnosticsCurrent: true,
+      analyticsVersionCurrent: true,
+      diagnosticsVersionCurrent: false,
       hasServerRecord: true,
     });
 
@@ -817,6 +827,8 @@ describe("auth store onboarding flag reconciliation", () => {
       shareDiagnostics: true,
       analyticsCurrent: false,
       diagnosticsCurrent: false,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: false,
       hasServerRecord: true,
     });
 
@@ -838,6 +850,8 @@ describe("auth store onboarding flag reconciliation", () => {
       shareDiagnostics: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
+      analyticsVersionCurrent: true,
+      diagnosticsVersionCurrent: true,
       hasServerRecord: true,
     });
 
@@ -860,6 +874,8 @@ describe("auth store onboarding flag reconciliation", () => {
       shareDiagnostics: true,
       analyticsCurrent: false,
       diagnosticsCurrent: false,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: false,
       hasServerRecord: true,
     });
     restoreConsentForUserMock.mockReturnValueOnce({
@@ -907,6 +923,8 @@ describe("auth store onboarding flag reconciliation", () => {
       shareDiagnostics: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
+      analyticsVersionCurrent: true,
+      diagnosticsVersionCurrent: true,
       hasServerRecord: true,
     });
     restoreConsentForUserMock.mockReturnValueOnce({
@@ -937,6 +955,8 @@ describe("auth store onboarding flag reconciliation", () => {
       shareDiagnostics: true,
       analyticsCurrent: false,
       diagnosticsCurrent: false,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: false,
       hasServerRecord: true,
     });
     restoreConsentForUserMock.mockReturnValueOnce({

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -763,11 +763,13 @@ describe("auth store onboarding flag reconciliation", () => {
 
   test("device-consent fallback reopens the diagnostics reporting gate for a device-confirmed opt-in", async () => {
     // Empty server record, but the user has a current device-side diagnostics
-    // ack and an opted-in preference. The no-server-record chokepoint closes
-    // the gate; the fallback must reopen it so a confirmed opted-in user isn't
-    // left with Sentry disabled.
+    // ack and an opted-in preference. The chokepoint resolves the unknown
+    // server value from the device preference, reopening a gate an earlier
+    // build left closed so a confirmed opted-in user isn't left with Sentry
+    // disabled.
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockStoreShareDiagnostics = true;
+    localStorage.setItem("device:share_diagnostics", "true");
     localStorage.setItem("device:diagnostics_reporting", "false");
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
@@ -782,10 +784,12 @@ describe("auth store onboarding flag reconciliation", () => {
   });
 
   test("device-consent fallback keeps the gate closed for a device opt-out", async () => {
-    // Same empty-record fallback, but the device preference is opted out — the
-    // gate must stay false even though the device ack is current.
+    // Same empty-record fallback, but the device preference is an explicit
+    // opt-out — the unknown server value must not reopen the gate even though
+    // the device ack is current.
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockStoreShareDiagnostics = false;
+    localStorage.setItem("device:share_diagnostics", "false");
     localStorage.setItem("device:diagnostics_reporting", "true");
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -771,6 +771,29 @@ describe("auth store onboarding flag reconciliation", () => {
     );
   });
 
+  test("failed consent fetch on a fresh device writes a conservative closed gate", async () => {
+    // A confirmed session with a throwing consent fetch must not let the
+    // never-written gate fall open on hydration — the server may hold an
+    // explicit opt-out this device hasn't seen yet.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    fetchConsentMock.mockRejectedValueOnce(new Error("offline"));
+    localStorage.removeItem("device:diagnostics_reporting");
+
+    await useAuthStore.getState().initSession();
+
+    expect(localStorage.getItem("device:diagnostics_reporting")).toBe("false");
+  });
+
+  test("failed consent fetch leaves an already-resolved gate untouched", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    fetchConsentMock.mockRejectedValueOnce(new Error("offline"));
+    localStorage.setItem("device:diagnostics_reporting", "true");
+
+    await useAuthStore.getState().initSession();
+
+    expect(localStorage.getItem("device:diagnostics_reporting")).toBe("true");
+  });
+
   test("device-consent fallback reopens the diagnostics reporting gate for a device-confirmed opt-in", async () => {
     // Empty server record, but the user has a current device-side diagnostics
     // ack and an opted-in preference. The chokepoint resolves the unknown

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -632,6 +632,58 @@ describe("auth store onboarding flag reconciliation", () => {
     });
   });
 
+  test("never-asked diagnostics (null on a real record) hydrates current but earns no device ack", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      shareAnalytics: true,
+      shareDiagnostics: null,
+      analyticsCurrent: true,
+      // The resolver reads a null share_diagnostics as "nothing to re-review".
+      diagnosticsCurrent: true,
+      hasServerRecord: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    // No bounce to review-terms...
+    expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    // ...but no versioned ack either: only an explicit choice may attest a
+    // confirmation that could later backfill a server version stamp.
+    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
+      analyticsCurrent: true,
+    });
+    // A null server value never overwrites the device-local preference.
+    expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
+  });
+
+  test("no-record fallback without any device acks stays current and backfills neither toggle", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    restoreConsentForUserMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      analyticsCurrent: false,
+      diagnosticsCurrent: false,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    // Never-asked toggles (no server record, no device acks) must not bounce
+    // the user to review-terms.
+    expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    // The backfill seeds the server without any share-toggle fields — the
+    // server keeps both null until the user makes an explicit choice.
+    const body = patchConsentMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("share_analytics" in body).toBe(false);
+    expect("share_analytics_accepted_version" in body).toBe(false);
+    expect("share_diagnostics" in body).toBe(false);
+    expect("share_diagnostics_accepted_version" in body).toBe(false);
+    // No ack keys are written for never-asked toggles.
+    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {});
+  });
+
   test("initSession falls through to device keys when server versions are empty", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
 

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -336,13 +336,12 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         store.setShareAnalytics(resolved.shareAnalytics);
       }
 
-      // Diagnostics routes through the single version-aware, direction-
-      // asymmetric chokepoint: a stale-version acceptance never keeps
-      // diagnostics on, and an unknown grant leaves the mirror untouched.
+      // Diagnostics routes through the single direction-asymmetric
+      // chokepoint: only an explicit revoke closes the reporting gate
+      // (opt-out), and an unknown grant leaves the saved preference untouched.
       applyResolvedDiagnosticsConsent(
         {
           shareDiagnostics: resolved.shareDiagnostics,
-          diagnosticsVersionCurrent: resolved.diagnosticsCurrent,
           hasServerRecord: resolved.hasServerRecord,
         },
         store.setShareDiagnostics,
@@ -358,32 +357,32 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       let privacy = resolved.privacy;
       let analyticsCurrent = resolved.analyticsCurrent;
       let diagnosticsCurrent = resolved.diagnosticsCurrent;
-      // Genuine "confirmed under the current version" attestation, distinct
-      // from `analyticsCurrent`, which also reads never-asked (null server
-      // value — onboarding doesn't show the analytics toggle) as "nothing to
-      // re-review". Only the genuine ack may be device-persisted or backfill
-      // a server version stamp.
+      // Genuine "confirmed under the current version" attestations, distinct
+      // from the `*Current` flags, which also read never-asked (null server
+      // value — onboarding shows neither toggle) as "nothing to re-review".
+      // Only a genuine ack may be device-persisted or backfill a server
+      // version stamp.
       let analyticsAck =
         resolved.shareAnalytics !== null && resolved.analyticsCurrent;
+      let diagnosticsAck =
+        resolved.shareDiagnostics !== null && resolved.diagnosticsCurrent;
 
       // Fall back to device keys for a TRULY empty record: the device ack
       // keys are the only consent evidence, so they drive all four axes and
       // seed the server via the backfill.
       if (!resolved.hasServerRecord) {
         const deviceConsent = restoreConsentForUser(nextUserId);
-        // No server record means no explicit analytics consent exists —
-        // never-asked, so nothing to re-review regardless of the device ack.
+        // No server record means no explicit share-toggle consent exists —
+        // never-asked, so nothing to re-review regardless of the device acks.
         analyticsCurrent = true;
         analyticsAck = deviceConsent.analyticsCurrent;
-        diagnosticsCurrent = deviceConsent.diagnosticsCurrent;
-        // The chokepoint above closed the reporting gate because the server has
-        // no record yet. Reopen it from the device-confirmed consent so an
-        // opted-in user whose acceptance lives only in the per-device cache
-        // isn't left with Sentry disabled. The live-session requirement still
-        // applies via sentry-control's composed gate.
-        setDiagnosticsReportingGate(
-          store.shareDiagnostics && diagnosticsCurrent,
-        );
+        diagnosticsCurrent = true;
+        diagnosticsAck = deviceConsent.diagnosticsCurrent;
+        // The chokepoint above left the gate open (no record reads as
+        // never-asked, and telemetry is opt-out). Re-apply the device-local
+        // preference so an explicit device opt-out whose backfill patch
+        // hasn't landed on the server yet still closes the gate.
+        setDiagnosticsReportingGate(store.shareDiagnostics);
         if (deviceConsent.tos && deviceConsent.privacy) {
           tos = true;
           privacy = true;
@@ -395,7 +394,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
               tos: true,
               privacy: true,
               analytics: analyticsAck,
-              diagnostics: diagnosticsCurrent,
+              diagnostics: diagnosticsAck,
               shareValues: {
                 analytics: store.shareAnalytics,
                 diagnostics: store.shareDiagnostics,
@@ -432,15 +431,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         }
         if (diagnosticsFromDevice) {
           diagnosticsCurrent = true;
-          // Diagnostics currency comes from the device ack, so reopen the
-          // reporting gate the chokepoint closed for the stale server version
-          // — same `preference && currency` rule as the no-record branch.
-          // Re-read the preference: the server's authoritative share value
-          // was written to the store above.
-          setDiagnosticsReportingGate(
-            useOnboardingStore.getState().shareDiagnostics &&
-              diagnosticsCurrent,
-          );
+          diagnosticsAck = true;
         }
         if (
           tosFromDevice ||
@@ -464,12 +455,12 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       store.setAnalyticsConsentCurrent(analyticsCurrent);
       store.setDiagnosticsConsentCurrent(diagnosticsCurrent);
       persistConsentForUser(nextUserId, tos, privacy);
-      // A false analytics ack is never written: absent ≡ false for every
+      // A false toggle ack is never written: absent ≡ false for every
       // reader, and writing false would erase a genuine device attestation
       // whose backfill patch simply hasn't landed on the server yet.
       persistToggleConsent(nextUserId, {
         ...(analyticsAck ? { analyticsCurrent: true } : {}),
-        diagnosticsCurrent,
+        ...(diagnosticsAck ? { diagnosticsCurrent: true } : {}),
       });
       syncOrganizationState(nextUserId);
       store.setConsentHydrated(true);
@@ -484,12 +475,12 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   store.setTosAccepted(consent.tos);
   store.setPrivacyConsent(consent.privacy);
   // An absent device ack here can't be told apart from never-asked (the
-  // onboarding flow doesn't show the analytics toggle), and only the server
-  // can attest an explicit stale consent — never bounce to review-terms on
+  // onboarding flow shows neither share toggle), and only the server can
+  // attest an explicit stale consent — never bounce to review-terms on
   // device evidence alone. A genuinely stale consent re-bounces on the next
   // successful sync.
   store.setAnalyticsConsentCurrent(true);
-  store.setDiagnosticsConsentCurrent(consent.diagnosticsCurrent);
+  store.setDiagnosticsConsentCurrent(true);
   syncOrganizationState(nextUserId);
   store.setConsentHydrated(true);
 }

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -72,7 +72,11 @@ import {
   DIAGNOSTICS_CONSENT_VERSION,
 } from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
-import { applyResolvedDiagnosticsConsent } from "@/lib/consent/diagnostics-consent";
+import {
+  applyResolvedDiagnosticsConsent,
+  setDiagnosticsReportingGate,
+} from "@/lib/consent/diagnostics-consent";
+import { getDeviceSetting } from "@/utils/device-settings";
 import {
   clearOrganization,
   useOrganizationStore,
@@ -465,6 +469,14 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
 
   const consent = restoreConsentForUser(nextUserId);
   const store = useOnboardingStore.getState();
+  // Consent fetch failed for a platform user and this device has never
+  // resolved a diagnostics gate: fail closed until a successful sync can
+  // reveal a server-side explicit opt-out — hydration alone must not let the
+  // opt-out default open the gate. Every successful sync path writes the
+  // gate, so this conservative value never outlives the outage.
+  if (nextUserId && getDeviceSetting("diagnosticsReporting", "") === "") {
+    setDiagnosticsReportingGate(false);
+  }
   store.setTosAccepted(consent.tos);
   store.setPrivacyConsent(consent.privacy);
   // An absent device ack here can't be told apart from never-asked (the

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -355,14 +355,15 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       let analyticsCurrent = resolved.analyticsCurrent;
       let diagnosticsCurrent = resolved.diagnosticsCurrent;
       // Genuine "confirmed under the current version" attestations, distinct
-      // from the `*Current` flags, which also read never-asked (null server
-      // value — onboarding shows neither toggle) as "nothing to re-review".
-      // Only a genuine ack may be device-persisted or backfill a server
-      // version stamp.
+      // from the `*Current` flags, which also read never-asked (a null server
+      // value, or an implicit pre-nullable-platform default — onboarding
+      // shows neither toggle) as "nothing to re-review". Only a genuine ack
+      // may be device-persisted or backfill a server version stamp, so acks
+      // key off the raw version currency.
       let analyticsAck =
-        resolved.shareAnalytics !== null && resolved.analyticsCurrent;
+        resolved.shareAnalytics !== null && resolved.analyticsVersionCurrent;
       let diagnosticsAck =
-        resolved.shareDiagnostics !== null && resolved.diagnosticsCurrent;
+        resolved.shareDiagnostics !== null && resolved.diagnosticsVersionCurrent;
 
       // Fall back to device keys for a TRULY empty record: the device ack
       // keys are the only consent evidence, so they drive all four axes and

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -72,10 +72,7 @@ import {
   DIAGNOSTICS_CONSENT_VERSION,
 } from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
-import {
-  applyResolvedDiagnosticsConsent,
-  setDiagnosticsReportingGate,
-} from "@/lib/consent/diagnostics-consent";
+import { applyResolvedDiagnosticsConsent } from "@/lib/consent/diagnostics-consent";
 import {
   clearOrganization,
   useOrganizationStore,
@@ -378,11 +375,6 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         analyticsAck = deviceConsent.analyticsCurrent;
         diagnosticsCurrent = true;
         diagnosticsAck = deviceConsent.diagnosticsCurrent;
-        // The chokepoint above left the gate open (no record reads as
-        // never-asked, and telemetry is opt-out). Re-apply the device-local
-        // preference so an explicit device opt-out whose backfill patch
-        // hasn't landed on the server yet still closes the gate.
-        setDiagnosticsReportingGate(store.shareDiagnostics);
         if (deviceConsent.tos && deviceConsent.privacy) {
           tos = true;
           privacy = true;

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -185,10 +185,32 @@ describe("resolveServerConsent", () => {
     expect(resolved.diagnosticsCurrent).toBe(false);
   });
 
-  test("reports stale toggles for empty versions", () => {
+  test("implicit defaults (true + empty version) read as never-asked, not stale", () => {
+    // A pre-nullable platform materializes its DB default `true` with no
+    // version on rows created without the toggles shown — never-asked in
+    // disguise. Must not bounce to review-terms, but earns no version ack.
     const r = resolveServerConsent(
       makeConsent({
+        share_analytics: true,
         share_analytics_accepted_version: "",
+        share_diagnostics: true,
+        share_diagnostics_accepted_version: "",
+      }),
+    );
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+    expect(r.analyticsVersionCurrent).toBe(false);
+    expect(r.diagnosticsVersionCurrent).toBe(false);
+  });
+
+  test("reports stale toggles for explicit opt-outs with empty versions", () => {
+    // An explicit false is never excused by an empty version — it still
+    // owes a re-review.
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics: false,
+        share_analytics_accepted_version: "",
+        share_diagnostics: false,
         share_diagnostics_accepted_version: "",
       }),
     );

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -43,7 +43,7 @@ mock.module("@/domains/account/profile", () => ({
 }));
 mock.module("@/generated/api/client.gen", () => ({ client: {} }));
 
-const setDeviceBoolMock = mock(() => {});
+const setDeviceBoolMock = mock((_name: string, _value: boolean) => {});
 mock.module("@/utils/device-settings", () => ({
   setDeviceBool: setDeviceBoolMock,
 }));

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -543,7 +543,24 @@ describe("saveConsent", () => {
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(null);
     // Never-asked has nothing to re-review — must not bounce to review-terms.
     expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
-    // Opt-out: never-asked leaves the effective reporting gate OPEN.
+    // Null must not touch the gate: an explicit device opt-out survives
+    // flows that don't show the toggle (a never-written gate reads open by
+    // default via the opt-out read fallback).
+    const gateWrites = setDeviceBoolMock.mock.calls.filter(
+      (call) => call[0] === "diagnosticsReporting",
+    );
+    expect(gateWrites).toEqual([]);
+  });
+
+  test("explicit shareDiagnostics=true opens the reporting gate", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: true,
+      hasPlatformSession: false,
+    });
     expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", true);
   });
 

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -171,6 +171,20 @@ describe("resolveServerConsent", () => {
     expect(resolved.analyticsCurrent).toBe(false);
   });
 
+  test("null share_diagnostics (never asked) resolves diagnostics current — nothing to re-review", () => {
+    const resolved = resolveServerConsent(
+      makeConsent({ share_diagnostics: null, share_diagnostics_accepted_version: "" }),
+    );
+    expect(resolved.diagnosticsCurrent).toBe(true);
+  });
+
+  test("an explicit diagnostics choice under a stale version still requires re-review", () => {
+    const resolved = resolveServerConsent(
+      makeConsent({ share_diagnostics: false, share_diagnostics_accepted_version: "2026-01-01" }),
+    );
+    expect(resolved.diagnosticsCurrent).toBe(false);
+  });
+
   test("reports stale toggles for empty versions", () => {
     const r = resolveServerConsent(
       makeConsent({
@@ -513,6 +527,42 @@ describe("saveConsent", () => {
     expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
   });
 
+  test("null shareDiagnostics (toggle not shown) omits diagnostics from the patch, skips its ack, and keeps the gate open", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: null,
+      hasPlatformSession: true,
+    });
+    const body = patchConsentMock.mock.calls[0][0];
+    expect("share_diagnostics" in body).toBe(false);
+    expect("share_diagnostics_accepted_version" in body).toBe(false);
+    expect(storeState.setShareDiagnostics).not.toHaveBeenCalled();
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(null);
+    // Never-asked has nothing to re-review — must not bounce to review-terms.
+    expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
+    // Opt-out: never-asked leaves the effective reporting gate OPEN.
+    expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", true);
+  });
+
+  test("explicit shareDiagnostics=false persists the opt-out and closes the reporting gate", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: false,
+      hasPlatformSession: true,
+    });
+    expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", false);
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.share_diagnostics).toBe(false);
+    expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+  });
+
   test("marks consent hydrated — an explicit acceptance is authoritative", () => {
     saveConsent({
       userId: "user-1",
@@ -556,6 +606,19 @@ describe("savePreferenceToggle", () => {
     expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
     expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
     expect(patchConsentMock).not.toHaveBeenCalled();
+  });
+
+  test("an offline diagnostics opt-out still closes the reporting gate (opt-out follows the preference)", () => {
+    savePreferenceToggle("share_diagnostics", false, { userId: "user-1", hasPlatformSession: false });
+    expect(setDeviceBoolMock).toHaveBeenCalledWith("shareDiagnostics", false);
+    expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", false);
+    expect(storeState.setDiagnosticsConsentCurrent).not.toHaveBeenCalled();
+    expect(patchConsentMock).not.toHaveBeenCalled();
+  });
+
+  test("an offline diagnostics opt-in opens the reporting gate", () => {
+    savePreferenceToggle("share_diagnostics", true, { userId: "user-1", hasPlatformSession: false });
+    expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", true);
   });
 });
 

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -187,6 +187,15 @@ export function resolveServerConsent(
   shareDiagnostics: boolean | null;
   analyticsCurrent: boolean;
   diagnosticsCurrent: boolean;
+  /**
+   * Raw version currency for each toggle — true only when the recorded
+   * accepted version is at/past the build's constant. Unlike the `*Current`
+   * flags (which also read never-asked as "nothing to re-review"), these back
+   * the genuine "confirmed under the current version" attestation that may be
+   * device-persisted or backfilled to the server.
+   */
+  analyticsVersionCurrent: boolean;
+  diagnosticsVersionCurrent: boolean;
   hasServerRecord: boolean;
 } {
   if (!consent) {
@@ -197,9 +206,19 @@ export function resolveServerConsent(
       shareDiagnostics: null,
       analyticsCurrent: false,
       diagnosticsCurrent: false,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: false,
       hasServerRecord: false,
     };
   }
+  const analyticsVersionCurrent = versionIsCurrent(
+    consent.share_analytics_accepted_version,
+    ANALYTICS_CONSENT_VERSION,
+  );
+  const diagnosticsVersionCurrent = versionIsCurrent(
+    consent.share_diagnostics_accepted_version,
+    DIAGNOSTICS_CONSENT_VERSION,
+  );
   // The endpoint always returns an object; for a user with no stored row it
   // returns the API defaults (empty versions, share booleans true). Any
   // non-empty version or any `false` share boolean can only have come from a
@@ -226,22 +245,26 @@ export function resolveServerConsent(
       versionIsCurrent(consent.ai_data_sharing_accepted_version, PRIVACY_CONSENT_VERSION),
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
-    // Share-toggle re-review is owed only for an explicit choice on record.
-    // Onboarding shows neither toggle, so both stay null until the user
-    // makes a choice via settings or review-terms — null reads as "nothing
-    // to re-review", not as stale consent.
+    // Share-toggle re-review is owed only for an explicit, genuinely stale
+    // choice on record. Onboarding shows neither toggle, so null (never
+    // chose) reads as "nothing to re-review". An implicit grant — true with
+    // an EMPTY version — is never-asked in disguise, not stale consent: a
+    // pre-nullable platform materializes its DB default `true` on rows this
+    // flow creates without the toggle shown, while every explicit write
+    // stamps a version. An explicit opt-out (false) is never excused this
+    // way — a false with a stale/empty version still re-reviews.
     analyticsCurrent:
       consent.share_analytics === null ||
-      versionIsCurrent(
-        consent.share_analytics_accepted_version,
-        ANALYTICS_CONSENT_VERSION,
-      ),
+      (consent.share_analytics === true &&
+        consent.share_analytics_accepted_version === "") ||
+      analyticsVersionCurrent,
     diagnosticsCurrent:
       consent.share_diagnostics === null ||
-      versionIsCurrent(
-        consent.share_diagnostics_accepted_version,
-        DIAGNOSTICS_CONSENT_VERSION,
-      ),
+      (consent.share_diagnostics === true &&
+        consent.share_diagnostics_accepted_version === "") ||
+      diagnosticsVersionCurrent,
+    analyticsVersionCurrent,
+    diagnosticsVersionCurrent,
     hasServerRecord,
   };
 }

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -259,8 +259,10 @@ export function saveConsent(opts: {
    * choice is recorded anywhere — the server keeps the column null and no
    * versioned device ack is stamped — but the in-memory currency flag is
    * still set: never-asked consent has nothing to re-review, so it must not
-   * bounce the user to review-terms. Telemetry is opt-out, so a null
-   * diagnostics choice leaves the effective reporting gate OPEN.
+   * bounce the user to review-terms. A null diagnostics choice also leaves
+   * the effective reporting gate untouched: a never-written gate reads open
+   * by default (telemetry is opt-out), while an explicit device opt-out must
+   * survive flows that don't show the toggle.
    */
   shareAnalytics: boolean | null;
   /** See {@link shareAnalytics}. */
@@ -275,14 +277,15 @@ export function saveConsent(opts: {
   }
   if (opts.shareDiagnostics !== null) {
     store.setShareDiagnostics(opts.shareDiagnostics);
+    // Only an explicit choice writes the gate; null leaves the existing
+    // gate (and any explicit device opt-out) untouched.
+    setDiagnosticsReportingGate(opts.shareDiagnostics);
   }
   store.setAnalyticsConsentCurrent(true);
   store.setDiagnosticsConsentCurrent(true);
   // An explicit user acceptance is authoritative hydration — route guards may
   // trust the flags without waiting for a session sync.
   store.setConsentHydrated(true);
-  // Opt-out: only an explicit "off" closes the gate; never-asked stays open.
-  setDiagnosticsReportingGate(opts.shareDiagnostics !== false);
 
   persistConsentForUser(opts.userId, opts.tos, opts.privacy);
   persistToggleConsent(opts.userId, {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -226,20 +226,22 @@ export function resolveServerConsent(
       versionIsCurrent(consent.ai_data_sharing_accepted_version, PRIVACY_CONSENT_VERSION),
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
-    // Analytics re-review is owed only for an explicit choice on record.
-    // Onboarding doesn't show the analytics toggle, so `share_analytics`
-    // stays null until the user opts in via settings or review-terms — null
-    // reads as "nothing to re-review", not as stale consent.
+    // Share-toggle re-review is owed only for an explicit choice on record.
+    // Onboarding shows neither toggle, so both stay null until the user
+    // makes a choice via settings or review-terms — null reads as "nothing
+    // to re-review", not as stale consent.
     analyticsCurrent:
       consent.share_analytics === null ||
       versionIsCurrent(
         consent.share_analytics_accepted_version,
         ANALYTICS_CONSENT_VERSION,
       ),
-    diagnosticsCurrent: versionIsCurrent(
-      consent.share_diagnostics_accepted_version,
-      DIAGNOSTICS_CONSENT_VERSION,
-    ),
+    diagnosticsCurrent:
+      consent.share_diagnostics === null ||
+      versionIsCurrent(
+        consent.share_diagnostics_accepted_version,
+        DIAGNOSTICS_CONSENT_VERSION,
+      ),
     hasServerRecord,
   };
 }
@@ -253,14 +255,16 @@ export function saveConsent(opts: {
   tos: boolean;
   privacy: boolean;
   /**
-   * Null when the analytics toggle wasn't shown on the saving surface. No
-   * explicit choice is recorded anywhere — the server keeps
-   * `share_analytics` null and no versioned device ack is stamped — but the
-   * in-memory currency flag is still set: never-asked consent has nothing to
-   * re-review, so it must not bounce the user to review-terms.
+   * Null when the toggle wasn't shown on the saving surface. No explicit
+   * choice is recorded anywhere — the server keeps the column null and no
+   * versioned device ack is stamped — but the in-memory currency flag is
+   * still set: never-asked consent has nothing to re-review, so it must not
+   * bounce the user to review-terms. Telemetry is opt-out, so a null
+   * diagnostics choice leaves the effective reporting gate OPEN.
    */
   shareAnalytics: boolean | null;
-  shareDiagnostics: boolean;
+  /** See {@link shareAnalytics}. */
+  shareDiagnostics: boolean | null;
   hasPlatformSession: boolean;
 }): void {
   const store = useOnboardingStore.getState();
@@ -269,19 +273,21 @@ export function saveConsent(opts: {
   if (opts.shareAnalytics !== null) {
     store.setShareAnalytics(opts.shareAnalytics);
   }
-  store.setShareDiagnostics(opts.shareDiagnostics);
+  if (opts.shareDiagnostics !== null) {
+    store.setShareDiagnostics(opts.shareDiagnostics);
+  }
   store.setAnalyticsConsentCurrent(true);
   store.setDiagnosticsConsentCurrent(true);
   // An explicit user acceptance is authoritative hydration — route guards may
   // trust the flags without waiting for a session sync.
   store.setConsentHydrated(true);
-  // Version is current by construction here, so the gate equals the preference.
-  setDiagnosticsReportingGate(opts.shareDiagnostics);
+  // Opt-out: only an explicit "off" closes the gate; never-asked stays open.
+  setDiagnosticsReportingGate(opts.shareDiagnostics !== false);
 
   persistConsentForUser(opts.userId, opts.tos, opts.privacy);
   persistToggleConsent(opts.userId, {
     ...(opts.shareAnalytics !== null ? { analyticsCurrent: true } : {}),
-    diagnosticsCurrent: true,
+    ...(opts.shareDiagnostics !== null ? { diagnosticsCurrent: true } : {}),
   });
 
   if (opts.hasPlatformSession) {
@@ -295,8 +301,12 @@ export function saveConsent(opts: {
             share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
           }
         : {}),
-      share_diagnostics: opts.shareDiagnostics,
-      share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
+      ...(opts.shareDiagnostics !== null
+        ? {
+            share_diagnostics: opts.shareDiagnostics,
+            share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
+          }
+        : {}),
     }).catch(() => {});
   }
 }
@@ -322,16 +332,13 @@ export function savePreferenceToggle(
   } else {
     store.setShareDiagnostics(value);
     setDeviceBool("shareDiagnostics", value);
+    // Opt-out: the effective gate equals the preference — an explicit "off"
+    // closes it, anything else keeps it open. The version-currency ack below
+    // is separate: it is only earned with a live session to record it against.
+    setDiagnosticsReportingGate(value);
     if (hasPlatformSession) {
       store.setDiagnosticsConsentCurrent(true);
-      // Version is current here (a live session re-stamps it), so the effective
-      // reporting gate equals the preference.
-      setDiagnosticsReportingGate(value);
       persistToggleConsent(userId, { diagnosticsCurrent: true });
-    } else {
-      // Offline: no version ack is earned, so the effective gate stays closed
-      // regardless of the toggle value until a live session re-confirms.
-      setDiagnosticsReportingGate(false);
     }
   }
 


### PR DESCRIPTION
## Summary

- **Diagnostics consent goes fully symmetric with analytics (#37912):** the onboarding privacy step no longer shows the Share Diagnostics toggle (the preferences card is gone from that screen — only ToS/privacy remain), so onboarding persists `shareDiagnostics: null` and the server keeps the column null until the user makes an explicit choice in settings or review-terms. Review-terms persists a toggle only when it was actually on screen (shown + acknowledged counts as consent, even untouched); `saveConsent` omits the field + version stamp and skips the device ack when null; `resolveServerConsent` reads a null `share_diagnostics` as "nothing to re-review" (no review-terms bounce); the auth-store sync tracks a genuine `diagnosticsAck` separate from the currency flag, exactly like `analyticsAck`.
- **Client consent gates flip to opt-out (deliberate semantics decision by Noa):** telemetry defaults ON; only an explicit opt-out disables it. The diagnostics reporting gate (Sentry, browser + Electron main + capacitor) is now closed only by an explicit `share_diagnostics === false` — never-asked (null / no record / absent device key) reads as open, and a stale-version explicit grant keeps reporting while the review-terms bounce is still owed. `readShareAnalytics()` (funnel/analytics emitters) likewise defaults ON when no device preference exists. The live-platform-session requirement for Sentry is unchanged (fail-closed offline).
- **`UserConsent.share_diagnostics` is now `boolean | null`** and the version-currency term was dropped from the diagnostics chokepoint (`ResolvedDiagnosticsConsent` loses `diagnosticsVersionCurrent`).

## Deploy order (important)

This PR must deploy **before** the platform PR that makes `share_diagnostics` nullable (`null=True, default=None`). Until then the platform keeps returning booleans, which this code handles unchanged. If the platform change shipped first, a null `share_diagnostics` + empty version would read as stale on old web code and bounce every fresh onboarder to review-terms.

## Original prompt

Noa is making both share toggles (analytics + diagnostics) opt-out rather than opt-in: telemetry defaults to enabled, the DB keeps `null` until a user explicitly consents one way or the other so the consent ledger doubles as an audit log of who chose what and when. A toggle that was on screen and acknowledged persists an explicit value even if untouched; a toggle never shown persists nothing. Null stays a platform-internal ledger artifact for the daemon-facing API (which returns resolved booleans), while our own web endpoint keeps returning null — this PR teaches the web client to interpret it with opt-out semantics before the platform starts sending it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)