### PR TITLE
Exempt incoming telemetry-wire.generated.ts from knip unused-file check

### DIFF
--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -9,7 +9,10 @@
     "src/config/bundled-skills/**/tools/**/*.ts!"
   ],
   "project": ["src/**/*.ts!", "src/**/*.tsx!", "scripts/**/*.ts"],
-  "ignore": ["src/config/preloaded-apps/**"],
+  "ignore": [
+    "src/config/preloaded-apps/**",
+    "src/telemetry/telemetry-wire.generated.ts"
+  ],
   "ignoreDependencies": [
     "@microsoft/api-extractor",
     "@vellumai/ces-client",


### PR DESCRIPTION
## Summary
- Pre-exempts `assistant/src/telemetry/telemetry-wire.generated.ts` from knip's `lint:unused` file check.

## Why
`vellum-ai/vellum-assistant-platform` is adding an automated sync workflow that PRs a generated telemetry wire-contract module (zod v4 schemas + inferred types, generated from the platform's telemetry ingest DRF serializers) into `assistant/src/telemetry/telemetry-wire.generated.ts`. The first sync PR lands the file **before** any code imports it (daemon adoption is a separate follow-up), so knip would flag it as an unused file and fail `lint:unused` on an otherwise-mergeable automated PR.

## Verification
With the generated file present in `assistant/src/telemetry/`:
- without this exemption: `bun run lint:unused` exits 1 — `Unused files (1): src/telemetry/telemetry-wire.generated.ts`
- with it: exits 0

## Follow-up
Once the daemon's `src/telemetry/types.ts` adopts the generated module (imports it via the planned override layer), this exemption becomes unnecessary and can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)