### PR TITLE
fix(macos): stop host-proxy router from warn-logging the event firehose

### DIFF
--- a/clients/macos/src/main/host-proxy-router.test.ts
+++ b/clients/macos/src/main/host-proxy-router.test.ts
@@ -29,13 +29,15 @@ mock.module("./lockfile-watcher", () => ({
   getWatchedLockfile: () => ({ assistants: [], activeAssistant: null }),
 }));
 
-// Stub electron-log
+// Stub electron-log. `warn` is a tracked mock so tests can assert the
+// router doesn't log for expected firehose traffic.
+const mockLogWarn = mock((..._args: unknown[]) => {});
 mock.module("electron-log/main", () => {
   const noop = () => {};
   return {
     default: {
       info: noop,
-      warn: noop,
+      warn: mockLogWarn,
       error: noop,
       debug: noop,
       initialize: noop,
@@ -530,6 +532,43 @@ describe("host-proxy-router", () => {
         { type: "host_unknown_request", requestId: "u1" },
         poster,
       );
+    });
+
+    test("drops non-host firehose events silently (no warn spam)", () => {
+      const poster = new HostProxyPoster({
+        endpointBase: "http://127.0.0.1:9000/v1",
+        authHeaders: () => ({ Authorization: "Bearer t" }),
+        fetch: (async () => new Response("ok")) as unknown as typeof globalThis.fetch,
+      });
+
+      mockLogWarn.mockClear();
+      // /v1/events is the full assistant-event firehose. These are the
+      // high-volume streaming/tool events this connection ignores — none
+      // should warn, or the log fills with tens of thousands of lines.
+      for (const type of [
+        "assistant_thinking_delta",
+        "assistant_text_delta",
+        "tool_output_chunk",
+        "message_complete",
+        "sync_changed",
+      ]) {
+        __testing.dispatchMessage({ type }, poster);
+      }
+
+      expect(mockLogWarn).not.toHaveBeenCalled();
+    });
+
+    test("warns on a host_*-shaped type it cannot route", () => {
+      const poster = new HostProxyPoster({
+        endpointBase: "http://127.0.0.1:9000/v1",
+        authHeaders: () => ({ Authorization: "Bearer t" }),
+        fetch: (async () => new Response("ok")) as unknown as typeof globalThis.fetch,
+      });
+
+      mockLogWarn.mockClear();
+      __testing.dispatchMessage({ type: "host_teleport_request" }, poster);
+
+      expect(mockLogWarn).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/clients/macos/src/main/host-proxy-router.ts
+++ b/clients/macos/src/main/host-proxy-router.ts
@@ -93,7 +93,19 @@ function dispatchMessage(message: HostProxySseMessage, poster: HostProxyPoster):
   const { type } = message;
   const route = executorKindForType(type);
   if (!route) {
-    log.warn("[host-proxy-router] unknown message type, ignoring", { type });
+    // The gateway's /v1/events endpoint is the full assistant-event
+    // firehose — streaming deltas (assistant_text_delta,
+    // assistant_thinking_delta), tool events, sync notifications, and so
+    // on. This connection exists only to service host_* proxy requests, so
+    // every other event type is expected traffic we deliberately drop.
+    // Only a host_*-shaped type we can't route is genuinely anomalous;
+    // reserve the warning for that and ignore the rest silently. (Warning
+    // per message previously emitted tens of thousands of lines per session
+    // — dominated by streaming deltas — which buried real errors in the log
+    // and pushed it toward the 10 MB rotation cap.)
+    if (type.startsWith("host_")) {
+      log.warn("[host-proxy-router] unrecognized host proxy message type, ignoring", { type });
+    }
     return;
   }
 


### PR DESCRIPTION
## Prompt / plan

Triaging a user report ("streaming issues and loading issues this morning with Becky") from an exported diagnostics bundle. The streaming/loading failures themselves trace to **upstream `HTTP 502`s from the managed `becky` runtime** (server-side/infra, not a client change) — see the investigation summary below. This PR fixes a client-side defect that showed up while digging: the Electron main log was ~5 MB / 44k lines, of which **~41k were `[host-proxy-router] unknown message type` warnings** that buried the real errors.

### Root cause of the log spam

The macOS host proxy connects to the gateway's `/v1/events` endpoint to service `host_*` proxy requests (`host_bash`, `host_file`, `host_cu`, …). But `/v1/events` is the **full assistant-event firehose** — streaming deltas, tool events, sync notifications, etc. (confirmed by the unwrap comment in `host-proxy-sse.ts`). The router's `dispatchMessage` logged a `warn` for every event type it didn't recognize, so a single session emitted tens of thousands of lines, dominated by:

| type | count (one session) |
|---|---|
| `assistant_thinking_delta` | 25,133 |
| `assistant_text_delta` | 10,743 |
| `assistant_activity_state` | 1,349 |
| `tool_output_chunk` / `tool_result` / … | ~2,000 |

These are all **expected** traffic this connection deliberately ignores.

### Change

Only warn for a `host_*`-shaped type the router genuinely can't route (a real anomaly); drop all other firehose events silently. Also pushes `vellum.log` away from its 10 MB rotation cap, so real errors survive long enough to be exported.

## Test plan

- `bun test src/main/host-proxy-router.test.ts` → 25 pass. Added two cases:
  - non-host firehose events (`assistant_thinking_delta`, `assistant_text_delta`, `tool_output_chunk`, `message_complete`, `sync_changed`) produce **zero** warns
  - a `host_*`-shaped type the router can't route still warns exactly once
- `bunx tsc --noEmit` → clean

<!-- CLI verb checklist section omitted: no new IPC route added. -->

---

### Note on the underlying incident (not fixed here)

The reported streaming/loading failures were caused by intermittent **`HTTP 502` (Bad Gateway)** responses from the `becky` managed runtime when the client re-fetched conversation messages during SSE recovery (`sse_transport_recovery`), clustered ~09:10–09:46 local. These are server-side and need an infra/runtime look — no client code change resolves them. This PR only removes the noise that made that diagnosis harder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ci7JyiwEPhfYu12yCH6fE

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ci7JyiwEPhfYu12yCH6fE)_