### PR TITLE
feat(intelligence): memory graph delight + onboarding (Slice A)

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { X } from "lucide-react";
+import { MessageCircle, Sparkles, X } from "lucide-react";
 import { useEffect } from "react";
 
 import { FileMarkdown } from "@/components/file-markdown";
@@ -16,6 +16,12 @@ interface ConceptDetailPanelProps {
   assistantId: string;
   node: ConceptDetailNode;
   onClose: () => void;
+  /**
+   * Opens a fresh chat seeded with a message about this concept. When absent,
+   * the chat-from-node actions are hidden (read-only drawer). Provided from the
+   * identity page, which navigates to a draft conversation and auto-sends.
+   */
+  onOpenThread?: (message: string) => void;
 }
 
 function formatUpdated(ms: number | undefined): string | null {
@@ -36,10 +42,12 @@ export function ConceptDetailPanel({
   assistantId,
   node,
   onClose,
+  onOpenThread,
 }: ConceptDetailPanelProps) {
   const query = useQuery(memoryGraphNodeOptions(assistantId, node.id));
   const detail = query.data;
   const updated = formatUpdated(node.updatedAtMs);
+  const title = detail?.title ?? node.label;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -127,6 +135,40 @@ export function ConceptDetailPanel({
             </p>
           )}
         </div>
+
+        {onOpenThread ? (
+          <footer
+            className="flex shrink-0 gap-2 border-t px-5 py-3"
+            style={{ borderColor: "var(--border-base)" }}
+          >
+            <Button
+              variant="outlined"
+              size="regular"
+              className="flex-1"
+              leftIcon={<MessageCircle size={16} aria-hidden />}
+              onClick={() =>
+                onOpenThread(
+                  `Tell me what you remember about "${title}" and how it connects to the rest of what you know.`,
+                )
+              }
+            >
+              Ask about this
+            </Button>
+            <Button
+              variant="primary"
+              size="regular"
+              className="flex-1"
+              leftIcon={<Sparkles size={16} aria-hidden />}
+              onClick={() =>
+                onOpenThread(
+                  `I want to refine what you remember about "${title}". Ask me what's off and we'll correct it together.`,
+                )
+              }
+            >
+              Refine
+            </Button>
+          </footer>
+        ) : null}
       </aside>
     </div>
   );

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
@@ -1,0 +1,64 @@
+import { Sparkles, X } from "lucide-react";
+
+import { Button } from "@vellumai/design-library";
+
+interface ConceptGraphIntroBannerProps {
+  onDismiss: () => void;
+}
+
+/**
+ * First-run explainer overlaid on the memory graph: says what the graph is and
+ * that it keeps growing. Dismissible; dismissal is persisted per-assistant by
+ * the caller so it never returns once closed. Rendered over both the empty
+ * "no concepts yet" state (where it matters most) and a populated graph.
+ *
+ * Tagged `data-graph-control` so a pointer-down on the card doesn't start a
+ * drag-orbit on the canvas behind it.
+ */
+export function ConceptGraphIntroBanner({
+  onDismiss,
+}: ConceptGraphIntroBannerProps) {
+  return (
+    <div
+      data-graph-control
+      className="pointer-events-auto absolute left-1/2 top-4 z-10 flex w-[min(30rem,calc(100%-6rem))] -translate-x-1/2 items-start gap-3 rounded-xl px-4 py-3"
+      style={{
+        backgroundColor: "var(--surface-lift)",
+        border: "1px solid var(--border-base)",
+        boxShadow:
+          "0 8px 24px color-mix(in srgb, var(--content-default) 12%, transparent)",
+      }}
+    >
+      <span
+        className="mt-0.5 shrink-0"
+        style={{ color: "var(--primary-base)" }}
+        aria-hidden
+      >
+        <Sparkles size={18} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p
+          className="text-body-medium-emphasised"
+          style={{ color: "var(--content-default)" }}
+        >
+          This is your assistant's mind
+        </p>
+        <p
+          className="mt-0.5 text-body-small-default"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          Every idea it learns — and the links it draws between them — shows up
+          here. The map grows and rearranges itself as you talk, so the more you
+          share, the richer it gets.
+        </p>
+      </div>
+      <Button
+        variant="ghost"
+        iconOnly={<X aria-hidden />}
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        tintColor="var(--content-tertiary)"
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -8,9 +8,11 @@ import { Button } from "@vellumai/design-library";
 
 import { buildForceLayout } from "./build-force-layout";
 import { ConceptDetailPanel, type ConceptDetailNode } from "./concept-detail-panel";
+import { ConceptGraphIntroBanner } from "./concept-graph-intro-banner";
 import { ConceptGraphLegend } from "./concept-graph-legend";
 import { EDGE_LEARNED_COLOR, NODE_KIND_COLORS } from "./constants";
 import type { ConceptNodeKind, GraphLayoutNode } from "./types";
+import { useGraphIntroDismissed } from "./use-graph-intro-dismissed";
 
 const NODE_KIND_ORDER: ConceptNodeKind[] = [
   "concept",
@@ -29,6 +31,13 @@ const DEPTH_ALPHA_MIN = 0.32;
 const MIN_ZOOM = 0.45;
 const MAX_ZOOM = 3;
 const HUB_LABEL_DEGREE = 4;
+
+// Recency emphasis: recently-updated concepts glow brighter, and the freshest
+// gently pulse, so the map reads as alive and "what did it just learn?" pops.
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RECENCY_GLOW_WINDOW_MS = 14 * DAY_MS; // recency fades out over ~2 weeks
+const RECENCY_GLOW_MAX = 12; // extra shadowBlur at peak freshness
+const PULSE_WINDOW_MS = 2 * DAY_MS; // newer than this → pulses (unless reduced motion)
 
 interface Projected {
   id: string;
@@ -56,6 +65,9 @@ export interface ConceptGraphViewProps {
   className?: string;
   isFullscreen?: boolean;
   onToggleFullscreen?: () => void;
+  /** Opens a fresh chat seeded with a message; wired to the node detail drawer's
+   * chat-from-node actions. When absent, those actions are hidden. */
+  onOpenThread?: (message: string) => void;
 }
 
 function CenteredMessage({ title, detail }: { title: string; detail?: string }) {
@@ -84,6 +96,7 @@ export function ConceptGraphView({
   className,
   isFullscreen,
   onToggleFullscreen,
+  onOpenThread,
 }: ConceptGraphViewProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -156,6 +169,10 @@ export function ConceptGraphView({
   // The concept opened into the detail drawer (null = graph only).
   const [openNode, setOpenNode] = useState<ConceptDetailNode | null>(null);
 
+  // First-run explainer: shown over the graph (empty or populated) until the
+  // user dismisses it; the dismissal sticks per-assistant.
+  const [introDismissed, dismissIntro] = useGraphIntroDismissed(assistantId);
+
   const labelFor = useCallback(
     (id: string | null): string | null => {
       if (!id) {return null;}
@@ -227,6 +244,7 @@ export function ConceptGraphView({
       last = t;
       const v = view.current;
       const colors = colorsRef.current;
+      const nowMs = Date.now();
 
       const idle = !v.dragging && t - v.lastInteractAt > IDLE_RESUME_MS;
       if (idle && !reduceMotion) {
@@ -322,7 +340,21 @@ export function ConceptGraphView({
         const depthA = DEPTH_ALPHA_MIN + (1 - DEPTH_ALPHA_MIN) * p.depth;
         const alpha = lit ? depthA : depthA * 0.18;
 
-        const glow = (isActive ? 16 : node.degree >= HUB_LABEL_DEGREE ? 8 : 4) * p.depth;
+        let glow = (isActive ? 16 : node.degree >= HUB_LABEL_DEGREE ? 8 : 4) * p.depth;
+        // Recency: fresh concepts glow brighter; the very newest pulse. Static
+        // (no pulse) under reduced motion, which only ever redraws on input.
+        const updatedAtMs = node.updatedAtMs;
+        if (updatedAtMs) {
+          const age = nowMs - updatedAtMs;
+          const recency = Math.max(0, 1 - age / RECENCY_GLOW_WINDOW_MS);
+          if (recency > 0) {
+            let boost = recency * RECENCY_GLOW_MAX;
+            if (!reduceMotion && age < PULSE_WINDOW_MS) {
+              boost *= 0.55 + 0.45 * Math.sin(t / 420 + idx * 1.7);
+            }
+            glow += boost * p.depth;
+          }
+        }
         ctx.shadowColor = color;
         ctx.shadowBlur = lit ? glow : 0;
 
@@ -504,6 +536,10 @@ export function ConceptGraphView({
   const hasLearned = useMemo(() => layout.edges.some((e) => e.kind === "learned"), [layout.edges]);
   const hasLinks = useMemo(() => layout.edges.some((e) => e.kind !== "learned"), [layout.edges]);
 
+  // The intro banner shows over a supported graph (empty or populated), never
+  // over the loading / error / unsupported states.
+  const showIntro = query.data?.kind === "ready" && !introDismissed;
+
   let body: React.ReactNode;
   if (query.isLoading) {
     body = (
@@ -546,7 +582,7 @@ export function ConceptGraphView({
           hasLearned={hasLearned}
         />
 
-        {focusLabel ? (
+        {focusLabel && !showIntro ? (
           <div
             className="pointer-events-none absolute left-1/2 top-4 max-w-[80%] -translate-x-1/2 truncate rounded-full px-3 py-1 text-[12px]"
             style={{
@@ -622,6 +658,8 @@ export function ConceptGraphView({
         </div>
       ) : null}
 
+      {showIntro ? <ConceptGraphIntroBanner onDismiss={dismissIntro} /> : null}
+
       {body}
 
       {ready && openNode ? (
@@ -629,6 +667,7 @@ export function ConceptGraphView({
           assistantId={assistantId}
           node={openNode}
           onClose={() => setOpenNode(null)}
+          onOpenThread={onOpenThread}
         />
       ) : null}
     </div>

--- a/clients/web/src/domains/intelligence/components/concept-graph/use-graph-intro-dismissed.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/use-graph-intro-dismissed.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Tracks whether the first-run "what is this graph" intro banner has been
+ * dismissed, persisted per assistant in localStorage so it stays gone across
+ * reloads. Keyed per-assistant (not globally) so a user's second assistant
+ * still gets the explainer the first time its graph is opened.
+ *
+ * When storage is unavailable (private mode / blocked), reads resolve to
+ * "dismissed" so we never nag on every load with a dismissal that can't stick.
+ */
+const KEY_PREFIX = "vellum:memoryGraph:introDismissed:";
+
+function storageKey(assistantId: string): string {
+  return `${KEY_PREFIX}${assistantId}`;
+}
+
+function readDismissed(assistantId: string): boolean {
+  if (!assistantId) {
+    return true;
+  }
+  try {
+    return window.localStorage.getItem(storageKey(assistantId)) === "1";
+  } catch {
+    return true;
+  }
+}
+
+export function useGraphIntroDismissed(
+  assistantId: string,
+): [boolean, () => void] {
+  const [dismissed, setDismissed] = useState(() => readDismissed(assistantId));
+
+  // Re-read when the active assistant changes — the identity pane reuses this
+  // component instance across assistant switches.
+  useEffect(() => {
+    setDismissed(readDismissed(assistantId));
+  }, [assistantId]);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+    try {
+      window.localStorage.setItem(storageKey(assistantId), "1");
+    } catch {
+      // Best-effort; the in-memory state above still hides it for this session.
+    }
+  }, [assistantId]);
+
+  return [dismissed, dismiss];
+}

--- a/clients/web/src/domains/intelligence/components/identity-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-tab.tsx
@@ -310,6 +310,7 @@ export function IdentityTab({ assistantId, onOpenThread }: IdentityTabProps) {
             className="h-full w-full"
             isFullscreen={graphFullscreen}
             onToggleFullscreen={() => setGraphFullscreen((v) => !v)}
+            onOpenThread={onOpenThread}
           />
         )}
       </div>


### PR DESCRIPTION
## What

Slice A of evolving the identity-page **memory concept graph** (behind the `memory-concept-graph` flag) so it feels alive and explains itself. Three additions:

### 1. First-run intro banner
A dismissible card overlaid on the graph that says what the map is and that it keeps growing. Dismissal persists **per-assistant** in `localStorage` (so a user's second assistant still gets the explainer). Renders over **both** the empty `no concepts yet` state — where it matters most for a brand-new assistant — and a populated graph. Tagged `data-graph-control` so pointer-down on it never starts a drag-orbit; suppresses the hover tooltip while shown to avoid a top-center collision.

### 2. Recency glow + "just-learned" pulse
The canvas render loop now uses each node's `updatedAtMs` (previously carried but visually unused): freshly-updated concepts glow brighter, fading over ~2 weeks, and the very newest (< 2 days) gently pulse with a per-node phase offset so they don't blink in sync. Fully **static under `prefers-reduced-motion`** (no forced redraws). This is the cheapest lever for making the map read as *living*.

### 3. Chat-from-node (chat-seeded refinement)
The node detail drawer gains an **"Ask about this"** + **"Refine"** footer. Each opens a fresh chat seeded with a complete message about that concept via the existing `onOpenThread` wiring (threaded down through `IdentityTab` → `ConceptGraphView` → `ConceptDetailPanel`). `?prompt=` **auto-sends** (`useAutoSendEffects`), so the seeds are self-contained — "Refine" opens the loop and the assistant asks what's off, editing its own memory through its tools. Deliberately **not** an inline markdown editor: these pages are the assistant's own memory, and a raw editor risks desyncing belief from page.

## Files
- **new** `concept-graph-intro-banner.tsx`, `use-graph-intro-dismissed.ts`
- **edit** `concept-graph-view.tsx` (recency glow/pulse, banner, `onOpenThread`), `concept-detail-panel.tsx` (footer actions), `identity-tab.tsx` (thread `onOpenThread` to the graph)

## Verification
- `tsc` clean on all changed files; `eslint` exit 0, zero warnings on them.
- Existing concept-graph layout tests pass (5/5).
- Not driven in a live browser — rendering needs the flag on, a memory-v3 backend, and a populated graph.

## Notes for reviewers
- **Kept the diff focused:** the touched files carry pervasive pre-existing prettier drift (whole-file). I did not run a format sweep here — none of my new blocks are affected — to avoid ~180 lines of unrelated reformatting and merge-conflict risk. Happy to do a separate format-only PR if wanted.
- The design library has no banner/callout primitive; the banner is a custom token-styled overlay, consistent with the view's existing legend / hint / focus-label overlays.

## Follow-ups (not in this PR)
- **Slice B — anti-clutter for growth:** legend-as-filter (isolate by kind), fade learned edges out of the resting state as density climbs, surface the backend `truncated` flag, optional search.
- **Slice C — functionality nodes:** admit *connected* installed skills/plugins as nodes (hide orphans) + a detail source for them (`getMemoryGraphNode` currently returns `found:false` for non-concept slugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)