### PR TITLE
feat(migrations): defer steps whose dependsOn prerequisites are not applied

### DIFF
--- a/assistant/src/__tests__/db-migration-rollback.test.ts
+++ b/assistant/src/__tests__/db-migration-rollback.test.ts
@@ -69,6 +69,7 @@ import { migrateRenameThreadStartersCheckpointsDown } from "../persistence/migra
 import { migrateBackfillAudioAttachmentMimeTypesDown } from "../persistence/migrations/191-backfill-audio-attachment-mime-types.js";
 import { migrateLlmUsageAttribution } from "../persistence/migrations/235-llm-usage-attribution.js";
 import {
+  getStepName,
   type MigrationStep,
   runMigrationSteps,
 } from "../persistence/migrations/run-migrations.js";
@@ -902,6 +903,27 @@ describe("schema-drift recovery: migration handles unexpected schema state", () 
         expect(allNames.has(dep)).toBe(true);
       }
     }
+  });
+
+  test("migrationSteps: every dependsOn reference points to an earlier step", () => {
+    // The runner defers a step whose dependsOn prerequisites are not yet
+    // applied. A dependency declared at a later index or a misspelled name can
+    // never be satisfied when both steps are pending, which would leave the
+    // step deferring forever at runtime. This test makes such mis-declarations
+    // a CI failure instead.
+    const indexByName = new Map<string, number>();
+    migrationSteps.forEach((step, index) => {
+      indexByName.set(getStepName(step), index);
+    });
+    migrationSteps.forEach((step, index) => {
+      if (typeof step === "function") return;
+      if (!step.dependsOn) return;
+      for (const dep of step.dependsOn) {
+        const depIndex = indexByName.get(dep);
+        expect(depIndex).toBeDefined();
+        expect(depIndex!).toBeLessThan(index);
+      }
+    });
   });
 
   test("migrateMemoryEntityRelationDedup: idempotent on already-deduplicated table", () => {

--- a/assistant/src/persistence/db-init.ts
+++ b/assistant/src/persistence/db-init.ts
@@ -87,7 +87,7 @@ export async function initializeDb(): Promise<{ migrationsOk: boolean }> {
   // broken migration doesn't prevent independent later ones from succeeding.
   // The runner creates the checkpoint ledger, recovers crashed migrations, then
   // records each step so an already-migrated database skips it on later boots.
-  const { applied, failed, skipped } = await runMigrationSteps(
+  const { applied, failed, skipped, deferred } = await runMigrationSteps(
     database,
     migrationSteps,
   );
@@ -108,6 +108,13 @@ export async function initializeDb(): Promise<{ migrationsOk: boolean }> {
     );
   }
 
+  if (deferred.length > 0) {
+    log.error(
+      { deferredMigrations: deferred, count: deferred.length },
+      `DB initialization completed with ${deferred.length} deferred migration(s) whose prerequisites are not applied`,
+    );
+  }
+
   // A passing post-run validation is part of readiness: validateMigrationState
   // flags schema inconsistencies (e.g. a completed step missing a declared
   // dependsOn checkpoint) that no individual step body surfaces as a failure.
@@ -119,7 +126,11 @@ export async function initializeDb(): Promise<{ migrationsOk: boolean }> {
     log.error({ err }, "validateMigrationState failed");
   }
 
-  // migrationsOk reflects BOTH no failed migration steps AND a passing
+  // migrationsOk requires no failed steps, no deferred steps, and a passing
   // post-run validation, so an inconsistent schema keeps /readyz at 503.
-  return { migrationsOk: failed.length === 0 && validationOk };
+  // Deferrals count because a mis-declared dependsOn would otherwise leave a
+  // step silently never running while the daemon reports ready.
+  return {
+    migrationsOk: failed.length === 0 && deferred.length === 0 && validationOk,
+  };
 }

--- a/assistant/src/persistence/migrations/__tests__/run-migrations.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/run-migrations.test.ts
@@ -346,6 +346,161 @@ describe("runMigrationSteps — checkpointing", () => {
     expect(result.skipped).toEqual([]);
   });
 
+  test("defers a step whose dependency failed this boot, without checkpointing it", async () => {
+    /**
+     * A step must not run against the missing state a failed prerequisite was
+     * supposed to create. It is deferred — not run, not checkpointed — and
+     * reported in `deferred` so readiness gating can surface it.
+     */
+
+    // GIVEN a failing creator step and a dependent step
+    const calls = { creator: 0, dependent: 0 };
+    const steps: MigrationStep[] = [
+      {
+        name: "creatorStep",
+        run: () => {
+          calls.creator++;
+          throw new Error("creator failed");
+        },
+      },
+      {
+        name: "dependentStep",
+        dependsOn: ["creatorStep"],
+        run: () => {
+          calls.dependent++;
+        },
+      },
+    ];
+    const db = createTestDb();
+
+    // WHEN the runner executes
+    const result = await runMigrationSteps(db, steps);
+
+    // THEN the dependent step never ran and is reported deferred
+    expect(calls.dependent).toBe(0);
+    expect(result.failed).toEqual(["creatorStep"]);
+    expect(result.deferred).toEqual(["dependentStep"]);
+
+    // AND nothing was written to the ledger for the deferred step —
+    // no 'started' marker and no applied checkpoint
+    const rows = getSqliteFrom(db)
+      .query(
+        `SELECT 1 FROM memory_checkpoints WHERE key = 'step:dependentStep'`,
+      )
+      .all();
+    expect(rows).toEqual([]);
+  });
+
+  test("a deferred step runs on the next boot once its dependency succeeds", async () => {
+    /**
+     * Deferral is a retry mechanism, not a permanent skip: once the
+     * prerequisite is applied on a later boot, the deferred step runs.
+     */
+
+    // GIVEN a creator that fails on its first run and a dependent step
+    const calls = { creator: 0, dependent: 0 };
+    const steps: MigrationStep[] = [
+      {
+        name: "creatorStep",
+        run: () => {
+          calls.creator++;
+          if (calls.creator === 1) {
+            throw new Error("transient failure");
+          }
+        },
+      },
+      {
+        name: "dependentStep",
+        dependsOn: ["creatorStep"],
+        run: () => {
+          calls.dependent++;
+        },
+      },
+    ];
+    const db = createTestDb();
+
+    // WHEN the first boot defers the dependent step
+    const first = await runMigrationSteps(db, steps);
+    expect(first.deferred).toEqual(["dependentStep"]);
+
+    // AND the next boot retries
+    const second = await runMigrationSteps(db, steps);
+
+    // THEN both steps run and nothing is deferred or failed
+    expect(calls).toEqual({ creator: 2, dependent: 1 });
+    expect(second.applied).toEqual(["creatorStep", "dependentStep"]);
+    expect(second.deferred).toEqual([]);
+    expect(second.failed).toEqual([]);
+  });
+
+  test("a step depending on an earlier same-boot step runs without deferral", async () => {
+    /**
+     * The runner adds each success to the in-memory applied set, so a
+     * dependency satisfied earlier in the same boot does not defer the
+     * dependent step — creator and dependent can ship in one release.
+     */
+
+    // GIVEN a creator and a dependent, both pending
+    const order: string[] = [];
+    const steps: MigrationStep[] = [
+      {
+        name: "creatorStep",
+        run: () => {
+          order.push("creator");
+        },
+      },
+      {
+        name: "dependentStep",
+        dependsOn: ["creatorStep"],
+        run: () => {
+          order.push("dependent");
+        },
+      },
+    ];
+    const db = createTestDb();
+
+    // WHEN the runner executes both in one boot
+    const result = await runMigrationSteps(db, steps);
+
+    // THEN they run in order with no deferral
+    expect(order).toEqual(["creator", "dependent"]);
+    expect(result.applied).toEqual(["creatorStep", "dependentStep"]);
+    expect(result.deferred).toEqual([]);
+  });
+
+  test("a step whose dependency is already checkpointed runs normally", async () => {
+    /**
+     * A dependency applied on a prior boot satisfies dependsOn through the
+     * checkpoint ledger, so the dependent step runs even though the creator
+     * was skipped this boot.
+     */
+
+    // GIVEN a database where the creator step was applied on a prior boot
+    const creator: MigrationStep = {
+      name: "creatorStep",
+      run: () => {
+        // no-op
+      },
+    };
+    const db = createTestDb();
+    await runMigrationSteps(db, [creator]);
+
+    // WHEN a dependent step ships in a later release
+    const dependent: MigrationStep = {
+      name: "dependentStep",
+      dependsOn: ["creatorStep"],
+      run: () => {
+        // no-op
+      },
+    };
+    const result = await runMigrationSteps(db, [creator, dependent]);
+
+    // THEN the dependent step runs while the creator is skipped
+    expect(result.skipped).toEqual(["creatorStep"]);
+    expect(result.applied).toEqual(["dependentStep"]);
+    expect(result.deferred).toEqual([]);
+  });
+
   test("writes 'started' marker before running each step", async () => {
     const db = createTestDb();
     const raw = getSqliteFrom(db);

--- a/assistant/src/persistence/migrations/run-migrations.ts
+++ b/assistant/src/persistence/migrations/run-migrations.ts
@@ -109,6 +109,8 @@ export interface MigrationRunResult {
   failed: string[];
   /** Steps skipped because a prior run already applied them. */
   skipped: string[];
+  /** Steps not run because a declared dependsOn prerequisite is not applied. */
+  deferred: string[];
 }
 
 /**
@@ -213,6 +215,11 @@ export function recoverCrashedMigrations(database: DrizzleDb): string[] {
  * Individual step failures are caught and logged so one broken migration does
  * not prevent independent later ones from succeeding; a failed step is not
  * checkpointed and is retried on the next boot.
+ *
+ * A step whose declared `dependsOn` prerequisites are not all applied — because
+ * a dependency failed this boot or was never run — is deferred rather than
+ * executed against missing state. A deferred step writes nothing to the ledger,
+ * so it retries on the next boot once its prerequisites have been applied.
  */
 export async function runMigrationSteps(
   database: DrizzleDb,
@@ -242,6 +249,7 @@ export async function runMigrationSteps(
   const failed: string[] = [];
   const skipped: string[] = [];
   const ran: string[] = [];
+  const deferred: string[] = [];
 
   const totalSteps = steps.length;
   for (const [index, step] of steps.entries()) {
@@ -254,6 +262,19 @@ export async function runMigrationSteps(
     if (checkpointable && applied.has(name)) {
       skipped.push(name);
       log.debug({ migration: name }, `Skipping applied migration: ${name}`);
+      continue;
+    }
+
+    // Defer a step whose prerequisites are not applied rather than run it
+    // against missing state. Nothing is written to the ledger — no 'started'
+    // marker, no checkpoint — so the step retries on the next boot.
+    const missing = (obj.dependsOn ?? []).filter((dep) => !applied.has(dep));
+    if (missing.length > 0) {
+      deferred.push(name);
+      log.warn(
+        { migration: name, missing, step: stepNumber, totalSteps },
+        `Deferring migration "${name}" — prerequisites not applied: ${missing.join(", ")}`,
+      );
       continue;
     }
 
@@ -276,6 +297,9 @@ export async function runMigrationSteps(
       if (checkpointable) {
         markApplied.run(`${STEP_CHECKPOINT_PREFIX}${name}`, Date.now());
         ran.push(name);
+        // Record the success in the in-memory set too, so a later step in this
+        // same boot can depend on it without being deferred.
+        applied.add(name);
       }
     } catch (err) {
       // Leave the 'started' marker in place (if one was written) —
@@ -289,7 +313,7 @@ export async function runMigrationSteps(
     }
   }
 
-  return { applied: ran, failed, skipped };
+  return { applied: ran, failed, skipped, deferred };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Migration runner now defers a step whose declared dependsOn prerequisites are not checkpointed, instead of running it against missing state; deferred steps retry next boot.
- Deferrals count against migration readiness alongside failures.
- Static test pins that every dependsOn declaration points to an earlier step.

Part of plan: memory-db-wave1.md (PR 1 of 3)