### PR TITLE
fix(live-voice): don't attach audio artifacts to voice turns by default (JARVIS-1283)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -901,6 +901,7 @@ describe("AssistantConfigSchema", () => {
         bargeInMinSpeechMs: 60,
       },
       maxSessionDurationSeconds: 1800,
+      archiveAudio: false,
     });
   });
 

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -69,7 +69,25 @@ describe("LiveVoiceConfigSchema", () => {
         bargeInMinSpeechMs: 60,
       },
       maxSessionDurationSeconds: 1800,
+      // Off by default: voice turns carry only their transcript, no audio
+      // artifacts on the conversation messages (JARVIS-1283).
+      archiveAudio: false,
     });
+  });
+
+  test("archiveAudio can be enabled", () => {
+    expect(
+      LiveVoiceConfigSchema.parse({ archiveAudio: true }).archiveAudio,
+    ).toBe(true);
+  });
+
+  test("rejects a non-boolean archiveAudio", () => {
+    const result = LiveVoiceConfigSchema.safeParse({ archiveAudio: "yes" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(msgs.some((m) => m.includes("liveVoice.archiveAudio"))).toBe(true);
+    }
   });
 
   test("accepts overrides", () => {

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -68,6 +68,12 @@ export const LiveVoiceConfigSchema = z
       )
       .default(1800)
       .describe("Maximum duration of a single live voice session in seconds"),
+    archiveAudio: z
+      .boolean({ error: "liveVoice.archiveAudio must be a boolean" })
+      .default(false)
+      .describe(
+        "Persist the recorded user + assistant audio of each voice turn as attachments on the conversation messages. Off by default: voice turns carry only their transcribed text, so no audio-file artifacts land in the conversation history. Enable for playback/debugging.",
+      ),
   })
   .describe(
     "Live voice (in-app duplex audio) configuration — mic mode, VAD tuning, and session limits",

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -1,14 +1,16 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 
 import type {
   VoiceTurnCallbacks,
   VoiceTurnOptions,
 } from "../../calls/voice-session-bridge.js";
+import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
 import type { LiveVoiceAudioArchiveResult } from "../live-voice-archive.js";
+import * as liveVoiceArchive from "../live-voice-archive.js";
 import {
   createLiveVoiceSession,
   type LiveVoiceSessionArchiveAudioInput,
@@ -217,7 +219,9 @@ async function waitFor(
   message = "Timed out waiting for live voice integration condition",
 ): Promise<void> {
   for (let attempt = 0; attempt < 80; attempt += 1) {
-    if (predicate()) return;
+    if (predicate()) {
+      return;
+    }
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error(message);
@@ -670,5 +674,115 @@ describe("LiveVoiceSession integration smoke harness", () => {
       Buffer.from(firstUtteranceAudio),
       Buffer.from(secondUtteranceAudio),
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Audio archiving is config-gated and OFF by default (JARVIS-1283): a voice
+// turn persists only its transcribed text, so no audio-file artifact lands on
+// the conversation messages unless `liveVoice.archiveAudio` is enabled. These
+// exercise the production factory's config resolution (no injected archiver).
+// ---------------------------------------------------------------------------
+
+describe("live-voice audio archiving default (JARVIS-1283)", () => {
+  function makeSingleTurnLegs() {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.persisted_user_message_id?.("user-message-123");
+      options.callbacks?.assistant_text_delta?.(
+        makeTextDelta("Hello from the assistant."),
+      );
+      options.callbacks?.message_complete?.(makeMessageComplete());
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    return { startVoiceTurn, streamTtsAudio };
+  }
+
+  async function driveOneTurn(
+    session: ReturnType<typeof createLiveVoiceSession>,
+    frames: LiveVoiceServerFrame[],
+  ) {
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1, 2, 3, 4]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+  }
+
+  test("with no injected archiver and default config, nothing is archived", async () => {
+    const { startVoiceTurn, streamTtsAudio } = makeSingleTurnLegs();
+    const { context, frames } = createContext();
+    // No `archiveAudio` option → the factory consults config, which defaults
+    // off in the test workspace.
+    const session = createLiveVoiceSession(context, {
+      resolveCredentialReadiness: null,
+      resolveTranscriber: mock(async () => new FakeStreamingTranscriber()),
+      startVoiceTurn,
+      streamTtsAudio,
+      metricsClock: createClock(),
+      createTurnId: () => "live-turn-1",
+    });
+
+    await driveOneTurn(session, frames);
+
+    // The turn completed, but no `archived` frame was emitted — no audio
+    // attachment was written to either message.
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(frames.some((frame) => frame.type === "archived")).toBe(false);
+    expect(frameTypes(frames)).not.toContain("archived");
+  });
+
+  test("liveVoice.archiveAudio=true wires the default archiver through the factory", async () => {
+    // The real linkers write to the DB; these are role-less inputs, so stub
+    // them (synchronously — the linkers are sync) with a valid archived result
+    // per role. The point under test is the config→default-archiver wiring, not
+    // the DB write, which the injected-archiver tests above already cover.
+    const audioInput = {
+      sessionId: "session-123",
+      turnId: "live-turn-1",
+      mimeType: "audio/pcm",
+      audio: {
+        type: "base64" as const,
+        dataBase64: Buffer.from([1, 2, 3, 4]).toString("base64"),
+      },
+    };
+    const userSpy = spyOn(
+      liveVoiceArchive,
+      "linkLiveVoiceUserUtteranceAudioToMessage",
+    ).mockReturnValue(makeArchiveResult({ ...audioInput, role: "user" }));
+    const assistantSpy = spyOn(
+      liveVoiceArchive,
+      "linkLiveVoiceAssistantResponseAudioToMessage",
+    ).mockReturnValue(makeArchiveResult({ ...audioInput, role: "assistant" }));
+    const originalRaw = loadRawConfig();
+    saveRawConfig({ ...originalRaw, liveVoice: { archiveAudio: true } });
+
+    try {
+      const { startVoiceTurn, streamTtsAudio } = makeSingleTurnLegs();
+      const { context, frames } = createContext();
+      // Still no injected `archiveAudio` — the config default must supply it.
+      const session = createLiveVoiceSession(context, {
+        resolveCredentialReadiness: null,
+        resolveTranscriber: mock(async () => new FakeStreamingTranscriber()),
+        startVoiceTurn,
+        streamTtsAudio,
+        metricsClock: createClock(),
+        createTurnId: () => "live-turn-1",
+      });
+
+      await driveOneTurn(session, frames);
+
+      expect(userSpy).toHaveBeenCalledTimes(1);
+      expect(assistantSpy).toHaveBeenCalledTimes(1);
+      expect(frames.filter((frame) => frame.type === "archived")).toHaveLength(
+        2,
+      );
+    } finally {
+      saveRawConfig(originalRaw);
+      userSpy.mockRestore();
+      assistantSpy.mockRestore();
+    }
   });
 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2072,9 +2072,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (activeTurn?.token !== token) {
       return;
     }
-    activeTurn.assistantAudioChunks.push(
-      Buffer.from(chunk.dataBase64, "base64"),
-    );
+    // Only retain the assistant TTS audio when it will be archived (see
+    // collectUserAudio); the mime/sample-rate are cheap and left unconditional.
+    if (this.archiveAudio) {
+      activeTurn.assistantAudioChunks.push(
+        Buffer.from(chunk.dataBase64, "base64"),
+      );
+    }
     activeTurn.assistantAudioMimeType = chunk.contentType;
     activeTurn.assistantAudioSampleRate = chunk.sampleRate;
     job.frames = job.frames.then(async () => {
@@ -2114,7 +2118,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private collectUserAudio(utterance: UtteranceCycle, chunk: Buffer): void {
-    utterance.userAudioChunks.push(Buffer.from(chunk));
+    // Only retain the raw audio when it will actually be archived — otherwise
+    // buffering a whole turn's PCM is dead memory. The first-audio metric is
+    // independent of archiving, so it stays unconditional.
+    if (this.archiveAudio) {
+      utterance.userAudioChunks.push(Buffer.from(chunk));
+    }
     this.markUtteranceMetric(utterance, "firstAudioAtMs", (turnId) =>
       this.metrics.markFirstAudio(turnId),
     );
@@ -2509,7 +2518,8 @@ export function createLiveVoiceSession(
   // unchanged. Optional-chained
   // because hand-built test configs may predate the liveVoice namespace;
   // absent config falls through to the in-code defaults.
-  const vadConfig = getConfig().liveVoice?.vad;
+  const liveVoiceConfig = getConfig().liveVoice;
+  const vadConfig = liveVoiceConfig?.vad;
   return new LiveVoiceSession(context, {
     ...options,
     turnDetectorConfig:
@@ -2533,9 +2543,16 @@ export function createLiveVoiceSession(
       options.streamTtsAudio === undefined
         ? defaultStreamLiveVoiceTtsAudio
         : options.streamTtsAudio,
+    // Off by default (see the `liveVoice.archiveAudio` schema): voice turns
+    // persist only their transcribed text, so the recorded audio never lands
+    // as an attachment on the conversation messages. Enable via config for
+    // playback/debugging. An explicit option (incl. `null`) always wins — the
+    // test seam and any future caller override.
     archiveAudio:
       options.archiveAudio === undefined
-        ? defaultArchiveLiveVoiceAudio
+        ? liveVoiceConfig?.archiveAudio
+          ? defaultArchiveLiveVoiceAudio
+          : null
         : options.archiveAudio,
     emitMetrics: options.emitMetrics ?? true,
   });


### PR DESCRIPTION
## Summary

Live-voice turns showed up in the conversation transcript with audio-file artifacts (JARVIS-1283, from voice QA). The live-voice session persisted the turn's transcribed text like the text path, but then **additionally** archived the recorded user + assistant audio as `message_attachments` rows (plus `liveVoiceAudioArtifacts` message metadata) on the conversation messages.

That archive step ran **unconditionally** in production, and nothing in the codebase (client or server) consumes the archived audio — it was added speculatively in #28292/#28300. So the attachments were pure transcript clutter.

## Fix

Gate archiving behind a new `liveVoice.archiveAudio` config flag, **defaulting off**:

- Voice turns now persist only their transcribed text — no audio-file artifacts in the conversation history.
- The archive machinery is fully preserved and re-enablable via `liveVoice.archiveAudio: true` for playback/debugging.
- When archiving is off, the per-turn PCM is not buffered at all (it was dead memory otherwise). The first-audio metric stays unconditional.
- An explicit `archiveAudio` option still overrides the config default — the test seam and any future caller.

The config is read via `getConfig().liveVoice?.archiveAudio` inside `createLiveVoiceSession`, mirroring how the existing `liveVoice.vad` tuning already flows into the session (no call-site plumbing).

## Tests

- `config/schemas/__tests__/live-voice.test.ts` + `__tests__/config-schema.test.ts`: `archiveAudio` defaults to `false`, accepts `true`, rejects non-booleans.
- `live-voice/__tests__/live-voice-integration.test.ts`: two factory-level tests driving a full turn —
  - default config + no injected archiver → **no `archived` frame** emitted (nothing attached);
  - `liveVoice.archiveAudio: true` → the default archiver is wired and both roles archive.

Full `src/live-voice` suite (179 tests) + config-schema suites green; `tsc`, eslint, and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)