### PR TITLE
fix(plugins): describe search icon as emoji-or-URL to match the platform contract

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -23142,7 +23142,9 @@ paths:
                           description: Short description, when known (external entries only today).
                           type: string
                         icon:
-                          description: Curated author/curator emoji from the marketplace entry, when present.
+                          description:
+                            "Plugin icon: a curated emoji from the marketplace entry, or an icon URL served by the platform catalog
+                            when the plugin ships a bundled image."
                           type: string
                         category:
                           anyOf:

--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -142,6 +142,7 @@ mock.module("../persistence/jobs-store.js", () => ({
   failStalledJobs: mockFailStalledJobs,
   getMemoryJobCounts: mock(() => ({})),
   hasActiveJobOfType: mock(() => false),
+  hasPendingJobOfType: mock(() => false),
   isMemoryEnabled: () => true,
   MEMORY_V2_CONSOLIDATION_JOB_TRIGGERS: {
     automatic: "automatic",

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -43,7 +43,10 @@ export interface PluginSearchMatch {
   readonly path: string;
   /** Short description, when known (external entries only today). */
   readonly description?: string;
-  /** Curated author/curator emoji from the marketplace entry, when present. */
+  /**
+   * Plugin icon: a curated emoji from the marketplace entry, or an icon URL
+   * served by the platform catalog when the plugin ships a bundled image.
+   */
   readonly icon?: string;
   /**
    * Free-form grouping hint from the curated marketplace entry (e.g.

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -215,7 +215,9 @@ const pluginSearchMatchSchema = z.object({
   icon: z
     .string()
     .optional()
-    .describe("Curated author/curator emoji from the marketplace entry, when present."),
+    .describe(
+      "Plugin icon: a curated emoji from the marketplace entry, or an icon URL served by the platform catalog when the plugin ships a bundled image.",
+    ),
   category: z
     .string()
     .nullable()


### PR DESCRIPTION
## Summary
- Broadens the /v1/plugins/search icon field description (PluginSearchMatch jsdoc, route schema, openapi) to 'curated emoji or an icon URL from the platform catalog', matching docs/plugin-icon-contract.md. The platform path can carry a PNG GCS URL, so the prior emoji-only description was inaccurate. No validation logic changed.

Fixes a gap identified during plan self-review for plugin-icons-marketing.md.