### PR TITLE
fix: preserve active-surface context for voice surface resumes

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -597,8 +597,52 @@ describe("surface action delivery to assistant", () => {
       expect(resumeCalls[0]!.opts?.displayContent).not.toContain(
         "[User action on",
       );
+      // The completed surface's id rides into the resume so the resumed turn
+      // restores its active-surface context (parity with the text path).
+      expect(resumeCalls[0]!.opts?.activeSurfaceId).toBe(surfaceId);
       // The pending-surface guard is cleared on the voice-routed path too.
       expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      unregisterVoiceResumeHandler("conv-1", handler);
+    }
+  });
+
+  test("live-voice resume: dynamic_page action forwards activeSurfaceId so the resumed turn keeps app context", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // Seed a dynamic_page surface directly (a real ui_show would pull from the
+    // app store; the routing under test only needs the pending + state entries).
+    const surfaceId = "surface-dynamic-page-1";
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType: "dynamic_page",
+      data: { html: "<p>app</p>" } as unknown as SurfaceData,
+      title: "My App",
+    });
+    ctx.pendingSurfaceActions.set(surfaceId, { surfaceType: "dynamic_page" });
+
+    const resumeCalls: Array<{ content: string; opts?: VoiceResumeOptions }> =
+      [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler("conv-1", handler);
+
+    try {
+      await handleSurfaceAction(ctx, surfaceId, "submit_answer", {
+        choice: "b",
+      });
+
+      // Routed to the spoken voice resume, NOT the silent text path.
+      expect(ctx.processMessageCalls.length).toBe(0);
+      expect(resumeCalls.length).toBe(1);
+      expect(resumeCalls[0]!.content).toContain("dynamic_page");
+      // The dynamic_page id threads through so the resumed turn's
+      // `buildActiveSurfaceContext` re-injects the app the user just acted on.
+      expect(resumeCalls[0]!.opts?.activeSurfaceId).toBe(surfaceId);
+      // The accepted surface-action request id still rides along for
+      // surface-gated tools.
+      expect(resumeCalls[0]!.opts?.requestId).toBeDefined();
     } finally {
       unregisterVoiceResumeHandler("conv-1", handler);
     }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -237,6 +237,15 @@ export interface VoiceTurnOptions {
    * still receives `content`. Undefined = persist/echo `content`.
    */
   displayContent?: string;
+  /**
+   * Completed interactive-surface id to restore as the turn's active surface.
+   * Set by a live-voice surface resume so `runAgentLoop` feeds it to
+   * `buildActiveSurfaceContext` and the model sees the active `dynamic_page`/app
+   * HTML + schema it just acted on — parity with the text path, which threads
+   * `activeSurfaceId` into `conversation.currentActiveSurfaceId`. Undefined =
+   * a normal STT turn with no active surface (left at the per-turn default).
+   */
+  activeSurfaceId?: string;
 }
 
 export interface VoiceTurnHandle {
@@ -989,6 +998,14 @@ export async function startVoiceTurn(
       // flag into subsequent non-voice turns on the same conversation.
       conversation.forcePromptSideEffects =
         !isGuardian && !usesLocalInteractiveApprovals;
+      // Restore the active-surface context for a surface-resume turn so
+      // `runAgentLoop` → `buildActiveSurfaceContext` re-injects the completed
+      // `dynamic_page`/app the user acted on (parity with the text path's
+      // `currentActiveSurfaceId`). Guarded so a normal STT turn leaves the field
+      // at its per-turn default (reset to undefined by the agent loop).
+      if (opts.activeSurfaceId !== undefined) {
+        conversation.currentActiveSurfaceId = opts.activeSurfaceId;
+      }
       await conversation.runAgentLoop(persistedContent, messageId, {
         onEvent: (msg: ServerMessage) => {
           if (msg.type === "error") {

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2475,6 +2475,7 @@ export async function handleSurfaceAction(
     voiceResumeHandler.resumeWithText(content, {
       ...(displayContent !== undefined ? { displayContent } : {}),
       requestId,
+      activeSurfaceId: surfaceId,
     });
     log.info(
       { surfaceId, actionId, requestId },

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -469,7 +469,7 @@ describe("LiveVoiceSession surface resume", () => {
     expect(getVoiceResumeHandler("conversation-123")).toBeUndefined();
   });
 
-  test("threads the surface-action requestId and displayContent into the resumed turn", async () => {
+  test("threads the surface-action requestId, displayContent, and activeSurfaceId into the resumed turn", async () => {
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
       options.callbacks?.assistant_text_delta?.({
         type: "assistant_text_delta",
@@ -489,22 +489,26 @@ describe("LiveVoiceSession surface resume", () => {
     session.resumeWithText("[User action on table surface: archive]", {
       displayContent: "Archive selected emails",
       requestId: "surface-request-1",
+      activeSurfaceId: "surface-1",
     });
     await waitFor(() => startVoiceTurn.mock.calls.length > 0);
 
     // The surface request id becomes the resumed turn's request id so
     // `currentRequestId` lands in `surfaceActionRequestIds` and surface-gated
-    // tools run; the display label rides along for the persisted/echoed row.
+    // tools run; the display label rides along for the persisted/echoed row;
+    // the active-surface id restores the completed surface's context for the
+    // resumed turn (parity with the text path).
     expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
       content: "[User action on table surface: archive]",
       requestId: "surface-request-1",
       displayContent: "Archive selected emails",
+      activeSurfaceId: "surface-1",
     });
 
     await session.close("client_end");
   });
 
-  test("a resume without opts mints no requestId or displayContent override", async () => {
+  test("a resume without opts mints no requestId, displayContent, or activeSurfaceId override", async () => {
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
       options.callbacks?.message_complete?.({
         type: "message_complete",
@@ -522,6 +526,7 @@ describe("LiveVoiceSession surface resume", () => {
     const opts = startVoiceTurn.mock.calls[0]?.[0];
     expect(opts?.requestId).toBeUndefined();
     expect(opts?.displayContent).toBeUndefined();
+    expect(opts?.activeSurfaceId).toBeUndefined();
 
     await session.close("client_end");
   });

--- a/assistant/src/live-voice/live-voice-resume-registry.ts
+++ b/assistant/src/live-voice/live-voice-resume-registry.ts
@@ -27,6 +27,12 @@
  * path so the transcript shows the friendly label, not the raw
  * `[User action on …]` payload.
  *
+ * `activeSurfaceId` (when supplied) is the completed surface's id. The resumed
+ * turn adopts it as `conversation.currentActiveSurfaceId` so `runAgentLoop`
+ * feeds it to `buildActiveSurfaceContext` and the model sees the active
+ * `dynamic_page`/app HTML + schema it just acted on — parity with the text
+ * path, which passes `activeSurfaceId` into `processMessage`.
+ *
  * Voice trust is not carried here: a live-voice turn's trust is established
  * once on the conversation at session adoption, so a resumed turn inherits the
  * same trust context as any speech turn.
@@ -34,6 +40,7 @@
 export interface VoiceResumeOptions {
   displayContent?: string;
   requestId?: string;
+  activeSurfaceId?: string;
 }
 
 export interface VoiceResumeHandler {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1566,14 +1566,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       },
       "Live voice resume requested from interactive surface completion",
     );
-    // The surface-action request id and user-facing label ride the turn down to
-    // `startVoiceTurn`: the id keeps `currentRequestId` inside the accepted
-    // `surfaceActionRequestIds` set (so surface-gated tools run), and the label
-    // is what the persisted user row / echo shows instead of the raw payload.
+    // The surface-action request id, user-facing label, and active-surface id
+    // ride the turn down to `startVoiceTurn`: the id keeps `currentRequestId`
+    // inside the accepted `surfaceActionRequestIds` set (so surface-gated tools
+    // run), the label is what the persisted user row / echo shows instead of the
+    // raw payload, and the active-surface id restores the completed
+    // `dynamic_page`/app context so the model doesn't run blind to what it acted
+    // on (parity with the text path).
     const resume: VoiceResumeOptions = {
       ...(opts?.requestId !== undefined ? { requestId: opts.requestId } : {}),
       ...(opts?.displayContent !== undefined
         ? { displayContent: opts.displayContent }
+        : {}),
+      ...(opts?.activeSurfaceId !== undefined
+        ? { activeSurfaceId: opts.activeSurfaceId }
         : {}),
     };
     this.resumeChain = this.resumeChain
@@ -1708,6 +1714,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         ...(resume?.requestId != null ? { requestId: resume.requestId } : {}),
         ...(resume?.displayContent != null
           ? { displayContent: resume.displayContent }
+          : {}),
+        ...(resume?.activeSurfaceId != null
+          ? { activeSurfaceId: resume.activeSurfaceId }
           : {}),
         callbacks: {
           assistant_text_delta: (msg) => {


### PR DESCRIPTION
## Summary
Review remediation for plan voice-seam-oauth.md: the voice surface-resume path dropped activeSurfaceId, so dynamic_page/app actions resumed via voice lost their active-surface context (buildActiveSurfaceContext returned null). Threads activeSurfaceId end-to-end like requestId, primary-leg only.

**Gap:** activeSurfaceId dropped on voice resume
**What was expected:** parity with the text path's active-surface context
**What was found:** dynamic_page/app resume ran without page/app state