### PR TITLE
Validate telemetry batches against the generated wire schemas before POST

### DIFF
--- a/assistant/src/telemetry/telemetry-wire-validation.test.ts
+++ b/assistant/src/telemetry/telemetry-wire-validation.test.ts
@@ -5,7 +5,8 @@
  * filter, or block — and its warn payloads must carry the event type and
  * issue `{ path, code }` shapes only, never field values. `daemon_event_id`
  * is a field value too: activation-funnel ids embed the onboarding session
- * id (traces/claims can hold PII).
+ * id (traces/claims can hold PII). Issue paths are sanitized as well: dynamic
+ * record keys (e.g. `client` bag keys) are redacted to `*` before logging.
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
@@ -226,6 +227,33 @@ describe("validateWireEvents", () => {
     expect(lifecyclePaths).toContain("event_name");
 
     // The planted sentinel (a field value) must be absent from all log args.
+    expect(JSON.stringify(warnCalls)).not.toInclude(sentinel);
+  });
+
+  test("dynamic record keys in issue paths are redacted to *", () => {
+    const sentinel = "sentinel-user@example.com";
+    const invalidTurn = {
+      type: "turn",
+      daemon_event_id: "turn-key",
+      recorded_at: 1_700_000_000_012,
+      assistant_version: "1.2.3",
+      conversation_id: "conv-1",
+      turn_index: 1,
+      // The client bag's keys come from an uncontrolled JSON metadata column;
+      // the superRefine emits issues at ['client', <key>], so a key carrying
+      // user text must be redacted from the logged path. The nested object
+      // value makes the bag invalid.
+      client: { [sentinel]: { nested: true } },
+    };
+
+    const result = validateWireEvents([invalidTurn], stubLog);
+    expect(result).toEqual({ checked: 1, invalid: 1, unknownTypes: [] });
+    expect(warnCalls).toHaveLength(1);
+
+    const bag = warnCalls[0][0] as { issues: Array<{ path: string }> };
+    // The dynamic key component is replaced with a literal `*`; the
+    // schema-defined depth-0 component (`client`) is kept.
+    expect(bag.issues.map((issue) => issue.path)).toContain("client.*");
     expect(JSON.stringify(warnCalls)).not.toInclude(sentinel);
   });
 

--- a/assistant/src/telemetry/telemetry-wire-validation.test.ts
+++ b/assistant/src/telemetry/telemetry-wire-validation.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for pre-flush telemetry wire validation.
+ *
+ * Validation is observability only — it must count and warn, never mutate,
+ * filter, or block — and its warn payloads must carry issue `{ path, code }`
+ * shapes only, never field values (traces/claims can hold PII).
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { Logger } from "pino";
+
+import { telemetryEventSchema } from "./telemetry-wire.generated.js";
+import {
+  resetUnknownTypeWarningsForTests,
+  validateWireEvents,
+  wireSchemaByType,
+} from "./telemetry-wire-validation.js";
+
+let warnCalls: unknown[][] = [];
+const stubLog = {
+  warn: (...args: unknown[]) => {
+    warnCalls.push(args);
+  },
+} as unknown as Logger;
+
+/** One wire-valid sample per generated event type. */
+const validEvents = [
+  {
+    type: "llm_usage",
+    daemon_event_id: "llm-1",
+    recorded_at: 1_700_000_000_000,
+    assistant_version: "1.2.3",
+    provider: "anthropic",
+    model: "claude-fable-5",
+    llm_call_site: "mainAgent",
+    inference_profile: "balanced",
+    inference_profile_source: "active",
+    input_tokens: 1200,
+    output_tokens: 80,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 900,
+    raw_usage: { input_tokens: 1200, output_tokens: 80 },
+    actor: "assistant",
+    cost: 0.0042,
+    conversation_id: "conv-1",
+    conversation_type: "standard",
+    turn_index: 0,
+    llm_call_count: 2,
+  },
+  {
+    type: "turn",
+    daemon_event_id: "turn-1",
+    recorded_at: 1_700_000_000_001,
+    assistant_version: "1.2.3",
+    conversation_type: "standard",
+    conversation_id: "conv-1",
+    turn_index: 1,
+    interface_id: "web",
+    channel_id: "vellum",
+    client: { os: "macos", interface_version: "0.8.2" },
+    outcome: "failed",
+    failure_code: "PROVIDER_RATE_LIMIT",
+    trace: null,
+  },
+  {
+    type: "lifecycle",
+    daemon_event_id: "life-1",
+    recorded_at: 1_700_000_000_002,
+    assistant_version: "1.2.3",
+    event_name: "app_open",
+  },
+  {
+    type: "onboarding",
+    daemon_event_id: "onb-1",
+    recorded_at: 1_700_000_000_003,
+    assistant_version: "1.2.3",
+    screen: "welcome",
+    tools: ["calendar"],
+    google_connected: true,
+  },
+  {
+    type: "auth_fallback",
+    daemon_event_id: "auth-1",
+    recorded_at: 1_700_000_000_004,
+    assistant_version: "1.2.3",
+    guard: "edge",
+    failure_kind: "missing_authorization",
+    path: "/v1/conversations",
+    count: 3,
+    window_start: 1_700_000_000_000,
+    window_end: 1_700_000_300_000,
+  },
+  {
+    type: "tool_executed",
+    daemon_event_id: "tool-1",
+    recorded_at: 1_700_000_000_005,
+    assistant_version: "1.2.3",
+    provider: "anthropic",
+    model: "claude-fable-5",
+    inference_profile: null,
+    inference_profile_source: null,
+    tool_name: "bash",
+    status: "fulfilled",
+    duration_ms: 120,
+    arg_bytes: 64,
+    result_bytes: 512,
+    conversation_id: "conv-1",
+  },
+  {
+    type: "skill_loaded",
+    daemon_event_id: "skill-1",
+    recorded_at: 1_700_000_000_006,
+    assistant_version: "1.2.3",
+    provider: null,
+    model: null,
+    inference_profile: null,
+    inference_profile_source: null,
+    skill_name: "plugin-builder",
+    skill_updated_at: "2026-07-01T00:00:00Z",
+    conversation_id: null,
+  },
+  {
+    type: "watchdog",
+    daemon_event_id: "watch-1",
+    recorded_at: 1_700_000_000_007,
+    assistant_version: "1.2.3",
+    check_name: "event_loop_blocked",
+    value: 1500,
+    detail: { threshold_ms: 1000 },
+  },
+  {
+    type: "config_setting",
+    daemon_event_id: "conf-1",
+    recorded_at: 1_700_000_000_008,
+    assistant_version: "1.2.3",
+    config_key: "memory.enabled",
+    config_value: "true",
+  },
+];
+
+function makeOnboardingResearchEvent() {
+  return {
+    type: "onboarding_research",
+    daemon_event_id: "research-1",
+    recorded_at: 1_700_000_000_009,
+    assistant_version: "1.2.3",
+    conversation_id: "conv-1",
+    status: "done",
+    claims: [],
+    claim_count: 0,
+    claims_confident: 0,
+    claims_maybe: 0,
+    claims_guessing: 0,
+    suggestions: [],
+    suggestion_count: 0,
+    plugins: [],
+    installed_plugins: [],
+  };
+}
+
+describe("validateWireEvents", () => {
+  beforeEach(() => {
+    warnCalls = [];
+    resetUnknownTypeWarningsForTests();
+  });
+
+  test("a valid event of each wire type passes with no warnings", () => {
+    const result = validateWireEvents(validEvents, stubLog);
+    expect(result).toEqual({ checked: 9, invalid: 0, unknownTypes: [] });
+    expect(warnCalls).toHaveLength(0);
+  });
+
+  test("invalid events are counted and warned with {path, code} issues and no field values", () => {
+    const sentinel = "SENTINEL_PII_VALUE_do_not_log";
+    const invalidTurn = {
+      type: "turn",
+      daemon_event_id: "turn-bad",
+      recorded_at: 1_700_000_000_010,
+      assistant_version: "1.2.3",
+      conversation_id: "conv-1",
+      turn_index: 1,
+      // Nested object values violate the wire contract's client bounds; the
+      // sentinel must never appear in any warn payload.
+      client: { nested: { secret: sentinel } },
+    };
+    const invalidLifecycle = {
+      type: "lifecycle",
+      daemon_event_id: "life-bad",
+      recorded_at: 1_700_000_000_011,
+      assistant_version: sentinel,
+      // event_name is missing.
+    };
+
+    const result = validateWireEvents([invalidTurn, invalidLifecycle], stubLog);
+    expect(result).toEqual({ checked: 2, invalid: 2, unknownTypes: [] });
+    expect(warnCalls).toHaveLength(2);
+
+    for (const call of warnCalls) {
+      const bag = call[0] as {
+        eventType: string;
+        issues: Array<Record<string, unknown>>;
+      };
+      expect(bag.issues.length).toBeGreaterThan(0);
+      for (const issue of bag.issues) {
+        // Issues carry path + code only — never messages or field values.
+        expect(Object.keys(issue).sort()).toEqual(["code", "path"]);
+        expect(issue.path).toBeString();
+        expect(issue.code).toBeString();
+      }
+    }
+    expect(
+      (warnCalls[0][0] as { issues: Array<{ path: string }> }).issues[0].path,
+    ).toStartWith("client");
+    expect(
+      (warnCalls[1][0] as { issues: Array<{ path: string }> }).issues[0].path,
+    ).toBe("event_name");
+
+    // The planted sentinel (a field value) must be absent from all log args.
+    expect(JSON.stringify(warnCalls)).not.toInclude(sentinel);
+  });
+
+  test("unknown event types are reported and warned once per process per type", () => {
+    const first = validateWireEvents([makeOnboardingResearchEvent()], stubLog);
+    const second = validateWireEvents([makeOnboardingResearchEvent()], stubLog);
+
+    expect(first).toEqual({
+      checked: 0,
+      invalid: 0,
+      unknownTypes: ["onboarding_research"],
+    });
+    expect(second.unknownTypes).toEqual(["onboarding_research"]);
+
+    // Rate-limited: the warn fires exactly once across both calls.
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0][0]).toEqual({ eventType: "onboarding_research" });
+  });
+
+  test("schema map covers every discriminator of the generated union", () => {
+    const discriminators = telemetryEventSchema.options.map(
+      (option) => option.shape.type.value,
+    );
+    expect(new Set(wireSchemaByType.keys())).toEqual(new Set(discriminators));
+    expect(discriminators.length).toBeGreaterThanOrEqual(9);
+  });
+});

--- a/assistant/src/telemetry/telemetry-wire-validation.test.ts
+++ b/assistant/src/telemetry/telemetry-wire-validation.test.ts
@@ -2,8 +2,10 @@
  * Tests for pre-flush telemetry wire validation.
  *
  * Validation is observability only — it must count and warn, never mutate,
- * filter, or block — and its warn payloads must carry issue `{ path, code }`
- * shapes only, never field values (traces/claims can hold PII).
+ * filter, or block — and its warn payloads must carry the event type and
+ * issue `{ path, code }` shapes only, never field values. `daemon_event_id`
+ * is a field value too: activation-funnel ids embed the onboarding session
+ * id (traces/claims can hold PII).
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
@@ -185,7 +187,10 @@ describe("validateWireEvents", () => {
     };
     const invalidLifecycle = {
       type: "lifecycle",
-      daemon_event_id: "life-bad",
+      // Mirrors the activation-funnel id shape (`version:sessionId:step`),
+      // which embeds the onboarding session id and exceeds the wire schema's
+      // 36-char daemon_event_id bound — the id itself must never be logged.
+      daemon_event_id: `activation_v1_2026_06:${sentinel}:activation_moment_1_complete`,
       recorded_at: 1_700_000_000_011,
       assistant_version: sentinel,
       // event_name is missing.
@@ -200,6 +205,9 @@ describe("validateWireEvents", () => {
         eventType: string;
         issues: Array<Record<string, unknown>>;
       };
+      // The bag carries the event type and issues only — no daemon_event_id
+      // (it is a payload value; activation ids embed the session id).
+      expect(Object.keys(bag).sort()).toEqual(["eventType", "issues"]);
       expect(bag.issues.length).toBeGreaterThan(0);
       for (const issue of bag.issues) {
         // Issues carry path + code only — never messages or field values.
@@ -211,9 +219,11 @@ describe("validateWireEvents", () => {
     expect(
       (warnCalls[0][0] as { issues: Array<{ path: string }> }).issues[0].path,
     ).toStartWith("client");
-    expect(
-      (warnCalls[1][0] as { issues: Array<{ path: string }> }).issues[0].path,
-    ).toBe("event_name");
+    const lifecyclePaths = (
+      warnCalls[1][0] as { issues: Array<{ path: string }> }
+    ).issues.map((issue) => issue.path);
+    expect(lifecyclePaths).toContain("daemon_event_id");
+    expect(lifecyclePaths).toContain("event_name");
 
     // The planted sentinel (a field value) must be absent from all log args.
     expect(JSON.stringify(warnCalls)).not.toInclude(sentinel);

--- a/assistant/src/telemetry/telemetry-wire-validation.ts
+++ b/assistant/src/telemetry/telemetry-wire-validation.ts
@@ -46,6 +46,26 @@ export function resetUnknownTypeWarningsForTests(): void {
   warnedUnknownTypes.clear();
 }
 
+/**
+ * Render a zod issue path for logging without leaking dynamic record keys.
+ *
+ * Rule: keep numeric components (array indices — structural, never data) and
+ * keep the first (depth-0) component; redact every deeper string component to
+ * a literal `*`. Depth-0 is safe because every generated event schema is a
+ * flat `z.object`, so top-level path components are schema-defined field
+ * names. Deeper string components can be dynamic record keys — e.g. the turn
+ * schema's `client` bag superRefine emits issues at `['client', <key>]` where
+ * `<key>` comes from an uncontrolled JSON metadata column and could carry
+ * user text.
+ */
+function sanitizeIssuePath(path: ReadonlyArray<PropertyKey>): string {
+  return path
+    .map((component, depth) =>
+      typeof component === "number" || depth === 0 ? String(component) : "*",
+    )
+    .join(".");
+}
+
 export interface WireValidationResult {
   /** Events whose type had a wire schema and were parsed against it. */
   checked: number;
@@ -59,7 +79,8 @@ export interface WireValidationResult {
  * Validate a batch of outgoing telemetry events against the platform wire
  * schemas, logging a structured warning for each event the server would
  * silently drop. Warn payloads carry the event `type` and issue
- * `{ path, code }` shapes only — never field values. That includes
+ * `{ path, code }` shapes only — never field values, and never dynamic key
+ * components inside paths (see {@link sanitizeIssuePath}). That includes
  * `daemon_event_id`: traces/claims can hold PII, and activation-funnel ids
  * embed the onboarding session id.
  *
@@ -91,7 +112,7 @@ export function validateWireEvents(
     if (!result.success) {
       invalid += 1;
       const issues = result.error.issues.map((issue) => ({
-        path: issue.path.map(String).join("."),
+        path: sanitizeIssuePath(issue.path),
         code: issue.code,
       }));
       log.warn(

--- a/assistant/src/telemetry/telemetry-wire-validation.ts
+++ b/assistant/src/telemetry/telemetry-wire-validation.ts
@@ -58,14 +58,16 @@ export interface WireValidationResult {
 /**
  * Validate a batch of outgoing telemetry events against the platform wire
  * schemas, logging a structured warning for each event the server would
- * silently drop. Warn payloads carry issue `{ path, code }` shapes only —
- * never field values, since traces/claims can hold PII.
+ * silently drop. Warn payloads carry the event `type` and issue
+ * `{ path, code }` shapes only — never field values. That includes
+ * `daemon_event_id`: traces/claims can hold PII, and activation-funnel ids
+ * embed the onboarding session id.
  *
  * Never mutates, filters, or blocks: callers send the batch unchanged
  * regardless of the result.
  */
 export function validateWireEvents(
-  events: readonly { type: string; daemon_event_id?: string }[],
+  events: readonly { type: string }[],
   log: Logger,
 ): WireValidationResult {
   let checked = 0;
@@ -93,11 +95,7 @@ export function validateWireEvents(
         code: issue.code,
       }));
       log.warn(
-        {
-          eventType: event.type,
-          daemonEventId: event.daemon_event_id,
-          issues,
-        },
+        { eventType: event.type, issues },
         "telemetry event fails platform wire contract — server will silently drop it",
       );
     }

--- a/assistant/src/telemetry/telemetry-wire-validation.ts
+++ b/assistant/src/telemetry/telemetry-wire-validation.ts
@@ -1,0 +1,106 @@
+/**
+ * Pre-flush validation of outgoing telemetry events against the
+ * platform-generated wire schemas (`telemetry-wire.generated.ts`).
+ *
+ * The platform ingest endpoint rejects individual events that violate its
+ * serializer bounds and skips event types it has no serializer for — both
+ * silently from the daemon's point of view (the batch still 2xxes). This
+ * module surfaces those would-be-silent drops as structured warnings at the
+ * source, right before each POST.
+ *
+ * Observability only: validation never mutates, filters, or blocks a batch.
+ * The server remains the authority on what it accepts; in particular the
+ * `.trim()`-transformed parse output is never substituted for the original
+ * events.
+ */
+
+import type { z } from "zod";
+
+import type { getLogger } from "../util/logger.js";
+import { telemetryEventSchema } from "./telemetry-wire.generated.js";
+
+type Logger = ReturnType<typeof getLogger>;
+
+/**
+ * Per-event-type wire schema, derived by introspecting the generated
+ * discriminated union (`.options` + each member's `type` literal), so a new
+ * generated event type is validated with zero hand edits here.
+ */
+export const wireSchemaByType: ReadonlyMap<string, z.ZodType> = new Map(
+  telemetryEventSchema.options.map((option) => [
+    option.shape.type.value,
+    option,
+  ]),
+);
+
+/**
+ * Event types already warned about as absent from the wire contract.
+ * Unknown-type warnings are rate-limited to once per process per type —
+ * without this, a daemon-only extension type (e.g. `onboarding_research`)
+ * would warn on every 5-minute flush forever.
+ */
+const warnedUnknownTypes = new Set<string>();
+
+/** Clears the once-per-process unknown-type warning rate limit. Test-only. */
+export function resetUnknownTypeWarningsForTests(): void {
+  warnedUnknownTypes.clear();
+}
+
+export interface WireValidationResult {
+  /** Events whose type had a wire schema and were parsed against it. */
+  checked: number;
+  /** Checked events that failed their wire schema. */
+  invalid: number;
+  /** Distinct event types with no wire schema — the server drops these. */
+  unknownTypes: string[];
+}
+
+/**
+ * Validate a batch of outgoing telemetry events against the platform wire
+ * schemas, logging a structured warning for each event the server would
+ * silently drop. Warn payloads carry issue `{ path, code }` shapes only —
+ * never field values, since traces/claims can hold PII.
+ *
+ * Never mutates, filters, or blocks: callers send the batch unchanged
+ * regardless of the result.
+ */
+export function validateWireEvents(
+  events: readonly { type: string; daemon_event_id?: string }[],
+  log: Logger,
+): WireValidationResult {
+  let checked = 0;
+  let invalid = 0;
+  const unknownTypes = new Set<string>();
+  for (const event of events) {
+    const schema = wireSchemaByType.get(event.type);
+    if (!schema) {
+      unknownTypes.add(event.type);
+      if (!warnedUnknownTypes.has(event.type)) {
+        warnedUnknownTypes.add(event.type);
+        log.warn(
+          { eventType: event.type },
+          "telemetry event type not in platform wire contract — server drops these; see telemetry-wire.generated.ts",
+        );
+      }
+      continue;
+    }
+    checked += 1;
+    const result = schema.safeParse(event);
+    if (!result.success) {
+      invalid += 1;
+      const issues = result.error.issues.map((issue) => ({
+        path: issue.path.map(String).join("."),
+        code: issue.code,
+      }));
+      log.warn(
+        {
+          eventType: event.type,
+          daemonEventId: event.daemon_event_id,
+          issues,
+        },
+        "telemetry event fails platform wire contract — server will silently drop it",
+      );
+    }
+  }
+  return { checked, invalid, unknownTypes: [...unknownTypes] };
+}

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -46,6 +46,7 @@ import {
   watermarkKeysForSource,
 } from "./telemetry-event-sources.js";
 import { useReadOnlyMainDbForTelemetry } from "./telemetry-main-db.js";
+import { validateWireEvents } from "./telemetry-wire-validation.js";
 
 const log = getLogger("usage-telemetry");
 
@@ -404,6 +405,10 @@ export class UsageTelemetryReporter {
       // Build payload — sources in construction order, each source's events
       // in cursor order.
       const typedEvents = batches.flatMap(({ batch }) => batch.events);
+
+      // Pre-flush wire validation — observability only: warns about events
+      // the server would silently drop; the batch is POSTed unchanged.
+      validateWireEvents(typedEvents, log);
 
       const organizationId = getPlatformOrganizationId() || undefined;
       const userId = getPlatformUserId() || undefined;

--- a/assistant/src/telemetry/watchdog-direct-emit.ts
+++ b/assistant/src/telemetry/watchdog-direct-emit.ts
@@ -25,6 +25,7 @@ import { arePlatformFeaturesEnabled } from "../platform/feature-gate.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
+import { validateWireEvents } from "./telemetry-wire-validation.js";
 import type { WatchdogTelemetryEvent } from "./types.js";
 
 const log = getLogger("watchdog-direct-emit");
@@ -62,6 +63,11 @@ export async function emitWatchdogEventDirect(
       detail,
       assistant_version: APP_VERSION,
     };
+
+    // Pre-flush wire validation — observability only: warns when the server
+    // would silently drop the event; the POST proceeds unchanged.
+    validateWireEvents([event], log);
+
     const organizationId = getPlatformOrganizationId() || undefined;
     const userId = getPlatformUserId() || undefined;
     const resp = await client.fetch(TELEMETRY_INGEST_PATH, {


### PR DESCRIPTION
## Summary
- New telemetry-wire-validation module: safeParse each outgoing event against the platform-generated zod schemas; structured warn on contract violations (issue paths/codes only, no field values) and rate-limited warn for event types the server will drop (onboarding_research today)
- Wired at both POST sites (batch reporter flush + watchdog direct emit); observability only — never mutates, filters, or blocks a batch

Part of plan: telemetry-wire-adoption.md (PR 2 of 3)