### PR TITLE
feat(memory): remember-time [[slug]] page hints, read first at consolidation

### DIFF
--- a/assistant/src/plugins/defaults/memory/graph/tools.ts
+++ b/assistant/src/plugins/defaults/memory/graph/tools.ts
@@ -62,20 +62,27 @@ export const graphRecallDefinition = {
 const REMEMBER_DESCRIPTION =
   "Remember anything concrete shared in conversation: corrections, plans, decisions, felt moments, names, dates, commitments, preferences. Corrections are the highest priority — call `remember` the same turn the correction lands. You don't have to call this on every turn; a retrospective pass reviews the conversation after each message-count / time interval and saves what you didn't capture. Use judgment: pause and remember when something feels worth marking, not because the volume is required.";
 
+const REMEMBER_CONTENT_DESCRIPTION =
+  "The fact(s) to remember. Pass a single string for one fact, or an array of strings to record several independent facts in one call. When a turn surfaces multiple unrelated facts, pass them all as an array in one call rather than calling `remember` once per fact. Write naturally — a preference, a detail, a commitment, a plan. No need to categorize.";
+
 /**
- * Save a fact to the assistant's knowledge base. The fact is appended to
- * `buffer.md` (immediately available in the next conversation) and the daily
- * archive (permanent date-indexed record). When `memory.v2.enabled` is true,
- * writes go under `memory/`; otherwise they go under `pkb/`. Consolidation
- * of the buffer into longer-form storage runs as a separate periodic job in
- * both modes. Facts may carry inline `[[slug]]` wikilink hints naming the
- * memory pages they relate to; the consolidation prompts treat those as
- * read-first candidates when filing buffer entries.
+ * Appended to the `content` description only under the wiki memory model
+ * (memory v2/v3), where the v2/v3 consolidation prompts treat `[[slug]]`
+ * hints as read-first candidates when filing buffer entries. v1/PKB
+ * workspaces have no wiki pages for the hints to reference, and the pkb
+ * filing job has no instruction to interpret or strip the markup, so it
+ * would persist as literal buffer text there.
  */
-export const graphRememberDefinition = {
-  name: "remember",
-  description: REMEMBER_DESCRIPTION,
-  input_schema: {
+export const REMEMBER_PAGE_HINT_GUIDANCE =
+  "When a fact relates to memory pages already in your context, reference the most specific ones inline as [[slug]] wikilinks — consolidation reads hinted pages first when filing the fact, which matters most for corrections (the hint names the page carrying the outdated fact). Hint only pages you have actually seen, and prefer specific pages over broad hubs.";
+
+/**
+ * Build the `remember` input schema. `pageHints` reflects the wiki-memory
+ * (`memory.v2.enabled`) state and appends
+ * {@link REMEMBER_PAGE_HINT_GUIDANCE} to the `content` description.
+ */
+export function buildRememberInputSchema(options: { pageHints: boolean }) {
+  return {
     type: "object",
     properties: {
       content: {
@@ -83,8 +90,9 @@ export const graphRememberDefinition = {
           { type: "string" },
           { type: "array", items: { type: "string" }, minItems: 1 },
         ],
-        description:
-          "The fact(s) to remember. Pass a single string for one fact, or an array of strings to record several independent facts in one call. When a turn surfaces multiple unrelated facts, pass them all as an array in one call rather than calling `remember` once per fact. Write naturally — a preference, a detail, a commitment, a plan. No need to categorize. When a fact relates to memory pages already in your context, reference the most specific ones inline as [[slug]] wikilinks — consolidation reads hinted pages first when filing the fact, which matters most for corrections (the hint names the page carrying the outdated fact). Hint only pages you have actually seen, and prefer specific pages over broad hubs.",
+        description: options.pageHints
+          ? `${REMEMBER_CONTENT_DESCRIPTION} ${REMEMBER_PAGE_HINT_GUIDANCE}`
+          : REMEMBER_CONTENT_DESCRIPTION,
       },
       finish_turn: {
         type: "boolean",
@@ -93,5 +101,21 @@ export const graphRememberDefinition = {
       },
     },
     required: ["content"],
-  },
+  };
+}
+
+/**
+ * Save a fact to the assistant's knowledge base. The fact is appended to
+ * `buffer.md` (immediately available in the next conversation) and the daily
+ * archive (permanent date-indexed record). When `memory.v2.enabled` is true,
+ * writes go under `memory/`; otherwise they go under `pkb/`. Consolidation
+ * of the buffer into longer-form storage runs as a separate periodic job in
+ * both modes. This base definition carries the mode-neutral schema; the
+ * registered tool appends the page-hint guidance on wiki-memory installs via
+ * {@link buildRememberInputSchema}.
+ */
+export const graphRememberDefinition = {
+  name: "remember",
+  description: REMEMBER_DESCRIPTION,
+  input_schema: buildRememberInputSchema({ pageHints: false }),
 } satisfies ToolDefinition;

--- a/assistant/src/plugins/defaults/memory/graph/tools.ts
+++ b/assistant/src/plugins/defaults/memory/graph/tools.ts
@@ -79,9 +79,15 @@ export const REMEMBER_PAGE_HINT_GUIDANCE =
 /**
  * Build the `remember` input schema. `pageHints` reflects the wiki-memory
  * (`memory.v2.enabled`) state and appends
- * {@link REMEMBER_PAGE_HINT_GUIDANCE} to the `content` description.
+ * {@link REMEMBER_PAGE_HINT_GUIDANCE} to the `content` description. It is a
+ * thunk re-resolved on every read of that description: the registry's
+ * finalized tool shares the returned schema object by reference, so a
+ * runtime config edit is reflected on the next schema serialization without
+ * re-registering the tool.
  */
-export function buildRememberInputSchema(options: { pageHints: boolean }) {
+export function buildRememberInputSchema(options: {
+  pageHints: () => boolean;
+}) {
   return {
     type: "object",
     properties: {
@@ -90,9 +96,11 @@ export function buildRememberInputSchema(options: { pageHints: boolean }) {
           { type: "string" },
           { type: "array", items: { type: "string" }, minItems: 1 },
         ],
-        description: options.pageHints
-          ? `${REMEMBER_CONTENT_DESCRIPTION} ${REMEMBER_PAGE_HINT_GUIDANCE}`
-          : REMEMBER_CONTENT_DESCRIPTION,
+        get description(): string {
+          return options.pageHints()
+            ? `${REMEMBER_CONTENT_DESCRIPTION} ${REMEMBER_PAGE_HINT_GUIDANCE}`
+            : REMEMBER_CONTENT_DESCRIPTION;
+        },
       },
       finish_turn: {
         type: "boolean",
@@ -117,5 +125,5 @@ export function buildRememberInputSchema(options: { pageHints: boolean }) {
 export const graphRememberDefinition = {
   name: "remember",
   description: REMEMBER_DESCRIPTION,
-  input_schema: buildRememberInputSchema({ pageHints: false }),
+  input_schema: buildRememberInputSchema({ pageHints: () => false }),
 } satisfies ToolDefinition;

--- a/assistant/src/plugins/defaults/memory/graph/tools.ts
+++ b/assistant/src/plugins/defaults/memory/graph/tools.ts
@@ -68,7 +68,9 @@ const REMEMBER_DESCRIPTION =
  * archive (permanent date-indexed record). When `memory.v2.enabled` is true,
  * writes go under `memory/`; otherwise they go under `pkb/`. Consolidation
  * of the buffer into longer-form storage runs as a separate periodic job in
- * both modes.
+ * both modes. Facts may carry inline `[[slug]]` wikilink hints naming the
+ * memory pages they relate to; the consolidation prompts treat those as
+ * read-first candidates when filing buffer entries.
  */
 export const graphRememberDefinition = {
   name: "remember",
@@ -82,7 +84,7 @@ export const graphRememberDefinition = {
           { type: "array", items: { type: "string" }, minItems: 1 },
         ],
         description:
-          "The fact(s) to remember. Pass a single string for one fact, or an array of strings to record several independent facts in one call. When a turn surfaces multiple unrelated facts, pass them all as an array in one call rather than calling `remember` once per fact. Write naturally — a preference, a detail, a commitment, a plan. No need to categorize.",
+          "The fact(s) to remember. Pass a single string for one fact, or an array of strings to record several independent facts in one call. When a turn surfaces multiple unrelated facts, pass them all as an array in one call rather than calling `remember` once per fact. Write naturally — a preference, a detail, a commitment, a plan. No need to categorize. When a fact relates to memory pages already in your context, reference the most specific ones inline as [[slug]] wikilinks — consolidation reads hinted pages first when filing the fact, which matters most for corrections (the hint names the page carrying the outdated fact). Hint only pages you have actually seen, and prefer specific pages over broad hubs.",
       },
       finish_turn: {
         type: "boolean",

--- a/assistant/src/plugins/defaults/memory/tools.test.ts
+++ b/assistant/src/plugins/defaults/memory/tools.test.ts
@@ -389,5 +389,18 @@ describe("rememberTool definition — page-hint guidance gating", () => {
     expect(rememberTool.input_schema.properties.content.description).toContain(
       "[[slug]] wikilinks",
     );
+    // The gate must survive JSON serialization — that's how the schema
+    // reaches the provider wire format.
+    expect(JSON.stringify(rememberTool.input_schema)).toContain(
+      "[[slug]] wikilinks",
+    );
+  });
+
+  test("re-resolves against config on each read, without re-registration", () => {
+    const schema = rememberTool.input_schema;
+    setConfig("memory", { v2: { enabled: true } });
+    expect(schema.properties.content.description).toContain("[[slug]]");
+    setConfig("memory", { v2: { enabled: false } });
+    expect(schema.properties.content.description).not.toContain("[[slug]]");
   });
 });

--- a/assistant/src/plugins/defaults/memory/tools.test.ts
+++ b/assistant/src/plugins/defaults/memory/tools.test.ts
@@ -370,3 +370,24 @@ describe("rememberTool.execute — batch (array) content", () => {
     expect(enqueueCalls).toHaveLength(0);
   });
 });
+
+describe("rememberTool definition — page-hint guidance gating", () => {
+  // The rest of this file exercises the v1 PKB path; restore its seed.
+  afterAll(() => {
+    setConfig("memory", { v2: { enabled: false } });
+  });
+
+  test("omits the [[slug]] hint guidance in v1/PKB mode", () => {
+    setConfig("memory", { v2: { enabled: false } });
+    expect(
+      rememberTool.input_schema.properties.content.description,
+    ).not.toContain("[[slug]]");
+  });
+
+  test("includes the [[slug]] hint guidance under wiki memory (v2)", () => {
+    setConfig("memory", { v2: { enabled: true } });
+    expect(rememberTool.input_schema.properties.content.description).toContain(
+      "[[slug]] wikilinks",
+    );
+  });
+});

--- a/assistant/src/plugins/defaults/memory/tools.ts
+++ b/assistant/src/plugins/defaults/memory/tools.ts
@@ -7,7 +7,7 @@
  * memory feature (`src/memory/*`).
  */
 
-import { getConfig } from "../../../config/loader.js";
+import { getConfig, getConfigReadOnly } from "../../../config/loader.js";
 import { RiskLevel } from "../../../permissions/types.js";
 import { resolveCapabilities } from "../../../runtime/capabilities.js";
 import type {
@@ -19,6 +19,7 @@ import { runAgenticRecall } from "./context-search/agent-runner.js";
 import type { RecallInput } from "./context-search/types.js";
 import { handleRemember, type RememberInput } from "./graph/tool-handlers.js";
 import {
+  buildRememberInputSchema,
   graphRecallDefinition,
   graphRememberDefinition,
 } from "./graph/tools.js";
@@ -31,7 +32,16 @@ export const rememberTool = {
   category: "memory",
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
-  input_schema: graphRememberDefinition.input_schema,
+  // The [[slug]] page-hint guidance applies only under the wiki memory model
+  // (v1/PKB has no pages for hints to reference), so the schema is resolved
+  // against config when the registry finalizes the tool at startup rather
+  // than baked in statically. Read-only accessor: a definition read must
+  // never create workspace directories.
+  get input_schema() {
+    return buildRememberInputSchema({
+      pageHints: getConfigReadOnly().memory.v2.enabled,
+    });
+  },
 
   async execute(
     input: Record<string, unknown>,

--- a/assistant/src/plugins/defaults/memory/tools.ts
+++ b/assistant/src/plugins/defaults/memory/tools.ts
@@ -33,15 +33,15 @@ export const rememberTool = {
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
   // The [[slug]] page-hint guidance applies only under the wiki memory model
-  // (v1/PKB has no pages for hints to reference), so the schema is resolved
-  // against config when the registry finalizes the tool at startup rather
-  // than baked in statically. Read-only accessor: a definition read must
-  // never create workspace directories.
-  get input_schema() {
-    return buildRememberInputSchema({
-      pageHints: getConfigReadOnly().memory.v2.enabled,
-    });
-  },
+  // (v1/PKB has no pages for hints to reference). The thunk is re-resolved on
+  // every read of the content description — the registry's finalized tool
+  // shares this schema object by reference — so a runtime edit of
+  // `memory.v2.enabled` reaches the model on the next request, in lockstep
+  // with handleRemember re-reading config per call. Read-only accessor: a
+  // definition read must never create workspace directories.
+  input_schema: buildRememberInputSchema({
+    pageHints: () => getConfigReadOnly().memory.v2.enabled,
+  }),
 
   async execute(
     input: Record<string, unknown>,

--- a/assistant/src/plugins/defaults/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/plugins/defaults/memory/v2/prompts/consolidation.ts
@@ -260,6 +260,8 @@ For entries with timestamp < \`${CUTOFF_PLACEHOLDER}\`, ask both questions in pa
 
 > **B. What in this buffer is recognizable as a thing the principal comes back to?** *(Inclusion-first. List everything that fits a spawn trigger, then spawn each. Don't ask "have I earned this article?" — that's gatekeep-shaped and wrong.)*
 
+**Buffer entries may carry \`[[slug]]\` wikilink hints** — pages that were in context when the fact was saved. Read hinted pages first when planning where an entry lands; correction entries usually hint the exact page carrying the stale fact. Hints are advisory, not routing: verify the fact belongs where the hint points (pages get renamed and merged between passes), and a hint to an existing page never substitutes for the spawn check — a recognizable new thing near a hinted parent still means spawn the stub and edge it to the hinted page.
+
 **Default spawn triggers — if any are present, the answer is "spawn the stub":**
 
 - **named objects** — a specific physical artifact, a digital asset, a recurring document → \`concepts/objects/<slug>.md\`
@@ -661,6 +663,8 @@ For entries with timestamp < \`${CUTOFF_PLACEHOLDER}\`, ask both questions in pa
 > **A. Which EVENT articles does this create or extend?** A new day-arc, a moment that deserves its own article, an extension to a long-running pattern, a procedure I invented today.
 
 > **B. What in this buffer is recognizable as a thing the principal comes back to?** *(Inclusion-first. List everything that fits a spawn trigger, then spawn each. Don't ask "have I earned this article?" — that's gatekeep-shaped and wrong.)*
+
+**Buffer entries may carry \`[[slug]]\` wikilink hints** — pages that were in context when the fact was saved. Read hinted pages first when planning where an entry lands; correction entries usually hint the exact page carrying the stale fact. Hints are advisory, not routing: verify the fact belongs where the hint points (pages get renamed and merged between passes), and a hint to an existing page never substitutes for the spawn check — a recognizable new thing near a hinted parent still means spawn the child, set \`main:\`, and link it from the hinted page.
 
 **Default spawn triggers — if any are present, the answer is "spawn the stub":** named objects · named phrases · named people · named events · active projects · named places · services / infrastructure · substances / habits / health things · rules / protocols / disciplines · landmark day-narratives (used sparingly).
 


### PR DESCRIPTION
## Summary
- The `remember` tool's content-field description now encourages inline `[[slug]]` wikilink hints referencing the most specific memory pages already in context — only pages actually seen, prefer specific pages over broad hubs, with corrections called out as the highest-value case (the hint names the page carrying the outdated fact). The guidance is gated to wiki-memory (v2/v3) installs: a getter on the content description re-resolves `memory.v2.enabled` on every schema read (the registry's finalized tool shares the schema object by reference), so v1/PKB workspaces — which have no wiki pages for hints to reference — keep the mode-neutral schema, and runtime config edits take effect on the next request in lockstep with the write path.
- Both consolidation prompt templates (v2 fragment shape and v3 lead-plus-sections) gain a step-2 paragraph: read hinted pages first when planning where a buffer entry lands, treat hints as advisory rather than routing (slugs go stale between passes), and never let a hint substitute for the spawn check — a hinted parent plus a recognizable new thing still means spawn and link.
- The retrospective pass exposes the same `remember` tool definition, so the guidance reaches that writer with no extra change.

## Notes for review
- Installs with a custom `memory.v2.consolidation_prompt_path` override serve the override verbatim, so they won't pick up the consolidation-side guidance until the override file is updated.
- The paragraph is intentionally duplicated across the two templates rather than extracted: the file keeps each template self-contained (the only shared constant is the flag-gated core-pages section), and the closing clause differs (v2 edge vocabulary vs v3 `main:`/`links:`).
- Hints stay a soft, advisory channel by design — buffer content is partially untrusted, so consolidation must keep treating wikilinks as read-first candidates, never mechanical routing.

## Original prompt
Consolidation currently has to figure out which memory wiki pages each buffer entry touches with no guidance beyond the text of the `remember` calls, even though the agent saving the fact had the relevant pages in context at write-time. Sidd proposed encouraging page hints via the `remember` tool description; discussion settled on inline `[[slug]]` wikilinks (corpus-native, no schema or buffer-format change) shipped together with matching consolidation-prompt guidance framing hints as read-first candidates — explicitly not routing and not a substitute for spawning new pages, so hints cannot anchor consolidation into folding new facts into existing pages. PR intentionally left unmerged for manual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
