### PR TITLE
Voice first-run card copy pass + custom-avatar room parity (JARVIS-1278)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -24,7 +24,9 @@ import {
 import { VoiceAvatar } from "./voice-avatar";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
 import {
+  VoiceRespondingRings,
   VoiceRoomColorLook,
+  VoiceStateCaption,
   resolveVoiceRoomLook,
   type VoiceEyePlacement,
   type VoiceRespondingStyle,
@@ -36,11 +38,12 @@ import {
  * with the `amplitude` slider or the `oscillate` "simulated speech" toggle — no
  * live mic / STT / TTS session required.
  *
- * `listening` renders the bottom-edge waves (energy coming *in* from the user)
- * and the avatar stays at rest; `responding` is the avatar's own outward pulse
- * (energy going *out*). Wave `waveStyle` (fill / line) and `palette` (aurora /
- * accent) are the design knobs. `realAvatar` swaps the "V" fallback for a real
- * bundled character.
+ * `listening` renders the top-edge waves (energy coming *in* from the user)
+ * and the avatar stays at rest; `responding` radiates the concentric rings from
+ * behind the avatar (energy going *out*, the same treatment the color look's
+ * eyes use). Wave `waveStyle` (fill / line) and `palette` (aurora / accent) are
+ * the design knobs. `realAvatar` swaps the "V" fallback for a real bundled
+ * character.
  *
  * Nothing hits the network: the real avatar is seeded into the query cache
  * below, on the room's own deep-dark `data-theme="dark"` void.
@@ -143,8 +146,12 @@ interface RoomSceneProps {
 
 /**
  * A full room scene for one visual: the deep-dark void, ambient particles, the
- * bottom listening waves (only in `listening`), and the centered avatar — all
- * driven by one shared amplitude source so the avatar and waves move together.
+ * top-edge listening waves (only in `listening`), the responding rings behind
+ * the avatar (only in `responding`), the centered avatar, and the shared state
+ * caption below it — all driven by one shared amplitude source so the avatar,
+ * waves, and rings move together. Mirrors the app's void look, which shares the
+ * color look's foreground chrome (top waves + rings + caption) bar the
+ * full-screen color and eyes.
  */
 function RoomScene({
   visual,
@@ -157,8 +164,10 @@ function RoomScene({
   minHeight = 420,
 }: RoomSceneProps) {
   const getAmplitude = useAmplitudeDriver(amplitude, oscillate);
+  const { ref, size: box } = useBoxSize();
   return (
     <div
+      ref={ref}
       data-theme="dark"
       className="relative flex items-center justify-center overflow-hidden rounded-lg"
       style={{ background: "#05060b", minHeight, ["--avatar-accent" as string]: SAMPLE_ACCENT }}
@@ -169,7 +178,15 @@ function RoomScene({
           getAmplitude={getAmplitude}
           waveStyle={waveStyle}
           palette={palette}
+          // Same top edge as the color look — positional parity.
+          placement="top"
         />
+      ) : null}
+      {/* Responding: the same concentric rings the color look radiates from
+          behind the eyes, here behind the centered avatar. Sized against the
+          story box (not the window) so they match this frame. */}
+      {visual === "responding" && box.w > 0 ? (
+        <VoiceRespondingRings getAmplitude={getAmplitude} viewport={box} />
       ) : null}
       <div className="relative z-0 flex items-center justify-center">
         <VoiceAvatar
@@ -179,6 +196,12 @@ function RoomScene({
           size={size}
         />
       </div>
+      {/* Shared caption below the centered avatar (half its size from center,
+          plus a gap), matching the app's void look. */}
+      <VoiceStateCaption
+        visual={visual}
+        top={`calc(50% + ${size / 2}px + 1.25rem)`}
+      />
     </div>
   );
 }
@@ -510,7 +533,7 @@ const voidArgTypes = {
   replay: { table: { disable: true } },
 };
 
-/** Void-look playground — the centered avatar, ambient void, and bottom waves. */
+/** Void-look playground — the centered avatar, ambient void, and top waves. */
 export const VoidLookPlayground: VoidStory = {
   name: "Void Look — Playground",
   render: (args) => <RoomScene {...args} />,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -54,7 +54,7 @@ describe("VoiceFirstRunCard", () => {
     );
 
     expect(getByText("Voice mode")).toBeTruthy();
-    expect(getByText("Start")).toBeTruthy();
+    expect(getByText("Start talking")).toBeTruthy();
     expect(onStart).not.toHaveBeenCalled();
   });
 
@@ -77,7 +77,7 @@ describe("VoiceFirstRunCard", () => {
       <VoiceFirstRunCard assistantId="asst_test" onStart={onStart} />,
     );
 
-    fireEvent.click(getByText("Start"));
+    fireEvent.click(getByText("Start talking"));
     expect(onStart).toHaveBeenCalledTimes(1);
   });
 
@@ -90,7 +90,7 @@ describe("VoiceFirstRunCard", () => {
     );
 
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
-    fireEvent.click(getByText("Start"));
+    fireEvent.click(getByText("Start talking"));
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -5,6 +5,7 @@ import { Modal } from "@vellumai/design-library/components/modal";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /**
  * One-time welcome card shown the first time a user enters voice mode, before
@@ -41,6 +42,9 @@ export function VoiceFirstRunCard({
 }: VoiceFirstRunCardProps) {
   const { components, traits, customImageUrl } =
     useAssistantAvatar(assistantId);
+  const assistantName = useResolvedAssistantsStore.use
+    .assistants()
+    .find((a) => a.id === assistantId)?.name;
 
   return (
     <Modal.Root
@@ -67,53 +71,46 @@ export function VoiceFirstRunCard({
             <Modal.Title>Voice mode</Modal.Title>
           </div>
           <Modal.Description>
-            A hands-free, spoken conversation with your assistant.
+            A hands-free, spoken conversation with {assistantName ?? "your assistant"}.
           </Modal.Description>
         </Modal.Header>
         <Modal.Body>
-          <div className="flex flex-col gap-3">
-            {/* Each bullet's icon matches the in-session control it describes,
-                so the card doubles as a legend for the room. */}
-            <ul className="flex flex-col gap-2.5">
-              <li className="flex items-start gap-2.5">
-                <AudioLines
-                  aria-hidden
-                  className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
-                />
-                <span className="text-body-medium-default">
-                  Speak naturally — your assistant listens and replies out
-                  loud.
-                </span>
-              </li>
-              <li className="flex items-start gap-2.5">
-                <MicOff
-                  aria-hidden
-                  className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
-                />
-                <span className="text-body-medium-default">
-                  Mute the mic whenever you need to, without ending the
-                  session.
-                </span>
-              </li>
-              <li className="flex items-start gap-2.5">
-                <Captions
-                  aria-hidden
-                  className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
-                />
-                <span className="text-body-medium-default">
-                  Turn on live captions from the session controls.
-                </span>
-              </li>
-            </ul>
-            <p className="text-body-small-default text-[var(--content-tertiary)]">
-              You can change any of this anytime, in the session or in
-              Settings.
-            </p>
-          </div>
+          {/* Each bullet's icon matches the in-session control it describes,
+              so the card doubles as a legend for the room. */}
+          <ul className="flex flex-col gap-4">
+            <li className="flex items-start gap-2.5">
+              <AudioLines
+                aria-hidden
+                className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
+              />
+              <span className="text-body-medium-default">
+                Speak naturally and {assistantName ?? "your assistant"} replies
+                out loud.
+              </span>
+            </li>
+            <li className="flex items-start gap-2.5">
+              <MicOff
+                aria-hidden
+                className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
+              />
+              <span className="text-body-medium-default">
+                Mute the mic without ending the session.
+              </span>
+            </li>
+            <li className="flex items-start gap-2.5">
+              <Captions
+                aria-hidden
+                className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
+              />
+              <span className="text-body-medium-default">
+                Turn on live captions anytime.
+              </span>
+            </li>
+          </ul>
         </Modal.Body>
         <Modal.Footer>
           <Button variant="primary" onClick={onStart}>
-            Start
+            Start talking
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
@@ -2,9 +2,9 @@
  * Listening-state waves for the voice room: layered sine waves that swell as
  * the user speaks — the visual language of energy coming *in* (the user's
  * voice arriving), the counterpart to the assistant's outward `responding`
- * pulse on the avatar. `placement` anchors the band: `bottom` rises from the
- * floor edge (the void look), `center` is a symmetric band around the middle
- * (the color look, gathering behind the centered eyes).
+ * pulse on the avatar. `placement` anchors the band: `top` sweeps in from the
+ * ceiling edge (both looks — above the centerpiece, leaving it clear), `bottom`
+ * rises from the floor edge, `center` is a symmetric band around the middle.
  *
  * The waves always drift horizontally (a slow CSS loop); the user's live mic
  * amplitude drives how high they rise and how bright they are, written
@@ -72,9 +72,9 @@ export type VoiceWaveStyle = "fill" | "line";
 export type VoiceWavePalette = "aurora" | "accent" | "tone";
 
 /**
- * Where the wave band sits: `bottom` rises from the floor edge (the void
- * look), `top` sweeps in from the ceiling edge (the color look — the voice
- * arriving above the centered eyes, leaving them clear), `center` swells
+ * Where the wave band sits: `top` sweeps in from the ceiling edge (both room
+ * looks — the voice arriving above the centered eyes / avatar, leaving the
+ * centerpiece clear), `bottom` rises from the floor edge, `center` swells
  * symmetrically around the middle of the screen.
  */
 export type VoiceWavePlacement = "bottom" | "top" | "center";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -421,16 +421,18 @@ export function VoiceRoomColorLook({
  * negative space below the eyes, in the room's foreground tone. Cross-fades on
  * state change and simply isn't there for states without a caption
  * ({@link EYE_STATE_CAPTION}) — idle and the connecting-side states, which the
- * room's own connect label already covers. `top` is a stable px anchor from the
- * eyes' full-size bottom edge (the per-state resize is centered, so it doesn't
- * shift this).
+ * room's own connect label already covers. `top` is a stable anchor from the
+ * centerpiece's bottom edge — a px number off the eyes' full-size bottom (color
+ * look; the per-state resize is centered, so it doesn't shift this), or a CSS
+ * length off the fixed avatar size (the void look). Shared by both looks so the
+ * caption reads in the same place regardless of avatar type.
  */
-function VoiceStateCaption({
+export function VoiceStateCaption({
   visual,
   top,
 }: {
   visual: VoiceAvatarVisual;
-  top: number;
+  top: number | string;
 }) {
   const reduce = useReducedMotion();
   const label = EYE_STATE_CAPTION[visual];
@@ -640,6 +642,7 @@ function VoiceRespondingTreatment({
     <div
       ref={ampRef}
       aria-hidden="true"
+      data-testid="voice-responding-rings"
       className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center"
       style={{ opacity: "calc(0.25 + var(--resp-amp, 0) * 0.75)" }}
     >
@@ -665,6 +668,35 @@ function VoiceRespondingTreatment({
         />
       ))}
     </div>
+  );
+}
+
+/**
+ * The `rings` responding treatment as a self-contained layer: the concentric
+ * rings radiating outward from screen center on the TTS-output amplitude, sized
+ * against the live window (pass `viewport` to size against a box instead —
+ * Storybook). Exported for the void look, which renders it behind the centered
+ * avatar so a custom avatar emits the same rings the eyes do in the color look.
+ */
+export function VoiceRespondingRings({
+  getAmplitude,
+  viewport,
+}: {
+  /** TTS (output) amplitude source (0–1) — drives the rings' presence. */
+  getAmplitude?: () => number;
+  /** Override the room box (Storybook renders in a box, not the full window). */
+  viewport?: { w: number; h: number };
+}) {
+  const measured = useViewportSize();
+  return (
+    <VoiceRespondingTreatment
+      style="rings"
+      getAmplitude={getAmplitude}
+      // waveStyle/wavePlacement are only read by the `waveform` style; inert here.
+      waveStyle="fill"
+      wavePlacement="top"
+      viewport={viewport ?? measured}
+    />
   );
 }
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -198,7 +198,7 @@ describe("VoiceRoom — visibility", () => {
 describe("VoiceRoom — listening waves", () => {
   const waves = () => screen.queryByTestId("listening-waves");
 
-  test("mounts the bottom waves while listening (energy coming in)", () => {
+  test("mounts the listening waves while listening (energy coming in)", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     expect(roomDialog()).not.toBeNull();
@@ -449,7 +449,7 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
   });
 });
 
-describe("VoiceRoom — color-look state caption", () => {
+describe("VoiceRoom — state caption (shared across looks)", () => {
   const caption = () => screen.queryByTestId("voice-state-caption");
 
   function renderCharacterLook(state: LiveVoiceSessionState) {
@@ -457,6 +457,18 @@ describe("VoiceRoom — color-look state caption", () => {
       components: CHARACTER_COMPONENTS,
       traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
       customImageUrl: null,
+    };
+    startOwnedSession(state);
+    render(<VoiceRoom />);
+  }
+
+  // The void look (custom-image / unresolved avatar) carries the centered
+  // avatar, not the eyes, but shares the same caption in the same beat.
+  function renderVoidLook(state: LiveVoiceSessionState) {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: null,
+      customImageUrl: "blob:custom-avatar",
     };
     startOwnedSession(state);
     render(<VoiceRoom />);
@@ -479,6 +491,48 @@ describe("VoiceRoom — color-look state caption", () => {
     useVoicePrefsStore.setState({ showUserTranscript: true });
     renderCharacterLook("listening");
     expect(caption()?.textContent).toBe("Listening");
+  });
+
+  test("the void look shows the same caption below the custom avatar (parity)", () => {
+    renderVoidLook("speaking");
+    // Void look — the centered avatar, not the eyes — still names the beat.
+    expect(screen.getByTestId("voice-avatar")).toBeTruthy();
+    expect(screen.queryByTestId("voice-room-eyes")).toBeNull();
+    expect(caption()?.textContent).toBe("Speaking");
+  });
+
+  test("the void look stands its caption down for the assistant transcript too", () => {
+    useVoicePrefsStore.setState({ showAssistantTranscript: true });
+    renderVoidLook("speaking");
+    expect(caption()).toBeNull();
+  });
+});
+
+describe("VoiceRoom — void-look responding rings", () => {
+  const rings = () => screen.queryByTestId("voice-responding-rings");
+
+  function renderVoidLook(state: LiveVoiceSessionState) {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: null,
+      customImageUrl: "blob:custom-avatar",
+    };
+    startOwnedSession(state);
+    render(<VoiceRoom />);
+  }
+
+  test("emits the same concentric rings behind the custom avatar while responding", () => {
+    renderVoidLook("speaking");
+    // The custom avatar (not the eyes) is the centerpiece, but it radiates the
+    // color look's rings — parity with the eyes' responding treatment.
+    expect(screen.getByTestId("voice-avatar")).toBeTruthy();
+    expect(screen.queryByTestId("voice-room-eyes")).toBeNull();
+    expect(rings()).toBeTruthy();
+  });
+
+  test("shows no rings outside responding (energy going out only while speaking)", () => {
+    renderVoidLook("listening");
+    expect(rings()).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -67,10 +67,23 @@ import { VoiceAvatar } from "./voice-avatar";
 import { VoiceListeningWaves } from "./voice-listening-waves";
 import { AVATAR_ENTER_SPRING } from "./voice-motion";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
-import { VoiceRoomColorLook, resolveVoiceRoomLook } from "./voice-room-eyes";
+import {
+  VoiceRespondingRings,
+  VoiceRoomColorLook,
+  VoiceStateCaption,
+  resolveVoiceRoomLook,
+} from "./voice-room-eyes";
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
 
 const AVATAR_SIZE = 220;
+/**
+ * State caption anchor for the void look — just below the centered avatar's
+ * bottom edge (half its size from center, plus a gap), the void-look counterpart
+ * to the color look's caption below the eyes. Sits above the assistant
+ * transcript's `50% + 15vmin + 2.5rem` clearance on any typical viewport, and it
+ * only shows when that transcript is off (see below), so the two never collide.
+ */
+const VOID_CAPTION_TOP = `calc(50% + ${AVATAR_SIZE / 2}px + 1.75rem)`;
 
 /**
  * Safe-area insets (see `docs/CAPACITOR.md`): the `var()` is set by
@@ -208,8 +221,11 @@ function VoiceRoomOverlay() {
     >
       {/* The color look (body grow entrance + color fade + centered waves +
           centered eyes) is the entire cast; the void look expresses the
-          session through the centered avatar and the bottom listening waves
-          instead. Both draw the waves only while `listening`, from live mic
+          session through the centered avatar, but shares the color look's
+          foreground chrome — the listening waves sweep in from the same top edge
+          and the same state caption names the beat below the centerpiece — so
+          the room reads identically for a custom avatar bar the full-screen
+          color + eyes. Both draw the waves only while `listening`, from live mic
           amplitude. */}
       {look ? (
         <VoiceRoomColorLook
@@ -231,7 +247,24 @@ function VoiceRoomOverlay() {
             <VoiceListeningWaves
               getAmplitude={getLiveVoiceInputAmplitude}
               palette="accent"
+              // Same top edge as the color look, above the centered avatar —
+              // positional parity, only the aurora/accent color differs from the
+              // color look's avatar-toned band.
+              placement="top"
             />
+          ) : null}
+          {/* Responding: the same concentric rings the color look radiates from
+              behind the eyes, here behind the centered avatar (both centered, so
+              they emanate from the centerpiece the same way). Rendered before the
+              avatar so it paints them behind it; rides the TTS-output amplitude. */}
+          {visual === "responding" ? (
+            <VoiceRespondingRings getAmplitude={getLiveVoiceOutputAmplitude} />
+          ) : null}
+          {/* Same state caption + gating as the color look (stands down only for
+              the assistant-transcript pref), anchored below the centered avatar
+              instead of the eyes. */}
+          {!showAssistantTranscript ? (
+            <VoiceStateCaption visual={visual} top={VOID_CAPTION_TOP} />
           ) : null}
         </>
       )}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -392,7 +392,7 @@ body {
  * the `responding` visual rides live amplitude (the assistant's TTS output),
  * fed imperatively through the `--voice-amp` custom property by a
  * requestAnimationFrame loop — never React state. `listening` stays at rest;
- * the user's voice is expressed by the bottom waves coming in (see
+ * the user's voice is expressed by the top-edge waves coming in (see
  * voice-listening-waves.tsx). See voice-avatar.tsx.
  *
  * The sonar ripple's cyan→indigo gradient is a deliberate decorative accent
@@ -452,7 +452,7 @@ body {
 
 /* Listening — the avatar stays receptive: no outward emanation (that moved to
  * responding), just a slight constant breathing pulse. The user's voice is
- * carried by the bottom waves coming in (see voice-listening-waves.tsx), not by
+ * carried by the top-edge waves coming in (see voice-listening-waves.tsx), not by
  * the avatar reacting to mic amplitude. */
 @keyframes voice-avatar-soft-pulse {
   0%, 100% { transform: scale(1); }
@@ -775,10 +775,11 @@ body {
   transform: scaleY(-1);
 }
 
-/* Placement: top = the band sweeps in from the ceiling edge (the color look —
- * the user's voice arriving above the centered eyes, leaving them clear). The
- * wave fill hugs the bottom of its viewBox, so a vertical flip pins the crests
- * to the top edge, rippling downward; the amplitude translate recedes the band
+/* Placement: top = the band sweeps in from the ceiling edge (both room looks —
+ * the user's voice arriving above the centered eyes / avatar, leaving the
+ * centerpiece clear). The wave fill hugs the bottom of its viewBox, so a
+ * vertical flip pins the crests to the top edge, rippling downward; the
+ * amplitude translate recedes the band
  * up out of view when quiet (the mirror of the bottom placement's recede-down). */
 .voice-listening-waves--top {
   top: 0;


### PR DESCRIPTION
Closes JARVIS-1278

Two related voice-room polish changes, one commit each.

## First-run card copy (`voice-first-run-card.tsx`)
- Subtitle and first bullet now use the **assistant's name**, resolved from `resolved-assistants-store` (falls back to "your assistant" before the store hydrates).
- Bullets tightened to single lines; em dash removed; dropped the trailing "You can change any of this…" line.
- More vertical breathing room between bullets (`gap-2.5` → `gap-4`).
- Primary action relabeled **"Start talking"**.

## Custom-avatar room parity — the void look
The void look (custom-image avatars) previously fell back to a bare centered avatar + bottom listening waves. It now shares the **color look's foreground chrome**:
- Listening waves sweep in from the **same top edge** (above the centerpiece), only the aurora/accent tone differs.
- The **responding rings** radiate from behind the centered avatar on **TTS-output amplitude** — the same emanation the eyes get in the color look (new exported `VoiceRespondingRings`).
- The **state caption** is anchored just below the centered avatar (new exported `VoiceStateCaption`, gated the same way — stands down only for the assistant-transcript pref).

Net: a custom-avatar room reads the same as a character room, minus the full-screen color + eyes.

## Verification
- `voice-first-run-card.test.tsx` + `voice-room.test.tsx` — 43 pass (copy assertions + new void-look parity coverage).
- `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)