### PR TITLE
fix(speech): derive velay origin from platform environment for self-hosted managed speech

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/vellum-managed-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/vellum-managed-realtime.test.ts
@@ -204,7 +204,7 @@ describe("VellumManagedRealtimeTranscriber", () => {
       expect.objectContaining({
         type: "error",
         category: "auth",
-        message: expect.stringContaining("platform connect"),
+        message: expect.stringContaining("VELAY_BASE_URL"),
       }),
     );
   });

--- a/assistant/src/providers/speech-to-text/__tests__/vellum-speech-relay-connection.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/vellum-speech-relay-connection.test.ts
@@ -54,7 +54,10 @@ describe("resolveSpeechRelayConnection", () => {
 
 describe("mapVelayError", () => {
   test("maps the relay contract's codes onto categories", () => {
-    expect(mapVelayError({ code: "invalid_key" }).category).toBe("auth");
+    expect(mapVelayError({ code: "invalid_key" })).toMatchObject({
+      category: "auth",
+      message: expect.stringContaining("VELAY_BASE_URL"),
+    });
     expect(
       mapVelayError({ code: "missing_platform_connection" }),
     ).toMatchObject({

--- a/assistant/src/providers/speech-to-text/vellum-speech-relay-connection.ts
+++ b/assistant/src/providers/speech-to-text/vellum-speech-relay-connection.ts
@@ -99,6 +99,11 @@ export function mapVelayError(error: VelayErrorInfo): {
 } {
   switch (error.code) {
     case "invalid_key":
+      return {
+        category: "auth",
+        message:
+          "The Vellum speech relay rejected this assistant's API key — the assistant's platform environment may not match the relay it is dialing (set VELAY_BASE_URL on the gateway to the matching environment, e.g. https://velay-staging.vellum.ai for staging).",
+      };
     case "missing_platform_connection":
       return {
         category: "auth",

--- a/gateway/src/__tests__/speech-relay-websocket.test.ts
+++ b/gateway/src/__tests__/speech-relay-websocket.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from "bun:test";
+import { afterAll, beforeAll, describe, test, expect, mock } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { initSigningKey, mintToken } from "../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
@@ -6,6 +6,7 @@ import type { CredentialCache } from "../credential-cache.js";
 import {
   createSpeechRelayUpgradeHandler,
   getSpeechRelayWebsocketHandlers,
+  velayOriginForPlatformHost,
   type SpeechRelaySocketData,
 } from "../http/routes/speech-relay-websocket.js";
 import { VELAY_FORWARDED_HEADER } from "../velay/bridge-utils.js";
@@ -80,6 +81,126 @@ async function bodyOf(
 }
 
 const TOKEN = mintDaemonServiceToken();
+
+function makeKeyedCredentials(
+  values: Record<string, string | undefined>,
+): CredentialCache {
+  return {
+    get: mock(async (key: string) => values[key]),
+  } as unknown as CredentialCache;
+}
+
+describe("velay origin derivation", () => {
+  // getPlatformBaseUrl falls back to this env var; pin it absent so the
+  // missing-credential cases below are deterministic on dev machines.
+  const savedPlatformUrl = process.env.VELLUM_PLATFORM_URL;
+  beforeAll(() => {
+    delete process.env.VELLUM_PLATFORM_URL;
+  });
+  afterAll(() => {
+    if (savedPlatformUrl !== undefined) {
+      process.env.VELLUM_PLATFORM_URL = savedPlatformUrl;
+    }
+  });
+
+  test("velayOriginForPlatformHost follows the deployment naming convention", () => {
+    expect(velayOriginForPlatformHost("platform.vellum.ai")).toBe(
+      "https://velay.vellum.ai",
+    );
+    expect(velayOriginForPlatformHost("staging-platform.vellum.ai")).toBe(
+      "https://velay-staging.vellum.ai",
+    );
+    expect(velayOriginForPlatformHost("dev-platform.vellum.ai")).toBe(
+      "https://velay-dev.vellum.ai",
+    );
+    expect(velayOriginForPlatformHost("localhost")).toBeNull();
+    expect(velayOriginForPlatformHost("example.com")).toBeNull();
+    expect(
+      velayOriginForPlatformHost("staging-platform.vellum.ai.evil.com"),
+    ).toBeNull();
+  });
+
+  test("derives the velay origin from the stored platform base URL when VELAY_BASE_URL is unset", async () => {
+    const server = makeFakeServer();
+    const handler = createSpeechRelayUpgradeHandler(
+      makeConfig({ velayBaseUrl: undefined }),
+      "stt",
+      {
+        credentials: makeKeyedCredentials({
+          "credential/vellum/assistant_api_key": "vk-1",
+          "credential/vellum/platform_base_url":
+            "https://staging-platform.vellum.ai",
+        }),
+      },
+    );
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    expect(await handler(req, server)).toBeUndefined();
+    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
+    expect(new URL(data.data.upstreamWsUrl).origin).toBe(
+      "wss://velay-staging.vellum.ai",
+    );
+    expect(new URL(data.data.upstreamHttpUrl).origin).toBe(
+      "https://velay-staging.vellum.ai",
+    );
+  });
+
+  test("falls back to prod velay for an off-convention or missing platform base URL", async () => {
+    for (const platformBaseUrl of [
+      "http://localhost:8000",
+      "not a url",
+      undefined,
+    ]) {
+      const server = makeFakeServer();
+      const handler = createSpeechRelayUpgradeHandler(
+        makeConfig({ velayBaseUrl: undefined }),
+        "stt",
+        {
+          credentials: makeKeyedCredentials({
+            "credential/vellum/assistant_api_key": "vk-1",
+            "credential/vellum/platform_base_url": platformBaseUrl,
+          }),
+        },
+      );
+      const req = new Request(
+        `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}`,
+        { headers: { upgrade: "websocket" } },
+      );
+
+      expect(await handler(req, server)).toBeUndefined();
+      const data = (
+        server.upgrade as unknown as { mock: { calls: unknown[][] } }
+      ).mock.calls[0]![1] as { data: SpeechRelaySocketData };
+      expect(new URL(data.data.upstreamWsUrl).origin).toBe(
+        "wss://velay.vellum.ai",
+      );
+    }
+  });
+
+  test("an explicit VELAY_BASE_URL wins over the stored platform base URL", async () => {
+    const server = makeFakeServer();
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
+      credentials: makeKeyedCredentials({
+        "credential/vellum/assistant_api_key": "vk-1",
+        "credential/vellum/platform_base_url":
+          "https://staging-platform.vellum.ai",
+      }),
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    expect(await handler(req, server)).toBeUndefined();
+    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
+    expect(new URL(data.data.upstreamWsUrl).origin).toBe("wss://velay.test");
+  });
+});
 
 describe("createSpeechRelayUpgradeHandler — gate", () => {
   test("upgrades a daemon service connection and strips the key param", async () => {

--- a/gateway/src/http/routes/speech-relay-websocket.ts
+++ b/gateway/src/http/routes/speech-relay-websocket.ts
@@ -27,6 +27,7 @@ import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
 import { getLogger } from "../../logger.js";
+import { getPlatformBaseUrl } from "../../platform-url.js";
 import { VELAY_FORWARDED_HEADER } from "../../velay/bridge-utils.js";
 import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
 
@@ -108,17 +109,58 @@ function jsonError(status: number, code: string, detail: string): Response {
   });
 }
 
-function velaySpeechUrls(
+/**
+ * Map a Vellum platform host onto its environment's velay origin, following
+ * the deployment naming convention (`platform.vellum.ai` → `velay.vellum.ai`,
+ * `{env}-platform.vellum.ai` → `velay-{env}.vellum.ai`). Returns null for
+ * hosts outside that convention (localhost, custom domains).
+ */
+export function velayOriginForPlatformHost(host: string): string | null {
+  if (host === "platform.vellum.ai") {
+    return "https://velay.vellum.ai";
+  }
+  const match = /^([a-z0-9-]+)-platform\.vellum\.ai$/.exec(host);
+  return match ? `https://velay-${match[1]}.vellum.ai` : null;
+}
+
+/**
+ * Resolve the velay origin for this dial. An explicit VELAY_BASE_URL always
+ * wins; otherwise derive it from the stored platform base URL so a non-prod
+ * assistant's key is presented to its own environment's velay rather than
+ * prod (which would reject it with `invalid_key`).
+ */
+async function resolveVelayBaseUrl(
   config: GatewayConfig,
+  deps: SpeechRelayDeps,
+): Promise<string> {
+  if (config.velayBaseUrl) {
+    return config.velayBaseUrl;
+  }
+  const platformBaseUrl = await getPlatformBaseUrl(deps.credentials);
+  if (platformBaseUrl) {
+    try {
+      const derived = velayOriginForPlatformHost(
+        new URL(platformBaseUrl).hostname,
+      );
+      if (derived) {
+        return derived;
+      }
+    } catch {
+      // Unparseable platform URL — fall through to the prod default.
+    }
+  }
+  return DEFAULT_VELAY_BASE_URL;
+}
+
+function velaySpeechUrls(
+  velayBaseUrl: string,
   operation: SpeechRelayOperation,
   params: URLSearchParams,
 ): { wsUrl: string; httpUrl: string } {
   // The velay tunnel client accepts ws(s):// bases too — normalize to the
   // http(s) twin first so the probe URL is always fetchable, then derive
   // the ws(s) dial URL from that.
-  const httpBase = (config.velayBaseUrl ?? DEFAULT_VELAY_BASE_URL)
-    .replace(/\/+$/, "")
-    .replace(/^ws/, "http");
+  const httpBase = velayBaseUrl.replace(/\/+$/, "").replace(/^ws/, "http");
   const query = params.toString();
   const path = `/v1/speech/${operation}/stream${query ? `?${query}` : ""}`;
   return {
@@ -221,7 +263,11 @@ export function createSpeechRelayUpgradeHandler(
         );
       }
     }
-    const { wsUrl, httpUrl } = velaySpeechUrls(config, operation, params);
+    const { wsUrl, httpUrl } = velaySpeechUrls(
+      await resolveVelayBaseUrl(config, deps),
+      operation,
+      params,
+    );
 
     // Non-upgrade request: this is the daemon's dial-failure probe.
     // Replay the gate and hand back velay's own rejection.


### PR DESCRIPTION
## Summary
- The gateway speech relay (`/v1/speech/{stt,tts}/stream`) dialed the hardcoded prod default `https://velay.vellum.ai` whenever `VELAY_BASE_URL` was unset — which is every self-hosted/Electron/laptop hatch. A staging- or dev-connected assistant therefore presented its non-prod API key to prod velay and got `invalid_key`. The relay now derives the velay origin from the stored platform base URL (`platform.vellum.ai` → `velay.vellum.ai`, `{env}-platform.vellum.ai` → `velay-{env}.vellum.ai`, matching the deploy values in vellum-assistant-platform); off-convention hosts (localhost, custom domains) keep the prod default, and an explicit `VELAY_BASE_URL` still wins unconditionally.
- Split the daemon's `invalid_key` mapping out of the shared "reconnect with 'assistant platform connect'" message — reconnecting can never fix an environment mismatch. `invalid_key` now points at the environment/`VELAY_BASE_URL` mismatch; `missing_platform_connection` keeps the reconnect message.

## Original prompt
A freshly hatched self-hosted assistant connected to the staging platform (`vellum-kind-elk-kvl36h`) showed "Managed speech needs a working Vellum platform connection — reconnect with 'assistant platform connect'" on realtime managed speech even though managed inference worked. Gateway logs showed the relay's upstream dial failing with `invalid_key`: the gateway was presenting the staging-minted assistant API key to prod velay because `VELAY_BASE_URL` is only provisioned on vembda/k8s managed deployments. The fix requested: derive the velay origin from the platform environment on the speech-relay route (explicit `VELAY_BASE_URL` still winning), and give `invalid_key` its own actionable error message instead of the misleading reconnect advice.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->