### PR TITLE
telemetry: migrate onboarding/auth-fallback/lifecycle store tests to the outbox harness

### DIFF
--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -1,29 +1,17 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-let shareAnalytics = true;
-
-mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
-import * as dbConnection from "../persistence/db-connection.js";
-import { initializeDb } from "../persistence/db-init.js";
 import {
   type AuthFallbackCount,
   recordAuthFallbackCounts,
 } from "../security/auth-fallback-events-store.js";
 import {
-  discardPendingTelemetryOutboxEvents,
-  queryTelemetryOutboxBatch,
-} from "../telemetry/telemetry-events-outbox.js";
+  pendingOutboxRows,
+  resetOutboxTable,
+  setShareAnalytics,
+  withTelemetryDbUnavailable,
+} from "../telemetry/__tests__/outbox-test-harness.js";
 import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
-
-await initializeDb();
-
-function pendingRows() {
-  return queryTelemetryOutboxBatch("auth_fallback", 100);
-}
 
 const SAMPLE: AuthFallbackCount[] = [
   {
@@ -42,15 +30,15 @@ const SAMPLE: AuthFallbackCount[] = [
 
 describe("auth-fallback-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    discardPendingTelemetryOutboxEvents("auth_fallback");
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("records one outbox row per count entry with the full wire payload", () => {
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(2);
 
-    const rows = pendingRows();
+    const rows = pendingOutboxRows("auth_fallback");
     expect(rows.length).toBe(2);
     const payloads = rows.map(
       (r) => JSON.parse(r.payload) as AuthFallbackTelemetryEvent,
@@ -82,26 +70,23 @@ describe("auth-fallback-events-store", () => {
   });
 
   test("honors the share_analytics opt-out (records nothing)", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(0);
-    expect(pendingRows().length).toBe(0);
+    expect(pendingOutboxRows("auth_fallback").length).toBe(0);
   });
 
   test("empty counts batch is a no-op", () => {
     expect(recordAuthFallbackCounts(1000, 2000, [])).toBe(0);
-    expect(pendingRows().length).toBe(0);
+    expect(pendingOutboxRows("auth_fallback").length).toBe(0);
   });
 
   test("records all-or-nothing: db unavailable returns 0 with no rows", () => {
-    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
-    try {
+    withTelemetryDbUnavailable(() => {
       expect(recordAuthFallbackCounts(1000, 2000, SAMPLE)).toBe(0);
-    } finally {
-      spy.mockRestore();
-    }
+    });
     // No partial batch: the gateway's `recorded === 0` retry contract means
     // any committed remnant would later double-count.
-    expect(pendingRows().length).toBe(0);
+    expect(pendingOutboxRows("auth_fallback").length).toBe(0);
   });
 });

--- a/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
@@ -1,20 +1,13 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-// Mutable consent gate, flipped per-test.
-let shareAnalytics = true;
-mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
-import * as dbConnection from "../../persistence/db-connection.js";
+import { getTelemetrySqlite } from "../../persistence/db-connection.js";
 import {
-  getTelemetryDb,
-  getTelemetrySqlite,
-} from "../../persistence/db-connection.js";
-import { initializeDb } from "../../persistence/db-init.js";
-import { telemetryEvents } from "../../persistence/schema/index.js";
+  pendingOutboxPayloads,
+  resetOutboxTable,
+  setShareAnalytics,
+  withTelemetryDbUnavailable,
+} from "../../telemetry/__tests__/outbox-test-harness.js";
 import { ACTIVATION_FUNNEL_VERSION } from "../../telemetry/activation-funnel.js";
-import { queryTelemetryOutboxBatch } from "../../telemetry/telemetry-events-outbox.js";
 import type { OnboardingTelemetryEvent } from "../../telemetry/types.js";
 import { APP_VERSION } from "../../version.js";
 import {
@@ -22,33 +15,15 @@ import {
   recordOnboardingEvent,
 } from "../onboarding-events-store.js";
 
-await initializeDb();
-
-function resetTable(): void {
-  getTelemetryDb()!.delete(telemetryEvents).run();
-}
-
 /** Pending onboarding outbox payloads, parsed, in `(created_at, id)` order. */
 function pendingOnboardingPayloads(): OnboardingTelemetryEvent[] {
-  return queryTelemetryOutboxBatch("onboarding", 10).map(
-    (row) => JSON.parse(row.payload) as OnboardingTelemetryEvent,
-  );
-}
-
-/** Run `fn` with the dedicated telemetry connection reported as unavailable. */
-function withTelemetryDbUnavailable(fn: () => void): void {
-  const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
-  try {
-    fn();
-  } finally {
-    spy.mockRestore();
-  }
+  return pendingOutboxPayloads<OnboardingTelemetryEvent>("onboarding", 10);
 }
 
 describe("onboarding-events-store: recordActivationEvent", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    resetTable();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("stores the full wire payload with the deterministic activation daemon_event_id", () => {
@@ -104,7 +79,7 @@ describe("onboarding-events-store: recordActivationEvent", () => {
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     const event = recordActivationEvent({
       stepName: "activation_moment_1_complete",
       sessionId: "conv-3",
@@ -129,8 +104,8 @@ describe("onboarding-events-store: recordActivationEvent", () => {
 
 describe("onboarding-events-store: recordOnboardingEvent", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    resetTable();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("stores a pre-chat wire payload with daemon_event_id = row id and no funnel fields", () => {
@@ -168,7 +143,7 @@ describe("onboarding-events-store: recordOnboardingEvent", () => {
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     expect(recordOnboardingEvent({ screen: "tools" })).toBeNull();
     expect(pendingOnboardingPayloads()).toHaveLength(0);
   });

--- a/assistant/src/persistence/lifecycle-events-store.test.ts
+++ b/assistant/src/persistence/lifecycle-events-store.test.ts
@@ -1,22 +1,16 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-// Mutable consent gate, flipped per-test.
-let shareAnalytics = true;
-mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
+import {
+  resetOutboxTable,
+  setShareAnalytics,
+  withTelemetryDbUnavailable,
+} from "../telemetry/__tests__/outbox-test-harness.js";
 import { APP_VERSION } from "../version.js";
-import * as dbConnection from "./db-connection.js";
-import { getTelemetryDb, getTelemetrySqlite } from "./db-connection.js";
-import { initializeDb } from "./db-init.js";
+import { getTelemetrySqlite } from "./db-connection.js";
 import {
   buildLifecycleTelemetryEvent,
   recordLifecycleEvent,
 } from "./lifecycle-events-store.js";
-import { telemetryEvents } from "./schema.js";
-
-await initializeDb();
 
 interface RawOutboxRow {
   id: string;
@@ -35,20 +29,10 @@ function outboxRows(): RawOutboxRow[] {
     .all() as RawOutboxRow[];
 }
 
-/** Run `fn` with the dedicated telemetry connection reported as unavailable. */
-function withTelemetryDbUnavailable(fn: () => void): void {
-  const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
-  try {
-    fn();
-  } finally {
-    spy.mockRestore();
-  }
-}
-
 describe("lifecycle-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    getTelemetryDb()!.delete(telemetryEvents).run();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("record writes a telemetry_events outbox row carrying the wire payload", () => {
@@ -85,7 +69,7 @@ describe("lifecycle-events-store", () => {
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     expect(recordLifecycleEvent("app_open")).toBeNull();
     expect(outboxRows()).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- Migrates the last three outbox store test files to the shared outbox-test-harness
- Deletes the per-file consent mock / initializeDb / reset scaffolding duplicates
- Test names and assertion strength unchanged

Part of plan: telemetry-outbox-ergonomics.md (PR 5 of 5)