### PR TITLE
refactor(tools): scope-aware per-turn plugin resolver + registeredToolDefinitions cleanup

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -36,7 +36,6 @@ describe("always-loaded tool count", () => {
     const minimalContext: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: true,
       channelCapabilities: undefined,

--- a/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
@@ -114,7 +114,6 @@ function makeCtx(overrides: Partial<Context> = {}): Conversation {
     channelCapabilities: undefined,
     commandIntent: undefined,
     trustContext: undefined,
-    coreToolNames: new Set(),
     allowedToolNames: undefined,
     preactivatedSkillIds: undefined,
     skillProjectionState: new Map(),

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -427,7 +427,6 @@ function makeCtx(
     commandIntent: undefined,
     trustContext: undefined,
 
-    coreToolNames: new Set(),
     allowedToolNames: undefined,
     preactivatedSkillIds: undefined,
     skillProjectionState: new Map(),

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -583,7 +583,6 @@ function makeCtx(
     commandIntent: undefined,
     trustContext: undefined,
 
-    coreToolNames: new Set(),
     allowedToolNames: undefined,
     preactivatedSkillIds: undefined,
     skillProjectionState: new Map(),

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -776,7 +776,6 @@ function makeCtx(
     commandIntent: undefined,
     trustContext: undefined,
 
-    coreToolNames: new Set(),
     allowedToolNames: undefined,
     preactivatedSkillIds: undefined,
     skillProjectionState: new Map(),

--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -415,7 +415,9 @@ describe("End-to-end session creation benchmark", () => {
       if (i === 0) {
         // Tool infrastructure is wired (the executor records audit/telemetry
         // and profiler timings directly to their module-level terminals).
-        expect(session.coreToolNames.size).toBeGreaterThan(0);
+        expect(session.getRegisteredToolDefinitions().length).toBeGreaterThan(
+          0,
+        );
       }
       session.dispose();
     }

--- a/assistant/src/__tests__/conversation-tool-setup-tools-disabled.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-tools-disabled.test.ts
@@ -47,7 +47,6 @@ function makeCtx(
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: {} as SkillProjectionCache,
-    coreToolNames: new Set(["tool_a", "tool_b"]),
     toolsDisabledDepth: 0,
     ...overrides,
   };
@@ -155,7 +154,7 @@ describe("createResolveToolsCallback — toolsDisabledDepth", () => {
     expect(ctx.allowedToolNames).toEqual(new Set());
   });
 
-  test("records the resolved set on lastResolvedToolNames for inventory queries", () => {
+  test("records the resolved set on registeredToolDefinitions for inventory queries", () => {
     // GIVEN a normal resolver call
     const toolDefs = [makeToolDef("tool_a"), makeToolDef("tool_b")];
     const ctx = makeCtx();
@@ -165,18 +164,21 @@ describe("createResolveToolsCallback — toolsDisabledDepth", () => {
     resolve(EMPTY_HISTORY);
 
     // THEN the durable snapshot mirrors the per-turn gate
-    expect(ctx.lastResolvedToolNames).toEqual(ctx.allowedToolNames!);
-    expect(ctx.lastResolvedToolNames?.has("tool_a")).toBe(true);
-    expect(ctx.lastResolvedToolNames?.has("tool_b")).toBe(true);
+    const resolvedNames = new Set(
+      ctx.registeredToolDefinitions?.map((d) => d.name),
+    );
+    expect(resolvedNames).toEqual(ctx.allowedToolNames!);
+    expect(resolvedNames.has("tool_a")).toBe(true);
+    expect(resolvedNames.has("tool_b")).toBe(true);
   });
 
-  test("preserves lastResolvedToolNames when a later call disables tools", () => {
+  test("preserves registeredToolDefinitions when a later call disables tools", () => {
     // GIVEN a conversation that resolved tools on a normal turn
     const toolDefs = [makeToolDef("tool_a"), makeToolDef("tool_b")];
     const ctx = makeCtx();
     const resolve = createResolveToolsCallback(toolDefs, ctx)!;
     resolve(EMPTY_HISTORY);
-    const snapshot = ctx.lastResolvedToolNames;
+    const snapshot = ctx.registeredToolDefinitions;
 
     // WHEN a subsequent call disables tools (e.g. pointer generation, or the
     // turn-teardown that clears the per-turn gate)
@@ -185,7 +187,9 @@ describe("createResolveToolsCallback — toolsDisabledDepth", () => {
 
     // THEN the per-turn gate is empty but the inventory snapshot survives
     expect(ctx.allowedToolNames).toEqual(new Set());
-    expect(ctx.lastResolvedToolNames).toBe(snapshot);
-    expect(ctx.lastResolvedToolNames?.has("tool_a")).toBe(true);
+    expect(ctx.registeredToolDefinitions).toBe(snapshot);
+    expect(
+      ctx.registeredToolDefinitions?.some((d) => d.name === "tool_a"),
+    ).toBe(true);
   });
 });

--- a/assistant/src/__tests__/disk-pressure-tools.test.ts
+++ b/assistant/src/__tests__/disk-pressure-tools.test.ts
@@ -79,7 +79,6 @@ function makeProjectionCtx(
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: {} as SkillProjectionCache,
-    coreToolNames: new Set(),
     toolsDisabledDepth: 0,
     ...overrides,
   };

--- a/assistant/src/__tests__/file-list-tool.test.ts
+++ b/assistant/src/__tests__/file-list-tool.test.ts
@@ -189,7 +189,6 @@ describe("file_list subagent visibility", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(["file_list"]),
       toolsDisabledDepth: 0,
     };
     expect(isToolActiveForContext("file_list", ctx)).toBe(false);
@@ -199,7 +198,6 @@ describe("file_list subagent visibility", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(["file_list"]),
       toolsDisabledDepth: 0,
       isSubagent: undefined,
     };
@@ -210,7 +208,6 @@ describe("file_list subagent visibility", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(["file_list"]),
       toolsDisabledDepth: 0,
       isSubagent: true,
     };

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -170,7 +170,6 @@ describe("notify_parent tool definition", () => {
       preactivatedSkillIds: [],
       skillProjectionState: new Map(),
       skillProjectionCache: new Map(),
-      coreToolNames: new Set<string>(),
       toolsDisabledDepth: 0,
     } as unknown as import("../daemon/conversation-tool-setup.js").SkillProjectionContext;
     expect(isToolActiveForContext("notify_parent", ctx)).toBe(false);
@@ -181,7 +180,6 @@ describe("notify_parent tool definition", () => {
       preactivatedSkillIds: [],
       skillProjectionState: new Map(),
       skillProjectionCache: new Map(),
-      coreToolNames: new Set<string>(),
       toolsDisabledDepth: 0,
     } as unknown as import("../daemon/conversation-tool-setup.js").SkillProjectionContext;
     expect(isToolActiveForContext("notify_parent", ctx)).toBe(false);
@@ -193,7 +191,6 @@ describe("notify_parent tool definition", () => {
       preactivatedSkillIds: [],
       skillProjectionState: new Map(),
       skillProjectionCache: new Map(),
-      coreToolNames: new Set<string>(),
       toolsDisabledDepth: 0,
     } as unknown as import("../daemon/conversation-tool-setup.js").SkillProjectionContext;
     expect(isToolActiveForContext("notify_parent", ctx)).toBe(true);

--- a/assistant/src/__tests__/subagent-tool-filtering.test.ts
+++ b/assistant/src/__tests__/subagent-tool-filtering.test.ts
@@ -21,7 +21,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: false,
       isSubagent: false,
@@ -34,7 +33,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: false,
     };
@@ -46,7 +44,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: true,
       isSubagent: true,
@@ -59,7 +56,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: false,
       isSubagent: false,
@@ -75,7 +71,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: false,
       isSubagent: true,
@@ -94,7 +89,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: false,
       subagentAllowedTools: new Set(["remember"]),
@@ -109,7 +103,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: false,
       subagentAllowedTools: new Set(["remember"]),
@@ -126,7 +119,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 1,
       hasNoClient: false,
       subagentAllowedTools: new Set(["remember"]),
@@ -143,7 +135,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 1,
       hasNoClient: false,
     };
@@ -158,7 +149,6 @@ describe("subagent-only tool filtering", () => {
     const ctx: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
-      coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: false,
       diskPressureCleanupModeActive: true,

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -100,7 +100,6 @@ function makeProjectionCtx(
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: {} as SkillProjectionCache,
-    coreToolNames: new Set(["remember", "tool_b"]),
     toolsDisabledDepth: 0,
     ...overrides,
   };
@@ -241,7 +240,6 @@ describe("createResolveToolsCallback — toolContextPin", () => {
     overrides: Partial<SkillProjectionContext> = {},
   ): SkillProjectionContext {
     return makeProjectionCtx({
-      coreToolNames: new Set(CLIENT_GATED_DEFS.map((d) => d.name)),
       hasNoClient: true,
       subagentAllowedTools: new Set(["remember"]),
       subagentToolGateMode: "execution",

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1964,7 +1964,6 @@ describe("Advisor role is tool-less", () => {
     const ctx = {
       skillProjectionState: new Map<string, string>(),
       skillProjectionCache: new Map(),
-      coreToolNames: new Set(toolDefs.map((d) => d.name)),
       toolsDisabledDepth: 0,
       // The advisor role applies `new Set(allowedTools)` — empty Set here.
       subagentAllowedTools: new Set<string>(advisorAllowed),

--- a/assistant/src/__tests__/tools-get-route.test.ts
+++ b/assistant/src/__tests__/tools-get-route.test.ts
@@ -77,7 +77,8 @@ const handler = (() => {
  */
 function registerFakeConversation(id: string, toolNames: string[]): void {
   setConversation(id, {
-    getRegisteredToolNames: () => new Set(toolNames),
+    getRegisteredToolDefinitions: () =>
+      toolNames.map((name) => ({ name, description: "", input_schema: {} })),
   } as unknown as Conversation);
 }
 

--- a/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import * as configLoader from "../../config/loader.js";
 import type { AssistantConfig } from "../../config/schema.js";
+import * as disabledState from "../../plugins/disabled-state.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import {
   __clearRegistryForTesting,
@@ -62,6 +63,15 @@ function withExclude(exclude: string[]) {
 }
 
 let getConfigSpy: ReturnType<typeof withExclude> | undefined;
+let disabledSpy: ReturnType<typeof spyOn> | undefined;
+
+/** Stub the workspace `.disabled` sentinel so the named plugins read disabled. */
+function disableWorkspacePlugins(...names: string[]) {
+  const set = new Set(names);
+  disabledSpy = spyOn(disabledState, "isPluginDisabled").mockImplementation(
+    (name: string) => set.has(name),
+  );
+}
 
 beforeEach(() => {
   __clearRegistryForTesting();
@@ -70,6 +80,8 @@ beforeEach(() => {
 afterEach(() => {
   getConfigSpy?.mockRestore();
   getConfigSpy = undefined;
+  disabledSpy?.mockRestore();
+  disabledSpy = undefined;
   __clearRegistryForTesting();
 });
 
@@ -172,6 +184,55 @@ describe("createResolveToolsCallback — config.tools.exclude", () => {
       makeCtx(),
     );
     expect(resolver!([]).map((d) => d.name)).toEqual(["file_read"]);
+  });
+
+  test("workspace-disabled plugin tool stays hidden with no per-chat scope", () => {
+    registerPluginTools("scoped-plugin", [pluginTool("scoped_plugin_tool")]);
+    disableWorkspacePlugins("scoped-plugin");
+    getConfigSpy = withExclude([]);
+
+    // enabledPlugins undefined -> null scope: the workspace `.disabled` gate
+    // hides the plugin's tools (the default, non-overridden behaviour).
+    const resolver = createResolveToolsCallback([def("file_read")], makeCtx());
+    expect(resolver!([]).map((d) => d.name)).not.toContain(
+      "scoped_plugin_tool",
+    );
+  });
+
+  test("explicit per-chat scope re-enables a workspace-disabled plugin's tool", () => {
+    // A plugin disabled at the workspace level whose tool the conversation
+    // explicitly re-enables. Rule 1 (per-conversation enable) beats rule 2
+    // (workspace disable): the tool must surface for this chat even though a
+    // scope-less chat would not see it (see getEffectiveEnabledPluginSet).
+    registerPluginTools("scoped-plugin", [pluginTool("scoped_plugin_tool")]);
+    disableWorkspacePlugins("scoped-plugin");
+    getConfigSpy = withExclude([]);
+
+    const resolver = createResolveToolsCallback(
+      [def("file_read")],
+      makeCtx({ enabledPlugins: ["scoped-plugin"] }),
+    );
+    const names = resolver!([]).map((d) => d.name);
+    expect(names).toContain("scoped_plugin_tool");
+    expect(names).toContain("file_read");
+  });
+
+  test("per-chat scope omitting a workspace-disabled plugin keeps it hidden", () => {
+    // Two workspace-disabled plugins; the chat re-enables only one. The other
+    // must stay filtered out — the explicit scope is an allowlist, so a
+    // disabled plugin it does not list is not resurrected.
+    registerPluginTools("keep-plugin", [pluginTool("keep_plugin_tool")]);
+    registerPluginTools("drop-plugin", [pluginTool("drop_plugin_tool")]);
+    disableWorkspacePlugins("keep-plugin", "drop-plugin");
+    getConfigSpy = withExclude([]);
+
+    const resolver = createResolveToolsCallback(
+      [def("file_read")],
+      makeCtx({ enabledPlugins: ["keep-plugin"] }),
+    );
+    const names = resolver!([]).map((d) => d.name);
+    expect(names).toContain("keep_plugin_tool");
+    expect(names).not.toContain("drop_plugin_tool");
   });
 
   test("excluded tool stays excluded under disk-pressure cleanup mode", () => {

--- a/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
@@ -49,7 +49,6 @@ function makeCtx(
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: { fingerprints: new Map() } as SkillProjectionCache,
-    coreToolNames: new Set<string>(),
     toolsDisabledDepth: 0,
     ...overrides,
   };

--- a/assistant/src/daemon/__tests__/conversation-tool-setup-plugin-scope.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-plugin-scope.test.ts
@@ -41,7 +41,6 @@ function makeCtx(
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: { fingerprints: new Map() } as SkillProjectionCache,
-    coreToolNames: new Set<string>(),
     toolsDisabledDepth: 0,
     ...overrides,
   };

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -62,7 +62,6 @@ function makeCtx(
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: {} as SkillProjectionCache,
-    coreToolNames: new Set<string>(),
     toolsDisabledDepth: 0,
     ...overrides,
   };

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -842,29 +842,27 @@ export function createResolveToolsCallback(
     // is picked up without recreating the conversation.
     void loadPluginTools();
 
-    // Re-read plugin tool definitions from the registry each turn and scope them
-    // to the conversation's per-chat plugin set. Plugin tools share core's
-    // context filter + allowlist path, so combine them with the core snapshot
-    // before filtering. Ownership lives in the registry (queried via
-    // getToolOwner), not on the Tool object.
+    // Read every registered plugin tool each turn (so runtime installs/edits
+    // are picked up) and let one filter decide visibility, making the two
+    // precedence rules explicit side by side. Plugin tools share core's context
+    // filter + allowlist path, so combine them with the core snapshot before
+    // filtering. Ownership lives in the registry (getToolOwner), not on the Tool.
     //
-    // `null` = no per-chat restriction: use the workspace-gated read so a
-    // `.disabled` plugin's tools stay hidden. Otherwise the conversation's
-    // explicit scope is the single authority (rule 1 > rule 2, see
-    // getEffectiveEnabledPluginSet), so read ALL plugin tools — including those
-    // from a workspace-disabled plugin — and keep only the ones the effective
-    // set enables. This lets a chat re-enable a workspace-disabled plugin for
-    // itself; a workspace-disabled plugin absent from the set stays filtered out
-    // because it is not in the effective set.
-    const scopedPluginDefs =
-      effectiveEnabledPluginSet === null
-        ? getPluginToolDefinitions()
-        : getAllPluginToolDefinitions().filter((d) => {
-            const ownerId = getToolOwner(d.name)?.id;
-            return (
-              ownerId !== undefined && effectiveEnabledPluginSet.has(ownerId)
-            );
-          });
+    //   - No per-chat scope (null): keep tools whose plugin is not disabled at
+    //     the workspace level (the `.disabled` sentinel gate).
+    //   - Explicit per-chat scope: the scope is the sole authority (rule 1 >
+    //     rule 2, see getEffectiveEnabledPluginSet) — keep tools the scope
+    //     enables, so a chat can re-enable a workspace-disabled plugin for
+    //     itself while a plugin the scope omits stays hidden.
+    const scopedPluginDefs = getAllPluginToolDefinitions().filter((d) => {
+      const ownerId = getToolOwner(d.name)?.id;
+      if (ownerId === undefined) {
+        return false;
+      }
+      return effectiveEnabledPluginSet === null
+        ? !isPluginDisabled(ownerId)
+        : effectiveEnabledPluginSet.has(ownerId);
+    });
 
     // Filter core + plugin tools based on current conversation context so that
     // tools irrelevant to this turn (e.g. UI tools when no client is connected)
@@ -957,12 +955,24 @@ export function createResolveToolsCallback(
     // any degraded-mode narrowing below — `allowedToolNames` is the per-turn
     // execution gate (cleared at teardown and restricted under disk pressure),
     // whereas this snapshot answers "what tools does this conversation have".
-    // Resolve names to definitions against the live registry so skill/MCP/
-    // plugin tools — whose defs are not in the base turn snapshot — are
-    // captured with their metadata.
+    // Reuse the definitions already resolved this turn (base + appended skill
+    // defs); only active-skill names that carry no appended definition (the
+    // cached skill-projection path returns names without defs) fall back to a
+    // registry lookup for their metadata.
+    const resolvedDefsByName = new Map<string, ToolDefinition>();
+    for (const def of allBaseDefs) {
+      resolvedDefsByName.set(def.name, def);
+    }
+    for (const def of projection.toolDefinitions) {
+      resolvedDefsByName.set(def.name, def);
+    }
     ctx.registeredToolDefinitions = Array.from(turnAllowed)
       .sort((a, b) => a.localeCompare(b))
       .map((name) => {
+        const known = resolvedDefsByName.get(name);
+        if (known !== undefined) {
+          return known;
+        }
         const tool = getTool(name);
         return {
           name,

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -24,6 +24,7 @@ import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
 import type { ToolExecutor } from "../tools/executor.js";
 import {
+  getAllPluginToolDefinitions,
   getMcpToolDefinitions,
   getPluginToolDefinitions,
   getTool,
@@ -841,20 +842,24 @@ export function createResolveToolsCallback(
     // is picked up without recreating the conversation.
     void loadPluginTools();
 
-    // Re-read plugin tool definitions from the registry each turn. Plugin
-    // tools share core's context filter + allowlist path, so combine them
-    // with the core snapshot before filtering.
-    const currentPluginDefs = getPluginToolDefinitions();
-
-    // Scope plugin tools to the conversation's per-chat plugin set. `null`
-    // leaves the list unchanged (no per-chat restriction); otherwise keep only
-    // tools whose owning plugin id is in the set, mirroring the
-    // `subagentAllowedTools` intersection below. Ownership lives in the registry
-    // (queried via getToolOwner), not on the Tool object.
+    // Re-read plugin tool definitions from the registry each turn and scope them
+    // to the conversation's per-chat plugin set. Plugin tools share core's
+    // context filter + allowlist path, so combine them with the core snapshot
+    // before filtering. Ownership lives in the registry (queried via
+    // getToolOwner), not on the Tool object.
+    //
+    // `null` = no per-chat restriction: use the workspace-gated read so a
+    // `.disabled` plugin's tools stay hidden. Otherwise the conversation's
+    // explicit scope is the single authority (rule 1 > rule 2, see
+    // getEffectiveEnabledPluginSet), so read ALL plugin tools — including those
+    // from a workspace-disabled plugin — and keep only the ones the effective
+    // set enables. This lets a chat re-enable a workspace-disabled plugin for
+    // itself; a workspace-disabled plugin absent from the set stays filtered out
+    // because it is not in the effective set.
     const scopedPluginDefs =
       effectiveEnabledPluginSet === null
-        ? currentPluginDefs
-        : currentPluginDefs.filter((d) => {
+        ? getPluginToolDefinitions()
+        : getAllPluginToolDefinitions().filter((d) => {
             const ownerId = getToolOwner(d.name)?.id;
             return (
               ownerId !== undefined && effectiveEnabledPluginSet.has(ownerId)

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -488,14 +488,14 @@ export interface SkillProjectionContext {
   preactivatedSkillIds?: string[];
   readonly skillProjectionState: Map<string, string>;
   readonly skillProjectionCache: SkillProjectionCache;
-  readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
   /**
-   * Durable copy of the full tool set resolved on the most recent turn, used
-   * by read-only inventory queries. Set alongside {@link allowedToolNames}
-   * but, unlike that per-turn execution gate, never cleared at turn teardown.
+   * Durable copy of the full tool definitions resolved on the most recent
+   * turn, used by read-only inventory queries. Set alongside
+   * {@link allowedToolNames} but, unlike that per-turn execution gate, never
+   * cleared at turn teardown.
    */
-  lastResolvedToolNames?: Set<string>;
+  registeredToolDefinitions?: ToolDefinition[];
   /** When > 0, the resolveTools callback returns no tools at all. */
   toolsDisabledDepth: number;
   /** Channel capabilities — read lazily per turn for conditional tool filtering. */
@@ -957,7 +957,19 @@ export function createResolveToolsCallback(
     // any degraded-mode narrowing below — `allowedToolNames` is the per-turn
     // execution gate (cleared at teardown and restricted under disk pressure),
     // whereas this snapshot answers "what tools does this conversation have".
-    ctx.lastResolvedToolNames = turnAllowed;
+    // Resolve names to definitions against the live registry so skill/MCP/
+    // plugin tools — whose defs are not in the base turn snapshot — are
+    // captured with their metadata.
+    ctx.registeredToolDefinitions = Array.from(turnAllowed)
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => {
+        const tool = getTool(name);
+        return {
+          name,
+          description: tool?.description ?? "",
+          input_schema: tool?.input_schema ?? {},
+        };
+      });
     if (ctx.diskPressureCleanupModeActive === true) {
       const cleanupDefs = allBaseDefs.filter((d) =>
         isDiskPressureCleanupToolName(d.name),

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2360,19 +2360,7 @@ export class Conversation {
 
   // ── Tools ────────────────────────────────────────────────────────
 
-  /**
-   * The full tool definitions (name, description, input schema) available to
-   * this conversation as of its most recent turn — including skill/MCP tools
-   * registered over the conversation's lifecycle. Returns the durable
-   * {@link registeredToolDefinitions} snapshot the `resolveTools` callback
-   * records each turn (which, unlike the per-turn `allowedToolNames` gate, is
-   * not cleared at turn teardown); before the first turn it is the initial
-   * snapshot seeded in the constructor. This is a pure read: it does not re-run
-   * `resolveTools`, which has registry/projection side effects that must not
-   * fire outside a turn. Consumers (e.g. turn-trace telemetry, the tool
-   * inventory route) read this instead of reaching into the tool registry
-   * themselves.
-   */
+  /** The tool inventory resolved on this conversation's most recent turn. */
   getRegisteredToolDefinitions(): ToolDefinition[] {
     return this.registeredToolDefinitions;
   }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -88,7 +88,7 @@ import {
   isActivationMomentParam,
 } from "../telemetry/activation-funnel.js";
 import { ToolExecutor } from "../tools/executor.js";
-import { getAllToolDefinitions, getTool } from "../tools/registry.js";
+import { getAllToolDefinitions } from "../tools/registry.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
 import type { AbortReason } from "../util/abort-reasons.js";
 import { UserError } from "../util/errors.js";
@@ -305,10 +305,12 @@ export class Conversation {
    * kept for read-only inventory queries. Unlike {@link allowedToolNames}
    * — the per-turn execution gate the agent loop clears at turn teardown —
    * this survives between turns so a query against an idle conversation
-   * still reports the skill/MCP tools it gained over its lifecycle.
+   * still reports the skill/MCP tools it gained over its lifecycle. Seeded in
+   * the constructor from the initial tool snapshot and overwritten by the
+   * `resolveTools` callback each turn.
    * @internal
    */
-  lastResolvedToolNames?: Set<string>;
+  registeredToolDefinitions: ToolDefinition[];
   /** @internal */ diskPressureCleanupModeActive?: boolean;
   /** @internal */ toolsDisabledDepth = 0;
   /** @internal */ preactivatedSkillIds?: string[];
@@ -328,7 +330,6 @@ export class Conversation {
    * @internal
    */
   toolContextPin?: WakeToolContextPin;
-  /** @internal */ coreToolNames: Set<string>;
   /** @internal */ readonly skillProjectionState = new Map<string, string>();
   /** @internal */ readonly skillProjectionCache: SkillProjectionCache = {};
   /** @internal */ usageStats: UsageStats = {
@@ -716,7 +717,7 @@ export class Conversation {
     this.executor = new ToolExecutor(this.prompter);
 
     const toolDefs = getAllToolDefinitions();
-    this.coreToolNames = new Set(toolDefs.map((d) => d.name));
+    this.registeredToolDefinitions = toolDefs;
     const toolExecutor = createToolExecutor(
       this.executor,
       this.prompter,
@@ -2360,37 +2361,20 @@ export class Conversation {
   // ── Tools ────────────────────────────────────────────────────────
 
   /**
-   * The set of tool names available to this conversation as of its most
-   * recent turn — including skill/MCP tools registered over the
-   * conversation's lifecycle. Reads the durable {@link lastResolvedToolNames}
-   * snapshot the `resolveTools` callback records each turn (which, unlike the
-   * per-turn `allowedToolNames` gate, is not cleared at turn teardown); before
-   * the first turn it falls back to the core tool set. This is a pure read: it
-   * does not re-run `resolveTools`, which has registry/projection side effects
-   * that must not fire outside a turn.
-   */
-  getRegisteredToolNames(): Set<string> {
-    return new Set(this.lastResolvedToolNames ?? this.coreToolNames);
-  }
-
-  /**
-   * The {@link getRegisteredToolNames} inventory resolved to full definitions
-   * (name, description, input schema), sorted by name. Resolution reads the
-   * live registry so skill/MCP tools — whose definitions are not in the base
-   * turn snapshot — are included. Consumers (e.g. turn-trace telemetry) read
-   * this instead of reaching into the tool registry themselves.
+   * The full tool definitions (name, description, input schema) available to
+   * this conversation as of its most recent turn — including skill/MCP tools
+   * registered over the conversation's lifecycle. Returns the durable
+   * {@link registeredToolDefinitions} snapshot the `resolveTools` callback
+   * records each turn (which, unlike the per-turn `allowedToolNames` gate, is
+   * not cleared at turn teardown); before the first turn it is the initial
+   * snapshot seeded in the constructor. This is a pure read: it does not re-run
+   * `resolveTools`, which has registry/projection side effects that must not
+   * fire outside a turn. Consumers (e.g. turn-trace telemetry, the tool
+   * inventory route) read this instead of reaching into the tool registry
+   * themselves.
    */
   getRegisteredToolDefinitions(): ToolDefinition[] {
-    return Array.from(this.getRegisteredToolNames())
-      .sort((a, b) => a.localeCompare(b))
-      .map((name) => {
-        const tool = getTool(name);
-        return {
-          name,
-          description: tool?.description ?? "",
-          input_schema: tool?.input_schema ?? {},
-        };
-      });
+    return this.registeredToolDefinitions;
   }
 
   // ── History ──────────────────────────────────────────────────────

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -523,7 +523,6 @@ function handleAgentToolList(agent: string): ToolNamesListResponse {
   //   - hasNoClient: true (subagents have no direct client)
   //   - no channel capabilities, no disk pressure, tools enabled
   const toolDefs = getAllToolDefinitions();
-  const coreToolNames = new Set(toolDefs.map((d) => d.name));
   const mergedSkillIds = mergeSkillIds(
     roleConfig.skillIds,
     DEFAULT_PREACTIVATED_SKILL_IDS,
@@ -538,7 +537,6 @@ function handleAgentToolList(agent: string): ToolNamesListResponse {
     diskPressureCleanupModeActive: false,
     skillProjectionState: new Map<string, string>(),
     skillProjectionCache: {},
-    coreToolNames,
     hasNoClient: true,
     preactivatedSkillIds: mergedSkillIds,
   };
@@ -579,7 +577,7 @@ function handleAgentToolList(agent: string): ToolNamesListResponse {
  * Scope the tool inventory to a single conversation. Conversations gain
  * tools over their lifecycle (skill loads, MCP reloads), so the global
  * registry over-reports what a given conversation can actually call. We
- * read the conversation's turn snapshot (`getRegisteredToolNames()`) — a
+ * read the conversation's turn snapshot (`getRegisteredToolDefinitions()`) — a
  * pure read that does not re-run the side-effecting `resolveTools`
  * callback — and resolve each name's metadata/schema from the registry.
  */
@@ -593,9 +591,10 @@ function handleConversationToolList(
     );
   }
 
-  const names = Array.from(conversation.getRegisteredToolNames()).sort((a, b) =>
-    a.localeCompare(b),
-  );
+  const names = conversation
+    .getRegisteredToolDefinitions()
+    .map((d) => d.name)
+    .sort((a, b) => a.localeCompare(b));
 
   const schemaByName = new Map<string, SchemaShape>(
     injectActivityField(getAllTools(), ACTIVITY_SKIP_SET).map((d) => [

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -591,26 +591,21 @@ function handleConversationToolList(
     );
   }
 
-  const names = conversation
-    .getRegisteredToolDefinitions()
-    .map((d) => d.name)
-    .sort((a, b) => a.localeCompare(b));
+  // The snapshot already carries each tool's definition, so read schemas off it
+  // directly (activity-injected the same way the global catalog is) rather than
+  // flattening to names and re-looking-them-up in the registry.
+  const defs = injectActivityField(
+    conversation.getRegisteredToolDefinitions(),
+    ACTIVITY_SKIP_SET,
+  ).sort((a, b) => a.name.localeCompare(b.name));
 
-  const schemaByName = new Map<string, SchemaShape>(
-    injectActivityField(getAllTools(), ACTIVITY_SKIP_SET).map((d) => [
-      d.name,
-      d.input_schema as SchemaShape,
-    ]),
-  );
-
+  const names: string[] = [];
   const schemas: Record<string, SchemaShape> = {};
   const tools: ToolListEntry[] = [];
-  for (const name of names) {
-    const schema = schemaByName.get(name);
-    if (schema) {
-      schemas[name] = schema;
-    }
-    tools.push(toolEntryForName(name));
+  for (const def of defs) {
+    names.push(def.name);
+    schemas[def.name] = def.input_schema as SchemaShape;
+    tools.push(toolEntryForName(def.name));
   }
 
   return { names, schemas, tools };

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -641,23 +641,37 @@ export function getMcpToolDefinitions(): Tool[] {
 }
 
 /**
- * Return tool definitions for all currently registered plugin-origin tools.
- * Used by the session resolver to dynamically pick up plugin tools that were
- * registered after session creation — e.g. a plugin installed at runtime and
- * activated on a subsequent turn (see `plugins/mtime-cache.ts`). Mirrors
+ * Return tool definitions for every registered plugin-origin tool, INCLUDING
+ * tools from workspace-disabled plugins. This does NOT apply the `.disabled`
+ * sentinel gate — the caller owns the scoping decision. Use this when a
+ * conversation's explicit `enabledPlugins` scope is the authority (a plugin the
+ * conversation explicitly enabled must surface its tools even when it is
+ * disabled at the workspace level; see `getEffectiveEnabledPluginSet`). Callers
+ * that report the workspace-level *available* surface want
+ * {@link getPluginToolDefinitions} instead.
+ */
+export function getAllPluginToolDefinitions(): Tool[] {
+  return Array.from(tools.values()).filter(
+    (t) => ownersByName.get(t.name)?.kind === "plugin",
+  );
+}
+
+/**
+ * Return tool definitions for currently registered plugin-origin tools, minus
+ * those contributed by a workspace-disabled plugin. Used by the session
+ * resolver to dynamically pick up plugin tools that were registered after
+ * session creation — e.g. a plugin installed at runtime and activated on a
+ * subsequent turn (see `plugins/mtime-cache.ts`). Mirrors
  * {@link getMcpToolDefinitions} so a plugin install behaves like `mcp reload`.
+ *
+ * The `.disabled` sentinel is filtered at read time so `assistant plugins
+ * disable <name>` takes effect on the next turn without a daemon restart,
+ * mirroring `getHooksFor` (plugins/registry.ts).
  */
 export function getPluginToolDefinitions(): Tool[] {
-  return Array.from(tools.values()).filter((t) => {
+  return getAllPluginToolDefinitions().filter((t) => {
     const owner = ownersByName.get(t.name);
-    if (owner?.kind !== "plugin") {
-      return false;
-    }
-    // Filter out tools contributed by disabled plugins at read time so
-    // `assistant plugins disable <name>` takes effect on the next turn
-    // without a daemon restart. Mirrors the `.disabled` sentinel filtering
-    // in `getHooksFor` (plugins/registry.ts).
-    return !isPluginDisabled(owner.id);
+    return owner !== undefined && !isPluginDisabled(owner.id);
   });
 }
 


### PR DESCRIPTION
## Prompt / plan

First increment toward fixing a real bug we found while QA-ing plugin tools: **a per-conversation `enabledPlugins` override does not re-enable a workspace-disabled plugin's tools.** More PRs will follow before the bug is fully solved — this one lands the read-side groundwork and a supporting cleanup so the rest is easier to review.

### The bug (context)

Three manual QA cases against a live daemon:

1. install plugin → message → tools in context ✅
2. install → disable globally → message → tools **not** in context ✅
3. install → disable globally → message **with the plugin re-enabled for that chat** → tools in context ❌ (got: absent)

Case 3 contradicts the documented precedence in `conversation-tool-setup.ts` (`getEffectiveEnabledPluginSet`): rule 1 (per-conversation enable) is supposed to beat rule 2 (workspace `.disabled`). Root cause is two layers deep — the per-turn resolver read plugin tools through a *workspace-gated* accessor before the per-chat scope was applied, and (found later) the plugin reconcile evicts a disabled plugin's tools from the registry entirely. This PR fixes the first layer; the eviction/lifecycle layer is a follow-up (the tool-vs-hook decoupling is still an open design call).

### Commit 1 — make the per-turn plugin resolver scope-aware

`registry.ts` gains `getAllPluginToolDefinitions()` (every registered plugin tool, **no** `.disabled` gate); `getPluginToolDefinitions()` is refactored to filter that by the sentinel, so the existing gated read is unchanged.

In `conversation-tool-setup.ts`'s per-turn resolver: when a conversation has **no** per-chat scope (`null`), keep the workspace-gated read (a `.disabled` plugin stays hidden — case 2 preserved). When it has an **explicit** scope, that scope is the single authority: read *all* plugin tools and keep only those the effective set enables — so an explicitly re-enabled, workspace-disabled plugin can surface its tools, while a disabled plugin the scope omits stays filtered out.

> Note: on its own this is necessary but **not sufficient** to close case 3 across turns — the reconcile still tears a disabled plugin's tools out of the registry on the next tick, so there's nothing to surface after the first post-disable turn. That eviction is the subject of the next PR.

### Commit 2 — collapse the conversation tool-inventory snapshot

Independent cleanup on the same path. The conversation kept two overlapping inventory fields — `coreToolNames` (constructor snapshot, used only as a pre-first-turn fallback) and `lastResolvedToolNames` (per-turn resolved name set) — and resolved names to definitions lazily.

Collapsed into one `registeredToolDefinitions: ToolDefinition[]`:
- seeded directly in the constructor from the initial snapshot (where `coreToolNames` used to be set), so it's always populated and the `?? coreToolNames` fallback is gone;
- the `resolveTools` callback records resolved definitions each turn (resolving skill/MCP/plugin tools against the live registry);
- `coreToolNames` and `getRegisteredToolNames` deleted (the one name-only consumer derives names from the defs);
- `getRegisteredToolDefinitions()` is now a plain getter.

No behaviour change to the reported inventory.

## Test plan

- New regression coverage in `conversation-tool-setup-exclude.test.ts`: workspace-disabled plugin stays hidden with no per-chat scope; an explicit scope re-enables its tool; a scope that omits a disabled plugin keeps it hidden.
- `conversation-tool-setup-tools-disabled.test.ts` updated for the `registeredToolDefinitions` shape; `tools-get-route` + `turn-trace-store` (the two external consumers) green.
- End-to-end against a Docker-hatched local daemon: cases 1 & 2 pass; case 3 now surfaces the tool on the first post-disable turn (the multi-turn regression is the follow-up's job).
- Full affected suite green per-file (registry, conversation-tool-setup-*, subagent-*, tools-get-route, turn-trace-store, file-list-tool, agent-loop-*, benchmark). `tsc` + eslint clean; pre-commit/pre-push hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ok5MKKrM4ZnmqG3AeXWtc

---
_Generated by [Claude Code](https://claude.ai/code/session_014ok5MKKrM4ZnmqG3AeXWtc)_