### PR TITLE
fix(lexical): reconcile segment count on existing messages_lexical collections

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
@@ -31,7 +31,10 @@ let deleteCollectionCalls: string[];
 let payloadIndexCalls: Array<Record<string, unknown>>;
 // Sparse-vector config reported by getCollection for an existing collection.
 let mockSparseVectors: Record<string, unknown> | null;
+// Optimizer config reported by getCollection for an existing collection.
+let mockOptimizerConfig: Record<string, unknown> | null;
 let updateCollectionCalls: Array<{ name: string; params: unknown }>;
+let mockUpdateCollectionError: Error | null;
 let mockQueryPoints: Array<{
   id: string | number;
   score: number;
@@ -47,7 +50,9 @@ function resetMockState() {
   deleteCollectionCalls = [];
   payloadIndexCalls = [];
   mockSparseVectors = { sparse: { index: { on_disk: true } } };
+  mockOptimizerConfig = { default_segment_number: 2 };
   updateCollectionCalls = [];
+  mockUpdateCollectionError = null;
   mockQueryPoints = [];
 }
 
@@ -68,11 +73,17 @@ mock.module("@qdrant/js-client-rest", () => ({
           params: {
             ...(mockSparseVectors ? { sparse_vectors: mockSparseVectors } : {}),
           },
+          ...(mockOptimizerConfig
+            ? { optimizer_config: mockOptimizerConfig }
+            : {}),
         },
       };
     }
 
     async updateCollection(name: string, params: unknown) {
+      if (mockUpdateCollectionError) {
+        throw mockUpdateCollectionError;
+      }
       updateCollectionCalls.push({ name, params });
     }
 
@@ -187,6 +198,71 @@ describe("MessagesLexicalIndex", () => {
     await index.ensureCollection();
 
     expect(updateCollectionCalls).toEqual([]);
+  });
+
+  test("sets the explicit segment count on an existing auto-sized collection", async () => {
+    mockCollectionExists = true;
+    // Collection created before the explicit count: Qdrant auto-detected 8
+    // segments from the node's CPU count.
+    mockOptimizerConfig = { default_segment_number: 8 };
+
+    const index = makeIndex();
+    await index.ensureCollection();
+
+    expect(createCollectionCalls).toEqual([]);
+    expect(deleteCollectionCalls).toEqual([]);
+    expect(updateCollectionCalls).toEqual([
+      {
+        name: "messages_lexical",
+        params: { optimizers_config: { default_segment_number: 2 } },
+      },
+    ]);
+  });
+
+  test("treats an unset segment count (auto) as needing the explicit value", async () => {
+    mockCollectionExists = true;
+    mockOptimizerConfig = { default_segment_number: null };
+
+    const index = makeIndex();
+    await index.ensureCollection();
+
+    expect(updateCollectionCalls).toEqual([
+      {
+        name: "messages_lexical",
+        params: { optimizers_config: { default_segment_number: 2 } },
+      },
+    ]);
+  });
+
+  test("leaves a collection already at the target segment count alone", async () => {
+    mockCollectionExists = true;
+    mockOptimizerConfig = { default_segment_number: 2 };
+
+    const index = makeIndex();
+    await index.ensureCollection();
+
+    expect(updateCollectionCalls).toEqual([]);
+  });
+
+  test("a failed segment-count update is swallowed and startup continues", async () => {
+    mockCollectionExists = true;
+    mockOptimizerConfig = { default_segment_number: 8 };
+    mockUpdateCollectionError = new Error("qdrant unavailable");
+
+    const index = makeIndex();
+    await index.ensureCollection();
+
+    // No update recorded (it threw) — but ensureCollection completed and the
+    // payload indexes were still ensured.
+    expect(updateCollectionCalls).toEqual([]);
+    expect(payloadIndexCalls.length).toBeGreaterThan(0);
+
+    // The collection is usable: a subsequent write goes straight through.
+    await index.upsertMessage("m1", SPARSE, {
+      conversationId: "c1",
+      createdAt: 1,
+    });
+    expect(upsertCalls.length).toBe(1);
   });
 
   test("upsertMessage writes a deterministic point id and a sparse-only vector with the right payload", async () => {

--- a/assistant/src/persistence/embeddings/messages-lexical-index.ts
+++ b/assistant/src/persistence/embeddings/messages-lexical-index.ts
@@ -96,6 +96,7 @@ export class MessagesLexicalIndex {
       const exists = await this.client.collectionExists(this.collection);
       if (exists.exists) {
         await this.reconcileSparseIndexOnDisk();
+        await this.reconcileSegmentNumber();
         if (await this.ensurePayloadIndexesSafe()) {
           this.collectionReady = true;
         }
@@ -398,6 +399,54 @@ export class MessagesLexicalIndex {
       log.warn(
         { err, collection: this.collection, onDisk: this.onDisk },
         "Failed to update sparse index placement — continuing with current index",
+      );
+    }
+  }
+
+  /**
+   * Align an existing collection's segment count with
+   * {@link DEFAULT_SEGMENT_NUMBER}. A collection created without an explicit
+   * count keeps Qdrant's CPU-count auto-detection (reported as unset/0);
+   * `updateCollection` sets the target and the background optimizer merges
+   * segments toward it in place.
+   *
+   * Best-effort: a failed probe or update logs and leaves the collection
+   * serving with its current segments — search keeps working either way.
+   */
+  private async reconcileSegmentNumber(): Promise<void> {
+    try {
+      const info = await this.client.getCollection(this.collection);
+      const current =
+        (
+          info.config as
+            | {
+                optimizer_config?: {
+                  default_segment_number?: number | null;
+                } | null;
+              }
+            | undefined
+        )?.optimizer_config?.default_segment_number ?? 0;
+      if (current === DEFAULT_SEGMENT_NUMBER) {
+        return;
+      }
+
+      await this.client.updateCollection(this.collection, {
+        optimizers_config: {
+          default_segment_number: DEFAULT_SEGMENT_NUMBER,
+        },
+      });
+      log.info(
+        {
+          collection: this.collection,
+          from: current,
+          to: DEFAULT_SEGMENT_NUMBER,
+        },
+        "Set explicit segment count on existing Qdrant collection",
+      );
+    } catch (err) {
+      log.warn(
+        { err, collection: this.collection },
+        "Failed to update collection segment count — continuing with current segments",
       );
     }
   }


### PR DESCRIPTION
ref ATL-1026

Existing installs' `messages_lexical` collections were created with qdrant's auto segment count (CPU-count = 8 on production nodes); #38017 fixes only newly created collections.

This adds a startup reconcile in `ensureCollection`'s exists-branch, mirroring the shipped `reconcileSparseIndexOnDisk` pattern: on the first lexical index operation after boot, if the collection reports a `default_segment_number` other than 2 (including unset/auto), it PATCHes `optimizers_config.default_segment_number = 2`. Best-effort (update failure logs a warning, never blocks startup or search) and idempotent (no-op once the value matches). Qdrant's background optimizer then merges existing segments toward the target — roughly 384 MB back per managed assistant (8→2 segments × 2 stores × 32 MiB pages).

**Validation:** the config-update mechanism is precedented, but optimizer merge-down of existing segments is documented qdrant behavior not yet verified on our build — hold merge until this check converges on an internal pod:

```bash
curl -s localhost:6333/collections/messages_lexical | jq '.result.segments_count'   # before (expect 8)
curl -s -X PATCH localhost:6333/collections/messages_lexical -H 'Content-Type: application/json' -d '{"optimizers_config":{"default_segment_number":2}}'
watch -n 30 "curl -s localhost:6333/collections/messages_lexical | jq '.result.segments_count'"   # expect convergence toward 2 (confirm with du on the collection dir)
```

Tests cover: update issued for a live value of 8 and for null/auto, no-op at 2, and a thrown update error swallowed with startup continuing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)