### PR TITLE
docs: remove the escalate channel policy from user-facing copy and architecture docs

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -509,7 +509,6 @@ gateway trust verdict → trustClass
         ├── guardian / trusted_contact → normal call flow
         ├── blocked → immediate denial + disconnect
         ├── policy: deny → immediate denial + disconnect
-        ├── policy: escalate → denial (voice cannot hold for async approval)
         |
         └── unknown (no binding) ──┐
                                    |

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -281,25 +281,13 @@ The ingress ACL runs at the top of the channel inbound handler, before guardian 
 4. **Policy check** — The member's `policy` field determines routing:
    - `allow` — Message proceeds to normal agent processing.
    - `deny` — Message is rejected with `policy_deny`.
-   - `escalate` — Message is held for guardian approval (see Escalation Flow below).
-
-### Escalation Flow
-
-When a member's policy is `escalate`:
-
-1. The handler looks up the guardian binding for the `(assistantId, channel)` pair. If no binding exists, the message is denied with `escalate_no_guardian` (fail-closed).
-2. The raw message payload is stored so it can be recovered on approval.
-3. A gateway `guardian_requests` row (kind `tool_approval`) is created with a 30-minute TTL.
-4. The guardian is notified via the shared notification pipeline (`emitNotificationSignal`), which routes the escalation alert to all configured channels (Telegram push, desktop notification).
-5. On **approve**, the stored payload is replayed through the agent pipeline and the assistant's response is delivered to the external user. On **deny**, a refusal message is sent.
 
 ### How the Systems Connect
 
 Guardian verification and ingress contact management are complementary but independent systems:
 
-- **Guardian verification** establishes _who controls the assistant_ on a given channel. The guardian can approve sensitive actions, approve escalated messages, and is the trust anchor.
+- **Guardian verification** establishes _who controls the assistant_ on a given channel. The guardian can approve sensitive actions and is the trust anchor.
 - **Ingress contacts** control _who can interact with the assistant_ on a given channel. Contacts are created via invite redemption, not via guardian verification.
-- **Dependency**: Escalation requires a guardian binding — if no guardian has been verified for the channel, `escalate` policy messages are denied. This means guardian verification must precede any escalation-based access control.
 
 ### Key Modules
 
@@ -307,7 +295,7 @@ Guardian verification and ingress contact management are complementary but indep
 | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `src/runtime/channel-verification-service.ts`       | Verification lifecycle: `createInboundVerificationSession`, `validateAndConsumeVerification`, `getGuardianBinding`, `isGuardian` |
 | `src/runtime/trust-context-resolver.ts`             | Actor role classification: guardian / non-guardian / unverified_channel                                                          |
-| `src/runtime/routes/inbound-message-handler.ts`     | Ingress ACL enforcement, verification-code intercept, escalation creation                                                        |
+| `src/runtime/routes/inbound-message-handler.ts`     | Ingress ACL enforcement, verification-code intercept                                                                             |
 | `src/contacts/contact-store.ts`                     | Contact + channel CRUD: `findContactChannel`, `upsertContact`, `updateChannelStatus`, `searchContacts`                           |
 | `src/memory/channel-verification-sessions.ts`       | Guardian binding types and verification challenge persistence                                                                    |
 | `src/memory/guardian-approvals.ts`                  | Approval request persistence                                                                                                     |
@@ -366,11 +354,11 @@ All endpoints are bearer-authenticated. Skills and clients should call the gatew
 | `src/runtime/channel-readiness-service.ts`       | Service class with probe registration, cached readiness evaluation, and built-in channel probes |
 | `src/runtime/routes/channel-readiness-routes.ts` | HTTP route handlers for `/v1/channels/readiness` and `/v1/channels/readiness/refresh`           |
 
-## Ingress Membership + Escalation
+## Ingress Membership
 
 Secure cross-user messaging allows external users (non-guardians) to interact with the assistant through channels (Telegram) under the owner's control. Access is governed by an invite-based membership system with per-member policy enforcement.
 
-### Ingress Membership
+### Invite-Based Onboarding
 
 External users join through **invite tokens**. There are two invite flows:
 
@@ -399,17 +387,8 @@ Redemption auto-creates a **member** record with an access policy:
 
 - **`allow`** — Messages are processed normally through the agent pipeline.
 - **`deny`** — Messages are rejected with a refusal notice.
-- **`escalate`** — Messages are held for guardian (owner) approval before processing.
 
 Non-members (senders with no invite redemption) are denied by default. Contacts can be listed, updated, revoked, or blocked via the HTTP API (`/v1/contacts` and `/v1/contact-channels`).
-
-### Escalation Flow
-
-When a member's policy is `escalate`, inbound messages create a gateway `guardian_requests` row and the guardian is notified through the shared notification pipeline (`emitNotificationSignal`). The pipeline routes the escalation alert to all configured channels (Telegram push, desktop notification).
-
-On **approve**: the original message payload is recovered from the channel delivery store and processed through the agent pipeline. The assistant's reply is delivered back to the external user via the gateway. On **deny**: a refusal message is sent to the external user.
-
-If no guardian binding exists, escalation fails closed — the message is denied rather than left in a silent wait state.
 
 ### HTTP API
 
@@ -423,7 +402,7 @@ If no guardian binding exists, escalation fails closed — the message is denied
 | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `src/contacts/contact-store.ts`                           | Contact + channel CRUD with policy enforcement                                                                   |
 | `src/runtime/routes/contact-routes.ts`                    | HTTP/IPC invite handlers — relay mint/list/revoke/redeem to the gateway's invite IPC routes                      |
-| `src/runtime/routes/inbound-message-handler.ts`           | ACL enforcement point — member lookup, policy check, escalation creation                                         |
+| `src/runtime/routes/inbound-message-handler.ts`           | ACL enforcement point — member lookup, policy check                                                              |
 | `gateway/src/verification/invite-redemption.ts` (gateway) | Core redemption engine — token/code validation, atomic claim, ACL activation, discriminated-union outcomes       |
 | `src/runtime/channel-invite-transport.ts`                 | Transport adapter registry — `buildShareableInvite` / `extractInboundToken` per channel                          |
 | `src/runtime/channel-invite-transports/telegram.ts`       | Telegram adapter — builds `t.me/<bot>?start=iv_<token>` deep links, extracts `iv_` tokens from `/start` commands |

--- a/assistant/src/calls/call-setup-router.ts
+++ b/assistant/src/calls/call-setup-router.ts
@@ -279,7 +279,7 @@ export async function routeSetup(ctx: SetupContext): Promise<{
 
   // Floor-deny outcome shared by the unknown-caller and member-caller branches.
   // Live calls cannot await async re-verification, so the floor's
-  // `shouldChallenge` upgrade UX is not surfaced — same rationale as `escalate`.
+  // `shouldChallenge` upgrade UX is not surfaced.
   const floorDeny = (
     denyVerdict: Extract<AdmissionPolicyResult, { admitted: false }>,
   ) => {

--- a/assistant/src/cli/commands/contacts.help.ts
+++ b/assistant/src/cli/commands/contacts.help.ts
@@ -130,7 +130,7 @@ Run \`assistant contacts prompt --help\` for full option details.`,
 Channels represent external communication endpoints linked to contacts —
 phone numbers, Telegram IDs, email addresses, etc. Each channel has a
 status (active, pending, revoked, blocked, unverified) and a policy
-(allow, deny, escalate) that controls how the assistant handles messages
+(allow, deny) that controls how the assistant handles messages
 from that channel.
 
 Examples:
@@ -148,7 +148,7 @@ Examples:
             },
             {
               flags: "--policy <policy>",
-              description: "New channel policy: allow, deny, or escalate",
+              description: "New channel policy: allow or deny",
             },
             {
               flags: "--reason <reason>",
@@ -168,7 +168,7 @@ channel record. When --status is "blocked", --reason is mapped to
 blockedReason. The --reason flag is ignored for other status values.
 
 Valid --status values: active, revoked, blocked
-Valid --policy values: allow, deny, escalate
+Valid --policy values: allow, deny
 
 Examples:
   $ assistant contacts channels update-status abc-123 --status revoked --reason "No longer needed" --json

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -90,7 +90,7 @@ The response contains `{ ok: true, contacts: [...] }` where each contact has:
   - `displayName` -- channel-specific display name
   - `username` -- channel username (e.g., Telegram @handle)
   - `status` -- current status (`active`, `revoked`, `blocked`, etc.)
-  - `policy` -- current policy (`allow`, `deny`, `escalate`)
+  - `policy` -- current policy (`allow`, `deny`)
 - `createdAt` -- when the contact was added
 
 **Presenting results**: Format the contact list as a readable table or list. Include display name, role, and per-channel status/policy. If no contacts exist, tell the user their contact list is empty.

--- a/assistant/src/daemon/message-types/inbox.ts
+++ b/assistant/src/daemon/message-types/inbox.ts
@@ -1,4 +1,4 @@
-// Contacts access control: invite management, member management, and escalation decisions.
+// Contacts access control: invite management and member management.
 
 // === Client → Server ===
 
@@ -23,21 +23,6 @@ export interface ContactsInviteRequest {
   externalChatId?: string;
   /** Filter by status (list only). */
   status?: string;
-}
-
-export interface AssistantInboxEscalationRequest {
-  type: "assistant_inbox_escalation";
-  action: "list" | "decide";
-  /** Filter by assistant ID (list only). */
-  assistantId?: string;
-  /** Filter by status (list only). */
-  status?: string;
-  /** Approval request ID (required for decide). */
-  approvalRequestId?: string;
-  /** Decision (required for decide). */
-  decision?: "approve" | "deny";
-  /** Reason for the decision (decide only). */
-  reason?: string;
 }
 
 // === Server → Client ===
@@ -73,36 +58,8 @@ export interface ContactsInviteResponse {
   }>;
 }
 
-export interface AssistantInboxEscalationResponse {
-  type: "assistant_inbox_escalation_response";
-  success: boolean;
-  error?: string;
-  /** List of escalations (returned on list). */
-  escalations?: Array<{
-    id: string;
-    runId: string;
-    conversationId: string;
-    channel: string;
-    requesterExternalUserId: string;
-    requesterChatId: string;
-    status: string;
-    requestSummary?: string;
-    createdAt: number;
-  }>;
-  /** Decision result (returned on decide). */
-  decision?: {
-    id: string;
-    status: string;
-    decidedAt: number;
-  };
-}
-
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _InboxClientMessages =
-  | ContactsInviteRequest
-  | AssistantInboxEscalationRequest;
+export type _InboxClientMessages = ContactsInviteRequest;
 
-export type _InboxServerMessages =
-  | ContactsInviteResponse
-  | AssistantInboxEscalationResponse;
+export type _InboxServerMessages = ContactsInviteResponse;

--- a/assistant/src/notifications/adapters/platform.ts
+++ b/assistant/src/notifications/adapters/platform.ts
@@ -9,7 +9,7 @@
  * with `{ skipped: "flag_off" }` when the flag is OFF — no action needed
  * from the daemon).
  *
- * Guardian-sensitive notifications (approval requests, escalation alerts)
+ * Guardian-sensitive notifications (approval requests, access requests)
  * are annotated with `targetGuardianPrincipalId` so the platform can
  * scope APNs fan-out to guardian-bound devices, mirroring the macOS adapter.
  */

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -510,14 +510,8 @@ flowchart TD
 
     POLICY_CHECK -- deny --> DENY_POLICY["Deny: policy_deny"]
     POLICY_CHECK -- allow --> RECORD
-    POLICY_CHECK -- escalate --> RECORD
 
-    RECORD --> ESCALATE_CHECK{"Policy = escalate?"}
-    ESCALATE_CHECK -- Yes --> HAS_BINDING{"Guardian binding<br/>exists?"}
-    HAS_BINDING -- No --> DENY_ESCALATE["Deny: escalate_no_guardian"]
-    HAS_BINDING -- Yes --> CREATE_APPROVAL["Create approval request<br/>+ notify guardian (dual-surface)"]
-
-    ESCALATE_CHECK -- No --> VERIFY_CHECK{"Guardian verify<br/>code?"}
+    RECORD --> VERIFY_CHECK{"Guardian verify<br/>code?"}
     VERIFY_CHECK -- Yes --> VERIFY["Validate challenge<br/>→ create guardian binding"]
     VERIFY_CHECK -- No --> ROLE_RESOLVE["Resolve actor role<br/>(trust-context-resolver)"]
     ROLE_RESOLVE --> APPROVAL_INTERCEPT["Approval interception<br/>+ message processing"]
@@ -576,12 +570,12 @@ Approval state lives in the gateway's `guardian_requests` table (kind `tool_appr
 | `assistant/src/channels/gateway-verification-sessions.ts` | Guardian binding types and verification-session relay to the gateway store                                                   |
 | `assistant/src/runtime/channel-verification-service.ts`   | Challenge creation/validation, guardian identity checks (`isGuardian()`, `getGuardianBinding()`) -- all accept `assistantId` |
 | `assistant/src/runtime/trust-context-resolver.ts`         | Actor role classification: guardian / non-guardian / unverified_channel based on binding state + sender identity             |
-| `assistant/src/runtime/routes/inbound-message-handler.ts` | Ingress ACL enforcement, verification-code intercept, escalation creation, actor role resolution                             |
+| `assistant/src/runtime/routes/inbound-message-handler.ts` | Ingress ACL enforcement, verification-code intercept, actor role resolution                                                  |
 | `assistant/src/runtime/routes/guardian-expiry-sweep.ts`   | Proactive 60s expiry sweep: gateway CAS-expiry plus card-withdrawal and requester-notice fan-out                             |
 | `assistant/src/calls/guardian-dispatch.ts`                | Cross-channel ASK_GUARDIAN dispatch: creates gateway guardian requests, fans out to mac/telegram, records deliveries         |
 | `assistant/src/calls/guardian-action-sweep.ts`            | Expiry notice delivery to guardian destinations (vellum conversation message or direct channel reply)                        |
 
-### Ingress Membership and Escalation
+### Ingress Membership
 
 The ingress membership system extends the guardian security model to support controlled cross-user access. External users interact with the assistant through channels (Telegram, WhatsApp) under an invite-based membership system with per-member access policies.
 
@@ -592,50 +586,11 @@ The channel inbound handler (`inbound-message-handler.ts`) enforces an access co
 1. When `actorExternalId` is present, the handler looks up the sender in the `contacts` table via `findContactChannel` by `(channelType, externalUserId)` or `(channelType, externalChatId)`.
 2. If no member record exists, the message is denied (`not_a_member`).
 3. If a member exists but is not `active` (e.g., `revoked`, `blocked`), the message is denied.
-4. If the member's `policy` is `deny`, the message is rejected. If `allow`, the message proceeds to normal processing. If `escalate`, the message is held for guardian approval.
+4. If the member's `policy` is `deny`, the message is rejected. If `allow`, the message proceeds to normal processing.
 
 **Invite-based onboarding:** Invite tokens are minted by the gateway via the invite HTTP API and stored SHA-256 hashed on the gateway DB's `ingress_invites` row -- the raw token is returned exactly once at creation time. External users redeem invites by sending the token as a channel message, which atomically creates a member record with `active` status and `allow` policy.
 
-**Relationship to guardian verification:** Guardian verification and ingress contact management are independent systems. Guardian verification establishes who controls the assistant on a channel (the trust anchor for approvals and escalations). Ingress contacts control who can interact with the assistant. Escalation (`policy=escalate`) depends on a guardian binding existing for the channel -- without one, escalated messages are denied (fail-closed).
-
-#### Escalation Data Flow
-
-When a member's policy is `escalate`:
-
-```mermaid
-sequenceDiagram
-    participant Ext as External User
-    participant GW as Gateway
-    participant RT as Runtime (channel-routes)
-    participant DB as SQLite
-    participant Guardian as Guardian (Channel)
-
-    Ext->>GW: Send message via channel
-    GW->>RT: POST /channels/inbound
-    RT->>DB: Look up ingress member -> policy = escalate
-    RT->>DB: Store raw payload (delivery-crud)
-    RT->>GW: Create guardian_requests row (guardian_requests_create)
-    RT->>RT: emitNotificationSignal (escalation alert)
-    RT->>GW: Notify guardian via notification pipeline
-    GW->>Guardian: Deliver escalation notice (Telegram/desktop)
-
-    alt Guardian approves
-        Guardian->>RT: Approve decision
-        RT->>DB: Resolve approval request
-        RT->>DB: Recover stored payload
-        RT->>RT: Process message through agent pipeline
-        RT->>GW: Deliver assistant reply
-        GW->>Ext: Reply via channel
-    else Guardian denies
-        Guardian->>RT: Deny decision
-        RT->>GW: Deliver refusal message
-        GW->>Ext: Refusal via channel
-    end
-```
-
-Escalation alerts are routed through the shared notification pipeline (`emitNotificationSignal`), which delivers to all configured channels (Telegram push, desktop notification). The guardian can approve or deny from any channel. All decisions commit through the gateway's `guardian_requests_decide` route against the same `guardian_requests` row.
-
-If no guardian binding exists for the channel, escalation fails closed -- the message is denied with `escalate_no_guardian`.
+**Relationship to guardian verification:** Guardian verification and ingress contact management are independent systems. Guardian verification establishes who controls the assistant on a channel (the trust anchor for approvals). Ingress contacts control who can interact with the assistant.
 
 #### SQLite Tables
 
@@ -644,7 +599,7 @@ If no guardian binding exists for the channel, escalation fails closed -- the me
 | Table              | Purpose                                                                |
 | ------------------ | ---------------------------------------------------------------------- |
 | `contacts`         | Contact records with role, relationship, and per-contact metadata      |
-| `contact_channels` | Channel bindings per contact with access policy (allow/deny/escalate)  |
+| `contact_channels` | Channel bindings per contact with access policy (allow/deny)           |
 
 **Gateway DB** (`gateway.sqlite` — canonical owner of invites and contact auth/authz):
 
@@ -668,7 +623,7 @@ The gateway declares `contacts` and `contact_channels` tables and exposes them v
 | `assistant/src/contacts/contact-store.ts`                 | Contact and channel lookups (findContactChannel, guardian bindings)        |
 | `assistant/src/contacts/contacts-write.ts`                | Contact and channel identity/info writes (upsert, redemption info mirror — ACL is gateway-owned) |
 | `assistant/src/ipc/routes/invite-ipc-routes.ts`           | `invite_redeemed` info mirror — local contact/channel identity upsert      |
-| `assistant/src/runtime/routes/inbound-message-handler.ts` | ACL enforcement point -- member lookup, policy check, escalation creation  |
+| `assistant/src/runtime/routes/inbound-message-handler.ts` | ACL enforcement point -- member lookup, policy check                       |
 | `gateway/src/db/contact-store.ts`                         | Gateway-side ContactStore — contact/channel reads and invite CRUD          |
 | `gateway/src/ipc/contact-handlers.ts`                     | IPC route handlers for contact reads                                       |
 

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -15,7 +15,7 @@
     },
     "contacts": {
       "docsSlug": "contacts",
-      "sha256": "41289fd9467deafe39eecf1a5484799642755332f3ff1fb963aa51b8983bb2bf"
+      "sha256": "8dd93ed4ba48690e223f2af4719743b1fd1cb1ece530f13a58d961d871db592d"
     },
     "document-editor": {
       "docsSlug": "document",


### PR DESCRIPTION
## Summary
- Sweeps the removed escalate channel policy out of assistant/README.md, both ARCHITECTURE.md files, the CLI contacts help, and the bundled contacts skill
- Fixes the dangling escalate-rationale comment in call-setup-router.ts
- Grep-gate extras (hits that fit no KEEP bucket, fixed here): deletes the dead `assistant_inbox_escalation` wire types in `assistant/src/daemon/message-types/inbox.ts` (the removed feature's list/decide surface — zero references anywhere) and fixes the stale "escalation alerts" guardian-sensitive comment in `assistant/src/notifications/adapters/platform.ts` (its macOS mirror was already fixed by PR 3)
- Full bucketed repo grep-gate quoted below proves the channel-policy bucket is empty (remaining escalate hits are the unrelated trust-rules intent, escalate-and-wait capability, voice-triage leg, watcher.escalation, plain-English usage, and immutable migration history)
- gateway/ARCHITECTURE.md has no data-migrations listing section (m0005 is not described anywhere), so no m0017 doc entry was added, per plan

Part of plan: remove-escalate-policy.md (PR 5 of 5)

## Grep-gate

Command: `grep -rni 'escalat' assistant gateway packages clients apps cli docs --exclude-dir=node_modules --exclude='.tsbuildinfo'` at this PR's tip — 593 hits in 130 files, every one in a KEEP bucket. **The escalate channel-policy bucket is EMPTY**: the only `policy`-adjacent hits are this plan's own rejection/backstop test pins, m0017, and immutable migration comments (verified by inspecting every `policy|contact|ingress|channel|member|inbox|guardian|approval`-adjacent hit line individually).

<details>
<summary>Per-file bucketed listing (593 hits, 130 files)</summary>

**(a) trust-rules intent (`auto_approve|escalate`, incl. openapi specs)** — 12 hits in 7 files
- `assistant/openapi.yaml` (1)
- `assistant/src/runtime/routes/suggest-trust-rule-routes.ts` (4)
- `gateway/openapi.json` (1)
- `gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts` (3)
- `gateway/src/__tests__/trust-rule-cache.test.ts` (1)
- `gateway/src/http/routes/trust-rules-routes.ts` (1)
- `gateway/src/ipc/assistant-client.ts` (1)

**(b) `escalate-and-wait` sensitive-tool-approval capability (tool-grant escalation subsystem)** — 79 hits in 13 files
- `assistant/src/__tests__/tool-approval-handler.test.ts` (3)
- `assistant/src/__tests__/tool-grant-request-escalation.test.ts` (10)
- `assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts` (5)
- `assistant/src/approvals/guardian-request-resolvers.ts` (2)
- `assistant/src/runtime/capabilities.test.ts` (3)
- `assistant/src/runtime/capabilities.ts` (6)
- `assistant/src/runtime/confirmation-request-guardian-bridge.ts` (2)
- `assistant/src/runtime/routes/guardian-approval-interception.ts` (1)
- `assistant/src/runtime/tool-grant-request-helper.ts` (4)
- `assistant/src/tools/tool-approval-handler.ts` (39)
- `assistant/src/tools/tool-types.ts` (1)
- `assistant/src/tools/types.ts` (2)
- `gateway/AGENTS.md` (1)

**(c) voice-triage `"escalated"` routing leg (incl. its feature flag)** — 207 hits in 10 files
- `assistant/src/calls/__tests__/voice-control-protocol.test.ts` (9)
- `assistant/src/calls/__tests__/voice-session-bridge.test.ts` (12)
- `assistant/src/calls/__tests__/voice-triage-escalate.test.ts` (36)
- `assistant/src/calls/media-stream-server.ts` (1)
- `assistant/src/calls/voice-control-protocol.ts` (5)
- `assistant/src/calls/voice-session-bridge.ts` (22)
- `assistant/src/calls/voice-triage-escalate.ts` (26)
- `assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts` (52)
- `assistant/src/live-voice/live-voice-session.ts` (40)
- `clients/web/src/lib/feature-flags/feature-flag-registry.json` (4)

**(d) `watcher.escalation` event + watcher_events disposition** — 8 hits in 5 files
- `assistant/src/__tests__/notification-telegram-adapter.test.ts` (2)
- `assistant/src/notifications/copy-composer.ts` (2)
- `assistant/src/notifications/signal.ts` (1)
- `assistant/src/persistence/schema/infrastructure.ts` (1)
- `assistant/src/watcher/engine.ts` (2)

**(f) immutable assistant migration history** — 13 hits in 7 files
- `assistant/src/persistence/migrations/014-backfill-inbox-thread-state.ts` (2)
- `assistant/src/persistence/migrations/112-assistant-inbox.ts` (4)
- `assistant/src/persistence/migrations/129-contact-channels-access-fields.ts` (1)
- `assistant/src/persistence/migrations/136-drop-assistant-id-columns.ts` (2)
- `assistant/src/persistence/migrations/286-workflow-run-trust.ts` (1)
- `assistant/src/persistence/migrations/__tests__/014-backfill-inbox-thread-state.test.ts` (2)
- `assistant/src/persistence/migrations/__tests__/136-drop-assistant-id-columns.test.ts` (1)

**(g) m0017 coercion migration + this plan's test pins (400-rejection / fail-closed backstop)** — 32 hits in 7 files
- `assistant/src/runtime/__tests__/trust-verdict-consumer.test.ts` (2)
- `assistant/src/runtime/trust-verdict-consumer.ts` (1)
- `gateway/src/__tests__/contacts-control-plane-proxy.test.ts` (5)
- `gateway/src/__tests__/data-migration-m0017-coerce-escalate-policy.test.ts` (12)
- `gateway/src/__tests__/ipc-contact-routes.test.ts` (2)
- `gateway/src/db/data-migrations/index.ts` (2)
- `gateway/src/db/data-migrations/m0017-coerce-escalate-policy.ts` (8)

**(e) plain-English privilege-escalation / risk-escalation / log-severity prose and unrelated copy** — 242 hits in 76 files
- `assistant/ARCHITECTURE.md` (5)
- `assistant/docs/architecture/scheduling.md` (2)
- `assistant/docs/architecture/security.md` (5)
- `assistant/docs/credential-execution-service.md` (1)
- `assistant/docs/skills.md` (3)
- `assistant/docs/workflows.md` (1)
- `assistant/src/__tests__/agent-loop.test.ts` (2)
- `assistant/src/__tests__/app-store-dir-names.test.ts` (1)
- `assistant/src/__tests__/channel-retry-sweep.test.ts` (1)
- `assistant/src/__tests__/checker.test.ts` (6)
- `assistant/src/__tests__/context-overflow-reducer.test.ts` (1)
- `assistant/src/__tests__/conversation-agent-loop-overflow.test.ts` (4)
- `assistant/src/__tests__/conversation-agent-loop.test.ts` (1)
- `assistant/src/__tests__/conversation-runtime-assembly.test.ts` (1)
- `assistant/src/__tests__/host-cu-proxy.test.ts` (1)
- `assistant/src/__tests__/qdrant-manager.test.ts` (1)
- `assistant/src/__tests__/slack-channels-routes.test.ts` (2)
- `assistant/src/__tests__/system-prompt.test.ts` (2)
- `assistant/src/cli/lib/bundled-marketplace.json` (1)
- `assistant/src/config/bundled-skills/schedule/references/SCRIPT_MODE_PATTERNS.md` (3)
- `assistant/src/config/schemas/llm.ts` (1)
- `assistant/src/context/compactor.ts` (1)
- `assistant/src/daemon/__tests__/route-conversation-post.test.ts` (2)
- `assistant/src/daemon/conversation-agent-loop-handlers.ts` (3)
- `assistant/src/daemon/conversation-agent-loop.ts` (2)
- `assistant/src/daemon/conversation-turn-finalize.ts` (1)
- `assistant/src/daemon/host-cu-proxy.ts` (1)
- `assistant/src/daemon/route-conversation-post.ts` (1)
- `assistant/src/notifications/AGENTS.md` (1)
- `assistant/src/notifications/guardian-delivery-recorder.ts` (1)
- `assistant/src/permissions/checker.ts` (2)
- `assistant/src/permissions/ipc-risk-types.ts` (2)
- `assistant/src/permissions/risk-types.ts` (1)
- `assistant/src/persistence/job-handlers/message-lexical.ts` (1)
- `assistant/src/plugins/defaults/compaction/compact.ts` (1)
- `assistant/src/plugins/defaults/compaction/context-overflow-reducer.ts` (1)
- `assistant/src/plugins/defaults/compaction/window-manager.ts` (4)
- `assistant/src/plugins/defaults/memory/memory-retrospective-job.ts` (1)
- `assistant/src/prompts/templates/SOUL.md` (1)
- `assistant/src/runtime/channel-retry-sweep.ts` (2)
- `assistant/src/runtime/trust-class.ts` (1)
- `assistant/src/util/platform.ts` (6)
- `assistant/src/workflows/run-manager.test.ts` (2)
- `assistant/src/workflows/run-manager.ts` (1)
- `cli/src/lib/nginx-ingress.ts` (1)
- `clients/macos/scripts/reclaim-dev-port.ts` (1)
- `clients/web/src/assistant/lifecycle-service.ts` (1)
- `clients/web/src/components/disk-pressure-banner.tsx` (1)
- `clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx` (1)
- `clients/web/src/domains/chat/chat-page.tsx` (1)
- `clients/web/src/domains/chat/hooks/use-stuck-connecting.test.tsx` (2)
- `clients/web/src/domains/chat/hooks/use-stuck-connecting.ts` (1)
- `clients/web/src/domains/chat/onboarding-research/research-activity-feed.tsx` (1)
- `clients/web/src/domains/contacts/contacts-page.test.tsx` (1)
- `clients/web/src/domains/settings/pages/notifications-page.test.tsx` (1)
- `clients/web/src/utils/mutation-error.ts` (1)
- `docs/internal-reference.md` (1)
- `gateway/ARCHITECTURE.md` (1)
- `gateway/src/__tests__/bash-risk-classifier.test.ts` (4)
- `gateway/src/__tests__/contact-store-mirror-op-missing.test.ts` (7)
- `gateway/src/db/contact-store.ts` (3)
- `gateway/src/ipc/risk-classification-handlers.test.ts` (4)
- `gateway/src/ipc/risk-classification-handlers.ts` (4)
- `gateway/src/risk/bash-risk-classifier.test.ts` (36)
- `gateway/src/risk/bash-risk-classifier.ts` (26)
- `gateway/src/risk/command-registry.test.ts` (3)
- `gateway/src/risk/command-registry/AGENTS.md` (1)
- `gateway/src/risk/file-risk-classifier.test.ts` (24)
- `gateway/src/risk/file-risk-classifier.ts` (15)
- `gateway/src/risk/risk-types.ts` (1)
- `gateway/src/risk/schedule-risk-classifier.test.ts` (3)
- `gateway/src/risk/schedule-risk-classifier.ts` (4)
- `gateway/src/risk/skill-risk-classifier.ts` (2)
- `gateway/src/risk/web-risk-classifier.ts` (3)
- `gateway/src/slack/errors.ts` (1)
- `packages/credential-storage/src/oauth-runtime.ts` (2)

Total: 593 hits

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)