### PR TITLE
feat(email): support outbound attachments on the native emailer

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11173,6 +11173,23 @@ paths:
                   type: array
                   items:
                     type: string
+                attachments:
+                  description: File attachments
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      filename:
+                        type: string
+                      content_type:
+                        type: string
+                      content:
+                        type: string
+                        description: Base64-encoded file content
+                    required:
+                      - filename
+                      - content_type
+                      - content
                 reply_to:
                   description: Reply-to email ID
                   type: string

--- a/assistant/src/cli/commands/email.help.ts
+++ b/assistant/src/cli/commands/email.help.ts
@@ -95,6 +95,10 @@ Examples:
         { flags: "--cc <address>", description: "CC recipient (repeatable)" },
         { flags: "--bcc <address>", description: "BCC recipient (repeatable)" },
         {
+          flags: "--attach <path>",
+          description: "File to attach (repeatable)",
+        },
+        {
           flags: "--reply-to <email_id>",
           description:
             "Reply to an email by its ID (auto-resolves threading headers and subject)",
@@ -126,6 +130,9 @@ Examples:
 
   $ assistant email send user@example.com -b "Thanks!" --reply-to 019d96e4-e5d2-7201-890e-04a21e8f95bb
   ✓ Sent to user@example.com (delivery_id: ghi789)
+
+  $ assistant email send user@example.com -s "Report" -b "Attached" --attach report.pdf --attach data.csv
+  ✓ Sent to user@example.com (delivery_id: jkl012)
 
   $ assistant email send user@example.com -s "Hello" -b "Hi" --json
   {"delivery_id":"abc123","status":"accepted"}`,

--- a/assistant/src/cli/commands/email.ts
+++ b/assistant/src/cli/commands/email.ts
@@ -14,6 +14,7 @@ import {
   cliIpcCallStream,
   exitFromIpcResult,
 } from "../../ipc/cli-client.js";
+import { guessMimeType } from "../../util/mime-type.js";
 import { readStdinSync } from "../../util/read-stdin.js";
 import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
@@ -402,7 +403,11 @@ Examples:
       // imperatively to the declaratively-registered options.
       const send = subcommand(email, "send");
       const collect = (val: string, prev: string[]) => [...prev, val];
-      for (const flags of ["--cc <address>", "--bcc <address>"]) {
+      for (const flags of [
+        "--cc <address>",
+        "--bcc <address>",
+        "--attach <path>",
+      ]) {
         const option = send.options.find((o) => o.flags === flags);
         if (!option) {
           throw new Error(
@@ -422,6 +427,7 @@ Examples:
             html?: string;
             cc?: string[];
             bcc?: string[];
+            attach?: string[];
             replyTo?: string;
           },
           cmd: Command,
@@ -472,6 +478,31 @@ Examples:
             }
           }
 
+          // Read attachments and base64-encode their content for the JSON
+          // wire to the platform proxy.
+          let attachments:
+            | { filename: string; content_type: string; content: string }[]
+            | undefined;
+          if (opts.attach && opts.attach.length > 0) {
+            attachments = [];
+            for (const path of opts.attach) {
+              try {
+                const data = readFileSync(path);
+                attachments.push({
+                  filename: basename(path),
+                  content_type: guessMimeType(path),
+                  content: data.toString("base64"),
+                });
+              } catch (err) {
+                log.error(
+                  `Failed to read --attach ${path}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+                process.exitCode = 1;
+                return;
+              }
+            }
+          }
+
           const params: Record<string, unknown> = { to, text };
           if (opts.subject) {
             params.subject = opts.subject;
@@ -484,6 +515,9 @@ Examples:
           }
           if (opts.bcc && opts.bcc.length > 0) {
             params.bcc = opts.bcc;
+          }
+          if (attachments && attachments.length > 0) {
+            params.attachments = attachments;
           }
           if (opts.replyTo) {
             params.reply_to = opts.replyTo;

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -20,7 +20,7 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import { getLogger } from "../../../../util/logger.js";
-import { guessMimeType } from "./gmail-mime-helpers.js";
+import { guessMimeType } from "../../../../util/mime-type.js";
 import {
   err,
   extractEmail,

--- a/assistant/src/ipc/__tests__/email-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/email-ipc.test.ts
@@ -11,6 +11,9 @@
 // Must be first — before any imports that resolve socket paths
 delete process.env.ASSISTANT_IPC_SOCKET_DIR;
 
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 
 import { runAssistantCommandFull } from "../../cli/__tests__/run-assistant-command.js";
@@ -356,6 +359,93 @@ test("send --json returns delivery_id", async () => {
   const parsed = JSON.parse(stdout.trim());
   expect(parsed.delivery_id).toBe("del_abc123");
   expect(process.exitCode).toBe(0);
+});
+
+test("send --attach reads the file and forwards base64 attachments to the platform", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "email-attach-"));
+  const filePath = join(dir, "report.pdf");
+  const fileBytes = "pdf-bytes-here";
+  writeFileSync(filePath, fileBytes);
+
+  let sendBody: Record<string, unknown> | null = null;
+  mockFetchFn = async (path, init) => {
+    if (path.includes("/email-addresses/")) {
+      return new Response(
+        JSON.stringify({
+          results: [{ id: "addr-1", address: "mybot@example.com" }],
+        }),
+        { status: 200 },
+      );
+    }
+    // send endpoint — capture the forwarded payload
+    sendBody = JSON.parse(init?.body as string);
+    return new Response(
+      JSON.stringify({ delivery_id: "del_attach", status: "accepted" }),
+      { status: 200 },
+    );
+  };
+
+  try {
+    await runAssistantCommandFull(
+      "email",
+      "--json",
+      "send",
+      "user@example.com",
+      "-s",
+      "Report",
+      "-b",
+      "Attached",
+      "--attach",
+      filePath,
+    );
+
+    expect(sendBody).not.toBeNull();
+    expect(sendBody!.attachments).toEqual([
+      {
+        filename: "report.pdf",
+        content_type: "application/pdf",
+        content: Buffer.from(fileBytes).toString("base64"),
+      },
+    ]);
+    expect(process.exitCode).toBe(0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("send with a missing --attach path fails without calling the platform", async () => {
+  let sendCalled = false;
+  mockFetchFn = async (path) => {
+    if (path.includes("/email-addresses/")) {
+      return new Response(
+        JSON.stringify({
+          results: [{ id: "addr-1", address: "mybot@example.com" }],
+        }),
+        { status: 200 },
+      );
+    }
+    sendCalled = true;
+    return new Response(
+      JSON.stringify({ delivery_id: "x", status: "accepted" }),
+      { status: 200 },
+    );
+  };
+
+  await runAssistantCommandFull(
+    "email",
+    "--json",
+    "send",
+    "user@example.com",
+    "-s",
+    "Report",
+    "-b",
+    "Attached",
+    "--attach",
+    join(tmpdir(), "does-not-exist-xyz.pdf"),
+  );
+
+  expect(process.exitCode).not.toBe(0);
+  expect(sendCalled).toBe(false);
 });
 
 test("send: 402 billing error surfaces", async () => {

--- a/assistant/src/runtime/routes/email-routes.ts
+++ b/assistant/src/runtime/routes/email-routes.ts
@@ -240,13 +240,18 @@ async function handleEmailDownload({ queryParams = {} }: RouteHandlerArgs) {
 }
 
 async function handleEmailSend({ body = {} }: RouteHandlerArgs) {
-  const { to, text, subject, html, cc, bcc, reply_to } = body as {
+  const { to, text, subject, html, cc, bcc, attachments, reply_to } = body as {
     to: string[];
     text: string;
     subject?: string;
     html?: string;
     cc?: string[];
     bcc?: string[];
+    attachments?: {
+      filename: string;
+      content_type: string;
+      content: string;
+    }[];
     reply_to?: string;
   };
 
@@ -293,6 +298,7 @@ async function handleEmailSend({ body = {} }: RouteHandlerArgs) {
   if (resolvedHtml) payload.html = resolvedHtml;
   if (cc && cc.length > 0) payload.cc = cc;
   if (bcc && bcc.length > 0) payload.bcc = bcc;
+  if (attachments && attachments.length > 0) payload.attachments = attachments;
   if (reply_to) payload.reply_to = reply_to;
 
   const response = await client.fetch("/v1/runtime-proxy/email/send/", {
@@ -567,6 +573,16 @@ export const ROUTES: RouteDefinition[] = [
         .describe("HTML body (auto-generated from text if omitted)"),
       cc: z.array(z.string()).optional().describe("CC recipients"),
       bcc: z.array(z.string()).optional().describe("BCC recipients"),
+      attachments: z
+        .array(
+          z.object({
+            filename: z.string(),
+            content_type: z.string(),
+            content: z.string().describe("Base64-encoded file content"),
+          }),
+        )
+        .optional()
+        .describe("File attachments"),
       reply_to: z.string().optional().describe("Reply-to email ID"),
     }),
     responseBody: z.object({

--- a/assistant/src/util/mime-type.ts
+++ b/assistant/src/util/mime-type.ts
@@ -1,5 +1,8 @@
 /**
- * Shared MIME type guessing for Gmail attachment support.
+ * Best-effort MIME type inference from a file path's extension.
+ *
+ * Used to label outbound attachments (Gmail/Outlook multipart parts, native
+ * email attachments) when the source is a local file with no declared type.
  */
 
 import { extname } from "node:path";


### PR DESCRIPTION
## Prompt / plan

Follow-up to #38047. That PR added outbound attachments to the Gmail/Outlook **provider** send path, but the user clarified they meant Vellum's **native emailer** — `assistant email send`, which sends from the assistant's own registered `@…` address via the platform runtime proxy. That command could set subject/body/html/cc/bcc/reply-to but had **no way to attach files** (even though inbound attachment *download* already exists via `assistant email attachment`).

This adds a repeatable `--attach <path>` flag to `assistant email send`.

### What changed

- **CLI** (`email.ts` / `email.help.ts`) — `--attach <path>` (repeatable, same collect pattern as `--cc`/`--bcc`). Each file is read, its filename (basename) and content type (`guessMimeType`) derived, bytes base64-encoded, and passed as an `attachments` array through the `email_send` IPC route. A missing/unreadable path fails with exit 1 **before** any platform call.
- **Route** (`email-routes.ts`) — `handleEmailSend` forwards `attachments` in the `/v1/runtime-proxy/email/send/` payload; the `email_send` request schema documents the shape.
- **Shared util** — extracted the MIME-type guesser out of the messaging skill's `gmail-mime-helpers.ts` into `util/mime-type.ts` (git tracks it as a rename) so the messaging tools and the email CLI share one copy instead of duplicating the map.
- Regenerated `openapi.yaml` for the new request field.

### Wire shape — confirmed against the platform

Each attachment is `{ filename, content_type, content }` with `content` base64-encoded. This matches the companion `vellum-assistant-platform` endpoint, which accepts exactly:

```json
"attachments": [
  { "filename": "notes.pdf", "content": "<base64>", "content_type": "application/pdf" }
]
```

The platform-side support has landed separately, so this CLI half and the proxy endpoint are in sync — no further cross-repo work required.

## Test plan

- New IPC round-trip tests in `email-ipc.test.ts`: `send --attach` reads the file and forwards base64 `attachments` (filename + content_type + content) in the platform payload; a missing `--attach` path exits non-zero without calling the platform.
- `bun test` on `email-ipc.test.ts` green (19/19); `messaging-send-tool.test.ts` still green after the helper move; `bunx tsc --noEmit` clean; prettier/lint clean (remaining lint output is pre-existing `curly` warnings).
- Note: several email suites share IPC-server/mock state and fail when *run together in one process* — this is a pre-existing cross-file isolation issue (identical on `main`); each file passes in isolation.

<!-- CLI verb checklist: no new IPC routes added — extends the existing email_send route/verb. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zpRSHVvD7vWymD83q7jkt