### PR TITLE
fix(tests): add hasPendingJobOfType to jobs-store mock in disk-pressure test

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -142,6 +142,7 @@ mock.module("../persistence/jobs-store.js", () => ({
   failStalledJobs: mockFailStalledJobs,
   getMemoryJobCounts: mock(() => ({})),
   hasActiveJobOfType: mock(() => false),
+  hasPendingJobOfType: mock(() => false),
   isMemoryEnabled: () => true,
   MEMORY_V2_CONSOLIDATION_JOB_TRIGGERS: {
     automatic: "automatic",


### PR DESCRIPTION
## Summary
- Adds `hasPendingJobOfType: mock(() => false)` to the partial `jobs-store.js` mock in `background-workers-disk-pressure.test.ts`, mirroring the existing `hasActiveJobOfType` entry.
- #37972 added `hasPendingJobOfType` to `jobs-store.ts` and imports it from `consolidation-job.ts`, which is in this test's import graph via `jobs-worker.js`; the full-replacement mock lacked the export, so Bun failed module resolution with `Export named 'hasPendingJobOfType' not found`.
- Fixes the `Test` job failure on main: https://github.com/vellum-ai/vellum-assistant/actions/runs/29286298946/job/86939528611 (verified locally: the file fails on `origin/main` and passes with this change).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29286298946/job/86939528611