### PR TITLE
feat(memory): include connected skills/capabilities in the concept graph (Slice C)

### DIFF
--- a/assistant/src/plugins/defaults/memory/graph-topology/__tests__/build-memory-graph.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/__tests__/build-memory-graph.test.ts
@@ -162,4 +162,17 @@ describe("assembleMemoryGraph", () => {
     });
     expect(nodes.map((n) => n.id).sort()).toEqual(["a", "skills/orphan"]);
   });
+
+  it("treats a real page under a reserved prefix as a concept, not a prunable skill", () => {
+    // A non-colliding user page like `skills/my-notes` survives the page index
+    // with a real mtime; it must classify as a concept (by modifiedAt, not the
+    // slug prefix) and therefore never be pruned as a disconnected skill.
+    const { nodes } = assembleMemoryGraph({
+      entries: [entry("skills/my-notes", { modifiedAt: 5 })],
+      staticAdjacency: adjacency([]),
+      pruneDisconnectedNonConcepts: true,
+    });
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]).toMatchObject({ id: "skills/my-notes", kind: "concept" });
+  });
 });

--- a/assistant/src/plugins/defaults/memory/graph-topology/__tests__/build-memory-graph.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/__tests__/build-memory-graph.test.ts
@@ -4,7 +4,10 @@ import type { PageIndexEntry } from "../../v2/page-index.js";
 import type { Slug } from "../../v3/types.js";
 import { assembleMemoryGraph } from "../build-memory-graph.js";
 
-function entry(slug: string, over: Partial<PageIndexEntry> = {}): PageIndexEntry {
+function entry(
+  slug: string,
+  over: Partial<PageIndexEntry> = {},
+): PageIndexEntry {
   return {
     id: 0,
     slug,
@@ -40,7 +43,9 @@ describe("assembleMemoryGraph", () => {
         entry("skills/agent-mail", { modifiedAt: 0 }),
         entry("send-email", { modifiedAt: 0 }),
       ],
-      staticAdjacency: adjacency([["my-concept", "skills/agent-mail", undefined]]),
+      staticAdjacency: adjacency([
+        ["my-concept", "skills/agent-mail", undefined],
+      ]),
     });
 
     const byId = new Map(nodes.map((n) => [n.id, n]));
@@ -126,5 +131,35 @@ describe("assembleMemoryGraph", () => {
       expect(nodes.some((n) => n.id === edge.source)).toBe(true);
       expect(nodes.some((n) => n.id === edge.target)).toBe(true);
     }
+  });
+
+  it("prunes disconnected functionality nodes but keeps connected ones and all concepts", () => {
+    const { nodes } = assembleMemoryGraph({
+      entries: [
+        entry("lonely-concept"), // concept, degree 0 → kept
+        entry("linked-concept"), // concept, links to a skill
+        entry("skills/connected", { modifiedAt: 0 }), // skill, degree 1 → kept
+        entry("skills/orphan", { modifiedAt: 0 }), // skill, degree 0 → pruned
+        entry("cli-commands/orphan", { modifiedAt: 0 }), // capability, degree 0 → pruned
+      ],
+      staticAdjacency: adjacency([
+        ["linked-concept", "skills/connected", undefined],
+      ]),
+      pruneDisconnectedNonConcepts: true,
+    });
+
+    expect(nodes.map((n) => n.id).sort()).toEqual([
+      "linked-concept",
+      "lonely-concept",
+      "skills/connected",
+    ]);
+  });
+
+  it("keeps disconnected functionality nodes when pruning is off (default)", () => {
+    const { nodes } = assembleMemoryGraph({
+      entries: [entry("a"), entry("skills/orphan", { modifiedAt: 0 })],
+      staticAdjacency: adjacency([]),
+    });
+    expect(nodes.map((n) => n.id).sort()).toEqual(["a", "skills/orphan"]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/graph-topology/__tests__/build-memory-graph.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/__tests__/build-memory-graph.test.ts
@@ -163,6 +163,37 @@ describe("assembleMemoryGraph", () => {
     expect(nodes.map((n) => n.id).sort()).toEqual(["a", "skills/orphan"]);
   });
 
+  it("re-prunes a functionality node stranded by truncation", () => {
+    const { nodes, edges, truncated } = assembleMemoryGraph({
+      entries: [
+        entry("hub"),
+        entry("h1"),
+        entry("h2"),
+        entry("h3"),
+        entry("p"),
+        entry("q"),
+        entry("skills/s", { modifiedAt: 0 }),
+      ],
+      // hub has degree 3; skills/s has degree 2 (p, q). The cap keeps the top 2
+      // by degree (hub, skills/s) but drops every one of skills/s's neighbors.
+      staticAdjacency: adjacency([
+        ["hub", "h1", undefined],
+        ["hub", "h2", undefined],
+        ["hub", "h3", undefined],
+        ["skills/s", "p", undefined],
+        ["skills/s", "q", undefined],
+      ]),
+      maxNodes: 2,
+      pruneDisconnectedNonConcepts: true,
+    });
+
+    expect(truncated).toBe(true);
+    // skills/s survived the cap but lost both neighbors → re-pruned as isolated;
+    // the isolated concept hub is kept (concepts always survive).
+    expect(nodes.map((n) => n.id)).toEqual(["hub"]);
+    expect(edges).toEqual([]);
+  });
+
   it("treats a real page under a reserved prefix as a concept, not a prunable skill", () => {
     // A non-colliding user page like `skills/my-notes` survives the page index
     // with a real mtime; it must classify as a concept (by modifiedAt, not the

--- a/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
@@ -314,21 +314,23 @@ export async function getMemoryGraphNode(
   if (!isMemoryConceptGraphEnabled(config) || !isMemoryV3Live(config) || !id) {
     return { found: false };
   }
-  // A real on-disk page wins — including a user page that happens to live under
-  // a reserved prefix (its slug isn't a seeded skill/CLI slug, so the index
-  // keeps it with a real mtime). Read it before falling back to a capability.
-  const page = await readPage(getWorkspaceDir(), id).catch(() => null);
-  if (page) {
-    return { found: true, title: humanizeSlug(id), content: page.body };
-  }
-  // No page on disk — a synthetic capability slug. Its detail is the rendered
-  // capability statement (`renderCapabilityContent` degrades to "" — never
-  // throws — when the capability cache is cold).
+  // Seeded skill/CLI capabilities take precedence over any on-disk page at the
+  // same slug: the page index drops a colliding page and lets the synthetic win
+  // (v2/page-index.ts), so a `skills/foo` node built as the capability must not
+  // surface a stale disk page. renderCapabilityContent returns the rendered
+  // statement for a seeded capability, "" for an unseeded reserved-prefix slug
+  // (a real user page), and null for a normal concept slug.
   if (isCapabilitySlug(id)) {
     const content = renderCapabilityContent(id);
     if (content) {
       return { found: true, title: humanizeSlug(id), content };
     }
+  }
+  // A real on-disk page: a concept, or a user page under a reserved prefix that
+  // isn't a seeded capability (kept in the index with a real mtime).
+  const page = await readPage(getWorkspaceDir(), id).catch(() => null);
+  if (page) {
+    return { found: true, title: humanizeSlug(id), content: page.body };
   }
   return { found: false };
 }

--- a/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
@@ -220,6 +220,20 @@ export function assembleMemoryGraph(input: AssembleMemoryGraphInput): {
   const keptEdges = edges.filter(
     (e) => kept.has(e.source) && kept.has(e.target),
   );
+
+  // Truncation can strand a functionality node whose only neighbors were
+  // dropped. Re-prune against post-truncation degree so the connected-only
+  // guarantee holds even in a capped graph. An isolated node touches no kept
+  // edge by definition, so no further edge cleanup is needed.
+  if (input.pruneDisconnectedNonConcepts) {
+    const connected = new Set<string>();
+    for (const e of keptEdges) {
+      connected.add(e.source);
+      connected.add(e.target);
+    }
+    nodes = nodes.filter((n) => n.kind === "concept" || connected.has(n.id));
+  }
+
   return { nodes, edges: keptEdges, truncated: true };
 }
 

--- a/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
@@ -81,14 +81,14 @@ function humanizeSlug(slug: string): string {
   return words.replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/** Node taxonomy tag used for coloring. Synthetic capability slugs (skills /
- * CLI commands) carry `modifiedAt: 0`; real concept pages carry a file mtime. */
+/** Node taxonomy tag used for coloring. Only synthetic rows (`modifiedAt: 0`)
+ * are functionality: skills carry the `skills/` prefix, other synthetics (CLI
+ * commands) are capabilities. A real on-disk page keeps a file mtime and is a
+ * concept even when it happens to sit under a reserved prefix (e.g. a user page
+ * `skills/my-notes` with no matching skill survives the page index). */
 function nodeKind(entry: PageIndexEntry): string {
-  if (isSkillSlug(entry.slug)) {
-    return "skill";
-  }
   if (entry.modifiedAt <= 0) {
-    return "capability";
+    return isSkillSlug(entry.slug) ? "skill" : "capability";
   }
   return "concept";
 }
@@ -244,12 +244,19 @@ export async function getMemoryGraph(
   // Functionality nodes that end up disconnected are pruned in assembleMemoryGraph.
   const entries = pageIndex.entries;
 
+  // Synthetic rows (skills / CLI commands) carry `modifiedAt: 0` and have no
+  // on-disk page. Keyed by slug (not prefix) so a real user page that happens
+  // to live under a reserved prefix is NOT mistaken for a synthetic one.
+  const syntheticSlugs = new Set(
+    entries.filter((e) => e.modifiedAt <= 0).map((e) => e.slug),
+  );
+
   // Raw (frontmatter + body) page reader, matching the v3 lane build. A read
   // that rejects drops that article's authored/wikilink edges but keeps its
-  // numeric fallbacks. Capability slugs have no on-disk page, so short-circuit
-  // to an empty body — they contribute no outbound links, only inbound ones.
+  // numeric fallbacks. Synthetic capability rows have no page, so short-circuit
+  // their guaranteed-miss read; a real page is read so its links are captured.
   const pageRaw = async (slug: Slug): Promise<string> => {
-    if (isCapabilitySlug(slug)) {
+    if (syntheticSlugs.has(slug)) {
       return "";
     }
     const page = await readPage(workspaceDir, slug);
@@ -307,18 +314,21 @@ export async function getMemoryGraphNode(
   if (!isMemoryConceptGraphEnabled(config) || !isMemoryV3Live(config) || !id) {
     return { found: false };
   }
-  // Functionality nodes have no on-disk page; their detail is the rendered
+  // A real on-disk page wins — including a user page that happens to live under
+  // a reserved prefix (its slug isn't a seeded skill/CLI slug, so the index
+  // keeps it with a real mtime). Read it before falling back to a capability.
+  const page = await readPage(getWorkspaceDir(), id).catch(() => null);
+  if (page) {
+    return { found: true, title: humanizeSlug(id), content: page.body };
+  }
+  // No page on disk — a synthetic capability slug. Its detail is the rendered
   // capability statement (`renderCapabilityContent` degrades to "" — never
   // throws — when the capability cache is cold).
   if (isCapabilitySlug(id)) {
     const content = renderCapabilityContent(id);
-    return content
-      ? { found: true, title: humanizeSlug(id), content }
-      : { found: false };
+    if (content) {
+      return { found: true, title: humanizeSlug(id), content };
+    }
   }
-  const page = await readPage(getWorkspaceDir(), id).catch(() => null);
-  if (!page) {
-    return { found: false };
-  }
-  return { found: true, title: humanizeSlug(id), content: page.body };
+  return { found: false };
 }

--- a/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
@@ -22,7 +22,10 @@ import { getWorkspaceDir } from "../paths.js";
 import { getPageIndex, type PageIndexEntry } from "../v2/page-index.js";
 import { readPage, renderPageContent } from "../v2/page-store.js";
 import { isSkillSlug } from "../v2/skill-store.js";
-import { isCapabilitySlug } from "../v3/capabilities.js";
+import {
+  isCapabilitySlug,
+  renderCapabilityContent,
+} from "../v3/capabilities.js";
 import { buildEdgeGraph } from "../v3/edge.js";
 import { computeLearnedEdgeGraph } from "../v3/learned-edges.js";
 import type { Slug } from "../v3/types.js";
@@ -90,12 +93,6 @@ function nodeKind(entry: PageIndexEntry): string {
   return "concept";
 }
 
-/** A real concept page: on-disk (has an mtime) and not a synthetic skill or
- * CLI-command capability slug. The graph shows concepts only. */
-function isConceptEntry(entry: PageIndexEntry): boolean {
-  return entry.modifiedAt > 0 && !isCapabilitySlug(entry.slug);
-}
-
 export interface AssembleMemoryGraphInput {
   /** Every article node in the corpus (page-index entries). */
   entries: readonly PageIndexEntry[];
@@ -105,6 +102,12 @@ export interface AssembleMemoryGraphInput {
   learnedAdjacency?: Adjacency;
   /** Node cap; defaults to {@link DEFAULT_MAX_NODES}. */
   maxNodes?: number;
+  /**
+   * When set, drop functionality nodes (kind `skill` / `capability`) that ended
+   * up with no edges — a skill nobody links to or co-selects is inert clutter.
+   * Concept nodes are always kept, even when isolated.
+   */
+  pruneDisconnectedNonConcepts?: boolean;
 }
 
 /**
@@ -199,6 +202,12 @@ export function assembleMemoryGraph(input: AssembleMemoryGraphInput): {
     return node;
   });
 
+  // Prune disconnected functionality nodes (see the option's doc). `weight` is
+  // the node's degree, so weight 0 ⇒ no incident edges ⇒ no edge cleanup needed.
+  if (input.pruneDisconnectedNonConcepts) {
+    nodes = nodes.filter((n) => n.kind === "concept" || (n.weight ?? 0) > 0);
+  }
+
   if (nodes.length <= maxNodes) {
     return { nodes, edges };
   }
@@ -228,15 +237,21 @@ export async function getMemoryGraph(
 
   const workspaceDir = getWorkspaceDir();
   const pageIndex = await getPageIndex(workspaceDir);
-  // Concepts only: exclude synthetic skill / CLI-command slugs so the graph is
-  // purely the assistant's learned/authored concept pages. Edges to excluded
-  // slugs drop out downstream because they aren't in the node set.
-  const conceptEntries = pageIndex.entries.filter(isConceptEntry);
+  // Concepts plus functionality (skills / CLI-command capabilities). Feeding the
+  // full set to the edge builders is what lets a concept's `[[skills/foo]]` link
+  // and skill↔concept co-selections resolve to real edges — buildEdgeGraph and
+  // computeLearnedEdgeGraph both drop endpoints outside the set they're given.
+  // Functionality nodes that end up disconnected are pruned in assembleMemoryGraph.
+  const entries = pageIndex.entries;
 
   // Raw (frontmatter + body) page reader, matching the v3 lane build. A read
   // that rejects drops that article's authored/wikilink edges but keeps its
-  // numeric fallbacks.
+  // numeric fallbacks. Capability slugs have no on-disk page, so short-circuit
+  // to an empty body — they contribute no outbound links, only inbound ones.
   const pageRaw = async (slug: Slug): Promise<string> => {
+    if (isCapabilitySlug(slug)) {
+      return "";
+    }
     const page = await readPage(workspaceDir, slug);
     if (!page) {
       throw new Error(`page not found: ${slug}`);
@@ -244,7 +259,7 @@ export async function getMemoryGraph(
     return renderPageContent(page);
   };
 
-  const staticGraph = await buildEdgeGraph(conceptEntries, pageRaw, {
+  const staticGraph = await buildEdgeGraph(entries, pageRaw, {
     hubDegree: config.memory.v3.edge.hubDegree,
   });
 
@@ -265,35 +280,41 @@ export async function getMemoryGraph(
       maxPerPage: Math.max(learned.maxPerPage, GRAPH_LEARNED_MIN_MAX_PER_PAGE),
       now: Date.now(),
       windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
-      knownSlugs: new Set(conceptEntries.map((e) => e.slug)),
+      knownSlugs: new Set(entries.map((e) => e.slug)),
     },
   );
 
   const assembled = assembleMemoryGraph({
-    entries: conceptEntries,
+    entries,
     staticAdjacency: staticGraph.adjacency,
     learnedAdjacency: learnedGraph.adjacency,
+    pruneDisconnectedNonConcepts: true,
   });
 
   return { backend: BACKEND_MEMORY_V3, supported: true, ...assembled };
 }
 
 /**
- * Fetch a single concept node's content (its markdown body) by id. Used when a
- * user opens a node in the graph. Concepts only — skill/capability slugs and
- * unreadable pages return `{ found: false }`.
+ * Fetch a single node's content by id. Used when a user opens a node in the
+ * graph. Concept nodes return their page's markdown body; functionality nodes
+ * (skills / CLI commands) return the rendered capability statement. Unknown or
+ * unreadable ids return `{ found: false }`.
  */
 export async function getMemoryGraphNode(
   config: AssistantConfig,
   id: string,
 ): Promise<MemoryGraphNodeDetail> {
-  if (
-    !isMemoryConceptGraphEnabled(config) ||
-    !isMemoryV3Live(config) ||
-    !id ||
-    isCapabilitySlug(id)
-  ) {
+  if (!isMemoryConceptGraphEnabled(config) || !isMemoryV3Live(config) || !id) {
     return { found: false };
+  }
+  // Functionality nodes have no on-disk page; their detail is the rendered
+  // capability statement (`renderCapabilityContent` degrades to "" — never
+  // throws — when the capability cache is cold).
+  if (isCapabilitySlug(id)) {
+    const content = renderCapabilityContent(id);
+    return content
+      ? { found: true, title: humanizeSlug(id), content }
+      : { found: false };
   }
   const page = await readPage(getWorkspaceDir(), id).catch(() => null);
   if (!page) {


### PR DESCRIPTION
## What
Fourth slice of the memory concept graph work. Makes the graph show what the assistant **is** (its functionality), not only what it has learned — the first of your original four asks.

Admits **functionality nodes** (installed skills + CLI-command capabilities) into the graph, but only when they're actually **connected**, so they enrich the map instead of littering it with inert dots.

## How (backend only)
All in `assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts`:

- `getMemoryGraph` now feeds the **full** page-index set (concepts + skills + CLI) to `buildEdgeGraph` and `computeLearnedEdgeGraph`. Both drop endpoints outside the set they're handed, so this is exactly what lets a concept's `[[skills/foo]]` link and skill↔concept co-selections resolve to real edges. `knownSlugs` is widened to match (it filters learned edges at **both** endpoints, so leaving it concept-only would silently drop every skill↔concept association).
- `assembleMemoryGraph` gains `pruneDisconnectedNonConcepts`: skill/capability nodes that end up with **zero degree** are dropped; concept nodes are always kept, even isolated. `weight` is the node's degree, so a pruned node had no edges — no edge cleanup needed. Off by default (kept behavior for existing callers/tests).
- `pageRaw` short-circuits capability slugs to `""` (they have no on-disk page) — avoids N wasted fs misses now that the article set is larger, and they contribute no outbound links anyway.
- `getMemoryGraphNode` serves functionality-node detail via `renderCapabilityContent` (`# Skill: …` / `# CLI command: …`) instead of the old `{ found: false }`.

## Why no client change
The web renderer already colors and legends the `skill` + `capability` node kinds (they were built in from the start), the force layout already handles them, and the detail drawer renders markdown — so a `# Skill: …` body renders as-is. This PR just stops the backend from filtering them out. (The legend now shows multiple kinds; making the legend a **filter** is the natural pair-up — see Slice B #38036's deferral note.)

## Tests
- `build-memory-graph.test.ts`: added coverage that a **connected** skill is included, that **disconnected** skill/capability nodes are pruned while a **disconnected concept survives**, and that pruning is **off by default**. Per-file run green (7/7).
- Full `assistant` typecheck clean (0 errors).

## Notes for reviewers
- Skill/CLI nodes are near-pure sinks (`edges: []`, no readable body): they get only inbound `link` edges from concepts plus undirected `learned` edges. Expected, not a bug.
- `hubDegree` has no effect on this endpoint (`assembleMemoryGraph` never reads `EdgeGraph.hubs`), so enlarging the node set doesn't trip hub logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)