### PR TITLE
fix: harden live-voice surface resume routing and options

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -14,7 +14,10 @@ const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
 
 const { registerVoiceResumeHandler, unregisterVoiceResumeHandler } =
   await import("../live-voice/live-voice-resume-registry.js");
-import type { VoiceResumeHandler } from "../live-voice/live-voice-resume-registry.js";
+import type {
+  VoiceResumeHandler,
+  VoiceResumeOptions,
+} from "../live-voice/live-voice-resume-registry.js";
 
 const { LiveVoiceSession } =
   await import("../live-voice/live-voice-session.js");
@@ -545,11 +548,7 @@ describe("surface action delivery to assistant", () => {
 
     const resumeCalls: Array<{
       content: string;
-      opts?: {
-        displayContent?: string;
-        sourceActorPrincipalId?: string;
-        requestId?: string;
-      };
+      opts?: VoiceResumeOptions;
     }> = [];
     const handler: VoiceResumeHandler = {
       resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
@@ -586,9 +585,6 @@ describe("surface action delivery to assistant", () => {
       expect(ctx.processMessageCalls.length).toBe(0);
       expect(resumeCalls.length).toBe(1);
       expect(resumeCalls[0]!.content).toContain("oauth_connect");
-      expect(resumeCalls[0]!.opts?.sourceActorPrincipalId).toBe(
-        "principal-committer",
-      );
       // The accepted surface-action request id rides into the resume and is the
       // one tracked in `surfaceActionRequestIds`, so the resumed turn adopting
       // it keeps `currentRequestId` inside the surface-action set.
@@ -602,6 +598,63 @@ describe("surface action delivery to assistant", () => {
         "[User action on",
       );
       // The pending-surface guard is cleared on the voice-routed path too.
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      unregisterVoiceResumeHandler("conv-1", handler);
+    }
+  });
+
+  test("live-voice resume: busy conversation routes to resumeWithText, not the text queue", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+    // The conversation is processing a turn: without the pre-enqueue voice
+    // dispatch, the completion would be pushed onto the silent text queue
+    // (`queued: true`) and later drained via `processMessage`, never spoken.
+    ctx.isProcessing = () => true;
+    let enqueueCalls = 0;
+    ctx.enqueueMessage = () => {
+      enqueueCalls += 1;
+      return { queued: true, requestId: "queued-req" };
+    };
+
+    const resumeCalls: Array<{ content: string; opts?: VoiceResumeOptions }> =
+      [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler("conv-1", handler);
+
+    try {
+      await surfaceProxyResolver(ctx, "ui_show", {
+        surface_type: "oauth_connect",
+        title: "Connect Google",
+        data: { providerKey: "google", displayName: "Google" },
+      });
+
+      const showMessage = sent.find(
+        (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+      ) as UiSurfaceShow;
+      const surfaceId = showMessage.surfaceId;
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(true);
+
+      await handleSurfaceAction(ctx, surfaceId, "connect", {
+        status: "connected",
+        providerKey: "google",
+        providerLabel: "Google",
+        accountLabel: "user@example.com",
+      });
+
+      // Routed to the spoken resume even though the conversation is busy — and
+      // NOT pushed onto the silent text queue.
+      expect(resumeCalls.length).toBe(1);
+      expect(resumeCalls[0]!.content).toContain("oauth_connect");
+      expect(enqueueCalls).toBe(0);
+      expect(ctx.processMessageCalls.length).toBe(0);
+      // No text-queue side effects leak to the client.
+      expect(broadcastedMessages.some((m) => m.type === "message_queued")).toBe(
+        false,
+      );
+      // The pending-surface guard is still cleared on the busy voice path.
       expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
     } finally {
       unregisterVoiceResumeHandler("conv-1", handler);
@@ -634,6 +687,50 @@ describe("surface action delivery to assistant", () => {
     expect(ctx.processMessageCalls.length).toBe(1);
     expect(ctx.processMessageCalls[0]!.content).toContain("oauth_connect");
     expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+  });
+
+  test("live-voice resume: surface action carrying attachments falls back to processMessage", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const resumeCalls: Array<{ content: string; opts?: VoiceResumeOptions }> =
+      [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler("conv-1", handler);
+
+    try {
+      await surfaceProxyResolver(ctx, "ui_show", {
+        surface_type: "file_upload",
+        title: "Upload",
+        data: { accept: "*" },
+      });
+
+      const showMessage = sent.find(
+        (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+      ) as UiSurfaceShow;
+      const surfaceId = showMessage.surfaceId;
+
+      await handleSurfaceAction(ctx, surfaceId, "submit", {
+        files: [
+          {
+            filename: "doc.pdf",
+            mimeType: "application/pdf",
+            data: "base64content",
+          },
+        ],
+      });
+
+      // Attachments never travel the voice path — the model still sees them via
+      // the text `processMessage`, and the spoken resume is skipped.
+      expect(resumeCalls.length).toBe(0);
+      expect(ctx.processMessageCalls.length).toBe(1);
+      expect(ctx.processMessageCalls[0]!.attachments.length).toBe(1);
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      unregisterVoiceResumeHandler("conv-1", handler);
+    }
   });
 
   test("live-voice resume end-to-end: oauth_connect completion runs a spoken continuation turn and clears the pending guard", async () => {

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2355,6 +2355,27 @@ export async function handleSurfaceAction(
   const onEvent = (msg: ServerMessage) =>
     broadcastMessage(msg, ctx.conversationId);
 
+  // A live-voice conversation resumes as a *spoken* turn: route the follow-up
+  // through the voice session instead of the silent text `processMessage`
+  // path, so completing e.g. an oauth_connect surface produces a spoken
+  // continuation that re-reads connection state at turn start (JARVIS-1286/7).
+  // This must be decided BEFORE the enqueue below: a busy conversation would
+  // otherwise push the completion onto the silent text queue and drain it via
+  // `processMessage`, never speaking it. `resumeWithText` serializes on the
+  // session's resume chain and waits for any in-flight turn to go idle, so it
+  // safely handles a busy session without touching the text queue.
+  // Attachments never travel this path (OAuth connect carries none); if any
+  // are present, fall back to the text path so the model still sees them.
+  const voiceResumeHandler = getVoiceResumeHandler(ctx.conversationId);
+  const routeToVoice =
+    voiceResumeHandler !== undefined && pendingAttachments.length === 0;
+  if (voiceResumeHandler && pendingAttachments.length > 0) {
+    log.warn(
+      { surfaceId, actionId, attachmentCount: pendingAttachments.length },
+      "Live-voice resume skipped: surface action carries attachments; falling back to text processMessage",
+    );
+  }
+
   log.info(
     {
       surfaceId,
@@ -2366,20 +2387,25 @@ export async function handleSurfaceAction(
         dataLength: a.data?.length ?? 0,
       })),
       contentPreview: content.slice(0, 200),
+      routeToVoice,
     },
     "Surface action follow-up: preparing to send message to model",
   );
 
-  const result = ctx.enqueueMessage({
-    content,
-    attachments: pendingAttachments,
-    onEvent,
-    requestId,
-    activeSurfaceId: surfaceId,
-    displayContent,
-    sourceActorPrincipalId,
-  });
-  if (result.rejected) {
+  // The voice path bypasses the queue entirely; the text path enqueues, which
+  // may reject (queue full) or queue behind an in-flight turn.
+  const result = routeToVoice
+    ? null
+    : ctx.enqueueMessage({
+        content,
+        attachments: pendingAttachments,
+        onEvent,
+        requestId,
+        activeSurfaceId: surfaceId,
+        displayContent,
+        sourceActorPrincipalId,
+      });
+  if (result?.rejected) {
     ctx.surfaceActionRequestIds.delete(requestId);
     return;
   }
@@ -2434,11 +2460,31 @@ export async function handleSurfaceAction(
       conversationId: ctx.conversationId,
     });
   }
-  if (result.queued) {
+  // Consume the pending-surface guard for every delivery path (voice, queued
+  // text, immediate text). The rejected path returned above without clearing
+  // it, so the surface stays active and retryable there.
+  if (!retainPending) {
+    ctx.pendingSurfaceActions.delete(surfaceId);
+  }
+
+  if (voiceResumeHandler && routeToVoice) {
+    // Reuse the accepted surface-action `requestId` (already in
+    // `ctx.surfaceActionRequestIds`) as the resumed turn's request id, so a
+    // tool gated on `triggeredBySurfaceAction` still sees `currentRequestId`
+    // in the set — parity with the text path, which passes it too.
+    voiceResumeHandler.resumeWithText(content, {
+      ...(displayContent !== undefined ? { displayContent } : {}),
+      requestId,
+    });
+    log.info(
+      { surfaceId, actionId, requestId },
+      "Surface action routed to live-voice spoken resume",
+    );
+    return;
+  }
+
+  if (result?.queued) {
     const position = ctx.getQueueDepth();
-    if (!retainPending) {
-      ctx.pendingSurfaceActions.delete(surfaceId);
-    }
     log.info(
       { surfaceId, actionId, requestId },
       "Surface action queued (conversation busy)",
@@ -2452,9 +2498,6 @@ export async function handleSurfaceAction(
     return;
   }
 
-  if (!retainPending) {
-    ctx.pendingSurfaceActions.delete(surfaceId);
-  }
   log.info(
     {
       surfaceId,
@@ -2464,34 +2507,6 @@ export async function handleSurfaceAction(
     },
     "Processing surface action as follow-up with attachments",
   );
-
-  // A live-voice conversation resumes as a *spoken* turn: route the follow-up
-  // through the voice session instead of the silent text `processMessage`
-  // path, so completing e.g. an oauth_connect surface produces a spoken
-  // continuation that re-reads connection state at turn start (JARVIS-1286/7).
-  // Attachments never travel this path (OAuth connect carries none); if any
-  // are present, fall back to `processMessage` so the model still sees them.
-  const voiceResumeHandler = getVoiceResumeHandler(ctx.conversationId);
-  if (voiceResumeHandler && pendingAttachments.length === 0) {
-    // Reuse the accepted surface-action `requestId` (already in
-    // `ctx.surfaceActionRequestIds`) as the resumed turn's request id, so a
-    // tool gated on `triggeredBySurfaceAction` still sees `currentRequestId`
-    // in the set — parity with the text path below, which passes it too.
-    voiceResumeHandler.resumeWithText(content, {
-      ...(displayContent !== undefined ? { displayContent } : {}),
-      ...(sourceActorPrincipalId !== undefined
-        ? { sourceActorPrincipalId }
-        : {}),
-      requestId,
-    });
-    return;
-  }
-  if (voiceResumeHandler && pendingAttachments.length > 0) {
-    log.warn(
-      { surfaceId, actionId, attachmentCount: pendingAttachments.length },
-      "Live-voice resume skipped: surface action carries attachments; falling back to text processMessage",
-    );
-  }
 
   ctx
     .processMessage({

--- a/assistant/src/live-voice/live-voice-resume-registry.ts
+++ b/assistant/src/live-voice/live-voice-resume-registry.ts
@@ -12,31 +12,37 @@
  * without forming a require cycle.
  */
 
+/**
+ * Per-turn overrides carried from an interactive-surface completion into the
+ * resumed voice turn.
+ *
+ * `requestId` (when supplied) is the accepted surface-action request id. The
+ * resumed turn adopts it as its own request id so `currentRequestId` lands in
+ * the conversation's `surfaceActionRequestIds` set — otherwise a tool gated on
+ * `ToolContext.triggeredBySurfaceAction` (e.g. archive-by-sender) would reject
+ * the resumed turn even though the user clicked the surface.
+ *
+ * `displayContent` (when supplied) is the user-facing label the resumed turn
+ * persists and echoes instead of the model-facing `content`, matching the text
+ * path so the transcript shows the friendly label, not the raw
+ * `[User action on …]` payload.
+ *
+ * Voice trust is not carried here: a live-voice turn's trust is established
+ * once on the conversation at session adoption, so a resumed turn inherits the
+ * same trust context as any speech turn.
+ */
+export interface VoiceResumeOptions {
+  displayContent?: string;
+  requestId?: string;
+}
+
 export interface VoiceResumeHandler {
   /**
    * Run `content` as a spoken assistant turn on the live-voice session. The
    * turn is synthetic (no user speech): it is not echoed as a user utterance
    * and connection state is re-read at turn start.
-   *
-   * `requestId` (when supplied) is the accepted surface-action request id. The
-   * resumed turn adopts it as its own request id so `currentRequestId` lands in
-   * the conversation's `surfaceActionRequestIds` set — otherwise a tool gated on
-   * `ToolContext.triggeredBySurfaceAction` (e.g. archive-by-sender) would reject
-   * the resumed turn even though the user clicked the surface.
-   *
-   * `displayContent` (when supplied) is the user-facing label the resumed turn
-   * persists and echoes instead of the model-facing `content`, matching the
-   * text path so the transcript shows the friendly label, not the raw
-   * `[User action on …]` payload.
    */
-  resumeWithText(
-    content: string,
-    opts?: {
-      displayContent?: string;
-      sourceActorPrincipalId?: string;
-      requestId?: string;
-    },
-  ): void;
+  resumeWithText(content: string, opts?: VoiceResumeOptions): void;
 }
 
 const handlers = new Map<string, VoiceResumeHandler>();

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -58,6 +58,7 @@ import {
   registerVoiceResumeHandler,
   unregisterVoiceResumeHandler,
   type VoiceResumeHandler,
+  type VoiceResumeOptions,
 } from "./live-voice-resume-registry.js";
 import {
   type LiveVoiceSession as LiveVoiceSessionContract,
@@ -121,18 +122,6 @@ export type LiveVoiceCredentialReadinessResolver =
 export type LiveVoiceTurnStarter = (
   options: VoiceTurnOptions,
 ) => Promise<VoiceTurnHandle>;
-
-/**
- * Per-turn overrides carried from an interactive-surface completion into the
- * resumed voice turn. `requestId` is the accepted surface-action request id
- * (keeps `currentRequestId` in the conversation's `surfaceActionRequestIds`
- * set); `displayContent` is the user-facing label persisted/echoed in place of
- * the model-facing content.
- */
-interface ResumeTurnMetadata {
-  requestId?: string;
-  displayContent?: string;
-}
 
 export type LiveVoiceTtsStreamer = (
   options: LiveVoiceTtsOptions,
@@ -1494,7 +1483,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private async startAssistantTurnForUtterance(
     utterance: UtteranceCycle,
     content: string,
-    resume?: ResumeTurnMetadata,
+    resume?: VoiceResumeOptions,
   ): Promise<void> {
     utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
@@ -1564,14 +1553,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * Resumes serialize on {@link resumeChain} and wait for any in-flight turn to
    * go idle rather than throwing CONVERSATION_BUSY.
    */
-  resumeWithText(
-    content: string,
-    opts?: {
-      displayContent?: string;
-      sourceActorPrincipalId?: string;
-      requestId?: string;
-    },
-  ): void {
+  resumeWithText(content: string, opts?: VoiceResumeOptions): void {
     const trimmed = content.trim();
     if (trimmed.length === 0) {
       return;
@@ -1580,7 +1562,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       {
         conversationId: this.conversationId,
         hasDisplayContent: opts?.displayContent != null,
-        sourceActorPrincipalId: opts?.sourceActorPrincipalId,
         requestId: opts?.requestId,
       },
       "Live voice resume requested from interactive surface completion",
@@ -1589,7 +1570,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // `startVoiceTurn`: the id keeps `currentRequestId` inside the accepted
     // `surfaceActionRequestIds` set (so surface-gated tools run), and the label
     // is what the persisted user row / echo shows instead of the raw payload.
-    const resume: ResumeTurnMetadata = {
+    const resume: VoiceResumeOptions = {
       ...(opts?.requestId !== undefined ? { requestId: opts.requestId } : {}),
       ...(opts?.displayContent !== undefined
         ? { displayContent: opts.displayContent }
@@ -1603,7 +1584,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async runResumeTurn(
     content: string,
-    resume?: ResumeTurnMetadata,
+    resume?: VoiceResumeOptions,
   ): Promise<void> {
     if (this.isClosedOrFailed || !this.startVoiceTurn) {
       return;
@@ -1650,7 +1631,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // the escalated continuation leg without it: that leg persists an internal
     // `[continue]` prompt, so it must neither reuse the surface request id nor
     // show the surface's user-facing label.
-    resume?: ResumeTurnMetadata,
+    resume?: VoiceResumeOptions,
   ): Promise<void> {
     if (!this.startVoiceTurn) {
       return;


### PR DESCRIPTION
## Summary
Review remediation for plan voice-seam-oauth.md:
- Route surface-action completions to the voice resume handler even when the conversation is processing (was falling through to the silent text queue)
- Drop the dead sourceActorPrincipalId param and its misleading comments (voice trust is conversation-established)
- Consolidate the duplicated resume-options type