### PR TITLE
feat(settings): Managed/Your Own toggle for Text-to-Speech and Speech-to-Text cards

### DIFF
--- a/clients/web/src/domains/settings/ai/local-storage-keys.ts
+++ b/clients/web/src/domains/settings/ai/local-storage-keys.ts
@@ -14,8 +14,10 @@ export const LS_WEB_FETCH_PROVIDER = "vellum:ai:webFetchProvider";
 export const LS_EMAIL_MODE = "vellum:ai:emailMode";
 export const LS_EMAIL_BYO_PROVIDER = "vellum:ai:emailByoProvider";
 
+export const LS_TTS_MODE = "vellum:voice:ttsMode";
 export const LS_TTS_PROVIDER = "vellum:voice:ttsProvider";
 export const LS_TTS_API_KEY_PREFIX = "vellum:voice:ttsApiKey:";
 export const LS_TTS_VOICE_ID_PREFIX = "vellum:voice:ttsVoiceId:";
+export const LS_STT_MODE = "vellum:voice:sttMode";
 export const LS_STT_PROVIDER = "vellum:voice:sttProvider";
 export const LS_STT_API_KEY_PREFIX = "vellum:voice:sttApiKey:";

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -21,6 +21,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 
 let nativeDictationSupported = false;
@@ -118,6 +119,11 @@ function selectOption(label: string): void {
     );
   }
   fireEvent.click(option);
+}
+
+function setMode(label: "Managed" | "Your Own"): void {
+  const group = screen.getByRole("radiogroup", { name: "Service mode" });
+  fireEvent.click(within(group).getByRole("radio", { name: label }));
 }
 
 describe("SpeechToTextCard — macOS Native Dictation option", () => {
@@ -228,15 +234,17 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     expect(sttBody?.services?.stt ?? {}).not.toHaveProperty("provider");
   });
 
-  test("saving a key switches a managed-mode daemon back to your-own", async () => {
-    // Managed speech was auto-defaulted on connection; saving a BYOK key from
-    // this card is explicit intent to use it, so the mode must flip too —
+  test("saving a key from the Your Own panel switches a managed-mode daemon back", async () => {
+    // Managed speech was auto-defaulted on connection; toggling to "Your Own"
+    // and saving a BYOK key is explicit intent to use it, so the mode flips —
     // otherwise the key appears to save but the daemon stays on managed.
     daemonConfigData = {
       services: { stt: { provider: "deepgram", mode: "managed" } },
     };
     renderCard();
 
+    // The card opens on the Managed panel; toggle to reach the BYOK inputs.
+    setMode("Your Own");
     const keyInput = screen.getByPlaceholderText(/Enter your Deepgram API key/);
     fireEvent.change(keyInput, { target: { value: "dg-secret" } });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
@@ -247,23 +255,74 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     });
   });
 
-  test("a provider change with no key keeps managed mode", async () => {
-    // Switching the BYOK preference without supplying a credential must not
-    // trade a working managed setup for a credential-less provider.
+  test("a provider change with no key from the Your Own panel leaves managed mode", async () => {
+    // Reaching the provider dropdown requires toggling off Managed, so saving —
+    // even without a new key — is explicit intent to use your own provider and
+    // must flip the daemon off managed.
     daemonConfigData = {
       services: { stt: { provider: "deepgram", mode: "managed" } },
     };
     renderCard();
 
+    setMode("Your Own");
     openProviderDropdown();
     selectOption("OpenAI");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { stt: { provider: "openai-whisper", mode: "your-own" } },
+    });
+    expect(credentialsSetCalls).toHaveLength(0);
+  });
+
+  test("renders the Managed panel (no BYOK inputs) when the daemon is managed", () => {
+    daemonConfigData = {
+      services: { stt: { provider: "deepgram", mode: "managed" } },
+    };
+    renderCard();
+
+    expect(
+      screen.getByText(/Managed transcription is included/),
+    ).toBeDefined();
+    // The provider dropdown belongs to the Your Own panel and must be absent.
+    expect(
+      document.querySelector('button[aria-label="STT provider"]'),
+    ).toBeNull();
+  });
+
+  test("Managed Save preserves an existing provider by writing mode only", async () => {
+    // The daemon deep-merges PATCHes, so a mode-only write keeps the stored
+    // BYOK provider as the restore value for toggling back.
+    daemonConfigData = { services: { stt: { provider: "deepgram" } } };
+    renderCard();
+
+    setMode("Managed");
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
     const sttBody = configPatchCalls[0]!.body as {
       services: { stt: Record<string, unknown> };
     };
-    expect(sttBody.services.stt.mode).toBeUndefined();
+    expect(sttBody.services.stt.mode).toBe("managed");
+    expect(sttBody.services.stt.provider).toBeUndefined();
     expect(credentialsSetCalls).toHaveLength(0);
+  });
+
+  test("Managed Save supplies a daemon fallback provider when the daemon has none", async () => {
+    // With no existing services.stt, a mode-only write would fail the schema's
+    // required `provider`, so the PATCH must carry a valid daemon provider id.
+    daemonConfigData = { services: {} };
+    renderCard();
+
+    setMode("Managed");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const sttBody = configPatchCalls[0]!.body as {
+      services: { stt: Record<string, unknown> };
+    };
+    expect(sttBody.services.stt.mode).toBe("managed");
+    expect(sttBody.services.stt.provider).toBe("deepgram");
   });
 });

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -350,6 +350,30 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     });
   });
 
+  test("escaping managed to native dictation still flips the daemon mode", async () => {
+    // Native is client-only (no daemon mapping), but leaving managed must still
+    // PATCH services.stt.mode server-side — otherwise a refetch snaps the card
+    // back to Managed. The stored provider is preserved via deep-merge.
+    nativeDictationSupported = true;
+    daemonConfigData = {
+      services: { stt: { provider: "deepgram", mode: "managed" } },
+    };
+    renderCard();
+
+    setMode("Your Own");
+    openProviderDropdown();
+    selectOption("macOS Native Dictation");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const sttBody = configPatchCalls[0]!.body as {
+      services: { stt: Record<string, unknown> };
+    };
+    expect(sttBody.services.stt.mode).toBe("your-own");
+    expect(sttBody.services.stt).not.toHaveProperty("provider");
+    expect(credentialsSetCalls).toHaveLength(0);
+  });
+
   test("leaving managed without a provider change preserves an unlisted provider", async () => {
     // Daemon provider is a valid one the dropdown can't show (set via CLI).
     // Toggling to Your Own and saving mode-only must not overwrite it with the

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -308,6 +308,21 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     expect(credentialsSetCalls).toHaveLength(0);
   });
 
+  test("Managed Save preserves an unlisted daemon provider as the restore value", async () => {
+    // A valid daemon provider the dropdown can't represent (set via CLI) must
+    // survive a managed save so toggling back restores it.
+    daemonConfigData = { services: { stt: { provider: "google-gemini" } } };
+    renderCard();
+
+    setMode("Managed");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { stt: { mode: "managed", provider: "google-gemini" } },
+    });
+  });
+
   test("Managed Save repoints a native-dictation choice off macos-native", async () => {
     // prefersMacosNativeStt() keys off LS_STT_PROVIDER alone, so leaving it on
     // "macos-native" would keep this client bypassing managed STT even after

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -308,6 +308,24 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     expect(credentialsSetCalls).toHaveLength(0);
   });
 
+  test("Managed Save repoints a native-dictation choice off macos-native", async () => {
+    // prefersMacosNativeStt() keys off LS_STT_PROVIDER alone, so leaving it on
+    // "macos-native" would keep this client bypassing managed STT even after
+    // saving Managed.
+    nativeDictationSupported = true;
+    localStorage.setItem(LS_STT_PROVIDER, "macos-native");
+    renderCard();
+
+    setMode("Managed");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(localStorage.getItem(LS_STT_PROVIDER)).not.toBe("macos-native");
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { stt: { mode: "managed", provider: "deepgram" } },
+    });
+  });
+
   test("toggling to Your Own is a saveable change on its own", async () => {
     // A managed daemon with a stored provider has nothing else to edit —
     // flipping the toggle must enable Save and persist mode: your-own.

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -250,8 +250,17 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { stt: { provider: "deepgram", mode: "your-own" } },
+    // Provider is unchanged (Deepgram), so it's preserved via deep-merge and
+    // omitted from the PATCH; the mode flips and the key is stored.
+    const sttBody = configPatchCalls[0]!.body as {
+      services: { stt: Record<string, unknown> };
+    };
+    expect(sttBody.services.stt.mode).toBe("your-own");
+    expect(sttBody.services.stt).not.toHaveProperty("provider");
+    expect(credentialsSetCalls).toHaveLength(1);
+    expect(credentialsSetCalls[0]!.body).toMatchObject({
+      service: "deepgram",
+      value: "dg-secret",
     });
   });
 
@@ -341,9 +350,31 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     });
   });
 
+  test("leaving managed without a provider change preserves an unlisted provider", async () => {
+    // Daemon provider is a valid one the dropdown can't show (set via CLI).
+    // Toggling to Your Own and saving mode-only must not overwrite it with the
+    // Deepgram fallback — the PATCH omits provider so deep-merge keeps it.
+    daemonConfigData = {
+      services: { stt: { provider: "google-gemini", mode: "managed" } },
+    };
+    renderCard();
+
+    setMode("Your Own");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const sttBody = configPatchCalls[0]!.body as {
+      services: { stt: Record<string, unknown> };
+    };
+    expect(sttBody.services.stt.mode).toBe("your-own");
+    expect(sttBody.services.stt).not.toHaveProperty("provider");
+    expect(credentialsSetCalls).toHaveLength(0);
+  });
+
   test("toggling to Your Own is a saveable change on its own", async () => {
     // A managed daemon with a stored provider has nothing else to edit —
-    // flipping the toggle must enable Save and persist mode: your-own.
+    // flipping the toggle must enable Save and persist mode: your-own. The
+    // stored provider is preserved via deep-merge (omitted from the PATCH).
     daemonConfigData = {
       services: { stt: { provider: "deepgram", mode: "managed" } },
     };
@@ -355,9 +386,11 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     fireEvent.click(save);
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { stt: { provider: "deepgram", mode: "your-own" } },
-    });
+    const sttBody = configPatchCalls[0]!.body as {
+      services: { stt: Record<string, unknown> };
+    };
+    expect(sttBody.services.stt.mode).toBe("your-own");
+    expect(sttBody.services.stt).not.toHaveProperty("provider");
     expect(credentialsSetCalls).toHaveLength(0);
   });
 });

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -291,9 +291,10 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     ).toBeNull();
   });
 
-  test("Managed Save preserves an existing provider by writing mode only", async () => {
-    // The daemon deep-merges PATCHes, so a mode-only write keeps the stored
-    // BYOK provider as the restore value for toggling back.
+  test("Managed Save writes a daemon-mapped provider as the restore value", async () => {
+    // The stored provider is the your-own restore value for toggling back and
+    // must be a valid daemon id; effectiveSttProvider routes managed mode to
+    // Vellum at runtime.
     daemonConfigData = { services: { stt: { provider: "deepgram" } } };
     renderCard();
 
@@ -301,28 +302,29 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const sttBody = configPatchCalls[0]!.body as {
-      services: { stt: Record<string, unknown> };
-    };
-    expect(sttBody.services.stt.mode).toBe("managed");
-    expect(sttBody.services.stt.provider).toBeUndefined();
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { stt: { mode: "managed", provider: "deepgram" } },
+    });
     expect(credentialsSetCalls).toHaveLength(0);
   });
 
-  test("Managed Save supplies a daemon fallback provider when the daemon has none", async () => {
-    // With no existing services.stt, a mode-only write would fail the schema's
-    // required `provider`, so the PATCH must carry a valid daemon provider id.
-    daemonConfigData = { services: {} };
+  test("toggling to Your Own is a saveable change on its own", async () => {
+    // A managed daemon with a stored provider has nothing else to edit —
+    // flipping the toggle must enable Save and persist mode: your-own.
+    daemonConfigData = {
+      services: { stt: { provider: "deepgram", mode: "managed" } },
+    };
     renderCard();
 
-    setMode("Managed");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    setMode("Your Own");
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(save);
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const sttBody = configPatchCalls[0]!.body as {
-      services: { stt: Record<string, unknown> };
-    };
-    expect(sttBody.services.stt.mode).toBe("managed");
-    expect(sttBody.services.stt.provider).toBe("deepgram");
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { stt: { provider: "deepgram", mode: "your-own" } },
+    });
+    expect(credentialsSetCalls).toHaveLength(0);
   });
 });

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -159,8 +159,11 @@ export function SpeechToTextCard() {
   const hasChanges = useMemo(() => {
     const providerChanged = draftProvider !== serverProvider;
     const hasNewKey = apiKeyText.trim().length > 0;
-    return providerChanged || hasNewKey;
-  }, [draftProvider, serverProvider, apiKeyText]);
+    // Toggling off managed is itself a saveable change: a user with a BYOK
+    // provider+key already stored has nothing else to edit.
+    const modeChanged = mode !== serverMode;
+    return providerChanged || hasNewKey || modeChanged;
+  }, [draftProvider, serverProvider, apiKeyText, mode, serverMode]);
 
   const handleSave = useCallback(async () => {
     const trimmedKey = apiKeyText.trim();
@@ -267,21 +270,22 @@ export function SpeechToTextCard() {
   const handleSaveManaged = useCallback(async () => {
     setSaving(true);
     try {
-      // The daemon deep-merges config PATCHes, so a mode-only write preserves an
-      // existing BYOK `provider` (the restore value for toggling back). Only
-      // when the daemon has no stt provider yet must we supply one — the schema
-      // requires `services.stt.provider`, and it must be a daemon provider id
-      // (never the client-only native dictation choice). `effectiveSttProvider`
-      // routes managed mode to Vellum at runtime regardless of this value.
-      const sttBody = daemonHasProvider
-        ? { mode: "managed" }
-        : {
-            mode: "managed",
-            provider: STT_DAEMON_PROVIDER[draftProvider]?.provider ?? "deepgram",
-          };
+      // Persist the effective BYOK provider as the restore value for toggling
+      // back — mapped to a daemon provider id (the schema requires one and
+      // rejects the client-only native dictation choice; "deepgram" is the
+      // sane default for those). The daemon's `effectiveSttProvider` routes
+      // managed mode to Vellum at runtime regardless of this value.
       const { response: cfgRes } = await configPatch({
         path: { assistant_id: assistantId },
-        body: { services: { stt: sttBody } },
+        body: {
+          services: {
+            stt: {
+              mode: "managed",
+              provider:
+                STT_DAEMON_PROVIDER[draftProvider]?.provider ?? "deepgram",
+            },
+          },
+        },
         throwOnError: false,
       });
       if (!cfgRes?.ok) {
@@ -303,7 +307,7 @@ export function SpeechToTextCard() {
     } finally {
       setSaving(false);
     }
-  }, [assistantId, daemonHasProvider, draftProvider, queryClient]);
+  }, [assistantId, draftProvider, queryClient]);
 
   const handleReset = useCallback(() => {
     setLocalSetting(LS_STT_API_KEY_PREFIX + draftProvider, "");

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -19,19 +19,22 @@ import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import {
-  ByoServiceCard,
   CredentialsGuide,
   ResetButton,
   SaveButton,
+  ServiceCard,
 } from "@/domains/settings/ai/shared-ui";
 import {
   LS_STT_API_KEY_PREFIX,
+  LS_STT_MODE,
   LS_STT_PROVIDER,
 } from "@/domains/settings/ai/local-storage-keys";
 import {
   MACOS_NATIVE_STT_PROVIDER_ID,
   STT_PROVIDERS,
 } from "@/domains/settings/ai/provider-catalogs";
+import { parseServiceMode } from "@/domains/settings/ai/utils";
+import type { ServiceMode } from "@/generated/daemon/types.gen";
 
 /**
  * How the daemon addresses each card provider: `provider` is the
@@ -87,6 +90,20 @@ export function SpeechToTextCard() {
     { provider?: string; mode?: string } | undefined;
   const daemonSttProvider = daemonStt?.provider;
   const daemonManaged = daemonStt?.mode === "managed";
+
+  // Managed vs. your-own toggle. Derived from the daemon (source of truth),
+  // falling back to localStorage so the toggle doesn't flash "your-own" before
+  // the config query resolves. `useDraftOverride` lets the user flip it locally
+  // until a save + refetch converges the server value.
+  const serverMode = useMemo<ServiceMode>(
+    () =>
+      parseServiceMode(
+        daemonStt?.mode ?? getLocalSetting(LS_STT_MODE, "your-own"),
+        "your-own",
+      ),
+    [daemonStt?.mode],
+  );
+  const [mode, setDraftMode] = useDraftOverride(serverMode);
 
   const serverProvider = useMemo(() => {
     const mapped = daemonSttProvider
@@ -148,7 +165,9 @@ export function SpeechToTextCard() {
   const handleSave = useCallback(async () => {
     const trimmedKey = apiKeyText.trim();
 
-    // Local settings back the client-side voice path; keep them in sync.
+    // Local settings back the client-side voice path; keep them in sync. This
+    // handler serves the "Your Own" panel, so the effective mode is your-own.
+    setLocalSetting(LS_STT_MODE, "your-own");
     setLocalSetting(LS_STT_PROVIDER, draftProvider);
     if (trimmedKey.length > 0) {
       setLocalSetting(LS_STT_API_KEY_PREFIX + draftProvider, trimmedKey);
@@ -189,13 +208,11 @@ export function SpeechToTextCard() {
         // Only PATCH the provider when it truly diverges from the persisted
         // value (or the daemon has none yet); otherwise a re-save with just a
         // new key would silently switch a provider set elsewhere — including
-        // one the dropdown can't represent. Saving a key from this card is
-        // explicit BYOK intent, so a managed-mode daemon is also switched
-        // back to your-own — otherwise the saved key would appear to take
-        // effect while the daemon kept using managed speech. Without an
-        // effective key the mode stays managed: flipping would trade a
-        // working managed setup for a credential-less BYOK provider.
-        const escapeManaged = daemonManaged && effectiveKey.length > 0;
+        // one the dropdown can't represent. Saving from the "Your Own" panel is
+        // explicit BYOK intent, so a managed-mode daemon is switched back to
+        // your-own even without a new key — the user reached these inputs by
+        // toggling off Managed.
+        const escapeManaged = daemonManaged;
         const shouldSetProvider =
           draftProvider !== serverProvider || !daemonHasProvider;
         if (shouldSetProvider || escapeManaged) {
@@ -247,6 +264,47 @@ export function SpeechToTextCard() {
     queryClient,
   ]);
 
+  const handleSaveManaged = useCallback(async () => {
+    setSaving(true);
+    try {
+      // The daemon deep-merges config PATCHes, so a mode-only write preserves an
+      // existing BYOK `provider` (the restore value for toggling back). Only
+      // when the daemon has no stt provider yet must we supply one — the schema
+      // requires `services.stt.provider`, and it must be a daemon provider id
+      // (never the client-only native dictation choice). `effectiveSttProvider`
+      // routes managed mode to Vellum at runtime regardless of this value.
+      const sttBody = daemonHasProvider
+        ? { mode: "managed" }
+        : {
+            mode: "managed",
+            provider: STT_DAEMON_PROVIDER[draftProvider]?.provider ?? "deepgram",
+          };
+      const { response: cfgRes } = await configPatch({
+        path: { assistant_id: assistantId },
+        body: { services: { stt: sttBody } },
+        throwOnError: false,
+      });
+      if (!cfgRes?.ok) {
+        throw new Error(
+          `Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`,
+        );
+      }
+      setLocalSetting(LS_STT_MODE, "managed");
+      void queryClient.invalidateQueries({
+        queryKey: configGetQueryKey({ path: { assistant_id: assistantId } }),
+      });
+      toast.success("Speech-to-text settings saved");
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to save speech-to-text settings",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [assistantId, daemonHasProvider, draftProvider, queryClient]);
+
   const handleReset = useCallback(() => {
     setLocalSetting(LS_STT_API_KEY_PREFIX + draftProvider, "");
     setProviderHasKey(false);
@@ -258,54 +316,68 @@ export function SpeechToTextCard() {
     : selectedProvider.apiKeyPlaceholder;
 
   return (
-    <ByoServiceCard title="Speech-to-Text" subtitle={selectedProvider.subtitle}>
-      <div className="space-y-4">
-        <div className="space-y-1">
-          <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Provider
-          </label>
-          <Dropdown
-            value={draftProvider}
-            onChange={setDraftProvider}
-            options={providers.map((p) => ({
-              value: p.id,
-              label: p.displayName,
-            }))}
-            aria-label="STT provider"
-          />
+    <ServiceCard
+      title="Speech-to-Text"
+      subtitle="Configure how your assistant transcribes speech"
+      mode={mode}
+      onModeChange={(m) => setDraftMode(m)}
+    >
+      {mode === "managed" ? (
+        <div className="space-y-3">
+          <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+            Managed transcription is included with your Vellum connection.
+          </p>
+          <SaveButton onClick={handleSaveManaged} disabled={saving} />
         </div>
-
-        {requiresApiKey && (
+      ) : (
+        <div className="space-y-4">
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              API Key
+              Provider
             </label>
-            <Input
-              type="password"
-              value={apiKeyText}
-              onChange={(e) => setApiKeyText(e.target.value)}
-              placeholder={apiKeyPlaceholder}
-              fullWidth
+            <Dropdown
+              value={draftProvider}
+              onChange={setDraftProvider}
+              options={providers.map((p) => ({
+                value: p.id,
+                label: p.displayName,
+              }))}
+              aria-label="STT provider"
             />
           </div>
-        )}
 
-        {selectedProvider.setupWarning && (
-          <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
-            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-mid-strong)]" />
-            <span>{selectedProvider.setupWarning}</span>
+          {requiresApiKey && (
+            <div className="space-y-1">
+              <label className="block text-body-small-default text-[var(--content-tertiary)]">
+                API Key
+              </label>
+              <Input
+                type="password"
+                value={apiKeyText}
+                onChange={(e) => setApiKeyText(e.target.value)}
+                placeholder={apiKeyPlaceholder}
+                fullWidth
+              />
+            </div>
+          )}
+
+          {selectedProvider.setupWarning && (
+            <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
+              <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-mid-strong)]" />
+              <span>{selectedProvider.setupWarning}</span>
+            </div>
+          )}
+
+          {selectedProvider.credentialsGuide && (
+            <CredentialsGuide guide={selectedProvider.credentialsGuide} />
+          )}
+
+          <div className="flex items-center justify-end gap-2">
+            <SaveButton onClick={handleSave} disabled={!hasChanges || saving} />
+            {providerHasKey && <ResetButton onClick={handleReset} />}
           </div>
-        )}
-
-        {selectedProvider.credentialsGuide && (
-          <CredentialsGuide guide={selectedProvider.credentialsGuide} />
-        )}
-
-        <div className="flex items-center justify-end gap-2">
-          <SaveButton onClick={handleSave} disabled={!hasChanges || saving} />
-          {providerHasKey && <ResetButton onClick={handleReset} />}
         </div>
-      </div>
-    </ByoServiceCard>
+      )}
+    </ServiceCard>
   );
 }

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -208,41 +208,48 @@ export function SpeechToTextCard() {
             );
           }
         }
-        // Saving from the "Your Own" panel is explicit BYOK intent, so a
-        // managed-mode daemon is switched back to your-own even without a new
-        // key — the user reached these inputs by toggling off Managed.
-        const escapeManaged = daemonManaged;
-        const shouldSetProvider =
-          draftProvider !== serverProvider || !daemonHasProvider;
-        // Only write `provider` when the user actually changed it, or when
-        // escaping managed leaves nothing valid to keep (no stored provider, or
-        // the managed-only "vellum" sentinel the schema rejects outside managed
-        // mode). Otherwise write mode only and let the daemon's deep-merge
-        // preserve the stored BYOK provider — which may be one the dropdown
-        // can't represent (e.g. google-gemini set via CLI) and would be
-        // silently overwritten by the mapped fallback.
-        const writeProvider =
-          shouldSetProvider ||
-          (escapeManaged &&
-            (!daemonSttProvider || daemonSttProvider === "vellum"));
-        if (writeProvider || escapeManaged) {
-          const { response: cfgRes } = await configPatch({
-            path: { assistant_id: assistantId },
-            body: {
-              services: {
-                stt: {
-                  ...(writeProvider ? { provider: daemon.provider } : {}),
-                  ...(escapeManaged ? { mode: "your-own" } : {}),
-                },
+      }
+
+      // The config PATCH runs even for the client-only native choice (which has
+      // no daemon mapping): leaving managed must still flip services.stt.mode
+      // server-side, or a refetch snaps the card back to Managed. Saving from
+      // the "Your Own" panel is explicit BYOK intent, so a managed daemon flips
+      // even without a new key — the user reached these inputs by toggling off
+      // Managed.
+      const escapeManaged = daemonManaged;
+      const providerChanged =
+        !!daemon && (draftProvider !== serverProvider || !daemonHasProvider);
+      // Write `provider` only when the user changed it, or when escaping managed
+      // leaves nothing valid to keep (no stored provider, or the managed-only
+      // "vellum" sentinel the schema rejects outside managed mode). Otherwise
+      // write mode only and let the daemon's deep-merge preserve the stored
+      // provider — which may be one the dropdown can't represent (e.g.
+      // google-gemini via CLI) and would be silently overwritten by the fallback.
+      const writeProvider =
+        providerChanged ||
+        (escapeManaged &&
+          (!daemonSttProvider || daemonSttProvider === "vellum"));
+      if (writeProvider || escapeManaged) {
+        const providerValue =
+          daemon?.provider ??
+          STT_DAEMON_PROVIDER[draftProvider]?.provider ??
+          "deepgram";
+        const { response: cfgRes } = await configPatch({
+          path: { assistant_id: assistantId },
+          body: {
+            services: {
+              stt: {
+                ...(writeProvider ? { provider: providerValue } : {}),
+                ...(escapeManaged ? { mode: "your-own" } : {}),
               },
             },
-            throwOnError: false,
-          });
-          if (!cfgRes?.ok) {
-            throw new Error(
-              `Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`,
-            );
-          }
+          },
+          throwOnError: false,
+        });
+        if (!cfgRes?.ok) {
+          throw new Error(
+            `Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`,
+          );
         }
       }
 

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -294,6 +294,13 @@ export function SpeechToTextCard() {
         );
       }
       setLocalSetting(LS_STT_MODE, "managed");
+      // The client-only native-dictation choice makes `prefersMacosNativeStt()`
+      // keep routing transcription locally, bypassing managed STT on this
+      // client. Repoint the stored provider at a daemon-backed one so Managed
+      // actually takes effect.
+      if (draftProvider === MACOS_NATIVE_STT_PROVIDER_ID) {
+        setLocalSetting(LS_STT_PROVIDER, defaultProviderId);
+      }
       void queryClient.invalidateQueries({
         queryKey: configGetQueryKey({ path: { assistant_id: assistantId } }),
       });
@@ -307,7 +314,7 @@ export function SpeechToTextCard() {
     } finally {
       setSaving(false);
     }
-  }, [assistantId, draftProvider, queryClient]);
+  }, [assistantId, draftProvider, defaultProviderId, queryClient]);
 
   const handleReset = useCallback(() => {
     setLocalSetting(LS_STT_API_KEY_PREFIX + draftProvider, "");

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -270,22 +270,21 @@ export function SpeechToTextCard() {
   const handleSaveManaged = useCallback(async () => {
     setSaving(true);
     try {
-      // Persist the effective BYOK provider as the restore value for toggling
-      // back — mapped to a daemon provider id (the schema requires one and
-      // rejects the client-only native dictation choice; "deepgram" is the
-      // sane default for those). The daemon's `effectiveSttProvider` routes
-      // managed mode to Vellum at runtime regardless of this value.
+      // Persist the BYOK provider as the restore value for toggling back. Keep
+      // the daemon's existing provider when it has one — it may be a valid
+      // provider the dropdown can't represent (e.g. google-gemini set via CLI),
+      // which the fallback would silently overwrite. Only synthesize one for a
+      // sparse config or the client-only native dictation choice ("deepgram" is
+      // the sane default there); the schema requires a provider and rejects
+      // "vellum" outside managed. `effectiveSttProvider` routes managed mode to
+      // Vellum at runtime regardless of this value.
+      const restoreProvider =
+        daemonSttProvider && daemonSttProvider !== "vellum"
+          ? daemonSttProvider
+          : STT_DAEMON_PROVIDER[draftProvider]?.provider ?? "deepgram";
       const { response: cfgRes } = await configPatch({
         path: { assistant_id: assistantId },
-        body: {
-          services: {
-            stt: {
-              mode: "managed",
-              provider:
-                STT_DAEMON_PROVIDER[draftProvider]?.provider ?? "deepgram",
-            },
-          },
-        },
+        body: { services: { stt: { mode: "managed", provider: restoreProvider } } },
         throwOnError: false,
       });
       if (!cfgRes?.ok) {
@@ -314,7 +313,13 @@ export function SpeechToTextCard() {
     } finally {
       setSaving(false);
     }
-  }, [assistantId, draftProvider, defaultProviderId, queryClient]);
+  }, [
+    assistantId,
+    daemonSttProvider,
+    draftProvider,
+    defaultProviderId,
+    queryClient,
+  ]);
 
   const handleReset = useCallback(() => {
     setLocalSetting(LS_STT_API_KEY_PREFIX + draftProvider, "");

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -208,23 +208,30 @@ export function SpeechToTextCard() {
             );
           }
         }
-        // Only PATCH the provider when it truly diverges from the persisted
-        // value (or the daemon has none yet); otherwise a re-save with just a
-        // new key would silently switch a provider set elsewhere — including
-        // one the dropdown can't represent. Saving from the "Your Own" panel is
-        // explicit BYOK intent, so a managed-mode daemon is switched back to
-        // your-own even without a new key — the user reached these inputs by
-        // toggling off Managed.
+        // Saving from the "Your Own" panel is explicit BYOK intent, so a
+        // managed-mode daemon is switched back to your-own even without a new
+        // key — the user reached these inputs by toggling off Managed.
         const escapeManaged = daemonManaged;
         const shouldSetProvider =
           draftProvider !== serverProvider || !daemonHasProvider;
-        if (shouldSetProvider || escapeManaged) {
+        // Only write `provider` when the user actually changed it, or when
+        // escaping managed leaves nothing valid to keep (no stored provider, or
+        // the managed-only "vellum" sentinel the schema rejects outside managed
+        // mode). Otherwise write mode only and let the daemon's deep-merge
+        // preserve the stored BYOK provider — which may be one the dropdown
+        // can't represent (e.g. google-gemini set via CLI) and would be
+        // silently overwritten by the mapped fallback.
+        const writeProvider =
+          shouldSetProvider ||
+          (escapeManaged &&
+            (!daemonSttProvider || daemonSttProvider === "vellum"));
+        if (writeProvider || escapeManaged) {
           const { response: cfgRes } = await configPatch({
             path: { assistant_id: assistantId },
             body: {
               services: {
                 stt: {
-                  provider: daemon.provider,
+                  ...(writeProvider ? { provider: daemon.provider } : {}),
                   ...(escapeManaged ? { mode: "your-own" } : {}),
                 },
               },
@@ -264,6 +271,7 @@ export function SpeechToTextCard() {
     serverProvider,
     daemonHasProvider,
     daemonManaged,
+    daemonSttProvider,
     queryClient,
   ]);
 

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -260,9 +260,9 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     ).toBeNull();
   });
 
-  test("Managed Save preserves an existing provider by writing mode only", async () => {
-    // The daemon deep-merges PATCHes, so a mode-only write keeps the stored
-    // BYOK provider as the restore value for toggling back.
+  test("Managed Save writes the effective BYOK provider as the restore value", async () => {
+    // The stored provider is the your-own restore value for toggling back;
+    // effectiveTtsProvider routes managed mode to Vellum at runtime.
     daemonConfigData = { services: { tts: { provider: "fish-audio" } } };
     renderCard();
 
@@ -270,21 +270,21 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const ttsBody = configPatchCalls[0]!.body as {
-      services: { tts: Record<string, unknown> };
-    };
-    expect(ttsBody.services.tts.mode).toBe("managed");
-    expect(ttsBody.services.tts.provider).toBeUndefined();
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { tts: { mode: "managed", provider: "fish-audio" } },
+    });
     expect(credentialsSetCalls).toHaveLength(0);
   });
 
-  test("Managed Save supplies a fallback provider when the daemon has none", async () => {
-    // With no existing services.tts, a mode-only write would fail the schema's
-    // required `provider`, so the PATCH must carry one.
-    daemonConfigData = { services: {} };
+  test("Managed Save always carries a representable provider (never vellum)", async () => {
+    // A managed daemon may report the reserved "vellum" provider; the write
+    // must fall back to a representable id so the restore value stays usable
+    // and the schema (which forbids "vellum" only outside managed) is happy.
+    daemonConfigData = {
+      services: { tts: { provider: "vellum", mode: "managed" } },
+    };
     renderCard();
 
-    setMode("Managed");
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
@@ -293,5 +293,26 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     };
     expect(ttsBody.services.tts.mode).toBe("managed");
     expect(ttsBody.services.tts.provider).toBeDefined();
+    expect(ttsBody.services.tts.provider).not.toBe("vellum");
+  });
+
+  test("toggling to Your Own is a saveable change on its own", async () => {
+    // A managed daemon with a stored provider has nothing else to edit —
+    // flipping the toggle must enable Save and persist mode: your-own.
+    daemonConfigData = {
+      services: { tts: { provider: "fish-audio", mode: "managed" } },
+    };
+    renderCard();
+
+    setMode("Your Own");
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(save);
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { tts: { provider: "fish-audio", mode: "your-own" } },
+    });
+    expect(credentialsSetCalls).toHaveLength(0);
   });
 });

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -17,6 +17,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 
 const ASSISTANT_ID = "asst-test";
@@ -98,6 +99,11 @@ function selectProvider(label: string): void {
   fireEvent.click(option);
 }
 
+function setMode(label: "Managed" | "Your Own"): void {
+  const group = screen.getByRole("radiogroup", { name: "Service mode" });
+  fireEvent.click(within(group).getByRole("radio", { name: label }));
+}
+
 describe("TextToSpeechCard — daemon provisioning on Save", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -162,15 +168,17 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     expect(ttsBody?.services?.tts ?? {}).not.toHaveProperty("provider");
   });
 
-  test("saving a key switches a managed-mode daemon back to your-own", async () => {
-    // Managed speech was auto-defaulted on connection; saving a BYOK key from
-    // this card is explicit intent to use it, so the mode must flip too —
+  test("saving a key from the Your Own panel switches a managed-mode daemon back", async () => {
+    // Managed speech was auto-defaulted on connection; toggling to "Your Own"
+    // and saving a BYOK key is explicit intent to use it, so the mode flips —
     // otherwise the key appears to save but the daemon stays on managed.
     daemonConfigData = {
       services: { tts: { provider: "fish-audio", mode: "managed" } },
     };
     renderCard();
 
+    // The card opens on the Managed panel; toggle to reach the BYOK inputs.
+    setMode("Your Own");
     fireEvent.change(screen.getByPlaceholderText(/Fish Audio API key/), {
       target: { value: "fish-secret" },
     });
@@ -182,25 +190,25 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     });
   });
 
-  test("a voice-ID-only save with no key keeps managed mode", async () => {
-    // Editing a voice preference without supplying a credential must not
-    // trade a working managed setup for a credential-less BYOK provider.
+  test("a voice-ID-only save from the Your Own panel leaves managed mode", async () => {
+    // Reaching the voice-ID input requires toggling off Managed, so saving —
+    // even without a new key — is explicit intent to use your own provider and
+    // must flip the daemon off managed.
     daemonConfigData = {
       services: { tts: { provider: "fish-audio", mode: "managed" } },
     };
     renderCard();
 
+    setMode("Your Own");
     fireEvent.change(screen.getByPlaceholderText("Enter a voice ID"), {
       target: { value: "voice-456" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const ttsBody = configPatchCalls[0]!.body as {
-      services: { tts: Record<string, unknown> };
-    };
-    expect(ttsBody.services.tts.mode).toBeUndefined();
-    expect(ttsBody.services.tts.provider).toBeUndefined();
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { tts: { provider: "fish-audio", mode: "your-own" } },
+    });
     expect(credentialsSetCalls).toHaveLength(0);
   });
 
@@ -213,6 +221,7 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     };
     renderCard();
 
+    setMode("Your Own");
     // The dropdown falls back to the first representable provider
     // (ElevenLabs, whose key placeholder is "sk_…").
     fireEvent.change(screen.getByPlaceholderText("sk_…"), {
@@ -234,5 +243,55 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     expect((credentialsSetCalls[0]!.body as { service: string }).service).toBe(
       ttsBody.services.tts.provider as string,
     );
+  });
+
+  test("renders the Managed panel (no BYOK inputs) when the daemon is managed", async () => {
+    daemonConfigData = {
+      services: { tts: { provider: "fish-audio", mode: "managed" } },
+    };
+    renderCard();
+
+    expect(
+      screen.getByText(/Managed speech synthesis is included/),
+    ).toBeDefined();
+    // The provider dropdown belongs to the Your Own panel and must be absent.
+    expect(
+      document.querySelector('button[aria-label="TTS provider"]'),
+    ).toBeNull();
+  });
+
+  test("Managed Save preserves an existing provider by writing mode only", async () => {
+    // The daemon deep-merges PATCHes, so a mode-only write keeps the stored
+    // BYOK provider as the restore value for toggling back.
+    daemonConfigData = { services: { tts: { provider: "fish-audio" } } };
+    renderCard();
+
+    setMode("Managed");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const ttsBody = configPatchCalls[0]!.body as {
+      services: { tts: Record<string, unknown> };
+    };
+    expect(ttsBody.services.tts.mode).toBe("managed");
+    expect(ttsBody.services.tts.provider).toBeUndefined();
+    expect(credentialsSetCalls).toHaveLength(0);
+  });
+
+  test("Managed Save supplies a fallback provider when the daemon has none", async () => {
+    // With no existing services.tts, a mode-only write would fail the schema's
+    // required `provider`, so the PATCH must carry one.
+    daemonConfigData = { services: {} };
+    renderCard();
+
+    setMode("Managed");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const ttsBody = configPatchCalls[0]!.body as {
+      services: { tts: Record<string, unknown> };
+    };
+    expect(ttsBody.services.tts.mode).toBe("managed");
+    expect(ttsBody.services.tts.provider).toBeDefined();
   });
 });

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -129,8 +129,19 @@ export function TextToSpeechCard() {
     const providerChanged = draftProvider !== serverProvider;
     const hasNewKey = apiKeyText.trim().length > 0;
     const voiceIdChanged = voiceIdText.trim() !== initialVoiceId;
-    return providerChanged || hasNewKey || voiceIdChanged;
-  }, [draftProvider, serverProvider, apiKeyText, voiceIdText, initialVoiceId]);
+    // Toggling off managed is itself a saveable change: a user with a BYOK
+    // provider+key already stored has nothing else to edit.
+    const modeChanged = mode !== serverMode;
+    return providerChanged || hasNewKey || voiceIdChanged || modeChanged;
+  }, [
+    draftProvider,
+    serverProvider,
+    apiKeyText,
+    voiceIdText,
+    initialVoiceId,
+    mode,
+    serverMode,
+  ]);
 
   const handleSave = useCallback(async () => {
     const trimmedKey = apiKeyText.trim();
@@ -245,17 +256,16 @@ export function TextToSpeechCard() {
   const handleSaveManaged = useCallback(async () => {
     setSaving(true);
     try {
-      // The daemon deep-merges config PATCHes, so a mode-only write preserves an
-      // existing BYOK `provider` (the restore value for toggling back). Only
-      // when the daemon has no tts provider yet must we supply one — the schema
-      // requires `services.tts.provider`. `effectiveTtsProvider` routes managed
-      // mode to Vellum at runtime regardless of this stored value.
-      const ttsBody = daemonHasProvider
-        ? { mode: "managed" }
-        : { mode: "managed", provider: draftProvider };
+      // Persist the effective BYOK provider as the restore value for toggling
+      // back — `selectedProvider.id` is always representable (never the reserved
+      // "vellum" id). The daemon's `effectiveTtsProvider` routes managed mode to
+      // Vellum at runtime regardless; the schema only forbids "vellum" outside
+      // managed mode, which this write is not.
       const { response: cfgRes } = await configPatch({
         path: { assistant_id: assistantId },
-        body: { services: { tts: ttsBody } },
+        body: {
+          services: { tts: { mode: "managed", provider: selectedProvider.id } },
+        },
         throwOnError: false,
       });
       if (!cfgRes?.ok) {
@@ -277,7 +287,7 @@ export function TextToSpeechCard() {
     } finally {
       setSaving(false);
     }
-  }, [assistantId, daemonHasProvider, draftProvider, queryClient]);
+  }, [assistantId, selectedProvider, queryClient]);
 
   const handleReset = useCallback(() => {
     setLocalSetting(LS_TTS_API_KEY_PREFIX + draftProvider, "");

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -20,17 +20,20 @@ import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import {
-  ByoServiceCard,
   CredentialsGuide,
   ResetButton,
   SaveButton,
+  ServiceCard,
 } from "@/domains/settings/ai/shared-ui";
 import {
   LS_TTS_API_KEY_PREFIX,
+  LS_TTS_MODE,
   LS_TTS_PROVIDER,
   LS_TTS_VOICE_ID_PREFIX,
 } from "@/domains/settings/ai/local-storage-keys";
 import { TTS_PROVIDERS } from "@/domains/settings/ai/provider-catalogs";
+import { parseServiceMode } from "@/domains/settings/ai/utils";
+import type { ServiceMode } from "@/generated/daemon/types.gen";
 
 /**
  * The daemon config key that the "Voice ID" input maps to, per provider, under
@@ -72,6 +75,20 @@ export function TextToSpeechCard() {
     { provider?: string; mode?: string } | undefined;
   const daemonTtsProvider = daemonTts?.provider;
   const daemonManaged = daemonTts?.mode === "managed";
+
+  // Managed vs. your-own toggle. Derived from the daemon (source of truth),
+  // falling back to localStorage so the toggle doesn't flash "your-own" before
+  // the config query resolves. `useDraftOverride` lets the user flip it locally
+  // until a save + refetch converges the server value.
+  const serverMode = useMemo<ServiceMode>(
+    () =>
+      parseServiceMode(
+        daemonTts?.mode ?? getLocalSetting(LS_TTS_MODE, "your-own"),
+        "your-own",
+      ),
+    [daemonTts?.mode],
+  );
+  const [mode, setDraftMode] = useDraftOverride(serverMode);
 
   const defaultProviderId = providers[0]?.id ?? "elevenlabs";
   const serverProvider = useMemo(
@@ -126,7 +143,9 @@ export function TextToSpeechCard() {
     // provider the save activates.
     const activeProvider = selectedProvider.id;
 
-    // Local settings back the client-side voice path; keep them in sync.
+    // Local settings back the client-side voice path; keep them in sync. This
+    // handler serves the "Your Own" panel, so the effective mode is your-own.
+    setLocalSetting(LS_TTS_MODE, "your-own");
     setLocalSetting(LS_TTS_PROVIDER, activeProvider);
     if (trimmedKey.length > 0) {
       setLocalSetting(LS_TTS_API_KEY_PREFIX + activeProvider, trimmedKey);
@@ -164,14 +183,11 @@ export function TextToSpeechCard() {
       }
       // Only PATCH the provider when it truly diverges from the persisted
       // value (or the daemon has none yet); otherwise a re-save with just a new
-      // key/voice would silently switch a provider set elsewhere. Saving a key
-      // from this card is explicit BYOK intent, so a managed-mode daemon is
-      // also switched back to your-own — otherwise the key would appear to
-      // take effect while the daemon kept using managed speech. Without an
-      // effective key (e.g. a voice-ID-only save) the mode stays managed:
-      // flipping would trade a working managed setup for a credential-less
-      // BYOK provider.
-      const escapeManaged = daemonManaged && effectiveKey.length > 0;
+      // key/voice would silently switch a provider set elsewhere. Saving from
+      // the "Your Own" panel is explicit BYOK intent, so a managed-mode daemon
+      // is switched back to your-own even without a new key — the user reached
+      // these inputs by toggling off Managed.
+      const escapeManaged = daemonManaged;
       const shouldSetProvider =
         draftProvider !== serverProvider || !daemonHasProvider;
       const ttsBody = {
@@ -225,6 +241,43 @@ export function TextToSpeechCard() {
     daemonManaged,
     queryClient,
   ]);
+
+  const handleSaveManaged = useCallback(async () => {
+    setSaving(true);
+    try {
+      // The daemon deep-merges config PATCHes, so a mode-only write preserves an
+      // existing BYOK `provider` (the restore value for toggling back). Only
+      // when the daemon has no tts provider yet must we supply one — the schema
+      // requires `services.tts.provider`. `effectiveTtsProvider` routes managed
+      // mode to Vellum at runtime regardless of this stored value.
+      const ttsBody = daemonHasProvider
+        ? { mode: "managed" }
+        : { mode: "managed", provider: draftProvider };
+      const { response: cfgRes } = await configPatch({
+        path: { assistant_id: assistantId },
+        body: { services: { tts: ttsBody } },
+        throwOnError: false,
+      });
+      if (!cfgRes?.ok) {
+        throw new Error(
+          `Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`,
+        );
+      }
+      setLocalSetting(LS_TTS_MODE, "managed");
+      void queryClient.invalidateQueries({
+        queryKey: configGetQueryKey({ path: { assistant_id: assistantId } }),
+      });
+      toast.success("Text-to-speech settings saved");
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to save text-to-speech settings",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [assistantId, daemonHasProvider, draftProvider, queryClient]);
 
   const handleReset = useCallback(() => {
     setLocalSetting(LS_TTS_API_KEY_PREFIX + draftProvider, "");
@@ -284,63 +337,80 @@ export function TextToSpeechCard() {
     : selectedProvider.apiKeyPlaceholder;
 
   return (
-    <ByoServiceCard title="Text-to-Speech" subtitle={selectedProvider.subtitle}>
-      <div className="space-y-4">
-        <div className="space-y-1">
-          <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Provider
-          </label>
-          <Dropdown
-            value={draftProvider}
-            onChange={setDraftProvider}
-            options={providers.map((p) => ({
-              value: p.id,
-              label: p.displayName,
-            }))}
-            aria-label="TTS provider"
-          />
+    <ServiceCard
+      title="Text-to-Speech"
+      subtitle="Configure how your assistant speaks"
+      mode={mode}
+      onModeChange={(m) => setDraftMode(m)}
+    >
+      {mode === "managed" ? (
+        <div className="space-y-3">
+          <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+            Managed speech synthesis is included with your Vellum connection.
+          </p>
+          <SaveButton onClick={handleSaveManaged} disabled={saving} />
         </div>
-
-        <div className="space-y-1">
-          <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            API Key
-          </label>
-          <Input
-            type="password"
-            value={apiKeyText}
-            onChange={(e) => setApiKeyText(e.target.value)}
-            placeholder={apiKeyPlaceholder}
-            fullWidth
-          />
-        </div>
-
-        {selectedProvider.supportsVoiceSelection && (
+      ) : (
+        <div className="space-y-4">
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Voice ID
+              Provider
+            </label>
+            <Dropdown
+              value={draftProvider}
+              onChange={setDraftProvider}
+              options={providers.map((p) => ({
+                value: p.id,
+                label: p.displayName,
+              }))}
+              aria-label="TTS provider"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              API Key
             </label>
             <Input
-              type="text"
-              value={voiceIdText}
-              onChange={(e) => setVoiceIdText(e.target.value)}
-              placeholder="Enter a voice ID"
+              type="password"
+              value={apiKeyText}
+              onChange={(e) => setApiKeyText(e.target.value)}
+              placeholder={apiKeyPlaceholder}
               fullWidth
             />
           </div>
-        )}
 
-        <CredentialsGuide guide={selectedProvider.credentialsGuide} />
+          {selectedProvider.supportsVoiceSelection && (
+            <div className="space-y-1">
+              <label className="block text-body-small-default text-[var(--content-tertiary)]">
+                Voice ID
+              </label>
+              <Input
+                type="text"
+                value={voiceIdText}
+                onChange={(e) => setVoiceIdText(e.target.value)}
+                placeholder="Enter a voice ID"
+                fullWidth
+              />
+            </div>
+          )}
 
-        <div className="flex items-center gap-2">
-          <Button variant="outlined" onClick={handleTest} disabled={testing}>
-            {testing ? "Testing…" : "Test"}
-          </Button>
-          <div className="ml-auto flex items-center gap-2">
-            <SaveButton onClick={handleSave} disabled={!hasChanges || saving} />
-            {providerHasKey && <ResetButton onClick={handleReset} />}
+          <CredentialsGuide guide={selectedProvider.credentialsGuide} />
+
+          <div className="flex items-center gap-2">
+            <Button variant="outlined" onClick={handleTest} disabled={testing}>
+              {testing ? "Testing…" : "Test"}
+            </Button>
+            <div className="ml-auto flex items-center gap-2">
+              <SaveButton
+                onClick={handleSave}
+                disabled={!hasChanges || saving}
+              />
+              {providerHasKey && <ResetButton onClick={handleReset} />}
+            </div>
           </div>
         </div>
-      </div>
-    </ByoServiceCard>
+      )}
+    </ServiceCard>
   );
 }


### PR DESCRIPTION
## Summary

- The **Text-to-Speech** and **Speech-to-Text** settings cards now use `ServiceCard`, gaining the **Managed / Your Own** toggle already shown by the Web Search and Image Generation cards. Previously these were BYOK-only (`ByoServiceCard`), so managed voice — though fully implemented on the backend — was never selectable in the UI and only reachable by auto-defaulting on platform connect.
- **Managed** shows a minimal panel ("Managed speech synthesis/transcription is included with your Vellum connection") + Save. The save writes `services.{tts,stt}.mode = "managed"` and stores the **effective BYOK provider** (the representable dropdown selection, mapped to a valid daemon id for STT) as the restore value for toggling back. It never stores `provider: "vellum"` — the daemon's `effective{Tts,Stt}Provider` routes managed mode to Vellum at runtime, and the schema only forbids `"vellum"` outside managed mode.
- **Your Own** keeps the existing provider/key (and Voice ID) inputs. Toggling off managed is now a saveable change on its own (`mode !== serverMode` folds into `hasChanges`), so a user with BYOK creds already stored can switch back without a throwaway edit. Leaving managed no longer requires typing a new key.
- Ungated on platform-connection availability, matching the Web Search / Image Generation precedent.

## Review cycle

- **Codex (P2 ×2) + Devin**: the Your Own Save stayed disabled when the only change was toggling off managed — fixed by folding `mode !== serverMode` into `hasChanges`, with a "toggling to Your Own is saveable on its own" test per card.
- **Codex (P2)**: `prefersMacosNativeStt()` keys off `LS_STT_PROVIDER` alone, so a macOS user who had `macos-native` selected and saved Managed would keep bypassing managed STT locally — the managed STT save now repoints the stored provider at the daemon default in that case (test added).
- The managed save was also simplified to always write the effective provider (dropping a `daemonHasProvider` branch).


## Tests

`text-to-speech-card.test.tsx` (9) and `speech-to-text-card.test.tsx` (11): managed-panel rendering, managed save writes mode + representable provider, toggling to Your Own is saveable on its own, and the existing BYOK/escape-managed flows updated for the toggle. Typecheck + lint clean.

## Original prompt

While QAing managed voice mode on a locally hosted assistant, managed speech wasn't visible in Models & Services — the TTS/STT cards were BYOK-only while Image Generation and Web Search already had a Managed/Your Own toggle. The ask was to give the two speech cards that same toggle (mirroring those cards), with a minimal managed panel, and without gating the option on a live platform connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

