### PR TITLE
fix(plugins): parity-test trigger on validator source; drop dead IconFetchError export/status

### DIFF
--- a/.github/workflows/pr-marketplace.yaml
+++ b/.github/workflows/pr-marketplace.yaml
@@ -13,6 +13,7 @@ on:
       - 'plugins/assets/**'
       - 'plugins/plugin-icons.json'
       - 'scripts/plugins/**'
+      - 'assistant/src/cli/lib/plugin-icon-file.ts'
       - '.github/workflows/pr-marketplace.yaml'
 
 concurrency:

--- a/scripts/plugins/generate-plugin-icons.mjs
+++ b/scripts/plugins/generate-plugin-icons.mjs
@@ -131,12 +131,11 @@ function iconContentsUrl(entry) {
  * (429/5xx/network) vs a hard error. A 404 never reaches here — it is a normal
  * "no icon" result, not a failure.
  */
-export class IconFetchError extends Error {
-  constructor(message, { transient = false, status } = {}) {
+class IconFetchError extends Error {
+  constructor(message, { transient = false } = {}) {
     super(message);
     this.name = "IconFetchError";
     this.transient = transient;
-    if (status !== undefined) this.status = status;
   }
 }
 
@@ -185,7 +184,6 @@ async function fetchIconBytes(fetchImpl, entry, token) {
   if (!res.ok) {
     throw new IconFetchError(`HTTP ${res.status}`, {
       transient: isTransientUpstreamStatus(res),
-      status: res.status,
     });
   }
   // Reject an oversized icon on its advertised Content-Length before buffering
@@ -196,7 +194,7 @@ async function fetchIconBytes(fetchImpl, entry, token) {
   if (Number.isFinite(contentLength) && contentLength > MAX_ICON_BYTES) {
     throw new IconFetchError(
       `icon.png is ${contentLength} bytes, over the ${MAX_ICON_BYTES}-byte cap`,
-      { transient: false, status: res.status },
+      { transient: false },
     );
   }
   return Buffer.from(await res.arrayBuffer());


### PR DESCRIPTION
## Summary
- Adds assistant/src/cli/lib/plugin-icon-file.ts to pr-marketplace.yaml paths so the TS<->mjs validator parity test fires when the source-of-truth validator changes (previously only .mjs edits triggered it).
- Drops the unused IconFetchError export and its never-read status field/param (dead code from the round-1 hardening).

Fixes gaps from plan self-review round 2 for plugin-icons-marketing.md.