### PR TITLE
feat(intelligence): move memory concept graph to its own Memory tab

### DIFF
--- a/clients/web/src/domains/intelligence/components/identity-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-tab.tsx
@@ -6,9 +6,7 @@ import { getAssistant } from "@/assistant/api";
 import { fetchAssistantIdentity } from "@/assistant/identity";
 import { AvatarManagementModal } from "@/components/avatar/avatar-management-modal";
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
-import { ConceptGraphView } from "@/domains/intelligence/components/concept-graph/concept-graph-view";
 import { ConstellationView } from "@/domains/intelligence/components/constellation-view/constellation-view";
-import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
 import type { SkillInfo } from "@/domains/intelligence/skills/types";
 import { skillsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { IdentityGetResponse } from "@/generated/daemon/types.gen";
@@ -183,19 +181,12 @@ export function IdentityTab({ assistantId, onOpenThread }: IdentityTabProps) {
   const [assistantCreatedAt, setAssistantCreatedAt] = useState<string | null>(null);
   const [loadedAssistantId, setLoadedAssistantId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
-  const [graphFullscreen, setGraphFullscreen] = useState(false);
+  const [paneFullscreen, setPaneFullscreen] = useState(false);
 
-  // The concept graph only exists when the active backend exposes one (memory-v3)
-  // AND the memory-concept-graph flag is on; otherwise the endpoint reports
-  // `unsupported` and we fall back to the skills constellation, so this pane is
-  // never empty on backends/assistants without the graph. A failed graph fetch
-  // (daemon predating the route, transient error) falls back the same way
-  // rather than stranding the pane on the graph's error state.
-  const graphQuery = useQuery(memoryGraphOptions(assistantId));
-  const useSkillsFallback =
-    graphQuery.data?.kind === "unsupported" || graphQuery.isError;
-  // Fetched in parallel with the graph probe so the fallback constellation
-  // renders populated as soon as it is chosen, not one round-trip later.
+  // The Identity tab's companion pane is the skills constellation. The memory
+  // concept graph now lives on its own Memory tab (`/assistant/memory`, gated
+  // by the memory-concept-graph flag), so it is no longer probed or rendered
+  // here.
   const skillsQuery = useQuery({
     ...skillsGetOptions({
       path: { assistant_id: assistantId },
@@ -277,7 +268,7 @@ export function IdentityTab({ assistantId, onOpenThread }: IdentityTabProps) {
     <div className="flex h-full min-h-0 flex-col gap-6 lg:flex-row lg:items-stretch">
       <div
         className={`mx-auto w-full max-w-md lg:mx-0 lg:h-full lg:shrink-0 lg:overflow-y-auto ${
-          graphFullscreen ? "hidden" : "flex"
+          paneFullscreen ? "hidden" : "flex"
         }`}
       >
         <IdentityCard
@@ -294,25 +285,15 @@ export function IdentityTab({ assistantId, onOpenThread }: IdentityTabProps) {
       </div>
 
       <div className="min-h-[480px] min-w-0 flex-1 lg:min-h-0">
-        {useSkillsFallback ? (
-          <ConstellationView
-            skills={skillsQuery.data ?? []}
-            components={components}
-            traits={traits}
-            customImageUrl={customImageUrl}
-            className="h-full w-full"
-            isFullscreen={graphFullscreen}
-            onToggleFullscreen={() => setGraphFullscreen((v) => !v)}
-          />
-        ) : (
-          <ConceptGraphView
-            assistantId={assistantId}
-            className="h-full w-full"
-            isFullscreen={graphFullscreen}
-            onToggleFullscreen={() => setGraphFullscreen((v) => !v)}
-            onOpenThread={onOpenThread}
-          />
-        )}
+        <ConstellationView
+          skills={skillsQuery.data ?? []}
+          components={components}
+          traits={traits}
+          customImageUrl={customImageUrl}
+          className="h-full w-full"
+          isFullscreen={paneFullscreen}
+          onToggleFullscreen={() => setPaneFullscreen((v) => !v)}
+        />
       </div>
 
       <AvatarManagementModal

--- a/clients/web/src/domains/intelligence/components/identity-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-tab.tsx
@@ -183,10 +183,9 @@ export function IdentityTab({ assistantId, onOpenThread }: IdentityTabProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [paneFullscreen, setPaneFullscreen] = useState(false);
 
-  // The Identity tab's companion pane is the skills constellation. The memory
-  // concept graph now lives on its own Memory tab (`/assistant/memory`, gated
-  // by the memory-concept-graph flag), so it is no longer probed or rendered
-  // here.
+  // The Identity tab's companion pane is the skills constellation. (The memory
+  // concept graph has its own Memory tab at `/assistant/memory`, gated by the
+  // memory-concept-graph flag.)
   const skillsQuery = useQuery({
     ...skillsGetOptions({
       path: { assistant_id: assistantId },

--- a/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
@@ -60,7 +60,10 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   useAssistantIdentityStore.getState().clearIdentity();
-  useAssistantFeatureFlagStore.setState({ channelTrustFloors: false });
+  useAssistantFeatureFlagStore.setState({
+    channelTrustFloors: false,
+    memoryConceptGraph: false,
+  });
 });
 
 describe("IntelligenceLayout", () => {
@@ -109,6 +112,30 @@ describe("IntelligenceLayout — Plugins tab version gate", () => {
       "Contacts",
       "Channels",
     ]);
+  });
+
+  test("shows the Memory tab (after Skills) when memory-concept-graph is on", () => {
+    useAssistantIdentityStore.getState().setIdentity("Ada", MIN_VERSION);
+    useAssistantFeatureFlagStore.setState({
+      channelTrustFloors: true,
+      memoryConceptGraph: true,
+    });
+    const { container } = renderLayout();
+    expect(tabLabels(container)).toEqual([
+      "Identity",
+      "Plugins",
+      "Skills",
+      "Memory",
+      "Workspace",
+      "Contacts",
+      "Channels",
+    ]);
+  });
+
+  test("hides the Memory tab while memory-concept-graph is off", () => {
+    useAssistantIdentityStore.getState().setIdentity("Ada", MIN_VERSION);
+    const { container } = renderLayout();
+    expect(tabLabels(container)).not.toContain("Memory");
   });
 
   test("hides the Channels tab while channel-trust-floors is off", () => {

--- a/clients/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.tsx
@@ -28,6 +28,11 @@ const PLUGINS_TAB: IntelligenceTab = {
   to: routes.plugins,
 };
 
+const MEMORY_TAB: IntelligenceTab = {
+  label: "Memory",
+  to: routes.memory,
+};
+
 const CHANNELS_TAB: IntelligenceTab = {
   label: "Channels",
   to: routes.channels,
@@ -35,9 +40,10 @@ const CHANNELS_TAB: IntelligenceTab = {
 
 /**
  * Shared layout for the "About Assistant" pages (Identity, Skills,
- * Workspace, Contacts, plus Plugins on plugin-capable assistants and
- * Channels behind the `channel-trust-floors` flag). Renders a heading +
- * tab bar above an `<Outlet />` for the active tab's content.
+ * Workspace, Contacts, plus Plugins on plugin-capable assistants, Memory
+ * behind the `memory-concept-graph` flag, and Channels behind the
+ * `channel-trust-floors` flag). Renders a heading + tab bar above an
+ * `<Outlet />` for the active tab's content.
  *
  * Mounted as a pathless layout route in `routes.tsx` so the child
  * routes keep their existing URL paths (`/assistant/identity`, etc.)
@@ -49,6 +55,7 @@ export function IntelligenceLayout() {
   const assistantName = useAssistantIdentityStore.use.name();
   const supportsPlugins = useSupportsPluginsSurface();
   const showChannelsTab = useAssistantFeatureFlagStore.use.channelTrustFloors();
+  const showMemoryTab = useAssistantFeatureFlagStore.use.memoryConceptGraph();
   const { pathname } = useLocation();
   const isMobile = useIsMobile();
   const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
@@ -66,9 +73,17 @@ export function IntelligenceLayout() {
   const withPlugins: readonly IntelligenceTab[] = supportsPlugins
     ? [BASE_INTELLIGENCE_TABS[0], PLUGINS_TAB, ...BASE_INTELLIGENCE_TABS.slice(1)]
     : BASE_INTELLIGENCE_TABS;
-  const tabs: readonly IntelligenceTab[] = showChannelsTab
-    ? [...withPlugins, CHANNELS_TAB]
+  // The Memory tab (concept graph) slots in right after Skills, gated on the
+  // memory-concept-graph flag. Registry default off, so it stays hidden until
+  // the flag store hydrates with the flag on — same discipline as Plugins.
+  const withMemory: readonly IntelligenceTab[] = showMemoryTab
+    ? withPlugins.flatMap((tab) =>
+        tab.to === routes.skills.root ? [tab, MEMORY_TAB] : [tab],
+      )
     : withPlugins;
+  const tabs: readonly IntelligenceTab[] = showChannelsTab
+    ? [...withMemory, CHANNELS_TAB]
+    : withMemory;
 
   // On mobile the title moves out of the page body and into the shared top
   // bar — centered between the hamburger menu and the search icon — so the

--- a/clients/web/src/domains/intelligence/memory-graph/get-memory-graph.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/get-memory-graph.ts
@@ -3,7 +3,10 @@
  * endpoint. The POST-less read returns the assistant's memory as a canonical
  * node/edge graph; `supported: false` maps to a `{ kind: "unsupported" }`
  * success-shaped result so React Query does not treat "this backend has no
- * graph" as a retryable failure. Transport / non-2xx errors throw.
+ * graph" as a retryable failure. A 404 (an older assistant predating the route)
+ * maps to `unsupported` too, so it degrades to the feature-off empty state
+ * rather than an error (see `docs/BACKWARDS_COMPAT.md`). Other non-2xx / transport
+ * errors throw.
  */
 
 import { queryOptions } from "@tanstack/react-query";
@@ -32,6 +35,13 @@ export function memoryGraphOptions(assistantId: string) {
       });
 
       assertHasResponse(response, error, FAILURE_MESSAGE);
+
+      // An assistant/daemon predating the `/memory-graph` route answers 404;
+      // treat that as "not supported here" so an older assistant shows the
+      // graceful empty state instead of an error (BACKWARDS_COMPAT read rule).
+      if (response.status === 404) {
+        return { kind: "unsupported" };
+      }
 
       if (!response.ok) {
         throw new ApiError(

--- a/clients/web/src/domains/intelligence/memory-page.tsx
+++ b/clients/web/src/domains/intelligence/memory-page.tsx
@@ -1,0 +1,28 @@
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { ConceptGraphView } from "@/domains/intelligence/components/concept-graph/concept-graph-view";
+
+interface MemoryPageProps {
+  onOpenThread?: (message: string) => void;
+}
+
+/**
+ * The Memory tab (`/assistant/memory`): a full-bleed home for the assistant's
+ * memory concept graph. Gated into the nav by the `memory-concept-graph` flag
+ * (see `intelligence-layout.tsx`); the graph view handles its own
+ * loading / empty / unsupported states, so on a flag-on backend that doesn't
+ * expose a graph it shows the graph's "not available" copy rather than a blank
+ * tab. The skills constellation stays on the Identity tab.
+ */
+export function MemoryPage({ onOpenThread }: MemoryPageProps) {
+  const assistantId = useActiveAssistantId();
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <ConceptGraphView
+        assistantId={assistantId}
+        className="h-full w-full"
+        onOpenThread={onOpenThread}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -311,7 +311,7 @@
       "scope": "assistant",
       "key": "memory-concept-graph",
       "label": "Memory concept graph",
-      "description": "Gates the Obsidian-style memory concept graph on the assistant identity page and the backend-agnostic /memory-graph + /memory-graph-node routes that feed it. When off, the identity page shows the skills constellation instead. Only produces a graph on memory-v3 backends. Default off.",
+      "description": "Gates the Obsidian-style memory concept graph on its own Memory tab (/assistant/memory) and the backend-agnostic /memory-graph + /memory-graph-node routes that feed it. When off, the Memory tab is hidden; the identity page keeps the skills constellation. Only produces a graph on memory-v3 backends. Default off.",
       "defaultEnabled": false
     },
     {

--- a/clients/web/src/memory-page-route.tsx
+++ b/clients/web/src/memory-page-route.tsx
@@ -1,11 +1,8 @@
 import { useNavigate } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
-import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { MemoryPage } from "@/domains/intelligence/memory-page";
-import { useConversationStore } from "@/stores/conversation-store";
-import { useViewerStore } from "@/stores/viewer-store";
-import { routes } from "@/utils/routes";
+import { navigateToNewConversation } from "@/utils/conversation-navigation";
 
 export function MemoryPageRoute() {
   const navigate = useNavigate();
@@ -15,14 +12,7 @@ export function MemoryPageRoute() {
     <MemoryPage
       key={assistantId}
       onOpenThread={(message) => {
-        useViewerStore.getState().setMainView("chat");
-        const draftConversationId = createDraftConversationId();
-        useConversationStore
-          .getState()
-          .setActiveConversationId(draftConversationId);
-        void navigate(
-          `${routes.conversation(draftConversationId)}?prompt=${encodeURIComponent(message)}`,
-        );
+        navigateToNewConversation(navigate, { prompt: message });
       }}
     />
   );

--- a/clients/web/src/memory-page-route.tsx
+++ b/clients/web/src/memory-page-route.tsx
@@ -1,0 +1,29 @@
+import { useNavigate } from "react-router";
+
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { MemoryPage } from "@/domains/intelligence/memory-page";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
+import { routes } from "@/utils/routes";
+
+export function MemoryPageRoute() {
+  const navigate = useNavigate();
+  const assistantId = useActiveAssistantId();
+
+  return (
+    <MemoryPage
+      key={assistantId}
+      onOpenThread={(message) => {
+        useViewerStore.getState().setMainView("chat");
+        const draftConversationId = createDraftConversationId();
+        useConversationStore
+          .getState()
+          .setActiveConversationId(draftConversationId);
+        void navigate(
+          `${routes.conversation(draftConversationId)}?prompt=${encodeURIComponent(message)}`,
+        );
+      }}
+    />
+  );
+}

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -351,6 +351,7 @@ export const routeTree = [
                   lazy: { Component: () => import("@/domains/intelligence/intelligence-layout").then((m) => m.IntelligenceLayout) },
                   children: [
                     { path: "identity", lazy: { Component: () => import("@/identity-page-route").then((m) => m.IdentityPageRoute) } },
+                    { path: "memory", lazy: { Component: () => import("@/memory-page-route").then((m) => m.MemoryPageRoute) } },
                     { path: "plugins", lazy: { Component: () => import("@/domains/intelligence/plugins-page").then((m) => m.PluginsPage) } },
                     { path: "plugins/:name", lazy: { Component: () => import("@/domains/intelligence/plugin-detail-page").then((m) => m.PluginDetailPage) } },
                     { path: "skills", lazy: { Component: () => import("@/domains/intelligence/skills-page").then((m) => m.SkillsPage) } },

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -139,6 +139,7 @@ export const routes = {
       dyn(r("/assistant/schedules"), scheduleId),
   },
   identity: r("/assistant/identity"),
+  memory: r("/assistant/memory"),
   plugins: r("/assistant/plugins"),
   /**
    * Skills surface — the list plus a dedicated per-skill detail page.

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -222,6 +222,7 @@ export const routes = {
  */
 const ABOUT_ASSISTANT_PATHS: readonly string[] = [
   routes.identity,
+  routes.memory,
   routes.plugins,
   routes.skills.root,
   routes.workspace,

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -311,7 +311,7 @@
       "scope": "assistant",
       "key": "memory-concept-graph",
       "label": "Memory concept graph",
-      "description": "Gates the Obsidian-style memory concept graph on the assistant identity page and the backend-agnostic /memory-graph + /memory-graph-node routes that feed it. When off, the identity page shows the skills constellation instead. Only produces a graph on memory-v3 backends. Default off.",
+      "description": "Gates the Obsidian-style memory concept graph on its own Memory tab (/assistant/memory) and the backend-agnostic /memory-graph + /memory-graph-node routes that feed it. When off, the Memory tab is hidden; the identity page keeps the skills constellation. Only produces a graph on memory-v3 backends. Default off.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## What
Follow-up to #38005 (Slice A, merged). The memory concept graph has outgrown the Identity page, so it gets a first-class home.

- **New Memory tab** at `/assistant/memory`, gated on the `memory-concept-graph` flag and slotted in right after **Skills**. Hidden until the flag store hydrates on — same discipline as the Plugins tab.
- The Memory page is a **full-bleed `ConceptGraphView`**. It keeps its own loading / empty / unsupported states, so a flag-on non-v3 backend shows the graph's "not available" copy rather than a blank tab.
- **Identity tab** reverts to identity card + skills constellation only; it no longer probes or renders the graph. For flag-off assistants (the common case) nothing changes — that pane was already the constellation.
- Route + wrapper mirror the identity page (`onOpenThread` → draft chat), so **chat-from-node still works** from the Memory tab.
- Registry description updated in **both** copies (web + meta) to reflect the new location.

## Tab order
`Identity · Plugins · Skills · `**`Memory`**` · Workspace · Contacts · Channels` (Plugins/Memory/Channels each conditionally shown).

## Tests
- `intelligence-layout.test.tsx`: added coverage that the Memory tab shows after Skills when the flag is on and is hidden when off (8/8 pass).
- tsc + eslint clean on changed files.
- Not driven in a live browser — needs the flag on + a memory-v3 backend.

## Notes for reviewers
- Gated the tab on the **flag** (cheap, via the assistant feature-flag store) rather than the `/memory-graph` availability probe, so we don't fire the heavy per-request graph build on every About-page load just to decide tab visibility. Flag-on implies someone deliberately enabled it on a v3 assistant; the page handles the rare flag-on-non-v3 case.
- Whole-file prettier drift on `identity-tab.tsx` left untouched (kept the diff focused), consistent with #38005.

## Follow-ups (unchanged)
- **Slice B** — anti-clutter for growth (legend-as-filter, edge-fog fade, surface `truncated`, search).
- **Slice C** — functionality nodes (connected skills/plugins + a detail source for them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)