### PR TITLE
feat(plugins): confirm external install via ?success=true deep-link

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -894,6 +894,7 @@ export function useLiveVoice(
                 release,
                 interrupt,
                 setMuted,
+                updateConfig,
               });
               console.warn(
                 `live-voice: initial connect failed (${err.reason}); retrying ` +

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.test.tsx
@@ -21,7 +21,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { PLUGIN_INSTALL_ERROR } from "@/domains/intelligence/plugins/constants";
 import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categories";
 import type {
@@ -198,20 +198,33 @@ function catalog(overrides: Partial<CatalogMatch> = {}): CatalogMatch {
   };
 }
 
-function renderTab(props: { plugin?: string } = {}) {
+function renderTab(props: { plugin?: string; success?: boolean } = {}) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
-  const entry = props.plugin
-    ? `/assistant/plugins?plugin=${encodeURIComponent(props.plugin)}`
-    : "/assistant/plugins";
+  const params = new URLSearchParams();
+  if (props.plugin) {
+    params.set("plugin", props.plugin);
+  }
+  if (props.success) {
+    params.set("success", "true");
+  }
+  const query = params.toString();
+  const entry = query ? `/assistant/plugins?${query}` : "/assistant/plugins";
   return render(
     <MemoryRouter initialEntries={[entry]}>
       <QueryClientProvider client={client}>
         <PluginsTab assistantId={ASSISTANT_ID} />
       </QueryClientProvider>
+      <LocationProbe />
     </MemoryRouter>,
   );
+}
+
+/** Surfaces the live URL search string so tests can assert param changes. */
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-search">{location.search}</div>;
 }
 
 /** Click the Status option whose visible label matches (popover portal). */
@@ -392,6 +405,33 @@ describe("PluginsTab", () => {
     await waitFor(() => expect(toastSuccessSpy).toHaveBeenCalledTimes(1));
     expect(toastSuccessSpy.mock.calls[0]?.[0]).toContain("apollo-bot-brain");
     expect(toastErrorSpy).not.toHaveBeenCalled();
+  });
+
+  test("confirms an external install via ?success=true and strips the flag", async () => {
+    installedPlugins = [installed({ name: "coffee-aficionado" })];
+
+    renderTab({ plugin: "coffee-aficionado", success: true });
+
+    await waitFor(() => expect(toastSuccessSpy).toHaveBeenCalledTimes(1));
+    expect(toastSuccessSpy.mock.calls[0]?.[0]).toContain("coffee-aficionado");
+    expect(toastErrorSpy).not.toHaveBeenCalled();
+
+    // `success` is stripped (so a refresh won't re-toast); `plugin` stays so the
+    // installed plugin's detail is still what's open.
+    await waitFor(() => {
+      const search = screen.getByTestId("location-search").textContent ?? "";
+      expect(search).not.toContain("success");
+      expect(search).toContain("plugin=coffee-aficionado");
+    });
+  });
+
+  test("does not toast on a normal deep-link without ?success", async () => {
+    installedPlugins = [installed({ name: "coffee-aficionado" })];
+
+    renderTab({ plugin: "coffee-aficionado" });
+
+    await screen.findByTestId("location-search");
+    expect(toastSuccessSpy).not.toHaveBeenCalled();
   });
 
   test("a failed inline install surfaces an error toast", async () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugins-tab.tsx
@@ -9,7 +9,7 @@ import {
     TriangleAlert,
     X,
 } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 
 import { PluginDetail } from "@/domains/intelligence/components/plugins/plugin-detail";
@@ -78,6 +78,31 @@ export function PluginsTab({ assistantId }: PluginsTabProps) {
   const isMobile = useIsMobile();
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedPluginName = searchParams.get("plugin");
+
+  // `?success=true` is set when another surface (e.g. the marketing plugin
+  // page's "Install in your assistant" button) installs a plugin and then
+  // deep-links here. Confirm it with a toast once, then strip the flag so a
+  // refresh or back/forward doesn't re-fire it. The `?plugin=` param stays, so
+  // the just-installed plugin's detail opens as usual.
+  const successFlag = searchParams.get("success");
+  const successToastedRef = useRef(false);
+  useEffect(() => {
+    if (successFlag !== "true" || successToastedRef.current) {
+      return;
+    }
+    successToastedRef.current = true;
+    if (selectedPluginName) {
+      toast.success(`Installed ${selectedPluginName}`);
+    }
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("success");
+        return next;
+      },
+      { replace: true },
+    );
+  }, [successFlag, selectedPluginName, setSearchParams]);
 
   const [searchValue, setSearchValue] = useState("");
   const [filter, setFilter] = useState<PluginFilter>("all");


### PR DESCRIPTION
## Prompt / plan

Companion to vellum-ai/vellum-assistant-platform#9086. That PR added a dev-only "Install in your assistant" button on the marketing plugin pages: it installs the plugin through the runtime proxy, then deep-links here to `/assistant/plugins?plugin=<name>&success=true`. This PR makes the `success=true` flag meaningful in the app.

## What

**Plugins (`plugins-tab.tsx`)** — when the URL carries `?success=true`, show a one-time success toast for the deep-linked plugin, then strip the `success` flag (via `setSearchParams(..., { replace: true })`) so a refresh or back/forward doesn't re-fire it. The `?plugin=` param is left intact, so the just-installed plugin's detail opens as usual.

- A `useRef` guard prevents a double toast (e.g. StrictMode's double-invoked effect).
- Toast copy mirrors the tab's own inline install (`Installed <name>`), so external and in-tab installs read the same.

**Also included — an unrelated CI fix (`use-live-voice.ts`):** the initial-connect retry path built a `LiveVoiceSessionControls` object without `updateConfig`, so it failed the repo's Type Check job. This is a **pre-existing error on `main`** (reproducible at `v0.10.9` with this branch's plugins change stashed), not a regression from this PR — it was just blocking Type Check CI here. Added `updateConfig`, matching the two other `setControls` call sites. Happy to split it into its own PR if you'd prefer a focused diff.

## Test plan

- `bun test src/domains/intelligence/components/plugins/plugins-tab.test.tsx` — **28 pass, 0 fail**, including two new cases:
  - confirms an external install via `?success=true` (toast fires once with the plugin name) **and** strips the flag while keeping `?plugin=` (asserted via a `LocationProbe`);
  - a normal deep-link **without** `?success` does not toast.
- `bunx tsc --noEmit` — **0 errors** (was 1, the `use-live-voice.ts` error above).
- `eslint` on the touched files — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CcxFKF87z1wx4gCnL2Q23