### PR TITLE
refactor(plugins): expose validatePluginIconBytes for reuse by tooling

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
@@ -12,7 +12,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { readValidatedPluginIcon } from "../plugin-icon-file.js";
+import {
+  MAX_ICON_BYTES,
+  MAX_ICON_DIMENSION,
+  readValidatedPluginIcon,
+  validatePluginIconBytes,
+} from "../plugin-icon-file.js";
 
 const PNG_SIGNATURE = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
@@ -138,5 +143,49 @@ describe("readValidatedPluginIcon", () => {
   test("returns hasIcon:false for a non-existent plugin directory", () => {
     const missing = join(pluginDir, "does-not-exist");
     expect(readValidatedPluginIcon(missing)).toEqual({ hasIcon: false });
+  });
+});
+
+describe("validatePluginIconBytes", () => {
+  test("accepts a valid <=128x128 PNG with a content-hash version (no path)", () => {
+    // GIVEN well-formed in-memory PNG bytes
+    const bytes = makePng(64, 64);
+
+    // WHEN we validate them directly
+    const result = validatePluginIconBytes(bytes);
+
+    // THEN it is surfaced with a stable content-hash version and no path
+    expect(result).toEqual({ hasIcon: true, iconVersion: sha16(bytes) });
+  });
+
+  test("accepts exactly MAX_ICON_DIMENSION (the boundary)", () => {
+    const bytes = makePng(MAX_ICON_DIMENSION, MAX_ICON_DIMENSION);
+    expect(validatePluginIconBytes(bytes).hasIcon).toBe(true);
+  });
+
+  test("rejects oversized dimensions (129x129)", () => {
+    const bytes = makePng(MAX_ICON_DIMENSION + 1, MAX_ICON_DIMENSION + 1);
+    expect(validatePluginIconBytes(bytes)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a buffer larger than MAX_ICON_BYTES", () => {
+    const bytes = makePng(64, 64, MAX_ICON_BYTES + 1);
+    expect(validatePluginIconBytes(bytes)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a buffer with wrong magic bytes", () => {
+    const jpeg = Buffer.alloc(24);
+    jpeg.writeUInt16BE(0xffd8, 0); // JPEG SOI marker
+    expect(validatePluginIconBytes(jpeg)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a signature-prefixed buffer whose first chunk is not IHDR", () => {
+    const buf = makePng(64, 64);
+    buf.write("IDAT", 12, "ascii");
+    expect(validatePluginIconBytes(buf)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a buffer shorter than the minimum header", () => {
+    expect(validatePluginIconBytes(PNG_SIGNATURE)).toEqual({ hasIcon: false });
   });
 });

--- a/assistant/src/cli/lib/plugin-icon-file.ts
+++ b/assistant/src/cli/lib/plugin-icon-file.ts
@@ -17,11 +17,11 @@ import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 /** Fixed icon filename in the plugin root — no author path, no traversal. */
-const ICON_FILENAME = "icon.png";
+export const ICON_FILENAME = "icon.png";
 /** Byte cap: reject anything larger (also bounds what we read into memory). */
-const MAX_ICON_BYTES = 32 * 1024;
+export const MAX_ICON_BYTES = 32 * 1024;
 /** Dimension cap (px) enforced against the IHDR width/height. */
-const MAX_ICON_DIMENSION = 128;
+export const MAX_ICON_DIMENSION = 128;
 /** PNG signature: the first 8 bytes of every PNG file. */
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 /** The first chunk of a valid PNG is always IHDR with a 13-byte payload. */
@@ -41,29 +41,13 @@ export interface ValidatedPluginIcon {
 }
 
 /**
- * Read and validate `<pluginDir>/icon.png`. Returns `{ hasIcon: true }` with a
- * content-hash `iconVersion` and `path` only when the file is a PNG whose IHDR
- * dimensions are within {@link MAX_ICON_DIMENSION} and whose size is within
- * {@link MAX_ICON_BYTES}. Every other case returns `{ hasIcon: false }`.
+ * Validate in-memory PNG bytes against the icon contract. Returns
+ * `{ hasIcon: true, iconVersion }` — a content-hash version — only when the
+ * bytes are a PNG whose IHDR dimensions are within {@link MAX_ICON_DIMENSION}
+ * and whose size is within {@link MAX_ICON_BYTES}. Every other case returns
+ * `{ hasIcon: false }`. No `path`: the bytes source is caller-defined.
  */
-export function readValidatedPluginIcon(
-  pluginDir: string,
-): ValidatedPluginIcon {
-  const iconPath = join(pluginDir, ICON_FILENAME);
-
-  let bytes: Buffer;
-  try {
-    const stat = statSync(iconPath);
-    // Size-gate before reading so an oversized file never enters memory.
-    // A missing file throws here and is caught as "no icon".
-    if (!stat.isFile() || stat.size > MAX_ICON_BYTES) {
-      return { hasIcon: false };
-    }
-    bytes = readFileSync(iconPath);
-  } catch {
-    return { hasIcon: false };
-  }
-
+export function validatePluginIconBytes(bytes: Buffer): ValidatedPluginIcon {
   if (bytes.length < MIN_HEADER_BYTES || bytes.length > MAX_ICON_BYTES) {
     return { hasIcon: false };
   }
@@ -97,5 +81,33 @@ export function readValidatedPluginIcon(
     .update(bytes)
     .digest("hex")
     .slice(0, 16);
-  return { hasIcon: true, iconVersion, path: iconPath };
+  return { hasIcon: true, iconVersion };
+}
+
+/**
+ * Read and validate `<pluginDir>/icon.png`. Returns `{ hasIcon: true }` with a
+ * content-hash `iconVersion` and `path` only when the file is a PNG whose IHDR
+ * dimensions are within {@link MAX_ICON_DIMENSION} and whose size is within
+ * {@link MAX_ICON_BYTES}. Every other case returns `{ hasIcon: false }`.
+ */
+export function readValidatedPluginIcon(
+  pluginDir: string,
+): ValidatedPluginIcon {
+  const iconPath = join(pluginDir, ICON_FILENAME);
+
+  let bytes: Buffer;
+  try {
+    const stat = statSync(iconPath);
+    // Size-gate before reading so an oversized file never enters memory.
+    // A missing file throws here and is caught as "no icon".
+    if (!stat.isFile() || stat.size > MAX_ICON_BYTES) {
+      return { hasIcon: false };
+    }
+    bytes = readFileSync(iconPath);
+  } catch {
+    return { hasIcon: false };
+  }
+
+  const result = validatePluginIconBytes(bytes);
+  return result.hasIcon ? { ...result, path: iconPath } : result;
 }


### PR DESCRIPTION
## Summary
- Extracts the in-memory PNG checks from readValidatedPluginIcon into an exported pure validatePluginIconBytes(bytes) and re-exports the limit constants, so plan tooling (the icon generator) and the daemon route share ONE validator. readValidatedPluginIcon keeps its exact behavior and delegates.

Part of plan: plugin-icons-marketing.md (PR 3 of 6)