### PR TITLE
refactor: channel policy vocabulary is allow|deny — escalate removed from types and validators

### DIFF
--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -45,7 +45,7 @@ export type ChannelStatus =
   | "revoked"
   | "blocked"
   | "unverified";
-export type ChannelPolicy = "allow" | "deny" | "escalate";
+export type ChannelPolicy = "allow" | "deny";
 
 export interface ContactChannel {
   id: string;

--- a/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
+++ b/assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts
@@ -113,7 +113,7 @@ describe("trustContextFromVerdict", () => {
       type: "slack",
       address: "u-1",
       status: "unverified",
-      policy: "escalate",
+      policy: "deny",
     } satisfies TrustVerdict;
 
     const result = trustContextFromVerdict(verdict, {
@@ -124,7 +124,7 @@ describe("trustContextFromVerdict", () => {
     expect(result.requesterContactId).toBe("contact-1");
     // "unverified" maps to the API-facing "pending" member status.
     expect(result.memberStatus).toBe("pending");
-    expect(result.memberPolicy).toBe("escalate");
+    expect(result.memberPolicy).toBe("deny");
   });
 
   test("carries the verdict's gateway-owned interaction count onto the context", () => {
@@ -436,7 +436,7 @@ describe("actorTrustContextFromVerdict", () => {
       type: "slack",
       address: "u-1",
       status: "unverified",
-      policy: "escalate",
+      policy: "deny",
       memberDisplayName: "Dora",
     } satisfies TrustVerdict;
     const input = {
@@ -490,7 +490,7 @@ describe("toTrustContext member grounding", () => {
   function ctxWithMember(
     acl: { status: ChannelStatus; policy: ChannelPolicy } = {
       status: "unverified",
-      policy: "escalate",
+      policy: "deny",
     },
   ): ActorTrustContext {
     return {
@@ -522,7 +522,7 @@ describe("toTrustContext member grounding", () => {
     expect(context.requesterContactId).toBe("contact-1");
     // "unverified" maps to the API-facing "pending" member status.
     expect(context.memberStatus).toBe("pending");
-    expect(context.memberPolicy).toBe("escalate");
+    expect(context.memberPolicy).toBe("deny");
   });
 
   test("passes through active status + allow policy", () => {
@@ -635,6 +635,23 @@ describe("verdictMemberFromVerdict", () => {
         policy: "bogus",
       } satisfies TrustVerdict),
     ).toBeNull();
+  });
+
+  test('stale "escalate" policy returns null (fail-closed backstop for un-migrated gateways)', () => {
+    const verdict = {
+      trustClass: "trusted_contact",
+      canonicalSenderId: "u-8",
+      contactId: "contact-8",
+      channelId: "channel-8",
+      status: "active",
+      policy: "escalate",
+    } satisfies TrustVerdict;
+
+    expect(verdictMemberFromVerdict(verdict)).toBeNull();
+    expect(verdictUsability(verdict)).toEqual({
+      usable: false,
+      reason: "member unresolvable",
+    });
   });
 
   test("missing status or policy returns null (fail-closed)", () => {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -1,6 +1,6 @@
 /**
  * Ingress ACL enforcement stage: resolves the inbound actor to a member
- * record, enforces allow/deny/escalate policies, and notifies the guardian
+ * record, enforces allow/deny policies, and notifies the guardian
  * of denied access requests.
  *
  * Invite code/token redemption is intercepted at gateway ingress; redeemed
@@ -175,7 +175,7 @@ export interface AclResult {
 
 /**
  * Enforce ingress ACL rules: member lookup, non-member/inactive denial,
- * policy enforcement (allow/deny/escalate bypass), and guardian
+ * policy enforcement (allow/deny), and guardian
  * notification for denied access.
  */
 export async function enforceIngressAcl(

--- a/assistant/src/runtime/trust-verdict-consumer.ts
+++ b/assistant/src/runtime/trust-verdict-consumer.ts
@@ -178,6 +178,8 @@ export function verdictUsability(
 }
 
 // Allowed ACL enum values, kept in sync with the ContactChannel union types.
+// An unrecognized policy (e.g. a stale value from an un-migrated gateway)
+// yields an unresolvable member → the fail-closed deny backstop.
 const CHANNEL_STATUS_VALUES: readonly ChannelStatus[] = [
   "active",
   "pending",
@@ -185,11 +187,7 @@ const CHANNEL_STATUS_VALUES: readonly ChannelStatus[] = [
   "blocked",
   "unverified",
 ];
-const CHANNEL_POLICY_VALUES: readonly ChannelPolicy[] = [
-  "allow",
-  "deny",
-  "escalate",
-];
+const CHANNEL_POLICY_VALUES: readonly ChannelPolicy[] = ["allow", "deny"];
 
 function isChannelStatus(value: string): value is ChannelStatus {
   return (CHANNEL_STATUS_VALUES as readonly string[]).includes(value);

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -214,7 +214,7 @@ describe("ContactStore.listContactsRich", () => {
       type: "telegram",
       address: "tg-001",
       status: "active",
-      policy: "escalate",
+      policy: "deny",
       verifiedAt: 555,
       revokedReason: "spam",
       interactionCount: 4,
@@ -241,7 +241,7 @@ describe("ContactStore.listContactsRich", () => {
     // Channel ACL fields from gateway DB.
     const ch = c1.channels[0];
     expect(ch.status).toBe("active");
-    expect(ch.policy).toBe("escalate");
+    expect(ch.policy).toBe("deny");
     expect(ch.verifiedAt).toBe(555);
     expect(ch.revokedReason).toBe("spam");
     expect(ch.blockedReason).toBeNull();

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -767,6 +767,27 @@ describe("handleUpsertContact (gateway-native)", () => {
     expect(contactStoreUpsertMock).not.toHaveBeenCalled();
   });
 
+  test('rejects a channel carrying policy "escalate" with a 400', async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleUpsertContact(
+      new Request("http://localhost:7830/v1/contacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          displayName: "Alice",
+          channels: [
+            { type: "email", address: "alice@example.com", policy: "escalate" },
+          ],
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/Invalid channel policy/);
+    expect(contactStoreUpsertMock).not.toHaveBeenCalled();
+  });
+
   test("rejects unsupported species (e.g. openclaw)", async () => {
     const handler = createContactsControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleUpsertContact(
@@ -1293,7 +1314,7 @@ describe("handleListContacts ACL overlay (filtered/search path)", () => {
                     type: "telegram",
                     address: "@alice",
                     status: "active",
-                    policy: "escalate",
+                    policy: "deny",
                     verifiedAt: 9999,
                     verifiedVia: "manual",
                     revokedReason: null,
@@ -1316,7 +1337,7 @@ describe("handleListContacts ACL overlay (filtered/search path)", () => {
     expect(body.contacts[0].role).toBe("guardian");
     const ch = body.contacts[0].channels[0];
     expect(ch.status).toBe("active");
-    expect(ch.policy).toBe("escalate");
+    expect(ch.policy).toBe("deny");
     expect(ch.verifiedAt).toBe(9999);
     expect(ch.verifiedVia).toBe("manual");
     expect(contactStoreGetAclMock).toHaveBeenCalledTimes(1);
@@ -1642,7 +1663,7 @@ describe("handleListContacts ACL overlay (filtered/search path)", () => {
                     type: "telegram",
                     address: "@alice",
                     status: "active",
-                    policy: "escalate",
+                    policy: "deny",
                     verifiedAt: 9999,
                     verifiedVia: "manual",
                     revokedReason: null,
@@ -1871,6 +1892,24 @@ describe("handleUpdateContactChannel (gateway-native)", () => {
     const body = await res.json();
     expect(body.error.code).toBe("BAD_REQUEST");
     expect(body.error.message).toMatch(/policy/);
+  });
+
+  test('rejects policy "escalate" with a 400', async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleUpdateContactChannel(
+      new Request("http://localhost:7830/v1/contact-channels/ch_1", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ policy: "escalate" }),
+      }),
+      "ch_1",
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toMatch(/policy/);
+    expect(contactStoreUpdateChannelMock).not.toHaveBeenCalled();
   });
 
   test("returns 400 when neither status nor policy provided", async () => {

--- a/gateway/src/__tests__/ipc-contact-routes.test.ts
+++ b/gateway/src/__tests__/ipc-contact-routes.test.ts
@@ -157,7 +157,7 @@ function seedTestData(): void {
         isPrimary: true,
         externalChatId: null,
         status: "unverified",
-        policy: "escalate",
+        policy: "allow",
         interactionCount: 0,
         createdAt: now,
       },
@@ -465,7 +465,7 @@ describe("IPC contact routes", () => {
         address: "trusted@example.com",
         isPrimary: true,
         status: "active",
-        policy: "escalate",
+        policy: "deny",
         verifiedAt: now,
         verifiedVia: "manual",
         interactionCount: 3,
@@ -492,7 +492,7 @@ describe("IPC contact routes", () => {
     expect(channels).toHaveLength(1);
     // Status/policy/verification preserved — NOT overwritten to unverified/allow.
     expect(channels[0].status).toBe("active");
-    expect(channels[0].policy).toBe("escalate");
+    expect(channels[0].policy).toBe("deny");
     expect(channels[0].verifiedAt).toBe(now);
     expect(channels[0].verifiedVia).toBe("manual");
   });
@@ -880,6 +880,29 @@ describe("IPC contact routes", () => {
       expect(res.statusCode).toBe(400);
       expect(res.errorCode).toBe("BAD_REQUEST");
       expect(res.error).toMatch(/policy/);
+    });
+
+    test('rejects policy "escalate" as a 400', async () => {
+      seedTestData();
+      await startServerAndConnect();
+
+      const res = await sendRequest(client, "update_contact_channel", {
+        contactChannelId: "ch3",
+        policy: "escalate",
+      });
+
+      expect(res.error).toBeDefined();
+      expect(res.statusCode).toBe(400);
+      expect(res.errorCode).toBe("BAD_REQUEST");
+      expect(res.error).toMatch(/policy/);
+
+      // The row must be untouched.
+      const row = getGatewayDb()
+        .select()
+        .from(contactChannels)
+        .where(eq(contactChannels.id, "ch3"))
+        .get();
+      expect(row?.policy).toBe("allow");
     });
 
     test("revoking a blocked channel returns the conflict error", async () => {

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -655,7 +655,7 @@ const VALID_CHANNEL_STATUSES = [
   "blocked",
   "unverified",
 ] as const;
-const VALID_CHANNEL_POLICIES = ["allow", "deny", "escalate"] as const;
+const VALID_CHANNEL_POLICIES = ["allow", "deny"] as const;
 
 type ContactType = (typeof VALID_CONTACT_TYPES)[number];
 type AssistantSpecies = (typeof VALID_ASSISTANT_SPECIES)[number];


### PR DESCRIPTION
## Summary
- ChannelPolicy and the gateway/daemon validators shrink to allow|deny; writes of escalate are rejected 400 at the only validator that ever accepted them
- A stale escalate value on the verdict wire now reads as an unresolvable member → the existing fail-closed deny backstop (pinned by a new test); m0017 (already on this branch) coerces persisted rows to explicit deny
- Trust-rules intent enum, escalate-and-wait capability, and the voice-triage escalated leg are untouched

Part of plan: remove-escalate-policy.md (PR 2 of 5)