### PR TITLE
fix(speech): default to managed from connection state at startup

### DIFF
--- a/assistant/src/__tests__/managed-speech-defaults.test.ts
+++ b/assistant/src/__tests__/managed-speech-defaults.test.ts
@@ -2,27 +2,13 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import * as actualTtsCapability from "../calls/telephony-tts-capability.js";
 import * as actualManagedSpeech from "../platform/managed-speech.js";
-import * as actualResolve from "../providers/speech-to-text/resolve.js";
 
 let mockManagedSpeechAvailable = false;
-let mockSttKeyResolves = false;
-let mockTtsSecretResolves = false;
 
 mock.module("../platform/managed-speech.js", () => ({
   ...actualManagedSpeech,
   managedSpeechAvailable: async () => mockManagedSpeechAvailable,
-}));
-
-mock.module("../providers/speech-to-text/resolve.js", () => ({
-  ...actualResolve,
-  sttProviderKeyResolves: async () => mockSttKeyResolves,
-}));
-
-mock.module("../calls/telephony-tts-capability.js", () => ({
-  ...actualTtsCapability,
-  ttsSecretResolves: async () => mockTtsSecretResolves,
 }));
 
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
@@ -50,19 +36,17 @@ beforeEach(() => {
   ensureTestDir();
   writeConfig({});
   mockManagedSpeechAvailable = false;
-  mockSttKeyResolves = false;
-  mockTtsSecretResolves = false;
 });
 
 describe("maybeDefaultSpeechToManaged", () => {
-  test("no-ops when managed speech is unavailable", async () => {
+  test("logged out: no-op — the schema's BYOK default stands", async () => {
     await maybeDefaultSpeechToManaged();
 
     const config = readConfig();
     expect(config.services).toBeUndefined();
   });
 
-  test("defaults both services to managed when no BYOK credentials resolve", async () => {
+  test("logged in: defaults both services to managed", async () => {
     mockManagedSpeechAvailable = true;
 
     await maybeDefaultSpeechToManaged();
@@ -76,52 +60,29 @@ describe("maybeDefaultSpeechToManaged", () => {
     expect(getConfig().services.stt.mode).toBe("managed");
   });
 
-  test("leaves a service alone when its BYOK credential resolves", async () => {
-    mockManagedSpeechAvailable = true;
-    mockSttKeyResolves = true;
-
-    await maybeDefaultSpeechToManaged();
-
-    const config = readConfig();
-    expect((config.services as any)?.stt?.mode).toBeUndefined();
-    expect((config.services as any)?.tts?.mode).toBe("managed");
-  });
-
-  test("no-ops when both BYOK credentials resolve", async () => {
-    mockManagedSpeechAvailable = true;
-    mockSttKeyResolves = true;
-    mockTtsSecretResolves = true;
-
-    await maybeDefaultSpeechToManaged();
-
-    const config = readConfig();
-    expect(config.services).toBeUndefined();
-  });
-
-  test("no-ops when services are already managed", async () => {
+  test("logged in with BYOK providers configured but no explicit mode: still defaults to managed", async () => {
+    // Connection state drives the default — a stored provider key without
+    // an explicit mode choice does not pin BYOK.
     mockManagedSpeechAvailable = true;
     writeConfig({
       services: {
-        stt: { mode: "managed", provider: "deepgram" },
-        tts: { mode: "managed" },
+        stt: { provider: "deepgram" },
+        tts: { provider: "elevenlabs" },
       },
     });
 
     await maybeDefaultSpeechToManaged();
 
     const config = readConfig();
-    expect(config).toEqual({
-      services: {
-        stt: { mode: "managed", provider: "deepgram" },
-        tts: { mode: "managed" },
-      },
-    });
+    expect((config.services as any).stt.mode).toBe("managed");
+    expect((config.services as any).tts.mode).toBe("managed");
+    // The BYOK provider choice is preserved for a later switch back.
+    expect((config.services as any).stt.provider).toBe("deepgram");
+    expect((config.services as any).tts.provider).toBe("elevenlabs");
   });
 
-  test("never downgrades an explicit your-own mode with resolving credentials", async () => {
+  test("explicit your-own modes always win over the logged-in default", async () => {
     mockManagedSpeechAvailable = true;
-    mockSttKeyResolves = true;
-    mockTtsSecretResolves = true;
     writeConfig({
       services: {
         stt: { mode: "your-own", provider: "deepgram" },
@@ -134,5 +95,28 @@ describe("maybeDefaultSpeechToManaged", () => {
     const config = readConfig();
     expect((config.services as any).stt.mode).toBe("your-own");
     expect((config.services as any).tts.mode).toBe("your-own");
+  });
+
+  test("one explicit mode: only the unset service is defaulted", async () => {
+    mockManagedSpeechAvailable = true;
+    writeConfig({
+      services: { stt: { mode: "your-own", provider: "deepgram" } },
+    });
+
+    await maybeDefaultSpeechToManaged();
+
+    const config = readConfig();
+    expect((config.services as any).stt.mode).toBe("your-own");
+    expect((config.services as any).tts.mode).toBe("managed");
+  });
+
+  test("idempotent: a second run rewrites nothing", async () => {
+    mockManagedSpeechAvailable = true;
+    await maybeDefaultSpeechToManaged();
+    const first = readFileSync(CONFIG_PATH, "utf8");
+
+    await maybeDefaultSpeechToManaged();
+
+    expect(readFileSync(CONFIG_PATH, "utf8")).toBe(first);
   });
 });

--- a/assistant/src/config/managed-speech-defaults.ts
+++ b/assistant/src/config/managed-speech-defaults.ts
@@ -1,20 +1,19 @@
 /**
- * Managed-speech defaulting on Vellum connection.
+ * Connection-state speech-mode defaulting.
  *
- * When the platform connection completes and a speech service has no working
- * BYOK credential, default that service to `mode: "managed"` so a fresh
- * Vellum connection gets voice features with zero configuration. A service
- * whose BYOK credential is already configured is never modified — connecting
- * Vellum must not silently reroute an existing voice setup — and a service
- * already in managed mode is left alone.
+ * The default speech mode follows the platform connection: logged in ⇒
+ * managed, logged out ⇒ BYOK (the schema default). An explicit
+ * `services.stt.mode` / `services.tts.mode` key in the raw config always
+ * wins — defaulting only ever fills an absent key, so a user's choice
+ * (made via the settings tool or the Voice settings cards, both of which
+ * persist `mode`) is never overridden, in either direction.
+ *
+ * Runs at daemon startup and when the platform connection completes, so
+ * bare-metal and Docker installs that were already logged in before this
+ * defaulting existed converge on their next boot.
  */
 
-import { ttsSecretResolves } from "../calls/telephony-tts-capability.js";
 import { managedSpeechAvailable } from "../platform/managed-speech.js";
-import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
-import { sttProviderKeyResolves } from "../providers/speech-to-text/resolve.js";
-import type { SttProviderId } from "../stt/types.js";
-import { getCatalogProvider } from "../tts/provider-catalog.js";
 import { getLogger } from "../util/logger.js";
 import {
   getConfig,
@@ -23,42 +22,32 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "./loader.js";
-import { effectiveTtsProvider } from "./schemas/tts.js";
 
 const log = getLogger("managed-speech-defaults");
 
-/** Whether the configured BYOK STT provider has a usable credential. */
-async function sttByokCredentialResolves(provider: string): Promise<boolean> {
-  const entry = getProviderEntry(provider as SttProviderId);
-  if (!entry) {
-    return false;
+/** Read the raw (pre-schema) mode key for one speech service, if present. */
+function rawMode(
+  raw: Record<string, unknown>,
+  service: "stt" | "tts",
+): unknown {
+  const services = raw.services;
+  if (!services || typeof services !== "object") {
+    return undefined;
   }
-  return sttProviderKeyResolves(entry.credentialProvider);
-}
-
-/** Whether the configured BYOK TTS provider has all its secrets. */
-async function ttsByokCredentialsResolve(provider: string): Promise<boolean> {
-  let entry;
-  try {
-    entry = getCatalogProvider(provider);
-  } catch {
-    return false;
+  const entry = (services as Record<string, unknown>)[service];
+  if (!entry || typeof entry !== "object") {
+    return undefined;
   }
-  for (const secret of entry.secretRequirements) {
-    if (!(await ttsSecretResolves(secret.credentialStoreKey))) {
-      return false;
-    }
-  }
-  return true;
+  return (entry as Record<string, unknown>).mode;
 }
 
 /**
- * Default unconfigured speech services to managed mode.
+ * Default speech services with no explicit mode to managed when the
+ * platform connection is fully usable.
  *
- * Safe to call repeatedly (idempotent) and safe to fire-and-forget: it
- * no-ops unless the platform connection is fully usable, and it only ever
- * flips `mode` from `"your-own"` to `"managed"` for services with no
- * working BYOK credential.
+ * Safe to call repeatedly (idempotent — once written, the mode key is
+ * present and never touched again) and safe to fire-and-forget: it no-ops
+ * entirely when logged out, leaving the schema's BYOK default in place.
  */
 export async function maybeDefaultSpeechToManaged(): Promise<void> {
   try {
@@ -66,47 +55,38 @@ export async function maybeDefaultSpeechToManaged(): Promise<void> {
       return;
     }
 
-    const services = getConfig().services;
+    const raw = loadRawConfig();
     const updates: string[] = [];
-
-    if (
-      services.stt.mode !== "managed" &&
-      !(await sttByokCredentialResolves(services.stt.provider))
-    ) {
+    if (rawMode(raw, "stt") === undefined) {
       updates.push("services.stt.mode");
     }
-
-    if (services.tts.mode !== "managed") {
-      const byokProvider = effectiveTtsProvider({
-        mode: "your-own",
-        provider: services.tts.provider,
-      });
-      if (!(await ttsByokCredentialsResolve(byokProvider))) {
-        updates.push("services.tts.mode");
-      }
+    if (rawMode(raw, "tts") === undefined) {
+      updates.push("services.tts.mode");
     }
-
     if (updates.length === 0) {
       return;
     }
 
-    const raw = loadRawConfig();
     for (const path of updates) {
       setNestedValue(raw, path, "managed");
     }
     // SttServiceSchema requires `provider` whenever the stt object exists, so
     // a sparse config would become invalid if we wrote `mode` alone.
     if (updates.includes("services.stt.mode")) {
-      setNestedValue(raw, "services.stt.provider", services.stt.provider);
+      setNestedValue(
+        raw,
+        "services.stt.provider",
+        getConfig().services.stt.provider,
+      );
     }
     saveRawConfig(raw);
     invalidateConfigCache();
     log.info(
       { defaulted: updates },
-      "Defaulted unconfigured speech services to managed mode after Vellum connection",
+      "Defaulted speech services to managed mode (platform connection present)",
     );
   } catch (err) {
-    // Convenience defaulting must never break credential storage.
+    // Convenience defaulting must never break startup or credential storage.
     log.warn(
       { error: err instanceof Error ? err.message : String(err) },
       "Managed speech defaulting failed (non-fatal)",

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -10,6 +10,7 @@ import {
   loadConfig,
   mergeDefaultWorkspaceConfig,
 } from "../config/loader.js";
+import { maybeDefaultSpeechToManaged } from "../config/managed-speech-defaults.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
 import { startCes } from "../credential-execution/ces-runtime.js";
@@ -566,6 +567,13 @@ export async function runDaemon(): Promise<void> {
   // on failure. The sidecar accepts exactly one bootstrap connection, so this
   // happens at the process level.
   await startCes(config);
+
+  // Speech-mode defaulting follows the platform connection (logged in ⇒
+  // managed, explicit modes always win). Placed after startCes so the
+  // credential store — where the platform connection lives in Docker/managed
+  // mode — is readable; runs every boot so installs that connected before this
+  // defaulting existed converge. Detached — must not block startup.
+  void maybeDefaultSpeechToManaged();
 
   // Bring up the plugin layer: install the runtime bridge, register the
   // first-party defaults, load user plugins, and run every plugin's


### PR DESCRIPTION
## Problem
Managed-speech defaulting (B4, #37916) fires from a single place: the `secret-routes` hook that runs when Vellum credentials are **written**. So it only defaults when credentials are *freshly stored* this session.

A daemon that was already connected in a prior session only **rehydrates** its platform connection at boot (`rehydratePlatformCredentials` repopulates in-memory env from the store — no store event), so the defaulting never re-runs. Two user-visible symptoms, same root cause:

- An **upgraded platform-hosted** assistant kept erroring for a Deepgram key even though it was logged in.
- The **Electron desktop app** adopts an already-connected local daemon (no re-provisioning), so it never defaulted — while web, whose flow re-provisions credentials through the secret route, did.

## Fix
1. **Run the defaulting at daemon startup too** (`lifecycle.ts`), placed after `startCes` so the credential store — where the platform connection lives in Docker/managed mode — is actually readable. (Caught in review of my own first draft: an earlier placement ran before `startCes` and would have silently no-op'd on Docker.)
2. **Key the default off connection state, not BYOK-credential resolution.** Logged in + no explicit `services.stt/tts.mode` ⇒ managed. An explicit mode always wins, in either direction — so a deliberate BYOK choice (set via the settings tool or Voice cards, which persist `mode`) is never silently rerouted, and managed is never downgraded. This also means an explicit BYOK-without-keys config is **left alone** for a runtime offer (follow-up), rather than auto-switched.

Net: defaulting is now deterministic on every boot — rehydrated or freshly stored, web or Electron, bare-metal or Docker.

## Note on scope
This is Tier 1 (proactive default) of the two-tier model. Tier 2 — the reactive "no key set; you're connected to Vellum, use managed?" offer for an *explicit* BYOK config that hits a missing-key error — is a follow-up (a preflight message change, and optionally an interactive prompt).

## Tests
Rewritten `managed-speech-defaults.test.ts` for the connection-state semantics: logged-out no-op; logged-in defaults both; logged-in with BYOK providers configured but no explicit mode still defaults (connection state wins); explicit modes always win; one-explicit-one-unset; idempotent second run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->