### PR TITLE
Trigger release cut at 8:52am ET, drop the wait-until-9am sleep

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -10,7 +10,7 @@ Cut a new release. Releases are a **two-step** process:
 1. **Branch cut → staging bake**: `create-release-branch.yml` computes the version from the bump type, deletes any stale `release/v<X.Y.Z>` branch, cuts a fresh one from `main` HEAD with the version-bump commit, and pushes it. That push triggers a `Release` run on the branch which is a **staging** deploy (push-triggered and main-dispatched `Release` runs are always staging).
 2. **Production**: dispatching `release.yml` **on the `release/v<X.Y.Z>` branch** runs the full production release — tag, GitHub Release, DMG sign/notarize/publish, npm packages, Docker Hub images, iOS TestFlight, platform dependency bump, and the merge-back of the release branch to `main`.
 
-The scheduled Tue/Fri 9am ET cut performs step 1 automatically; a human performs step 2 after the staging bake is green. A `release/v<X.Y.Z>` branch with no corresponding GitHub Release means a cut was never promoted — re-running step 1 refreshes it from current `main`.
+The scheduled Tue/Fri 8:52am ET cut performs step 1 automatically; a human performs step 2 after the staging bake is green. A `release/v<X.Y.Z>` branch with no corresponding GitHub Release means a cut was never promoted — re-running step 1 refreshes it from current `main`.
 
 The user may pass `$ARGUMENTS` as the bump type for step 1: `patch`, `minor`, `major`, or `hotfix` (patch cut from the latest release tag's commit instead of `main`, pushed `[skip ci]` for manual cherry-picks). Default to `patch`.
 

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -2,13 +2,11 @@ name: Create Release Branch
 
 on:
   schedule:
-    # Release at 9am ET every Tuesday and Friday. Two entries cover EDT (UTC-4)
-    # and EST (UTC-5); schedule-guard picks the one matching today's offset and
-    # drops the other. Scheduled at 7:50am ET (~70 min early) so GitHub's
-    # variable cron delay can't push us past 9am; schedule-guard then sleeps off
-    # the remaining buffer so the release lands at exactly 9am ET.
-    - cron: "50 11 * * 2,5"  # EDT: 7:50am ET
-    - cron: "50 12 * * 2,5"  # EST: 7:50am ET
+    # Release at 8:52am ET every Tuesday and Friday. Two entries cover EDT
+    # (UTC-4) and EST (UTC-5); schedule-guard picks the one matching today's
+    # offset and drops the other.
+    - cron: "52 12 * * 2,5"  # EDT: 8:52am ET
+    - cron: "52 13 * * 2,5"  # EST: 8:52am ET
   workflow_dispatch:
     inputs:
       bump:
@@ -31,41 +29,32 @@ concurrency:
 jobs:
   schedule-guard:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 5
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
     steps:
-      - name: Wait until 9am ET, then decide
+      - name: Pick the cron entry matching today's ET offset
         id: check
         run: |
           if [ "${{ github.event_name }}" != "schedule" ]; then
             echo "should-run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Two cron entries fire (11:50 and 12:50 UTC) to cover EDT/EST. Run
+          # Two cron entries fire (12:52 and 13:52 UTC) to cover EDT/EST. Run
           # only the entry matching today's Eastern offset so the release fires
           # once. Keying off the triggering cron (not the wall-clock hour at job
           # start) stays correct even when GitHub delays the scheduled run.
           OFFSET=$(TZ=America/New_York date +%z)
           if [ "$OFFSET" = "-0400" ]; then
-            EXPECTED="50 11 * * 2,5"  # EDT: 7:50am ET = 11:50 UTC
+            EXPECTED="52 12 * * 2,5"  # EDT: 8:52am ET = 12:52 UTC
           else
-            EXPECTED="50 12 * * 2,5"  # EST: 7:50am ET = 12:50 UTC
+            EXPECTED="52 13 * * 2,5"  # EST: 8:52am ET = 13:52 UTC
           fi
           if [ "${{ github.event.schedule }}" != "$EXPECTED" ]; then
             echo "should-run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "should-run=true" >> "$GITHUB_OUTPUT"
-          # Crons are scheduled ~70 min early to absorb GitHub's variable delay;
-          # sleep off whatever buffer remains so downstream jobs start at 9am ET.
-          # If GitHub already delayed us past 9am, proceed immediately.
-          TARGET=$(TZ=America/New_York date -d 'today 09:00' +%s)
-          NOW=$(date +%s)
-          if [ "$NOW" -lt "$TARGET" ]; then
-            echo "Waiting $((TARGET - NOW))s until 9:00am ET"
-            sleep $((TARGET - NOW))
-          fi
 
   compute-version:
     needs: schedule-guard

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -618,7 +618,7 @@ Releases are cut using the `/release` Claude Code command and follow a two-step 
 Run `/release [patch|minor|major|hotfix]` in Claude Code. The command:
 
 1. Pulls the latest `main` branch and shows the commits the release will carry
-2. Dispatches `create-release-branch.yml` with the bump type. The workflow computes the version from the latest tag, deletes any stale `release/vX.Y.Z` branch, cuts a fresh one from `main` HEAD with the version-bump commit ("Release vX.Y.Z"), and pushes it — which triggers a **staging** `Release` run on the branch (push-triggered and main-dispatched `Release` runs are always staging; the scheduled Tue/Fri 9am ET cut is this same step)
+2. Dispatches `create-release-branch.yml` with the bump type. The workflow computes the version from the latest tag, deletes any stale `release/vX.Y.Z` branch, cuts a fresh one from `main` HEAD with the version-bump commit ("Release vX.Y.Z"), and pushes it — which triggers a **staging** `Release` run on the branch (push-triggered and main-dispatched `Release` runs are always staging; the scheduled Tue/Fri 8:52am ET cut is this same step)
 3. Waits for the staging bake to succeed — it is the CI bake for the exact release payload; a failure means fixing `main` and re-cutting
 4. Dispatches `release.yml` on `release/vX.Y.Z` — "manual dispatch on a release branch" is the **full production release**: tags `vX.Y.Z`, publishes npm packages, builds/signs/notarizes and publishes the macOS DMG, pushes Docker Hub images, uploads iOS to TestFlight, creates the GitHub Release, updates the `vellum-assistant-platform` dependency, and merges the release branch back to `main`
 


### PR DESCRIPTION
## Summary
- Move the scheduled release-cut crons from 7:50am ET to 8:52am ET (`52 12` UTC for EDT, `52 13` UTC for EST) and delete the schedule-guard sleep that previously idled the runner until 9:00am ET.
- Preserve the dual-cron DST logic: both entries still fire, and schedule-guard still runs only the entry matching today's Eastern offset so the cut happens exactly once year-round.
- Update the schedule-guard step name/timeout and the two docs that referenced the 9am ET cut (`.claude/skills/release/SKILL.md`, `docs/internal-reference.md`).

## Original prompt
The release job currently triggers at 7:50am ET and then sleeps in the schedule-guard job until 9:00am ET before cutting the release branch. The user wants to remove that wait and simply trigger the job at 8:52am ET instead, while preserving the dual cron entries and offset-matching guard that keep the schedule correct across daylight-saving transitions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->