### PR TITLE
Telemetry outbox ergonomics: cheaper introduction of new event types

### DIFF
--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -1,29 +1,17 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-let shareAnalytics = true;
-
-mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
-import * as dbConnection from "../persistence/db-connection.js";
-import { initializeDb } from "../persistence/db-init.js";
 import {
   type AuthFallbackCount,
   recordAuthFallbackCounts,
 } from "../security/auth-fallback-events-store.js";
 import {
-  discardPendingTelemetryOutboxEvents,
-  queryTelemetryOutboxBatch,
-} from "../telemetry/telemetry-events-outbox.js";
+  pendingOutboxRows,
+  resetOutboxTable,
+  setShareAnalytics,
+  withTelemetryDbUnavailable,
+} from "../telemetry/__tests__/outbox-test-harness.js";
 import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
-
-await initializeDb();
-
-function pendingRows() {
-  return queryTelemetryOutboxBatch("auth_fallback", 100);
-}
 
 const SAMPLE: AuthFallbackCount[] = [
   {
@@ -42,15 +30,15 @@ const SAMPLE: AuthFallbackCount[] = [
 
 describe("auth-fallback-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    discardPendingTelemetryOutboxEvents("auth_fallback");
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("records one outbox row per count entry with the full wire payload", () => {
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(2);
 
-    const rows = pendingRows();
+    const rows = pendingOutboxRows("auth_fallback");
     expect(rows.length).toBe(2);
     const payloads = rows.map(
       (r) => JSON.parse(r.payload) as AuthFallbackTelemetryEvent,
@@ -82,26 +70,23 @@ describe("auth-fallback-events-store", () => {
   });
 
   test("honors the share_analytics opt-out (records nothing)", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(0);
-    expect(pendingRows().length).toBe(0);
+    expect(pendingOutboxRows("auth_fallback").length).toBe(0);
   });
 
   test("empty counts batch is a no-op", () => {
     expect(recordAuthFallbackCounts(1000, 2000, [])).toBe(0);
-    expect(pendingRows().length).toBe(0);
+    expect(pendingOutboxRows("auth_fallback").length).toBe(0);
   });
 
   test("records all-or-nothing: db unavailable returns 0 with no rows", () => {
-    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
-    try {
+    withTelemetryDbUnavailable(() => {
       expect(recordAuthFallbackCounts(1000, 2000, SAMPLE)).toBe(0);
-    } finally {
-      spy.mockRestore();
-    }
+    });
     // No partial batch: the gateway's `recorded === 0` retry contract means
     // any committed remnant would later double-count.
-    expect(pendingRows().length).toBe(0);
+    expect(pendingOutboxRows("auth_fallback").length).toBe(0);
   });
 });

--- a/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/onboarding/__tests__/onboarding-events-store.test.ts
@@ -1,20 +1,13 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-// Mutable consent gate, flipped per-test.
-let shareAnalytics = true;
-mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
-import * as dbConnection from "../../persistence/db-connection.js";
+import { getTelemetrySqlite } from "../../persistence/db-connection.js";
 import {
-  getTelemetryDb,
-  getTelemetrySqlite,
-} from "../../persistence/db-connection.js";
-import { initializeDb } from "../../persistence/db-init.js";
-import { telemetryEvents } from "../../persistence/schema/index.js";
+  pendingOutboxPayloads,
+  resetOutboxTable,
+  setShareAnalytics,
+  withTelemetryDbUnavailable,
+} from "../../telemetry/__tests__/outbox-test-harness.js";
 import { ACTIVATION_FUNNEL_VERSION } from "../../telemetry/activation-funnel.js";
-import { queryTelemetryOutboxBatch } from "../../telemetry/telemetry-events-outbox.js";
 import type { OnboardingTelemetryEvent } from "../../telemetry/types.js";
 import { APP_VERSION } from "../../version.js";
 import {
@@ -22,33 +15,15 @@ import {
   recordOnboardingEvent,
 } from "../onboarding-events-store.js";
 
-await initializeDb();
-
-function resetTable(): void {
-  getTelemetryDb()!.delete(telemetryEvents).run();
-}
-
 /** Pending onboarding outbox payloads, parsed, in `(created_at, id)` order. */
 function pendingOnboardingPayloads(): OnboardingTelemetryEvent[] {
-  return queryTelemetryOutboxBatch("onboarding", 10).map(
-    (row) => JSON.parse(row.payload) as OnboardingTelemetryEvent,
-  );
-}
-
-/** Run `fn` with the dedicated telemetry connection reported as unavailable. */
-function withTelemetryDbUnavailable(fn: () => void): void {
-  const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
-  try {
-    fn();
-  } finally {
-    spy.mockRestore();
-  }
+  return pendingOutboxPayloads<OnboardingTelemetryEvent>("onboarding", 10);
 }
 
 describe("onboarding-events-store: recordActivationEvent", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    resetTable();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("stores the full wire payload with the deterministic activation daemon_event_id", () => {
@@ -104,7 +79,7 @@ describe("onboarding-events-store: recordActivationEvent", () => {
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     const event = recordActivationEvent({
       stepName: "activation_moment_1_complete",
       sessionId: "conv-3",
@@ -129,8 +104,8 @@ describe("onboarding-events-store: recordActivationEvent", () => {
 
 describe("onboarding-events-store: recordOnboardingEvent", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    resetTable();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("stores a pre-chat wire payload with daemon_event_id = row id and no funnel fields", () => {
@@ -168,7 +143,7 @@ describe("onboarding-events-store: recordOnboardingEvent", () => {
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     expect(recordOnboardingEvent({ screen: "tools" })).toBeNull();
     expect(pendingOnboardingPayloads()).toHaveLength(0);
   });

--- a/assistant/src/persistence/lifecycle-events-store.test.ts
+++ b/assistant/src/persistence/lifecycle-events-store.test.ts
@@ -1,22 +1,16 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-// Mutable consent gate, flipped per-test.
-let shareAnalytics = true;
-mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
+import {
+  resetOutboxTable,
+  setShareAnalytics,
+  withTelemetryDbUnavailable,
+} from "../telemetry/__tests__/outbox-test-harness.js";
 import { APP_VERSION } from "../version.js";
-import * as dbConnection from "./db-connection.js";
-import { getTelemetryDb, getTelemetrySqlite } from "./db-connection.js";
-import { initializeDb } from "./db-init.js";
+import { getTelemetrySqlite } from "./db-connection.js";
 import {
   buildLifecycleTelemetryEvent,
   recordLifecycleEvent,
 } from "./lifecycle-events-store.js";
-import { telemetryEvents } from "./schema.js";
-
-await initializeDb();
 
 interface RawOutboxRow {
   id: string;
@@ -35,20 +29,10 @@ function outboxRows(): RawOutboxRow[] {
     .all() as RawOutboxRow[];
 }
 
-/** Run `fn` with the dedicated telemetry connection reported as unavailable. */
-function withTelemetryDbUnavailable(fn: () => void): void {
-  const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
-  try {
-    fn();
-  } finally {
-    spy.mockRestore();
-  }
-}
-
 describe("lifecycle-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    getTelemetryDb()!.delete(telemetryEvents).run();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("record writes a telemetry_events outbox row carrying the wire payload", () => {
@@ -85,7 +69,7 @@ describe("lifecycle-events-store", () => {
   });
 
   test("returns null and writes no row when share_analytics is disabled", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     expect(recordLifecycleEvent("app_open")).toBeNull();
     expect(outboxRows()).toHaveLength(0);
   });

--- a/assistant/src/persistence/lifecycle-events-store.ts
+++ b/assistant/src/persistence/lifecycle-events-store.ts
@@ -1,4 +1,4 @@
-import { recordTelemetryOutboxEvent } from "../telemetry/telemetry-events-outbox.js";
+import { recordTelemetryEvent } from "../telemetry/telemetry-events-outbox.js";
 import type { LifecycleTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
 
@@ -9,8 +9,10 @@ export interface LifecycleEvent {
 }
 
 /**
- * Wire shape of one lifecycle event, stamped with the record-time binary's
- * `APP_VERSION` (the outbox stores the full wire payload at record time).
+ * Wire shape of one lifecycle event, for callers that insert outbox rows via
+ * raw SQL (conversation-crud's clearAll audit path). Mirrors the shape
+ * `recordTelemetryEvent` stamps — the shared `LifecycleTelemetryEvent` type
+ * keeps them in sync.
  */
 export function buildLifecycleTelemetryEvent(
   id: string,
@@ -28,12 +30,11 @@ export function buildLifecycleTelemetryEvent(
 
 /**
  * Record a lifecycle event (e.g. app_open, hatch) into the `telemetry_events`
- * outbox. Returns null when usage data collection is disabled or the
- * telemetry database is unavailable (degraded mode).
+ * outbox. Consent gating and degraded-mode `null` are `recordTelemetryEvent`'s.
  */
 export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
-  const recorded = recordTelemetryOutboxEvent("lifecycle", (id, createdAt) =>
-    buildLifecycleTelemetryEvent(id, eventName, createdAt),
-  );
+  const recorded = recordTelemetryEvent("lifecycle", {
+    event_name: eventName,
+  });
   return recorded ? { ...recorded, eventName } : null;
 }

--- a/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-events-store.test.ts
@@ -1,49 +1,29 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-let shareAnalytics = true;
-
-mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
-import { getTelemetryDb } from "../../persistence/db-connection.js";
-import { initializeDb } from "../../persistence/db-init.js";
-import { telemetryEvents } from "../../persistence/schema/index.js";
 import { APP_VERSION } from "../../version.js";
 import { recordConfigSettingEvent } from "../config-setting-events-store.js";
-import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
-
-await initializeDb();
-
-function pendingConfigSettingPayloads(): Array<Record<string, unknown>> {
-  return queryTelemetryOutboxBatch("config_setting", 100).map(
-    (row) => JSON.parse(row.payload) as Record<string, unknown>,
-  );
-}
-
-function clearEvents(): void {
-  const db = getTelemetryDb();
-  if (!db) {
-    throw new Error("telemetry DB unavailable in test");
-  }
-  db.delete(telemetryEvents).run();
-}
+import {
+  pendingOutboxPayloads,
+  pendingOutboxRows,
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./outbox-test-harness.js";
 
 describe("config-setting-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    clearEvents();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("honors the share_analytics opt-out (records nothing, returns false)", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     expect(
       recordConfigSettingEvent({
         configKey: "memory.enabled",
         configValue: "true",
       }),
     ).toBe(false);
-    expect(queryTelemetryOutboxBatch("config_setting", 10)).toHaveLength(0);
+    expect(pendingOutboxRows("config_setting", 10)).toHaveLength(0);
   });
 
   test("records the full wire event and returns true", () => {
@@ -54,7 +34,7 @@ describe("config-setting-events-store", () => {
       }),
     ).toBe(true);
 
-    const rows = queryTelemetryOutboxBatch("config_setting", 10);
+    const rows = pendingOutboxRows("config_setting", 10);
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
     expect(row.id).toBeString();
@@ -75,7 +55,7 @@ describe("config-setting-events-store", () => {
       configValue: "v".repeat(300),
     });
 
-    const payloads = pendingConfigSettingPayloads();
+    const payloads = pendingOutboxPayloads("config_setting");
     expect(payloads).toHaveLength(1);
     expect(payloads[0]!.config_key).toBe("k".repeat(128));
     expect(payloads[0]!.config_value).toBe("v".repeat(256));

--- a/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
@@ -1,22 +1,15 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-let shareAnalytics = true;
-
-mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../../config/schema.js";
-import { getTelemetryDb } from "../../persistence/db-connection.js";
-import { initializeDb } from "../../persistence/db-init.js";
-import { telemetryEvents } from "../../persistence/schema/index.js";
 import {
   recordConfigSettingSnapshot,
   resetConfigSettingSnapshotForTesting,
 } from "../config-setting-snapshot.js";
-import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
-
-await initializeDb();
+import {
+  pendingOutboxPayloads,
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./outbox-test-harness.js";
 
 function makeConfig(
   memoryEnabled: boolean,
@@ -28,27 +21,16 @@ function makeConfig(
 }
 
 function recordedPairs(): Array<[string, string]> {
-  return queryTelemetryOutboxBatch("config_setting", 100).map((row) => {
-    const event = JSON.parse(row.payload) as {
-      config_key: string;
-      config_value: string;
-    };
-    return [event.config_key, event.config_value];
-  });
-}
-
-function clearEvents(): void {
-  const db = getTelemetryDb();
-  if (!db) {
-    throw new Error("telemetry DB unavailable in test");
-  }
-  db.delete(telemetryEvents).run();
+  return pendingOutboxPayloads<{
+    config_key: string;
+    config_value: string;
+  }>("config_setting").map((event) => [event.config_key, event.config_value]);
 }
 
 describe("config-setting-snapshot", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    clearEvents();
+    setShareAnalytics(true);
+    resetOutboxTable();
     resetConfigSettingSnapshotForTesting();
   });
 
@@ -71,7 +53,7 @@ describe("config-setting-snapshot", () => {
 
   test("a changed value records only the changed key", () => {
     recordConfigSettingSnapshot(makeConfig(true, true));
-    clearEvents();
+    resetOutboxTable();
 
     recordConfigSettingSnapshot(makeConfig(true, false));
 
@@ -79,14 +61,14 @@ describe("config-setting-snapshot", () => {
   });
 
   test("consent off drops the snapshot without poisoning the memo", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs()).toHaveLength(0);
 
     // A later opted-in snapshot records the full set — the opted-out attempt
     // must not have memoized the values (mirrors the reporter's flush retry
     // once consent resolves).
-    shareAnalytics = true;
+    setShareAnalytics(true);
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs()).toHaveLength(2);
   });
@@ -95,17 +77,17 @@ describe("config-setting-snapshot", () => {
     // Recorded while opted in.
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs()).toHaveLength(2);
-    clearEvents();
+    resetOutboxTable();
 
     // Opt out: the reporter's opt-out flush discards any pending rows, so the
     // memo must be cleared here too.
-    shareAnalytics = false;
+    setShareAnalytics(false);
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs()).toHaveLength(0);
 
     // Re-opt-in with the SAME config: the full snapshot re-records rather than
     // being skipped by a stale memo.
-    shareAnalytics = true;
+    setShareAnalytics(true);
     recordConfigSettingSnapshot(makeConfig(true, true));
     expect(recordedPairs().sort()).toEqual([
       ["memory.enabled", "true"],

--- a/assistant/src/telemetry/__tests__/outbox-test-harness.ts
+++ b/assistant/src/telemetry/__tests__/outbox-test-harness.ts
@@ -1,0 +1,60 @@
+import { mock, spyOn } from "bun:test";
+
+let shareAnalytics = true;
+
+// Installed when this harness is imported. bun's mock.module patches
+// retroactively (live bindings), so importers need no special import order.
+// This harness is imported by *.test.ts files only — never by the test
+// preload — so it runs after the per-test workspace override, where src/
+// imports are as safe as in the test files themselves (AGENTS.md "Test
+// machinery isolation" scopes its no-src/ rule to preload-time machinery).
+mock.module("../../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
+}));
+
+import * as dbConnection from "../../persistence/db-connection.js";
+import { getTelemetryDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { telemetryEvents } from "../../persistence/schema/index.js";
+import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
+
+await initializeDb();
+
+/** Flip the mocked share_analytics consent; call with true in beforeEach. */
+export function setShareAnalytics(value: boolean): void {
+  shareAnalytics = value;
+}
+
+/** Delete every telemetry_events row. */
+export function resetOutboxTable(): void {
+  const db = getTelemetryDb();
+  if (!db) {
+    throw new Error("telemetry DB unavailable in test");
+  }
+  db.delete(telemetryEvents).run();
+}
+
+/** Pending rows for one event name in (created_at, id) order. */
+export function pendingOutboxRows(name: string, limit = 100) {
+  return queryTelemetryOutboxBatch(name, limit);
+}
+
+/** Pending payloads for one event name, JSON-parsed, in flush order. */
+export function pendingOutboxPayloads<T = Record<string, unknown>>(
+  name: string,
+  limit = 100,
+): T[] {
+  return pendingOutboxRows(name, limit).map(
+    (row) => JSON.parse(row.payload) as T,
+  );
+}
+
+/** Run `fn` with the telemetry connection reported as unavailable. */
+export function withTelemetryDbUnavailable(fn: () => void): void {
+  const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+}

--- a/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
+++ b/assistant/src/telemetry/__tests__/watchdog-events-store.test.ts
@@ -1,44 +1,24 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-let shareAnalytics = true;
-
-mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
-import { getTelemetryDb } from "../../persistence/db-connection.js";
-import { initializeDb } from "../../persistence/db-init.js";
-import { telemetryEvents } from "../../persistence/schema/index.js";
 import { APP_VERSION } from "../../version.js";
-import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
 import { recordWatchdogEvent } from "../watchdog-events-store.js";
-
-await initializeDb();
-
-function pendingWatchdogPayloads(): Array<Record<string, unknown>> {
-  return queryTelemetryOutboxBatch("watchdog", 100).map(
-    (row) => JSON.parse(row.payload) as Record<string, unknown>,
-  );
-}
-
-function clearEvents(): void {
-  const db = getTelemetryDb();
-  if (!db) {
-    throw new Error("telemetry DB unavailable in test");
-  }
-  db.delete(telemetryEvents).run();
-}
+import {
+  pendingOutboxPayloads,
+  pendingOutboxRows,
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./outbox-test-harness.js";
 
 describe("watchdog-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    clearEvents();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("honors the share_analytics opt-out (records nothing)", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     recordWatchdogEvent({ checkName: "event_loop_blocked", value: 60000 });
-    expect(queryTelemetryOutboxBatch("watchdog", 10)).toHaveLength(0);
+    expect(pendingOutboxRows("watchdog", 10)).toHaveLength(0);
   });
 
   test("records the full wire event, with detail as a nested object", () => {
@@ -48,7 +28,7 @@ describe("watchdog-events-store", () => {
       detail: { reason: "no_bytes_60s", threshold_ms: 5000 },
     });
 
-    const rows = queryTelemetryOutboxBatch("watchdog", 10);
+    const rows = pendingOutboxRows("watchdog", 10);
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
     expect(row.id).toBeString();
@@ -67,7 +47,7 @@ describe("watchdog-events-store", () => {
   test("omitted value and detail persist as null", () => {
     recordWatchdogEvent({ checkName: "stream_idle" });
 
-    const payloads = pendingWatchdogPayloads();
+    const payloads = pendingOutboxPayloads("watchdog");
     expect(payloads).toHaveLength(1);
     expect(payloads[0]).toMatchObject({
       check_name: "stream_idle",
@@ -83,7 +63,7 @@ describe("watchdog-events-store", () => {
       detail: null,
     });
 
-    const payloads = pendingWatchdogPayloads();
+    const payloads = pendingOutboxPayloads("watchdog");
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.value).toBeNull();
     expect(payloads[0]?.detail).toBeNull();

--- a/assistant/src/telemetry/config-setting-events-store.ts
+++ b/assistant/src/telemetry/config-setting-events-store.ts
@@ -1,6 +1,4 @@
-import { APP_VERSION } from "../version.js";
-import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
-import type { ConfigSettingTelemetryEvent } from "./types.js";
+import { recordTelemetryEvent } from "./telemetry-events-outbox.js";
 
 /**
  * Server-side bounds from the platform `ConfigSettingTelemetryEventSerializer`.
@@ -23,28 +21,20 @@ export interface ConfigSettingEventRecord {
 }
 
 /**
- * Record a `config_setting` telemetry event. Builds the full wire event and
- * enqueues it on the `telemetry_events` outbox. No-ops when usage data
- * collection is disabled (the event is dropped to honor the opt-out,
- * matching the rest of telemetry). Returns whether the event was persisted,
- * so a caller with its own dedupe memo (config-setting-snapshot.ts) only
- * advances the memo on a real write and keeps retrying while consent is off
- * or the telemetry DB is unavailable.
+ * Record a `config_setting` telemetry event, enqueued on the
+ * `telemetry_events` outbox. Consent gating and degraded-mode behavior are
+ * `recordTelemetryEvent`'s. Returns whether the event was persisted, so a
+ * caller with its own dedupe memo (config-setting-snapshot.ts) only advances
+ * the memo on a real write and keeps retrying while consent is off or the
+ * telemetry DB is unavailable.
  */
 export function recordConfigSettingEvent(
   record: ConfigSettingEventRecord,
 ): boolean {
   return (
-    recordTelemetryOutboxEvent(
-      "config_setting",
-      (id, createdAt): ConfigSettingTelemetryEvent => ({
-        type: "config_setting",
-        daemon_event_id: id,
-        recorded_at: createdAt,
-        config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
-        config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
-        assistant_version: APP_VERSION,
-      }),
-    ) !== null
+    recordTelemetryEvent("config_setting", {
+      config_key: record.configKey.slice(0, MAX_CONFIG_KEY_CHARS),
+      config_value: record.configValue.slice(0, MAX_CONFIG_VALUE_CHARS),
+    }) !== null
   );
 }

--- a/assistant/src/telemetry/skill-loaded-events-store.test.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.test.ts
@@ -1,18 +1,13 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-let shareAnalytics = true;
-
-mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import { getTelemetryDb } from "../persistence/db-connection.js";
-import { initializeDb } from "../persistence/db-init.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
 import { APP_VERSION } from "../version.js";
+import {
+  resetOutboxTable,
+  setShareAnalytics,
+} from "./__tests__/outbox-test-harness.js";
 import { recordSkillLoadedEvent } from "./skill-loaded-events-store.js";
-
-await initializeDb();
 
 function pendingRows(): Array<{
   id: string;
@@ -33,12 +28,12 @@ function pendingRows(): Array<{
 
 describe("skill-loaded-events-store", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    getTelemetryDb()!.delete(telemetryEvents).run();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("honors the share_analytics opt-out (records nothing)", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     recordSkillLoadedEvent({ skillName: "web-research" });
     expect(pendingRows()).toHaveLength(0);
   });

--- a/assistant/src/telemetry/skill-loaded-events-store.ts
+++ b/assistant/src/telemetry/skill-loaded-events-store.ts
@@ -1,8 +1,6 @@
 import type { UsageAttributionColumns } from "../usage/attribution.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
-import { APP_VERSION } from "../version.js";
-import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
-import type { SkillLoadedTelemetryEvent } from "./types.js";
+import { recordTelemetryEvent } from "./telemetry-events-outbox.js";
 
 /**
  * Input for one `skill_loaded` telemetry event. Metadata only — never skill
@@ -18,21 +16,15 @@ export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns>
 }
 
 /**
- * Record a `skill_loaded` telemetry event for a skill activation. The full
- * wire event (record-time `assistant_version` included) goes into the
- * `telemetry_events` outbox, with the conversation id in its dedicated
- * column so conversation deletion redacts pending rows via an indexed
- * delete. No-ops when usage data collection is disabled (the event is
- * dropped to honor the opt-out, matching the rest of telemetry) or when the
- * telemetry DB is unavailable.
+ * Record a `skill_loaded` telemetry event for a skill activation, enqueued on
+ * the `telemetry_events` outbox with the conversation id in its dedicated
+ * column so conversation deletion redacts pending rows via an indexed delete.
+ * Consent gating and degraded-mode behavior are `recordTelemetryEvent`'s.
  */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
-  recordTelemetryOutboxEvent(
+  recordTelemetryEvent(
     "skill_loaded",
-    (id, createdAt): SkillLoadedTelemetryEvent => ({
-      type: "skill_loaded",
-      daemon_event_id: id,
-      recorded_at: createdAt,
+    {
       skill_name: record.skillName,
       skill_updated_at: record.skillUpdatedAt ?? null,
       conversation_id: record.conversationId ?? null,
@@ -41,8 +33,7 @@ export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
       inference_profile: record.inferenceProfile ?? null,
       inference_profile_source: (record.inferenceProfileSource ??
         null) as UsageAttributionProfileSource | null,
-      assistant_version: APP_VERSION,
-    }),
+    },
     { conversationId: record.conversationId ?? null },
   );
 }

--- a/assistant/src/telemetry/telemetry-event-sources.test.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.test.ts
@@ -11,6 +11,7 @@ import {
   DAEMON_TELEMETRY_EVENT_SOURCES,
   MONITOR_TELEMETRY_EVENT_SOURCES,
 } from "./telemetry-event-sources.js";
+import { OUTBOX_TELEMETRY_EVENT_NAMES } from "./types.js";
 
 describe("telemetry event source partition", () => {
   test("the full source list carries every event type in payload order", () => {
@@ -37,6 +38,13 @@ describe("telemetry event source partition", () => {
         (id) => id !== "turns",
       ),
     );
+  });
+
+  test("every outbox event name has a registered source", () => {
+    const sourceIds = new Set(ALL_TELEMETRY_EVENT_SOURCES.map((s) => s.id));
+    for (const name of OUTBOX_TELEMETRY_EVENT_NAMES) {
+      expect(sourceIds.has(name)).toBe(true);
+    }
   });
 
   test("daemon and monitor partition the full list — no overlap, no gaps", () => {

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -26,7 +26,11 @@ import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.
 import { isDiagnosticsConsentVersionEligible } from "./trace-collection-policy.js";
 import { queryUnreportedTurnEvents } from "./turn-events-store.js";
 import { assembleBoundedTurnTrace, isTurnSettled } from "./turn-trace-store.js";
-import type { TelemetryEvent, TurnTelemetryClientInfo } from "./types.js";
+import type {
+  OutboxTelemetryEventName,
+  TelemetryEvent,
+  TurnTelemetryClientInfo,
+} from "./types.js";
 
 const log = getLogger("usage-telemetry");
 
@@ -134,7 +138,9 @@ function simpleSource<Row extends { id: string; createdAt: number }>(
  * to an object is purged immediately with a warn: an early empty-batch return
  * in the reporter would otherwise strand it at the head of the queue forever.
  */
-export function outboxSource(name: string): TelemetryEventSource {
+export function outboxSource(
+  name: OutboxTelemetryEventName,
+): TelemetryEventSource {
   return {
     id: name,
     collect(_afterCreatedAt, _afterId, limit) {
@@ -397,14 +403,6 @@ const turnSource: TelemetryEventSource = {
   },
 };
 
-const lifecycleSource = outboxSource("lifecycle");
-
-// Onboarding/activation events are outbox-backed: the store builds the wire
-// event (including the activation daemon_event_id override) at record time.
-const onboardingSource = outboxSource("onboarding");
-
-const authFallbackSource = outboxSource("auth_fallback");
-
 const toolExecutedSource = simpleSource(
   "tool_executed",
   (afterCreatedAt, afterId, limit) =>
@@ -434,12 +432,6 @@ const toolExecutedSource = simpleSource(
   }),
 );
 
-const skillLoadedSource = outboxSource("skill_loaded");
-
-const watchdogSource = outboxSource("watchdog");
-
-const configSettingSource = outboxSource("config_setting");
-
 /**
  * Watermark key namespace of the tool_executed source — referenced by the
  * absent-watermark init that runs at daemon startup.
@@ -455,13 +447,13 @@ export const TOOL_EXECUTED_SOURCE_ID = toolExecutedSource.id;
 export const ALL_TELEMETRY_EVENT_SOURCES: readonly TelemetryEventSource[] = [
   usageSource,
   turnSource,
-  lifecycleSource,
-  onboardingSource,
-  authFallbackSource,
+  outboxSource("lifecycle"),
+  outboxSource("onboarding"),
+  outboxSource("auth_fallback"),
   toolExecutedSource,
-  skillLoadedSource,
-  watchdogSource,
-  configSettingSource,
+  outboxSource("skill_loaded"),
+  outboxSource("watchdog"),
+  outboxSource("config_setting"),
 ];
 
 /**

--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -1,16 +1,13 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
-let shareAnalytics = true;
-
-mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
-}));
-
-import * as dbConnection from "../persistence/db-connection.js";
 import { getTelemetryDb } from "../persistence/db-connection.js";
-import { initializeDb } from "../persistence/db-init.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
 import { APP_VERSION } from "../version.js";
+import {
+  resetOutboxTable,
+  setShareAnalytics,
+  withTelemetryDbUnavailable,
+} from "./__tests__/outbox-test-harness.js";
 import {
   deleteTelemetryOutboxEvents,
   discardPendingTelemetryOutboxEvents,
@@ -20,8 +17,6 @@ import {
   recordTelemetryEvent,
 } from "./telemetry-events-outbox.js";
 import type { LifecycleTelemetryEvent } from "./types.js";
-
-await initializeDb();
 
 function lifecycleEvent(
   id: string,
@@ -57,8 +52,8 @@ function allIds(): string[] {
 
 describe("telemetry-events-outbox", () => {
   beforeEach(() => {
-    shareAnalytics = true;
-    getTelemetryDb()!.delete(telemetryEvents).run();
+    setShareAnalytics(true);
+    resetOutboxTable();
   });
 
   test("insert + query round-trips the wire payload", () => {
@@ -126,8 +121,7 @@ describe("telemetry-events-outbox", () => {
   });
 
   test("batch insert returns false when the telemetry DB is unavailable", () => {
-    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
-    try {
+    withTelemetryDbUnavailable(() => {
       expect(
         insertTelemetryOutboxEvents([
           {
@@ -138,9 +132,7 @@ describe("telemetry-events-outbox", () => {
           },
         ]),
       ).toBe(false);
-    } finally {
-      spy.mockRestore();
-    }
+    });
     expect(allIds()).toEqual([]);
   });
 
@@ -299,7 +291,7 @@ describe("telemetry-events-outbox", () => {
   });
 
   test("recordTelemetryEvent honors the share_analytics opt-out", () => {
-    shareAnalytics = false;
+    setShareAnalytics(false);
     expect(
       recordTelemetryEvent("watchdog", {
         check_name: "c",
@@ -311,8 +303,7 @@ describe("telemetry-events-outbox", () => {
   });
 
   test("recordTelemetryEvent returns null when the telemetry DB is unavailable", () => {
-    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
-    try {
+    withTelemetryDbUnavailable(() => {
       expect(
         recordTelemetryEvent("watchdog", {
           check_name: "c",
@@ -320,9 +311,7 @@ describe("telemetry-events-outbox", () => {
           detail: null,
         }),
       ).toBeNull();
-    } finally {
-      spy.mockRestore();
-    }
+    });
     expect(queryTelemetryOutboxBatch("watchdog", 10)).toEqual([]);
   });
 

--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -1,15 +1,23 @@
-import { beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+let shareAnalytics = true;
+
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
+}));
 
 import * as dbConnection from "../persistence/db-connection.js";
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
+import { APP_VERSION } from "../version.js";
 import {
   deleteTelemetryOutboxEvents,
   discardPendingTelemetryOutboxEvents,
   insertTelemetryOutboxEvent,
   insertTelemetryOutboxEvents,
   queryTelemetryOutboxBatch,
+  recordTelemetryEvent,
 } from "./telemetry-events-outbox.js";
 import type { LifecycleTelemetryEvent } from "./types.js";
 
@@ -49,6 +57,7 @@ function allIds(): string[] {
 
 describe("telemetry-events-outbox", () => {
   beforeEach(() => {
+    shareAnalytics = true;
     getTelemetryDb()!.delete(telemetryEvents).run();
   });
 
@@ -216,6 +225,105 @@ describe("telemetry-events-outbox", () => {
     deleteTelemetryOutboxEvents(ids);
 
     expect(allIds()).toEqual(["evt-keep"]);
+  });
+
+  test("recordTelemetryEvent stamps the base fields", () => {
+    const fields = {
+      check_name: "db_size",
+      value: 42,
+      detail: { table: "messages" },
+    };
+    const recorded = recordTelemetryEvent("watchdog", fields);
+    expect(recorded).not.toBeNull();
+
+    const rows = queryTelemetryOutboxBatch("watchdog", 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe(recorded!.id);
+    expect(JSON.parse(rows[0]!.payload)).toEqual({
+      type: "watchdog",
+      daemon_event_id: recorded!.id,
+      recorded_at: recorded!.createdAt,
+      assistant_version: APP_VERSION,
+      ...fields,
+    });
+  });
+
+  test("recordTelemetryEvent stamps win over base keys smuggled in via a widened fields value", () => {
+    // A variable (not a literal) skips excess-property checking, so base
+    // keys can reach the helper structurally. The stamps must still win.
+    const widened = {
+      check_name: "db_size",
+      value: null,
+      detail: null,
+      daemon_event_id: "spoofed-id",
+      recorded_at: 1,
+      assistant_version: "0.0.0-spoof",
+    };
+    const recorded = recordTelemetryEvent("watchdog", widened);
+    expect(recorded).not.toBeNull();
+
+    const payload = JSON.parse(
+      queryTelemetryOutboxBatch("watchdog", 10)[0]!.payload,
+    ) as Record<string, unknown>;
+    expect(payload.daemon_event_id).toBe(recorded!.id);
+    expect(payload.recorded_at).toBe(recorded!.createdAt);
+    expect(payload.assistant_version).toBe(APP_VERSION);
+  });
+
+  test("recordTelemetryEvent persists conversation_id in its column", () => {
+    const withConv = recordTelemetryEvent(
+      "watchdog",
+      { check_name: "c1", value: null, detail: null },
+      { conversationId: "conv-1" },
+    );
+    const withoutConv = recordTelemetryEvent("watchdog", {
+      check_name: "c2",
+      value: null,
+      detail: null,
+    });
+
+    const rows = getTelemetryDb()!
+      .select({
+        id: telemetryEvents.id,
+        conversationId: telemetryEvents.conversationId,
+      })
+      .from(telemetryEvents)
+      .all();
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.id === withConv!.id)!.conversationId).toBe(
+      "conv-1",
+    );
+    expect(rows.find((r) => r.id === withoutConv!.id)!.conversationId).toBe(
+      null,
+    );
+  });
+
+  test("recordTelemetryEvent honors the share_analytics opt-out", () => {
+    shareAnalytics = false;
+    expect(
+      recordTelemetryEvent("watchdog", {
+        check_name: "c",
+        value: null,
+        detail: null,
+      }),
+    ).toBeNull();
+    expect(queryTelemetryOutboxBatch("watchdog", 10)).toEqual([]);
+  });
+
+  test("recordTelemetryEvent returns null when the telemetry DB is unavailable", () => {
+    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+    try {
+      expect(
+        recordTelemetryEvent("watchdog", {
+          check_name: "c",
+          value: null,
+          detail: null,
+        }),
+      ).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+    expect(queryTelemetryOutboxBatch("watchdog", 10)).toEqual([]);
   });
 
   test("discards all pending rows for one name only", () => {

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -12,7 +12,13 @@ import { v4 as uuid } from "uuid";
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
 import { getCachedShareAnalytics } from "../platform/consent-cache.js";
-import type { TelemetryEvent } from "./types.js";
+import { APP_VERSION } from "../version.js";
+import type {
+  OutboxTelemetryEventName,
+  OutboxTelemetryEventOf,
+  TelemetryEvent,
+  TelemetryEventBase,
+} from "./types.js";
 
 /** Ids per DELETE chunk — stays under SQLite's bound-variable limit. */
 const DELETE_CHUNK_SIZE = 500;
@@ -74,12 +80,14 @@ export function insertTelemetryOutboxEvent(
 }
 
 /**
- * Record one telemetry event: gate on usage-data consent, generate the outbox
- * row id and record-time timestamp, build the wire payload via `buildEvent`
- * (which owns per-type stamping, e.g. `daemon_event_id` overrides), and
- * insert. Returns the generated row identity, or null when usage data
- * collection is disabled (the event is dropped to honor the opt-out) or the
- * telemetry DB is unavailable (degraded mode).
+ * Lower-level record escape hatch: for payloads that need the record-time
+ * `(id, createdAt)` inside type-specific fields (onboarding's activation
+ * `daemon_event_id` override and `completed_at`). Gates on usage-data
+ * consent, generates the outbox row identity, builds the wire payload via
+ * `buildEvent` (which owns all stamping), and inserts. Returns the generated
+ * row identity, or null when usage data collection is disabled (the event is
+ * dropped to honor the opt-out) or the telemetry DB is unavailable (degraded
+ * mode). Prefer `recordTelemetryEvent` when the payload doesn't need them.
  */
 export function recordTelemetryOutboxEvent(
   name: string,
@@ -99,6 +107,35 @@ export function recordTelemetryOutboxEvent(
     event: buildEvent(id, createdAt),
   });
   return inserted ? { id, createdAt } : null;
+}
+
+/**
+ * Preferred record API for outbox events whose payload does not depend on
+ * the record-time `(id, createdAt)`: stamps the `TelemetryEventBase` fields
+ * (record-time `assistant_version` included) and inherits
+ * `recordTelemetryOutboxEvent`'s consent gate and degraded-mode `null`.
+ */
+export function recordTelemetryEvent<N extends OutboxTelemetryEventName>(
+  name: N,
+  fields: Omit<OutboxTelemetryEventOf<N>, keyof TelemetryEventBase>,
+  opts?: { conversationId?: string | null },
+): { id: string; createdAt: number } | null {
+  return recordTelemetryOutboxEvent(
+    name,
+    (id, createdAt) =>
+      // Cast: TS cannot re-associate the `Omit<...>` spread with the stamped
+      // base fields across a generic; `fields`' type guarantees the shape.
+      // Base fields are stamped after the spread so a widened `fields` value
+      // carrying base keys can never override them.
+      ({
+        ...fields,
+        type: name,
+        daemon_event_id: id,
+        recorded_at: createdAt,
+        assistant_version: APP_VERSION,
+      }) as OutboxTelemetryEventOf<N>,
+    opts,
+  );
 }
 
 /**

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -522,3 +522,21 @@ export type TelemetryEvent =
   | SkillLoadedTelemetryEvent
   | WatchdogTelemetryEvent
   | ConfigSettingTelemetryEvent;
+
+/**
+ * Event names backed by the `telemetry_events` outbox. Each name doubles as
+ * the wire `type` discriminant and the flush-group key, so names must never
+ * change once shipped. The watermark-flushed types (`llm_usage`, `turn`,
+ * `tool_executed`) live on their own tables and are deliberately excluded.
+ */
+export type OutboxTelemetryEventName =
+  | "lifecycle"
+  | "onboarding"
+  | "auth_fallback"
+  | "skill_loaded"
+  | "watchdog"
+  | "config_setting";
+
+/** Wire event type for one outbox event name. */
+export type OutboxTelemetryEventOf<N extends OutboxTelemetryEventName> =
+  Extract<TelemetryEvent, { type: N }>;

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -529,13 +529,17 @@ export type TelemetryEvent =
  * change once shipped. The watermark-flushed types (`llm_usage`, `turn`,
  * `tool_executed`) live on their own tables and are deliberately excluded.
  */
+export const OUTBOX_TELEMETRY_EVENT_NAMES = [
+  "lifecycle",
+  "onboarding",
+  "auth_fallback",
+  "skill_loaded",
+  "watchdog",
+  "config_setting",
+] as const;
+
 export type OutboxTelemetryEventName =
-  | "lifecycle"
-  | "onboarding"
-  | "auth_fallback"
-  | "skill_loaded"
-  | "watchdog"
-  | "config_setting";
+  (typeof OUTBOX_TELEMETRY_EVENT_NAMES)[number];
 
 /** Wire event type for one outbox event name. */
 export type OutboxTelemetryEventOf<N extends OutboxTelemetryEventName> =

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -217,7 +217,7 @@ import {
   insertTelemetryOutboxEvent,
   queryTelemetryOutboxBatch,
 } from "./telemetry-events-outbox.js";
-import type { TelemetryEvent } from "./types.js";
+import type { OutboxTelemetryEventName, TelemetryEvent } from "./types.js";
 import {
   initToolExecutedWatermarkIfAbsent,
   UsageTelemetryReporter,
@@ -2933,7 +2933,9 @@ describe("UsageTelemetryReporter", () => {
   // outboxSource (real telemetry_events outbox behind an ack-mode source)
   // -------------------------------------------------------------------------
 
-  const OUTBOX_NAME = "test_outbox";
+  // Synthetic name: these tests exercise the generic outbox machinery, not a
+  // shipped event type.
+  const OUTBOX_NAME = "test_outbox" as OutboxTelemetryEventName;
 
   function seedOutboxRow(id: string, createdAt: number): void {
     insertTelemetryOutboxEvent({

--- a/assistant/src/telemetry/watchdog-events-store.ts
+++ b/assistant/src/telemetry/watchdog-events-store.ts
@@ -1,6 +1,4 @@
-import { APP_VERSION } from "../version.js";
-import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
-import type { WatchdogTelemetryEvent } from "./types.js";
+import { recordTelemetryEvent } from "./telemetry-events-outbox.js";
 
 /**
  * Input for one `watchdog` telemetry event. Metadata only — never conversation
@@ -17,23 +15,14 @@ export interface WatchdogEventRecord {
 }
 
 /**
- * Record a `watchdog` telemetry event for a watchdog check firing. Builds the
- * full wire event and enqueues it on the `telemetry_events` outbox. No-ops
- * when usage data collection is disabled (the event is dropped to honor the
- * opt-out, matching the rest of telemetry) or when the telemetry DB is
- * unavailable.
+ * Record a `watchdog` telemetry event for a watchdog check firing, enqueued
+ * on the `telemetry_events` outbox. Consent gating and degraded-mode behavior
+ * are `recordTelemetryEvent`'s.
  */
 export function recordWatchdogEvent(record: WatchdogEventRecord): void {
-  recordTelemetryOutboxEvent(
-    "watchdog",
-    (id, createdAt): WatchdogTelemetryEvent => ({
-      type: "watchdog",
-      daemon_event_id: id,
-      recorded_at: createdAt,
-      check_name: record.checkName,
-      value: record.value ?? null,
-      detail: record.detail ?? null,
-      assistant_version: APP_VERSION,
-    }),
-  );
+  recordTelemetryEvent("watchdog", {
+    check_name: record.checkName,
+    value: record.value ?? null,
+    detail: record.detail ?? null,
+  });
 }


### PR DESCRIPTION
## Summary
Follow-up to the telemetry outbox consolidation (#37952). Introducing a new telemetry-only event type now needs just: a wire interface + one list entry in `types.ts`, one `outboxSource("name")` line in the sources array, and a `recordTelemetryEvent(...)` call site — no store file, no migration, no per-file test scaffolding.

- **Typed record API**: `recordTelemetryEvent(name, fields, opts?)` stamps the four `TelemetryEventBase` fields (record-time `assistant_version` included) and owns the consent gate / degraded-mode null; `fields` is spread first so the stamps are always authoritative (regression-tested). `recordTelemetryOutboxEvent` stays as the documented escape hatch for payloads needing record-time `(id, createdAt)` — onboarding's activation `daemon_event_id` override.
- **Typo-proof registration**: `outboxSource(name: OutboxTelemetryEventName)` — a typo'd name is now a compile error instead of a silently-never-flushed queue; the six single-use source consts are inlined at identical positions (flush order unchanged, pinned by tests). `OUTBOX_TELEMETRY_EVENT_NAMES` is the single source of truth for the name set, and a sources test asserts every name has a registered source (a union name without one now fails tests).
- **Shared test harness**: `outbox-test-harness.ts` owns the consent mock, `initializeDb`, table reset, payload readers, and degraded-mode spy; all 8 outbox-touching test files migrated (net scaffolding deletion), test names and assertion strength unchanged.
- **Store adoption**: watchdog, config_setting, skill_loaded, lifecycle record via the typed helper; public store APIs unchanged; payload parity proven by store tests that were not edited in the adoption PR. onboarding and auth_fallback intentionally stay on the lower-level APIs (record-time-dependent payload / batch atomicity + gateway retry contract).

### Behavior notes for the reviewer
- **JSON key order inside stored payloads changed** for the four converted stores (type-specific fields now precede the base fields). Semantically identical; the only payload consumer is `JSON.parse` at flush and platform dedup keys on `daemon_event_id`, not payload bytes. Flagged for completeness.
- A Codex P1 on the harness ("shared test helpers must not import src/") was **declined with rationale**: `assistant/AGENTS.md` scopes that rule to preload-time machinery; the harness is imported only by test files post-workspace-override (precedent: `src/__tests__/helpers/seed-contact-channel.ts`). The scoping is documented in the harness comment — worth a second human look if you read that rule more strictly.

## Self-review result
Round 1: 4 passes → 2 substantive gaps found and fixed (see fix PRs); several letter-level findings triaged with rationale. Round 2: all 4 passes PASS (external-feedback, plan-faithfulness, integration incl. mutation-probing the new completeness test, slop audit).

## PRs merged into feature branch
- #37963: telemetry: typed recordTelemetryEvent helper stamps the outbox base fields
- #37961: telemetry: shared outbox test harness for consent + telemetry-DB scaffolding
- #37973: telemetry: type outboxSource names and inline outbox source registration
- #37971: telemetry: record fixed-payload outbox events via recordTelemetryEvent
- #37974: telemetry: migrate onboarding/auth-fallback/lifecycle store tests to the outbox harness

### Fix PRs
- #37982: fix: migrate telemetry-events-outbox.test.ts scaffolding to the outbox harness
- #37983: fix: single source of truth for outbox event names + source-coverage test

Part of plan: telemetry-outbox-ergonomics.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)