### PR TITLE
docs(routes): update `assistant routes` help for plugin routes

### DIFF
--- a/assistant/src/cli/commands/routes.help.ts
+++ b/assistant/src/cli/commands/routes.help.ts
@@ -8,8 +8,10 @@ export const routesHelp: CliCommandHelp = {
     "Manage user-defined authenticated HTTP route handlers under /x/*",
   helpText: `
 User-defined routes let you expose custom HTTP endpoints by dropping handler
-files into /workspace/routes/. Each file exports named HTTP method functions
-(GET, POST, etc.) and becomes reachable at /x/<path>.
+files into /workspace/routes/ (reachable at /x/<path>) or into a plugin's
+/workspace/plugins/<name>/routes/ (reachable in that plugin's namespace at
+/x/plugins/<name>/<path>). Each file exports named HTTP method functions
+(GET, POST, etc.).
 
 These routes require edge authentication — they are intended for
 assistant-internal or user-facing endpoints, not for unauthenticated provider
@@ -21,7 +23,8 @@ needed.
 Examples:
   $ assistant routes list
   $ assistant routes list --json
-  $ assistant routes inspect my-dashboard-api/submit`,
+  $ assistant routes inspect my-dashboard-api/submit
+  $ assistant routes inspect plugins/my-plugin/status`,
   subcommands: [
     {
       name: "list",
@@ -33,8 +36,9 @@ Examples:
         },
       ],
       helpText: `
-Scans /workspace/routes/ for handler files (.ts, .js) and displays the route
-path, exported HTTP methods, optional description, and file location.
+Scans /workspace/routes/ and each enabled plugin's /workspace/plugins/<name>/routes/
+for handler files (.ts, .js) and displays the route path, exported HTTP
+methods, optional description, and file location.
 
 Examples:
   $ assistant routes list
@@ -52,14 +56,16 @@ Examples:
       ],
       helpText: `
 Arguments:
-  path   Route path relative to /x/ (e.g. "my-dashboard-api/submit").
-         Do not include the /x/ prefix.
+  path   Route path relative to /x/ (e.g. "my-dashboard-api/submit" or
+         "plugins/my-plugin/status"). The /x/ prefix is optional, so a path
+         copied straight from 'routes list' works too.
 
 Loads the handler file and displays exported methods, description, file path,
 public URL, file size, and last modified time.
 
 Examples:
   $ assistant routes inspect my-dashboard-api/submit
+  $ assistant routes inspect plugins/my-plugin/status
   $ assistant routes inspect items --json`,
     },
   ],


### PR DESCRIPTION
## Prompt / plan

Small doc-consistency follow-up to #38050. The `assistant routes` help text still described the surface as workspace-only, which is now stale after that PR made the CLI plugin-aware.

## What changed (docs only, `routes.help.ts`)

- Top-level help now mentions plugin routes (`/workspace/plugins/<name>/routes/` → `/x/plugins/<name>/<path>`), not just `/workspace/routes/`.
- `list` help now says it scans each enabled plugin's `routes/` too (matches what `list` actually returns).
- `inspect` help no longer says "Do not include the /x/ prefix" — that PR made `inspect` accept the `/x/`-prefixed form, so a path copied straight from `routes list` works. Added a plugin-route example.

No code or behavior change; the pre-commit hook (typecheck, lint, format) passed.

## CLI verb checklist

No new routes — help text only for the existing `assistant routes` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQb9MhUecmyXQBZxih2dfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQb9MhUecmyXQBZxih2dfu)_