### PR TITLE
feat(marketplace): curate emoji icons for all plugins missing one

### DIFF
--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -16,7 +16,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/admin-copilot",
       "license": "MIT",
-      "icon": "\ud83e\uddd1\u200d\ud83d\udcbc"
+      "icon": "🧑‍💼"
     },
     {
       "name": "agent-wrapped",
@@ -30,7 +30,7 @@
       "license": "MIT",
       "submittedBy": "marina",
       "homepage": "https://agent-wrapped.com",
-      "icon": "\ud83c\udf81"
+      "icon": "🎁"
     },
     {
       "name": "ai-hero-engineer-kit",
@@ -39,11 +39,11 @@
         "repo": "marinatrajk/ai-hero-engineer-kit",
         "ref": "18d33c62b15a3e2cc22dc070723fe3077749dcec"
       },
-      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
+      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' — plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
       "category": "developer",
       "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
       "license": "MIT",
-      "icon": "\ud83e\uddf0"
+      "icon": "🧰"
     },
     {
       "name": "amex-perk-reminder",
@@ -56,7 +56,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/amex-perk-reminder",
       "license": "MIT",
-      "icon": "\ud83d\udcb3"
+      "icon": "💳"
     },
     {
       "name": "astrology-horoscope",
@@ -69,7 +69,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/astrology-horoscope",
       "license": "MIT",
-      "icon": "\ud83d\udd2e"
+      "icon": "🔮"
     },
     {
       "name": "caveman",
@@ -82,7 +82,7 @@
       "category": "productivity",
       "homepage": "https://github.com/JuliusBrussee/caveman",
       "license": "MIT",
-      "icon": "\ud83e\uddb4"
+      "icon": "🦴"
     },
     {
       "name": "coffee-aficionado",
@@ -95,7 +95,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/coffee-aficionado",
       "license": "MIT",
-      "icon": "\u2615"
+      "icon": "☕"
     },
     {
       "name": "cofounder",
@@ -108,7 +108,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/cofounder",
       "license": "MIT",
-      "icon": "\ud83e\udd1d"
+      "icon": "🤝"
     },
     {
       "name": "cognee",
@@ -121,7 +121,7 @@
       "description": "Cognee knowledge graph memory for Vellum Assistant: session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
       "category": "memory",
       "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/vellum-assistant",
-      "icon": "\ud83d\udd78\ufe0f"
+      "icon": "🕸️"
     },
     {
       "name": "dynamic-notch",
@@ -134,7 +134,7 @@
       "category": "interface",
       "homepage": "https://github.com/AnitaKirkovska/dynamic-notch",
       "license": "MIT",
-      "icon": "\ud83d\udcbb"
+      "icon": "💻"
     },
     {
       "name": "family-briefing",
@@ -147,7 +147,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/family-briefing",
       "license": "MIT",
-      "icon": "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66"
+      "icon": "👨‍👩‍👧‍👦"
     },
     {
       "name": "fitness-companion",
@@ -160,7 +160,7 @@
       "category": "health",
       "homepage": "https://github.com/vellum-ai/fitness-companion",
       "license": "MIT",
-      "icon": "\ud83d\udcaa"
+      "icon": "💪"
     },
     {
       "name": "git-workflow",
@@ -173,7 +173,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/git-workflow",
       "license": "MIT",
-      "icon": "\ud83d\udd00"
+      "icon": "🔀"
     },
     {
       "name": "google-drive-search",
@@ -186,7 +186,7 @@
       "category": "productivity",
       "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
       "license": "Apache-2.0",
-      "icon": "\ud83d\udd0d"
+      "icon": "🔍"
     },
     {
       "name": "influencer-marketing",
@@ -199,7 +199,7 @@
       "category": "marketing",
       "homepage": "https://github.com/ZeebBoyBlue/influencer",
       "license": "MIT",
-      "icon": "\ud83d\udce3"
+      "icon": "📣"
     },
     {
       "name": "kitchen-companion",
@@ -212,7 +212,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/kitchen-companion",
       "license": "MIT",
-      "icon": "\ud83c\udf73"
+      "icon": "🍳"
     },
     {
       "name": "level-up",
@@ -225,7 +225,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/level-up",
       "license": "MIT",
-      "icon": "\ud83c\udd99"
+      "icon": "🆙"
     },
     {
       "name": "marketing-expert",
@@ -238,7 +238,7 @@
       "category": "marketing",
       "homepage": "https://github.com/vellum-ai/marketing-expert",
       "license": "MIT",
-      "icon": "\ud83d\udcc8"
+      "icon": "📈"
     },
     {
       "name": "model-router",
@@ -251,7 +251,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/model-router",
       "license": "MIT",
-      "icon": "\ud83d\udea6"
+      "icon": "🚦"
     },
     {
       "name": "motion-design",
@@ -264,7 +264,7 @@
       "category": "creative",
       "homepage": "https://github.com/vellum-ai/motion-design",
       "license": "MIT",
-      "icon": "\ud83c\udfac"
+      "icon": "🎬"
     },
     {
       "name": "originkit",
@@ -277,7 +277,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/originkit",
       "license": "MIT",
-      "icon": "\ud83e\uddf1"
+      "icon": "🧱"
     },
     {
       "name": "personal-finance",
@@ -290,7 +290,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/personal-finance",
       "license": "MIT",
-      "icon": "\ud83d\udcb0"
+      "icon": "💰"
     },
     {
       "name": "plant-doctor",
@@ -303,7 +303,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/plant-doctor",
       "license": "MIT",
-      "icon": "\ud83e\udeb4"
+      "icon": "🪴"
     },
     {
       "name": "polyglot",
@@ -316,7 +316,7 @@
       "category": "education",
       "homepage": "https://github.com/vellum-ai/polyglot",
       "license": "MIT",
-      "icon": "\ud83d\udde3\ufe0f"
+      "icon": "🗣️"
     },
     {
       "name": "proactive-slacks",
@@ -329,7 +329,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
       "license": "MIT",
-      "icon": "\ud83d\udcac"
+      "icon": "💬"
     },
     {
       "name": "reading-pal",
@@ -342,7 +342,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/reading-pal",
       "license": "MIT",
-      "icon": "\ud83d\udcda"
+      "icon": "📚"
     },
     {
       "name": "simple-memory",
@@ -355,7 +355,7 @@
       "category": "memory",
       "homepage": "https://github.com/vellum-ai/simple-memory",
       "license": "MIT",
-      "icon": "\ud83e\udde0"
+      "icon": "🧠"
     },
     {
       "name": "smb-inbox-brief",
@@ -368,7 +368,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
       "license": "MIT",
-      "icon": "\ud83d\udce7"
+      "icon": "📧"
     },
     {
       "name": "tennis-companion",
@@ -381,7 +381,7 @@
       "category": "health",
       "homepage": "https://github.com/vellum-ai/tennis-companion",
       "license": "MIT",
-      "icon": "\ud83c\udfbe"
+      "icon": "🎾"
     },
     {
       "name": "travel-planner",
@@ -394,7 +394,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/travel-planner",
       "license": "MIT",
-      "icon": "\u2708\ufe0f"
+      "icon": "✈️"
     },
     {
       "name": "vellum-client-qa",
@@ -407,7 +407,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/vellum-client-qa",
       "license": "MIT",
-      "icon": "\ud83e\uddea"
+      "icon": "🧪"
     },
     {
       "name": "writing-coach",
@@ -420,7 +420,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/writing-coach",
       "license": "MIT",
-      "icon": "\u270d\ufe0f"
+      "icon": "✍️"
     }
   ]
 }

--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -15,7 +15,8 @@
       "description": "Proactive chief-of-staff: a morning digest, propose-then-confirm inbox triage, calendar prep, and a weekly competitor brief.",
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/admin-copilot",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\uddd1\u200d\ud83d\udcbc"
     },
     {
       "name": "agent-wrapped",
@@ -28,7 +29,8 @@
       "category": "creative",
       "license": "MIT",
       "submittedBy": "marina",
-      "homepage": "https://agent-wrapped.com"
+      "homepage": "https://agent-wrapped.com",
+      "icon": "\ud83c\udf81"
     },
     {
       "name": "ai-hero-engineer-kit",
@@ -40,7 +42,8 @@
       "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
       "category": "developer",
       "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\uddf0"
     },
     {
       "name": "amex-perk-reminder",
@@ -52,7 +55,8 @@
       "description": "Track every credit on the Amex cards you hold (Platinum, Gold, Business Platinum, Delta Gold/Platinum/Reserve) with status-aware reminders before any window closes.",
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/amex-perk-reminder",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcb3"
     },
     {
       "name": "astrology-horoscope",
@@ -64,7 +68,8 @@
       "description": "Western tropical natal chart and transit computation. Local ephemeris (astronomy-engine, no API keys) for planet positions, ascendant/midheaven, whole-sign houses, and aspects, plus a natal-reading skill that interprets the raw chart into a readable report.",
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/astrology-horoscope",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udd2e"
     },
     {
       "name": "caveman",
@@ -102,7 +107,8 @@
       "description": "AI co-founder that remembers your company context, challenges your thinking, and tracks your decisions.",
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/cofounder",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\udd1d"
     },
     {
       "name": "cognee",
@@ -114,7 +120,8 @@
       },
       "description": "Cognee knowledge graph memory for Vellum Assistant: session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
       "category": "memory",
-      "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/vellum-assistant"
+      "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/vellum-assistant",
+      "icon": "\ud83d\udd78\ufe0f"
     },
     {
       "name": "dynamic-notch",
@@ -126,7 +133,8 @@
       "description": "Put your Vellum assistant inside your MacBook's notch: click to chat, hold Ctrl+Option to talk, and get a floating task bulb while it works, with live-streamed replies and per-sentence voice.",
       "category": "interface",
       "homepage": "https://github.com/AnitaKirkovska/dynamic-notch",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcbb"
     },
     {
       "name": "family-briefing",
@@ -138,7 +146,8 @@
       "description": "Daily morning briefing for parents: merges family calendars, triages school emails, and detects scheduling conflicts.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/family-briefing",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66"
     },
     {
       "name": "fitness-companion",
@@ -150,7 +159,8 @@
       "description": "Fitness and nutrition companion. Logs meals, workouts, and weight; looks up nutrition data from OpenFoodFacts; calculates macro targets; and injects daily fitness context into every conversation.",
       "category": "health",
       "homepage": "https://github.com/vellum-ai/fitness-companion",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcaa"
     },
     {
       "name": "git-workflow",
@@ -162,7 +172,8 @@
       "description": "Git workflow tools and multi-perspective code review: branch management, push, stash, PR creation/review/merge/checkout, diffs, logs, changelog generation, and parallel subagent code review with confidence scoring.",
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/git-workflow",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udd00"
     },
     {
       "name": "google-drive-search",
@@ -174,7 +185,8 @@
       "description": "Local full-text search across your Google Drive. Indexes file metadata and document content into SQLite FTS5 for instant, private search.",
       "category": "productivity",
       "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "icon": "\ud83d\udd0d"
     },
     {
       "name": "influencer-marketing",
@@ -186,7 +198,8 @@
       "description": "Find and research influencers on Instagram, TikTok, and X/Twitter. Includes a strategy builder that walks from campaign brief to research criteria, a research skill that discovers real profiles via browser automation, scores candidates, and exports ranked shortlists, and a dashboard skill that turns the shortlist into an interactive outreach tracker.",
       "category": "marketing",
       "homepage": "https://github.com/ZeebBoyBlue/influencer",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udce3"
     },
     {
       "name": "kitchen-companion",
@@ -198,7 +211,8 @@
       "description": "Full kitchen companion. Scan your fridge with a photo to stock a pantry inventory and get 3 makeable-now recipes, get alerts before food expires, clip recipes from any URL into a clean format, and generate meal plans with grocery lists from what you actually have.",
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/kitchen-companion",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83c\udf73"
     },
     {
       "name": "level-up",
@@ -210,7 +224,8 @@
       "description": "Surfaces a first-class \"Level Up\" diff card whenever the assistant edits its own skills or plugins, so you can see how it improved itself after the fact.",
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/level-up",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83c\udd99"
     },
     {
       "name": "marketing-expert",
@@ -222,7 +237,8 @@
       "description": "Acts as a full-stack marketing expert for any business (B2B or B2C): an on-demand persona plus playbook skills (positioning, demand planning, launches, content & copywriting, brand voice, email sequences, SEO & GEO, competitive teardown, board reporting) and deterministic funnel/positioning/GTM/competitive tools.",
       "category": "marketing",
       "homepage": "https://github.com/vellum-ai/marketing-expert",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcc8"
     },
     {
       "name": "model-router",
@@ -234,7 +250,8 @@
       "description": "Routes each user-facing message to one of your workspace's inference profiles, so model selection can vary per call instead of staying pinned to a single profile.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/model-router",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udea6"
     },
     {
       "name": "motion-design",
@@ -246,7 +263,8 @@
       "description": "Teaches the assistant to build polished UI animations with Motion (motion.dev) for React: animated product mockups, chat replays, typing effects, and staggered reveals, with a complete animated chat example included.",
       "category": "creative",
       "homepage": "https://github.com/vellum-ai/motion-design",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83c\udfac"
     },
     {
       "name": "originkit",
@@ -258,7 +276,8 @@
       "description": "Browse and import animated UI components from Originkit, a free library of 50 animated components. Browse by category or search term without an API key; fetch component source code (React, Next.js, Vite, Framer) with a free key from originkit.dev.",
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/originkit",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\uddf1"
     },
     {
       "name": "personal-finance",
@@ -270,7 +289,8 @@
       "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/personal-finance",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcb0"
     },
     {
       "name": "plant-doctor",
@@ -282,7 +302,8 @@
       "description": "Diagnose plants from photos. Identifies the species, assesses health with visible evidence, and returns a care plan. Named plants get a persistent checkup history so you can track whether they are improving.",
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/plant-doctor",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\udeb4"
     },
     {
       "name": "polyglot",
@@ -294,7 +315,8 @@
       "description": "Ambient language acquisition through your assistant. Three graduated modes (practice, ambient, immersive) weave a target language into your real conversations, with SM-2 spaced repetition, error-pattern tracking, and CEFR level history.",
       "category": "education",
       "homepage": "https://github.com/vellum-ai/polyglot",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udde3\ufe0f"
     },
     {
       "name": "proactive-slacks",
@@ -306,7 +328,8 @@
       "description": "Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcac"
     },
     {
       "name": "reading-pal",
@@ -318,7 +341,8 @@
       "description": "Your reading life in one plugin. Track your TBR pile, get guilt-tripped about your backlog, find your next read, and sync from Goodreads.",
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/reading-pal",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcda"
     },
     {
       "name": "simple-memory",
@@ -330,7 +354,8 @@
       "description": "Reference memory plugin that exercises the full plugin API with low-cost variants of Vellum's memory defaults.",
       "category": "memory",
       "homepage": "https://github.com/vellum-ai/simple-memory",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\udde0"
     },
     {
       "name": "smb-inbox-brief",
@@ -342,7 +367,8 @@
       "description": "Find urgent replies, overdue invoices, quotes, and customer follow-ups before they slip. Scans email, logs business items, delivers urgency-ranked daily briefs.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udce7"
     },
     {
       "name": "tennis-companion",
@@ -354,7 +380,8 @@
       "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
       "category": "health",
       "homepage": "https://github.com/vellum-ai/tennis-companion",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83c\udfbe"
     },
     {
       "name": "travel-planner",
@@ -366,7 +393,8 @@
       "description": "A travel EA for your assistant. Remembers how you travel (carrier, miles, hotel budget, card benefits), keeps per-trip records, watches Gmail for booking changes, syncs your calendar, and emails an EA-style trip brief 48 hours before departure.",
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/travel-planner",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\u2708\ufe0f"
     },
     {
       "name": "vellum-client-qa",
@@ -378,7 +406,8 @@
       "description": "Cross-platform QA rig for vellum-assistant clients: mock the platform backend, boot the real chat UI, and verify feature branches in headless Chromium (web), an iOS simulator, or Electron with screenshot and video proof.",
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/vellum-client-qa",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\uddea"
     },
     {
       "name": "writing-coach",
@@ -390,7 +419,8 @@
       "description": "A writing coach in your pocket. Daily prompts that escalate with your streak, savage-but-constructive draft roasts, query letter critiques, and a word count enforcer that guilt-trips you when you skip.",
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/writing-coach",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\u270d\ufe0f"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -16,7 +16,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/admin-copilot",
       "license": "MIT",
-      "icon": "\ud83e\uddd1\u200d\ud83d\udcbc"
+      "icon": "🧑‍💼"
     },
     {
       "name": "agent-wrapped",
@@ -30,7 +30,7 @@
       "license": "MIT",
       "submittedBy": "marina",
       "homepage": "https://agent-wrapped.com",
-      "icon": "\ud83c\udf81"
+      "icon": "🎁"
     },
     {
       "name": "ai-hero-engineer-kit",
@@ -39,11 +39,11 @@
         "repo": "marinatrajk/ai-hero-engineer-kit",
         "ref": "18d33c62b15a3e2cc22dc070723fe3077749dcec"
       },
-      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
+      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' — plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
       "category": "developer",
       "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
       "license": "MIT",
-      "icon": "\ud83e\uddf0"
+      "icon": "🧰"
     },
     {
       "name": "amex-perk-reminder",
@@ -56,7 +56,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/amex-perk-reminder",
       "license": "MIT",
-      "icon": "\ud83d\udcb3"
+      "icon": "💳"
     },
     {
       "name": "astrology-horoscope",
@@ -69,7 +69,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/astrology-horoscope",
       "license": "MIT",
-      "icon": "\ud83d\udd2e"
+      "icon": "🔮"
     },
     {
       "name": "caveman",
@@ -82,7 +82,7 @@
       "category": "productivity",
       "homepage": "https://github.com/JuliusBrussee/caveman",
       "license": "MIT",
-      "icon": "\ud83e\uddb4"
+      "icon": "🦴"
     },
     {
       "name": "coffee-aficionado",
@@ -95,7 +95,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/coffee-aficionado",
       "license": "MIT",
-      "icon": "\u2615"
+      "icon": "☕"
     },
     {
       "name": "cofounder",
@@ -108,7 +108,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/cofounder",
       "license": "MIT",
-      "icon": "\ud83e\udd1d"
+      "icon": "🤝"
     },
     {
       "name": "cognee",
@@ -121,7 +121,7 @@
       "description": "Cognee knowledge graph memory for Vellum Assistant: session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
       "category": "memory",
       "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/vellum-assistant",
-      "icon": "\ud83d\udd78\ufe0f"
+      "icon": "🕸️"
     },
     {
       "name": "dynamic-notch",
@@ -134,7 +134,7 @@
       "category": "interface",
       "homepage": "https://github.com/AnitaKirkovska/dynamic-notch",
       "license": "MIT",
-      "icon": "\ud83d\udcbb"
+      "icon": "💻"
     },
     {
       "name": "family-briefing",
@@ -147,7 +147,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/family-briefing",
       "license": "MIT",
-      "icon": "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66"
+      "icon": "👨‍👩‍👧‍👦"
     },
     {
       "name": "fitness-companion",
@@ -160,7 +160,7 @@
       "category": "health",
       "homepage": "https://github.com/vellum-ai/fitness-companion",
       "license": "MIT",
-      "icon": "\ud83d\udcaa"
+      "icon": "💪"
     },
     {
       "name": "git-workflow",
@@ -173,7 +173,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/git-workflow",
       "license": "MIT",
-      "icon": "\ud83d\udd00"
+      "icon": "🔀"
     },
     {
       "name": "google-drive-search",
@@ -186,7 +186,7 @@
       "category": "productivity",
       "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
       "license": "Apache-2.0",
-      "icon": "\ud83d\udd0d"
+      "icon": "🔍"
     },
     {
       "name": "influencer-marketing",
@@ -199,7 +199,7 @@
       "category": "marketing",
       "homepage": "https://github.com/ZeebBoyBlue/influencer",
       "license": "MIT",
-      "icon": "\ud83d\udce3"
+      "icon": "📣"
     },
     {
       "name": "kitchen-companion",
@@ -212,7 +212,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/kitchen-companion",
       "license": "MIT",
-      "icon": "\ud83c\udf73"
+      "icon": "🍳"
     },
     {
       "name": "level-up",
@@ -225,7 +225,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/level-up",
       "license": "MIT",
-      "icon": "\ud83c\udd99"
+      "icon": "🆙"
     },
     {
       "name": "marketing-expert",
@@ -238,7 +238,7 @@
       "category": "marketing",
       "homepage": "https://github.com/vellum-ai/marketing-expert",
       "license": "MIT",
-      "icon": "\ud83d\udcc8"
+      "icon": "📈"
     },
     {
       "name": "model-router",
@@ -251,7 +251,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/model-router",
       "license": "MIT",
-      "icon": "\ud83d\udea6"
+      "icon": "🚦"
     },
     {
       "name": "motion-design",
@@ -264,7 +264,7 @@
       "category": "creative",
       "homepage": "https://github.com/vellum-ai/motion-design",
       "license": "MIT",
-      "icon": "\ud83c\udfac"
+      "icon": "🎬"
     },
     {
       "name": "originkit",
@@ -277,7 +277,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/originkit",
       "license": "MIT",
-      "icon": "\ud83e\uddf1"
+      "icon": "🧱"
     },
     {
       "name": "personal-finance",
@@ -290,7 +290,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/personal-finance",
       "license": "MIT",
-      "icon": "\ud83d\udcb0"
+      "icon": "💰"
     },
     {
       "name": "plant-doctor",
@@ -303,7 +303,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/plant-doctor",
       "license": "MIT",
-      "icon": "\ud83e\udeb4"
+      "icon": "🪴"
     },
     {
       "name": "polyglot",
@@ -316,7 +316,7 @@
       "category": "education",
       "homepage": "https://github.com/vellum-ai/polyglot",
       "license": "MIT",
-      "icon": "\ud83d\udde3\ufe0f"
+      "icon": "🗣️"
     },
     {
       "name": "proactive-slacks",
@@ -329,7 +329,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
       "license": "MIT",
-      "icon": "\ud83d\udcac"
+      "icon": "💬"
     },
     {
       "name": "reading-pal",
@@ -342,7 +342,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/reading-pal",
       "license": "MIT",
-      "icon": "\ud83d\udcda"
+      "icon": "📚"
     },
     {
       "name": "simple-memory",
@@ -355,7 +355,7 @@
       "category": "memory",
       "homepage": "https://github.com/vellum-ai/simple-memory",
       "license": "MIT",
-      "icon": "\ud83e\udde0"
+      "icon": "🧠"
     },
     {
       "name": "smb-inbox-brief",
@@ -368,7 +368,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
       "license": "MIT",
-      "icon": "\ud83d\udce7"
+      "icon": "📧"
     },
     {
       "name": "tennis-companion",
@@ -381,7 +381,7 @@
       "category": "health",
       "homepage": "https://github.com/vellum-ai/tennis-companion",
       "license": "MIT",
-      "icon": "\ud83c\udfbe"
+      "icon": "🎾"
     },
     {
       "name": "travel-planner",
@@ -394,7 +394,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/travel-planner",
       "license": "MIT",
-      "icon": "\u2708\ufe0f"
+      "icon": "✈️"
     },
     {
       "name": "vellum-client-qa",
@@ -407,7 +407,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/vellum-client-qa",
       "license": "MIT",
-      "icon": "\ud83e\uddea"
+      "icon": "🧪"
     },
     {
       "name": "writing-coach",
@@ -420,7 +420,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/writing-coach",
       "license": "MIT",
-      "icon": "\u270d\ufe0f"
+      "icon": "✍️"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -15,7 +15,8 @@
       "description": "Proactive chief-of-staff: a morning digest, propose-then-confirm inbox triage, calendar prep, and a weekly competitor brief.",
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/admin-copilot",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\uddd1\u200d\ud83d\udcbc"
     },
     {
       "name": "agent-wrapped",
@@ -28,7 +29,8 @@
       "category": "creative",
       "license": "MIT",
       "submittedBy": "marina",
-      "homepage": "https://agent-wrapped.com"
+      "homepage": "https://agent-wrapped.com",
+      "icon": "\ud83c\udf81"
     },
     {
       "name": "ai-hero-engineer-kit",
@@ -40,7 +42,8 @@
       "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
       "category": "developer",
       "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\uddf0"
     },
     {
       "name": "amex-perk-reminder",
@@ -52,7 +55,8 @@
       "description": "Track every credit on the Amex cards you hold (Platinum, Gold, Business Platinum, Delta Gold/Platinum/Reserve) with status-aware reminders before any window closes.",
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/amex-perk-reminder",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcb3"
     },
     {
       "name": "astrology-horoscope",
@@ -64,7 +68,8 @@
       "description": "Western tropical natal chart and transit computation. Local ephemeris (astronomy-engine, no API keys) for planet positions, ascendant/midheaven, whole-sign houses, and aspects, plus a natal-reading skill that interprets the raw chart into a readable report.",
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/astrology-horoscope",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udd2e"
     },
     {
       "name": "caveman",
@@ -102,7 +107,8 @@
       "description": "AI co-founder that remembers your company context, challenges your thinking, and tracks your decisions.",
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/cofounder",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\udd1d"
     },
     {
       "name": "cognee",
@@ -114,7 +120,8 @@
       },
       "description": "Cognee knowledge graph memory for Vellum Assistant: session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
       "category": "memory",
-      "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/vellum-assistant"
+      "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/vellum-assistant",
+      "icon": "\ud83d\udd78\ufe0f"
     },
     {
       "name": "dynamic-notch",
@@ -126,7 +133,8 @@
       "description": "Put your Vellum assistant inside your MacBook's notch: click to chat, hold Ctrl+Option to talk, and get a floating task bulb while it works, with live-streamed replies and per-sentence voice.",
       "category": "interface",
       "homepage": "https://github.com/AnitaKirkovska/dynamic-notch",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcbb"
     },
     {
       "name": "family-briefing",
@@ -138,7 +146,8 @@
       "description": "Daily morning briefing for parents: merges family calendars, triages school emails, and detects scheduling conflicts.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/family-briefing",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66"
     },
     {
       "name": "fitness-companion",
@@ -150,7 +159,8 @@
       "description": "Fitness and nutrition companion. Logs meals, workouts, and weight; looks up nutrition data from OpenFoodFacts; calculates macro targets; and injects daily fitness context into every conversation.",
       "category": "health",
       "homepage": "https://github.com/vellum-ai/fitness-companion",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcaa"
     },
     {
       "name": "git-workflow",
@@ -162,7 +172,8 @@
       "description": "Git workflow tools and multi-perspective code review: branch management, push, stash, PR creation/review/merge/checkout, diffs, logs, changelog generation, and parallel subagent code review with confidence scoring.",
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/git-workflow",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udd00"
     },
     {
       "name": "google-drive-search",
@@ -174,7 +185,8 @@
       "description": "Local full-text search across your Google Drive. Indexes file metadata and document content into SQLite FTS5 for instant, private search.",
       "category": "productivity",
       "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "icon": "\ud83d\udd0d"
     },
     {
       "name": "influencer-marketing",
@@ -186,7 +198,8 @@
       "description": "Find and research influencers on Instagram, TikTok, and X/Twitter. Includes a strategy builder that walks from campaign brief to research criteria, a research skill that discovers real profiles via browser automation, scores candidates, and exports ranked shortlists, and a dashboard skill that turns the shortlist into an interactive outreach tracker.",
       "category": "marketing",
       "homepage": "https://github.com/ZeebBoyBlue/influencer",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udce3"
     },
     {
       "name": "kitchen-companion",
@@ -198,7 +211,8 @@
       "description": "Full kitchen companion. Scan your fridge with a photo to stock a pantry inventory and get 3 makeable-now recipes, get alerts before food expires, clip recipes from any URL into a clean format, and generate meal plans with grocery lists from what you actually have.",
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/kitchen-companion",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83c\udf73"
     },
     {
       "name": "level-up",
@@ -210,7 +224,8 @@
       "description": "Surfaces a first-class \"Level Up\" diff card whenever the assistant edits its own skills or plugins, so you can see how it improved itself after the fact.",
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/level-up",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83c\udd99"
     },
     {
       "name": "marketing-expert",
@@ -222,7 +237,8 @@
       "description": "Acts as a full-stack marketing expert for any business (B2B or B2C): an on-demand persona plus playbook skills (positioning, demand planning, launches, content & copywriting, brand voice, email sequences, SEO & GEO, competitive teardown, board reporting) and deterministic funnel/positioning/GTM/competitive tools.",
       "category": "marketing",
       "homepage": "https://github.com/vellum-ai/marketing-expert",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcc8"
     },
     {
       "name": "model-router",
@@ -234,7 +250,8 @@
       "description": "Routes each user-facing message to one of your workspace's inference profiles, so model selection can vary per call instead of staying pinned to a single profile.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/model-router",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udea6"
     },
     {
       "name": "motion-design",
@@ -246,7 +263,8 @@
       "description": "Teaches the assistant to build polished UI animations with Motion (motion.dev) for React: animated product mockups, chat replays, typing effects, and staggered reveals, with a complete animated chat example included.",
       "category": "creative",
       "homepage": "https://github.com/vellum-ai/motion-design",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83c\udfac"
     },
     {
       "name": "originkit",
@@ -258,7 +276,8 @@
       "description": "Browse and import animated UI components from Originkit, a free library of 50 animated components. Browse by category or search term without an API key; fetch component source code (React, Next.js, Vite, Framer) with a free key from originkit.dev.",
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/originkit",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\uddf1"
     },
     {
       "name": "personal-finance",
@@ -270,7 +289,8 @@
       "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/personal-finance",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcb0"
     },
     {
       "name": "plant-doctor",
@@ -282,7 +302,8 @@
       "description": "Diagnose plants from photos. Identifies the species, assesses health with visible evidence, and returns a care plan. Named plants get a persistent checkup history so you can track whether they are improving.",
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/plant-doctor",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\udeb4"
     },
     {
       "name": "polyglot",
@@ -294,7 +315,8 @@
       "description": "Ambient language acquisition through your assistant. Three graduated modes (practice, ambient, immersive) weave a target language into your real conversations, with SM-2 spaced repetition, error-pattern tracking, and CEFR level history.",
       "category": "education",
       "homepage": "https://github.com/vellum-ai/polyglot",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udde3\ufe0f"
     },
     {
       "name": "proactive-slacks",
@@ -306,7 +328,8 @@
       "description": "Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcac"
     },
     {
       "name": "reading-pal",
@@ -318,7 +341,8 @@
       "description": "Your reading life in one plugin. Track your TBR pile, get guilt-tripped about your backlog, find your next read, and sync from Goodreads.",
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/reading-pal",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udcda"
     },
     {
       "name": "simple-memory",
@@ -330,7 +354,8 @@
       "description": "Reference memory plugin that exercises the full plugin API with low-cost variants of Vellum's memory defaults.",
       "category": "memory",
       "homepage": "https://github.com/vellum-ai/simple-memory",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\udde0"
     },
     {
       "name": "smb-inbox-brief",
@@ -342,7 +367,8 @@
       "description": "Find urgent replies, overdue invoices, quotes, and customer follow-ups before they slip. Scans email, logs business items, delivers urgency-ranked daily briefs.",
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83d\udce7"
     },
     {
       "name": "tennis-companion",
@@ -354,7 +380,8 @@
       "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
       "category": "health",
       "homepage": "https://github.com/vellum-ai/tennis-companion",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83c\udfbe"
     },
     {
       "name": "travel-planner",
@@ -366,7 +393,8 @@
       "description": "A travel EA for your assistant. Remembers how you travel (carrier, miles, hotel budget, card benefits), keeps per-trip records, watches Gmail for booking changes, syncs your calendar, and emails an EA-style trip brief 48 hours before departure.",
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/travel-planner",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\u2708\ufe0f"
     },
     {
       "name": "vellum-client-qa",
@@ -378,7 +406,8 @@
       "description": "Cross-platform QA rig for vellum-assistant clients: mock the platform backend, boot the real chat UI, and verify feature branches in headless Chromium (web), an iOS simulator, or Electron with screenshot and video proof.",
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/vellum-client-qa",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\ud83e\uddea"
     },
     {
       "name": "writing-coach",
@@ -390,7 +419,8 @@
       "description": "A writing coach in your pocket. Daily prompts that escalate with your streak, savage-but-constructive draft roasts, query letter critiques, and a word count enforcer that guilt-trips you when you skip.",
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/writing-coach",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "\u270d\ufe0f"
     }
   ]
 }

--- a/scripts/plugins/__tests__/add-plugin-icon.test.mjs
+++ b/scripts/plugins/__tests__/add-plugin-icon.test.mjs
@@ -61,20 +61,20 @@ afterEach(() => {
 });
 
 describe("serializeMarketplace", () => {
-  test("escapes non-ASCII (emoji, punctuation) and ends with a newline", () => {
+  test("emits raw human-readable UTF-8 (no \\uXXXX escaping) and a trailing newline", () => {
     const out = serializeMarketplace({ plugins: [entry("coffee", { icon: COFFEE })] });
     expect(out.endsWith("\n")).toBe(true);
-    // Emoji + em-dash are ASCII-escaped, never emitted raw.
-    expect(out).toContain("\\u2615");
-    expect(out).toContain("\\u2014");
-    expect(out.includes(COFFEE)).toBe(false);
-    expect(out.includes(EM_DASH)).toBe(false);
+    // Emoji + em-dash are kept raw, never escaped.
+    expect(out.includes(COFFEE)).toBe(true);
+    expect(out.includes(EM_DASH)).toBe(true);
+    expect(out).not.toContain("\\u2615");
+    expect(out).not.toContain("\\u2014");
   });
 
-  test("escapes astral emoji as a surrogate pair", () => {
+  test("emits astral emoji raw, not as a surrogate-pair escape", () => {
     const out = serializeMarketplace({ plugins: [entry("caveman", { icon: BONE })] });
-    expect(out).toContain("\\ud83e\\uddb4");
-    expect(out.includes(BONE)).toBe(false);
+    expect(out.includes(BONE)).toBe(true);
+    expect(out).not.toContain("\\ud83e\\uddb4");
   });
 
   test("is a stable round-trip of its own output", () => {
@@ -137,8 +137,8 @@ describe("addPluginIcon", () => {
     // Exactly the change of setting coffee.icon = ☕, nothing else.
     data.plugins[1].icon = COFFEE;
     expect(after).toBe(serializeMarketplace(data));
-    // The emoji is escaped, and the only textual delta is the added icon line.
-    expect(after).toContain("\\u2615");
+    // The emoji is written raw, and the only textual delta is the added icon line.
+    expect(after).toContain(COFFEE);
     const removedUnchanged = before
       .split("\n")
       .filter((l) => !after.split("\n").includes(l));

--- a/scripts/plugins/add-plugin-icon.mjs
+++ b/scripts/plugins/add-plugin-icon.mjs
@@ -41,17 +41,14 @@ const SYNC_SCRIPT = "meta/sync-bundled-copies.ts";
 
 /**
  * Serialize marketplace data to the exact on-disk canonical form: 2-space
- * indent, non-ASCII escaped as `\uXXXX` (matching the committed file, which
- * escapes emoji and punctuation like `—`), trailing newline. `JSON.stringify`
- * emits raw Unicode, so the escape pass is what keeps a one-field edit from
- * flipping every existing escaped character in the file.
+ * indent, raw UTF-8 (emoji and punctuation like `—` are kept human-readable,
+ * not `\uXXXX`-escaped), trailing newline — matching how `JSON.stringify`
+ * emits Unicode. The whole file is stored raw, so a one-field edit here
+ * reproduces it byte-for-byte and the stability guard in `addPluginIcon`
+ * stays satisfied.
  */
 export function serializeMarketplace(data) {
-  const json = JSON.stringify(data, null, 2).replace(
-    /[\u007f-\uffff]/g,
-    (c) => "\\u" + c.charCodeAt(0).toString(16).padStart(4, "0"),
-  );
-  return `${json}\n`;
+  return `${JSON.stringify(data, null, 2)}\n`;
 }
 
 /**
@@ -132,7 +129,7 @@ export async function addPluginIcon({
       // otherwise a one-field edit would silently reformat unrelated entries.
       if (serializeMarketplace(data) !== raw) {
         throw new Error(
-          `${marketplacePath} is not in the canonical 2-space, ASCII-escaped JSON ` +
+          `${marketplacePath} is not in the canonical 2-space, raw-UTF-8 JSON ` +
             `form this tool writes. Refusing to rewrite it to avoid a large unrelated ` +
             `diff — normalize the file first.`,
         );


### PR DESCRIPTION
## Summary
- Curates a single-glyph `icon` emoji for the **30** marketplace plugins that lacked one (only `caveman` 🦴 and `coffee-aficionado` ☕ already had icons). Every plugin now surfaces a recognizable glyph on the marketing catalog instead of the generic 🧩 fallback.
- **Stores `marketplace.json` (and its synced bundled copy) as raw, human-readable UTF-8** instead of `\uXXXX` escapes, so the emoji and text render as themselves in this diff and future ones. `JSON.parse` decodes both forms identically, so this is purely a serialization change — but it means the em-dash lines in existing descriptions also flip from `—` to `—`. The `add-plugin-icon` serializer is updated to stop escaping non-ASCII (tests flipped to match).
- Re-synced `assistant/src/cli/lib/bundled-marketplace.json` (a byte-for-byte mirror, so it's raw too). No PNGs involved, so `plugins/plugin-icons.json` and `plugins/assets/` are untouched (an emoji is the tier-2 fallback; a plugin can still get a PNG later that wins over it).

## Emoji choices
Each is ≤ 8 code points with no slash/URL, so all pass `marketplaceEntrySchema.icon`. None reuse the generic 🧩/📦 fallback glyphs; all 30 are distinct.

| Plugin | Icon | Why |
| --- | --- | --- |
| admin-copilot | 🧑‍💼 | chief-of-staff |
| agent-wrapped | 🎁 | a "wrapped" |
| ai-hero-engineer-kit | 🧰 | engineering kit |
| amex-perk-reminder | 💳 | credit card |
| astrology-horoscope | 🔮 | astrology |
| cofounder | 🤝 | co-founder |
| cognee | 🕸️ | knowledge graph |
| dynamic-notch | 💻 | MacBook notch |
| family-briefing | 👨‍👩‍👧‍👦 | family |
| fitness-companion | 💪 | fitness |
| git-workflow | 🔀 | branches |
| google-drive-search | 🔍 | search |
| influencer-marketing | 📣 | outreach |
| kitchen-companion | 🍳 | cooking |
| level-up | 🆙 | "Level Up" |
| marketing-expert | 📈 | growth |
| model-router | 🚦 | routing |
| motion-design | 🎬 | animation |
| originkit | 🧱 | UI building blocks |
| personal-finance | 💰 | money |
| plant-doctor | 🪴 | plants |
| polyglot | 🗣️ | languages |
| proactive-slacks | 💬 | messaging |
| reading-pal | 📚 | reading |
| simple-memory | 🧠 | memory |
| smb-inbox-brief | 📧 | email |
| tennis-companion | 🎾 | tennis |
| travel-planner | ✈️ | travel |
| vellum-client-qa | 🧪 | QA |
| writing-coach | ✍️ | writing |

## Original prompt
Now that the `add-plugin-icon` tooling has merged, curate emoji icons for every marketplace plugin that doesn't yet have one, so the catalog stops falling back to the generic glyph. This is emoji curation (not PNG vendoring), so it's applied as one canonical-form edit plus a single bundled-copy sync rather than N generator runs.
