### PR TITLE
feat(apps): resolve and open plugin-bundled apps in the library

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -606,6 +606,8 @@ paths:
                           type: string
                         contentId:
                           type: string
+                        origin:
+                          type: string
                       required:
                         - id
                         - name
@@ -613,6 +615,7 @@ paths:
                         - updatedAt
                         - version
                         - contentId
+                        - origin
                       additionalProperties: false
                 required:
                   - apps

--- a/assistant/src/__tests__/list-all-apps.test.ts
+++ b/assistant/src/__tests__/list-all-apps.test.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { createApp, listAllApps, listPluginApps } from "../apps/app-store.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): string {
+  return join(
+    tmpdir(),
+    `vellum-list-all-apps-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+}
+
+/**
+ * Materialize an installed plugin under `<workspace>/plugins/<name>/` with a
+ * package.json manifest. Returns the plugin directory path.
+ */
+function installPlugin(
+  name: string,
+  opts: { disabled?: boolean } = {},
+): string {
+  const pluginDir = join(getWorkspacePluginsDir(), name);
+  mkdirSync(pluginDir, { recursive: true });
+  writeFileSync(
+    join(pluginDir, "package.json"),
+    JSON.stringify({ name, version: "1.0.0" }),
+  );
+  if (opts.disabled) {
+    writeFileSync(join(pluginDir, ".disabled"), "");
+  }
+  return pluginDir;
+}
+
+/**
+ * Bundle an app inside a plugin as a directory under `<pluginDir>/apps/<app>/`.
+ */
+function bundleApp(pluginDir: string, app: string): void {
+  const appDir = join(pluginDir, "apps", app);
+  mkdirSync(appDir, { recursive: true });
+  writeFileSync(join(appDir, "index.html"), "<h1>Plugin app</h1>");
+}
+
+beforeEach(() => {
+  workspaceDir = freshWorkspace();
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("listAllApps", () => {
+  test("returns nothing when no apps exist", () => {
+    expect(listAllApps()).toEqual([]);
+    expect(listPluginApps()).toEqual([]);
+  });
+
+  test("tags workspace apps with the workspace origin", () => {
+    const created = createApp({
+      name: "Budget",
+      schemaJson: "{}",
+      htmlDefinition: "<h1>Budget</h1>",
+    });
+
+    const all = listAllApps();
+    expect(all).toHaveLength(1);
+    expect(all[0].origin).toEqual({ kind: "workspace" });
+    expect(all[0].name).toBe("Budget");
+    // Workspace source resolves through the dirName-based resolver.
+    expect(all[0].sourcePath).toContain(join("data", "apps"));
+    expect(all[0].sourcePath).toContain(created.dirName ?? created.id);
+  });
+
+  test("discovers plugin apps by directory, tagged plugin:<name>", () => {
+    createApp({
+      name: "Budget",
+      schemaJson: "{}",
+      htmlDefinition: "<h1>Budget</h1>",
+    });
+    const pluginDir = installPlugin("acme");
+    bundleApp(pluginDir, "acme-dashboard");
+
+    const plugin = listPluginApps();
+    expect(plugin).toHaveLength(1);
+    expect(plugin[0].origin).toEqual({ kind: "plugin", pluginName: "acme" });
+    expect(plugin[0].name).toBe("acme-dashboard");
+    expect(plugin[0].sourcePath).toBe(
+      join(pluginDir, "apps", "acme-dashboard"),
+    );
+
+    // Workspace apps come first, then plugin apps.
+    const all = listAllApps();
+    expect(all.map((a) => a.origin.kind)).toEqual(["workspace", "plugin"]);
+  });
+
+  test("ignores directories under plugins/ without a package.json manifest", () => {
+    // A stray directory that is not an installed plugin, even with an apps/ dir.
+    const strayDir = join(getWorkspacePluginsDir(), "not-a-plugin");
+    mkdirSync(join(strayDir, "apps", "ghost"), { recursive: true });
+
+    expect(listPluginApps()).toEqual([]);
+  });
+
+  test("includes apps from a symlinked plugin directory", () => {
+    // Real plugin lives outside plugins/; plugins/<name> is a symlink to it.
+    const realPluginDir = join(workspaceDir, "external-acme");
+    mkdirSync(realPluginDir, { recursive: true });
+    writeFileSync(
+      join(realPluginDir, "package.json"),
+      JSON.stringify({ name: "acme", version: "1.0.0" }),
+    );
+    bundleApp(realPluginDir, "acme-dashboard");
+
+    mkdirSync(getWorkspacePluginsDir(), { recursive: true });
+    symlinkSync(realPluginDir, join(getWorkspacePluginsDir(), "acme"));
+
+    const plugin = listPluginApps();
+    expect(plugin).toHaveLength(1);
+    expect(plugin[0].name).toBe("acme-dashboard");
+    expect(plugin[0].origin).toEqual({ kind: "plugin", pluginName: "acme" });
+  });
+
+  test("excludes apps from disabled plugins", () => {
+    const pluginDir = installPlugin("acme", { disabled: true });
+    bundleApp(pluginDir, "acme-dashboard");
+
+    expect(listPluginApps()).toEqual([]);
+    expect(listAllApps()).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/list-all-apps.test.ts
+++ b/assistant/src/__tests__/list-all-apps.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { createApp, listAllApps, listPluginApps } from "../apps/app-store.js";
+import {
+  createApp,
+  listAllApps,
+  listPluginApps,
+  resolveAppSource,
+} from "../apps/app-store.js";
 import { getWorkspacePluginsDir } from "../util/platform.js";
 
 let workspaceDir: string;
@@ -69,6 +74,7 @@ describe("listAllApps", () => {
     const all = listAllApps();
     expect(all).toHaveLength(1);
     expect(all[0].origin).toEqual({ kind: "workspace" });
+    expect(all[0].id).toBe(created.id);
     expect(all[0].name).toBe("Budget");
     // Workspace source resolves through the dirName-based resolver.
     expect(all[0].sourcePath).toContain(join("data", "apps"));
@@ -87,6 +93,7 @@ describe("listAllApps", () => {
     const plugin = listPluginApps();
     expect(plugin).toHaveLength(1);
     expect(plugin[0].origin).toEqual({ kind: "plugin", pluginName: "acme" });
+    expect(plugin[0].id).toBe("plugins/acme/acme-dashboard");
     expect(plugin[0].name).toBe("acme-dashboard");
     expect(plugin[0].sourcePath).toBe(
       join(pluginDir, "apps", "acme-dashboard"),
@@ -130,5 +137,68 @@ describe("listAllApps", () => {
 
     expect(listPluginApps()).toEqual([]);
     expect(listAllApps()).toEqual([]);
+  });
+});
+
+describe("resolveAppSource", () => {
+  test("resolves a workspace app by its UUID", () => {
+    const created = createApp({
+      name: "Budget",
+      schemaJson: "{}",
+      htmlDefinition: "<h1>Budget</h1>",
+    });
+
+    const source = resolveAppSource(created.id);
+    expect(source).not.toBeNull();
+    expect(source!.origin).toEqual({ kind: "workspace" });
+    expect(source!.name).toBe("Budget");
+    expect(source!.sourceDir).toContain(join("data", "apps"));
+    // Single-file app (index.html at root).
+    expect(source!.formatVersion).toBe(1);
+  });
+
+  test("resolves a plugin app by its plugins/<name>/<app> id", () => {
+    const pluginDir = installPlugin("acme");
+    bundleApp(pluginDir, "acme-dashboard");
+
+    const source = resolveAppSource("plugins/acme/acme-dashboard");
+    expect(source).not.toBeNull();
+    expect(source!.origin).toEqual({ kind: "plugin", pluginName: "acme" });
+    expect(source!.name).toBe("acme-dashboard");
+    expect(source!.sourceDir).toBe(join(pluginDir, "apps", "acme-dashboard"));
+    // bundleApp writes index.html at the root → single-file.
+    expect(source!.formatVersion).toBe(1);
+  });
+
+  test("returns null for an unknown workspace id", () => {
+    expect(resolveAppSource("11111111-1111-1111-1111-111111111111")).toBeNull();
+  });
+
+  test("returns null for a plugin app whose plugin is disabled", () => {
+    const pluginDir = installPlugin("acme", { disabled: true });
+    bundleApp(pluginDir, "acme-dashboard");
+
+    expect(resolveAppSource("plugins/acme/acme-dashboard")).toBeNull();
+  });
+
+  test("returns null for a plugin dir without a package.json manifest", () => {
+    // Stray directory shaped like a plugin app but not an installed plugin.
+    const strayApp = join(
+      getWorkspacePluginsDir(),
+      "not-a-plugin",
+      "apps",
+      "x",
+    );
+    mkdirSync(strayApp, { recursive: true });
+
+    expect(resolveAppSource("plugins/not-a-plugin/x")).toBeNull();
+  });
+
+  test("returns null for traversal and malformed plugin ids", () => {
+    installPlugin("acme");
+    expect(resolveAppSource("plugins/../secrets")).toBeNull();
+    expect(resolveAppSource("plugins/acme/../..")).toBeNull();
+    expect(resolveAppSource("plugins/acme")).toBeNull(); // missing app segment
+    expect(resolveAppSource("plugins/acme/a/b")).toBeNull(); // too deep
   });
 });

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -35,10 +35,11 @@ import {
 } from "node:path";
 
 import { rawAll } from "../persistence/raw-query.js";
+import { isPluginDisabled } from "../plugins/disabled-state.js";
 import type { EditEngineResult } from "../tools/shared/filesystem/edit-engine.js";
 import { applyEdit } from "../tools/shared/filesystem/edit-engine.js";
 import { getLogger } from "../util/logger.js";
-import { getDataDir } from "../util/platform.js";
+import { getDataDir, getWorkspacePluginsDir } from "../util/platform.js";
 
 export interface AppDefinition {
   id: string;
@@ -622,6 +623,121 @@ export function listApps(): AppDefinition[] {
   }
   apps.sort((a, b) => b.updatedAt - a.updatedAt);
   return apps;
+}
+
+// ---------------------------------------------------------------------------
+// Cross-source enumeration (workspace + plugin-bundled apps)
+// ---------------------------------------------------------------------------
+
+/**
+ * Where an app is provided from. Workspace apps are user-created and live under
+ * `<workspace>/data/apps/`; plugin apps are bundled by an installed plugin
+ * under `<workspace>/plugins/<name>/apps/`.
+ */
+export type AppOrigin =
+  | { readonly kind: "workspace" }
+  | { readonly kind: "plugin"; readonly pluginName: string };
+
+/** An app paired with the absolute path to its source and its origin. */
+export interface EnumeratedApp {
+  /** Human-readable app name. */
+  readonly name: string;
+  /** Absolute path to the app's source directory. */
+  readonly sourcePath: string;
+  /** Where the app is provided from. */
+  readonly origin: AppOrigin;
+}
+
+/**
+ * Enumerate apps bundled under a single plugin's `apps/` directory. Each
+ * immediate subdirectory is one app: its directory name is the app name and
+ * its path is the source.
+ */
+function listAppsForPlugin(
+  pluginName: string,
+  pluginDir: string,
+): EnumeratedApp[] {
+  const appsDir = join(pluginDir, "apps");
+  let entries: string[];
+  try {
+    entries = readdirSync(appsDir);
+  } catch {
+    // No apps/ directory (or unreadable) — this plugin bundles no apps.
+    return [];
+  }
+  const apps: EnumeratedApp[] = [];
+  for (const entry of entries) {
+    const appDir = join(appsDir, entry);
+    try {
+      // statSync follows symlinks so a symlinked app directory still counts.
+      if (!statSync(appDir).isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    apps.push({
+      name: entry,
+      sourcePath: appDir,
+      origin: { kind: "plugin", pluginName },
+    });
+  }
+  return apps;
+}
+
+/**
+ * Enumerate apps bundled by installed, enabled plugins under
+ * `<workspace>/plugins/<name>/apps/`.
+ *
+ * Plugin discovery mirrors the plugin loader's `scanPlugins`: a plugin is an
+ * entry that resolves to a directory (following symlinks) and carries a
+ * `package.json` manifest. Stray directories without a manifest are ignored,
+ * and disabled plugins (those with a `.disabled` sentinel) contribute nothing,
+ * matching how their other surfaces (tools, hooks, routes) are gated.
+ */
+export function listPluginApps(): EnumeratedApp[] {
+  const pluginsRoot = getWorkspacePluginsDir();
+  if (!existsSync(pluginsRoot)) {
+    return [];
+  }
+  let entries: string[];
+  try {
+    entries = readdirSync(pluginsRoot);
+  } catch {
+    return [];
+  }
+  const apps: EnumeratedApp[] = [];
+  for (const name of entries) {
+    const pluginDir = join(pluginsRoot, name);
+    try {
+      if (!statSync(pluginDir).isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    if (!existsSync(join(pluginDir, "package.json"))) {
+      continue;
+    }
+    if (isPluginDisabled(name)) {
+      continue;
+    }
+    apps.push(...listAppsForPlugin(name, pluginDir));
+  }
+  return apps;
+}
+
+/**
+ * Enumerate every app the assistant can surface, tagged with its origin:
+ * workspace apps (user-created) followed by apps bundled by installed plugins.
+ */
+export function listAllApps(): EnumeratedApp[] {
+  const workspaceApps: EnumeratedApp[] = listApps().map((definition) => ({
+    name: definition.name,
+    sourcePath: getAppDirPath(definition.id),
+    origin: { kind: "workspace" as const },
+  }));
+  return [...workspaceApps, ...listPluginApps()];
 }
 
 export function updateApp(

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -87,6 +87,28 @@ export function resolveEffectiveAppHtml(app: AppDefinition): string {
 }
 
 /**
+ * Resolve the effective, self-contained HTML for an app given its source
+ * directory and format, without needing a loaded {@link AppDefinition}. Used
+ * to render apps addressed by path (e.g. plugin-bundled apps). Single-file
+ * apps serve their root index.html; multi-file apps serve the compiled
+ * dist/index.html with JS/CSS inlined.
+ */
+export function resolveEffectiveAppHtmlFromDir(
+  sourceDir: string,
+  formatVersion: number,
+): string {
+  if (formatVersion !== 2) {
+    const indexPath = join(sourceDir, "index.html");
+    return existsSync(indexPath) ? readFileSync(indexPath, "utf-8") : "";
+  }
+  const distIndex = join(sourceDir, "dist", "index.html");
+  if (existsSync(distIndex)) {
+    return inlineDistAssets(sourceDir, readFileSync(distIndex, "utf-8"));
+  }
+  return `<p>App compilation failed. Edit a source file to trigger a rebuild.</p>`;
+}
+
+/**
  * Inline dist assets (main.js, main.css) into the compiled HTML so it can be
  * delivered as a self-contained string via loadHTMLString/SSE without needing
  * the client to resolve external script/stylesheet URLs.
@@ -638,8 +660,27 @@ export type AppOrigin =
   | { readonly kind: "workspace" }
   | { readonly kind: "plugin"; readonly pluginName: string };
 
+/**
+ * Id prefix marking a plugin-bundled app. A plugin app's id is its location:
+ * `plugins/<pluginName>/<appDir>`, which maps directly to
+ * `<workspace>/plugins/<pluginName>/apps/<appDir>` (the `apps/` segment is
+ * implied). Unlike workspace apps — whose id is an opaque UUID looked up by
+ * scanning — a plugin app is resolved by a direct path build.
+ */
+const PLUGIN_APP_ID_PREFIX = "plugins/";
+
+/** Build the addressable id for a plugin-bundled app. */
+function pluginAppId(pluginName: string, appDir: string): string {
+  return `${PLUGIN_APP_ID_PREFIX}${pluginName}/${appDir}`;
+}
+
 /** An app paired with the absolute path to its source and its origin. */
 export interface EnumeratedApp {
+  /**
+   * Addressable app id: an opaque UUID for workspace apps, or
+   * `plugins/<name>/<app>` for plugin-bundled apps.
+   */
+  readonly id: string;
   /** Human-readable app name. */
   readonly name: string;
   /** Absolute path to the app's source directory. */
@@ -677,6 +718,7 @@ function listAppsForPlugin(
       continue;
     }
     apps.push({
+      id: pluginAppId(pluginName, entry),
       name: entry,
       sourcePath: appDir,
       origin: { kind: "plugin", pluginName },
@@ -733,11 +775,115 @@ export function listPluginApps(): EnumeratedApp[] {
  */
 export function listAllApps(): EnumeratedApp[] {
   const workspaceApps: EnumeratedApp[] = listApps().map((definition) => ({
+    id: definition.id,
     name: definition.name,
     sourcePath: getAppDirPath(definition.id),
     origin: { kind: "workspace" as const },
   }));
   return [...workspaceApps, ...listPluginApps()];
+}
+
+/** An app id resolved to its on-disk source and metadata. */
+export interface ResolvedAppSource {
+  /** The id that was resolved (echoed back for the caller). */
+  readonly id: string;
+  /** Human-readable app name. */
+  readonly name: string;
+  /** Filesystem directory stem — the workspace slug or the plugin app dir. */
+  readonly dirName: string;
+  /** Absolute path to the app's source directory. */
+  readonly sourceDir: string;
+  /** Where the app is provided from. */
+  readonly origin: AppOrigin;
+  /** 1 = single-file (index.html at root); 2 = multi-file (compiled dist/). */
+  readonly formatVersion: number;
+}
+
+/**
+ * Validate a single plugin-app id path segment (plugin name or app directory).
+ * Rejects empty, traversal, separators, and untrimmed values so an id can be
+ * mapped to a filesystem path without escaping the plugins root.
+ */
+function isSafeIdSegment(segment: string): boolean {
+  return (
+    segment.length > 0 &&
+    segment === segment.trim() &&
+    !segment.includes("/") &&
+    !segment.includes("\\") &&
+    !segment.includes("..") &&
+    segment !== "."
+  );
+}
+
+/**
+ * Resolve an app id to its on-disk source, for both workspace apps (opaque
+ * UUID, looked up via {@link getApp}) and plugin-bundled apps
+ * (`plugins/<name>/<app>`, resolved by direct path build). Returns null when
+ * the app does not exist, or when a plugin id fails the same installed-plugin
+ * gates as discovery (directory, `package.json` manifest, not disabled).
+ */
+export function resolveAppSource(id: string): ResolvedAppSource | null {
+  if (id.startsWith(PLUGIN_APP_ID_PREFIX)) {
+    const rest = id.slice(PLUGIN_APP_ID_PREFIX.length);
+    const slash = rest.indexOf("/");
+    if (slash === -1) {
+      return null;
+    }
+    const pluginName = rest.slice(0, slash);
+    const appDirName = rest.slice(slash + 1);
+    // Both segments must be single safe path components (rejects a deeper
+    // `plugins/<name>/<a>/<b>` since appDirName would then contain a slash).
+    if (!isSafeIdSegment(pluginName) || !isSafeIdSegment(appDirName)) {
+      return null;
+    }
+    const pluginDir = join(getWorkspacePluginsDir(), pluginName);
+    try {
+      if (!statSync(pluginDir).isDirectory()) {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+    if (!existsSync(join(pluginDir, "package.json"))) {
+      return null;
+    }
+    if (isPluginDisabled(pluginName)) {
+      return null;
+    }
+    const sourceDir = join(pluginDir, "apps", appDirName);
+    try {
+      if (!statSync(sourceDir).isDirectory()) {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+    // Single-file apps ship index.html at the root; anything else is treated
+    // as multi-file (served from a compiled dist/).
+    const formatVersion = existsSync(join(sourceDir, "index.html")) ? 1 : 2;
+    return {
+      id,
+      name: appDirName,
+      dirName: appDirName,
+      sourceDir,
+      origin: { kind: "plugin", pluginName },
+      formatVersion,
+    };
+  }
+
+  const app = getApp(id);
+  if (!app) {
+    return null;
+  }
+  const { dirName } = resolveAppDir(id);
+  return {
+    id,
+    name: app.name,
+    dirName,
+    sourceDir: getAppDirPath(id),
+    origin: { kind: "workspace" },
+    formatVersion: app.formatVersion ?? 1,
+  };
 }
 
 export function updateApp(

--- a/assistant/src/cli/commands/apps.help.ts
+++ b/assistant/src/cli/commands/apps.help.ts
@@ -4,15 +4,21 @@ import type { CliCommandHelp } from "../lib/cli-command-help.js";
 
 export const appsHelp: CliCommandHelp = {
   name: "apps",
-  description: "Inspect user-defined apps and their on-disk source",
+  description: "Inspect apps and their on-disk source",
   helpText: `
-Apps are user-defined mini-applications stored under the workspace apps
-directory (~/.vellum/apps/<slug>/). Each app has a human-readable name and a
+Apps are mini-applications the assistant can surface. Each has a name and a
 source directory holding its HTML/TSX definition, pages, and records.
 
-This surface is read-only. Apps are created, edited, and deleted through the
-app-builder skill and its tools (app-create, app-update, app-delete) — there is
-no CLI create/update/delete verb by design.
+Apps come from two places, distinguished by their source path:
+  workspace   User-created apps under the workspace apps directory
+              (~/.vellum/apps/<slug>/).
+  plugin      Apps bundled by an installed plugin, each a directory under
+              ~/.vellum/plugins/<name>/apps/<app>/. Stray directories without
+              a plugin package.json, and disabled plugins, contribute nothing.
+
+This surface is read-only. Workspace apps are created, edited, and deleted
+through the app-builder skill and its tools (app-create, app-update,
+app-delete); plugin apps are owned by their plugin.
 
 Examples:
   $ assistant apps list
@@ -25,12 +31,12 @@ Examples:
         { flags: "--json", description: "Machine-readable JSON output" },
       ],
       helpText: `
-Lists every app with its name and the absolute path to its source directory.
-The source path is the app's directory under the workspace apps directory; it
-holds index.html (single-file apps) or the TSX source tree (multi-file apps).
+Lists every app with its name and the absolute path to its source directory —
+the path itself shows whether the app is a workspace app or bundled by a plugin
+(~/.vellum/plugins/<name>/apps/...). Workspace apps are listed first, then
+plugin-bundled apps; both are sorted by name.
 
-Pass --json for the full record, including the app ID, format version, and
-last-updated time.
+Pass --json for machine-readable output.
 
 Examples:
   $ assistant apps list

--- a/assistant/src/cli/commands/apps.ts
+++ b/assistant/src/cli/commands/apps.ts
@@ -8,9 +8,6 @@ import { appsHelp } from "./apps.help.js";
 interface AppListEntry {
   name: string;
   source: string;
-  id: string;
-  formatVersion: number;
-  updatedAt: number;
 }
 
 export function registerAppsCommand(program: Command): void {
@@ -24,17 +21,10 @@ export function registerAppsCommand(program: Command): void {
       subcommand(apps, "list").action(async (opts: { json?: boolean }) => {
         // Lazy-import the app store so the daemon module graph loads only when
         // this command runs (cli/no-daemon-internals).
-        const { getAppDirPath, listApps } =
-          await import("../../apps/app-store.js");
+        const { listAllApps } = await import("../../apps/app-store.js");
 
-        const entries: AppListEntry[] = listApps()
-          .map((app) => ({
-            name: app.name,
-            source: getAppDirPath(app.id),
-            id: app.id,
-            formatVersion: app.formatVersion ?? 1,
-            updatedAt: app.updatedAt,
-          }))
+        const entries: AppListEntry[] = listAllApps()
+          .map(({ name, sourcePath }) => ({ name, source: sourcePath }))
           .sort((a, b) => a.name.localeCompare(b.name));
 
         if (opts.json) {
@@ -48,7 +38,7 @@ export function registerAppsCommand(program: Command): void {
         }
 
         // Name and source lead; align the name into a column so the source
-        // path is scannable across rows.
+        // path (which also identifies the app's origin) stays scannable.
         const nameWidth = Math.max(4, ...entries.map((e) => e.name.length));
         log.info(`Apps (${entries.length}):\n`);
         log.info(`  ${"NAME".padEnd(nameWidth)}  SOURCE`);

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -8,6 +8,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { stat, unlink } from "node:fs/promises";
@@ -22,15 +23,15 @@ import {
   createAppRecord,
   deleteApp,
   deleteAppRecord,
-  getApp,
+  type EnumeratedApp,
   getAppDirPath,
   getAppPreview,
-  isMultifileApp,
   listApps,
   listAppsByConversation,
+  listPluginApps,
   queryAppRecords,
-  resolveAppDir,
-  resolveEffectiveAppHtml,
+  resolveAppSource,
+  resolveEffectiveAppHtmlFromDir,
   updateApp,
   updateAppRecord,
 } from "../../apps/app-store.js";
@@ -75,7 +76,7 @@ function getSharedAppsDir(): string {
 // Extracted business logic
 // ---------------------------------------------------------------------------
 
-function listAppsFiltered(apps?: AppDefinition[]): Array<{
+interface AppListItem {
   id: string;
   name: string;
   description?: string;
@@ -84,21 +85,44 @@ function listAppsFiltered(apps?: AppDefinition[]): Array<{
   updatedAt: number;
   version: string;
   contentId: string;
-}> {
-  return (apps ?? listApps()).map((a) => {
-    const version = a.version ?? "1.0.0";
-    const contentId = computeContentId(a.name);
-    return {
-      id: a.id,
-      name: a.name,
-      description: a.description,
-      icon: a.icon,
-      createdAt: a.createdAt,
-      updatedAt: a.updatedAt,
-      version,
-      contentId,
-    };
-  });
+  /** "workspace" or "plugin:<name>" — identifies where the app comes from. */
+  origin: string;
+}
+
+function workspaceAppItem(a: AppDefinition): AppListItem {
+  return {
+    id: a.id,
+    name: a.name,
+    description: a.description,
+    icon: a.icon,
+    createdAt: a.createdAt,
+    updatedAt: a.updatedAt,
+    version: a.version ?? "1.0.0",
+    contentId: computeContentId(a.name),
+    origin: "workspace",
+  };
+}
+
+function pluginAppItem(app: EnumeratedApp): AppListItem {
+  // Plugin apps carry no stored timestamps; use the source dir mtime so the
+  // library can still order them sensibly.
+  let mtime = 0;
+  try {
+    mtime = statSync(app.sourcePath).mtimeMs;
+  } catch {
+    // Directory vanished between enumeration and stat — leave mtime at 0.
+  }
+  const pluginName =
+    app.origin.kind === "plugin" ? app.origin.pluginName : "unknown";
+  return {
+    id: app.id,
+    name: app.name,
+    createdAt: mtime,
+    updatedAt: mtime,
+    version: "1.0.0",
+    contentId: computeContentId(app.name),
+    origin: `plugin:${pluginName}`,
+  };
 }
 
 function getAppDataResult(
@@ -507,9 +531,17 @@ async function importBundle(
 function handleListApps({ queryParams }: RouteHandlerArgs) {
   const conversationId = queryParams?.conversationId;
   if (conversationId) {
-    return { apps: listAppsFiltered(listAppsByConversation(conversationId)) };
+    // Conversation scoping is a workspace-app concept; plugin apps are not
+    // associated with conversations, so they are omitted from this view.
+    return {
+      apps: listAppsByConversation(conversationId).map(workspaceAppItem),
+    };
   }
-  return { apps: listAppsFiltered() };
+  const apps: AppListItem[] = [
+    ...listApps().map(workspaceAppItem),
+    ...listPluginApps().map(pluginAppItem),
+  ];
+  return { apps };
 }
 
 async function handleOpenBundle({ body }: RouteHandlerArgs) {
@@ -619,16 +651,19 @@ function handleMutateAppData({ pathParams, body }: RouteHandlerArgs) {
 
 async function handleOpenApp({ pathParams }: RouteHandlerArgs) {
   const appId = pathParams?.id as string;
-  const app = getApp(appId);
-  if (!app) {
+  const source = resolveAppSource(appId);
+  if (!source) {
     throw new NotFoundError(`App not found: ${appId}`);
   }
 
-  if (isMultifileApp(app)) {
-    const appDir = getAppDirPath(appId);
-    const distIndex = join(appDir, "dist", "index.html");
+  // Multifile workspace apps auto-compile on open when their dist is missing.
+  // Plugin apps are not compiled here — a compile cache for plugin sources is a
+  // follow-up — so a multifile plugin app without a prebuilt dist/ renders its
+  // fallback message.
+  if (source.formatVersion === 2 && source.origin.kind === "workspace") {
+    const distIndex = join(source.sourceDir, "dist", "index.html");
     if (!existsSync(distIndex)) {
-      const result = await compileApp(appDir);
+      const result = await compileApp(source.sourceDir);
       if (!result.ok) {
         log.warn(
           { appId, errors: result.errors },
@@ -637,9 +672,17 @@ async function handleOpenApp({ pathParams }: RouteHandlerArgs) {
       }
     }
   }
-  const html = resolveEffectiveAppHtml(app);
-  const { dirName } = resolveAppDir(app.id);
-  return { appId: app.id, dirName, name: app.name, html };
+
+  const html = resolveEffectiveAppHtmlFromDir(
+    source.sourceDir,
+    source.formatVersion,
+  );
+  return {
+    appId: source.id,
+    dirName: source.dirName,
+    name: source.name,
+    html,
+  };
 }
 
 function handleDeleteApp({ pathParams, headers }: RouteHandlerArgs) {
@@ -721,6 +764,7 @@ export const ROUTES: RouteDefinition[] = [
           updatedAt: z.number(),
           version: z.string(),
           contentId: z.string(),
+          origin: z.string(),
         }),
       ),
     }),


### PR DESCRIPTION
## Prompt / plan

Next step toward apps as a pluginnable surface: make plugin-bundled apps **appear in the library and open**, not just be discoverable. This adds a path-based plugin app id and a single resolver that the list and open routes flow through.

> **Heads-up on the base.** This branch re-lands the plugin-discovery seam from #38021 as its first commit (`Surface plugin-bundled apps in apps list`). That PR was merged into its stacked base branch rather than `main`, so `listAllApps`/`listPluginApps` never actually reached `main` — I cherry-picked the exact merged commit here so this branch builds on it cleanly. The second commit is the new work.

### Design
- **Plugin app id = its location.** `plugins/<name>/<app>` maps directly to `<workspace>/plugins/<name>/apps/<app>` (the `apps/` segment implied). Unlike workspace apps (opaque UUID looked up by scanning), a plugin app resolves by a direct path build — no scan, no metadata file. `EnumeratedApp` now carries this `id`.
- **One resolver seam — `resolveAppSource(id)`.** Workspace ids go through `getApp`; plugin ids branch *before* `validateId` (which rejects `/`), validate their path segments (reject traversal/separators/too-deep), and apply the same installed-plugin gates as discovery (directory via `statSync` so symlinks are followed, `package.json` manifest, not `.disabled`). Returns `{ id, name, dirName, sourceDir, origin, formatVersion }` or `null`.
- **`resolveEffectiveAppHtmlFromDir(sourceDir, formatVersion)`** renders an app from its directory without a loaded `AppDefinition` (single-file → `index.html`; multi-file → inlined compiled `dist/`).

### Wiring
- `apps_open` (`POST /v1/apps/:id/open`) resolves via `resolveAppSource` and renders from the directory. Workspace multi-file apps still auto-compile on open; plugin apps aren't compiled here (see follow-ups), so a multi-file plugin app without a prebuilt `dist/` shows the fallback message.
- `apps_list` (`GET /v1/apps`) now returns workspace **and** plugin apps, each with an `origin` field (`"workspace"` | `"plugin:<name>"`). OpenAPI spec regenerated (`origin` added to the response — 3-line diff).

### Out of scope (follow-ups)
- Compile cache for multi-file plugin sources (plugin dirs are plugin-owned; we shouldn't write `dist/` back into them).
- Read-only gating of `delete`/`preview`/`bundle`/`share` for plugin apps.
- Routing the dist/asset serve routes (`apps_dist_file`, `apps_asset`, `pages_serve`) through the same resolver — needed once a multi-file plugin app ships.

## Test plan

- `src/__tests__/list-all-apps.test.ts` extended to **12 tests**: the discovery seam (workspace/plugin tagging, ordering, disabled + missing-manifest + symlink cases) plus a new `resolveAppSource` suite — workspace UUID, plugin id, unknown id, disabled plugin, no-manifest dir, and traversal/malformed/too-deep ids all covered.
- `bunx tsc --noEmit` clean; eslint 0 errors (pre-existing curly warnings only); `app-dir-path-guard` passes; existing app route/executor tests green (`app-executors`, `app-routes-csp`, `app-open-proxy` — 45 pass).
- OpenAPI regenerated via `bun run generate:openapi`; diff is the single `origin` field.

Not driven end-to-end through a live daemon since no plugin ships an app yet — the resolver and both handlers are unit-covered and the existing route tests exercise the open/list paths.

## CLI verb checklist

No new routes — this extends the existing `apps_list` / `apps_open` handlers. `apps_list` gains an `origin` response field (OpenAPI regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG

---
_Generated by [Claude Code](https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG)_