### PR TITLE
fix(voice): make voice-room top-right controls clickable on macOS

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -302,6 +302,24 @@ describe("VoiceRoom — captions toggle", () => {
   });
 });
 
+describe("VoiceRoom — Electron title-bar clickability", () => {
+  // Regression: the top-right controls sit in the band where the still-mounted
+  // ChatLayoutHeader owns the `-webkit-app-region: drag` window-drag region. A
+  // drag region stays draggable under a painted-over overlay, so without a
+  // `no-drag` carve-out these buttons swallow their clicks on macOS.
+  test("top-right controls carve out of the window-drag region", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    const exit = screen.getByRole("button", { name: "Exit voice session" });
+    const captions = screen.getByRole("button", { name: "Show captions" });
+    const cluster = exit.closest<HTMLElement>("[class*='no-drag']");
+    expect(cluster).not.toBeNull();
+    expect(cluster?.className).toContain("[-webkit-app-region:no-drag]");
+    // Both top-right controls share the one carved-out cluster.
+    expect(cluster?.contains(captions)).toBe(true);
+  });
+});
+
 describe("VoiceRoom — mute toggle", () => {
   test("mute drives the registered setMuted control", () => {
     startOwnedSession("listening");

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -253,7 +253,14 @@ function VoiceRoomOverlay() {
           top: `max(1.25rem, ${SAFE_AREA_TOP})`,
           right: `max(1.25rem, ${SAFE_AREA_RIGHT})`,
         }}
-        className="absolute z-10 flex items-center gap-1"
+        // This cluster sits in the top band where `ChatLayoutHeader` (still
+        // mounted under the room) owns the Electron window-drag region
+        // (`-webkit-app-region: drag`). A drag region stays draggable even
+        // under a painted-over overlay, so without opting these buttons back
+        // out they are unclickable on macOS — the click drags the window.
+        // Mirrors the header's own `[&_button]:no-drag` carve-out; inert off
+        // Electron (web / iOS set no app-region).
+        className="absolute z-10 flex items-center gap-1 [&_button]:[-webkit-app-region:no-drag]"
       >
         <Tooltip content={captionsOn ? "Hide captions" : "Show captions"}>
           <button


### PR DESCRIPTION
## Problem

In the macOS Electron app, the voice room's top-right controls — the **Show captions** toggle and the exit **✕** — do nothing when clicked. (The bottom mic/stop controls work; they're clear of the affected band.)

## Cause

`ChatLayoutHeader` is the macOS title bar and owns the Electron window-drag region (`-webkit-app-region: drag`, `minHeight: 44px`, pinned to the top of the window). It **stays mounted under the voice room** — the room is a sibling overlay mounted at layout scope (`chat-layout.tsx`), not a remount. The room (`fixed inset-0 z-50`) paints over the header, and its top-right cluster sits at `top: 20px` with `size-10` (40px) buttons, so the button centers land inside the header's 44px drag band.

An Electron `-webkit-app-region: drag` region stays draggable even when another element is painted on top of it, unless that element carves out a `no-drag` hole. The room's buttons didn't, so a click there dragged the window instead of firing. macOS/Electron-only — web and iOS set no `app-region`.

## Fix

Carve the top-right cluster out with `[&_button]:[-webkit-app-region:no-drag]`, mirroring `ChatLayoutHeader`'s own `[&_button]:no-drag` idiom and the existing precedent in `attachment-preview-modal.tsx` and `voice-session-pill.tsx`. Window dragging from the room's empty top band is preserved; the buttons become clickable. Adds a regression test asserting both controls share the carved-out cluster.

## Testing

- `bun test voice-room.test.tsx` — 36 pass (incl. new test)
- `bun run typecheck` — clean

Fixes JARVIS-1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)