### PR TITLE
fix: expect the curated caveman icon in the bundled catalog shape test

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-catalog-local.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-catalog-local.test.ts
@@ -37,6 +37,7 @@ describe("buildBundledPluginCatalog", () => {
       category: "productivity",
       homepage: "https://github.com/JuliusBrussee/caveman",
       license: "MIT",
+      icon: "🦴",
       source: {
         kind: "github",
         repo: "JuliusBrussee/caveman",


### PR DESCRIPTION
Main's `Test` job is red since #38044: it curated emoji icons onto the bundled plugin catalog entries, but the projection-shape test in `plugin-catalog-local.test.ts` still expects the pre-icon shape, so `buildBundledPluginCatalog > projects each entry to the expected match shape` fails on every branch that merges current main (first seen blocking #37940's CI).

One-line fix: add `icon: "🦴"` to the expected `caveman` match. Verified locally — the file's 4 tests plus the 5 neighboring plugin-catalog suites (192 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)