### PR TITLE
feat(plugins): resolve/validate/vendor icon.png and index it in plugin-icons.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+plugins/assets/**/*.png binary

--- a/plugins/plugin-icons.json
+++ b/plugins/plugin-icons.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "plugins": {}
+}

--- a/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
+++ b/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
@@ -1,0 +1,266 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  checkPluginIcons,
+  generatePluginIcons,
+  validatePluginIconBytes,
+} from "../generate-plugin-icons.mjs";
+
+// The assistant validator is the source of truth for the byte format; assert
+// the mirrored .mjs validator agrees with it on the same inputs.
+import { validatePluginIconBytes as tsValidate } from "../../../assistant/src/cli/lib/plugin-icon-file.ts";
+
+/** Build a minimal but structurally valid PNG with the given IHDR dimensions. */
+function makePng(width, height, { padTo = 0 } = {}) {
+  const magic = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdrLen = Buffer.alloc(4);
+  ihdrLen.writeUInt32BE(13);
+  const ihdrType = Buffer.from("IHDR", "ascii");
+  const ihdrData = Buffer.alloc(13);
+  ihdrData.writeUInt32BE(width, 0);
+  ihdrData.writeUInt32BE(height, 4);
+  ihdrData[8] = 8; // bit depth
+  ihdrData[9] = 6; // color type (RGBA)
+  let buf = Buffer.concat([magic, ihdrLen, ihdrType, ihdrData]);
+  if (padTo > buf.length) {
+    buf = Buffer.concat([buf, Buffer.alloc(padTo - buf.length)]);
+  }
+  return buf;
+}
+
+const sha16 = (b) => createHash("sha256").update(b).digest("hex").slice(0, 16);
+
+/** A fetch stub keyed by GitHub Contents URL substring `<repo>`. */
+function stubFetch(byRepo) {
+  return async (url) => {
+    const match = Object.keys(byRepo).find((repo) => url.includes(`/repos/${repo}/`));
+    const entry = match ? byRepo[match] : undefined;
+    if (!entry) {
+      return { ok: false, status: 404 };
+    }
+    if (typeof entry.status === "number" && entry.status !== 200) {
+      return { ok: false, status: entry.status };
+    }
+    const bytes = entry.bytes;
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: async () =>
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    };
+  };
+}
+
+let dir;
+let marketplacePath;
+let assetsDir;
+let manifestPath;
+
+function writeMarketplace(plugins) {
+  writeFileSync(
+    marketplacePath,
+    JSON.stringify({ name: "vellum-assistant", plugins }, null, 2),
+  );
+}
+
+function pluginEntry(name, repo, extra = {}) {
+  return {
+    name,
+    source: {
+      source: "github",
+      repo,
+      ref: "a".repeat(40),
+      ...extra,
+    },
+  };
+}
+
+const run = (fetch) =>
+  generatePluginIcons({
+    fetch,
+    marketplacePath,
+    assetsDir,
+    manifestPath,
+    token: undefined,
+    log: { log() {}, warn() {} },
+  });
+
+const check = () => checkPluginIcons({ assetsDir, manifestPath });
+
+const readManifest = () => JSON.parse(readFileSync(manifestPath, "utf-8"));
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "plugin-icons-"));
+  marketplacePath = join(dir, "marketplace.json");
+  assetsDir = join(dir, "assets");
+  manifestPath = join(dir, "plugin-icons.json");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("validatePluginIconBytes mirrors the assistant validator", () => {
+  test("agrees with the TS validator across cases", () => {
+    const cases = [
+      makePng(64, 64),
+      makePng(128, 128),
+      makePng(129, 64), // oversized dimension
+      makePng(64, 64, { padTo: 32 * 1024 + 1 }), // oversized bytes
+      Buffer.from("not a png at all, definitely not"),
+    ];
+    for (const bytes of cases) {
+      expect(validatePluginIconBytes(bytes)).toEqual(tsValidate(bytes));
+    }
+  });
+});
+
+describe("generatePluginIcons (write mode)", () => {
+  test("valid PNG is vendored and indexed with the correct iconVersion", async () => {
+    const png = makePng(64, 64);
+    writeMarketplace([pluginEntry("good", "owner/good")]);
+
+    const result = await run(stubFetch({ "owner/good": { bytes: png } }));
+
+    expect(result.vendored).toEqual(["good"]);
+    const vendored = readFileSync(join(assetsDir, "good", "icon.png"));
+    expect(vendored.equals(png)).toBe(true);
+    expect(readManifest()).toEqual({
+      version: 1,
+      plugins: { good: { iconVersion: sha16(png) } },
+    });
+  });
+
+  test("oversized/invalid PNG is skipped, not vendored, absent from manifest", async () => {
+    const huge = makePng(64, 64, { padTo: 32 * 1024 + 1 });
+    writeMarketplace([pluginEntry("big", "owner/big")]);
+
+    const result = await run(stubFetch({ "owner/big": { bytes: huge } }));
+
+    expect(result.vendored).toEqual([]);
+    expect(result.skipped).toEqual(["big"]);
+    expect(readManifest().plugins).toEqual({});
+  });
+
+  test("missing icon (404) is absent from the manifest", async () => {
+    writeMarketplace([pluginEntry("none", "owner/none")]);
+
+    const result = await run(stubFetch({}));
+
+    expect(result.skipped).toEqual(["none"]);
+    expect(readManifest().plugins).toEqual({});
+  });
+
+  test("respects source.path when building the fetch URL", async () => {
+    const png = makePng(32, 32);
+    writeMarketplace([pluginEntry("nested", "owner/mono", { path: "sub/dir" })]);
+
+    let requestedUrl;
+    const fetch = async (url) => {
+      requestedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () =>
+          png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength),
+      };
+    };
+
+    await run(fetch);
+    expect(requestedUrl).toContain("/repos/owner/mono/contents/sub/dir/icon.png");
+  });
+
+  test("prunes stale asset dirs for plugins that lost/never had an icon", async () => {
+    // Pre-seed a stale vendored asset for a plugin absent from the marketplace.
+    mkdirSync(join(assetsDir, "stale"), { recursive: true });
+    writeFileSync(join(assetsDir, "stale", "icon.png"), makePng(16, 16));
+
+    const png = makePng(48, 48);
+    writeMarketplace([pluginEntry("keep", "owner/keep")]);
+
+    await run(stubFetch({ "owner/keep": { bytes: png } }));
+
+    expect(check().ok).toBe(true);
+    expect(readManifest().plugins).toEqual({ keep: { iconVersion: sha16(png) } });
+    // Stale dir removed.
+    let staleExists = true;
+    try {
+      readFileSync(join(assetsDir, "stale", "icon.png"));
+    } catch {
+      staleExists = false;
+    }
+    expect(staleExists).toBe(false);
+  });
+
+  test("output is deterministic across runs", async () => {
+    writeMarketplace([
+      pluginEntry("bravo", "owner/bravo"),
+      pluginEntry("alpha", "owner/alpha"),
+    ]);
+    const fetch = stubFetch({
+      "owner/alpha": { bytes: makePng(20, 20) },
+      "owner/bravo": { bytes: makePng(30, 30) },
+    });
+
+    await run(fetch);
+    const first = readFileSync(manifestPath, "utf-8");
+    await run(fetch);
+    const second = readFileSync(manifestPath, "utf-8");
+
+    expect(first).toBe(second);
+    // Names sorted, trailing newline.
+    expect(first.endsWith("\n")).toBe(true);
+    expect(first.indexOf('"alpha"')).toBeLessThan(first.indexOf('"bravo"'));
+  });
+});
+
+describe("checkPluginIcons (check mode)", () => {
+  test("passes on a consistent tree", async () => {
+    writeMarketplace([pluginEntry("good", "owner/good")]);
+    await run(stubFetch({ "owner/good": { bytes: makePng(64, 64) } }));
+
+    expect(check()).toEqual({ ok: true, errors: [] });
+  });
+
+  test("fails on a hand-mutated manifest iconVersion", async () => {
+    writeMarketplace([pluginEntry("good", "owner/good")]);
+    await run(stubFetch({ "owner/good": { bytes: makePng(64, 64) } }));
+
+    const manifest = readManifest();
+    manifest.plugins.good.iconVersion = "0000000000000000";
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("iconVersion mismatch");
+  });
+
+  test("fails on an orphan manifest entry with no asset", async () => {
+    mkdirSync(assetsDir, { recursive: true });
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({ version: 1, plugins: { ghost: { iconVersion: "abc" } } }, null, 2)}\n`,
+    );
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("no vendored asset");
+  });
+
+  test("fails on an unlisted asset dir", async () => {
+    mkdirSync(join(assetsDir, "surprise"), { recursive: true });
+    writeFileSync(join(assetsDir, "surprise", "icon.png"), makePng(16, 16));
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({ version: 1, plugins: {} }, null, 2)}\n`,
+    );
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("not listed in the manifest");
+  });
+});

--- a/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
+++ b/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
@@ -155,6 +155,87 @@ describe("generatePluginIcons (write mode)", () => {
     expect(readManifest().plugins).toEqual({});
   });
 
+  for (const status of [500, 429]) {
+    test(`transient HTTP ${status} aborts without mutating assets/manifest`, async () => {
+      // Pre-seed a valid vendored icon + manifest for a plugin that will fail
+      // transiently: the run must NOT prune it.
+      const existing = makePng(64, 64);
+      mkdirSync(join(assetsDir, "keep"), { recursive: true });
+      writeFileSync(join(assetsDir, "keep", "icon.png"), existing);
+      writeFileSync(
+        manifestPath,
+        `${JSON.stringify(
+          { version: 1, plugins: { keep: { iconVersion: sha16(existing) } } },
+          null,
+          2,
+        )}\n`,
+      );
+
+      writeMarketplace([pluginEntry("keep", "owner/keep")]);
+
+      await expect(
+        run(stubFetch({ "owner/keep": { status } })),
+      ).rejects.toThrow(/Aborting icon generation/);
+
+      // Working tree untouched: existing icon + manifest survive verbatim.
+      expect(readFileSync(join(assetsDir, "keep", "icon.png")).equals(existing)).toBe(
+        true,
+      );
+      expect(readManifest().plugins).toEqual({ keep: { iconVersion: sha16(existing) } });
+    });
+  }
+
+  test("a network/DNS throw aborts and leaves the tree unchanged", async () => {
+    const existing = makePng(48, 48);
+    mkdirSync(join(assetsDir, "keep"), { recursive: true });
+    writeFileSync(join(assetsDir, "keep", "icon.png"), existing);
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify(
+        { version: 1, plugins: { keep: { iconVersion: sha16(existing) } } },
+        null,
+        2,
+      )}\n`,
+    );
+    writeMarketplace([pluginEntry("keep", "owner/keep")]);
+
+    const throwingFetch = async () => {
+      throw new Error("getaddrinfo ENOTFOUND api.github.com");
+    };
+
+    await expect(run(throwingFetch)).rejects.toThrow(/Aborting icon generation/);
+    expect(readFileSync(join(assetsDir, "keep", "icon.png")).equals(existing)).toBe(
+      true,
+    );
+    expect(readManifest().plugins).toEqual({ keep: { iconVersion: sha16(existing) } });
+  });
+
+  test("a transient failure does not vendor an earlier-processed plugin", async () => {
+    // "alpha" fetches fine, "bravo" fails transiently: alpha must not be
+    // written to disk since the whole run aborts before any mutation.
+    writeMarketplace([
+      pluginEntry("alpha", "owner/alpha"),
+      pluginEntry("bravo", "owner/bravo"),
+    ]);
+
+    await expect(
+      run(
+        stubFetch({
+          "owner/alpha": { bytes: makePng(32, 32) },
+          "owner/bravo": { status: 503 },
+        }),
+      ),
+    ).rejects.toThrow(/Aborting icon generation/);
+
+    let alphaExists = true;
+    try {
+      readFileSync(join(assetsDir, "alpha", "icon.png"));
+    } catch {
+      alphaExists = false;
+    }
+    expect(alphaExists).toBe(false);
+  });
+
   test("respects source.path when building the fetch URL", async () => {
     const png = makePng(32, 32);
     writeMarketplace([pluginEntry("nested", "owner/mono", { path: "sub/dir" })]);
@@ -262,5 +343,43 @@ describe("checkPluginIcons (check mode)", () => {
     const result = check();
     expect(result.ok).toBe(false);
     expect(result.errors.join(" ")).toContain("not listed in the manifest");
+  });
+
+  test("fails on a hash-matching but non-PNG vendored asset", async () => {
+    // A malformed blob committed as icon.png, with the manifest hash tuned to
+    // match it — the hash check alone would pass; contract validation must not.
+    const bogus = Buffer.from("this is not a png but has a matching hash!!");
+    mkdirSync(join(assetsDir, "evil"), { recursive: true });
+    writeFileSync(join(assetsDir, "evil", "icon.png"), bogus);
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify(
+        { version: 1, plugins: { evil: { iconVersion: sha16(bogus) } } },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("not a contract-valid PNG");
+  });
+
+  test("fails on a hash-matching but oversized vendored asset", async () => {
+    const huge = makePng(64, 64, { padTo: 32 * 1024 + 1 });
+    mkdirSync(join(assetsDir, "big"), { recursive: true });
+    writeFileSync(join(assetsDir, "big", "icon.png"), huge);
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify(
+        { version: 1, plugins: { big: { iconVersion: sha16(huge) } } },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("not a contract-valid PNG");
   });
 });

--- a/scripts/plugins/generate-plugin-icons.mjs
+++ b/scripts/plugins/generate-plugin-icons.mjs
@@ -7,12 +7,15 @@
  * `<source.path>/icon.png` at the pinned `source.ref` via the GitHub Contents
  * API, validate the bytes against the icon contract, and — on success —
  * vendor them to `plugins/assets/<name>/icon.png` and index the plugin in
- * `plugins/plugin-icons.json`. Invalid, missing, or unfetchable icons are
- * fail-closed: skipped, pruned, and omitted from the manifest.
+ * `plugins/plugin-icons.json`. Invalid or missing (404) icons are fail-closed:
+ * skipped, pruned, and omitted from the manifest. A non-404 fetch failure
+ * (transient 429/5xx/network or a hard error) aborts the whole run before any
+ * asset/manifest is written, so an outage never silently drops a pinned icon.
  *
- * CHECK mode (`--check`): purely local. Recompute the content hash of every
- * vendored `icon.png` and assert it matches the committed manifest, with no
- * orphan manifest entries and no unlisted asset dirs. No network.
+ * CHECK mode (`--check`): purely local. Re-validate every vendored `icon.png`
+ * against the icon contract and assert its content hash matches the committed
+ * manifest, with no orphan manifest entries and no unlisted asset dirs. No
+ * network.
  *
  * Usage:
  *   node scripts/plugins/generate-plugin-icons.mjs          # write
@@ -123,9 +126,40 @@ function iconContentsUrl(entry) {
 }
 
 /**
+ * A non-404 icon fetch failure. Mirrors `MarketplaceFetchError` in
+ * `plugin-marketplace.ts`: `transient` flags a retryable upstream hiccup
+ * (429/5xx/network) vs a hard error. A 404 never reaches here — it is a normal
+ * "no icon" result, not a failure.
+ */
+export class IconFetchError extends Error {
+  constructor(message, { transient = false, status } = {}) {
+    super(message);
+    this.name = "IconFetchError";
+    this.transient = transient;
+    if (status !== undefined) this.status = status;
+  }
+}
+
+/**
+ * Classify an upstream GitHub status as transient (worth retrying) vs hard.
+ * Mirrors `isTransientUpstreamStatus` in `plugin-marketplace.ts`: 429 or 5xx
+ * is always transient; a 403 is a rate-limit signal only when the remaining
+ * quota header is exhausted, otherwise it is a hard authorization failure.
+ */
+function isTransientUpstreamStatus(res) {
+  if (res.status === 429 || res.status >= 500) return true;
+  if (res.status === 403) {
+    return res.headers?.get?.("x-ratelimit-remaining") === "0";
+  }
+  return false;
+}
+
+/**
  * Fetch a plugin's raw `icon.png` bytes at its pinned ref. Returns the Buffer,
- * or `null` for a missing file (404) — both normal, non-fatal outcomes. Any
- * other HTTP failure throws so the caller can log and fail-closed.
+ * or `null` for a missing file (404) — the only "no icon" outcome. Every other
+ * failure throws {@link IconFetchError}: a network/DNS error or a 429/5xx is
+ * `transient`, so the caller aborts rather than silently dropping a still-valid
+ * vendored icon.
  */
 async function fetchIconBytes(fetchImpl, entry, token) {
   const headers = {
@@ -136,12 +170,23 @@ async function fetchIconBytes(fetchImpl, entry, token) {
     headers.Authorization = `Bearer ${token}`;
   }
 
-  const res = await fetchImpl(iconContentsUrl(entry), { headers });
+  let res;
+  try {
+    res = await fetchImpl(iconContentsUrl(entry), { headers });
+  } catch (err) {
+    // Network/DNS/connection throw — retryable upstream hiccup.
+    throw new IconFetchError(`network error: ${err.message}`, {
+      transient: true,
+    });
+  }
   if (res.status === 404) {
     return null;
   }
   if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`);
+    throw new IconFetchError(`HTTP ${res.status}`, {
+      transient: isTransientUpstreamStatus(res),
+      status: res.status,
+    });
   }
   return Buffer.from(await res.arrayBuffer());
 }
@@ -176,17 +221,25 @@ export async function generatePluginIcons({
   const entries = manifest.plugins ?? [];
 
   const versionsByName = {};
+  const toVendor = [];
   const vendored = [];
   const skipped = [];
 
+  // Resolve every icon fully in memory before touching disk. A non-404 fetch
+  // failure (transient 429/5xx/network or a hard error) aborts here — we cannot
+  // confirm the icon is gone, so treating it as "no icon" would prune a
+  // still-valid vendored icon during an outage. Deferring all writes past this
+  // loop guarantees an abort leaves the working tree unchanged.
   for (const entry of entries) {
     let bytes;
     try {
       bytes = await fetchIconBytes(fetchImpl, entry, token);
     } catch (err) {
-      log.warn?.(`skip ${entry.name}: icon fetch failed (${err.message})`);
-      skipped.push(entry.name);
-      continue;
+      const kind = err.transient ? "transient " : "";
+      throw new Error(
+        `Aborting icon generation: ${kind}icon fetch failed for ${entry.name} (${err.message}). ` +
+          `No assets or manifest were modified; re-run once upstream recovers.`,
+      );
     }
 
     if (!bytes) {
@@ -201,11 +254,16 @@ export async function generatePluginIcons({
       continue;
     }
 
-    const dir = join(assetsDir, entry.name);
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, ICON_FILENAME), bytes);
+    toVendor.push({ name: entry.name, bytes });
     versionsByName[entry.name] = result.iconVersion;
     vendored.push(entry.name);
+  }
+
+  // Every icon resolved cleanly — safe to mutate the working tree now.
+  for (const { name, bytes } of toVendor) {
+    const dir = join(assetsDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ICON_FILENAME), bytes);
   }
 
   // Prune asset dirs no longer backed by a valid vendored icon.
@@ -259,7 +317,17 @@ export function checkPluginIcons({
       errors.push(`asset dir "${name}" has no ${ICON_FILENAME}`);
       continue;
     }
-    const version = iconVersionOf(readFileSync(iconPath));
+    // Re-run the icon contract (PNG magic + IHDR dims + byte cap), not just the
+    // hash: a hand-committed malformed/oversized blob whose manifest hash was
+    // updated to match must still fail this network-free guard.
+    const result = validatePluginIconBytes(readFileSync(iconPath));
+    if (!result.hasIcon) {
+      errors.push(
+        `asset "${name}" is not a contract-valid PNG (magic/dimensions/size)`,
+      );
+      continue;
+    }
+    const version = result.iconVersion;
     const entry = manifestPlugins[name];
     if (!entry) {
       errors.push(`asset "${name}" is not listed in the manifest`);

--- a/scripts/plugins/generate-plugin-icons.mjs
+++ b/scripts/plugins/generate-plugin-icons.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Resolve, validate, and vendor marketplace plugin `icon.png` files, then
+ * emit the derived `plugins/plugin-icons.json` index.
+ *
+ * WRITE mode (default): for each entry in `plugins/marketplace.json`, fetch
+ * `<source.path>/icon.png` at the pinned `source.ref` via the GitHub Contents
+ * API, validate the bytes against the icon contract, and — on success —
+ * vendor them to `plugins/assets/<name>/icon.png` and index the plugin in
+ * `plugins/plugin-icons.json`. Invalid, missing, or unfetchable icons are
+ * fail-closed: skipped, pruned, and omitted from the manifest.
+ *
+ * CHECK mode (`--check`): purely local. Recompute the content hash of every
+ * vendored `icon.png` and assert it matches the committed manifest, with no
+ * orphan manifest entries and no unlisted asset dirs. No network.
+ *
+ * Usage:
+ *   node scripts/plugins/generate-plugin-icons.mjs          # write
+ *   node scripts/plugins/generate-plugin-icons.mjs --check  # verify
+ */
+
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../..");
+const MARKETPLACE_PATH = join(REPO_ROOT, "plugins/marketplace.json");
+const ASSETS_DIR = join(REPO_ROOT, "plugins/assets");
+const MANIFEST_PATH = join(REPO_ROOT, "plugins/plugin-icons.json");
+const ICON_FILENAME = "icon.png";
+
+// ---------------------------------------------------------------------------
+// Icon validation
+//
+// Mirrors `validatePluginIconBytes` in
+// `assistant/src/cli/lib/plugin-icon-file.ts` — the authoritative
+// implementation — kept byte-identical so a plugin that validates for the
+// assistant vendors here too. See `docs/plugin-icon-contract.md` for the spec.
+// Re-implemented (not imported) because this script runs under plain `node`,
+// which cannot import the TypeScript source.
+// ---------------------------------------------------------------------------
+
+const MAX_ICON_BYTES = 32 * 1024;
+const MAX_ICON_DIMENSION = 128;
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PNG_IHDR_LENGTH = 13;
+const PNG_IHDR_TYPE = Buffer.from("IHDR", "ascii");
+const MIN_HEADER_BYTES = 24;
+
+/**
+ * Validate in-memory PNG bytes against the icon contract. Returns
+ * `{ hasIcon: true, iconVersion }` only for a PNG whose IHDR dimensions and
+ * total size are within bounds; every other case returns `{ hasIcon: false }`.
+ */
+export function validatePluginIconBytes(bytes) {
+  if (bytes.length < MIN_HEADER_BYTES || bytes.length > MAX_ICON_BYTES) {
+    return { hasIcon: false };
+  }
+  if (!bytes.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+    return { hasIcon: false };
+  }
+  if (
+    bytes.readUInt32BE(8) !== PNG_IHDR_LENGTH ||
+    !bytes.subarray(12, 16).equals(PNG_IHDR_TYPE)
+  ) {
+    return { hasIcon: false };
+  }
+
+  const width = bytes.readUInt32BE(16);
+  const height = bytes.readUInt32BE(20);
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    width > MAX_ICON_DIMENSION ||
+    height > MAX_ICON_DIMENSION
+  ) {
+    return { hasIcon: false };
+  }
+
+  return { hasIcon: true, iconVersion: iconVersionOf(bytes) };
+}
+
+/** First 16 hex chars of sha256(bytes) — the stable content version. */
+export function iconVersionOf(bytes) {
+  return createHash("sha256").update(bytes).digest("hex").slice(0, 16);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isFile(path) {
+  return statSync(path, { throwIfNoEntry: false })?.isFile() ?? false;
+}
+
+/** Names of `plugins/assets/*` subdirectories (icon may or may not be present). */
+function listAssetDirs(assetsDir) {
+  return readdirSync(assetsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+/** GitHub Contents API URL for a plugin's `icon.png` at its pinned ref. */
+function iconContentsUrl(entry) {
+  const filePath = entry.source.path
+    ? `${entry.source.path}/${ICON_FILENAME}`
+    : ICON_FILENAME;
+  return (
+    `https://api.github.com/repos/${entry.source.repo}` +
+    `/contents/${filePath}?ref=${encodeURIComponent(entry.source.ref)}`
+  );
+}
+
+/**
+ * Fetch a plugin's raw `icon.png` bytes at its pinned ref. Returns the Buffer,
+ * or `null` for a missing file (404) — both normal, non-fatal outcomes. Any
+ * other HTTP failure throws so the caller can log and fail-closed.
+ */
+async function fetchIconBytes(fetchImpl, entry, token) {
+  const headers = {
+    Accept: "application/vnd.github.raw",
+    "User-Agent": "vellum-assistant-cli",
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const res = await fetchImpl(iconContentsUrl(entry), { headers });
+  if (res.status === 404) {
+    return null;
+  }
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+/** Serialize the manifest deterministically: sorted names, trailing newline. */
+function serializeManifest(versionsByName) {
+  const plugins = {};
+  for (const name of Object.keys(versionsByName).sort()) {
+    plugins[name] = { iconVersion: versionsByName[name] };
+  }
+  return `${JSON.stringify({ version: 1, plugins }, null, 2)}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Write mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve, validate, and vendor every marketplace plugin's `icon.png`, then
+ * write the derived manifest. Prunes asset dirs for plugins that no longer
+ * ship a valid icon. Returns `{ vendored, skipped }` name lists.
+ */
+export async function generatePluginIcons({
+  fetch: fetchImpl = globalThis.fetch,
+  marketplacePath = MARKETPLACE_PATH,
+  assetsDir = ASSETS_DIR,
+  manifestPath = MANIFEST_PATH,
+  token = process.env.GITHUB_TOKEN,
+  log = console,
+} = {}) {
+  const manifest = JSON.parse(readFileSync(marketplacePath, "utf-8"));
+  const entries = manifest.plugins ?? [];
+
+  const versionsByName = {};
+  const vendored = [];
+  const skipped = [];
+
+  for (const entry of entries) {
+    let bytes;
+    try {
+      bytes = await fetchIconBytes(fetchImpl, entry, token);
+    } catch (err) {
+      log.warn?.(`skip ${entry.name}: icon fetch failed (${err.message})`);
+      skipped.push(entry.name);
+      continue;
+    }
+
+    if (!bytes) {
+      skipped.push(entry.name);
+      continue;
+    }
+
+    const result = validatePluginIconBytes(bytes);
+    if (!result.hasIcon) {
+      log.warn?.(`skip ${entry.name}: icon.png failed validation`);
+      skipped.push(entry.name);
+      continue;
+    }
+
+    const dir = join(assetsDir, entry.name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ICON_FILENAME), bytes);
+    versionsByName[entry.name] = result.iconVersion;
+    vendored.push(entry.name);
+  }
+
+  // Prune asset dirs no longer backed by a valid vendored icon.
+  const keep = new Set(vendored);
+  if (statSync(assetsDir, { throwIfNoEntry: false })?.isDirectory()) {
+    for (const name of listAssetDirs(assetsDir)) {
+      if (!keep.has(name)) {
+        rmSync(join(assetsDir, name), { recursive: true, force: true });
+      }
+    }
+  }
+
+  writeFileSync(manifestPath, serializeManifest(versionsByName));
+
+  log.log?.(
+    `Vendored ${vendored.length} icon(s); ${skipped.length} plugin(s) without a valid icon.`,
+  );
+  return { vendored: vendored.sort(), skipped: skipped.sort() };
+}
+
+// ---------------------------------------------------------------------------
+// Check mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify the committed manifest against the vendored assets, purely locally:
+ * every asset's content hash matches its manifest entry, with no orphan
+ * manifest entries and no unlisted or icon-less asset dirs. Returns
+ * `{ ok, errors }`.
+ */
+export function checkPluginIcons({
+  assetsDir = ASSETS_DIR,
+  manifestPath = MANIFEST_PATH,
+} = {}) {
+  const errors = [];
+
+  let manifestPlugins = {};
+  try {
+    manifestPlugins = JSON.parse(readFileSync(manifestPath, "utf-8")).plugins ?? {};
+  } catch (err) {
+    return { ok: false, errors: [`cannot read ${manifestPath}: ${err.message}`] };
+  }
+
+  const assetNames = statSync(assetsDir, { throwIfNoEntry: false })?.isDirectory()
+    ? listAssetDirs(assetsDir)
+    : [];
+
+  for (const name of assetNames) {
+    const iconPath = join(assetsDir, name, ICON_FILENAME);
+    if (!isFile(iconPath)) {
+      errors.push(`asset dir "${name}" has no ${ICON_FILENAME}`);
+      continue;
+    }
+    const version = iconVersionOf(readFileSync(iconPath));
+    const entry = manifestPlugins[name];
+    if (!entry) {
+      errors.push(`asset "${name}" is not listed in the manifest`);
+    } else if (entry.iconVersion !== version) {
+      errors.push(
+        `iconVersion mismatch for "${name}": asset=${version} manifest=${entry.iconVersion}`,
+      );
+    }
+  }
+
+  const assetSet = new Set(assetNames);
+  for (const name of Object.keys(manifestPlugins)) {
+    if (!assetSet.has(name)) {
+      errors.push(`manifest entry "${name}" has no vendored asset`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+async function cli(argv) {
+  if (argv.includes("--check")) {
+    const { ok, errors } = checkPluginIcons();
+    if (!ok) {
+      console.error("plugin-icons.json is out of sync with plugins/assets/:");
+      for (const e of errors) {
+        console.error(`  - ${e}`);
+      }
+      console.error(
+        "\nRun `node scripts/plugins/generate-plugin-icons.mjs` and commit the result.",
+      );
+      process.exit(1);
+    }
+    console.log("OK: plugin-icons.json matches the vendored assets.");
+    return;
+  }
+
+  await generatePluginIcons();
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(realpathSync(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedPath) {
+  await cli(process.argv.slice(2));
+}


### PR DESCRIPTION
## Summary
- Adds scripts/plugins/generate-plugin-icons.mjs: fetches each marketplace plugin's icon.png at its pinned SHA, validates it against the shared icon contract (PNG magic + IHDR <=128x128 + <=32KB, fail-closed), vendors valid bytes to plugins/assets/<name>/icon.png, and writes the derived plugins/plugin-icons.json index (name -> iconVersion). A network-free --check verifies manifest<->asset consistency.

Part of plan: plugin-icons-marketing.md (PR 4 of 6)