### PR TITLE
fix(voice): resolve guardian trust for local live-voice turns (JARVIS-1277)

### DIFF
--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -26,6 +26,7 @@ import {
 } from "../calls/voice-triage-escalate.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
 import {
   listProviderIds,
@@ -2575,8 +2576,49 @@ async function defaultStartVoiceTurn(
       options.conversationId,
     );
   }
+  // Stamp the turn with the guardian's trust context — the same resolution the
+  // text-send route runs for a local vellum principal. A local live-voice
+  // session only exists for the guardian's own authenticated client (the
+  // gateway pins the `/v1/live-voice` upgrade to the bound guardian), but the
+  // live-voice ingress bypasses the send-message route, so without this stamp
+  // the turn resolved to the fail-closed `unknown` trust class and every
+  // sensitive tool was denied. Resolution stays fail-closed: a gateway miss /
+  // missing binding leaves the context unset (`unknown`), never a blind grant.
+  const trustContext = await resolveLocalLiveVoiceTrustContext(
+    options.conversationId,
+  );
   const { startVoiceTurn } = await import("../calls/voice-session-bridge.js");
-  return startVoiceTurn(options);
+  return startVoiceTurn({
+    ...options,
+    ...(trustContext ? { trustContext } : {}),
+  });
+}
+
+/**
+ * Resolve the local guardian's {@link TrustContext} for a live-voice turn, or
+ * `undefined` when it cannot be established (no vellum guardian binding, or
+ * the gateway is unreachable) — the turn then runs under the fail-closed
+ * `unknown` capability set, exactly as an unstamped turn does.
+ */
+async function resolveLocalLiveVoiceTrustContext(
+  conversationId: string,
+): Promise<TrustContext | undefined> {
+  const { findLocalGuardianPrincipalId } =
+    await import("../runtime/local-actor-identity.js");
+  const { resolveLocalPrincipalTrustContext } =
+    await import("../runtime/local-principal-trust.js");
+  const guardianPrincipalId = await findLocalGuardianPrincipalId();
+  if (!guardianPrincipalId) {
+    return undefined;
+  }
+  const trustContext = await resolveLocalPrincipalTrustContext({
+    actorPrincipalId: guardianPrincipalId,
+    sourceChannel: "vellum",
+    conversationExternalId: conversationId,
+  });
+  // Only stamp a positive guardian resolution; the resolver's own
+  // fail-closed `unknown` carries no more information than no stamp.
+  return trustContext.trustClass === "guardian" ? trustContext : undefined;
 }
 
 async function defaultStreamLiveVoiceTtsAudio(

--- a/gateway/src/__tests__/live-voice-websocket.test.ts
+++ b/gateway/src/__tests__/live-voice-websocket.test.ts
@@ -16,6 +16,10 @@ import type { GatewayConfig } from "../config.js";
 import type { LiveVoiceSocketData } from "../http/routes/live-voice-websocket.js";
 import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
 
+// The bound-guardian platform user id, shared by the velay mock and the velay
+// tests (their attested caller must match it to authenticate).
+const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
+
 // The live-voice upgrade pins actor tokens to the bound guardian. Mock the
 // binding lookup (set BEFORE importing the module under test) so the actor
 // path is testable without gateway DB state; the default binding matches
@@ -27,6 +31,16 @@ let mockFindVellumGuardian = mock(
 );
 mock.module("../auth/guardian-bootstrap.js", () => ({
   findVellumGuardian: () => mockFindVellumGuardian(),
+}));
+
+// The managed/velay path cross-checks the attested caller against the stored
+// `platform_user_id`. Default the credential to `VELAY_USER_ID` so the velay
+// success cases match; negative cases override this mock.
+let mockReadCredential = mock(
+  async (_key: string): Promise<string | undefined> => VELAY_USER_ID,
+);
+mock.module("../credential-reader.js", () => ({
+  readCredential: (key: string) => mockReadCredential(key),
 }));
 
 const { createLiveVoiceWebsocketHandler, getLiveVoiceWebsocketHandlers } =
@@ -140,10 +154,11 @@ function createFakeUpstreamWs() {
   };
 }
 
-// Reset to the default binding that matches `mintEdgeToken`'s principal —
-// file-scoped so per-test overrides never leak into later describes.
+// Reset both mocks to their success defaults — file-scoped so per-test
+// overrides never leak into later describes.
 beforeEach(() => {
   mockFindVellumGuardian = mock(async () => ({ principalId: "test-user" }));
+  mockReadCredential = mock(async () => VELAY_USER_ID);
 });
 
 describe("createLiveVoiceWebsocketHandler", () => {
@@ -323,7 +338,7 @@ describe("createLiveVoiceWebsocketHandler", () => {
 
 describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () => {
   const TEST_TOKEN = mintEdgeToken();
-  const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
+  // VELAY_USER_ID is declared at module scope (shared with the credential mock).
   const VELAY_ORG_ID = "22222222-2222-2222-2222-222222222222";
   const originalIsPlatform = process.env.IS_PLATFORM;
 
@@ -368,6 +383,48 @@ describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () =
 
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  // Guardian pinning on the velay path: the attested caller must match the
+  // stored platform_user_id, or the daemon's guardian stamp would be unbacked.
+  test("managed mode + bridge proof but velay user is not the bound guardian is rejected", async () => {
+    setPlatform(true);
+    mockReadCredential = mock(
+      async () => "99999999-9999-9999-9999-999999999999",
+    );
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const server = makeFakeServer();
+    const res = await handler(makeVelayReq(), server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("managed mode + bridge proof but no platform_user_id stored is rejected", async () => {
+    setPlatform(true);
+    mockReadCredential = mock(async () => undefined);
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const server = makeFakeServer();
+    const res = await handler(makeVelayReq(), server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("managed mode + bridge proof but platform_user_id lookup fails returns 503", async () => {
+    setPlatform(true);
+    mockReadCredential = mock(async () => {
+      throw new Error("credential store unavailable");
+    });
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const server = makeFakeServer();
+    const res = await handler(makeVelayReq(), server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(503);
+    expect(server.upgrade).not.toHaveBeenCalled();
   });
 
   test("managed mode + spoofed X-Velay-* headers without bridge proof is rejected", async () => {

--- a/gateway/src/__tests__/live-voice-websocket.test.ts
+++ b/gateway/src/__tests__/live-voice-websocket.test.ts
@@ -13,12 +13,24 @@ import {
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import { initSigningKey, mintToken } from "../auth/token-service.js";
 import type { GatewayConfig } from "../config.js";
-import {
-  createLiveVoiceWebsocketHandler,
-  getLiveVoiceWebsocketHandlers,
-  type LiveVoiceSocketData,
-} from "../http/routes/live-voice-websocket.js";
+import type { LiveVoiceSocketData } from "../http/routes/live-voice-websocket.js";
 import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
+
+// The live-voice upgrade pins actor tokens to the bound guardian. Mock the
+// binding lookup (set BEFORE importing the module under test) so the actor
+// path is testable without gateway DB state; the default binding matches
+// `mintEdgeToken`'s default principal.
+let mockFindVellumGuardian = mock(
+  async (): Promise<{ principalId: string } | null> => ({
+    principalId: "test-user",
+  }),
+);
+mock.module("../auth/guardian-bootstrap.js", () => ({
+  findVellumGuardian: () => mockFindVellumGuardian(),
+}));
+
+const { createLiveVoiceWebsocketHandler, getLiveVoiceWebsocketHandlers } =
+  await import("../http/routes/live-voice-websocket.js");
 
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
 initSigningKey(TEST_SIGNING_KEY);
@@ -128,10 +140,16 @@ function createFakeUpstreamWs() {
   };
 }
 
+// Reset to the default binding that matches `mintEdgeToken`'s principal —
+// file-scoped so per-test overrides never leak into later describes.
+beforeEach(() => {
+  mockFindVellumGuardian = mock(async () => ({ principalId: "test-user" }));
+});
+
 describe("createLiveVoiceWebsocketHandler", () => {
   const TEST_TOKEN = mintEdgeToken();
 
-  test("upgrades when token query parameter is a valid actor edge token", () => {
+  test("upgrades when token query parameter is a valid actor edge token", async () => {
     const config = makeConfig();
     const handler = createLiveVoiceWebsocketHandler(config);
     const req = new Request(
@@ -139,7 +157,7 @@ describe("createLiveVoiceWebsocketHandler", () => {
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer();
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
@@ -153,7 +171,7 @@ describe("createLiveVoiceWebsocketHandler", () => {
     });
   });
 
-  test("upgrades when Authorization header is a valid actor edge token", () => {
+  test("upgrades when Authorization header is a valid actor edge token", async () => {
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/live-voice", {
       headers: {
@@ -162,40 +180,40 @@ describe("createLiveVoiceWebsocketHandler", () => {
       },
     });
     const server = makeFakeServer();
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
   });
 
-  test("returns 401 when auth is required and no token is provided", () => {
+  test("returns 401 when auth is required and no token is provided", async () => {
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/live-voice", {
       headers: { upgrade: "websocket" },
     });
     const server = makeFakeServer();
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(401);
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("returns 401 when token is invalid", () => {
+  test("returns 401 when token is invalid", async () => {
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const req = new Request(
       "http://localhost:7830/v1/live-voice?token=bad-token",
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer();
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(401);
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("returns 401 when token lacks an actor principal", () => {
+  test("returns 401 when token lacks an actor principal", async () => {
     const serviceToken = mintServiceEdgeToken();
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const req = new Request(
@@ -203,50 +221,103 @@ describe("createLiveVoiceWebsocketHandler", () => {
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer();
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(401);
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("allows unauthenticated upgrade when runtime proxy auth is disabled", () => {
+  test("allows unauthenticated upgrade when runtime proxy auth is disabled", async () => {
     const config = makeConfig({ runtimeProxyRequireAuth: false });
     const handler = createLiveVoiceWebsocketHandler(config);
     const req = new Request("http://localhost:7830/v1/live-voice", {
       headers: { upgrade: "websocket" },
     });
     const server = makeFakeServer();
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
   });
 
-  test("returns 426 when upgrade header is not websocket", () => {
+  test("returns 426 when upgrade header is not websocket", async () => {
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const req = new Request(
       `http://localhost:7830/v1/live-voice?token=${TEST_TOKEN}`,
     );
     const server = makeFakeServer();
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(426);
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("returns 500 when Bun.serve upgrade fails", () => {
+  test("returns 500 when Bun.serve upgrade fails", async () => {
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const req = new Request(
       `http://localhost:7830/v1/live-voice?token=${TEST_TOKEN}`,
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer(false);
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(500);
+  });
+
+  // Guardian pinning: live voice is a guardian-only surface (the daemon stamps
+  // each voice turn with the guardian's trust context on that basis), so a
+  // valid actor token whose principal is not the bound guardian must not
+  // upgrade.
+  test("returns 403 when the actor token is valid but not the bound guardian", async () => {
+    mockFindVellumGuardian = mock(async () => ({
+      principalId: "someone-else",
+    }));
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/live-voice?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 403 when no guardian binding exists", async () => {
+    mockFindVellumGuardian = mock(async () => null);
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/live-voice?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 503 when the guardian binding lookup fails", async () => {
+    mockFindVellumGuardian = mock(async () => {
+      throw new Error("gateway db unavailable");
+    });
+    const handler = createLiveVoiceWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/live-voice?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(503);
+    expect(server.upgrade).not.toHaveBeenCalled();
   });
 });
 
@@ -289,46 +360,49 @@ describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () =
     }
   });
 
-  test("managed mode + valid X-Velay-* headers with bridge proof authorizes the upgrade", () => {
+  test("managed mode + valid X-Velay-* headers with bridge proof authorizes the upgrade", async () => {
     setPlatform(true);
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const server = makeFakeServer();
-    const res = handler(makeVelayReq(), server);
+    const res = await handler(makeVelayReq(), server);
 
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
   });
 
-  test("managed mode + spoofed X-Velay-* headers without bridge proof is rejected", () => {
+  test("managed mode + spoofed X-Velay-* headers without bridge proof is rejected", async () => {
     setPlatform(true);
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const server = makeFakeServer();
-    const res = handler(makeVelayReq(undefined, { bridgeAuth: false }), server);
+    const res = await handler(
+      makeVelayReq(undefined, { bridgeAuth: false }),
+      server,
+    );
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(401);
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("managed mode without velay headers and without actor JWT is rejected", () => {
+  test("managed mode without velay headers and without actor JWT is rejected", async () => {
     setPlatform(true);
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const req = new Request("http://localhost:7830/v1/live-voice", {
       headers: { upgrade: "websocket" },
     });
     const server = makeFakeServer();
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(401);
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("managed mode with X-Velay-Actor other than 'user' is rejected", () => {
+  test("managed mode with X-Velay-Actor other than 'user' is rejected", async () => {
     setPlatform(true);
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const server = makeFakeServer();
-    const res = handler(
+    const res = await handler(
       makeVelayReq({
         "x-velay-user-id": VELAY_USER_ID,
         "x-velay-org-id": VELAY_ORG_ID,
@@ -342,11 +416,11 @@ describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () =
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("managed mode missing org id falls through and is rejected", () => {
+  test("managed mode missing org id falls through and is rejected", async () => {
     setPlatform(true);
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const server = makeFakeServer();
-    const res = handler(
+    const res = await handler(
       makeVelayReq({
         "x-velay-user-id": VELAY_USER_ID,
         "x-velay-actor": "user",
@@ -359,18 +433,18 @@ describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () =
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("local mode does NOT trust X-Velay-* headers even with bridge proof", () => {
+  test("local mode does NOT trust X-Velay-* headers even with bridge proof", async () => {
     setPlatform(false);
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const server = makeFakeServer();
-    const res = handler(makeVelayReq(), server);
+    const res = await handler(makeVelayReq(), server);
 
     expect(res).toBeInstanceOf(Response);
     expect(res!.status).toBe(401);
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("managed mode still accepts a valid actor edge JWT (no velay headers)", () => {
+  test("managed mode still accepts a valid actor edge JWT (no velay headers)", async () => {
     setPlatform(true);
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const req = new Request(
@@ -378,7 +452,7 @@ describe("createLiveVoiceWebsocketHandler — velay-attested managed auth", () =
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer();
-    const res = handler(req, server);
+    const res = await handler(req, server);
 
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
@@ -407,7 +481,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
     globalThis.WebSocket = OriginalWebSocket;
   });
 
-  test("open targets the runtime live voice websocket with a service token", () => {
+  test("open targets the runtime live voice websocket with a service token", async () => {
     const ws = createFakeDownstreamWs({
       wsType: "live-voice",
       config: makeConfig({
@@ -426,7 +500,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
     expect(parsed.searchParams.get("token")).toMatch(/^ey/);
   });
 
-  test("buffers downstream text and binary messages before upstream opens", () => {
+  test("buffers downstream text and binary messages before upstream opens", async () => {
     const ws = createFakeDownstreamWs({
       wsType: "live-voice",
       config: makeConfig(),
@@ -441,7 +515,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
     expect(fakeUpstream.sent).toEqual([]);
   });
 
-  test("flushes buffered messages on upstream open", () => {
+  test("flushes buffered messages on upstream open", async () => {
     const ws = createFakeDownstreamWs({
       wsType: "live-voice",
       config: makeConfig(),
@@ -459,7 +533,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
     expect(ws.data.pendingMessages).toBeUndefined();
   });
 
-  test("forwards downstream binary audio frames without JSON conversion", () => {
+  test("forwards downstream binary audio frames without JSON conversion", async () => {
     const ws = createFakeDownstreamWs({
       wsType: "live-voice",
       config: makeConfig(),
@@ -475,7 +549,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
     expect(fakeUpstream.sent[0]).toBe(binaryFrame);
   });
 
-  test("forwards upstream text and binary frames to the downstream socket", () => {
+  test("forwards upstream text and binary frames to the downstream socket", async () => {
     const ws = createFakeDownstreamWs({
       wsType: "live-voice",
       config: makeConfig(),
@@ -490,7 +564,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
     expect(Array.from(ws.sent[1] as Uint8Array)).toEqual([5, 6]);
   });
 
-  test("closes downstream with 1008 on pending buffer overflow", () => {
+  test("closes downstream with 1008 on pending buffer overflow", async () => {
     const ws = createFakeDownstreamWs({
       wsType: "live-voice",
       config: makeConfig(),
@@ -505,7 +579,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
     expect(ws.closes).toEqual([{ code: 1008, reason: "Buffer overflow" }]);
   });
 
-  test("downstream close clears pending messages and closes connecting upstream", () => {
+  test("downstream close clears pending messages and closes connecting upstream", async () => {
     const ws = createFakeDownstreamWs({
       wsType: "live-voice",
       config: makeConfig(),
@@ -521,7 +595,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
     ]);
   });
 
-  test("upstream close and error events close the downstream socket", () => {
+  test("upstream close and error events close the downstream socket", async () => {
     const ws = createFakeDownstreamWs({
       wsType: "live-voice",
       config: makeConfig(),
@@ -539,7 +613,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
 });
 
 describe("live voice gateway boundary", () => {
-  test("handler does not import assistant package files", () => {
+  test("handler does not import assistant package files", async () => {
     const source = readFileSync(
       new URL("../http/routes/live-voice-websocket.ts", import.meta.url),
       "utf8",
@@ -549,7 +623,7 @@ describe("live voice gateway boundary", () => {
     expect(source).not.toContain('from "assistant/');
   });
 
-  test("gateway index routes live voice websocket upgrades before the runtime proxy", () => {
+  test("gateway index routes live voice websocket upgrades before the runtime proxy", async () => {
     const source = readFileSync(
       new URL("../index.ts", import.meta.url),
       "utf8",
@@ -578,7 +652,7 @@ describe("live voice gateway boundary", () => {
     expect(source).toContain("handleSttStreamWs(req, server)");
   });
 
-  test("gateway websocket lifecycle dispatches live voice socket data", () => {
+  test("gateway websocket lifecycle dispatches live voice socket data", async () => {
     const source = readFileSync(
       new URL("../index.ts", import.meta.url),
       "utf8",
@@ -650,7 +724,7 @@ describe("createLiveVoiceWebsocketHandler — revocation", () => {
 
     const handler = createLiveVoiceWebsocketHandler(makeConfig());
     const server = makeFakeServer();
-    const res = handler(
+    const res = await handler(
       new Request(`http://127.0.0.1:7830/v1/live-voice?token=${jwt}`, {
         headers: { upgrade: "websocket" },
       }),

--- a/gateway/src/http/routes/live-voice-websocket.ts
+++ b/gateway/src/http/routes/live-voice-websocket.ts
@@ -8,6 +8,8 @@ import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
 import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
+import { credentialKey } from "../../credential-key.js";
+import { readCredential } from "../../credential-reader.js";
 import { getLogger } from "../../logger.js";
 import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
 
@@ -123,6 +125,16 @@ async function checkLiveVoiceAuth(
     const velayContext = extractVelayAttestedContext(req);
     if (velayContext) {
       if (requestHasVelayBridgeAuth(req)) {
+        // Live voice is a guardian-only surface — the daemon stamps each voice
+        // turn with the guardian's trust context. The velay attestation proves
+        // the caller is *a* platform user who traversed velay, not that they
+        // are THIS assistant's guardian, so cross-check the velay user id
+        // against the stored `platform_user_id` (the same guardian check the
+        // edge-auth middleware applies to guardian routes under the managed
+        // bypass). Without it, any velay-authorized org user reaching this
+        // assistant would be stamped guardian downstream.
+        const guardianError = await requireManagedGuardian(velayContext.userId);
+        if (guardianError) return guardianError;
         log.info(
           { userId: velayContext.userId, orgId: velayContext.orgId },
           "Live voice WS: authenticated via velay-attested managed context",
@@ -193,6 +205,35 @@ async function checkLiveVoiceAuth(
     return new Response("Forbidden", { status: 403 });
   }
 
+  return null;
+}
+
+/**
+ * Managed-mode guardian check: cross-check a velay-attested caller's platform
+ * user id against the stored `platform_user_id` credential — the same guard the
+ * edge-auth middleware applies to guardian routes under the platform bypass.
+ * Returns null when the caller is the guardian, else a 403/503 Response.
+ */
+async function requireManagedGuardian(
+  velayUserId: string,
+): Promise<Response | null> {
+  let storedUserId: string | undefined;
+  try {
+    storedUserId = await readCredential(
+      credentialKey("vellum", "platform_user_id"),
+    );
+  } catch (err) {
+    log.error({ err }, "Live voice WS: platform_user_id lookup failed");
+    return new Response("Service Unavailable", { status: 503 });
+  }
+  if (!storedUserId) {
+    log.warn("Live voice WS: no platform_user_id stored on this assistant");
+    return new Response("Forbidden", { status: 403 });
+  }
+  if (storedUserId !== velayUserId) {
+    log.warn("Live voice WS: velay caller is not the bound guardian");
+    return new Response("Forbidden", { status: 403 });
+  }
   return null;
 }
 

--- a/gateway/src/http/routes/live-voice-websocket.ts
+++ b/gateway/src/http/routes/live-voice-websocket.ts
@@ -5,6 +5,7 @@ import {
   mintServiceToken,
 } from "../../auth/token-exchange.js";
 import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
+import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
@@ -77,16 +78,16 @@ export type LiveVoiceSocketData = {
  * gateway clients and the runtime's /v1/live-voice endpoint.
  */
 export function createLiveVoiceWebsocketHandler(config: GatewayConfig) {
-  return function handleUpgrade(
+  return async function handleUpgrade(
     req: Request,
     server: import("bun").Server<unknown>,
-  ): Response | undefined {
+  ): Promise<Response | undefined> {
     if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return new Response("Upgrade Required", { status: 426 });
     }
 
     const url = new URL(req.url);
-    const authResponse = checkLiveVoiceAuth(req, url, config);
+    const authResponse = await checkLiveVoiceAuth(req, url, config);
     if (authResponse) return authResponse;
 
     const upgraded = server.upgrade(req, {
@@ -104,11 +105,11 @@ export function createLiveVoiceWebsocketHandler(config: GatewayConfig) {
   };
 }
 
-function checkLiveVoiceAuth(
+async function checkLiveVoiceAuth(
   req: Request,
   url: URL,
   config: GatewayConfig,
-): Response | null {
+): Promise<Response | null> {
   if (!config.runtimeProxyRequireAuth) {
     return null;
   }
@@ -172,6 +173,24 @@ function checkLiveVoiceAuth(
       "Live voice WS: denied token without actor principal",
     );
     return new Response("Unauthorized", { status: 401 });
+  }
+
+  // Live voice is a guardian-only surface: the room runs in the owner's own
+  // client, and the daemon stamps each voice turn with the guardian's trust
+  // context on that basis — so pin the upgrade to the bound guardian, the same
+  // check the guardian edge-auth middleware applies to guardian-only HTTP
+  // routes. Any valid-but-non-guardian actor token is rejected here rather
+  // than reaching the daemon with an identity the voice path can't represent.
+  let guardian: { principalId: string } | null;
+  try {
+    guardian = await findVellumGuardian();
+  } catch (err) {
+    log.error({ err }, "Live voice WS: findVellumGuardian failed");
+    return new Response("Service Unavailable", { status: 503 });
+  }
+  if (!guardian || guardian.principalId !== parsed.actorPrincipalId) {
+    log.warn("Live voice WS: rejected — caller is not the bound guardian");
+    return new Response("Forbidden", { status: 403 });
   }
 
   return null;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1981,7 +1981,7 @@ async function main() {
     }
 
     if (url.pathname === "/v1/live-voice") {
-      const upgradeResult = handleLiveVoiceWs(req, server);
+      const upgradeResult = await handleLiveVoiceWs(req, server);
       if (upgradeResult !== undefined) return upgradeResult;
       return undefined as unknown as Response;
     }


### PR DESCRIPTION
## Problem

Asking your own assistant to do something sensitive **by voice** fails:

> `Permission denied for "file_edit": this action requires guardian approval from a verified channel identity.`

The local live-voice ingress bypasses the text-send route and dispatches turns with **no `trustContext`**, so `resolveCapabilities()` fail-closes the actor to the `unknown` trust class → `sensitiveToolApproval: "deny"`. The same request typed into the same authenticated client runs as guardian. Third member of the voice-bypasses-text-path bug family (JARVIS-1258, JARVIS-1259).

## Fix — two halves, every fail-closed property kept

**Daemon** (`live-voice-session.ts`): `defaultStartVoiceTurn` now resolves the local guardian's trust context through the **same fail-closed resolver the text-send route uses** (`findLocalGuardianPrincipalId` → `resolveLocalPrincipalTrustContext`) and stamps the turn. A gateway miss / missing binding leaves the turn unstamped (`unknown`) — never a blind grant. Lives in the production wiring next to the sibling conversation-row fix, so session unit tests stay DB-free.

**Gateway** (`live-voice-websocket.ts`): the `/v1/live-voice` upgrade now **pins actor tokens to the bound guardian** — the same check the guardian edge-auth middleware applies to guardian-only HTTP routes (non-guardian actor → 403, lookup failure → 503). This makes "live-voice session ⇒ guardian" a transport guarantee rather than an assumption, which is what justifies the daemon-side stamp. Velay-attested managed auth is unchanged.

## Out of scope (deliberate)

Whether sensitive tools in a hands-free open-mic session should *confirm* rather than self-approve (anything audible becomes a turn) is a modality-level policy question — the `approvalMode: "local-live-voice"` knob is the natural home if we want it. This PR only fixes the identity axis.

## Testing

- Gateway: `live-voice-websocket.test.ts` — handler now async; added guardian-pinning cases (non-guardian 403, missing binding 403, lookup failure 503). 30 pass.
- Daemon: `src/live-voice/` 175 pass; `voice-session-bridge` 25 pass.
- `tsc` clean in both services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)