### PR TITLE
Repin agent-wrapped to be38bd9 (skill: forbid app-builder, use standalone Vercel page)

### DIFF
--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -23,7 +23,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "1bfa2b9c0735662e4c493955a414b6b62136a380"
+        "ref": "be38bd9cd57aaac6bf06b22d82885c09219320bf"
       },
       "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -23,7 +23,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "1bfa2b9c0735662e4c493955a414b6b62136a380"
+        "ref": "be38bd9cd57aaac6bf06b22d82885c09219320bf"
       },
       "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
       "category": "creative",


### PR DESCRIPTION
Repins agent-wrapped from 1bfa2b9 to be38bd9.

What's in the new pin:
- Skill now explicitly forbids using the Vellum app-builder skill for the cards UI
- Cards experience should be built as a standalone static HTML page for Vercel, not an in-app artifact
- Points to vercel-static-deploy skill for deployment

Both `plugins/marketplace.json` and the bundled offline mirror are updated in sync.