### PR TITLE
feat(messaging): support outbound email attachments on Outlook

### DIFF
--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { MessagingProvider } from "../messaging/provider.js";
@@ -129,6 +132,7 @@ describe("messaging-send tool", () => {
         subject: undefined,
         inReplyTo: undefined,
         threadId: undefined,
+        attachments: undefined,
         assistantId: "ast-alpha",
       },
     );
@@ -159,9 +163,72 @@ describe("messaging-send tool", () => {
         subject: undefined,
         inReplyTo: undefined,
         threadId: "thread-abc",
+        attachments: undefined,
         assistantId: "ast-alpha",
       },
     );
+  });
+
+  test("rejects attachments on platforms that can't carry them", async () => {
+    const result = await run(
+      {
+        platform: "phone",
+        conversation_id: "+12025550142",
+        text: "with a file",
+        attachment_paths: ["/tmp/does-not-matter.pdf"],
+      },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-1",
+        assistantId: "ast-alpha",
+        trustClass: "guardian" as const,
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Gmail and Outlook");
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("reads and forwards attachments to attachment-capable non-Gmail providers", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "msg-send-att-"));
+    const filePath = join(dir, "report.pdf");
+    writeFileSync(filePath, "pdf-bytes");
+    provider.id = "outlook";
+
+    try {
+      const result = await run(
+        {
+          platform: "outlook",
+          conversation_id: "user@example.com",
+          text: "see attached",
+          subject: "Docs",
+          attachment_paths: [filePath],
+        },
+        {
+          workingDir: "/tmp",
+          conversationId: "conv-1",
+          assistantId: "ast-alpha",
+          trustClass: "guardian" as const,
+        },
+      );
+
+      expect(result.isError).toBe(false);
+      const options = sendMessageMock.mock.calls[0][3] as {
+        attachments?: Array<{
+          filename: string;
+          mimeType: string;
+          data: Buffer;
+        }>;
+      };
+      expect(options.attachments).toHaveLength(1);
+      expect(options.attachments?.[0]?.filename).toBe("report.pdf");
+      expect(options.attachments?.[0]?.mimeType).toBe("application/pdf");
+      expect(options.attachments?.[0]?.data.toString()).toBe("pdf-bytes");
+    } finally {
+      provider.id = "phone";
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("cross-posts outbound message to bound conversation", async () => {

--- a/assistant/src/__tests__/outlook-messaging-provider.test.ts
+++ b/assistant/src/__tests__/outlook-messaging-provider.test.ts
@@ -473,12 +473,83 @@ describe("Outlook messaging provider", () => {
         conn,
         "original-msg-id",
         "Reply text",
+        undefined,
       );
       expect(mockSendMessage).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         conversationId: "conv-id",
         threadId: "thread-123",
       });
+    });
+
+    test("attaches files to a new message as Graph file attachments", async () => {
+      const conn = createMockConnection();
+      await outlookMessagingProvider.sendMessage(
+        conn,
+        "recipient@example.com",
+        "See attached",
+        {
+          subject: "Docs",
+          attachments: [
+            {
+              filename: "report.pdf",
+              mimeType: "application/pdf",
+              data: Buffer.from("pdf-bytes"),
+            },
+          ],
+        },
+      );
+
+      expect(mockSendMessage).toHaveBeenCalledWith(conn, {
+        message: {
+          subject: "Docs",
+          body: { contentType: "text", content: "See attached" },
+          toRecipients: [
+            { emailAddress: { address: "recipient@example.com" } },
+          ],
+          attachments: [
+            {
+              "@odata.type": "#microsoft.graph.fileAttachment",
+              name: "report.pdf",
+              contentType: "application/pdf",
+              contentBytes: Buffer.from("pdf-bytes").toString("base64"),
+            },
+          ],
+        },
+      });
+    });
+
+    test("forwards attachments to replyToMessage when replying", async () => {
+      const conn = createMockConnection();
+      await outlookMessagingProvider.sendMessage(
+        conn,
+        "conv-id",
+        "Reply body",
+        {
+          inReplyTo: "original-msg-id",
+          attachments: [
+            {
+              filename: "report.pdf",
+              mimeType: "application/pdf",
+              data: Buffer.from("pdf-bytes"),
+            },
+          ],
+        },
+      );
+
+      expect(mockReplyToMessage).toHaveBeenCalledWith(
+        conn,
+        "original-msg-id",
+        "Reply body",
+        [
+          {
+            "@odata.type": "#microsoft.graph.fileAttachment",
+            name: "report.pdf",
+            contentType: "application/pdf",
+            contentBytes: Buffer.from("pdf-bytes").toString("base64"),
+          },
+        ],
+      );
     });
 
     test("throws when connection is undefined", async () => {

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -125,7 +125,7 @@
     },
     {
       "name": "messaging_send",
-      "description": "Send a message, reply to a thread, or create a draft. On Gmail, always creates a draft for review. Supports replies (via thread_id), attachments (via attachment_paths, Gmail only), and all messaging platforms.",
+      "description": "Send a message, reply to a thread, or create a draft. On Gmail, always creates a draft for review. Supports replies (via thread_id), attachments (via attachment_paths, Gmail and Outlook), and all messaging platforms.",
       "category": "messaging",
       "risk": "high",
       "input_schema": {
@@ -160,7 +160,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Absolute file paths of attachments to include (Gmail only)"
+            "description": "Absolute file paths of attachments to include (Gmail and Outlook)"
           },
           "thread_id": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 
+import type { OutboundAttachment } from "../../../../messaging/provider-types.js";
 import {
   createDraft,
   createDraftRaw,
@@ -32,6 +33,20 @@ import {
 
 const log = getLogger("messaging-send");
 
+/** Read attachment files from disk into in-memory parts for outbound sending. */
+async function readAttachments(paths: string[]): Promise<OutboundAttachment[]> {
+  return Promise.all(
+    paths.map(async (filePath) => ({
+      filename: basename(filePath),
+      mimeType: guessMimeType(filePath),
+      data: await readFile(filePath),
+    })),
+  );
+}
+
+/** Email providers that accept file attachments on outbound sends. */
+const ATTACHMENT_CAPABLE_PLATFORMS = new Set(["gmail", "outlook"]);
+
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
@@ -54,9 +69,12 @@ export async function run(
   try {
     const provider = await resolveProvider(platform);
 
-    // Non-Gmail platforms: reject attachment_paths
-    if (provider.id !== "gmail" && attachmentPaths?.length) {
-      return err("Attachments are only supported on Gmail.");
+    // Reject attachments on platforms that can't carry them (e.g. Telegram, WhatsApp).
+    if (
+      attachmentPaths?.length &&
+      !ATTACHMENT_CAPABLE_PLATFORMS.has(provider.id)
+    ) {
+      return err("Attachments are only supported on Gmail and Outlook.");
     }
 
     const account = input.account as string | undefined;
@@ -125,14 +143,7 @@ export async function run(
 
         // With attachments: build multipart MIME for threaded reply
         if (attachmentPaths?.length) {
-          const attachments = await Promise.all(
-            attachmentPaths.map(async (filePath) => {
-              const data = await readFile(filePath);
-              const filename = basename(filePath);
-              const mimeType = guessMimeType(filePath);
-              return { filename, mimeType, data };
-            }),
-          );
+          const attachments = await readAttachments(attachmentPaths);
 
           const raw = buildMultipartMime({
             to: toList.join(", "),
@@ -176,14 +187,7 @@ export async function run(
 
       // With attachments: build multipart MIME and use createDraftRaw
       if (attachmentPaths?.length) {
-        const attachments = await Promise.all(
-          attachmentPaths.map(async (filePath) => {
-            const data = await readFile(filePath);
-            const filename = basename(filePath);
-            const mimeType = guessMimeType(filePath);
-            return { filename, mimeType, data };
-          }),
-        );
+        const attachments = await readAttachments(attachmentPaths);
 
         const raw = buildMultipartMime({
           to: conversationId,
@@ -217,10 +221,14 @@ export async function run(
     }
 
     // Non-Gmail platforms
+    const attachments = attachmentPaths?.length
+      ? await readAttachments(attachmentPaths)
+      : undefined;
     const result = await provider.sendMessage(conn, conversationId, text, {
       subject,
       inReplyTo,
       threadId,
+      attachments,
       assistantId: context.assistantId,
     });
 

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -81,12 +81,21 @@ export interface SearchOptions {
   cursor?: string;
 }
 
+/** A file to attach to an outbound message, with its content already read into memory. */
+export interface OutboundAttachment {
+  filename: string;
+  mimeType: string;
+  data: Buffer;
+}
+
 export interface SendOptions {
   threadId?: string;
   /** For email: subject line */
   subject?: string;
   /** For email: in-reply-to message ID */
   inReplyTo?: string;
+  /** For email: files to attach. Providers that don't support attachments ignore this. */
+  attachments?: OutboundAttachment[];
   /** Optional assistant scope for multi-assistant channels. */
   assistantId?: string;
 }

--- a/assistant/src/messaging/providers/outlook/adapter.ts
+++ b/assistant/src/messaging/providers/outlook/adapter.ts
@@ -19,7 +19,18 @@ import type {
   SendResult,
 } from "../../provider-types.js";
 import * as outlook from "./client.js";
-import type { OutlookMessage } from "./types.js";
+import type { OutlookMessage, OutlookSendFileAttachment } from "./types.js";
+
+function toGraphAttachments(
+  attachments: NonNullable<SendOptions["attachments"]>,
+): OutlookSendFileAttachment[] {
+  return attachments.map((att) => ({
+    "@odata.type": "#microsoft.graph.fileAttachment",
+    name: att.filename,
+    contentType: att.mimeType,
+    contentBytes: att.data.toString("base64"),
+  }));
+}
 
 function requireConnection(
   connection: OAuthConnection | undefined,
@@ -143,9 +154,12 @@ export const outlookMessagingProvider: MessagingProvider = {
     options?: SendOptions,
   ): Promise<SendResult> {
     const conn = requireConnection(connection);
+    const attachments = options?.attachments?.length
+      ? toGraphAttachments(options.attachments)
+      : undefined;
 
     if (options?.inReplyTo) {
-      await outlook.replyToMessage(conn, options.inReplyTo, text);
+      await outlook.replyToMessage(conn, options.inReplyTo, text, attachments);
       return {
         id: "",
         timestamp: Date.now(),
@@ -159,6 +173,7 @@ export const outlookMessagingProvider: MessagingProvider = {
         subject: options?.subject ?? "",
         body: { contentType: "text", content: text },
         toRecipients: [{ emailAddress: { address: conversationId } }],
+        ...(attachments ? { attachments } : {}),
       },
     });
 

--- a/assistant/src/messaging/providers/outlook/client.ts
+++ b/assistant/src/messaging/providers/outlook/client.ts
@@ -17,6 +17,7 @@ import type {
   OutlookMessageRule,
   OutlookMessageRuleListResponse,
   OutlookRecipient,
+  OutlookSendFileAttachment,
   OutlookSendMessagePayload,
   OutlookUserProfile,
 } from "./types.js";
@@ -201,18 +202,26 @@ export async function sendMessage(
   });
 }
 
-/** Reply to an existing message. */
+/** Reply to an existing message, optionally with file attachments. */
 export async function replyToMessage(
   connection: OAuthConnection,
   messageId: string,
   comment: string,
+  attachments?: OutlookSendFileAttachment[],
 ): Promise<void> {
+  const body: {
+    comment: string;
+    message?: { attachments: OutlookSendFileAttachment[] };
+  } = { comment };
+  if (attachments?.length) {
+    body.message = { attachments };
+  }
   await request<void>(
     connection,
     `/v1.0/me/messages/${encodeURIComponent(messageId)}/reply`,
     {
       method: "POST",
-      body: JSON.stringify({ comment }),
+      body: JSON.stringify(body),
     },
   );
 }

--- a/assistant/src/messaging/providers/outlook/types.ts
+++ b/assistant/src/messaging/providers/outlook/types.ts
@@ -71,6 +71,14 @@ export interface OutlookMailFolderListResponse {
   "@odata.nextLink"?: string;
 }
 
+/** Outbound file attachment for sendMail/reply (base64-encoded content). */
+export interface OutlookSendFileAttachment {
+  "@odata.type": "#microsoft.graph.fileAttachment";
+  name: string;
+  contentType: string;
+  contentBytes: string;
+}
+
 /** Payload for sending a message via Microsoft Graph */
 export interface OutlookSendMessagePayload {
   message: {
@@ -78,6 +86,7 @@ export interface OutlookSendMessagePayload {
     body: OutlookItemBody;
     toRecipients: OutlookRecipient[];
     ccRecipients?: OutlookRecipient[];
+    attachments?: OutlookSendFileAttachment[];
   };
   saveToSentItems?: boolean;
 }


### PR DESCRIPTION
## Prompt / plan

Two user reports: the email send command has no way to send attachments. Plan was to do **outbound** first, then follow up on inbound attachment pulling separately.

Investigation found that the unified `messaging_send` tool already supported attachments on **Gmail** (reads files → multipart MIME → draft), but hard-rejected `attachment_paths` on every other provider with *"Attachments are only supported on Gmail."* **Outlook** — the other email provider — had no outbound attachment path at all. This PR brings Outlook to parity. (Telegram/WhatsApp/etc. still can't carry file attachments and are still rejected.)

### What changed

- **`SendOptions`** gains a provider-agnostic `attachments: OutboundAttachment[]` field (`{ filename, mimeType, data }`). Providers that don't support attachments ignore it.
- **Outlook client** — `replyToMessage` accepts optional file attachments (Microsoft Graph's reply action takes a `message.attachments` array alongside `comment`); the `sendMail` payload type carries `attachments`.
- **Outlook adapter** — maps `OutboundAttachment`s into Graph `#microsoft.graph.fileAttachment` parts for both new messages and replies.
- **`messaging_send` tool** — allows attachments on Gmail **and** Outlook, reads the files once via a shared `readAttachments` helper (deduping the two prior inline Gmail copies), and forwards them through `SendOptions` for non-Gmail providers.
- **TOOLS.json** — advertises attachment support for "Gmail and Outlook".

Inbound attachment pulling (the second user report) is a separate follow-up.

## Test plan

- New unit tests in `outlook-messaging-provider.test.ts`: new message and reply both carry Graph file-attachment parts; existing reply assertion updated for the new 4th arg.
- New unit tests in `messaging-send-tool.test.ts`: rejection message updated for unsupported platforms; attachment-capable non-Gmail provider reads files and forwards them via `SendOptions`.
- `bun test` on both files green; `bunx tsc --noEmit` clean; lint/prettier clean (remaining lint output is pre-existing `curly` warnings on untouched lines).

<!-- CLI verb checklist omitted: no new IPC routes under assistant/src/runtime/routes/. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zpRSHVvD7vWymD83q7jkt

---
_Generated by [Claude Code](https://claude.ai/code/session_015zpRSHVvD7vWymD83q7jkt)_