### PR TITLE
feat(apps): slash-free wire form for plugin app ids

### DIFF
--- a/assistant/src/__tests__/list-all-apps.test.ts
+++ b/assistant/src/__tests__/list-all-apps.test.ts
@@ -93,7 +93,7 @@ describe("listAllApps", () => {
     const plugin = listPluginApps();
     expect(plugin).toHaveLength(1);
     expect(plugin[0].origin).toEqual({ kind: "plugin", pluginName: "acme" });
-    expect(plugin[0].id).toBe("plugins/acme/acme-dashboard");
+    expect(plugin[0].id).toBe("plugins~acme~acme-dashboard");
     expect(plugin[0].name).toBe("acme-dashboard");
     expect(plugin[0].sourcePath).toBe(
       join(pluginDir, "apps", "acme-dashboard"),
@@ -157,11 +157,11 @@ describe("resolveAppSource", () => {
     expect(source!.formatVersion).toBe(1);
   });
 
-  test("resolves a plugin app by its plugins/<name>/<app> id", () => {
+  test("resolves a plugin app by its plugins~<name>~<app> id", () => {
     const pluginDir = installPlugin("acme");
     bundleApp(pluginDir, "acme-dashboard");
 
-    const source = resolveAppSource("plugins/acme/acme-dashboard");
+    const source = resolveAppSource("plugins~acme~acme-dashboard");
     expect(source).not.toBeNull();
     expect(source!.origin).toEqual({ kind: "plugin", pluginName: "acme" });
     expect(source!.name).toBe("acme-dashboard");
@@ -178,7 +178,7 @@ describe("resolveAppSource", () => {
     const pluginDir = installPlugin("acme", { disabled: true });
     bundleApp(pluginDir, "acme-dashboard");
 
-    expect(resolveAppSource("plugins/acme/acme-dashboard")).toBeNull();
+    expect(resolveAppSource("plugins~acme~acme-dashboard")).toBeNull();
   });
 
   test("returns null for a plugin dir without a package.json manifest", () => {
@@ -191,14 +191,14 @@ describe("resolveAppSource", () => {
     );
     mkdirSync(strayApp, { recursive: true });
 
-    expect(resolveAppSource("plugins/not-a-plugin/x")).toBeNull();
+    expect(resolveAppSource("plugins~not-a-plugin~x")).toBeNull();
   });
 
   test("returns null for traversal and malformed plugin ids", () => {
     installPlugin("acme");
-    expect(resolveAppSource("plugins/../secrets")).toBeNull();
-    expect(resolveAppSource("plugins/acme/../..")).toBeNull();
-    expect(resolveAppSource("plugins/acme")).toBeNull(); // missing app segment
-    expect(resolveAppSource("plugins/acme/a/b")).toBeNull(); // too deep
+    expect(resolveAppSource("plugins~..~secrets")).toBeNull(); // traversal name
+    expect(resolveAppSource("plugins~acme~..")).toBeNull(); // traversal app
+    expect(resolveAppSource("plugins~acme")).toBeNull(); // missing app segment
+    expect(resolveAppSource("plugins~acme~sub/dir")).toBeNull(); // slash in app
   });
 });

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -661,24 +661,29 @@ export type AppOrigin =
   | { readonly kind: "plugin"; readonly pluginName: string };
 
 /**
- * Id prefix marking a plugin-bundled app. A plugin app's id is its location:
- * `plugins/<pluginName>/<appDir>`, which maps directly to
+ * Id prefix marking a plugin-bundled app. A plugin app's id encodes its
+ * location: `plugins~<pluginName>~<appDir>`, which maps to
  * `<workspace>/plugins/<pluginName>/apps/<appDir>` (the `apps/` segment is
  * implied). Unlike workspace apps — whose id is an opaque UUID looked up by
  * scanning — a plugin app is resolved by a direct path build.
+ *
+ * The delimiter is `~` (a URL-unreserved character), not `/`, so the id is a
+ * single URL path segment: it survives `:id` route params and proxies without
+ * percent-encoding (`%2F` in a path is widely mishandled).
  */
-const PLUGIN_APP_ID_PREFIX = "plugins/";
+const PLUGIN_APP_ID_PREFIX = "plugins~";
+const PLUGIN_APP_ID_SEP = "~";
 
 /** Build the addressable id for a plugin-bundled app. */
 function pluginAppId(pluginName: string, appDir: string): string {
-  return `${PLUGIN_APP_ID_PREFIX}${pluginName}/${appDir}`;
+  return `${PLUGIN_APP_ID_PREFIX}${pluginName}${PLUGIN_APP_ID_SEP}${appDir}`;
 }
 
 /** An app paired with the absolute path to its source and its origin. */
 export interface EnumeratedApp {
   /**
    * Addressable app id: an opaque UUID for workspace apps, or
-   * `plugins/<name>/<app>` for plugin-bundled apps.
+   * `plugins~<name>~<app>` for plugin-bundled apps.
    */
   readonly id: string;
   /** Human-readable app name. */
@@ -818,21 +823,23 @@ function isSafeIdSegment(segment: string): boolean {
 /**
  * Resolve an app id to its on-disk source, for both workspace apps (opaque
  * UUID, looked up via {@link getApp}) and plugin-bundled apps
- * (`plugins/<name>/<app>`, resolved by direct path build). Returns null when
+ * (`plugins~<name>~<app>`, resolved by direct path build). Returns null when
  * the app does not exist, or when a plugin id fails the same installed-plugin
  * gates as discovery (directory, `package.json` manifest, not disabled).
  */
 export function resolveAppSource(id: string): ResolvedAppSource | null {
   if (id.startsWith(PLUGIN_APP_ID_PREFIX)) {
     const rest = id.slice(PLUGIN_APP_ID_PREFIX.length);
-    const slash = rest.indexOf("/");
-    if (slash === -1) {
+    // Split on the first delimiter: the plugin name is kebab-case (no `~`), so
+    // everything after it is the app directory (which may itself contain `~`).
+    const sep = rest.indexOf(PLUGIN_APP_ID_SEP);
+    if (sep === -1) {
       return null;
     }
-    const pluginName = rest.slice(0, slash);
-    const appDirName = rest.slice(slash + 1);
-    // Both segments must be single safe path components (rejects a deeper
-    // `plugins/<name>/<a>/<b>` since appDirName would then contain a slash).
+    const pluginName = rest.slice(0, sep);
+    const appDirName = rest.slice(sep + PLUGIN_APP_ID_SEP.length);
+    // Both must be safe single path components — the app segment, used as a
+    // directory name, must not smuggle in separators or traversal.
     if (!isSafeIdSegment(pluginName) || !isSafeIdSegment(appDirName)) {
       return null;
     }


### PR DESCRIPTION
## Prompt / plan

Prep for wiring plugin apps through the by-id HTTP routes: change the plugin-bundled app id from `plugins/<name>/<app>` to **`plugins~<name>~<app>`** so it's a single URL path segment.

### Why
The id is carried in `:id` route params (`apps/:id/open` today; the serve/asset/pages routes next). The router (`http-router.ts`) matches each param as a single segment `([^/]+)` and runs `decodeURIComponent`. A `/` in the id forces clients to percent-encode it as `%2F` — which the platform's Django proxy and the self-hosted path rewrite mishandle (encoded slashes in a path are widely normalized/rejected). `~` is a **URL-unreserved** character, so the id rides through path params and proxies verbatim, with no encoding and none of the `%2F` fragility.

### What changed
- `plugins/<name>/<app>` → `plugins~<name>~<app>` (prefix `plugins~`, delimiter `~`).
- **Wire form only.** The filesystem mapping is unchanged (`plugins~<name>~<app>` → `<workspace>/plugins/<name>/apps/<app>`), and `resolveAppSource` still splits on the first delimiter — plugin names are kebab-case (no `~`), so the app segment is unambiguous even if it itself contains `~`.
- Path-segment safety is unchanged: the app segment is still rejected if it contains `/`, `\`, or `..`.
- Ids are computed on read and never persisted, and no plugin ships an app yet, so there's nothing to migrate and no client depends on the old form.

This is the id-scheme decision from the single-app-fetch PR (#38031) discussion. The serve/asset/pages routes (`app-routes.ts`) still resolve workspace ids only — routing those through `resolveAppSource` is the **next** PR.

## Test plan

- `src/__tests__/list-all-apps.test.ts` updated to the new form (12 tests pass): id assertion (`plugins~acme~acme-dashboard`), the `resolveAppSource` suite, and the traversal/malformed cases (`plugins~..~secrets`, `plugins~acme~..`, missing app segment, and a `/`-in-app-segment id all resolve to `null`).
- `bunx tsc --noEmit` clean; eslint 0 errors (pre-existing curly warnings only).
- No OpenAPI change — the id is a value, not a schema change (`id` stays `z.string()`).

## CLI verb checklist

No route or contract changes — this only changes the string value of a plugin app id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG

---
_Generated by [Claude Code](https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG)_