### PR TITLE
marketplace: repin agent-wrapped to v0.6.0

### DIFF
--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -22,9 +22,9 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "64686ed3b50997048e76e7e0abfb5d7ace23cd7e"
+        "ref": "5889e3717f46f798c78c002f56c00eb0f7d88a98"
       },
-      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and your era. Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
+      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",
       "license": "MIT",
       "submittedBy": "marina",
@@ -37,7 +37,7 @@
         "repo": "marinatrajk/ai-hero-engineer-kit",
         "ref": "18d33c62b15a3e2cc22dc070723fe3077749dcec"
       },
-      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' — plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
+      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
       "category": "developer",
       "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
       "license": "MIT"
@@ -77,7 +77,7 @@
       "category": "productivity",
       "homepage": "https://github.com/JuliusBrussee/caveman",
       "license": "MIT",
-      "icon": "🦴"
+      "icon": "\ud83e\uddb4"
     },
     {
       "name": "coffee-aficionado",
@@ -90,7 +90,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/coffee-aficionado",
       "license": "MIT",
-      "icon": "☕"
+      "icon": "\u2615"
     },
     {
       "name": "cofounder",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -22,9 +22,9 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "64686ed3b50997048e76e7e0abfb5d7ace23cd7e"
+        "ref": "5889e3717f46f798c78c002f56c00eb0f7d88a98"
       },
-      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and your era. Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
+      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",
       "license": "MIT",
       "submittedBy": "marina",
@@ -37,7 +37,7 @@
         "repo": "marinatrajk/ai-hero-engineer-kit",
         "ref": "18d33c62b15a3e2cc22dc070723fe3077749dcec"
       },
-      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' — plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
+      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
       "category": "developer",
       "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
       "license": "MIT"
@@ -77,7 +77,7 @@
       "category": "productivity",
       "homepage": "https://github.com/JuliusBrussee/caveman",
       "license": "MIT",
-      "icon": "🦴"
+      "icon": "\ud83e\uddb4"
     },
     {
       "name": "coffee-aficionado",
@@ -90,7 +90,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/coffee-aficionado",
       "license": "MIT",
-      "icon": "☕"
+      "icon": "\u2615"
     },
     {
       "name": "cofounder",


### PR DESCRIPTION
Repins agent-wrapped to 5889e37 (v0.6.0) and updates the description.

Changes in v0.6.0:
- Finale card is now Tokens spent (total tokens + LLM calls) instead of Your era
- Collector gathers receipt data from usage totals (vellum source)
- README, skill, command, and tool descriptions updated to match

Entry description updated to mention the receipt instead of the era.