### PR TITLE
fix(memory): stop indexing the consolidation kickoff prompt

### DIFF
--- a/assistant/src/__tests__/add-message-skip-indexing.test.ts
+++ b/assistant/src/__tests__/add-message-skip-indexing.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Indexing side effects of `addMessage({ skipIndexing })`.
+ *
+ * A message saved with `skipIndexing: true` must persist (visible in the
+ * transcript) while producing NO indexing artifacts: no `memory_segments`
+ * rows, no `embed_segment` tickets, no `index_message_lexical` ticket. A
+ * message saved without the flag must produce all of them — the default is
+ * unchanged. This is the contract the consolidation kickoff prompt relies on
+ * (threaded via `runBackgroundJob({ skipPromptIndexing })` →
+ * `processMessage({ skipUserMessageIndexing })`).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+mock.module("../persistence/embeddings/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => [],
+    hybridSearch: async () => [],
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+  }),
+  initQdrantClient: () => {},
+  resolveQdrantUrl: () => "http://127.0.0.1:6333",
+}));
+
+import { addMessage } from "../persistence/conversation-crud.js";
+import { getDb, getMemoryDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  conversations,
+  memoryJobs,
+  memorySegments,
+  messages,
+} from "../persistence/schema/index.js";
+import { setConfig } from "./helpers/set-config.js";
+
+// Deterministic extraction: keep the LLM out of the indexer path. Everything
+// else (including `memory.enabled: true`) is the schema default.
+setConfig("memory", { extraction: { useLLM: false } });
+
+await initializeDb();
+
+// Open the memory connection before any test mutates state so the jobs table
+// is reachable through the same path the enqueue helpers use.
+getMemoryDb();
+
+const CONVERSATION_ID = "conv-skip-indexing";
+
+const LONG_TEXT =
+  "You are running memory consolidation. Read the buffer, route each entry " +
+  "into the matching concept page, rewrite the recent file, and trim the " +
+  "buffer down to entries that arrived after the cutoff. Alice prefers " +
+  "VS Code over Vim for large projects and ships at the end of the day.";
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM memory_segments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+  getMemoryDb()!.run("DELETE FROM memory_jobs");
+
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id: CONVERSATION_ID,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    })
+    .run();
+}
+
+function messageRow(messageId: string) {
+  return getDb()
+    .select()
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+}
+
+function segmentCountFor(messageId: string): number {
+  return getDb()
+    .select()
+    .from(memorySegments)
+    .where(eq(memorySegments.messageId, messageId))
+    .all().length;
+}
+
+/** Memory-jobs of `type` whose payload references `messageId` (embed_segment
+ *  payloads carry segment metadata, so those are matched by conversation-wide
+ *  count instead — callers reset the table between saves). */
+function jobCount(type: string): number {
+  return getMemoryDb()!
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.type, type))
+    .all().length;
+}
+
+function blocks(text: string): string {
+  return JSON.stringify([{ type: "text", text }]);
+}
+
+beforeEach(() => {
+  resetTables();
+});
+
+describe("addMessage skipIndexing contract", () => {
+  test("skipIndexing: true persists the row but produces zero segments and zero tickets", async () => {
+    const saved = await addMessage(CONVERSATION_ID, "user", blocks(LONG_TEXT), {
+      skipIndexing: true,
+    });
+
+    // The row exists — the message is part of the transcript.
+    expect(messageRow(saved.id)).toBeDefined();
+
+    // No indexing artifacts of any kind.
+    expect(segmentCountFor(saved.id)).toBe(0);
+    expect(jobCount("embed_segment")).toBe(0);
+    expect(jobCount("index_message_lexical")).toBe(0);
+  });
+
+  test("default save indexes: segments, embed tickets, and a lexical ticket", async () => {
+    const saved = await addMessage(CONVERSATION_ID, "user", blocks(LONG_TEXT));
+
+    expect(messageRow(saved.id)).toBeDefined();
+    expect(segmentCountFor(saved.id)).toBeGreaterThan(0);
+    expect(jobCount("embed_segment")).toBeGreaterThan(0);
+
+    const lexicalPayloads = getMemoryDb()!
+      .select({ payload: memoryJobs.payload })
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "index_message_lexical"))
+      .all()
+      .map((row) => JSON.parse(row.payload) as { messageId?: string });
+    expect(lexicalPayloads).toEqual([{ messageId: saved.id }]);
+  });
+
+  test("a default-path save after a skipped save still indexes (per-message flag)", async () => {
+    const skipped = await addMessage(
+      CONVERSATION_ID,
+      "user",
+      blocks(LONG_TEXT),
+      { skipIndexing: true },
+    );
+    const reply = await addMessage(
+      CONVERSATION_ID,
+      "assistant",
+      blocks(LONG_TEXT),
+    );
+
+    expect(segmentCountFor(skipped.id)).toBe(0);
+    expect(segmentCountFor(reply.id)).toBeGreaterThan(0);
+    expect(jobCount("index_message_lexical")).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -5,6 +5,7 @@ const addMessageCalls: Array<{
   role: string;
   content: string;
   metadata?: Record<string, unknown>;
+  skipIndexing?: boolean;
 }> = [];
 
 let activeConversation: unknown;
@@ -66,13 +67,14 @@ mock.module("../persistence/conversation-crud.js", () => ({
     conversationId: string,
     role: string,
     content: string,
-    options?: { metadata?: Record<string, unknown> },
+    options?: { metadata?: Record<string, unknown>; skipIndexing?: boolean },
   ) => {
     addMessageCalls.push({
       conversationId,
       role,
       content,
       metadata: options?.metadata,
+      skipIndexing: options?.skipIndexing,
     });
     return { id: `persisted-${addMessageCalls.length}` };
   },
@@ -226,6 +228,7 @@ function makeTestConversation() {
       metadata?: Record<string, unknown>;
       displayContent?: string;
       clientMessageId?: string;
+      skipIndexing?: boolean;
     }) =>
       persistQueuedMessageBody(messagingCtx, {
         ...options,
@@ -505,5 +508,38 @@ describe("processMessage displayContent", () => {
 
     const conversation = await expectEmptyDisplayContentHonored(modelContent);
     expect(conversation.forceCompact).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("processMessage skipUserMessageIndexing", () => {
+  beforeEach(() => {
+    addMessageCalls.length = 0;
+    activeConversation = undefined;
+    resolveSlashForTest = (content) => ({ kind: "passthrough", content });
+  });
+
+  test("threads skipIndexing to the initial user-message save", async () => {
+    const conversation = makeTestConversation();
+    activeConversation = conversation;
+
+    await processMessage("conv-display-content", "kickoff prompt body", {
+      skipUserMessageIndexing: true,
+    });
+
+    expect(addMessageCalls).toHaveLength(1);
+    expect(addMessageCalls[0]!.role).toBe("user");
+    expect(addMessageCalls[0]!.skipIndexing).toBe(true);
+    // The turn itself still runs — only the save's indexing is skipped.
+    expect(conversation.runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+
+  test("default save is indexed (no skipIndexing option)", async () => {
+    const conversation = makeTestConversation();
+    activeConversation = conversation;
+
+    await processMessage("conv-display-content", "ordinary message", {});
+
+    expect(addMessageCalls).toHaveLength(1);
+    expect(addMessageCalls[0]!.skipIndexing).toBeUndefined();
   });
 });

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -625,6 +625,12 @@ export interface PersistMessageOptions {
   metadata?: Record<string, unknown>;
   displayContent?: string;
   clientMessageId?: string;
+  /**
+   * Persist the row without indexing it (no memory segments, embeddings, or
+   * lexical-index entry). For machine-authored prompts that must not enter
+   * memory or search; see `ProcessMessageOptions.skipUserMessageIndexing`.
+   */
+  skipIndexing?: boolean;
 }
 
 // ── persistUserMessage ───────────────────────────────────────────────
@@ -721,6 +727,7 @@ export async function persistQueuedMessageBody(
     metadata,
     displayContent,
     clientMessageId,
+    skipIndexing,
   } = options;
   const attachmentInputs: MessageAttachmentInput[] = attachments.map(
     (attachment) => ({
@@ -823,7 +830,12 @@ export async function persistQueuedMessageBody(
       ctx.conversationId,
       "user",
       contentToPersist,
-      { metadata: mergedMetadata, clientMessageId, id: requestId },
+      {
+        metadata: mergedMetadata,
+        clientMessageId,
+        id: requestId,
+        ...(skipIndexing ? { skipIndexing: true } : {}),
+      },
     );
 
     if (persistedUserMessage.deduplicated) {

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -107,6 +107,14 @@ type ProcessMessageOptions = ConversationCreateOptions & {
    * are not presented to the model). Ignored when `allowedTools` is absent.
    */
   toolGateMode?: SubagentToolGateMode;
+  /**
+   * Persist the inbound user message without indexing it — no memory
+   * segments, no embeddings, no lexical-index entry. Threaded from
+   * `runBackgroundJob` for machine-authored kickoff prompts (e.g. memory
+   * consolidation) whose static instruction text must not enter memory or
+   * search. Every other message in the turn indexes normally.
+   */
+  skipUserMessageIndexing?: boolean;
 };
 
 function buildEventEmitter(
@@ -624,6 +632,7 @@ export async function processMessage(
     requestId,
     metadata: persistMetadata,
     displayContent: options?.displayContent,
+    ...(options?.skipUserMessageIndexing ? { skipIndexing: true } : {}),
   });
   publishConversationMessagesChanged(conversationId);
 

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/consolidation-job.test.ts
@@ -537,6 +537,16 @@ describe("memoryV2ConsolidateJob — non-empty buffer", () => {
     expect(prompt).toMatch(/\b[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2} (AM|PM)\b/);
   });
 
+  test("dispatches with skipPromptIndexing so the kickoff prompt is not indexed", async () => {
+    // The prompt is a static instruction manual — indexing it would write
+    // near-identical memory segments, embeddings, and a lexical entry on
+    // every scheduled run.
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(runnerCalls).toBe(1);
+    expect(runnerLastArgs?.skipPromptIndexing).toBe(true);
+  });
+
   test("wire-scopes the run to local memory-file tools — no network egress or host tools", async () => {
     // Security: the consolidation run is guardian-trust + non-interactive, so
     // the permission checker auto-approves any tool within the background

--- a/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
+++ b/assistant/src/plugins/defaults/memory/v2/consolidation-job.ts
@@ -450,6 +450,10 @@ export async function memoryV2ConsolidateJob(
       // Wire-scope the guardian-trust background run to local memory-file
       // tools only — no network egress, no host proxy. See the constant.
       allowedTools: CONSOLIDATION_ALLOWED_TOOLS,
+      // The kickoff prompt is a static instruction manual; indexing it would
+      // write near-identical memory segments, embeddings, and a lexical
+      // entry on every run. The agent's replies still index normally.
+      skipPromptIndexing: true,
     });
 
     if (!runResult.ok) {

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -209,6 +209,25 @@ describe("runBackgroundJob", () => {
     expect(opts.toolGateMode).toBeUndefined();
   });
 
+  test("threads skipPromptIndexing as skipUserMessageIndexing when set", async () => {
+    await runBackgroundJob(baseOpts({ skipPromptIndexing: true }));
+
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].options).toMatchObject({
+      skipUserMessageIndexing: true,
+    });
+  });
+
+  test("omits skipUserMessageIndexing when skipPromptIndexing is unset (prompts index by default)", async () => {
+    await runBackgroundJob(baseOpts());
+
+    expect(processMessageCalls).toHaveLength(1);
+    const opts = processMessageCalls[0].options as {
+      skipUserMessageIndexing?: unknown;
+    };
+    expect(opts.skipUserMessageIndexing).toBeUndefined();
+  });
+
   test("generic exception: returns ok=false with errorKind=exception and emits activity.failed with dedupeKey", async () => {
     processMessageImpl = async () => {
       throw new Error("boom");

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -193,6 +193,14 @@ export interface RunBackgroundJobOptions {
    * run completes successfully. See `notifications/deferred-emit.ts`.
    */
   deferNotifications?: boolean;
+  /**
+   * Persist the kickoff `prompt` without indexing it — no memory segments,
+   * no embeddings, no lexical-index entry. Opt-in for jobs whose prompt is a
+   * static machine-authored instruction manual (e.g. memory consolidation)
+   * that must not enter memory or search on every run. The run's replies and
+   * all other messages index normally. Defaults to false.
+   */
+  skipPromptIndexing?: boolean;
 }
 
 export interface RunBackgroundJobResult {
@@ -349,6 +357,7 @@ export async function runBackgroundJob(
       ...(opts.cronRunId ? { cronRunId: opts.cronRunId } : {}),
       ...(opts.allowedTools ? { allowedTools: opts.allowedTools } : {}),
       ...(opts.toolGateMode ? { toolGateMode: opts.toolGateMode } : {}),
+      ...(opts.skipPromptIndexing ? { skipUserMessageIndexing: true } : {}),
     });
     // Absorb late rejections: if the timeout wins the race, `work` keeps
     // running and may eventually reject — swallow so it doesn't surface as


### PR DESCRIPTION
ref fix/consolidation-prompt-skip-indexing

## Problem

The memory-v2 consolidation kickoff prompt (the ~30KB static instruction manual from `v2/prompts/consolidation.ts`) is persisted as an ordinary user message, so the generic message-save path indexes it on every scheduled run: ~20 `memory_segments` rows, ~20 `embed_segment` tickets, and one lexical-index ticket — near-identical machine instruction text (only the cutoff timestamp differs) entering memory and the search index over and over.

## Fix

An opt-in flag threaded through the existing persist plumbing to the initial save, which already supports `skipIndexing`:

- `RunBackgroundJobOptions.skipPromptIndexing` (background-job-runner.ts) →
- `ProcessMessageOptions.skipUserMessageIndexing` (process-message.ts) →
- `PersistMessageOptions.skipIndexing` (conversation-messaging.ts, `persistQueuedMessageBody`) →
- `addMessage({ skipIndexing: true })` — suppresses segment indexing, embed tickets, and the lexical ticket for exactly that row.

`consolidation-job.ts` is the **only** caller that sets the flag. The prompt row still persists (visible in the transcript); the run's replies and all other messages index normally.

## Explicitly NOT changed

- No other background job (heartbeat, retrospectives, watchers, schedules) sets the flag — their prompts index exactly as before; default behavior is byte-for-byte unchanged.
- No refactor of `processMessage` or the message pipeline; the flag is additive at each layer.

## Tests

- New `add-message-skip-indexing.test.ts` (real DB): a `skipIndexing` save persists the row with zero `memory_segments` rows, zero `embed_segment` tickets, zero `index_message_lexical` tickets; a default save produces all three; a default save after a skipped save still indexes (per-message flag).
- `process-message-display-content.test.ts`: `skipUserMessageIndexing` reaches the initial user-message save as `skipIndexing: true`; default save carries no flag.
- `background-job-runner.test.ts`: `skipPromptIndexing` threads to `processMessage` as `skipUserMessageIndexing`; unset ⇒ option absent (other jobs unchanged).
- `consolidation-job.test.ts`: consolidation dispatches with `skipPromptIndexing: true`.

Checks: scoped `bun test` on all touched test files (93 pass, 0 fail across 5 files), `bun run typecheck:fast` clean, ESLint 0 errors on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)