### PR TITLE
repin agent-wrapped to 64686ed + add homepage (delete feature, slug fixes)

### DIFF
--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -22,12 +22,13 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "9df51d57e239105b3c587a25292f5aaa96c41b6b"
+        "ref": "64686ed3b50997048e76e7e0abfb5d7ace23cd7e"
       },
       "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and your era. Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",
       "license": "MIT",
-      "submittedBy": "marina"
+      "submittedBy": "marina",
+      "homepage": "https://agent-wrapped.com"
     },
     {
       "name": "ai-hero-engineer-kit",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -22,12 +22,13 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "9df51d57e239105b3c587a25292f5aaa96c41b6b"
+        "ref": "64686ed3b50997048e76e7e0abfb5d7ace23cd7e"
       },
       "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and your era. Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",
       "license": "MIT",
-      "submittedBy": "marina"
+      "submittedBy": "marina",
+      "homepage": "https://agent-wrapped.com"
     },
     {
       "name": "ai-hero-engineer-kit",


### PR DESCRIPTION
Repins agent-wrapped from 9df51d5 to 64686ed and adds the homepage field per the distribution docs.

What is new in 64686ed:
- Delete mode: publish.js --delete --push removes a page instantly via /api/delete
- Auto-increment: if a slug is taken, server returns name-1, name-2 etc
- Slug guidance in SKILL.md: use the assistant name, not the user name
- /api/delete endpoint deployed and live

Both files updated:
- plugins/marketplace.json: ref + homepage
- assistant/src/cli/lib/bundled-marketplace.json: synced

Merge is Marina call.