### PR TITLE
fix(ces): dial CES over IPv4 loopback and pin its bind host

### DIFF
--- a/cli/src/lib/statefulset.ts
+++ b/cli/src/lib/statefulset.ts
@@ -186,7 +186,9 @@ export const DOCKER_STATEFUL_SET_SPEC: DockerStatefulSetSpec = {
         { kind: "static", name: "VELLUM_WORKSPACE_DIR",      value: "/workspace" },
         { kind: "static", name: "VELLUM_BACKUP_DIR",         value: "/workspace/.backups" },
         { kind: "static", name: "VELLUM_BACKUP_KEY_PATH",    value: "/workspace/.backup.key" },
-        { kind: "static", name: "CES_CREDENTIAL_URL",        value: "http://localhost:8090" },
+        // Literal IPv4, not `localhost`: in-pod `localhost` can resolve to
+        // `::1` first, but CES only binds IPv4, so the name would refuse.
+        { kind: "static", name: "CES_CREDENTIAL_URL",        value: "http://127.0.0.1:8090" },
         { kind: "static", name: "GATEWAY_IPC_SOCKET_DIR",    value: "/run/gateway-ipc" },
         { kind: "static", name: "ASSISTANT_IPC_SOCKET_DIR",  value: "/run/assistant-ipc" },
         { kind: "secret", name: "CES_SERVICE_TOKEN",         secret: "cesServiceToken" },
@@ -216,7 +218,9 @@ export const DOCKER_STATEFUL_SET_SPEC: DockerStatefulSetSpec = {
         { kind: "static", name: "VELLUM_WORKSPACE_DIR",      value: "/workspace" },
         { kind: "static", name: "GATEWAY_SECURITY_DIR",      value: "/gateway-security" },
         { kind: "static", name: "ASSISTANT_HOST",            value: "localhost" },
-        { kind: "static", name: "CES_CREDENTIAL_URL",        value: "http://localhost:8090" },
+        // Literal IPv4, not `localhost`: in-pod `localhost` can resolve to
+        // `::1` first, but CES only binds IPv4, so the name would refuse.
+        { kind: "static", name: "CES_CREDENTIAL_URL",        value: "http://127.0.0.1:8090" },
         { kind: "static", name: "GATEWAY_IPC_SOCKET_DIR",    value: "/run/gateway-ipc" },
         { kind: "static", name: "ASSISTANT_IPC_SOCKET_DIR",  value: "/run/assistant-ipc" },
         { kind: "static", name: "GATEWAY_PORT",              value: `${GATEWAY_INTERNAL_PORT}` },

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -239,6 +239,7 @@ function startHealthServer(
 ): ReturnType<typeof Bun.serve> {
   const server = Bun.serve({
     port,
+    hostname: "0.0.0.0",
     async fetch(req) {
       const url = new URL(req.url);
       if (url.pathname === "/healthz") {


### PR DESCRIPTION
## Summary
- Point both `CES_CREDENTIAL_URL` env values (assistant runtime + gateway sidecar) at `http://127.0.0.1:8090` instead of `http://localhost:8090`, so the dial can't resolve to an interface CES doesn't serve.
- Pin `hostname: "0.0.0.0"` on CES's `Bun.serve` in `startHealthServer` so the bind interface is explicit rather than an implicit Bun default.

## Why
A stuck production assistant surfaced "Assistant is unreachable". Pod logs showed the gateway getting continuous `ConnectionRefused` dialing `http://localhost:8090` for the assistant API key, while `127.0.0.1:8090` answered `200` from the same container. Root cause: CES binds IPv4 only, but the clients dial it by the name `localhost`, which in these pods can resolve to IPv6 `::1` first (and this pod's IPv6 stack was itself broken). No CES key → velay tunnel never establishes → control plane can't reach the runtime → `runtime_unreachable`.

`ASSISTANT_HOST=localhost` is left as-is: it's the same latent pattern but runs mostly over IPC sockets and wasn't confirmed, so it's out of scope here.

Note: this is a config/bind fix for future provisioning; an already-stuck pod still needs a restart to recover.

## Original prompt
Investigating a support bundle for a "Assistant is unreachable" report, we traced it through the pod logs to a gateway↔CES interface mismatch: CES binds IPv4 but the gateway dials `localhost`, which resolves to `::1` and is refused. The ask was to implement the minimal fix — dial the literal IPv4 loopback and pin CES's bind host — on a fresh branch off main and open a PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->