### PR TITLE
Refactor telemetry types.ts into an override layer over the generated wire module

### DIFF
--- a/assistant/src/telemetry/types.test.ts
+++ b/assistant/src/telemetry/types.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, test } from "bun:test";
+
+import { telemetryEventSchema } from "./telemetry-wire.generated.js";
+import type {
+  AuthFallbackTelemetryEvent,
+  ConfigSettingTelemetryEvent,
+  LifecycleTelemetryEvent,
+  LlmUsageTelemetryEvent,
+  OnboardingResearchTelemetryEvent,
+  OnboardingTelemetryEvent,
+  SkillLoadedTelemetryEvent,
+  ToolExecutedTelemetryEvent,
+  TurnTelemetryEvent,
+  TurnTrace,
+  WatchdogTelemetryEvent,
+} from "./types.js";
+
+// Runtime contract test: events constructed with the daemon's types must
+// parse against the generated wire schemas — the same validation the
+// platform's ingest serializers apply. A daemon type whose values can't
+// round-trip through `telemetryEventSchema` produces events the server
+// silently drops.
+
+const RECORDED_AT = 1_750_000_000_000;
+
+const llmUsage: LlmUsageTelemetryEvent = {
+  type: "llm_usage",
+  daemon_event_id: "evt-llm-usage-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  conversation_id: "conv-xyz",
+  conversation_type: "standard",
+  // Zero is legitimate here (wire bound is min(0)) — the wire schema must
+  // not reject it.
+  turn_index: 0,
+  provider: "anthropic",
+  model: "claude-fable-5",
+  input_tokens: 1200,
+  output_tokens: 340,
+  cache_creation_input_tokens: 256,
+  cache_read_input_tokens: 1024,
+  llm_call_count: 3,
+  raw_usage: {
+    input_tokens: 1200,
+    cache_creation: { ephemeral_5m_input_tokens: 256 },
+  },
+  actor: "user",
+  llm_call_site: "mainAgent",
+  inference_profile: "balanced",
+  inference_profile_source: "active",
+  cost: 0.0123,
+};
+
+const trace: TurnTrace = {
+  schema_version: 3,
+  messages: [
+    {
+      id: "msg-1",
+      role: "user",
+      created_at: RECORDED_AT - 5_000,
+      content: [{ type: "text", text: "What's on my calendar today?" }],
+      model: null,
+    },
+    {
+      id: "msg-2",
+      role: "assistant",
+      created_at: RECORDED_AT - 1_000,
+      content: [{ type: "text", text: "You have two meetings." }],
+      model: "claude-fable-5",
+    },
+  ],
+  tool_calls: [
+    {
+      id: "inv-1",
+      tool_name: "bash",
+      input: { command: "ls" },
+      result: "ok",
+      decision: "allow",
+      duration_ms: 42,
+      created_at: RECORDED_AT - 3_000,
+    },
+  ],
+  system_prompt: "You are a helpful assistant.",
+  tool_definitions: [
+    {
+      name: "bash",
+      description: "Run a shell command",
+      input_schema: { type: "object", properties: {} },
+    },
+  ],
+};
+
+const turn: TurnTelemetryEvent = {
+  type: "turn",
+  daemon_event_id: "evt-turn-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  conversation_id: "conv-xyz",
+  conversation_type: "standard",
+  turn_index: 1,
+  interface_id: "web",
+  channel_id: "vellum",
+  client: {
+    browser_family: "chrome",
+    browser_version: "124",
+    os: "macos",
+    interface_version: "0.8.2",
+  },
+  outcome: "failed",
+  failure_code: "PROVIDER_RATE_LIMIT",
+  trace,
+};
+
+const lifecycle: LifecycleTelemetryEvent = {
+  type: "lifecycle",
+  daemon_event_id: "evt-lifecycle-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  event_name: "app_open",
+};
+
+const onboarding: OnboardingTelemetryEvent = {
+  type: "onboarding",
+  daemon_event_id: "evt-onboarding-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  screen: "tools",
+  tools: ["gmail", "calendar"],
+  tasks: ["email-triage"],
+  tone: "friendly",
+  google_connected: true,
+  google_scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+  ab_variant: "control",
+  session_id: "sess-123",
+  step_name: "select-tools",
+  step_index: 2,
+  completed_at: "2026-07-13T00:00:00Z",
+  funnel_version: "v2",
+  user_id: "user-123",
+};
+
+const authFallback: AuthFallbackTelemetryEvent = {
+  type: "auth_fallback",
+  daemon_event_id: "evt-auth-fallback-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  guard: "edge",
+  path: "/v1/conversations",
+  failure_kind: "missing_authorization",
+  count: 7,
+  window_start: RECORDED_AT - 300_000,
+  window_end: RECORDED_AT,
+};
+
+const toolExecuted: ToolExecutedTelemetryEvent = {
+  type: "tool_executed",
+  daemon_event_id: "evt-tool-executed-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  provider: "anthropic",
+  model: "claude-fable-5",
+  inference_profile: "balanced",
+  inference_profile_source: "call_site",
+  tool_name: "bash",
+  status: "fulfilled",
+  duration_ms: 42,
+  arg_bytes: 128,
+  result_bytes: 2048,
+  conversation_id: "conv-xyz",
+};
+
+const skillLoaded: SkillLoadedTelemetryEvent = {
+  type: "skill_loaded",
+  daemon_event_id: "evt-skill-loaded-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  provider: "anthropic",
+  model: "claude-fable-5",
+  inference_profile: "balanced",
+  inference_profile_source: "conversation",
+  skill_name: "plugin-builder",
+  skill_updated_at: "2026-06-01T00:00:00Z",
+  conversation_id: "conv-xyz",
+};
+
+const watchdog: WatchdogTelemetryEvent = {
+  type: "watchdog",
+  daemon_event_id: "evt-watchdog-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  check_name: "event_loop_blocked",
+  value: 1200,
+  detail: { reason: "gc", blocked_ms: 1200 },
+};
+
+const configSetting: ConfigSettingTelemetryEvent = {
+  type: "config_setting",
+  daemon_event_id: "evt-config-setting-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  config_key: "memory.enabled",
+  config_value: "true",
+};
+
+describe("daemon telemetry types against the wire contract", () => {
+  const wireSamples = [
+    llmUsage,
+    turn,
+    lifecycle,
+    onboarding,
+    authFallback,
+    toolExecuted,
+    skillLoaded,
+    watchdog,
+    configSetting,
+  ] as const;
+
+  for (const sample of wireSamples) {
+    test(`daemon-typed ${sample.type} event parses against the wire schema`, () => {
+      const result = telemetryEventSchema.safeParse(sample);
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+    });
+  }
+
+  test("turn client bag with a nested value fails the wire superRefine", () => {
+    // Structurally valid for the daemon's `TurnTelemetryClientInfo` (extra
+    // properties are allowed outside fresh-literal checks), but the wire
+    // schema mirrors the server's validate_client: nested objects in the
+    // `client` bag reject the event at ingest.
+    const nestedClient = { os: "macos", screen: { width: 1512, height: 982 } };
+    const invalidTurn: TurnTelemetryEvent = { ...turn, client: nestedClient };
+    const result = telemetryEventSchema.safeParse(invalidTurn);
+    expect(result.success).toBe(false);
+  });
+
+  test("onboarding_research is not in the wire contract — the server drops it", () => {
+    // Documents the extension gap: `onboarding_research` is daemon-only and
+    // has no platform ingest serializer, so the server silently drops these
+    // events. The platform-repo follow-up (serializer + Terraform + dbt)
+    // closes this; until then the schema rejects the unknown discriminator.
+    const onboardingResearch: OnboardingResearchTelemetryEvent = {
+      type: "onboarding_research",
+      daemon_event_id: "evt-onboarding-research-1",
+      recorded_at: RECORDED_AT,
+      assistant_version: "1.2.3",
+      conversation_id: "conv-xyz",
+      status: "done",
+      claims: [
+        {
+          claim: "Works on developer tooling",
+          confidence: "confident",
+          sources: ["https://example.com/profile"],
+        },
+      ],
+      claim_count: 1,
+      claims_confident: 1,
+      claims_maybe: 0,
+      claims_guessing: 0,
+      suggestions: [
+        {
+          suggestion: "Set up email triage",
+          prompt: "Help me triage my inbox",
+        },
+      ],
+      suggestion_count: 1,
+      plugins: ["gmail"],
+      installed_plugins: ["gmail", "calendar"],
+    };
+    const result = telemetryEventSchema.safeParse(onboardingResearch);
+    expect(result.success).toBe(false);
+  });
+});

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -1,5 +1,7 @@
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
+import type * as wire from "./telemetry-wire.generated.js";
+import type { TurnOutcome } from "./turn-outcome.js";
 
 /** Base fields present on every telemetry event. */
 export interface TelemetryEventBase {
@@ -53,6 +55,18 @@ export interface ModelTelemetryEventBase extends TelemetryEventBase {
   /** How the profile was attributed (same enum as llm_usage). */
   inference_profile_source: UsageAttributionProfileSource | null;
 }
+
+/**
+ * Applies the daemon's record-time guarantee to a wire-derived event type.
+ *
+ * The wire contract marks `assistant_version` optional for back-compat with
+ * old daemons; under the platform's per-event-wins contract a present
+ * per-event value (including explicit `null`) beats the envelope fallback.
+ * This daemon always stamps the field at record time (see
+ * {@link TelemetryEventBase.assistant_version} for the full contract), so
+ * wire-derived event types are re-typed with the field required.
+ */
+type Daemonize<T> = T & { assistant_version: string | null };
 
 /**
  * LLM usage event — one per persisted usage row. The main agent loop
@@ -329,7 +343,7 @@ export interface TurnTelemetryEvent extends TelemetryEventBase {
    * could land — so `absent + no assistant message in trace` isolates the
    * genuinely anomalous (crashed/unknown) turns.
    */
-  outcome?: "batched" | "failed" | "cancelled";
+  outcome?: TurnOutcome;
   /**
    * For `outcome: "batched"` turns: the `daemon_event_id` of the
    * batch-final turn whose window carries the shared response. Omitted
@@ -356,64 +370,6 @@ export interface TurnTelemetryEvent extends TelemetryEventBase {
    * serialized trace exceeded the size cap.
    */
   trace?: TurnTrace | null;
-}
-
-/** Lifecycle event — app_open, hatch, etc. */
-export interface LifecycleTelemetryEvent extends TelemetryEventBase {
-  type: "lifecycle";
-  event_name: string;
-}
-
-/** Onboarding event — pre-chat selections and Google connect status. */
-export interface OnboardingTelemetryEvent extends TelemetryEventBase {
-  type: "onboarding";
-  screen: string;
-  tools?: string[];
-  tasks?: string[];
-  tone?: string;
-  google_connected?: boolean;
-  google_scopes?: string[];
-  ab_variant?: string;
-  /**
-   * Activation-funnel fields (mirror the web funnel shape and the platform
-   * serializer). The platform accepts an onboarding event via either the
-   * legacy `screen` path or the all-funnel-fields path (`session_id` +
-   * `step_name` + `step_index` + `completed_at` + `funnel_version` +
-   * `ab_variant`).
-   */
-  session_id?: string;
-  step_name?: string;
-  step_index?: number;
-  completed_at?: string;
-  funnel_version?: string;
-  user_id?: string;
-}
-
-/**
- * Auth-fallback event — aggregated count of requests served via the legacy
- * loopback auth fallback. One event per (guard, path, failure_kind) per flush
- * window. Lets the platform see which deployments still rely on the loopback
- * exemption instead of sending a bearer token.
- */
-export interface AuthFallbackTelemetryEvent extends TelemetryEventBase {
-  type: "auth_fallback";
-  /** Which auth guard fell back: `"edge"` | `"edge-scoped"` | `"edge-guardian"`. */
-  guard: string;
-  /** Request pathname that fell back. */
-  path: string;
-  /**
-   * Why the bearer-token check did not succeed before the fallback:
-   * `"missing_authorization"` | `"malformed_authorization"` |
-   * `"token_validation_failed"` | `"insufficient_scope"` |
-   * `"non_actor_principal"` | `"guardian_mismatch"`.
-   */
-  failure_kind: string;
-  /** Number of requests that fell back for this key during the window. */
-  count: number;
-  /** Window start (epoch ms) the count was accumulated over. */
-  window_start: number;
-  /** Window end (epoch ms) the count was accumulated over. */
-  window_end: number;
 }
 
 /**
@@ -490,27 +446,6 @@ export interface WatchdogTelemetryEvent extends TelemetryEventBase {
   detail: Record<string, unknown> | null;
 }
 
-/**
- * Config-setting event — records a tracked config key's effective value.
- * A single string:string pair on top of the standard envelope, mirroring
- * the platform `ConfigSettingTelemetryEventSerializer`:
- *
- *   - `config_key` — dotted config path (e.g. `"memory.enabled"`).
- *     Bounded server-side at 128 chars.
- *   - `config_value` — the effective value rendered as a string
- *     (`"true"` / `"false"` for booleans). Bounded server-side at 256
- *     chars.
- *
- * Metadata only — emitters record an explicit allowlist of non-sensitive
- * settings, never free-form config content. Dedupe downstream on
- * `daemon_event_id` (the daemon retries a batch on transient POST failure).
- */
-export interface ConfigSettingTelemetryEvent extends TelemetryEventBase {
-  type: "config_setting";
-  config_key: string;
-  config_value: string;
-}
-
 /** One inferred fact from the onboarding research-onboarding web-search turn. */
 export interface OnboardingResearchClaim {
   claim: string;
@@ -553,18 +488,123 @@ export interface OnboardingResearchTelemetryEvent extends TelemetryEventBase {
   installed_plugins: string[];
 }
 
+/**
+ * Wire-derived event types with the daemon's record-time
+ * `assistant_version` guarantee applied. New event types added to the wire
+ * contract flow through here with zero hand edits.
+ */
+type WireDaemonized = {
+  [K in keyof wire.WireEventMap]: Daemonize<wire.WireEventMap[K]>;
+};
+
+/** Events where the daemon's type is intentionally narrower than the wire. */
+type Overrides = {
+  llm_usage: LlmUsageTelemetryEvent;
+  turn: TurnTelemetryEvent;
+  tool_executed: ToolExecutedTelemetryEvent;
+  skill_loaded: SkillLoadedTelemetryEvent;
+  watchdog: WatchdogTelemetryEvent;
+};
+
+/**
+ * Daemon-only event types not (yet) in the platform wire contract.
+ *
+ * WARNING: the platform ingest endpoint DROPS `onboarding_research` — it has
+ * no serializer in the platform's `TELEMETRY_EVENT_SERIALIZERS`, so
+ * `POST /v1/telemetry/ingest/` silently skips these events. Adding the
+ * serializer (plus its Terraform and dbt touchpoints) is a platform-repo
+ * follow-up. When the platform adds a wire type for an extension key, the
+ * key must leave `Extensions` — into `Overrides` if the daemon type stays
+ * narrower, or plain wire flow-through otherwise (the collision guard below
+ * enforces this).
+ */
+type Extensions = {
+  onboarding_research: OnboardingResearchTelemetryEvent;
+};
+
+type EventMap = Omit<WireDaemonized, keyof Overrides> & Overrides & Extensions;
+
 /** Discriminated union of all telemetry event types. */
-export type TelemetryEvent =
-  | LlmUsageTelemetryEvent
-  | TurnTelemetryEvent
-  | LifecycleTelemetryEvent
-  | OnboardingTelemetryEvent
-  | AuthFallbackTelemetryEvent
-  | ToolExecutedTelemetryEvent
-  | SkillLoadedTelemetryEvent
-  | WatchdogTelemetryEvent
-  | ConfigSettingTelemetryEvent
-  | OnboardingResearchTelemetryEvent;
+export type TelemetryEvent = EventMap[keyof EventMap];
+
+/**
+ * Lifecycle event — app_open, hatch, etc. 1:1 with the wire contract:
+ * `telemetry-wire.generated.ts` (from the platform's
+ * `LifecycleTelemetryEventSerializer`) is the source of truth.
+ */
+export type LifecycleTelemetryEvent = EventMap["lifecycle"];
+
+/**
+ * Onboarding event — pre-chat selections, Google connect status, and
+ * activation-funnel steps. 1:1 with the wire contract
+ * (`OnboardingTelemetryEventSerializer`); the platform accepts either the
+ * legacy `screen` shape or the complete funnel step field set — see the wire
+ * schema's superRefine.
+ */
+export type OnboardingTelemetryEvent = EventMap["onboarding"];
+
+/**
+ * Auth-fallback event — aggregated count of requests served via the legacy
+ * loopback auth fallback, one event per (guard, path, failure_kind) per
+ * flush window (`count` is a per-window delta, not a running total). 1:1
+ * with the wire contract (`AuthFallbackTelemetryEventSerializer`).
+ */
+export type AuthFallbackTelemetryEvent = EventMap["auth_fallback"];
+
+/**
+ * Config-setting event — a tracked config key's effective value rendered as
+ * a string; emitters record an explicit allowlist of non-sensitive settings,
+ * never free-form config content. 1:1 with the wire contract
+ * (`ConfigSettingTelemetryEventSerializer`).
+ */
+export type ConfigSettingTelemetryEvent = EventMap["config_setting"];
+
+// ---- Compile-time drift guards ----
+// Each `_*Narrows` alias fails to compile when the daemon's hand-written
+// event type stops being assignable to the generated wire type, so a wire
+// sync PR that moves the platform contract turns red here instead of
+// drifting silently.
+type AssertNarrows<_Narrow extends Wide, Wide> = true;
+type AssertNoWireCollision<_Keys extends never> = true;
+
+// `raw_usage` is excluded: the server treats it as an opaque JSONField, so
+// the daemon's `Record<string, unknown>` (not structurally assignable to the
+// wire's recursive `JsonValue`) is wire-safe — any JSON-serializable shape
+// ships fine.
+type _llmUsageNarrows = AssertNarrows<
+  Omit<LlmUsageTelemetryEvent, "raw_usage">,
+  Omit<wire.LlmUsageTelemetryEvent, "raw_usage">
+>;
+// `trace` and `client` are excluded: the server treats both as opaque JSON
+// (JSONField/DictField), so the daemon's richer `TurnTrace`
+// (`content: unknown`) and `TurnTelemetryClientInfo` shapes are wire-safe
+// even though they are not assignable to `JsonValue`. Runtime bounds are
+// enforced by the wire schema's superRefines, not by these types.
+type _turnNarrows = AssertNarrows<
+  Omit<TurnTelemetryEvent, "trace" | "client">,
+  Omit<wire.TurnTelemetryEvent, "trace" | "client">
+>;
+type _toolExecutedNarrows = AssertNarrows<
+  ToolExecutedTelemetryEvent,
+  wire.ToolExecutedTelemetryEvent
+>;
+type _skillLoadedNarrows = AssertNarrows<
+  SkillLoadedTelemetryEvent,
+  wire.SkillLoadedTelemetryEvent
+>;
+// `detail` is excluded: the server treats it as an opaque JSONField, so the
+// daemon's `Record<string, unknown>` bag is wire-safe; the serialized-size
+// bound is enforced by the wire schema's superRefine.
+type _watchdogNarrows = AssertNarrows<
+  Omit<WatchdogTelemetryEvent, "detail">,
+  Omit<wire.WatchdogTelemetryEvent, "detail">
+>;
+// An `Extensions` key that also exists in the wire map would silently
+// shadow the generated type; this stays `never` only while the key sets
+// are disjoint.
+type _extensionsDontCollide = AssertNoWireCollision<
+  keyof Extensions & keyof wire.WireEventMap
+>;
 
 /**
  * Event names backed by the `telemetry_events` outbox. Each name doubles as


### PR DESCRIPTION
## Summary
- types.ts now composes from telemetry-wire.generated.ts: simple events re-exported via WireEventMap (zero restatement), rich daemon types kept as Overrides with AssertNarrows compile-time drift guards, onboarding_research isolated as a daemon-only Extension
- Runtime contract test binds daemon-typed samples to the wire schemas
- Public symbol surface unchanged — zero consumer edits

Part of plan: telemetry-wire-adoption.md (PR 1 of 3)