### PR TITLE
fix: single source of truth for outbox event names + source-coverage test

### DIFF
--- a/assistant/src/telemetry/telemetry-event-sources.test.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.test.ts
@@ -11,6 +11,7 @@ import {
   DAEMON_TELEMETRY_EVENT_SOURCES,
   MONITOR_TELEMETRY_EVENT_SOURCES,
 } from "./telemetry-event-sources.js";
+import { OUTBOX_TELEMETRY_EVENT_NAMES } from "./types.js";
 
 describe("telemetry event source partition", () => {
   test("the full source list carries every event type in payload order", () => {
@@ -37,6 +38,13 @@ describe("telemetry event source partition", () => {
         (id) => id !== "turns",
       ),
     );
+  });
+
+  test("every outbox event name has a registered source", () => {
+    const sourceIds = new Set(ALL_TELEMETRY_EVENT_SOURCES.map((s) => s.id));
+    for (const name of OUTBOX_TELEMETRY_EVENT_NAMES) {
+      expect(sourceIds.has(name)).toBe(true);
+    }
   });
 
   test("daemon and monitor partition the full list — no overlap, no gaps", () => {

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -529,13 +529,17 @@ export type TelemetryEvent =
  * change once shipped. The watermark-flushed types (`llm_usage`, `turn`,
  * `tool_executed`) live on their own tables and are deliberately excluded.
  */
+export const OUTBOX_TELEMETRY_EVENT_NAMES = [
+  "lifecycle",
+  "onboarding",
+  "auth_fallback",
+  "skill_loaded",
+  "watchdog",
+  "config_setting",
+] as const;
+
 export type OutboxTelemetryEventName =
-  | "lifecycle"
-  | "onboarding"
-  | "auth_fallback"
-  | "skill_loaded"
-  | "watchdog"
-  | "config_setting";
+  (typeof OUTBOX_TELEMETRY_EVENT_NAMES)[number];
 
 /** Wire event type for one outbox event name. */
 export type OutboxTelemetryEventOf<N extends OutboxTelemetryEventName> =


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for telemetry-outbox-ergonomics.md.

**Gap:** the outbox name set was hand-maintained in two places (OutboxTelemetryEventName union + inline outboxSource entries), and a union name without a registered source would compile yet silently never flush.
**Fix:** OUTBOX_TELEMETRY_EVENT_NAMES as-const list derives the union; a new sources test asserts every name has a registered source. Flush order untouched.