### PR TITLE
feat(voice): reduce self-interruption + configurable pause/interrupt sensitivity (JARVIS-1284)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -896,9 +896,9 @@ describe("AssistantConfigSchema", () => {
       mode: "open-mic",
       vad: {
         speechEnergyThreshold: 800,
-        silenceThresholdMs: 800,
+        silenceThresholdMs: 1200,
         maxTurnDurationMs: 30000,
-        bargeInMinSpeechMs: 60,
+        bargeInMinSpeechMs: 250,
       },
       maxSessionDurationSeconds: 1800,
     });

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -11,9 +11,9 @@ describe("LiveVoiceVadConfigSchema", () => {
     const parsed = LiveVoiceVadConfigSchema.parse({});
     expect(parsed).toEqual({
       speechEnergyThreshold: 800,
-      silenceThresholdMs: 800,
+      silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
-      bargeInMinSpeechMs: 60,
+      bargeInMinSpeechMs: 250,
     });
   });
 
@@ -64,9 +64,9 @@ describe("LiveVoiceConfigSchema", () => {
       mode: "open-mic",
       vad: {
         speechEnergyThreshold: 800,
-        silenceThresholdMs: 800,
+        silenceThresholdMs: 1200,
         maxTurnDurationMs: 30_000,
-        bargeInMinSpeechMs: 60,
+        bargeInMinSpeechMs: 250,
       },
       maxSessionDurationSeconds: 1800,
     });
@@ -75,11 +75,11 @@ describe("LiveVoiceConfigSchema", () => {
   test("accepts overrides", () => {
     const parsed = LiveVoiceConfigSchema.parse({
       mode: "ptt",
-      vad: { silenceThresholdMs: 1200 },
+      vad: { silenceThresholdMs: 900 },
       maxSessionDurationSeconds: 600,
     });
     expect(parsed.mode).toBe("ptt");
-    expect(parsed.vad.silenceThresholdMs).toBe(1200);
+    expect(parsed.vad.silenceThresholdMs).toBe(900);
     // Unspecified vad fields still get defaults
     expect(parsed.vad.speechEnergyThreshold).toBe(800);
     expect(parsed.vad.maxTurnDurationMs).toBe(30_000);

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -20,9 +20,9 @@ export const LiveVoiceVadConfigSchema = z
       .number({ error: "liveVoice.vad.silenceThresholdMs must be a number" })
       .int("liveVoice.vad.silenceThresholdMs must be an integer")
       .positive("liveVoice.vad.silenceThresholdMs must be a positive integer")
-      .default(800)
+      .default(1200)
       .describe(
-        "Trailing silence duration (ms) after speech that ends the user's turn",
+        "Trailing silence duration (ms) after speech that ends the user's turn — the default 'pause before reply'. Clients may override it per-session via the start frame.",
       ),
     maxTurnDurationMs: z
       .number({ error: "liveVoice.vad.maxTurnDurationMs must be a number" })
@@ -38,9 +38,9 @@ export const LiveVoiceVadConfigSchema = z
       .nonnegative(
         "liveVoice.vad.bargeInMinSpeechMs must be a nonnegative integer",
       )
-      .default(60)
+      .default(250)
       .describe(
-        "Sustained speech (ms) required before speech during assistant playback interrupts it; 0 disables the guard",
+        "Sustained speech (ms) required before speech during assistant playback interrupts it — the default 'interrupt sensitivity' (higher = harder to interrupt). 0 disables the guard. Clients may override it per-session via the start frame. Raised from 60 so brief TTS bleed through imperfect echo cancellation no longer self-interrupts the assistant.",
       ),
   })
   .describe(

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -63,9 +63,10 @@ function pcm(amplitude: number, sampleCount = 240): Uint8Array {
 
 // 10 ms of speech at 24 kHz.
 const LOUD_CHUNK = pcm(8_000);
-// 60 ms of speech at 24 kHz — meets the default sustained-speech barge-in
-// guard (bargeInMinSpeechMs) in a single chunk.
-const SUSTAINED_LOUD_CHUNK = pcm(8_000, 1_440);
+// 300 ms of speech at 24 kHz — comfortably exceeds the default sustained-speech
+// barge-in guard (bargeInMinSpeechMs, 250 ms) in a single chunk, so a lone
+// chunk trips barge-in. Must stay above that default.
+const SUSTAINED_LOUD_CHUNK = pcm(8_000, 7_200);
 const SILENT_CHUNK = pcm(0);
 
 class MockStreamingTranscriber implements StreamingTranscriber {
@@ -1110,14 +1111,14 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
     expect(countType(raisedGate.frames, "speech_started")).toBe(0);
   });
 
-  test("with no config set the factory defaults to 800 energy / 800 ms silence / 30 s max turn", async () => {
+  test("with no config set the factory defaults to 800 energy / 1200 ms silence / 30 s max turn / 250 ms barge-in", async () => {
     // The test workspace has no liveVoice config, so the factory reads the
-    // schema defaults — which must equal the historical code constants.
+    // schema defaults.
     expect(getConfig().liveVoice.vad).toEqual({
       speechEnergyThreshold: 800,
-      silenceThresholdMs: 800,
+      silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
-      bargeInMinSpeechMs: 60,
+      bargeInMinSpeechMs: 250,
     });
 
     const { frames, session } = createHarness({ viaFactory: true });
@@ -1172,6 +1173,30 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
       saveRawConfig(originalRaw);
     }
   });
+
+  // JARVIS-1284: the per-session start-frame `silenceThresholdMs` wins over the
+  // daemon-config/option value, so the client's "pause before reply" setting
+  // takes effect.
+  test("start-frame silenceThresholdMs overrides the option value", async () => {
+    const { frames, session } = createHarness({
+      // A short per-session pause on the start frame…
+      startFrame: { ...VAD_START_FRAME, silenceThresholdMs: 60 },
+      // …beats a long option/config threshold that would otherwise time the
+      // waitFor out.
+      turnDetectorConfig: { silenceThresholdMs: 5_000 },
+      finals: ["configured turn"],
+      startVoiceTurn: makeAutoCompletingTurnStarter(["Done."]).startVoiceTurn,
+    });
+    await session.start();
+
+    // One speech chunk, then silence: the turn ends ~60 ms later (the frame's
+    // value), well inside the waitFor budget — the 5 s option would time out.
+    await session.handleBinaryAudio(pcm(3_000));
+    await waitFor(() => countType(frames, "utterance_end") === 1);
+    expect(
+      frames.find((frame) => frame.type === "utterance_end"),
+    ).toMatchObject({ type: "utterance_end", reason: "silence" });
+  });
 });
 
 describe("LiveVoiceSession sustained-speech barge-in guard", () => {
@@ -1182,6 +1207,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   function createSpeakingTurnHarness(options: {
     bargeInMinSpeechMs: number;
     finals?: string[];
+    startFrame?: LiveVoiceClientStartFrame;
   }) {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();
@@ -1199,6 +1225,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       streamTtsAudio,
       bargeInMinSpeechMs: options.bargeInMinSpeechMs,
       turnDetectorConfig: { silenceThresholdMs: 5_000 },
+      ...(options.startFrame ? { startFrame: options.startFrame } : {}),
     });
 
     async function speakFirstReply(): Promise<void> {
@@ -1397,5 +1424,30 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     await waitFor(() => countType(frames, "speech_started") === baseline + 1);
     expect(countType(frames, "turn_cancelled")).toBe(0);
     expect(abort).not.toHaveBeenCalled();
+  });
+
+  // JARVIS-1284: the per-session start-frame `bargeInMinSpeechMs` wins over the
+  // daemon-config/option value, so the client's "interrupt sensitivity" setting
+  // takes effect.
+  test("start-frame bargeInMinSpeechMs overrides the option value (0 → instant barge-in)", async () => {
+    const { frames, session, abort, speakFirstReply } =
+      createSpeakingTurnHarness({
+        // The option (daemon config) would make barge-in effectively impossible…
+        bargeInMinSpeechMs: 5_000,
+        // …but the start-frame override disables the guard, so barge-in is
+        // instant.
+        startFrame: { ...VAD_START_FRAME, bargeInMinSpeechMs: 0 },
+      });
+    await speakFirstReply();
+
+    // A single speech chunk barges in immediately — proving the frame's 0 won.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ type: "turn_cancelled", turnId: "live-turn-1" });
+    await waitFor(() => abort.mock.calls.length === 1);
   });
 });

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -264,6 +264,80 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
+  test("parses per-session silenceThresholdMs and bargeInMinSpeechMs overrides", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        turnDetection: "server_vad",
+        silenceThresholdMs: 1500,
+        bargeInMinSpeechMs: 400,
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.frame).toMatchObject({
+      type: "start",
+      silenceThresholdMs: 1500,
+      bargeInMinSpeechMs: 400,
+    });
+  });
+
+  test("accepts bargeInMinSpeechMs of 0 (barge-in guard disabled)", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        bargeInMinSpeechMs: 0,
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.frame).toMatchObject({ bargeInMinSpeechMs: 0 });
+  });
+
+  test("omits silenceThresholdMs / bargeInMinSpeechMs when absent", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect("silenceThresholdMs" in result.frame).toBe(false);
+    expect("bargeInMinSpeechMs" in result.frame).toBe(false);
+  });
+
+  test.each([
+    ["silenceThresholdMs", 50], // below MIN_SILENCE_THRESHOLD_MS
+    ["silenceThresholdMs", 10_000], // above MAX_SILENCE_THRESHOLD_MS
+    ["silenceThresholdMs", 800.5], // non-integer
+    ["bargeInMinSpeechMs", -1], // below MIN_BARGE_IN_MIN_SPEECH_MS
+    ["bargeInMinSpeechMs", 9_000], // above MAX_BARGE_IN_MIN_SPEECH_MS
+    ["bargeInMinSpeechMs", 250.5], // non-integer
+  ])(
+    "returns a typed protocol error for out-of-range %s=%p",
+    (field, badValue) => {
+      const result = validateLiveVoiceClientFrame({
+        type: "start",
+        [field]: badValue,
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toMatchObject({
+        code: "invalid_field",
+        field,
+        frameType: "start",
+      });
+    },
+  );
+
   test("returns typed protocol errors for missing audio configuration fields", () => {
     const result = validateLiveVoiceClientFrame({
       type: "start",

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -93,10 +93,12 @@ const SERVER_VAD_PRE_ROLL_MAX_CHUNKS = 25;
 // provider keeps its own, longer, finalize fallback).
 const FINALIZE_GRACE_MS = 1_000;
 // Consecutive speech (ms) required before speech during assistant playback
-// flushes it (speech_started) and cancels the turn, so a cough or noise blip
-// cannot kill a reply mid-sentence. Mirrors the liveVoice.vad.bargeInMinSpeechMs
-// schema default; 0 disables the guard for instant barge-in.
-const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 60;
+// flushes it (speech_started) and cancels the turn, so a cough, a filler word,
+// or the assistant's own TTS bleeding through imperfect browser echo
+// cancellation cannot kill a reply mid-sentence. Mirrors the
+// liveVoice.vad.bargeInMinSpeechMs schema default; 0 disables the guard for
+// instant barge-in.
+const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one
 // prefetching job. The prefetch buffers its chunks in memory until promoted;
@@ -386,12 +388,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ...(options.metricsClock ? { clock: options.metricsClock } : {}),
     });
     this.speechEnergyThreshold = options.speechEnergyThreshold;
+    // Precedence for the two sensitivity knobs: per-session start-frame
+    // override (the client's user setting) > daemon `liveVoice.vad` config
+    // (seeded into `options` by the factory) > in-code default.
     this.bargeInMinSpeechMs =
-      options.bargeInMinSpeechMs ?? DEFAULT_BARGE_IN_MIN_SPEECH_MS;
+      context.startFrame.bargeInMinSpeechMs ??
+      options.bargeInMinSpeechMs ??
+      DEFAULT_BARGE_IN_MIN_SPEECH_MS;
     this.finalizeGraceMs = options.finalizeGraceMs ?? FINALIZE_GRACE_MS;
+    const turnDetectorConfig: TurnDetectorConfig = {
+      ...(options.turnDetectorConfig ?? {}),
+      ...(context.startFrame.silenceThresholdMs !== undefined
+        ? { silenceThresholdMs: context.startFrame.silenceThresholdMs }
+        : {}),
+    };
     this.turnDetector =
       context.startFrame.turnDetection === "server_vad"
-        ? new MediaTurnDetector(options.turnDetectorConfig ?? {}, {
+        ? new MediaTurnDetector(turnDetectorConfig, {
             onTurnStart: () => this.handleVadSpeechStart(),
             onTurnEnd: (reason) => this.handleVadUtteranceEnd(reason),
           })

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -78,7 +78,35 @@ export interface LiveVoiceClientStartFrame {
    * utterance boundaries and runs repeated utterance→turn cycles.
    */
   readonly turnDetection?: LiveVoiceTurnDetectionMode;
+  /**
+   * Per-session override for the trailing-silence duration (ms) that ends the
+   * user's turn — the "pause before reply" the client exposes as a setting.
+   * Absent falls back to the daemon `liveVoice.vad.silenceThresholdMs` config.
+   * Only meaningful for `turnDetection: "server_vad"`. Bounded to
+   * [{@link MIN_SILENCE_THRESHOLD_MS}, {@link MAX_SILENCE_THRESHOLD_MS}].
+   */
+  readonly silenceThresholdMs?: number;
+  /**
+   * Per-session override for the sustained speech (ms) required before the
+   * user's speech interrupts the assistant mid-reply — the "interrupt
+   * sensitivity" the client exposes as a setting (higher = harder to
+   * interrupt; 0 disables the guard so barge-in is immediate). Absent falls
+   * back to the daemon `liveVoice.vad.bargeInMinSpeechMs` config. Bounded to
+   * [{@link MIN_BARGE_IN_MIN_SPEECH_MS}, {@link MAX_BARGE_IN_MIN_SPEECH_MS}].
+   */
+  readonly bargeInMinSpeechMs?: number;
 }
+
+/**
+ * Bounds for the per-session turn-detection overrides carried on the start
+ * frame. Kept deliberately wide — they only reject nonsensical values (a
+ * sub-100 ms pause would end turns mid-word; a 10 s barge-in guard would make
+ * the assistant uninterruptible). The daemon config defaults sit inside these.
+ */
+export const MIN_SILENCE_THRESHOLD_MS = 100;
+export const MAX_SILENCE_THRESHOLD_MS = 5_000;
+export const MIN_BARGE_IN_MIN_SPEECH_MS = 0;
+export const MAX_BARGE_IN_MIN_SPEECH_MS = 3_000;
 
 export interface LiveVoiceClientAudioFrame {
   readonly type: "audio";
@@ -448,6 +476,38 @@ function validateStartFrame(
     );
   }
 
+  if (
+    "silenceThresholdMs" in value &&
+    !isIntInRange(
+      value.silenceThresholdMs,
+      MIN_SILENCE_THRESHOLD_MS,
+      MAX_SILENCE_THRESHOLD_MS,
+    )
+  ) {
+    return protocolError(
+      "invalid_field",
+      `start frame field silenceThresholdMs must be an integer in [${MIN_SILENCE_THRESHOLD_MS}, ${MAX_SILENCE_THRESHOLD_MS}]`,
+      "silenceThresholdMs",
+      "start",
+    );
+  }
+
+  if (
+    "bargeInMinSpeechMs" in value &&
+    !isIntInRange(
+      value.bargeInMinSpeechMs,
+      MIN_BARGE_IN_MIN_SPEECH_MS,
+      MAX_BARGE_IN_MIN_SPEECH_MS,
+    )
+  ) {
+    return protocolError(
+      "invalid_field",
+      `start frame field bargeInMinSpeechMs must be an integer in [${MIN_BARGE_IN_MIN_SPEECH_MS}, ${MAX_BARGE_IN_MIN_SPEECH_MS}]`,
+      "bargeInMinSpeechMs",
+      "start",
+    );
+  }
+
   return {
     ok: true,
     frame: {
@@ -459,8 +519,24 @@ function validateStartFrame(
       ...(isLiveVoiceTurnDetectionMode(value.turnDetection)
         ? { turnDetection: value.turnDetection }
         : {}),
+      ...(typeof value.silenceThresholdMs === "number"
+        ? { silenceThresholdMs: value.silenceThresholdMs }
+        : {}),
+      ...(typeof value.bargeInMinSpeechMs === "number"
+        ? { bargeInMinSpeechMs: value.bargeInMinSpeechMs }
+        : {}),
     },
   };
+}
+
+/** Whether `value` is an integer within the inclusive `[min, max]` range. */
+function isIntInRange(value: unknown, min: number, max: number): boolean {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= min &&
+    value <= max
+  );
 }
 
 function validateAudioFrame(

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -12,14 +12,7 @@
  * failure, and clean `end()` / `close()` teardown.
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let mintResult: Promise<{ token: string; expiresAt: string }> = Promise.resolve(
   { token: "tok-abc", expiresAt: "2026-06-01T00:05:00Z" },
@@ -42,7 +35,8 @@ mock.module("@/domains/chat/voice/live-voice/connection", () => ({
       const { token } = await mintResult;
       const url = new URL(`wss://velay.vellum.ai/${assistantId}/v1/live-voice`);
       url.searchParams.set("token", token);
-      if (conversationId) url.searchParams.set("conversationId", conversationId);
+      if (conversationId)
+        url.searchParams.set("conversationId", conversationId);
       return url.toString();
     },
   ),
@@ -53,9 +47,8 @@ import type { LiveVoiceChannelClient as LiveVoiceChannelClientType } from "@/dom
 // Import the module under test *after* registering the connection mock, so the
 // mock is in place before the real connection.ts (which imports the generated
 // SDK client) would otherwise be pulled into the static import graph.
-const { LiveVoiceChannelClient } = await import(
-  "@/domains/chat/voice/live-voice/live-voice-client"
-);
+const { LiveVoiceChannelClient } =
+  await import("@/domains/chat/voice/live-voice/live-voice-client");
 
 // ---------------------------------------------------------------------------
 // Fake WebSocket
@@ -132,7 +125,8 @@ class FakeWebSocket {
 }
 
 function makeClient(connectTimeoutMs = 10_000) {
-  const factory = (url: string) => new FakeWebSocket(url) as unknown as WebSocket;
+  const factory = (url: string) =>
+    new FakeWebSocket(url) as unknown as WebSocket;
   const client = new LiveVoiceChannelClient({
     webSocketFactory: factory,
     connectTimeoutMs,
@@ -147,6 +141,8 @@ async function connectAndGetSocket(
     assistantId: string;
     conversationId?: string;
     turnDetection?: "manual" | "server_vad";
+    silenceThresholdMs?: number;
+    bargeInMinSpeechMs?: number;
   } = { assistantId: "assistant-1" },
 ): Promise<FakeWebSocket> {
   await client.connect(args);
@@ -231,6 +227,36 @@ describe("connect", () => {
     ]);
   });
 
+  test("includes per-session silenceThresholdMs and bargeInMinSpeechMs in the start frame", async () => {
+    const ws = await connectAndGetSocket(makeClient(), {
+      assistantId: "assistant-1",
+      turnDetection: "server_vad",
+      silenceThresholdMs: 1500,
+      bargeInMinSpeechMs: 600,
+    });
+    ws.open();
+    expect(ws.sentJson).toEqual([
+      {
+        type: "start",
+        audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
+        turnDetection: "server_vad",
+        silenceThresholdMs: 1500,
+        bargeInMinSpeechMs: 600,
+      },
+    ]);
+  });
+
+  test("omits silenceThresholdMs and bargeInMinSpeechMs from the start frame when not provided", async () => {
+    const ws = await connectAndGetSocket(makeClient(), {
+      assistantId: "assistant-1",
+      turnDetection: "server_vad",
+    });
+    ws.open();
+    const frame = ws.sentJson[0]!;
+    expect("silenceThresholdMs" in frame).toBe(false);
+    expect("bargeInMinSpeechMs" in frame).toBe(false);
+  });
+
   test("emits error when token minting fails", async () => {
     mintResult = Promise.reject(new Error("mint boom"));
     const client = makeClient();
@@ -257,7 +283,12 @@ describe("server frame dispatch", () => {
     const client = makeClient();
     const ws = await connectAndGetSocket(client);
     ws.open();
-    ws.receive({ type: "ready", seq: 1, sessionId: "s1", conversationId: "c1" });
+    ws.receive({
+      type: "ready",
+      seq: 1,
+      sessionId: "s1",
+      conversationId: "c1",
+    });
     return { client, ws };
   }
 
@@ -356,8 +387,12 @@ describe("server frame dispatch", () => {
       sessionId: "s1",
     });
 
-    expect(got.sttPartial).toEqual([{ type: "stt_partial", seq: 2, text: "hel" }]);
-    expect(got.sttFinal).toEqual([{ type: "stt_final", seq: 3, text: "hello" }]);
+    expect(got.sttPartial).toEqual([
+      { type: "stt_partial", seq: 2, text: "hel" },
+    ]);
+    expect(got.sttFinal).toEqual([
+      { type: "stt_final", seq: 3, text: "hello" },
+    ]);
     expect(got.thinking).toEqual([{ type: "thinking", seq: 4, turnId: "t1" }]);
     expect(got.assistantTextDelta).toEqual([
       { type: "assistant_text_delta", seq: 5, text: "hi" },
@@ -467,7 +502,9 @@ describe("server frame dispatch", () => {
     const seen: unknown[] = [];
     client.on("sttPartial", (f) => seen.push(f));
     ws.receive({ type: "stt_partial", seq: 11, text: "still here" });
-    expect(seen).toEqual([{ type: "stt_partial", seq: 11, text: "still here" }]);
+    expect(seen).toEqual([
+      { type: "stt_partial", seq: 11, text: "still here" },
+    ]);
   });
 
   test("recoverable error before ready is still fatal", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -61,9 +61,7 @@ export const RETRYABLE_LIVE_VOICE_CLOSE_CODES: ReadonlySet<number> = new Set([
 
 /** Reason a live-voice session failed, surfaced via the `error` event. */
 export type LiveVoiceClientErrorReason =
-  | "connection-failed"
-  | "protocol-error"
-  | "timeout";
+  "connection-failed" | "protocol-error" | "timeout";
 
 export interface LiveVoiceClientError {
   readonly reason: LiveVoiceClientErrorReason;
@@ -137,6 +135,16 @@ export interface LiveVoiceConnectArgs {
    * (push-to-talk).
    */
   turnDetection?: LiveVoiceTurnDetectionMode;
+  /**
+   * Per-session "pause before reply" (ms) sent on the `start` frame. Omitted
+   * lets the daemon use its configured default.
+   */
+  silenceThresholdMs?: number;
+  /**
+   * Per-session "interrupt sensitivity" (ms of sustained speech to barge in)
+   * sent on the `start` frame. Omitted lets the daemon use its default.
+   */
+  bargeInMinSpeechMs?: number;
 }
 
 /** Factory so tests can inject a mock WebSocket. Defaults to the global. */
@@ -164,6 +172,8 @@ export class LiveVoiceChannelClient {
   private connectTimeout: ReturnType<typeof setTimeout> | null = null;
   private conversationId: string | undefined;
   private turnDetection: LiveVoiceTurnDetectionMode | undefined;
+  private silenceThresholdMs: number | undefined;
+  private bargeInMinSpeechMs: number | undefined;
 
   private readonly listeners: {
     [E in LiveVoiceClientEventName]: Set<LiveVoiceClientEventHandler<E>>;
@@ -224,11 +234,15 @@ export class LiveVoiceChannelClient {
     assistantId,
     conversationId,
     turnDetection,
+    silenceThresholdMs,
+    bargeInMinSpeechMs,
   }: LiveVoiceConnectArgs): Promise<void> {
     if (this.state !== "idle") return;
     this.state = "connecting";
     this.conversationId = conversationId;
     this.turnDetection = turnDetection;
+    this.silenceThresholdMs = silenceThresholdMs;
+    this.bargeInMinSpeechMs = bargeInMinSpeechMs;
 
     let url: string;
     try {
@@ -247,7 +261,10 @@ export class LiveVoiceChannelClient {
     try {
       ws = this.webSocketFactory(url);
     } catch (err) {
-      this.fail("connection-failed", messageOf(err, "Failed to open live-voice WebSocket"));
+      this.fail(
+        "connection-failed",
+        messageOf(err, "Failed to open live-voice WebSocket"),
+      );
       return;
     }
     this.ws = ws;
@@ -261,7 +278,10 @@ export class LiveVoiceChannelClient {
 
     this.connectTimeout = setTimeout(() => {
       if (this.state === "connecting") {
-        this.fail("timeout", `Live-voice connection timed out after ${this.connectTimeoutMs}ms`);
+        this.fail(
+          "timeout",
+          `Live-voice connection timed out after ${this.connectTimeoutMs}ms`,
+        );
       }
     }, this.connectTimeoutMs);
   }
@@ -312,6 +332,12 @@ export class LiveVoiceChannelClient {
       audio: LIVE_VOICE_AUDIO_FORMAT,
       ...(this.conversationId ? { conversationId: this.conversationId } : {}),
       ...(this.turnDetection ? { turnDetection: this.turnDetection } : {}),
+      ...(this.silenceThresholdMs !== undefined
+        ? { silenceThresholdMs: this.silenceThresholdMs }
+        : {}),
+      ...(this.bargeInMinSpeechMs !== undefined
+        ? { bargeInMinSpeechMs: this.bargeInMinSpeechMs }
+        : {}),
     };
     this.trySend(JSON.stringify(startFrame));
   }
@@ -412,7 +438,10 @@ export class LiveVoiceChannelClient {
       this.state === "connecting" &&
       !RETRYABLE_LIVE_VOICE_CLOSE_CODES.has(event.code)
     ) {
-      this.fail("connection-failed", "Live-voice WebSocket closed before ready");
+      this.fail(
+        "connection-failed",
+        "Live-voice WebSocket closed before ready",
+      );
       return;
     }
     this.teardown();

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -41,6 +41,8 @@ export class FakeClient {
     assistantId: string;
     conversationId?: string;
     turnDetection?: "manual" | "server_vad";
+    silenceThresholdMs?: number;
+    bargeInMinSpeechMs?: number;
   } | null = null;
   sentAudio: ArrayBuffer[] = [];
   pttReleaseCount = 0;
@@ -70,6 +72,8 @@ export class FakeClient {
     assistantId: string;
     conversationId?: string;
     turnDetection?: "manual" | "server_vad";
+    silenceThresholdMs?: number;
+    bargeInMinSpeechMs?: number;
   }): Promise<void> {
     this.connectArgs = args;
   }

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -55,6 +55,19 @@ export interface LiveVoiceClientStartFrame {
    * utterance boundaries and runs repeated utterance→turn cycles.
    */
   readonly turnDetection?: LiveVoiceTurnDetectionMode;
+  /**
+   * Per-session override for the trailing-silence duration (ms) that ends the
+   * user's turn — the "pause before reply" voice setting. Absent lets the
+   * daemon use its configured default. Only meaningful for `server_vad`.
+   */
+  readonly silenceThresholdMs?: number;
+  /**
+   * Per-session override for the sustained speech (ms) required to interrupt
+   * the assistant mid-reply — the "interrupt sensitivity" voice setting
+   * (higher = harder to interrupt; 0 = instant barge-in). Absent lets the
+   * daemon use its configured default.
+   */
+  readonly bargeInMinSpeechMs?: number;
 }
 
 export interface LiveVoiceClientPttReleaseFrame {
@@ -144,8 +157,7 @@ export interface LiveVoiceUtteranceEndServerFrame extends LiveVoiceServerFrameBa
  * usable speech (noise/cough): it is dropped without an assistant turn and
  * the client should return to listening.
  */
-export interface LiveVoiceUtteranceDiscardedServerFrame
-  extends LiveVoiceServerFrameBase {
+export interface LiveVoiceUtteranceDiscardedServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "utterance_discarded";
 }
 
@@ -164,8 +176,7 @@ export interface LiveVoiceThinkingServerFrame extends LiveVoiceServerFrameBase {
   readonly turnId: string;
 }
 
-export interface LiveVoiceAssistantTextDeltaServerFrame
-  extends LiveVoiceServerFrameBase {
+export interface LiveVoiceAssistantTextDeltaServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "assistant_text_delta";
   readonly text: string;
 }
@@ -303,7 +314,10 @@ function isLiveVoiceServerFrameType(
  */
 export function parseServerFrame(
   raw: string,
-): LiveVoiceServerFrame | LiveVoiceInvalidJsonFrame | LiveVoiceUnknownServerFrame {
+):
+  | LiveVoiceServerFrame
+  | LiveVoiceInvalidJsonFrame
+  | LiveVoiceUnknownServerFrame {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -41,6 +41,11 @@ import {
 const { useLiveVoiceSessionController } = await import(
   "@/domains/chat/voice/live-voice/use-live-voice-session-controller"
 );
+const {
+  useVoicePrefsStore,
+  DEFAULT_PAUSE_BEFORE_REPLY_MS,
+  DEFAULT_INTERRUPT_SENSITIVITY,
+} = await import("@/stores/voice-prefs-store");
 const { useLiveVoiceStore } = await import(
   "@/domains/chat/voice/live-voice/live-voice-store"
 );
@@ -108,6 +113,13 @@ async function startListeningViaStarter(
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
   useLiveVoiceStore.getState().setStarter(null);
+  // The voice-prefs store is a persisted singleton shared across test files;
+  // pin the turn-taking settings to defaults so connect-args assertions are
+  // deterministic regardless of test order.
+  useVoicePrefsStore.setState({
+    pauseBeforeReplyMs: DEFAULT_PAUSE_BEFORE_REPLY_MS,
+    interruptSensitivity: DEFAULT_INTERRUPT_SENSITIVITY,
+  });
 });
 
 afterEach(() => {
@@ -139,6 +151,8 @@ describe("starter registration", () => {
       assistantId: "assistant-1",
       conversationId: "conv-1",
       turnDetection: "server_vad",
+      silenceThresholdMs: 1200,
+      bargeInMinSpeechMs: 250,
     });
     expect(useLiveVoiceStore.getState().state).toBe("listening");
     expect(useLiveVoiceStore.getState().conversationId).toBe("conv-1");
@@ -156,6 +170,8 @@ describe("starter registration", () => {
       assistantId: "assistant-1",
       conversationId: undefined,
       turnDetection: "server_vad",
+      silenceThresholdMs: 1200,
+      bargeInMinSpeechMs: 250,
     });
     expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
   });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -38,17 +38,11 @@ import {
 
 // Imported after the connection mock so the real connection.ts never enters
 // the static import graph.
-const { useLiveVoiceSessionController } = await import(
-  "@/domains/chat/voice/live-voice/use-live-voice-session-controller"
-);
-const {
-  useVoicePrefsStore,
-  DEFAULT_PAUSE_BEFORE_REPLY_MS,
-  DEFAULT_INTERRUPT_SENSITIVITY,
-} = await import("@/stores/voice-prefs-store");
-const { useLiveVoiceStore } = await import(
-  "@/domains/chat/voice/live-voice/live-voice-store"
-);
+const { useLiveVoiceSessionController } =
+  await import("@/domains/chat/voice/live-voice/use-live-voice-session-controller");
+const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
+const { useLiveVoiceStore } =
+  await import("@/domains/chat/voice/live-voice/live-voice-store");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -114,11 +108,11 @@ beforeEach(() => {
   useLiveVoiceStore.getState().reset();
   useLiveVoiceStore.getState().setStarter(null);
   // The voice-prefs store is a persisted singleton shared across test files;
-  // pin the turn-taking settings to defaults so connect-args assertions are
+  // pin the turn-taking settings to unset (null) so connect-args assertions are
   // deterministic regardless of test order.
   useVoicePrefsStore.setState({
-    pauseBeforeReplyMs: DEFAULT_PAUSE_BEFORE_REPLY_MS,
-    interruptSensitivity: DEFAULT_INTERRUPT_SENSITIVITY,
+    pauseBeforeReplyMs: null,
+    interruptSensitivity: null,
   });
 });
 
@@ -151,8 +145,6 @@ describe("starter registration", () => {
       assistantId: "assistant-1",
       conversationId: "conv-1",
       turnDetection: "server_vad",
-      silenceThresholdMs: 1200,
-      bargeInMinSpeechMs: 250,
     });
     expect(useLiveVoiceStore.getState().state).toBe("listening");
     expect(useLiveVoiceStore.getState().conversationId).toBe("conv-1");
@@ -170,8 +162,6 @@ describe("starter registration", () => {
       assistantId: "assistant-1",
       conversationId: undefined,
       turnDetection: "server_vad",
-      silenceThresholdMs: 1200,
-      bargeInMinSpeechMs: 250,
     });
     expect(useLiveVoiceStore.getState().startedConversationId).toBeNull();
   });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -7,7 +7,15 @@
  * AudioContext is touched.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
 // The default client factory in use-live-voice statically imports the real
@@ -37,12 +45,15 @@ import {
 // Import the controller + store *after* the connection mock is registered, so
 // the real connection.ts (which imports the generated SDK) never enters the
 // static import graph.
-const { useLiveVoice } = await import(
-  "@/domains/chat/voice/live-voice/use-live-voice"
-);
-const { useLiveVoiceStore } = await import(
-  "@/domains/chat/voice/live-voice/live-voice-store"
-);
+const { useLiveVoice } =
+  await import("@/domains/chat/voice/live-voice/use-live-voice");
+const { useLiveVoiceStore } =
+  await import("@/domains/chat/voice/live-voice/live-voice-store");
+const {
+  useVoicePrefsStore,
+  DEFAULT_PAUSE_BEFORE_REPLY_MS,
+  DEFAULT_INTERRUPT_SENSITIVITY,
+} = await import("@/stores/voice-prefs-store");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -120,6 +131,13 @@ async function startListening(
 
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
+  // The voice-prefs store is a persisted singleton — reset the two turn-taking
+  // settings to their defaults so a test that changes them can't leak into the
+  // connect-args assertions of the next.
+  useVoicePrefsStore.setState({
+    pauseBeforeReplyMs: DEFAULT_PAUSE_BEFORE_REPLY_MS,
+    interruptSensitivity: DEFAULT_INTERRUPT_SENSITIVITY,
+  });
 });
 
 afterEach(() => {
@@ -472,7 +490,26 @@ describe("hands-free mode", () => {
     });
   }
 
-  test("connects with server_vad turn detection", async () => {
+  test("connects with server_vad turn detection and the default pause + interrupt settings", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    // Defaults: 1200 ms pause, "medium" interrupt sensitivity → 250 ms.
+    expect(h.client.connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-1",
+      turnDetection: "server_vad",
+      silenceThresholdMs: 1200,
+      bargeInMinSpeechMs: 250,
+    });
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("sends the user's pause + interrupt-sensitivity settings on a hands-free connect", async () => {
+    useVoicePrefsStore.setState({
+      pauseBeforeReplyMs: 1500,
+      interruptSensitivity: "low", // low sensitivity → 600 ms guard
+    });
     const h = renderController();
     await startListening(h, { handsFree: true });
 
@@ -480,8 +517,19 @@ describe("hands-free mode", () => {
       assistantId: "assistant-1",
       conversationId: "conv-1",
       turnDetection: "server_vad",
+      silenceThresholdMs: 1500,
+      bargeInMinSpeechMs: 600,
     });
-    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("omits turn-detection + pause + interrupt settings for a manual (non-hands-free) connect", async () => {
+    const h = renderController();
+    await startListening(h); // manual
+
+    expect(h.client.connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-1",
+    });
   });
 
   test("runs two full turns on one socket without a second client or ptt_release", async () => {
@@ -773,7 +821,10 @@ describe("hands-free session controls (send now / stop response / mute)", () => 
   }
 
   /** Drive the session into `speaking` with one thinking + tts frame. */
-  function driveToSpeaking(h: ReturnType<typeof renderController>, turnId = "t1") {
+  function driveToSpeaking(
+    h: ReturnType<typeof renderController>,
+    turnId = "t1",
+  ) {
     act(() => {
       h.client.emit("thinking", { type: "thinking", seq: 2, turnId });
       h.client.emit("ttsAudio", {
@@ -2074,7 +2125,11 @@ describe("observeAudioState", () => {
     const rendersBefore = h.getRenderCount();
     act(() => {
       h.client.emit("sttPartial", { type: "stt_partial", seq: 2, text: "hel" });
-      h.client.emit("sttPartial", { type: "stt_partial", seq: 3, text: "hello" });
+      h.client.emit("sttPartial", {
+        type: "stt_partial",
+        seq: 3,
+        text: "hello",
+      });
     });
     // Transcript writes reached the store but not the consumer.
     expect(useLiveVoiceStore.getState().partialTranscript).toBe("hello");
@@ -2308,7 +2363,8 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
     expect(h.view.result.current.state).toBe("connecting");
     expect(useLiveVoiceStore.getState().controls).not.toBeNull();
 
-    // Backoff elapses → a fresh connect to the SAME conversation.
+    // Backoff elapses → a fresh connect to the SAME conversation, carrying the
+    // default turn-taking settings (1200 ms pause / 250 ms barge-in).
     await act(async () => {
       await sleep(80);
     });
@@ -2316,6 +2372,8 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
       assistantId: "assistant-1",
       conversationId: "conv-1",
       turnDetection: "server_vad",
+      silenceThresholdMs: 1200,
+      bargeInMinSpeechMs: 250,
     });
 
     // The reconnected session's `ready` resumes listening (a torn-down session
@@ -2457,7 +2515,8 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
 
 describe("reconnecting signal", () => {
   const FAST_BACKOFF = [20, 40, 60];
-  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
 
   test("a retryable close flips reconnecting true while connecting; ready clears it", async () => {
     const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
@@ -2590,7 +2649,8 @@ describe("initial-connect resilience (JARVIS-1282)", () => {
     expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
     expect(useLiveVoiceStore.getState().controls).not.toBeNull();
 
-    // Backoff elapses → a fresh connect to the same conversation.
+    // Backoff elapses → a fresh connect to the same conversation, carrying the
+    // default turn-taking settings (1200 ms pause / 250 ms barge-in).
     await act(async () => {
       await sleep(30);
     });
@@ -2598,6 +2658,8 @@ describe("initial-connect resilience (JARVIS-1282)", () => {
       assistantId: "assistant-1",
       conversationId: "conv-1",
       turnDetection: "server_vad",
+      silenceThresholdMs: 1200,
+      bargeInMinSpeechMs: 250,
     });
 
     // The retry readies → listening; the error never appeared.

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -49,11 +49,7 @@ const { useLiveVoice } =
   await import("@/domains/chat/voice/live-voice/use-live-voice");
 const { useLiveVoiceStore } =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
-const {
-  useVoicePrefsStore,
-  DEFAULT_PAUSE_BEFORE_REPLY_MS,
-  DEFAULT_INTERRUPT_SENSITIVITY,
-} = await import("@/stores/voice-prefs-store");
+const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -132,11 +128,11 @@ async function startListening(
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
   // The voice-prefs store is a persisted singleton — reset the two turn-taking
-  // settings to their defaults so a test that changes them can't leak into the
+  // settings to unset (null) so a test that sets them can't leak into the
   // connect-args assertions of the next.
   useVoicePrefsStore.setState({
-    pauseBeforeReplyMs: DEFAULT_PAUSE_BEFORE_REPLY_MS,
-    interruptSensitivity: DEFAULT_INTERRUPT_SENSITIVITY,
+    pauseBeforeReplyMs: null,
+    interruptSensitivity: null,
   });
 });
 
@@ -490,17 +486,16 @@ describe("hands-free mode", () => {
     });
   }
 
-  test("connects with server_vad turn detection and the default pause + interrupt settings", async () => {
+  test("connects with server_vad turn detection, omitting the pause + interrupt overrides when unset", async () => {
     const h = renderController();
     await startListening(h, { handsFree: true });
 
-    // Defaults: 1200 ms pause, "medium" interrupt sensitivity → 250 ms.
+    // With no user preference set, the overrides are omitted so the daemon's
+    // configured VAD defaults govern (never clobbered by a client default).
     expect(h.client.connectArgs).toEqual({
       assistantId: "assistant-1",
       conversationId: "conv-1",
       turnDetection: "server_vad",
-      silenceThresholdMs: 1200,
-      bargeInMinSpeechMs: 250,
     });
     expect(h.view.result.current.state).toBe("listening");
   });
@@ -2363,8 +2358,8 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
     expect(h.view.result.current.state).toBe("connecting");
     expect(useLiveVoiceStore.getState().controls).not.toBeNull();
 
-    // Backoff elapses → a fresh connect to the SAME conversation, carrying the
-    // default turn-taking settings (1200 ms pause / 250 ms barge-in).
+    // Backoff elapses → a fresh connect to the SAME conversation (no turn-taking
+    // overrides, since none were set).
     await act(async () => {
       await sleep(80);
     });
@@ -2372,8 +2367,6 @@ describe("hands-free reconnect (retryable tunnel close)", () => {
       assistantId: "assistant-1",
       conversationId: "conv-1",
       turnDetection: "server_vad",
-      silenceThresholdMs: 1200,
-      bargeInMinSpeechMs: 250,
     });
 
     // The reconnected session's `ready` resumes listening (a torn-down session
@@ -2649,8 +2642,8 @@ describe("initial-connect resilience (JARVIS-1282)", () => {
     expect(useLiveVoiceStore.getState().reconnecting).toBe(false);
     expect(useLiveVoiceStore.getState().controls).not.toBeNull();
 
-    // Backoff elapses → a fresh connect to the same conversation, carrying the
-    // default turn-taking settings (1200 ms pause / 250 ms barge-in).
+    // Backoff elapses → a fresh connect to the same conversation (no turn-taking
+    // overrides, since none were set).
     await act(async () => {
       await sleep(30);
     });
@@ -2658,8 +2651,6 @@ describe("initial-connect resilience (JARVIS-1282)", () => {
       assistantId: "assistant-1",
       conversationId: "conv-1",
       turnDetection: "server_vad",
-      silenceThresholdMs: 1200,
-      bargeInMinSpeechMs: 250,
     });
 
     // The retry readies → listening; the error never appeared.

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -960,21 +960,27 @@ export function useLiveVoice(
         }),
       );
 
+      // The pause + interrupt-sensitivity settings only apply to hands-free
+      // (server_vad) sessions — server VAD owns endpointing and barge-in. Read
+      // from the store (not the `.use.*` hook) since this is a callback, so a
+      // mid-session settings change also takes effect on the next reconnect.
+      // Each override is sent ONLY when the user has explicitly set it (non-null):
+      // otherwise it is omitted so the daemon's configured `liveVoice.vad`
+      // defaults govern, rather than a web-client default silently clobbering a
+      // self-hosted workspace's configuration.
+      const voicePrefs = useVoicePrefsStore.getState();
+      const pauseMs = voicePrefs.pauseBeforeReplyMs;
+      const sensitivity = voicePrefs.interruptSensitivity;
       await client.connect({
         assistantId,
         conversationId,
-        // The pause + interrupt-sensitivity settings only apply to hands-free
-        // (server_vad) sessions — server VAD owns endpointing and barge-in. Read
-        // from the store (not the `.use.*` hook) since this is a callback, so a
-        // mid-session settings change also takes effect on the next reconnect.
         ...(session.handsFree
           ? {
               turnDetection: "server_vad" as const,
-              silenceThresholdMs:
-                useVoicePrefsStore.getState().pauseBeforeReplyMs,
-              bargeInMinSpeechMs: interruptSensitivityToMs(
-                useVoicePrefsStore.getState().interruptSensitivity,
-              ),
+              ...(pauseMs !== null ? { silenceThresholdMs: pauseMs } : {}),
+              ...(sensitivity !== null
+                ? { bargeInMinSpeechMs: interruptSensitivityToMs(sensitivity) }
+                : {}),
             }
           : {}),
       });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -98,6 +98,10 @@ import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  interruptSensitivityToMs,
+  useVoicePrefsStore,
+} from "@/stores/voice-prefs-store";
 
 // ---------------------------------------------------------------------------
 // Thresholds (mirror the macOS LiveVoiceChannelManager defaults)
@@ -549,11 +553,20 @@ export function useLiveVoice(
       // Registered here (not on `ready`) so a globally mounted surface can
       // drive the session from the moment it exists; cleared by the store
       // reset in teardown()/stop().
-      store.setControls({ stop: () => void stop(), release, interrupt, setMuted });
+      store.setControls({
+        stop: () => void stop(),
+        release,
+        interrupt,
+        setMuted,
+      });
 
       const opts = optionsRef.current;
-      const client = (opts.createClient ?? (() => new LiveVoiceChannelClient()))();
-      const player = (opts.createPlayer ?? (() => new LiveVoiceAudioPlayer()))();
+      const client = (
+        opts.createClient ?? (() => new LiveVoiceChannelClient())
+      )();
+      const player = (
+        opts.createPlayer ?? (() => new LiveVoiceAudioPlayer())
+      )();
       // Resume the playback AudioContext now, while we're still in the
       // mic-button click's gesture. Deferring to the first `tts_audio` frame
       // (its lazy creation point) lands outside any gesture, so the browser
@@ -588,9 +601,12 @@ export function useLiveVoice(
         assistantAudioIdleTimer: null,
       };
 
-      const capture = (opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o)))({
+      const capture = (
+        opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o))
+      )({
         onChunk: (buf) => handleChunk(session, buf),
-        onAmplitude: (amplitude) => handleAmplitude(session, amplitude, teardown),
+        onAmplitude: (amplitude) =>
+          handleAmplitude(session, amplitude, teardown),
       });
       session.capture = capture;
       sessionRef.current = session;
@@ -809,7 +825,11 @@ export function useLiveVoice(
         }),
         client.on("busy", () => {
           if (!live()) return;
-          finishWithError(session, teardown, "Another live-voice session is active.");
+          finishWithError(
+            session,
+            teardown,
+            "Another live-voice session is active.",
+          );
         }),
         client.on("error", (err: LiveVoiceClientError) => {
           if (!live()) return;
@@ -917,7 +937,12 @@ export function useLiveVoice(
             // timer re-enters `connectSession`) so the surface shows a
             // reconnect, not a fresh connect. Cleared on `ready`/teardown.
             s.setReconnecting(true);
-            s.setControls({ stop: () => void stop(), release, interrupt, setMuted });
+            s.setControls({
+              stop: () => void stop(),
+              release,
+              interrupt,
+              setMuted,
+            });
             console.warn(
               `live-voice: transport closed (code ${info.code}); reconnecting ` +
                 `(attempt ${attempt + 1}/${backoff.length})`,
@@ -938,7 +963,20 @@ export function useLiveVoice(
       await client.connect({
         assistantId,
         conversationId,
-        ...(session.handsFree ? { turnDetection: "server_vad" as const } : {}),
+        // The pause + interrupt-sensitivity settings only apply to hands-free
+        // (server_vad) sessions — server VAD owns endpointing and barge-in. Read
+        // from the store (not the `.use.*` hook) since this is a callback, so a
+        // mid-session settings change also takes effect on the next reconnect.
+        ...(session.handsFree
+          ? {
+              turnDetection: "server_vad" as const,
+              silenceThresholdMs:
+                useVoicePrefsStore.getState().pauseBeforeReplyMs,
+              bargeInMinSpeechMs: interruptSensitivityToMs(
+                useVoicePrefsStore.getState().interruptSensitivity,
+              ),
+            }
+          : {}),
       });
     },
     [teardown, stop, release, interrupt, setMuted],
@@ -1105,7 +1143,11 @@ function handleAmplitude(
   // barge-in) from a muted mic would contradict the substituted stream.
   const muted = useLiveVoiceStore.getState().muted;
   useLiveVoiceStore.getState().setInputAmplitude(muted ? 0 : amplitude);
-  if (!muted && !session.handsFree && amplitude >= BARGE_IN_AMPLITUDE_THRESHOLD) {
+  if (
+    !muted &&
+    !session.handsFree &&
+    amplitude >= BARGE_IN_AMPLITUDE_THRESHOLD
+  ) {
     interruptIfSpeaking(session, teardown);
   }
 }
@@ -1114,7 +1156,10 @@ function handleAmplitude(
  * Track speech / trailing-silence durations and auto-release push-to-talk once
  * a real utterance is followed by a long-enough silence window.
  */
-function updateAutomaticRelease(session: SessionContext, buf: ArrayBuffer): void {
+function updateAutomaticRelease(
+  session: SessionContext,
+  buf: ArrayBuffer,
+): void {
   if (useLiveVoiceStore.getState().state !== "listening") return;
   const durationMs = chunkDurationMs(buf);
   if (durationMs <= 0) return;

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -17,6 +17,8 @@ import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import { DetailCard } from "@/components/detail-card";
 import {
+  DEFAULT_INTERRUPT_SENSITIVITY,
+  DEFAULT_PAUSE_BEFORE_REPLY_MS,
   MAX_PAUSE_BEFORE_REPLY_MS,
   MIN_PAUSE_BEFORE_REPLY_MS,
   useVoicePrefsStore,
@@ -570,7 +572,9 @@ function PauseBeforeReplyCard() {
     >
       <div className="max-w-xs">
         <Slider
-          value={pauseMs / 1000}
+          // Unset (null) shows the default as the resting value; moving the
+          // slider records an explicit preference (which is then sent).
+          value={(pauseMs ?? DEFAULT_PAUSE_BEFORE_REPLY_MS) / 1000}
           onValueChange={(next) => {
             if (typeof next === "number") setPauseMs(Math.round(next * 1000));
           }}
@@ -600,7 +604,9 @@ function InterruptSensitivityCard() {
       <div className="max-w-xs">
         <SegmentControl<InterruptSensitivity>
           items={INTERRUPT_SENSITIVITY_ITEMS}
-          value={sensitivity}
+          // Unset (null) shows the default; picking a level records an explicit
+          // preference (which is then sent).
+          value={sensitivity ?? DEFAULT_INTERRUPT_SENSITIVITY}
           onChange={setSensitivity}
           ariaLabel="Interrupt sensitivity"
         />

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -1,42 +1,50 @@
 import { ArrowUpRight, Info } from "lucide-react";
 import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { Link } from "react-router";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { SegmentControl } from "@vellumai/design-library/components/segment-control";
+import { Slider } from "@vellumai/design-library/components/slider";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import { DetailCard } from "@/components/detail-card";
+import {
+  MAX_PAUSE_BEFORE_REPLY_MS,
+  MIN_PAUSE_BEFORE_REPLY_MS,
+  useVoicePrefsStore,
+  type InterruptSensitivity,
+} from "@/stores/voice-prefs-store";
 import { VoiceTranscriptToggles } from "@/components/voice-transcript-toggles";
 import {
-    getLocalSetting,
-    removeLocalSetting,
-    setLocalSetting,
+  getLocalSetting,
+  removeLocalSetting,
+  setLocalSetting,
 } from "@/utils/local-settings";
 import {
-    CTRL_PTT_ACTIVATOR,
-    FN_PTT_ACTIVATOR,
-    LS_PTT_ACTIVATION_KEY,
-    activatorDisplayName,
-    activatorsEqual,
-    modifierLabel,
-    parseActivator,
-    serializeActivator,
-    sortModifiers,
-    type PTTActivator,
-    type PTTModifier,
+  CTRL_PTT_ACTIVATOR,
+  FN_PTT_ACTIVATOR,
+  LS_PTT_ACTIVATION_KEY,
+  activatorDisplayName,
+  activatorsEqual,
+  modifierLabel,
+  parseActivator,
+  serializeActivator,
+  sortModifiers,
+  type PTTActivator,
+  type PTTModifier,
 } from "@/utils/ptt-activator";
 import { routes } from "@/utils/routes";
 import {
-    LS_VOICE_INPUT_DEVICE,
-    getPreferredInputDeviceId,
+  LS_VOICE_INPUT_DEVICE,
+  getPreferredInputDeviceId,
 } from "@/utils/voice-input-device";
 import { canConfigureFnPushToTalk } from "@/runtime/hotkey";
 import { VOICE_TRANSCRIPT_RECOMMENDATION } from "@/utils/voice-transcript-prefs";
@@ -76,8 +84,7 @@ type ConversationTimeoutValue =
 
 const DEFAULT_CONVERSATION_TIMEOUT: ConversationTimeoutValue = "30";
 
-const labelClasses =
-  "text-body-small-default text-[var(--content-tertiary)]";
+const labelClasses = "text-body-small-default text-[var(--content-tertiary)]";
 
 export function VoicePage() {
   return (
@@ -86,6 +93,8 @@ export function VoicePage() {
       <MicrophoneCard />
       <PushToTalkCard />
       <ConversationTimeoutCard />
+      <PauseBeforeReplyCard />
+      <InterruptSensitivityCard />
       <TranscriptionCard />
     </div>
   );
@@ -458,9 +467,10 @@ function PushToTalkCard() {
               <div className="flex items-start gap-1 pt-1 text-body-small-default text-[var(--content-quiet)]">
                 <Info className="mt-0.5 h-3 w-3 shrink-0" />
                 <span>
-                  Push-to-Talk only works while this tab is focused, and browsers
-                  may intercept some shortcuts (e.g. Ctrl+T) before the page can
-                  see them. For always-on PTT, use the Vellum desktop app.
+                  Push-to-Talk only works while this tab is focused, and
+                  browsers may intercept some shortcuts (e.g. Ctrl+T) before the
+                  page can see them. For always-on PTT, use the Vellum desktop
+                  app.
                 </span>
               </div>
             )}
@@ -534,6 +544,65 @@ function ConversationTimeoutCard() {
           value={timeout}
           onChange={handleChange}
           aria-label="Conversation timeout"
+        />
+      </div>
+    </DetailCard>
+  );
+}
+
+const INTERRUPT_SENSITIVITY_ITEMS: {
+  value: InterruptSensitivity;
+  label: string;
+}[] = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+];
+
+function PauseBeforeReplyCard() {
+  const pauseMs = useVoicePrefsStore.use.pauseBeforeReplyMs();
+  const setPauseMs = useVoicePrefsStore.use.setPauseBeforeReplyMs();
+
+  return (
+    <DetailCard
+      title="Pause before reply"
+      subtitle="How long the assistant waits after you stop speaking before it replies. A longer pause lets you gather your thoughts mid-sentence without being cut off."
+    >
+      <div className="max-w-xs">
+        <Slider
+          value={pauseMs / 1000}
+          onValueChange={(next) => {
+            if (typeof next === "number") setPauseMs(Math.round(next * 1000));
+          }}
+          min={MIN_PAUSE_BEFORE_REPLY_MS / 1000}
+          max={MAX_PAUSE_BEFORE_REPLY_MS / 1000}
+          step={0.1}
+          showValue
+          formatValue={(value) =>
+            `${(typeof value === "number" ? value : value[0]).toFixed(1)}s`
+          }
+          aria-label="Pause before reply"
+        />
+      </div>
+    </DetailCard>
+  );
+}
+
+function InterruptSensitivityCard() {
+  const sensitivity = useVoicePrefsStore.use.interruptSensitivity();
+  const setSensitivity = useVoicePrefsStore.use.setInterruptSensitivity();
+
+  return (
+    <DetailCard
+      title="Interrupt sensitivity"
+      subtitle="How easily talking over the assistant interrupts it. Lower it if the assistant cuts itself off on background noise or filler words; raise it to interrupt more quickly."
+    >
+      <div className="max-w-xs">
+        <SegmentControl<InterruptSensitivity>
+          items={INTERRUPT_SENSITIVITY_ITEMS}
+          value={sensitivity}
+          onChange={setSensitivity}
+          ariaLabel="Interrupt sensitivity"
         />
       </div>
     </DetailCard>

--- a/clients/web/src/stores/voice-prefs-store.test.ts
+++ b/clients/web/src/stores/voice-prefs-store.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
-  DEFAULT_INTERRUPT_SENSITIVITY,
   DEFAULT_PAUSE_BEFORE_REPLY_MS,
   MAX_PAUSE_BEFORE_REPLY_MS,
   MIN_PAUSE_BEFORE_REPLY_MS,
@@ -17,8 +16,8 @@ beforeEach(() => {
     showUserTranscript: false,
     showAssistantTranscript: false,
     firstRunSeen: false,
-    pauseBeforeReplyMs: DEFAULT_PAUSE_BEFORE_REPLY_MS,
-    interruptSensitivity: DEFAULT_INTERRUPT_SENSITIVITY,
+    pauseBeforeReplyMs: null,
+    interruptSensitivity: null,
   });
 });
 
@@ -88,13 +87,14 @@ describe("useVoicePrefsStore — voice-mode preferences", () => {
 });
 
 describe("useVoicePrefsStore — turn-taking settings (JARVIS-1284)", () => {
-  test("defaults: 1200 ms pause, medium sensitivity", () => {
-    expect(useVoicePrefsStore.getState().pauseBeforeReplyMs).toBe(1200);
-    expect(useVoicePrefsStore.getState().interruptSensitivity).toBe("medium");
+  test("defaults are unset (null) so the daemon config governs", () => {
+    expect(useVoicePrefsStore.getState().pauseBeforeReplyMs).toBeNull();
+    expect(useVoicePrefsStore.getState().interruptSensitivity).toBeNull();
+    // The default constant still exists for the UI's resting value.
     expect(DEFAULT_PAUSE_BEFORE_REPLY_MS).toBe(1200);
   });
 
-  test("setInterruptSensitivity records the level", () => {
+  test("setInterruptSensitivity records an explicit level", () => {
     useVoicePrefsStore.getState().setInterruptSensitivity("high");
     expect(useVoicePrefsStore.getState().interruptSensitivity).toBe("high");
   });

--- a/clients/web/src/stores/voice-prefs-store.test.ts
+++ b/clients/web/src/stores/voice-prefs-store.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+import {
+  DEFAULT_INTERRUPT_SENSITIVITY,
+  DEFAULT_PAUSE_BEFORE_REPLY_MS,
+  MAX_PAUSE_BEFORE_REPLY_MS,
+  MIN_PAUSE_BEFORE_REPLY_MS,
+  interruptSensitivityToMs,
+  useVoicePrefsStore,
+} from "@/stores/voice-prefs-store";
 
 const VOICE_PREFS_STORE_KEY = "vellum:voice-prefs";
 
@@ -10,6 +17,8 @@ beforeEach(() => {
     showUserTranscript: false,
     showAssistantTranscript: false,
     firstRunSeen: false,
+    pauseBeforeReplyMs: DEFAULT_PAUSE_BEFORE_REPLY_MS,
+    interruptSensitivity: DEFAULT_INTERRUPT_SENSITIVITY,
   });
 });
 
@@ -63,6 +72,8 @@ describe("useVoicePrefsStore — voice-mode preferences", () => {
     useVoicePrefsStore.getState().setShowUserTranscript(true);
     useVoicePrefsStore.getState().setShowAssistantTranscript(true);
     useVoicePrefsStore.getState().markFirstRunSeen();
+    useVoicePrefsStore.getState().setPauseBeforeReplyMs(1500);
+    useVoicePrefsStore.getState().setInterruptSensitivity("low");
 
     const raw = localStorage.getItem(VOICE_PREFS_STORE_KEY);
     expect(raw).not.toBeNull();
@@ -71,5 +82,48 @@ describe("useVoicePrefsStore — voice-mode preferences", () => {
     expect(persisted.showUserTranscript).toBe(true);
     expect(persisted.showAssistantTranscript).toBe(true);
     expect(persisted.firstRunSeen).toBe(true);
+    expect(persisted.pauseBeforeReplyMs).toBe(1500);
+    expect(persisted.interruptSensitivity).toBe("low");
+  });
+});
+
+describe("useVoicePrefsStore — turn-taking settings (JARVIS-1284)", () => {
+  test("defaults: 1200 ms pause, medium sensitivity", () => {
+    expect(useVoicePrefsStore.getState().pauseBeforeReplyMs).toBe(1200);
+    expect(useVoicePrefsStore.getState().interruptSensitivity).toBe("medium");
+    expect(DEFAULT_PAUSE_BEFORE_REPLY_MS).toBe(1200);
+  });
+
+  test("setInterruptSensitivity records the level", () => {
+    useVoicePrefsStore.getState().setInterruptSensitivity("high");
+    expect(useVoicePrefsStore.getState().interruptSensitivity).toBe("high");
+  });
+
+  test("interruptSensitivityToMs maps inversely (higher sensitivity → fewer ms)", () => {
+    expect(interruptSensitivityToMs("high")).toBe(100);
+    expect(interruptSensitivityToMs("medium")).toBe(250);
+    expect(interruptSensitivityToMs("low")).toBe(600);
+  });
+
+  test("setPauseBeforeReplyMs clamps to the supported range and rounds", () => {
+    const set = useVoicePrefsStore.getState().setPauseBeforeReplyMs;
+
+    set(1234.6);
+    expect(useVoicePrefsStore.getState().pauseBeforeReplyMs).toBe(1235);
+
+    set(50); // below MIN
+    expect(useVoicePrefsStore.getState().pauseBeforeReplyMs).toBe(
+      MIN_PAUSE_BEFORE_REPLY_MS,
+    );
+
+    set(99_999); // above MAX
+    expect(useVoicePrefsStore.getState().pauseBeforeReplyMs).toBe(
+      MAX_PAUSE_BEFORE_REPLY_MS,
+    );
+
+    set(Number.NaN); // guards against non-finite
+    expect(useVoicePrefsStore.getState().pauseBeforeReplyMs).toBe(
+      DEFAULT_PAUSE_BEFORE_REPLY_MS,
+    );
   });
 });

--- a/clients/web/src/stores/voice-prefs-store.ts
+++ b/clients/web/src/stores/voice-prefs-store.ts
@@ -90,10 +90,20 @@ export interface VoicePrefsState {
    * assistant replies — the "pause before reply" setting. Sent as the session's
    * `silenceThresholdMs`. A longer pause tolerates mid-thought pauses without
    * the assistant jumping in.
+   *
+   * `null` means the user hasn't set a preference — the session omits the
+   * override so the daemon's configured `liveVoice.vad.silenceThresholdMs`
+   * governs (never silently clobbering a self-hosted workspace's config). The
+   * UI still shows {@link DEFAULT_PAUSE_BEFORE_REPLY_MS} as the resting value.
    */
-  pauseBeforeReplyMs: number;
-  /** How easily the user can interrupt the assistant mid-reply. */
-  interruptSensitivity: InterruptSensitivity;
+  pauseBeforeReplyMs: number | null;
+  /**
+   * How easily the user can interrupt the assistant mid-reply. `null` means no
+   * preference set — the daemon's configured `bargeInMinSpeechMs` governs (see
+   * {@link pauseBeforeReplyMs}); the UI shows
+   * {@link DEFAULT_INTERRUPT_SENSITIVITY} as the resting value.
+   */
+  interruptSensitivity: InterruptSensitivity | null;
 }
 
 export interface VoicePrefsActions {
@@ -115,8 +125,10 @@ const INITIAL_STATE: VoicePrefsState = {
   showUserTranscript: false,
   showAssistantTranscript: false,
   firstRunSeen: false,
-  pauseBeforeReplyMs: DEFAULT_PAUSE_BEFORE_REPLY_MS,
-  interruptSensitivity: DEFAULT_INTERRUPT_SENSITIVITY,
+  // Unset until the user picks a value — see the field docs. Omitting the
+  // override lets the daemon's configured VAD defaults stand.
+  pauseBeforeReplyMs: null,
+  interruptSensitivity: null,
 };
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/stores/voice-prefs-store.ts
+++ b/clients/web/src/stores/voice-prefs-store.ts
@@ -28,6 +28,56 @@ import { createSelectors } from "@/utils/create-selectors";
 // State + Actions
 // ---------------------------------------------------------------------------
 
+/**
+ * "Interrupt sensitivity" — how easily the user's speech cuts off the
+ * assistant mid-reply. Higher sensitivity interrupts sooner (less sustained
+ * speech required); lower is more forgiving of coughs, filler words, and the
+ * assistant's own TTS bleeding through imperfect echo cancellation. Maps to the
+ * daemon's `bargeInMinSpeechMs` — note the mapping is *inverse* (more sensitive
+ * ⇒ fewer ms). See {@link INTERRUPT_SENSITIVITY_TO_MS}.
+ */
+export type InterruptSensitivity = "low" | "medium" | "high";
+
+/** Default "pause before reply" (ms) — mirrors the daemon `liveVoice.vad.silenceThresholdMs` default. */
+export const DEFAULT_PAUSE_BEFORE_REPLY_MS = 1200;
+/** Bounds for the "pause before reply" slider (ms); stays inside the daemon's accepted range. */
+export const MIN_PAUSE_BEFORE_REPLY_MS = 500;
+export const MAX_PAUSE_BEFORE_REPLY_MS = 3000;
+
+/** Default interrupt sensitivity — the ms value mirrors the daemon `bargeInMinSpeechMs` default (250). */
+export const DEFAULT_INTERRUPT_SENSITIVITY: InterruptSensitivity = "medium";
+
+/**
+ * Interrupt-sensitivity level → sustained-speech ms sent as `bargeInMinSpeechMs`.
+ * Inverse: a *higher* sensitivity needs *less* speech to barge in.
+ */
+export const INTERRUPT_SENSITIVITY_TO_MS: Record<InterruptSensitivity, number> =
+  {
+    high: 100,
+    medium: 250,
+    low: 600,
+  };
+
+/** Resolve an interrupt-sensitivity level to the `bargeInMinSpeechMs` it sends. */
+export function interruptSensitivityToMs(level: InterruptSensitivity): number {
+  return INTERRUPT_SENSITIVITY_TO_MS[level];
+}
+
+/**
+ * Clamp a "pause before reply" value to the supported range and round to a
+ * whole millisecond, so neither the slider nor a stale persisted value can send
+ * an out-of-range `silenceThresholdMs` the daemon would reject.
+ */
+export function clampPauseBeforeReplyMs(ms: number): number {
+  if (!Number.isFinite(ms)) return DEFAULT_PAUSE_BEFORE_REPLY_MS;
+  return Math.round(
+    Math.min(
+      MAX_PAUSE_BEFORE_REPLY_MS,
+      Math.max(MIN_PAUSE_BEFORE_REPLY_MS, ms),
+    ),
+  );
+}
+
 export interface VoicePrefsState {
   /** Whether the user-side transcript is shown in the voice UI. */
   showUserTranscript: boolean;
@@ -35,6 +85,15 @@ export interface VoicePrefsState {
   showAssistantTranscript: boolean;
   /** True once the user has seen the first-run voice experience. */
   firstRunSeen: boolean;
+  /**
+   * Trailing-silence duration (ms) after the user stops speaking before the
+   * assistant replies — the "pause before reply" setting. Sent as the session's
+   * `silenceThresholdMs`. A longer pause tolerates mid-thought pauses without
+   * the assistant jumping in.
+   */
+  pauseBeforeReplyMs: number;
+  /** How easily the user can interrupt the assistant mid-reply. */
+  interruptSensitivity: InterruptSensitivity;
 }
 
 export interface VoicePrefsActions {
@@ -42,6 +101,8 @@ export interface VoicePrefsActions {
   setShowAssistantTranscript: (next: boolean) => void;
   /** Flip `firstRunSeen` to true on first observation. No-op afterwards. */
   markFirstRunSeen: () => void;
+  setPauseBeforeReplyMs: (next: number) => void;
+  setInterruptSensitivity: (next: InterruptSensitivity) => void;
 }
 
 export type VoicePrefsStore = VoicePrefsState & VoicePrefsActions;
@@ -54,6 +115,8 @@ const INITIAL_STATE: VoicePrefsState = {
   showUserTranscript: false,
   showAssistantTranscript: false,
   firstRunSeen: false,
+  pauseBeforeReplyMs: DEFAULT_PAUSE_BEFORE_REPLY_MS,
+  interruptSensitivity: DEFAULT_INTERRUPT_SENSITIVITY,
 };
 
 // ---------------------------------------------------------------------------
@@ -76,6 +139,12 @@ const useVoicePrefsStoreBase = create<VoicePrefsStore>()(
           set({ firstRunSeen: true });
         }
       },
+      setPauseBeforeReplyMs: (next: number) =>
+        set({
+          pauseBeforeReplyMs: clampPauseBeforeReplyMs(next),
+        }),
+      setInterruptSensitivity: (next: InterruptSensitivity) =>
+        set({ interruptSensitivity: next }),
     }),
     {
       name: VOICE_PREFS_STORE_KEY,
@@ -84,6 +153,8 @@ const useVoicePrefsStoreBase = create<VoicePrefsStore>()(
         showUserTranscript: state.showUserTranscript,
         showAssistantTranscript: state.showAssistantTranscript,
         firstRunSeen: state.firstRunSeen,
+        pauseBeforeReplyMs: state.pauseBeforeReplyMs,
+        interruptSensitivity: state.interruptSensitivity,
       }),
     },
   ),


### PR DESCRIPTION
## Summary

Two changes from voice QA (JARVIS-1284): the assistant "interrupts itself," and the pause/interrupt behavior wasn't user-adjustable.

### 1. Reduce self-interruption
Barge-in cancelled the assistant after only **60ms** of sustained speech, so the assistant's own TTS bleeding through imperfect browser echo cancellation (or a cough / filler word) would cut off its reply. There's no server-side echo guard — the only protection is that threshold + browser AEC.

- `liveVoice.vad.bargeInMinSpeechMs` default **60 → 250ms** (+ the mirrored in-code constant) — brief bleed no longer interrupts; genuine barge-in still works.
- `liveVoice.vad.silenceThresholdMs` ("pause before reply") default **800 → 1200ms** — mid-thought pauses don't get endpointed.

### 2. Per-session configurable pause + interrupt sensitivity
Previously these knobs were daemon-config-only. Now they're user settings:

- **Protocol:** optional `silenceThresholdMs` + `bargeInMinSpeechMs` on the live-voice `start` frame, validated and bounded. Precedence: **start-frame (user setting) > daemon config > in-code default.**
- **Web UI:** `Settings → Voice` gains a **"Pause before reply"** slider (0.5–3.0s) and an **"Interrupt sensitivity"** segmented control (Low / Medium / High), persisted in the `voice-prefs` store and sent on every hands-free connect (and on reconnect).

Interrupt sensitivity maps inversely to `bargeInMinSpeechMs` (High=100ms, Medium=250ms, Low=600ms).

## Files
- **Daemon:** `live-voice/protocol.ts` (start-frame fields + bounded validation), `live-voice/live-voice-session.ts` (apply overrides, retune barge-in constant), `config/schemas/live-voice.ts` (retuned defaults).
- **Web:** `live-voice/protocol.ts` + `live-voice-client.ts` (carry the fields on the start frame), `stores/voice-prefs-store.ts` (two settings + sensitivity→ms mapping + clamped pause), `settings/pages/voice-page.tsx` (Slider + SegmentControl), `use-live-voice.ts` (thread store values into `connect`).

## Tests
- **Daemon** (188 live-voice + config-schema green): protocol parse/validate of the new fields (accept, omit, out-of-range, `bargeInMinSpeechMs: 0`); session-level precedence — start-frame `silenceThresholdMs` and `bargeInMinSpeechMs` override the config/option; retuned config defaults.
- **Web** (voice-prefs-store, live-voice-client, use-live-voice(+controller), voice-page all green in isolation): store defaults/mapping/clamp/persist; start frame carries the fields; hands-free connect sends the user's settings (and omits them for manual). Updated the JARVIS-1282/1255 reconnect connect-arg assertions for the new default fields. (The lone `tts-playback.test.ts` failure in a combined run is the known bun cross-file `mock.module` leak — passes 24/24 alone.)

## Note
Alex chose "retune the barge-in threshold" over an onset grace window (which would briefly block legitimate early barge-in), and the full per-session + web-UI scope for configurability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)