### PR TITLE
fix: clear stale page context on voice surface resumes

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -74,6 +74,8 @@ interface FakeConversation {
   callSessionId: string | undefined;
   forcePromptSideEffects: boolean;
   currentRequestId: string | undefined;
+  currentActiveSurfaceId?: string | undefined;
+  currentPage?: string | undefined;
   isProcessing: () => boolean;
   hasQueuedMessages?: () => boolean;
   waitForIdle: (options: WaitForIdleCall) => Promise<boolean>;
@@ -120,6 +122,8 @@ function makeFakeConversation(opts: {
     callSessionId: undefined,
     forcePromptSideEffects: false,
     currentRequestId: undefined,
+    currentActiveSurfaceId: undefined,
+    currentPage: undefined,
     isProcessing: () => opts.processing,
     hasQueuedMessages: opts.hasQueuedMessages,
     waitForIdle: (options) => {
@@ -373,6 +377,46 @@ describe("startVoiceTurn surface-resume metadata", () => {
 
     const echo = broadcasts.find((m) => m.type === "user_message_echo");
     expect(echo?.text).toBe("what's the weather");
+  });
+
+  test("a resume restores activeSurfaceId and clears a stale currentPage", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+    // A prior turn left a page live; the agent loop clears
+    // `currentActiveSurfaceId` between turns but not `currentPage`. The mock
+    // starts with `currentActiveSurfaceId` already undefined.
+    fake.conversation.currentPage = "settings.html";
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "[User action on dynamic_page surface: submit]",
+      requestId: "surface-request-page",
+      activeSurfaceId: "surface-app-1",
+      // The surface action carries no page — the resume must clear the stale one.
+    });
+
+    // The resumed surface is restored, paired with its own (undefined) page
+    // rather than the prior turn's stale `settings.html`.
+    expect(fake.conversation.currentActiveSurfaceId).toBe("surface-app-1");
+    expect(fake.conversation.currentPage).toBeUndefined();
+  });
+
+  test("a normal turn leaves activeSurfaceId/currentPage untouched", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+    fake.conversation.currentActiveSurfaceId = "prior-surface";
+    fake.conversation.currentPage = "prior.html";
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what's the weather",
+    });
+
+    // No `activeSurfaceId` on a normal STT turn → the guarded assignment is
+    // skipped and the fields keep their per-turn defaults (the agent loop, not
+    // the bridge, owns resetting them).
+    expect(fake.conversation.currentActiveSurfaceId).toBe("prior-surface");
+    expect(fake.conversation.currentPage).toBe("prior.html");
   });
 });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -246,6 +246,16 @@ export interface VoiceTurnOptions {
    * a normal STT turn with no active surface (left at the per-turn default).
    */
   activeSurfaceId?: string;
+  /**
+   * Page to pair with `activeSurfaceId` for a surface-resume turn. Threaded
+   * into `conversation.currentPage` alongside `activeSurfaceId` so
+   * `buildActiveSurfaceContext` injects the right page — parity with the text
+   * path, which sets `currentPage` every turn. `runAgentLoop` clears
+   * `currentActiveSurfaceId` at turn end but not `currentPage`, so a resume
+   * must set it (to `undefined` when the surface action carries no page) to
+   * avoid pairing the resumed surface with a stale page from a prior turn.
+   */
+  currentPage?: string;
 }
 
 export interface VoiceTurnHandle {
@@ -1003,8 +1013,12 @@ export async function startVoiceTurn(
       // `dynamic_page`/app the user acted on (parity with the text path's
       // `currentActiveSurfaceId`). Guarded so a normal STT turn leaves the field
       // at its per-turn default (reset to undefined by the agent loop).
+      // `currentPage` is set alongside because the agent loop does not reset it
+      // between turns, so a resume must pair the surface with its own page
+      // (undefined when the action carries none) rather than a stale one.
       if (opts.activeSurfaceId !== undefined) {
         conversation.currentActiveSurfaceId = opts.activeSurfaceId;
+        conversation.currentPage = opts.currentPage;
       }
       await conversation.runAgentLoop(persistedContent, messageId, {
         onEvent: (msg: ServerMessage) => {


### PR DESCRIPTION
## Summary
Review remediation for plan voice-seam-oauth.md: the voice surface-resume path set currentActiveSurfaceId without clearing currentPage (which runAgentLoop does not reset between turns), so a resumed dynamic_page surface could pair with a stale page from a prior turn. Clears currentPage alongside activeSurfaceId, matching the text path.

**Gap:** stale currentPage on voice resume
**What was expected:** parity with the text path (sets currentPage each surface action)
**What was found:** resumed dynamic_page could inject a prior app's page