### PR TITLE
Cross-client voice-mode parity: filled entry button, iOS first-run card, iOS-15 ring fallback

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -117,8 +117,16 @@ mock.module("@/domains/chat/components/voice-input-button", () => ({
 // irrelevant to the composer's interception wiring, which is all these tests
 // assert. Full card behavior lives in `voice-first-run-card.test.tsx`.
 mock.module("@/domains/chat/voice/voice-room/voice-first-run-card", () => ({
-  VoiceFirstRunCard: (props: { onStart: () => void; onDismiss?: () => void }) => (
-    <div data-testid="first-run-card">
+  VoiceFirstRunCard: (props: {
+    onStart: () => void;
+    onDismiss?: () => void;
+    nonDismissible?: boolean;
+  }) => (
+    <div
+      data-testid="first-run-card"
+      // Surface the lock so a test can assert the composer passes it on iOS.
+      data-non-dismissible={String(props.nonDismissible ?? false)}
+    >
       <button type="button" onClick={props.onStart}>
         first-run-start
       </button>
@@ -866,8 +874,12 @@ describe("ChatComposer — live-voice integration", () => {
     const { getByLabelText, getByTestId } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN the prefs card appears and the session has NOT started yet
+    // THEN the prefs card appears (dismissible on web) and the session has NOT
+    // started yet
     expect(getByTestId("first-run-card")).toBeTruthy();
+    expect(
+      getByTestId("first-run-card").getAttribute("data-non-dismissible"),
+    ).toBe("false");
     expect(liveStarterSpy).not.toHaveBeenCalled();
   });
 
@@ -922,8 +934,12 @@ describe("ChatComposer — live-voice integration", () => {
     fireEvent.click(getByLabelText("Start voice mode"));
 
     // THEN the same prefs card appears and the session has NOT started yet —
-    // identical to the web first-run path.
+    // like web, but locked (non-dismissible) so it leads straight to the mic
+    // alert per CAPACITOR.md.
     expect(getByTestId("first-run-card")).toBeTruthy();
+    expect(
+      getByTestId("first-run-card").getAttribute("data-non-dismissible"),
+    ).toBe("true");
     expect(liveStarterSpy).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -39,11 +39,11 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => mockIsElectron,
 }));
 
-// Capacitor-iOS detection. The composer skips the first-run prefs card on the
-// native iOS shell (a dismissible pre-prompt before the `getUserMedia`
-// permission alert violates `docs/CAPACITOR.md` § OS permission requests) and
-// starts the session directly. Defaults to non-iOS (web) so the existing
-// first-run tests exercise the card path unchanged.
+// Capacitor-iOS detection, kept as a regression guard. The first-run prefs card
+// is now shown on EVERY platform, the native iOS shell included (a deliberate
+// parity choice that knowingly deviates from `docs/CAPACITOR.md` § OS permission
+// requests — see the composer's `handleLiveVoiceStart` note), so setting this to
+// iOS must NOT suppress the card. Defaults to non-iOS (web).
 let mockIsNativeIOS = false;
 mock.module("@/runtime/platform-detection", () => ({
   isNativeIOS: () => mockIsNativeIOS,
@@ -906,25 +906,25 @@ describe("ChatComposer — live-voice integration", () => {
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
   });
 
-  test("Capacitor iOS: first-ever entry skips the card and starts directly (permission alert reached)", () => {
+  test("Capacitor iOS: first-ever entry shows the prefs card too (web↔iOS parity)", () => {
     // GIVEN the native iOS shell, the flag on, no session, and a first-ever
-    // entry — a dismissible pre-prompt here would violate CAPACITOR.md
-    // § OS permission requests, so the card must be skipped.
+    // entry. The card is intentionally shown on every platform — a deliberate
+    // deviation from CAPACITOR.md's "no dismissible pre-prompt before
+    // getUserMedia" rule, chosen for parity with web (see the composer's
+    // handleLiveVoiceStart note) — so the iOS shell must get it too.
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockIsNativeIOS = true;
     useVoicePrefsStore.setState({ firstRunSeen: false });
 
     // WHEN the user clicks the entry-point mic
-    const { getByLabelText, queryByTestId } = renderVoiceComposer();
+    const { getByLabelText, getByTestId } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN no card renders and the session starts straight away so the OS
-    // getUserMedia alert is the next thing the user sees. The first-run flag
-    // is left untouched (the card, not the mic, owns marking it seen).
-    expect(queryByTestId("first-run-card")).toBeNull();
-    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
-    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    // THEN the same prefs card appears and the session has NOT started yet —
+    // identical to the web first-run path.
+    expect(getByTestId("first-run-card")).toBeTruthy();
+    expect(liveStarterSpy).not.toHaveBeenCalled();
   });
 
   test("Capacitor iOS: returning-user entry still starts directly (unchanged)", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -53,7 +53,6 @@ import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
-import { isNativeIOS } from "@/runtime/platform-detection";
 import { isPointerCoarse } from "@/utils/pointer";
 import { Button, Notice, Popover } from "@vellumai/design-library";
 
@@ -355,15 +354,17 @@ export function ChatComposer({
         return;
       }
       liveVoiceEntryOriginRef.current = origin ?? null;
-      // First-run preferences card — shown on every platform EXCEPT Capacitor
-      // iOS. On the iOS shell a dismissible pre-prompt before the live-voice
-      // `getUserMedia` permission alert violates `docs/CAPACITOR.md` § OS
-      // permission requests (Apple HIG / App Store Review 5.1.1(iv)) and the
-      // `voice/live-voice/pcm-capture.ts` caller contract, which require any
-      // pre-permission UI to lead directly to the system alert. On iOS we
-      // therefore start directly (same as the returning-user path) so the OS
-      // alert is reached without an intervening dismissible modal.
-      if (!useVoicePrefsStore.getState().firstRunSeen && !isNativeIOS()) {
+      // First-run preferences card — shown on the first-ever voice entry on
+      // EVERY platform, the Capacitor iOS shell included. This is a deliberate
+      // product decision (web↔iOS parity for the welcome card) that knowingly
+      // deviates from `docs/CAPACITOR.md` § OS permission requests and the
+      // `voice/live-voice/pcm-capture.ts` caller contract, which ask that no
+      // dismissible pre-prompt precede the live-voice `getUserMedia` alert on
+      // iOS (Apple HIG / App Store Review 5.1.1(iv)). The card's only forward
+      // action ("Start talking") leads straight to that alert; dismissing is a
+      // plain cancel that never reaches it. If this is ever revisited, re-sync
+      // the two docs above with the choice made here.
+      if (!useVoicePrefsStore.getState().firstRunSeen) {
         setFirstRunCardOpen(true);
         return;
       }

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -53,6 +53,7 @@ import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
+import { isNativeIOS } from "@/runtime/platform-detection";
 import { isPointerCoarse } from "@/utils/pointer";
 import { Button, Notice, Popover } from "@vellumai/design-library";
 
@@ -355,15 +356,13 @@ export function ChatComposer({
       }
       liveVoiceEntryOriginRef.current = origin ?? null;
       // First-run preferences card — shown on the first-ever voice entry on
-      // EVERY platform, the Capacitor iOS shell included. This is a deliberate
-      // product decision (web↔iOS parity for the welcome card) that knowingly
-      // deviates from `docs/CAPACITOR.md` § OS permission requests and the
-      // `voice/live-voice/pcm-capture.ts` caller contract, which ask that no
-      // dismissible pre-prompt precede the live-voice `getUserMedia` alert on
-      // iOS (Apple HIG / App Store Review 5.1.1(iv)). The card's only forward
-      // action ("Start talking") leads straight to that alert; dismissing is a
-      // plain cancel that never reaches it. If this is ever revisited, re-sync
-      // the two docs above with the choice made here.
+      // EVERY platform, the Capacitor iOS shell included (web↔iOS parity for the
+      // welcome card). On iOS the card renders locked (`nonDismissible`, see its
+      // render below), which keeps it compliant with `docs/CAPACITOR.md` § OS
+      // permission requests: the card precedes the live-voice `getUserMedia`
+      // alert, and a locked pre-prompt whose only action leads straight to that
+      // alert is the sanctioned pattern (Apple HIG / App Store Review 5.1.1(iv))
+      // — a *dismissible* pre-prompt is the disallowed one.
       if (!useVoicePrefsStore.getState().firstRunSeen) {
         setFirstRunCardOpen(true);
         return;
@@ -494,11 +493,17 @@ export function ChatComposer({
       {firstRunCardOpen && (
         // First voice-mode entry only — the card commits prefs + starts via
         // `handleFirstRunStart`; a plain dismiss cancels without consuming the
-        // first run, so it returns on the next entry.
+        // first run, so it returns on the next entry. On Capacitor iOS the card
+        // is locked (no ✕ / backdrop / Escape): it precedes the live-voice
+        // `getUserMedia` alert, so per `docs/CAPACITOR.md` § OS permission
+        // requests the pre-prompt must lead straight to that alert — its only
+        // action is "Start talking", and there is no card-level cancel (backing
+        // out means denying the OS mic prompt, or ✕ once the room opens).
         <VoiceFirstRunCard
           assistantId={assistantId}
           onStart={handleFirstRunStart}
           onDismiss={() => setFirstRunCardOpen(false)}
+          nonDismissible={isNativeIOS()}
         />
       )}
       {/* Composer-owned draft/attachment notices (self-sourced), above the

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -43,7 +43,11 @@ export function LiveVoiceButton({
 
   return (
     <Button
-      variant="ghost"
+      // Filled `primary` (black) so the voice entry point carries the same
+      // prominence as the send button it shares the composer's send slot with
+      // (both `Button variant="primary"` icon-only, so identical footprint +
+      // fill) — rather than a low-emphasis ghost that reads as secondary.
+      variant="primary"
       iconOnly={<AudioLines strokeWidth={2} />}
       onClick={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
@@ -52,7 +56,6 @@ export function LiveVoiceButton({
       disabled={disabled}
       aria-label="Start voice mode"
       title="Start voice mode"
-      className="[--vbtn-fg:var(--content-secondary)]"
     />
   );
 }

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -14,8 +14,11 @@
  * The capture is permission-agnostic: it requests `getUserMedia` directly and
  * surfaces a denial as a typed `LiveVoiceCaptureResult` rather than throwing.
  * Per `clients/web/AGENTS.md` / `docs/CAPACITOR.md` § OS permission requests,
- * callers own any pre-permission UX (and must not render a dismissible
- * pre-prompt on Capacitor iOS).
+ * callers own any pre-permission UX; the guidance there is that no dismissible
+ * pre-prompt should precede this `getUserMedia` alert on Capacitor iOS. NOTE:
+ * the live-voice composer deliberately overrides that for its first-run card
+ * (shown on iOS too, for web↔iOS parity) — see `chat-composer.tsx`'s
+ * `handleLiveVoiceStart`. Other callers should still follow the guidance.
  */
 
 // Import the worklet as a Vite-bundled, *transpiled* classic script asset and

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -14,11 +14,11 @@
  * The capture is permission-agnostic: it requests `getUserMedia` directly and
  * surfaces a denial as a typed `LiveVoiceCaptureResult` rather than throwing.
  * Per `clients/web/AGENTS.md` / `docs/CAPACITOR.md` § OS permission requests,
- * callers own any pre-permission UX; the guidance there is that no dismissible
- * pre-prompt should precede this `getUserMedia` alert on Capacitor iOS. NOTE:
- * the live-voice composer deliberately overrides that for its first-run card
- * (shown on iOS too, for web↔iOS parity) — see `chat-composer.tsx`'s
- * `handleLiveVoiceStart`. Other callers should still follow the guidance.
+ * callers own any pre-permission UX: no *dismissible* pre-prompt may precede
+ * this `getUserMedia` alert on Capacitor iOS. The live-voice composer's
+ * first-run card complies by rendering locked (no ✕ / backdrop / Escape, a
+ * single "Start talking" that leads straight here) on iOS — see
+ * `chat-composer.tsx`'s `handleLiveVoiceStart` and `VoiceFirstRunCard`.
  */
 
 // Import the worklet as a Vite-bundled, *transpiled* classic script asset and

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -93,4 +93,26 @@ describe("VoiceFirstRunCard", () => {
     fireEvent.click(getByText("Start talking"));
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
   });
+
+  test("dismissible by default (web): renders the ✕ close affordance", () => {
+    const { getByLabelText } = render(
+      <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
+    );
+    expect(getByLabelText("Close")).toBeTruthy();
+  });
+
+  test("nonDismissible (iOS lock): no ✕, only Start talking leads forward", () => {
+    // The lock strips the close affordance so the pre-permission card leads
+    // straight to the mic alert (CAPACITOR.md § OS permission requests); there
+    // is intentionally no card-level cancel.
+    const { queryByLabelText, getByText } = render(
+      <VoiceFirstRunCard
+        assistantId="asst_test"
+        onStart={() => {}}
+        nonDismissible
+      />,
+    );
+    expect(queryByLabelText("Close")).toBeNull();
+    expect(getByText("Start talking")).toBeTruthy();
+  });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -21,6 +21,14 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
  * the card returns on the next entry. Only committing via "Start" advances the
  * first-run flag, and that lives in the caller's `onStart` handler (the
  * composer) alongside actually starting the session.
+ *
+ * `nonDismissible` locks the card to a single forward action — no ✕, backdrop,
+ * or Escape. The composer sets it on Capacitor iOS, where the card precedes the
+ * live-voice `getUserMedia` alert: per `docs/CAPACITOR.md` § OS permission
+ * requests (Apple HIG / App Store Review 5.1.1(iv)) such a pre-prompt must lead
+ * straight to the system alert, so a dismissible one is disallowed. Locked,
+ * there is no card-level cancel by design — backing out means denying the OS
+ * mic prompt (or ✕ once the room opens).
  */
 
 /** Mini idle avatar diameter — a quiet, in-context echo of the room avatar. */
@@ -33,12 +41,19 @@ export interface VoiceFirstRunCardProps {
   onStart: () => void;
   /** Cancel: dismissed without starting (does not consume the first run). */
   onDismiss?: () => void;
+  /**
+   * Lock the card: no ✕ / backdrop / Escape, only "Start talking". Set on
+   * Capacitor iOS so the pre-permission card leads straight to the mic alert
+   * (see the module docstring). Defaults to dismissible (web).
+   */
+  nonDismissible?: boolean;
 }
 
 export function VoiceFirstRunCard({
   assistantId,
   onStart,
   onDismiss,
+  nonDismissible = false,
 }: VoiceFirstRunCardProps) {
   const { components, traits, customImageUrl } =
     useAssistantAvatar(assistantId);
@@ -51,13 +66,27 @@ export function VoiceFirstRunCard({
       open
       onOpenChange={(next) => {
         // Escape / backdrop / ✕ all route through here; treat any close as a
-        // cancel so the first run stays un-consumed.
+        // cancel so the first run stays un-consumed. Inert when locked (those
+        // affordances are removed / prevented below), so `onDismiss` only fires
+        // on the dismissible (web) path.
         if (!next) {
           onDismiss?.();
         }
       }}
     >
-      <Modal.Content size="sm">
+      <Modal.Content
+        size="sm"
+        // iOS lock: strip the ✕, the backdrop-tap dismiss, and Escape so the
+        // only way forward is "Start talking" → the mic alert.
+        hideCloseButton={nonDismissible}
+        dismissOnOverlayClick={!nonDismissible}
+        onEscapeKeyDown={
+          nonDismissible ? (event) => event.preventDefault() : undefined
+        }
+        onInteractOutside={
+          nonDismissible ? (event) => event.preventDefault() : undefined
+        }
+      >
         <Modal.Header>
           <div className="flex items-center gap-3">
             <span className="shrink-0">

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -621,12 +621,13 @@ function VoiceRespondingTreatment({
         className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center"
       >
         <div
+          // Tint (with iOS-15 rgba fallback) lives in `.voice-responding-halo`;
+          // the amplitude-driven size/scale/opacity stay inline.
+          className="voice-responding-halo"
           style={{
             width: Math.round(0.9 * M),
             height: Math.round(0.9 * M),
             borderRadius: "9999px",
-            background:
-              "radial-gradient(circle, color-mix(in srgb, var(--room-fg, #ffffff) 24%, transparent) 0%, transparent 66%)",
             transform: "scale(calc(0.8 + var(--resp-amp, 0) * 0.5))",
             opacity: "calc(0.35 + var(--resp-amp, 0) * 0.65)",
             transformOrigin: "center",
@@ -649,12 +650,12 @@ function VoiceRespondingTreatment({
       {[0, 1, 2].map((i) => (
         <motion.span
           key={i}
-          className="absolute rounded-full border-2"
+          // Border tint (with iOS-15 rgba fallback) lives in
+          // `.voice-responding-ring`; the amplitude-driven size stays inline.
+          className="voice-responding-ring absolute rounded-full border-2"
           style={{
             width: Math.round(0.5 * M),
             height: Math.round(0.5 * M),
-            borderColor:
-              "color-mix(in srgb, var(--room-fg, #ffffff) 55%, transparent)",
           }}
           initial={reduce ? false : { scale: 0.4, opacity: 0.55 }}
           animate={

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -808,3 +808,30 @@ body {
     opacity: 0.4;
   }
 }
+
+/* Responding-treatment tint (the concentric rings + the halo bloom radiating
+ * from behind the eyes / avatar; see the responding treatments in
+ * voice-room-eyes.tsx). Follows the room foreground tone (--room-fg) so it reads
+ * on any avatar-color background, and — like the wave palette rules above —
+ * declares a plain rgba() BEFORE the color-mix() so engines without color-mix
+ * (Safari/iOS < 16.2; the iOS shell still targets 15.0) keep the visible white
+ * fallback instead of dropping the invalid declaration to `currentColor`. The
+ * amplitude-driven size/opacity stay inline at the call site; only the tinted
+ * color lives here (the fallback pattern needs two declarations, which a React
+ * inline style object can't express). */
+.voice-responding-ring {
+  border-color: rgba(255, 255, 255, 0.55);
+  border-color: color-mix(in srgb, var(--room-fg, #ffffff) 55%, transparent);
+}
+.voice-responding-halo {
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.24) 0%,
+    transparent 66%
+  );
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--room-fg, #ffffff) 24%, transparent) 0%,
+    transparent 66%
+  );
+}


### PR DESCRIPTION
Voice-mode parity/polish. All changes live in the shared `clients/web` app, so they flow to **every shell client** — web, iOS (Capacitor WKWebView), and macOS (Electron).

## Changes

### 1. Voice entry button → filled, matching the send button
`LiveVoiceButton` was a low-emphasis `ghost` while the `ArrowUp` send button it swaps with (in the composer's send slot) is a filled `primary`. Switched it to `variant="primary"` and dropped the `--vbtn-fg` secondary override — both are now `Button` icon-only `primary`, so identical footprint + black fill. The button only occupies the slot when there's nothing to send; once text is typed, the send arrow takes over as before.

### 2. First-run voice card now shown on iOS too — locked (P1 fix)
The first-run preferences card was skipped on the Capacitor iOS shell. It now shows on **every** platform for web↔iOS parity, but on iOS it renders **non-dismissible**.

The card precedes the live-voice `getUserMedia` alert, so a *dismissible* pre-prompt (auto ✕ / backdrop / Escape) violates `docs/CAPACITOR.md` § OS permission requests (Apple HIG / Review 5.1.1(iv)) — the reported **P1**. The `nonDismissible` path (set via `isNativeIOS()`) strips the ✕, the backdrop-tap dismiss, and Escape, leaving a single "Start talking" that leads straight to the mic alert — the sanctioned pattern (CAPACITOR.md option B), so this **complies** rather than deviating. Web keeps its normal dismissible modal.

**Back-out UX on iOS:** there is intentionally no card-level cancel (a cancel is the exact affordance the guideline forbids). A user who changes their mind taps "Start talking" and then denies the OS mic prompt (first-ever entry — handled gracefully via the existing `permission-denied` composer notice), or ✕'s out once the room opens. It's a one-time card, so the friction is minimal.

### 3. Responding rings/halo: iOS-15 `color-mix` fallback
The `responding` rings' border and the halo bloom set their tint with an inline `color-mix()` and **no fallback**. On the iOS 15 WKWebView (which the shell still targets, and which lacks `color-mix`) the declaration is invalid and drops to `currentColor`. Moved the tint into `.voice-responding-ring` / `.voice-responding-halo` classes that declare a plain `rgba()` before the `color-mix()` — the same rgba-then-color-mix cascade the wave palette already uses — so iOS 15 keeps a visible color. (Inline React style objects can't express the two-declaration fallback, hence the move to CSS.)

## Verification
- `bun run typecheck` — clean
- `chat-composer.test.tsx` — 77/77 (incl. iOS card shows + locked, web card dismissible)
- `voice-first-run-card.test.tsx` — 6/6 (✕ present on web, absent when locked)
- `voice-room.test.tsx` — 39/39
- lint clean on touched files (only pre-existing `curly` style warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)