### PR TITLE
oauth(google): inject bearer token for docs.googleapis.com

### DIFF
--- a/assistant/src/__tests__/oauth-provider-profiles.test.ts
+++ b/assistant/src/__tests__/oauth-provider-profiles.test.ts
@@ -23,7 +23,7 @@ describe("oauth provider profiles (DB-seeded)", () => {
     );
   });
 
-  test("google provider row contains bearer injection templates for 3 Google API hosts", () => {
+  test("google provider row contains bearer injection templates for 4 Google API hosts", () => {
     const provider = getProvider("google");
 
     expect(provider).toBeDefined();

--- a/assistant/src/__tests__/oauth-provider-profiles.test.ts
+++ b/assistant/src/__tests__/oauth-provider-profiles.test.ts
@@ -36,7 +36,7 @@ describe("oauth provider profiles (DB-seeded)", () => {
       valuePrefix: string;
     }>;
 
-    expect(templates).toHaveLength(3);
+    expect(templates).toHaveLength(4);
 
     const byHost = new Map(templates.map((t) => [t.hostPattern, t]));
 
@@ -44,6 +44,7 @@ describe("oauth provider profiles (DB-seeded)", () => {
       "gmail.googleapis.com",
       "www.googleapis.com",
       "people.googleapis.com",
+      "docs.googleapis.com",
     ]) {
       const tpl = byHost.get(host);
       expect(tpl).toBeDefined();

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -131,6 +131,12 @@ export const PROVIDER_SEED_DATA: Record<
         headerName: "Authorization",
         valuePrefix: "Bearer ",
       },
+      {
+        hostPattern: "docs.googleapis.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
     ],
     revokeUrl: "https://oauth2.googleapis.com/revoke",
     revokeBodyTemplate: { token: "{access_token}" },


### PR DESCRIPTION
## What changed

Adds a `docs.googleapis.com` injection template to the Google provider seed, alongside the existing `gmail.googleapis.com`, `www.googleapis.com`, and `people.googleapis.com` entries.

Closes vellum-ai/vellum-assistant#37938, together with vellum-ai/vellum-assistant-platform#9077.

## Why this is required even for managed mode

Worth being explicit, since the issue frames this as a platform-side allowlist change. There are **two independent host gates**, and this one fires in both modes:

| Gate | Where | Fires in |
|---|---|---|
| `assertOAuthRequestUrlAllowed` | daemon, `oauth-commands-routes.ts:177` | **managed + BYO** |
| `_resolve_proxy_base_url` | platform, `views.py:694` | managed only |

The daemon builds its allowlist from `injectionTemplates[].hostPattern` and rejects the URL client-side, before it ever reaches the platform proxy. So the platform PR alone is not sufficient — an absolute Docs URL would still fail locally with `OAuth request URL host "docs.googleapis.com" is not allowed for "google"`.

## No new scope

The Docs API accepts the `https://www.googleapis.com/auth/drive` scope already in `defaultScopes`. Verified end-to-end against a live connection before writing the change — `documents.create`, `batchUpdate` → `createHeader`, and `batchUpdate` → `insertText` + `updateTextStyle` (bold + brand color) all returned 200, producing a real page header with brand-colored text.

This mattered: the alternative (`auth/documents`) is also a Google *restricted* scope and would have forced re-consent for every existing user plus a CASA assessment. It doesn't.

Connections predating the `auth/drive` addition lack the scope and will 403 until reconnected — scopes freeze at consent time. `connection-resolver.ts` already turns that into an actionable "reconnect to grant X" for callers passing `requiredScopes`; wiring it for Docs callers is follow-up, not required here.

## Two deliberate non-changes

**`baseUrl` stays `www.googleapis.com`.** Docs calls must pass an absolute URL; relative paths still resolve to the generic host. Repointing `baseUrl` would break every Gmail and Calendar relative path in the codebase. The existing 404 diagnostic at `oauth-commands-routes.ts:917` already tells callers to use an absolute URL for a different service.

**No migration.** `injectionTemplates` is overwritten unconditionally on re-seed (`oauth-store.ts:248`), so existing installs pick this up on daemon restart. (Contrast `baseUrl`, which is `COALESCE`-guarded and would *not* update — not an issue here, since this adds a host rather than changing the base.)

## Rollout

**Merge vellum-ai/vellum-assistant-platform#9077 first and let it deploy**, then this. Reversing the order opens the daemon gate onto a platform allowlist that isn't live yet, so managed connections would fail at the proxy with a 400.

## Checks

`bunx tsc --noEmit` clean, `bun run lint` clean (0 errors), scoped tests pass. `oauth-provider-profiles.test.ts` asserted an exact list of 3 hosts and now asserts 4 — it failed until updated, which is the test doing its job.

Coverage note: the generic matcher (`matchHostPattern`) is already covered by `credential-host-pattern-match.test.ts`, and the seed assertion covers this entry. `assertOAuthRequestUrlAllowed`'s glue has no direct test — pre-existing, and out of scope for a data-only change.

Not exercised end-to-end here: my local daemon points at `dev-platform.vellum.ai`, so managed-mode verification needs the platform PR deployed first. The scope question — the only genuinely uncertain part — was settled by the live test above.

## Security

Narrowest possible change: one exact-match host, `docs.googleapis.com`, a first-party Google API on the same OAuth app and scope set as the three hosts already templated. No wildcard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->