### PR TITLE
feat(plugins): allow a curated icon emoji on marketplace entries

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -23141,6 +23141,9 @@ paths:
                         description:
                           description: Short description, when known (external entries only today).
                           type: string
+                        icon:
+                          description: Curated author/curator emoji from the marketplace entry, when present.
+                          type: string
                         category:
                           anyOf:
                             - type: string

--- a/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
@@ -40,10 +40,10 @@ describe("fetchPluginCatalogFromPlatform", () => {
             category: "productivity",
             homepage: "https://example.com",
             license: "MIT",
+            icon: "🧠",
             // dropped keys
             id: "abc",
             display_name: "Memory Graph",
-            icon: "🧠",
           },
           {
             name: "alpha-tool",
@@ -65,6 +65,7 @@ describe("fetchPluginCatalogFromPlatform", () => {
       name: "memory-graph",
       path: `github:acme/memory-graph/packages/plugin@${SHA_B}`,
       description: "graph memory",
+      icon: "🧠",
       category: "productivity",
       homepage: "https://example.com",
       license: "MIT",
@@ -78,6 +79,7 @@ describe("fetchPluginCatalogFromPlatform", () => {
 
     const alpha = catalog.matches[0];
     expect(alpha.category).toBeNull();
+    expect(alpha.icon).toBeUndefined();
     expect(alpha.homepage).toBeUndefined();
     expect(alpha.license).toBeUndefined();
     expect(alpha.source).toEqual({

--- a/assistant/src/cli/lib/__tests__/plugin-marketplace.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-marketplace.test.ts
@@ -212,6 +212,30 @@ describe("fetchMarketplaceEntries", () => {
     expect(entries[0]!.icon).toBe("🦣");
   });
 
+  test("accepts a multi-code-unit ZWJ emoji (bounded by code points)", async () => {
+    // GIVEN the family ZWJ emoji: one grapheme, 7 code points, 11 UTF-16 units.
+    const fetch = manifestFetch({
+      name: "x",
+      plugins: [
+        {
+          name: "caveman",
+          source: {
+            source: "github",
+            repo: "JuliusBrussee/caveman",
+            ref: CAVEMAN_SHA,
+          },
+          icon: "👩‍👩‍👧‍👦",
+        },
+      ],
+    });
+
+    // WHEN we fetch the entries
+    const entries = await fetchMarketplaceEntries({ fetch }, { ref: "main" });
+
+    // THEN the ZWJ emoji survives validation (would fail under `.length`)
+    expect(entries[0]!.icon).toBe("👩‍👩‍👧‍👦");
+  });
+
   test("rejects an over-long icon string", async () => {
     // GIVEN an icon far longer than a single emoji
     const fetch = manifestFetch({

--- a/assistant/src/cli/lib/__tests__/plugin-marketplace.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-marketplace.test.ts
@@ -188,6 +188,76 @@ describe("fetchMarketplaceEntries", () => {
     ).rejects.toBeInstanceOf(MarketplaceFetchError);
   });
 
+  test("parses and round-trips an entry with a valid icon emoji", async () => {
+    // GIVEN an entry carrying a curated single-emoji icon
+    const fetch = manifestFetch({
+      name: "x",
+      plugins: [
+        {
+          name: "caveman",
+          source: {
+            source: "github",
+            repo: "JuliusBrussee/caveman",
+            ref: CAVEMAN_SHA,
+          },
+          icon: "🦣",
+        },
+      ],
+    });
+
+    // WHEN we fetch the entries
+    const entries = await fetchMarketplaceEntries({ fetch }, { ref: "main" });
+
+    // THEN the emoji is preserved on the parsed entry
+    expect(entries[0]!.icon).toBe("🦣");
+  });
+
+  test("rejects an over-long icon string", async () => {
+    // GIVEN an icon far longer than a single emoji
+    const fetch = manifestFetch({
+      name: "x",
+      plugins: [
+        {
+          name: "caveman",
+          source: {
+            source: "github",
+            repo: "JuliusBrussee/caveman",
+            ref: CAVEMAN_SHA,
+          },
+          icon: "not-an-emoji-just-text",
+        },
+      ],
+    });
+
+    // WHEN / THEN the refine rejects it
+    await expect(
+      fetchMarketplaceEntries({ fetch }, { ref: "main" }),
+    ).rejects.toBeInstanceOf(MarketplaceFetchError);
+  });
+
+  test("rejects an icon that looks like a URL or path", async () => {
+    // GIVEN an icon that is a URL rather than an emoji
+    const fetch = manifestFetch({
+      name: "x",
+      plugins: [
+        {
+          name: "caveman",
+          source: {
+            source: "github",
+            repo: "JuliusBrussee/caveman",
+            ref: CAVEMAN_SHA,
+          },
+          icon: "http://x",
+        },
+      ],
+    });
+
+    // WHEN / THEN a URL/path-shaped icon is rejected by the refine
+    await expect(
+      fetchMarketplaceEntries({ fetch }, { ref: "main" }),
+    ).rejects.toBeInstanceOf(MarketplaceFetchError);
+  });
+
   test("rejects a path that escapes the repo root", async () => {
     // GIVEN an entry whose path contains a parent-segment escape
     const fetch = manifestFetch({

--- a/assistant/src/cli/lib/__tests__/search-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/search-plugins.test.ts
@@ -33,6 +33,7 @@ function entry(
   extra?: {
     path?: string;
     description?: string;
+    icon?: string;
     category?: string;
     homepage?: string;
     license?: string;
@@ -47,6 +48,7 @@ function entry(
       ref,
     },
     ...(extra?.description ? { description: extra.description } : {}),
+    ...(extra?.icon ? { icon: extra.icon } : {}),
     ...(extra?.category ? { category: extra.category } : {}),
     ...(extra?.homepage ? { homepage: extra.homepage } : {}),
     ...(extra?.license ? { license: extra.license } : {}),
@@ -220,6 +222,17 @@ describe("marketplaceMatch", () => {
     );
     expect(match.homepage).toBeUndefined();
     expect(match.license).toBeUndefined();
+  });
+
+  test("carries the curated icon, leaving it undefined when absent", () => {
+    expect(
+      marketplaceMatch(
+        entry("calendar-sync", "acme/calendar-sync", SHA_A, { icon: "📅" }),
+      ).icon,
+    ).toBe("📅");
+    expect(
+      marketplaceMatch(entry("plain-plugin", "acme/plain-plugin", SHA_B)).icon,
+    ).toBeUndefined();
   });
 });
 

--- a/assistant/src/cli/lib/plugin-catalog-platform.ts
+++ b/assistant/src/cli/lib/plugin-catalog-platform.ts
@@ -26,8 +26,7 @@ import {
 
 /**
  * One flattened row from the platform catalog. Unknown keys (`id`,
- * `display_name`, `icon`) are accepted and dropped — zod strips them by
- * default.
+ * `display_name`) are accepted and dropped — zod strips them by default.
  */
 const platformPluginRowSchema = z.object({
   name: z.string(),
@@ -35,6 +34,7 @@ const platformPluginRowSchema = z.object({
   ref: z.string().nullable().optional(),
   path: z.string().nullable().optional(),
   description: z.string().optional(),
+  icon: z.string().nullable().optional(),
   category: z.string().nullable().optional(),
   homepage: z.string().nullable().optional(),
   license: z.string().nullable().optional(),
@@ -106,6 +106,7 @@ export async function fetchPluginCatalogFromPlatform(
         path: row.path ?? undefined,
       },
       description: row.description ?? undefined,
+      icon: row.icon ?? undefined,
       category: row.category ?? undefined,
       homepage: row.homepage ?? undefined,
       license: row.license ?? undefined,

--- a/assistant/src/cli/lib/plugin-marketplace.ts
+++ b/assistant/src/cli/lib/plugin-marketplace.ts
@@ -107,7 +107,7 @@ const marketplaceEntrySchema = z.object({
   icon: z
     .string()
     .refine(
-      (s) => s.length <= 8 && !/[/\\]|^https?:/i.test(s),
+      (s) => [...s].length <= 8 && !/[/\\]|^https?:/i.test(s),
       "expected a short emoji, not a URL or path",
     )
     .optional(),

--- a/assistant/src/cli/lib/plugin-marketplace.ts
+++ b/assistant/src/cli/lib/plugin-marketplace.ts
@@ -98,6 +98,19 @@ const marketplaceEntrySchema = z.object({
   category: z.string().optional(),
   homepage: z.string().optional(),
   license: z.string().optional(),
+  /**
+   * A single curated author/curator emoji shown as the plugin's icon (e.g. on
+   * the marketing catalog). Not a URL or file path — bounded to a short
+   * emoji-length string; a multi-code-point emoji (skin tone, ZWJ sequence)
+   * still fits comfortably under the cap.
+   */
+  icon: z
+    .string()
+    .refine(
+      (s) => s.length <= 8 && !/[/\\]|^https?:/i.test(s),
+      "expected a short emoji, not a URL or path",
+    )
+    .optional(),
 });
 
 export const marketplaceManifestSchema = z.object({

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -43,6 +43,8 @@ export interface PluginSearchMatch {
   readonly path: string;
   /** Short description, when known (external entries only today). */
   readonly description?: string;
+  /** Curated author/curator emoji from the marketplace entry, when present. */
+  readonly icon?: string;
   /**
    * Free-form grouping hint from the curated marketplace entry (e.g.
    * `productivity`), or `null` when the entry declares none.
@@ -128,6 +130,7 @@ export function marketplaceMatch(entry: MarketplaceEntry): PluginSearchMatch {
     name: entry.name,
     path: locator,
     description: entry.description,
+    icon: entry.icon,
     category: entry.category ?? null,
     homepage: entry.homepage,
     license: entry.license,

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -997,6 +997,32 @@ describe("GET /v1/plugins/search", () => {
     });
   });
 
+  test("projects the marketplace `icon` onto the wire match, omitting it when absent", async () => {
+    getCatalogSpy.mockImplementation(async (ref) =>
+      catalog(ref, [
+        {
+          name: "calendar-sync",
+          path: "github:acme/calendar-sync@v1",
+          icon: "📅",
+          category: null,
+          source: { kind: "github", repo: "acme/calendar-sync", ref: "v1" },
+        },
+        {
+          name: "plain-plugin",
+          path: "github:acme/plain-plugin@v1",
+          category: null,
+          source: { kind: "github", repo: "acme/plain-plugin", ref: "v1" },
+        },
+      ]),
+    );
+
+    const result = await invokeSearch();
+    const byName = new Map(result.matches.map((m) => [m.name, m]));
+    expect(byName.get("calendar-sync")?.icon).toBe("📅");
+    // Absent icon is omitted from the wire object, not set to null/undefined.
+    expect("icon" in byName.get("plain-plugin")!).toBe(false);
+  });
+
   test("normalizes match categories to the Skills taxonomy (`developer` → `development`, `hobby` → null)", async () => {
     getCatalogSpy.mockImplementation(async (ref) =>
       catalog(ref, [

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -212,6 +212,10 @@ const pluginSearchMatchSchema = z.object({
     .string()
     .optional()
     .describe("Short description, when known (external entries only today)."),
+  icon: z
+    .string()
+    .optional()
+    .describe("Curated author/curator emoji from the marketplace entry, when present."),
   category: z
     .string()
     .nullable()
@@ -788,6 +792,7 @@ interface PluginMatchView {
   name: string;
   path: string;
   description?: string;
+  icon?: string;
   category: string | null;
   source: { kind: "github"; repo: string; path?: string; ref: string };
 }
@@ -814,6 +819,9 @@ function projectMatch(
   };
   if (m.description !== undefined) {
     view.description = m.description;
+  }
+  if (m.icon !== undefined) {
+    view.icon = m.icon;
   }
   return view;
 }


### PR DESCRIPTION
## Summary
- Adds an optional `icon` emoji field to the marketplace entry schema (marketplaceEntrySchema), curated alongside description/category. It flows through the existing platform /v1/plugins/ catalog path and the bundled-marketplace.json offline copy with no new tooling — the emoji quick-win for plugin icons on the marketing site.

Part of plan: plugin-icons-marketing.md (PR 2 of 6)