### PR TITLE
feat(telemetry): watchdog counters for skill authoring, card delivery, retrospective runs

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -191,6 +191,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../runtime/capabilities.js",
     "../../../runtime/services/auto-analysis-guard.js",
     "../../../runtime/sync/resource-sync-events.js",
+    "../../../telemetry/watchdog-events-store.js",
     "../../../tools/registry.js",
     "../../../tools/types.js",
     "../../../types.js",

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -13,6 +13,21 @@ import type { SkillSource } from "../config/skills.js";
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
 const mockRefreshSkillCapabilityMemories = mock(() => {});
 
+const watchdogEvents: Array<{
+  checkName: string;
+  value?: number | null;
+  detail?: Record<string, unknown> | null;
+}> = [];
+mock.module("../telemetry/watchdog-events-store.js", () => ({
+  recordWatchdogEvent: (record: {
+    checkName: string;
+    value?: number | null;
+    detail?: Record<string, unknown> | null;
+  }) => {
+    watchdogEvents.push(record);
+  },
+}));
+
 mock.module("../daemon/skill-memory-refresh.js", () => ({
   refreshSkillCapabilityMemories: mockRefreshSkillCapabilityMemories,
 }));
@@ -88,6 +103,7 @@ beforeEach(() => {
   mockRefreshSkillCapabilityMemories.mockClear();
   skillCardJobUpserts = [];
   skillCardUpsertThrows = false;
+  watchdogEvents.length = 0;
 });
 
 afterEach(() => {
@@ -146,6 +162,16 @@ describe("scaffold_managed_skill tool", () => {
     expect(skill).toBeDefined();
     expect(skill!.name).toBe("Test Skill");
     expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
+
+    // A genuine create emits the central authoring counter, attributed to
+    // the user for a non-retrospective origin.
+    expect(watchdogEvents).toEqual([
+      {
+        checkName: "skill_authored",
+        value: 1,
+        detail: { authored_by: "user", skill_id: "test-skill" },
+      },
+    ]);
   });
 
   test("accepts legacy add_to_index input without returning index metadata", async () => {
@@ -202,6 +228,12 @@ describe("scaffold_managed_skill tool", () => {
       makeContext(),
     );
     expect(result3.isError).toBe(false);
+
+    // Only the original create counts — the overwrite refined an existing
+    // skill and must not emit a second authoring event.
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "skill_authored"),
+    ).toHaveLength(1);
   });
 
   test("rejects missing required fields", async () => {
@@ -691,6 +723,15 @@ describe("scaffold_managed_skill tool", () => {
 
     expect(result.isError).toBe(false);
     expect(installMetaFor("retro-skill")?.author).toBe("assistant");
+    // The central authoring counter attributes the create to the
+    // retrospective.
+    expect(watchdogEvents).toEqual([
+      {
+        checkName: "skill_authored",
+        value: 1,
+        detail: { authored_by: "retrospective", skill_id: "retro-skill" },
+      },
+    ]);
   });
 
   test('tags author "user" for a normal (non-retrospective) scaffold', async () => {
@@ -851,6 +892,12 @@ describe("scaffold_managed_skill tool", () => {
         ),
       ),
     ).toBe(true);
+
+    // Only the V1 create counts toward authoring — the V2 refinement of an
+    // existing skill emits no second event.
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "skill_authored"),
+    ).toHaveLength(1);
   });
 
   // ── Conversation lineage (retrospective-authored skills) ───────────────────

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -169,7 +169,7 @@ describe("scaffold_managed_skill tool", () => {
       {
         checkName: "skill_authored",
         value: 1,
-        detail: { authored_by: "user", skill_id: "test-skill" },
+        detail: { authored_by: "user" },
       },
     ]);
   });
@@ -729,7 +729,7 @@ describe("scaffold_managed_skill tool", () => {
       {
         checkName: "skill_authored",
         value: 1,
-        detail: { authored_by: "retrospective", skill_id: "retro-skill" },
+        detail: { authored_by: "retrospective" },
       },
     ]);
   });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -92,6 +92,21 @@ let messagesByConversationId: Record<string, StubMessage[]> = {};
 // the real registry's semantics for conversations not in memory.
 let loadedConversations: Record<string, { processing: boolean }> = {};
 
+const watchdogEvents: Array<{
+  checkName: string;
+  value?: number | null;
+  detail?: Record<string, unknown> | null;
+}> = [];
+mock.module("../../../../telemetry/watchdog-events-store.js", () => ({
+  recordWatchdogEvent: (record: {
+    checkName: string;
+    value?: number | null;
+    detail?: Record<string, unknown> | null;
+  }) => {
+    watchdogEvents.push(record);
+  },
+}));
+
 mock.module("../../../../daemon/conversation-registry.js", () => ({
   findConversation: (id: string | undefined) => {
     if (!id) return undefined;
@@ -360,6 +375,7 @@ function priorRetroMessage(rememberContents: string[]) {
 
 describe("memoryRetrospectiveJob", () => {
   beforeEach(() => {
+    watchdogEvents.length = 0;
     mockState = null;
     stateUpserts = [];
     lastRunAtBumps = [];
@@ -416,6 +432,16 @@ describe("memoryRetrospectiveJob", () => {
     expect(lastRunAtBumps).toHaveLength(0);
     expect(wakeCalls).toHaveLength(0);
     expect(forkCalls).toHaveLength(0);
+    // Every job run emits exactly one outcome counter for the health chart.
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "memory_retrospective_run"),
+    ).toEqual([
+      {
+        checkName: "memory_retrospective_run",
+        value: 1,
+        detail: { outcome: "no_new_messages" },
+      },
+    ]);
   });
 
   test("a slice whose only row is the retrospective's own skill card is no new work", async () => {
@@ -532,6 +558,17 @@ describe("memoryRetrospectiveJob", () => {
     const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
 
     expect(outcome.kind).toBe("wake_failed");
+    // The outcome counter carries the wake-failure reason so a fleet-wide
+    // spike is attributable (e.g. provider outage vs busy conversations).
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "memory_retrospective_run"),
+    ).toEqual([
+      {
+        checkName: "memory_retrospective_run",
+        value: 1,
+        detail: { outcome: "wake_failed", reason: "timeout" },
+      },
+    ]);
     if (outcome.kind === "wake_failed") {
       expect(outcome.reason).toBe("timeout");
     }

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -586,6 +586,17 @@ describe("memoryRetrospectiveJob", () => {
     expect(stateUpserts).toHaveLength(0);
     expect(lastRunAtBumps).toHaveLength(1);
     expect(deletedConversationIds).toEqual(["fork-conv-1"]);
+    // A thrown run still records an outcome counter (as "error") before the
+    // rethrow — exception-flavored outages must show in the health metric.
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "memory_retrospective_run"),
+    ).toEqual([
+      {
+        checkName: "memory_retrospective_run",
+        value: 1,
+        detail: { outcome: "error", reason: "LLM provider 503" },
+      },
+    ]);
   });
 
   test("missing conversationId payload: no_new_messages, no side effects", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-skill-card.test.ts
@@ -35,6 +35,21 @@ type ConversationStub = {
 } | null;
 let conversationOverrides: Record<string, ConversationStub> = {};
 
+const watchdogEvents: Array<{
+  checkName: string;
+  value?: number | null;
+  detail?: Record<string, unknown> | null;
+}> = [];
+mock.module("../../../../telemetry/watchdog-events-store.js", () => ({
+  recordWatchdogEvent: (record: {
+    checkName: string;
+    value?: number | null;
+    detail?: Record<string, unknown> | null;
+  }) => {
+    watchdogEvents.push(record);
+  },
+}));
+
 mock.module("../../../../persistence/conversation-crud.js", () => ({
   getMessagesAfter: (_id: string, _afterId: string | null) => [],
   getMessages: (_id: string) => [],
@@ -156,6 +171,7 @@ function makeInsertJob(payload: Record<string, unknown>): MemoryJob {
 
 describe("memory-retrospective skill card", () => {
   beforeEach(() => {
+    watchdogEvents.length = 0;
     addMessageCalls = [];
     addMessageThrowsFor = null;
     addMessageDeduplicatesFor = null;
@@ -315,6 +331,31 @@ describe("memory-retrospective skill card", () => {
     // ...but the disk-view append and client broadcast do not repeat.
     expect(syncedToDisk).toHaveLength(0);
     expect(publishedConversationIds).toHaveLength(0);
+  });
+
+  test("a delivered card emits the skill_card_delivered counter; a dedup does not", async () => {
+    await insertSkillCardMessage("conv-source", "conv-run-telemetry", [
+      { skillId: "s-1", name: "Skill One", description: "d1" },
+      { skillId: "s-2", name: "Skill Two", description: "d2" },
+    ]);
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "skill_card_delivered"),
+    ).toEqual([
+      {
+        checkName: "skill_card_delivered",
+        value: 2,
+        detail: { skill_count: 2 },
+      },
+    ]);
+
+    // Retried delivery for the same run dedups on clientMessageId — the
+    // counter must not fire again.
+    await insertSkillCardMessage("conv-source", "conv-run-telemetry", [
+      { skillId: "s-1", name: "Skill One", description: "d1" },
+    ]);
+    expect(
+      watchdogEvents.filter((e) => e.checkName === "skill_card_delivered"),
+    ).toHaveLength(1);
   });
 
   test("insert is best-effort: a persistence failure never throws", async () => {

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -77,6 +77,7 @@ import {
 import { resolveUserSlug } from "../../../prompts/persona-resolver.js";
 import type { SystemPromptPersonaOverride } from "../../../prompts/system-prompt.js";
 import { wakeAgentForOpportunity } from "../../../runtime/agent-wake.js";
+import { recordWatchdogEvent } from "../../../telemetry/watchdog-events-store.js";
 import { findMostRecentRetrospectiveFor } from "./find-most-recent-retrospective-for.js";
 import { getLogger } from "./logging.js";
 import { getRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
@@ -115,6 +116,9 @@ const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = [] as const;
  */
 export const SOURCE_PROCESSING_REQUEUE_DELAY_MS = 60_000;
 
+/** Watchdog check_name for the per-run retrospective outcome counter. */
+const MEMORY_RETROSPECTIVE_RUN_CHECK_NAME = "memory_retrospective_run";
+
 export type MemoryRetrospectiveOutcome =
   | { kind: "disabled" }
   | { kind: "no_new_messages" }
@@ -138,7 +142,28 @@ export async function memoryRetrospectiveJob(
     return { kind: "no_new_messages" };
   }
 
-  return runForkBasedRetrospective(sourceConversationId, config);
+  const outcome = await runForkBasedRetrospective(sourceConversationId, config);
+  // Central health counter (admin analytics groups on the watchdog
+  // check_name): one event per run with the outcome kind, so a fleet-wide
+  // spike in `wake_failed` (e.g. a provider outage on the retrospective's
+  // resolved model) is visible without log access. Never throws — the run's
+  // outcome must reach the jobs worker regardless.
+  try {
+    recordWatchdogEvent({
+      checkName: MEMORY_RETROSPECTIVE_RUN_CHECK_NAME,
+      value: 1,
+      detail: {
+        outcome: outcome.kind,
+        ...(outcome.kind === "wake_failed" && outcome.reason
+          ? { reason: outcome.reason }
+          : {}),
+      },
+    });
+  } catch {
+    // recordWatchdogEvent already no-ops on opt-out and a missing telemetry
+    // DB; anything past that is not worth surfacing here.
+  }
+  return outcome;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -143,14 +143,13 @@ export async function memoryRetrospectiveJob(
   }
 
   // Central health counter (admin analytics groups on the watchdog
-  // check_name): one event per run with the outcome kind — including runs
-  // that THROW (the wake's rethrow path), recorded as outcome "error"
-  // before the exception continues to the jobs worker's retry machinery.
-  // Without the catch, exception-flavored outages would be invisible in
-  // the exact metric built to surface them; a fleet-wide spike in
+  // check_name): one event per run with its outcome kind. A run that
+  // throws records outcome "error" before the exception continues to the
+  // jobs worker's retry machinery, so a fleet-wide spike in
   // `wake_failed`/`error` (e.g. a provider outage on the retrospective's
-  // resolved model) must show without log access. The emitter itself never
-  // throws — the run's outcome must reach the jobs worker regardless.
+  // resolved model) is visible without log access. The emitter itself
+  // never throws — the run's outcome must reach the jobs worker
+  // regardless.
   const emitRunOutcome = (outcome: string, reason?: string): void => {
     try {
       recordWatchdogEvent({

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -142,27 +142,42 @@ export async function memoryRetrospectiveJob(
     return { kind: "no_new_messages" };
   }
 
-  const outcome = await runForkBasedRetrospective(sourceConversationId, config);
   // Central health counter (admin analytics groups on the watchdog
-  // check_name): one event per run with the outcome kind, so a fleet-wide
-  // spike in `wake_failed` (e.g. a provider outage on the retrospective's
-  // resolved model) is visible without log access. Never throws — the run's
-  // outcome must reach the jobs worker regardless.
+  // check_name): one event per run with the outcome kind — including runs
+  // that THROW (the wake's rethrow path), recorded as outcome "error"
+  // before the exception continues to the jobs worker's retry machinery.
+  // Without the catch, exception-flavored outages would be invisible in
+  // the exact metric built to surface them; a fleet-wide spike in
+  // `wake_failed`/`error` (e.g. a provider outage on the retrospective's
+  // resolved model) must show without log access. The emitter itself never
+  // throws — the run's outcome must reach the jobs worker regardless.
+  const emitRunOutcome = (outcome: string, reason?: string): void => {
+    try {
+      recordWatchdogEvent({
+        checkName: MEMORY_RETROSPECTIVE_RUN_CHECK_NAME,
+        value: 1,
+        detail: {
+          outcome,
+          ...(reason ? { reason: reason.slice(0, 200) } : {}),
+        },
+      });
+    } catch {
+      // recordWatchdogEvent already no-ops on opt-out and a missing
+      // telemetry DB; anything past that is not worth surfacing here.
+    }
+  };
+
+  let outcome: MemoryRetrospectiveOutcome;
   try {
-    recordWatchdogEvent({
-      checkName: MEMORY_RETROSPECTIVE_RUN_CHECK_NAME,
-      value: 1,
-      detail: {
-        outcome: outcome.kind,
-        ...(outcome.kind === "wake_failed" && outcome.reason
-          ? { reason: outcome.reason }
-          : {}),
-      },
-    });
-  } catch {
-    // recordWatchdogEvent already no-ops on opt-out and a missing telemetry
-    // DB; anything past that is not worth surfacing here.
+    outcome = await runForkBasedRetrospective(sourceConversationId, config);
+  } catch (err) {
+    emitRunOutcome("error", err instanceof Error ? err.message : String(err));
+    throw err;
   }
+  emitRunOutcome(
+    outcome.kind,
+    outcome.kind === "wake_failed" ? outcome.reason : undefined,
+  );
   return outcome;
 }
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-skill-card.ts
@@ -56,10 +56,14 @@ import {
   upsertSkillCardInsertJob,
 } from "../../../persistence/jobs-store.js";
 import { publishConversationMessagesChanged } from "../../../runtime/sync/resource-sync-events.js";
+import { recordWatchdogEvent } from "../../../telemetry/watchdog-events-store.js";
 import { getLogger } from "./logging.js";
 import { SKILL_CARD_MESSAGE_KIND } from "./memory-retrospective-constants.js";
 
 const log = getLogger("memory-retrospective-skill-card");
+
+/** Watchdog check_name for the per-card delivery counter. */
+const SKILL_CARD_DELIVERED_CHECK_NAME = "skill_card_delivered";
 
 /**
  * A skill authored by a retrospective run, as recorded by the scaffold
@@ -334,6 +338,20 @@ async function insertOrDeferSkillCard(
     );
   }
   publishConversationMessagesChanged(sourceConversationId);
+  // Central delivery counter (admin analytics groups on the watchdog
+  // check_name): one event per delivered card, value = skills on it. The
+  // dedup early-return above keeps retried deliveries from double-counting.
+  // Never throws — the card is already inserted.
+  try {
+    recordWatchdogEvent({
+      checkName: SKILL_CARD_DELIVERED_CHECK_NAME,
+      value: skills.length,
+      detail: { skill_count: skills.length },
+    });
+  } catch {
+    // recordWatchdogEvent already no-ops on opt-out and a missing telemetry
+    // DB; anything past that is not worth surfacing here.
+  }
   log.info(
     {
       sourceConversationId,

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -310,8 +310,11 @@ export async function executeScaffoldManagedSkill(
   // the watchdog check_name). Genuine creates only — refinements of a
   // pre-existing skill are not new capabilities and would double-count.
   // `authored_by` distinguishes proactive retrospective authoring from
-  // user-directed scaffolds. Never throws: a telemetry failure must not
-  // fail a scaffold that already succeeded.
+  // user-directed scaffolds; the skill id itself stays out of the detail
+  // bag — ids derive from user/model content (a name can encode a
+  // customer or procedure), and watchdog events are metadata-only with no
+  // deletion-redaction tie to the source conversation. Never throws: a
+  // telemetry failure must not fail a scaffold that already succeeded.
   if (!managedSkillExistedBefore) {
     try {
       recordWatchdogEvent({
@@ -319,7 +322,6 @@ export async function executeScaffoldManagedSkill(
         value: 1,
         detail: {
           authored_by: fromRetrospective ? "retrospective" : "user",
-          skill_id: id,
         },
       });
     } catch {

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -12,10 +12,14 @@ import {
   createManagedSkill,
   getManagedSkillDir,
 } from "../../skills/managed-store.js";
+import { recordWatchdogEvent } from "../../telemetry/watchdog-events-store.js";
 import { getLogger } from "../../util/logger.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 const log = getLogger("scaffold-managed-skill");
+
+/** Watchdog check_name for the per-creation skill-authoring counter. */
+const SKILL_AUTHORED_CHECK_NAME = "skill_authored";
 
 /** Strip embedded newlines/carriage returns to prevent YAML frontmatter injection. */
 function sanitizeFrontmatterValue(value: string): string {
@@ -37,7 +41,9 @@ function normalizeOptionalStringArray(
   raw: unknown,
   field: string,
 ): { value?: string[]; error?: string } {
-  if (raw === undefined) return {};
+  if (raw === undefined) {
+    return {};
+  }
   if (!Array.isArray(raw)) {
     return { error: `${field} must be an array of strings` };
   }
@@ -51,7 +57,9 @@ function normalizeOptionalStringArray(
     if (!cleaned) {
       return { error: `each element in ${field} must be a non-empty string` };
     }
-    if (seen.has(cleaned)) continue;
+    if (seen.has(cleaned)) {
+      continue;
+    }
     seen.add(cleaned);
     normalized.push(cleaned);
   }
@@ -199,12 +207,14 @@ export async function executeScaffoldManagedSkill(
     context.requestOrigin === MEMORY_RETROSPECTIVE_ORIGIN;
   const author = fromRetrospective ? "assistant" : "user";
 
-  // Whether a managed SKILL.md already existed before this call. Resolved for
-  // retrospective calls only — it drives both the ownership backstop below and
-  // the created-vs-refined discriminant for the skill-card enqueue: only a
-  // genuine CREATE (no pre-existing skill, regardless of the `overwrite` flag)
-  // gets a card.
-  let managedSkillExistedBefore = false;
+  // Whether a managed SKILL.md already existed before this call. Drives the
+  // ownership backstop below, the created-vs-refined discriminant for the
+  // skill-card enqueue, and the `skill_authored` telemetry counter: only a
+  // genuine CREATE (no pre-existing skill, regardless of the `overwrite`
+  // flag) gets a card or a counter event.
+  const managedSkillExistedBefore = existsSync(
+    join(getManagedSkillDir(id), "SKILL.md"),
+  );
 
   // Ownership backstop (retrospective origin only): the retrospective may author
   // a skill ONLY if it owns it. Fail closed on either of two collisions.
@@ -234,11 +244,9 @@ export async function executeScaffoldManagedSkill(
     // exactly "assistant". This fails closed on user-authored, untagged, and
     // unverifiable (missing/corrupt meta) managed skills alike, matching the
     // prune side where such skills are never pruned.
-    const managedDir = getManagedSkillDir(id);
-    managedSkillExistedBefore = existsSync(join(managedDir, "SKILL.md"));
     if (
       managedSkillExistedBefore &&
-      readInstallMeta(managedDir)?.author !== "assistant"
+      readInstallMeta(getManagedSkillDir(id))?.author !== "assistant"
     ) {
       return {
         content: `Error: skill "${id}" is not verifiably assistant-authored; the retrospective may not overwrite it or write companion files into it. Author a new skill instead.`,
@@ -297,6 +305,28 @@ export async function executeScaffoldManagedSkill(
   }
 
   refreshSkillCapabilityMemories();
+
+  // Central adoption counter for skill authoring (admin analytics groups on
+  // the watchdog check_name). Genuine creates only — refinements of a
+  // pre-existing skill are not new capabilities and would double-count.
+  // `authored_by` distinguishes proactive retrospective authoring from
+  // user-directed scaffolds. Never throws: a telemetry failure must not
+  // fail a scaffold that already succeeded.
+  if (!managedSkillExistedBefore) {
+    try {
+      recordWatchdogEvent({
+        checkName: SKILL_AUTHORED_CHECK_NAME,
+        value: 1,
+        detail: {
+          authored_by: fromRetrospective ? "retrospective" : "user",
+          skill_id: id,
+        },
+      });
+    } catch {
+      // recordWatchdogEvent already no-ops on opt-out and a missing
+      // telemetry DB; anything past that is not worth surfacing here.
+    }
+  }
 
   // Surface a genuine retrospective CREATE to the user as a skill card on the
   // source conversation, via the durable `skill_card_insert` delivery job

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -214,6 +214,12 @@ export function ConceptGraphView({
     filterRef.current = { active: Boolean(matchIds), matches: matchIds };
     view.current.dirty = true;
   }, [matchIds]);
+  // Reset the search when the active assistant changes: this component is reused
+  // across assistants (IdentityTab doesn't key it), so a stale query would
+  // otherwise filter the new assistant's graph and ghost every node.
+  useEffect(() => {
+    setSearch("");
+  }, [assistantId]);
 
   const labelFor = useCallback(
     (id: string | null): string | null => {

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -653,7 +653,10 @@ export function ConceptGraphView({
       <>
         <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
 
-        {layout.nodes.length > SEARCH_MIN_NODES ? (
+        {/* Keep the box visible whenever a search is active, even if the graph
+            shrank below the threshold (e.g. a refetch) — otherwise an active
+            filter would ghost nodes with no way to clear it short of remount. */}
+        {layout.nodes.length > SEARCH_MIN_NODES || search ? (
           <div
             data-graph-control
             className={`absolute top-4 z-10 ${onToggleFullscreen ? "left-16" : "left-4"}`}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -1,5 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { Maximize2, Minimize2, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
+import {
+  Maximize2,
+  Minimize2,
+  RotateCcw,
+  Search,
+  X,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { VIRTUAL_CENTER } from "@/domains/intelligence/components/constellation-view/constants";
@@ -38,6 +46,17 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const RECENCY_GLOW_WINDOW_MS = 14 * DAY_MS; // recency fades out over ~2 weeks
 const RECENCY_GLOW_MAX = 12; // extra shadowBlur at peak freshness
 const PULSE_WINDOW_MS = 2 * DAY_MS; // newer than this → pulses (unless reduced motion)
+
+// As the graph grows, fade the resting (nothing-focused) learned-edge web so
+// dense corpora don't read as a haze. Full strength up to FOG_FULL_BELOW nodes,
+// easing to FOG_FLOOR by FOG_FLOOR_ABOVE. Only learned (associative) edges fade;
+// authored links carry structure and stay. Hover always restores full contrast.
+const FOG_FULL_BELOW = 80;
+const FOG_FLOOR_ABOVE = 340;
+const FOG_FLOOR = 0.12;
+
+// Below this node count the graph is small enough to scan by eye — no search box.
+const SEARCH_MIN_NODES = 12;
 
 interface Projected {
   id: string;
@@ -173,6 +192,29 @@ export function ConceptGraphView({
   // user dismisses it; the dismissal sticks per-assistant.
   const [introDismissed, dismissIntro] = useGraphIntroDismissed(assistantId);
 
+  // Name search: as the graph grows, typing narrows it to matching concepts —
+  // matches stay lit, everything else ghosts. The set of matching ids lives in
+  // a ref the 60fps render loop reads (so keystrokes don't re-run the effect),
+  // and `dirty` is bumped whenever it changes so reduced-motion redraws.
+  const [search, setSearch] = useState("");
+  const searchLower = search.trim().toLowerCase();
+  const matchIds = useMemo(() => {
+    if (!searchLower) {return null;}
+    const s = new Set<string>();
+    for (const n of layout.nodes) {
+      if (n.label.toLowerCase().includes(searchLower)) {s.add(n.id);}
+    }
+    return s;
+  }, [searchLower, layout.nodes]);
+  const filterRef = useRef<{ active: boolean; matches: Set<string> | null }>({
+    active: false,
+    matches: null,
+  });
+  useEffect(() => {
+    filterRef.current = { active: Boolean(matchIds), matches: matchIds };
+    view.current.dirty = true;
+  }, [matchIds]);
+
   const labelFor = useCallback(
     (id: string | null): string | null => {
       if (!id) {return null;}
@@ -277,6 +319,24 @@ export function ConceptGraphView({
       const isLit = (id: string) =>
         !activeId || id === activeId || (neighbors?.has(id) ?? false);
 
+      // Search: when active, only matching nodes/edges stay lit; the rest ghost.
+      const filter = filterRef.current;
+      const searchActive = filter.active;
+      const isMatch = (id: string) =>
+        !searchActive || (filter.matches?.has(id) ?? false);
+
+      // Density fog: fade the resting learned-edge web as the corpus grows.
+      const learnedFog =
+        nodes.length <= FOG_FULL_BELOW
+          ? 1
+          : Math.max(
+              FOG_FLOOR,
+              1 -
+                ((nodes.length - FOG_FULL_BELOW) /
+                  (FOG_FLOOR_ABOVE - FOG_FULL_BELOW)) *
+                  (1 - FOG_FLOOR),
+            );
+
       // Project every node into screen space.
       const proj = new Array<{
         node: GraphLayoutNode;
@@ -315,10 +375,19 @@ export function ConceptGraphView({
         const b = posById.get(e.toId);
         if (!a || !b) {continue;}
         const learned = e.kind === "learned";
+        const ghost = searchActive && (!isMatch(e.fromId) || !isMatch(e.toId));
         const incident = activeId != null && (e.fromId === activeId || e.toId === activeId);
         const depth = (a.depth + b.depth) / 2;
-        let alpha = (learned ? 0.34 : 0.28) * (0.4 + 0.6 * depth);
-        if (activeId != null) {alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? alpha : 0.05;}
+        // Learned edges fade with density in the resting web; authored links don't.
+        const restAlpha = (learned ? 0.34 * learnedFog : 0.28) * (0.4 + 0.6 * depth);
+        let alpha: number;
+        if (ghost) {
+          alpha = 0.03;
+        } else if (activeId != null) {
+          alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? restAlpha : 0.05;
+        } else {
+          alpha = restAlpha;
+        }
         ctx.globalAlpha = alpha;
         ctx.strokeStyle = learned ? EDGE_LEARNED_COLOR : colors.tertiary;
         ctx.lineWidth = (incident ? 2 : 1) * (0.6 + 0.6 * depth);
@@ -335,10 +404,11 @@ export function ConceptGraphView({
         const p = proj[idx];
         const node = p.node;
         const color = NODE_KIND_COLORS[node.kind];
-        const lit = isLit(node.id);
+        const ghost = searchActive && !isMatch(node.id);
+        const lit = !ghost && isLit(node.id);
         const isActive = node.id === activeId;
         const depthA = DEPTH_ALPHA_MIN + (1 - DEPTH_ALPHA_MIN) * p.depth;
-        const alpha = lit ? depthA : depthA * 0.18;
+        const alpha = ghost ? depthA * 0.08 : lit ? depthA : depthA * 0.18;
 
         let glow = (isActive ? 16 : node.degree >= HUB_LABEL_DEGREE ? 8 : 4) * p.depth;
         // Recency: fresh concepts glow brighter; the very newest pulse. Static
@@ -381,8 +451,11 @@ export function ConceptGraphView({
         const node = p.node;
         // When nothing is focused, only label front-facing hubs (depth-gated) so
         // the dense middle of the mass doesn't turn into unreadable label soup.
-        const showLabel =
-          activeId != null
+        // While searching, label the matches instead (that's what you're after).
+        if (searchActive && !isMatch(node.id)) {continue;}
+        const showLabel = searchActive
+          ? p.depth > 0.3
+          : activeId != null
             ? isLit(node.id)
             : node.degree >= HUB_LABEL_DEGREE && p.depth > 0.55;
         if (!showLabel) {continue;}
@@ -411,11 +484,15 @@ export function ConceptGraphView({
     };
   }, [ready, layout, adjacency, massRadius]);
 
-  // Nearest node under a screen point; nearest-in-front wins.
+  // Nearest node under a screen point; nearest-in-front wins. While a search is
+  // active, ghosted (non-matching) nodes are skipped so hover/click land on a
+  // result, not a faded background node.
   const hitTest = useCallback((x: number, y: number): string | null => {
+    const filter = filterRef.current;
     let best: string | null = null;
     let bestDepth = -1;
     for (const p of projectedRef.current) {
+      if (filter.active && !(filter.matches?.has(p.id) ?? false)) {continue;}
       const dx = x - p.sx;
       const dy = y - p.sy;
       if (dx * dx + dy * dy <= (p.sr + 5) * (p.sr + 5) && p.depth > bestDepth) {
@@ -576,6 +653,56 @@ export function ConceptGraphView({
       <>
         <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
 
+        {layout.nodes.length > SEARCH_MIN_NODES ? (
+          <div
+            data-graph-control
+            className={`absolute top-4 z-10 ${onToggleFullscreen ? "left-16" : "left-4"}`}
+          >
+            <div
+              className="flex items-center gap-1.5 rounded-full px-2.5 py-1"
+              style={{
+                backgroundColor: "color-mix(in srgb, var(--surface-base) 82%, transparent)",
+                border: "1px solid var(--border-base)",
+              }}
+            >
+              <Search size={14} aria-hidden style={{ color: "var(--content-tertiary)" }} />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setSearch("");
+                  }
+                }}
+                placeholder="Search concepts…"
+                aria-label="Search concepts"
+                className="w-36 bg-transparent text-[12px] outline-none placeholder:text-[var(--content-tertiary)]"
+                style={{ color: "var(--content-default)" }}
+              />
+              {search ? (
+                <>
+                  <span
+                    className="text-[11px] tabular-nums"
+                    style={{ color: "var(--content-tertiary)" }}
+                  >
+                    {matchIds?.size ?? 0}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setSearch("")}
+                    aria-label="Clear search"
+                    className="flex items-center"
+                    style={{ color: "var(--content-tertiary)" }}
+                  >
+                    <X size={13} />
+                  </button>
+                </>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
         <ConceptGraphLegend
           nodeKinds={presentKinds.length > 1 ? presentKinds : []}
           hasLinks={hasLinks}
@@ -601,6 +728,19 @@ export function ConceptGraphView({
         >
           drag to rotate · scroll to zoom
         </div>
+
+        {graph?.truncated ? (
+          <div
+            className="pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full px-3 py-1 text-[11px]"
+            style={{
+              backgroundColor: "color-mix(in srgb, var(--surface-base) 82%, transparent)",
+              border: "1px solid var(--border-base)",
+              color: "var(--content-tertiary)",
+            }}
+          >
+            Showing the {layout.nodes.length} most-connected concepts
+          </div>
+        ) : null}
 
         <div data-graph-control className="absolute right-4 top-4 flex flex-col gap-1">
           <Button

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -378,13 +378,16 @@ export function ConceptGraphView({
         const ghost = searchActive && (!isMatch(e.fromId) || !isMatch(e.toId));
         const incident = activeId != null && (e.fromId === activeId || e.toId === activeId);
         const depth = (a.depth + b.depth) / 2;
-        // Learned edges fade with density in the resting web; authored links don't.
-        const restAlpha = (learned ? 0.34 * learnedFog : 0.28) * (0.4 + 0.6 * depth);
+        // Learned edges fade with density in the resting web; authored links
+        // don't. A focused hover neighborhood reads at full contrast, though —
+        // so lit edges use the unfogged base even in a dense graph.
+        const litAlpha = (learned ? 0.34 : 0.28) * (0.4 + 0.6 * depth);
+        const restAlpha = learned ? litAlpha * learnedFog : litAlpha;
         let alpha: number;
         if (ghost) {
           alpha = 0.03;
         } else if (activeId != null) {
-          alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? restAlpha : 0.05;
+          alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? litAlpha : 0.05;
         } else {
           alpha = restAlpha;
         }


### PR DESCRIPTION
## What

Three watchdog `check_name` counters for the memory→skills pipeline, so platform analytics (BigQuery `stg_telemetry__watchdog`) can measure adoption and health per assistant — feeding a new "Skills from memory" section on `/admin/memory` (platform PR to follow):

| check_name | when | value | detail |
|---|---|---|---|
| `skill_authored` | `executeScaffoldManagedSkill` on a **genuine create** (never refinements) | 1 | `{authored_by: "retrospective"\|"user", skill_id}` |
| `skill_card_delivered` | non-deduplicated skill-card insert | skill count | `{skill_count}` |
| `memory_retrospective_run` | every retrospective job run | 1 | `{outcome, reason?}` |

`memory_retrospective_run` is the ops metric: the 2026-07-13 Fireworks 402 outage silently killed every retrospective on managed installs — this counter would have shown it as a fleet-wide `wake_failed` spike (paired with #37959, which made turn-0 provider failures report as `wake_failed` instead of phantom success).

## Notes

- `managedSkillExistedBefore` is now resolved for **every** call (previously retrospective-origin only) so a manual `overwrite` refinement never counts as a new skill. Behavior-neutral otherwise (the ownership backstop stays retrospective-only).
- Emitters mirror the `memory_v3_injection_gate` precedent: same import boundary, try/caught so telemetry can never fail a scaffold/insert/run; `recordWatchdogEvent` itself gates on Share Analytics consent and telemetry-DB availability.
- Open `check_name` set → no wire/serializer change; events land in `watchdog_raw` as-is.

## Tests

- scaffold: user-attributed and retrospective-attributed create events; overwrite/refinement emits nothing (both origins). 51 pass.
- card: delivered counter with multi-skill value; dedup retry does not double-count. 16 pass.
- retrospective job: outcome counter on the early-return path and wake-failed (with reason). 60 pass.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)