### PR TITLE
feat(tts): managed streaming TTS through the gateway speech relay (R2)

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/vellum-speech-relay-connection.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/vellum-speech-relay-connection.test.ts
@@ -63,7 +63,7 @@ describe("mapVelayError", () => {
     });
     expect(mapVelayError({ code: "invalid_token" })).toMatchObject({
       category: "auth",
-      message: expect.stringContaining("service token"),
+      message: expect.stringContaining("restart the assistant"),
     });
     expect(mapVelayError({ code: "insufficient_balance" })).toMatchObject({
       category: "provider-error",

--- a/assistant/src/providers/speech-to-text/vellum-speech-relay-connection.ts
+++ b/assistant/src/providers/speech-to-text/vellum-speech-relay-connection.ts
@@ -109,7 +109,7 @@ export function mapVelayError(error: VelayErrorInfo): {
       return {
         category: "auth",
         message:
-          "The gateway rejected the daemon's service token for managed speech — the daemon and gateway may be out of sync; restart the assistant services.",
+          "The assistant's managed-speech session was rejected by its gateway — the services may be out of sync; restart the assistant.",
       };
     case "insufficient_balance":
       return {

--- a/assistant/src/tts/__tests__/vellum-provider.test.ts
+++ b/assistant/src/tts/__tests__/vellum-provider.test.ts
@@ -177,6 +177,9 @@ describe("vellum TTS streaming", () => {
     expect(url.searchParams.get("key")).toBe("tok-1");
     expect(url.searchParams.get("encoding")).toBe("linear16");
     expect(url.searchParams.get("sample_rate")).toBe("16000");
+    // Raw PCM, not Deepgram's default WAV container — RIFF headers would
+    // play as static on the headerless media-stream path.
+    expect(url.searchParams.get("container")).toBe("none");
     expect(result.contentType).toBe("audio/pcm");
     expect(chunks).toHaveLength(1);
     // Batch path untouched.

--- a/assistant/src/tts/__tests__/vellum-provider.test.ts
+++ b/assistant/src/tts/__tests__/vellum-provider.test.ts
@@ -18,6 +18,41 @@ mock.module("../../platform/managed-speech.js", () => ({
   },
 }));
 
+let mockRelayConnection: {
+  wsBaseUrl: string;
+  httpBaseUrl: string;
+  mintServiceToken: () => string;
+} | null = null;
+
+mock.module(
+  "../../providers/speech-to-text/vellum-speech-relay-connection.js",
+  () => ({
+    resolveSpeechRelayConnection: async () => mockRelayConnection,
+    mapVelayError: (e: { code: string }) => ({
+      category: "provider-error",
+      message: `mapped:${e.code}`,
+    }),
+    probeVelayRejection: async () => mockProbeRejection,
+  }),
+);
+let mockProbeRejection: { code: string; detail?: string } | null = null;
+
+let socketCalls: Array<{ url: string; text: string }> = [];
+let mockSocketResult: () => Promise<Buffer> = async () => Buffer.from("pcm");
+
+mock.module("../providers/vellum-tts-socket.js", () => ({
+  synthesizeOverVellumTtsSocket: async (opts: {
+    url: string;
+    text: string;
+    onChunk?: (c: Uint8Array) => void;
+  }) => {
+    socketCalls.push({ url: opts.url, text: opts.text });
+    const audio = await mockSocketResult();
+    opts.onChunk?.(audio);
+    return audio;
+  },
+}));
+
 import {
   createVellumProvider,
   vellumTtsProviderDefinition,
@@ -39,6 +74,14 @@ function request(
 describe("vellum TTS adapter", () => {
   beforeEach(() => {
     synthesizeCalls = [];
+    socketCalls = [];
+    mockProbeRejection = null;
+    mockSocketResult = async () => Buffer.from("pcm");
+    mockRelayConnection = {
+      wsBaseUrl: "ws://gateway.test",
+      httpBaseUrl: "http://gateway.test",
+      mintServiceToken: () => "tok-1",
+    };
     mockSynthesizeResult = {
       ok: true,
       value: { audio: MP3_BYTES, contentType: "audio/mpeg" },
@@ -101,10 +144,89 @@ describe("vellum TTS adapter", () => {
   });
 });
 
+describe("vellum TTS streaming", () => {
+  beforeEach(() => {
+    synthesizeCalls = [];
+    socketCalls = [];
+    mockProbeRejection = null;
+    mockSocketResult = async () => Buffer.from("pcm");
+    mockRelayConnection = {
+      wsBaseUrl: "ws://gateway.test",
+      httpBaseUrl: "http://gateway.test",
+      mintServiceToken: () => "tok-1",
+    };
+    mockSynthesizeResult = {
+      ok: true,
+      value: { audio: MP3_BYTES, contentType: "audio/mpeg" },
+    };
+  });
+
+  test("PCM streaming dials the gateway relay with token and audio params", async () => {
+    const provider = createVellumProvider();
+    const chunks: Uint8Array[] = [];
+
+    const result = await provider.synthesizeStream!(
+      request({ outputFormat: "pcm" }),
+      (c) => chunks.push(c),
+    );
+
+    expect(socketCalls).toHaveLength(1);
+    const url = new URL(socketCalls[0]!.url);
+    expect(url.origin).toBe("ws://gateway.test");
+    expect(url.pathname).toBe("/v1/speech/tts/stream");
+    expect(url.searchParams.get("key")).toBe("tok-1");
+    expect(url.searchParams.get("encoding")).toBe("linear16");
+    expect(url.searchParams.get("sample_rate")).toBe("16000");
+    expect(result.contentType).toBe("audio/pcm");
+    expect(chunks).toHaveLength(1);
+    // Batch path untouched.
+    expect(synthesizeCalls).toHaveLength(0);
+  });
+
+  test("non-PCM streaming delegates to the batch path with one chunk", async () => {
+    const provider = createVellumProvider();
+    const chunks: Uint8Array[] = [];
+
+    const result = await provider.synthesizeStream!(request(), (c) =>
+      chunks.push(c),
+    );
+
+    expect(socketCalls).toHaveLength(0);
+    expect(synthesizeCalls).toEqual([{ text: "hello", format: "mp3" }]);
+    expect(result.contentType).toBe("audio/mpeg");
+    expect(chunks).toHaveLength(1);
+  });
+
+  test("a rejected dial surfaces the relay's mapped rejection via the probe", async () => {
+    mockSocketResult = async () => {
+      throw new Error("socket closed before Flushed");
+    };
+    mockProbeRejection = { code: "insufficient_balance" };
+    const provider = createVellumProvider();
+
+    await expect(
+      provider.synthesizeStream!(request({ outputFormat: "pcm" }), () => {}),
+    ).rejects.toThrow("mapped:insufficient_balance");
+  });
+
+  test("no relay connection throws a connect-your-account message", async () => {
+    mockRelayConnection = null;
+    const provider = createVellumProvider();
+
+    await expect(
+      provider.synthesizeStream!(request({ outputFormat: "pcm" }), () => {}),
+    ).rejects.toThrow(/platform connect/);
+  });
+
+  test("streaming capability is advertised", () => {
+    expect(createVellumProvider().capabilities.supportsStreaming).toBe(true);
+  });
+});
+
 describe("vellum TTS definition", () => {
-  test("declares batch-only synthesized-play with PCM media-stream playback", () => {
+  test("declares streaming synthesized-play with PCM media-stream playback", () => {
     expect(vellumTtsProviderDefinition.capabilities.supportsStreaming).toBe(
-      false,
+      true,
     );
     expect(vellumTtsProviderDefinition.callMode).toBe("synthesized-play");
     expect(vellumTtsProviderDefinition.allowNativeFallback).toBe(false);

--- a/assistant/src/tts/providers/__tests__/vellum-tts-socket.test.ts
+++ b/assistant/src/tts/providers/__tests__/vellum-tts-socket.test.ts
@@ -239,6 +239,22 @@ describe("synthesizeOverVellumTtsSocket", () => {
     expect(audio.toString()).toBe("late");
   });
 
+  test("control frames alone cannot keep a stuck stream open", async () => {
+    // A stream that heartbeats Metadata/Warning without ever producing
+    // audio must still fail on the first-audio budget.
+    const session = startSession({ firstChunkTimeoutMs: 30 });
+    mockWs.simulateOpen();
+    const heartbeat = setInterval(() => {
+      mockWs.simulateMessage(JSON.stringify({ type: "Metadata" }));
+    }, 5);
+
+    try {
+      await expect(session).rejects.toThrow("timeout:30");
+    } finally {
+      clearInterval(heartbeat);
+    }
+  });
+
   test("pre-aborted signal rejects without dialing frames", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/assistant/src/tts/providers/__tests__/vellum-tts-socket.test.ts
+++ b/assistant/src/tts/providers/__tests__/vellum-tts-socket.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { VellumTtsSocketOptions } from "../vellum-tts-socket.js";
+import { synthesizeOverVellumTtsSocket } from "../vellum-tts-socket.js";
+
+const TEST_URL =
+  "ws://gateway.test/v1/speech/tts/stream?key=tok&encoding=linear16&sample_rate=16000";
+
+type WsEventType = "open" | "close" | "error" | "message";
+type WsListener = (...args: unknown[]) => void;
+
+/** Minimal mock WebSocket simulating the gateway speech relay. */
+class MockWebSocket {
+  readyState = 0;
+  binaryType = "";
+  sentData: (string | Uint8Array)[] = [];
+  closeCalled = false;
+
+  private listeners = new Map<WsEventType, WsListener[]>();
+
+  addEventListener(type: WsEventType, listener: WsListener): void {
+    const list = this.listeners.get(type) ?? [];
+    list.push(listener);
+    this.listeners.set(type, list);
+  }
+
+  send(data: string | Uint8Array): void {
+    if (this.readyState !== 1) {
+      throw new Error("WebSocket is not open");
+    }
+    this.sentData.push(data);
+  }
+
+  close(): void {
+    this.closeCalled = true;
+    this.readyState = 3;
+  }
+
+  simulateOpen(): void {
+    this.readyState = 1;
+    for (const l of this.listeners.get("open") ?? []) {
+      l();
+    }
+  }
+
+  simulateMessage(data: unknown): void {
+    for (const l of this.listeners.get("message") ?? []) {
+      l({ data });
+    }
+  }
+
+  simulateClose(code = 1000, reason = ""): void {
+    this.readyState = 3;
+    for (const l of this.listeners.get("close") ?? []) {
+      l({ code, reason });
+    }
+  }
+
+  simulateError(err: unknown = new Error("boom")): void {
+    for (const l of this.listeners.get("error") ?? []) {
+      l(err);
+    }
+  }
+}
+
+function audioFrame(bytes: string): ArrayBuffer {
+  const buf = Buffer.from(bytes);
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+}
+
+function sentJson(ws: MockWebSocket): Array<Record<string, unknown>> {
+  return ws.sentData
+    .filter((d): d is string => typeof d === "string")
+    .map((d) => JSON.parse(d) as Record<string, unknown>);
+}
+
+describe("synthesizeOverVellumTtsSocket", () => {
+  let mockWs: MockWebSocket;
+  let originalWebSocket: unknown;
+
+  beforeEach(() => {
+    mockWs = new MockWebSocket();
+    originalWebSocket = (globalThis as Record<string, unknown>).WebSocket;
+    (globalThis as Record<string, unknown>).WebSocket = class {
+      constructor(_url: string) {
+        return mockWs;
+      }
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).WebSocket = originalWebSocket;
+  });
+
+  function startSession(
+    overrides: Partial<VellumTtsSocketOptions> = {},
+  ): Promise<Buffer> {
+    return synthesizeOverVellumTtsSocket({
+      url: TEST_URL,
+      text: "hello world",
+      makeTimeoutError: (ms) => new Error(`timeout:${ms}`),
+      makeStreamError: (detail) => new Error(`stream:${detail}`),
+      makeEmptyError: () => new Error("empty"),
+      makeRelayError: (code, detail) => new Error(`relay:${code}:${detail}`),
+      ...overrides,
+    });
+  }
+
+  test("sends Speak then Flush, resolves concatenated audio on Flushed", async () => {
+    const chunks: Uint8Array[] = [];
+    const session = startSession({ onChunk: (c) => chunks.push(c) });
+
+    mockWs.simulateOpen();
+    expect(sentJson(mockWs)).toEqual([
+      { type: "Speak", text: "hello world" },
+      { type: "Flush" },
+    ]);
+    expect(mockWs.binaryType).toBe("arraybuffer");
+
+    mockWs.simulateMessage(audioFrame("aaa"));
+    mockWs.simulateMessage(JSON.stringify({ type: "Metadata" }));
+    mockWs.simulateMessage(audioFrame("bbb"));
+    mockWs.simulateMessage(JSON.stringify({ type: "Flushed" }));
+
+    const audio = await session;
+    expect(audio.toString()).toBe("aaabbb");
+    expect(chunks.map((c) => Buffer.from(c).toString())).toEqual([
+      "aaa",
+      "bbb",
+    ]);
+    // Close is sent after Flushed, then the socket is torn down.
+    expect(sentJson(mockWs).at(-1)).toEqual({ type: "Close" });
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  test("splits long text into 2000-char Speak frames before one Flush", async () => {
+    const text = "x".repeat(4500);
+    const session = startSession({ text });
+
+    mockWs.simulateOpen();
+    const frames = sentJson(mockWs);
+    expect(frames.map((f) => f.type)).toEqual([
+      "Speak",
+      "Speak",
+      "Speak",
+      "Flush",
+    ]);
+    expect(
+      frames
+        .slice(0, 3)
+        .map((f) => (f.text as string).length)
+        .reduce((a, b) => a + b, 0),
+    ).toBe(4500);
+
+    mockWs.simulateMessage(audioFrame("a"));
+    mockWs.simulateMessage(JSON.stringify({ type: "Flushed" }));
+    await session;
+  });
+
+  test("a velay_error frame fails via the relay-error factory", async () => {
+    const session = startSession();
+    mockWs.simulateOpen();
+
+    mockWs.simulateMessage(
+      JSON.stringify({
+        type: "velay_error",
+        code: "insufficient_balance",
+        detail: "empty",
+      }),
+    );
+
+    await expect(session).rejects.toThrow("relay:insufficient_balance:empty");
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  test("abort sends Clear and Close for barge-in, rejects with the abort reason", async () => {
+    const controller = new AbortController();
+    const session = startSession({ signal: controller.signal });
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(audioFrame("partial"));
+
+    controller.abort();
+
+    await expect(session).rejects.toThrow(/aborted/i);
+    const frames = sentJson(mockWs);
+    expect(frames.at(-2)).toEqual({ type: "Clear" });
+    expect(frames.at(-1)).toEqual({ type: "Close" });
+    expect(mockWs.closeCalled).toBe(true);
+  });
+
+  test("close before Flushed fails via the stream-error factory", async () => {
+    const session = startSession();
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(audioFrame("partial"));
+
+    mockWs.simulateClose(1011, "upstream_error");
+
+    await expect(session).rejects.toThrow(/stream:socket closed/);
+  });
+
+  test("Flushed with no audio fails via the empty-error factory", async () => {
+    const session = startSession();
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(JSON.stringify({ type: "Flushed" }));
+
+    await expect(session).rejects.toThrow("empty");
+  });
+
+  test("typed-array binary frames are forwarded as chunks", async () => {
+    const chunks: Uint8Array[] = [];
+    const session = startSession({ onChunk: (c) => chunks.push(c) });
+    mockWs.simulateOpen();
+
+    mockWs.simulateMessage(new Uint8Array(Buffer.from("view")));
+    mockWs.simulateMessage(JSON.stringify({ type: "Flushed" }));
+
+    const audio = await session;
+    expect(audio.toString()).toBe("view");
+    expect(chunks).toHaveLength(1);
+  });
+
+  test("pre-aborted signal rejects without dialing frames", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const session = startSession({ signal: controller.signal });
+
+    await expect(session).rejects.toThrow(/aborted/i);
+    expect(mockWs.sentData).toHaveLength(0);
+  });
+});

--- a/assistant/src/tts/providers/__tests__/vellum-tts-socket.test.ts
+++ b/assistant/src/tts/providers/__tests__/vellum-tts-socket.test.ts
@@ -219,6 +219,26 @@ describe("synthesizeOverVellumTtsSocket", () => {
     expect(chunks).toHaveLength(1);
   });
 
+  test("control frames do not collapse the first-chunk budget", async () => {
+    // Deepgram sends Metadata immediately on connect; the stall budget must
+    // stay on firstChunkTimeoutMs until actual audio arrives.
+    const session = startSession({
+      firstChunkTimeoutMs: 50,
+      idleTimeoutMs: 1,
+    });
+    mockWs.simulateOpen();
+    mockWs.simulateMessage(JSON.stringify({ type: "Metadata" }));
+
+    // Idle budget (1ms) would have expired well within this window; the
+    // first-chunk budget (50ms) has not.
+    await new Promise((r) => setTimeout(r, 20));
+    mockWs.simulateMessage(audioFrame("late"));
+    mockWs.simulateMessage(JSON.stringify({ type: "Flushed" }));
+
+    const audio = await session;
+    expect(audio.toString()).toBe("late");
+  });
+
   test("pre-aborted signal rejects without dialing frames", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/assistant/src/tts/providers/vellum-provider.ts
+++ b/assistant/src/tts/providers/vellum-provider.ts
@@ -117,6 +117,9 @@ async function performStreamingSynthesis(
     key: connection.mintServiceToken(),
     encoding: "linear16",
     sample_rate: String(VELLUM_PCM_SAMPLE_RATE_HZ),
+    // Deepgram defaults linear16 to a WAV container; the media-stream path
+    // consumes headerless PCM, so RIFF header bytes would play as static.
+    container: "none",
   });
   const url = `${connection.wsBaseUrl}${TTS_STREAM_PATH}?${params.toString()}`;
 

--- a/assistant/src/tts/providers/vellum-provider.ts
+++ b/assistant/src/tts/providers/vellum-provider.ts
@@ -1,11 +1,18 @@
 /**
  * Vellum-managed TTS: synthesis through the platform's managed speech
- * endpoint (Vellum-held Deepgram key, billed to Vellum credits). No provider
+ * surfaces (Vellum-held Deepgram key, billed to Vellum credits). No provider
  * API key exists on this machine — the platform connection is the credential.
  *
- * Batch-only: `supportsStreaming: false`. `allowNativeFallback: false` means
- * synthesis failures propagate to the caller's error handler, so failures
- * here throw with user-actionable messages rather than returning silence.
+ * Two paths:
+ * - Batch `synthesize` (read-aloud, mp3 surfaces) via the Django endpoint.
+ * - Streaming `synthesizeStream` (live voice, telephony PCM) via the
+ *   gateway's speech relay (gateway → velay → Deepgram; velay contact is
+ *   gateway-only — the daemon holds no velay address and no speech
+ *   credential).
+ *
+ * `allowNativeFallback: false` means synthesis failures propagate to the
+ * caller's error handler, so failures here throw with user-actionable
+ * messages rather than returning silence.
  */
 
 import {
@@ -13,6 +20,12 @@ import {
   managedSpeechSynthesize,
   type ManagedSpeechTtsFormat,
 } from "../../platform/managed-speech.js";
+import {
+  mapVelayError,
+  probeVelayRejection,
+  resolveSpeechRelayConnection,
+} from "../../providers/speech-to-text/vellum-speech-relay-connection.js";
+import { getLogger } from "../../util/logger.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
 import type {
   TtsProvider,
@@ -20,6 +33,11 @@ import type {
   TtsSynthesisRequest,
   TtsSynthesisResult,
 } from "../types.js";
+import { synthesizeOverVellumTtsSocket } from "./vellum-tts-socket.js";
+
+const log = getLogger("vellum-tts");
+
+const TTS_STREAM_PATH = "/v1/speech/tts/stream";
 
 /**
  * The platform's PCM format is fixed at 16 kHz, 16-bit LE mono — the
@@ -72,9 +90,81 @@ async function performSynthesis(
   };
 }
 
+/**
+ * Stream one PCM utterance through the gateway's speech relay. Non-PCM
+ * requests delegate to the batch path — streaming exists for realtime PCM
+ * consumers (live voice, telephony), and the relay's format is pinned to
+ * linear16.
+ */
+async function performStreamingSynthesis(
+  request: TtsSynthesisRequest,
+  onChunk: (chunk: Uint8Array) => void,
+): Promise<TtsSynthesisResult> {
+  if (request.outputFormat !== "pcm") {
+    const result = await performSynthesis(request);
+    onChunk(result.audio);
+    return result;
+  }
+
+  const connection = await resolveSpeechRelayConnection();
+  if (!connection) {
+    throw new Error(
+      "Managed speech is unavailable: the daemon cannot reach the gateway's speech relay. Run 'assistant platform connect' to connect your Vellum account.",
+    );
+  }
+
+  const params = new URLSearchParams({
+    key: connection.mintServiceToken(),
+    encoding: "linear16",
+    sample_rate: String(VELLUM_PCM_SAMPLE_RATE_HZ),
+  });
+  const url = `${connection.wsBaseUrl}${TTS_STREAM_PATH}?${params.toString()}`;
+
+  log.info(
+    { textLength: request.text.length },
+    "Starting managed streaming TTS synthesis",
+  );
+
+  try {
+    const audio = await synthesizeOverVellumTtsSocket({
+      url,
+      text: request.text,
+      onChunk,
+      signal: request.signal,
+      makeTimeoutError: (timeoutMs) =>
+        new Error(`Managed streaming TTS timed out after ${timeoutMs}ms`),
+      makeStreamError: (detail) =>
+        new Error(`Managed streaming TTS failed: ${detail}`),
+      makeEmptyError: () =>
+        new Error("Managed streaming TTS returned no audio"),
+      makeRelayError: (code, detail) =>
+        new Error(mapVelayError({ code, detail }).message),
+    });
+    return {
+      audio,
+      contentType: "audio/pcm",
+    };
+  } catch (err) {
+    if (request.signal?.aborted) {
+      throw err;
+    }
+    // A rejected upgrade hides the relay's {code, detail}; replay the gate
+    // as a plain GET (the gateway probes velay's own gate too) so auth and
+    // balance failures surface with their mapped messages.
+    const probeKey = encodeURIComponent(connection.mintServiceToken());
+    const rejection = await probeVelayRejection(
+      `${connection.httpBaseUrl}${TTS_STREAM_PATH}?key=${probeKey}`,
+    );
+    if (rejection) {
+      throw new Error(mapVelayError(rejection).message);
+    }
+    throw err;
+  }
+}
+
 export function createVellumProvider(): TtsProvider {
   const capabilities: TtsProviderCapabilities = {
-    supportsStreaming: false,
+    supportsStreaming: true,
     supportedFormats: ["mp3", "pcm"],
   };
 
@@ -86,6 +176,7 @@ export function createVellumProvider(): TtsProvider {
     resolveOutputSampleRateHz: (request) =>
       request.outputFormat === "pcm" ? VELLUM_PCM_SAMPLE_RATE_HZ : undefined,
     synthesize: performSynthesis,
+    synthesizeStream: performStreamingSynthesis,
   };
 }
 
@@ -110,7 +201,7 @@ export const vellumTtsProviderDefinition: TtsProviderDefinition = {
   callMode: "synthesized-play",
   allowNativeFallback: false,
   capabilities: {
-    supportsStreaming: false,
+    supportsStreaming: true,
     supportedFormats: ["mp3", "pcm"],
   },
   // The adapter honours the PCM hint via the platform's pcm_16000 format.

--- a/assistant/src/tts/providers/vellum-provider.ts
+++ b/assistant/src/tts/providers/vellum-provider.ts
@@ -109,7 +109,7 @@ async function performStreamingSynthesis(
   const connection = await resolveSpeechRelayConnection();
   if (!connection) {
     throw new Error(
-      "Managed speech is unavailable: the daemon cannot reach the gateway's speech relay. Run 'assistant platform connect' to connect your Vellum account.",
+      "Managed speech is unavailable: the assistant cannot reach its speech relay. Run 'assistant platform connect' to connect your Vellum account.",
     );
   }
 

--- a/assistant/src/tts/providers/vellum-tts-socket.ts
+++ b/assistant/src/tts/providers/vellum-tts-socket.ts
@@ -199,10 +199,12 @@ export function synthesizeOverVellumTtsSocket(
 
     /**
      * (Re)arm the stall timer: first-chunk budget until AUDIO arrives, idle
-     * budget between frames thereafter. Unlike the xAI session (where the
-     * first server frame is audio), Deepgram sends a Metadata control frame
-     * immediately on connect — counting it would collapse the first-chunk
-     * budget to the shorter idle budget before synthesis even starts.
+     * budget between audio chunks thereafter. Only audio drives the timer.
+     * Unlike the xAI session (where the first server frame is audio),
+     * Deepgram emits control frames (Metadata, Warning) around the audio —
+     * counting them would either collapse the first-chunk budget to the
+     * shorter idle budget, or let a stuck stream that heartbeats control
+     * frames without ever producing audio stay open indefinitely.
      */
     const armStallTimer = () => {
       if (stallTimer !== null) {
@@ -260,11 +262,12 @@ export function synthesizeOverVellumTtsSocket(
         return;
       }
 
-      // Binary frames are the audio itself.
+      // Binary frames are the audio itself — and the only thing that
+      // feeds the stall timer.
       if (ev.data instanceof ArrayBuffer || ArrayBuffer.isView(ev.data)) {
         receivedAudio = true;
+        armStallTimer();
       }
-      armStallTimer();
 
       if (ev.data instanceof ArrayBuffer) {
         const chunk = Buffer.from(ev.data);

--- a/assistant/src/tts/providers/vellum-tts-socket.ts
+++ b/assistant/src/tts/providers/vellum-tts-socket.ts
@@ -1,0 +1,369 @@
+/**
+ * Vellum managed TTS WebSocket streaming session.
+ *
+ * Runs a single-utterance synthesis session against the gateway's managed
+ * speech relay (`/v1/speech/tts/stream`, gateway → velay → Deepgram; velay
+ * contact is gateway-only). The wire protocol is Deepgram's Speak
+ * WebSocket: `Speak` text frames followed by one `Flush`; binary audio
+ * frames stream down until a `Flushed` control frame marks the utterance
+ * complete. The relay adds one control frame of its own — `velay_error`,
+ * surfaced through the caller-owned `makeRelayError` factory.
+ *
+ * Error codes/wording are caller-owned via error factories (stream-read
+ * pattern), keeping this module free of provider imports.
+ */
+
+import { getLogger } from "../../util/logger.js";
+import { isHighSurrogate } from "../../util/unicode.js";
+import type { StreamReadTimeouts } from "../stream-read.js";
+import {
+  DEFAULT_FIRST_CHUNK_TIMEOUT_MS,
+  DEFAULT_IDLE_TIMEOUT_MS,
+} from "../stream-read.js";
+
+const log = getLogger("vellum-tts-socket");
+
+/** Default timeout (ms) for the WebSocket connection handshake. */
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+
+/** Maximum characters per Deepgram `Speak` frame. */
+const MAX_SPEAK_CHARS = 2_000;
+
+/**
+ * Minimal structural WebSocket interface so tests can substitute a mock.
+ * Mirrors xai-tts-socket's local copy — kept local so tts/ stays free of
+ * a cross-subsystem dependency on the STT adapter.
+ */
+interface WsLike {
+  binaryType?: string;
+  send(data: string): void;
+  close(): void;
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(
+    type: "close",
+    listener: (ev: { code: number; reason: string }) => void,
+  ): void;
+  addEventListener(type: "error", listener: (ev: unknown) => void): void;
+  addEventListener(
+    type: "message",
+    listener: (ev: { data: unknown }) => void,
+  ): void;
+}
+
+/**
+ * Relay control frames: Deepgram's `Metadata`/`Flushed`/`Warning` plus the
+ * relay's own `velay_error`.
+ */
+interface RelayTtsFrame {
+  type?: string;
+  code?: string;
+  detail?: string;
+  description?: string;
+}
+
+/**
+ * Create the relay WebSocket. Auth rides in the URL (`?key=` carries the
+ * daemon-minted gateway service token), so no headers are needed.
+ */
+function createWebSocket(url: string): WsLike {
+  const WebSocketCtor = (
+    globalThis as unknown as {
+      WebSocket: new (url: string) => WsLike;
+    }
+  ).WebSocket;
+  if (typeof WebSocketCtor !== "function") {
+    throw new Error("global WebSocket is not available in this runtime");
+  }
+  const ws = new WebSocketCtor(url);
+  try {
+    ws.binaryType = "arraybuffer";
+  } catch {
+    // Test fakes may not implement the setter.
+  }
+  return ws;
+}
+
+export interface VellumTtsSocketOptions extends StreamReadTimeouts {
+  /** Full ws(s):// relay URL including `?key=` and audio params. */
+  url: string;
+  /** Full utterance text; split into ≤2,000-char Speak frames. */
+  text: string;
+  onChunk?: (chunk: Uint8Array) => void;
+  signal?: AbortSignal;
+  connectTimeoutMs?: number;
+  /** Error factories keep provider-owned codes/wording (stream-read pattern). */
+  makeTimeoutError: (timeoutMs: number) => Error;
+  makeStreamError: (detail: string) => Error;
+  makeEmptyError: () => Error;
+  /** A `velay_error` control frame arrived — code per the relay contract. */
+  makeRelayError: (code: string, detail: string) => Error;
+}
+
+/**
+ * Synthesize one utterance over the managed speech relay, resolving with
+ * the complete audio. Binary chunks are forwarded to `onChunk` as they
+ * arrive. Abort sends `Clear` (barge-in: discard buffered synthesis)
+ * before closing the socket.
+ */
+export function synthesizeOverVellumTtsSocket(
+  options: VellumTtsSocketOptions,
+): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    const {
+      signal,
+      onChunk,
+      makeTimeoutError,
+      makeStreamError,
+      makeEmptyError,
+      makeRelayError,
+    } = options;
+    const connectTimeoutMs =
+      options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    const firstChunkTimeoutMs =
+      options.firstChunkTimeoutMs ?? DEFAULT_FIRST_CHUNK_TIMEOUT_MS;
+    const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+
+    const abortReason = () =>
+      signal?.reason ??
+      new DOMException("This operation was aborted", "AbortError");
+
+    if (signal?.aborted) {
+      reject(abortReason());
+      return;
+    }
+
+    let ws: WsLike;
+    try {
+      ws = createWebSocket(options.url);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    let settled = false;
+    let opened = false;
+    const chunks: Buffer[] = [];
+    let receivedAnyFrame = false;
+    let connectTimer: ReturnType<typeof setTimeout> | null = null;
+    let stallTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearTimers = () => {
+      if (connectTimer !== null) {
+        clearTimeout(connectTimer);
+        connectTimer = null;
+      }
+      if (stallTimer !== null) {
+        clearTimeout(stallTimer);
+        stallTimer = null;
+      }
+    };
+
+    const closeSocket = () => {
+      try {
+        ws.close();
+      } catch {
+        // Best effort — already-closed sockets may throw.
+      }
+    };
+
+    const settle = (fn: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimers();
+      signal?.removeEventListener("abort", onAbort);
+      fn();
+    };
+
+    const fail = (err: unknown) => {
+      settle(() => {
+        closeSocket();
+        reject(err);
+      });
+    };
+
+    const onAbort = () => {
+      // Barge-in: tell the provider to discard buffered synthesis before
+      // tearing the socket down, so unspoken audio is not generated.
+      if (opened) {
+        try {
+          ws.send(JSON.stringify({ type: "Clear" }));
+          ws.send(JSON.stringify({ type: "Close" }));
+        } catch {
+          // The socket may already be closing.
+        }
+      }
+      fail(abortReason());
+    };
+
+    /**
+     * (Re)arm the stall timer: first-chunk budget until any server frame
+     * arrives, idle budget between frames thereafter.
+     */
+    const armStallTimer = () => {
+      if (stallTimer !== null) {
+        clearTimeout(stallTimer);
+      }
+      const timeoutMs = receivedAnyFrame ? idleTimeoutMs : firstChunkTimeoutMs;
+      stallTimer = setTimeout(() => {
+        fail(makeTimeoutError(timeoutMs));
+      }, timeoutMs);
+    };
+
+    connectTimer = setTimeout(() => {
+      fail(makeTimeoutError(connectTimeoutMs));
+    }, connectTimeoutMs);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    ws.addEventListener("open", () => {
+      if (settled) {
+        return;
+      }
+      opened = true;
+      if (connectTimer !== null) {
+        clearTimeout(connectTimer);
+        connectTimer = null;
+      }
+      try {
+        const text = options.text;
+        let offset = 0;
+        while (offset < text.length) {
+          let end = Math.min(offset + MAX_SPEAK_CHARS, text.length);
+          // Never split a surrogate pair across Speak frames.
+          if (end < text.length && isHighSurrogate(text.charCodeAt(end - 1))) {
+            end -= 1;
+          }
+          ws.send(
+            JSON.stringify({ type: "Speak", text: text.slice(offset, end) }),
+          );
+          offset = end;
+        }
+        ws.send(JSON.stringify({ type: "Flush" }));
+      } catch (err) {
+        fail(
+          makeStreamError(
+            `failed to send Speak frames: ${err instanceof Error ? err.message : String(err)}`,
+          ),
+        );
+        return;
+      }
+      armStallTimer();
+    });
+
+    ws.addEventListener("message", (ev) => {
+      if (settled) {
+        return;
+      }
+
+      receivedAnyFrame = true;
+      armStallTimer();
+
+      // Binary frames are the audio itself.
+      if (ev.data instanceof ArrayBuffer) {
+        const chunk = Buffer.from(ev.data);
+        if (chunk.byteLength === 0) {
+          return;
+        }
+        chunks.push(chunk);
+        try {
+          onChunk?.(chunk);
+        } catch (err) {
+          // Propagate sink failures like readChunkedBody: fail the session.
+          fail(err);
+        }
+        return;
+      }
+      if (ArrayBuffer.isView(ev.data)) {
+        const view = ev.data as ArrayBufferView;
+        const chunk = Buffer.from(
+          view.buffer,
+          view.byteOffset,
+          view.byteLength,
+        );
+        if (chunk.byteLength === 0) {
+          return;
+        }
+        chunks.push(Buffer.from(chunk));
+        try {
+          onChunk?.(chunk);
+        } catch (err) {
+          fail(err);
+        }
+        return;
+      }
+      if (typeof ev.data !== "string") {
+        return;
+      }
+
+      let frame: RelayTtsFrame;
+      try {
+        frame = JSON.parse(ev.data) as RelayTtsFrame;
+      } catch {
+        log.debug("Dropped non-JSON relay TTS frame");
+        return;
+      }
+      if (!frame || typeof frame !== "object") {
+        return;
+      }
+
+      switch (frame.type) {
+        case "Flushed":
+          // All audio for the flushed text has been delivered.
+          settle(() => {
+            try {
+              ws.send(JSON.stringify({ type: "Close" }));
+            } catch {
+              // Best effort — the audio is already complete.
+            }
+            closeSocket();
+            if (chunks.length === 0) {
+              reject(makeEmptyError());
+              return;
+            }
+            resolve(Buffer.concat(chunks));
+          });
+          return;
+
+        case "velay_error":
+          fail(
+            makeRelayError(
+              typeof frame.code === "string" ? frame.code : "upstream_error",
+              typeof frame.detail === "string" ? frame.detail : "",
+            ),
+          );
+          return;
+
+        case "Warning":
+          log.warn(
+            { description: frame.description },
+            "Relay TTS warning frame",
+          );
+          return;
+
+        default:
+          // Metadata and other control frames are informational.
+          return;
+      }
+    });
+
+    ws.addEventListener("close", (ev) => {
+      fail(
+        makeStreamError(
+          `socket closed before Flushed (code=${ev.code}, reason=${ev.reason})`,
+        ),
+      );
+    });
+
+    ws.addEventListener("error", (ev) => {
+      const message =
+        ev instanceof Error
+          ? ev.message
+          : typeof ev === "object" && ev !== null && "message" in ev
+            ? String((ev as { message: unknown }).message)
+            : "WebSocket error";
+      fail(makeStreamError(message));
+    });
+  });
+}

--- a/assistant/src/tts/providers/vellum-tts-socket.ts
+++ b/assistant/src/tts/providers/vellum-tts-socket.ts
@@ -143,7 +143,7 @@ export function synthesizeOverVellumTtsSocket(
     let settled = false;
     let opened = false;
     const chunks: Buffer[] = [];
-    let receivedAnyFrame = false;
+    let receivedAudio = false;
     let connectTimer: ReturnType<typeof setTimeout> | null = null;
     let stallTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -198,14 +198,17 @@ export function synthesizeOverVellumTtsSocket(
     };
 
     /**
-     * (Re)arm the stall timer: first-chunk budget until any server frame
-     * arrives, idle budget between frames thereafter.
+     * (Re)arm the stall timer: first-chunk budget until AUDIO arrives, idle
+     * budget between frames thereafter. Unlike the xAI session (where the
+     * first server frame is audio), Deepgram sends a Metadata control frame
+     * immediately on connect — counting it would collapse the first-chunk
+     * budget to the shorter idle budget before synthesis even starts.
      */
     const armStallTimer = () => {
       if (stallTimer !== null) {
         clearTimeout(stallTimer);
       }
-      const timeoutMs = receivedAnyFrame ? idleTimeoutMs : firstChunkTimeoutMs;
+      const timeoutMs = receivedAudio ? idleTimeoutMs : firstChunkTimeoutMs;
       stallTimer = setTimeout(() => {
         fail(makeTimeoutError(timeoutMs));
       }, timeoutMs);
@@ -257,10 +260,12 @@ export function synthesizeOverVellumTtsSocket(
         return;
       }
 
-      receivedAnyFrame = true;
+      // Binary frames are the audio itself.
+      if (ev.data instanceof ArrayBuffer || ArrayBuffer.isView(ev.data)) {
+        receivedAudio = true;
+      }
       armStallTimer();
 
-      // Binary frames are the audio itself.
       if (ev.data instanceof ArrayBuffer) {
         const chunk = Buffer.from(ev.data);
         if (chunk.byteLength === 0) {


### PR DESCRIPTION
Second PR of the realtime-adapters plan (R2 of R1–R3), on top of the merged #37921 (R1) and #37937 (gateway relay). Shares R1's `vellum-speech-relay-connection.ts` (gateway origin + per-dial service-token minting) and dials the gateway TTS route #37937 already serves. Same security model: the daemon holds no velay address and no speech credential.

## What

**`vellum-tts-socket.ts`** (new, templated on `xai-tts-socket.ts`): a single-utterance Deepgram Speak session over the gateway relay.
- Sends `Speak` frames (2,000-char Deepgram limit, surrogate-safe splits) followed by one `Flush`; binary PCM chunks stream to `onChunk` as they arrive; `Flushed` settles the session with the concatenated audio and sends `Close`.
- **Barge-in**: abort sends `Clear` (discard buffered synthesis) then `Close` before teardown.
- `velay_error` control frames (velay's own, or synthesized by the gateway for upstream failures) surface through a caller-owned `makeRelayError` factory, following the module's error-factory pattern.
- Connect/first-chunk/idle stall timeouts mirror the xAI session.

**`vellum-provider.ts`**: `synthesizeStream` — PCM requests dial the relay at `linear16`/16 kHz (the params the gateway's allowlist admits); non-PCM requests delegate to the existing batch path (read-aloud/mp3 unchanged). Rejected dials replay the gate as a plain GET via the shared probe, so auth/balance failures surface with their mapped messages. `supportsStreaming: true` on both the adapter and the definition.

No gateway changes — #37937 shipped the TTS route with tests.

## Tests
- `vellum-tts-socket.test.ts` (8): Speak/Flush ordering + Close after Flushed, 2,000-char splitting, binary chunk forwarding (ArrayBuffer + typed-array), `velay_error` factory routing, barge-in Clear/Close on abort, close-before-Flushed, empty-audio, pre-aborted signal.
- `vellum-provider.test.ts` (+5): relay URL/params/token, non-PCM batch delegation, probe-mapped rejection, missing-connection message, capability flip.

## Follow-up
R3: live-voice preflight vellum branches + the manual dev voice-room E2E (the plan's definition of done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->