### PR TITLE
feat(live-voice): managed-speech preflight (R3)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-credential-preflight.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-credential-preflight.test.ts
@@ -40,6 +40,9 @@ const realSttResolveModule = {
 const realSecureKeysModule = {
   ...(await import("../../security/secure-keys.js")),
 };
+const realManagedSpeechModule = {
+  ...(await import("../../platform/managed-speech.js")),
+};
 
 // -- Mutable stub state --------------------------------------------------------
 
@@ -69,6 +72,16 @@ mock.module("../../security/secure-keys.js", () => ({
     preflightMocksActive
       ? undefined
       : realSecureKeysModule.getSecureKeyAsync(account),
+}));
+
+let managedAvailable = false;
+
+mock.module("../../platform/managed-speech.js", () => ({
+  ...realManagedSpeechModule,
+  managedSpeechAvailable: async () =>
+    preflightMocksActive
+      ? managedAvailable
+      : realManagedSpeechModule.managedSpeechAvailable(),
 }));
 
 import { setConfig } from "../../__tests__/helpers/set-config.js";
@@ -122,6 +135,7 @@ beforeEach(() => {
   sttProvider = "deepgram";
   ttsProvider = "fish-audio";
   ttsProviders = { "fish-audio": { referenceId: "ref-123" } };
+  managedAvailable = false;
 });
 
 function expectNotReady(
@@ -268,5 +282,34 @@ describe("resolveLiveVoiceCredentialReadiness", () => {
     // Single sentence: suitable for the client `error` frame.
     expect(readiness.userMessage).not.toContain("\n");
     expect(readiness.userMessage.endsWith(".")).toBe(true);
+  });
+});
+
+describe("resolveLiveVoiceCredentialReadiness — managed (vellum) TTS", () => {
+  test("vellum TTS with a full platform connection → ready", async () => {
+    ttsProvider = "vellum";
+    ttsProviders = {};
+    managedAvailable = true;
+
+    const readiness = await runReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+  });
+
+  test("vellum TTS without a platform connection → connection copy, not API-key copy", async () => {
+    ttsProvider = "vellum";
+    ttsProviders = {};
+    managedAvailable = false;
+
+    const readiness = expectNotReady(await runReadiness());
+    expect(readiness.missing).toEqual([
+      {
+        kind: "tts",
+        providerId: "vellum",
+        reason:
+          'TTS provider "vellum" needs a Vellum platform connection for managed speech',
+      },
+    ]);
+    expect(readiness.userMessage).toContain("assistant platform connect");
+    expect(readiness.userMessage).not.toContain("API key");
   });
 });

--- a/assistant/src/live-voice/live-voice-credential-preflight.ts
+++ b/assistant/src/live-voice/live-voice-credential-preflight.ts
@@ -16,8 +16,8 @@ import {
   ttsSecretResolves,
 } from "../calls/telephony-tts-capability.js";
 import { getConfig } from "../config/loader.js";
-import { managedSpeechAvailable } from "../platform/managed-speech.js";
 import { effectiveSttProvider } from "../config/schemas/stt.js";
+import { managedSpeechAvailable } from "../platform/managed-speech.js";
 import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import {
   resolveStreamingTranscriber,

--- a/assistant/src/live-voice/live-voice-credential-preflight.ts
+++ b/assistant/src/live-voice/live-voice-credential-preflight.ts
@@ -16,6 +16,7 @@ import {
   ttsSecretResolves,
 } from "../calls/telephony-tts-capability.js";
 import { getConfig } from "../config/loader.js";
+import { managedSpeechAvailable } from "../platform/managed-speech.js";
 import { effectiveSttProvider } from "../config/schemas/stt.js";
 import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import {
@@ -180,6 +181,24 @@ async function resolveTtsGap(): Promise<GapWithClause | null> {
       },
       clause: `a text-to-speech provider that supports streaming synthesis (the configured "${entry.id}" does not)`,
     };
+  }
+
+  // Managed speech authenticates via the platform connection — full
+  // availability (API key + assistant ID) is the credential, so the
+  // stored-secret loop below would pass half-connected states that
+  // synthesis rejects.
+  if (entry.id === "vellum") {
+    if (!(await managedSpeechAvailable())) {
+      return {
+        gap: {
+          kind: "tts",
+          providerId: entry.id,
+          reason: `TTS provider "${entry.id}" needs a Vellum platform connection for managed speech`,
+        },
+        clause: `a Vellum platform connection for managed speech (run 'assistant platform connect')`,
+      };
+    }
+    return null;
   }
 
   for (const secret of entry.secretRequirements) {

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -1018,6 +1018,19 @@ describe("vellum managed resolution", () => {
     ]);
   });
 
+  test("streaming resolver returns null when the platform connection is unavailable", async () => {
+    mockVellumAvailable = false;
+    mockVelayConnection = {
+      wsBaseUrl: "ws://gateway.test",
+      httpBaseUrl: "http://gateway.test",
+      mintServiceToken: () => "vk-test",
+    };
+    applyConfig({ provider: "deepgram", mode: "managed" });
+
+    expect(await resolveStreamingTranscriber({ sampleRate: 16000 })).toBeNull();
+    expect(vellumStreamCtorCalls).toHaveLength(0);
+  });
+
   test("streaming resolver returns null when the velay connection is missing", async () => {
     mockVellumAvailable = true;
     mockVelayConnection = null;

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -478,6 +478,15 @@ async function createStreamingTranscriber(
       // ignored, matching Gemini/Whisper — as is utteranceEndMs (the relay
       // allowlist has no utterance_end_ms; boundary finals ride on
       // endpointing alone).
+      // The gateway is the credential authority, but the platform
+      // connection (API key + assistant ID) is checkable locally — gate
+      // here so preflight reports "connect your account" instead of
+      // resolving a transcriber whose dial is doomed.
+      const { vellumManagedSpeechAvailable } =
+        await import("./vellum-managed.js");
+      if (!(await vellumManagedSpeechAvailable())) {
+        return null;
+      }
       const { resolveSpeechRelayConnection } =
         await import("./vellum-speech-relay-connection.js");
       const connection = await resolveSpeechRelayConnection();


### PR DESCRIPTION
Final code PR of the realtime-adapters plan (R3 of R1–R3). **Stacked on #37989 (R2)** — the TTS readiness check needs R2's `supportsStreaming` flip. Small by design: B2/B3 already landed most of the connection-aware preflight copy; this closes the two real gaps.

## What

**Streaming resolver availability gate** (`resolve.ts`): the gateway-mediated rework (#37921) reduced the vellum streaming case's availability signal to "can mint a service token" — which is always true with a signing key. With `mode: "managed"` and no platform connection, preflight would resolve a transcriber whose dial is doomed to the gateway's `missing_platform_connection` rejection. The case now gates on `vellumManagedSpeechAvailable()` (API key + assistant ID, checkable locally), so the preflight's gap classification reaches B2's connection-aware copy instead of reporting ready.

**Live-voice TTS gap** (`live-voice-credential-preflight.ts`): `resolveTtsGap` gets a vellum branch on `managedSpeechAvailable()` — the generic stored-secret loop only checked the API key, passing half-connected states (key present, assistant ID missing) that synthesis rejects, and produced "an API key for the text-to-speech provider" copy. The vellum gap now reads *a Vellum platform connection for managed speech (run 'assistant platform connect')*, matching the STT leg's B2 copy.

## Tests
- Preflight: vellum TTS + full connection → ready; without connection → connection copy, no "API key" wording.
- Resolver: managed mode + relay connection but no platform connection → null transcriber (no adapter constructed).

## Definition of done (manual, after merge)
The plan's acceptance is a live dev E2E: `voice-mode` flag on, `services.stt.mode` + `services.tts.mode: "managed"`, **zero BYOK keys** → hold a voice-room conversation, confirm transcripts + spoken replies, then verify two `managed_speech_proxy` usage events (one `streamed_audio_minute`, one `character`) in dev Django. Happy to drive that checklist once this stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/37999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->