### PR TITLE
Show the OAuth connect card in the voice room and refresh connections

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
@@ -1,10 +1,23 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  type QueryKey,
+} from "@tanstack/react-query";
+import type { ReactElement } from "react";
 
 mock.module("@/domains/chat/components/chat-markdown-message", () => ({
   ChatMarkdownMessage: ({ content }: { content: string }) => (
     <div>{content}</div>
   ),
+}));
+
+// The connections-cache invalidation resolves the platform-scoped assistant id
+// first; short-circuit it to the input so the invalidated key is deterministic
+// and no local-mode / gateway graph is exercised.
+mock.module("@/lib/local-platform-identity", () => ({
+  resolveLocalAssistantPlatformIdentity: async (id: string) => id,
 }));
 
 import { ChoiceSurface } from "@/domains/chat/components/surfaces/choice-surface";
@@ -14,6 +27,7 @@ import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router
 import type { ManagedOAuthConnectClient } from "@/domains/chat/api/managed-oauth";
 import type { OAuthConnection } from "@/generated/api/types.gen";
 import type { Surface } from "@/domains/chat/types/types";
+import { assistantsOauthConnectionsListQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 
 afterAll(() => {
   mock.restore();
@@ -30,6 +44,22 @@ function makeSurface(overrides: Partial<Surface>): Surface {
     data: {},
     ...overrides,
   };
+}
+
+/**
+ * Render inside a real QueryClient (OAuthConnectSurface calls `useQueryClient`),
+ * with `invalidateQueries` spied so the connections-cache refresh is assertable.
+ */
+function renderWithClient(ui: ReactElement) {
+  const queryClient = new QueryClient();
+  const invalidateQueries = mock((_arg?: { queryKey?: QueryKey }) =>
+    Promise.resolve(),
+  );
+  queryClient.invalidateQueries = invalidateQueries as never;
+  const result = render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+  return { ...result, queryClient, invalidateQueries };
 }
 
 describe("ChoiceSurface", () => {
@@ -195,7 +225,7 @@ describe("OAuthConnectSurface", () => {
       })),
     };
 
-    const { getByRole, queryByText } = render(
+    const { getByRole, queryByText } = renderWithClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -246,7 +276,7 @@ describe("OAuthConnectSurface", () => {
       connect: mock(async () => ({ status: "cancelled" as const })),
     };
 
-    const { getByText, queryByText } = render(
+    const { getByText, queryByText } = renderWithClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -279,7 +309,7 @@ describe("OAuthConnectSurface", () => {
       connect: mock(async () => ({ status: "cancelled" as const })),
     };
 
-    const { getByRole } = render(
+    const { getByRole } = renderWithClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -302,6 +332,108 @@ describe("OAuthConnectSurface", () => {
       providerKey: "linear",
       providerLabel: "Linear",
     });
+  });
+
+  test("refreshes the connections cache after a successful connect (still fires onAction)", async () => {
+    const onAction = mock(() => {});
+    const oauthClient: ManagedOAuthConnectClient = {
+      fetchProvider: mock(async () => null),
+      connect: mock(async () => ({
+        status: "connected" as const,
+        connection: {
+          id: "conn-1",
+          provider: "google",
+          status: "ACTIVE",
+          connected: true,
+          account_label: "user@example.com",
+          scopes_granted: [],
+          expires_at: null,
+        } as OAuthConnection,
+      })),
+    };
+
+    const { getByRole, invalidateQueries } = renderWithClient(
+      <OAuthConnectSurface
+        surface={makeSurface({
+          surfaceType: "oauth_connect",
+          data: { providerKey: "google", displayName: "Google" },
+        })}
+        assistantId="assistant-1"
+        oauthClient={oauthClient}
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Connect" }));
+
+    // The connections list query is keyed by the platform-scoped assistant id
+    // (mocked to the input here); a successful connect must invalidate it so a
+    // just-connected account repaints as connected wherever the list is mounted.
+    const expectedKey = assistantsOauthConnectionsListQueryKey({
+      path: { assistant_id: "assistant-1" },
+    });
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: expectedKey });
+      expect(onAction).toHaveBeenCalledWith(
+        "surface-1",
+        "connect",
+        expect.objectContaining({ status: "connected", providerKey: "google" }),
+      );
+    });
+  });
+
+  test("does not refresh the connections cache when the user cancels", async () => {
+    const oauthClient: ManagedOAuthConnectClient = {
+      fetchProvider: mock(async () => null),
+      connect: mock(async () => ({ status: "cancelled" as const })),
+    };
+
+    const { getByRole, invalidateQueries } = renderWithClient(
+      <OAuthConnectSurface
+        surface={makeSurface({
+          surfaceType: "oauth_connect",
+          data: { providerKey: "google", displayName: "Google" },
+        })}
+        assistantId="assistant-1"
+        oauthClient={oauthClient}
+        onAction={mock(() => {})}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => {
+      expect(oauthClient.connect).toHaveBeenCalledTimes(1);
+    });
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  test("does not refresh the connections cache on a connect error", async () => {
+    const oauthClient: ManagedOAuthConnectClient = {
+      fetchProvider: mock(async () => null),
+      connect: mock(async () => ({
+        status: "error" as const,
+        message: "Authorization failed.",
+      })),
+    };
+
+    const { getByRole, findByText, invalidateQueries } = renderWithClient(
+      <OAuthConnectSurface
+        surface={makeSurface({
+          surfaceType: "oauth_connect",
+          data: { providerKey: "google", displayName: "Google" },
+        })}
+        assistantId="assistant-1"
+        oauthClient={oauthClient}
+        onAction={mock(() => {})}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Connect" }));
+
+    // The error message surfaces once the flow settles.
+    expect(await findByText("Authorization failed.")).toBeTruthy();
+    expect(invalidateQueries).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
@@ -160,12 +160,11 @@ export function OAuthConnectSurface({
         accountLabel: result.connection?.account_label,
         scopesGranted: result.connection?.scopes_granted ?? [],
       });
-      // The settings connect hooks (use-oauth-connect) refresh the connections
-      // list on success, but this surface-driven flow never did — so a
-      // just-connected account still read as unconnected anywhere the list
-      // query is mounted (e.g. the settings integrations page). Invalidate the
-      // platform-assistant-scoped list key so it refetches. Best-effort: skip
-      // silently if the platform id can't resolve.
+      // Invalidate the platform-assistant-scoped connections list so anywhere
+      // that query is mounted (e.g. the settings integrations page) refetches
+      // and reflects the just-connected account. Mirrors the settings connect
+      // hooks (use-oauth-connect). Best-effort: skip silently if the platform
+      // id can't resolve.
       void resolveLocalAssistantPlatformIdentity(assistantId)
         .then((platformAssistantId) => {
           void queryClient.invalidateQueries({

--- a/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@vellumai/design-library";
+import { useQueryClient } from "@tanstack/react-query";
 import {
     CheckCircle2,
     ExternalLink,
@@ -16,6 +17,8 @@ import {
     type ManagedOAuthProviderSummary,
 } from "@/domains/chat/api/managed-oauth";
 import type { Surface } from "@/domains/chat/types/types";
+import { assistantsOauthConnectionsListQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 
 interface OAuthConnectSurfaceData {
   providerKey?: string;
@@ -99,6 +102,7 @@ export function OAuthConnectSurface({
   assistantDisplayName,
   oauthClient = defaultManagedOAuthConnectClient,
 }: OAuthConnectSurfaceProps) {
+  const queryClient = useQueryClient();
   const data = surface.data as OAuthConnectSurfaceData;
   const providerKey = data.providerKey ?? "";
   const [provider, setProvider] = useState<ManagedOAuthProviderSummary | null>(
@@ -156,6 +160,21 @@ export function OAuthConnectSurface({
         accountLabel: result.connection?.account_label,
         scopesGranted: result.connection?.scopes_granted ?? [],
       });
+      // The settings connect hooks (use-oauth-connect) refresh the connections
+      // list on success, but this surface-driven flow never did — so a
+      // just-connected account still read as unconnected anywhere the list
+      // query is mounted (e.g. the settings integrations page). Invalidate the
+      // platform-assistant-scoped list key so it refetches. Best-effort: skip
+      // silently if the platform id can't resolve.
+      void resolveLocalAssistantPlatformIdentity(assistantId)
+        .then((platformAssistantId) => {
+          void queryClient.invalidateQueries({
+            queryKey: assistantsOauthConnectionsListQueryKey({
+              path: { assistant_id: platformAssistantId },
+            }),
+          });
+        })
+        .catch(() => {});
       return;
     }
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -30,6 +30,8 @@ import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
@@ -90,6 +92,43 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
   avatarQueryKey: (id: string) => ["assistantAvatar", id],
 }));
 
+// Stub the OAuth connect surface (managed-oauth + React Query graph): the room
+// only needs to mount it with the right props and let its Connect fire the
+// shared surface-action handler, so a button that echoes those props is enough.
+mock.module("@/domains/chat/components/surfaces/oauth-connect-surface", () => ({
+  OAuthConnectSurface: ({
+    surface,
+    assistantId,
+    assistantDisplayName,
+    onAction,
+  }: {
+    surface: { surfaceId: string };
+    assistantId: string | null;
+    assistantDisplayName?: string | null;
+    onAction: (surfaceId: string, actionId: string, data?: unknown) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="room-oauth-connect"
+      data-assistant-id={assistantId ?? ""}
+      data-assistant-name={assistantDisplayName ?? ""}
+      onClick={() => onAction(surface.surfaceId, "connect", {})}
+    >
+      Connect
+    </button>
+  ),
+}));
+
+// The room routes an in-room connect through the same imperative handler the
+// transcript uses; stub it so a click is assertable without the stream/turn
+// store side effects.
+const mockHandleSurfaceAction = mock(
+  (..._args: unknown[]): Promise<void> => Promise.resolve(),
+);
+mock.module("@/domains/chat/surface-actions", () => ({
+  handleSurfaceAction: (...args: unknown[]) => mockHandleSurfaceAction(...args),
+}));
+
 /** Minimal character components: one body/eye/color of each. */
 const CHARACTER_COMPONENTS = {
   bodyShapes: [
@@ -131,6 +170,7 @@ beforeEach(() => {
   controls.stop.mockClear();
   controls.release.mockClear();
   controls.interrupt.mockClear();
+  mockHandleSurfaceAction.mockClear();
   useLiveVoiceStore.getState().reset();
   useConversationStore
     .getState()
@@ -146,7 +186,44 @@ afterEach(() => {
   cleanup();
   useLiveVoiceStore.getState().reset();
   useConversationStore.getState().reset();
+  // Clear any seeded transcript / identity so the pending-surface slot never
+  // bleeds into another test's room.
+  useChatSessionStore.setState({ snapshot: null } as never);
+  useAssistantIdentityStore.getState().clearIdentity();
 });
+
+/**
+ * Seed a single assistant message carrying one `oauth_connect` surface into the
+ * transcript snapshot the room reads from.
+ */
+function seedOAuthConnectSurface(
+  overrides: { completed?: boolean } = {},
+): void {
+  useChatSessionStore.setState({
+    snapshot: {
+      messages: [
+        {
+          id: "assistant-msg-1",
+          role: "assistant",
+          surfaces: [
+            {
+              surfaceId: "oauth-1",
+              surfaceType: "oauth_connect",
+              data: { providerKey: "google", displayName: "Google" },
+              ...(overrides.completed ? { completed: true } : {}),
+            },
+          ],
+        },
+      ],
+      seq: 1,
+      processing: false,
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+      backgroundToolCompletions: [],
+    },
+  } as never);
+}
 
 const roomDialog = () =>
   screen.queryByRole("dialog", { name: "Voice session" });
@@ -594,5 +671,49 @@ describe("VoiceRoom — no push-to-talk / manual-release affordance (hands-free)
     render(<VoiceRoom />);
     expect(screen.queryByRole("button", { name: "Speak" })).toBeNull();
     expect(screen.queryByRole("button", { name: /Send now/ })).toBeNull();
+  });
+});
+
+describe("VoiceRoom — in-room OAuth connect card", () => {
+  const connectCard = () => screen.queryByTestId("room-oauth-connect");
+
+  test("renders no connect card when no oauth_connect surface is pending", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(roomDialog()).not.toBeNull();
+    expect(connectCard()).toBeNull();
+  });
+
+  test("mounts a clickable connect card for a pending oauth_connect surface, threading assistant props", () => {
+    // A live-voice turn's connect card is otherwise stranded behind the modal;
+    // the room re-hosts it so the user can actually connect.
+    useAssistantIdentityStore.getState().setIdentity("Aria", null);
+    seedOAuthConnectSurface();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    const card = connectCard();
+    expect(card).not.toBeNull();
+    expect((card as HTMLButtonElement).disabled).toBe(false);
+    // Wired like the transcript's SurfaceRouter: the session assistant + its
+    // display name.
+    expect(card!.getAttribute("data-assistant-id")).toBe(ASSISTANT_ID);
+    expect(card!.getAttribute("data-assistant-name")).toBe("Aria");
+  });
+
+  test("an in-room connect routes through the shared surface-action handler", () => {
+    seedOAuthConnectSurface();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    fireEvent.click(connectCard()!);
+    expect(mockHandleSurfaceAction).toHaveBeenCalledWith("oauth-1", "connect", {});
+  });
+
+  test("does not render a completed oauth_connect surface", () => {
+    seedOAuthConnectSurface({ completed: true });
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(connectCard()).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -39,7 +39,7 @@
  * is. The key handler attaches only while the room is mounted.
  */
 
-import { useEffect, type CSSProperties } from "react";
+import { useEffect, useMemo, type CSSProperties } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Captions, CaptionsOff, Mic, MicOff, Square, X } from "lucide-react";
 
@@ -54,8 +54,13 @@ import {
   stopLiveVoiceResponse,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { OAuthConnectSurface } from "@/domains/chat/components/surfaces/oauth-connect-surface";
+import { handleSurfaceAction } from "@/domains/chat/surface-actions";
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import type { Surface } from "@/domains/chat/types/types";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { toneForBg } from "@/utils/surface-tone";
 
@@ -284,6 +289,13 @@ function VoiceRoomOverlay() {
           avatar and stays absent by default. */}
       <VoiceAmbientTranscript />
 
+      {/* A pending OAuth connect surface raised by the (voice) turn. The
+          transcript's own copy of this card is sealed behind the room's
+          `pointer-events-none blur-sm` cover (chat-layout), so a live-voice
+          turn that needs an account connected would strand the user — render a
+          live, clickable instance here inside the modal instead. */}
+      <VoiceRoomOAuthConnectSlot assistantId={assistantId} />
+
       {/* Room controls — captions toggle and the persistent exit. Rendered
           above all room chrome; ✕ is never gated behind avatar readiness, so
           ending works even mid-load / on failure. */}
@@ -436,5 +448,60 @@ function VoiceRoomOverlay() {
         {muted ? `Muted — ${stateLabel}` : stateLabel}
       </div>
     </motion.div>
+  );
+}
+
+/**
+ * The transcript surface the room re-hosts: the newest pending (not yet
+ * completed) `oauth_connect` card. Read from the same transcript state the
+ * chat body renders from, so completing it there (or from here — both go
+ * through {@link handleSurfaceAction}) drops it from both instances at once.
+ */
+function usePendingOAuthConnectSurface(): Surface | null {
+  const messages = useTranscriptMessages();
+  return useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const match = messages[i]?.surfaces?.find(
+        (s) => s.surfaceType === "oauth_connect" && !s.completed,
+      );
+      if (match) return match;
+    }
+    return null;
+  }, [messages]);
+}
+
+/**
+ * In-room mount of the active pending `oauth_connect` surface. The room is a
+ * `fixed inset-0` modal over the sealed (`pointer-events-none`) transcript, so
+ * the transcript's own card is invisible and unclickable during a session —
+ * this is the only reachable Connect button while voice is live. Wired exactly
+ * as {@link SurfaceRouter} wires it in the transcript (assistantId, the
+ * assistant display name, {@link handleSurfaceAction}), so a connect here is
+ * indistinguishable from one in the transcript. Renders nothing when no
+ * `oauth_connect` is pending.
+ */
+function VoiceRoomOAuthConnectSlot({
+  assistantId,
+}: {
+  assistantId: string | null;
+}) {
+  const surface = usePendingOAuthConnectSurface();
+  const assistantName = useAssistantIdentityStore.use.name();
+  if (!surface) return null;
+
+  return (
+    // The card floats above the room's centerpiece, clearing the bottom-corner
+    // session controls; only the card itself takes pointer events so the rest
+    // of the modal stays as it was.
+    <div className="pointer-events-none absolute inset-x-0 bottom-28 z-20 flex justify-center px-4">
+      <div className="pointer-events-auto w-full max-w-md">
+        <OAuthConnectSurface
+          surface={surface}
+          onAction={handleSurfaceAction}
+          assistantId={assistantId}
+          assistantDisplayName={assistantName?.trim() || undefined}
+        />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Render the active pending oauth_connect surface inside the voice-room modal so users can connect during a live-voice session
- Invalidate the OAuth connections query cache after a successful surface-driven connect

Part of plan: voice-seam-oauth.md (PR 2 of 2)