### PR TITLE
refactor(cli): move Velay tunnel status to `gateway status`

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11561,7 +11561,7 @@ paths:
     get:
       operationId: gateway_status_get
       summary: Get gateway status
-      description: Reports the live Velay tunnel status from the gateway. The Velay tunnel only matters for tunnelling inbound Twilio webhooks and live voice/audio WebSockets; velayTunnel is null when the gateway is not running.
+      description: Reports the gateway's public tunnel status. `tunnel` holds the active public URL when a tunnel is connected and is omitted otherwise. The tunnel only matters for routing inbound Twilio webhooks and live voice/audio WebSockets.
       tags:
         - gateway
       responses:
@@ -11572,23 +11572,8 @@ paths:
               schema:
                 type: object
                 properties:
-                  velayTunnel:
-                    anyOf:
-                      - type: object
-                        properties:
-                          connected:
-                            type: boolean
-                          publicUrl:
-                            anyOf:
-                              - type: string
-                              - type: "null"
-                        required:
-                          - connected
-                          - publicUrl
-                        additionalProperties: false
-                      - type: "null"
-                required:
-                  - velayTunnel
+                  tunnel:
+                    type: string
                 additionalProperties: false
   /v1/groups:
     get:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11561,7 +11561,10 @@ paths:
     get:
       operationId: gateway_status_get
       summary: Get gateway status
-      description: Reports the gateway's public tunnel status. `tunnel` holds the active public URL when a tunnel is connected and is omitted otherwise. The tunnel only matters for routing inbound Twilio webhooks and live voice/audio WebSockets.
+      description:
+        Reports the gateway's public tunnel status. `tunnel` holds the active public URL when a tunnel is connected
+        and is omitted otherwise. Errors with 503 when the gateway is not running. The tunnel only matters for routing
+        inbound Twilio webhooks and live voice/audio WebSockets.
       tags:
         - gateway
       responses:
@@ -21946,7 +21949,9 @@ paths:
     get:
       operationId: platform_status_get
       summary: Get platform deployment context and connection status
-      description: Aggregates platform context, credentials, assistant ID, and webhook secret. Velay tunnel status is reported separately by gateway_status.
+      description:
+        Aggregates platform context, credentials, assistant ID, and webhook secret. Velay tunnel status is reported
+        separately by gateway_status.
       tags:
         - platform
       responses:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11557,6 +11557,39 @@ paths:
                   - lines
                   - truncated
                 additionalProperties: false
+  /v1/gateway/status:
+    get:
+      operationId: gateway_status_get
+      summary: Get gateway status
+      description: Reports the live Velay tunnel status from the gateway. The Velay tunnel only matters for tunnelling inbound Twilio webhooks and live voice/audio WebSockets; velayTunnel is null when the gateway is not running.
+      tags:
+        - gateway
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  velayTunnel:
+                    anyOf:
+                      - type: object
+                        properties:
+                          connected:
+                            type: boolean
+                          publicUrl:
+                            anyOf:
+                              - type: string
+                              - type: "null"
+                        required:
+                          - connected
+                          - publicUrl
+                        additionalProperties: false
+                      - type: "null"
+                required:
+                  - velayTunnel
+                additionalProperties: false
   /v1/groups:
     get:
       operationId: groups_get
@@ -21928,7 +21961,7 @@ paths:
     get:
       operationId: platform_status_get
       summary: Get platform deployment context and connection status
-      description: Aggregates platform context, credentials, assistant ID, webhook secret, and Velay tunnel status.
+      description: Aggregates platform context, credentials, assistant ID, and webhook secret. Velay tunnel status is reported separately by gateway_status.
       tags:
         - platform
       responses:
@@ -21963,21 +21996,6 @@ paths:
                     anyOf:
                       - type: string
                       - type: "null"
-                  velayTunnel:
-                    anyOf:
-                      - type: object
-                        properties:
-                          connected:
-                            type: boolean
-                          publicUrl:
-                            anyOf:
-                              - type: string
-                              - type: "null"
-                        required:
-                          - connected
-                          - publicUrl
-                        additionalProperties: false
-                      - type: "null"
                 required:
                   - isPlatform
                   - baseUrl
@@ -21988,7 +22006,6 @@ paths:
                   - available
                   - organizationId
                   - userId
-                  - velayTunnel
                 additionalProperties: false
   /v1/playground/seed-conversation:
     post:

--- a/assistant/src/cli/commands/__tests__/gateway.test.ts
+++ b/assistant/src/cli/commands/__tests__/gateway.test.ts
@@ -180,6 +180,44 @@ describe("gateway logs tail — IPC params", () => {
 });
 
 // ---------------------------------------------------------------------------
+// gateway status
+// ---------------------------------------------------------------------------
+
+describe("gateway status", () => {
+  test("--json passes through the connected tunnel payload", async () => {
+    mockResponses.push({
+      ok: true,
+      result: { tunnel: "https://abc123.vellum.ai" },
+    });
+
+    const { stdout, exitCode } = await runCommand([
+      "gateway",
+      "status",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls[0].method).toBe("gateway_status");
+    expect(JSON.parse(stdout.trim())).toEqual({
+      tunnel: "https://abc123.vellum.ai",
+    });
+  });
+
+  test("--json emits {} when no tunnel is connected", async () => {
+    mockResponses.push({ ok: true, result: {} });
+
+    const { stdout, exitCode } = await runCommand([
+      "gateway",
+      "status",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.trim())).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Pretty-print output
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/cli/commands/__tests__/gateway.test.ts
+++ b/assistant/src/cli/commands/__tests__/gateway.test.ts
@@ -33,6 +33,7 @@ let mockResponses: Array<{
   ok: boolean;
   result?: unknown;
   error?: string;
+  statusCode?: number;
 }> = [];
 
 // ---------------------------------------------------------------------------
@@ -43,6 +44,10 @@ mock.module("../../../ipc/cli-client.js", () => ({
   cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
     ipcCalls.push({ method, params });
     return mockResponses.shift() ?? { ok: true, result: null };
+  },
+  exitFromIpcResult: (r: { error?: string }) => {
+    process.exitCode = 1;
+    if (r.error) process.stderr.write(r.error);
   },
 }));
 
@@ -214,6 +219,18 @@ describe("gateway status", () => {
 
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout.trim())).toEqual({});
+  });
+
+  test("exits non-zero when the gateway is not running", async () => {
+    mockResponses.push({
+      ok: false,
+      error: "Gateway is not running or is unreachable over IPC.",
+      statusCode: 503,
+    });
+
+    const { exitCode } = await runCommand(["gateway", "status"]);
+
+    expect(exitCode).not.toBe(0);
   });
 });
 

--- a/assistant/src/cli/commands/gateway.help.ts
+++ b/assistant/src/cli/commands/gateway.help.ts
@@ -11,11 +11,36 @@ manages trust rules, routes traffic to the assistant, and records
 structured logs for all inbound activity.
 
 Examples:
+  $ assistant gateway status
   $ assistant gateway logs tail
   $ assistant gateway logs tail -n 50
   $ assistant gateway logs tail --level warn
   $ assistant gateway logs tail --module cors`,
   subcommands: [
+    {
+      name: "status",
+      description: "Show gateway status (Velay tunnel state)",
+      helpText: `
+Reports the live status of the gateway's Velay tunnel — the outbound
+public-ingress transport.
+
+The Velay tunnel is ONLY used to tunnel inbound Twilio webhooks and live
+voice/audio WebSockets through to this assistant. It has nothing to do with
+platform credentials, the managed LLM proxy, or text channels. If you are not
+using Twilio voice or live audio, a "disconnected" tunnel is expected and
+harmless.
+
+Fields (--json):
+  velayTunnel            Live tunnel status, or null when the gateway is not
+                         running.
+  velayTunnel.connected  Whether the tunnel is currently registered (boolean).
+  velayTunnel.publicUrl  The public base URL Twilio/voice traffic arrives on,
+                         or null when disconnected.
+
+Examples:
+  $ assistant gateway status
+  $ assistant gateway status --json`,
+    },
     {
       name: "logs",
       description: "Gateway log operations",

--- a/assistant/src/cli/commands/gateway.help.ts
+++ b/assistant/src/cli/commands/gateway.help.ts
@@ -19,23 +19,26 @@ Examples:
   subcommands: [
     {
       name: "status",
-      description: "Show gateway status (Velay tunnel state)",
+      description: "Show gateway status (public tunnel state)",
+      options: [
+        {
+          flags: "--json",
+          description: "Machine-readable compact JSON output",
+        },
+      ],
       helpText: `
-Reports the live status of the gateway's Velay tunnel — the outbound
-public-ingress transport.
+Reports the live status of the gateway's public tunnel — the outbound
+public-ingress transport (currently Velay).
 
-The Velay tunnel is ONLY used to tunnel inbound Twilio webhooks and live
-voice/audio WebSockets through to this assistant. It has nothing to do with
-platform credentials, the managed LLM proxy, or text channels. If you are not
-using Twilio voice or live audio, a "disconnected" tunnel is expected and
-harmless.
+The tunnel is ONLY used to route inbound Twilio webhooks and live voice/audio
+WebSockets through to this assistant. It has nothing to do with platform
+credentials, the managed LLM proxy, or text channels. If you are not using
+Twilio voice or live audio, a "not connected" tunnel is expected and harmless.
 
-Fields (--json):
-  velayTunnel            Live tunnel status, or null when the gateway is not
-                         running.
-  velayTunnel.connected  Whether the tunnel is currently registered (boolean).
-  velayTunnel.publicUrl  The public base URL Twilio/voice traffic arrives on,
-                         or null when disconnected.
+JSON output (--json):
+  { "tunnel": "<public-url>" }   when a tunnel is connected
+  { }                            when no tunnel is connected (or the gateway
+                                 is not running)
 
 Examples:
   $ assistant gateway status

--- a/assistant/src/cli/commands/gateway.help.ts
+++ b/assistant/src/cli/commands/gateway.help.ts
@@ -37,8 +37,10 @@ Twilio voice or live audio, a "not connected" tunnel is expected and harmless.
 
 JSON output (--json):
   { "tunnel": "<public-url>" }   when a tunnel is connected
-  { }                            when no tunnel is connected (or the gateway
-                                 is not running)
+  { }                            when the gateway is running but no tunnel is up
+
+If the gateway itself is not running, the command exits non-zero with an error
+rather than reporting an empty tunnel.
 
 Examples:
   $ assistant gateway status

--- a/assistant/src/cli/commands/gateway.ts
+++ b/assistant/src/cli/commands/gateway.ts
@@ -25,7 +25,7 @@ interface PinoEntry {
 }
 
 interface GatewayStatusResult {
-  velayTunnel: { connected: boolean; publicUrl: string | null } | null;
+  tunnel?: string;
 }
 
 // -- Helpers ------------------------------------------------------------------
@@ -90,18 +90,13 @@ export function registerGatewayCommand(program: Command): void {
           return;
         }
 
-        if (result.velayTunnel === null) {
-          log.info("Velay tunnel: (gateway not running)");
-        } else if (result.velayTunnel.connected) {
-          const url = result.velayTunnel.publicUrl
-            ? ` (${result.velayTunnel.publicUrl})`
-            : "";
-          log.info(`Velay tunnel: connected${url}`);
+        if (result.tunnel) {
+          log.info(`Tunnel: connected (${result.tunnel})`);
         } else {
-          log.info("Velay tunnel: disconnected");
+          log.info("Tunnel: not connected");
         }
         log.info(
-          "  The Velay tunnel is only used to tunnel inbound Twilio webhooks and",
+          "  The public tunnel is only used to route inbound Twilio webhooks and",
         );
         log.info(
           "  live voice/audio WebSockets. It is not needed for text channels or",

--- a/assistant/src/cli/commands/gateway.ts
+++ b/assistant/src/cli/commands/gateway.ts
@@ -2,12 +2,13 @@
  * `assistant gateway` CLI namespace.
  *
  * Subcommands:
+ *   status   — Show the gateway's public tunnel status via the daemon IPC proxy.
  *   logs tail — Show the last N gateway log entries via the daemon IPC proxy.
  */
 
 import type { Command } from "commander";
 
-import { cliIpcCall } from "../../ipc/cli-client.js";
+import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
 import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
@@ -77,11 +78,11 @@ export function registerGatewayCommand(program: Command): void {
 
       subcommand(gateway, "status").action(async (_opts, cmd: Command) => {
         const r = await cliIpcCall<GatewayStatusResult>("gateway_status", {});
-        if (!r.ok) {
-          log.error(r.error ?? "Failed to fetch gateway status");
-          process.exitCode = 1;
-          return;
-        }
+        if (!r.ok)
+          return exitFromIpcResult(
+            { ok: false, error: r.error, statusCode: r.statusCode },
+            cmd,
+          );
 
         const result = r.result!;
 

--- a/assistant/src/cli/commands/gateway.ts
+++ b/assistant/src/cli/commands/gateway.ts
@@ -11,6 +11,7 @@ import { cliIpcCall } from "../../ipc/cli-client.js";
 import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
 import { gatewayHelp } from "./gateway.help.js";
 
 // -- Types --------------------------------------------------------------------
@@ -21,6 +22,10 @@ interface PinoEntry {
   module?: string;
   msg?: string;
   [key: string]: unknown;
+}
+
+interface GatewayStatusResult {
+  velayTunnel: { connected: boolean; publicUrl: string | null } | null;
 }
 
 // -- Helpers ------------------------------------------------------------------
@@ -65,6 +70,44 @@ export function registerGatewayCommand(program: Command): void {
     description: gatewayHelp.description,
     build: (gateway) => {
       applyCommandHelp(gateway, gatewayHelp);
+
+      // -----------------------------------------------------------------------
+      // status
+      // -----------------------------------------------------------------------
+
+      subcommand(gateway, "status").action(async (_opts, cmd: Command) => {
+        const r = await cliIpcCall<GatewayStatusResult>("gateway_status", {});
+        if (!r.ok) {
+          log.error(r.error ?? "Failed to fetch gateway status");
+          process.exitCode = 1;
+          return;
+        }
+
+        const result = r.result!;
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, result);
+          return;
+        }
+
+        if (result.velayTunnel === null) {
+          log.info("Velay tunnel: (gateway not running)");
+        } else if (result.velayTunnel.connected) {
+          const url = result.velayTunnel.publicUrl
+            ? ` (${result.velayTunnel.publicUrl})`
+            : "";
+          log.info(`Velay tunnel: connected${url}`);
+        } else {
+          log.info("Velay tunnel: disconnected");
+        }
+        log.info(
+          "  The Velay tunnel is only used to tunnel inbound Twilio webhooks and",
+        );
+        log.info(
+          "  live voice/audio WebSockets. It is not needed for text channels or",
+        );
+        log.info("  the managed LLM proxy.");
+      });
 
       const logs = subcommand(gateway, "logs");
 

--- a/assistant/src/cli/commands/platform/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/status.test.ts
@@ -18,7 +18,6 @@ let mockResponse: unknown = {
     available: false,
     organizationId: null,
     userId: null,
-    velayTunnel: null,
   },
 };
 
@@ -63,7 +62,6 @@ describe("assistant platform status", () => {
         available: false,
         organizationId: null,
         userId: null,
-        velayTunnel: null,
       },
     };
     process.exitCode = 0;
@@ -81,7 +79,6 @@ describe("assistant platform status", () => {
         available: true,
         organizationId: "org-456",
         userId: "user-789",
-        velayTunnel: null,
       },
     };
 
@@ -116,93 +113,6 @@ describe("assistant platform status", () => {
     expect(parsed.available).toBe(true);
     expect(parsed.organizationId).toBe("org-456");
     expect(parsed.userId).toBe("user-789");
-    expect(parsed.velayTunnel).toBeNull();
-  });
-
-  test("velayTunnel connected with publicUrl is returned when gateway is live", async () => {
-    mockResponse = {
-      ok: true,
-      result: {
-        isPlatform: false,
-        baseUrl: "",
-        assistantId: "",
-        hasAssistantApiKey: false,
-        hasWebhookSecret: false,
-        available: false,
-        organizationId: null,
-        userId: null,
-        velayTunnel: {
-          connected: true,
-          publicUrl: "https://abc123.vellum.ai",
-        },
-      },
-    };
-
-    const program = buildProgram();
-    const stdoutChunks: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: unknown) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
-      return true;
-    }) as typeof process.stdout.write;
-
-    try {
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "status",
-        "--json",
-      ]);
-    } finally {
-      process.stdout.write = origWrite;
-    }
-
-    const parsed = JSON.parse(stdoutChunks.join(""));
-    expect(parsed.velayTunnel).toEqual({
-      connected: true,
-      publicUrl: "https://abc123.vellum.ai",
-    });
-  });
-
-  test("velayTunnel disconnected when gateway reports no active connection", async () => {
-    mockResponse = {
-      ok: true,
-      result: {
-        isPlatform: false,
-        baseUrl: "",
-        assistantId: "",
-        hasAssistantApiKey: false,
-        hasWebhookSecret: false,
-        available: false,
-        organizationId: null,
-        userId: null,
-        velayTunnel: { connected: false, publicUrl: null },
-      },
-    };
-
-    const program = buildProgram();
-    const stdoutChunks: string[] = [];
-    const origWrite = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: unknown) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
-      return true;
-    }) as typeof process.stdout.write;
-
-    try {
-      await program.parseAsync([
-        "node",
-        "assistant",
-        "platform",
-        "status",
-        "--json",
-      ]);
-    } finally {
-      process.stdout.write = origWrite;
-    }
-
-    const parsed = JSON.parse(stdoutChunks.join(""));
-    expect(parsed.velayTunnel).toEqual({ connected: false, publicUrl: null });
   });
 
   test("plain text mode does not emit JSON to stdout", async () => {

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -58,8 +58,9 @@ Fields:
   available           Whether callback registration prerequisites are satisfied
   organizationId      The platform organization ID (from stored credentials)
   userId              The platform user ID (from stored credentials)
-  velayTunnel         Live Velay tunnel status from the gateway IPC socket
-                      (null when the gateway is not running)
+
+For the Velay tunnel state (only relevant for Twilio webhooks and live
+voice/audio), use 'assistant gateway status' instead.
 
 Examples:
   $ assistant platform status

--- a/assistant/src/cli/commands/platform/index.ts
+++ b/assistant/src/cli/commands/platform/index.ts
@@ -24,7 +24,6 @@ interface PlatformStatusResult {
   available: boolean;
   organizationId: string | null;
   userId: string | null;
-  velayTunnel: { connected: boolean; publicUrl: string | null } | null;
 }
 
 interface PlatformCreditsResult {
@@ -87,14 +86,6 @@ export function registerPlatformCommand(program: Command): void {
               `Organization ID: ${result.organizationId || "(not set)"}`,
             );
             log.info(`User ID: ${result.userId || "(not set)"}`);
-            if (result.velayTunnel !== null) {
-              const tunnelState = result.velayTunnel.connected
-                ? `connected${result.velayTunnel.publicUrl ? ` (${result.velayTunnel.publicUrl})` : ""}`
-                : "disconnected";
-              log.info(`Velay tunnel: ${tunnelState}`);
-            } else {
-              log.info(`Velay tunnel: (gateway not running)`);
-            }
           }
         },
       );

--- a/assistant/src/config/bundled-skills/phone-calls/references/TROUBLESHOOTING.md
+++ b/assistant/src/config/bundled-skills/phone-calls/references/TROUBLESHOOTING.md
@@ -16,18 +16,18 @@ First check whether this is a managed/platform assistant:
 assistant platform status --json
 ```
 
-If it reports an available platform assistant, do not install or start ngrok for Twilio. The gateway should use Velay, and `velayTunnel.connected` should become `true` after registration. If this is a local/self-hosted assistant without Velay, run the **public-ingress** skill to set up ngrok or another custom tunnel and configure `ingress.publicBaseUrl`.
+If it reports an available platform assistant, do not install or start ngrok for Twilio. The gateway should use Velay; run `assistant gateway status --json` and confirm `velayTunnel.connected` becomes `true` after registration. If this is a local/self-hosted assistant without Velay, run the **public-ingress** skill to set up ngrok or another custom tunnel and configure `ingress.publicBaseUrl`.
 
 ## Call fails immediately after initiating
 
 - Check that the phone number is in E.164 format
 - Verify Twilio credentials are correct (wrong auth token causes API errors)
 - On trial accounts, ensure the destination number is verified
-- Check that the configured tunnel is still running. For ngrok, use `curl -s http://127.0.0.1:4040/api/tunnels`. For Velay, run `assistant platform status --json` and confirm `velayTunnel.connected` is `true`, or check gateway logs for `Velay tunnel registered`.
+- Check that the configured tunnel is still running. For ngrok, use `curl -s http://127.0.0.1:4040/api/tunnels`. For Velay, run `assistant gateway status --json` and confirm `velayTunnel.connected` is `true`, or check gateway logs for `Velay tunnel registered`.
 
 ## Call connects but no audio / one-way audio
 
-- The media-stream WebSocket may not be connecting. If you are using ngrok or a custom tunnel, check that `ingress.publicBaseUrl` is correct and the tunnel is active. If you are using Velay, check `assistant platform status --json`; a 503 from `https://velay.../<assistant-id>/...` usually means the assistant tunnel is not connected or the gateway did not complete the WebSocket open, not that ngrok is required.
+- The media-stream WebSocket may not be connecting. If you are using ngrok or a custom tunnel, check that `ingress.publicBaseUrl` is correct and the tunnel is active. If you are using Velay, check `assistant gateway status --json`; a 503 from `https://velay.../<assistant-id>/...` usually means the assistant tunnel is not connected or the gateway did not complete the WebSocket open, not that ngrok is required.
 - Verify the assistant is running
 
 ## "Number not eligible for caller identity"

--- a/assistant/src/config/bundled-skills/phone-calls/references/TROUBLESHOOTING.md
+++ b/assistant/src/config/bundled-skills/phone-calls/references/TROUBLESHOOTING.md
@@ -16,14 +16,14 @@ First check whether this is a managed/platform assistant:
 assistant platform status --json
 ```
 
-If it reports an available platform assistant, do not install or start ngrok for Twilio. The gateway should use Velay; run `assistant gateway status --json` and confirm `velayTunnel.connected` becomes `true` after registration. If this is a local/self-hosted assistant without Velay, run the **public-ingress** skill to set up ngrok or another custom tunnel and configure `ingress.publicBaseUrl`.
+If it reports an available platform assistant, do not install or start ngrok for Twilio. The gateway should use Velay; run `assistant gateway status --json` and confirm it reports a `tunnel` URL (a `{ "tunnel": "..." }` object, not `{}`) after registration. If this is a local/self-hosted assistant without Velay, run the **public-ingress** skill to set up ngrok or another custom tunnel and configure `ingress.publicBaseUrl`.
 
 ## Call fails immediately after initiating
 
 - Check that the phone number is in E.164 format
 - Verify Twilio credentials are correct (wrong auth token causes API errors)
 - On trial accounts, ensure the destination number is verified
-- Check that the configured tunnel is still running. For ngrok, use `curl -s http://127.0.0.1:4040/api/tunnels`. For Velay, run `assistant gateway status --json` and confirm `velayTunnel.connected` is `true`, or check gateway logs for `Velay tunnel registered`.
+- Check that the configured tunnel is still running. For ngrok, use `curl -s http://127.0.0.1:4040/api/tunnels`. For Velay, run `assistant gateway status --json` and confirm it reports a `tunnel` URL (not `{}`), or check gateway logs for `Velay tunnel registered`.
 
 ## Call connects but no audio / one-way audio
 

--- a/assistant/src/runtime/routes/__tests__/gateway-status-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/gateway-status-routes.test.ts
@@ -39,40 +39,44 @@ describe("gateway_status route", () => {
     expect(gatewayStatusRoute.endpoint).toBe("gateway/status");
   });
 
-  test("returns connected tunnel status with publicUrl", async () => {
+  test("returns the tunnel URL when a tunnel is connected", async () => {
     ipcResult = { connected: true, publicUrl: "https://abc123.vellum.ai" };
 
     const result = await gatewayStatusRoute.handler({});
 
-    expect(result).toEqual({
-      velayTunnel: { connected: true, publicUrl: "https://abc123.vellum.ai" },
-    });
+    expect(result).toEqual({ tunnel: "https://abc123.vellum.ai" });
   });
 
-  test("returns disconnected tunnel status", async () => {
+  test("returns {} when the tunnel is disconnected", async () => {
     ipcResult = { connected: false, publicUrl: null };
 
     const result = await gatewayStatusRoute.handler({});
 
-    expect(result).toEqual({
-      velayTunnel: { connected: false, publicUrl: null },
-    });
+    expect(result).toEqual({});
   });
 
-  test("returns null velayTunnel when the gateway is unreachable", async () => {
+  test("returns {} when connected but no public URL is registered yet", async () => {
+    ipcResult = { connected: true, publicUrl: null };
+
+    const result = await gatewayStatusRoute.handler({});
+
+    expect(result).toEqual({});
+  });
+
+  test("returns {} when the gateway is unreachable", async () => {
     ipcResult = null;
 
     const result = await gatewayStatusRoute.handler({});
 
-    expect(result).toEqual({ velayTunnel: null });
+    expect(result).toEqual({});
   });
 
-  test("swallows gateway IPC errors and reports the gateway as not running", async () => {
+  test("swallows gateway IPC errors and reports no tunnel", async () => {
     ipcError = new Error("Gateway IPC socket disconnected");
 
     const result = await gatewayStatusRoute.handler({});
 
     expect(ipcCallCount).toBe(1);
-    expect(result).toEqual({ velayTunnel: null });
+    expect(result).toEqual({});
   });
 });

--- a/assistant/src/runtime/routes/__tests__/gateway-status-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/gateway-status-routes.test.ts
@@ -4,6 +4,8 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { ServiceUnavailableError } from "../errors.js";
+
 let ipcResult: unknown = null;
 let ipcError: Error | undefined;
 let ipcCallCount = 0;
@@ -63,20 +65,20 @@ describe("gateway_status route", () => {
     expect(result).toEqual({});
   });
 
-  test("returns {} when the gateway is unreachable", async () => {
+  test("errors with 503 when the gateway is unreachable", async () => {
     ipcResult = null;
 
-    const result = await gatewayStatusRoute.handler({});
-
-    expect(result).toEqual({});
+    await expect(gatewayStatusRoute.handler({})).rejects.toBeInstanceOf(
+      ServiceUnavailableError,
+    );
   });
 
-  test("swallows gateway IPC errors and reports no tunnel", async () => {
+  test("errors when the gateway IPC call throws (gateway not running)", async () => {
     ipcError = new Error("Gateway IPC socket disconnected");
 
-    const result = await gatewayStatusRoute.handler({});
-
+    await expect(gatewayStatusRoute.handler({})).rejects.toBeInstanceOf(
+      ServiceUnavailableError,
+    );
     expect(ipcCallCount).toBe(1);
-    expect(result).toEqual({});
   });
 });

--- a/assistant/src/runtime/routes/__tests__/gateway-status-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/gateway-status-routes.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the gateway_status route handler.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let ipcResult: unknown = null;
+let ipcError: Error | undefined;
+let ipcCallCount = 0;
+
+const ipcGetVelayStatusMock = mock(async () => {
+  ipcCallCount += 1;
+  if (ipcError) throw ipcError;
+  return ipcResult;
+});
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ipcGetVelayStatus: ipcGetVelayStatusMock,
+}));
+
+import { ROUTES } from "../gateway-status-routes.js";
+
+const gatewayStatusRoute = ROUTES.find(
+  (r) => r.operationId === "gateway_status",
+)!;
+
+describe("gateway_status route", () => {
+  beforeEach(() => {
+    ipcResult = null;
+    ipcError = undefined;
+    ipcCallCount = 0;
+    ipcGetVelayStatusMock.mockClear();
+  });
+
+  test("route is registered with correct operationId, method, and endpoint", () => {
+    expect(gatewayStatusRoute).toBeDefined();
+    expect(gatewayStatusRoute.operationId).toBe("gateway_status");
+    expect(gatewayStatusRoute.method).toBe("GET");
+    expect(gatewayStatusRoute.endpoint).toBe("gateway/status");
+  });
+
+  test("returns connected tunnel status with publicUrl", async () => {
+    ipcResult = { connected: true, publicUrl: "https://abc123.vellum.ai" };
+
+    const result = await gatewayStatusRoute.handler({});
+
+    expect(result).toEqual({
+      velayTunnel: { connected: true, publicUrl: "https://abc123.vellum.ai" },
+    });
+  });
+
+  test("returns disconnected tunnel status", async () => {
+    ipcResult = { connected: false, publicUrl: null };
+
+    const result = await gatewayStatusRoute.handler({});
+
+    expect(result).toEqual({
+      velayTunnel: { connected: false, publicUrl: null },
+    });
+  });
+
+  test("returns null velayTunnel when the gateway is unreachable", async () => {
+    ipcResult = null;
+
+    const result = await gatewayStatusRoute.handler({});
+
+    expect(result).toEqual({ velayTunnel: null });
+  });
+
+  test("swallows gateway IPC errors and reports the gateway as not running", async () => {
+    ipcError = new Error("Gateway IPC socket disconnected");
+
+    const result = await gatewayStatusRoute.handler({});
+
+    expect(ipcCallCount).toBe(1);
+    expect(result).toEqual({ velayTunnel: null });
+  });
+});

--- a/assistant/src/runtime/routes/gateway-status-routes.ts
+++ b/assistant/src/runtime/routes/gateway-status-routes.ts
@@ -1,0 +1,56 @@
+/**
+ * Gateway status route — Velay tunnel status via the gateway IPC proxy.
+ *
+ * The Velay tunnel is the gateway's outbound public-ingress transport. It is
+ * only used to tunnel inbound Twilio webhooks and live voice/audio WebSockets
+ * to this assistant — it plays no part in platform credentials or the managed
+ * LLM proxy. The handler reads the live status from the gateway over the local
+ * IPC socket, so the assistant does not need gateway signing material.
+ */
+import { z } from "zod";
+
+import { ipcGetVelayStatus } from "../../ipc/gateway-client.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// ── Schemas ─────────────────────────────────────────────────────────────
+
+const VelayTunnelStatusSchema = z.object({
+  connected: z.boolean(),
+  publicUrl: z.string().nullable(),
+});
+
+const GatewayStatusResponseSchema = z.object({
+  // null when the gateway is unreachable (i.e. not running).
+  velayTunnel: VelayTunnelStatusSchema.nullable(),
+});
+type GatewayStatusResponse = z.infer<typeof GatewayStatusResponseSchema>;
+
+// ── Handlers ────────────────────────────────────────────────────────────
+
+async function handleGatewayStatus(
+  _args: RouteHandlerArgs,
+): Promise<GatewayStatusResponse> {
+  const velayTunnel = await ipcGetVelayStatus().catch(() => null);
+  return { velayTunnel };
+}
+
+// ── Route definitions ───────────────────────────────────────────────────
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "gateway_status",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    endpoint: "gateway/status",
+    handler: handleGatewayStatus,
+    summary: "Get gateway status",
+    description:
+      "Reports the live Velay tunnel status from the gateway. The Velay tunnel only matters for tunnelling inbound Twilio webhooks and live voice/audio WebSockets; velayTunnel is null when the gateway is not running.",
+    tags: ["gateway"],
+    responseBody: GatewayStatusResponseSchema,
+  },
+];

--- a/assistant/src/runtime/routes/gateway-status-routes.ts
+++ b/assistant/src/runtime/routes/gateway-status-routes.ts
@@ -1,11 +1,16 @@
 /**
- * Gateway status route — Velay tunnel status via the gateway IPC proxy.
+ * Gateway status route — public tunnel status via the gateway IPC proxy.
  *
- * The Velay tunnel is the gateway's outbound public-ingress transport. It is
- * only used to tunnel inbound Twilio webhooks and live voice/audio WebSockets
- * to this assistant — it plays no part in platform credentials or the managed
+ * The tunnel is the gateway's outbound public-ingress transport. It is only
+ * used to tunnel inbound Twilio webhooks and live voice/audio WebSockets to
+ * this assistant — it plays no part in platform credentials or the managed
  * LLM proxy. The handler reads the live status from the gateway over the local
  * IPC socket, so the assistant does not need gateway signing material.
+ *
+ * The response is deliberately tunnel-agnostic: a single `tunnel` field holding
+ * the active public URL, omitted entirely when no tunnel is connected. This
+ * keeps the contract stable if the underlying transport (currently Velay) is
+ * ever swapped for another tunnel.
  */
 import { z } from "zod";
 
@@ -15,14 +20,10 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Schemas ─────────────────────────────────────────────────────────────
 
-const VelayTunnelStatusSchema = z.object({
-  connected: z.boolean(),
-  publicUrl: z.string().nullable(),
-});
-
 const GatewayStatusResponseSchema = z.object({
-  // null when the gateway is unreachable (i.e. not running).
-  velayTunnel: VelayTunnelStatusSchema.nullable(),
+  // Present with the public tunnel URL when a tunnel is connected; omitted
+  // (so the object is `{}`) when no tunnel is up or the gateway is not running.
+  tunnel: z.string().optional(),
 });
 type GatewayStatusResponse = z.infer<typeof GatewayStatusResponseSchema>;
 
@@ -31,8 +32,10 @@ type GatewayStatusResponse = z.infer<typeof GatewayStatusResponseSchema>;
 async function handleGatewayStatus(
   _args: RouteHandlerArgs,
 ): Promise<GatewayStatusResponse> {
-  const velayTunnel = await ipcGetVelayStatus().catch(() => null);
-  return { velayTunnel };
+  const status = await ipcGetVelayStatus().catch(() => null);
+  return status?.connected && status.publicUrl
+    ? { tunnel: status.publicUrl }
+    : {};
 }
 
 // ── Route definitions ───────────────────────────────────────────────────
@@ -49,7 +52,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handleGatewayStatus,
     summary: "Get gateway status",
     description:
-      "Reports the live Velay tunnel status from the gateway. The Velay tunnel only matters for tunnelling inbound Twilio webhooks and live voice/audio WebSockets; velayTunnel is null when the gateway is not running.",
+      "Reports the gateway's public tunnel status. `tunnel` holds the active public URL when a tunnel is connected and is omitted otherwise. The tunnel only matters for routing inbound Twilio webhooks and live voice/audio WebSockets.",
     tags: ["gateway"],
     responseBody: GatewayStatusResponseSchema,
   },

--- a/assistant/src/runtime/routes/gateway-status-routes.ts
+++ b/assistant/src/runtime/routes/gateway-status-routes.ts
@@ -8,14 +8,16 @@
  * IPC socket, so the assistant does not need gateway signing material.
  *
  * The response is deliberately tunnel-agnostic: a single `tunnel` field holding
- * the active public URL, omitted entirely when no tunnel is connected. This
- * keeps the contract stable if the underlying transport (currently Velay) is
- * ever swapped for another tunnel.
+ * the active public URL, omitted entirely when a tunnel is up but has no URL.
+ * This keeps the contract stable if the underlying transport (currently Velay)
+ * is ever swapped for another tunnel. If the gateway is not running (no IPC
+ * answer), the handler errors instead of returning an empty result.
  */
 import { z } from "zod";
 
 import { ipcGetVelayStatus } from "../../ipc/gateway-client.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { ServiceUnavailableError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Schemas ─────────────────────────────────────────────────────────────
@@ -33,7 +35,15 @@ async function handleGatewayStatus(
   _args: RouteHandlerArgs,
 ): Promise<GatewayStatusResponse> {
   const status = await ipcGetVelayStatus().catch(() => null);
-  return status?.connected && status.publicUrl
+  // A null status means the gateway did not answer over IPC — i.e. it is not
+  // running. That is a fatal condition for this command, not a "no tunnel"
+  // state, so surface it as an error rather than an empty result.
+  if (status === null) {
+    throw new ServiceUnavailableError(
+      "Gateway is not running or is unreachable over IPC.",
+    );
+  }
+  return status.connected && status.publicUrl
     ? { tunnel: status.publicUrl }
     : {};
 }
@@ -52,7 +62,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handleGatewayStatus,
     summary: "Get gateway status",
     description:
-      "Reports the gateway's public tunnel status. `tunnel` holds the active public URL when a tunnel is connected and is omitted otherwise. The tunnel only matters for routing inbound Twilio webhooks and live voice/audio WebSockets.",
+      "Reports the gateway's public tunnel status. `tunnel` holds the active public URL when a tunnel is connected and is omitted otherwise. Errors with 503 when the gateway is not running. The tunnel only matters for routing inbound Twilio webhooks and live voice/audio WebSockets.",
     tags: ["gateway"],
     responseBody: GatewayStatusResponseSchema,
   },

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -68,6 +68,7 @@ import { ROUTES as EMAIL_ROUTES } from "./email-routes.js";
 import { ROUTES as EVENTS_ROUTES } from "./events-routes.js";
 import { ROUTES as FILING_ROUTES } from "./filing-routes.js";
 import { ROUTES as GATEWAY_LOG_ROUTES } from "./gateway-log-routes.js";
+import { ROUTES as GATEWAY_STATUS_ROUTES } from "./gateway-status-routes.js";
 import { ROUTES as GLOBAL_SEARCH_ROUTES } from "./global-search-routes.js";
 import { ROUTES as GROUP_ROUTES } from "./group-routes.js";
 import { ROUTES as GUARDIAN_ACTION_ROUTES } from "./guardian-action-routes.js";
@@ -210,6 +211,7 @@ export const ROUTES: RouteDefinition[] = [
   ...EVENTS_ROUTES,
   ...FILING_ROUTES,
   ...GATEWAY_LOG_ROUTES,
+  ...GATEWAY_STATUS_ROUTES,
   ...GLOBAL_SEARCH_ROUTES,
   ...GROUP_ROUTES,
   ...GUARDIAN_ACTION_ROUTES,

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -3,7 +3,8 @@
  *
  * Serves six operations:
  *   - platform_status (GET platform/status): aggregates platform context,
- *     credentials, assistant ID, webhook secret, and Velay tunnel status.
+ *     credentials, assistant ID, and webhook secret. (Velay tunnel status
+ *     lives on the gateway — see gateway_status.)
  *   - platform_connect (POST platform/connect): checks existing credentials
  *     and emits the show_platform_login signal to connected clients.
  *   - platform_disconnect (POST platform/disconnect): deletes stored platform
@@ -23,7 +24,6 @@ import {
   registerCallbackRoute,
   resolvePlatformCallbackRegistrationContext,
 } from "../../inbound/platform-callback-registration.js";
-import { ipcGetVelayStatus } from "../../ipc/gateway-client.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
@@ -56,11 +56,6 @@ const CREDENTIAL_KEYS = {
 // Schemas
 // ---------------------------------------------------------------------------
 
-const VelayTunnelStatusSchema = z.object({
-  connected: z.boolean(),
-  publicUrl: z.string().nullable(),
-});
-
 const PlatformStatusResponseSchema = z.object({
   isPlatform: z.boolean(),
   baseUrl: z.string(),
@@ -71,7 +66,6 @@ const PlatformStatusResponseSchema = z.object({
   available: z.boolean(),
   organizationId: z.string().nullable(),
   userId: z.string().nullable(),
-  velayTunnel: VelayTunnelStatusSchema.nullable(),
 });
 type PlatformStatusResponse = z.infer<typeof PlatformStatusResponseSchema>;
 
@@ -137,10 +131,7 @@ type PlatformCreditsResponse = z.infer<typeof PlatformCreditsResponseSchema>;
 async function handlePlatformStatus(
   _args: RouteHandlerArgs,
 ): Promise<PlatformStatusResponse> {
-  const [context, velayTunnel] = await Promise.all([
-    resolvePlatformCallbackRegistrationContext(),
-    ipcGetVelayStatus().catch(() => null),
-  ]);
+  const context = await resolvePlatformCallbackRegistrationContext();
 
   const [orgIdRaw, userIdRaw, webhookSecretRaw] = await Promise.all([
     getSecureKeyAsync(
@@ -172,7 +163,6 @@ async function handlePlatformStatus(
     available: context.enabled,
     organizationId: organizationId || null,
     userId: userId || null,
-    velayTunnel,
   };
 }
 
@@ -433,7 +423,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Get platform deployment context and connection status",
     description:
-      "Aggregates platform context, credentials, assistant ID, webhook secret, and Velay tunnel status.",
+      "Aggregates platform context, credentials, assistant ID, and webhook secret. Velay tunnel status is reported separately by gateway_status.",
     tags: ["platform"],
     handler: handlePlatformStatus,
     responseBody: PlatformStatusResponseSchema,

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -123,6 +123,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "db status",
   "db repair",
   "gateway",
+  "gateway status",
   "gateway logs",
   "gateway logs tail",
   "image-generation",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -716,7 +716,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-14T10:48:52.000Z"
+      "updatedAt": "2026-07-14T12:09:21.000Z"
     },
     {
       "id": "public-ingress",
@@ -950,7 +950,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "updatedAt": "2026-07-14T19:51:12.000Z"
     },
     {
       "id": "typescript-eval",

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -59,9 +59,10 @@ Mark setup as started before doing any read-only checks. This lets a managed gat
 ```bash
 assistant config set twilio.setupStarted true
 assistant platform status --json
+assistant gateway status --json
 ```
 
-If `assistant platform status --json` reports an available platform assistant but `velayTunnel.connected` is `false`, continue with setup and check status again before configuring webhooks. Do not treat this as an ngrok setup problem unless the assistant is local/self-hosted without Velay.
+If `assistant platform status --json` reports an available platform assistant but `assistant gateway status --json` shows `velayTunnel.connected` is `false`, continue with setup and check status again before configuring webhooks. Do not treat this as an ngrok setup problem unless the assistant is local/self-hosted without Velay.
 
 Refer to "Checking Current Configuration" above to see the current state of the user's Twilio setup. If Twilio appears to be fully configured. Offer to show status or reconfigure. Otherwise, continue to the missing steps below.
 
@@ -165,9 +166,10 @@ Twilio needs publicly reachable HTTP webhooks and, for live calls, a publicly re
 
 ```bash
 assistant platform status --json
+assistant gateway status --json
 ```
 
-If this reports an available platform assistant and `velayTunnel.connected` is `true`, do not load `public-ingress` or install ngrok. Use the managed Velay route for the WebSocket leg. If `velayTunnel.connected` is `false`, restart or re-hatch the assistant/gateway and check gateway logs for `Velay tunnel registered`; do not treat that as an ngrok setup problem.
+If `assistant platform status --json` reports an available platform assistant and `assistant gateway status --json` shows `velayTunnel.connected` is `true`, do not load `public-ingress` or install ngrok. Use the managed Velay route for the WebSocket leg. If `velayTunnel.connected` is `false`, restart or re-hatch the assistant/gateway and check gateway logs for `Velay tunnel registered`; do not treat that as an ngrok setup problem.
 
 For local/self-hosted assistants without Velay, load the `public-ingress` skill to determine whether `ingress.publicBaseUrl` is configured and walk the user through setting one up if not.
 

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -62,7 +62,7 @@ assistant platform status --json
 assistant gateway status --json
 ```
 
-If `assistant platform status --json` reports an available platform assistant but `assistant gateway status --json` shows `velayTunnel.connected` is `false`, continue with setup and check status again before configuring webhooks. Do not treat this as an ngrok setup problem unless the assistant is local/self-hosted without Velay.
+If `assistant platform status --json` reports an available platform assistant but `assistant gateway status --json` returns `{}` (no `tunnel` URL yet), continue with setup and check status again before configuring webhooks. Do not treat this as an ngrok setup problem unless the assistant is local/self-hosted without Velay.
 
 Refer to "Checking Current Configuration" above to see the current state of the user's Twilio setup. If Twilio appears to be fully configured. Offer to show status or reconfigure. Otherwise, continue to the missing steps below.
 
@@ -169,7 +169,7 @@ assistant platform status --json
 assistant gateway status --json
 ```
 
-If `assistant platform status --json` reports an available platform assistant and `assistant gateway status --json` shows `velayTunnel.connected` is `true`, do not load `public-ingress` or install ngrok. Use the managed Velay route for the WebSocket leg. If `velayTunnel.connected` is `false`, restart or re-hatch the assistant/gateway and check gateway logs for `Velay tunnel registered`; do not treat that as an ngrok setup problem.
+If `assistant platform status --json` reports an available platform assistant and `assistant gateway status --json` reports a `tunnel` URL (a `{ "tunnel": "..." }` object), do not load `public-ingress` or install ngrok. Use the managed Velay route for the WebSocket leg. If it returns `{}`, restart or re-hatch the assistant/gateway and check gateway logs for `Velay tunnel registered`; do not treat that as an ngrok setup problem.
 
 For local/self-hosted assistants without Velay, load the `public-ingress` skill to determine whether `ingress.publicBaseUrl` is configured and walk the user through setting one up if not.
 


### PR DESCRIPTION
## Prompt / plan

`Velay tunnel: disconnected` was distracting noise on `assistant platform status` — it's really only relevant for Twilio and voice/WebSocket use cases. The ask was to move it to `assistant gateway status` and make clear that Velay is only needed for tunnelling live calls/audio.

The Velay tunnel is the gateway's outbound public-ingress transport; its status comes from the gateway IPC (`get_velay_status`). It has nothing to do with platform credentials or the managed LLM proxy, so it belongs under `gateway`, not `platform`.

**Changes**
- Add `assistant gateway status` — a new shared `gateway_status` route that reports the live Velay tunnel state (connected / disconnected / gateway-not-running) and clarifies inline + in `--help` that the tunnel only matters for inbound Twilio webhooks and live voice/audio WebSockets.
- Remove `velayTunnel` from `assistant platform status` entirely — text output, `--json` field, and the `platform_status` response schema. The platform status help now points to `gateway status`.
- Update the phone-calls `TROUBLESHOOTING.md` and `twilio-setup` `SKILL.md` to read `velayTunnel.connected` from `assistant gateway status --json` instead of `platform status --json`.
- Add `"gateway status"` to the gateway bash risk command registry.
- Regenerate `assistant/openapi.yaml` (drop `velayTunnel` from `platform_status`, add the `gateway_status` path).

## Test plan

- New unit tests: `gateway-status-routes.test.ts` (connected / disconnected / gateway-unreachable / IPC-error → null).
- Updated `platform status` CLI test to drop the removed `velayTunnel` field and its two velay-specific cases.
- `bunx tsc --noEmit` — clean (0 errors).
- `eslint` on all touched files — 0 errors.
- Gateway risk `command-registry` suite — 52 pass.
- The gitignored web client SDK regenerated cleanly from the updated OpenAPI spec, confirming the schema edit is well-formed.

## CLI verb checklist

- [x] This PR adds a new route (`gateway_status` in `assistant/src/runtime/routes/gateway-status-routes.ts`) and its `assistant gateway status` CLI wrapper in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSHwdsv1FByPi5qKbVHjSF)_