### PR TITLE
refactor(tools): drop SkillProjectionContext for the Conversation type

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -13,10 +13,8 @@
 
 import { afterAll, describe, expect, test } from "bun:test";
 
-import {
-  isToolActiveForContext,
-  type SkillProjectionContext,
-} from "../daemon/conversation-tool-setup.js";
+import type { Conversation } from "../daemon/conversation.js";
+import { isToolActiveForContext } from "../daemon/conversation-tool-setup.js";
 import {
   __resetRegistryForTesting,
   getAllToolDefinitions,
@@ -33,13 +31,13 @@ describe("always-loaded tool count", () => {
     const allDefs = getAllToolDefinitions();
 
     // Minimal context: no client, no capabilities
-    const minimalContext: SkillProjectionContext = {
+    const minimalContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       hasNoClient: true,
       channelCapabilities: undefined,
-    };
+    } as unknown as Conversation;
 
     const activeTools = allDefs.filter((def) =>
       isToolActiveForContext(def.name, minimalContext),

--- a/assistant/src/__tests__/conversation-tool-setup-tools-disabled.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-tools-disabled.test.ts
@@ -28,10 +28,8 @@ mock.module("../daemon/conversation-skill-tools.js", () => ({
 // Import after mocks
 // ---------------------------------------------------------------------------
 
-import {
-  createResolveToolsCallback,
-  type SkillProjectionContext,
-} from "../daemon/conversation-tool-setup.js";
+import type { Conversation } from "../daemon/conversation.js";
+import { createResolveToolsCallback } from "../daemon/conversation-tool-setup.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,15 +39,13 @@ function makeToolDef(name: string): ToolDefinition {
   return { name, description: `${name} tool`, input_schema: {} };
 }
 
-function makeCtx(
-  overrides: Partial<SkillProjectionContext> = {},
-): SkillProjectionContext {
+function makeCtx(overrides: Partial<Conversation> = {}): Conversation {
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: {} as SkillProjectionCache,
     toolsDisabledDepth: 0,
     ...overrides,
-  };
+  } as unknown as Conversation;
 }
 
 const EMPTY_HISTORY: Message[] = [];

--- a/assistant/src/__tests__/disk-pressure-tools.test.ts
+++ b/assistant/src/__tests__/disk-pressure-tools.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { Conversation } from "../daemon/conversation.js";
 import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
-import type { SkillProjectionContext } from "../daemon/conversation-tool-setup.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { DiskUsageInfo } from "../util/disk-usage.js";
 import * as realDiskUsage from "../util/disk-usage.js";
@@ -74,14 +74,14 @@ function makeToolDef(name: string): ToolDefinition {
 }
 
 function makeProjectionCtx(
-  overrides: Partial<SkillProjectionContext> = {},
-): SkillProjectionContext {
+  overrides: Partial<Conversation> = {},
+): Conversation {
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: {} as SkillProjectionCache,
     toolsDisabledDepth: 0,
     ...overrides,
-  };
+  } as unknown as Conversation;
 }
 
 function setDiskUsage(usedMb: number, totalMb = 100): void {

--- a/assistant/src/__tests__/file-list-tool.test.ts
+++ b/assistant/src/__tests__/file-list-tool.test.ts
@@ -9,9 +9,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
+import type { Conversation } from "../daemon/conversation.js";
 import {
   isToolActiveForContext,
-  type SkillProjectionContext,
   SUBAGENT_ONLY_TOOL_NAMES,
 } from "../daemon/conversation-tool-setup.js";
 import { fileListTool } from "../tools/filesystem/list.js";
@@ -60,7 +60,9 @@ describe("FileSystemOps.listDirSafe", () => {
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
     const result = ops.listDirSafe({ path: dir });
     expect(result.ok).toBe(true);
-    if (!result.ok) return;
+    if (!result.ok) {
+      return;
+    }
 
     const lines = result.value.listing.split("\n");
     // Directories first with trailing /
@@ -81,7 +83,9 @@ describe("FileSystemOps.listDirSafe", () => {
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
     const result = ops.listDirSafe({ path: dir, glob: "*.md" });
     expect(result.ok).toBe(true);
-    if (!result.ok) return;
+    if (!result.ok) {
+      return;
+    }
 
     const lines = result.value.listing.split("\n");
     expect(lines.length).toBe(2);
@@ -96,7 +100,9 @@ describe("FileSystemOps.listDirSafe", () => {
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
     const result = ops.listDirSafe({ path: join(dir, "regular-file.txt") });
     expect(result.ok).toBe(false);
-    if (result.ok) return;
+    if (result.ok) {
+      return;
+    }
     expect(result.error.code).toBe("NOT_A_DIRECTORY");
   });
 
@@ -106,7 +112,9 @@ describe("FileSystemOps.listDirSafe", () => {
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
     const result = ops.listDirSafe({ path: join(dir, "nonexistent") });
     expect(result.ok).toBe(false);
-    if (result.ok) return;
+    if (result.ok) {
+      return;
+    }
     expect(result.error.code).toBe("NOT_FOUND");
   });
 
@@ -116,7 +124,9 @@ describe("FileSystemOps.listDirSafe", () => {
     const ops = new FileSystemOps(sandboxPolicyFor(dir));
     const result = ops.listDirSafe({ path: "../../../etc" });
     expect(result.ok).toBe(false);
-    if (result.ok) return;
+    if (result.ok) {
+      return;
+    }
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
   });
 });
@@ -186,31 +196,31 @@ describe("file_list subagent visibility", () => {
   });
 
   test("isToolActiveForContext hides file_list when isSubagent is false", () => {
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
-    };
+    } as unknown as Conversation;
     expect(isToolActiveForContext("file_list", ctx)).toBe(false);
   });
 
   test("isToolActiveForContext hides file_list when isSubagent is undefined", () => {
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       isSubagent: undefined,
-    };
+    } as unknown as Conversation;
     expect(isToolActiveForContext("file_list", ctx)).toBe(false);
   });
 
   test("isToolActiveForContext shows file_list when isSubagent is true", () => {
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       isSubagent: true,
-    };
+    } as unknown as Conversation;
     expect(isToolActiveForContext("file_list", ctx)).toBe(true);
   });
 });

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -79,6 +79,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: () => {},
 }));
 
+import type { Conversation } from "../daemon/conversation.js";
 import { isToolActiveForContext } from "../daemon/conversation-tool-setup.js";
 import type { SubagentRecord } from "../persistence/subagent-store.js";
 import { notifyParentFromChild } from "../subagent/notify.js";
@@ -171,7 +172,7 @@ describe("notify_parent tool definition", () => {
       skillProjectionState: new Map(),
       skillProjectionCache: new Map(),
       toolsDisabledDepth: 0,
-    } as unknown as import("../daemon/conversation-tool-setup.js").SkillProjectionContext;
+    } as unknown as Conversation;
     expect(isToolActiveForContext("notify_parent", ctx)).toBe(false);
   });
 
@@ -181,7 +182,7 @@ describe("notify_parent tool definition", () => {
       skillProjectionState: new Map(),
       skillProjectionCache: new Map(),
       toolsDisabledDepth: 0,
-    } as unknown as import("../daemon/conversation-tool-setup.js").SkillProjectionContext;
+    } as unknown as Conversation;
     expect(isToolActiveForContext("notify_parent", ctx)).toBe(false);
   });
 
@@ -192,7 +193,7 @@ describe("notify_parent tool definition", () => {
       skillProjectionState: new Map(),
       skillProjectionCache: new Map(),
       toolsDisabledDepth: 0,
-    } as unknown as import("../daemon/conversation-tool-setup.js").SkillProjectionContext;
+    } as unknown as Conversation;
     expect(isToolActiveForContext("notify_parent", ctx)).toBe(true);
   });
 });

--- a/assistant/src/__tests__/subagent-tool-filtering.test.ts
+++ b/assistant/src/__tests__/subagent-tool-filtering.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import type { Conversation } from "../daemon/conversation.js";
 import {
   isToolActiveForContext,
-  type SkillProjectionContext,
   SUBAGENT_ONLY_TOOL_NAMES,
 } from "../daemon/conversation-tool-setup.js";
 
@@ -18,48 +18,48 @@ describe("subagent-only tool filtering", () => {
   });
 
   test("hides subagent-only tools from main conversations (isSubagent=false)", () => {
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       hasNoClient: false,
       isSubagent: false,
-    };
+    } as unknown as Conversation;
 
     expect(isToolActiveForContext(TEST_TOOL_NAME, ctx)).toBe(false);
   });
 
   test("hides subagent-only tools when isSubagent is undefined", () => {
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       hasNoClient: false,
-    };
+    } as unknown as Conversation;
 
     expect(isToolActiveForContext(TEST_TOOL_NAME, ctx)).toBe(false);
   });
 
   test("shows subagent-only tools to subagent conversations (isSubagent=true)", () => {
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       hasNoClient: true,
       isSubagent: true,
-    };
+    } as unknown as Conversation;
 
     expect(isToolActiveForContext(TEST_TOOL_NAME, ctx)).toBe(true);
   });
 
   test("does not affect regular tools when isSubagent is false", () => {
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       hasNoClient: false,
       isSubagent: false,
-    };
+    } as unknown as Conversation;
 
     // A regular tool not in SUBAGENT_ONLY_TOOL_NAMES should still be active
     expect(isToolActiveForContext("bash", ctx)).toBe(true);
@@ -68,14 +68,14 @@ describe("subagent-only tool filtering", () => {
   test("respects subagentAllowedTools — tools outside the allowlist are inactive", () => {
     // Mirrors `createResolveToolsCallback`'s post-filter so callers see the
     // same final tool set the LLM receives.
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       hasNoClient: false,
       isSubagent: true,
       subagentAllowedTools: new Set(["bash"]),
-    };
+    } as unknown as Conversation;
 
     expect(isToolActiveForContext("bash", ctx)).toBe(true);
     expect(isToolActiveForContext("ask_question", ctx)).toBe(false);
@@ -86,28 +86,28 @@ describe("subagent-only tool filtering", () => {
     // `subagentToolGateMode: "execution"` keeps the full tool surface on the
     // wire for provider prompt-cache parity; the executor callback rejects
     // non-allowlisted calls instead.
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       hasNoClient: false,
       subagentAllowedTools: new Set(["remember"]),
       subagentToolGateMode: "execution",
-    };
+    } as unknown as Conversation;
 
     expect(isToolActiveForContext("remember", ctx)).toBe(true);
     expect(isToolActiveForContext("bash", ctx)).toBe(true);
   });
 
   test("explicit wire gate mode filters exactly like the absent default", () => {
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       hasNoClient: false,
       subagentAllowedTools: new Set(["remember"]),
       subagentToolGateMode: "wire",
-    };
+    } as unknown as Conversation;
 
     expect(isToolActiveForContext("remember", ctx)).toBe(true);
     expect(isToolActiveForContext("bash", ctx)).toBe(false);
@@ -116,14 +116,14 @@ describe("subagent-only tool filtering", () => {
   test("execution gate mode still applies non-allowlist filters (toolsDisabledDepth)", () => {
     // The execution gate only bypasses the subagent allowlist's wire filter;
     // every other visibility rule still applies.
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 1,
       hasNoClient: false,
       subagentAllowedTools: new Set(["remember"]),
       subagentToolGateMode: "execution",
-    };
+    } as unknown as Conversation;
 
     expect(isToolActiveForContext("remember", ctx)).toBe(false);
     expect(isToolActiveForContext("bash", ctx)).toBe(false);
@@ -132,12 +132,12 @@ describe("subagent-only tool filtering", () => {
   test("returns false for every tool when toolsDisabledDepth > 0", () => {
     // `createResolveToolsCallback` returns an empty tool list when tools are
     // disabled; mirror it here so this helper reports the same final tool set.
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 1,
       hasNoClient: false,
-    };
+    } as unknown as Conversation;
 
     expect(isToolActiveForContext("bash", ctx)).toBe(false);
     expect(isToolActiveForContext("ask_question", ctx)).toBe(false);
@@ -146,13 +146,13 @@ describe("subagent-only tool filtering", () => {
   test("under disk-pressure cleanup mode, only cleanup-safe tools are active", () => {
     // `createResolveToolsCallback` restricts the turn to cleanup-safe tools
     // (`file_remove`, `bash`, etc.); ensure the helper agrees.
-    const ctx: SkillProjectionContext = {
+    const ctx = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       toolsDisabledDepth: 0,
       hasNoClient: false,
       diskPressureCleanupModeActive: true,
-    };
+    } as unknown as Conversation;
 
     // `bash` is in DISK_PRESSURE_CLEANUP_TOOL_NAMES; `ask_question` is not.
     expect(isToolActiveForContext("bash", ctx)).toBe(true);

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -72,10 +72,10 @@ mock.module("../daemon/conversation-skill-tools.js", () => ({
 // Imports after mocks are in place
 // ---------------------------------------------------------------------------
 
+import type { Conversation } from "../daemon/conversation.js";
 import {
   createResolveToolsCallback,
   createToolExecutor,
-  type SkillProjectionContext,
   type ToolSetupContext,
 } from "../daemon/conversation-tool-setup.js";
 import {
@@ -95,14 +95,14 @@ function makeToolDef(name: string): ToolDefinition {
 }
 
 function makeProjectionCtx(
-  overrides: Partial<SkillProjectionContext> = {},
-): SkillProjectionContext {
+  overrides: Partial<Conversation> = {},
+): Conversation {
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: {} as SkillProjectionCache,
     toolsDisabledDepth: 0,
     ...overrides,
-  };
+  } as unknown as Conversation;
 }
 
 function makeSetupCtx(
@@ -237,8 +237,8 @@ describe("createResolveToolsCallback — toolContextPin", () => {
 
   /** Execution-gate ctx shaped like a clientless fork-retrospective wake. */
   function clientlessExecutionCtx(
-    overrides: Partial<SkillProjectionContext> = {},
-  ): SkillProjectionContext {
+    overrides: Partial<Conversation> = {},
+  ): Conversation {
     return makeProjectionCtx({
       hasNoClient: true,
       subagentAllowedTools: new Set(["remember"]),

--- a/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-exclude.test.ts
@@ -16,10 +16,9 @@ import {
   registerPluginTools,
 } from "../../tools/registry.js";
 import type { Tool } from "../../tools/types.js";
+import type { Conversation } from "../conversation.js";
 import { createResolveToolsCallback } from "../conversation-tool-setup.js";
 
-type SkillProjectionContext =
-  import("../conversation-tool-setup.js").SkillProjectionContext;
 type SkillProjectionCache =
   import("../conversation-skill-tools.js").SkillProjectionCache;
 
@@ -43,15 +42,13 @@ function pluginTool(name: string): Tool {
   } as unknown as Tool;
 }
 
-function makeCtx(
-  overrides: Partial<SkillProjectionContext> = {},
-): SkillProjectionContext {
+function makeCtx(overrides: Partial<Conversation> = {}): Conversation {
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: { fingerprints: new Map() } as SkillProjectionCache,
     toolsDisabledDepth: 0,
     ...overrides,
-  };
+  } as unknown as Conversation;
 }
 
 function withExclude(exclude: string[]) {

--- a/assistant/src/daemon/__tests__/conversation-tool-setup-plugin-scope.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-plugin-scope.test.ts
@@ -16,10 +16,9 @@ import {
   registerPluginTools,
 } from "../../tools/registry.js";
 import type { Tool } from "../../tools/types.js";
+import type { Conversation } from "../conversation.js";
 import { createResolveToolsCallback } from "../conversation-tool-setup.js";
 
-type SkillProjectionContext =
-  import("../conversation-tool-setup.js").SkillProjectionContext;
 type SkillProjectionCache =
   import("../conversation-skill-tools.js").SkillProjectionCache;
 
@@ -35,15 +34,13 @@ function pluginTool(name: string): Tool {
   } as unknown as Tool;
 }
 
-function makeCtx(
-  overrides: Partial<SkillProjectionContext> = {},
-): SkillProjectionContext {
+function makeCtx(overrides: Partial<Conversation> = {}): Conversation {
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: { fingerprints: new Map() } as SkillProjectionCache,
     toolsDisabledDepth: 0,
     ...overrides,
-  };
+  } as unknown as Conversation;
 }
 
 let getConfigSpy: ReturnType<typeof spyOn> | undefined;

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -29,6 +29,9 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { Conversation } from "../conversation.js";
+import type { ChannelCapabilities } from "../conversation-runtime-assembly.js";
+
 // ── Module-level mocks ─────────────────────────────────────────────
 
 // Control how many capable clients the hub reports per capability.
@@ -51,20 +54,20 @@ mock.module("../../runtime/assistant-event-hub.js", () => ({
 // before the modules under test are loaded.
 const { HOST_TOOL_NAMES, HOST_TOOL_TO_CAPABILITY, isToolActiveForContext } =
   await import("../conversation-tool-setup.js");
-type SkillProjectionContext =
-  import("../conversation-tool-setup.js").SkillProjectionContext;
 type SkillProjectionCache =
   import("../conversation-skill-tools.js").SkillProjectionCache;
 
 function makeCtx(
-  overrides: Partial<SkillProjectionContext> = {},
-): SkillProjectionContext {
+  overrides: Partial<Omit<Conversation, "channelCapabilities">> & {
+    channelCapabilities?: Partial<ChannelCapabilities>;
+  } = {},
+): Conversation {
   return {
     skillProjectionState: new Map(),
     skillProjectionCache: {} as SkillProjectionCache,
     toolsDisabledDepth: 0,
     ...overrides,
-  };
+  } as unknown as Conversation;
 }
 
 beforeEach(() => {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -8,12 +8,10 @@
 
 import {
   type HostProxyCapability,
-  type InterfaceId,
   supportsHostProxy,
 } from "../channels/types.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
-import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { getBindingByConversation } from "../persistence/external-conversation-store.js";
@@ -58,10 +56,8 @@ import {
   type UsageAttributionSnapshot,
 } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
-import {
-  projectSkillTools,
-  type SkillProjectionCache,
-} from "./conversation-skill-tools.js";
+import type { Conversation } from "./conversation.js";
+import { projectSkillTools } from "./conversation-skill-tools.js";
 import { surfaceProxyResolver } from "./conversation-surfaces.js";
 import {
   isDoordashCommand,
@@ -73,11 +69,7 @@ import { FALLBACK_TURN_TRUST, resolveTrustClass } from "./trust-context.js";
 
 const log = getLogger("conversation-tool-setup");
 
-import type {
-  SubagentToolGateMode,
-  ToolSetupContext,
-  WakeToolContextPin,
-} from "./tool-setup-types.js";
+import type { ToolSetupContext } from "./tool-setup-types.js";
 export type {
   SubagentToolGateMode,
   ToolSetupContext,
@@ -480,83 +472,6 @@ export function createProxyApprovalCallback(
  */
 export const DEFAULT_PREACTIVATED_SKILL_IDS = ["notifications", "subagent"];
 
-/**
- * Subset of Conversation state that the resolveTools callback reads at each
- * agent turn. Properties are read lazily from this reference.
- */
-export interface SkillProjectionContext {
-  preactivatedSkillIds?: string[];
-  readonly skillProjectionState: Map<string, string>;
-  readonly skillProjectionCache: SkillProjectionCache;
-  allowedToolNames?: Set<string>;
-  /**
-   * Durable copy of the full tool definitions resolved on the most recent
-   * turn, used by read-only inventory queries. Set alongside
-   * {@link allowedToolNames} but, unlike that per-turn execution gate, never
-   * cleared at turn teardown.
-   */
-  registeredToolDefinitions?: ToolDefinition[];
-  /** When > 0, the resolveTools callback returns no tools at all. */
-  toolsDisabledDepth: number;
-  /** Channel capabilities — read lazily per turn for conditional tool filtering. */
-  readonly channelCapabilities?: {
-    channel: string;
-    supportsDynamicUi: boolean;
-    clientOS?: string;
-  };
-  /** True when no client is connected (HTTP-only). */
-  readonly hasNoClient?: boolean;
-  /** When set, only tools in this set are included in the resolved tool list (subagent delegation). */
-  subagentAllowedTools?: Set<string>;
-  /**
-   * How {@link subagentAllowedTools} is enforced — see
-   * {@link SubagentToolGateMode}. Absent means `"wire"`.
-   */
-  subagentToolGateMode?: SubagentToolGateMode;
-  /**
-   * When set (execution-gate-mode wakes), tool-definition resolution reads
-   * `hasNoClient` / `transportInterface` / `channelCapabilities` exclusively
-   * from this pin instead of the live conversation — see
-   * {@link WakeToolContextPin}.
-   */
-  readonly toolContextPin?: WakeToolContextPin;
-  /** True when the current turn is restricted to disk-pressure cleanup-safe tools. */
-  diskPressureCleanupModeActive?: boolean;
-  /** True when this conversation belongs to a subagent spawned by SubagentManager. */
-  readonly isSubagent?: boolean;
-  /**
-   * The interface id of the connected client driving the current turn (e.g.
-   * "macos", "chrome-extension"). Used to gate host tools by per-capability
-   * `supportsHostProxy(transport, capability)` so that interfaces which only
-   * support a subset of the host proxy set (e.g. chrome-extension supports
-   * `host_browser` but not `host_bash`/`host_file`) do not leak unsupported
-   * host tools into the LLM tool definitions.
-   */
-  readonly transportInterface?: InterfaceId;
-  /** Per-turn override profile. */
-  currentTurnOverrideProfile?: string;
-  /**
-   * The conversation's per-chat plugin scope (mirrors
-   * {@link Conversation.enabledPlugins}). `null`/absent means no per-chat
-   * restriction; otherwise plugin-owned tools and skills are intersected with
-   * the effective set (the scope unioned with the always-on first-party
-   * defaults) via {@link getEffectiveEnabledPluginSet}. Read per turn so a
-   * mid-conversation scope change is picked up.
-   */
-  readonly enabledPlugins?: string[] | null;
-  /**
-   * Conversation id for `skill_loaded` telemetry. Absent (e.g. minimal test
-   * contexts) disables telemetry recording in the skill projection.
-   */
-  readonly conversationId?: string;
-  /**
-   * The LLM call site driving the current turn (see
-   * {@link ToolSetupContext.currentCallSite}) — read per turn so skill_loaded
-   * telemetry attributes the provider/model/profile the turn actually ran on.
-   */
-  currentCallSite?: LLMCallSite;
-}
-
 // ── Conditional tool sets ────────────────────────────────────────────
 
 const UI_SURFACE_TOOL_NAMES = new Set(["ui_show", "ui_update", "ui_dismiss"]);
@@ -646,7 +561,7 @@ export const SUBAGENT_ONLY_TOOL_NAMES = new Set<string>([
  */
 export function isToolActiveForContext(
   name: string,
-  ctx: SkillProjectionContext,
+  ctx: Conversation,
 ): boolean {
   // Execution-gate-mode wakes pin the client-context inputs so the wire tool
   // surface matches the SOURCE conversation's live turns rather than the
@@ -780,7 +695,7 @@ export function isToolActiveForContext(
  */
 export function createResolveToolsCallback(
   toolDefs: ToolDefinition[],
-  ctx: SkillProjectionContext,
+  ctx: Conversation,
 ): ((history: Message[]) => ToolDefinition[]) | undefined {
   if (toolDefs.length === 0) {
     return undefined;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2286,8 +2286,8 @@ export class Conversation {
   }
 
   /**
-   * Implements the `transportInterface` field of `SkillProjectionContext` so
-   * that `isToolActiveForContext` can gate host tools by per-capability
+   * The `transportInterface` the tool resolver reads so
+   * `isToolActiveForContext` can gate host tools by per-capability
    * `supportsHostProxy(transport, capability)`. Derived from the live turn
    * interface context so it tracks the connected client across turns.
    */

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -16,11 +16,11 @@ import {
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { getGuardianDelivery } from "../../contacts/guardian-delivery-reader.js";
+import type { Conversation } from "../../daemon/conversation.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import {
   createResolveToolsCallback,
   DEFAULT_PREACTIVATED_SKILL_IDS,
-  type SkillProjectionContext,
 } from "../../daemon/conversation-tool-setup.js";
 import {
   computeGatewayTarget,
@@ -487,8 +487,8 @@ function handleToolNamesList(
  * Resolve the tool surface a subagent would receive, identified either by a
  * role name (e.g. "researcher") or a live subagent id.
  *
- * For a role name: build a {@link SkillProjectionContext} matching what the
- * {@link SubagentManager} sets up at spawn time (isSubagent, allowedTools,
+ * For a role name: build a minimal {@link Conversation} stand-in matching what
+ * the {@link SubagentManager} sets up at spawn time (isSubagent, allowedTools,
  * preactivated skill ids, no client), then run the exact same
  * {@link createResolveToolsCallback} the real subagent uses to project tools
  * for its first turn. This ensures the diagnostic reports the same tool set
@@ -516,7 +516,9 @@ function handleAgentToolList(agent: string): ToolNamesListResponse {
     );
   }
 
-  // Build the same context the SubagentManager creates at spawn time:
+  // Build the same context the SubagentManager creates at spawn time. The
+  // resolver reads only this subset of Conversation state, so a minimal
+  // stand-in cast to Conversation is enough:
   //   - isSubagent: true (gates subagent-only tools like notify_parent)
   //   - subagentAllowedTools: the role's allowlist (wire gate mode by default)
   //   - preactivatedSkillIds: role skill ids merged with defaults
@@ -527,7 +529,7 @@ function handleAgentToolList(agent: string): ToolNamesListResponse {
     roleConfig.skillIds,
     DEFAULT_PREACTIVATED_SKILL_IDS,
   );
-  const ctx: SkillProjectionContext = {
+  const ctx = {
     isSubagent: true,
     subagentAllowedTools: roleConfig.allowedTools
       ? new Set(roleConfig.allowedTools)
@@ -539,7 +541,7 @@ function handleAgentToolList(agent: string): ToolNamesListResponse {
     skillProjectionCache: {},
     hasNoClient: true,
     preactivatedSkillIds: mergedSkillIds,
-  };
+  } as unknown as Conversation;
 
   // Run the real tool resolver — the same callback a subagent conversation
   // uses each turn. An empty message history simulates the first turn before


### PR DESCRIPTION
## Prompt / plan

Follow-up from #38019 review ([thread](https://github.com/vellum-ai/vellum-assistant/pull/38019#discussion_r3577741250)): *"get rid of this type, and others like it, to just import the `type Conversation`."*

The tool resolver took a hand-maintained `SkillProjectionContext` interface — a structural subset of `Conversation`'s fields that had to be kept in sync by hand. `Conversation` already satisfies it (that's what the `this as SkillProjectionContext` casts relied on), so this deletes the interface and has the resolver import `type Conversation` directly.

### Changes

- **`conversation-tool-setup.ts`**: delete the `SkillProjectionContext` interface. `createResolveToolsCallback` and `isToolActiveForContext` now take `Conversation` (type-only import). Removed the imports that only the interface referenced (`InterfaceId`, `LLMCallSite`, `SkillProjectionCache`, and the local `SubagentToolGateMode`/`WakeToolContextPin` — the latter two stay re-exported).
- **`settings-routes.ts`**: the subagent tool-projection path builds a minimal `Conversation` stand-in (`as unknown as Conversation`) instead of a typed context literal.
- **Tests (10 files)**: `makeCtx` helpers type overrides as `Partial<Conversation>` and cast their minimal literals `as unknown as Conversation`. One file (`conversation-tool-setup.test.ts`) widens only its `channelCapabilities` override, because `Conversation.channelCapabilities` is the full `ChannelCapabilities` (requires `dashboardCapable`/`supportsVoiceInput`) where the old inline type was looser — a type relaxation only, no field values changed.
- Updated two doc comments that named the deleted type.

Scoped to `SkillProjectionContext` (the commented type). `ToolSetupContext` / `SurfaceConversationContext` are the remaining "others like it" — a good next PR.

**No runtime change** — `Conversation` is a superset of what the resolver reads, so every call site passes the same object it did before.

## Note on `lint:circular`

The `import type { Conversation }` edge is **type-only** — erased at compile time, so it creates no runtime cycle. But madge counts type imports, so `bun run lint:circular` reports **104** cycles instead of 103. All 104 are pre-existing/type-level; no new *runtime* cycle is introduced (verified: swapping the import in/out only moves the count by this one type edge). If we'd rather the count not grow, a small follow-up could enable madge's `skipTypeImports` so the circular check ignores erased type edges — happy to do that separately.

## Test plan

- `bunx tsc --noEmit` clean; `eslint` clean; pre-commit/pre-push hooks passed.
- All 10 affected test suites green per-file (conversation-tool-setup-*, subagent-*, tools-get-route via the subagent-projection ctx literal, file-list, disk-pressure, always-loaded). No behavior assertions changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ok5MKKrM4ZnmqG3AeXWtc

---
_Generated by [Claude Code](https://claude.ai/code/session_014ok5MKKrM4ZnmqG3AeXWtc)_