### PR TITLE
fix(plugins): log platform catalog outages before mapping to 503

### DIFF
--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -112,6 +112,24 @@ import {
   type UpgradePluginOptions,
 } from "../../../cli/lib/upgrade-plugin.js";
 
+// Spy on the route logger so tests can assert that a platform-catalog outage
+// is recorded before it is mapped to a client 503. The catalog fetcher and the
+// transport adapters swallow the failure otherwise (`RouteError` → wire error,
+// no capture), so the log line is the only trace an operator gets — assert it.
+const logErrorSpy = mock((..._args: unknown[]) => {});
+const logWarnSpy = mock((..._args: unknown[]) => {});
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: logWarnSpy,
+    error: logErrorSpy,
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+  }),
+}));
+
 // Mutable list returned by the mocked library function. Tests reassign
 // `installedFixture` before invoking the handler.
 let installedFixture: InstalledPluginInfo[] = [];
@@ -302,6 +320,11 @@ const broadcastMessageSpy = mock((_msg: unknown): void => {});
 
 mock.module("../../assistant-event-hub.js", () => ({
   broadcastMessage: broadcastMessageSpy,
+  // Stub the hub singleton so the (now dynamically imported) plugins-routes
+  // dependency graph links — some transitive importer statically imports this
+  // binding. No tested path calls it; publishing goes through the mocked
+  // `broadcastMessage` above.
+  assistantEventHub: {},
 }));
 
 // Make the valid-slug source deterministic: the real `getLocalCategorySlugs`
@@ -335,11 +358,15 @@ import {
   NotFoundError,
   ServiceUnavailableError,
 } from "../errors.js";
-import {
+// `plugins-routes.js` is dynamically imported AFTER the logger mock above so
+// its module-level `const log = getLogger(...)` binds to the mocked logger. A
+// static import evaluates before any `mock.module` runs and would capture the
+// real logger at module init (same reason as `request-logger.test.ts`).
+const {
   loadCategoryMapBounded,
   normalizeMarketplaceCategory,
-  ROUTES as PLUGINS_ROUTES,
-} from "../plugins-routes.js";
+  ROUTES: PLUGINS_ROUTES,
+}: typeof import("../plugins-routes.js") = await import("../plugins-routes.js");
 import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
 import { RouteResponse } from "../types.js";
 
@@ -1099,6 +1126,7 @@ describe("GET /v1/plugins/search", () => {
   });
 
   test("PluginCatalogUnavailableError → ServiceUnavailableError (503)", async () => {
+    logErrorSpy.mockClear();
     getCatalogSpy.mockImplementation(async () => {
       throw new PluginCatalogUnavailableError(
         "GitHub contents listing failed for plugins @ main: HTTP 403",
@@ -1111,6 +1139,14 @@ describe("GET /v1/plugins/search", () => {
     await expect(
       invokeSearch({ queryParams: { q: "memory" } }),
     ).rejects.toBeInstanceOf(ServiceUnavailableError);
+
+    // The outage must be logged before it is mapped to a 503 — otherwise the
+    // transport adapters return the RouteError with no capture and the incident
+    // is invisible. The log carries the true upstream status the 503 collapses.
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    const [fields, msg] = logErrorSpy.mock.calls[0]!;
+    expect(msg).toBe("Platform plugin catalog unavailable");
+    expect(fields).toMatchObject({ operation: "search", upstreamStatus: 403 });
   });
 
   test("unknown errors → InternalError with original message preserved", async () => {
@@ -1579,6 +1615,7 @@ describe("POST /v1/plugins/install", () => {
   test("a catalog outage on the no-pin path → ServiceUnavailableError (503)", async () => {
     // A rate-limited or unavailable platform catalog (no stale fallback) is
     // transient — the route surfaces it as retryable, not a misleading 500.
+    logErrorSpy.mockClear();
     getCatalogSpy.mockImplementation(async () => {
       throw new PluginCatalogUnavailableError("HTTP 403", 403);
     });
@@ -1587,6 +1624,13 @@ describe("POST /v1/plugins/install", () => {
       invokeInstall({ body: { name: "caveman" } }),
     ).rejects.toBeInstanceOf(ServiceUnavailableError);
     expect(installSpy).not.toHaveBeenCalled();
+
+    // The outage is logged (operation "install") before the 503 mapping, so
+    // an install-path catalog failure is diagnosable rather than invisible.
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+    const [fields, msg] = logErrorSpy.mock.calls[0]!;
+    expect(msg).toBe("Platform plugin catalog unavailable");
+    expect(fields).toMatchObject({ operation: "install", upstreamStatus: 403 });
   });
 
   test("a missing name short-circuits to BadRequestError without calling the lib", async () => {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -88,9 +88,11 @@ import {
   PluginNotUpgradableError,
   upgradePlugin,
 } from "../../cli/lib/upgrade-plugin.js";
+import { getPlatformBaseUrl } from "../../config/env.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { ensurePluginApiShim } from "../../plugins/ensure-plugin-api-shim.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
+import { getLogger } from "../../util/logger.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -701,6 +703,37 @@ const pluginDiffResponseSchema = z.object({
 // Helpers
 // ---------------------------------------------------------------------------
 
+const log = getLogger("plugins-routes");
+
+/**
+ * Emit a structured log for a platform plugin-catalog outage before the caller
+ * maps it to a client-facing error.
+ *
+ * The catalog fetcher (`plugin-catalog-platform.ts`) throws
+ * `PluginCatalogUnavailableError` without logging, and the transport adapters
+ * return the resulting `RouteError` (a 503) without any Sentry capture — so an
+ * outage on the platform-first paths (`search`, `install`, the remote-only
+ * detail view) otherwise leaves no trace beyond the daemon access-log status
+ * code, and the real upstream status / URL is lost. Log at `error` so the
+ * outage is time-correlatable in the daemon log and surfaces in Sentry;
+ * `upstreamStatus` preserves the true platform status (e.g. 404 / 500 / 503)
+ * that the client-facing 503 collapses.
+ */
+function logPluginCatalogUnavailable(
+  operation: string,
+  err: PluginCatalogUnavailableError,
+): void {
+  log.error(
+    {
+      err,
+      operation,
+      upstreamStatus: err.status,
+      platformBaseUrl: getPlatformBaseUrl(),
+    },
+    "Platform plugin catalog unavailable",
+  );
+}
+
 interface PluginView {
   id: string;
   name: string;
@@ -880,10 +913,31 @@ export async function loadCategoryMapBounded(
       }),
     ]);
     if (!catalog) {
+      // Timed out past the budget: the installed list degrades to no
+      // categories rather than stalling. Non-fatal, but log it so a slow
+      // marketplace is diagnosable and not silently invisible.
+      log.warn(
+        { timeoutMs, platformBaseUrl: getPlatformBaseUrl() },
+        "Plugin catalog lookup timed out; listing without categories",
+      );
       return new Map();
     }
     return new Map(catalog.matches.map((m) => [m.name, m.category]));
-  } catch {
+  } catch (err) {
+    // The installed list must never fail on a catalog outage, so this degrades
+    // to no categories — but log it (warn: the request still succeeds) so the
+    // same platform outage that hard-fails search/install is not invisible on
+    // the list path. `upstreamStatus` is preserved when the failure carries one.
+    log.warn(
+      {
+        err,
+        platformBaseUrl: getPlatformBaseUrl(),
+        ...(err instanceof PluginCatalogUnavailableError
+          ? { upstreamStatus: err.status }
+          : {}),
+      },
+      "Plugin catalog lookup failed; listing without categories",
+    );
     return new Map();
   } finally {
     if (timer) {
@@ -999,6 +1053,7 @@ async function handleSearchPlugins({
     // misleading 500 so the client can show a "temporarily unavailable"
     // state and retry later.
     if (err instanceof PluginCatalogUnavailableError) {
+      logPluginCatalogUnavailable("search", err);
       throw new ServiceUnavailableError(err.message);
     }
     throw new InternalError(
@@ -1080,6 +1135,7 @@ async function handleGetPluginDetails({
     // transient — surface it as retryable rather than a misleading 404/500 so
     // clients retry instead of treating the plugin as permanently gone.
     if (err instanceof PluginCatalogUnavailableError) {
+      logPluginCatalogUnavailable("details", err);
       throw new ServiceUnavailableError(err.message);
     }
     throw new InternalError(
@@ -1207,6 +1263,7 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
     // A rate-limited or unavailable platform catalog (no stale fallback) is
     // transient — surface it as retryable rather than a misleading 500.
     if (err instanceof PluginCatalogUnavailableError) {
+      logPluginCatalogUnavailable("install", err);
       throw new ServiceUnavailableError(err.message);
     }
     throw new InternalError(


### PR DESCRIPTION
## Prompt / plan

Investigation handoff: a user hit deterministic 503s from the daemon on `GET /v1/plugins/search` and `POST /v1/plugins/install` (rendered as "upstream plugin registry backend problem… needs support@vellum.ai"), while `GET /v1/plugins` and `GET /v1/plugins/:name/inspect` returned 200. The 503 appeared in the daemon access log but **nowhere in Sentry or the GCP load-balancer logs**.

### Root cause

The two failing endpoints resolve their source from the **platform-first catalog** (`getPluginCatalog` → `GET {PLATFORM}/v1/plugins/`), which is intentionally fail-hard (no stale fallback). The endpoints that kept working don't depend on it the same way:

- `search` / `install` → `getPluginCatalog` → hard-fail → `PluginCatalogUnavailableError` → mapped to **503**.
- `GET /v1/plugins` (list) → same fetch via `loadCategoryMapBounded`, but bounded + swallowed → degrades to no categories → **200**.
- `GET /v1/plugins/:name/inspect` → reads GitHub (`api.github.com`) directly, and tolerates a remote failure via `remote-unavailable` → **200**.

This split (search/install on the platform catalog) was introduced by #37954 "Plugin catalog source consistency"; before it, they read GitHub like `inspect` still does.

**Why it was invisible:** the gateway calls these routes over **IPC**, not HTTP through the GCP LB, so the LB never sees the request or its 503. And `ServiceUnavailableError` is a `RouteError` — both the HTTP and IPC adapters map it straight to a wire error with no Sentry capture — while the catalog fetcher throws with no logging. The real upstream status (404/500/503) is collapsed into a flat 503 with no trace.

This PR is **lever 1 (observability only)** of the fix — it does not change the fail-hard behavior; that resilience decision (bundled-catalog fallback) is a separate follow-up.

### What changed

- Emit a structured `log.error` (`"Platform plugin catalog unavailable"`) at the three platform-first catch sites (`search`, `install`, remote-only `details`) **before** the 503 mapping, carrying `operation`, the true `upstreamStatus`, and `platformBaseUrl`.
- Log (at `warn`) the two swallowed degradation paths in the installed-list category lookup (timeout and error), so the same outage is not silently invisible on the list path.

No client-facing behavior changes: the 503 mapping and the list's graceful degradation are unchanged — the outage is now diagnosable in the daemon log and Sentry.

## Test plan

- Extended `plugins-routes.test.ts`: the `search` and `install` catalog-outage cases now assert the outage is logged once with the preserved `upstreamStatus`. The route module is dynamically imported after the logger mock so its module-level logger binds to the spy (mirrors `request-logger.test.ts`).
- `bun test src/runtime/routes/__tests__/plugins-routes.test.ts` → 111 pass, 0 fail.
- `tsc --noEmit` and `eslint` clean (also enforced by the pre-commit/pre-push hooks).

## CLI verb checklist

No new routes added — this only adds logging inside existing route handlers, so no `assistant` CLI verb is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lv24Sprv5JoA9Y5om8X8KC)_