### PR TITLE
telemetry: type outboxSource names and inline outbox source registration

### DIFF
--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -26,7 +26,11 @@ import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.
 import { isDiagnosticsConsentVersionEligible } from "./trace-collection-policy.js";
 import { queryUnreportedTurnEvents } from "./turn-events-store.js";
 import { assembleBoundedTurnTrace, isTurnSettled } from "./turn-trace-store.js";
-import type { TelemetryEvent, TurnTelemetryClientInfo } from "./types.js";
+import type {
+  OutboxTelemetryEventName,
+  TelemetryEvent,
+  TurnTelemetryClientInfo,
+} from "./types.js";
 
 const log = getLogger("usage-telemetry");
 
@@ -134,7 +138,9 @@ function simpleSource<Row extends { id: string; createdAt: number }>(
  * to an object is purged immediately with a warn: an early empty-batch return
  * in the reporter would otherwise strand it at the head of the queue forever.
  */
-export function outboxSource(name: string): TelemetryEventSource {
+export function outboxSource(
+  name: OutboxTelemetryEventName,
+): TelemetryEventSource {
   return {
     id: name,
     collect(_afterCreatedAt, _afterId, limit) {
@@ -397,14 +403,6 @@ const turnSource: TelemetryEventSource = {
   },
 };
 
-const lifecycleSource = outboxSource("lifecycle");
-
-// Onboarding/activation events are outbox-backed: the store builds the wire
-// event (including the activation daemon_event_id override) at record time.
-const onboardingSource = outboxSource("onboarding");
-
-const authFallbackSource = outboxSource("auth_fallback");
-
 const toolExecutedSource = simpleSource(
   "tool_executed",
   (afterCreatedAt, afterId, limit) =>
@@ -434,12 +432,6 @@ const toolExecutedSource = simpleSource(
   }),
 );
 
-const skillLoadedSource = outboxSource("skill_loaded");
-
-const watchdogSource = outboxSource("watchdog");
-
-const configSettingSource = outboxSource("config_setting");
-
 /**
  * Watermark key namespace of the tool_executed source — referenced by the
  * absent-watermark init that runs at daemon startup.
@@ -455,13 +447,13 @@ export const TOOL_EXECUTED_SOURCE_ID = toolExecutedSource.id;
 export const ALL_TELEMETRY_EVENT_SOURCES: readonly TelemetryEventSource[] = [
   usageSource,
   turnSource,
-  lifecycleSource,
-  onboardingSource,
-  authFallbackSource,
+  outboxSource("lifecycle"),
+  outboxSource("onboarding"),
+  outboxSource("auth_fallback"),
   toolExecutedSource,
-  skillLoadedSource,
-  watchdogSource,
-  configSettingSource,
+  outboxSource("skill_loaded"),
+  outboxSource("watchdog"),
+  outboxSource("config_setting"),
 ];
 
 /**

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -217,7 +217,7 @@ import {
   insertTelemetryOutboxEvent,
   queryTelemetryOutboxBatch,
 } from "./telemetry-events-outbox.js";
-import type { TelemetryEvent } from "./types.js";
+import type { OutboxTelemetryEventName, TelemetryEvent } from "./types.js";
 import {
   initToolExecutedWatermarkIfAbsent,
   UsageTelemetryReporter,
@@ -2933,7 +2933,9 @@ describe("UsageTelemetryReporter", () => {
   // outboxSource (real telemetry_events outbox behind an ack-mode source)
   // -------------------------------------------------------------------------
 
-  const OUTBOX_NAME = "test_outbox";
+  // Synthetic name: these tests exercise the generic outbox machinery, not a
+  // shipped event type.
+  const OUTBOX_NAME = "test_outbox" as OutboxTelemetryEventName;
 
   function seedOutboxRow(id: string, createdAt: number): void {
     insertTelemetryOutboxEvent({


### PR DESCRIPTION
## Summary
- outboxSource now takes OutboxTelemetryEventName — a typo'd name is a compile error instead of a silently stranded queue
- Six single-use source consts inlined into ALL_TELEMETRY_EVENT_SOURCES at identical positions (flush order unchanged, pinned by tests)

Part of plan: telemetry-outbox-ergonomics.md (PR 2 of 5)