### PR TITLE
ci(plugins): verify plugin-icons.json matches vendored assets on marketplace PRs

### DIFF
--- a/.github/workflows/pr-marketplace.yaml
+++ b/.github/workflows/pr-marketplace.yaml
@@ -52,11 +52,10 @@ jobs:
       - name: Verify bundled copies match canonical sources
         run: bun run meta/sync-bundled-copies.ts --check
 
-  # The check is purely local: it verifies plugins/plugin-icons.json matches the
-  # vendored PNGs under plugins/assets/, so the derived manifest can't drift from
-  # the assets a PR commits. It cannot detect that a repinned plugin's upstream
-  # icon.png changed without a regen — write mode is network-bound and author-run.
-  # A future non-blocking network drift job could harden that gap; do not build it here.
+  # Purely local: verifies plugins/plugin-icons.json matches the vendored PNGs
+  # under plugins/assets/, so the derived manifest can't drift from the assets a
+  # PR commits. Does not re-fetch upstream, so a repinned plugin whose upstream
+  # icon.png changed without a regen is not detected here.
   check-plugin-icons:
     name: Check Plugin Icons In Sync
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-marketplace.yaml
+++ b/.github/workflows/pr-marketplace.yaml
@@ -10,6 +10,9 @@ on:
       - 'meta/sync-bundled-copies.ts'
       - 'assistant/src/cli/lib/bundled-marketplace.json'
       - 'clients/web/src/lib/feature-flags/feature-flag-registry.json'
+      - 'plugins/assets/**'
+      - 'plugins/plugin-icons.json'
+      - 'scripts/plugins/generate-plugin-icons.mjs'
       - '.github/workflows/pr-marketplace.yaml'
 
 concurrency:
@@ -48,3 +51,24 @@ jobs:
 
       - name: Verify bundled copies match canonical sources
         run: bun run meta/sync-bundled-copies.ts --check
+
+  # The check is purely local: it verifies plugins/plugin-icons.json matches the
+  # vendored PNGs under plugins/assets/, so the derived manifest can't drift from
+  # the assets a PR commits. It cannot detect that a repinned plugin's upstream
+  # icon.png changed without a regen — write mode is network-bound and author-run.
+  # A future non-blocking network drift job could harden that gap; do not build it here.
+  check-plugin-icons:
+    name: Check Plugin Icons In Sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22.22.2'
+
+      - name: Verify plugin-icons.json matches vendored assets
+        run: node scripts/plugins/generate-plugin-icons.mjs --check


### PR DESCRIPTION
## Summary
- Adds a check-plugin-icons job to pr-marketplace.yaml running the network-free `node scripts/plugins/generate-plugin-icons.mjs --check`, and adds plugins/assets/**, plugins/plugin-icons.json, and the generator script to the workflow's paths triggers, so the derived manifest can't drift from the vendored PNGs. Documents the repin caveat.

Part of plan: plugin-icons-marketing.md (PR 5 of 6)