### PR TITLE
fix(plugins): detect runtime plugin installs on coarse-mtime filesystems

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -679,6 +679,48 @@ describe("plugin runtime activation", () => {
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
   });
 
+  test("a runtime install is reconciled even when the sentinel mtime never moves (coarse-mtime filesystems)", async () => {
+    await populateCacheAtBoot(); // empty plugins dir
+
+    // Pin every sentinel write back to the SAME timestamp, simulating a
+    // filesystem whose mtime granularity can't distinguish two rewrites (the
+    // virtiofs / 9p / network mounts the watcher polls precisely because their
+    // timestamps are unreliable). Only the sentinel's size + inode move — and
+    // the reconcile gate keys on those, not mtime alone.
+    const FIXED = new Date("2020-01-01T00:00:00.000Z");
+    const pinMtime = (): void =>
+      utimesSync(getSourceVersionsPath(), FIXED, FIXED);
+
+    // First install → publish → dispatch. Pin the mtime so the SECOND publish
+    // below shares it exactly.
+    const dirA = freshPluginDir("coarse-a");
+    writePackageJson(dirA, { ...SIMPLE_PKG, name: "coarse-a" });
+    writeTool(dirA, "coarse-a-tool", TOOL_SRC("coarse-a-tool"));
+    expect(publishSourceChanges()).toBe(true);
+    pinMtime();
+    await getUserHooksFor("user-prompt-submit");
+    await loadPluginTools();
+    expect(
+      getAllToolDefinitions().some((t) => t.name === "coarse-a-tool"),
+    ).toBe(true);
+
+    // Second install → publish → pin the SAME mtime as the first. An mtime-only
+    // gate would see no change and never reconcile (the plugin would go live
+    // only at the next daemon restart); the composite signature still moves —
+    // the atomic rename swaps in a fresh inode and the sentinel grew — so the
+    // plugin goes live on the very next dispatch.
+    const dirB = freshPluginDir("coarse-b");
+    writePackageJson(dirB, { ...SIMPLE_PKG, name: "coarse-b" });
+    writeTool(dirB, "coarse-b-tool", TOOL_SRC("coarse-b-tool"));
+    expect(publishSourceChanges()).toBe(true);
+    pinMtime();
+    await getUserHooksFor("user-prompt-submit");
+    await loadPluginTools();
+    expect(
+      getAllToolDefinitions().some((t) => t.name === "coarse-b-tool"),
+    ).toBe(true);
+  });
+
   test("activation is idempotent — republishing without changes does not re-run init", async () => {
     const dir = freshPluginDir("idem-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "idem-plugin" });

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -72,6 +72,7 @@ import {
 import {
   clearSurfaceImportInflight,
   evictModule,
+  getFileSignature,
   getMtime,
   importWithTimeout,
   setSurfaceImportTimeout,
@@ -204,8 +205,13 @@ const disabledPluginDirs = new Set<string>();
  */
 let lastVersions: Record<string, PluginSourceVersion> = {};
 
-/** mtime of the sentinel document as of the last look; 0 = never seen. */
-let lastSentinelMtime = 0;
+/**
+ * Change signature (`mtimeMs:size:ino`) of the sentinel document as of the last
+ * look; `""` = never seen. A composite signature rather than mtime alone so a
+ * publish is detected even when the filesystem's mtime granularity can't move
+ * the timestamp between two rewrites (see {@link getFileSignature}).
+ */
+let lastSentinelSignature = "";
 
 /** In-flight reconcile — concurrent dispatches await it rather than racing. */
 let reconcileInFlight: Promise<void> | null = null;
@@ -254,10 +260,17 @@ export async function getUserHooksFor<TCtx = unknown>(
 
 /**
  * Dispatch-path gate: one stat of the source-versions sentinel. When its
- * mtime is unchanged since the last look (the overwhelmingly common case)
- * this returns immediately, and dispatch runs entirely on memory. When the
- * watcher published a change, the document is applied before the dispatch
+ * change signature is unchanged since the last look (the overwhelmingly common
+ * case) this returns immediately, and dispatch runs entirely on memory. When
+ * the watcher published a change, the document is applied before the dispatch
  * proceeds, so the turn that follows an edit already runs the new code.
+ *
+ * The signature is `mtimeMs:size:ino`, not mtime alone: the sentinel is
+ * published via temp-file + atomic rename, which swaps in a fresh inode on
+ * every write, so a runtime install is picked up even on filesystems whose
+ * mtime granularity is too coarse to move the timestamp between two publishes
+ * (virtiofs / 9p / network mounts). With an mtime-only gate such a publish is
+ * invisible until the next daemon restart re-walks the plugins directory.
  *
  * A missing or unreadable sentinel is degraded mode, not an error: the
  * boot-time state keeps serving, and live reload resumes when the monitor
@@ -273,14 +286,14 @@ async function maybeReconcileFromSentinel(): Promise<void> {
       await reconcileInFlight;
       continue;
     }
-    const mtime = getMtime(getSourceVersionsPath());
-    if (mtime === lastSentinelMtime) {
+    const signature = getFileSignature(getSourceVersionsPath());
+    if (signature === lastSentinelSignature) {
       return;
     }
-    // Claim the mtime before any async work, so a concurrent dispatch either
-    // finds the in-flight promise above or skips on the updated mtime.
-    lastSentinelMtime = mtime;
-    if (mtime === 0) {
+    // Claim the signature before any async work, so a concurrent dispatch
+    // either finds the in-flight promise above or skips on the updated value.
+    lastSentinelSignature = signature;
+    if (signature === "") {
       return;
     }
     const doc = readSourceVersions();
@@ -544,7 +557,7 @@ function seedVersionBaseline(): void {
     };
   }
   lastVersions = seeded;
-  lastSentinelMtime = getMtime(getSourceVersionsPath());
+  lastSentinelSignature = getFileSignature(getSourceVersionsPath());
 }
 
 // ─── Tool cache ──────────────────────────────────────────────────────────────
@@ -1031,7 +1044,7 @@ export function resetPluginCacheForTests(): void {
   activatedNames.clear();
   disabledPluginDirs.clear();
   lastVersions = {};
-  lastSentinelMtime = 0;
+  lastSentinelSignature = "";
   reconcileInFlight = null;
 }
 

--- a/assistant/src/plugins/surface-import.ts
+++ b/assistant/src/plugins/surface-import.ts
@@ -51,6 +51,34 @@ export function getMtime(filePath: string): number {
 }
 
 /**
+ * Composite change signature for a file — `mtimeMs:size:ino` — or `""` when the
+ * file is absent or can't be stat'd.
+ *
+ * Unlike {@link getMtime}, this detects a rewrite even when the filesystem's
+ * mtime resolution is too coarse to move the timestamp (or two rewrites land in
+ * the same timestamp granule). The source-versions sentinel is published via a
+ * temp-file + atomic rename, which swaps in a fresh inode on every write, so
+ * `ino` changes even when `mtimeMs` does not — and `size` shifts too whenever
+ * the plugin set does. Gating the reconcile on this signature (rather than
+ * mtime alone) is what lets a plugin installed at runtime go live on
+ * filesystems whose mtime granularity is coarse (virtiofs / 9p / network mounts
+ * — the same mounts the plugin-source watcher polls precisely because their
+ * timestamps are unreliable) instead of only after the next daemon restart.
+ *
+ * Change detection only — the exact numbers are never interpreted, so inode
+ * values above 2^53 losing float precision cannot cause a missed update: `mtime`
+ * and `size` still move on a real publish.
+ */
+export function getFileSignature(filePath: string): string {
+  try {
+    const st = statSync(filePath);
+    return `${st.mtimeMs}:${st.size}:${st.ino}`;
+  } catch {
+    return "";
+  }
+}
+
+/**
  * Evict `filePath` from the runtime module registry so the next dynamic
  * `import()` of that path re-evaluates the file from disk.
  *


### PR DESCRIPTION
## Prompt / plan

From partner QA of the assistant's cognee integration (first of three reported issues, tackled separately):

> The top of init.ts's docstring promises that the init hook fires upon installation … but this isn't true in practice. This plugin only initializes at agent boot — so you have to provision the agent, run `assistant install plugins cognee`, and then `vellum sleep`/`vellum wake` that agent to get the init hook to fire & make cognee usable.

### Root cause

A plugin installed while the daemon runs is *designed* to go live — and run its `init` hook — without a restart: the resource-monitor watcher republishes the source-versions sentinel, and the daemon's dispatch-path reconcile (`maybeReconcileFromSentinel`) applies the diff on the next turn, bringing the plugin up and running `init`.

That reconcile gate keyed sentinel change-detection on **file mtime alone**. On filesystems whose mtime resolution is coarse — the virtiofs / 9p / network mounts the watcher *already polls precisely because their timestamps are unreliable*, Docker Desktop's VM mount among them (the same environment flagged in the reporter's second note) — a post-boot publish can land in the same timestamp granule as the previous one, leaving mtime unmoved. The daemon then never observes the change, so the plugin (and its `init`) only comes up at the next daemon boot, which re-walks the plugins directory from scratch. That is exactly the "only initializes at agent boot" symptom.

The test suite's own `publishSourceChanges` helper already documented and worked around this by force-bumping the sentinel mtime to a strictly increasing value "even when two land inside the same filesystem-timestamp granule" — production had no such workaround.

### Fix

Gate the reconcile on a composite `mtimeMs:size:ino` signature instead of mtime alone. The sentinel is published via temp-file + atomic rename, which swaps in a fresh inode on every write, so the change is detected even when mtime can't move. The dispatch hot path still does a single `stat`.

## Test plan

- Added a regression test (`a runtime install is reconciled even when the sentinel mtime never moves`) that pins the sentinel mtime constant across two publishes and asserts the second install still goes live. Confirmed it **fails** under the old mtime-only gate and **passes** with the composite signature.
- `bun test src/__tests__/mtime-cache.test.ts` — 33 pass.
- `bun test src/__tests__/plugin-bootstrap.test.ts src/hooks/__tests__/hook-live-reload.test.ts` — 18 pass.
- Format, lint, and typecheck pass (pre-commit hooks green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9acFDET16R38truw2dFYU

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9acFDET16R38truw2dFYU)_