### PR TITLE
Repin agent-wrapped to 1bfa2b9 (platform attribution)

### DIFF
--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -22,7 +22,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "5889e3717f46f798c78c002f56c00eb0f7d88a98"
+        "ref": "1bfa2b9c0735662e4c493955a414b6b62136a380"
       },
       "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -22,7 +22,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "5889e3717f46f798c78c002f56c00eb0f7d88a98"
+        "ref": "1bfa2b9c0735662e4c493955a414b6b62136a380"
       },
       "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",


### PR DESCRIPTION
Repins agent-wrapped from 5889e37 to 1bfa2b9.

What's in the new pin:
- Published share pages keep a sanitized `source` field (vellum/claude/hermes/openclaw) so the site's share text can tag the right platform handle
- Share text rewritten to a challenge format with platform attribution
- Discord share button on share pages
- Tokens-spent card and cache-busted page fetch on the site

Both `plugins/marketplace.json` and the bundled offline mirror are updated in sync.