### PR TITLE
feat(apps): compile plugin-bundled apps in the source-watch loop

### DIFF
--- a/assistant/src/cli/lib/__tests__/plugin-fingerprint.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-fingerprint.test.ts
@@ -243,3 +243,34 @@ describe("computeContentHash", () => {
     expect(second).not.toBe(first);
   });
 });
+
+describe("generated app build output is excluded", () => {
+  test("apps/<app>/dist is not fingerprinted, so a build is never drift", () => {
+    // Installed source: an app with a src/ entry point (no dist yet).
+    write("apps/dash/src/main.tsx", "export default 1;");
+    write("hooks/stop.ts", "export default () => 1;");
+    const baseline = computeFingerprint(root);
+    expect(Object.keys(baseline.files)).toContain("apps/dash/src/main.tsx");
+
+    // The watcher later compiles src -> apps/dash/dist. That generated output
+    // must not surface as drift (added files) against the pinned commit.
+    write("apps/dash/dist/main.js", "console.log(1)");
+    write("apps/dash/dist/index.html", "<html></html>");
+    const cmp = compareFingerprint(root, baseline);
+    expect(cmp.clean).toBe(true);
+    expect(cmp.added).toEqual([]);
+
+    // A plugin's own top-level dist/ is still tracked (not an app build dir).
+    write("dist/bundle.js", "x");
+    expect(compareFingerprint(root, baseline).added).toEqual([
+      "dist/bundle.js",
+    ]);
+  });
+
+  test("content hash ignores apps/<app>/dist", () => {
+    write("apps/dash/src/main.tsx", "export default 1;");
+    const before = computeContentHash(root);
+    write("apps/dash/dist/main.js", "console.log(1)");
+    expect(computeContentHash(root)).toBe(before);
+  });
+});

--- a/assistant/src/cli/lib/plugin-fingerprint.ts
+++ b/assistant/src/cli/lib/plugin-fingerprint.ts
@@ -18,7 +18,10 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
-import { walkPluginTree } from "../../plugins/plugin-tree-walk.js";
+import {
+  isGeneratedAppBuildDir,
+  walkPluginTree,
+} from "../../plugins/plugin-tree-walk.js";
 
 /** Digest algorithm recorded alongside the file map, for forward compatibility. */
 export type FingerprintAlgorithm = "sha256";
@@ -64,9 +67,13 @@ export function computeFingerprint(
   exclude: readonly string[] = [],
 ): Fingerprint {
   const files: Record<string, string> = {};
-  walkPluginTree(root, { excludeRootEntries: exclude }, (rel, abs) => {
-    files[rel] = hashFile(abs);
-  });
+  walkPluginTree(
+    root,
+    { excludeRootEntries: exclude, excludeDir: isGeneratedAppBuildDir },
+    (rel, abs) => {
+      files[rel] = hashFile(abs);
+    },
+  );
   return { algorithm: "sha256", files };
 }
 
@@ -178,9 +185,13 @@ export function computeContentHash(
   exclude: readonly string[] = [],
 ): string {
   const entries: Array<{ rel: string; abs: string }> = [];
-  walkPluginTree(root, { excludeRootEntries: exclude }, (rel, abs) => {
-    entries.push({ rel, abs });
-  });
+  walkPluginTree(
+    root,
+    { excludeRootEntries: exclude, excludeDir: isGeneratedAppBuildDir },
+    (rel, abs) => {
+      entries.push({ rel, abs });
+    },
+  );
   entries.sort((a, b) => a.rel.localeCompare(b.rel));
 
   const hash = createHash("sha256");

--- a/assistant/src/monitoring/__tests__/plugin-source-watch.test.ts
+++ b/assistant/src/monitoring/__tests__/plugin-source-watch.test.ts
@@ -212,3 +212,40 @@ describe("plugin source watch", () => {
     expect(versions[join(PLUGINS_DIR, "not-a-plugin")]).toBeUndefined();
   });
 });
+
+describe("compilePluginApps", () => {
+  test("builds only apps that have a src/ entry point", async () => {
+    const built: string[] = [];
+    const { mock } = await import("bun:test");
+    mock.module("../../bundler/app-compiler.js", () => ({
+      compileApp: (appDir: string) => {
+        built.push(appDir);
+        return Promise.resolve({ ok: true });
+      },
+    }));
+
+    const { compilePluginApps } = await import("../plugin-source-watch.js");
+
+    const pluginDir = join(PLUGINS_DIR, "with-apps");
+    // Multi-file app (has src/) → built.
+    mkdirSync(join(pluginDir, "apps", "multi", "src"), { recursive: true });
+    writeFileSync(
+      join(pluginDir, "apps", "multi", "src", "main.tsx"),
+      "export default 1;",
+    );
+    // Single-file app (index.html, no src/) → skipped.
+    mkdirSync(join(pluginDir, "apps", "single"), { recursive: true });
+    writeFileSync(join(pluginDir, "apps", "single", "index.html"), "<div/>");
+
+    await compilePluginApps(pluginDir);
+
+    expect(built).toEqual([join(pluginDir, "apps", "multi")]);
+  });
+
+  test("no-ops when the plugin bundles no apps", async () => {
+    const { compilePluginApps } = await import("../plugin-source-watch.js");
+    const pluginDir = join(PLUGINS_DIR, "no-apps");
+    mkdirSync(pluginDir, { recursive: true });
+    await expect(compilePluginApps(pluginDir)).resolves.toBeUndefined();
+  });
+});

--- a/assistant/src/monitoring/plugin-source-watch.ts
+++ b/assistant/src/monitoring/plugin-source-watch.ts
@@ -158,6 +158,46 @@ export function createSourceWatchState(): SourceWatchState {
 }
 
 /**
+ * Compile every multi-file app bundled by a plugin from its `apps/<app>/src`
+ * into the sibling `apps/<app>/dist`. Single-file apps (a root `index.html`,
+ * no `src/`) need no build and are skipped.
+ *
+ * Runs here — off the daemon's hot path — because the monitor has just detected
+ * the change. The generated `dist/` is excluded from the source fingerprint
+ * ({@link isGeneratedAppBuildDir}), so writing it does not re-trigger a pass.
+ * The bundler (esbuild) is imported lazily so the monitor only pulls it in when
+ * a plugin actually ships a buildable app.
+ */
+export async function compilePluginApps(pluginDir: string): Promise<void> {
+  const appsDir = join(pluginDir, "apps");
+  let appEntries: string[];
+  try {
+    appEntries = readdirSync(appsDir);
+  } catch {
+    return; // No apps/ directory — nothing to build.
+  }
+  const buildable = appEntries.filter((app) => {
+    const appDir = join(appsDir, app);
+    try {
+      return statSync(appDir).isDirectory() && existsSync(join(appDir, "src"));
+    } catch {
+      return false;
+    }
+  });
+  if (buildable.length === 0) {
+    return;
+  }
+  const { compileApp } = await import("../bundler/app-compiler.js");
+  for (const app of buildable) {
+    const appDir = join(appsDir, app);
+    const result = await compileApp(appDir);
+    if (!result.ok) {
+      log.warn({ appDir, errors: result.errors }, "plugin app compile failed");
+    }
+  }
+}
+
+/**
  * Run one detection pass: walk, compare against the last published state,
  * and rewrite the sentinel if anything changed. Returns whether a rewrite
  * happened. Never throws — a failed pass is logged and retried on the next
@@ -202,6 +242,19 @@ export function runSourceWatchPass(state: SourceWatchState): boolean {
       { generation: state.generation, changedDirs },
       "plugin source change published",
     );
+
+    // Rebuild multi-file apps for each changed, enabled plugin. Fire-and-forget
+    // so a slow build never stalls the watch loop; the generated dist is
+    // excluded from the fingerprint, so it does not re-trigger this pass.
+    for (const dir of changedDirs) {
+      const version = current[dir];
+      if (version !== undefined && !version.disabled) {
+        void compilePluginApps(dir).catch((err) => {
+          log.error({ err, dir }, "plugin app compile pass failed");
+        });
+      }
+    }
+
     return true;
   } catch (err) {
     log.error({ err }, "plugin source watch pass failed — will retry");

--- a/assistant/src/plugins/__tests__/source-fingerprint.test.ts
+++ b/assistant/src/plugins/__tests__/source-fingerprint.test.ts
@@ -81,6 +81,47 @@ describe("snapshotPluginSource", () => {
     expect(names).not.toContain("/.disabled");
   });
 
+  test("excludes generated apps/<app>/dist but tracks app src and top-level dist", () => {
+    const dir = makePluginDir();
+    // App source is tracked.
+    mkdirSync(join(dir, "apps", "dash", "src"), { recursive: true });
+    writeStamped(
+      join(dir, "apps", "dash", "src", "main.tsx"),
+      "export default 1;",
+    );
+    // Generated app build output is excluded (the watcher writes it).
+    mkdirSync(join(dir, "apps", "dash", "dist"), { recursive: true });
+    writeStamped(
+      join(dir, "apps", "dash", "dist", "main.js"),
+      "console.log(1)",
+    );
+    // A plugin's own top-level dist/ is NOT an app build dir — still tracked.
+    mkdirSync(join(dir, "dist"), { recursive: true });
+    writeStamped(join(dir, "dist", "bundle.js"), "x");
+
+    const names = snapshotPluginSource(dir).evictionPaths.map((p) =>
+      p.slice(dir.length),
+    );
+    expect(names).toContain("/apps/dash/src/main.tsx");
+    expect(names).toContain("/dist/bundle.js");
+    expect(names).not.toContain("/apps/dash/dist/main.js");
+
+    // Editing the generated dist does not move the fingerprint (no re-trigger)...
+    const base = snapshotPluginSource(dir).fingerprint;
+    writeStamped(
+      join(dir, "apps", "dash", "dist", "main.js"),
+      "console.log(2)",
+    );
+    expect(snapshotPluginSource(dir).fingerprint).toBe(base);
+
+    // ...but editing the app source does.
+    writeStamped(
+      join(dir, "apps", "dash", "src", "main.tsx"),
+      "export default 2;",
+    );
+    expect(snapshotPluginSource(dir).fingerprint).not.toBe(base);
+  });
+
   test("is stable across identical walks and moves on edit, add, delete, and rename", () => {
     const dir = makePluginDir();
     const helper = join(dir, "hooks", "helper.ts");

--- a/assistant/src/plugins/plugin-tree-walk.ts
+++ b/assistant/src/plugins/plugin-tree-walk.ts
@@ -40,12 +40,39 @@ export const PRESERVED_ENTRIES = [
   ".disabled",
 ] as const;
 
+/**
+ * A generated app build directory: `apps/<app>/dist`. This is compiled output
+ * (the plugin source watcher builds each multi-file app's `src/` into its
+ * sibling `dist/`), never tracked source, so every fingerprint walk excludes
+ * it:
+ *
+ * - the **live-reload** change detector (`./source-fingerprint.ts`), so the
+ *   watcher's own compile does not read as a source change and re-trigger
+ *   itself in a loop, and
+ * - the **install/drift** fingerprint (`../cli/lib/plugin-fingerprint.ts`), so
+ *   generated output is not reported as drift/added against the pinned commit.
+ *
+ * Scoped to `apps/<app>/dist` specifically — a plugin's own top-level `dist/`
+ * (if it ships built code its hooks import) is still tracked.
+ */
+export function isGeneratedAppBuildDir(relDir: string): boolean {
+  const parts = relDir.split("/");
+  return parts.length === 3 && parts[0] === "apps" && parts[2] === "dist";
+}
+
 /** Options controlling which entries a {@link walkPluginTree} visits. */
 export interface PluginTreeWalkOptions {
   /** Top-level entry names to skip (e.g. {@link PRESERVED_ENTRIES}). */
   readonly excludeRootEntries?: Iterable<string>;
   /** Directory names skipped at any depth (e.g. `node_modules`). */
   readonly excludeDirsAnywhere?: ReadonlySet<string>;
+  /**
+   * Skip a directory (and its whole subtree) by its POSIX path relative to the
+   * walk root. Called for each directory before descending — use for
+   * path-scoped exclusions a bare directory name can't express (e.g. generated
+   * `apps/<app>/dist`, via {@link isGeneratedAppBuildDir}).
+   */
+  readonly excludeDir?: (relDir: string) => boolean;
   /** Skip entries whose name starts with `.`, at any depth. */
   readonly excludeDotEntries?: boolean;
   /**
@@ -94,6 +121,9 @@ export function walkPluginTree(
       const rel = relDir ? `${relDir}/${name}` : name;
       if (entry.isDirectory()) {
         if (options.excludeDirsAnywhere?.has(name) === true) {
+          continue;
+        }
+        if (options.excludeDir?.(rel) === true) {
           continue;
         }
         walk(rel);

--- a/assistant/src/plugins/source-fingerprint.ts
+++ b/assistant/src/plugins/source-fingerprint.ts
@@ -18,7 +18,9 @@
  *
  * Exclusions: dot-entries anywhere (`.disabled`, `.git`, …), `node_modules`
  * anywhere (vendored deps change only through install flows, which recycle
- * the plugin directory), and — at the plugin root only — the runtime-owned
+ * the plugin directory), generated app build output ({@link
+ * isGeneratedAppBuildDir}, so the watcher's own compile does not re-trigger a
+ * pass), and — at the plugin root only — the runtime-owned
  * {@link PRESERVED_ENTRIES} (`data/`, `config.json`, `install-meta.json`),
  * none of which are importable source. Symlinked entries inside the tree are
  * neither watched nor followed (see {@link walkPluginTree}); a symlinked
@@ -30,7 +32,11 @@
 
 import { realpathSync, statSync } from "node:fs";
 
-import { PRESERVED_ENTRIES, walkPluginTree } from "./plugin-tree-walk.js";
+import {
+  isGeneratedAppBuildDir,
+  PRESERVED_ENTRIES,
+  walkPluginTree,
+} from "./plugin-tree-walk.js";
 
 /** Directory names skipped at any depth. */
 const EXCLUDED_DIRS_ANYWHERE = new Set(["node_modules"]);
@@ -78,6 +84,7 @@ export function snapshotPluginSource(pluginDir: string): SourceSnapshot {
     {
       excludeRootEntries: PRESERVED_ENTRIES,
       excludeDirsAnywhere: EXCLUDED_DIRS_ANYWHERE,
+      excludeDir: isGeneratedAppBuildDir,
       excludeDotEntries: true,
       bestEffort: true,
     },


### PR DESCRIPTION
## Prompt / plan

Closes the loop on multi-file (TSX) plugin apps: they now compile **automatically**, exactly like workspace apps, so plugin authors ship source only — no prebuilt `dist/`.

### How
The plugin source watcher (`plugin-source-watch.ts`, in the resource-monitor process) already fingerprints each plugin's source and republishes a change sentinel when it moves. On a detected change to an **enabled** plugin, it now also builds every bundled app that has a `src/` entry point into its sibling `apps/<app>/dist` (single-file apps need no build). This runs **off the daemon's hot path**, and the bundler (esbuild) is imported lazily so the monitor only pulls it in when a plugin actually ships a buildable app.

### The dist exclusion (why it's load-bearing)
The generated `dist/` must not read as a change, or the watcher would recompile in an **infinite loop**; and it must not read as install **drift**, or `plugins inspect` would report every built plugin as modified. Both fingerprint walks go through `walkPluginTree`, so a shared predicate (`isGeneratedAppBuildDir` in `plugin-tree-walk.ts`) drops `apps/<app>/dist` from **both** the live-reload fingerprint (`source-fingerprint.ts`) and the install/drift fingerprint (`plugin-fingerprint.ts`).

> Note: this corrects the "exclude from live-reload only" framing from the earlier discussion — I verified the drift path (`compareFingerprint`) would flag a generated `dist` as `added`, so it has to be excluded from the provenance walk too. Generated build output is never install content, so this is the right semantics.

Scoped to `apps/<app>/dist` specifically — a plugin's own top-level `dist/` (if it ships built code its hooks import) stays tracked. `walkPluginTree` gains an `excludeDir(relDir)` predicate for the path-scoped skip (it was name-only before).

### Serve side: unchanged
The resolver/serve routes already read `<appDir>/dist` — exactly where these builds land — so nothing there changed. On upgrade the install recycles the tree and the source fingerprint moves, so the next tick recompiles; self-healing, same as workspace apps.

## Test plan
- `source-fingerprint.test.ts`: a change under `apps/<app>/dist` moves neither the fingerprint nor the eviction set; a change under `apps/<app>/src` does; a top-level `dist/` still counts.
- `plugin-fingerprint.test.ts`: a generated `apps/<app>/dist` is never `added`/drift and doesn't move the content hash; a top-level `dist/` still does.
- `plugin-source-watch.test.ts`: `compilePluginApps` builds only apps with a `src/`, and no-ops when a plugin bundles none.
- Each touched file + the two `walkPluginTree` consumers + the install/upgrade suite pass in isolation; `tsc` clean; eslint 0 errors; no OpenAPI change.

## CLI verb checklist
No routes or schema changes — this is monitor-side build orchestration plus a shared fingerprint exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG

---
_Generated by [Claude Code](https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG)_