### PR TITLE
refactor(assistant): remove the ingress.escalation notification event

### DIFF
--- a/assistant/src/__tests__/conversation-seed-composer.test.ts
+++ b/assistant/src/__tests__/conversation-seed-composer.test.ts
@@ -570,9 +570,9 @@ describe("composeConversationSeed", () => {
       expect(seed.trim().length).toBeGreaterThan(0);
     });
 
-    test('uses context payload "senderIdentifier" for escalation events', () => {
+    test('uses context payload "senderIdentifier" for access-request events', () => {
       const signal = makeSignal({
-        sourceEventName: "ingress.escalation",
+        sourceEventName: "ingress.access_request",
         contextPayload: { senderIdentifier: "Alice" },
       });
       const copy = makeCopy({ title: "", body: "" });
@@ -581,7 +581,7 @@ describe("composeConversationSeed", () => {
         "vellum" as NotificationChannel,
         copy,
       );
-      expect(seed).toBe("Ingress escalation: Alice");
+      expect(seed).toBe("Ingress access request: Alice");
     });
 
     test('prefers "message" over "summary" in context payload', () => {

--- a/assistant/src/approvals/guardian-expiry-notifier.ts
+++ b/assistant/src/approvals/guardian-expiry-notifier.ts
@@ -84,13 +84,14 @@ export async function notifyExpiredGuardianRequest(
  *
  * `tool_approval` is the one interaction-bound kind the periodic sweep can
  * reach (it carries a 30-minute `expiresAt`). In practice the request
- * id does not key a *blocking* prompter interaction: ingress escalations — the
- * sole producer of this kind — register no interaction at all, and
- * PermissionPrompter confirmations are keyed by their own request id with their
- * own (far shorter) timeout. So this is a safe cleanup: it no-ops when nothing
- * is registered under the request id, and otherwise drops a waiter-less async
- * entry and emits `interaction_resolved` so clients clear the attention
- * indicator. `cancelled` is the documented runtime-termination/timeout outcome.
+ * id does not key a *blocking* prompter interaction: PermissionPrompter
+ * confirmations are keyed by their own request id with their own (far
+ * shorter) timeout, so a `tool_approval` row without a live pending
+ * interaction can occur transiently. So this is a safe cleanup: it no-ops
+ * when nothing is registered under the request id, and otherwise drops a
+ * waiter-less async entry and emits `interaction_resolved` so clients clear
+ * the attention indicator. `cancelled` is the documented
+ * runtime-termination/timeout outcome.
  */
 function releaseExpiredInteraction(request: GuardianRequestWire): void {
   const released = pendingInteractions.resolve(request.id, "cancelled");

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -314,7 +314,7 @@ Connected channels are resolved at signal emission time by `getConnectedChannels
 
 ## Conversation Materialization
 
-The system uses a single conversation materialization path for **all** notifications -- there are no legacy bypass paths or dual-broadcast mechanisms. Every notification, including guardian questions and ingress escalation alerts, flows through `emitNotificationSignal()`:
+The system uses a single conversation materialization path for **all** notifications -- there are no legacy bypass paths or dual-broadcast mechanisms. Every notification, including guardian questions and access-request alerts, flows through `emitNotificationSignal()`:
 
 1. `emitNotificationSignal()` evaluates the signal and dispatches to channels.
 2. `NotificationBroadcaster` pairs each delivery with a conversation via `pairDeliveryWithConversation()`, executing the per-channel conversation action (start_new or reuse_existing).

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -11,7 +11,7 @@
  * does not surface a push banner. Urgent signals (`high`/`critical`)
  * broadcast with `silent: false` and fire the banner.
  *
- * Guardian-sensitive notifications (approval requests, escalation alerts)
+ * Guardian-sensitive notifications (approval requests, access requests)
  * are annotated with `targetGuardianPrincipalId` so that only clients
  * bound to the guardian identity display them. Non-guardian clients
  * should ignore notifications with a `targetGuardianPrincipalId` that
@@ -51,13 +51,11 @@ export type BroadcastFn = (
 
 /**
  * Event name prefixes that carry guardian-sensitive content (approval
- * requests, escalation alerts, access requests). Notifications for
- * these events are scoped to bound guardian devices via
- * `targetGuardianPrincipalId`.
+ * requests, access requests). Notifications for these events are scoped
+ * to bound guardian devices via `targetGuardianPrincipalId`.
  */
 const GUARDIAN_SENSITIVE_EVENT_PREFIXES = [
   "guardian.question",
-  "ingress.escalation",
   "ingress.access_request",
   "guardian.channel_activation",
 ] as const;

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -237,12 +237,6 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     };
   },
 
-  "ingress.escalation": (payload) => ({
-    title: "Escalation",
-    body:
-      str(payload.senderIdentifier, "An incoming message") + " needs attention",
-  }),
-
   "watcher.notification": (payload) => ({
     title: str(payload.title, "Watcher Notification"),
     body: str(payload.body, "A watcher event occurred"),

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -159,7 +159,6 @@ const EVENT_CATEGORY_MAP: Record<string, FeedItemCategory> = {
   "guardian.question": "security",
   "guardian.channel_activation": "security",
   "ingress.access_request": "security",
-  "ingress.escalation": "security",
 };
 
 function deriveCategory(signal: NotificationSignal): FeedItemCategory {
@@ -269,7 +268,6 @@ const NOTEWORTHY_EVENT_NAMES: ReadonlySet<string> = new Set([
   "guardian.question",
   "guardian.channel_activation",
   "ingress.access_request",
-  "ingress.escalation",
   "credential.health_alert",
 ]);
 

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -79,10 +79,6 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     description: "Caller requested callback while unreachable",
   },
   {
-    id: "ingress.escalation",
-    description: "Incoming message escalated for attention",
-  },
-  {
     id: "ingress.trusted_contact.guardian_decision",
     description: "Guardian decided on trusted contact request",
   },


### PR DESCRIPTION
## Summary
- Removes the ingress.escalation event registration, copy, home-feed category/noteworthy entries, and macOS guardian-sensitive entry — its only emitter (the escalation intercept) was deleted in PR 1
- watcher.escalation (unrelated watcher subsystem) untouched
- The platform-side push-collapse rule for this event is removed by the companion platform plan

## Grep-gate
- `grep -rn 'ingress\.escalation'` across the repo: **zero hits** (code, tests, and docs — including the PR 5 doc files, which never used the literal event name)
- `grep -rni 'ingress escalation'` prose sweep: zero hits (guardian-expiry-notifier comment and notifications/README.md updated here since neither is in PR 5 scope)
- `watcher.escalation` pins intact: `signal.ts:102`, `copy-composer.ts:245`, `notification-telegram-adapter.test.ts:157`
- The macOS guardian-sensitive entry was the exact event name (not a prefix shared with other events), so removal is safe

Part of plan: remove-escalate-policy.md (PR 3 of 5)