### PR TITLE
feat(plugins): run plugin init/shutdown in the daemon on install/uninstall

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -752,6 +752,36 @@ describe("plugin runtime activation", () => {
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
   });
 
+  test("reconcilePluginSourcesNow deactivates a removed plugin without re-running shutdown", async () => {
+    await populateCacheAtBoot(); // empty plugins dir
+
+    const dir = freshPluginDir("teardown-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "teardown-plugin" });
+    writeTool(dir, "teardown-tool", TOOL_SRC("teardown-tool"));
+    const shutdownMarker = join(ROOT, "teardown-shutdown.log");
+    writeMarkerHook(dir, "shutdown", shutdownMarker, "bye");
+
+    await reconcilePluginSourcesNow();
+    await loadPluginTools();
+    expect(
+      getAllToolDefinitions().some((t) => t.name === "teardown-tool"),
+    ).toBe(true);
+
+    // This is the daemon uninstall route's teardown path: the managed uninstall
+    // runs `shutdown` itself (while the files are present) and removes the
+    // directory, then reconciles. The reconcile here only mirrors the removal —
+    // it drops the plugin's tools/hooks but must NOT run `shutdown` a second
+    // time (the removal reason carries no shutdown).
+    rmSync(dir, { recursive: true, force: true });
+    await reconcilePluginSourcesNow();
+    await loadPluginTools();
+
+    expect(
+      getAllToolDefinitions().some((t) => t.name === "teardown-tool"),
+    ).toBe(false);
+    expect(existsSync(shutdownMarker)).toBe(false);
+  });
+
   test("activation is idempotent — republishing without changes does not re-run init", async () => {
     const dir = freshPluginDir("idem-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "idem-plugin" });

--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -39,6 +39,7 @@ import {
   getCachedUserTools,
   getUserHooksFor,
   populateCacheAtBoot,
+  reconcilePluginSourcesNow,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
 import { getSourceVersionsPath } from "../plugins/source-versions.js";
@@ -719,6 +720,36 @@ describe("plugin runtime activation", () => {
     expect(
       getAllToolDefinitions().some((t) => t.name === "coarse-b-tool"),
     ).toBe(true);
+  });
+
+  test("reconcilePluginSourcesNow brings a freshly installed plugin up immediately, without the sentinel", async () => {
+    await populateCacheAtBoot(); // empty plugins dir
+    expect(getAllToolDefinitions().some((t) => t.name === "eager-tool")).toBe(
+      false,
+    );
+
+    const dir = freshPluginDir("eager-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "eager-plugin" });
+    writeTool(dir, "eager-tool", TOOL_SRC("eager-tool"));
+    const initMarker = join(ROOT, "eager-init.log");
+    writeMarkerHook(dir, "init", initMarker, "init");
+
+    // Deliberately do NOT publish through the watcher and do NOT dispatch a
+    // hook — this is the imperative install path: the plugin's files land on
+    // disk and the daemon is told to bring it up right now.
+    await reconcilePluginSourcesNow();
+    await loadPluginTools();
+
+    expect(getAllToolDefinitions().some((t) => t.name === "eager-tool")).toBe(
+      true,
+    );
+    // init ran exactly once, as part of the reconcile — not at a later turn.
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
+
+    // Calling it again (e.g. the monitor's later sentinel publish, or a
+    // redundant poke) is a no-op — the plugin is already up.
+    await reconcilePluginSourcesNow();
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
   });
 
   test("activation is idempotent — republishing without changes does not re-run init", async () => {

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -223,20 +223,6 @@ export function registerPluginsCommand(program: Command): void {
               },
               "external plugin installed",
             );
-            // Poke the running daemon to bring the freshly materialized plugin
-            // up now — register its tools and run its `init` hook — instead of
-            // leaving it for the background source watcher plus a later turn (or
-            // the next daemon boot). Best-effort: this command materializes the
-            // files in its own process and works with the daemon stopped, so a
-            // poke that can't reach the daemon is not an install failure — the
-            // plugin is picked up on the daemon's next start.
-            const reconcile = await cliIpcCall("plugins_reconcile");
-            if (!reconcile.ok) {
-              log.debug(
-                { name: result.name, error: reconcile.error },
-                "post-install plugin reconcile poke did not reach the daemon; plugin will initialize on the daemon's next start",
-              );
-            }
             const pinned = result.commit
               ? ` at ${result.commit.slice(0, 7)}`
               : "";

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -584,7 +584,32 @@ export function registerPluginsCommand(program: Command): void {
                 return;
               }
             }
-            const result = await libs.uninstall.uninstallPlugin({ name });
+            // Prefer the daemon: it runs the plugin's `shutdown` hook and drops
+            // the plugin's tools/hooks in the main process — symmetric to how
+            // install runs `init` there. Fall back to a local uninstall only
+            // when the daemon is unreachable (a transport error carries no
+            // `statusCode`); an operator can still uninstall while it's stopped,
+            // and `shutdown` then runs in this process, the only one available.
+            const daemon = await cliIpcCall<{ name: string; target: string }>(
+              "plugins_uninstall",
+              { pathParams: { name } },
+            );
+            let result: { name: string; target: string };
+            if (daemon.ok && daemon.result) {
+              result = daemon.result;
+            } else if (daemon.statusCode === undefined) {
+              log.debug(
+                { name, error: daemon.error },
+                "uninstall could not reach the daemon; running shutdown + removal locally",
+              );
+              result = await libs.uninstall.uninstallPlugin({ name });
+            } else {
+              // The daemon reached a decision (not installed, bad name, …);
+              // surface it rather than silently retrying locally.
+              console.error(daemon.error ?? "Plugin uninstall failed.");
+              process.exitCode = 1;
+              return;
+            }
             log.info(
               { name: result.name, target: result.target },
               "external plugin uninstalled",

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -10,6 +10,7 @@ import { createRequire } from "node:module";
 
 import type { Command } from "commander";
 
+import { cliIpcCall } from "../../ipc/cli-client.js";
 import { yellow } from "../lib/cli-colors.js";
 import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { confirmPrompt } from "../lib/confirm-prompt.js";
@@ -222,6 +223,20 @@ export function registerPluginsCommand(program: Command): void {
               },
               "external plugin installed",
             );
+            // Poke the running daemon to bring the freshly materialized plugin
+            // up now — register its tools and run its `init` hook — instead of
+            // leaving it for the background source watcher plus a later turn (or
+            // the next daemon boot). Best-effort: this command materializes the
+            // files in its own process and works with the daemon stopped, so a
+            // poke that can't reach the daemon is not an install failure — the
+            // plugin is picked up on the daemon's next start.
+            const reconcile = await cliIpcCall("plugins_reconcile");
+            if (!reconcile.ok) {
+              log.debug(
+                { name: result.name, error: reconcile.error },
+                "post-install plugin reconcile poke did not reach the daemon; plugin will initialize on the daemon's next start",
+              );
+            }
             const pinned = result.commit
               ? ` at ${result.commit.slice(0, 7)}`
               : "";

--- a/assistant/src/monitoring/__tests__/plugin-source-watch.test.ts
+++ b/assistant/src/monitoring/__tests__/plugin-source-watch.test.ts
@@ -46,8 +46,10 @@ afterAll(() => {
   rmSync(ROOT, { recursive: true, force: true });
 });
 
-const { collectSourceVersions, createSourceWatchState, runSourceWatchPass } =
+const { createSourceWatchState, runSourceWatchPass } =
   await import("../plugin-source-watch.js");
+const { collectSourceVersions } =
+  await import("../../plugins/collect-source-versions.js");
 const { getSourceVersionsPath, readSourceVersions } =
   await import("../../plugins/source-versions.js");
 

--- a/assistant/src/monitoring/plugin-source-watch.ts
+++ b/assistant/src/monitoring/plugin-source-watch.ts
@@ -22,17 +22,9 @@
  * a walk trips over a half-written plugin directory.
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  renameSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
-import { readdirSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 
-import { snapshotPluginSource } from "../plugins/source-fingerprint.js";
+import { collectSourceVersions } from "../plugins/collect-source-versions.js";
 import type {
   PluginSourceVersion,
   SourceVersionsDocument,
@@ -43,68 +35,9 @@ import {
   SOURCE_VERSIONS_FORMAT,
 } from "../plugins/source-versions.js";
 import { getLogger } from "../util/logger.js";
-import {
-  getMonitoringDataDir,
-  getWorkspaceHooksDir,
-  getWorkspacePluginsDir,
-} from "../util/platform.js";
+import { getMonitoringDataDir } from "../util/platform.js";
 
 const log = getLogger("plugin-source-watch");
-
-/**
- * Collect the current source version of every watched directory: each
- * plugin directory under `<workspace>/plugins/` (same discovery rule as the
- * daemon's plugin scan — a directory with a `package.json`), plus the
- * standalone workspace hooks directory when it exists. Disabled plugins are
- * fingerprinted too: consumers need fresh state the moment a plugin is
- * re-enabled, and the `disabled` field is how they observe the toggle
- * itself (dotfiles are excluded from the fingerprint).
- */
-export function collectSourceVersions(): Record<string, PluginSourceVersion> {
-  const out: Record<string, PluginSourceVersion> = {};
-
-  const pluginsDir = getWorkspacePluginsDir();
-  let entries: string[] = [];
-  try {
-    entries = readdirSync(pluginsDir);
-  } catch {
-    // No plugins directory yet — nothing to watch there.
-  }
-  for (const entry of entries) {
-    if (entry.startsWith(".")) {
-      continue;
-    }
-    const dir = join(pluginsDir, entry);
-    try {
-      if (!statSync(dir).isDirectory()) {
-        continue;
-      }
-    } catch {
-      continue;
-    }
-    if (!existsSync(join(dir, "package.json"))) {
-      continue;
-    }
-    const snapshot = snapshotPluginSource(dir);
-    out[dir] = {
-      fingerprint: snapshot.fingerprint,
-      evictionPaths: snapshot.evictionPaths,
-      disabled: existsSync(join(dir, ".disabled")),
-    };
-  }
-
-  const workspaceHooksDir = getWorkspaceHooksDir();
-  if (existsSync(workspaceHooksDir)) {
-    const snapshot = snapshotPluginSource(workspaceHooksDir);
-    out[workspaceHooksDir] = {
-      fingerprint: snapshot.fingerprint,
-      evictionPaths: snapshot.evictionPaths,
-      disabled: false,
-    };
-  }
-
-  return out;
-}
 
 /**
  * Whether two version maps describe the same source state. Compares key

--- a/assistant/src/monitoring/plugin-source-watch.ts
+++ b/assistant/src/monitoring/plugin-source-watch.ts
@@ -22,7 +22,15 @@
  * a walk trips over a half-written plugin directory.
  */
 
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
 
 import { collectSourceVersions } from "../plugins/collect-source-versions.js";
 import type {

--- a/assistant/src/plugins/collect-source-versions.ts
+++ b/assistant/src/plugins/collect-source-versions.ts
@@ -1,0 +1,77 @@
+/**
+ * Walk the workspace's plugin directories and snapshot each one's current
+ * source version.
+ *
+ * This is the single collector shared by the two producers of a source-versions
+ * map: the resource monitor's watcher (which fingerprints on a timer and writes
+ * the sentinel — see `../monitoring/plugin-source-watch.ts`) and the daemon's
+ * imperative reconcile (which applies the walk directly, without waiting on the
+ * watcher — see `reconcilePluginSourcesNow` in `./mtime-cache.ts`). Keeping the
+ * walk in one place guarantees both paths produce byte-identical maps, so an
+ * imperative reconcile never disagrees with the watcher's next publish and
+ * causes a spurious reload.
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  getWorkspaceHooksDir,
+  getWorkspacePluginsDir,
+} from "../util/platform.js";
+import { snapshotPluginSource } from "./source-fingerprint.js";
+import type { PluginSourceVersion } from "./source-versions.js";
+
+/**
+ * Collect the current source version of every watched directory: each plugin
+ * directory under `<workspace>/plugins/` (a directory with a `package.json`),
+ * plus the standalone workspace hooks directory when it exists. Disabled
+ * plugins are fingerprinted too: consumers need fresh state the moment a plugin
+ * is re-enabled, and the `disabled` field is how they observe the toggle itself
+ * (dotfiles are excluded from the fingerprint).
+ */
+export function collectSourceVersions(): Record<string, PluginSourceVersion> {
+  const out: Record<string, PluginSourceVersion> = {};
+
+  const pluginsDir = getWorkspacePluginsDir();
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(pluginsDir);
+  } catch {
+    // No plugins directory yet — nothing to watch there.
+  }
+  for (const entry of entries) {
+    if (entry.startsWith(".")) {
+      continue;
+    }
+    const dir = join(pluginsDir, entry);
+    try {
+      if (!statSync(dir).isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    if (!existsSync(join(dir, "package.json"))) {
+      continue;
+    }
+    const snapshot = snapshotPluginSource(dir);
+    out[dir] = {
+      fingerprint: snapshot.fingerprint,
+      evictionPaths: snapshot.evictionPaths,
+      disabled: existsSync(join(dir, ".disabled")),
+    };
+  }
+
+  const workspaceHooksDir = getWorkspaceHooksDir();
+  if (existsSync(workspaceHooksDir)) {
+    const snapshot = snapshotPluginSource(workspaceHooksDir);
+    out[workspaceHooksDir] = {
+      fingerprint: snapshot.fingerprint,
+      evictionPaths: snapshot.evictionPaths,
+      disabled: false,
+    };
+  }
+
+  return out;
+}

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -58,6 +58,7 @@ import {
   getWorkspaceHooksDir,
   getWorkspacePluginsDir,
 } from "../util/platform.js";
+import { collectSourceVersions } from "./collect-source-versions.js";
 import {
   deriveToolName,
   listSurfaceDir,
@@ -306,6 +307,52 @@ async function maybeReconcileFromSentinel(): Promise<void> {
     await reconcileInFlight;
     return;
   }
+}
+
+/**
+ * Imperatively reconcile the plugin caches against the current on-disk state
+ * *now* — without waiting for the resource monitor to republish the
+ * source-versions sentinel or for the next hook dispatch to notice it.
+ *
+ * An install / uninstall / enable / disable materializes files on disk; the
+ * steady-state path picks that up eventually — the monitor republishes the
+ * sentinel and the dispatch-path gate applies the diff on the next turn. That
+ * is eventually-correct but not immediate: nothing runs a newly installed
+ * plugin's `init` until some later turn dispatches a hook. Callers that just
+ * changed the plugin set on disk (the install / uninstall routes, and the
+ * CLI's best-effort post-install poke) call this to bring the change up
+ * deterministically, so a freshly installed plugin's `init` fires as part of
+ * the install rather than at the next daemon boot.
+ *
+ * Reuses the same collector the monitor writes into the sentinel, so the map
+ * applied here is identical to the monitor's next publish — which then diffs to
+ * a no-op. Idempotent and safe to call redundantly: `applySourceVersions` only
+ * redeploys directories whose fingerprint moved, and activation is guarded so a
+ * plugin already up is never re-initialized. Never throws — a failure is
+ * contained inside `applySourceVersions` and logged there.
+ *
+ * Coordinates with the sentinel gate through the shared `reconcileInFlight`
+ * latch: it waits out any dispatch-driven reconcile already running, then
+ * claims the latch for its own apply, so the two paths never overlap.
+ */
+export async function reconcilePluginSourcesNow(): Promise<void> {
+  while (reconcileInFlight !== null) {
+    await reconcileInFlight;
+  }
+  // `applySourceVersions` contains its own failures, but the `collectSourceVersions()`
+  // walk that feeds it runs outside that guard — wrap the whole thing so an
+  // imperative reconcile never rejects into its callers (the install route must
+  // still return success for an install whose files already landed on disk).
+  reconcileInFlight = (async () => {
+    try {
+      await applySourceVersions(collectSourceVersions());
+    } catch (err) {
+      log.error({ err }, "imperative plugin reconcile failed");
+    }
+  })().finally(() => {
+    reconcileInFlight = null;
+  });
+  await reconcileInFlight;
 }
 
 /**

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1093,7 +1093,15 @@ async function handleUninstallPlugin({
   await ensurePluginApiShim().catch(() => {});
 
   try {
+    // `uninstallPlugin` runs the plugin's `shutdown` hook (while its files are
+    // still present) and then removes the directory — both in this daemon
+    // process. Following it with a reconcile drops the plugin's now-absent
+    // tools and hooks from the in-memory caches immediately (the `shutdown`
+    // already ran, so the reconcile's deactivation does not run it again),
+    // rather than leaving that to the background source watcher. Symmetric to
+    // the install route, which reconciles to bring a new plugin up.
     const result = await uninstallPlugin({ name: rawName });
+    await reconcilePluginSourcesNow();
     publishPluginsChanged(getOriginClientId(headers));
     return { name: result.name, target: result.target };
   } catch (err) {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -91,6 +91,7 @@ import {
 import { getPlatformBaseUrl } from "../../config/env.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { ensurePluginApiShim } from "../../plugins/ensure-plugin-api-shim.js";
+import { reconcilePluginSourcesNow } from "../../plugins/mtime-cache.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
@@ -1228,6 +1229,12 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
         { fetch: globalThis.fetch.bind(globalThis) },
       );
     }
+    // Bring the freshly materialized plugin up in-process right now — register
+    // its tools and run its `init` hook — instead of waiting for the resource
+    // monitor to republish the sentinel and a later turn to apply it. This is
+    // what makes `init` fire as part of the install rather than at the next
+    // daemon boot. Never throws; a failure is contained and logged.
+    await reconcilePluginSourcesNow();
     publishPluginsChanged(getOriginClientId(headers));
     return {
       ok: true as const,
@@ -1270,6 +1277,28 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
       err instanceof Error ? err.message : "plugin install failed",
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Handler — reconcile (bring installed plugins up now)
+// ---------------------------------------------------------------------------
+
+/**
+ * Imperatively reconcile the daemon's plugin caches against the current on-disk
+ * plugin set, right now. Registers a newly materialized plugin's tools and runs
+ * its `init` hook without waiting for the resource monitor to republish the
+ * source-versions sentinel or for a later turn to apply it.
+ *
+ * The daemon-side install route calls the reconcile primitive directly. This
+ * route exists for the CLI's `assistant plugins install`, which materializes
+ * the plugin locally (in its own process) and then pokes the daemon here so the
+ * install runs `init` immediately rather than at the next daemon boot. The poke
+ * is best-effort on the CLI side — a daemon that is down simply picks the plugin
+ * up on its next start.
+ */
+async function handlePluginsReconcile(): Promise<{ ok: true }> {
+  await reconcilePluginSourcesNow();
+  return { ok: true as const };
 }
 
 // ---------------------------------------------------------------------------
@@ -1970,5 +1999,20 @@ export const ROUTES: RouteDefinition[] = [
       },
     },
     handler: handleDisablePlugin,
+  },
+  {
+    operationId: "plugins_reconcile",
+    endpoint: "plugins/reconcile",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Reconcile installed plugins now",
+    description:
+      "Imperatively reconcile the daemon's in-memory plugin state against the current on-disk plugin set, right now — registering a newly installed plugin's tools and running its `init` hook without waiting for the background source watcher to republish or a later turn to apply the change. Idempotent: a plugin already up is not re-initialized. Primarily the target of the CLI's post-install poke (`assistant plugins install` materializes the plugin in its own process, then calls this so `init` fires as part of the install instead of at the next daemon boot).",
+    tags: ["plugins"],
+    responseBody: z.object({ ok: z.literal(true) }),
+    handler: handlePluginsReconcile,
   },
 ];

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1288,28 +1288,6 @@ async function handleInstallPlugin({ body = {}, headers }: RouteHandlerArgs) {
 }
 
 // ---------------------------------------------------------------------------
-// Handler — reconcile (bring installed plugins up now)
-// ---------------------------------------------------------------------------
-
-/**
- * Imperatively reconcile the daemon's plugin caches against the current on-disk
- * plugin set, right now. Registers a newly materialized plugin's tools and runs
- * its `init` hook without waiting for the resource monitor to republish the
- * source-versions sentinel or for a later turn to apply it.
- *
- * The daemon-side install route calls the reconcile primitive directly. This
- * route exists for the CLI's `assistant plugins install`, which materializes
- * the plugin locally (in its own process) and then pokes the daemon here so the
- * install runs `init` immediately rather than at the next daemon boot. The poke
- * is best-effort on the CLI side — a daemon that is down simply picks the plugin
- * up on its next start.
- */
-async function handlePluginsReconcile(): Promise<{ ok: true }> {
-  await reconcilePluginSourcesNow();
-  return { ok: true as const };
-}
-
-// ---------------------------------------------------------------------------
 // Handler — inspect (drift)
 // ---------------------------------------------------------------------------
 
@@ -2007,20 +1985,5 @@ export const ROUTES: RouteDefinition[] = [
       },
     },
     handler: handleDisablePlugin,
-  },
-  {
-    operationId: "plugins_reconcile",
-    endpoint: "plugins/reconcile",
-    method: "POST",
-    policy: {
-      requiredScopes: ["settings.write"],
-      allowedPrincipalTypes: ACTOR_PRINCIPALS,
-    },
-    summary: "Reconcile installed plugins now",
-    description:
-      "Imperatively reconcile the daemon's in-memory plugin state against the current on-disk plugin set, right now — registering a newly installed plugin's tools and running its `init` hook without waiting for the background source watcher to republish or a later turn to apply the change. Idempotent: a plugin already up is not re-initialized. Primarily the target of the CLI's post-install poke (`assistant plugins install` materializes the plugin in its own process, then calls this so `init` fires as part of the install instead of at the next daemon boot).",
-    tags: ["plugins"],
-    responseBody: z.object({ ok: z.literal(true) }),
-    handler: handlePluginsReconcile,
   },
 ];


### PR DESCRIPTION
## Prompt / plan

Follow-up to #38033. QA feedback wanted plugin lifecycle hooks to run in the daemon (the "main process"), not the ephemeral CLI process — since `init`/`shutdown` manage long-lived daemon state (memory/cognee workers, Qdrant/DB handles). This PR makes both symmetric.

### Install — `init` runs in the daemon

The passive path (install writes files → monitor republishes the sentinel → next hook dispatch runs `init`) is eventually-correct but not imperative. Added `reconcilePluginSourcesNow()`: walk the on-disk plugin set and bring new plugins up (tools + `init`) immediately, reusing the monitor's collector so it's idempotent with the watcher's next publish, and never throwing (an install whose files landed must still succeed).

- The in-daemon install route calls it directly → app/web/gateway installs run `init` in-process.
- New `POST /v1/plugins/reconcile` (IPC method `plugins_reconcile`) wraps the same primitive; the CLI `assistant plugins install` (which materializes in its own process) pokes it best-effort after install, so a CLI install also runs `init` in the daemon. Daemon down = no-op (picked up next boot).

### Uninstall — `shutdown` runs in the daemon

`uninstallPlugin` runs the `shutdown` hook in whatever process calls it; the CLI called it locally, so `shutdown` ran in the CLI. Now:

- The daemon uninstall route (`DELETE /v1/plugins/:name`) reconciles after `uninstallPlugin`, owning the full teardown in-process: run `shutdown` (files present) → remove → drop the plugin's now-absent tools/hooks from the caches. The reconcile's deactivation does not re-run `shutdown`.
- The CLI `plugins uninstall` prefers the daemon over IPC (so `shutdown` runs there), falling back to a local uninstall only when the daemon is unreachable (a transport error carries no `statusCode`); a daemon-side decision (not installed / bad name) is surfaced, not silently retried.

### Refactor

The source-version collector shared by the monitor and the reconcile moved from `monitoring/plugin-source-watch.ts` to `plugins/collect-source-versions.ts` so both import one implementation.

## Design note — what's *not* here yet

Fully routing install *execution* through the daemon (the "DRY so IPC-vs-local doesn't matter" cleanup, gating the rich source options — direct URL / `--allow-unreviewed` — on the `local` principal or an IPC-only route) is deliberately left out. `init` already runs in the daemon for every install path via the reconcile poke, so this is an architecture refinement of a security-sensitive path (two install mechanisms, an HTTP surface) that wants a live daemon E2E rather than a blind change.

## Test plan

- `reconcilePluginSourcesNow` brings a freshly installed plugin up with the monitor and dispatch both absent, running `init` exactly once (redundant call is a no-op).
- `reconcilePluginSourcesNow` deactivates a removed plugin (tools dropped) without re-running `shutdown` — the route's teardown path.
- `bun test` across `mtime-cache`, `plugin-source-watch`, `plugins-routes`, `plugin-bootstrap`, `route-adapter`, `gateway-only-guard` — green. Format/lint/typecheck green.

**QA note:** no live hatch was possible in this sandbox (Docker unavailable), so the daemon-side lifecycle is verified by integration tests exercising the real reconcile + activation/deactivation + hook code with the monitor and dispatch removed. The CLI↔daemon IPC round-trip (install poke, uninstall delegation, offline fallback) is typed and unit-covered but wants a live daemon to fully E2E before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9acFDET16R38truw2dFYU