### PR TITLE
feat(apps): serve plugin-bundled apps and gate their mutations

### DIFF
--- a/assistant/src/__tests__/app-routes-csp.test.ts
+++ b/assistant/src/__tests__/app-routes-csp.test.ts
@@ -27,10 +27,19 @@ const apps = new Map<string, typeof legacyApp | typeof multifileApp>([
 ]);
 
 mock.module("../apps/app-store.js", () => ({
-  getApp: (id: string) => apps.get(id) ?? null,
-  getAppsDir: () => "/fake/apps",
-  getAppDirPath: (appId: string) => `/fake/apps/${appId}`,
-  isMultifileApp: (app: Record<string, unknown>) => app.formatVersion === 2,
+  resolveAppSource: (id: string) => {
+    const app = apps.get(id);
+    if (!app) return null;
+    return {
+      id,
+      name: app.name,
+      dirName: id,
+      sourceDir: `/fake/apps/${id}`,
+      origin: { kind: "workspace" as const },
+      formatVersion: (app as { formatVersion?: number }).formatVersion ?? 1,
+    };
+  },
+  readAppFileBytesFromDir: () => Buffer.from(""),
 }));
 
 // Mock shared-app-links-store (imported by app-routes but unused here)

--- a/assistant/src/__tests__/plugin-app-serve-routes.test.ts
+++ b/assistant/src/__tests__/plugin-app-serve-routes.test.ts
@@ -1,0 +1,163 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { ROUTES as APP_MGMT_ROUTES } from "../runtime/routes/app-management-routes.js";
+import { ROUTES as APP_ROUTES } from "../runtime/routes/app-routes.js";
+import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
+import type {
+  ResponseHeaderArgs,
+  RouteDefinition,
+  RouteHandlerArgs,
+} from "../runtime/routes/types.js";
+import { getWorkspacePluginsDir } from "../util/platform.js";
+
+let workspaceDir: string;
+
+function findRoute(routes: RouteDefinition[], operationId: string) {
+  const route = routes.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route not found: ${operationId}`);
+  }
+  return route;
+}
+
+/** Install a plugin with a package.json and one bundled app directory. */
+function installPluginApp(
+  plugin: string,
+  app: string,
+  files: Record<string, string>,
+): void {
+  const appDir = join(getWorkspacePluginsDir(), plugin, "apps", app);
+  mkdirSync(appDir, { recursive: true });
+  writeFileSync(
+    join(getWorkspacePluginsDir(), plugin, "package.json"),
+    JSON.stringify({ name: plugin, version: "1.0.0" }),
+  );
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(appDir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-plugin-serve-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("plugin app serve routes", () => {
+  test("pages_serve renders a single-file plugin app's index.html", () => {
+    installPluginApp("acme", "dash", {
+      "index.html": "<div id='root'>Plugin Home</div>",
+    });
+    const handler = findRoute(APP_ROUTES, "pages_serve").handler;
+    const html = handler({
+      pathParams: { appId: "plugins~acme~dash" },
+    } as RouteHandlerArgs) as string;
+
+    expect(html).toContain("Plugin Home");
+    expect(html).toContain("<!DOCTYPE html>");
+  });
+
+  test("pages_serve 404s for an unknown / non-plugin id", () => {
+    const handler = findRoute(APP_ROUTES, "pages_serve").handler;
+    expect(() =>
+      handler({
+        pathParams: { appId: "plugins~acme~missing" },
+      } as RouteHandlerArgs),
+    ).toThrow(NotFoundError);
+  });
+
+  test("servePageHeaders CSP: single-file allows inline scripts, multifile does not", () => {
+    installPluginApp("acme", "single", {
+      "index.html": "<div>x</div>",
+    });
+    installPluginApp("acme", "multi", {
+      "dist/index.html": "<script src='main.js'></script>",
+    });
+    const route = findRoute(APP_ROUTES, "pages_serve");
+    const headersFn = route.responseHeaders as (
+      args: ResponseHeaderArgs,
+    ) => Record<string, string>;
+
+    const single = headersFn({ pathParams: { appId: "plugins~acme~single" } });
+    const multi = headersFn({ pathParams: { appId: "plugins~acme~multi" } });
+
+    expect(single["Content-Security-Policy"]).toContain(
+      "script-src 'self' 'unsafe-inline'",
+    );
+    expect(multi["Content-Security-Policy"]).toContain("script-src 'self';");
+    expect(multi["Content-Security-Policy"]).not.toContain(
+      "script-src 'self' 'unsafe-inline'",
+    );
+  });
+
+  test("apps_asset serves a bundled asset from a plugin app dir", () => {
+    installPluginApp("acme", "dash", {
+      "index.html": "<div>x</div>",
+      "logo.svg": "<svg>logo</svg>",
+    });
+    const handler = findRoute(APP_ROUTES, "apps_asset").handler;
+    const bytes = handler({
+      pathParams: { appId: "plugins~acme~dash", path: "logo.svg" },
+    } as RouteHandlerArgs) as Uint8Array;
+
+    expect(Buffer.from(bytes).toString("utf-8")).toBe("<svg>logo</svg>");
+  });
+
+  test("apps_asset rejects traversal out of a plugin app dir", () => {
+    installPluginApp("acme", "dash", { "index.html": "<div>x</div>" });
+    const handler = findRoute(APP_ROUTES, "apps_asset").handler;
+    expect(() =>
+      handler({
+        pathParams: { appId: "plugins~acme~dash", path: "../../package.json" },
+      } as RouteHandlerArgs),
+    ).toThrow(BadRequestError);
+  });
+
+  test("apps_dist_file serves a compiled asset from a plugin app dist/", () => {
+    installPluginApp("acme", "multi", {
+      "dist/index.html": "<html></html>",
+      "dist/main.js": "console.log(1)",
+    });
+    const handler = findRoute(APP_ROUTES, "apps_dist_file").handler;
+    const bytes = handler({
+      pathParams: { appId: "plugins~acme~multi", filename: "main.js" },
+    } as RouteHandlerArgs) as Uint8Array;
+
+    expect(Buffer.from(bytes).toString("utf-8")).toBe("console.log(1)");
+  });
+});
+
+describe("plugin apps are read-only over the management surface", () => {
+  test("apps_delete rejects a plugin app id", () => {
+    installPluginApp("acme", "dash", { "index.html": "<div>x</div>" });
+    const handler = findRoute(APP_MGMT_ROUTES, "apps_delete").handler;
+    expect(() =>
+      handler({
+        pathParams: { id: "plugins~acme~dash" },
+        headers: {},
+      } as RouteHandlerArgs),
+    ).toThrow(BadRequestError);
+  });
+
+  test("apps_data_mutate rejects a plugin app id", () => {
+    installPluginApp("acme", "dash", { "index.html": "<div>x</div>" });
+    const handler = findRoute(APP_MGMT_ROUTES, "apps_data_mutate").handler;
+    expect(() =>
+      handler({
+        pathParams: { id: "plugins~acme~dash" },
+        body: { method: "create", data: {} },
+      } as RouteHandlerArgs),
+    ).toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/apps/app-store.ts
+++ b/assistant/src/apps/app-store.ts
@@ -400,6 +400,16 @@ function invalidateDirNameCache(appId?: string): void {
  * Returns the resolved absolute path.
  */
 function validateFilePath(appId: string, path: string): string {
+  return validateFilePathInDir(getAppDirPath(appId), path);
+}
+
+/**
+ * Validate a relative file path within a known app directory (absolute path).
+ * Prevents path traversal and access to protected directories. Used when the
+ * app directory is already resolved (e.g. plugin-bundled apps addressed by
+ * path rather than by a workspace app id).
+ */
+function validateFilePathInDir(appDir: string, path: string): string {
   if (!path || path.trim() === "") {
     throw new Error(`Invalid file path: path is empty`);
   }
@@ -414,7 +424,6 @@ function validateFilePath(appId: string, path: string): string {
   if (normalized === "records" || normalized.startsWith("records/")) {
     throw new Error(`Invalid file path: 'records/' directory is protected`);
   }
-  const appDir = getAppDirPath(appId);
   const resolved = resolve(appDir, path);
   // Ensure the resolved path is still within the app directory
   if (!resolved.startsWith(appDir + "/") && resolved !== appDir) {
@@ -677,6 +686,11 @@ const PLUGIN_APP_ID_SEP = "~";
 /** Build the addressable id for a plugin-bundled app. */
 function pluginAppId(pluginName: string, appDir: string): string {
   return `${PLUGIN_APP_ID_PREFIX}${pluginName}${PLUGIN_APP_ID_SEP}${appDir}`;
+}
+
+/** True when an app id addresses a plugin-bundled app (vs a workspace app). */
+export function isPluginAppId(id: string): boolean {
+  return id.startsWith(PLUGIN_APP_ID_PREFIX);
 }
 
 /** An app paired with the absolute path to its source and its origin. */
@@ -1143,6 +1157,23 @@ export function readAppFile(appId: string, path: string): string {
 export function readAppFileBytes(appId: string, path: string): Buffer {
   validateId(appId);
   const resolved = validateFilePath(appId, path);
+  if (!existsSync(resolved)) {
+    throw new Error(`File not found: ${path}`);
+  }
+  return readFileSync(resolved);
+}
+
+/**
+ * Read a file as raw bytes from an app directory addressed by its absolute
+ * path (rather than by a workspace app id). Path is validated to prevent
+ * traversal. Used to serve assets for plugin-bundled apps, whose source dir is
+ * resolved via {@link resolveAppSource}.
+ */
+export function readAppFileBytesFromDir(
+  sourceDir: string,
+  path: string,
+): Buffer {
+  const resolved = validateFilePathInDir(sourceDir, path);
   if (!existsSync(resolved)) {
     throw new Error(`File not found: ${path}`);
   }

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -26,6 +26,7 @@ import {
   type EnumeratedApp,
   getAppDirPath,
   getAppPreview,
+  isPluginAppId,
   listApps,
   listAppsByConversation,
   listPluginApps,
@@ -639,6 +640,7 @@ function handleQueryAppData({ pathParams, queryParams }: RouteHandlerArgs) {
 
 function handleMutateAppData({ pathParams, body }: RouteHandlerArgs) {
   const appId = pathParams?.id as string;
+  assertNotPluginApp(appId, "modify a plugin app's data");
   const method = (body?.method as string) ?? "create";
   const result = getAppDataResult(
     method,
@@ -685,8 +687,23 @@ async function handleOpenApp({ pathParams }: RouteHandlerArgs) {
   };
 }
 
+/**
+ * Reject a mutation targeting a plugin-bundled app. Plugin apps are owned by
+ * their plugin and are read-only over this surface — their source is not
+ * user-editable and their lifecycle is the plugin's.
+ */
+function assertNotPluginApp(appId: string, action: string): void {
+  if (isPluginAppId(appId)) {
+    throw new BadRequestError(
+      `Plugin-bundled apps are read-only; cannot ${action}. This app is owned by its plugin.`,
+    );
+  }
+}
+
 function handleDeleteApp({ pathParams, headers }: RouteHandlerArgs) {
-  deleteApp(pathParams?.id as string);
+  const appId = pathParams?.id as string;
+  assertNotPluginApp(appId, "delete a plugin app");
+  deleteApp(appId);
   publishAppsChanged(getOriginClientId(headers));
   return { success: true };
 }
@@ -699,6 +716,7 @@ function handleGetPreview({ pathParams }: RouteHandlerArgs) {
 
 function handleUpdatePreview({ pathParams, body }: RouteHandlerArgs) {
   const appId = pathParams?.id as string;
+  assertNotPluginApp(appId, "update a plugin app's preview");
   if (!body?.preview) {
     throw new BadRequestError("preview is required");
   }
@@ -708,6 +726,7 @@ function handleUpdatePreview({ pathParams, body }: RouteHandlerArgs) {
 
 async function handleBundle({ pathParams }: RouteHandlerArgs) {
   const appId = pathParams?.id as string;
+  assertNotPluginApp(appId, "bundle a plugin app");
   const result = await packageApp(appId);
   return {
     type: "bundle_app_response",
@@ -719,6 +738,7 @@ async function handleBundle({ pathParams }: RouteHandlerArgs) {
 
 async function handleShareCloud({ pathParams }: RouteHandlerArgs) {
   const appId = pathParams?.id as string;
+  assertNotPluginApp(appId, "share a plugin app");
   const result = await packageApp(appId);
   const bundleData = readFileSync(result.bundlePath);
   const { shareToken } = createSharedAppLink(bundleData, result.manifest);

--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -9,10 +9,8 @@ import JSZip from "jszip";
 import { z } from "zod";
 
 import {
-  getApp,
-  getAppDirPath,
-  isMultifileApp,
-  readAppFileBytes,
+  readAppFileBytesFromDir,
+  resolveAppSource,
 } from "../../apps/app-store.js";
 import {
   createSharedAppLink,
@@ -78,11 +76,11 @@ function servePageHeaders({
   pathParams,
 }: ResponseHeaderArgs): Record<string, string> {
   const appId = pathParams?.appId as string;
-  const app = getApp(appId);
+  const source = resolveAppSource(appId);
   // Multifile apps use external scripts — no 'unsafe-inline' for script-src.
   // Legacy apps contain inline event handlers that require 'unsafe-inline'.
   const scriptSrc =
-    app && isMultifileApp(app) ? "'self'" : "'self' 'unsafe-inline'";
+    source && source.formatVersion === 2 ? "'self'" : "'self' 'unsafe-inline'";
   return {
     "Content-Type": "text/html; charset=utf-8",
     "Content-Security-Policy": buildCsp(scriptSrc),
@@ -95,18 +93,18 @@ function servePageHeaders({
 
 function handleServePage({ pathParams }: RouteHandlerArgs): string {
   const appId = pathParams?.appId as string;
-  const app = getApp(appId);
-  if (!app) {
+  const source = resolveAppSource(appId);
+  if (!source) {
     throw new NotFoundError("App not found");
   }
 
   // Multifile apps serve the compiled dist/index.html directly.
-  if (isMultifileApp(app)) {
-    return serveMultifileApp(appId, app.name);
+  if (source.formatVersion === 2) {
+    return serveMultifileApp(source.id, source.sourceDir, source.name);
   }
 
   const css = loadDesignSystemCss();
-  const escapedName = app.name.replace(
+  const escapedName = source.name.replace(
     /[<>&"]/g,
     (c) => HTML_ESCAPE_MAP[c] ?? c,
   );
@@ -114,9 +112,13 @@ function handleServePage({ pathParams }: RouteHandlerArgs): string {
   // Per-response nonce for inline <style> and <script> tags.
   const nonce = randomBytes(16).toString("base64");
 
+  // Single-file apps serve their root index.html.
+  const indexPath = join(source.sourceDir, "index.html");
+  const rawHtml = existsSync(indexPath) ? readFileSync(indexPath, "utf-8") : "";
+
   // Inject the nonce into any inline <script> tags from the app HTML definition
   // so they are allowed by the nonce-based CSP without 'unsafe-inline'.
-  const noncedHtml = app.htmlDefinition.replace(
+  const noncedHtml = rawHtml.replace(
     /<script(?=[\s>])/gi,
     `<script nonce="${nonce}"`,
   );
@@ -139,8 +141,12 @@ ${noncedHtml}
  * Serve compiled output for multifile TSX apps.
  * Falls back to a "not compiled yet" message if dist/index.html is missing.
  */
-function serveMultifileApp(appId: string, appName: string): string {
-  const distDir = join(getAppDirPath(appId), "dist");
+function serveMultifileApp(
+  appId: string,
+  appDir: string,
+  appName: string,
+): string {
+  const distDir = join(appDir, "dist");
   const indexPath = join(distDir, "index.html");
 
   if (!existsSync(indexPath)) {
@@ -236,7 +242,12 @@ function handleServeDistFile({ pathParams }: RouteHandlerArgs): Uint8Array {
     throw new BadRequestError("Invalid filename");
   }
 
-  const filePath = join(getAppDirPath(appId), "dist", filename);
+  const source = resolveAppSource(appId);
+  if (!source) {
+    throw new NotFoundError("App not found");
+  }
+
+  const filePath = join(source.sourceDir, "dist", filename);
   if (!existsSync(filePath)) {
     throw new NotFoundError("File not found");
   }
@@ -250,7 +261,7 @@ const MAX_APP_ASSET_BYTES = 25 * 1024 * 1024;
 /**
  * Serve a bundled file from anywhere in an app's directory (e.g.
  * `assets/intro.mp4`), for binary media an app can't practically inline as a
- * data-URI. `readAppFileBytes` runs the app-store path validation
+ * data-URI. `readAppFileBytesFromDir` runs the app-store path validation
  * (rejects `..`, absolute paths, symlink escapes, and the protected
  * `records/` directory), so authors bundle assets under the app dir and load
  * them via `window.vellum.asset(path)`.
@@ -272,9 +283,14 @@ function handleServeAppAsset({ pathParams }: RouteHandlerArgs): Uint8Array {
     throw new BadRequestError("Invalid asset path");
   }
 
+  const source = resolveAppSource(appId);
+  if (!source) {
+    throw new NotFoundError("Asset not found");
+  }
+
   let bytes: Buffer;
   try {
-    bytes = readAppFileBytes(appId, assetPath);
+    bytes = readAppFileBytesFromDir(source.sourceDir, assetPath);
   } catch (err) {
     const message = err instanceof Error ? err.message : "";
     if (message.includes("not found")) {


### PR DESCRIPTION
## Prompt / plan

Follow-up to the single-app-fetch work: route the **remaining** by-id app HTTP surface through `resolveAppSource` so a plugin app renders end-to-end in the library, and make plugin apps **read-only** over the management surface.

Before this, `apps_open` + `apps_list` were plugin-aware but the page/dist/asset routes still resolved workspace ids only — so a multi-file or asset-loading plugin app would 404 or resolve to the wrong path.

### Serve routes (`app-routes.ts`)
Page, dist, and asset handlers plus the CSP header builder used `getApp` / `getAppDirPath` / `readAppFileBytes` (workspace-only):
- `handleServePage` / `servePageHeaders` resolve via `resolveAppSource` and key CSP off `formatVersion`; single-file apps serve their root `index.html`.
- `serveMultifileApp` takes the resolved app dir instead of `getAppDirPath(id)`, so its `main.js`/`main.css` rewrite points at `/v1/apps/<id>/dist/...` for any origin.
- `handleServeDistFile` / `handleServeAppAsset` resolve the source dir via `resolveAppSource`; asset reads go through a new `readAppFileBytesFromDir`.

### `app-store.ts`
- Extracted `validateFilePathInDir(appDir, path)` from `validateFilePath` (which now delegates), and added `readAppFileBytesFromDir(sourceDir, path)` — same traversal/symlink/`records/` guards, but keyed off a directory rather than a workspace app id.
- Exported `isPluginAppId(id)`.

### Read-only gating (`app-management-routes.ts`)
`delete`, `preview-update`, `bundle`, `share`, and `data-mutate` now reject plugin app ids with a clear **400** — plugin apps are owned by their plugin, not user-editable. Reads (`list`, `open`, `preview-get`, `data-query`) are unaffected.

### Still out of scope (last follow-up)
Compile cache for multi-file plugin sources — until then, a multi-file plugin app renders its "not compiled yet" fallback unless it ships a prebuilt `dist/`. Single-file plugin apps work fully.

## Test plan

- New `plugin-app-serve-routes.test.ts` drives the **real** routes (no mocks) against a temp workspace: single-file page render, CSP by format (single-file → `unsafe-inline`, multi-file → `'self'`), asset + dist serve, traversal rejection, and `delete` / `data-mutate` gating (8 tests).
- `app-routes-csp.test.ts` mock updated from the old `getApp`/`isMultifileApp` surface to `resolveAppSource` (17 tests pass).
- Each affected file passes in isolation: `app-routes-csp` (17), `plugin-app-serve-routes` (8), `list-all-apps` (12), `app-asset-bytes` (3), `app-executors` (22), `app-dir-path-guard` (1).
- `bunx tsc --noEmit` clean; eslint 0 errors; no OpenAPI change (gating throws errors, no schema change; serve responses unchanged).

## CLI verb checklist

No new routes or response-schema changes — this reroutes existing handlers and adds 400s for plugin ids on mutating routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG

---
_Generated by [Claude Code](https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG)_