### PR TITLE
fix(lexical): create messages_lexical with an explicit segment count

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
@@ -143,6 +143,9 @@ describe("MessagesLexicalIndex", () => {
     expect(config.vectors).toBeUndefined();
     expect("vectors" in config).toBe(false);
 
+    // Explicit segment count — never Qdrant's CPU-count auto-detection.
+    expect(config.optimizers_config).toEqual({ default_segment_number: 2 });
+
     // Payload indexes on conversation_id (keyword) + created_at (integer).
     const fields = payloadIndexCalls.map((c) => c.field_name);
     expect(fields).toContain("conversation_id");

--- a/assistant/src/persistence/embeddings/messages-lexical-index.ts
+++ b/assistant/src/persistence/embeddings/messages-lexical-index.ts
@@ -23,6 +23,14 @@ export const MESSAGES_LEXICAL_COLLECTION = "messages_lexical";
  */
 const MESSAGE_POINT_NAMESPACE = "b6d0d3e2-1f1a-4c3e-9a7c-0e2f5a8d4c11";
 
+/**
+ * Explicit segment count for the collection. Left unset, Qdrant sizes the
+ * segment count to the node's CPU count, and each segment carries a fixed
+ * storage preallocation — a small sparse-only collection then idles at
+ * hundreds of MB. Matches the v2 concept-pages collection.
+ */
+const DEFAULT_SEGMENT_NUMBER = 2;
+
 export interface MessagesLexicalIndexConfig {
   url: string;
   collection?: string;
@@ -112,6 +120,9 @@ export class MessagesLexicalIndex {
           // RAM footprint grows without bound — keep it on disk alongside the
           // payloads.
           sparse: { index: { on_disk: this.onDisk } },
+        },
+        optimizers_config: {
+          default_segment_number: DEFAULT_SEGMENT_NUMBER,
         },
         on_disk_payload: this.onDisk,
       });


### PR DESCRIPTION
ref ATL-1029

ref ATL-1026

## Problem

The `messages_lexical` qdrant collection is created without an explicit segment count, so qdrant's auto-detection (`default_segment_number: 0`) sizes it to the detected CPU count. That detection is cgroup-naive: on production nodes it reads the node's cores (8), not the pod's quota, so every managed assistant's lexical collection is created with 8 segments.

Measured cost on a production pod: each segment materializes two Gridstore stores whose 32 MiB page files allocate in full on the sandbox pods' workspace filesystem (no sparse-file support — verified with a `truncate`/`stat` probe). 8 segments × 2 stores × 32 MiB ≈ 540 MB of idle allocation for a collection holding a few MB of sparse vectors. On a 2-CPU minikube the same code creates 2 segments (and its filesystem keeps the pages sparse), which is how the discrepancy was isolated.

## Fix

Pass `optimizers_config: { default_segment_number: 2 }` at collection creation, matching what `v2/qdrant.ts` already does for the concept-pages collection. A quota-capped assistant pod gains nothing from 8-way segment parallelism.

New installs only: this changes the creation params, so existing collections keep their current segment count. A follow-up commit (startup reconcile that updates the optimizer config on existing collections, mirroring the `reconcileSparseIndexOnDisk` pattern) is built and held back pending live validation that the background optimizer actually merges existing segments down after the config update.

## Tests

`messages-lexical-index.test.ts`: creation params carry the explicit segment count; adjacent lexical suites unaffected. 18 + 26 pass, 0 fail; `bun run typecheck:fast` clean; lint clean on touched lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)