### PR TITLE
Resume interactive surfaces as spoken voice turns

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -12,6 +12,13 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
   await import("../daemon/conversation-surfaces.js");
 
+const { registerVoiceResumeHandler, unregisterVoiceResumeHandler } =
+  await import("../live-voice/live-voice-resume-registry.js");
+import type { VoiceResumeHandler } from "../live-voice/live-voice-resume-registry.js";
+
+const { LiveVoiceSession } =
+  await import("../live-voice/live-voice-session.js");
+import type { VoiceTurnOptions } from "../calls/voice-session-bridge.js";
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type {
   SurfaceData,
@@ -19,6 +26,11 @@ import type {
   UiSurfaceShow,
 } from "../daemon/message-protocol.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice/live-voice-session-manager.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../stt/types.js";
 
 interface ProcessMessageCall {
   content: string;
@@ -76,6 +88,19 @@ function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext & {
     withSurface: createSurfaceMutex(),
     processMessageCalls,
   };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
 }
 
 describe("surface action delivery to assistant", () => {
@@ -512,6 +537,175 @@ describe("surface action delivery to assistant", () => {
     expect(completeMsg?.conversationId).toBe("conv-1");
     expect(completeMsg?.summary).toBe("Connected Google: user@example.com");
     expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+  });
+
+  test("live-voice resume: oauth_connect completion routes to resumeWithText, not processMessage", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const resumeCalls: Array<{
+      content: string;
+      opts?: { displayContent?: string; sourceActorPrincipalId?: string };
+    }> = [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler("conv-1", handler);
+
+    try {
+      await surfaceProxyResolver(ctx, "ui_show", {
+        surface_type: "oauth_connect",
+        title: "Connect Google",
+        data: { providerKey: "google", displayName: "Google" },
+      });
+
+      const showMessage = sent.find(
+        (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+      ) as UiSurfaceShow;
+      const surfaceId = showMessage.surfaceId;
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(true);
+
+      await handleSurfaceAction(
+        ctx,
+        surfaceId,
+        "connect",
+        {
+          status: "connected",
+          providerKey: "google",
+          providerLabel: "Google",
+          accountLabel: "user@example.com",
+        },
+        "principal-committer",
+      );
+
+      // Routed to the spoken voice resume, NOT the silent text path.
+      expect(ctx.processMessageCalls.length).toBe(0);
+      expect(resumeCalls.length).toBe(1);
+      expect(resumeCalls[0]!.content).toContain("oauth_connect");
+      expect(resumeCalls[0]!.opts?.sourceActorPrincipalId).toBe(
+        "principal-committer",
+      );
+      // The pending-surface guard is cleared on the voice-routed path too.
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      unregisterVoiceResumeHandler("conv-1", handler);
+    }
+  });
+
+  test("live-voice resume: falls back to processMessage when no handler is registered", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "oauth_connect",
+      title: "Connect Google",
+      data: { providerKey: "google", displayName: "Google" },
+    });
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    ) as UiSurfaceShow;
+    const surfaceId = showMessage.surfaceId;
+
+    await handleSurfaceAction(ctx, surfaceId, "connect", {
+      status: "connected",
+      providerKey: "google",
+      providerLabel: "Google",
+      accountLabel: "user@example.com",
+    });
+
+    // No voice handler for this conversation — the text path runs verbatim.
+    expect(ctx.processMessageCalls.length).toBe(1);
+    expect(ctx.processMessageCalls[0]!.content).toContain("oauth_connect");
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+  });
+
+  test("live-voice resume end-to-end: oauth_connect completion runs a spoken continuation turn and clears the pending guard", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // A real live-voice session that registers a resume handler for this
+    // conversation on start and speaks a continuation when resumed.
+    const sessionFrames: Array<{ type: string }> = [];
+    const sessionContext: LiveVoiceSessionFactoryContext = {
+      sessionId: "voice-session-e2e",
+      startFrame: {
+        type: "start",
+        conversationId: "conv-1",
+        audio: { mimeType: "audio/pcm", sampleRate: 24_000, channels: 1 },
+      },
+      sendFrame: async (payload) => {
+        const frame = { ...payload } as { type: string };
+        sessionFrames.push(frame);
+        return frame as never;
+      },
+    };
+    const idleTranscriber: StreamingTranscriber = {
+      providerId: "deepgram",
+      boundaryId: "daemon-streaming",
+      async start(_onEvent: (event: SttStreamServerEvent) => void) {
+        // Idle transcriber: the resume path never streams audio.
+      },
+      sendAudio() {},
+      stop() {},
+    };
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "Great, Google is connected.",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-e2e",
+      });
+      return { turnId: "bridge-e2e-1", abort: mock() };
+    });
+    const session = new LiveVoiceSession(sessionContext, {
+      resolveTranscriber: async () => idleTranscriber,
+      startVoiceTurn,
+      createTurnId: () => "voice-turn-e2e",
+      emitMetrics: false,
+    });
+
+    await session.start();
+
+    try {
+      // A voice turn raised an oauth_connect surface and yielded.
+      await surfaceProxyResolver(ctx, "ui_show", {
+        surface_type: "oauth_connect",
+        title: "Connect Google",
+        data: { providerKey: "google", displayName: "Google" },
+      });
+      const showMessage = sent.find(
+        (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+      ) as UiSurfaceShow;
+      const surfaceId = showMessage.surfaceId;
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(true);
+
+      // The user completes the connect surface.
+      await handleSurfaceAction(ctx, surfaceId, "connect", {
+        status: "connected",
+        providerKey: "google",
+        providerLabel: "Google",
+        accountLabel: "user@example.com",
+      });
+
+      // Spoken continuation ran through the live-voice session, not the
+      // silent text path.
+      await waitFor(() => sessionFrames.some((f) => f.type === "tts_done"));
+      expect(ctx.processMessageCalls.length).toBe(0);
+      expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+      const types = sessionFrames.map((f) => f.type);
+      expect(types).not.toContain("stt_final");
+      expect(types).toContain("thinking");
+      expect(types).toContain("assistant_text_delta");
+      // The pending-surface guard is cleared after the voice-routed completion.
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      await session.close("client_end");
+    }
   });
 
   test("table surface does NOT broadcast ui_surface_complete (not one-shot)", async () => {

--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -545,7 +545,11 @@ describe("surface action delivery to assistant", () => {
 
     const resumeCalls: Array<{
       content: string;
-      opts?: { displayContent?: string; sourceActorPrincipalId?: string };
+      opts?: {
+        displayContent?: string;
+        sourceActorPrincipalId?: string;
+        requestId?: string;
+      };
     }> = [];
     const handler: VoiceResumeHandler = {
       resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
@@ -584,6 +588,18 @@ describe("surface action delivery to assistant", () => {
       expect(resumeCalls[0]!.content).toContain("oauth_connect");
       expect(resumeCalls[0]!.opts?.sourceActorPrincipalId).toBe(
         "principal-committer",
+      );
+      // The accepted surface-action request id rides into the resume and is the
+      // one tracked in `surfaceActionRequestIds`, so the resumed turn adopting
+      // it keeps `currentRequestId` inside the surface-action set.
+      const resumeRequestId = resumeCalls[0]!.opts?.requestId;
+      expect(resumeRequestId).toBeDefined();
+      expect(ctx.surfaceActionRequestIds.has(resumeRequestId!)).toBe(true);
+      // The user-facing label (not the raw payload) rides along for the
+      // persisted/echoed user row.
+      expect(resumeCalls[0]!.opts?.displayContent).toBeDefined();
+      expect(resumeCalls[0]!.opts?.displayContent).not.toContain(
+        "[User action on",
       );
       // The pending-surface guard is cleared on the voice-routed path too.
       expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -20,8 +20,30 @@ import { describe, expect, mock, setSystemTime, test } from "bun:test";
 // Swapped per-test to hand startVoiceTurn a scripted fake conversation.
 let fakeConversation: FakeConversation;
 
+// Captures every message the bridge broadcasts (e.g. `user_message_echo`), so
+// tests can assert what the transcript/hub sees. Reset per test.
+const broadcasts: Array<{ type: string; [k: string]: unknown }> = [];
+
 mock.module("../../daemon/conversation-store.js", () => ({
   getOrCreateConversation: async () => fakeConversation,
+}));
+
+// Non-synthetic content reaches the user-echo broadcast + persisted-seq
+// side-effect path; stub those to capture the echo and keep the DB/event-hub
+// out of the unit test.
+mock.module("../../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: { type: string; [k: string]: unknown }) => {
+    broadcasts.push(msg);
+  },
+}));
+mock.module("../../persistence/conversation-crud.js", () => ({
+  recordConversationPersistedSeq: () => {},
+}));
+mock.module("../../runtime/assistant-stream-state.js", () => ({
+  getCurrentSeq: () => 0,
+}));
+mock.module("../../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationMessagesChanged: () => {},
 }));
 
 import { setConfig } from "../../__tests__/helpers/set-config.js";
@@ -65,6 +87,7 @@ interface FakeConversation {
   persistUserMessage: (opts: {
     content: string;
     requestId: string;
+    displayContent?: string;
     metadata?: Record<string, unknown>;
   }) => Promise<{ id: string }>;
   updateClient: (cb: unknown, reset?: boolean) => void;
@@ -85,7 +108,12 @@ function makeFakeConversation(opts: {
   const waitForIdleCalls: WaitForIdleCall[] = [];
   let persistCount = 0;
   let lastPersistOpts:
-    | { content: string; requestId: string; metadata?: Record<string, unknown> }
+    | {
+        content: string;
+        requestId: string;
+        displayContent?: string;
+        metadata?: Record<string, unknown>;
+      }
     | undefined;
   const conversation: FakeConversation = {
     conversationId: "conv-voice-bridge-test",
@@ -291,6 +319,60 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
     await startVoiceTurn(makeTurnOptions()); // content: CALL_OPENING_MARKER
 
     expect(fake.lastPersistOpts()?.metadata).toBeUndefined();
+  });
+});
+
+describe("startVoiceTurn surface-resume metadata", () => {
+  test("adopts the supplied requestId and persists/echoes displayContent", async () => {
+    broadcasts.length = 0;
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      // A real surface-resume turn: raw model-facing content + a friendly label
+      // + the accepted surface-action request id.
+      content: "[User action on table surface: archive]",
+      requestId: "surface-request-1",
+      displayContent: "Archive selected emails",
+    });
+
+    // The turn adopts the surface request id (so `currentRequestId` stays in
+    // `surfaceActionRequestIds`) rather than minting a fresh one.
+    expect(fake.lastPersistOpts()?.requestId).toBe("surface-request-1");
+    // The persisted row stores the friendly label; the model still receives the
+    // raw content.
+    expect(fake.lastPersistOpts()?.content).toBe(
+      "[User action on table surface: archive]",
+    );
+    expect(fake.lastPersistOpts()?.displayContent).toBe(
+      "Archive selected emails",
+    );
+
+    // The user echo carries the label, never the raw `[User action on …]`
+    // payload.
+    const echo = broadcasts.find((m) => m.type === "user_message_echo");
+    expect(echo).toBeDefined();
+    expect(echo?.text).toBe("Archive selected emails");
+    expect(echo?.requestId).toBe("surface-request-1");
+  });
+
+  test("a normal turn mints its own requestId and echoes raw content", async () => {
+    broadcasts.length = 0;
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what's the weather",
+    });
+
+    // No caller requestId → a fresh one is minted (not undefined).
+    expect(fake.lastPersistOpts()?.requestId).toBeString();
+    expect(fake.lastPersistOpts()?.displayContent).toBeUndefined();
+
+    const echo = broadcasts.find((m) => m.type === "user_message_echo");
+    expect(echo?.text).toBe("what's the weather");
   });
 });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -221,6 +221,22 @@ export interface VoiceTurnOptions {
    * supplies its own `voiceControlPrompt`.
    */
   routingLeg?: VoiceRoutingLeg;
+  /**
+   * Request id to adopt for this turn instead of minting a fresh one. Set by a
+   * live-voice surface resume to the accepted surface-action request id, so the
+   * turn's `currentRequestId` stays inside the conversation's
+   * `surfaceActionRequestIds` set and surface-gated tools
+   * (`ToolContext.triggeredBySurfaceAction`) run. Undefined = mint one.
+   */
+  requestId?: string;
+  /**
+   * User-facing label persisted and echoed for this turn's user message in
+   * place of the model-facing `content`. Set by a live-voice surface resume so
+   * the transcript/history shows the friendly surface label (parity with the
+   * text path) rather than the raw `[User action on …]` payload. The agent loop
+   * still receives `content`. Undefined = persist/echo `content`.
+   */
+  displayContent?: string;
 }
 
 export interface VoiceTurnHandle {
@@ -596,12 +612,18 @@ export async function startVoiceTurn(
     }
   };
 
-  const requestId = uuidv7();
+  const requestId = opts.requestId ?? uuidv7();
   const turnId = crypto.randomUUID();
   const persistTurnUserMessage = async (): Promise<string> => {
     const persistResult = await conversation.persistUserMessage({
       content: persistedContent,
       requestId,
+      // Persist the user-facing label (when the caller supplied one) so
+      // `/messages` shows it after a refetch — the agent loop still receives
+      // `persistedContent`. Parity with the text path's `displayContent`.
+      ...(opts.displayContent !== undefined
+        ? { displayContent: opts.displayContent }
+        : {}),
       ...(isHiddenSyntheticPrompt ? { metadata: { hidden: true } } : {}),
     });
     return persistResult.id;
@@ -799,7 +821,10 @@ export async function startVoiceTurn(
   if (!isSyntheticVoicePrompt) {
     broadcastMessage({
       type: "user_message_echo",
-      text: persistedContent,
+      // Echo the user-facing label when supplied (surface resume), matching the
+      // persisted row and the text path — never the raw `[User action on …]`
+      // payload.
+      text: opts.displayContent ?? persistedContent,
       conversationId: opts.conversationId,
       messageId,
       requestId,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -17,6 +17,7 @@ import {
   resolveEffectiveAppHtml,
   updateApp,
 } from "../apps/app-store.js";
+import { getVoiceResumeHandler } from "../live-voice/live-voice-resume-registry.js";
 import { recordActivationEvent } from "../onboarding/onboarding-events-store.js";
 import {
   getMessages,
@@ -2463,6 +2464,30 @@ export async function handleSurfaceAction(
     },
     "Processing surface action as follow-up with attachments",
   );
+
+  // A live-voice conversation resumes as a *spoken* turn: route the follow-up
+  // through the voice session instead of the silent text `processMessage`
+  // path, so completing e.g. an oauth_connect surface produces a spoken
+  // continuation that re-reads connection state at turn start (JARVIS-1286/7).
+  // Attachments never travel this path (OAuth connect carries none); if any
+  // are present, fall back to `processMessage` so the model still sees them.
+  const voiceResumeHandler = getVoiceResumeHandler(ctx.conversationId);
+  if (voiceResumeHandler && pendingAttachments.length === 0) {
+    voiceResumeHandler.resumeWithText(content, {
+      ...(displayContent !== undefined ? { displayContent } : {}),
+      ...(sourceActorPrincipalId !== undefined
+        ? { sourceActorPrincipalId }
+        : {}),
+    });
+    return;
+  }
+  if (voiceResumeHandler && pendingAttachments.length > 0) {
+    log.warn(
+      { surfaceId, actionId, attachmentCount: pendingAttachments.length },
+      "Live-voice resume skipped: surface action carries attachments; falling back to text processMessage",
+    );
+  }
+
   ctx
     .processMessage({
       content,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2473,11 +2473,16 @@ export async function handleSurfaceAction(
   // are present, fall back to `processMessage` so the model still sees them.
   const voiceResumeHandler = getVoiceResumeHandler(ctx.conversationId);
   if (voiceResumeHandler && pendingAttachments.length === 0) {
+    // Reuse the accepted surface-action `requestId` (already in
+    // `ctx.surfaceActionRequestIds`) as the resumed turn's request id, so a
+    // tool gated on `triggeredBySurfaceAction` still sees `currentRequestId`
+    // in the set — parity with the text path below, which passes it too.
     voiceResumeHandler.resumeWithText(content, {
       ...(displayContent !== undefined ? { displayContent } : {}),
       ...(sourceActorPrincipalId !== undefined
         ? { sourceActorPrincipalId }
         : {}),
+      requestId,
     });
     return;
   }

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -8,6 +8,7 @@ import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
+import { getVoiceResumeHandler } from "../live-voice-resume-registry.js";
 import {
   LiveVoiceSession,
   type LiveVoiceTurnStarter,
@@ -396,5 +397,75 @@ describe("LiveVoiceSession assistant turn", () => {
       "stt_final",
       "thinking",
     ]);
+  });
+});
+
+describe("LiveVoiceSession surface resume", () => {
+  test("resumeWithText runs a spoken synthetic turn with no user transcript", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "You're connected. ",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-resume",
+      });
+      return { turnId: "bridge-resume-1", abort: mock() };
+    });
+    const { frames, session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    session.resumeWithText("[User connected Google: user@example.com]");
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      conversationId: "conversation-123",
+      content: "[User connected Google: user@example.com]",
+      isInbound: true,
+    });
+    const types = frames.map((frame) => frame.type);
+    // No user speech is echoed for a resume: no stt_final frame is emitted.
+    expect(types).not.toContain("stt_final");
+    expect(types).toEqual([
+      "ready",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+
+    await session.close("client_end");
+  });
+
+  test("registers a discoverable resume handler while active and clears it on close", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "Done.",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-resume",
+      });
+      return { turnId: "bridge-resume-1", abort: mock() };
+    });
+    const { frames, session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+
+    const handler = getVoiceResumeHandler("conversation-123");
+    expect(handler).toBeDefined();
+
+    handler?.resumeWithText("[User connected Google]");
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+
+    await session.close("client_end");
+    expect(getVoiceResumeHandler("conversation-123")).toBeUndefined();
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -468,4 +468,61 @@ describe("LiveVoiceSession surface resume", () => {
     await session.close("client_end");
     expect(getVoiceResumeHandler("conversation-123")).toBeUndefined();
   });
+
+  test("threads the surface-action requestId and displayContent into the resumed turn", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "Archived. ",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-resume",
+      });
+      return { turnId: "bridge-resume-1", abort: mock() };
+    });
+    const { session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    session.resumeWithText("[User action on table surface: archive]", {
+      displayContent: "Archive selected emails",
+      requestId: "surface-request-1",
+    });
+    await waitFor(() => startVoiceTurn.mock.calls.length > 0);
+
+    // The surface request id becomes the resumed turn's request id so
+    // `currentRequestId` lands in `surfaceActionRequestIds` and surface-gated
+    // tools run; the display label rides along for the persisted/echoed row.
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      content: "[User action on table surface: archive]",
+      requestId: "surface-request-1",
+      displayContent: "Archive selected emails",
+    });
+
+    await session.close("client_end");
+  });
+
+  test("a resume without opts mints no requestId or displayContent override", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-resume",
+      });
+      return { turnId: "bridge-resume-1", abort: mock() };
+    });
+    const { session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    session.resumeWithText("[User connected Google]");
+    await waitFor(() => startVoiceTurn.mock.calls.length > 0);
+
+    const opts = startVoiceTurn.mock.calls[0]?.[0];
+    expect(opts?.requestId).toBeUndefined();
+    expect(opts?.displayContent).toBeUndefined();
+
+    await session.close("client_end");
+  });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-resume-registry.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-resume-registry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getVoiceResumeHandler,
+  registerVoiceResumeHandler,
+  unregisterVoiceResumeHandler,
+  type VoiceResumeHandler,
+} from "../live-voice-resume-registry.js";
+
+function makeHandler(): VoiceResumeHandler {
+  return { resumeWithText: () => {} };
+}
+
+describe("live-voice resume registry", () => {
+  test("register makes a handler discoverable by conversation id", () => {
+    const conversationId = `conv-${crypto.randomUUID()}`;
+    const handler = makeHandler();
+
+    expect(getVoiceResumeHandler(conversationId)).toBeUndefined();
+    registerVoiceResumeHandler(conversationId, handler);
+    expect(getVoiceResumeHandler(conversationId)).toBe(handler);
+
+    unregisterVoiceResumeHandler(conversationId, handler);
+  });
+
+  test("register overwrites an existing handler for the same conversation", () => {
+    const conversationId = `conv-${crypto.randomUUID()}`;
+    const first = makeHandler();
+    const second = makeHandler();
+
+    registerVoiceResumeHandler(conversationId, first);
+    registerVoiceResumeHandler(conversationId, second);
+    expect(getVoiceResumeHandler(conversationId)).toBe(second);
+
+    unregisterVoiceResumeHandler(conversationId, second);
+  });
+
+  test("unregister deletes only when the stored handler is the one passed", () => {
+    const conversationId = `conv-${crypto.randomUUID()}`;
+    const current = makeHandler();
+    const stale = makeHandler();
+
+    registerVoiceResumeHandler(conversationId, current);
+
+    // A stale (older) session tearing down must not evict the current handler.
+    unregisterVoiceResumeHandler(conversationId, stale);
+    expect(getVoiceResumeHandler(conversationId)).toBe(current);
+
+    // The owning handler's unregister clears it.
+    unregisterVoiceResumeHandler(conversationId, current);
+    expect(getVoiceResumeHandler(conversationId)).toBeUndefined();
+  });
+});

--- a/assistant/src/live-voice/live-voice-resume-registry.ts
+++ b/assistant/src/live-voice/live-voice-resume-registry.ts
@@ -1,0 +1,56 @@
+/**
+ * Per-conversation registry that lets an interactive surface completion resume
+ * a live-voice conversation as a *spoken* turn instead of a silent text turn.
+ *
+ * The live-voice session (producer) registers a {@link VoiceResumeHandler} once
+ * it adopts a stable conversation id, and the surface-action dispatcher
+ * (consumer, in `daemon/conversation-surfaces.ts`) looks one up before falling
+ * back to `processMessage`.
+ *
+ * This module deliberately imports nothing from `daemon/` or `calls/`: keeping
+ * it a pure registry lets both the producer and the consumer depend on it
+ * without forming a require cycle.
+ */
+
+export interface VoiceResumeHandler {
+  /**
+   * Run `content` as a spoken assistant turn on the live-voice session. The
+   * turn is synthetic (no user speech): it is not echoed as a user utterance
+   * and connection state is re-read at turn start.
+   */
+  resumeWithText(
+    content: string,
+    opts?: { displayContent?: string; sourceActorPrincipalId?: string },
+  ): void;
+}
+
+const handlers = new Map<string, VoiceResumeHandler>();
+
+export function registerVoiceResumeHandler(
+  conversationId: string,
+  handler: VoiceResumeHandler,
+): void {
+  handlers.set(conversationId, handler);
+}
+
+/**
+ * Remove the handler for a conversation, but only when the stored handler is
+ * referentially the one passed. A newer session that adopted the same
+ * conversation id must not have its handler dropped by an older session's
+ * teardown (mirrors the identity-checked `pendingTurnTeardowns` guard in
+ * `calls/voice-session-bridge.ts`).
+ */
+export function unregisterVoiceResumeHandler(
+  conversationId: string,
+  handler: VoiceResumeHandler,
+): void {
+  if (handlers.get(conversationId) === handler) {
+    handlers.delete(conversationId);
+  }
+}
+
+export function getVoiceResumeHandler(
+  conversationId: string,
+): VoiceResumeHandler | undefined {
+  return handlers.get(conversationId);
+}

--- a/assistant/src/live-voice/live-voice-resume-registry.ts
+++ b/assistant/src/live-voice/live-voice-resume-registry.ts
@@ -17,10 +17,25 @@ export interface VoiceResumeHandler {
    * Run `content` as a spoken assistant turn on the live-voice session. The
    * turn is synthetic (no user speech): it is not echoed as a user utterance
    * and connection state is re-read at turn start.
+   *
+   * `requestId` (when supplied) is the accepted surface-action request id. The
+   * resumed turn adopts it as its own request id so `currentRequestId` lands in
+   * the conversation's `surfaceActionRequestIds` set — otherwise a tool gated on
+   * `ToolContext.triggeredBySurfaceAction` (e.g. archive-by-sender) would reject
+   * the resumed turn even though the user clicked the surface.
+   *
+   * `displayContent` (when supplied) is the user-facing label the resumed turn
+   * persists and echoes instead of the model-facing `content`, matching the
+   * text path so the transcript shows the friendly label, not the raw
+   * `[User action on …]` payload.
    */
   resumeWithText(
     content: string,
-    opts?: { displayContent?: string; sourceActorPrincipalId?: string },
+    opts?: {
+      displayContent?: string;
+      sourceActorPrincipalId?: string;
+      requestId?: string;
+    },
   ): void;
 }
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -122,6 +122,18 @@ export type LiveVoiceTurnStarter = (
   options: VoiceTurnOptions,
 ) => Promise<VoiceTurnHandle>;
 
+/**
+ * Per-turn overrides carried from an interactive-surface completion into the
+ * resumed voice turn. `requestId` is the accepted surface-action request id
+ * (keeps `currentRequestId` in the conversation's `surfaceActionRequestIds`
+ * set); `displayContent` is the user-facing label persisted/echoed in place of
+ * the model-facing content.
+ */
+interface ResumeTurnMetadata {
+  requestId?: string;
+  displayContent?: string;
+}
+
 export type LiveVoiceTtsStreamer = (
   options: LiveVoiceTtsOptions,
 ) => Promise<LiveVoiceTtsResult>;
@@ -1482,6 +1494,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private async startAssistantTurnForUtterance(
     utterance: UtteranceCycle,
     content: string,
+    resume?: ResumeTurnMetadata,
   ): Promise<void> {
     utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
@@ -1536,6 +1549,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             frontDoor: true,
           }
         : { content },
+      resume,
     );
   }
 
@@ -1552,7 +1566,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    */
   resumeWithText(
     content: string,
-    opts?: { displayContent?: string; sourceActorPrincipalId?: string },
+    opts?: {
+      displayContent?: string;
+      sourceActorPrincipalId?: string;
+      requestId?: string;
+    },
   ): void {
     const trimmed = content.trim();
     if (trimmed.length === 0) {
@@ -1563,16 +1581,30 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         conversationId: this.conversationId,
         hasDisplayContent: opts?.displayContent != null,
         sourceActorPrincipalId: opts?.sourceActorPrincipalId,
+        requestId: opts?.requestId,
       },
       "Live voice resume requested from interactive surface completion",
     );
+    // The surface-action request id and user-facing label ride the turn down to
+    // `startVoiceTurn`: the id keeps `currentRequestId` inside the accepted
+    // `surfaceActionRequestIds` set (so surface-gated tools run), and the label
+    // is what the persisted user row / echo shows instead of the raw payload.
+    const resume: ResumeTurnMetadata = {
+      ...(opts?.requestId !== undefined ? { requestId: opts.requestId } : {}),
+      ...(opts?.displayContent !== undefined
+        ? { displayContent: opts.displayContent }
+        : {}),
+    };
     this.resumeChain = this.resumeChain
       .catch(() => {})
-      .then(() => this.runResumeTurn(trimmed));
+      .then(() => this.runResumeTurn(trimmed, resume));
     void this.resumeChain.catch(() => {});
   }
 
-  private async runResumeTurn(content: string): Promise<void> {
+  private async runResumeTurn(
+    content: string,
+    resume?: ResumeTurnMetadata,
+  ): Promise<void> {
     if (this.isClosedOrFailed || !this.startVoiceTurn) {
       return;
     }
@@ -1590,7 +1622,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       released: true,
       finalTranscriptSegments: [content],
     });
-    await this.startAssistantTurnForUtterance(utterance, content);
+    await this.startAssistantTurnForUtterance(utterance, content, resume);
   }
 
   /**
@@ -1614,6 +1646,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       routingLeg?: VoiceRoutingLeg;
       frontDoor?: boolean;
     },
+    // Surface-resume metadata for the primary leg only. `escalateTurn` starts
+    // the escalated continuation leg without it: that leg persists an internal
+    // `[continue]` prompt, so it must neither reuse the surface request id nor
+    // show the surface's user-facing label.
+    resume?: ResumeTurnMetadata,
   ): Promise<void> {
     if (!this.startVoiceTurn) {
       return;
@@ -1687,6 +1724,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           ? { overrideProfile: leg.overrideProfile }
           : {}),
         ...(leg.routingLeg != null ? { routingLeg: leg.routingLeg } : {}),
+        ...(resume?.requestId != null ? { requestId: resume.requestId } : {}),
+        ...(resume?.displayContent != null
+          ? { displayContent: resume.displayContent }
+          : {}),
         callbacks: {
           assistant_text_delta: (msg) => {
             if (!this.isForwardingAssistantText(token)) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -55,6 +55,11 @@ import {
   type LiveVoiceTurnSeedMarks,
 } from "./live-voice-metrics.js";
 import {
+  registerVoiceResumeHandler,
+  unregisterVoiceResumeHandler,
+  type VoiceResumeHandler,
+} from "./live-voice-resume-registry.js";
+import {
   type LiveVoiceSession as LiveVoiceSessionContract,
   type LiveVoiceSessionCloseReason,
   type LiveVoiceSessionFactoryContext,
@@ -302,6 +307,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private currentUtterance: UtteranceCycle | null = null;
   private outboundFrames: Promise<void> = Promise.resolve();
   private activeAssistantTurn: ActiveAssistantTurn | null = null;
+  // Serializes surface-completion resumes so back-to-back resumes on the same
+  // conversation run one after another rather than clobbering each other.
+  private resumeChain: Promise<void> = Promise.resolve();
+  // Resolved whenever the active assistant turn clears, so a queued resume can
+  // wait for turn-idle instead of throwing CONVERSATION_BUSY.
+  private assistantTurnIdleWaiters: Array<() => void> = [];
+  // Stable handler reference for the resume registry: the same object is used
+  // for register (on start) and the identity-checked unregister (on close).
+  private readonly voiceResumeHandler: VoiceResumeHandler = {
+    resumeWithText: (content, opts) => this.resumeWithText(content, opts),
+  };
   private sessionEndMetricsEmitted = false;
   // Non-null iff the start frame requested turnDetection "server_vad".
   private readonly turnDetector: MediaTurnDetector | null;
@@ -445,6 +461,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // through the pending/pre-roll paths and flushes on arm. An arm failure
     // surfaces as a non-recoverable error frame instead of a start rejection.
     this.state = "active";
+    // The conversation id is stable now (adopted from the start frame); expose a
+    // resume handler so an interactive-surface completion on this conversation
+    // resumes as a spoken voice turn instead of a silent text turn.
+    registerVoiceResumeHandler(this.conversationId, this.voiceResumeHandler);
     void this.armUtterance().catch(() => {});
     this.metrics.markReady();
     await this.sendFrame({
@@ -488,6 +508,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
+    unregisterVoiceResumeHandler(this.conversationId, this.voiceResumeHandler);
+    this.resolveAssistantTurnIdleWaiters();
     this.turnDetector?.dispose();
     this.stopSessionTranscriber();
     await this.cancelAssistantTurn("session_closed");
@@ -504,29 +526,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // mode, again after every finalized turn (per-utterance phase tracks the
   // cycle).
   private async beginUtterance(): Promise<UtteranceStartResult> {
-    const utterance: UtteranceCycle = {
-      phase: "pending",
-      released: false,
-      assistantTurnStarted: false,
-      completed: false,
-      finalizeRequested: false,
-      transcriber: null,
-      pendingAudioChunks: [],
-      pendingAudioBytes: 0,
-      finalTranscriptSegments: [],
-      turnId: null,
-      userMessageId: null,
-      userAudioChunks: [],
-      metricsTurnStarted: false,
-      metricsTurnFinished: false,
-      stashedMetricsMarks: {
-        firstAudioAtMs: null,
-        firstPartialAtMs: null,
-        speechStartAtMs: null,
-        utteranceEndAtMs: null,
-        finalTranscriptAtMs: null,
-      },
-    };
+    const utterance = createUtteranceCycle();
     this.currentUtterance = utterance;
     // Speech parked while the previous cycle wound down belongs to this
     // cycle: buffer it before the transcriber arms, and capture the detector
@@ -1469,6 +1469,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
+    await this.startAssistantTurnForUtterance(utterance, content);
+  }
+
+  /**
+   * Build the {@link ActiveAssistantTurn}, announce it (`thinking`), and drive
+   * its first model leg from `content`. Shared by the STT turn-start path and
+   * the surface-completion resume path — a resume supplies a synthetic stub
+   * utterance rather than a transcribed one, but the turn machinery downstream
+   * is identical.
+   */
+  private async startAssistantTurnForUtterance(
+    utterance: UtteranceCycle,
+    content: string,
+  ): Promise<void> {
     utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
     const turnId = this.ensureTurnId(utterance);
@@ -1493,7 +1507,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       assistantAudioChunks: [],
       assistantAudioMimeType: "audio/pcm",
     };
-    this.activeAssistantTurn = activeTurn;
+    this.setActiveAssistantTurn(activeTurn);
 
     await this.sendFrame({ type: "thinking", turnId });
     if (!this.isActiveAssistantTurn(token)) {
@@ -1523,6 +1537,60 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           }
         : { content },
     );
+  }
+
+  /**
+   * Resume the conversation as a spoken voice turn from supplied text (an
+   * interactive-surface completion, e.g. an OAuth connect). The turn is
+   * synthetic: no user audio is captured or archived, and no user transcript
+   * (`stt_final`) is emitted, so it does not surface as user speech. Registered
+   * per-conversation via {@link registerVoiceResumeHandler} and invoked by the
+   * surface-action dispatcher instead of the silent text `processMessage` path.
+   *
+   * Resumes serialize on {@link resumeChain} and wait for any in-flight turn to
+   * go idle rather than throwing CONVERSATION_BUSY.
+   */
+  resumeWithText(
+    content: string,
+    opts?: { displayContent?: string; sourceActorPrincipalId?: string },
+  ): void {
+    const trimmed = content.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    log.info(
+      {
+        conversationId: this.conversationId,
+        hasDisplayContent: opts?.displayContent != null,
+        sourceActorPrincipalId: opts?.sourceActorPrincipalId,
+      },
+      "Live voice resume requested from interactive surface completion",
+    );
+    this.resumeChain = this.resumeChain
+      .catch(() => {})
+      .then(() => this.runResumeTurn(trimmed));
+    void this.resumeChain.catch(() => {});
+  }
+
+  private async runResumeTurn(content: string): Promise<void> {
+    if (this.isClosedOrFailed || !this.startVoiceTurn) {
+      return;
+    }
+    await this.waitForAssistantTurnIdle();
+    if (this.isClosedOrFailed || this.activeAssistantTurn !== null) {
+      return;
+    }
+    // A turn-only synthetic utterance: the transcript is the supplied content
+    // and it carries no user audio, so the audio-archive step (which tolerates
+    // empty audio) records no user utterance. It is never installed as
+    // `currentUtterance`, so it doesn't disturb the transcriber listening for
+    // the next real utterance.
+    const utterance = createUtteranceCycle({
+      phase: "transcriber_closed",
+      released: true,
+      finalTranscriptSegments: [content],
+    });
+    await this.startAssistantTurnForUtterance(utterance, content);
   }
 
   /**
@@ -1716,7 +1784,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       if (current.finalized) {
-        this.activeAssistantTurn = null;
+        this.setActiveAssistantTurn(null);
         return;
       }
       // The front-door leg may have handed off before its handle resolved;
@@ -1732,7 +1800,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
 
-      this.activeAssistantTurn = null;
+      this.setActiveAssistantTurn(null);
       await this.sendFrame({
         type: "error",
         code: LiveVoiceProtocolErrorCode.InvalidField,
@@ -1788,7 +1856,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async cancelAssistantTurn(reason: string): Promise<void> {
     const turn = this.activeAssistantTurn;
-    this.activeAssistantTurn = null;
+    this.setActiveAssistantTurn(null);
     if (turn) {
       turn.abortController.abort();
       turn.handle?.abort();
@@ -1806,6 +1874,37 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       await this.finalizePendingUtterance(utterance, reason);
     }
     this.scheduleRearmAfterTurn();
+  }
+
+  // Single choke point for the active-turn slot so a queued resume can observe
+  // the turn clearing (see waitForAssistantTurnIdle).
+  private setActiveAssistantTurn(turn: ActiveAssistantTurn | null): void {
+    this.activeAssistantTurn = turn;
+    if (turn === null) {
+      this.resolveAssistantTurnIdleWaiters();
+    }
+  }
+
+  private resolveAssistantTurnIdleWaiters(): void {
+    if (this.activeAssistantTurn !== null && !this.isClosedOrFailed) {
+      return;
+    }
+    const waiters = this.assistantTurnIdleWaiters;
+    if (waiters.length === 0) {
+      return;
+    }
+    this.assistantTurnIdleWaiters = [];
+    for (const resolve of waiters) {
+      resolve();
+    }
+  }
+
+  private async waitForAssistantTurnIdle(): Promise<void> {
+    while (this.activeAssistantTurn !== null && !this.isClosedOrFailed) {
+      await new Promise<void>((resolve) => {
+        this.assistantTurnIdleWaiters.push(resolve);
+      });
+    }
   }
 
   private isActiveAssistantTurn(token: symbol): boolean {
@@ -1890,7 +1989,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
         if (this.activeAssistantTurn?.token === token) {
           if (currentTurn.handle && currentTurn.finalized) {
-            this.activeAssistantTurn = null;
+            this.setActiveAssistantTurn(null);
           }
         }
 
@@ -2298,7 +2397,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.activeAssistantTurn?.token === turn.token &&
       turn.handle
     ) {
-      this.activeAssistantTurn = null;
+      this.setActiveAssistantTurn(null);
     }
 
     if (options.rearm ?? true) {
@@ -2519,6 +2618,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private get isClosed(): boolean {
     return this.state === "closed";
   }
+
+  private get isClosedOrFailed(): boolean {
+    return this.state === "closed" || this.state === "failed";
+  }
 }
 
 export function createLiveVoiceSession(
@@ -2668,6 +2771,38 @@ async function defaultArchiveLiveVoiceAudio(
   return input.role === "user"
     ? linkLiveVoiceUserUtteranceAudioToMessage(input)
     : linkLiveVoiceAssistantResponseAudioToMessage(input);
+}
+
+// Fresh utterance record with per-cycle defaults; `overrides` tailor it (e.g. a
+// synthetic resume cycle that is already `transcriber_closed`). Every call
+// allocates its own arrays/objects so cycles never share mutable buffers.
+function createUtteranceCycle(
+  overrides?: Partial<UtteranceCycle>,
+): UtteranceCycle {
+  return {
+    phase: "pending",
+    released: false,
+    assistantTurnStarted: false,
+    completed: false,
+    finalizeRequested: false,
+    transcriber: null,
+    pendingAudioChunks: [],
+    pendingAudioBytes: 0,
+    finalTranscriptSegments: [],
+    turnId: null,
+    userMessageId: null,
+    userAudioChunks: [],
+    metricsTurnStarted: false,
+    metricsTurnFinished: false,
+    stashedMetricsMarks: {
+      firstAudioAtMs: null,
+      firstPartialAtMs: null,
+      speechStartAtMs: null,
+      utteranceEndAtMs: null,
+      finalTranscriptAtMs: null,
+    },
+    ...overrides,
+  };
 }
 
 function toSeedMarks(stashed: StashedMetricsMarks): LiveVoiceTurnSeedMarks {


### PR DESCRIPTION
## Summary
- Add per-conversation live-voice resume registry
- Live-voice session registers a resumeWithText handler that runs a spoken synthetic turn
- Surface-action completion routes through the voice resume when a live session is active, else falls back to processMessage

Part of plan: voice-seam-oauth.md (PR 1 of 2)