### PR TITLE
feat(skill-card): single learned-sentence row per skill, drop the generic header

### DIFF
--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
@@ -191,7 +191,7 @@ describe("memory-retrospective skill card", () => {
         type: "ui_surface",
         surfaceId: "skill-card-run-conv-1",
         surfaceType: "skill_card",
-        title: "New skill learned",
+        title: "I just learned how to do 2 new things",
         display: "inline",
         data: {
           skills: [
@@ -214,7 +214,7 @@ describe("memory-retrospective skill card", () => {
       // surface-capable clients skip it via the `_surfaceFallback` flag.
       {
         type: "text",
-        text: "New skill learned: Skill A, Skill B",
+        text: "I just learned how to do Skill A, Skill B",
         _surfaceFallback: true,
       },
     ]);
@@ -359,7 +359,7 @@ describe("memory-retrospective skill card", () => {
         type: "ui_surface",
         surfaceId: "skill-card-run-conv-1",
         surfaceType: "skill_card",
-        title: "New skill learned",
+        title: "I just learned how to do Skill A",
         display: "inline",
         data: {
           skills: [
@@ -374,7 +374,7 @@ describe("memory-retrospective skill card", () => {
       },
       {
         type: "text",
-        text: "New skill learned: Skill A",
+        text: "I just learned how to do Skill A",
         _surfaceFallback: true,
       },
     ]);
@@ -448,7 +448,7 @@ describe("memory-retrospective skill card", () => {
     ]);
     expect(blocks[1]).toEqual({
       type: "text",
-      text: "New skill learned: Skill A, Skill B",
+      text: "I just learned how to do Skill A, Skill B",
       _surfaceFallback: true,
     });
     expect(publishedConversationIds).toEqual(["src-conv-9"]);

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -277,11 +277,19 @@ async function insertOrDeferSkillCard(
     return;
   }
   const surfaceId = `skill-card-${runConversationId}`;
+  // Copy matches the web card's row sentence (skill-created-card.tsx): the
+  // card reads as the assistant sharing what it picked up, not a technical
+  // "skill created" notice. The title covers renderers that only show the
+  // block title; the web card renders per-skill rows from `data.skills`.
+  const learnedSentence =
+    skills.length === 1
+      ? `I just learned how to do ${skills[0]!.name}`
+      : `I just learned how to do ${skills.length} new things`;
   const surfaceBlock = {
     type: "ui_surface",
     surfaceId,
     surfaceType: "skill_card",
-    title: "New skill learned",
+    title: learnedSentence,
     display: "inline",
     data: {
       skills: skills.map((s) => ({
@@ -298,7 +306,7 @@ async function insertOrDeferSkillCard(
   // rendered content blocks so the card is never double-rendered.
   const fallbackBlock = {
     type: "text",
-    text: `New skill learned: ${skills.map((s) => s.name).join(", ")}`,
+    text: `I just learned how to do ${skills.map((s) => s.name).join(", ")}`,
     _surfaceFallback: true,
   };
   const persisted = await addMessage(

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
@@ -61,14 +61,17 @@ function renderCard(surface: Surface) {
 }
 
 describe("SkillCreatedCard", () => {
-  test("renders the header, subline, and a skill row", () => {
-    const { getByText, getByRole } = renderCard(makeSurface());
+  test("renders a single learned-sentence row per skill (no generic header)", () => {
+    const { getByText, getByRole, queryByText } = renderCard(makeSurface());
 
-    expect(getByText("New skill learned")).toBeTruthy();
+    // The generic header and subline are gone — the row title IS the copy.
+    expect(queryByText("New skill learned")).toBeNull();
     expect(
-      getByText("Saved to your skills from this conversation's work"),
+      queryByText("Saved to your skills from this conversation's work"),
+    ).toBeNull();
+    expect(
+      getByText("I just learned how to do Weekly report digest"),
     ).toBeTruthy();
-    expect(getByText("Weekly report digest")).toBeTruthy();
     expect(
       getByText("Compile the weekly report from the usual sources."),
     ).toBeTruthy();
@@ -90,8 +93,8 @@ describe("SkillCreatedCard", () => {
       }),
     );
 
-    expect(getByText("Skill one")).toBeTruthy();
-    expect(getByText("Skill two")).toBeTruthy();
+    expect(getByText("I just learned how to do Skill one")).toBeTruthy();
+    expect(getByText("I just learned how to do Skill two")).toBeTruthy();
     // Each row's action carries a skill-specific accessible name.
     expect(getByRole("button", { name: "View Skill one" })).toBeTruthy();
     expect(getByRole("button", { name: "View Skill two" })).toBeTruthy();
@@ -156,7 +159,7 @@ describe("SkillCreatedCard", () => {
       }),
     );
 
-    fireEvent.click(getByText("Skill two"));
+    fireEvent.click(getByText("I just learned how to do Skill two"));
 
     expect(useViewerStore.getState().mainView).toBe("skill-detail");
     expect(useViewerStore.getState().activeSkillDetailId).toBe("skill-2");
@@ -177,7 +180,7 @@ describe("SkillCreatedCard", () => {
   test("renders nothing when data.skills is missing", () => {
     const { queryByText } = renderCard(makeSurface({ data: {} }));
 
-    expect(queryByText("New skill learned")).toBeNull();
+    expect(queryByText(/I just learned how to do/)).toBeNull();
   });
 
   test("renders nothing when data.skills is malformed", () => {
@@ -185,7 +188,7 @@ describe("SkillCreatedCard", () => {
       makeSurface({ data: { skills: "not-an-array" } }),
     );
 
-    expect(queryByText("New skill learned")).toBeNull();
+    expect(queryByText(/I just learned how to do/)).toBeNull();
   });
 
   test("drops entries without a usable skillId or name but keeps valid ones", () => {
@@ -202,8 +205,8 @@ describe("SkillCreatedCard", () => {
       }),
     );
 
-    expect(getByText("Valid skill")).toBeTruthy();
-    expect(queryByText("Missing id")).toBeNull();
+    expect(getByText("I just learned how to do Valid skill")).toBeTruthy();
+    expect(queryByText(/Missing id/)).toBeNull();
     expect(getAllByRole("button", { name: /^View / })).toHaveLength(1);
   });
 });
@@ -217,6 +220,8 @@ describe("SurfaceRouter", () => {
     );
 
     expect(queryByText("Unsupported surface type: skill_card")).toBeNull();
-    expect(getByText("Weekly report digest")).toBeTruthy();
+    expect(
+      getByText("I just learned how to do Weekly report digest"),
+    ).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
@@ -64,7 +64,8 @@ describe("SkillCreatedCard", () => {
   test("renders a single learned-sentence row per skill (no generic header)", () => {
     const { getByText, getByRole, queryByText } = renderCard(makeSurface());
 
-    // The generic header and subline are gone — the row title IS the copy.
+    // The card renders no generic header or subline: each row's title
+    // carries the full learned sentence, so a header would double-announce.
     expect(queryByText("New skill learned")).toBeNull();
     expect(
       queryByText("Saved to your skills from this conversation's work"),

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
@@ -14,11 +14,12 @@ import { routes } from "@/utils/routes";
 
 /**
  * Card copy lives here as the single source so a design copy swap is a
- * one-line change. The subline is static because the card can arrive long
- * after the triggering work (the retrospective runs in the background).
+ * one-line change. Each skill renders as a single row whose title is the
+ * full "I just learned…" sentence (no generic card header): the card should
+ * read like the assistant sharing what it picked up, not like a technical
+ * "skill created" notice.
  */
-const SKILL_CARD_FALLBACK_TITLE = "New skill learned";
-const SKILL_CARD_SUBLINE = "Saved to your skills from this conversation's work";
+const skillRowTitle = (name: string) => `I just learned how to do ${name}`;
 
 interface SkillCardEntry {
   skillId: string;
@@ -87,14 +88,7 @@ export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
 
   return (
     <SurfaceContainer surface={surface} onAction={onAction} hideTitle>
-      <h3 className="text-title-small text-[var(--content-strong)]">
-        {surface.title ?? SKILL_CARD_FALLBACK_TITLE}
-      </h3>
-      <p className="mt-0.5 text-body-small-default text-[var(--content-quiet)]">
-        {SKILL_CARD_SUBLINE}
-      </p>
-
-      <div className="mt-3 divide-y divide-[var(--border-base)]">
+      <div className="divide-y divide-[var(--border-base)]">
         {/* The whole row is one native button (name, description, and the
             "View" chip all open the skill) — matching the clickable-row
             pattern in home-schedule-row.tsx. The chip is purely visual, so
@@ -115,7 +109,7 @@ export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
             </span>
             <div className="min-w-0 flex-1">
               <div className="truncate text-body-medium-default text-[var(--content-strong)]">
-                {skill.name}
+                {skillRowTitle(skill.name)}
               </div>
               {skill.description && (
                 <p className="truncate text-body-small-default text-[var(--content-tertiary)]">

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -214,6 +214,12 @@ export function ConceptGraphView({
     filterRef.current = { active: Boolean(matchIds), matches: matchIds };
     view.current.dirty = true;
   }, [matchIds]);
+  // Reset the search when the active assistant changes: this component is reused
+  // across assistants (IdentityTab doesn't key it), so a stale query would
+  // otherwise filter the new assistant's graph and ghost every node.
+  useEffect(() => {
+    setSearch("");
+  }, [assistantId]);
 
   const labelFor = useCallback(
     (id: string | null): string | null => {

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -653,7 +653,10 @@ export function ConceptGraphView({
       <>
         <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
 
-        {layout.nodes.length > SEARCH_MIN_NODES ? (
+        {/* Keep the box visible whenever a search is active, even if the graph
+            shrank below the threshold (e.g. a refetch) — otherwise an active
+            filter would ghost nodes with no way to clear it short of remount. */}
+        {layout.nodes.length > SEARCH_MIN_NODES || search ? (
           <div
             data-graph-control
             className={`absolute top-4 z-10 ${onToggleFullscreen ? "left-16" : "left-4"}`}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -1,5 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { Maximize2, Minimize2, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
+import {
+  Maximize2,
+  Minimize2,
+  RotateCcw,
+  Search,
+  X,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { VIRTUAL_CENTER } from "@/domains/intelligence/components/constellation-view/constants";
@@ -38,6 +46,17 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const RECENCY_GLOW_WINDOW_MS = 14 * DAY_MS; // recency fades out over ~2 weeks
 const RECENCY_GLOW_MAX = 12; // extra shadowBlur at peak freshness
 const PULSE_WINDOW_MS = 2 * DAY_MS; // newer than this → pulses (unless reduced motion)
+
+// As the graph grows, fade the resting (nothing-focused) learned-edge web so
+// dense corpora don't read as a haze. Full strength up to FOG_FULL_BELOW nodes,
+// easing to FOG_FLOOR by FOG_FLOOR_ABOVE. Only learned (associative) edges fade;
+// authored links carry structure and stay. Hover always restores full contrast.
+const FOG_FULL_BELOW = 80;
+const FOG_FLOOR_ABOVE = 340;
+const FOG_FLOOR = 0.12;
+
+// Below this node count the graph is small enough to scan by eye — no search box.
+const SEARCH_MIN_NODES = 12;
 
 interface Projected {
   id: string;
@@ -173,6 +192,29 @@ export function ConceptGraphView({
   // user dismisses it; the dismissal sticks per-assistant.
   const [introDismissed, dismissIntro] = useGraphIntroDismissed(assistantId);
 
+  // Name search: as the graph grows, typing narrows it to matching concepts —
+  // matches stay lit, everything else ghosts. The set of matching ids lives in
+  // a ref the 60fps render loop reads (so keystrokes don't re-run the effect),
+  // and `dirty` is bumped whenever it changes so reduced-motion redraws.
+  const [search, setSearch] = useState("");
+  const searchLower = search.trim().toLowerCase();
+  const matchIds = useMemo(() => {
+    if (!searchLower) {return null;}
+    const s = new Set<string>();
+    for (const n of layout.nodes) {
+      if (n.label.toLowerCase().includes(searchLower)) {s.add(n.id);}
+    }
+    return s;
+  }, [searchLower, layout.nodes]);
+  const filterRef = useRef<{ active: boolean; matches: Set<string> | null }>({
+    active: false,
+    matches: null,
+  });
+  useEffect(() => {
+    filterRef.current = { active: Boolean(matchIds), matches: matchIds };
+    view.current.dirty = true;
+  }, [matchIds]);
+
   const labelFor = useCallback(
     (id: string | null): string | null => {
       if (!id) {return null;}
@@ -277,6 +319,24 @@ export function ConceptGraphView({
       const isLit = (id: string) =>
         !activeId || id === activeId || (neighbors?.has(id) ?? false);
 
+      // Search: when active, only matching nodes/edges stay lit; the rest ghost.
+      const filter = filterRef.current;
+      const searchActive = filter.active;
+      const isMatch = (id: string) =>
+        !searchActive || (filter.matches?.has(id) ?? false);
+
+      // Density fog: fade the resting learned-edge web as the corpus grows.
+      const learnedFog =
+        nodes.length <= FOG_FULL_BELOW
+          ? 1
+          : Math.max(
+              FOG_FLOOR,
+              1 -
+                ((nodes.length - FOG_FULL_BELOW) /
+                  (FOG_FLOOR_ABOVE - FOG_FULL_BELOW)) *
+                  (1 - FOG_FLOOR),
+            );
+
       // Project every node into screen space.
       const proj = new Array<{
         node: GraphLayoutNode;
@@ -315,10 +375,19 @@ export function ConceptGraphView({
         const b = posById.get(e.toId);
         if (!a || !b) {continue;}
         const learned = e.kind === "learned";
+        const ghost = searchActive && (!isMatch(e.fromId) || !isMatch(e.toId));
         const incident = activeId != null && (e.fromId === activeId || e.toId === activeId);
         const depth = (a.depth + b.depth) / 2;
-        let alpha = (learned ? 0.34 : 0.28) * (0.4 + 0.6 * depth);
-        if (activeId != null) {alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? alpha : 0.05;}
+        // Learned edges fade with density in the resting web; authored links don't.
+        const restAlpha = (learned ? 0.34 * learnedFog : 0.28) * (0.4 + 0.6 * depth);
+        let alpha: number;
+        if (ghost) {
+          alpha = 0.03;
+        } else if (activeId != null) {
+          alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? restAlpha : 0.05;
+        } else {
+          alpha = restAlpha;
+        }
         ctx.globalAlpha = alpha;
         ctx.strokeStyle = learned ? EDGE_LEARNED_COLOR : colors.tertiary;
         ctx.lineWidth = (incident ? 2 : 1) * (0.6 + 0.6 * depth);
@@ -335,10 +404,11 @@ export function ConceptGraphView({
         const p = proj[idx];
         const node = p.node;
         const color = NODE_KIND_COLORS[node.kind];
-        const lit = isLit(node.id);
+        const ghost = searchActive && !isMatch(node.id);
+        const lit = !ghost && isLit(node.id);
         const isActive = node.id === activeId;
         const depthA = DEPTH_ALPHA_MIN + (1 - DEPTH_ALPHA_MIN) * p.depth;
-        const alpha = lit ? depthA : depthA * 0.18;
+        const alpha = ghost ? depthA * 0.08 : lit ? depthA : depthA * 0.18;
 
         let glow = (isActive ? 16 : node.degree >= HUB_LABEL_DEGREE ? 8 : 4) * p.depth;
         // Recency: fresh concepts glow brighter; the very newest pulse. Static
@@ -381,8 +451,11 @@ export function ConceptGraphView({
         const node = p.node;
         // When nothing is focused, only label front-facing hubs (depth-gated) so
         // the dense middle of the mass doesn't turn into unreadable label soup.
-        const showLabel =
-          activeId != null
+        // While searching, label the matches instead (that's what you're after).
+        if (searchActive && !isMatch(node.id)) {continue;}
+        const showLabel = searchActive
+          ? p.depth > 0.3
+          : activeId != null
             ? isLit(node.id)
             : node.degree >= HUB_LABEL_DEGREE && p.depth > 0.55;
         if (!showLabel) {continue;}
@@ -411,11 +484,15 @@ export function ConceptGraphView({
     };
   }, [ready, layout, adjacency, massRadius]);
 
-  // Nearest node under a screen point; nearest-in-front wins.
+  // Nearest node under a screen point; nearest-in-front wins. While a search is
+  // active, ghosted (non-matching) nodes are skipped so hover/click land on a
+  // result, not a faded background node.
   const hitTest = useCallback((x: number, y: number): string | null => {
+    const filter = filterRef.current;
     let best: string | null = null;
     let bestDepth = -1;
     for (const p of projectedRef.current) {
+      if (filter.active && !(filter.matches?.has(p.id) ?? false)) {continue;}
       const dx = x - p.sx;
       const dy = y - p.sy;
       if (dx * dx + dy * dy <= (p.sr + 5) * (p.sr + 5) && p.depth > bestDepth) {
@@ -576,6 +653,56 @@ export function ConceptGraphView({
       <>
         <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
 
+        {layout.nodes.length > SEARCH_MIN_NODES ? (
+          <div
+            data-graph-control
+            className={`absolute top-4 z-10 ${onToggleFullscreen ? "left-16" : "left-4"}`}
+          >
+            <div
+              className="flex items-center gap-1.5 rounded-full px-2.5 py-1"
+              style={{
+                backgroundColor: "color-mix(in srgb, var(--surface-base) 82%, transparent)",
+                border: "1px solid var(--border-base)",
+              }}
+            >
+              <Search size={14} aria-hidden style={{ color: "var(--content-tertiary)" }} />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setSearch("");
+                  }
+                }}
+                placeholder="Search concepts…"
+                aria-label="Search concepts"
+                className="w-36 bg-transparent text-[12px] outline-none placeholder:text-[var(--content-tertiary)]"
+                style={{ color: "var(--content-default)" }}
+              />
+              {search ? (
+                <>
+                  <span
+                    className="text-[11px] tabular-nums"
+                    style={{ color: "var(--content-tertiary)" }}
+                  >
+                    {matchIds?.size ?? 0}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setSearch("")}
+                    aria-label="Clear search"
+                    className="flex items-center"
+                    style={{ color: "var(--content-tertiary)" }}
+                  >
+                    <X size={13} />
+                  </button>
+                </>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
         <ConceptGraphLegend
           nodeKinds={presentKinds.length > 1 ? presentKinds : []}
           hasLinks={hasLinks}
@@ -601,6 +728,19 @@ export function ConceptGraphView({
         >
           drag to rotate · scroll to zoom
         </div>
+
+        {graph?.truncated ? (
+          <div
+            className="pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full px-3 py-1 text-[11px]"
+            style={{
+              backgroundColor: "color-mix(in srgb, var(--surface-base) 82%, transparent)",
+              border: "1px solid var(--border-base)",
+              color: "var(--content-tertiary)",
+            }}
+          >
+            Showing the {layout.nodes.length} most-connected concepts
+          </div>
+        ) : null}
 
         <div data-graph-control className="absolute right-4 top-4 flex flex-col gap-1">
           <Button

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -378,13 +378,16 @@ export function ConceptGraphView({
         const ghost = searchActive && (!isMatch(e.fromId) || !isMatch(e.toId));
         const incident = activeId != null && (e.fromId === activeId || e.toId === activeId);
         const depth = (a.depth + b.depth) / 2;
-        // Learned edges fade with density in the resting web; authored links don't.
-        const restAlpha = (learned ? 0.34 * learnedFog : 0.28) * (0.4 + 0.6 * depth);
+        // Learned edges fade with density in the resting web; authored links
+        // don't. A focused hover neighborhood reads at full contrast, though —
+        // so lit edges use the unfogged base even in a dense graph.
+        const litAlpha = (learned ? 0.34 : 0.28) * (0.4 + 0.6 * depth);
+        const restAlpha = learned ? litAlpha * learnedFog : litAlpha;
         let alpha: number;
         if (ghost) {
           alpha = 0.03;
         } else if (activeId != null) {
-          alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? restAlpha : 0.05;
+          alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? litAlpha : 0.05;
         } else {
           alpha = restAlpha;
         }


### PR DESCRIPTION
## What

Card copy iteration from the [team thread](https://vellumai.slack.com/archives/C04GKGGBRGT/p1783973557819679) on the V1 demo — Tirman: *"we have 2 rows in that card, one generic New skill learned and the other about your skill. I'd just combine them so we have 1 row in the card, and the title is 'I just learned how to do X'."*

**Before:** generic "New skill learned" header + subline, then a row per skill (name / description / View).
**After:** one row per skill whose title is the sentence **"I just learned how to do \<name\>"**, description as the subline, whole row still deep-links to the skill detail (side panel on desktop, `/assistant/skills/:id` on mobile). No header.

Daemon side, the surface block's `title` and the `_surfaceFallback` text (CLI, channels, search, strict OpenAI-compat providers) carry the same sentence — multi-skill batches title as "I just learned how to do N new things" while the web card renders one sentence row per skill.

Already-persisted cards render header-less with the new component and keep their raw skill name as the row title (data-driven) — graceful degradation, no migration.

## Tests

- `skill-created-card.test.tsx`: 10 pass — header/subline asserted absent, sentence rows asserted present (single, multi, malformed-entry, router cases), row-click behavior unchanged.
- `memory-retrospective-skill-card.test.ts`: 15 pass — contract-shape assertions updated for the new title/fallback strings.
- Typecheck clean on touched files (assistant package fully clean; web worktree has pre-existing unrelated @types noise, CI is the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)