### PR TITLE
fix: include opaque-JSON keys in reverse drift guards

### DIFF
--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -612,17 +612,19 @@ type _watchdogNarrows = AssertNarrows<
   Omit<WatchdogTelemetryEvent, "detail">,
   Omit<wire.WatchdogTelemetryEvent, "detail">
 >;
-// Reverse (key-existence) direction. The opaque-JSON fields excluded from the
-// `_*Narrows` guards above are excluded here too: the server treats them as
-// schemaless JSON columns, so their shape — and by the same token their
-// presence in the generated type — is not part of the typed contract these
-// guards pin.
+// Reverse (key-existence) direction. Unlike the `_*Narrows` guards, the
+// opaque-JSON fields are NOT excluded here: opacity is about a field's
+// SHAPE (the daemon's richer types aren't assignable to `JsonValue`), but
+// key PRESENCE is part of the typed contract — the generated wire types
+// declare `raw_usage`/`trace`/`client`/`detail`, and a platform sync that
+// removed or renamed one of them would otherwise leave every guard green
+// while the daemon kept emitting a field the server discards.
 type _llmUsageKeysExist = AssertNarrows<
-  Exclude<keyof LlmUsageTelemetryEvent, "raw_usage">,
+  keyof LlmUsageTelemetryEvent,
   keyof wire.LlmUsageTelemetryEvent
 >;
 type _turnKeysExist = AssertNarrows<
-  Exclude<keyof TurnTelemetryEvent, "trace" | "client">,
+  keyof TurnTelemetryEvent,
   keyof wire.TurnTelemetryEvent
 >;
 type _toolExecutedKeysExist = AssertNarrows<
@@ -634,7 +636,7 @@ type _skillLoadedKeysExist = AssertNarrows<
   keyof wire.SkillLoadedTelemetryEvent
 >;
 type _watchdogKeysExist = AssertNarrows<
-  Exclude<keyof WatchdogTelemetryEvent, "detail">,
+  keyof WatchdogTelemetryEvent,
   keyof wire.WatchdogTelemetryEvent
 >;
 // An `Extensions` key that also exists in the wire map would silently


### PR DESCRIPTION
## Summary
Addresses the Codex P2 that landed on #38013 one minute before merge: the reverse `_*KeysExist` guards excluded the opaque-JSON fields, conflating shape opacity (why the forward `_*Narrows` guards need `Omit`) with key presence (which the generated wire types do declare). A platform sync removing/renaming `raw_usage`/`trace`/`client`/`detail` would have drifted silently.

- Dropped the `Exclude<>`s from the three reverse guards; comment now explains the shape-vs-presence distinction
- Red-tested: renaming `raw_usage` in the generated file → TS2344 at `_llmUsageKeysExist` (previously green); reverted clean
- tsc clean, 15/15 telemetry tests, eslint/prettier clean