### PR TITLE
telemetry: record fixed-payload outbox events via recordTelemetryEvent

### DIFF
--- a/assistant/src/persistence/lifecycle-events-store.ts
+++ b/assistant/src/persistence/lifecycle-events-store.ts
@@ -1,4 +1,4 @@
-import { recordTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import { recordTelemetryEvent } from "../telemetry/telemetry-events-outbox.js";
 import type { LifecycleTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
 
@@ -9,8 +9,10 @@ export interface LifecycleEvent {
 }
 
 /**
- * Wire shape of one lifecycle event, stamped with the record-time binary's
- * `APP_VERSION` (the outbox stores the full wire payload at record time).
+ * Wire shape of one lifecycle event, for callers that insert outbox rows via
+ * raw SQL (conversation-crud's clearAll audit path). Mirrors the shape
+ * `recordTelemetryEvent` stamps — the shared `LifecycleTelemetryEvent` type
+ * keeps them in sync.
  */
 export function buildLifecycleTelemetryEvent(
   id: string,
@@ -28,12 +30,11 @@ export function buildLifecycleTelemetryEvent(
 
 /**
  * Record a lifecycle event (e.g. app_open, hatch) into the `telemetry_events`
- * outbox. Returns null when usage data collection is disabled or the
- * telemetry database is unavailable (degraded mode).
+ * outbox. Consent gating and degraded-mode `null` are `recordTelemetryEvent`'s.
  */
 export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
-  const recorded = recordTelemetryOutboxEvent("lifecycle", (id, createdAt) =>
-    buildLifecycleTelemetryEvent(id, eventName, createdAt),
-  );
+  const recorded = recordTelemetryEvent("lifecycle", {
+    event_name: eventName,
+  });
   return recorded ? { ...recorded, eventName } : null;
 }

--- a/assistant/src/telemetry/config-setting-events-store.ts
+++ b/assistant/src/telemetry/config-setting-events-store.ts
@@ -1,6 +1,4 @@
-import { APP_VERSION } from "../version.js";
-import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
-import type { ConfigSettingTelemetryEvent } from "./types.js";
+import { recordTelemetryEvent } from "./telemetry-events-outbox.js";
 
 /**
  * Server-side bounds from the platform `ConfigSettingTelemetryEventSerializer`.
@@ -23,28 +21,20 @@ export interface ConfigSettingEventRecord {
 }
 
 /**
- * Record a `config_setting` telemetry event. Builds the full wire event and
- * enqueues it on the `telemetry_events` outbox. No-ops when usage data
- * collection is disabled (the event is dropped to honor the opt-out,
- * matching the rest of telemetry). Returns whether the event was persisted,
- * so a caller with its own dedupe memo (config-setting-snapshot.ts) only
- * advances the memo on a real write and keeps retrying while consent is off
- * or the telemetry DB is unavailable.
+ * Record a `config_setting` telemetry event, enqueued on the
+ * `telemetry_events` outbox. Consent gating and degraded-mode behavior are
+ * `recordTelemetryEvent`'s. Returns whether the event was persisted, so a
+ * caller with its own dedupe memo (config-setting-snapshot.ts) only advances
+ * the memo on a real write and keeps retrying while consent is off or the
+ * telemetry DB is unavailable.
  */
 export function recordConfigSettingEvent(
   record: ConfigSettingEventRecord,
 ): boolean {
   return (
-    recordTelemetryOutboxEvent(
-      "config_setting",
-      (id, createdAt): ConfigSettingTelemetryEvent => ({
-        type: "config_setting",
-        daemon_event_id: id,
-        recorded_at: createdAt,
-        config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
-        config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
-        assistant_version: APP_VERSION,
-      }),
-    ) !== null
+    recordTelemetryEvent("config_setting", {
+      config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
+      config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
+    }) !== null
   );
 }

--- a/assistant/src/telemetry/skill-loaded-events-store.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.ts
@@ -1,8 +1,6 @@
 import type { UsageAttributionColumns } from "../usage/attribution.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
-import { APP_VERSION } from "../version.js";
-import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
-import type { SkillLoadedTelemetryEvent } from "./types.js";
+import { recordTelemetryEvent } from "./telemetry-events-outbox.js";
 
 /**
  * Input for one `skill_loaded` telemetry event. Metadata only — never skill
@@ -18,21 +16,15 @@ export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns>
 }
 
 /**
- * Record a `skill_loaded` telemetry event for a skill activation. The full
- * wire event (record-time `assistant_version` included) goes into the
- * `telemetry_events` outbox, with the conversation id in its dedicated
- * column so conversation deletion redacts pending rows via an indexed
- * delete. No-ops when usage data collection is disabled (the event is
- * dropped to honor the opt-out, matching the rest of telemetry) or when the
- * telemetry DB is unavailable.
+ * Record a `skill_loaded` telemetry event for a skill activation, enqueued on
+ * the `telemetry_events` outbox with the conversation id in its dedicated
+ * column so conversation deletion redacts pending rows via an indexed delete.
+ * Consent gating and degraded-mode behavior are `recordTelemetryEvent`'s.
  */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
-  recordTelemetryOutboxEvent(
+  recordTelemetryEvent(
     "skill_loaded",
-    (id, createdAt): SkillLoadedTelemetryEvent => ({
-      type: "skill_loaded",
-      daemon_event_id: id,
-      recorded_at: createdAt,
+    {
       skill_name: record.skillName,
       skill_updated_at: record.skillUpdatedAt ?? null,
       conversation_id: record.conversationId ?? null,
@@ -41,8 +33,7 @@ export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
       inference_profile: record.inferenceProfile ?? null,
       inference_profile_source: (record.inferenceProfileSource ??
         null) as UsageAttributionProfileSource | null,
-      assistant_version: APP_VERSION,
-    }),
+    },
     { conversationId: record.conversationId ?? null },
   );
 }

--- a/assistant/src/telemetry/watchdog-events-store.ts
+++ b/assistant/src/telemetry/watchdog-events-store.ts
@@ -1,6 +1,4 @@
-import { APP_VERSION } from "../version.js";
-import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
-import type { WatchdogTelemetryEvent } from "./types.js";
+import { recordTelemetryEvent } from "./telemetry-events-outbox.js";
 
 /**
  * Input for one `watchdog` telemetry event. Metadata only — never conversation
@@ -17,23 +15,14 @@ export interface WatchdogEventRecord {
 }
 
 /**
- * Record a `watchdog` telemetry event for a watchdog check firing. Builds the
- * full wire event and enqueues it on the `telemetry_events` outbox. No-ops
- * when usage data collection is disabled (the event is dropped to honor the
- * opt-out, matching the rest of telemetry) or when the telemetry DB is
- * unavailable.
+ * Record a `watchdog` telemetry event for a watchdog check firing, enqueued
+ * on the `telemetry_events` outbox. Consent gating and degraded-mode behavior
+ * are `recordTelemetryEvent`'s.
  */
 export function recordWatchdogEvent(record: WatchdogEventRecord): void {
-  recordTelemetryOutboxEvent(
-    "watchdog",
-    (id, createdAt): WatchdogTelemetryEvent => ({
-      type: "watchdog",
-      daemon_event_id: id,
-      recorded_at: createdAt,
-      check_name: record.checkName,
-      value: record.value ?? null,
-      detail: record.detail ?? null,
-      assistant_version: APP_VERSION,
-    }),
-  );
+  recordTelemetryEvent("watchdog", {
+    check_name: record.checkName,
+    value: record.value ?? null,
+    detail: record.detail ?? null,
+  });
 }


### PR DESCRIPTION
## Summary
- watchdog, config_setting, skill_loaded, and lifecycle stores now record via the typed recordTelemetryEvent helper — no store hand-builds the base fields
- Public store APIs and wire payloads unchanged (untouched store tests prove parity)
- onboarding and auth_fallback intentionally stay on the lower-level APIs

Part of plan: telemetry-outbox-ergonomics.md (PR 4 of 5)