### PR TITLE
fix: correct agent-wrapped pin SHA (URGENT - broken marketplace installs)

### DIFF
--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -22,7 +22,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "9df51d5425de55574d1ecd89175df083d2dbb21c"
+        "ref": "9df51d57e239105b3c587a25292f5aaa96c41b6b"
       },
       "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and your era. Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -22,7 +22,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "9df51d5425de55574d1ecd89175df083d2dbb21c"
+        "ref": "9df51d57e239105b3c587a25292f5aaa96c41b6b"
       },
       "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and your era. Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",


### PR DESCRIPTION
PR #38028 merged with an invalid fabricated SHA for agent-wrapped. The ref 9df51d5425de55574d1ecd89175df083d2dbb21c does not exist in the repo. This breaks all marketplace installs of agent-wrapped. This PR repoints to the real SHA 9df51d57e239105b3c587a25292f5aaa96c41b6b. Both files fixed. Merge ASAP. Merge is Marina call.