### PR TITLE
fix(routes): make the routes CLI plugin-aware and fix `routes inspect` over IPC

### DIFF
--- a/assistant/src/cli/commands/routes.ts
+++ b/assistant/src/cli/commands/routes.ts
@@ -68,7 +68,9 @@ export function registerRoutesCommand(program: Command): void {
         }
 
         if (discovered.length === 0) {
-          log.info("No route handlers found in /workspace/routes/.");
+          log.info(
+            "No route handlers found in /workspace/routes/ or /workspace/plugins/<name>/routes/.",
+          );
           log.info(
             "Create a .ts or .js file exporting named HTTP method functions (GET, POST, etc.).",
           );
@@ -108,7 +110,7 @@ export function registerRoutesCommand(program: Command): void {
             route.routePath.padEnd(routeWidth),
             formatMethods(route.methods).padEnd(methodsWidth),
             (route.description ?? "").padEnd(descWidth),
-            `routes/${route.filePath}`,
+            route.filePath,
           ].join("    ");
           log.info(`  ${cols}`);
         }
@@ -130,7 +132,7 @@ export function registerRoutesCommand(program: Command): void {
         async (routePath: string, opts: { json?: boolean }) => {
           const r = await cliIpcCall<{ route: InspectedRoute }>(
             "user_routes_inspect",
-            { path: routePath },
+            { body: { path: routePath } },
           );
           if (!r.ok) {
             if (opts.json) {

--- a/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the `assistant routes` discovery handlers (`user_routes_list`,
+ * `user_routes_inspect`).
+ *
+ * These assert the CLI's view of the route surface matches what the dispatcher
+ * serves: workspace routes appear at `/x/<path>`, plugin routes at
+ * `/x/plugins/<name>/<path>`, files shadowed by the reserved plugin prefix are
+ * excluded, and disabled plugins contribute nothing. Both handlers resolve
+ * through the shared `user-route-resolution` module the dispatcher uses.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getWorkspacePluginsDir,
+  getWorkspaceRoutesDir,
+} from "../../../util/platform.js";
+import type { RouteHandlerArgs } from "../types.js";
+import { ROUTES } from "../user-routes-cli.js";
+
+interface RouteEntry {
+  routePath: string;
+  methods: string[];
+  filePath: string;
+}
+
+const listHandler = ROUTES.find((r) => r.operationId === "user_routes_list")!
+  .handler as () => Promise<{ ok: true; routes: RouteEntry[] }>;
+const inspectHandler = ROUTES.find(
+  (r) => r.operationId === "user_routes_inspect",
+)!.handler as (args: RouteHandlerArgs) => Promise<{ route: RouteEntry }>;
+
+const GET_HANDLER = `export async function GET() { return Response.json({ ok: true }); }\n`;
+
+function writeWorkspaceRoute(relPath: string): void {
+  const full = join(getWorkspaceRoutesDir(), relPath);
+  mkdirSync(full.slice(0, full.lastIndexOf("/")), { recursive: true });
+  writeFileSync(full, GET_HANDLER);
+}
+
+function writePluginRoute(plugin: string, relPath: string): void {
+  const full = join(getWorkspacePluginsDir(), plugin, "routes", relPath);
+  mkdirSync(full.slice(0, full.lastIndexOf("/")), { recursive: true });
+  writeFileSync(full, GET_HANDLER);
+}
+
+function disablePlugin(plugin: string): void {
+  writeFileSync(join(getWorkspacePluginsDir(), plugin, ".disabled"), "");
+}
+
+beforeEach(() => {
+  mkdirSync(getWorkspaceRoutesDir(), { recursive: true });
+  mkdirSync(getWorkspacePluginsDir(), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(getWorkspaceRoutesDir(), { recursive: true, force: true });
+  rmSync(getWorkspacePluginsDir(), { recursive: true, force: true });
+});
+
+describe("routes list", () => {
+  test("lists workspace routes and plugin routes together", async () => {
+    writeWorkspaceRoute("ping.ts");
+    writePluginRoute("demo", "status.ts");
+    writePluginRoute("demo", "webhooks/incoming.ts");
+    writePluginRoute("demo", "index.ts");
+
+    const { routes } = await listHandler();
+    const byPath = new Map(routes.map((r) => [r.routePath, r]));
+
+    expect(byPath.has("/x/ping")).toBe(true);
+    expect(byPath.get("/x/ping")!.filePath).toBe("routes/ping.ts");
+
+    expect(byPath.has("/x/plugins/demo/status")).toBe(true);
+    expect(byPath.get("/x/plugins/demo/status")!.filePath).toBe(
+      "plugins/demo/routes/status.ts",
+    );
+    expect(byPath.has("/x/plugins/demo/webhooks/incoming")).toBe(true);
+    // routes/index.ts maps to the plugin namespace root.
+    expect(byPath.has("/x/plugins/demo")).toBe(true);
+  });
+
+  test("excludes workspace files shadowed by the reserved plugin prefix", async () => {
+    writeWorkspaceRoute("ping.ts");
+    // A workspace file under routes/plugins/ is unreachable (the dispatcher
+    // routes /x/plugins/* to plugin dirs), so it must not be listed.
+    writeWorkspaceRoute("plugins/foo.ts");
+
+    const { routes } = await listHandler();
+    const paths = routes.map((r) => r.routePath);
+
+    expect(paths).toContain("/x/ping");
+    expect(paths).not.toContain("/x/plugins/foo");
+  });
+
+  test("excludes disabled plugins' routes", async () => {
+    writePluginRoute("live", "status.ts");
+    writePluginRoute("dead", "status.ts");
+    disablePlugin("dead");
+
+    const { routes } = await listHandler();
+    const paths = routes.map((r) => r.routePath);
+
+    expect(paths).toContain("/x/plugins/live/status");
+    expect(paths).not.toContain("/x/plugins/dead/status");
+  });
+});
+
+describe("routes inspect", () => {
+  test("inspects a plugin route by sub-path and by /x/-prefixed path", async () => {
+    writePluginRoute("demo", "status.ts");
+
+    const bare = await inspectHandler({
+      body: { path: "plugins/demo/status" },
+    });
+    expect(bare.route.routePath).toBe("/x/plugins/demo/status");
+    expect(bare.route.methods).toEqual(["GET"]);
+    expect(bare.route.filePath).toBe("plugins/demo/routes/status.ts");
+
+    // The `/x/`-prefixed form that `routes list` prints is accepted too.
+    const prefixed = await inspectHandler({
+      body: { path: "/x/plugins/demo/status" },
+    });
+    expect(prefixed.route.routePath).toBe("/x/plugins/demo/status");
+  });
+
+  test("inspects a workspace route", async () => {
+    writeWorkspaceRoute("ping.ts");
+    const res = await inspectHandler({ body: { path: "ping" } });
+    expect(res.route.routePath).toBe("/x/ping");
+    expect(res.route.filePath).toBe("routes/ping.ts");
+  });
+
+  test("404s a shadowed, missing, or disabled route", async () => {
+    writeWorkspaceRoute("plugins/foo.ts"); // shadowed workspace file
+    writePluginRoute("dead", "status.ts");
+    disablePlugin("dead");
+
+    // Shadowed: resolves to plugin "foo" (which has no routes dir) → not found.
+    await expect(
+      inspectHandler({ body: { path: "plugins/foo" } }),
+    ).rejects.toThrow();
+    // Missing plugin.
+    await expect(
+      inspectHandler({ body: { path: "plugins/ghost/status" } }),
+    ).rejects.toThrow();
+    // Disabled plugin.
+    await expect(
+      inspectHandler({ body: { path: "plugins/dead/status" } }),
+    ).rejects.toThrow();
+  });
+});

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -27,17 +27,15 @@
  * whose file does not exist 404s — nothing is registered ahead of time.
  */
 
-import { existsSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { statSync } from "node:fs";
 
-import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { getLogger } from "../../util/logger.js";
-import {
-  getWorkspacePluginsDir,
-  getWorkspaceRoutesDir,
-} from "../../util/platform.js";
 import type { AssistantEventHub } from "../assistant-event-hub.js";
 import { httpError } from "../http-errors.js";
+import {
+  resolveHandlerFile,
+  resolveRouteLocation,
+} from "./user-route-resolution.js";
 
 const log = getLogger("user-routes");
 
@@ -131,44 +129,6 @@ interface CachedModule {
 /** Default per-request timeout for user-defined route handlers (30 seconds). */
 const DEFAULT_HANDLER_TIMEOUT_MS = 30_000;
 
-/** Supported file extensions for handler modules. */
-const HANDLER_EXTENSIONS = [".ts", ".js"] as const;
-
-/** Path segment reserved for plugin-namespaced routes under `/x/`. */
-const PLUGIN_ROUTE_SEGMENT = "plugins";
-
-/**
- * Resolve an `/x/` route path to the base directory + sub-path the handler file
- * is looked up under.
- *
- * `plugins/<name>/<rest>` resolves against that plugin's own
- * `<workspaceDir>/plugins/<name>/routes/` directory (`<rest>` may be empty,
- * mapping to the namespace's `index` handler). Everything else resolves against
- * the workspace `routes/` directory. Returns `null` (caller 404s) when:
- *
- * - the path is a malformed plugin path (`plugins` with no name segment), so it
- *   never falls back to a workspace route — the `plugins/` prefix is reserved
- *   for plugin routes; or
- * - the named plugin is disabled (`.disabled` sentinel present), so a disabled
- *   plugin serves no routes even though its files remain on disk.
- */
-function resolveRouteLocation(
-  routePath: string,
-): { routesDir: string; subPath: string } | null {
-  const segments = routePath.split("/");
-  if (segments[0] === PLUGIN_ROUTE_SEGMENT) {
-    const pluginName = segments[1];
-    if (!pluginName || isPluginDisabled(pluginName)) {
-      return null;
-    }
-    return {
-      routesDir: join(getWorkspacePluginsDir(), pluginName, "routes"),
-      subPath: segments.slice(2).join("/"),
-    };
-  }
-  return { routesDir: getWorkspaceRoutesDir(), subPath: routePath };
-}
-
 export class UserRouteDispatcher {
   private moduleCache = new Map<string, CachedModule>();
   private handlerTimeoutMs: number;
@@ -197,7 +157,7 @@ export class UserRouteDispatcher {
 
     const location = resolveRouteLocation(routePath);
     const filePath = location
-      ? this.resolveHandlerFile(location.routesDir, location.subPath)
+      ? resolveHandlerFile(location.routesDir, location.subPath)
       : null;
 
     if (!filePath) {
@@ -221,46 +181,6 @@ export class UserRouteDispatcher {
     }
 
     return this.executeHandler(handler, request, routePath);
-  }
-
-  /**
-   * Resolve a route path to a handler file on disk.
-   *
-   * Checks for direct file matches first (`<path>.ts`, `<path>.js`),
-   * then falls back to index files (`<path>/index.ts`, `<path>/index.js`).
-   *
-   * Returns the absolute path to the handler file, or null if not found.
-   */
-  private resolveHandlerFile(
-    routesDir: string,
-    routePath: string,
-  ): string | null {
-    const basePath = join(routesDir, routePath);
-    const resolved = resolve(basePath);
-
-    // Ensure the resolved path is within the routes directory to prevent
-    // any path traversal that slipped through the initial check.
-    if (!resolved.startsWith(resolve(routesDir))) {
-      return null;
-    }
-
-    // Direct file match: routes/<path>.ts or routes/<path>.js
-    for (const ext of HANDLER_EXTENSIONS) {
-      const candidate = `${resolved}${ext}`;
-      if (existsSync(candidate)) {
-        return candidate;
-      }
-    }
-
-    // Index file convention: routes/<path>/index.ts or routes/<path>/index.js
-    for (const ext of HANDLER_EXTENSIONS) {
-      const candidate = join(resolved, `index${ext}`);
-      if (existsSync(candidate)) {
-        return candidate;
-      }
-    }
-
-    return null;
   }
 
   /**

--- a/assistant/src/runtime/routes/user-route-resolution.ts
+++ b/assistant/src/runtime/routes/user-route-resolution.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared path resolution for `/x/*` user routes.
+ *
+ * Both the request dispatcher (`user-route-dispatcher.ts`) and the CLI
+ * discovery surface (`user-routes-cli.ts`) resolve `/x/` paths to on-disk
+ * handler files through this module, so what the CLI lists can never drift
+ * from what the dispatcher actually serves.
+ *
+ * Two locations back the surface:
+ * - `<workspaceDir>/routes/<path>` — workspace routes, served at `/x/<path>`.
+ * - `<workspaceDir>/plugins/<name>/routes/<path>` — a plugin's routes, served
+ *   in that plugin's reserved namespace at `/x/plugins/<name>/<path>`.
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { isPluginDisabled } from "../../plugins/disabled-state.js";
+import {
+  getWorkspacePluginsDir,
+  getWorkspaceRoutesDir,
+} from "../../util/platform.js";
+
+/** Supported file extensions for handler modules (`.js` preferred over `.ts`). */
+export const HANDLER_EXTENSIONS = [".ts", ".js"] as const;
+
+/** Path segment reserved for plugin-namespaced routes under `/x/`. */
+export const PLUGIN_ROUTE_SEGMENT = "plugins";
+
+export interface RouteLocation {
+  /** Absolute directory the handler file is resolved under. */
+  routesDir: string;
+  /** Path within `routesDir`, relative and without the `/x/` prefix. */
+  subPath: string;
+}
+
+/**
+ * Resolve an `/x/` route path to the base directory + sub-path the handler file
+ * is looked up under.
+ *
+ * `plugins/<name>/<rest>` resolves against that plugin's own
+ * `<workspaceDir>/plugins/<name>/routes/` directory (`<rest>` may be empty,
+ * mapping to the namespace's `index` handler). Everything else resolves against
+ * the workspace `routes/` directory. Returns `null` (caller 404s) when:
+ *
+ * - the path is a malformed plugin path (`plugins` with no name segment), so it
+ *   never falls back to a workspace route — the `plugins/` prefix is reserved
+ *   for plugin routes; or
+ * - the named plugin is disabled (`.disabled` sentinel present), so a disabled
+ *   plugin serves no routes even though its files remain on disk.
+ */
+export function resolveRouteLocation(routePath: string): RouteLocation | null {
+  const segments = routePath.split("/");
+  if (segments[0] === PLUGIN_ROUTE_SEGMENT) {
+    const pluginName = segments[1];
+    if (!pluginName || isPluginDisabled(pluginName)) {
+      return null;
+    }
+    return {
+      routesDir: join(getWorkspacePluginsDir(), pluginName, "routes"),
+      subPath: segments.slice(2).join("/"),
+    };
+  }
+  return { routesDir: getWorkspaceRoutesDir(), subPath: routePath };
+}
+
+/**
+ * Resolve a sub-path within `routesDir` to a handler file on disk.
+ *
+ * Checks for direct file matches first (`<path>.ts`, `<path>.js`), then falls
+ * back to index files (`<path>/index.ts`, `<path>/index.js`). Returns the
+ * absolute path to the handler file, or `null` if not found. Rejects any path
+ * that escapes `routesDir` (traversal backstop).
+ */
+export function resolveHandlerFile(
+  routesDir: string,
+  subPath: string,
+): string | null {
+  const resolved = resolve(join(routesDir, subPath));
+
+  if (!resolved.startsWith(resolve(routesDir))) {
+    return null;
+  }
+
+  for (const ext of HANDLER_EXTENSIONS) {
+    const candidate = `${resolved}${ext}`;
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  for (const ext of HANDLER_EXTENSIONS) {
+    const candidate = join(resolved, `index${ext}`);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * True when a workspace `/x/<path>` collides with the reserved plugin prefix
+ * (`plugins` or `plugins/…`). Such a file lives under `<workspaceDir>/routes/`
+ * but is shadowed by the plugin namespace and never served, so discovery must
+ * exclude it — {@link resolveRouteLocation} routes the same path to a plugin
+ * directory instead.
+ */
+export function isReservedWorkspaceRoutePath(routePath: string): boolean {
+  return (
+    routePath === PLUGIN_ROUTE_SEGMENT ||
+    routePath.startsWith(`${PLUGIN_ROUTE_SEGMENT}/`)
+  );
+}
+
+/**
+ * Enumerate enabled workspace plugins that ship a `routes/` directory, for
+ * route discovery. Mirrors {@link resolveRouteLocation}'s plugin resolution —
+ * same base directory, same disabled-sentinel gate — so discovery and dispatch
+ * agree on which plugin routes exist.
+ */
+export function listPluginRouteRoots(): {
+  pluginName: string;
+  routesDir: string;
+}[] {
+  const pluginsDir = getWorkspacePluginsDir();
+  if (!existsSync(pluginsDir)) {
+    return [];
+  }
+  const roots: { pluginName: string; routesDir: string }[] = [];
+  for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || isPluginDisabled(entry.name)) {
+      continue;
+    }
+    const routesDir = join(pluginsDir, entry.name, "routes");
+    if (existsSync(routesDir) && statSync(routesDir).isDirectory()) {
+      roots.push({ pluginName: entry.name, routesDir });
+    }
+  }
+  return roots;
+}

--- a/assistant/src/runtime/routes/user-routes-cli.ts
+++ b/assistant/src/runtime/routes/user-routes-cli.ts
@@ -13,10 +13,17 @@ import { z } from "zod";
 
 import { getConfig } from "../../config/loader.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
-import { getWorkspaceRoutesDir } from "../../util/platform.js";
+import { getWorkspaceDir, getWorkspaceRoutesDir } from "../../util/platform.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+import {
+  HANDLER_EXTENSIONS,
+  isReservedWorkspaceRoutePath,
+  listPluginRouteRoots,
+  resolveHandlerFile,
+  resolveRouteLocation,
+} from "./user-route-resolution.js";
 
 // ── Constants ───────────────────────────────────────────────────────
 
@@ -31,8 +38,6 @@ const HTTP_METHODS = [
 ] as const;
 
 type HttpMethod = (typeof HTTP_METHODS)[number];
-
-const HANDLER_EXTENSIONS = [".ts", ".js"] as const;
 
 type HandlerExtension = (typeof HANDLER_EXTENSIONS)[number];
 
@@ -146,51 +151,67 @@ function tryGetPublicBaseUrl(): string | null {
   }
 }
 
-function resolveHandlerFile(
-  routesDir: string,
-  routePath: string,
-): string | null {
-  const basePath = join(routesDir, routePath);
-
-  for (const ext of HANDLER_EXTENSIONS) {
-    const candidate = `${basePath}${ext}`;
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  for (const ext of HANDLER_EXTENSIONS) {
-    const candidate = join(basePath, `index${ext}`);
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  return null;
+/**
+ * Strip a leading `/x/` (or `x/`) and surrounding slashes from a route path so
+ * `routes inspect` accepts both the bare sub-path (`ping`) and the `/x/`-prefixed
+ * form that `routes list` prints (`/x/plugins/demo/status`).
+ */
+function normalizeInspectPath(input: string): string {
+  const trimmed = input.replace(/^\/+/, "");
+  return trimmed.startsWith("x/") ? trimmed.slice(2) : trimmed;
 }
 
 // ── Handlers ────────────────────────────────────────────────────────
 
 async function handleUserRoutesList() {
-  const routesDir = getWorkspaceRoutesDir();
-  const discovered = await discoverRoutes(routesDir);
   const publicBase = tryGetPublicBaseUrl();
+  const workspaceDir = getWorkspaceDir();
 
-  const routes = discovered.map((r) => ({
-    routePath: `/x/${r.routePath}`,
+  const toEntry = (xPath: string, r: DiscoveredRoute) => ({
+    routePath: `/x/${xPath}`,
     methods: r.methods,
     description: r.description ?? null,
-    filePath: relative(routesDir, r.filePath),
-    publicUrl: publicBase ? `${publicBase}/x/${r.routePath}` : null,
-  }));
+    filePath: relative(workspaceDir, r.filePath),
+    publicUrl: publicBase ? `${publicBase}/x/${xPath}` : null,
+  });
 
+  const routes: ReturnType<typeof toEntry>[] = [];
+
+  // Workspace routes at `/x/<path>`. Paths shadowed by the reserved plugin
+  // namespace are skipped: `resolveRouteLocation` routes those to a plugin
+  // directory, so a `<workspace>/routes/plugins/…` file is never served and
+  // must not be advertised here.
+  for (const r of await discoverRoutes(getWorkspaceRoutesDir())) {
+    if (isReservedWorkspaceRoutePath(r.routePath)) {
+      continue;
+    }
+    routes.push(toEntry(r.routePath, r));
+  }
+
+  // Plugin routes at `/x/plugins/<name>/<sub>`, from each enabled plugin's
+  // `routes/` directory (same enumeration the dispatcher resolves against).
+  for (const { pluginName, routesDir } of listPluginRouteRoots()) {
+    for (const r of await discoverRoutes(routesDir)) {
+      const xPath = r.routePath
+        ? `plugins/${pluginName}/${r.routePath}`
+        : `plugins/${pluginName}`;
+      routes.push(toEntry(xPath, r));
+    }
+  }
+
+  routes.sort((a, b) => a.routePath.localeCompare(b.routePath));
   return { ok: true, routes };
 }
 
 async function handleUserRoutesInspect({ body = {} }: RouteHandlerArgs) {
-  const { path: routePath } = InspectParams.parse(body);
-  const routesDir = getWorkspaceRoutesDir();
-  const filePath = resolveHandlerFile(routesDir, routePath);
+  const routePath = normalizeInspectPath(InspectParams.parse(body).path);
+
+  const location = routePath.includes("..")
+    ? null
+    : resolveRouteLocation(routePath);
+  const filePath = location
+    ? resolveHandlerFile(location.routesDir, location.subPath)
+    : null;
 
   if (!filePath) {
     throw new NotFoundError(
@@ -209,7 +230,7 @@ async function handleUserRoutesInspect({ body = {} }: RouteHandlerArgs) {
       routePath: `/x/${routePath}`,
       methods,
       description: description ?? null,
-      filePath,
+      filePath: relative(getWorkspaceDir(), filePath),
       publicUrl,
       fileSize: stat.size,
       modifiedAt: stat.mtime.toISOString(),


### PR DESCRIPTION
## Prompt / plan

Follow-up to the plugin-routes work (#37958). QA surfaced that `assistant routes list`/`inspect` had drifted from what the dispatcher actually serves once plugin routes landed, plus a pre-existing IPC bug in `inspect`.

## The problems

`routes list`/`inspect` scanned **only** `<workspace>/routes/`, so after `/x/plugins/<name>/` became a served, reserved surface:

1. **Plugin routes were invisible** — a plugin route that serves fine over HTTP never appeared in `routes list`.
2. **The CLI advertised URLs the dispatcher now 404s** — a `<workspace>/routes/plugins/foo.ts` file was listed at `/x/plugins/foo`, but the reserved prefix shadows it (the dispatcher resolves `/x/plugins/*` only against plugin dirs), so that URL returns 404.
3. **`routes inspect` was broken over IPC for _every_ route** (pre-existing, not from the plugin-routes PR): the CLI sent `cliIpcCall("user_routes_inspect", { path })`, but the handler reads `args.body.path` — over IPC, params only populate `args.body` when sent as `{ body: … }`. So even `inspect ping` failed with `path: undefined`.

Root cause of 1–2: discovery (`user-routes-cli.ts`) duplicated route resolution and diverged from the dispatcher's `resolveRouteLocation`.

## The fix

- **One shared resolver.** Extracted `resolveRouteLocation`, `resolveHandlerFile`, the reserved-prefix check, and plugin-route-root enumeration into `runtime/routes/user-route-resolution.ts`. The dispatcher imports it (dropping its private copies) so dispatch and discovery can't drift again.
- **`routes list`** now reports workspace routes at `/x/<path>` (excluding the reserved `plugins/` prefix) **and** each enabled plugin's `routes/` at `/x/plugins/<name>/<path>`. Disabled plugins contribute nothing (matches the dispatcher). File paths are workspace-relative (`routes/…` or `plugins/<name>/routes/…`) so the origin of each route is unambiguous.
- **`routes inspect`** resolves through the same shared logic, accepts both the bare sub-path and the `/x/`-prefixed form `list` prints, and the CLI now sends `{ body: { path } }` so it works over IPC.

## Test plan

- New `runtime/routes/__tests__/user-routes-cli.test.ts` (6 tests): list surfaces workspace + plugin routes, excludes shadowed `routes/plugins/*` and disabled plugins; inspect resolves plugin/workspace routes (bare and `/x/`-prefixed) and rejects shadowed/missing/disabled.
- Existing `user-route-dispatcher.test.ts` (28) still green after the resolver extraction — dispatch behavior unchanged.
- `bunx tsc --noEmit` and `eslint` clean.
- **Verified on a hatched local instance:** `routes list` shows plugin + workspace routes and hides the shadowed/disabled ones; `routes inspect` resolves every case over IPC (previously threw `path: undefined`).

## CLI verb checklist

No new routes added to `assistant/src/runtime/routes/` — this fixes the existing `user_routes_list`/`user_routes_inspect` handlers and their `assistant routes` CLI wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQb9MhUecmyXQBZxih2dfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQb9MhUecmyXQBZxih2dfu)_