### PR TITLE
Plugin marketplace icons — emit emoji + validated PNG data for the marketing catalog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+plugins/assets/**/*.png binary

--- a/.github/workflows/pr-marketplace.yaml
+++ b/.github/workflows/pr-marketplace.yaml
@@ -13,6 +13,7 @@ on:
       - 'plugins/assets/**'
       - 'plugins/plugin-icons.json'
       - 'scripts/plugins/**'
+      - 'assistant/src/cli/lib/plugin-icon-file.ts'
       - '.github/workflows/pr-marketplace.yaml'
 
 concurrency:

--- a/.github/workflows/pr-marketplace.yaml
+++ b/.github/workflows/pr-marketplace.yaml
@@ -10,6 +10,9 @@ on:
       - 'meta/sync-bundled-copies.ts'
       - 'assistant/src/cli/lib/bundled-marketplace.json'
       - 'clients/web/src/lib/feature-flags/feature-flag-registry.json'
+      - 'plugins/assets/**'
+      - 'plugins/plugin-icons.json'
+      - 'scripts/plugins/generate-plugin-icons.mjs'
       - '.github/workflows/pr-marketplace.yaml'
 
 concurrency:
@@ -48,3 +51,23 @@ jobs:
 
       - name: Verify bundled copies match canonical sources
         run: bun run meta/sync-bundled-copies.ts --check
+
+  # Purely local: verifies plugins/plugin-icons.json matches the vendored PNGs
+  # under plugins/assets/, so the derived manifest can't drift from the assets a
+  # PR commits. Does not re-fetch upstream, so a repinned plugin whose upstream
+  # icon.png changed without a regen is not detected here.
+  check-plugin-icons:
+    name: Check Plugin Icons In Sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22.22.2'
+
+      - name: Verify plugin-icons.json matches vendored assets
+        run: node scripts/plugins/generate-plugin-icons.mjs --check

--- a/.github/workflows/pr-marketplace.yaml
+++ b/.github/workflows/pr-marketplace.yaml
@@ -12,7 +12,7 @@ on:
       - 'clients/web/src/lib/feature-flags/feature-flag-registry.json'
       - 'plugins/assets/**'
       - 'plugins/plugin-icons.json'
-      - 'scripts/plugins/generate-plugin-icons.mjs'
+      - 'scripts/plugins/**'
       - '.github/workflows/pr-marketplace.yaml'
 
 concurrency:
@@ -69,5 +69,16 @@ jobs:
         with:
           node-version: '22.22.2'
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
       - name: Verify plugin-icons.json matches vendored assets
         run: node scripts/plugins/generate-plugin-icons.mjs --check
+
+      # Runs from scripts/ so the repo-root `bun test` preload guard does not
+      # apply; guards the TS<->mjs parity of the mirrored validator/classifier.
+      - name: Run plugin-icons generator tests
+        working-directory: scripts
+        run: bun test plugins/__tests__/

--- a/.github/workflows/upload-plugin-assets.yaml
+++ b/.github/workflows/upload-plugin-assets.yaml
@@ -1,0 +1,57 @@
+# Uploads vendored marketplace plugin icons to GCS. See docs/plugin-icon-contract.md.
+# Bytes are pre-vendored + CI-checked (no fetch/re-validation here).
+# External prereq (vellum-assistant-platform Terraform): the per-env GCS bucket,
+# WIF binding, and GCS_PLUGIN_ASSETS_BUCKET var. Until that lands the job skips cleanly.
+name: Upload Plugin Assets to GCS
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "plugins/assets/**"
+  workflow_dispatch:
+
+jobs:
+  upload:
+    name: Upload plugin assets (${{ matrix.environment }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [dev, staging, production]
+    environment: ${{ matrix.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Skip when bucket not configured
+        if: ${{ vars.GCS_PLUGIN_ASSETS_BUCKET == '' }}
+        run: echo "GCS_PLUGIN_ASSETS_BUCKET is unset — skipping (bucket not provisioned yet)."
+
+      - name: Checkout
+        if: ${{ vars.GCS_PLUGIN_ASSETS_BUCKET != '' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Authenticate to GCP
+        if: ${{ vars.GCS_PLUGIN_ASSETS_BUCKET != '' }}
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Upload plugin icons to GCS
+        if: ${{ vars.GCS_PLUGIN_ASSETS_BUCKET != '' }}
+        env:
+          BUCKET: ${{ vars.GCS_PLUGIN_ASSETS_BUCKET }}
+        run: |
+          set -euo pipefail
+          uploaded=0
+          for icon in plugins/assets/*/icon.png; do
+            [ -f "$icon" ] || continue
+            name=$(echo "$icon" | cut -d/ -f3)
+            gcloud storage cp \
+              --cache-control="public, max-age=86400" \
+              "$icon" "gs://${BUCKET}/${name}/icon.png"
+            uploaded=$((uploaded + 1))
+          done
+          echo "Uploaded ${uploaded} plugin icon(s) to gs://${BUCKET}/"

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -23142,7 +23142,9 @@ paths:
                           description: Short description, when known (external entries only today).
                           type: string
                         icon:
-                          description: Curated author/curator emoji from the marketplace entry, when present.
+                          description:
+                            "Plugin icon: a curated emoji from the marketplace entry, or an icon URL served by the platform catalog
+                            when the plugin ships a bundled image."
                           type: string
                         category:
                           anyOf:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -23141,6 +23141,9 @@ paths:
                         description:
                           description: Short description, when known (external entries only today).
                           type: string
+                        icon:
+                          description: Curated author/curator emoji from the marketplace entry, when present.
+                          type: string
                         category:
                           anyOf:
                             - type: string

--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -142,6 +142,7 @@ mock.module("../persistence/jobs-store.js", () => ({
   failStalledJobs: mockFailStalledJobs,
   getMemoryJobCounts: mock(() => ({})),
   hasActiveJobOfType: mock(() => false),
+  hasPendingJobOfType: mock(() => false),
   isMemoryEnabled: () => true,
   MEMORY_V2_CONSOLIDATION_JOB_TRIGGERS: {
     automatic: "automatic",

--- a/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-platform.test.ts
@@ -40,10 +40,10 @@ describe("fetchPluginCatalogFromPlatform", () => {
             category: "productivity",
             homepage: "https://example.com",
             license: "MIT",
+            icon: "🧠",
             // dropped keys
             id: "abc",
             display_name: "Memory Graph",
-            icon: "🧠",
           },
           {
             name: "alpha-tool",
@@ -65,6 +65,7 @@ describe("fetchPluginCatalogFromPlatform", () => {
       name: "memory-graph",
       path: `github:acme/memory-graph/packages/plugin@${SHA_B}`,
       description: "graph memory",
+      icon: "🧠",
       category: "productivity",
       homepage: "https://example.com",
       license: "MIT",
@@ -78,6 +79,7 @@ describe("fetchPluginCatalogFromPlatform", () => {
 
     const alpha = catalog.matches[0];
     expect(alpha.category).toBeNull();
+    expect(alpha.icon).toBeUndefined();
     expect(alpha.homepage).toBeUndefined();
     expect(alpha.license).toBeUndefined();
     expect(alpha.source).toEqual({

--- a/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-icon-file.test.ts
@@ -12,7 +12,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { readValidatedPluginIcon } from "../plugin-icon-file.js";
+import {
+  MAX_ICON_BYTES,
+  MAX_ICON_DIMENSION,
+  readValidatedPluginIcon,
+  validatePluginIconBytes,
+} from "../plugin-icon-file.js";
 
 const PNG_SIGNATURE = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
@@ -138,5 +143,49 @@ describe("readValidatedPluginIcon", () => {
   test("returns hasIcon:false for a non-existent plugin directory", () => {
     const missing = join(pluginDir, "does-not-exist");
     expect(readValidatedPluginIcon(missing)).toEqual({ hasIcon: false });
+  });
+});
+
+describe("validatePluginIconBytes", () => {
+  test("accepts a valid <=128x128 PNG with a content-hash version (no path)", () => {
+    // GIVEN well-formed in-memory PNG bytes
+    const bytes = makePng(64, 64);
+
+    // WHEN we validate them directly
+    const result = validatePluginIconBytes(bytes);
+
+    // THEN it is surfaced with a stable content-hash version and no path
+    expect(result).toEqual({ hasIcon: true, iconVersion: sha16(bytes) });
+  });
+
+  test("accepts exactly MAX_ICON_DIMENSION (the boundary)", () => {
+    const bytes = makePng(MAX_ICON_DIMENSION, MAX_ICON_DIMENSION);
+    expect(validatePluginIconBytes(bytes).hasIcon).toBe(true);
+  });
+
+  test("rejects oversized dimensions (129x129)", () => {
+    const bytes = makePng(MAX_ICON_DIMENSION + 1, MAX_ICON_DIMENSION + 1);
+    expect(validatePluginIconBytes(bytes)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a buffer larger than MAX_ICON_BYTES", () => {
+    const bytes = makePng(64, 64, MAX_ICON_BYTES + 1);
+    expect(validatePluginIconBytes(bytes)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a buffer with wrong magic bytes", () => {
+    const jpeg = Buffer.alloc(24);
+    jpeg.writeUInt16BE(0xffd8, 0); // JPEG SOI marker
+    expect(validatePluginIconBytes(jpeg)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a signature-prefixed buffer whose first chunk is not IHDR", () => {
+    const buf = makePng(64, 64);
+    buf.write("IDAT", 12, "ascii");
+    expect(validatePluginIconBytes(buf)).toEqual({ hasIcon: false });
+  });
+
+  test("rejects a buffer shorter than the minimum header", () => {
+    expect(validatePluginIconBytes(PNG_SIGNATURE)).toEqual({ hasIcon: false });
   });
 });

--- a/assistant/src/cli/lib/__tests__/plugin-marketplace.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-marketplace.test.ts
@@ -188,6 +188,100 @@ describe("fetchMarketplaceEntries", () => {
     ).rejects.toBeInstanceOf(MarketplaceFetchError);
   });
 
+  test("parses and round-trips an entry with a valid icon emoji", async () => {
+    // GIVEN an entry carrying a curated single-emoji icon
+    const fetch = manifestFetch({
+      name: "x",
+      plugins: [
+        {
+          name: "caveman",
+          source: {
+            source: "github",
+            repo: "JuliusBrussee/caveman",
+            ref: CAVEMAN_SHA,
+          },
+          icon: "🦣",
+        },
+      ],
+    });
+
+    // WHEN we fetch the entries
+    const entries = await fetchMarketplaceEntries({ fetch }, { ref: "main" });
+
+    // THEN the emoji is preserved on the parsed entry
+    expect(entries[0]!.icon).toBe("🦣");
+  });
+
+  test("accepts a multi-code-unit ZWJ emoji (bounded by code points)", async () => {
+    // GIVEN the family ZWJ emoji: one grapheme, 7 code points, 11 UTF-16 units.
+    const fetch = manifestFetch({
+      name: "x",
+      plugins: [
+        {
+          name: "caveman",
+          source: {
+            source: "github",
+            repo: "JuliusBrussee/caveman",
+            ref: CAVEMAN_SHA,
+          },
+          icon: "👩‍👩‍👧‍👦",
+        },
+      ],
+    });
+
+    // WHEN we fetch the entries
+    const entries = await fetchMarketplaceEntries({ fetch }, { ref: "main" });
+
+    // THEN the ZWJ emoji survives validation (would fail under `.length`)
+    expect(entries[0]!.icon).toBe("👩‍👩‍👧‍👦");
+  });
+
+  test("rejects an over-long icon string", async () => {
+    // GIVEN an icon far longer than a single emoji
+    const fetch = manifestFetch({
+      name: "x",
+      plugins: [
+        {
+          name: "caveman",
+          source: {
+            source: "github",
+            repo: "JuliusBrussee/caveman",
+            ref: CAVEMAN_SHA,
+          },
+          icon: "not-an-emoji-just-text",
+        },
+      ],
+    });
+
+    // WHEN / THEN the refine rejects it
+    await expect(
+      fetchMarketplaceEntries({ fetch }, { ref: "main" }),
+    ).rejects.toBeInstanceOf(MarketplaceFetchError);
+  });
+
+  test("rejects an icon that looks like a URL or path", async () => {
+    // GIVEN an icon that is a URL rather than an emoji
+    const fetch = manifestFetch({
+      name: "x",
+      plugins: [
+        {
+          name: "caveman",
+          source: {
+            source: "github",
+            repo: "JuliusBrussee/caveman",
+            ref: CAVEMAN_SHA,
+          },
+          icon: "http://x",
+        },
+      ],
+    });
+
+    // WHEN / THEN a URL/path-shaped icon is rejected by the refine
+    await expect(
+      fetchMarketplaceEntries({ fetch }, { ref: "main" }),
+    ).rejects.toBeInstanceOf(MarketplaceFetchError);
+  });
+
   test("rejects a path that escapes the repo root", async () => {
     // GIVEN an entry whose path contains a parent-segment escape
     const fetch = manifestFetch({

--- a/assistant/src/cli/lib/__tests__/search-plugins.test.ts
+++ b/assistant/src/cli/lib/__tests__/search-plugins.test.ts
@@ -33,6 +33,7 @@ function entry(
   extra?: {
     path?: string;
     description?: string;
+    icon?: string;
     category?: string;
     homepage?: string;
     license?: string;
@@ -47,6 +48,7 @@ function entry(
       ref,
     },
     ...(extra?.description ? { description: extra.description } : {}),
+    ...(extra?.icon ? { icon: extra.icon } : {}),
     ...(extra?.category ? { category: extra.category } : {}),
     ...(extra?.homepage ? { homepage: extra.homepage } : {}),
     ...(extra?.license ? { license: extra.license } : {}),
@@ -220,6 +222,17 @@ describe("marketplaceMatch", () => {
     );
     expect(match.homepage).toBeUndefined();
     expect(match.license).toBeUndefined();
+  });
+
+  test("carries the curated icon, leaving it undefined when absent", () => {
+    expect(
+      marketplaceMatch(
+        entry("calendar-sync", "acme/calendar-sync", SHA_A, { icon: "📅" }),
+      ).icon,
+    ).toBe("📅");
+    expect(
+      marketplaceMatch(entry("plain-plugin", "acme/plain-plugin", SHA_B)).icon,
+    ).toBeUndefined();
   });
 });
 

--- a/assistant/src/cli/lib/plugin-catalog-platform.ts
+++ b/assistant/src/cli/lib/plugin-catalog-platform.ts
@@ -26,8 +26,7 @@ import {
 
 /**
  * One flattened row from the platform catalog. Unknown keys (`id`,
- * `display_name`, `icon`) are accepted and dropped — zod strips them by
- * default.
+ * `display_name`) are accepted and dropped — zod strips them by default.
  */
 const platformPluginRowSchema = z.object({
   name: z.string(),
@@ -35,6 +34,7 @@ const platformPluginRowSchema = z.object({
   ref: z.string().nullable().optional(),
   path: z.string().nullable().optional(),
   description: z.string().optional(),
+  icon: z.string().nullable().optional(),
   category: z.string().nullable().optional(),
   homepage: z.string().nullable().optional(),
   license: z.string().nullable().optional(),
@@ -106,6 +106,7 @@ export async function fetchPluginCatalogFromPlatform(
         path: row.path ?? undefined,
       },
       description: row.description ?? undefined,
+      icon: row.icon ?? undefined,
       category: row.category ?? undefined,
       homepage: row.homepage ?? undefined,
       license: row.license ?? undefined,

--- a/assistant/src/cli/lib/plugin-icon-file.ts
+++ b/assistant/src/cli/lib/plugin-icon-file.ts
@@ -17,11 +17,11 @@ import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 /** Fixed icon filename in the plugin root — no author path, no traversal. */
-const ICON_FILENAME = "icon.png";
+export const ICON_FILENAME = "icon.png";
 /** Byte cap: reject anything larger (also bounds what we read into memory). */
-const MAX_ICON_BYTES = 32 * 1024;
+export const MAX_ICON_BYTES = 32 * 1024;
 /** Dimension cap (px) enforced against the IHDR width/height. */
-const MAX_ICON_DIMENSION = 128;
+export const MAX_ICON_DIMENSION = 128;
 /** PNG signature: the first 8 bytes of every PNG file. */
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 /** The first chunk of a valid PNG is always IHDR with a 13-byte payload. */
@@ -41,29 +41,13 @@ export interface ValidatedPluginIcon {
 }
 
 /**
- * Read and validate `<pluginDir>/icon.png`. Returns `{ hasIcon: true }` with a
- * content-hash `iconVersion` and `path` only when the file is a PNG whose IHDR
- * dimensions are within {@link MAX_ICON_DIMENSION} and whose size is within
- * {@link MAX_ICON_BYTES}. Every other case returns `{ hasIcon: false }`.
+ * Validate in-memory PNG bytes against the icon contract. Returns
+ * `{ hasIcon: true, iconVersion }` — a content-hash version — only when the
+ * bytes are a PNG whose IHDR dimensions are within {@link MAX_ICON_DIMENSION}
+ * and whose size is within {@link MAX_ICON_BYTES}. Every other case returns
+ * `{ hasIcon: false }`. No `path`: the bytes source is caller-defined.
  */
-export function readValidatedPluginIcon(
-  pluginDir: string,
-): ValidatedPluginIcon {
-  const iconPath = join(pluginDir, ICON_FILENAME);
-
-  let bytes: Buffer;
-  try {
-    const stat = statSync(iconPath);
-    // Size-gate before reading so an oversized file never enters memory.
-    // A missing file throws here and is caught as "no icon".
-    if (!stat.isFile() || stat.size > MAX_ICON_BYTES) {
-      return { hasIcon: false };
-    }
-    bytes = readFileSync(iconPath);
-  } catch {
-    return { hasIcon: false };
-  }
-
+export function validatePluginIconBytes(bytes: Buffer): ValidatedPluginIcon {
   if (bytes.length < MIN_HEADER_BYTES || bytes.length > MAX_ICON_BYTES) {
     return { hasIcon: false };
   }
@@ -97,5 +81,33 @@ export function readValidatedPluginIcon(
     .update(bytes)
     .digest("hex")
     .slice(0, 16);
-  return { hasIcon: true, iconVersion, path: iconPath };
+  return { hasIcon: true, iconVersion };
+}
+
+/**
+ * Read and validate `<pluginDir>/icon.png`. Returns `{ hasIcon: true }` with a
+ * content-hash `iconVersion` and `path` only when the file is a PNG whose IHDR
+ * dimensions are within {@link MAX_ICON_DIMENSION} and whose size is within
+ * {@link MAX_ICON_BYTES}. Every other case returns `{ hasIcon: false }`.
+ */
+export function readValidatedPluginIcon(
+  pluginDir: string,
+): ValidatedPluginIcon {
+  const iconPath = join(pluginDir, ICON_FILENAME);
+
+  let bytes: Buffer;
+  try {
+    const stat = statSync(iconPath);
+    // Size-gate before reading so an oversized file never enters memory.
+    // A missing file throws here and is caught as "no icon".
+    if (!stat.isFile() || stat.size > MAX_ICON_BYTES) {
+      return { hasIcon: false };
+    }
+    bytes = readFileSync(iconPath);
+  } catch {
+    return { hasIcon: false };
+  }
+
+  const result = validatePluginIconBytes(bytes);
+  return result.hasIcon ? { ...result, path: iconPath } : result;
 }

--- a/assistant/src/cli/lib/plugin-marketplace.ts
+++ b/assistant/src/cli/lib/plugin-marketplace.ts
@@ -98,6 +98,19 @@ const marketplaceEntrySchema = z.object({
   category: z.string().optional(),
   homepage: z.string().optional(),
   license: z.string().optional(),
+  /**
+   * A single curated author/curator emoji shown as the plugin's icon (e.g. on
+   * the marketing catalog). Not a URL or file path — bounded to a short
+   * emoji-length string; a multi-code-point emoji (skin tone, ZWJ sequence)
+   * still fits comfortably under the cap.
+   */
+  icon: z
+    .string()
+    .refine(
+      (s) => [...s].length <= 8 && !/[/\\]|^https?:/i.test(s),
+      "expected a short emoji, not a URL or path",
+    )
+    .optional(),
 });
 
 export const marketplaceManifestSchema = z.object({

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -43,7 +43,10 @@ export interface PluginSearchMatch {
   readonly path: string;
   /** Short description, when known (external entries only today). */
   readonly description?: string;
-  /** Curated author/curator emoji from the marketplace entry, when present. */
+  /**
+   * Plugin icon: a curated emoji from the marketplace entry, or an icon URL
+   * served by the platform catalog when the plugin ships a bundled image.
+   */
   readonly icon?: string;
   /**
    * Free-form grouping hint from the curated marketplace entry (e.g.

--- a/assistant/src/cli/lib/search-plugins.ts
+++ b/assistant/src/cli/lib/search-plugins.ts
@@ -43,6 +43,8 @@ export interface PluginSearchMatch {
   readonly path: string;
   /** Short description, when known (external entries only today). */
   readonly description?: string;
+  /** Curated author/curator emoji from the marketplace entry, when present. */
+  readonly icon?: string;
   /**
    * Free-form grouping hint from the curated marketplace entry (e.g.
    * `productivity`), or `null` when the entry declares none.
@@ -128,6 +130,7 @@ export function marketplaceMatch(entry: MarketplaceEntry): PluginSearchMatch {
     name: entry.name,
     path: locator,
     description: entry.description,
+    icon: entry.icon,
     category: entry.category ?? null,
     homepage: entry.homepage,
     license: entry.license,

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -997,6 +997,32 @@ describe("GET /v1/plugins/search", () => {
     });
   });
 
+  test("projects the marketplace `icon` onto the wire match, omitting it when absent", async () => {
+    getCatalogSpy.mockImplementation(async (ref) =>
+      catalog(ref, [
+        {
+          name: "calendar-sync",
+          path: "github:acme/calendar-sync@v1",
+          icon: "📅",
+          category: null,
+          source: { kind: "github", repo: "acme/calendar-sync", ref: "v1" },
+        },
+        {
+          name: "plain-plugin",
+          path: "github:acme/plain-plugin@v1",
+          category: null,
+          source: { kind: "github", repo: "acme/plain-plugin", ref: "v1" },
+        },
+      ]),
+    );
+
+    const result = await invokeSearch();
+    const byName = new Map(result.matches.map((m) => [m.name, m]));
+    expect(byName.get("calendar-sync")?.icon).toBe("📅");
+    // Absent icon is omitted from the wire object, not set to null/undefined.
+    expect("icon" in byName.get("plain-plugin")!).toBe(false);
+  });
+
   test("normalizes match categories to the Skills taxonomy (`developer` → `development`, `hobby` → null)", async () => {
     getCatalogSpy.mockImplementation(async (ref) =>
       catalog(ref, [

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -212,6 +212,10 @@ const pluginSearchMatchSchema = z.object({
     .string()
     .optional()
     .describe("Short description, when known (external entries only today)."),
+  icon: z
+    .string()
+    .optional()
+    .describe("Curated author/curator emoji from the marketplace entry, when present."),
   category: z
     .string()
     .nullable()
@@ -788,6 +792,7 @@ interface PluginMatchView {
   name: string;
   path: string;
   description?: string;
+  icon?: string;
   category: string | null;
   source: { kind: "github"; repo: string; path?: string; ref: string };
 }
@@ -814,6 +819,9 @@ function projectMatch(
   };
   if (m.description !== undefined) {
     view.description = m.description;
+  }
+  if (m.icon !== undefined) {
+    view.icon = m.icon;
   }
   return view;
 }

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -215,7 +215,9 @@ const pluginSearchMatchSchema = z.object({
   icon: z
     .string()
     .optional()
-    .describe("Curated author/curator emoji from the marketplace entry, when present."),
+    .describe(
+      "Plugin icon: a curated emoji from the marketplace entry, or an icon URL served by the platform catalog when the plugin ships a bundled image.",
+    ),
   category: z
     .string()
     .nullable()

--- a/docs/plugin-icon-contract.md
+++ b/docs/plugin-icon-contract.md
@@ -1,0 +1,91 @@
+# Plugin icon contract
+
+This doc is the single cross-repo source of truth for **marketplace plugin icons** — the small glyph shown next to a plugin in `assistant plugins search`, the desktop/web catalog, and the marketing site. It mirrors how skill icons work. Two repos consume this contract and MUST enforce identical rules:
+
+- **`vellum-ai/vellum-assistant`** (this repo) — the assistant validator at [`assistant/src/cli/lib/plugin-icon-file.ts`](../assistant/src/cli/lib/plugin-icon-file.ts) is the authoritative implementation. In-repo curation lives here (`plugins/marketplace.json`, `plugins/assets/`, `plugins/plugin-icons.json`).
+- **`vellum-ai/vellum-assistant-platform`** — a Django validator behind `/v1/plugins/` that MUST match this doc byte-for-byte. Uploads the PNGs to GCS and serves the combined catalog `icon` value.
+
+Any change to the format, limits, or manifest shape below is a **coordinated cross-repo change** — the TS validator and the Python validator move together, or a plugin that validates in one repo silently gets "no icon" in the other.
+
+## PNG icon rules (author-bundled)
+
+A plugin MAY ship a raster icon. The rules exist so third-party bytes served from a Vellum origin can never become a stored-XSS or path-traversal vector, and so a bad file degrades to "no icon" rather than an error.
+
+- **PNG only.** No SVG. SVG is executable markup; serving attacker-authored SVG from a Vellum origin is a stored-XSS risk. A single well-known container (PNG magic + IHDR) also keeps the parser tiny and dependency-free.
+- **Fixed filename, fixed location.** The file is always `icon.png` at the plugin root — `<source.path>/icon.png` for a plugin pinned to a repo subdirectory (`source.path`), or `icon.png` at the repo root when `source.path` is omitted. There is **no author-controlled path**, so there is no traversal surface.
+- **Dimensions ≤ 128×128 px**, validated against the PNG IHDR width/height (not a trusted sidecar).
+- **Size ≤ 32 KB.** The size gate runs before the bytes are read, so an oversized file never enters memory.
+- **Fail-closed.** Any problem — missing file, wrong magic bytes, non-IHDR first chunk, oversized bytes, oversized dimensions, unreadable — resolves to "no icon". Validation **never throws**; callers surface "no icon" uniformly with no per-source error handling.
+
+### `iconVersion`
+
+`iconVersion` is the **first 16 hex chars of `sha256(bytes)`** of the validated `icon.png`. It is a stable content hash: identical bytes ⇒ identical version, any byte change ⇒ new version. It is the cache-bust token (see [Bucket convention](#bucket-convention)) and the value recorded in the manifest.
+
+The authoritative constants — `MAX_ICON_BYTES = 32 * 1024`, `MAX_ICON_DIMENSION = 128`, the PNG magic signature, the IHDR checks, and the 16-hex `iconVersion` slice — all live in [`plugin-icon-file.ts`](../assistant/src/cli/lib/plugin-icon-file.ts). Treat that file as the spec; this doc explains it.
+
+## The two in-repo sources
+
+A plugin's icon can come from **either** a curated emoji **or** a vendored PNG. They are independent in-repo sources; the platform combines them into one catalog value (see [Platform combination](#platform-combination-and-precedence)).
+
+### 1. Emoji — `icon` field on the marketplace entry
+
+Each entry in [`plugins/marketplace.json`](../plugins/marketplace.json) MAY carry an optional `icon` string holding a single emoji. This is human-curated by whoever reviews the marketplace entry — the cheapest way to give a plugin a recognizable glyph with no asset pipeline.
+
+```json
+{
+  "name": "caveman",
+  "icon": "🪨",
+  "source": { "source": "github", "repo": "JuliusBrussee/caveman", "ref": "<full-commit-sha>" }
+}
+```
+
+The marketplace entry schema (name, `source.{repo,ref,path}` with `ref` pinned to a **full commit SHA**, description, category, homepage, license, and the optional `icon`) is defined in [`plugin-marketplace.ts`](../assistant/src/cli/lib/plugin-marketplace.ts). The `icon` field is curated in-repo, not fetched from the third-party plugin. It is wired end to end: `marketplaceEntrySchema` carries it through `marketplaceMatch` into the catalog projection and the `assistant plugins search` response, and the platform's `/v1/plugins/` reads the same curated emoji independently to render the marketing site.
+
+### 2. PNG — vendored asset + derived manifest
+
+An author-bundled `icon.png` (validated per the rules above) is **vendored into this repo** rather than served from the third-party source, so the bytes we serve are the exact bytes we reviewed:
+
+- **Asset:** `plugins/assets/<name>/icon.png` — the validated icon for marketplace plugin `<name>`.
+- **Manifest:** `plugins/plugin-icons.json` — a derived index. **An entry is present if and only if a valid vendored icon exists** for that plugin.
+
+```json
+{
+  "version": 1,
+  "plugins": {
+    "<name>": { "iconVersion": "<16hex>" }
+  }
+}
+```
+
+Both the vendored asset and the manifest are generated, not hand-edited (see [Adding or updating a plugin icon](#adding-or-updating-a-plugin-icon)).
+
+## Platform combination and precedence
+
+The platform serves each plugin a single `icon` value in `/v1/plugins/`, matching how skills expose one `icon`. It is a **URL-or-emoji** value resolved by this precedence:
+
+1. **PNG URL** — if `plugins/plugin-icons.json` has an entry for the plugin, the platform serves the GCS URL of the vendored `icon.png` (cache-busted by `iconVersion`; see below).
+2. **Emoji** — else if the marketplace entry has an `icon` emoji, serve that string.
+3. **`null`** — else no icon. The client then falls back to a generic 📦/🧩 glyph (per [PR #37087](https://github.com/vellum-ai/vellum-assistant/pull/37087)).
+
+A vendored PNG always wins over a curated emoji for the same plugin.
+
+## Bucket convention
+
+Vendored PNGs are uploaded to GCS and served publicly, mirroring the skill asset convention (`gs://<GCS_SKILL_ASSETS_BUCKET>/<id>/assets/icon.svg`, uploaded by [`.github/workflows/upload-skill-assets.yaml`](../.github/workflows/upload-skill-assets.yaml)).
+
+- **Object path:** `gs://<GCS_PLUGIN_ASSETS_BUCKET>/<name>/icon.png`.
+- **Serving:** public, long-lived cache (`Cache-Control: public, max-age=…`, matching the skill bucket's `max-age=86400`).
+- **Cache-busting:** because the object path is stable but the bytes can change, consumers request `…/<name>/icon.png?v=<iconVersion>`. A content change produces a new `iconVersion`, so the query string changes and caches miss exactly when they should.
+
+## Adding or updating a plugin icon
+
+**Emoji:**
+
+1. Set (or change) the `icon` string on the plugin's entry in `plugins/marketplace.json`.
+2. Run `sync-bundled-copies` (`meta/sync-bundled-copies.ts`) so the bundled offline copy at `assistant/src/cli/lib/bundled-marketplace.json` stays in sync.
+3. Commit both files.
+
+**PNG:**
+
+1. Run the generator `scripts/plugins/generate-plugin-icons.mjs` (added later in the plugin-icons plan). It fetches the plugin's `icon.png`, validates it against the rules above, vendors the valid bytes to `plugins/assets/<name>/icon.png`, and regenerates `plugins/plugin-icons.json`.
+2. Commit the vendored asset **and** the regenerated `plugins/plugin-icons.json` together. A plugin whose icon fails validation simply gets no manifest entry (and falls back to emoji or the generic glyph).

--- a/plugins/plugin-icons.json
+++ b/plugins/plugin-icons.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "plugins": {}
+}

--- a/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
+++ b/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
@@ -145,22 +145,80 @@ describe("isTransientUpstreamStatus mirrors the assistant classifier", () => {
 });
 
 describe("generatePluginIcons (write mode)", () => {
-  test("rejects an oversize Content-Length before buffering the body", async () => {
-    writeMarketplace([pluginEntry("big", "owner/big")]);
+  test("oversized Content-Length skips+prunes only that plugin, without buffering", async () => {
+    // Pre-seed a stale vendored icon for the plugin that will report oversized —
+    // it must be pruned, not left stale.
+    mkdirSync(join(assetsDir, "big"), { recursive: true });
+    writeFileSync(join(assetsDir, "big", "icon.png"), makePng(16, 16));
 
-    let buffered = false;
-    const fetch = async () => ({
-      ok: true,
-      status: 200,
-      headers: new Headers({ "content-length": String(32 * 1024 + 1) }),
-      arrayBuffer: async () => {
-        buffered = true;
-        return new ArrayBuffer(0);
-      },
-    });
+    const good = makePng(64, 64);
+    writeMarketplace([
+      pluginEntry("big", "owner/big"),
+      pluginEntry("good", "owner/good"),
+    ]);
 
-    await expect(run(fetch)).rejects.toThrow(/Aborting icon generation.*over the .*-byte cap/s);
-    expect(buffered).toBe(false);
+    let bigBuffered = false;
+    const fetch = async (url) => {
+      if (url.includes("/repos/owner/big/")) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-length": String(32 * 1024 + 1) }),
+          arrayBuffer: async () => {
+            bigBuffered = true;
+            return new ArrayBuffer(0);
+          },
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        arrayBuffer: async () =>
+          good.buffer.slice(good.byteOffset, good.byteOffset + good.byteLength),
+      };
+    };
+
+    const result = await run(fetch);
+
+    // Oversized body was never materialized.
+    expect(bigBuffered).toBe(false);
+    // Only the oversized plugin is skipped; the other is still vendored.
+    expect(result.vendored).toEqual(["good"]);
+    expect(result.skipped).toEqual(["big"]);
+    expect(readFileSync(join(assetsDir, "good", "icon.png")).equals(good)).toBe(true);
+    expect(readManifest().plugins).toEqual({ good: { iconVersion: sha16(good) } });
+    // Stale vendored icon for the oversized plugin was pruned.
+    let bigExists = true;
+    try {
+      readFileSync(join(assetsDir, "big", "icon.png"));
+    } catch {
+      bigExists = false;
+    }
+    expect(bigExists).toBe(false);
+  });
+
+  test("aborts on an entry name that fails PLUGIN_NAME_RE, writing nothing", async () => {
+    // A traversal-y name must never become a path segment; the run aborts before
+    // any fetch or write, and nothing is written outside plugins/assets/.
+    writeMarketplace([pluginEntry("../evil", "owner/evil")]);
+
+    let fetched = false;
+    const fetch = async () => {
+      fetched = true;
+      return { ok: true, status: 200, headers: new Headers(), arrayBuffer: async () => new ArrayBuffer(0) };
+    };
+
+    await expect(run(fetch)).rejects.toThrow(/invalid plugin name/);
+    expect(fetched).toBe(false);
+    // No stray asset written anywhere under the temp dir (e.g. a sibling of assets/).
+    let escaped = true;
+    try {
+      readFileSync(join(dir, "evil", "icon.png"));
+    } catch {
+      escaped = false;
+    }
+    expect(escaped).toBe(false);
   });
 
   test("valid PNG is vendored and indexed with the correct iconVersion", async () => {

--- a/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
+++ b/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
@@ -1,0 +1,385 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  checkPluginIcons,
+  generatePluginIcons,
+  validatePluginIconBytes,
+} from "../generate-plugin-icons.mjs";
+
+// The assistant validator is the source of truth for the byte format; assert
+// the mirrored .mjs validator agrees with it on the same inputs.
+import { validatePluginIconBytes as tsValidate } from "../../../assistant/src/cli/lib/plugin-icon-file.ts";
+
+/** Build a minimal but structurally valid PNG with the given IHDR dimensions. */
+function makePng(width, height, { padTo = 0 } = {}) {
+  const magic = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdrLen = Buffer.alloc(4);
+  ihdrLen.writeUInt32BE(13);
+  const ihdrType = Buffer.from("IHDR", "ascii");
+  const ihdrData = Buffer.alloc(13);
+  ihdrData.writeUInt32BE(width, 0);
+  ihdrData.writeUInt32BE(height, 4);
+  ihdrData[8] = 8; // bit depth
+  ihdrData[9] = 6; // color type (RGBA)
+  let buf = Buffer.concat([magic, ihdrLen, ihdrType, ihdrData]);
+  if (padTo > buf.length) {
+    buf = Buffer.concat([buf, Buffer.alloc(padTo - buf.length)]);
+  }
+  return buf;
+}
+
+const sha16 = (b) => createHash("sha256").update(b).digest("hex").slice(0, 16);
+
+/** A fetch stub keyed by GitHub Contents URL substring `<repo>`. */
+function stubFetch(byRepo) {
+  return async (url) => {
+    const match = Object.keys(byRepo).find((repo) => url.includes(`/repos/${repo}/`));
+    const entry = match ? byRepo[match] : undefined;
+    if (!entry) {
+      return { ok: false, status: 404 };
+    }
+    if (typeof entry.status === "number" && entry.status !== 200) {
+      return { ok: false, status: entry.status };
+    }
+    const bytes = entry.bytes;
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: async () =>
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    };
+  };
+}
+
+let dir;
+let marketplacePath;
+let assetsDir;
+let manifestPath;
+
+function writeMarketplace(plugins) {
+  writeFileSync(
+    marketplacePath,
+    JSON.stringify({ name: "vellum-assistant", plugins }, null, 2),
+  );
+}
+
+function pluginEntry(name, repo, extra = {}) {
+  return {
+    name,
+    source: {
+      source: "github",
+      repo,
+      ref: "a".repeat(40),
+      ...extra,
+    },
+  };
+}
+
+const run = (fetch) =>
+  generatePluginIcons({
+    fetch,
+    marketplacePath,
+    assetsDir,
+    manifestPath,
+    token: undefined,
+    log: { log() {}, warn() {} },
+  });
+
+const check = () => checkPluginIcons({ assetsDir, manifestPath });
+
+const readManifest = () => JSON.parse(readFileSync(manifestPath, "utf-8"));
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "plugin-icons-"));
+  marketplacePath = join(dir, "marketplace.json");
+  assetsDir = join(dir, "assets");
+  manifestPath = join(dir, "plugin-icons.json");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("validatePluginIconBytes mirrors the assistant validator", () => {
+  test("agrees with the TS validator across cases", () => {
+    const cases = [
+      makePng(64, 64),
+      makePng(128, 128),
+      makePng(129, 64), // oversized dimension
+      makePng(64, 64, { padTo: 32 * 1024 + 1 }), // oversized bytes
+      Buffer.from("not a png at all, definitely not"),
+    ];
+    for (const bytes of cases) {
+      expect(validatePluginIconBytes(bytes)).toEqual(tsValidate(bytes));
+    }
+  });
+});
+
+describe("generatePluginIcons (write mode)", () => {
+  test("valid PNG is vendored and indexed with the correct iconVersion", async () => {
+    const png = makePng(64, 64);
+    writeMarketplace([pluginEntry("good", "owner/good")]);
+
+    const result = await run(stubFetch({ "owner/good": { bytes: png } }));
+
+    expect(result.vendored).toEqual(["good"]);
+    const vendored = readFileSync(join(assetsDir, "good", "icon.png"));
+    expect(vendored.equals(png)).toBe(true);
+    expect(readManifest()).toEqual({
+      version: 1,
+      plugins: { good: { iconVersion: sha16(png) } },
+    });
+  });
+
+  test("oversized/invalid PNG is skipped, not vendored, absent from manifest", async () => {
+    const huge = makePng(64, 64, { padTo: 32 * 1024 + 1 });
+    writeMarketplace([pluginEntry("big", "owner/big")]);
+
+    const result = await run(stubFetch({ "owner/big": { bytes: huge } }));
+
+    expect(result.vendored).toEqual([]);
+    expect(result.skipped).toEqual(["big"]);
+    expect(readManifest().plugins).toEqual({});
+  });
+
+  test("missing icon (404) is absent from the manifest", async () => {
+    writeMarketplace([pluginEntry("none", "owner/none")]);
+
+    const result = await run(stubFetch({}));
+
+    expect(result.skipped).toEqual(["none"]);
+    expect(readManifest().plugins).toEqual({});
+  });
+
+  for (const status of [500, 429]) {
+    test(`transient HTTP ${status} aborts without mutating assets/manifest`, async () => {
+      // Pre-seed a valid vendored icon + manifest for a plugin that will fail
+      // transiently: the run must NOT prune it.
+      const existing = makePng(64, 64);
+      mkdirSync(join(assetsDir, "keep"), { recursive: true });
+      writeFileSync(join(assetsDir, "keep", "icon.png"), existing);
+      writeFileSync(
+        manifestPath,
+        `${JSON.stringify(
+          { version: 1, plugins: { keep: { iconVersion: sha16(existing) } } },
+          null,
+          2,
+        )}\n`,
+      );
+
+      writeMarketplace([pluginEntry("keep", "owner/keep")]);
+
+      await expect(
+        run(stubFetch({ "owner/keep": { status } })),
+      ).rejects.toThrow(/Aborting icon generation/);
+
+      // Working tree untouched: existing icon + manifest survive verbatim.
+      expect(readFileSync(join(assetsDir, "keep", "icon.png")).equals(existing)).toBe(
+        true,
+      );
+      expect(readManifest().plugins).toEqual({ keep: { iconVersion: sha16(existing) } });
+    });
+  }
+
+  test("a network/DNS throw aborts and leaves the tree unchanged", async () => {
+    const existing = makePng(48, 48);
+    mkdirSync(join(assetsDir, "keep"), { recursive: true });
+    writeFileSync(join(assetsDir, "keep", "icon.png"), existing);
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify(
+        { version: 1, plugins: { keep: { iconVersion: sha16(existing) } } },
+        null,
+        2,
+      )}\n`,
+    );
+    writeMarketplace([pluginEntry("keep", "owner/keep")]);
+
+    const throwingFetch = async () => {
+      throw new Error("getaddrinfo ENOTFOUND api.github.com");
+    };
+
+    await expect(run(throwingFetch)).rejects.toThrow(/Aborting icon generation/);
+    expect(readFileSync(join(assetsDir, "keep", "icon.png")).equals(existing)).toBe(
+      true,
+    );
+    expect(readManifest().plugins).toEqual({ keep: { iconVersion: sha16(existing) } });
+  });
+
+  test("a transient failure does not vendor an earlier-processed plugin", async () => {
+    // "alpha" fetches fine, "bravo" fails transiently: alpha must not be
+    // written to disk since the whole run aborts before any mutation.
+    writeMarketplace([
+      pluginEntry("alpha", "owner/alpha"),
+      pluginEntry("bravo", "owner/bravo"),
+    ]);
+
+    await expect(
+      run(
+        stubFetch({
+          "owner/alpha": { bytes: makePng(32, 32) },
+          "owner/bravo": { status: 503 },
+        }),
+      ),
+    ).rejects.toThrow(/Aborting icon generation/);
+
+    let alphaExists = true;
+    try {
+      readFileSync(join(assetsDir, "alpha", "icon.png"));
+    } catch {
+      alphaExists = false;
+    }
+    expect(alphaExists).toBe(false);
+  });
+
+  test("respects source.path when building the fetch URL", async () => {
+    const png = makePng(32, 32);
+    writeMarketplace([pluginEntry("nested", "owner/mono", { path: "sub/dir" })]);
+
+    let requestedUrl;
+    const fetch = async (url) => {
+      requestedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () =>
+          png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength),
+      };
+    };
+
+    await run(fetch);
+    expect(requestedUrl).toContain("/repos/owner/mono/contents/sub/dir/icon.png");
+  });
+
+  test("prunes stale asset dirs for plugins that lost/never had an icon", async () => {
+    // Pre-seed a stale vendored asset for a plugin absent from the marketplace.
+    mkdirSync(join(assetsDir, "stale"), { recursive: true });
+    writeFileSync(join(assetsDir, "stale", "icon.png"), makePng(16, 16));
+
+    const png = makePng(48, 48);
+    writeMarketplace([pluginEntry("keep", "owner/keep")]);
+
+    await run(stubFetch({ "owner/keep": { bytes: png } }));
+
+    expect(check().ok).toBe(true);
+    expect(readManifest().plugins).toEqual({ keep: { iconVersion: sha16(png) } });
+    // Stale dir removed.
+    let staleExists = true;
+    try {
+      readFileSync(join(assetsDir, "stale", "icon.png"));
+    } catch {
+      staleExists = false;
+    }
+    expect(staleExists).toBe(false);
+  });
+
+  test("output is deterministic across runs", async () => {
+    writeMarketplace([
+      pluginEntry("bravo", "owner/bravo"),
+      pluginEntry("alpha", "owner/alpha"),
+    ]);
+    const fetch = stubFetch({
+      "owner/alpha": { bytes: makePng(20, 20) },
+      "owner/bravo": { bytes: makePng(30, 30) },
+    });
+
+    await run(fetch);
+    const first = readFileSync(manifestPath, "utf-8");
+    await run(fetch);
+    const second = readFileSync(manifestPath, "utf-8");
+
+    expect(first).toBe(second);
+    // Names sorted, trailing newline.
+    expect(first.endsWith("\n")).toBe(true);
+    expect(first.indexOf('"alpha"')).toBeLessThan(first.indexOf('"bravo"'));
+  });
+});
+
+describe("checkPluginIcons (check mode)", () => {
+  test("passes on a consistent tree", async () => {
+    writeMarketplace([pluginEntry("good", "owner/good")]);
+    await run(stubFetch({ "owner/good": { bytes: makePng(64, 64) } }));
+
+    expect(check()).toEqual({ ok: true, errors: [] });
+  });
+
+  test("fails on a hand-mutated manifest iconVersion", async () => {
+    writeMarketplace([pluginEntry("good", "owner/good")]);
+    await run(stubFetch({ "owner/good": { bytes: makePng(64, 64) } }));
+
+    const manifest = readManifest();
+    manifest.plugins.good.iconVersion = "0000000000000000";
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("iconVersion mismatch");
+  });
+
+  test("fails on an orphan manifest entry with no asset", async () => {
+    mkdirSync(assetsDir, { recursive: true });
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({ version: 1, plugins: { ghost: { iconVersion: "abc" } } }, null, 2)}\n`,
+    );
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("no vendored asset");
+  });
+
+  test("fails on an unlisted asset dir", async () => {
+    mkdirSync(join(assetsDir, "surprise"), { recursive: true });
+    writeFileSync(join(assetsDir, "surprise", "icon.png"), makePng(16, 16));
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({ version: 1, plugins: {} }, null, 2)}\n`,
+    );
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("not listed in the manifest");
+  });
+
+  test("fails on a hash-matching but non-PNG vendored asset", async () => {
+    // A malformed blob committed as icon.png, with the manifest hash tuned to
+    // match it — the hash check alone would pass; contract validation must not.
+    const bogus = Buffer.from("this is not a png but has a matching hash!!");
+    mkdirSync(join(assetsDir, "evil"), { recursive: true });
+    writeFileSync(join(assetsDir, "evil", "icon.png"), bogus);
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify(
+        { version: 1, plugins: { evil: { iconVersion: sha16(bogus) } } },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("not a contract-valid PNG");
+  });
+
+  test("fails on a hash-matching but oversized vendored asset", async () => {
+    const huge = makePng(64, 64, { padTo: 32 * 1024 + 1 });
+    mkdirSync(join(assetsDir, "big"), { recursive: true });
+    writeFileSync(join(assetsDir, "big", "icon.png"), huge);
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify(
+        { version: 1, plugins: { big: { iconVersion: sha16(huge) } } },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = check();
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toContain("not a contract-valid PNG");
+  });
+});

--- a/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
+++ b/scripts/plugins/__tests__/generate-plugin-icons.test.mjs
@@ -7,11 +7,14 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   checkPluginIcons,
   generatePluginIcons,
+  isTransientUpstreamStatus,
   validatePluginIconBytes,
 } from "../generate-plugin-icons.mjs";
 
 // The assistant validator is the source of truth for the byte format; assert
-// the mirrored .mjs validator agrees with it on the same inputs.
+// the mirrored .mjs validator agrees with it on the same inputs. (The transient
+// classifier is covered separately below without a TS import — plugin-marketplace.ts
+// pulls in zod, which this install-free CI job cannot resolve.)
 import { validatePluginIconBytes as tsValidate } from "../../../assistant/src/cli/lib/plugin-icon-file.ts";
 
 /** Build a minimal but structurally valid PNG with the given IHDR dimensions. */
@@ -119,7 +122,47 @@ describe("validatePluginIconBytes mirrors the assistant validator", () => {
   });
 });
 
+describe("isTransientUpstreamStatus mirrors the assistant classifier", () => {
+  // Spec: `isTransientUpstreamStatus` in
+  // assistant/src/cli/lib/plugin-marketplace.ts — 429/5xx always transient; a
+  // 403 is transient only when the rate-limit quota header is exhausted.
+  test("classifies statuses per the TS spec", () => {
+    const res = (status, headers = {}) => ({ status, headers: new Headers(headers) });
+    const cases = [
+      [res(200), false],
+      [res(403), false], // hard authorization failure — quota not exhausted
+      [res(403, { "x-ratelimit-remaining": "0" }), true], // rate-limit signal
+      [res(404), false],
+      [res(408), false],
+      [res(429), true],
+      [res(500), true],
+      [res(503), true],
+    ];
+    for (const [r, expected] of cases) {
+      expect(isTransientUpstreamStatus(r)).toBe(expected);
+    }
+  });
+});
+
 describe("generatePluginIcons (write mode)", () => {
+  test("rejects an oversize Content-Length before buffering the body", async () => {
+    writeMarketplace([pluginEntry("big", "owner/big")]);
+
+    let buffered = false;
+    const fetch = async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": String(32 * 1024 + 1) }),
+      arrayBuffer: async () => {
+        buffered = true;
+        return new ArrayBuffer(0);
+      },
+    });
+
+    await expect(run(fetch)).rejects.toThrow(/Aborting icon generation.*over the .*-byte cap/s);
+    expect(buffered).toBe(false);
+  });
+
   test("valid PNG is vendored and indexed with the correct iconVersion", async () => {
     const png = makePng(64, 64);
     writeMarketplace([pluginEntry("good", "owner/good")]);

--- a/scripts/plugins/generate-plugin-icons.mjs
+++ b/scripts/plugins/generate-plugin-icons.mjs
@@ -94,7 +94,7 @@ export function validatePluginIconBytes(bytes) {
 }
 
 /** First 16 hex chars of sha256(bytes) — the stable content version. */
-export function iconVersionOf(bytes) {
+function iconVersionOf(bytes) {
   return createHash("sha256").update(bytes).digest("hex").slice(0, 16);
 }
 
@@ -146,7 +146,7 @@ export class IconFetchError extends Error {
  * is always transient; a 403 is a rate-limit signal only when the remaining
  * quota header is exhausted, otherwise it is a hard authorization failure.
  */
-function isTransientUpstreamStatus(res) {
+export function isTransientUpstreamStatus(res) {
   if (res.status === 429 || res.status >= 500) return true;
   if (res.status === 403) {
     return res.headers?.get?.("x-ratelimit-remaining") === "0";
@@ -187,6 +187,17 @@ async function fetchIconBytes(fetchImpl, entry, token) {
       transient: isTransientUpstreamStatus(res),
       status: res.status,
     });
+  }
+  // Reject an oversized icon on its advertised Content-Length before buffering
+  // it — a huge upstream icon.png would otherwise be materialized whole only to
+  // be rejected by the byte cap. A hard (non-transient) failure: the validator
+  // still catches a missing/lying length once the bytes are in memory.
+  const contentLength = Number(res.headers?.get?.("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_ICON_BYTES) {
+    throw new IconFetchError(
+      `icon.png is ${contentLength} bytes, over the ${MAX_ICON_BYTES}-byte cap`,
+      { transient: false, status: res.status },
+    );
   }
   return Buffer.from(await res.arrayBuffer());
 }

--- a/scripts/plugins/generate-plugin-icons.mjs
+++ b/scripts/plugins/generate-plugin-icons.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * Resolve, validate, and vendor marketplace plugin `icon.png` files, then
+ * emit the derived `plugins/plugin-icons.json` index.
+ *
+ * WRITE mode (default): for each entry in `plugins/marketplace.json`, fetch
+ * `<source.path>/icon.png` at the pinned `source.ref` via the GitHub Contents
+ * API, validate the bytes against the icon contract, and — on success —
+ * vendor them to `plugins/assets/<name>/icon.png` and index the plugin in
+ * `plugins/plugin-icons.json`. Invalid or missing (404) icons are fail-closed:
+ * skipped, pruned, and omitted from the manifest. A non-404 fetch failure
+ * (transient 429/5xx/network or a hard error) aborts the whole run before any
+ * asset/manifest is written, so an outage never silently drops a pinned icon.
+ *
+ * CHECK mode (`--check`): purely local. Re-validate every vendored `icon.png`
+ * against the icon contract and assert its content hash matches the committed
+ * manifest, with no orphan manifest entries and no unlisted asset dirs. No
+ * network.
+ *
+ * Usage:
+ *   node scripts/plugins/generate-plugin-icons.mjs          # write
+ *   node scripts/plugins/generate-plugin-icons.mjs --check  # verify
+ */
+
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../..");
+const MARKETPLACE_PATH = join(REPO_ROOT, "plugins/marketplace.json");
+const ASSETS_DIR = join(REPO_ROOT, "plugins/assets");
+const MANIFEST_PATH = join(REPO_ROOT, "plugins/plugin-icons.json");
+const ICON_FILENAME = "icon.png";
+
+// ---------------------------------------------------------------------------
+// Icon validation
+//
+// Mirrors `validatePluginIconBytes` in
+// `assistant/src/cli/lib/plugin-icon-file.ts` — the authoritative
+// implementation — kept byte-identical so a plugin that validates for the
+// assistant vendors here too. See `docs/plugin-icon-contract.md` for the spec.
+// Re-implemented (not imported) because this script runs under plain `node`,
+// which cannot import the TypeScript source.
+// ---------------------------------------------------------------------------
+
+const MAX_ICON_BYTES = 32 * 1024;
+const MAX_ICON_DIMENSION = 128;
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PNG_IHDR_LENGTH = 13;
+const PNG_IHDR_TYPE = Buffer.from("IHDR", "ascii");
+const MIN_HEADER_BYTES = 24;
+
+/**
+ * Validate in-memory PNG bytes against the icon contract. Returns
+ * `{ hasIcon: true, iconVersion }` only for a PNG whose IHDR dimensions and
+ * total size are within bounds; every other case returns `{ hasIcon: false }`.
+ */
+export function validatePluginIconBytes(bytes) {
+  if (bytes.length < MIN_HEADER_BYTES || bytes.length > MAX_ICON_BYTES) {
+    return { hasIcon: false };
+  }
+  if (!bytes.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)) {
+    return { hasIcon: false };
+  }
+  if (
+    bytes.readUInt32BE(8) !== PNG_IHDR_LENGTH ||
+    !bytes.subarray(12, 16).equals(PNG_IHDR_TYPE)
+  ) {
+    return { hasIcon: false };
+  }
+
+  const width = bytes.readUInt32BE(16);
+  const height = bytes.readUInt32BE(20);
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    width > MAX_ICON_DIMENSION ||
+    height > MAX_ICON_DIMENSION
+  ) {
+    return { hasIcon: false };
+  }
+
+  return { hasIcon: true, iconVersion: iconVersionOf(bytes) };
+}
+
+/** First 16 hex chars of sha256(bytes) — the stable content version. */
+export function iconVersionOf(bytes) {
+  return createHash("sha256").update(bytes).digest("hex").slice(0, 16);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isFile(path) {
+  return statSync(path, { throwIfNoEntry: false })?.isFile() ?? false;
+}
+
+/** Names of `plugins/assets/*` subdirectories (icon may or may not be present). */
+function listAssetDirs(assetsDir) {
+  return readdirSync(assetsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+/** GitHub Contents API URL for a plugin's `icon.png` at its pinned ref. */
+function iconContentsUrl(entry) {
+  const filePath = entry.source.path
+    ? `${entry.source.path}/${ICON_FILENAME}`
+    : ICON_FILENAME;
+  return (
+    `https://api.github.com/repos/${entry.source.repo}` +
+    `/contents/${filePath}?ref=${encodeURIComponent(entry.source.ref)}`
+  );
+}
+
+/**
+ * A non-404 icon fetch failure. Mirrors `MarketplaceFetchError` in
+ * `plugin-marketplace.ts`: `transient` flags a retryable upstream hiccup
+ * (429/5xx/network) vs a hard error. A 404 never reaches here — it is a normal
+ * "no icon" result, not a failure.
+ */
+export class IconFetchError extends Error {
+  constructor(message, { transient = false, status } = {}) {
+    super(message);
+    this.name = "IconFetchError";
+    this.transient = transient;
+    if (status !== undefined) this.status = status;
+  }
+}
+
+/**
+ * Classify an upstream GitHub status as transient (worth retrying) vs hard.
+ * Mirrors `isTransientUpstreamStatus` in `plugin-marketplace.ts`: 429 or 5xx
+ * is always transient; a 403 is a rate-limit signal only when the remaining
+ * quota header is exhausted, otherwise it is a hard authorization failure.
+ */
+function isTransientUpstreamStatus(res) {
+  if (res.status === 429 || res.status >= 500) return true;
+  if (res.status === 403) {
+    return res.headers?.get?.("x-ratelimit-remaining") === "0";
+  }
+  return false;
+}
+
+/**
+ * Fetch a plugin's raw `icon.png` bytes at its pinned ref. Returns the Buffer,
+ * or `null` for a missing file (404) — the only "no icon" outcome. Every other
+ * failure throws {@link IconFetchError}: a network/DNS error or a 429/5xx is
+ * `transient`, so the caller aborts rather than silently dropping a still-valid
+ * vendored icon.
+ */
+async function fetchIconBytes(fetchImpl, entry, token) {
+  const headers = {
+    Accept: "application/vnd.github.raw",
+    "User-Agent": "vellum-assistant-cli",
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  let res;
+  try {
+    res = await fetchImpl(iconContentsUrl(entry), { headers });
+  } catch (err) {
+    // Network/DNS/connection throw — retryable upstream hiccup.
+    throw new IconFetchError(`network error: ${err.message}`, {
+      transient: true,
+    });
+  }
+  if (res.status === 404) {
+    return null;
+  }
+  if (!res.ok) {
+    throw new IconFetchError(`HTTP ${res.status}`, {
+      transient: isTransientUpstreamStatus(res),
+      status: res.status,
+    });
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+/** Serialize the manifest deterministically: sorted names, trailing newline. */
+function serializeManifest(versionsByName) {
+  const plugins = {};
+  for (const name of Object.keys(versionsByName).sort()) {
+    plugins[name] = { iconVersion: versionsByName[name] };
+  }
+  return `${JSON.stringify({ version: 1, plugins }, null, 2)}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Write mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve, validate, and vendor every marketplace plugin's `icon.png`, then
+ * write the derived manifest. Prunes asset dirs for plugins that no longer
+ * ship a valid icon. Returns `{ vendored, skipped }` name lists.
+ */
+export async function generatePluginIcons({
+  fetch: fetchImpl = globalThis.fetch,
+  marketplacePath = MARKETPLACE_PATH,
+  assetsDir = ASSETS_DIR,
+  manifestPath = MANIFEST_PATH,
+  token = process.env.GITHUB_TOKEN,
+  log = console,
+} = {}) {
+  const manifest = JSON.parse(readFileSync(marketplacePath, "utf-8"));
+  const entries = manifest.plugins ?? [];
+
+  const versionsByName = {};
+  const toVendor = [];
+  const vendored = [];
+  const skipped = [];
+
+  // Resolve every icon fully in memory before touching disk. A non-404 fetch
+  // failure (transient 429/5xx/network or a hard error) aborts here — we cannot
+  // confirm the icon is gone, so treating it as "no icon" would prune a
+  // still-valid vendored icon during an outage. Deferring all writes past this
+  // loop guarantees an abort leaves the working tree unchanged.
+  for (const entry of entries) {
+    let bytes;
+    try {
+      bytes = await fetchIconBytes(fetchImpl, entry, token);
+    } catch (err) {
+      const kind = err.transient ? "transient " : "";
+      throw new Error(
+        `Aborting icon generation: ${kind}icon fetch failed for ${entry.name} (${err.message}). ` +
+          `No assets or manifest were modified; re-run once upstream recovers.`,
+      );
+    }
+
+    if (!bytes) {
+      skipped.push(entry.name);
+      continue;
+    }
+
+    const result = validatePluginIconBytes(bytes);
+    if (!result.hasIcon) {
+      log.warn?.(`skip ${entry.name}: icon.png failed validation`);
+      skipped.push(entry.name);
+      continue;
+    }
+
+    toVendor.push({ name: entry.name, bytes });
+    versionsByName[entry.name] = result.iconVersion;
+    vendored.push(entry.name);
+  }
+
+  // Every icon resolved cleanly — safe to mutate the working tree now.
+  for (const { name, bytes } of toVendor) {
+    const dir = join(assetsDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ICON_FILENAME), bytes);
+  }
+
+  // Prune asset dirs no longer backed by a valid vendored icon.
+  const keep = new Set(vendored);
+  if (statSync(assetsDir, { throwIfNoEntry: false })?.isDirectory()) {
+    for (const name of listAssetDirs(assetsDir)) {
+      if (!keep.has(name)) {
+        rmSync(join(assetsDir, name), { recursive: true, force: true });
+      }
+    }
+  }
+
+  writeFileSync(manifestPath, serializeManifest(versionsByName));
+
+  log.log?.(
+    `Vendored ${vendored.length} icon(s); ${skipped.length} plugin(s) without a valid icon.`,
+  );
+  return { vendored: vendored.sort(), skipped: skipped.sort() };
+}
+
+// ---------------------------------------------------------------------------
+// Check mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify the committed manifest against the vendored assets, purely locally:
+ * every asset's content hash matches its manifest entry, with no orphan
+ * manifest entries and no unlisted or icon-less asset dirs. Returns
+ * `{ ok, errors }`.
+ */
+export function checkPluginIcons({
+  assetsDir = ASSETS_DIR,
+  manifestPath = MANIFEST_PATH,
+} = {}) {
+  const errors = [];
+
+  let manifestPlugins = {};
+  try {
+    manifestPlugins = JSON.parse(readFileSync(manifestPath, "utf-8")).plugins ?? {};
+  } catch (err) {
+    return { ok: false, errors: [`cannot read ${manifestPath}: ${err.message}`] };
+  }
+
+  const assetNames = statSync(assetsDir, { throwIfNoEntry: false })?.isDirectory()
+    ? listAssetDirs(assetsDir)
+    : [];
+
+  for (const name of assetNames) {
+    const iconPath = join(assetsDir, name, ICON_FILENAME);
+    if (!isFile(iconPath)) {
+      errors.push(`asset dir "${name}" has no ${ICON_FILENAME}`);
+      continue;
+    }
+    // Re-run the icon contract (PNG magic + IHDR dims + byte cap), not just the
+    // hash: a hand-committed malformed/oversized blob whose manifest hash was
+    // updated to match must still fail this network-free guard.
+    const result = validatePluginIconBytes(readFileSync(iconPath));
+    if (!result.hasIcon) {
+      errors.push(
+        `asset "${name}" is not a contract-valid PNG (magic/dimensions/size)`,
+      );
+      continue;
+    }
+    const version = result.iconVersion;
+    const entry = manifestPlugins[name];
+    if (!entry) {
+      errors.push(`asset "${name}" is not listed in the manifest`);
+    } else if (entry.iconVersion !== version) {
+      errors.push(
+        `iconVersion mismatch for "${name}": asset=${version} manifest=${entry.iconVersion}`,
+      );
+    }
+  }
+
+  const assetSet = new Set(assetNames);
+  for (const name of Object.keys(manifestPlugins)) {
+    if (!assetSet.has(name)) {
+      errors.push(`manifest entry "${name}" has no vendored asset`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+async function cli(argv) {
+  if (argv.includes("--check")) {
+    const { ok, errors } = checkPluginIcons();
+    if (!ok) {
+      console.error("plugin-icons.json is out of sync with plugins/assets/:");
+      for (const e of errors) {
+        console.error(`  - ${e}`);
+      }
+      console.error(
+        "\nRun `node scripts/plugins/generate-plugin-icons.mjs` and commit the result.",
+      );
+      process.exit(1);
+    }
+    console.log("OK: plugin-icons.json matches the vendored assets.");
+    return;
+  }
+
+  await generatePluginIcons();
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(realpathSync(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedPath) {
+  await cli(process.argv.slice(2));
+}

--- a/scripts/plugins/generate-plugin-icons.mjs
+++ b/scripts/plugins/generate-plugin-icons.mjs
@@ -131,12 +131,11 @@ function iconContentsUrl(entry) {
  * (429/5xx/network) vs a hard error. A 404 never reaches here — it is a normal
  * "no icon" result, not a failure.
  */
-export class IconFetchError extends Error {
-  constructor(message, { transient = false, status } = {}) {
+class IconFetchError extends Error {
+  constructor(message, { transient = false } = {}) {
     super(message);
     this.name = "IconFetchError";
     this.transient = transient;
-    if (status !== undefined) this.status = status;
   }
 }
 
@@ -185,7 +184,6 @@ async function fetchIconBytes(fetchImpl, entry, token) {
   if (!res.ok) {
     throw new IconFetchError(`HTTP ${res.status}`, {
       transient: isTransientUpstreamStatus(res),
-      status: res.status,
     });
   }
   // Reject an oversized icon on its advertised Content-Length before buffering
@@ -196,7 +194,7 @@ async function fetchIconBytes(fetchImpl, entry, token) {
   if (Number.isFinite(contentLength) && contentLength > MAX_ICON_BYTES) {
     throw new IconFetchError(
       `icon.png is ${contentLength} bytes, over the ${MAX_ICON_BYTES}-byte cap`,
-      { transient: false, status: res.status },
+      { transient: false },
     );
   }
   return Buffer.from(await res.arrayBuffer());

--- a/scripts/plugins/generate-plugin-icons.mjs
+++ b/scripts/plugins/generate-plugin-icons.mjs
@@ -7,10 +7,11 @@
  * `<source.path>/icon.png` at the pinned `source.ref` via the GitHub Contents
  * API, validate the bytes against the icon contract, and — on success —
  * vendor them to `plugins/assets/<name>/icon.png` and index the plugin in
- * `plugins/plugin-icons.json`. Invalid or missing (404) icons are fail-closed:
- * skipped, pruned, and omitted from the manifest. A non-404 fetch failure
- * (transient 429/5xx/network or a hard error) aborts the whole run before any
- * asset/manifest is written, so an outage never silently drops a pinned icon.
+ * `plugins/plugin-icons.json`. Invalid, oversized, or missing (404) icons are
+ * fail-closed: skipped, pruned, and omitted from the manifest. A genuine non-404
+ * fetch failure (transient 429/5xx/network or a hard error) aborts the whole run
+ * before any asset/manifest is written, so an outage never silently drops a
+ * pinned icon. An invalid plugin name in the manifest also aborts.
  *
  * CHECK mode (`--check`): purely local. Re-validate every vendored `icon.png`
  * against the icon contract and assert its content hash matches the committed
@@ -41,6 +42,13 @@ const MARKETPLACE_PATH = join(REPO_ROOT, "plugins/marketplace.json");
 const ASSETS_DIR = join(REPO_ROOT, "plugins/assets");
 const MANIFEST_PATH = join(REPO_ROOT, "plugins/plugin-icons.json");
 const ICON_FILENAME = "icon.png";
+
+// Canonical single-segment kebab-case install name. Source of truth:
+// `PLUGIN_NAME_RE` in `assistant/src/cli/lib/plugin-marketplace.ts`. marketplace.json
+// is read here via a plain JSON.parse (not the zod schema), so every name must be
+// re-validated before it is used as a filesystem path segment — a name like "../x"
+// must never become a path.
+const PLUGIN_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
 
 // ---------------------------------------------------------------------------
 // Icon validation
@@ -154,11 +162,20 @@ export function isTransientUpstreamStatus(res) {
 }
 
 /**
+ * Sentinel: the icon advertised a Content-Length over the byte cap. This is a
+ * per-plugin validation failure under the icon contract (like invalid PNG bytes),
+ * NOT a fetch error — the caller skips + prunes just this plugin instead of
+ * aborting the run, and never buffers the oversized body.
+ */
+const OVERSIZED_ICON = Symbol("oversized-icon");
+
+/**
  * Fetch a plugin's raw `icon.png` bytes at its pinned ref. Returns the Buffer,
- * or `null` for a missing file (404) — the only "no icon" outcome. Every other
- * failure throws {@link IconFetchError}: a network/DNS error or a 429/5xx is
- * `transient`, so the caller aborts rather than silently dropping a still-valid
- * vendored icon.
+ * `null` for a missing file (404), or {@link OVERSIZED_ICON} when the advertised
+ * Content-Length exceeds the byte cap — the two "no valid icon" outcomes the
+ * caller skips + prunes. Every other failure throws {@link IconFetchError}: a
+ * network/DNS error or a 429/5xx is `transient`, so the caller aborts rather than
+ * silently dropping a still-valid vendored icon.
  */
 async function fetchIconBytes(fetchImpl, entry, token) {
   const headers = {
@@ -188,14 +205,12 @@ async function fetchIconBytes(fetchImpl, entry, token) {
   }
   // Reject an oversized icon on its advertised Content-Length before buffering
   // it — a huge upstream icon.png would otherwise be materialized whole only to
-  // be rejected by the byte cap. A hard (non-transient) failure: the validator
-  // still catches a missing/lying length once the bytes are in memory.
+  // be rejected by the byte cap. This is icon-contract validation, not a fetch
+  // failure: skip + prune this one plugin (no abort, no arrayBuffer). The
+  // validator still catches a missing/lying length once the bytes are in memory.
   const contentLength = Number(res.headers?.get?.("content-length"));
   if (Number.isFinite(contentLength) && contentLength > MAX_ICON_BYTES) {
-    throw new IconFetchError(
-      `icon.png is ${contentLength} bytes, over the ${MAX_ICON_BYTES}-byte cap`,
-      { transient: false },
-    );
+    return OVERSIZED_ICON;
   }
   return Buffer.from(await res.arrayBuffer());
 }
@@ -240,6 +255,18 @@ export async function generatePluginIcons({
   // still-valid vendored icon during an outage. Deferring all writes past this
   // loop guarantees an abort leaves the working tree unchanged.
   for (const entry of entries) {
+    // Validate the name before it is ever fetched or turned into a path. A name
+    // that fails PLUGIN_NAME_RE is a manifest-integrity defect (e.g. a traversal
+    // segment like "../evil"), not a "plugin has no icon" case, so abort — the
+    // manifest author must fix it. See PLUGIN_NAME_RE above.
+    if (typeof entry.name !== "string" || !PLUGIN_NAME_RE.test(entry.name)) {
+      throw new Error(
+        `Aborting icon generation: invalid plugin name ${JSON.stringify(entry.name)} ` +
+          `in ${marketplacePath}. Names must match ${PLUGIN_NAME_RE} ` +
+          `(single kebab-case segment). No assets or manifest were modified.`,
+      );
+    }
+
     let bytes;
     try {
       bytes = await fetchIconBytes(fetchImpl, entry, token);
@@ -249,6 +276,12 @@ export async function generatePluginIcons({
         `Aborting icon generation: ${kind}icon fetch failed for ${entry.name} (${err.message}). ` +
           `No assets or manifest were modified; re-run once upstream recovers.`,
       );
+    }
+
+    if (bytes === OVERSIZED_ICON) {
+      log.warn?.(`skip ${entry.name}: icon.png exceeds the ${MAX_ICON_BYTES}-byte cap`);
+      skipped.push(entry.name);
+      continue;
     }
 
     if (!bytes) {
@@ -321,6 +354,13 @@ export function checkPluginIcons({
     : [];
 
   for (const name of assetNames) {
+    // Never derive a path from a name that isn't a canonical install name — a
+    // stray traversal-y dir name must not be joined onto assetsDir. See
+    // PLUGIN_NAME_RE above.
+    if (!PLUGIN_NAME_RE.test(name)) {
+      errors.push(`asset dir "${name}" is not a valid plugin name`);
+      continue;
+    }
     const iconPath = join(assetsDir, name, ICON_FILENAME);
     if (!isFile(iconPath)) {
       errors.push(`asset dir "${name}" has no ${ICON_FILENAME}`);


### PR DESCRIPTION
## Summary
Emits plugin marketplace icon data from this repo so plugin cards can render icons on the marketing site (and the daemon catalog-browse), mirroring how skill icons already work. This is the assistant-repo half; the platform consumes it separately (see the sibling `plugin-icons-platform.md` plan in vellum-assistant-platform).

- **Curated emoji tier:** optional `icon` emoji on marketplace entries, threaded through the catalog/search path (schema → `marketplaceMatch` → platform row → `/v1/plugins/search` + openapi).
- **Bundled-PNG tier:** `scripts/plugins/generate-plugin-icons.mjs` fetches each plugin's `icon.png` at its pinned SHA, validates it (shared `validatePluginIconBytes`, fail-closed: PNG magic + IHDR ≤128×128 + ≤32 KB), vendors valid bytes to `plugins/assets/<name>/icon.png`, and indexes them in `plugins/plugin-icons.json`. A network-free `--check` (wired into `pr-marketplace.yaml`) guards manifest↔asset drift; `upload-plugin-assets.yaml` ships vendored PNGs to GCS (self-skips until the platform bucket exists).
- **Contract:** `docs/plugin-icon-contract.md` is the cross-repo source of truth.

Note: no marketplace plugin currently ships an `icon.png`, so `plugin-icons.json` is intentionally empty — the PNG pipeline is built and tested but has no payload yet. The emoji tier is the immediate win.

## Self-review result
PASS after 2 remediation rounds. Four fresh-eyes passes (external-feedback, plan-faithfulness, repo-integration, slop/reuse) ran twice. Round 1 fixed: CI wasn't running the generator/parity tests, an unbounded icon download, and an emoji-only `icon` description that can carry a URL. Round 2 fixed: parity test didn't trigger on TS-validator-source edits, plus two dead-code nits. Plan-faithfulness and integration both PASS; 176 assistant + 19 generator tests green.

## PRs merged into feature branch
- #37975 curated `icon` emoji + catalog threading · #37976 contract doc · #37977 `validatePluginIconBytes` extraction
- #37984 PNG resolve/vendor generator + manifest · #37987 CI drift-check · #37988 GCS upload workflow

### Self-review fix PRs
- #37991 `icon` description = emoji-or-URL (+ inherited disk-pressure mock fix) · #37992 CI test/parity enforcement + download cap · #37996 parity-trigger path + dead-code cleanup

## Before release / follow-ups
- Platform prerequisite (separate repo): Terraform `vellum-*-plugin-assets` bucket + WIF + `GCS_PLUGIN_ASSETS_BUCKET` var un-gate the upload workflow; Django `/v1/plugins/` serves the combined `icon`; marketing `onError` fallback. Tracked in `vellum-assistant-platform/.private/plans/plugin-icons-platform.md`.

Part of plan: plugin-icons-marketing.md