### PR TITLE
feat(web): remove error-state chrome from chat drawer timelines, dim connector lines

### DIFF
--- a/clients/web/src/domains/chat/components/activity-steps-panel.tsx
+++ b/clients/web/src/domains/chat/components/activity-steps-panel.tsx
@@ -226,7 +226,6 @@ function TimelineStep({
         label={truncate(step.text, THINKING_PILL_MAX_CHARS)}
         ariaLabel="View thinking"
         active={false}
-        tone="default"
         onClick={() =>
           onOpenDetail({
             kind: "thinking",
@@ -259,11 +258,6 @@ function TimelineStep({
       iconName={step.iconName}
       label={step.activity || step.info || step.title}
       active={activeDetail?.toolCallId === step.toolCallId}
-      tone={
-        step.status === "error" || step.status === "denied"
-          ? "error"
-          : "default"
-      }
       onClick={() => {
         if (!tc) {
           return;

--- a/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-phase-timeline.tsx
@@ -527,11 +527,6 @@ const SubagentPhaseRow = memo(function SubagentPhaseRow({
                         variant="tool"
                         iconName={step.iconName}
                         label={step.activity || step.info || step.title}
-                        tone={
-                          step.status === "error" || step.status === "denied"
-                            ? "error"
-                            : "default"
-                        }
                         ariaLabel="View tool details"
                         onClick={() => onStepDetailClick(detailKey)}
                       />
@@ -567,9 +562,9 @@ const SubagentPhaseRow = memo(function SubagentPhaseRow({
                     );
                   }
                   if (step.kind === "web_search_error") {
-                    // A failed search becomes an error-toned pill that opens the
-                    // full, untruncated provider error in the nested detail —
-                    // parity with a failed tool. Falls back to the inline error chip
+                    // A failed search becomes a pill that opens the full,
+                    // untruncated provider error in the nested detail —
+                    // parity with a failed tool. Falls back to the inline chip
                     // below when no detail handler is wired (deploy-safe).
                     return (
                       <ToolStepPill
@@ -577,7 +572,6 @@ const SubagentPhaseRow = memo(function SubagentPhaseRow({
                         variant="tool"
                         iconName="globe"
                         label={step.errorMessage}
-                        tone="error"
                         ariaLabel="View search error"
                         onClick={() => onStepDetailClick(detailKey)}
                       />

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.test.tsx
@@ -116,17 +116,17 @@ describe("PhaseGroupedStepList — phase header status icon", () => {
     expect(icons[0]!.children.length).toBe(3);
   });
 
-  test("phase with a tool_error step renders the failed icon", () => {
+  test("phase with a tool_error step renders the completed icon (no error chrome)", () => {
     const steps: ToolCallCardStep[] = [
       { kind: "tool_error", message: "context window exceeded" },
     ];
     const { getAllByTestId } = render(<PhaseGroupedStepList steps={steps} />);
     const icons = getAllByTestId("phase-header-status-icon");
     expect(icons.length).toBe(1);
-    expect(icons[0]!.getAttribute("data-status")).toBe("failed");
+    expect(icons[0]!.getAttribute("data-status")).toBe("completed");
   });
 
-  test("phase with a tool step status='error' renders the failed icon", () => {
+  test("phase with a tool step status='error' renders the completed icon (no error chrome)", () => {
     const steps: ToolCallCardStep[] = [
       bash("ls", "completed", "1s", "tc-a"),
       bash("rm -rf /nope", "error", "1s", "tc-b"),
@@ -134,17 +134,17 @@ describe("PhaseGroupedStepList — phase header status icon", () => {
     const { getAllByTestId } = render(<PhaseGroupedStepList steps={steps} />);
     const icons = getAllByTestId("phase-header-status-icon");
     expect(icons.length).toBe(1);
-    expect(icons[0]!.getAttribute("data-status")).toBe("failed");
+    expect(icons[0]!.getAttribute("data-status")).toBe("completed");
   });
 
-  test("phase with a tool step status='denied' renders the failed icon", () => {
+  test("phase with a tool step status='denied' renders the completed icon (no error chrome)", () => {
     const steps: ToolCallCardStep[] = [
       bash("sudo rm -rf /", "denied", "", "tc-a"),
     ];
     const { getAllByTestId } = render(<PhaseGroupedStepList steps={steps} />);
     const icons = getAllByTestId("phase-header-status-icon");
     expect(icons.length).toBe(1);
-    expect(icons[0]!.getAttribute("data-status")).toBe("failed");
+    expect(icons[0]!.getAttribute("data-status")).toBe("completed");
   });
 
   test("phase with a failed step and a running step renders three-dot (running wins)", () => {
@@ -257,7 +257,7 @@ describe("PhaseGroupedStepList — timeline mode", () => {
     expect(icons[0]!.tagName.toLowerCase()).toBe("svg");
   });
 
-  test("failed section renders the circular AlertCircle node with data-status", () => {
+  test("failed section renders the circular completed node (no error chrome)", () => {
     const steps: ToolCallCardStep[] = [
       { kind: "tool_error", message: "context window exceeded" },
     ];
@@ -265,7 +265,7 @@ describe("PhaseGroupedStepList — timeline mode", () => {
       <PhaseGroupedStepList steps={steps} timeline />,
     );
     const icons = getAllByTestId("phase-header-status-icon");
-    expect(icons[0]!.getAttribute("data-status")).toBe("failed");
+    expect(icons[0]!.getAttribute("data-status")).toBe("completed");
     expect(icons[0]!.tagName.toLowerCase()).toBe("svg");
   });
 
@@ -387,13 +387,13 @@ describe("phaseHeaderStatus", () => {
     expect(phaseHeaderStatus(steps)).toBe("running");
   });
 
-  test("returns 'failed' when a step errored or was denied with none running", () => {
+  test("returns 'completed' when a step errored or was denied with none running", () => {
     expect(
       phaseHeaderStatus([bash("rm -rf /nope", "error", "1s", "tc-a")]),
-    ).toBe("failed");
+    ).toBe("completed");
     expect(
       phaseHeaderStatus([bash("sudo rm -rf /", "denied", "", "tc-b")]),
-    ).toBe("failed");
+    ).toBe("completed");
   });
 
   test("returns 'completed' otherwise", () => {

--- a/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/phase-grouped-step-list.tsx
@@ -16,8 +16,6 @@
  */
 
 import {
-  AlertCircle,
-  AlertTriangle,
   Bolt,
   Brain,
   Check,
@@ -188,19 +186,15 @@ export function sumDurationLabels(labels: string[]): string {
   return formatMs(total);
 }
 
-/**
- * Header status states a phase can render. "Running" wins over "failed" so
- * an in-flight retry inside a phase that has already produced a failure
- * still reads as in-progress.
- */
-type PhaseHeaderStatus = "completed" | "failed" | "running";
+/** Header status states a phase can render. */
+type PhaseHeaderStatus = "completed" | "running";
 
 /**
- * Classify a phase's overall status for header icon rendering.
- *
- * Precedence: any running step → "running"; otherwise any failure
- * (`tool_error` / `web_search_error` / `tool` status `error`|`denied`) →
- * "failed"; otherwise → "completed".
+ * Classify a phase's overall status for header icon rendering: any running
+ * step → "running"; otherwise → "completed". Failures (`tool_error` /
+ * `web_search_error` / `tool` status `error`|`denied`) intentionally read as
+ * "completed" — error chrome carries no value for the user, so settled phases
+ * all render the same regardless of outcome.
  *
  * `web_search` steps carry no explicit status field — `useToolCallCardData`
  * encodes "in-flight" via the present-tense title ("Searching the web" vs
@@ -211,25 +205,18 @@ export function phaseHeaderStatus(
   steps: ToolCallCardStep[],
 ): PhaseHeaderStatus {
   if (steps.length === 0) return "running";
-  let failed = false;
   for (const step of steps) {
     if (step.kind === "tool") {
       if (step.status === "running") return "running";
-      if (step.status === "error" || step.status === "denied") failed = true;
       continue;
     }
     if (step.kind === "web_search") {
       // Title is the canonical in-flight signal — see `webSearchStepTitle`
       // in `use-tool-call-card-data.ts`.
       if (step.title === "Searching the web") return "running";
-      continue;
     }
-    if (step.kind === "tool_error" || step.kind === "web_search_error") {
-      failed = true;
-    }
-    // `thinking` is neutral — see docstring.
   }
-  return failed ? "failed" : "completed";
+  return "completed";
 }
 
 /** Phase-grouped section as consumed by the renderer. */
@@ -455,7 +442,7 @@ export function TimelineConnector({ className }: { className?: string }) {
     <div
       aria-hidden
       className={cn(
-        "absolute bottom-0 left-[6.5px] top-6 w-px bg-[var(--border-element)]",
+        "absolute bottom-0 left-[6.5px] top-6 w-px bg-[var(--border-subtle)]",
         className,
       )}
     />
@@ -490,10 +477,9 @@ export function TimelineNode({
 /**
  * Circular status node for the vertical timeline. Mirrors the card header's
  * iconography for visual harmony — a green `CheckCircle2` when the phase
- * completed, a red `AlertCircle` when it failed, and the animated
- * `ThreeDotIndicator` while running. Keeps the `data-testid` /
- * `data-status` attributes the flat `PhaseHeaderRow` stamps so existing
- * status-icon assertions resolve against either layout.
+ * settled and the animated `ThreeDotIndicator` while running. Keeps the
+ * `data-testid` / `data-status` attributes the flat `PhaseHeaderRow` stamps
+ * so existing status-icon assertions resolve against either layout.
  */
 function TimelineNodeIcon({
   status,
@@ -509,16 +495,6 @@ function TimelineNodeIcon({
         data-testid={testId}
         data-status="completed"
         className="h-[14px] w-[14px] shrink-0 text-[var(--system-positive-strong)]"
-      />
-    );
-  }
-  if (status === "failed") {
-    return (
-      <AlertCircle
-        aria-hidden="true"
-        data-testid={testId}
-        data-status="failed"
-        className="h-[14px] w-[14px] shrink-0 text-[var(--system-negative-strong)]"
       />
     );
   }
@@ -558,13 +534,6 @@ function PhaseHeaderRow({
             data-testid="phase-header-status-icon"
             data-status="completed"
             className="h-[14px] w-[14px] text-[var(--system-positive-strong)]"
-          />
-        ) : status === "failed" ? (
-          <AlertTriangle
-            aria-hidden="true"
-            data-testid="phase-header-status-icon"
-            data-status="failed"
-            className="h-[14px] w-[14px] text-[var(--system-negative-strong)]"
           />
         ) : (
           <ThreeDotIndicator
@@ -660,14 +629,14 @@ export function DefaultStepPill({ step }: { step: ToolCallCardStep }) {
   }
   if (step.kind === "tool_error") {
     return (
-      <StepPill tone="error">
+      <StepPill>
         <PillText>{step.message}</PillText>
       </StepPill>
     );
   }
   if (step.kind === "web_search_error") {
     return (
-      <StepPill tone="error">
+      <StepPill>
         <PillText>{step.errorMessage}</PillText>
       </StepPill>
     );
@@ -699,21 +668,11 @@ function PillText({ children }: { children: ReactNode }) {
   );
 }
 
-function StepPill({
-  tone = "default",
-  children,
-}: {
-  tone?: "default" | "error";
-  children: ReactNode;
-}) {
-  const toneClasses =
-    tone === "error"
-      ? "border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]"
-      : "border-[var(--border-element)] bg-transparent text-[var(--content-default)]";
+function StepPill({ children }: { children: ReactNode }) {
   return (
     <div
       data-testid="phase-step-pill"
-      className={`inline-flex min-w-0 max-w-full items-center gap-1 self-start rounded-full border px-2 py-1 ${toneClasses}`}
+      className="inline-flex min-w-0 max-w-full items-center gap-1 self-start rounded-full border border-[var(--border-element)] bg-transparent px-2 py-1 text-[var(--content-default)]"
     >
       {children}
     </div>

--- a/clients/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
@@ -25,10 +25,6 @@ const meta: Meta<typeof ToolStepPill> = {
       ],
     },
     label: { control: "text" },
-    tone: {
-      control: "inline-radio",
-      options: ["default", "error"],
-    },
     active: { control: "boolean" },
   },
 };
@@ -68,14 +64,6 @@ export const Clickable: Story = {
     iconName: "plug",
     label: "linear.createIssue",
     onClick: () => {},
-  },
-};
-
-export const ErrorTone: Story = {
-  args: {
-    iconName: "bolt",
-    label: "Command failed with exit code 1",
-    tone: "error",
   },
 };
 
@@ -182,7 +170,6 @@ export const AllVariants: Story = {
       <ToolStepPill
         iconName="bolt"
         label="Command failed with exit code 1"
-        tone="error"
       />
       <ToolStepPill
         iconName="sparkle"

--- a/clients/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
+++ b/clients/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
@@ -29,7 +29,6 @@ import { ICON_MAP } from "@/domains/chat/components/tool-progress-card/phase-gro
 interface ToolStepPillBaseProps {
   /** Truncating pill label. */
   label: string;
-  tone?: "default" | "error";
   /** Accessible label for the pill. Defaults per-variant. */
   ariaLabel?: string;
 }
@@ -81,12 +80,8 @@ const BASE_CLASSES =
 const INTERACTIVE_BASE =
   "transition-colors cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--border-focus)]";
 
-/** Resting / hover fill for a non-active pill in the given tone. */
-function idleColorClasses(tone: "default" | "error"): string {
-  return tone === "error"
-    ? "bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]"
-    : "bg-[var(--surface-overlay)] text-[var(--content-default)]";
-}
+/** Resting / hover fill for a non-active pill. */
+const IDLE_COLOR_CLASSES = "bg-[var(--surface-overlay)] text-[var(--content-default)]";
 
 /**
  * 14px favicon glyph occupying the same slot as the tool variant's lucide icon.
@@ -136,7 +131,6 @@ function WebStepPill({
   url,
   faviconUrl,
   domain,
-  tone = "default",
   ariaLabel,
 }: ToolStepPillWebProps) {
   return (
@@ -147,7 +141,7 @@ function WebStepPill({
       data-testid="tool-step-pill"
       data-variant="web"
       aria-label={ariaLabel ?? `Open ${label}`}
-      className={`${BASE_CLASSES} ${INTERACTIVE_BASE} max-w-[240px] no-underline hover:bg-[var(--surface-active)] ${idleColorClasses(tone)}`}
+      className={`${BASE_CLASSES} ${INTERACTIVE_BASE} max-w-[240px] no-underline hover:bg-[var(--surface-active)] ${IDLE_COLOR_CLASSES}`}
     >
       <PillFavicon faviconUrl={faviconUrl} domain={domain} label={label} />
       <Typography
@@ -164,40 +158,22 @@ export function ToolStepPill(props: ToolStepPillProps) {
   if (props.variant === "web") {
     return <WebStepPill {...props} />;
   }
-  const {
-    iconName,
-    label,
-    onClick,
-    tone = "default",
-    active = false,
-    ariaLabel,
-  } = props;
+  const { iconName, label, onClick, active = false, ariaLabel } = props;
   // Active = a filled `--surface-active` background with the resting border /
-  // text kept neutral (the colored border read poorly against the card). Active
-  // overrides tone's background wholesale so we never emit conflicting
-  // arbitrary-value classes — Tailwind resolves equal-specificity collisions by
-  // stylesheet order, not class-attribute order.
+  // text kept neutral (the colored border read poorly against the card).
   // No outline. Idle pills carry a `--surface-overlay` fill; the open pill
   // (its drawer showing) reads as active via the stronger `--surface-active`.
   const colorClasses = active
-    ? tone === "error"
-      ? "bg-[var(--surface-active)] text-[var(--system-negative-strong)]"
-      : "bg-[var(--surface-active)] text-[var(--content-default)]"
-    : tone === "error"
-      ? "bg-[var(--system-negative-weak)] text-[var(--system-negative-strong)]"
-      : "bg-[var(--surface-overlay)] text-[var(--content-default)]";
+    ? "bg-[var(--surface-active)] text-[var(--content-default)]"
+    : IDLE_COLOR_CLASSES;
 
   const Glyph = ICON_MAP[iconName] ?? Bolt;
-  const iconColor =
-    tone === "error"
-      ? "text-[var(--system-negative-strong)]"
-      : "text-[var(--content-tertiary)]";
 
   const labelContent = (
     <>
       <Glyph
         aria-hidden="true"
-        className={`h-3.5 w-3.5 shrink-0 ${iconColor}`}
+        className="h-3.5 w-3.5 shrink-0 text-[var(--content-tertiary)]"
       />
       <Typography
         variant="body-small-default"

--- a/clients/web/src/domains/chat/components/web-search/web-search-step-row.tsx
+++ b/clients/web/src/domains/chat/components/web-search/web-search-step-row.tsx
@@ -10,7 +10,6 @@
  * identical visuals for the same step descriptors.
  */
 
-import { AlertCircle } from "lucide-react";
 import { useState } from "react";
 
 import { Popover, Typography } from "@vellumai/design-library";
@@ -129,24 +128,19 @@ export function OverflowChip({ results }: { results: WebSearchResultItem[] }) {
 }
 
 /**
- * Negatively-toned chip used inside a `web_search_error` step row to
- * surface the provider's `errorMessage`. Mirrors the default pill's
- * outlined geometry but swaps the border + foreground tokens for the
- * `--system-negative-*` family so the failure reads as distinct from a
- * normal reasoning step.
+ * Chip used inside a `web_search_error` step row to surface the provider's
+ * `errorMessage`. Uses the default pill's outlined geometry and neutral
+ * tokens — failures render like any other step, without error chrome.
  */
 function ErrorChip({ message }: { message: string }) {
   return (
     <div
       data-testid="web-search-error-chip"
-      className="inline-flex items-center gap-1 rounded-[var(--radius-pill)] border border-[var(--system-negative-weak)] bg-[var(--system-negative-weak)] px-[10px] py-[6px]"
+      className="inline-flex items-center gap-1 rounded-[var(--radius-pill)] border border-[var(--border-element)] bg-transparent px-[10px] py-[6px]"
     >
-      <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
-        <AlertCircle className="h-[14px] w-[14px] text-[var(--system-negative-strong)]" />
-      </span>
       <Typography
         variant="body-small-default"
-        className="text-[var(--system-negative-strong)]"
+        className="text-[var(--content-default)]"
       >
         {message}
       </Typography>


### PR DESCRIPTION
## Summary
- Remove the red error pills and error icons from the chat page's detail side-drawer timelines (activity steps panel and subagent detail panel): failed tool / web-search steps now render as normal neutral pills, and settled phases always show the green check instead of a red `AlertCircle`/`AlertTriangle` — error chrome wasn't useful for the user.
- Drop the `tone` prop from `ToolStepPill` / `StepPill` and the negative tokens + alert icon from the web-search `ErrorChip`, since nothing renders an error tone anymore.
- Dim the vertical timeline connector lines in the drawer from `--border-element` to `--border-subtle` — they read too bright.

## Original prompt
On the chat page (post-polish), the detailed side-drawer shows red colors and error states. Remove all the red error state pills (render them normally instead) and the error icons — error states aren't really useful for the user. Also, the timeline lines in the drawer appear too bright; use a dimmer color for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)