### PR TITLE
feat(plugins): `add-plugin-icon` — curate emoji, vendor PNG, and sync in one command

### DIFF
--- a/docs/plugin-icon-contract.md
+++ b/docs/plugin-icon-contract.md
@@ -79,6 +79,35 @@ Vendored PNGs are uploaded to GCS and served publicly, mirroring the skill asset
 
 ## Adding or updating a plugin icon
 
+The one-command path handles all three artifacts (curated emoji, vendored PNG,
+bundled copy) in one shot:
+
+```bash
+# Vendor the PNG + set the curated emoji fallback in a single step:
+node scripts/plugins/add-plugin-icon.mjs <plugin-name> --emoji ☕
+
+# PNG only (leave any existing emoji as is):
+node scripts/plugins/add-plugin-icon.mjs <plugin-name>
+```
+
+It (1) optionally patches the plugin's `icon` field in `plugins/marketplace.json`
+— a surgical, churn-free edit that preserves the file's exact serialization —
+(2) runs the generator to vendor `plugins/assets/<name>/icon.png` and regenerate
+`plugins/plugin-icons.json`, then (3) runs `meta/sync-bundled-copies.ts` so
+`assistant/src/cli/lib/bundled-marketplace.json` stays in lockstep. Set
+`GITHUB_TOKEN` to lift the generator's unauthenticated GitHub rate limit. Then
+commit whatever changed (`marketplace.json`, the vendored asset,
+`plugin-icons.json`, and the bundled copy).
+
+The plugin must already exist in `plugins/marketplace.json` — an icon only
+attaches to a catalogued plugin. A plugin whose upstream `icon.png` fails
+validation simply gets no manifest entry and falls back to the emoji (or the
+generic glyph).
+
+### Under the hood
+
+If you'd rather run the steps by hand, or need only one of them:
+
 **Emoji:**
 
 1. Set (or change) the `icon` string on the plugin's entry in `plugins/marketplace.json`.
@@ -87,5 +116,5 @@ Vendored PNGs are uploaded to GCS and served publicly, mirroring the skill asset
 
 **PNG:**
 
-1. Run the generator `scripts/plugins/generate-plugin-icons.mjs` (added later in the plugin-icons plan). It fetches the plugin's `icon.png`, validates it against the rules above, vendors the valid bytes to `plugins/assets/<name>/icon.png`, and regenerates `plugins/plugin-icons.json`.
+1. Run the generator `scripts/plugins/generate-plugin-icons.mjs`. It fetches the plugin's `icon.png`, validates it against the rules above, vendors the valid bytes to `plugins/assets/<name>/icon.png`, and regenerates `plugins/plugin-icons.json`.
 2. Commit the vendored asset **and** the regenerated `plugins/plugin-icons.json` together. A plugin whose icon fails validation simply gets no manifest entry (and falls back to emoji or the generic glyph).

--- a/scripts/plugins/__tests__/add-plugin-icon.test.mjs
+++ b/scripts/plugins/__tests__/add-plugin-icon.test.mjs
@@ -1,0 +1,292 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  addPluginIcon,
+  isCuratedEmoji,
+  parseArgs,
+  serializeMarketplace,
+} from "../add-plugin-icon.mjs";
+
+const COFFEE = String.fromCodePoint(0x2615); // ☕
+const BONE = String.fromCodePoint(0x1f9b4); // 🦴  (outside the BMP → surrogate pair)
+const EM_DASH = String.fromCodePoint(0x2014); // —
+
+const quietLog = { log() {}, warn() {} };
+
+let dir;
+let marketplacePath;
+
+/** Canonical marketplace fixture written via the tool's own serializer. */
+function writeMarketplace(plugins) {
+  const data = { name: "vellum-assistant", plugins };
+  writeFileSync(marketplacePath, serializeMarketplace(data));
+  return data;
+}
+
+function entry(name, extra = {}) {
+  return {
+    name,
+    source: { source: "github", repo: `owner/${name}`, ref: "a".repeat(40) },
+    description: `The ${name} plugin ${EM_DASH} does things.`,
+    license: "MIT",
+    ...extra,
+  };
+}
+
+/** A generator stub that vendors the given names; records call count. */
+function stubGenerate(vendored = [], skipped = []) {
+  const calls = { n: 0 };
+  const fn = async () => {
+    calls.n++;
+    return { vendored, skipped };
+  };
+  return [fn, calls];
+}
+
+function stubSync() {
+  const calls = { n: 0 };
+  return [async () => void calls.n++, calls];
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "add-plugin-icon-"));
+  marketplacePath = join(dir, "marketplace.json");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("serializeMarketplace", () => {
+  test("escapes non-ASCII (emoji, punctuation) and ends with a newline", () => {
+    const out = serializeMarketplace({ plugins: [entry("coffee", { icon: COFFEE })] });
+    expect(out.endsWith("\n")).toBe(true);
+    // Emoji + em-dash are ASCII-escaped, never emitted raw.
+    expect(out).toContain("\\u2615");
+    expect(out).toContain("\\u2014");
+    expect(out.includes(COFFEE)).toBe(false);
+    expect(out.includes(EM_DASH)).toBe(false);
+  });
+
+  test("escapes astral emoji as a surrogate pair", () => {
+    const out = serializeMarketplace({ plugins: [entry("caveman", { icon: BONE })] });
+    expect(out).toContain("\\ud83e\\uddb4");
+    expect(out.includes(BONE)).toBe(false);
+  });
+
+  test("is a stable round-trip of its own output", () => {
+    const first = serializeMarketplace({
+      name: "vellum-assistant",
+      plugins: [entry("a", { icon: COFFEE }), entry("b")],
+    });
+    const second = serializeMarketplace(JSON.parse(first));
+    expect(second).toBe(first);
+  });
+});
+
+describe("isCuratedEmoji", () => {
+  test("accepts emoji glyphs, rejects URLs/paths/empties", () => {
+    expect(isCuratedEmoji(COFFEE)).toBe(true);
+    expect(isCuratedEmoji(BONE)).toBe(true);
+    expect(isCuratedEmoji("")).toBe(false);
+    expect(isCuratedEmoji("/icons/x.png")).toBe(false);
+    expect(isCuratedEmoji("https://example.com/x.png")).toBe(false);
+    expect(isCuratedEmoji("http://x")).toBe(false);
+    expect(isCuratedEmoji(undefined)).toBe(false);
+  });
+});
+
+describe("addPluginIcon", () => {
+  test("sets the emoji surgically, leaving other entries byte-identical", async () => {
+    const data = writeMarketplace([entry("alpha"), entry("coffee"), entry("bravo")]);
+    const before = readFileSync(marketplacePath, "utf-8");
+    const [gen, genCalls] = stubGenerate(["coffee"]);
+    const [sync, syncCalls] = stubSync();
+
+    const result = await addPluginIcon({
+      name: "coffee",
+      emoji: COFFEE,
+      marketplacePath,
+      runGenerate: gen,
+      runSync: sync,
+      log: quietLog,
+    });
+
+    const after = readFileSync(marketplacePath, "utf-8");
+    // Exactly the change of setting coffee.icon = ☕, nothing else.
+    data.plugins[1].icon = COFFEE;
+    expect(after).toBe(serializeMarketplace(data));
+    // The emoji is escaped, and the only textual delta is the added icon line.
+    expect(after).toContain("\\u2615");
+    const removedUnchanged = before
+      .split("\n")
+      .filter((l) => !after.split("\n").includes(l));
+    expect(removedUnchanged).toEqual([]); // no line was removed/altered, only added
+
+    expect(result.emojiChanged).toBe(true);
+    expect(result.vendored).toBe(true);
+    expect(genCalls.n).toBe(1);
+    expect(syncCalls.n).toBe(1);
+  });
+
+  test("is a no-op on the file when the emoji is already set, but still refreshes", async () => {
+    writeMarketplace([entry("coffee", { icon: COFFEE })]);
+    const before = readFileSync(marketplacePath, "utf-8");
+    const [gen, genCalls] = stubGenerate(["coffee"]);
+    const [sync, syncCalls] = stubSync();
+
+    const result = await addPluginIcon({
+      name: "coffee",
+      emoji: COFFEE,
+      marketplacePath,
+      runGenerate: gen,
+      runSync: sync,
+      log: quietLog,
+    });
+
+    expect(readFileSync(marketplacePath, "utf-8")).toBe(before);
+    expect(result.emojiChanged).toBe(false);
+    // Vendor refresh + sync still run — the point of a re-run.
+    expect(genCalls.n).toBe(1);
+    expect(syncCalls.n).toBe(1);
+  });
+
+  test("without --emoji, never touches marketplace.json but still vendors+syncs", async () => {
+    writeMarketplace([entry("coffee")]);
+    const before = readFileSync(marketplacePath, "utf-8");
+    const [gen, genCalls] = stubGenerate([], ["coffee"]);
+    const [sync, syncCalls] = stubSync();
+
+    const result = await addPluginIcon({
+      name: "coffee",
+      marketplacePath,
+      runGenerate: gen,
+      runSync: sync,
+      log: quietLog,
+    });
+
+    expect(readFileSync(marketplacePath, "utf-8")).toBe(before);
+    expect(result.emojiChanged).toBe(false);
+    expect(result.vendored).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(genCalls.n).toBe(1);
+    expect(syncCalls.n).toBe(1);
+  });
+
+  test("throws for a plugin absent from the marketplace, without vendoring", async () => {
+    writeMarketplace([entry("coffee")]);
+    const [gen, genCalls] = stubGenerate();
+    const [sync, syncCalls] = stubSync();
+
+    await expect(
+      addPluginIcon({
+        name: "ghost",
+        emoji: COFFEE,
+        marketplacePath,
+        runGenerate: gen,
+        runSync: sync,
+        log: quietLog,
+      }),
+    ).rejects.toThrow(/is not in/);
+    expect(genCalls.n).toBe(0);
+    expect(syncCalls.n).toBe(0);
+  });
+
+  test("rejects a URL/path emoji before doing anything", async () => {
+    writeMarketplace([entry("coffee")]);
+    const before = readFileSync(marketplacePath, "utf-8");
+    const [gen, genCalls] = stubGenerate();
+    const [sync, syncCalls] = stubSync();
+
+    await expect(
+      addPluginIcon({
+        name: "coffee",
+        emoji: "https://example.com/x.png",
+        marketplacePath,
+        runGenerate: gen,
+        runSync: sync,
+        log: quietLog,
+      }),
+    ).rejects.toThrow(/emoji glyph/);
+    expect(readFileSync(marketplacePath, "utf-8")).toBe(before);
+    expect(genCalls.n).toBe(0);
+    expect(syncCalls.n).toBe(0);
+  });
+
+  test("refuses to rewrite a non-canonical marketplace.json", async () => {
+    // 4-space indent → not the canonical form our serializer emits.
+    writeFileSync(
+      marketplacePath,
+      JSON.stringify({ name: "x", plugins: [entry("coffee")] }, null, 4) + "\n",
+    );
+    const before = readFileSync(marketplacePath, "utf-8");
+    const [gen, genCalls] = stubGenerate();
+    const [sync, syncCalls] = stubSync();
+
+    await expect(
+      addPluginIcon({
+        name: "coffee",
+        emoji: COFFEE,
+        marketplacePath,
+        runGenerate: gen,
+        runSync: sync,
+        log: quietLog,
+      }),
+    ).rejects.toThrow(/canonical/);
+    expect(readFileSync(marketplacePath, "utf-8")).toBe(before);
+    expect(genCalls.n).toBe(0);
+    expect(syncCalls.n).toBe(0);
+  });
+
+  test("a generator abort leaves marketplace.json untouched and skips sync", async () => {
+    writeMarketplace([entry("coffee")]);
+    const before = readFileSync(marketplacePath, "utf-8");
+    const [sync, syncCalls] = stubSync();
+
+    await expect(
+      addPluginIcon({
+        name: "coffee",
+        emoji: COFFEE,
+        marketplacePath,
+        runGenerate: async () => {
+          throw new Error("Aborting icon generation: transient");
+        },
+        runSync: sync,
+        log: quietLog,
+      }),
+    ).rejects.toThrow(/Aborting icon generation/);
+
+    // Emoji write happens only AFTER a successful generate — so the abort
+    // leaves the file pristine and never runs the sync.
+    expect(readFileSync(marketplacePath, "utf-8")).toBe(before);
+    expect(syncCalls.n).toBe(0);
+  });
+});
+
+describe("parseArgs", () => {
+  test("parses name and --emoji in both forms", () => {
+    expect(parseArgs(["coffee"])).toEqual({ name: "coffee", emoji: undefined });
+    expect(parseArgs(["coffee", "--emoji", COFFEE])).toEqual({
+      name: "coffee",
+      emoji: COFFEE,
+    });
+    expect(parseArgs(["coffee", `--emoji=${COFFEE}`])).toEqual({
+      name: "coffee",
+      emoji: COFFEE,
+    });
+  });
+
+  test("--help short-circuits", () => {
+    expect(parseArgs(["--help"])).toEqual({ help: true });
+    expect(parseArgs(["-h"])).toEqual({ help: true });
+  });
+
+  test("rejects a dangling --emoji, unknown flags, and extra args", () => {
+    expect(() => parseArgs(["coffee", "--emoji"])).toThrow(/requires a value/);
+    expect(() => parseArgs(["coffee", "--bogus"])).toThrow(/Unknown flag/);
+    expect(() => parseArgs(["coffee", "extra"])).toThrow(/extra argument/);
+  });
+});

--- a/scripts/plugins/__tests__/add-plugin-icon.test.mjs
+++ b/scripts/plugins/__tests__/add-plugin-icon.test.mjs
@@ -88,14 +88,32 @@ describe("serializeMarketplace", () => {
 });
 
 describe("isCuratedEmoji", () => {
-  test("accepts emoji glyphs, rejects URLs/paths/empties", () => {
+  // Must match the `icon` refinement in marketplaceEntrySchema
+  // (assistant/src/cli/lib/plugin-marketplace.ts) so this tool never writes a
+  // value the reader later rejects.
+  // 👨‍👩‍👧‍👦 = 4 emoji joined by 3 ZWJ (U+200D) → 7 code points.
+  const ZWJ = String.fromCodePoint(0x200d);
+  const FAMILY = [0x1f468, 0x1f469, 0x1f467, 0x1f466]
+    .map((cp) => String.fromCodePoint(cp))
+    .join(ZWJ);
+
+  test("accepts emoji glyphs, including multi-code-point sequences", () => {
     expect(isCuratedEmoji(COFFEE)).toBe(true);
     expect(isCuratedEmoji(BONE)).toBe(true);
+    expect(isCuratedEmoji(FAMILY)).toBe(true); // 7 code points ≤ 8
+  });
+
+  test("rejects URLs, slashes, over-length, and empties (schema parity)", () => {
     expect(isCuratedEmoji("")).toBe(false);
+    expect(isCuratedEmoji(undefined)).toBe(false);
     expect(isCuratedEmoji("/icons/x.png")).toBe(false);
     expect(isCuratedEmoji("https://example.com/x.png")).toBe(false);
+    expect(isCuratedEmoji("HTTPS://example.com/x.png")).toBe(false); // case-insensitive
     expect(isCuratedEmoji("http://x")).toBe(false);
-    expect(isCuratedEmoji(undefined)).toBe(false);
+    expect(isCuratedEmoji("a\\b")).toBe(false); // backslash anywhere
+    expect(isCuratedEmoji(`${COFFEE}/x`)).toBe(false); // slash not just leading
+    expect(isCuratedEmoji("not-an-emoji-just-text")).toBe(false); // > 8 code points
+    expect(isCuratedEmoji(COFFEE.repeat(9))).toBe(false); // 9 code points
   });
 });
 
@@ -210,7 +228,7 @@ describe("addPluginIcon", () => {
         runSync: sync,
         log: quietLog,
       }),
-    ).rejects.toThrow(/emoji glyph/);
+    ).rejects.toThrow(/short emoji/);
     expect(readFileSync(marketplacePath, "utf-8")).toBe(before);
     expect(genCalls.n).toBe(0);
     expect(syncCalls.n).toBe(0);

--- a/scripts/plugins/add-plugin-icon.mjs
+++ b/scripts/plugins/add-plugin-icon.mjs
@@ -55,17 +55,19 @@ export function serializeMarketplace(data) {
 }
 
 /**
- * Whether `value` is a curated emoji glyph rather than a URL or path. Mirrors
- * `_curated_emoji` in the platform's `django/app/plugins/serializers.py`: a
- * value that starts with `/` or `http` is treated as a URL/path (not an emoji)
- * and rejected here so it never lands in the curated `icon` field.
+ * Whether `value` is a valid curated `icon` per the marketplace schema — so this
+ * tool never writes a value the reader would later reject. Mirrors the `icon`
+ * refinement in `marketplaceEntrySchema` (`assistant/src/cli/lib/plugin-marketplace.ts`):
+ * at most 8 code points, and no slash/backslash or `http(s):` URL (case-insensitive).
+ * We additionally require it be non-empty, since the schema's `.optional()` covers
+ * "no icon" but an explicit empty `--emoji ""` is a user error here.
  */
 export function isCuratedEmoji(value) {
   return (
     typeof value === "string" &&
     value.length > 0 &&
-    !value.startsWith("/") &&
-    !value.startsWith("http")
+    [...value].length <= 8 &&
+    !/[/\\]|^https?:/i.test(value)
   );
 }
 
@@ -119,7 +121,8 @@ export async function addPluginIcon({
   if (emoji !== undefined) {
     if (!isCuratedEmoji(emoji)) {
       throw new Error(
-        `--emoji must be an emoji glyph, not a URL or path (got ${JSON.stringify(emoji)}).`,
+        `--emoji must be a short emoji (at most 8 code points, no slashes or ` +
+          `URLs), per the marketplace schema (got ${JSON.stringify(emoji)}).`,
       );
     }
     if (entry.icon === emoji) {

--- a/scripts/plugins/add-plugin-icon.mjs
+++ b/scripts/plugins/add-plugin-icon.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * One-command authoring flow for a marketplace plugin's icon.
+ *
+ * Collapses the three-step ritual (curate emoji → vendor PNG → sync bundled
+ * copy) into a single invocation:
+ *
+ *   1. (optional, with `--emoji`) set the curated `icon` emoji on the plugin's
+ *      entry in `plugins/marketplace.json`, patching just that one field and
+ *      preserving the file's exact serialization so unrelated entries don't churn.
+ *   2. run the icon generator to fetch/validate/vendor every plugin's `icon.png`
+ *      and regenerate `plugins/plugin-icons.json` (see generate-plugin-icons.mjs).
+ *   3. run `meta/sync-bundled-copies.ts` so the bundled offline marketplace copy
+ *      at `assistant/src/cli/lib/bundled-marketplace.json` stays in lockstep.
+ *
+ * All emoji preconditions (plugin exists, emoji shape, file is in canonical form)
+ * are validated up front, before any write or network call — so a transient
+ * generator failure leaves `marketplace.json` untouched, and the whole flow is
+ * safe to re-run idempotently.
+ *
+ * Usage:
+ *   node scripts/plugins/add-plugin-icon.mjs <plugin-name>
+ *   node scripts/plugins/add-plugin-icon.mjs <plugin-name> --emoji ☕
+ *
+ * A `GITHUB_TOKEN` in the environment lifts the generator's unauthenticated
+ * GitHub rate limit — recommended, since the generator re-fetches every plugin's
+ * icon.png on each run.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { generatePluginIcons } from "./generate-plugin-icons.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../..");
+const MARKETPLACE_PATH = join(REPO_ROOT, "plugins/marketplace.json");
+const SYNC_SCRIPT = "meta/sync-bundled-copies.ts";
+
+/**
+ * Serialize marketplace data to the exact on-disk canonical form: 2-space
+ * indent, non-ASCII escaped as `\uXXXX` (matching the committed file, which
+ * escapes emoji and punctuation like `—`), trailing newline. `JSON.stringify`
+ * emits raw Unicode, so the escape pass is what keeps a one-field edit from
+ * flipping every existing escaped character in the file.
+ */
+export function serializeMarketplace(data) {
+  const json = JSON.stringify(data, null, 2).replace(
+    /[\u007f-\uffff]/g,
+    (c) => "\\u" + c.charCodeAt(0).toString(16).padStart(4, "0"),
+  );
+  return `${json}\n`;
+}
+
+/**
+ * Whether `value` is a curated emoji glyph rather than a URL or path. Mirrors
+ * `_curated_emoji` in the platform's `django/app/plugins/serializers.py`: a
+ * value that starts with `/` or `http` is treated as a URL/path (not an emoji)
+ * and rejected here so it never lands in the curated `icon` field.
+ */
+export function isCuratedEmoji(value) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    !value.startsWith("/") &&
+    !value.startsWith("http")
+  );
+}
+
+/** Run the bundled-copies sync via Bun. Throws with a recovery hint on failure. */
+function runSyncScript({ repoRoot = REPO_ROOT, log = console } = {}) {
+  log.log?.(`Syncing bundled copies (${SYNC_SCRIPT})…`);
+  try {
+    execFileSync("bun", ["run", SYNC_SCRIPT], { cwd: repoRoot, stdio: "inherit" });
+  } catch (err) {
+    throw new Error(
+      `Failed to run ${SYNC_SCRIPT} (${err.message}). Ensure Bun is installed ` +
+        `and on PATH, then re-run \`bun run ${SYNC_SCRIPT}\` manually.`,
+    );
+  }
+}
+
+/**
+ * Vendor a plugin's icon and (optionally) set its curated emoji, then sync the
+ * bundled marketplace copy. Injectable `runGenerate`/`runSync` keep it unit
+ * testable without network or a Bun subprocess.
+ *
+ * Returns `{ emojiChanged, previousEmoji, vendored, skipped }` where `vendored`
+ * / `skipped` reflect whether THIS plugin ended up with a valid vendored PNG.
+ */
+export async function addPluginIcon({
+  name,
+  emoji,
+  marketplacePath = MARKETPLACE_PATH,
+  runGenerate = (log) => generatePluginIcons({ log }),
+  runSync = (log) => runSyncScript({ repoRoot: REPO_ROOT, log }),
+  log = console,
+} = {}) {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error("A plugin name is required.");
+  }
+
+  // --- Validate everything up front, before any write or network call. ---
+  const raw = readFileSync(marketplacePath, "utf-8");
+  const data = JSON.parse(raw);
+  const entry = (data.plugins ?? []).find((p) => p?.name === name);
+  if (!entry) {
+    throw new Error(
+      `Plugin "${name}" is not in ${marketplacePath}. Add its marketplace ` +
+        `entry first — an icon can only attach to a catalogued plugin.`,
+    );
+  }
+
+  let emojiChanged = false;
+  let previousEmoji;
+  let willWriteEmoji = false;
+  if (emoji !== undefined) {
+    if (!isCuratedEmoji(emoji)) {
+      throw new Error(
+        `--emoji must be an emoji glyph, not a URL or path (got ${JSON.stringify(emoji)}).`,
+      );
+    }
+    if (entry.icon === emoji) {
+      log.log?.(`Emoji already set to ${emoji} for "${name}" — leaving as is.`);
+    } else {
+      // Refuse to rewrite unless our serializer reproduces the file byte-for-byte;
+      // otherwise a one-field edit would silently reformat unrelated entries.
+      if (serializeMarketplace(data) !== raw) {
+        throw new Error(
+          `${marketplacePath} is not in the canonical 2-space, ASCII-escaped JSON ` +
+            `form this tool writes. Refusing to rewrite it to avoid a large unrelated ` +
+            `diff — normalize the file first.`,
+        );
+      }
+      willWriteEmoji = true;
+      previousEmoji = entry.icon;
+    }
+  }
+
+  // --- Vendor the PNG + regenerate the manifest first: this is the only step
+  //     that hits the network and can abort transiently. Doing it before the
+  //     marketplace write means an abort leaves marketplace.json pristine. ---
+  const { vendored, skipped } = await runGenerate(log);
+
+  // --- Now the guaranteed-to-succeed local writes. ---
+  if (willWriteEmoji) {
+    entry.icon = emoji;
+    writeFileSync(marketplacePath, serializeMarketplace(data));
+    emojiChanged = true;
+    log.log?.(
+      `Set emoji for "${name}": ${previousEmoji ? `${previousEmoji} → ` : ""}${emoji}`,
+    );
+  }
+
+  await runSync(log);
+
+  const didVendor = vendored.includes(name);
+  if (didVendor) {
+    log.log?.(`Vendored a PNG icon for "${name}".`);
+  } else {
+    log.log?.(
+      `No valid upstream icon.png for "${name}" — it will fall back to ` +
+        `${entry.icon ? `the emoji ${entry.icon}` : "the generic glyph"}.`,
+    );
+  }
+
+  return {
+    emojiChanged,
+    previousEmoji,
+    vendored: didVendor,
+    skipped: skipped.includes(name),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: node scripts/plugins/add-plugin-icon.mjs <plugin-name> [--emoji <emoji>]
+
+Vendors <plugin-name>'s icon.png, regenerates plugins/plugin-icons.json, and
+syncs the bundled marketplace copy. With --emoji, first sets the curated emoji
+fallback on the plugin's marketplace.json entry (a surgical, churn-free patch).
+
+Set GITHUB_TOKEN to lift the generator's unauthenticated GitHub rate limit.`;
+
+export function parseArgs(argv) {
+  let name;
+  let emoji;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "-h" || arg === "--help") {
+      return { help: true };
+    }
+    if (arg === "--emoji") {
+      emoji = argv[++i];
+      if (emoji === undefined) {
+        throw new Error("--emoji requires a value.");
+      }
+      continue;
+    }
+    if (arg.startsWith("--emoji=")) {
+      emoji = arg.slice("--emoji=".length);
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown flag: ${arg}`);
+    }
+    if (name === undefined) {
+      name = arg;
+      continue;
+    }
+    throw new Error(`Unexpected extra argument: ${arg}`);
+  }
+  return { name, emoji };
+}
+
+async function cli(argv) {
+  let parsed;
+  try {
+    parsed = parseArgs(argv);
+  } catch (err) {
+    console.error(err.message);
+    console.error(`\n${USAGE}`);
+    process.exit(2);
+  }
+
+  if (parsed.help || !parsed.name) {
+    console.log(USAGE);
+    process.exit(parsed.help ? 0 : 2);
+  }
+
+  try {
+    await addPluginIcon({ name: parsed.name, emoji: parsed.emoji });
+  } catch (err) {
+    console.error(`\n${err.message}`);
+    process.exit(1);
+  }
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(realpathSync(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedPath) {
+  await cli(process.argv.slice(2));
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/plugins/add-plugin-icon.mjs` — one command that collapses the plugin-icon authoring ritual: optionally set a plugin's curated `icon` emoji in `plugins/marketplace.json` (surgical, churn-free patch), vendor its `icon.png` + regenerate `plugins/plugin-icons.json`, then run `meta/sync-bundled-copies.ts` so `assistant/src/cli/lib/bundled-marketplace.json` stays in lockstep.
- **Churn-free emoji patch:** re-serializes `marketplace.json` in its exact on-disk canonical form (2-space indent, non-ASCII escaped as `\uXXXX`), and a stability guard refuses to rewrite the file if that form doesn't reproduce it byte-for-byte — so a one-field edit can never silently reformat unrelated entries.
- **Abort-safe & idempotent:** all preconditions (plugin exists, emoji shape, canonical form) are validated up front, and the network-touching generator runs *before* the marketplace write, so a transient fetch abort leaves `marketplace.json` pristine and the whole flow is safe to re-run.
- Adds 14 unit tests (`scripts/plugins/__tests__/add-plugin-icon.test.mjs`) and updates `docs/plugin-icon-contract.md` with the one-command flow.

## Original prompt
While reviewing the plugin-icon design, we agreed the read/serve path is near-optimal but the authoring side is a multi-repo, multi-step ritual a contributor has to remember (set the emoji in `marketplace.json`, run the generator to vendor the PNG, run the bundled-copy sync). This PR implements a single `add-plugin-icon` command that does all three — taking the desired emoji as an optional CLI arg and auto-running the bundled-copies sync at the end — with the explicit constraint that the emoji edit be a surgical, formatting-preserving patch rather than a full-file rewrite.