### PR TITLE
fix(voice): spoken resume + reachable connect card for OAuth in voice mode (JARVIS-1287)

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -12,6 +12,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
   await import("../daemon/conversation-surfaces.js");
 
+const { registerVoiceResumeHandler, unregisterVoiceResumeHandler } =
+  await import("../live-voice/live-voice-resume-registry.js");
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type {
   SurfaceData,
@@ -19,6 +21,7 @@ import type {
   UiSurfaceShow,
 } from "../daemon/message-protocol.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
+import type { VoiceResumeHandler } from "../live-voice/live-voice-resume-registry.js";
 
 interface ProcessMessageCall {
   content: string;
@@ -511,6 +514,81 @@ describe("surface action delivery to assistant", () => {
     expect(completeMsg).toBeDefined();
     expect(completeMsg?.conversationId).toBe("conv-1");
     expect(completeMsg?.summary).toBe("Connected Google: user@example.com");
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+  });
+
+  test("oauth_connect routes to the voice resume handler (spoken) and skips processMessage when a live-voice session owns the conversation", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const resumeCalls: Array<{
+      content: string;
+      opts?: { displayContent?: string; sourceActorPrincipalId?: string };
+    }> = [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler(ctx.conversationId, handler);
+
+    try {
+      await surfaceProxyResolver(ctx, "ui_show", {
+        surface_type: "oauth_connect",
+        title: "Connect Google",
+        data: { providerKey: "google", displayName: "Google" },
+      });
+      const showMessage = sent.find(
+        (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+      ) as UiSurfaceShow;
+      const surfaceId = showMessage.surfaceId;
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(true);
+
+      await handleSurfaceAction(ctx, surfaceId, "connect", {
+        status: "connected",
+        providerKey: "google",
+        providerLabel: "Google",
+        accountLabel: "user@example.com",
+      });
+
+      // Routed to the spoken resume, not the silent text pipeline.
+      expect(resumeCalls).toHaveLength(1);
+      expect(ctx.processMessageCalls).toHaveLength(0);
+      // The one-shot surface still completes and the pending guard is cleared.
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+      expect(
+        broadcastedMessages.some(
+          (msg) =>
+            msg.type === "ui_surface_complete" && msg.surfaceId === surfaceId,
+        ),
+      ).toBe(true);
+    } finally {
+      unregisterVoiceResumeHandler(ctx.conversationId, handler);
+    }
+  });
+
+  test("oauth_connect falls back to processMessage when no voice resume handler is registered", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+    // The prior voice test unregisters its handler, so "conv-1" has no handler.
+
+    await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "oauth_connect",
+      title: "Connect Google",
+      data: { providerKey: "google", displayName: "Google" },
+    });
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    ) as UiSurfaceShow;
+    const surfaceId = showMessage.surfaceId;
+
+    await handleSurfaceAction(ctx, surfaceId, "connect", {
+      status: "connected",
+      providerKey: "google",
+      providerLabel: "Google",
+      accountLabel: "user@example.com",
+    });
+
+    // Byte-for-byte the prior behavior: text pipeline runs, guard cleared.
+    expect(ctx.processMessageCalls).toHaveLength(1);
     expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
   });
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -17,6 +17,7 @@ import {
   resolveEffectiveAppHtml,
   updateApp,
 } from "../apps/app-store.js";
+import { getVoiceResumeHandler } from "../live-voice/live-voice-resume-registry.js";
 import { recordActivationEvent } from "../onboarding/onboarding-events-store.js";
 import {
   getMessages,
@@ -1825,6 +1826,18 @@ function completeSurfaceFromAction(
   markSurfaceCompleted(ctx, surfaceId, summary);
 }
 
+// One-shot interactive surfaces auto-complete once their action message is
+// accepted (they never accept further actions). Shared by the text-dispatch
+// path and the voice-resume branch in handleSurfaceAction.
+const ONE_SHOT_SURFACE_TYPES = [
+  "choice",
+  "oauth_connect",
+  "form",
+  "confirmation",
+  "file_upload",
+  "task_preferences",
+];
+
 export async function handleSurfaceAction(
   ctx: SurfaceConversationContext,
   surfaceId: string,
@@ -2369,6 +2382,58 @@ export async function handleSurfaceAction(
     "Surface action follow-up: preparing to send message to model",
   );
 
+  // A live-voice session owns this conversation: resume the follow-up as a
+  // SPOKEN turn on that session instead of an unspoken text run that never
+  // reaches TTS (JARVIS-1287). OAuth connect carries no attachments; if any are
+  // present, fall through to the text path (voice resume has no attachment
+  // pipeline). This branch mirrors the one-shot completion, accumulated-state
+  // cleanup, prompt echo, and pending-action delete of the text path below.
+  const voiceResumeHandler = getVoiceResumeHandler(ctx.conversationId);
+  if (voiceResumeHandler && pendingAttachments.length === 0) {
+    maybeEmitActivationMoment(ctx, surfaceId);
+    const requestedCompletionSummary =
+      getRequestedSurfaceCompletionSummary(mergedData);
+    if (
+      requestedCompletionSummary ||
+      ONE_SHOT_SURFACE_TYPES.includes(pending.surfaceType)
+    ) {
+      const completionSummary = requestedCompletionSummary ?? summary;
+      broadcastMessage({
+        type: "ui_surface_complete",
+        conversationId: ctx.conversationId,
+        surfaceId,
+        summary: completionSummary,
+        submittedData: mergedDataForText,
+      });
+      markSurfaceCompleted(ctx, surfaceId, completionSummary);
+    }
+    if (accumulatedState && Object.keys(accumulatedState).length > 0) {
+      ctx.accumulatedSurfaceState.delete(surfaceId);
+    }
+    if (shouldRelayPrompt && prompt) {
+      broadcastMessage({
+        type: "user_message_echo",
+        text: prompt,
+        conversationId: ctx.conversationId,
+      });
+    }
+    if (!retainPending) {
+      ctx.pendingSurfaceActions.delete(surfaceId);
+    }
+    // The voice-resume turn creates its own turn/events, so the tracking id
+    // minted for the (unused) text dispatch would otherwise linger.
+    ctx.surfaceActionRequestIds.delete(requestId);
+    log.info(
+      { surfaceId, actionId, conversationId: ctx.conversationId },
+      "Surface action follow-up: resuming as spoken live-voice turn",
+    );
+    voiceResumeHandler.resumeWithText(content, {
+      ...(displayContent ? { displayContent } : {}),
+      ...(sourceActorPrincipalId ? { sourceActorPrincipalId } : {}),
+    });
+    return;
+  }
+
   const result = ctx.enqueueMessage({
     content,
     attachments: pendingAttachments,
@@ -2395,14 +2460,6 @@ export async function handleSurfaceAction(
   // One-shot interactive surfaces — auto-complete now that the message has
   // been accepted. Deferred until after rejection check so the surface stays
   // active and retryable if the queue was full.
-  const ONE_SHOT_SURFACE_TYPES = [
-    "choice",
-    "oauth_connect",
-    "form",
-    "confirmation",
-    "file_upload",
-    "task_preferences",
-  ];
   if (
     requestedCompletionSummary ||
     ONE_SHOT_SURFACE_TYPES.includes(pending.surfaceType)

--- a/assistant/src/live-voice/__tests__/live-voice-resume-registry.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-resume-registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getVoiceResumeHandler,
+  registerVoiceResumeHandler,
+  unregisterVoiceResumeHandler,
+  type VoiceResumeHandler,
+} from "../live-voice-resume-registry.js";
+
+function makeHandler(): VoiceResumeHandler {
+  return { resumeWithText: () => {} };
+}
+
+describe("live-voice resume registry", () => {
+  test("register then get returns the handler", () => {
+    const conversationId = `conv-${Math.random()}`;
+    const handler = makeHandler();
+    registerVoiceResumeHandler(conversationId, handler);
+    expect(getVoiceResumeHandler(conversationId)).toBe(handler);
+    unregisterVoiceResumeHandler(conversationId, handler);
+  });
+
+  test("returns undefined for an unknown conversation", () => {
+    expect(getVoiceResumeHandler(`conv-${Math.random()}`)).toBeUndefined();
+  });
+
+  test("register overwrites an existing handler for the same conversation", () => {
+    const conversationId = `conv-${Math.random()}`;
+    const first = makeHandler();
+    const second = makeHandler();
+    registerVoiceResumeHandler(conversationId, first);
+    registerVoiceResumeHandler(conversationId, second);
+    expect(getVoiceResumeHandler(conversationId)).toBe(second);
+    unregisterVoiceResumeHandler(conversationId, second);
+  });
+
+  test("unregister removes only the current handler", () => {
+    const conversationId = `conv-${Math.random()}`;
+    const handler = makeHandler();
+    registerVoiceResumeHandler(conversationId, handler);
+    unregisterVoiceResumeHandler(conversationId, handler);
+    expect(getVoiceResumeHandler(conversationId)).toBeUndefined();
+  });
+
+  test("identity-checked unregister: a stale handler does not evict a newer one", () => {
+    const conversationId = `conv-${Math.random()}`;
+    const stale = makeHandler();
+    const current = makeHandler();
+    registerVoiceResumeHandler(conversationId, stale);
+    // A newer session adopts the same conversationId.
+    registerVoiceResumeHandler(conversationId, current);
+    // The stale session tears down; it must not remove the newer handler.
+    unregisterVoiceResumeHandler(conversationId, stale);
+    expect(getVoiceResumeHandler(conversationId)).toBe(current);
+    unregisterVoiceResumeHandler(conversationId, current);
+    expect(getVoiceResumeHandler(conversationId)).toBeUndefined();
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-resume-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-resume-turn.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  VoiceTurnCallbacks,
+  VoiceTurnOptions,
+} from "../../calls/voice-session-bridge.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import { getVoiceResumeHandler } from "../live-voice-resume-registry.js";
+import { LiveVoiceSession } from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceTtsAudioChunk,
+  LiveVoiceTtsOptions,
+  LiveVoiceTtsResult,
+} from "../live-voice-tts.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const CONVERSATION_ID = "conversation-resume-1";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: CONVERSATION_ID,
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  stopped = false;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(): void {}
+
+  stop(): void {
+    this.stopped = true;
+  }
+}
+
+function createContext(): {
+  context: LiveVoiceSessionFactoryContext;
+  frames: LiveVoiceServerFrame[];
+} {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+  return {
+    frames,
+    context: {
+      sessionId: "session-resume-1",
+      startFrame: START_FRAME,
+      sendFrame: mock(async (payload) => {
+        const frame = sequencer.next(payload);
+        frames.push(frame);
+        return frame;
+      }),
+    },
+  };
+}
+
+function makeTtsChunk(text: string): LiveVoiceTtsAudioChunk {
+  return {
+    type: "tts_audio",
+    contentType: "audio/pcm",
+    sampleRate: 24_000,
+    dataBase64: Buffer.from(text).toString("base64"),
+  };
+}
+
+function makeTtsResult(text: string): LiveVoiceTtsResult {
+  return {
+    provider: "fish-audio",
+    contentType: "audio/pcm",
+    sampleRate: 24_000,
+    chunks: 1,
+    bytes: Buffer.byteLength(text),
+  };
+}
+
+// A startVoiceTurn that immediately streams a reply delta and completes, with
+// no reliance on any audio input. Returned as the raw mock so tests can assert
+// on `.mock.calls`.
+function spokenReplyStarter() {
+  return mock(async (options: VoiceTurnOptions) => {
+    const callbacks: VoiceTurnCallbacks | undefined = options.callbacks;
+    callbacks?.assistant_text_delta?.({
+      type: "assistant_text_delta",
+      text: "All set, you are connected.",
+      conversationId: options.conversationId,
+    });
+    callbacks?.message_complete?.({
+      type: "message_complete",
+      conversationId: options.conversationId,
+      messageId: "assistant-message-resume",
+    });
+    return { turnId: "bridge-turn-resume", abort: mock() };
+  });
+}
+
+function createSessionHarness() {
+  const transcriber = new MockStreamingTranscriber();
+  const { context, frames } = createContext();
+  const streamTtsAudio = mock(async (opts: LiveVoiceTtsOptions) => {
+    opts.onAudioChunk(makeTtsChunk(`audio:${opts.text}`));
+    return makeTtsResult(opts.text);
+  });
+  const startVoiceTurn = spokenReplyStarter();
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber: mock(async () => transcriber),
+    startVoiceTurn,
+    streamTtsAudio,
+    createTurnId: () => "live-turn-resume",
+  });
+  return { frames, session, startVoiceTurn };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for live voice resume condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+describe("LiveVoiceSession surface resume", () => {
+  test("registers a discoverable resume handler for its conversation", async () => {
+    const { session } = createSessionHarness();
+    await session.start();
+    expect(getVoiceResumeHandler(CONVERSATION_ID)).toBeDefined();
+    await session.close("client_end");
+  });
+
+  test("resumeWithText drives a spoken turn (text delta + tts_audio + tts_done)", async () => {
+    const { frames, session, startVoiceTurn } = createSessionHarness();
+    await session.start();
+
+    const handler = getVoiceResumeHandler(CONVERSATION_ID);
+    expect(handler).toBeDefined();
+
+    // No audio input at all — the resume alone must produce a spoken turn.
+    handler?.resumeWithText("Thanks for connecting Google.");
+
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      conversationId: CONVERSATION_ID,
+      content: "Thanks for connecting Google.",
+    });
+    const frameTypes = frames.map((frame) => frame.type);
+    expect(frameTypes).toContain("assistant_text_delta");
+    expect(frameTypes).toContain("tts_audio");
+    expect(frameTypes).toContain("tts_done");
+    // A spoken resume is not echoed as user speech.
+    expect(frameTypes).not.toContain("user_message_echo");
+
+    await session.close("client_end");
+  });
+
+  test("unregisters the resume handler on close", async () => {
+    const { session } = createSessionHarness();
+    await session.start();
+    expect(getVoiceResumeHandler(CONVERSATION_ID)).toBeDefined();
+    await session.close("client_end");
+    expect(getVoiceResumeHandler(CONVERSATION_ID)).toBeUndefined();
+  });
+
+  test("ignores an empty resume and does not start a turn", async () => {
+    const { frames, session, startVoiceTurn } = createSessionHarness();
+    await session.start();
+    getVoiceResumeHandler(CONVERSATION_ID)?.resumeWithText("   ");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+    expect(frames.some((frame) => frame.type === "thinking")).toBe(false);
+    await session.close("client_end");
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-resume-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-resume-turn.test.ts
@@ -183,6 +183,68 @@ describe("LiveVoiceSession surface resume", () => {
     expect(getVoiceResumeHandler(CONVERSATION_ID)).toBeUndefined();
   });
 
+  test("flushes a resume deferred behind an active turn (manual/no-turnDetector path)", async () => {
+    // START_FRAME requests no server_vad, so this session has no turnDetector —
+    // the manual path where scheduleRearmAfterTurn no-ops. A resume that arrives
+    // while a turn is still speaking must still run once that turn settles.
+    const { context, frames } = createContext();
+    const streamTtsAudio = mock(async (opts: LiveVoiceTtsOptions) => {
+      opts.onAudioChunk(makeTtsChunk(`audio:${opts.text}`));
+      return makeTtsResult(opts.text);
+    });
+    // The first turn is held open (no message_complete) so a resume can arrive
+    // mid-turn; later turns complete immediately.
+    let callIndex = 0;
+    const held: Array<() => void> = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      const idx = callIndex++;
+      const callbacks = options.callbacks;
+      callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: `reply-${idx}`,
+        conversationId: options.conversationId,
+      });
+      const complete = () =>
+        callbacks?.message_complete?.({
+          type: "message_complete",
+          conversationId: options.conversationId,
+          messageId: `assistant-message-${idx}`,
+        });
+      if (idx === 0) {
+        held.push(complete);
+      } else {
+        complete();
+      }
+      return { turnId: `bridge-turn-${idx}`, abort: mock() };
+    });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+      startVoiceTurn,
+      streamTtsAudio,
+      createTurnId: () => "live-turn-resume",
+    });
+    await session.start();
+    const handler = getVoiceResumeHandler(CONVERSATION_ID);
+
+    // First resume starts a turn that stays active (not completed).
+    handler?.resumeWithText("First follow-up.");
+    await waitFor(() => startVoiceTurn.mock.calls.length === 1);
+
+    // Second resume arrives mid-turn — deferred, no new turn yet.
+    handler?.resumeWithText("Second follow-up.");
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+
+    // Completing the first turn must flush the deferred resume into a real turn.
+    held.shift()?.();
+    await waitFor(() => startVoiceTurn.mock.calls.length === 2);
+    expect(startVoiceTurn.mock.calls[1]?.[0]).toMatchObject({
+      content: "Second follow-up.",
+    });
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(true);
+
+    await session.close("client_end");
+  });
+
   test("ignores an empty resume and does not start a turn", async () => {
     const { frames, session, startVoiceTurn } = createSessionHarness();
     await session.start();

--- a/assistant/src/live-voice/live-voice-resume-registry.ts
+++ b/assistant/src/live-voice/live-voice-resume-registry.ts
@@ -1,0 +1,46 @@
+/**
+ * Registry that lets the HTTP surface-action path (`daemon/conversation-surfaces.ts`)
+ * hand a surface-completion follow-up back to the live-voice session that owns a
+ * conversation, so the resumed reply is SPOKEN (runs through the session's TTS
+ * pipeline) instead of being run silently through the text pipeline (JARVIS-1287).
+ *
+ * It is a pure module-level map with no imports from `daemon/` or `calls/`: the
+ * producer (`live-voice-session.ts`) and the consumer (`conversation-surfaces.ts`)
+ * both reference this module, and neither imports the other — avoiding a require
+ * cycle between the live-voice session and the daemon surface handler.
+ */
+export interface VoiceResumeHandler {
+  resumeWithText(
+    content: string,
+    opts?: { displayContent?: string; sourceActorPrincipalId?: string },
+  ): void;
+}
+
+const handlers = new Map<string, VoiceResumeHandler>();
+
+export function registerVoiceResumeHandler(
+  conversationId: string,
+  handler: VoiceResumeHandler,
+): void {
+  handlers.set(conversationId, handler);
+}
+
+/**
+ * Identity-checked removal: a session only clears the slot if it still holds its
+ * own handler. A newer session that adopted the same conversationId (e.g. after a
+ * reconnect) is never evicted by a stale session's teardown.
+ */
+export function unregisterVoiceResumeHandler(
+  conversationId: string,
+  handler: VoiceResumeHandler,
+): void {
+  if (handlers.get(conversationId) === handler) {
+    handlers.delete(conversationId);
+  }
+}
+
+export function getVoiceResumeHandler(
+  conversationId: string,
+): VoiceResumeHandler | undefined {
+  return handlers.get(conversationId);
+}

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -55,6 +55,11 @@ import {
   type LiveVoiceTurnSeedMarks,
 } from "./live-voice-metrics.js";
 import {
+  registerVoiceResumeHandler,
+  unregisterVoiceResumeHandler,
+  type VoiceResumeHandler,
+} from "./live-voice-resume-registry.js";
+import {
   type LiveVoiceSession as LiveVoiceSessionContract,
   type LiveVoiceSessionCloseReason,
   type LiveVoiceSessionFactoryContext,
@@ -367,6 +372,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   /** The cycle whose grace timer is armed (only the newest release has one). */
   private finalizeGraceCycle: UtteranceCycle | null = null;
   private readonly finalizeGraceMs: number;
+  // Registered in the registry so the HTTP surface-action path can resume a
+  // yielded interactive surface as a SPOKEN turn on this session (JARVIS-1287).
+  private readonly voiceResumeHandler: VoiceResumeHandler;
+  // A resume requested while an assistant turn was still in flight; dispatched
+  // once the active turn settles (see flushPendingResume).
+  private pendingResume: {
+    content: string;
+    opts?: { displayContent?: string; sourceActorPrincipalId?: string };
+  } | null = null;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -384,6 +398,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.createTurnId = options.createTurnId ?? randomUUID;
     this.conversationId =
       context.startFrame.conversationId ?? context.sessionId;
+    this.voiceResumeHandler = {
+      resumeWithText: (content, opts) => this.resumeWithText(content, opts),
+    };
+    registerVoiceResumeHandler(this.conversationId, this.voiceResumeHandler);
     this.metricsClock = options.metricsClock ?? Date.now;
     this.metrics = new LiveVoiceMetricsCollector({
       sessionId: context.sessionId,
@@ -510,6 +528,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
+    unregisterVoiceResumeHandler(this.conversationId, this.voiceResumeHandler);
     this.turnDetector?.dispose();
     this.stopSessionTranscriber();
     await this.cancelAssistantTurn("session_closed");
@@ -677,6 +696,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (this.isClosed || this.state === "failed") {
       return;
     }
+
+    // A resume deferred behind the finished turn takes the freed slot before a
+    // fresh utterance is armed (no-op when there's nothing pending).
+    this.flushPendingResume();
 
     const current = this.currentUtterance;
     if (current && !current.completed) {
@@ -1491,6 +1514,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
+    await this.launchAssistantTurn(utterance, content);
+  }
+
+  // Build the ActiveAssistantTurn for a released utterance and drive its model
+  // leg. Shared by the STT path (startAssistantTurnIfReady) and the spoken
+  // surface-resume path (startResumeTurn) so both run identical turn machinery.
+  private async launchAssistantTurn(
+    utterance: UtteranceCycle,
+    content: string,
+  ): Promise<void> {
     utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
     const turnId = this.ensureTurnId(utterance);
@@ -1545,6 +1578,109 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           }
         : { content },
     );
+  }
+
+  /**
+   * Resume a yielded interactive surface as a SPOKEN turn. The HTTP surface-
+   * action path calls this (via the resume registry) once the user completes a
+   * surface the voice turn raised, so the follow-up reply is synthesized to
+   * audio through this session's TTS pipeline instead of running silently
+   * through the text pipeline (JARVIS-1287).
+   *
+   * If a turn is still in flight the resume is deferred (pendingResume) and
+   * dispatched once that turn settles — never rejected with CONVERSATION_BUSY.
+   */
+  resumeWithText(
+    content: string,
+    opts?: { displayContent?: string; sourceActorPrincipalId?: string },
+  ): void {
+    const trimmed = content.trim();
+    if (
+      this.isClosed ||
+      this.state === "failed" ||
+      !this.startVoiceTurn ||
+      trimmed.length === 0
+    ) {
+      return;
+    }
+    if (this.activeAssistantTurn) {
+      this.pendingResume = { content: trimmed, opts };
+      return;
+    }
+    void this.startResumeTurn(trimmed, opts).catch((err) => {
+      log.error(
+        { err, conversationId: this.conversationId },
+        "live-voice resume turn failed",
+      );
+    });
+  }
+
+  private async startResumeTurn(
+    content: string,
+    _opts?: { displayContent?: string; sourceActorPrincipalId?: string },
+  ): Promise<void> {
+    if (this.isClosed || this.state === "failed" || !this.startVoiceTurn) {
+      return;
+    }
+    if (this.activeAssistantTurn) {
+      this.pendingResume = { content, opts: _opts };
+      return;
+    }
+    // A synthetic utterance carrying only the resume text: it is not
+    // this.currentUtterance (which holds the server-VAD armed next utterance),
+    // so the armed transcriber is untouched. finalizeAssistantTurn works on
+    // turn.utterance and tolerates the empty audio buffers.
+    const utterance: UtteranceCycle = {
+      phase: "transcriber_closed",
+      released: true,
+      assistantTurnStarted: false,
+      completed: false,
+      finalizeRequested: false,
+      transcriber: null,
+      pendingAudioChunks: [],
+      pendingAudioBytes: 0,
+      finalTranscriptSegments: [content],
+      turnId: null,
+      userMessageId: null,
+      userAudioChunks: [],
+      metricsTurnStarted: false,
+      metricsTurnFinished: false,
+      stashedMetricsMarks: {
+        firstAudioAtMs: null,
+        firstPartialAtMs: null,
+        speechStartAtMs: null,
+        utteranceEndAtMs: null,
+        finalTranscriptAtMs: null,
+      },
+    };
+    await this.launchAssistantTurn(utterance, content);
+  }
+
+  // Dispatch a resume deferred behind an in-flight turn, once that turn has
+  // settled. Null out pendingResume before dispatch so a re-entrant settle
+  // cannot double-fire the same resume.
+  private flushPendingResume(): void {
+    const deferred = this.pendingResume;
+    this.pendingResume = null;
+    if (
+      deferred &&
+      !this.activeAssistantTurn &&
+      !this.isClosed &&
+      this.state !== "failed"
+    ) {
+      void this.startResumeTurn(deferred.content, deferred.opts).catch(
+        (err) => {
+          log.error(
+            { err, conversationId: this.conversationId },
+            "live-voice deferred resume turn failed",
+          );
+        },
+      );
+    } else if (deferred) {
+      // Could not dispatch now (turn still active / session gone); keep it for
+      // the next settle point rather than dropping it.
+      this.pendingResume = deferred;
+    }
   }
 
   /**
@@ -2326,6 +2462,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (options.rearm ?? true) {
       this.scheduleRearmAfterTurn();
     }
+
+    // A surface-resume that arrived mid-turn waits here: the just-cleared
+    // active turn frees the slot, so dispatch it now. rearmAfterTurn also
+    // flushes (covers the manual path where scheduleRearmAfterTurn no-ops).
+    this.flushPendingResume();
   }
 
   private async archiveBufferedAudio(input: {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2052,6 +2052,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           }
         }
 
+        // Now that the active turn is actually cleared, dispatch a resume that
+        // arrived mid-turn. `finalizeAssistantTurn` runs its own flush too, but
+        // this path finalizes with `clearActive: false`, so at that point the
+        // slot was still taken and the flush re-stashed. `scheduleRearmAfterTurn`
+        // below no-ops in manual (no-`turnDetector`) sessions, so without this
+        // flush the deferred resume would never start there (JARVIS-1287).
+        this.flushPendingResume();
+
         // Re-arm only after the terminal tts_done frame so a slow or failing
         // next transcriber cannot block or precede turn completion. A
         // cancelled turn re-arms through cancelAssistantTurn instead.

--- a/clients/web/src/domains/chat/voice/voice-room/use-active-connect-surface.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-active-connect-surface.ts
@@ -1,0 +1,56 @@
+/**
+ * Selects the active (not completed, not dismissed) `oauth_connect` surface
+ * from the live transcript, for rendering inside the voice room.
+ *
+ * The voice room is a `fixed inset-0 z-50` modal over a blurred, pointer-events
+ * disabled transcript, so an `oauth_connect` card attached to a transcript
+ * message is invisible and unclickable during a live session — the user can
+ * never complete the connect the assistant asked for (JARVIS-1287). The room
+ * renders its own instance of the pending card (read from the same snapshot the
+ * transcript renders from) so Connect is reachable without leaving voice.
+ *
+ * Returns the surface object by reference; `attachSurface` / `completeSurface`
+ * only mint a new object for the surface that actually changed, so the selector
+ * returns a stable reference across unrelated transcript churn (streaming
+ * deltas) and does not re-render the room on every token.
+ */
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import type { DisplayMessage, Surface } from "@/domains/chat/types/types";
+
+function findActiveConnectSurface(
+  messages: DisplayMessage[],
+  dismissed: ReadonlySet<string>,
+): Surface | null {
+  // Most recent message wins: a later connect request supersedes an earlier one.
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const surfaces = messages[i]?.surfaces;
+    if (!surfaces) {
+      continue;
+    }
+    for (let j = surfaces.length - 1; j >= 0; j -= 1) {
+      const surface = surfaces[j]!;
+      if (
+        surface.surfaceType === "oauth_connect" &&
+        !surface.completed &&
+        !dismissed.has(surface.surfaceId)
+      ) {
+        return surface;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * The active pending `oauth_connect` surface to render in the voice room, or
+ * `null` when the assistant hasn't asked to connect anything.
+ */
+export function useActiveConnectSurface(): Surface | null {
+  return useChatSessionStore((state) =>
+    findActiveConnectSurface(
+      state.snapshot?.messages ?? [],
+      state.dismissedSurfaceIds,
+    ),
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -17,7 +17,13 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 
 import type { MainView } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
@@ -108,8 +114,77 @@ const CHARACTER_COMPONENTS = {
   colors: [{ id: "green", hex: "#4C9B50" }],
 };
 
+// Stub the OAuth connect surface (pulls the managed-oauth + generated-SDK
+// graph) so the room-slot tests assert only the wiring: that the room renders
+// the pending card and routes its action to `handleSurfaceAction`.
+mock.module("@/domains/chat/components/surfaces/oauth-connect-surface", () => ({
+  OAuthConnectSurface: ({
+    surface,
+    assistantId,
+    onAction,
+  }: {
+    surface: { surfaceId: string; data?: { providerKey?: string } };
+    assistantId?: string | null;
+    onAction: (surfaceId: string, actionId: string, data?: unknown) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="room-connect-card"
+      data-assistant={assistantId ?? ""}
+      data-provider={surface.data?.providerKey ?? ""}
+      onClick={() => onAction(surface.surfaceId, "connect", { ok: true })}
+    >
+      connect
+    </button>
+  ),
+}));
+
+const handleSurfaceActionSpy = mock(async () => {});
+mock.module("@/domains/chat/surface-actions", () => ({
+  handleSurfaceAction: handleSurfaceActionSpy,
+}));
+
 // Imported after the mocks so the room picks up the mocked modules.
-const { VoiceRoom } = await import("@/domains/chat/voice/voice-room/voice-room");
+const { VoiceRoom } =
+  await import("@/domains/chat/voice/voice-room/voice-room");
+const { useChatSessionStore } =
+  await import("@/domains/chat/chat-session-store");
+const { attachSurface } =
+  await import("@/domains/chat/utils/stream-updaters/surface-updaters");
+const { completeSurface } =
+  await import("@/domains/chat/utils/stream-updaters/surface-updaters");
+
+type TestSurface = Parameters<typeof attachSurface>[1];
+
+/** Build an `oauth_connect` surface for the transcript snapshot. */
+function connectSurface(
+  surfaceId = "surface-oauth-1",
+  providerKey = "google",
+): TestSurface {
+  return {
+    surfaceId,
+    surfaceType: "oauth_connect",
+    title: "Connect Gmail",
+    data: { providerKey },
+  } as TestSurface;
+}
+
+/** Seed the transcript snapshot with a single assistant message + surface. */
+function seedTranscriptSurface(surface: TestSurface, completed = false): void {
+  let messages = attachSurface([], surface, "assistant-msg-1");
+  if (completed) {
+    messages = completeSurface(messages, surface.surfaceId);
+  }
+  useChatSessionStore.setState({
+    snapshot: {
+      messages,
+      seq: null,
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+    },
+  });
+}
 
 const controls = makeControlsSpies();
 
@@ -140,12 +215,70 @@ beforeEach(() => {
     showUserTranscript: false,
     showAssistantTranscript: false,
   });
+  handleSurfaceActionSpy.mockClear();
+  useChatSessionStore.setState({
+    snapshot: null,
+    dismissedSurfaceIds: new Set(),
+  });
 });
 
 afterEach(() => {
   cleanup();
   useLiveVoiceStore.getState().reset();
   useConversationStore.getState().reset();
+});
+
+const connectCard = () => screen.queryByTestId("room-connect-card");
+
+describe("VoiceRoom — OAuth connect card", () => {
+  test("renders a reachable connect card when a pending oauth_connect surface exists", () => {
+    startOwnedSession("listening");
+    seedTranscriptSurface(connectSurface("surface-oauth-1", "google"));
+    render(<VoiceRoom />);
+
+    const card = connectCard();
+    expect(card).not.toBeNull();
+    // The room's live-voice assistant id threads through to the card.
+    expect(card?.getAttribute("data-assistant")).toBe(ASSISTANT_ID);
+    expect(card?.getAttribute("data-provider")).toBe("google");
+  });
+
+  test("routes the card action to handleSurfaceAction", () => {
+    startOwnedSession("listening");
+    seedTranscriptSurface(connectSurface("surface-oauth-1", "google"));
+    render(<VoiceRoom />);
+
+    fireEvent.click(connectCard()!);
+    expect(handleSurfaceActionSpy).toHaveBeenCalledTimes(1);
+    expect(handleSurfaceActionSpy).toHaveBeenCalledWith(
+      "surface-oauth-1",
+      "connect",
+      { ok: true },
+    );
+  });
+
+  test("renders no card when the surface is already completed", () => {
+    startOwnedSession("listening");
+    seedTranscriptSurface(connectSurface(), true);
+    render(<VoiceRoom />);
+    expect(connectCard()).toBeNull();
+  });
+
+  test("renders no card when there is no pending surface", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(connectCard()).toBeNull();
+  });
+
+  test("renders no card for a dismissed surface", () => {
+    startOwnedSession("listening");
+    seedTranscriptSurface(connectSurface("surface-oauth-1"));
+    useChatSessionStore.setState({
+      dismissedSurfaceIds: new Set(["surface-oauth-1"]),
+    });
+    render(<VoiceRoom />);
+    expect(connectCard()).toBeNull();
+  });
 });
 
 const roomDialog = () =>
@@ -235,7 +368,6 @@ describe("VoiceRoom — exit", () => {
     expect(exitButton()).not.toBeNull();
     expect(screen.getByTestId("voice-avatar").textContent).toBe("no-assistant");
   });
-
 });
 
 describe("VoiceRoom — no way out but ending the session", () => {
@@ -347,18 +479,18 @@ describe("VoiceRoom — connect feedback", () => {
   test("shows the connecting label while the session connects", () => {
     startOwnedSession("connecting");
     render(<VoiceRoom />);
-    expect(
-      screen.getByTestId("voice-room-connect-label").textContent,
-    ).toBe("Connecting…");
+    expect(screen.getByTestId("voice-room-connect-label").textContent).toBe(
+      "Connecting…",
+    );
   });
 
   test("relabels to Reconnecting… while retrying a dropped connection", () => {
     startOwnedSession("connecting");
     useLiveVoiceStore.getState().setReconnecting(true);
     render(<VoiceRoom />);
-    expect(
-      screen.getByTestId("voice-room-connect-label").textContent,
-    ).toBe("Reconnecting…");
+    expect(screen.getByTestId("voice-room-connect-label").textContent).toBe(
+      "Reconnecting…",
+    );
   });
 
   test("no connect label once listening", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -54,10 +54,14 @@ import {
   stopLiveVoiceResponse,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { OAuthConnectSurface } from "@/domains/chat/components/surfaces/oauth-connect-surface";
+import { handleSurfaceAction } from "@/domains/chat/surface-actions";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { toneForBg } from "@/utils/surface-tone";
+
+import { useActiveConnectSurface } from "./use-active-connect-surface";
 
 import { resolveWaveAccentHex } from "./wave-accent";
 
@@ -92,7 +96,8 @@ const VOID_CAPTION_TOP = `calc(50% + ${AVATAR_SIZE / 2}px + 1.75rem)`;
  * browsers with `viewport-fit=cover`, and `0px` covers desktop / non-notch
  * devices — so these are inert everywhere except a notched iOS shell.
  */
-const SAFE_AREA_TOP = "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))";
+const SAFE_AREA_TOP =
+  "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))";
 const SAFE_AREA_BOTTOM =
   "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))";
 const SAFE_AREA_LEFT =
@@ -161,11 +166,17 @@ function VoiceRoomOverlay() {
   const showAssistantTranscript =
     useVoicePrefsStore.use.showAssistantTranscript();
 
+  // A live `oauth_connect` card the assistant raised this turn. The transcript's
+  // copy is buried behind this modal, so the room renders its own reachable
+  // instance; completing it resumes the turn as a spoken reply (JARVIS-1287).
+  const connectSurface = useActiveConnectSurface();
+
   // Resolve the assistant's look: color-with-eyes for character avatars, the
   // ambient void otherwise. The accent var is still published for the
   // fallback look's listening waves (null for custom-image / "none" /
   // still-loading avatars, where the waves keep their aurora fallback).
-  const { components, traits, customImageUrl } = useAssistantAvatar(assistantId);
+  const { components, traits, customImageUrl } =
+    useAssistantAvatar(assistantId);
   const look = resolveVoiceRoomLook(components, traits, customImageUrl);
   const tone = look ? toneForBg(look.bgHex) : null;
   const accentHex = resolveWaveAccentHex(components, traits);
@@ -277,6 +288,36 @@ function VoiceRoomOverlay() {
           control above) and absolutely positioned, so it never shifts the
           avatar and stays absent by default. */}
       <VoiceAmbientTranscript />
+
+      {/* Reachable OAuth connect card. The room takes over the whole app, so the
+          transcript's copy of this surface is invisible/unclickable underneath —
+          render our own, anchored in the lower center above the session
+          controls, with pointer events re-enabled just for the card. Completing
+          it submits the same surface action the transcript would, which the
+          daemon resumes as a spoken turn (JARVIS-1287). */}
+      <AnimatePresence>
+        {connectSurface ? (
+          <motion.div
+            key={`connect-${connectSurface.surfaceId}`}
+            className="pointer-events-none absolute inset-x-0 z-20 flex justify-center px-4"
+            style={{ bottom: `calc(6rem + ${SAFE_AREA_BOTTOM})` }}
+            initial={reduce ? false : { opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 12 }}
+            transition={{ duration: reduce ? 0 : 0.3 }}
+          >
+            <div className="pointer-events-auto w-full max-w-[28rem]">
+              <OAuthConnectSurface
+                surface={connectSurface}
+                assistantId={assistantId}
+                onAction={(surfaceId, actionId, data) => {
+                  void handleSurfaceAction(surfaceId, actionId, data);
+                }}
+              />
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
 
       {/* Room controls — captions toggle and the persistent exit. Rendered
           above all room chrome; ✕ is never gated behind avatar readiness, so


### PR DESCRIPTION
## JARVIS-1287 — Voice mode becomes unresponsive after connecting Gmail OAuth

### Problem
When the assistant asks to connect an OAuth provider mid-voice-session, the flow was broken in two compounding ways:

1. **The connect card was unreachable.** The voice room is a `fixed inset-0 z-50` full-app takeover over a blurred, pointer-events-disabled transcript, and it rendered **no surfaces** — so the `oauth_connect` card the assistant raised sat invisible and unclickable underneath.
2. **The resumed reply was never spoken.** Completing a surface goes through HTTP `/v1/surface-actions` → the daemon's TEXT pipeline (`enqueueMessage`/`processMessage`, `onEvent = broadcastMessage`), which publishes only to the SSE hub. TTS is only synthesized for a live, non-completed voice turn, so the resumed reply streamed silently into the hidden transcript. The user saw the avatar sitting idle → "unresponsive."

### Fix (two parts)

**Daemon — resume the surface completion as a *spoken* voice turn.**
- New decoupled `live-voice-resume-registry.ts` (`Map<conversationId, VoiceResumeHandler>`, identity-checked unregister) so the session and the surface handler never form a require cycle.
- `LiveVoiceSession` registers a handler; `resumeWithText` → `startResumeTurn` drives a turn from a **synthetic `transcriber_closed`/`released` utterance** carrying the follow-up text, through the existing TTS pipeline. It never touches `this.currentUtterance` (the server-VAD armed next utterance); `finalizeAssistantTurn` already works on `turn.utterance` and tolerates empty audio. A resume arriving mid-turn is deferred and flushed when the active turn settles — never `CONVERSATION_BUSY`. The turn-launch block was extracted into a shared `launchAssistantTurn` (pure refactor).
- `conversation-surfaces.ts`: when a live-voice session owns the conversation (and the action has no attachments), route the follow-up to `resumeWithText` instead of the text path, mirroring the one-shot completion / echo / pending-delete bookkeeping. **The text path is byte-for-byte unchanged for non-voice conversations.**

**Client — make the connect card reachable in the room.**
- New `use-active-connect-surface.ts` selector (active, non-completed, non-dismissed `oauth_connect`, stable by reference so the room doesn't re-render per streaming token).
- A lower-center connect-card slot in `voice-room.tsx` with pointer events re-enabled just for the card; its action goes through the same `handleSurfaceAction` the transcript uses, which the daemon now resumes as spoken.

### Tests
- Daemon: registry unit tests; a session-level test proving a resume with **no audio input** drives `assistant_text_delta` + `tts_audio` + `tts_done` (spoken) and is not echoed as user speech; conversation-surfaces routing (handler present → spoken resume, no `processMessage`; absent → text fallback; pending cleared in both). `bun test src/live-voice/ src/__tests__/conversation-surfaces-action-delivery.test.ts` → 221 pass.
- Client: room renders the card only when a pending surface exists (not completed/dismissed/absent) and routes its action to `handleSurfaceAction`. `voice-room.test.tsx` → 45 pass.
- Typecheck + lint + prettier clean on both packages.

### Follow-ups (not blocking)
- `startResumeTurn` currently ignores `displayContent`/`sourceActorPrincipalId` (threads only the model-facing `content`), so the resumed user row shows the raw `[User action on …]` text rather than a friendly label. Cosmetic; threading `displayContent` into `VoiceTurnOptions` is a separate change. Local voice turns already resolve trust via the guardian path, so dropping `sourceActorPrincipalId` is consistent.
- Invalidating the connections-list query cache after a voice connect (so Settings→Integrations repaints) was deferred to avoid retrofitting `QueryClientProvider` into existing `OAuthConnectSurface` tests; the card flips to "Connected" locally and JARVIS-1286 fixes the root "not reflected as connected."

Related: JARVIS-1286 (multiple popups + not-connected) is #38095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)