### PR TITLE
chore: remove vestigial coding-agents-panel feature flag

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -179,14 +179,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "coding-agents-panel",
-      "scope": "client",
-      "key": "coding-agents-panel",
-      "label": "Coding Agents Panel",
-      "description": "Gate native macOS Coding Agents panel entry points and inline ACP session deep links.",
-      "defaultEnabled": false
-    },
-    {
       "id": "compaction-playground",
       "scope": "assistant",
       "key": "compaction-playground",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -179,14 +179,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "coding-agents-panel",
-      "scope": "client",
-      "key": "coding-agents-panel",
-      "label": "Coding Agents Panel",
-      "description": "Gate native macOS Coding Agents panel entry points and inline ACP session deep links.",
-      "defaultEnabled": false
-    },
-    {
       "id": "compaction-playground",
       "scope": "assistant",
       "key": "compaction-playground",


### PR DESCRIPTION
## Summary
- Remove the `coding-agents-panel` entry from the canonical feature-flag registry and its tracked web mirror (regenerated via `meta/sync-bundled-copies.ts`; the git-ignored assistant/gateway copies are CI-regenerated)
- The flag was provisioned to gate ACP/Coding Agents UI but was never read by any code — zero call sites across web, macOS, iOS, and daemon — while every ACP surface (daemon routes, ACP skill, inline run cards, detail panels) ships unconditionally
- Removing it also drops the dead toggle from the developer Feature Flags settings panel

## Original prompt
An audit of ACP feature gating across iOS, web, and macOS found that the `coding-agents-panel` flag existed only as a registry + LaunchDarkly definition with no consumers; the native macOS panel entry points and ACP deep links it was meant to gate were never built, and ACP is already rolled out unconditionally for everyone. Rather than defaulting the flag on (a no-op), the request was to remove it entirely. The platform-side LaunchDarkly terraform resource will be archived separately in vellum-assistant-platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)