### PR TITLE
feat(voice): in-session voice settings gear with live pause tuning (JARVIS-1289)

### DIFF
--- a/assistant/src/calls/media-turn-detector.ts
+++ b/assistant/src/calls/media-turn-detector.ts
@@ -75,7 +75,7 @@ export interface TurnDetectorCallbacks {
 // ---------------------------------------------------------------------------
 
 export class MediaTurnDetector {
-  private readonly silenceThresholdMs: number;
+  private silenceThresholdMs: number;
   private readonly maxTurnDurationMs: number;
   private readonly callbacks: TurnDetectorCallbacks;
 
@@ -114,6 +114,16 @@ export class MediaTurnDetector {
    */
   get isActive(): boolean {
     return this.active;
+  }
+
+  /**
+   * Update the trailing-silence threshold mid-session (the "pause before
+   * reply" live-tuning path). Applies from the next silence-timer arm — a
+   * countdown already in flight keeps its current duration until it resets on
+   * the next speech chunk — so the change takes effect on the next utterance.
+   */
+  setSilenceThresholdMs(silenceThresholdMs: number): void {
+    this.silenceThresholdMs = silenceThresholdMs;
   }
 
   /**

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1174,6 +1174,32 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
     }
   });
 
+  // JARVIS-1284 (in-session gear): a mid-session `update_config` frame retunes
+  // the live turn detector's pause, so the "pause before reply" slider in the
+  // voice room takes effect without reconnecting.
+  test("update_config retunes the live silence threshold mid-session", async () => {
+    const { frames, session } = createHarness({
+      // Start with a long pause that would time the waitFor out on its own.
+      startFrame: { ...VAD_START_FRAME, silenceThresholdMs: 5_000 },
+      finals: ["configured turn"],
+      startVoiceTurn: makeAutoCompletingTurnStarter(["Done."]).startVoiceTurn,
+    });
+    await session.start();
+
+    // Retune to a short pause mid-session…
+    await session.handleClientFrame({
+      type: "update_config",
+      silenceThresholdMs: 60,
+    });
+
+    // …so this utterance ends ~60 ms after speech, inside the waitFor budget.
+    await session.handleBinaryAudio(pcm(3_000));
+    await waitFor(() => countType(frames, "utterance_end") === 1);
+    expect(
+      frames.find((frame) => frame.type === "utterance_end"),
+    ).toMatchObject({ type: "utterance_end", reason: "silence" });
+  });
+
   // JARVIS-1284: the per-session start-frame `silenceThresholdMs` wins over the
   // daemon-config/option value, so the client's "pause before reply" setting
   // takes effect.

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -62,6 +62,54 @@ describe("parseLiveVoiceClientTextFrame", () => {
     }
   });
 
+  test("parses an update_config frame with both fields", () => {
+    const frame = {
+      type: "update_config",
+      silenceThresholdMs: 1400,
+      bargeInMinSpeechMs: 300,
+    } satisfies LiveVoiceClientFrame;
+    const result = parseLiveVoiceClientTextFrame(JSON.stringify(frame));
+    expect(result).toEqual({ ok: true, frame });
+  });
+
+  test("parses an update_config frame with a single field, omitting the other", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({ type: "update_config", silenceThresholdMs: 900 }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.frame).toEqual({
+      type: "update_config",
+      silenceThresholdMs: 900,
+    });
+  });
+
+  test("parses an empty update_config frame (no-op)", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({ type: "update_config" }),
+    );
+    expect(result).toEqual({ ok: true, frame: { type: "update_config" } });
+  });
+
+  test.each([
+    ["silenceThresholdMs", 50],
+    ["silenceThresholdMs", 10_000],
+    ["bargeInMinSpeechMs", -1],
+    ["bargeInMinSpeechMs", 9_000],
+  ])("rejects an out-of-range update_config %s=%p", (field, badValue) => {
+    const result = validateLiveVoiceClientFrame({
+      type: "update_config",
+      [field]: badValue,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field,
+      frameType: "update_config",
+    });
+  });
+
   test("returns typed protocol errors for invalid JSON", () => {
     const result = parseLiveVoiceClientTextFrame("{");
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -67,6 +67,7 @@ import type {
 } from "./live-voice-tts.js";
 import {
   type LiveVoiceClientFrame,
+  type LiveVoiceClientUpdateConfigFrame,
   LiveVoiceProtocolErrorCode,
   type LiveVoiceServerFramePayload,
 } from "./protocol.js";
@@ -308,7 +309,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // Energy gate for server-VAD speech classification; undefined defers to
   // DEFAULT_SPEECH_ENERGY_THRESHOLD.
   private readonly speechEnergyThreshold: number | undefined;
-  private readonly bargeInMinSpeechMs: number;
+  // Mutable so a mid-session `update_config` frame can retune "interrupt
+  // sensitivity" live (see applyConfigUpdate).
+  private bargeInMinSpeechMs: number;
   // Sustained-speech barge-in guard, armed at speech onset while the
   // assistant turn is audibly speaking: consecutive speech-chunk duration
   // accumulates until it reaches bargeInMinSpeechMs, then the deferred
@@ -474,6 +477,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       case "start":
         return;
+      case "update_config":
+        this.applyConfigUpdate(frame);
+        return;
+    }
+  }
+
+  /**
+   * Apply a mid-session `update_config` frame: retune the live turn detector's
+   * pause ("pause before reply") and/or the barge-in guard ("interrupt
+   * sensitivity") without reconnecting. Each field is optional and independent;
+   * changes take effect from the next utterance. A no-op on manual (non-
+   * server_vad) sessions, which have no turn detector.
+   */
+  private applyConfigUpdate(frame: LiveVoiceClientUpdateConfigFrame): void {
+    if (frame.silenceThresholdMs !== undefined) {
+      this.turnDetector?.setSilenceThresholdMs(frame.silenceThresholdMs);
+    }
+    if (frame.bargeInMinSpeechMs !== undefined) {
+      this.bargeInMinSpeechMs = frame.bargeInMinSpeechMs;
     }
   }
 

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -4,6 +4,7 @@ const LIVE_VOICE_CLIENT_FRAME_TYPES = [
   "ptt_release",
   "interrupt",
   "end",
+  "update_config",
 ] as const;
 
 type LiveVoiceClientFrameType = (typeof LIVE_VOICE_CLIENT_FRAME_TYPES)[number];
@@ -125,12 +126,26 @@ export interface LiveVoiceClientEndFrame {
   readonly type: "end";
 }
 
+/**
+ * Mid-session tuning update: applies the same turn-detection knobs the start
+ * frame carries to the *running* session, so the client can retune "pause
+ * before reply" / "interrupt sensitivity" without reconnecting. Each field is
+ * optional and independently applied; the same bounds as the start frame apply.
+ * Only meaningful for `server_vad` sessions.
+ */
+export interface LiveVoiceClientUpdateConfigFrame {
+  readonly type: "update_config";
+  readonly silenceThresholdMs?: number;
+  readonly bargeInMinSpeechMs?: number;
+}
+
 export type LiveVoiceClientFrame =
   | LiveVoiceClientStartFrame
   | LiveVoiceClientAudioFrame
   | LiveVoiceClientPttReleaseFrame
   | LiveVoiceClientInterruptFrame
-  | LiveVoiceClientEndFrame;
+  | LiveVoiceClientEndFrame
+  | LiveVoiceClientUpdateConfigFrame;
 
 interface LiveVoiceBinaryAudioFrame {
   readonly type: "binary_audio";
@@ -386,7 +401,58 @@ export function validateLiveVoiceClientFrame(
       return { ok: true, frame: { type: "interrupt" } };
     case "end":
       return { ok: true, frame: { type: "end" } };
+    case "update_config":
+      return validateUpdateConfigFrame(value);
   }
+}
+
+function validateUpdateConfigFrame(
+  value: Record<string, unknown>,
+): LiveVoiceParseResult<LiveVoiceClientUpdateConfigFrame> {
+  if (
+    "silenceThresholdMs" in value &&
+    !isIntInRange(
+      value.silenceThresholdMs,
+      MIN_SILENCE_THRESHOLD_MS,
+      MAX_SILENCE_THRESHOLD_MS,
+    )
+  ) {
+    return protocolError(
+      "invalid_field",
+      `update_config field silenceThresholdMs must be an integer in [${MIN_SILENCE_THRESHOLD_MS}, ${MAX_SILENCE_THRESHOLD_MS}]`,
+      "silenceThresholdMs",
+      "update_config",
+    );
+  }
+
+  if (
+    "bargeInMinSpeechMs" in value &&
+    !isIntInRange(
+      value.bargeInMinSpeechMs,
+      MIN_BARGE_IN_MIN_SPEECH_MS,
+      MAX_BARGE_IN_MIN_SPEECH_MS,
+    )
+  ) {
+    return protocolError(
+      "invalid_field",
+      `update_config field bargeInMinSpeechMs must be an integer in [${MIN_BARGE_IN_MIN_SPEECH_MS}, ${MAX_BARGE_IN_MIN_SPEECH_MS}]`,
+      "bargeInMinSpeechMs",
+      "update_config",
+    );
+  }
+
+  return {
+    ok: true,
+    frame: {
+      type: "update_config",
+      ...(typeof value.silenceThresholdMs === "number"
+        ? { silenceThresholdMs: value.silenceThresholdMs }
+        : {}),
+      ...(typeof value.bargeInMinSpeechMs === "number"
+        ? { bargeInMinSpeechMs: value.bargeInMinSpeechMs }
+        : {}),
+    },
+  };
 }
 
 export function parseLiveVoiceBinaryAudioFrame(

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -467,6 +467,40 @@ describe("server frame dispatch", () => {
     expect(ws.closed).toBe(true);
   });
 
+  test("an unknown_type error (older assistant rejecting update_config) is non-fatal and latches off further updates", async () => {
+    const { client, ws } = await ready();
+    const errors: unknown[] = [];
+    let closedCount = 0;
+    client.on("error", (e) => errors.push(e));
+    client.on("closed", () => closedCount++);
+
+    // A newer client sends update_config; an older daemon rejects the frame.
+    client.updateConfig({ silenceThresholdMs: 1400 });
+    ws.receive({
+      type: "error",
+      seq: 10,
+      code: "unknown_type",
+      message: "Unknown live voice client frame type: update_config",
+    });
+
+    // Not fatal: no error surfaced, session stays open, later frames dispatch.
+    expect(errors).toEqual([]);
+    expect(closedCount).toBe(0);
+    expect(ws.closed).toBe(false);
+
+    // Further updateConfig calls are suppressed (no more frames go out).
+    const sentBefore = ws.sentJson.length;
+    client.updateConfig({ silenceThresholdMs: 1600 });
+    expect(ws.sentJson.length).toBe(sentBefore);
+
+    const seen: unknown[] = [];
+    client.on("sttPartial", (f) => seen.push(f));
+    ws.receive({ type: "stt_partial", seq: 11, text: "still here" });
+    expect(seen).toEqual([
+      { type: "stt_partial", seq: 11, text: "still here" },
+    ]);
+  });
+
   test("recoverable error frame emits the error but keeps the session alive", async () => {
     const { client, ws } = await ready();
     const errors: {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -623,6 +623,35 @@ describe("control frames", () => {
       { type: "interrupt" },
     ]);
   });
+
+  test("updateConfig sends an update_config frame with only the provided fields when active", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open();
+    ws.receive({ type: "ready", seq: 1, sessionId: "s", conversationId: "c" });
+
+    client.updateConfig({ silenceThresholdMs: 1400 });
+
+    expect(ws.sentJson.slice(1)).toEqual([
+      { type: "update_config", silenceThresholdMs: 1400 },
+    ]);
+  });
+
+  test("updateConfig is a no-op before the session is active", async () => {
+    const client = makeClient();
+    const ws = await connectAndGetSocket(client);
+    ws.open(); // opened but no `ready` yet → still connecting, not active
+
+    client.updateConfig({ silenceThresholdMs: 1400 });
+
+    // Only the start frame was sent; the update was dropped.
+    expect(ws.sentJson).toEqual([
+      {
+        type: "start",
+        audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
+      },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -174,6 +174,11 @@ export class LiveVoiceChannelClient {
   private turnDetection: LiveVoiceTurnDetectionMode | undefined;
   private silenceThresholdMs: number | undefined;
   private bargeInMinSpeechMs: number | undefined;
+  // Set once an assistant running daemon code older than the `update_config`
+  // frame rejects it with `unknown_type`. We then stop sending config updates
+  // for this session so an older assistant is neither killed nor spammed by the
+  // voice-room settings (version-skew forward-compat).
+  private configUpdatesUnsupported = false;
 
   private readonly listeners: {
     [E in LiveVoiceClientEventName]: Set<LiveVoiceClientEventHandler<E>>;
@@ -312,7 +317,7 @@ export class LiveVoiceChannelClient {
     silenceThresholdMs?: number;
     bargeInMinSpeechMs?: number;
   }): void {
-    if (this.state !== "active") return;
+    if (this.state !== "active" || this.configUpdatesUnsupported) return;
     this.trySend(
       JSON.stringify({
         type: "update_config",
@@ -422,6 +427,20 @@ export class LiveVoiceChannelClient {
         this.emit("archived", frame);
         return;
       case "error":
+        // An assistant running daemon code older than a client frame we sent
+        // rejects it with `unknown_type`. The only frame we send optimistically
+        // is `update_config` (the voice-room settings), so this is a
+        // forward-compat no-op, not a session failure: latch it off and keep
+        // the session alive. Mirrors the `unknown_frame` handling below for the
+        // reverse (newer-server) direction.
+        if (frame.code === "unknown_type") {
+          this.configUpdatesUnsupported = true;
+          console.warn(
+            "live-voice: assistant rejected update_config (unknown_type); " +
+              "in-session settings changes won't apply until it is upgraded",
+          );
+          return;
+        }
         // A recoverable mid-session error leaves the transport open; the
         // session controller decides whether the session survives. (`in`
         // narrows past LiveVoiceInvalidJsonFrame, which is never recoverable.)

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -303,6 +303,30 @@ export class LiveVoiceChannelClient {
   }
 
   /**
+   * Retune the running session's turn-detection knobs ("pause before reply" /
+   * "interrupt sensitivity") without reconnecting. No-op unless the session is
+   * active; each field is optional. The daemon applies changes from the next
+   * utterance.
+   */
+  updateConfig(config: {
+    silenceThresholdMs?: number;
+    bargeInMinSpeechMs?: number;
+  }): void {
+    if (this.state !== "active") return;
+    this.trySend(
+      JSON.stringify({
+        type: "update_config",
+        ...(config.silenceThresholdMs !== undefined
+          ? { silenceThresholdMs: config.silenceThresholdMs }
+          : {}),
+        ...(config.bargeInMinSpeechMs !== undefined
+          ? { bargeInMinSpeechMs: config.bargeInMinSpeechMs }
+          : {}),
+      }),
+    );
+  }
+
+  /**
    * End the session gracefully: best-effort send `end`, then always close the
    * socket. A quick-cancel while still CONNECTING simply skips the (impossible)
    * `end` send and resolves as a clean close rather than a timeout failure.

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -47,6 +47,10 @@ export class FakeClient {
   sentAudio: ArrayBuffer[] = [];
   pttReleaseCount = 0;
   interruptCount = 0;
+  updateConfigCalls: {
+    silenceThresholdMs?: number;
+    bargeInMinSpeechMs?: number;
+  }[] = [];
   ended = false;
   closed = false;
 
@@ -86,6 +90,12 @@ export class FakeClient {
   }
   interrupt(): void {
     this.interruptCount++;
+  }
+  updateConfig(config: {
+    silenceThresholdMs?: number;
+    bargeInMinSpeechMs?: number;
+  }): void {
+    this.updateConfigCalls.push(config);
   }
   end(): void {
     this.ended = true;
@@ -218,6 +228,12 @@ export function makeControlsSpies() {
     release: mock(() => {}),
     interrupt: mock(() => {}),
     setMuted: mock((_muted: boolean) => {}),
+    updateConfig: mock(
+      (_config: {
+        silenceThresholdMs?: number;
+        bargeInMinSpeechMs?: number;
+      }) => {},
+    ),
   } satisfies LiveVoiceSessionControls;
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -19,6 +19,7 @@ import {
   releaseLiveVoiceTurn,
   setLiveVoiceMuted,
   stopLiveVoiceResponse,
+  updateLiveVoiceSessionConfig,
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
@@ -134,10 +135,20 @@ describe("useLiveVoiceStore — mute + handsFree", () => {
     expect(controls.interrupt).toHaveBeenCalledTimes(1);
   });
 
+  test("updateLiveVoiceSessionConfig drives the registered updateConfig control", () => {
+    const controls = makeControlsSpies();
+    useLiveVoiceStore.getState().setControls(controls);
+    updateLiveVoiceSessionConfig({ silenceThresholdMs: 1500 });
+    expect(controls.updateConfig).toHaveBeenCalledWith({
+      silenceThresholdMs: 1500,
+    });
+  });
+
   test("helpers are no-ops with no registered controls", () => {
     expect(() => {
       setLiveVoiceMuted(true);
       stopLiveVoiceResponse();
+      updateLiveVoiceSessionConfig({ silenceThresholdMs: 1500 });
     }).not.toThrow();
   });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -124,6 +124,16 @@ export interface LiveVoiceSessionControls {
    * published amplitude pins to 0.
    */
   setMuted: (muted: boolean) => void;
+  /**
+   * Retune the live session's turn-detection knobs ("pause before reply" /
+   * "interrupt sensitivity") without reconnecting. Each field is optional; the
+   * daemon applies the change from the next utterance. No-op unless the
+   * transport is active.
+   */
+  updateConfig: (config: {
+    silenceThresholdMs?: number;
+    bargeInMinSpeechMs?: number;
+  }) => void;
 }
 
 /**
@@ -516,6 +526,19 @@ export function stopLiveVoiceResponse(): void {
  */
 export function setLiveVoiceMuted(muted: boolean): void {
   useLiveVoiceStore.getState().controls?.setMuted(muted);
+}
+
+/**
+ * Retune the active session's "pause before reply" / "interrupt sensitivity"
+ * live through the store-registered controls (the in-session voice-room gear).
+ * No-op when no session exists or the transport isn't active. Module-level for
+ * the same stable-identity reasons as {@link endLiveVoiceSession}.
+ */
+export function updateLiveVoiceSessionConfig(config: {
+  silenceThresholdMs?: number;
+  bargeInMinSpeechMs?: number;
+}): void {
+  useLiveVoiceStore.getState().controls?.updateConfig(config);
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -82,11 +82,23 @@ export interface LiveVoiceClientEndFrame {
   readonly type: "end";
 }
 
+/**
+ * Mid-session tuning update — retunes "pause before reply" / "interrupt
+ * sensitivity" on the running server_vad session without reconnecting. Each
+ * field is optional; the daemon applies changes from the next utterance.
+ */
+export interface LiveVoiceClientUpdateConfigFrame {
+  readonly type: "update_config";
+  readonly silenceThresholdMs?: number;
+  readonly bargeInMinSpeechMs?: number;
+}
+
 export type LiveVoiceClientFrame =
   | LiveVoiceClientStartFrame
   | LiveVoiceClientPttReleaseFrame
   | LiveVoiceClientInterruptFrame
-  | LiveVoiceClientEndFrame;
+  | LiveVoiceClientEndFrame
+  | LiveVoiceClientUpdateConfigFrame;
 
 // ---------------------------------------------------------------------------
 // Server frames (text/JSON; every frame carries `seq`)

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -514,6 +514,19 @@ export function useLiveVoice(
     if (muted) s.setInputAmplitude(0);
   }, []);
 
+  /**
+   * Retune the running session's turn-detection knobs live (the voice-room
+   * gear). Delegates to the transport, which no-ops unless the socket is
+   * active; a no-op during the reconnect gap (no session) is fine — the fresh
+   * `connectSession` re-reads the current settings into its start frame.
+   */
+  const updateConfig = useCallback(
+    (config: { silenceThresholdMs?: number; bargeInMinSpeechMs?: number }) => {
+      sessionRef.current?.client.updateConfig(config);
+    },
+    [],
+  );
+
   // The connect flow, shared by the user-facing `start()` and the hands-free
   // reconnect path. `start()` owns the "already active" guard and resets the
   // reconnect budget; `connectSession` assumes it may run. On reconnect it is
@@ -558,6 +571,7 @@ export function useLiveVoice(
         release,
         interrupt,
         setMuted,
+        updateConfig,
       });
 
       const opts = optionsRef.current;
@@ -880,6 +894,7 @@ export function useLiveVoice(
                 release,
                 interrupt,
                 setMuted,
+                updateConfig,
               });
               console.warn(
                 `live-voice: initial connect failed (${err.reason}); retrying ` +
@@ -942,6 +957,7 @@ export function useLiveVoice(
               release,
               interrupt,
               setMuted,
+              updateConfig,
             });
             console.warn(
               `live-voice: transport closed (code ${info.code}); reconnecting ` +
@@ -985,7 +1001,7 @@ export function useLiveVoice(
           : {}),
       });
     },
-    [teardown, stop, release, interrupt, setMuted],
+    [teardown, stop, release, interrupt, setMuted, updateConfig],
   );
 
   // Let the transport `closed` handler re-enter the connect flow for a

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { makeControlsSpies } from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+
+import { VoiceRoomSettingsMenu } from "./voice-room-settings-menu";
+
+const controls = makeControlsSpies();
+
+beforeEach(() => {
+  useVoicePrefsStore.setState({
+    showUserTranscript: false,
+    showAssistantTranscript: false,
+    pauseBeforeReplyMs: null,
+    interruptSensitivity: null,
+  });
+  useLiveVoiceStore.getState().reset();
+  // A live session with registered controls, so the live-apply path is exercised.
+  useLiveVoiceStore.getState().setControls(controls);
+  controls.updateConfig.mockClear();
+});
+
+afterEach(() => cleanup());
+
+/** Render the menu and open the gear popover. */
+function openMenu() {
+  render(<VoiceRoomSettingsMenu triggerClassName="ctrl" />);
+  fireEvent.click(screen.getByRole("button", { name: "Voice settings" }));
+}
+
+describe("VoiceRoomSettingsMenu", () => {
+  test("captions toggle flips both transcript prefs together", () => {
+    openMenu();
+    fireEvent.click(screen.getByLabelText("Show captions"));
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(true);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(true);
+  });
+
+  test("captions toggle turns both off when already on", () => {
+    useVoicePrefsStore.setState({ showAssistantTranscript: true });
+    openMenu();
+    fireEvent.click(screen.getByLabelText("Show captions"));
+    expect(useVoicePrefsStore.getState().showUserTranscript).toBe(false);
+    expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(false);
+  });
+
+  test("moving the pause slider persists the value and live-applies it to the session", () => {
+    openMenu();
+    // Default resting value is 1.2s; one step right → 1.3s (1300 ms).
+    fireEvent.keyDown(screen.getByRole("slider"), { key: "ArrowRight" });
+
+    expect(useVoicePrefsStore.getState().pauseBeforeReplyMs).toBe(1300);
+    expect(controls.updateConfig).toHaveBeenCalledWith({
+      silenceThresholdMs: 1300,
+    });
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
@@ -18,6 +18,7 @@
 
 import { Settings } from "lucide-react";
 
+import { cn } from "@vellumai/design-library";
 import { Popover } from "@vellumai/design-library/components/popover";
 import { Slider } from "@vellumai/design-library/components/slider";
 import { Toggle } from "@vellumai/design-library/components/toggle";
@@ -34,6 +35,8 @@ interface VoiceRoomSettingsMenuProps {
   /** Styling for the gear trigger, so it matches the room's other controls. */
   triggerClassName: string;
 }
+
+const rowLabelClass = "text-body-medium-default text-[var(--content-default)]";
 
 export function VoiceRoomSettingsMenu({
   triggerClassName,
@@ -68,27 +71,36 @@ export function VoiceRoomSettingsMenu({
           type="button"
           aria-label="Voice settings"
           title="Voice settings"
-          className={triggerClassName}
+          className={cn(
+            triggerClassName,
+            // Show the active (open) state with the same room tokens the
+            // control's hover uses.
+            "data-[state=open]:bg-[var(--room-wash)] data-[state=open]:text-[var(--room-fg)]",
+          )}
         >
           <Settings className="size-5" />
         </button>
       </Popover.Trigger>
-      <Popover.Content side="bottom" align="end" sideOffset={8} className="w-64">
-        <div className="flex flex-col gap-4 p-1">
-          <label className="flex items-center justify-between gap-3">
-            <span className="text-body-medium-default text-[var(--content-default)]">
-              Captions
-            </span>
+      <Popover.Content
+        side="bottom"
+        align="end"
+        sideOffset={8}
+        className="w-64 p-3"
+      >
+        <div className="flex flex-col">
+          <label className="flex items-center justify-between gap-3 py-1">
+            <span className={rowLabelClass}>Captions</span>
             <Toggle
               checked={captionsOn}
               onChange={setCaptions}
               aria-label="Show captions"
             />
           </label>
-          <div className="flex flex-col gap-2">
-            <span className="text-body-medium-default text-[var(--content-default)]">
-              Pause before reply
-            </span>
+
+          <div className="my-2 border-t border-[var(--border-subtle)]" />
+
+          <div className="flex flex-col gap-2 py-1">
+            <span className={rowLabelClass}>Pause before reply</span>
             <Slider
               value={(pauseMs ?? DEFAULT_PAUSE_BEFORE_REPLY_MS) / 1000}
               onValueChange={handlePauseChange}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
@@ -1,0 +1,109 @@
+/**
+ * In-session voice settings — the gear the voice room shows in place of a bare
+ * captions toggle. Opens a small popover exposing the two settings worth
+ * reaching mid-call:
+ *
+ * - **Captions** — enable/disable the ambient transcript. Purely client-side
+ *   (the two `voice-prefs` transcript flags, toggled together), so it applies
+ *   instantly.
+ * - **Pause before reply** — the trailing-silence "pause" the server VAD waits
+ *   before the assistant replies. Persisted to the same `voice-prefs` store as
+ *   Settings → Voice AND pushed to the running session via
+ *   {@link updateLiveVoiceSessionConfig}, so a change takes effect on the next
+ *   utterance without reconnecting.
+ *
+ * Both controls are bound to the same store the Settings page and first-run
+ * card use, so a choice made here is the choice those surfaces show.
+ */
+
+import { Settings } from "lucide-react";
+
+import { Popover } from "@vellumai/design-library/components/popover";
+import { Slider } from "@vellumai/design-library/components/slider";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+import { updateLiveVoiceSessionConfig } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  DEFAULT_PAUSE_BEFORE_REPLY_MS,
+  MAX_PAUSE_BEFORE_REPLY_MS,
+  MIN_PAUSE_BEFORE_REPLY_MS,
+  useVoicePrefsStore,
+} from "@/stores/voice-prefs-store";
+
+interface VoiceRoomSettingsMenuProps {
+  /** Styling for the gear trigger, so it matches the room's other controls. */
+  triggerClassName: string;
+}
+
+export function VoiceRoomSettingsMenu({
+  triggerClassName,
+}: VoiceRoomSettingsMenuProps) {
+  const showUserTranscript = useVoicePrefsStore.use.showUserTranscript();
+  const showAssistantTranscript =
+    useVoicePrefsStore.use.showAssistantTranscript();
+  const captionsOn = showUserTranscript || showAssistantTranscript;
+  const setCaptions = (on: boolean) => {
+    const prefs = useVoicePrefsStore.getState();
+    prefs.setShowUserTranscript(on);
+    prefs.setShowAssistantTranscript(on);
+  };
+
+  const pauseMs = useVoicePrefsStore.use.pauseBeforeReplyMs();
+  const setPauseMs = useVoicePrefsStore.use.setPauseBeforeReplyMs();
+  const handlePauseChange = (next: number | [number, number]) => {
+    const seconds = typeof next === "number" ? next : next[0];
+    setPauseMs(Math.round(seconds * 1000));
+    // The setter clamps; read the applied value back and push it to the live
+    // session so the new pause takes effect on the next utterance.
+    const applied = useVoicePrefsStore.getState().pauseBeforeReplyMs;
+    if (applied !== null) {
+      updateLiveVoiceSessionConfig({ silenceThresholdMs: applied });
+    }
+  };
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          aria-label="Voice settings"
+          title="Voice settings"
+          className={triggerClassName}
+        >
+          <Settings className="size-5" />
+        </button>
+      </Popover.Trigger>
+      <Popover.Content side="bottom" align="end" sideOffset={8} className="w-64">
+        <div className="flex flex-col gap-4 p-1">
+          <label className="flex items-center justify-between gap-3">
+            <span className="text-body-medium-default text-[var(--content-default)]">
+              Captions
+            </span>
+            <Toggle
+              checked={captionsOn}
+              onChange={setCaptions}
+              aria-label="Show captions"
+            />
+          </label>
+          <div className="flex flex-col gap-2">
+            <span className="text-body-medium-default text-[var(--content-default)]">
+              Pause before reply
+            </span>
+            <Slider
+              value={(pauseMs ?? DEFAULT_PAUSE_BEFORE_REPLY_MS) / 1000}
+              onValueChange={handlePauseChange}
+              min={MIN_PAUSE_BEFORE_REPLY_MS / 1000}
+              max={MAX_PAUSE_BEFORE_REPLY_MS / 1000}
+              step={0.1}
+              showValue
+              formatValue={(value) =>
+                `${(typeof value === "number" ? value : value[0]).toFixed(1)}s`
+              }
+              aria-label="Pause before reply"
+            />
+          </div>
+        </div>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -281,24 +281,17 @@ describe("VoiceRoom — no way out but ending the session", () => {
   });
 });
 
-describe("VoiceRoom — captions toggle", () => {
-  test("toggling captions on flips both persisted transcript prefs", () => {
+describe("VoiceRoom — settings gear", () => {
+  // The captions toggle + pause slider now live in the settings-gear popover
+  // (see voice-room-settings-menu.test.tsx for their behavior). The room just
+  // renders the gear in place of the old direct captions button.
+  test("renders the voice-settings gear, not a bare captions button", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
-    fireEvent.click(screen.getByRole("button", { name: "Show captions" }));
-    const prefs = useVoicePrefsStore.getState();
-    expect(prefs.showUserTranscript).toBe(true);
-    expect(prefs.showAssistantTranscript).toBe(true);
-  });
-
-  test("with any transcript pref on, the control offers to hide and clears both", () => {
-    useVoicePrefsStore.setState({ showUserTranscript: true });
-    startOwnedSession("listening");
-    render(<VoiceRoom />);
-    fireEvent.click(screen.getByRole("button", { name: "Hide captions" }));
-    const prefs = useVoicePrefsStore.getState();
-    expect(prefs.showUserTranscript).toBe(false);
-    expect(prefs.showAssistantTranscript).toBe(false);
+    expect(
+      screen.getByRole("button", { name: "Voice settings" }),
+    ).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Show captions" })).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -41,7 +41,7 @@
 
 import { useEffect, type CSSProperties } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { Captions, CaptionsOff, Mic, MicOff, Square, X } from "lucide-react";
+import { Mic, MicOff, Square, X } from "lucide-react";
 
 import { Tooltip, cn } from "@vellumai/design-library";
 
@@ -63,6 +63,7 @@ import { resolveWaveAccentHex } from "./wave-accent";
 
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
 import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
+import { VoiceRoomSettingsMenu } from "./voice-room-settings-menu";
 import { VoiceAvatar } from "./voice-avatar";
 import { VoiceListeningWaves } from "./voice-listening-waves";
 import { AVATAR_ENTER_SPRING } from "./voice-motion";
@@ -154,18 +155,11 @@ function VoiceRoomOverlay() {
     state === "speaking" && !assistantAudioActive ? "thinking" : state;
   const stateLabel = liveVoiceStateLabel(labelState, reconnecting);
 
-  // Captions = the two persisted transcript prefs, toggled together from the
-  // room. Bound to the same `voice-prefs` store as the settings page and the
-  // first-run card, so a choice made here is the choice those surfaces show.
-  const showUserTranscript = useVoicePrefsStore.use.showUserTranscript();
+  // The state caption (e.g. "Listening…") shows only while the assistant
+  // transcript is hidden; the captions toggle itself lives in the room's
+  // settings gear ({@link VoiceRoomSettingsMenu}).
   const showAssistantTranscript =
     useVoicePrefsStore.use.showAssistantTranscript();
-  const captionsOn = showUserTranscript || showAssistantTranscript;
-  const toggleCaptions = () => {
-    const prefs = useVoicePrefsStore.getState();
-    prefs.setShowUserTranscript(!captionsOn);
-    prefs.setShowAssistantTranscript(!captionsOn);
-  };
 
   // Resolve the assistant's look: color-with-eyes for character avatars, the
   // ambient void otherwise. The accent var is still published for the
@@ -297,21 +291,7 @@ function VoiceRoomOverlay() {
         }}
         className="absolute z-10 flex items-center gap-1"
       >
-        <Tooltip content={captionsOn ? "Hide captions" : "Show captions"}>
-          <button
-            type="button"
-            onClick={toggleCaptions}
-            aria-label={captionsOn ? "Hide captions" : "Show captions"}
-            aria-pressed={captionsOn}
-            className={ROOM_CONTROL_CLASS}
-          >
-            {captionsOn ? (
-              <Captions className="size-5" />
-            ) : (
-              <CaptionsOff className="size-5" />
-            )}
-          </button>
-        </Tooltip>
+        <VoiceRoomSettingsMenu triggerClassName={ROOM_CONTROL_CLASS} />
         <Tooltip content="End voice session (Esc)">
           <button
             type="button"


### PR DESCRIPTION
## Summary

Builds on JARVIS-1284 (per-session voice settings) so the settings are reachable from **inside** a live call. The voice room's bare captions button becomes a **settings gear** that opens a popover exposing:

- **Captions** — enable/disable the ambient transcript (client-side, applies instantly).
- **Pause before reply** — a slider that persists to the same `voice-prefs` store as Settings → Voice **and** applies to the running session live.

### Live pause tuning
Dragging the pause slider mid-call retunes the **running** session — no reconnect. Added an `update_config` client frame to the live-voice protocol (same bounds/validation as the start frame); the daemon applies it to the session's turn detector (`MediaTurnDetector.setSilenceThresholdMs`) and barge-in guard, so the new pause takes effect on the next utterance.

### Files
- **Daemon:** `live-voice/protocol.ts` (`update_config` frame + validation), `live-voice/live-voice-session.ts` (`applyConfigUpdate`), `calls/media-turn-detector.ts` (silence-threshold setter).
- **Web:** `live-voice/protocol.ts` + `live-voice-client.ts` (mirror + `updateConfig()` send), `live-voice-store.ts` (`updateConfig` control + `updateLiveVoiceSessionConfig()` helper), `use-live-voice.ts` (register the control), new `voice-room/voice-room-settings-menu.tsx` (design-library `Popover` + `Toggle` + `Slider`), `voice-room.tsx` (gear replaces the captions button).

### Styling
The popover follows the canonical `PreferencesMenu` pattern — padding on `Popover.Content`, `--border-subtle` dividers, `--content-default` label tokens, and a `data-[state=open]` active state on the gear using the room tokens.

## Tests
- **Daemon:** protocol parse/validate of `update_config` (both/single/empty/out-of-range); a session test proving a mid-session `update_config` retunes the live silence threshold.
- **Web:** client sends `update_config` when active / no-op otherwise; the store helper delegates to the control; `VoiceRoomSettingsMenu` test (captions toggle flips both prefs; pause slider persists + live-applies); voice-room test updated for the gear.
- `tsc` / eslint / prettier clean in both packages.

## Note
This work was on the JARVIS-1284 branch but didn't make it into that PR's squash (merged at a lagging head), so it's re-based onto current main here as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)