### PR TITLE
Read a silent mid-turn voice room as thinking, not speaking (JARVIS-1279)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -237,4 +237,11 @@ export function seedLiveVoiceSession(
     store.setControls(options.controls);
   }
   store.setState(state);
+  // Mirror the controller's first-`tts_audio` write: entering `speaking` means
+  // audio is flowing, so the avatar reads `responding`. (A silent mid-turn
+  // `speaking` pause is the exception, exercised directly against
+  // `toVoiceAvatarVisual`.)
+  if (state === "speaking") {
+    store.setAssistantAudioActive(true);
+  }
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -167,6 +167,17 @@ export interface LiveVoiceState {
   /** Current phase of the session lifecycle. */
   state: LiveVoiceSessionState;
   /**
+   * Whether the assistant's TTS audio is actually queued/playing right now,
+   * tracked by the controller from the active {@link LiveVoiceAudioPlayer} with
+   * a short idle grace. The `speaking` phase mirrors server turn framing (set on
+   * the first `tts_audio`, cleared only on `tts_done`), so a turn that speaks an
+   * ack and then runs a tool stays `speaking` while silent; this flag lets the
+   * avatar distinguish "actively speaking" from "silent mid-turn" and read as
+   * `thinking` during the tool run (see `toVoiceAvatarVisual`, JARVIS-1279).
+   * Meaningful only while `state === "speaking"`.
+   */
+  assistantAudioActive: boolean;
+  /**
    * True while the controller is retrying a dropped connection (attempt > 0),
    * so surfaces can distinguish it from the initial-connect `connecting`.
    * Orthogonal to `state`, which stays a 1:1 mirror of the macOS enum.
@@ -254,6 +265,8 @@ export interface LiveVoiceState {
 export interface LiveVoiceActions {
   /** Replace the session phase. */
   setState: (state: LiveVoiceSessionState) => void;
+  /** Record whether assistant TTS audio is currently queued/playing. */
+  setAssistantAudioActive: (active: boolean) => void;
   /** Set whether the controller is retrying a dropped connection. */
   setReconnecting: (reconnecting: boolean) => void;
   /**
@@ -383,6 +396,7 @@ export function isLiveVoiceSessionOwnedBy(
 /** Session-scoped fields restored by `reset()`. Excludes `starter` (mount-scoped). */
 const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   state: "idle",
+  assistantAudioActive: false,
   reconnecting: false,
   assistantId: null,
   conversationId: null,
@@ -405,6 +419,8 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   starter: null,
 
   setState: (state) => set({ state }),
+  setAssistantAudioActive: (assistantAudioActive) =>
+    set({ assistantAudioActive }),
   setReconnecting: (reconnecting) => set({ reconnecting }),
   setSessionContext: (assistantId, conversationId) =>
     // A fresh session always opens with the mic live, even if the controller

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -212,6 +212,8 @@ describe("full turn", () => {
     });
     expect(h.view.result.current.state).toBe("speaking");
     expect(h.player.enqueued).toHaveLength(1);
+    // Audio is flowing, so the avatar reads `responding` (JARVIS-1279).
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
 
     // tts_done awaits playback drain, then ends the session (single-utterance):
     // the socket is closed and the mic is shut down, returning to idle.
@@ -223,6 +225,73 @@ describe("full turn", () => {
     expect(h.view.result.current.state).toBe("idle");
     expect(h.client.closed).toBe(true);
     expect(h.getCapture().shutdownCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Assistant-audio activity (mid-turn tool run) — JARVIS-1279
+// ---------------------------------------------------------------------------
+
+describe("assistant-audio activity", () => {
+  function emitTts(h: ReturnType<typeof renderController>, seq: number) {
+    h.client.emit("ttsAudio", {
+      type: "tts_audio",
+      seq,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+    });
+  }
+
+  test("stays `speaking` but marks audio inactive after the idle window when the player falls silent mid-turn", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      emitTts(h, 3);
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
+
+    // The ack audio finishes but the turn stays open — the assistant is now
+    // running a tool, so no `tts_done` arrives.
+    act(() => {
+      h.player.finishPlayback();
+    });
+
+    // After the idle grace with a silent player, audio is marked inactive while
+    // the phase is still `speaking`, so the avatar can read `thinking`.
+    await act(async () => {
+      await sleep(650); // > ASSISTANT_AUDIO_IDLE_MS (500ms)
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(false);
+
+    // More TTS for the same turn re-activates it (back to `responding`).
+    act(() => {
+      emitTts(h, 4);
+    });
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
+  });
+
+  test("keeps audio active across the idle window while the player is still draining", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      emitTts(h, 3);
+    });
+    // FakePlayer.enqueue leaves isPlaying true; never finish playback here.
+    expect(h.player.isPlaying).toBe(true);
+
+    // The idle check fires but re-arms because audio is still playing out — the
+    // avatar must not blink to `thinking` over audible speech.
+    await act(async () => {
+      await sleep(650);
+    });
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -282,6 +282,14 @@ interface SessionContext {
    * `metrics` frame always pairs with its own turn's measurement.
    */
   clientHeardLatencyMs: number | null;
+  /**
+   * Pending idle-check timer for the store's `assistantAudioActive` flag. Armed
+   * on each `tts_audio` frame and re-armed while the player is still draining;
+   * fires once audio has stopped flowing to mark the assistant silent (so a
+   * mid-turn tool run reads as `thinking`, not `speaking` — JARVIS-1279).
+   * Cleared on teardown/flush.
+   */
+  assistantAudioIdleTimer: ReturnType<typeof setTimeout> | null;
 }
 
 /** Number of bytes per Int16 PCM sample. */
@@ -413,6 +421,7 @@ export function useLiveVoice(
     const startGeneration = startGenerationRef.current;
     sessionRef.current = null;
     session.generation += 1;
+    clearAssistantAudioActive(session);
     useLiveVoiceStore.getState().setState("ending");
     for (const unsubscribe of session.unsubscribes) unsubscribe();
     session.unsubscribes = [];
@@ -561,6 +570,7 @@ export function useLiveVoice(
         speechEndedAtMs: null,
         turnHeardStampMs: null,
         clientHeardLatencyMs: null,
+        assistantAudioIdleTimer: null,
       };
 
       const capture = (opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o)))({
@@ -725,6 +735,10 @@ export function useLiveVoice(
             mimeType: frame.mimeType,
           };
           session.player.enqueue(chunk);
+          // Mark audio flowing before the phase flip so no render observes
+          // `speaking` without `assistantAudioActive` (which would blink the
+          // avatar to `thinking` at the top of every response — JARVIS-1279).
+          markAssistantAudioActive(session);
           useLiveVoiceStore.getState().setState("speaking");
         }),
         client.on("ttsDone", () => {
@@ -920,6 +934,7 @@ export function useLiveVoice(
  */
 function disposeSessionPrimitives(session: SessionContext): void {
   session.generation += 1;
+  clearAssistantAudioActive(session);
   for (const unsubscribe of session.unsubscribes) unsubscribe();
   session.unsubscribes = [];
   session.client.close();
@@ -1134,12 +1149,62 @@ function beginAssistantAudioIfNeeded(session: SessionContext): void {
 }
 
 /**
+ * Grace period after the player stops producing audio before the assistant is
+ * treated as silent within a still-open `speaking` turn. Long enough to bridge
+ * inter-frame network gaps and a short buffered tail, short enough that a real
+ * mid-turn pause (a tool call after a spoken ack) reads as `thinking` promptly.
+ */
+const ASSISTANT_AUDIO_IDLE_MS = 500;
+
+/**
+ * Mark assistant TTS audio as flowing and (re)arm the idle check. Called on
+ * every `tts_audio` frame: a continuous stream keeps re-arming the timer so the
+ * flag stays true for the whole spoken stretch; once frames stop and the queue
+ * drains, {@link scheduleAssistantAudioIdleCheck} flips it false. Drives the
+ * avatar's `speaking → responding` vs `thinking` split (JARVIS-1279).
+ */
+function markAssistantAudioActive(session: SessionContext): void {
+  useLiveVoiceStore.getState().setAssistantAudioActive(true);
+  scheduleAssistantAudioIdleCheck(session);
+}
+
+/**
+ * Arm (replacing any prior) the timer that marks the assistant silent once
+ * audio stops flowing. If the player is still draining its buffered tail when
+ * the timer fires, re-arm rather than blinking to silence over audible audio —
+ * only a genuinely idle player flips the flag false.
+ */
+function scheduleAssistantAudioIdleCheck(session: SessionContext): void {
+  if (session.assistantAudioIdleTimer !== null) {
+    clearTimeout(session.assistantAudioIdleTimer);
+  }
+  session.assistantAudioIdleTimer = setTimeout(() => {
+    session.assistantAudioIdleTimer = null;
+    if (session.player.isPlaying) {
+      scheduleAssistantAudioIdleCheck(session);
+      return;
+    }
+    useLiveVoiceStore.getState().setAssistantAudioActive(false);
+  }, ASSISTANT_AUDIO_IDLE_MS);
+}
+
+/** Cancel the idle check and clear the flag (barge-in, turn end, teardown). */
+function clearAssistantAudioActive(session: SessionContext): void {
+  if (session.assistantAudioIdleTimer !== null) {
+    clearTimeout(session.assistantAudioIdleTimer);
+    session.assistantAudioIdleTimer = null;
+  }
+  useLiveVoiceStore.getState().setAssistantAudioActive(false);
+}
+
+/**
  * Hands-free: flush local TTS playback immediately, drop expectations for the
  * in-flight response, and keep the session live in `listening`.
  */
 function flushPlaybackToListening(session: SessionContext): void {
   session.player.stop();
   session.responseAudioStarted = false;
+  clearAssistantAudioActive(session);
   useLiveVoiceStore.getState().setState("listening");
 }
 
@@ -1177,6 +1242,9 @@ async function finishResponseAfterPlayback(
 
   await session.player.waitUntilDrained();
   if (session.generation !== generation) return;
+  // Audio has fully drained — the assistant is no longer speaking regardless of
+  // where the turn goes next (a newer turn re-marks it on its own tts_audio).
+  clearAssistantAudioActive(session);
 
   const state = useLiveVoiceStore.getState().state;
   if (session.handsFree) {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -62,6 +62,7 @@ export function VoiceAmbientTranscript() {
   // `inputAmplitude` churn the narrow subscriptions above avoid.
   const state = useLiveVoiceStore.use.state();
   const reconnecting = useLiveVoiceStore.use.reconnecting();
+  const assistantAudioActive = useLiveVoiceStore.use.assistantAudioActive();
   const reduce = useReducedMotion();
 
   // In-flight partial wins over the last finalized transcript — same precedence
@@ -74,7 +75,7 @@ export function VoiceAmbientTranscript() {
   // assistant caption. Hide that half while listening (the assistant isn't
   // speaking then anyway); in thinking/responding the eyes are centered and the
   // clearance clears them.
-  const visual = toVoiceAvatarVisual(state, reconnecting);
+  const visual = toVoiceAvatarVisual(state, reconnecting, assistantAudioActive);
   const showUserHalf = showUser && userText.length > 0;
   const showAssistantHalf =
     showAssistant && assistantTranscript.length > 0 && visual !== "listening";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.test.ts
@@ -42,4 +42,28 @@ describe("toVoiceAvatarVisual", () => {
     expect(toVoiceAvatarVisual("listening", true)).toBe("listening");
     expect(toVoiceAvatarVisual("speaking", true)).toBe("responding");
   });
+
+  it("defaults assistantAudioActive to true (speaking → responding)", () => {
+    // Callers without the audio signal keep the plain mapping.
+    expect(toVoiceAvatarVisual("speaking", false)).toBe("responding");
+  });
+
+  it("maps speaking → thinking when no audio is flowing", () => {
+    // A turn that spoke an ack and is now running a tool stays `speaking` but
+    // is silent; the avatar must read `thinking`, not `responding` (JARVIS-1279).
+    expect(toVoiceAvatarVisual("speaking", false, false)).toBe("thinking");
+    expect(toVoiceAvatarVisual("speaking", true, false)).toBe("thinking");
+  });
+
+  it("keeps speaking → responding while audio is flowing", () => {
+    expect(toVoiceAvatarVisual("speaking", false, true)).toBe("responding");
+  });
+
+  it("ignores assistantAudioActive for every non-speaking phase", () => {
+    // The flag is only meaningful while `speaking`; it must not perturb others.
+    expect(toVoiceAvatarVisual("listening", false, false)).toBe("listening");
+    expect(toVoiceAvatarVisual("thinking", false, false)).toBe("thinking");
+    expect(toVoiceAvatarVisual("thinking", false, true)).toBe("thinking");
+    expect(toVoiceAvatarVisual("idle", false, false)).toBe("idle");
+  });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.ts
@@ -15,7 +15,8 @@ export type VoiceAvatarVisual =
 
 /**
  * Pure mapping from a live-voice session phase (plus the orthogonal
- * `reconnecting` retry signal) to the avatar's visual mode.
+ * `reconnecting` retry signal and whether assistant audio is actually flowing)
+ * to the avatar's visual mode.
  *
  * - `connecting` while `reconnecting` → `"reconnecting"` (a dropped connection
  *   is being retried; visually distinct from the initial connect).
@@ -23,11 +24,22 @@ export type VoiceAvatarVisual =
  *   express — hosts typically unmount the room in the terminal states).
  * - `listening` → `"listening"`.
  * - `transcribing` / `thinking` → `"thinking"`.
- * - `speaking` → `"responding"`.
+ * - `speaking` → `"responding"` while audio is flowing, else `"thinking"`.
+ *
+ * The `speaking` phase is a pure mirror of the server's turn framing — it is set
+ * on the first `tts_audio` frame and cleared only on `tts_done` (turn end) or a
+ * barge-in. A turn that speaks a short ack and then runs a tool (e.g. the
+ * app-builder skill) stays `speaking` for the whole silent tool run. Gating on
+ * `assistantAudioActive` (audio actually queued/playing, tracked by the
+ * controller from the player) collapses that silent stretch back to `thinking`,
+ * so the room stops claiming the assistant is talking mid-turn. Defaults to
+ * `true` — a non-`speaking` phase never reads it, and callers without the signal
+ * keep the plain `speaking → responding` behavior. (JARVIS-1279)
  */
 export function toVoiceAvatarVisual(
   state: LiveVoiceSessionState,
   reconnecting: boolean,
+  assistantAudioActive = true,
 ): VoiceAvatarVisual {
   switch (state) {
     case "connecting":
@@ -42,6 +54,6 @@ export function toVoiceAvatarVisual(
     case "thinking":
       return "thinking";
     case "speaking":
-      return "responding";
+      return assistantAudioActive ? "responding" : "thinking";
   }
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -375,6 +375,26 @@ describe("VoiceRoom — connect feedback", () => {
   });
 });
 
+describe("VoiceRoom — audio-aware status label (JARVIS-1279)", () => {
+  // The sr-only aria-live region uses the "…"-suffixed state labels, distinct
+  // from the caption's un-suffixed text (e.g. "Thinking" vs "Thinking…").
+  test("announces Thinking… (not Speaking…) during a silent mid-turn speaking phase", () => {
+    startOwnedSession("speaking");
+    // A mid-turn tool run: still `speaking`, but audio has stopped flowing.
+    useLiveVoiceStore.setState({ assistantAudioActive: false });
+    render(<VoiceRoom />);
+    expect(screen.getByText("Thinking…")).toBeTruthy();
+    expect(screen.queryByText("Speaking…")).toBeNull();
+  });
+
+  test("announces Speaking… while audio is actually flowing", () => {
+    // seedLiveVoiceSession marks a `speaking` session audio-active.
+    startOwnedSession("speaking");
+    render(<VoiceRoom />);
+    expect(screen.getByText("Speaking…")).toBeTruthy();
+  });
+});
+
 describe("VoiceRoom — full-app takeover", () => {
   test("the room is a modal full-viewport overlay", () => {
     startOwnedSession("listening");

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -131,6 +131,9 @@ export function VoiceRoom() {
 function VoiceRoomOverlay() {
   const state = useLiveVoiceStore.use.state();
   const reconnecting = useLiveVoiceStore.use.reconnecting();
+  // `speaking` stays set across a mid-turn tool run; gate `responding` on audio
+  // actually flowing so the room reads `thinking` while the tool works.
+  const assistantAudioActive = useLiveVoiceStore.use.assistantAudioActive();
   const assistantId = useLiveVoiceStore.use.assistantId();
   const muted = useLiveVoiceStore.use.muted();
   // Turn-scoped ■ stop is hands-free-only (a manual session's interrupt ends
@@ -142,7 +145,7 @@ function VoiceRoomOverlay() {
   const entryOrigin = useLiveVoiceStore.use.entryOrigin();
   const reduce = useReducedMotion();
 
-  const visual = toVoiceAvatarVisual(state, reconnecting);
+  const visual = toVoiceAvatarVisual(state, reconnecting, assistantAudioActive);
   const stateLabel = liveVoiceStateLabel(state, reconnecting);
 
   // Captions = the two persisted transcript prefs, toggled together from the

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -146,7 +146,13 @@ function VoiceRoomOverlay() {
   const reduce = useReducedMotion();
 
   const visual = toVoiceAvatarVisual(state, reconnecting, assistantAudioActive);
-  const stateLabel = liveVoiceStateLabel(state, reconnecting);
+  // The label + sr-only announcement must follow the same audio-aware mapping as
+  // the visual: a silent mid-turn `speaking` (ack spoken, tool now running)
+  // reads as "Thinking…", not "Speaking…", so screen-reader users aren't told
+  // the assistant is talking while it's actually silent (JARVIS-1279).
+  const labelState =
+    state === "speaking" && !assistantAudioActive ? "thinking" : state;
+  const stateLabel = liveVoiceStateLabel(labelState, reconnecting);
 
   // Captions = the two persisted transcript prefs, toggled together from the
   // room. Bound to the same `voice-prefs` store as the settings page and the


### PR DESCRIPTION
Closes JARVIS-1279

## The bug
The voice room shows the **speaking**/responding visual for the entire span between the first `tts_audio` frame and the turn's `tts_done`, regardless of whether audio is actually playing. When the assistant speaks a short ack and then runs a long tool (e.g. the app-builder skill) within the same turn, the room keeps claiming it's talking the whole silent time.

Root cause: the `speaking` phase is a pure mirror of server turn framing — set on `tts_audio` (`use-live-voice.ts`), cleared only on `tts_done`/barge-in. The player draining doesn't change state, and there's no tool-use event in the voice protocol.

## The fix (client-side)
Track whether TTS audio is **actually flowing** and gate the visual on it:
- New store field `assistantAudioActive`, driven by the controller from the player's `isPlaying` with a short idle grace (`ASSISTANT_AUDIO_IDLE_MS = 500ms`). Marked active on each `tts_audio`; an idle check re-arms while the player is still draining (so brief inter-frame gaps / buffered tails don't blink) and flips it off once the player is genuinely idle. Cleared on turn end, barge-in, and teardown.
- `toVoiceAvatarVisual(state, reconnecting, assistantAudioActive)` now maps `speaking → responding` only while audio flows, else `thinking`. Defaults to `true`, so callers/tests without the signal keep the old mapping.
- Both consumers (`voice-room.tsx`, `voice-ambient-transcript.tsx`) pass the flag.

So a mid-turn tool run now reads as **thinking** — the rings/emanation stand down and the caption/label follow.

## Follow-up
Daemon-side phase frame when TTS ends but the turn continues into tool execution — the authoritative fix (separate ticket).

## Tests
- `voice-avatar-state.test.ts` — the new `speaking + !active → thinking` mapping and that non-speaking phases ignore the flag.
- `use-live-voice.test.ts` — controller marks audio active on `tts_audio`, flips it inactive after the idle window when the player falls silent mid-turn (state stays `speaking`), re-activates on new audio, and holds active while the player is still draining.
- `seedLiveVoiceSession` mirrors the controller (a seeded `speaking` session is audio-active).
- Full voice suite + `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)