### PR TITLE
Derive outbox telemetry names + flush sources from the wire contract

### DIFF
--- a/assistant/src/telemetry/AGENTS.md
+++ b/assistant/src/telemetry/AGENTS.md
@@ -12,4 +12,30 @@ Pre-flush validation (`telemetry-wire-validation.ts`) checks outgoing events aga
 
 The ingest endpoint silently skips events whose type has no registered serializer (the batch still 2xxes and the daemon acks away its outbox rows), so an emitter shipped before its platform serializer loses every event it records — pre-flush validation logs the drop but does not prevent it.
 
-The full cross-repo checklist lives with the serializer registry it governs, in `vellum-assistant-platform` at `django/app/assistant/self_hosted_local/AGENTS.md` ("Adding a new telemetry ingest event type"). The daemon emitter is the **last** step — added only after the platform serializer has merged and the wire sync PR has landed here. A new emitter is an outbox store plus registration in `telemetry-event-sources.ts` (or a watermark source for high-volume tables); if the type previously existed daemon-only, also move it out of `Extensions` in `types.ts`.
+The full cross-repo checklist lives with the serializer registry it governs, in `vellum-assistant-platform` at `django/app/assistant/self_hosted_local/AGENTS.md` ("Adding a new telemetry ingest event type"). The daemon emitter is the **last** step — added only after the platform serializer has merged and the wire sync PR has landed here.
+
+### Emitting an outbox-backed event
+
+For a normal (outbox-backed) event, the sync PR is all the daemon needs — **no manual edits in this directory**. `OUTBOX_TELEMETRY_EVENT_NAMES` (in `types.ts`) and its flush source (in `telemetry-event-sources.ts`) are both **derived from the wire contract**, so a newly-synced type is outbox-backed and flushed automatically. Just call the generic, fully-typed recorder from your feature code:
+
+```ts
+import { recordTelemetryEvent } from "./telemetry-events-outbox.js";
+
+recordTelemetryEvent(
+  "my_new_event",
+  { some_field: value, conversation_id: conversationId ?? null },
+  { conversationId },
+);
+```
+
+`recordTelemetryEvent` stamps the base fields (`type`, `daemon_event_id`, `recorded_at`, `assistant_version`) and gates on consent; the `fields` argument is typed as everything except those.
+
+Manual edits in this directory are needed **only** to override a default:
+
+- **Watermark-flushed** (the type has its own high-volume table, not the outbox): add it to `WATERMARK_TELEMETRY_EVENT_NAMES` in `types.ts` and add its source to `WATERMARK_TELEMETRY_EVENT_SOURCES`.
+- **Diagnostics-gated flush** (payload carries PII, gate at flush like `onboarding_research`): add it to `OUTBOX_SOURCE_FACTORY` in `telemetry-event-sources.ts`.
+- **Daemon-partition flush** (needs live in-process state, like `turn`): add its source to `DAEMON_TELEMETRY_EVENT_SOURCES`.
+- **Richer daemon type** than the wire: add an `Overrides` entry in `types.ts` with the drift guards (see the wire-contract section above).
+- **A camelCase domain wrapper** (`record<Thing>Event`): optional sugar — write a small store module like `skill-loaded-events-store.ts` if you want a typed domain API instead of the raw snake-case `recordTelemetryEvent` call.
+
+If the type previously existed daemon-only, also move it out of `Extensions` in `types.ts`.

--- a/assistant/src/telemetry/telemetry-event-sources.test.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.test.ts
@@ -17,22 +17,56 @@ import {
   DAEMON_TELEMETRY_EVENT_SOURCES,
   MONITOR_TELEMETRY_EVENT_SOURCES,
 } from "./telemetry-event-sources.js";
-import { OUTBOX_TELEMETRY_EVENT_NAMES } from "./types.js";
+import { telemetryEventSchema } from "./telemetry-wire.generated.js";
+import {
+  OUTBOX_TELEMETRY_EVENT_NAMES,
+  WATERMARK_TELEMETRY_EVENT_NAMES,
+} from "./types.js";
 
 describe("telemetry event source partition", () => {
   test("the full source list carries every event type in payload order", () => {
+    // Watermark sources first (their ids are the table names, not the wire
+    // discriminants), then outbox events in wire-contract order.
     expect(ALL_TELEMETRY_EVENT_SOURCES.map((s) => s.id)).toEqual([
       "usage",
       "turns",
+      "tool_executed",
       "lifecycle",
       "onboarding",
       "auth_fallback",
-      "tool_executed",
       "skill_loaded",
       "watchdog",
       "config_setting",
       "onboarding_research",
     ]);
+  });
+
+  test("every wire event type is partitioned to exactly one flush lane", () => {
+    // The derivation's core guarantee: a new wire event type can't silently go
+    // unflushed. Every discriminant in the generated contract is either
+    // watermark-flushed or (by default) outbox-backed, never both, never
+    // neither — and the counts line up with one source per type.
+    const wireTypes = new Set(
+      telemetryEventSchema.options.map((o) => o.shape.type.value),
+    );
+    const partitioned = [
+      ...WATERMARK_TELEMETRY_EVENT_NAMES,
+      ...OUTBOX_TELEMETRY_EVENT_NAMES,
+    ];
+    expect(new Set(partitioned)).toEqual(wireTypes);
+    expect(partitioned.length).toBe(wireTypes.size); // disjoint: no double-count
+    expect(ALL_TELEMETRY_EVENT_SOURCES.length).toBe(wireTypes.size);
+  });
+
+  test("every watermark name is a real wire discriminant", () => {
+    // Guards a stale/typo watermark name that would wrongly exclude a live type
+    // from the outbox (and thus from any flush source).
+    const wireTypes = new Set(
+      telemetryEventSchema.options.map((o) => o.shape.type.value),
+    );
+    for (const name of WATERMARK_TELEMETRY_EVENT_NAMES) {
+      expect(wireTypes.has(name)).toBe(true);
+    }
   });
 
   test("the daemon flushes turns only", () => {

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -31,6 +31,7 @@ import type {
   TelemetryEvent,
   TurnTelemetryClientInfo,
 } from "./types.js";
+import { OUTBOX_TELEMETRY_EVENT_NAMES } from "./types.js";
 
 const log = getLogger("usage-telemetry");
 
@@ -480,27 +481,46 @@ const toolExecutedSource = simpleSource(
 export const TOOL_EXECUTED_SOURCE_ID = toolExecutedSource.id;
 
 /**
- * Every telemetry event source, in payload order. The order is part of the
- * observable wire behavior (events of different types appear in this order
- * within one batch), so keep it stable. This is the test/reference list;
- * production reporters run the daemon/monitor partitions below.
+ * Watermark-flushed sources — the high-volume events on their own SQLite
+ * tables (`WATERMARK_TELEMETRY_EVENT_NAMES`), read forward by a `(createdAt,
+ * id)` cursor rather than the generic outbox.
  */
-export const ALL_TELEMETRY_EVENT_SOURCES: readonly TelemetryEventSource[] = [
+const WATERMARK_TELEMETRY_EVENT_SOURCES: readonly TelemetryEventSource[] = [
   usageSource,
   turnSource,
-  outboxSource("lifecycle"),
-  outboxSource("onboarding"),
-  outboxSource("auth_fallback"),
   toolExecutedSource,
-  outboxSource("skill_loaded"),
-  outboxSource("watchdog"),
-  outboxSource("config_setting"),
-  // Onboarding research-turn results are client-orchestrated (the web
-  // client reports the settled `{claims, suggestions, plugins}` payload
-  // once via POST /v1/telemetry/onboarding-research) but land in the same
-  // outbox as every other event type. Diagnostics-gated at flush time (not
-  // just record time) since the payload carries raw inferred claims.
-  diagnosticsGatedOutboxSource("onboarding_research"),
+];
+
+/**
+ * Per-outbox-event flush-source override. The default for every outbox event is
+ * the plain {@link outboxSource}; list only the exceptions here. A new outbox
+ * event type therefore needs no edit — it flushes through `outboxSource`
+ * automatically. `onboarding_research` is diagnostics-gated at flush time (not
+ * just record time) because its payload carries raw inferred claims.
+ */
+const OUTBOX_SOURCE_FACTORY: Partial<
+  Record<
+    OutboxTelemetryEventName,
+    (name: OutboxTelemetryEventName) => TelemetryEventSource
+  >
+> = {
+  onboarding_research: diagnosticsGatedOutboxSource,
+};
+
+/**
+ * Every telemetry event source, in payload order (watermark sources first, then
+ * outbox events in wire-contract order). Derived from the wire contract via
+ * {@link OUTBOX_TELEMETRY_EVENT_NAMES}, so a new event type gets a flush source
+ * with no edit here. Intra-batch ordering is not load-bearing downstream
+ * (events are typed and deduped on `daemon_event_id`, not positional). This is
+ * the test/reference list; production reporters run the daemon/monitor
+ * partitions below.
+ */
+export const ALL_TELEMETRY_EVENT_SOURCES: readonly TelemetryEventSource[] = [
+  ...WATERMARK_TELEMETRY_EVENT_SOURCES,
+  ...OUTBOX_TELEMETRY_EVENT_NAMES.map((name) =>
+    (OUTBOX_SOURCE_FACTORY[name] ?? outboxSource)(name),
+  ),
 ];
 
 /**

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -1,6 +1,7 @@
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import type * as wire from "./telemetry-wire.generated.js";
+import { telemetryEventSchema } from "./telemetry-wire.generated.js";
 import type { TurnOutcome } from "./turn-outcome.js";
 
 /** Base fields present on every telemetry event. */
@@ -664,18 +665,42 @@ type _extensionsDontCollide = AssertNoWireCollision<
  * change once shipped. The watermark-flushed types (`llm_usage`, `turn`,
  * `tool_executed`) live on their own tables and are deliberately excluded.
  */
-export const OUTBOX_TELEMETRY_EVENT_NAMES = [
-  "lifecycle",
-  "onboarding",
-  "auth_fallback",
-  "skill_loaded",
-  "watchdog",
-  "config_setting",
-  "onboarding_research",
+/**
+ * Types NOT on the generic `telemetry_events` outbox — the high-volume events
+ * flushed from their own SQLite tables by a watermark source
+ * (`telemetry-event-sources.ts`). This is the ONLY hand-maintained partition
+ * fact; every other wire event type is outbox-backed by default. Add a name
+ * here only when a new type gets its own dedicated table.
+ */
+export const WATERMARK_TELEMETRY_EVENT_NAMES = [
+  "llm_usage",
+  "turn",
+  "tool_executed",
 ] as const;
 
-export type OutboxTelemetryEventName =
-  (typeof OUTBOX_TELEMETRY_EVENT_NAMES)[number];
+export type WatermarkTelemetryEventName =
+  (typeof WATERMARK_TELEMETRY_EVENT_NAMES)[number];
+
+/**
+ * Event names backed by the `telemetry_events` outbox: every wire event type
+ * that is not watermark-flushed. Derived from the generated wire contract, so a
+ * new event type added on the platform side flows onto the outbox — and gets a
+ * flush source (`telemetry-event-sources.ts`) and a fully-typed
+ * `recordTelemetryEvent` call — with NO edit here. Each name doubles as the
+ * wire `type` discriminant and the flush-group key.
+ */
+export type OutboxTelemetryEventName = Exclude<
+  keyof wire.WireEventMap,
+  WatermarkTelemetryEventName
+>;
+
+export const OUTBOX_TELEMETRY_EVENT_NAMES: readonly OutboxTelemetryEventName[] =
+  telemetryEventSchema.options
+    .map((option) => option.shape.type.value)
+    .filter(
+      (name): name is OutboxTelemetryEventName =>
+        !(WATERMARK_TELEMETRY_EVENT_NAMES as readonly string[]).includes(name),
+    );
 
 /** Wire event type for one outbox event name. */
 export type OutboxTelemetryEventOf<N extends OutboxTelemetryEventName> =


### PR DESCRIPTION
## Summary
- A newly-synced **outbox-backed** telemetry event type now needs **zero daemon edits** — just `recordTelemetryEvent("my_event", {...})`. `OUTBOX_TELEMETRY_EVENT_NAMES` (types.ts) and `ALL_TELEMETRY_EVENT_SOURCES` (telemetry-event-sources.ts) are both derived from the generated wire contract instead of hand-maintained.
- Manual edits are now override-only: `WATERMARK_TELEMETRY_EVENT_NAMES` (own-table types), `OUTBOX_SOURCE_FACTORY` (diagnostics-gated flush, e.g. onboarding_research), `DAEMON_TELEMETRY_EVENT_SOURCES` (in-process-state flush, e.g. turn), an `Overrides` entry (richer daemon type), or an optional camelCase `record…Event` wrapper.
- New source-partition tests assert every wire discriminant maps to exactly one flush lane and every watermark name is a real discriminant, so a future type can't silently go unflushed and a stale watermark/override entry fails CI. `src/telemetry/AGENTS.md` updated with the new emit-an-event guidance.

**Ordering note (my judgement, per the ask):** `ALL_TELEMETRY_EVENT_SOURCES` now orders watermark sources first, then outbox events in wire order — a change from the previous interleave. Intra-batch ordering isn't load-bearing downstream (events are typed and deduped on `daemon_event_id`, not positional), so deriving is safe.

Verified: full `tsc` clean; the affected telemetry tests pass (25); and a red-test injecting a fake 11th wire type proved it auto-joins the outbox names, auto-gets a flush source, and is callable via a fully-typed `recordTelemetryEvent` — all with zero edits to the two derivation files.

## Original prompt
Follow-up to the telemetry wire adoption work: for outbox-backed events, remove the three manual daemon edits (registering the name in `OUTBOX_TELEMETRY_EVENT_NAMES`, adding an `outboxSource(...)`, and writing a store wrapper) so that after a platform sync lands, a developer can immediately import and emit — with manual edits expected only when overriding something custom. The user delegated the intra-batch-ordering decision to my judgement.