### PR TITLE
cherry-pick: 0.10.9 round 1 (#38026, #38025, #38023)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -39,11 +39,11 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => mockIsElectron,
 }));
 
-// Capacitor-iOS detection. The composer skips the first-run prefs card on the
-// native iOS shell (a dismissible pre-prompt before the `getUserMedia`
-// permission alert violates `docs/CAPACITOR.md` § OS permission requests) and
-// starts the session directly. Defaults to non-iOS (web) so the existing
-// first-run tests exercise the card path unchanged.
+// Capacitor-iOS detection, kept as a regression guard. The first-run prefs card
+// is now shown on EVERY platform, the native iOS shell included (a deliberate
+// parity choice that knowingly deviates from `docs/CAPACITOR.md` § OS permission
+// requests — see the composer's `handleLiveVoiceStart` note), so setting this to
+// iOS must NOT suppress the card. Defaults to non-iOS (web).
 let mockIsNativeIOS = false;
 mock.module("@/runtime/platform-detection", () => ({
   isNativeIOS: () => mockIsNativeIOS,
@@ -117,8 +117,16 @@ mock.module("@/domains/chat/components/voice-input-button", () => ({
 // irrelevant to the composer's interception wiring, which is all these tests
 // assert. Full card behavior lives in `voice-first-run-card.test.tsx`.
 mock.module("@/domains/chat/voice/voice-room/voice-first-run-card", () => ({
-  VoiceFirstRunCard: (props: { onStart: () => void; onDismiss?: () => void }) => (
-    <div data-testid="first-run-card">
+  VoiceFirstRunCard: (props: {
+    onStart: () => void;
+    onDismiss?: () => void;
+    nonDismissible?: boolean;
+  }) => (
+    <div
+      data-testid="first-run-card"
+      // Surface the lock so a test can assert the composer passes it on iOS.
+      data-non-dismissible={String(props.nonDismissible ?? false)}
+    >
       <button type="button" onClick={props.onStart}>
         first-run-start
       </button>
@@ -866,8 +874,12 @@ describe("ChatComposer — live-voice integration", () => {
     const { getByLabelText, getByTestId } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN the prefs card appears and the session has NOT started yet
+    // THEN the prefs card appears (dismissible on web) and the session has NOT
+    // started yet
     expect(getByTestId("first-run-card")).toBeTruthy();
+    expect(
+      getByTestId("first-run-card").getAttribute("data-non-dismissible"),
+    ).toBe("false");
     expect(liveStarterSpy).not.toHaveBeenCalled();
   });
 
@@ -906,25 +918,29 @@ describe("ChatComposer — live-voice integration", () => {
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
   });
 
-  test("Capacitor iOS: first-ever entry skips the card and starts directly (permission alert reached)", () => {
+  test("Capacitor iOS: first-ever entry shows the prefs card too (web↔iOS parity)", () => {
     // GIVEN the native iOS shell, the flag on, no session, and a first-ever
-    // entry — a dismissible pre-prompt here would violate CAPACITOR.md
-    // § OS permission requests, so the card must be skipped.
+    // entry. The card is intentionally shown on every platform — a deliberate
+    // deviation from CAPACITOR.md's "no dismissible pre-prompt before
+    // getUserMedia" rule, chosen for parity with web (see the composer's
+    // handleLiveVoiceStart note) — so the iOS shell must get it too.
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
     mockIsNativeIOS = true;
     useVoicePrefsStore.setState({ firstRunSeen: false });
 
     // WHEN the user clicks the entry-point mic
-    const { getByLabelText, queryByTestId } = renderVoiceComposer();
+    const { getByLabelText, getByTestId } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN no card renders and the session starts straight away so the OS
-    // getUserMedia alert is the next thing the user sees. The first-run flag
-    // is left untouched (the card, not the mic, owns marking it seen).
-    expect(queryByTestId("first-run-card")).toBeNull();
-    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
-    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    // THEN the same prefs card appears and the session has NOT started yet —
+    // like web, but locked (non-dismissible) so it leads straight to the mic
+    // alert per CAPACITOR.md.
+    expect(getByTestId("first-run-card")).toBeTruthy();
+    expect(
+      getByTestId("first-run-card").getAttribute("data-non-dismissible"),
+    ).toBe("true");
+    expect(liveStarterSpy).not.toHaveBeenCalled();
   });
 
   test("Capacitor iOS: returning-user entry still starts directly (unchanged)", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -355,15 +355,15 @@ export function ChatComposer({
         return;
       }
       liveVoiceEntryOriginRef.current = origin ?? null;
-      // First-run preferences card — shown on every platform EXCEPT Capacitor
-      // iOS. On the iOS shell a dismissible pre-prompt before the live-voice
-      // `getUserMedia` permission alert violates `docs/CAPACITOR.md` § OS
-      // permission requests (Apple HIG / App Store Review 5.1.1(iv)) and the
-      // `voice/live-voice/pcm-capture.ts` caller contract, which require any
-      // pre-permission UI to lead directly to the system alert. On iOS we
-      // therefore start directly (same as the returning-user path) so the OS
-      // alert is reached without an intervening dismissible modal.
-      if (!useVoicePrefsStore.getState().firstRunSeen && !isNativeIOS()) {
+      // First-run preferences card — shown on the first-ever voice entry on
+      // EVERY platform, the Capacitor iOS shell included (web↔iOS parity for the
+      // welcome card). On iOS the card renders locked (`nonDismissible`, see its
+      // render below), which keeps it compliant with `docs/CAPACITOR.md` § OS
+      // permission requests: the card precedes the live-voice `getUserMedia`
+      // alert, and a locked pre-prompt whose only action leads straight to that
+      // alert is the sanctioned pattern (Apple HIG / App Store Review 5.1.1(iv))
+      // — a *dismissible* pre-prompt is the disallowed one.
+      if (!useVoicePrefsStore.getState().firstRunSeen) {
         setFirstRunCardOpen(true);
         return;
       }
@@ -493,11 +493,17 @@ export function ChatComposer({
       {firstRunCardOpen && (
         // First voice-mode entry only — the card commits prefs + starts via
         // `handleFirstRunStart`; a plain dismiss cancels without consuming the
-        // first run, so it returns on the next entry.
+        // first run, so it returns on the next entry. On Capacitor iOS the card
+        // is locked (no ✕ / backdrop / Escape): it precedes the live-voice
+        // `getUserMedia` alert, so per `docs/CAPACITOR.md` § OS permission
+        // requests the pre-prompt must lead straight to that alert — its only
+        // action is "Start talking", and there is no card-level cancel (backing
+        // out means denying the OS mic prompt, or ✕ once the room opens).
         <VoiceFirstRunCard
           assistantId={assistantId}
           onStart={handleFirstRunStart}
           onDismiss={() => setFirstRunCardOpen(false)}
+          nonDismissible={isNativeIOS()}
         />
       )}
       {/* Composer-owned draft/attachment notices (self-sourced), above the

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -43,7 +43,11 @@ export function LiveVoiceButton({
 
   return (
     <Button
-      variant="ghost"
+      // Filled `primary` (black) so the voice entry point carries the same
+      // prominence as the send button it shares the composer's send slot with
+      // (both `Button variant="primary"` icon-only, so identical footprint +
+      // fill) — rather than a low-emphasis ghost that reads as secondary.
+      variant="primary"
       iconOnly={<AudioLines strokeWidth={2} />}
       onClick={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
@@ -52,7 +56,6 @@ export function LiveVoiceButton({
       disabled={disabled}
       aria-label="Start voice mode"
       title="Start voice mode"
-      className="[--vbtn-fg:var(--content-secondary)]"
     />
   );
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -237,4 +237,11 @@ export function seedLiveVoiceSession(
     store.setControls(options.controls);
   }
   store.setState(state);
+  // Mirror the controller's first-`tts_audio` write: entering `speaking` means
+  // audio is flowing, so the avatar reads `responding`. (A silent mid-turn
+  // `speaking` pause is the exception, exercised directly against
+  // `toVoiceAvatarVisual`.)
+  if (state === "speaking") {
+    store.setAssistantAudioActive(true);
+  }
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -167,6 +167,17 @@ export interface LiveVoiceState {
   /** Current phase of the session lifecycle. */
   state: LiveVoiceSessionState;
   /**
+   * Whether the assistant's TTS audio is actually queued/playing right now,
+   * tracked by the controller from the active {@link LiveVoiceAudioPlayer} with
+   * a short idle grace. The `speaking` phase mirrors server turn framing (set on
+   * the first `tts_audio`, cleared only on `tts_done`), so a turn that speaks an
+   * ack and then runs a tool stays `speaking` while silent; this flag lets the
+   * avatar distinguish "actively speaking" from "silent mid-turn" and read as
+   * `thinking` during the tool run (see `toVoiceAvatarVisual`, JARVIS-1279).
+   * Meaningful only while `state === "speaking"`.
+   */
+  assistantAudioActive: boolean;
+  /**
    * True while the controller is retrying a dropped connection (attempt > 0),
    * so surfaces can distinguish it from the initial-connect `connecting`.
    * Orthogonal to `state`, which stays a 1:1 mirror of the macOS enum.
@@ -254,6 +265,8 @@ export interface LiveVoiceState {
 export interface LiveVoiceActions {
   /** Replace the session phase. */
   setState: (state: LiveVoiceSessionState) => void;
+  /** Record whether assistant TTS audio is currently queued/playing. */
+  setAssistantAudioActive: (active: boolean) => void;
   /** Set whether the controller is retrying a dropped connection. */
   setReconnecting: (reconnecting: boolean) => void;
   /**
@@ -383,6 +396,7 @@ export function isLiveVoiceSessionOwnedBy(
 /** Session-scoped fields restored by `reset()`. Excludes `starter` (mount-scoped). */
 const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   state: "idle",
+  assistantAudioActive: false,
   reconnecting: false,
   assistantId: null,
   conversationId: null,
@@ -405,6 +419,8 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   starter: null,
 
   setState: (state) => set({ state }),
+  setAssistantAudioActive: (assistantAudioActive) =>
+    set({ assistantAudioActive }),
   setReconnecting: (reconnecting) => set({ reconnecting }),
   setSessionContext: (assistantId, conversationId) =>
     // A fresh session always opens with the mic live, even if the controller

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -14,8 +14,11 @@
  * The capture is permission-agnostic: it requests `getUserMedia` directly and
  * surfaces a denial as a typed `LiveVoiceCaptureResult` rather than throwing.
  * Per `clients/web/AGENTS.md` / `docs/CAPACITOR.md` § OS permission requests,
- * callers own any pre-permission UX (and must not render a dismissible
- * pre-prompt on Capacitor iOS).
+ * callers own any pre-permission UX: no *dismissible* pre-prompt may precede
+ * this `getUserMedia` alert on Capacitor iOS. The live-voice composer's
+ * first-run card complies by rendering locked (no ✕ / backdrop / Escape, a
+ * single "Start talking" that leads straight here) on iOS — see
+ * `chat-composer.tsx`'s `handleLiveVoiceStart` and `VoiceFirstRunCard`.
  */
 
 // Import the worklet as a Vite-bundled, *transpiled* classic script asset and

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -212,6 +212,8 @@ describe("full turn", () => {
     });
     expect(h.view.result.current.state).toBe("speaking");
     expect(h.player.enqueued).toHaveLength(1);
+    // Audio is flowing, so the avatar reads `responding` (JARVIS-1279).
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
 
     // tts_done awaits playback drain, then ends the session (single-utterance):
     // the socket is closed and the mic is shut down, returning to idle.
@@ -223,6 +225,73 @@ describe("full turn", () => {
     expect(h.view.result.current.state).toBe("idle");
     expect(h.client.closed).toBe(true);
     expect(h.getCapture().shutdownCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Assistant-audio activity (mid-turn tool run) — JARVIS-1279
+// ---------------------------------------------------------------------------
+
+describe("assistant-audio activity", () => {
+  function emitTts(h: ReturnType<typeof renderController>, seq: number) {
+    h.client.emit("ttsAudio", {
+      type: "tts_audio",
+      seq,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+    });
+  }
+
+  test("stays `speaking` but marks audio inactive after the idle window when the player falls silent mid-turn", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      emitTts(h, 3);
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
+
+    // The ack audio finishes but the turn stays open — the assistant is now
+    // running a tool, so no `tts_done` arrives.
+    act(() => {
+      h.player.finishPlayback();
+    });
+
+    // After the idle grace with a silent player, audio is marked inactive while
+    // the phase is still `speaking`, so the avatar can read `thinking`.
+    await act(async () => {
+      await sleep(650); // > ASSISTANT_AUDIO_IDLE_MS (500ms)
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(false);
+
+    // More TTS for the same turn re-activates it (back to `responding`).
+    act(() => {
+      emitTts(h, 4);
+    });
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
+  });
+
+  test("keeps audio active across the idle window while the player is still draining", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      emitTts(h, 3);
+    });
+    // FakePlayer.enqueue leaves isPlaying true; never finish playback here.
+    expect(h.player.isPlaying).toBe(true);
+
+    // The idle check fires but re-arms because audio is still playing out — the
+    // avatar must not blink to `thinking` over audible speech.
+    await act(async () => {
+      await sleep(650);
+    });
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -282,6 +282,14 @@ interface SessionContext {
    * `metrics` frame always pairs with its own turn's measurement.
    */
   clientHeardLatencyMs: number | null;
+  /**
+   * Pending idle-check timer for the store's `assistantAudioActive` flag. Armed
+   * on each `tts_audio` frame and re-armed while the player is still draining;
+   * fires once audio has stopped flowing to mark the assistant silent (so a
+   * mid-turn tool run reads as `thinking`, not `speaking` — JARVIS-1279).
+   * Cleared on teardown/flush.
+   */
+  assistantAudioIdleTimer: ReturnType<typeof setTimeout> | null;
 }
 
 /** Number of bytes per Int16 PCM sample. */
@@ -413,6 +421,7 @@ export function useLiveVoice(
     const startGeneration = startGenerationRef.current;
     sessionRef.current = null;
     session.generation += 1;
+    clearAssistantAudioActive(session);
     useLiveVoiceStore.getState().setState("ending");
     for (const unsubscribe of session.unsubscribes) unsubscribe();
     session.unsubscribes = [];
@@ -561,6 +570,7 @@ export function useLiveVoice(
         speechEndedAtMs: null,
         turnHeardStampMs: null,
         clientHeardLatencyMs: null,
+        assistantAudioIdleTimer: null,
       };
 
       const capture = (opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o)))({
@@ -725,6 +735,10 @@ export function useLiveVoice(
             mimeType: frame.mimeType,
           };
           session.player.enqueue(chunk);
+          // Mark audio flowing before the phase flip so no render observes
+          // `speaking` without `assistantAudioActive` (which would blink the
+          // avatar to `thinking` at the top of every response — JARVIS-1279).
+          markAssistantAudioActive(session);
           useLiveVoiceStore.getState().setState("speaking");
         }),
         client.on("ttsDone", () => {
@@ -920,6 +934,7 @@ export function useLiveVoice(
  */
 function disposeSessionPrimitives(session: SessionContext): void {
   session.generation += 1;
+  clearAssistantAudioActive(session);
   for (const unsubscribe of session.unsubscribes) unsubscribe();
   session.unsubscribes = [];
   session.client.close();
@@ -1134,12 +1149,62 @@ function beginAssistantAudioIfNeeded(session: SessionContext): void {
 }
 
 /**
+ * Grace period after the player stops producing audio before the assistant is
+ * treated as silent within a still-open `speaking` turn. Long enough to bridge
+ * inter-frame network gaps and a short buffered tail, short enough that a real
+ * mid-turn pause (a tool call after a spoken ack) reads as `thinking` promptly.
+ */
+const ASSISTANT_AUDIO_IDLE_MS = 500;
+
+/**
+ * Mark assistant TTS audio as flowing and (re)arm the idle check. Called on
+ * every `tts_audio` frame: a continuous stream keeps re-arming the timer so the
+ * flag stays true for the whole spoken stretch; once frames stop and the queue
+ * drains, {@link scheduleAssistantAudioIdleCheck} flips it false. Drives the
+ * avatar's `speaking → responding` vs `thinking` split (JARVIS-1279).
+ */
+function markAssistantAudioActive(session: SessionContext): void {
+  useLiveVoiceStore.getState().setAssistantAudioActive(true);
+  scheduleAssistantAudioIdleCheck(session);
+}
+
+/**
+ * Arm (replacing any prior) the timer that marks the assistant silent once
+ * audio stops flowing. If the player is still draining its buffered tail when
+ * the timer fires, re-arm rather than blinking to silence over audible audio —
+ * only a genuinely idle player flips the flag false.
+ */
+function scheduleAssistantAudioIdleCheck(session: SessionContext): void {
+  if (session.assistantAudioIdleTimer !== null) {
+    clearTimeout(session.assistantAudioIdleTimer);
+  }
+  session.assistantAudioIdleTimer = setTimeout(() => {
+    session.assistantAudioIdleTimer = null;
+    if (session.player.isPlaying) {
+      scheduleAssistantAudioIdleCheck(session);
+      return;
+    }
+    useLiveVoiceStore.getState().setAssistantAudioActive(false);
+  }, ASSISTANT_AUDIO_IDLE_MS);
+}
+
+/** Cancel the idle check and clear the flag (barge-in, turn end, teardown). */
+function clearAssistantAudioActive(session: SessionContext): void {
+  if (session.assistantAudioIdleTimer !== null) {
+    clearTimeout(session.assistantAudioIdleTimer);
+    session.assistantAudioIdleTimer = null;
+  }
+  useLiveVoiceStore.getState().setAssistantAudioActive(false);
+}
+
+/**
  * Hands-free: flush local TTS playback immediately, drop expectations for the
  * in-flight response, and keep the session live in `listening`.
  */
 function flushPlaybackToListening(session: SessionContext): void {
   session.player.stop();
   session.responseAudioStarted = false;
+  clearAssistantAudioActive(session);
   useLiveVoiceStore.getState().setState("listening");
 }
 
@@ -1177,6 +1242,9 @@ async function finishResponseAfterPlayback(
 
   await session.player.waitUntilDrained();
   if (session.generation !== generation) return;
+  // Audio has fully drained — the assistant is no longer speaking regardless of
+  // where the turn goes next (a newer turn re-marks it on its own tts_audio).
+  clearAssistantAudioActive(session);
 
   const state = useLiveVoiceStore.getState().state;
   if (session.handsFree) {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -62,6 +62,7 @@ export function VoiceAmbientTranscript() {
   // `inputAmplitude` churn the narrow subscriptions above avoid.
   const state = useLiveVoiceStore.use.state();
   const reconnecting = useLiveVoiceStore.use.reconnecting();
+  const assistantAudioActive = useLiveVoiceStore.use.assistantAudioActive();
   const reduce = useReducedMotion();
 
   // In-flight partial wins over the last finalized transcript — same precedence
@@ -74,7 +75,7 @@ export function VoiceAmbientTranscript() {
   // assistant caption. Hide that half while listening (the assistant isn't
   // speaking then anyway); in thinking/responding the eyes are centered and the
   // clearance clears them.
-  const visual = toVoiceAvatarVisual(state, reconnecting);
+  const visual = toVoiceAvatarVisual(state, reconnecting, assistantAudioActive);
   const showUserHalf = showUser && userText.length > 0;
   const showAssistantHalf =
     showAssistant && assistantTranscript.length > 0 && visual !== "listening";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.test.ts
@@ -42,4 +42,28 @@ describe("toVoiceAvatarVisual", () => {
     expect(toVoiceAvatarVisual("listening", true)).toBe("listening");
     expect(toVoiceAvatarVisual("speaking", true)).toBe("responding");
   });
+
+  it("defaults assistantAudioActive to true (speaking → responding)", () => {
+    // Callers without the audio signal keep the plain mapping.
+    expect(toVoiceAvatarVisual("speaking", false)).toBe("responding");
+  });
+
+  it("maps speaking → thinking when no audio is flowing", () => {
+    // A turn that spoke an ack and is now running a tool stays `speaking` but
+    // is silent; the avatar must read `thinking`, not `responding` (JARVIS-1279).
+    expect(toVoiceAvatarVisual("speaking", false, false)).toBe("thinking");
+    expect(toVoiceAvatarVisual("speaking", true, false)).toBe("thinking");
+  });
+
+  it("keeps speaking → responding while audio is flowing", () => {
+    expect(toVoiceAvatarVisual("speaking", false, true)).toBe("responding");
+  });
+
+  it("ignores assistantAudioActive for every non-speaking phase", () => {
+    // The flag is only meaningful while `speaking`; it must not perturb others.
+    expect(toVoiceAvatarVisual("listening", false, false)).toBe("listening");
+    expect(toVoiceAvatarVisual("thinking", false, false)).toBe("thinking");
+    expect(toVoiceAvatarVisual("thinking", false, true)).toBe("thinking");
+    expect(toVoiceAvatarVisual("idle", false, false)).toBe("idle");
+  });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar-state.ts
@@ -15,7 +15,8 @@ export type VoiceAvatarVisual =
 
 /**
  * Pure mapping from a live-voice session phase (plus the orthogonal
- * `reconnecting` retry signal) to the avatar's visual mode.
+ * `reconnecting` retry signal and whether assistant audio is actually flowing)
+ * to the avatar's visual mode.
  *
  * - `connecting` while `reconnecting` → `"reconnecting"` (a dropped connection
  *   is being retried; visually distinct from the initial connect).
@@ -23,11 +24,22 @@ export type VoiceAvatarVisual =
  *   express — hosts typically unmount the room in the terminal states).
  * - `listening` → `"listening"`.
  * - `transcribing` / `thinking` → `"thinking"`.
- * - `speaking` → `"responding"`.
+ * - `speaking` → `"responding"` while audio is flowing, else `"thinking"`.
+ *
+ * The `speaking` phase is a pure mirror of the server's turn framing — it is set
+ * on the first `tts_audio` frame and cleared only on `tts_done` (turn end) or a
+ * barge-in. A turn that speaks a short ack and then runs a tool (e.g. the
+ * app-builder skill) stays `speaking` for the whole silent tool run. Gating on
+ * `assistantAudioActive` (audio actually queued/playing, tracked by the
+ * controller from the player) collapses that silent stretch back to `thinking`,
+ * so the room stops claiming the assistant is talking mid-turn. Defaults to
+ * `true` — a non-`speaking` phase never reads it, and callers without the signal
+ * keep the plain `speaking → responding` behavior. (JARVIS-1279)
  */
 export function toVoiceAvatarVisual(
   state: LiveVoiceSessionState,
   reconnecting: boolean,
+  assistantAudioActive = true,
 ): VoiceAvatarVisual {
   switch (state) {
     case "connecting":
@@ -42,6 +54,6 @@ export function toVoiceAvatarVisual(
     case "thinking":
       return "thinking";
     case "speaking":
-      return "responding";
+      return assistantAudioActive ? "responding" : "thinking";
   }
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -24,7 +24,9 @@ import {
 import { VoiceAvatar } from "./voice-avatar";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
 import {
+  VoiceRespondingRings,
   VoiceRoomColorLook,
+  VoiceStateCaption,
   resolveVoiceRoomLook,
   type VoiceEyePlacement,
   type VoiceRespondingStyle,
@@ -36,11 +38,12 @@ import {
  * with the `amplitude` slider or the `oscillate` "simulated speech" toggle — no
  * live mic / STT / TTS session required.
  *
- * `listening` renders the bottom-edge waves (energy coming *in* from the user)
- * and the avatar stays at rest; `responding` is the avatar's own outward pulse
- * (energy going *out*). Wave `waveStyle` (fill / line) and `palette` (aurora /
- * accent) are the design knobs. `realAvatar` swaps the "V" fallback for a real
- * bundled character.
+ * `listening` renders the top-edge waves (energy coming *in* from the user)
+ * and the avatar stays at rest; `responding` radiates the concentric rings from
+ * behind the avatar (energy going *out*, the same treatment the color look's
+ * eyes use). Wave `waveStyle` (fill / line) and `palette` (aurora / accent) are
+ * the design knobs. `realAvatar` swaps the "V" fallback for a real bundled
+ * character.
  *
  * Nothing hits the network: the real avatar is seeded into the query cache
  * below, on the room's own deep-dark `data-theme="dark"` void.
@@ -143,8 +146,12 @@ interface RoomSceneProps {
 
 /**
  * A full room scene for one visual: the deep-dark void, ambient particles, the
- * bottom listening waves (only in `listening`), and the centered avatar — all
- * driven by one shared amplitude source so the avatar and waves move together.
+ * top-edge listening waves (only in `listening`), the responding rings behind
+ * the avatar (only in `responding`), the centered avatar, and the shared state
+ * caption below it — all driven by one shared amplitude source so the avatar,
+ * waves, and rings move together. Mirrors the app's void look, which shares the
+ * color look's foreground chrome (top waves + rings + caption) bar the
+ * full-screen color and eyes.
  */
 function RoomScene({
   visual,
@@ -157,8 +164,10 @@ function RoomScene({
   minHeight = 420,
 }: RoomSceneProps) {
   const getAmplitude = useAmplitudeDriver(amplitude, oscillate);
+  const { ref, size: box } = useBoxSize();
   return (
     <div
+      ref={ref}
       data-theme="dark"
       className="relative flex items-center justify-center overflow-hidden rounded-lg"
       style={{ background: "#05060b", minHeight, ["--avatar-accent" as string]: SAMPLE_ACCENT }}
@@ -169,7 +178,15 @@ function RoomScene({
           getAmplitude={getAmplitude}
           waveStyle={waveStyle}
           palette={palette}
+          // Same top edge as the color look — positional parity.
+          placement="top"
         />
+      ) : null}
+      {/* Responding: the same concentric rings the color look radiates from
+          behind the eyes, here behind the centered avatar. Sized against the
+          story box (not the window) so they match this frame. */}
+      {visual === "responding" && box.w > 0 ? (
+        <VoiceRespondingRings getAmplitude={getAmplitude} viewport={box} />
       ) : null}
       <div className="relative z-0 flex items-center justify-center">
         <VoiceAvatar
@@ -179,6 +196,12 @@ function RoomScene({
           size={size}
         />
       </div>
+      {/* Shared caption below the centered avatar (half its size from center,
+          plus a gap), matching the app's void look. */}
+      <VoiceStateCaption
+        visual={visual}
+        top={`calc(50% + ${size / 2}px + 1.25rem)`}
+      />
     </div>
   );
 }
@@ -510,7 +533,7 @@ const voidArgTypes = {
   replay: { table: { disable: true } },
 };
 
-/** Void-look playground — the centered avatar, ambient void, and bottom waves. */
+/** Void-look playground — the centered avatar, ambient void, and top waves. */
 export const VoidLookPlayground: VoidStory = {
   name: "Void Look — Playground",
   render: (args) => <RoomScene {...args} />,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -93,4 +93,26 @@ describe("VoiceFirstRunCard", () => {
     fireEvent.click(getByText("Start"));
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
   });
+
+  test("dismissible by default (web): renders the ✕ close affordance", () => {
+    const { getByLabelText } = render(
+      <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
+    );
+    expect(getByLabelText("Close")).toBeTruthy();
+  });
+
+  test("nonDismissible (iOS lock): no ✕, only Start talking leads forward", () => {
+    // The lock strips the close affordance so the pre-permission card leads
+    // straight to the mic alert (CAPACITOR.md § OS permission requests); there
+    // is intentionally no card-level cancel.
+    const { queryByLabelText, getByText } = render(
+      <VoiceFirstRunCard
+        assistantId="asst_test"
+        onStart={() => {}}
+        nonDismissible
+      />,
+    );
+    expect(queryByLabelText("Close")).toBeNull();
+    expect(getByText("Start talking")).toBeTruthy();
+  });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -54,7 +54,7 @@ describe("VoiceFirstRunCard", () => {
     );
 
     expect(getByText("Voice mode")).toBeTruthy();
-    expect(getByText("Start")).toBeTruthy();
+    expect(getByText("Start talking")).toBeTruthy();
     expect(onStart).not.toHaveBeenCalled();
   });
 
@@ -77,7 +77,7 @@ describe("VoiceFirstRunCard", () => {
       <VoiceFirstRunCard assistantId="asst_test" onStart={onStart} />,
     );
 
-    fireEvent.click(getByText("Start"));
+    fireEvent.click(getByText("Start talking"));
     expect(onStart).toHaveBeenCalledTimes(1);
   });
 
@@ -90,7 +90,7 @@ describe("VoiceFirstRunCard", () => {
     );
 
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
-    fireEvent.click(getByText("Start"));
+    fireEvent.click(getByText("Start talking"));
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
   });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -20,6 +20,14 @@ import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
  * the card returns on the next entry. Only committing via "Start" advances the
  * first-run flag, and that lives in the caller's `onStart` handler (the
  * composer) alongside actually starting the session.
+ *
+ * `nonDismissible` locks the card to a single forward action — no ✕, backdrop,
+ * or Escape. The composer sets it on Capacitor iOS, where the card precedes the
+ * live-voice `getUserMedia` alert: per `docs/CAPACITOR.md` § OS permission
+ * requests (Apple HIG / App Store Review 5.1.1(iv)) such a pre-prompt must lead
+ * straight to the system alert, so a dismissible one is disallowed. Locked,
+ * there is no card-level cancel by design — backing out means denying the OS
+ * mic prompt (or ✕ once the room opens).
  */
 
 /** Mini idle avatar diameter — a quiet, in-context echo of the room avatar. */
@@ -32,12 +40,19 @@ export interface VoiceFirstRunCardProps {
   onStart: () => void;
   /** Cancel: dismissed without starting (does not consume the first run). */
   onDismiss?: () => void;
+  /**
+   * Lock the card: no ✕ / backdrop / Escape, only "Start talking". Set on
+   * Capacitor iOS so the pre-permission card leads straight to the mic alert
+   * (see the module docstring). Defaults to dismissible (web).
+   */
+  nonDismissible?: boolean;
 }
 
 export function VoiceFirstRunCard({
   assistantId,
   onStart,
   onDismiss,
+  nonDismissible = false,
 }: VoiceFirstRunCardProps) {
   const { components, traits, customImageUrl } =
     useAssistantAvatar(assistantId);
@@ -47,13 +62,27 @@ export function VoiceFirstRunCard({
       open
       onOpenChange={(next) => {
         // Escape / backdrop / ✕ all route through here; treat any close as a
-        // cancel so the first run stays un-consumed.
+        // cancel so the first run stays un-consumed. Inert when locked (those
+        // affordances are removed / prevented below), so `onDismiss` only fires
+        // on the dismissible (web) path.
         if (!next) {
           onDismiss?.();
         }
       }}
     >
-      <Modal.Content size="sm">
+      <Modal.Content
+        size="sm"
+        // iOS lock: strip the ✕, the backdrop-tap dismiss, and Escape so the
+        // only way forward is "Start talking" → the mic alert.
+        hideCloseButton={nonDismissible}
+        dismissOnOverlayClick={!nonDismissible}
+        onEscapeKeyDown={
+          nonDismissible ? (event) => event.preventDefault() : undefined
+        }
+        onInteractOutside={
+          nonDismissible ? (event) => event.preventDefault() : undefined
+        }
+      >
         <Modal.Header>
           <div className="flex items-center gap-3">
             <span className="shrink-0">

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -5,6 +5,7 @@ import { Modal } from "@vellumai/design-library/components/modal";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /**
  * One-time welcome card shown the first time a user enters voice mode, before
@@ -56,6 +57,9 @@ export function VoiceFirstRunCard({
 }: VoiceFirstRunCardProps) {
   const { components, traits, customImageUrl } =
     useAssistantAvatar(assistantId);
+  const assistantName = useResolvedAssistantsStore.use
+    .assistants()
+    .find((a) => a.id === assistantId)?.name;
 
   return (
     <Modal.Root
@@ -96,53 +100,46 @@ export function VoiceFirstRunCard({
             <Modal.Title>Voice mode</Modal.Title>
           </div>
           <Modal.Description>
-            A hands-free, spoken conversation with your assistant.
+            A hands-free, spoken conversation with {assistantName ?? "your assistant"}.
           </Modal.Description>
         </Modal.Header>
         <Modal.Body>
-          <div className="flex flex-col gap-3">
-            {/* Each bullet's icon matches the in-session control it describes,
-                so the card doubles as a legend for the room. */}
-            <ul className="flex flex-col gap-2.5">
-              <li className="flex items-start gap-2.5">
-                <AudioLines
-                  aria-hidden
-                  className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
-                />
-                <span className="text-body-medium-default">
-                  Speak naturally — your assistant listens and replies out
-                  loud.
-                </span>
-              </li>
-              <li className="flex items-start gap-2.5">
-                <MicOff
-                  aria-hidden
-                  className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
-                />
-                <span className="text-body-medium-default">
-                  Mute the mic whenever you need to, without ending the
-                  session.
-                </span>
-              </li>
-              <li className="flex items-start gap-2.5">
-                <Captions
-                  aria-hidden
-                  className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
-                />
-                <span className="text-body-medium-default">
-                  Turn on live captions from the session controls.
-                </span>
-              </li>
-            </ul>
-            <p className="text-body-small-default text-[var(--content-tertiary)]">
-              You can change any of this anytime, in the session or in
-              Settings.
-            </p>
-          </div>
+          {/* Each bullet's icon matches the in-session control it describes,
+              so the card doubles as a legend for the room. */}
+          <ul className="flex flex-col gap-4">
+            <li className="flex items-start gap-2.5">
+              <AudioLines
+                aria-hidden
+                className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
+              />
+              <span className="text-body-medium-default">
+                Speak naturally and {assistantName ?? "your assistant"} replies
+                out loud.
+              </span>
+            </li>
+            <li className="flex items-start gap-2.5">
+              <MicOff
+                aria-hidden
+                className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
+              />
+              <span className="text-body-medium-default">
+                Mute the mic without ending the session.
+              </span>
+            </li>
+            <li className="flex items-start gap-2.5">
+              <Captions
+                aria-hidden
+                className="mt-0.5 size-4 shrink-0 text-[var(--content-secondary)]"
+              />
+              <span className="text-body-medium-default">
+                Turn on live captions anytime.
+              </span>
+            </li>
+          </ul>
         </Modal.Body>
         <Modal.Footer>
           <Button variant="primary" onClick={onStart}>
-            Start
+            Start talking
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
@@ -2,9 +2,9 @@
  * Listening-state waves for the voice room: layered sine waves that swell as
  * the user speaks — the visual language of energy coming *in* (the user's
  * voice arriving), the counterpart to the assistant's outward `responding`
- * pulse on the avatar. `placement` anchors the band: `bottom` rises from the
- * floor edge (the void look), `center` is a symmetric band around the middle
- * (the color look, gathering behind the centered eyes).
+ * pulse on the avatar. `placement` anchors the band: `top` sweeps in from the
+ * ceiling edge (both looks — above the centerpiece, leaving it clear), `bottom`
+ * rises from the floor edge, `center` is a symmetric band around the middle.
  *
  * The waves always drift horizontally (a slow CSS loop); the user's live mic
  * amplitude drives how high they rise and how bright they are, written
@@ -72,9 +72,9 @@ export type VoiceWaveStyle = "fill" | "line";
 export type VoiceWavePalette = "aurora" | "accent" | "tone";
 
 /**
- * Where the wave band sits: `bottom` rises from the floor edge (the void
- * look), `top` sweeps in from the ceiling edge (the color look — the voice
- * arriving above the centered eyes, leaving them clear), `center` swells
+ * Where the wave band sits: `top` sweeps in from the ceiling edge (both room
+ * looks — the voice arriving above the centered eyes / avatar, leaving the
+ * centerpiece clear), `bottom` rises from the floor edge, `center` swells
  * symmetrically around the middle of the screen.
  */
 export type VoiceWavePlacement = "bottom" | "top" | "center";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -421,16 +421,18 @@ export function VoiceRoomColorLook({
  * negative space below the eyes, in the room's foreground tone. Cross-fades on
  * state change and simply isn't there for states without a caption
  * ({@link EYE_STATE_CAPTION}) — idle and the connecting-side states, which the
- * room's own connect label already covers. `top` is a stable px anchor from the
- * eyes' full-size bottom edge (the per-state resize is centered, so it doesn't
- * shift this).
+ * room's own connect label already covers. `top` is a stable anchor from the
+ * centerpiece's bottom edge — a px number off the eyes' full-size bottom (color
+ * look; the per-state resize is centered, so it doesn't shift this), or a CSS
+ * length off the fixed avatar size (the void look). Shared by both looks so the
+ * caption reads in the same place regardless of avatar type.
  */
-function VoiceStateCaption({
+export function VoiceStateCaption({
   visual,
   top,
 }: {
   visual: VoiceAvatarVisual;
-  top: number;
+  top: number | string;
 }) {
   const reduce = useReducedMotion();
   const label = EYE_STATE_CAPTION[visual];
@@ -641,6 +643,7 @@ function VoiceRespondingTreatment({
     <div
       ref={ampRef}
       aria-hidden="true"
+      data-testid="voice-responding-rings"
       className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center"
       style={{ opacity: "calc(0.25 + var(--resp-amp, 0) * 0.75)" }}
     >
@@ -666,6 +669,35 @@ function VoiceRespondingTreatment({
         />
       ))}
     </div>
+  );
+}
+
+/**
+ * The `rings` responding treatment as a self-contained layer: the concentric
+ * rings radiating outward from screen center on the TTS-output amplitude, sized
+ * against the live window (pass `viewport` to size against a box instead —
+ * Storybook). Exported for the void look, which renders it behind the centered
+ * avatar so a custom avatar emits the same rings the eyes do in the color look.
+ */
+export function VoiceRespondingRings({
+  getAmplitude,
+  viewport,
+}: {
+  /** TTS (output) amplitude source (0–1) — drives the rings' presence. */
+  getAmplitude?: () => number;
+  /** Override the room box (Storybook renders in a box, not the full window). */
+  viewport?: { w: number; h: number };
+}) {
+  const measured = useViewportSize();
+  return (
+    <VoiceRespondingTreatment
+      style="rings"
+      getAmplitude={getAmplitude}
+      // waveStyle/wavePlacement are only read by the `waveform` style; inert here.
+      waveStyle="fill"
+      wavePlacement="top"
+      viewport={viewport ?? measured}
+    />
   );
 }
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -619,12 +619,13 @@ function VoiceRespondingTreatment({
         className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center"
       >
         <div
+          // Tint (with iOS-15 rgba fallback) lives in `.voice-responding-halo`;
+          // the amplitude-driven size/scale/opacity stay inline.
+          className="voice-responding-halo"
           style={{
             width: Math.round(0.9 * M),
             height: Math.round(0.9 * M),
             borderRadius: "9999px",
-            background:
-              "radial-gradient(circle, color-mix(in srgb, var(--room-fg, #ffffff) 24%, transparent) 0%, transparent 66%)",
             transform: "scale(calc(0.8 + var(--resp-amp, 0) * 0.5))",
             opacity: "calc(0.35 + var(--resp-amp, 0) * 0.65)",
             transformOrigin: "center",
@@ -646,12 +647,12 @@ function VoiceRespondingTreatment({
       {[0, 1, 2].map((i) => (
         <motion.span
           key={i}
-          className="absolute rounded-full border-2"
+          // Border tint (with iOS-15 rgba fallback) lives in
+          // `.voice-responding-ring`; the amplitude-driven size stays inline.
+          className="voice-responding-ring absolute rounded-full border-2"
           style={{
             width: Math.round(0.5 * M),
             height: Math.round(0.5 * M),
-            borderColor:
-              "color-mix(in srgb, var(--room-fg, #ffffff) 55%, transparent)",
           }}
           initial={reduce ? false : { scale: 0.4, opacity: 0.55 }}
           animate={

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -375,6 +375,26 @@ describe("VoiceRoom — connect feedback", () => {
   });
 });
 
+describe("VoiceRoom — audio-aware status label (JARVIS-1279)", () => {
+  // The sr-only aria-live region uses the "…"-suffixed state labels, distinct
+  // from the caption's un-suffixed text (e.g. "Thinking" vs "Thinking…").
+  test("announces Thinking… (not Speaking…) during a silent mid-turn speaking phase", () => {
+    startOwnedSession("speaking");
+    // A mid-turn tool run: still `speaking`, but audio has stopped flowing.
+    useLiveVoiceStore.setState({ assistantAudioActive: false });
+    render(<VoiceRoom />);
+    expect(screen.getByText("Thinking…")).toBeTruthy();
+    expect(screen.queryByText("Speaking…")).toBeNull();
+  });
+
+  test("announces Speaking… while audio is actually flowing", () => {
+    // seedLiveVoiceSession marks a `speaking` session audio-active.
+    startOwnedSession("speaking");
+    render(<VoiceRoom />);
+    expect(screen.getByText("Speaking…")).toBeTruthy();
+  });
+});
+
 describe("VoiceRoom — full-app takeover", () => {
   test("the room is a modal full-viewport overlay", () => {
     startOwnedSession("listening");

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -198,7 +198,7 @@ describe("VoiceRoom — visibility", () => {
 describe("VoiceRoom — listening waves", () => {
   const waves = () => screen.queryByTestId("listening-waves");
 
-  test("mounts the bottom waves while listening (energy coming in)", () => {
+  test("mounts the listening waves while listening (energy coming in)", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     expect(roomDialog()).not.toBeNull();
@@ -469,7 +469,7 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
   });
 });
 
-describe("VoiceRoom — color-look state caption", () => {
+describe("VoiceRoom — state caption (shared across looks)", () => {
   const caption = () => screen.queryByTestId("voice-state-caption");
 
   function renderCharacterLook(state: LiveVoiceSessionState) {
@@ -477,6 +477,18 @@ describe("VoiceRoom — color-look state caption", () => {
       components: CHARACTER_COMPONENTS,
       traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
       customImageUrl: null,
+    };
+    startOwnedSession(state);
+    render(<VoiceRoom />);
+  }
+
+  // The void look (custom-image / unresolved avatar) carries the centered
+  // avatar, not the eyes, but shares the same caption in the same beat.
+  function renderVoidLook(state: LiveVoiceSessionState) {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: null,
+      customImageUrl: "blob:custom-avatar",
     };
     startOwnedSession(state);
     render(<VoiceRoom />);
@@ -499,6 +511,48 @@ describe("VoiceRoom — color-look state caption", () => {
     useVoicePrefsStore.setState({ showUserTranscript: true });
     renderCharacterLook("listening");
     expect(caption()?.textContent).toBe("Listening");
+  });
+
+  test("the void look shows the same caption below the custom avatar (parity)", () => {
+    renderVoidLook("speaking");
+    // Void look — the centered avatar, not the eyes — still names the beat.
+    expect(screen.getByTestId("voice-avatar")).toBeTruthy();
+    expect(screen.queryByTestId("voice-room-eyes")).toBeNull();
+    expect(caption()?.textContent).toBe("Speaking");
+  });
+
+  test("the void look stands its caption down for the assistant transcript too", () => {
+    useVoicePrefsStore.setState({ showAssistantTranscript: true });
+    renderVoidLook("speaking");
+    expect(caption()).toBeNull();
+  });
+});
+
+describe("VoiceRoom — void-look responding rings", () => {
+  const rings = () => screen.queryByTestId("voice-responding-rings");
+
+  function renderVoidLook(state: LiveVoiceSessionState) {
+    mockAvatarData = {
+      components: CHARACTER_COMPONENTS,
+      traits: null,
+      customImageUrl: "blob:custom-avatar",
+    };
+    startOwnedSession(state);
+    render(<VoiceRoom />);
+  }
+
+  test("emits the same concentric rings behind the custom avatar while responding", () => {
+    renderVoidLook("speaking");
+    // The custom avatar (not the eyes) is the centerpiece, but it radiates the
+    // color look's rings — parity with the eyes' responding treatment.
+    expect(screen.getByTestId("voice-avatar")).toBeTruthy();
+    expect(screen.queryByTestId("voice-room-eyes")).toBeNull();
+    expect(rings()).toBeTruthy();
+  });
+
+  test("shows no rings outside responding (energy going out only while speaking)", () => {
+    renderVoidLook("listening");
+    expect(rings()).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -118,6 +118,9 @@ export function VoiceRoom() {
 function VoiceRoomOverlay() {
   const state = useLiveVoiceStore.use.state();
   const reconnecting = useLiveVoiceStore.use.reconnecting();
+  // `speaking` stays set across a mid-turn tool run; gate `responding` on audio
+  // actually flowing so the room reads `thinking` while the tool works.
+  const assistantAudioActive = useLiveVoiceStore.use.assistantAudioActive();
   const assistantId = useLiveVoiceStore.use.assistantId();
   const muted = useLiveVoiceStore.use.muted();
   // Turn-scoped ■ stop is hands-free-only (a manual session's interrupt ends
@@ -129,8 +132,14 @@ function VoiceRoomOverlay() {
   const entryOrigin = useLiveVoiceStore.use.entryOrigin();
   const reduce = useReducedMotion();
 
-  const visual = toVoiceAvatarVisual(state, reconnecting);
-  const stateLabel = liveVoiceStateLabel(state, reconnecting);
+  const visual = toVoiceAvatarVisual(state, reconnecting, assistantAudioActive);
+  // The label + sr-only announcement must follow the same audio-aware mapping as
+  // the visual: a silent mid-turn `speaking` (ack spoken, tool now running)
+  // reads as "Thinking…", not "Speaking…", so screen-reader users aren't told
+  // the assistant is talking while it's actually silent (JARVIS-1279).
+  const labelState =
+    state === "speaking" && !assistantAudioActive ? "thinking" : state;
+  const stateLabel = liveVoiceStateLabel(labelState, reconnecting);
 
   // Captions = the two persisted transcript prefs, toggled together from the
   // room. Bound to the same `voice-prefs` store as the settings page and the

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -67,10 +67,23 @@ import { VoiceAvatar } from "./voice-avatar";
 import { VoiceListeningWaves } from "./voice-listening-waves";
 import { AVATAR_ENTER_SPRING } from "./voice-motion";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
-import { VoiceRoomColorLook, resolveVoiceRoomLook } from "./voice-room-eyes";
+import {
+  VoiceRespondingRings,
+  VoiceRoomColorLook,
+  VoiceStateCaption,
+  resolveVoiceRoomLook,
+} from "./voice-room-eyes";
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
 
 const AVATAR_SIZE = 220;
+/**
+ * State caption anchor for the void look — just below the centered avatar's
+ * bottom edge (half its size from center, plus a gap), the void-look counterpart
+ * to the color look's caption below the eyes. Sits above the assistant
+ * transcript's `50% + 15vmin + 2.5rem` clearance on any typical viewport, and it
+ * only shows when that transcript is off (see below), so the two never collide.
+ */
+const VOID_CAPTION_TOP = `calc(50% + ${AVATAR_SIZE / 2}px + 1.75rem)`;
 
 /**
  * Safe-area insets (see `docs/CAPACITOR.md`): the `var()` is set by
@@ -217,8 +230,11 @@ function VoiceRoomOverlay() {
     >
       {/* The color look (body grow entrance + color fade + centered waves +
           centered eyes) is the entire cast; the void look expresses the
-          session through the centered avatar and the bottom listening waves
-          instead. Both draw the waves only while `listening`, from live mic
+          session through the centered avatar, but shares the color look's
+          foreground chrome — the listening waves sweep in from the same top edge
+          and the same state caption names the beat below the centerpiece — so
+          the room reads identically for a custom avatar bar the full-screen
+          color + eyes. Both draw the waves only while `listening`, from live mic
           amplitude. */}
       {look ? (
         <VoiceRoomColorLook
@@ -240,7 +256,24 @@ function VoiceRoomOverlay() {
             <VoiceListeningWaves
               getAmplitude={getLiveVoiceInputAmplitude}
               palette="accent"
+              // Same top edge as the color look, above the centered avatar —
+              // positional parity, only the aurora/accent color differs from the
+              // color look's avatar-toned band.
+              placement="top"
             />
+          ) : null}
+          {/* Responding: the same concentric rings the color look radiates from
+              behind the eyes, here behind the centered avatar (both centered, so
+              they emanate from the centerpiece the same way). Rendered before the
+              avatar so it paints them behind it; rides the TTS-output amplitude. */}
+          {visual === "responding" ? (
+            <VoiceRespondingRings getAmplitude={getLiveVoiceOutputAmplitude} />
+          ) : null}
+          {/* Same state caption + gating as the color look (stands down only for
+              the assistant-transcript pref), anchored below the centered avatar
+              instead of the eyes. */}
+          {!showAssistantTranscript ? (
+            <VoiceStateCaption visual={visual} top={VOID_CAPTION_TOP} />
           ) : null}
         </>
       )}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -807,3 +807,30 @@ body {
     opacity: 0.4;
   }
 }
+
+/* Responding-treatment tint (the concentric rings + the halo bloom radiating
+ * from behind the eyes / avatar; see the responding treatments in
+ * voice-room-eyes.tsx). Follows the room foreground tone (--room-fg) so it reads
+ * on any avatar-color background, and — like the wave palette rules above —
+ * declares a plain rgba() BEFORE the color-mix() so engines without color-mix
+ * (Safari/iOS < 16.2; the iOS shell still targets 15.0) keep the visible white
+ * fallback instead of dropping the invalid declaration to `currentColor`. The
+ * amplitude-driven size/opacity stay inline at the call site; only the tinted
+ * color lives here (the fallback pattern needs two declarations, which a React
+ * inline style object can't express). */
+.voice-responding-ring {
+  border-color: rgba(255, 255, 255, 0.55);
+  border-color: color-mix(in srgb, var(--room-fg, #ffffff) 55%, transparent);
+}
+.voice-responding-halo {
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.24) 0%,
+    transparent 66%
+  );
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--room-fg, #ffffff) 24%, transparent) 0%,
+    transparent 66%
+  );
+}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -392,7 +392,7 @@ body {
  * the `responding` visual rides live amplitude (the assistant's TTS output),
  * fed imperatively through the `--voice-amp` custom property by a
  * requestAnimationFrame loop — never React state. `listening` stays at rest;
- * the user's voice is expressed by the bottom waves coming in (see
+ * the user's voice is expressed by the top-edge waves coming in (see
  * voice-listening-waves.tsx). See voice-avatar.tsx.
  *
  * The sonar ripple's cyan→indigo gradient is a deliberate decorative accent
@@ -452,7 +452,7 @@ body {
 
 /* Listening — the avatar stays receptive: no outward emanation (that moved to
  * responding), just a slight constant breathing pulse. The user's voice is
- * carried by the bottom waves coming in (see voice-listening-waves.tsx), not by
+ * carried by the top-edge waves coming in (see voice-listening-waves.tsx), not by
  * the avatar reacting to mic amplitude. */
 @keyframes voice-avatar-soft-pulse {
   0%, 100% { transform: scale(1); }
@@ -775,10 +775,11 @@ body {
   transform: scaleY(-1);
 }
 
-/* Placement: top = the band sweeps in from the ceiling edge (the color look —
- * the user's voice arriving above the centered eyes, leaving them clear). The
- * wave fill hugs the bottom of its viewBox, so a vertical flip pins the crests
- * to the top edge, rippling downward; the amplitude translate recedes the band
+/* Placement: top = the band sweeps in from the ceiling edge (both room looks —
+ * the user's voice arriving above the centered eyes / avatar, leaving the
+ * centerpiece clear). The wave fill hugs the bottom of its viewBox, so a
+ * vertical flip pins the crests to the top edge, rippling downward; the
+ * amplitude translate recedes the band
  * up out of view when quiet (the mirror of the bottom placement's recede-down). */
 .voice-listening-waves--top {
   top: 0;


### PR DESCRIPTION
## Cherry picks for v0.10.9 — Round 1

Cherry-picking the following merged PRs onto `cherry-pick/release/v0.10.9`:

| PR | Title |
| --- | --- |
| #38026 | Cross-client voice-mode parity: filled entry button, iOS first-run card, iOS-15 ring fallback |
| #38025 | Read a silent mid-turn voice room as thinking, not speaking (JARVIS-1279) |
| #38023 | Voice first-run card copy pass + custom-avatar room parity (JARVIS-1278) |

### Notes
- #38066 (coding-agents-panel flag removal) was already on the cherry-pick branch.
- All three cherry-picked cleanly with no conflicts.
- All changes are web client voice/voice-room UI fixes.