### PR TITLE
fix(voice): dial loopback gateway directly for local live-voice WS

### DIFF
--- a/clients/web/src/domains/chat/voice/dictation-stream.test.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.test.ts
@@ -135,7 +135,9 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("buildSttStreamWsUrl", () => {
-  test("http ingress with a path prefix maps to ws and keeps the prefix", () => {
+  test("local __gateway proxy path dials the loopback gateway directly", () => {
+    // The HTTP-only __gateway proxy can't carry a WS upgrade, so the dictation
+    // stream must bypass it and hit 127.0.0.1:<port> directly (shared bypass).
     const url = new URL(
       buildSttStreamWsUrl({
         ingressUrl: "http://localhost:3000/assistant/__gateway/8500/",
@@ -144,7 +146,8 @@ describe("buildSttStreamWsUrl", () => {
     );
 
     expect(url.protocol).toBe("ws:");
-    expect(url.pathname).toBe("/assistant/__gateway/8500/v1/stt/stream");
+    expect(url.host).toBe("127.0.0.1:8500");
+    expect(url.pathname).toBe("/v1/stt/stream");
     expect(url.searchParams.get("token")).toBe("tok en");
     expect(url.searchParams.get("mimeType")).toBe("audio/pcm");
     expect(url.searchParams.get("sampleRate")).toBe("16000");

--- a/clients/web/src/domains/chat/voice/dictation-stream.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.ts
@@ -33,6 +33,7 @@ import {
   type LiveVoiceAudioCaptureOptions,
   type LiveVoiceCaptureResult,
 } from "@/domains/chat/voice/live-voice/pcm-capture";
+import { buildSelfHostedGatewayWsUrl } from "@/domains/chat/voice/live-voice/connection";
 import { LIVE_VOICE_AUDIO_FORMAT } from "@/domains/chat/voice/live-voice/protocol";
 import {
   getSelfHostedActorToken,
@@ -75,10 +76,10 @@ export interface DictationStreamOptions {
  *
  *   ws(s)://<ingressHost>/v1/stt/stream?token=…&mimeType=audio/pcm&sampleRate=16000
  *
- * Same shape rules as `buildSelfHostedLiveVoiceWsUrl`: scheme follows the
- * ingress (`http`→`ws`, `https`→`wss`), any ingress path prefix is preserved
- * (local Docker mode proxies the gateway at a sub-path), and query/hash on
- * the ingress are dropped. Exported for unit tests.
+ * Delegates to {@link buildSelfHostedGatewayWsUrl} so this dictation stream and
+ * live-voice share one transport rule set — including the local
+ * `/assistant/__gateway/<port>` → loopback bypass (the HTTP-only proxy can't
+ * carry a WS upgrade). Exported for unit tests.
  */
 export function buildSttStreamWsUrl({
   ingressUrl,
@@ -87,16 +88,15 @@ export function buildSttStreamWsUrl({
   ingressUrl: string;
   token: string;
 }): string {
-  const url = new URL(ingressUrl);
-  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
-  const prefix = url.pathname.replace(/\/+$/, "");
-  url.pathname = `${prefix}/v1/stt/stream`;
-  url.search = "";
-  url.hash = "";
-  url.searchParams.set("token", token);
-  url.searchParams.set("mimeType", LIVE_VOICE_AUDIO_FORMAT.mimeType);
-  url.searchParams.set("sampleRate", String(LIVE_VOICE_AUDIO_FORMAT.sampleRate));
-  return url.toString();
+  return buildSelfHostedGatewayWsUrl({
+    ingressUrl,
+    routePath: "/v1/stt/stream",
+    token,
+    params: {
+      mimeType: LIVE_VOICE_AUDIO_FORMAT.mimeType,
+      sampleRate: String(LIVE_VOICE_AUDIO_FORMAT.sampleRate),
+    },
+  });
 }
 
 /** Join transcript segments with a single space, ignoring blanks. */

--- a/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
@@ -206,8 +206,9 @@ describe("buildSelfHostedLiveVoiceWsUrl", () => {
     expect(url.pathname).toBe("/v1/live-voice");
   });
 
-  test("preserves the ingress path prefix (local Docker proxy) and drops query/hash", () => {
-    // Local mode reaches the gateway at a path-based proxy under the SPA origin.
+  test("local __gateway proxy path: dials the loopback gateway port directly", () => {
+    // The HTTP-only __gateway proxy can't carry a WS upgrade, so live-voice must
+    // bypass it and hit 127.0.0.1:<port> directly. Origin host + prefix dropped.
     const url = new URL(
       buildSelfHostedLiveVoiceWsUrl({
         ingressUrl: "http://localhost:3000/assistant/__gateway/7821?a=1#frag",
@@ -216,13 +217,43 @@ describe("buildSelfHostedLiveVoiceWsUrl", () => {
       }),
     );
     expect(url.protocol).toBe("ws:");
-    expect(url.host).toBe("localhost:3000");
-    // Prefix preserved, /v1/live-voice appended — matches the HTTP interceptor.
-    expect(url.pathname).toBe("/assistant/__gateway/7821/v1/live-voice");
+    expect(url.host).toBe("127.0.0.1:7821");
+    expect(url.pathname).toBe("/v1/live-voice");
     expect(url.hash).toBe("");
     expect(url.searchParams.get("a")).toBeNull();
     expect(url.searchParams.get("token")).toBe("actor-tok");
     expect(url.searchParams.get("conversationId")).toBe("conv-xyz");
+  });
+
+  test("local __gateway path bypasses even an https origin (Electron app://-style)", () => {
+    // The bypass keys off the proxy path, not the origin scheme, so a live-voice
+    // WS never rides the same-origin proxy regardless of host.
+    const url = new URL(
+      buildSelfHostedLiveVoiceWsUrl({
+        ingressUrl: "https://app.example/assistant/__gateway/18101",
+        token: "actor-tok",
+      }),
+    );
+    expect(url.protocol).toBe("ws:");
+    expect(url.host).toBe("127.0.0.1:18101");
+    expect(url.pathname).toBe("/v1/live-voice");
+  });
+
+  test("remote ingress (no __gateway path) keeps its host and appends the route", () => {
+    // A real remote gateway ingress is dialled as-is — only the local proxy path
+    // is rewritten to loopback.
+    const url = new URL(
+      buildSelfHostedLiveVoiceWsUrl({
+        ingressUrl: "https://x.ngrok-free.app/gw?a=1#frag",
+        token: "actor-tok",
+      }),
+    );
+    expect(url.protocol).toBe("wss:");
+    expect(url.host).toBe("x.ngrok-free.app");
+    expect(url.pathname).toBe("/gw/v1/live-voice");
+    expect(url.hash).toBe("");
+    expect(url.searchParams.get("a")).toBeNull();
+    expect(url.searchParams.get("token")).toBe("actor-tok");
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -186,56 +186,80 @@ export interface BuildSelfHostedLiveVoiceWsUrlArgs {
  */
 const LOCAL_GATEWAY_PROXY_PATH = /^\/assistant\/__gateway\/(\d+)\/?$/;
 
+export interface BuildSelfHostedGatewayWsUrlArgs {
+  /**
+   * The user's gateway ingress URL (e.g. `https://x.ngrok-free.app` or the local
+   * `/assistant/__gateway/<port>` proxy path), from {@link getSelfHostedIngressUrl}.
+   */
+  ingressUrl: string;
+  /** Gateway route to open, e.g. `/v1/live-voice` or `/v1/stt/stream`. */
+  routePath: string;
+  /** Platform actor edge JWT from {@link getSelfHostedActorToken}. */
+  token: string;
+  /** Extra query params to append after `token` (e.g. `conversationId`). */
+  params?: Record<string, string>;
+}
+
 /**
- * Build the live-voice WebSocket URL for the self-hosted / local path:
+ * Build a self-hosted gateway WebSocket URL. Shared by every gateway WS the
+ * browser opens (`/v1/live-voice`, `/v1/stt/stream`) so the transport rules stay
+ * in one place:
  *
- *   ws(s)://<ingressHost>/v1/live-voice?token=<actorToken>[&conversationId=<id>]
- *
- * Differences from the cloud (velay) URL:
- * - **No `/<assistantId>` path prefix.** That prefix is velay's tunnel routing;
- *   the gateway serves `/v1/live-voice` directly.
  * - **Scheme follows the ingress:** `https`→`wss`, `http`→`ws`, so a plain-HTTP
  *   local gateway is reachable over `ws`.
  * - **The token is the actor edge JWT**, not a minted velay token. It rides in
  *   `?token=` because the browser WebSocket API can't set an `Authorization`
- *   header; the gateway's non-managed `checkLiveVoiceAuth` reads it there.
- *
- * When the ingress is the local `/assistant/__gateway/<port>` proxy path we dial
- * the loopback gateway (`ws://127.0.0.1:<port>/v1/live-voice`) directly, since
- * that HTTP-only proxy can't carry the WS upgrade — see
- * {@link LOCAL_GATEWAY_PROXY_PATH}. A remote ingress (e.g. an ngrok `wss://`
- * URL) keeps its host and path prefix, with `/v1/live-voice` appended. Any
- * query/hash on the ingress is dropped.
+ *   header; the gateway's non-managed auth reads it there.
+ * - **Local `/assistant/__gateway/<port>` proxy path → direct loopback dial**
+ *   (`ws://127.0.0.1:<port>{routePath}`), since that HTTP-only proxy can't carry
+ *   the WS upgrade — see {@link LOCAL_GATEWAY_PROXY_PATH}.
+ * - **Remote ingress** (e.g. an ngrok `wss://` URL) keeps its host and path
+ *   prefix, with `routePath` appended. Any query/hash on the ingress is dropped.
+ */
+export function buildSelfHostedGatewayWsUrl({
+  ingressUrl,
+  routePath,
+  token,
+  params,
+}: BuildSelfHostedGatewayWsUrlArgs): string {
+  const ingress = new URL(ingressUrl);
+  const localProxy = ingress.pathname.match(LOCAL_GATEWAY_PROXY_PATH);
+
+  let target: URL;
+  if (localProxy) {
+    target = new URL(`ws://127.0.0.1:${localProxy[1]}${routePath}`);
+  } else {
+    ingress.protocol = ingress.protocol === "http:" ? "ws:" : "wss:";
+    const prefix = ingress.pathname.replace(/\/+$/, "");
+    ingress.pathname = `${prefix}${routePath}`;
+    ingress.search = "";
+    ingress.hash = "";
+    target = ingress;
+  }
+
+  target.searchParams.set("token", token);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    target.searchParams.set(key, value);
+  }
+  return target.toString();
+}
+
+/**
+ * Build the live-voice WebSocket URL for the self-hosted / local path. Thin
+ * wrapper over {@link buildSelfHostedGatewayWsUrl} for the `/v1/live-voice`
+ * route; the gateway serves it directly (no velay `/<assistantId>` prefix).
  */
 export function buildSelfHostedLiveVoiceWsUrl({
   ingressUrl,
   conversationId,
   token,
 }: BuildSelfHostedLiveVoiceWsUrlArgs): string {
-  const url = new URL(ingressUrl);
-
-  // Local `__gateway` proxy path: the HTTP-only proxy can't carry a WS upgrade,
-  // so dial the loopback gateway port directly (see LOCAL_GATEWAY_PROXY_PATH).
-  const localProxy = url.pathname.match(LOCAL_GATEWAY_PROXY_PATH);
-  if (localProxy) {
-    const direct = new URL(`ws://127.0.0.1:${localProxy[1]}/v1/live-voice`);
-    direct.searchParams.set("token", token);
-    if (conversationId) {
-      direct.searchParams.set("conversationId", conversationId);
-    }
-    return direct.toString();
-  }
-
-  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
-  const prefix = url.pathname.replace(/\/+$/, "");
-  url.pathname = `${prefix}/v1/live-voice`;
-  url.search = "";
-  url.hash = "";
-  url.searchParams.set("token", token);
-  if (conversationId) {
-    url.searchParams.set("conversationId", conversationId);
-  }
-  return url.toString();
+  return buildSelfHostedGatewayWsUrl({
+    ingressUrl,
+    routePath: "/v1/live-voice",
+    token,
+    params: conversationId ? { conversationId } : undefined,
+  });
 }
 
 export interface ResolveLiveVoiceWsUrlArgs {

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -175,6 +175,18 @@ export interface BuildSelfHostedLiveVoiceWsUrlArgs {
 }
 
 /**
+ * Local gateway proxy path (`/assistant/__gateway/<port>`) as produced by
+ * `gatewayProxyUrl` in local-mode. HTTP gateway traffic rides this same-origin
+ * proxy, but a live-voice WebSocket cannot: both hosts that serve the proxy —
+ * the Vite dev-server middleware and the Electron `app://` protocol forward —
+ * proxy HTTP only and drop the WS upgrade, so a WS dialled at the proxy path
+ * never reaches the gateway. When the ingress is this proxy path we therefore
+ * bypass it and dial the loopback gateway port directly (the `ws://127.0.0.1:*`
+ * shape the desktop CSP already allowlists).
+ */
+const LOCAL_GATEWAY_PROXY_PATH = /^\/assistant\/__gateway\/(\d+)\/?$/;
+
+/**
  * Build the live-voice WebSocket URL for the self-hosted / local path:
  *
  *   ws(s)://<ingressHost>/v1/live-voice?token=<actorToken>[&conversationId=<id>]
@@ -188,11 +200,12 @@ export interface BuildSelfHostedLiveVoiceWsUrlArgs {
  *   `?token=` because the browser WebSocket API can't set an `Authorization`
  *   header; the gateway's non-managed `checkLiveVoiceAuth` reads it there.
  *
- * The ingress *path prefix* is preserved and `/v1/live-voice` is appended to it
- * — in local Docker mode the gateway is reached at a path-based proxy
- * (`<origin>/assistant/__gateway/{port}`), exactly as the HTTP interceptor
- * (`rewriteForSelfHostedIngress`) splices it. Any query/hash on the ingress is
- * dropped.
+ * When the ingress is the local `/assistant/__gateway/<port>` proxy path we dial
+ * the loopback gateway (`ws://127.0.0.1:<port>/v1/live-voice`) directly, since
+ * that HTTP-only proxy can't carry the WS upgrade — see
+ * {@link LOCAL_GATEWAY_PROXY_PATH}. A remote ingress (e.g. an ngrok `wss://`
+ * URL) keeps its host and path prefix, with `/v1/live-voice` appended. Any
+ * query/hash on the ingress is dropped.
  */
 export function buildSelfHostedLiveVoiceWsUrl({
   ingressUrl,
@@ -200,6 +213,19 @@ export function buildSelfHostedLiveVoiceWsUrl({
   token,
 }: BuildSelfHostedLiveVoiceWsUrlArgs): string {
   const url = new URL(ingressUrl);
+
+  // Local `__gateway` proxy path: the HTTP-only proxy can't carry a WS upgrade,
+  // so dial the loopback gateway port directly (see LOCAL_GATEWAY_PROXY_PATH).
+  const localProxy = url.pathname.match(LOCAL_GATEWAY_PROXY_PATH);
+  if (localProxy) {
+    const direct = new URL(`ws://127.0.0.1:${localProxy[1]}/v1/live-voice`);
+    direct.searchParams.set("token", token);
+    if (conversationId) {
+      direct.searchParams.set("conversationId", conversationId);
+    }
+    return direct.toString();
+  }
+
   url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
   const prefix = url.pathname.replace(/\/+$/, "");
   url.pathname = `${prefix}/v1/live-voice`;


### PR DESCRIPTION
## Summary
- Local-hosted live-voice never connected: the client dialled its WebSocket at the same-origin `/assistant/__gateway/<port>` proxy path, but that proxy carries HTTP only (Vite dev middleware and the Electron `app://` forward both drop the WS upgrade), so the upgrade never reached the gateway — surfacing as "Live-voice connection timed out after 10000ms" or "Live-voice WebSocket error".
- `buildSelfHostedLiveVoiceWsUrl` now detects the local `__gateway` proxy path and dials the loopback gateway directly (`ws://127.0.0.1:<port>/v1/live-voice`) — the exact shape the desktop CSP already allowlists (`ws://127.0.0.1:*`). Web-dev works too (http page → `ws://localhost` is not mixed-content).
- Scoped tightly: only the local proxy path is rewritten. Remote gateway ingress (ngrok `wss://`) and the cloud/velay path are untouched, and the gateway still authenticates the `?token=` (no Origin check in `checkLiveVoiceAuth`, so no gateway change needed).
- Updated/added unit tests for the URL builder (direct-loopback for local proxy path incl. https/app://-style origin; remote ingress unchanged).

## Original prompt
While debugging why voice mode timed out on a locally-hosted assistant, we traced it past several red herrings (wrong environment, platform login, managed-speech config) to the real cause: the live-voice WebSocket never reaches the local gateway because the `/assistant/__gateway/<port>` proxy is HTTP-only on both the web-dev (Vite) and desktop (Electron `app://`) surfaces. Rather than add WS-upgrade proxying in two places, the fix has the live-voice client emit a direct `ws://127.0.0.1:<port>` URL in local mode — the loopback dial the Electron CSP already anticipates — while leaving the remote-ingress and cloud/velay paths alone. This is the missing local-transport piece for the recently-landed live-voice feature (JARVIS-1276/1277).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->