### PR TITLE
Close the live-voice surface/OAuth seam (JARVIS-1286, JARVIS-1287)

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -597,8 +597,52 @@ describe("surface action delivery to assistant", () => {
       expect(resumeCalls[0]!.opts?.displayContent).not.toContain(
         "[User action on",
       );
+      // The completed surface's id rides into the resume so the resumed turn
+      // restores its active-surface context (parity with the text path).
+      expect(resumeCalls[0]!.opts?.activeSurfaceId).toBe(surfaceId);
       // The pending-surface guard is cleared on the voice-routed path too.
       expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      unregisterVoiceResumeHandler("conv-1", handler);
+    }
+  });
+
+  test("live-voice resume: dynamic_page action forwards activeSurfaceId so the resumed turn keeps app context", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // Seed a dynamic_page surface directly (a real ui_show would pull from the
+    // app store; the routing under test only needs the pending + state entries).
+    const surfaceId = "surface-dynamic-page-1";
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType: "dynamic_page",
+      data: { html: "<p>app</p>" } as unknown as SurfaceData,
+      title: "My App",
+    });
+    ctx.pendingSurfaceActions.set(surfaceId, { surfaceType: "dynamic_page" });
+
+    const resumeCalls: Array<{ content: string; opts?: VoiceResumeOptions }> =
+      [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler("conv-1", handler);
+
+    try {
+      await handleSurfaceAction(ctx, surfaceId, "submit_answer", {
+        choice: "b",
+      });
+
+      // Routed to the spoken voice resume, NOT the silent text path.
+      expect(ctx.processMessageCalls.length).toBe(0);
+      expect(resumeCalls.length).toBe(1);
+      expect(resumeCalls[0]!.content).toContain("dynamic_page");
+      // The dynamic_page id threads through so the resumed turn's
+      // `buildActiveSurfaceContext` re-injects the app the user just acted on.
+      expect(resumeCalls[0]!.opts?.activeSurfaceId).toBe(surfaceId);
+      // The accepted surface-action request id still rides along for
+      // surface-gated tools.
+      expect(resumeCalls[0]!.opts?.requestId).toBeDefined();
     } finally {
       unregisterVoiceResumeHandler("conv-1", handler);
     }

--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -12,6 +12,13 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
   await import("../daemon/conversation-surfaces.js");
 
+const { registerVoiceResumeHandler, unregisterVoiceResumeHandler } =
+  await import("../live-voice/live-voice-resume-registry.js");
+import type { VoiceResumeHandler } from "../live-voice/live-voice-resume-registry.js";
+
+const { LiveVoiceSession } =
+  await import("../live-voice/live-voice-session.js");
+import type { VoiceTurnOptions } from "../calls/voice-session-bridge.js";
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type {
   SurfaceData,
@@ -19,6 +26,11 @@ import type {
   UiSurfaceShow,
 } from "../daemon/message-protocol.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice/live-voice-session-manager.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../stt/types.js";
 
 interface ProcessMessageCall {
   content: string;
@@ -76,6 +88,19 @@ function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext & {
     withSurface: createSurfaceMutex(),
     processMessageCalls,
   };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
 }
 
 describe("surface action delivery to assistant", () => {
@@ -512,6 +537,191 @@ describe("surface action delivery to assistant", () => {
     expect(completeMsg?.conversationId).toBe("conv-1");
     expect(completeMsg?.summary).toBe("Connected Google: user@example.com");
     expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+  });
+
+  test("live-voice resume: oauth_connect completion routes to resumeWithText, not processMessage", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const resumeCalls: Array<{
+      content: string;
+      opts?: {
+        displayContent?: string;
+        sourceActorPrincipalId?: string;
+        requestId?: string;
+      };
+    }> = [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler("conv-1", handler);
+
+    try {
+      await surfaceProxyResolver(ctx, "ui_show", {
+        surface_type: "oauth_connect",
+        title: "Connect Google",
+        data: { providerKey: "google", displayName: "Google" },
+      });
+
+      const showMessage = sent.find(
+        (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+      ) as UiSurfaceShow;
+      const surfaceId = showMessage.surfaceId;
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(true);
+
+      await handleSurfaceAction(
+        ctx,
+        surfaceId,
+        "connect",
+        {
+          status: "connected",
+          providerKey: "google",
+          providerLabel: "Google",
+          accountLabel: "user@example.com",
+        },
+        "principal-committer",
+      );
+
+      // Routed to the spoken voice resume, NOT the silent text path.
+      expect(ctx.processMessageCalls.length).toBe(0);
+      expect(resumeCalls.length).toBe(1);
+      expect(resumeCalls[0]!.content).toContain("oauth_connect");
+      expect(resumeCalls[0]!.opts?.sourceActorPrincipalId).toBe(
+        "principal-committer",
+      );
+      // The accepted surface-action request id rides into the resume and is the
+      // one tracked in `surfaceActionRequestIds`, so the resumed turn adopting
+      // it keeps `currentRequestId` inside the surface-action set.
+      const resumeRequestId = resumeCalls[0]!.opts?.requestId;
+      expect(resumeRequestId).toBeDefined();
+      expect(ctx.surfaceActionRequestIds.has(resumeRequestId!)).toBe(true);
+      // The user-facing label (not the raw payload) rides along for the
+      // persisted/echoed user row.
+      expect(resumeCalls[0]!.opts?.displayContent).toBeDefined();
+      expect(resumeCalls[0]!.opts?.displayContent).not.toContain(
+        "[User action on",
+      );
+      // The pending-surface guard is cleared on the voice-routed path too.
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      unregisterVoiceResumeHandler("conv-1", handler);
+    }
+  });
+
+  test("live-voice resume: falls back to processMessage when no handler is registered", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "oauth_connect",
+      title: "Connect Google",
+      data: { providerKey: "google", displayName: "Google" },
+    });
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    ) as UiSurfaceShow;
+    const surfaceId = showMessage.surfaceId;
+
+    await handleSurfaceAction(ctx, surfaceId, "connect", {
+      status: "connected",
+      providerKey: "google",
+      providerLabel: "Google",
+      accountLabel: "user@example.com",
+    });
+
+    // No voice handler for this conversation — the text path runs verbatim.
+    expect(ctx.processMessageCalls.length).toBe(1);
+    expect(ctx.processMessageCalls[0]!.content).toContain("oauth_connect");
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+  });
+
+  test("live-voice resume end-to-end: oauth_connect completion runs a spoken continuation turn and clears the pending guard", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // A real live-voice session that registers a resume handler for this
+    // conversation on start and speaks a continuation when resumed.
+    const sessionFrames: Array<{ type: string }> = [];
+    const sessionContext: LiveVoiceSessionFactoryContext = {
+      sessionId: "voice-session-e2e",
+      startFrame: {
+        type: "start",
+        conversationId: "conv-1",
+        audio: { mimeType: "audio/pcm", sampleRate: 24_000, channels: 1 },
+      },
+      sendFrame: async (payload) => {
+        const frame = { ...payload } as { type: string };
+        sessionFrames.push(frame);
+        return frame as never;
+      },
+    };
+    const idleTranscriber: StreamingTranscriber = {
+      providerId: "deepgram",
+      boundaryId: "daemon-streaming",
+      async start(_onEvent: (event: SttStreamServerEvent) => void) {
+        // Idle transcriber: the resume path never streams audio.
+      },
+      sendAudio() {},
+      stop() {},
+    };
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "Great, Google is connected.",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-e2e",
+      });
+      return { turnId: "bridge-e2e-1", abort: mock() };
+    });
+    const session = new LiveVoiceSession(sessionContext, {
+      resolveTranscriber: async () => idleTranscriber,
+      startVoiceTurn,
+      createTurnId: () => "voice-turn-e2e",
+      emitMetrics: false,
+    });
+
+    await session.start();
+
+    try {
+      // A voice turn raised an oauth_connect surface and yielded.
+      await surfaceProxyResolver(ctx, "ui_show", {
+        surface_type: "oauth_connect",
+        title: "Connect Google",
+        data: { providerKey: "google", displayName: "Google" },
+      });
+      const showMessage = sent.find(
+        (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+      ) as UiSurfaceShow;
+      const surfaceId = showMessage.surfaceId;
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(true);
+
+      // The user completes the connect surface.
+      await handleSurfaceAction(ctx, surfaceId, "connect", {
+        status: "connected",
+        providerKey: "google",
+        providerLabel: "Google",
+        accountLabel: "user@example.com",
+      });
+
+      // Spoken continuation ran through the live-voice session, not the
+      // silent text path.
+      await waitFor(() => sessionFrames.some((f) => f.type === "tts_done"));
+      expect(ctx.processMessageCalls.length).toBe(0);
+      expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+      const types = sessionFrames.map((f) => f.type);
+      expect(types).not.toContain("stt_final");
+      expect(types).toContain("thinking");
+      expect(types).toContain("assistant_text_delta");
+      // The pending-surface guard is cleared after the voice-routed completion.
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      await session.close("client_end");
+    }
   });
 
   test("table surface does NOT broadcast ui_surface_complete (not one-shot)", async () => {

--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -607,6 +607,57 @@ describe("surface action delivery to assistant", () => {
     }
   });
 
+  test("live-voice resume: relayed prompt is not pre-echoed (voice turn emits its own echo)", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // A relay_prompt surface: the text path echoes `prompt` here, but on the
+    // voice path `startVoiceTurn` emits its own user_message_echo for the
+    // resumed turn — so handleSurfaceAction must NOT also relay it.
+    const surfaceId = "relay-voice-surface";
+    ctx.surfaceState.set(surfaceId, {
+      surfaceType: "card",
+      data: { title: "Continue?", body: "Pick up where we left off." },
+      actions: [
+        {
+          id: "relay_prompt",
+          label: "Continue",
+          style: "primary",
+          data: {
+            prompt: "Continue from where you stopped.",
+            _completeSurface: true,
+            _completionSummary: "Continue",
+          },
+        },
+      ],
+    });
+    ctx.pendingSurfaceActions.set(surfaceId, { surfaceType: "card" });
+
+    const resumeCalls: Array<{ content: string; opts?: VoiceResumeOptions }> =
+      [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler("conv-1", handler);
+
+    try {
+      await handleSurfaceAction(ctx, surfaceId, "relay_prompt");
+
+      // Routed to the spoken resume, not the text path.
+      expect(resumeCalls.length).toBe(1);
+      expect(ctx.processMessageCalls.length).toBe(0);
+      // Exactly zero pre-echoes from handleSurfaceAction: the resumed turn's
+      // own user_message_echo (from startVoiceTurn, stubbed here) is the single
+      // source of the user bubble, so no double bubble for one click.
+      expect(
+        broadcastedMessages.filter((m) => m.type === "user_message_echo")
+          .length,
+      ).toBe(0);
+    } finally {
+      unregisterVoiceResumeHandler("conv-1", handler);
+    }
+  });
+
   test("live-voice resume: dynamic_page action forwards activeSurfaceId so the resumed turn keeps app context", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent);

--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -14,7 +14,10 @@ const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
 
 const { registerVoiceResumeHandler, unregisterVoiceResumeHandler } =
   await import("../live-voice/live-voice-resume-registry.js");
-import type { VoiceResumeHandler } from "../live-voice/live-voice-resume-registry.js";
+import type {
+  VoiceResumeHandler,
+  VoiceResumeOptions,
+} from "../live-voice/live-voice-resume-registry.js";
 
 const { LiveVoiceSession } =
   await import("../live-voice/live-voice-session.js");
@@ -545,11 +548,7 @@ describe("surface action delivery to assistant", () => {
 
     const resumeCalls: Array<{
       content: string;
-      opts?: {
-        displayContent?: string;
-        sourceActorPrincipalId?: string;
-        requestId?: string;
-      };
+      opts?: VoiceResumeOptions;
     }> = [];
     const handler: VoiceResumeHandler = {
       resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
@@ -586,9 +585,6 @@ describe("surface action delivery to assistant", () => {
       expect(ctx.processMessageCalls.length).toBe(0);
       expect(resumeCalls.length).toBe(1);
       expect(resumeCalls[0]!.content).toContain("oauth_connect");
-      expect(resumeCalls[0]!.opts?.sourceActorPrincipalId).toBe(
-        "principal-committer",
-      );
       // The accepted surface-action request id rides into the resume and is the
       // one tracked in `surfaceActionRequestIds`, so the resumed turn adopting
       // it keeps `currentRequestId` inside the surface-action set.
@@ -602,6 +598,63 @@ describe("surface action delivery to assistant", () => {
         "[User action on",
       );
       // The pending-surface guard is cleared on the voice-routed path too.
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      unregisterVoiceResumeHandler("conv-1", handler);
+    }
+  });
+
+  test("live-voice resume: busy conversation routes to resumeWithText, not the text queue", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+    // The conversation is processing a turn: without the pre-enqueue voice
+    // dispatch, the completion would be pushed onto the silent text queue
+    // (`queued: true`) and later drained via `processMessage`, never spoken.
+    ctx.isProcessing = () => true;
+    let enqueueCalls = 0;
+    ctx.enqueueMessage = () => {
+      enqueueCalls += 1;
+      return { queued: true, requestId: "queued-req" };
+    };
+
+    const resumeCalls: Array<{ content: string; opts?: VoiceResumeOptions }> =
+      [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler("conv-1", handler);
+
+    try {
+      await surfaceProxyResolver(ctx, "ui_show", {
+        surface_type: "oauth_connect",
+        title: "Connect Google",
+        data: { providerKey: "google", displayName: "Google" },
+      });
+
+      const showMessage = sent.find(
+        (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+      ) as UiSurfaceShow;
+      const surfaceId = showMessage.surfaceId;
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(true);
+
+      await handleSurfaceAction(ctx, surfaceId, "connect", {
+        status: "connected",
+        providerKey: "google",
+        providerLabel: "Google",
+        accountLabel: "user@example.com",
+      });
+
+      // Routed to the spoken resume even though the conversation is busy — and
+      // NOT pushed onto the silent text queue.
+      expect(resumeCalls.length).toBe(1);
+      expect(resumeCalls[0]!.content).toContain("oauth_connect");
+      expect(enqueueCalls).toBe(0);
+      expect(ctx.processMessageCalls.length).toBe(0);
+      // No text-queue side effects leak to the client.
+      expect(broadcastedMessages.some((m) => m.type === "message_queued")).toBe(
+        false,
+      );
+      // The pending-surface guard is still cleared on the busy voice path.
       expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
     } finally {
       unregisterVoiceResumeHandler("conv-1", handler);
@@ -634,6 +687,50 @@ describe("surface action delivery to assistant", () => {
     expect(ctx.processMessageCalls.length).toBe(1);
     expect(ctx.processMessageCalls[0]!.content).toContain("oauth_connect");
     expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+  });
+
+  test("live-voice resume: surface action carrying attachments falls back to processMessage", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const resumeCalls: Array<{ content: string; opts?: VoiceResumeOptions }> =
+      [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler("conv-1", handler);
+
+    try {
+      await surfaceProxyResolver(ctx, "ui_show", {
+        surface_type: "file_upload",
+        title: "Upload",
+        data: { accept: "*" },
+      });
+
+      const showMessage = sent.find(
+        (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+      ) as UiSurfaceShow;
+      const surfaceId = showMessage.surfaceId;
+
+      await handleSurfaceAction(ctx, surfaceId, "submit", {
+        files: [
+          {
+            filename: "doc.pdf",
+            mimeType: "application/pdf",
+            data: "base64content",
+          },
+        ],
+      });
+
+      // Attachments never travel the voice path — the model still sees them via
+      // the text `processMessage`, and the spoken resume is skipped.
+      expect(resumeCalls.length).toBe(0);
+      expect(ctx.processMessageCalls.length).toBe(1);
+      expect(ctx.processMessageCalls[0]!.attachments.length).toBe(1);
+      expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
+    } finally {
+      unregisterVoiceResumeHandler("conv-1", handler);
+    }
   });
 
   test("live-voice resume end-to-end: oauth_connect completion runs a spoken continuation turn and clears the pending guard", async () => {

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -74,6 +74,8 @@ interface FakeConversation {
   callSessionId: string | undefined;
   forcePromptSideEffects: boolean;
   currentRequestId: string | undefined;
+  currentActiveSurfaceId?: string | undefined;
+  currentPage?: string | undefined;
   isProcessing: () => boolean;
   hasQueuedMessages?: () => boolean;
   waitForIdle: (options: WaitForIdleCall) => Promise<boolean>;
@@ -120,6 +122,8 @@ function makeFakeConversation(opts: {
     callSessionId: undefined,
     forcePromptSideEffects: false,
     currentRequestId: undefined,
+    currentActiveSurfaceId: undefined,
+    currentPage: undefined,
     isProcessing: () => opts.processing,
     hasQueuedMessages: opts.hasQueuedMessages,
     waitForIdle: (options) => {
@@ -373,6 +377,46 @@ describe("startVoiceTurn surface-resume metadata", () => {
 
     const echo = broadcasts.find((m) => m.type === "user_message_echo");
     expect(echo?.text).toBe("what's the weather");
+  });
+
+  test("a resume restores activeSurfaceId and clears a stale currentPage", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+    // A prior turn left a page live; the agent loop clears
+    // `currentActiveSurfaceId` between turns but not `currentPage`. The mock
+    // starts with `currentActiveSurfaceId` already undefined.
+    fake.conversation.currentPage = "settings.html";
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "[User action on dynamic_page surface: submit]",
+      requestId: "surface-request-page",
+      activeSurfaceId: "surface-app-1",
+      // The surface action carries no page — the resume must clear the stale one.
+    });
+
+    // The resumed surface is restored, paired with its own (undefined) page
+    // rather than the prior turn's stale `settings.html`.
+    expect(fake.conversation.currentActiveSurfaceId).toBe("surface-app-1");
+    expect(fake.conversation.currentPage).toBeUndefined();
+  });
+
+  test("a normal turn leaves activeSurfaceId/currentPage untouched", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+    fake.conversation.currentActiveSurfaceId = "prior-surface";
+    fake.conversation.currentPage = "prior.html";
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what's the weather",
+    });
+
+    // No `activeSurfaceId` on a normal STT turn → the guarded assignment is
+    // skipped and the fields keep their per-turn defaults (the agent loop, not
+    // the bridge, owns resetting them).
+    expect(fake.conversation.currentActiveSurfaceId).toBe("prior-surface");
+    expect(fake.conversation.currentPage).toBe("prior.html");
   });
 });
 

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -20,8 +20,30 @@ import { describe, expect, mock, setSystemTime, test } from "bun:test";
 // Swapped per-test to hand startVoiceTurn a scripted fake conversation.
 let fakeConversation: FakeConversation;
 
+// Captures every message the bridge broadcasts (e.g. `user_message_echo`), so
+// tests can assert what the transcript/hub sees. Reset per test.
+const broadcasts: Array<{ type: string; [k: string]: unknown }> = [];
+
 mock.module("../../daemon/conversation-store.js", () => ({
   getOrCreateConversation: async () => fakeConversation,
+}));
+
+// Non-synthetic content reaches the user-echo broadcast + persisted-seq
+// side-effect path; stub those to capture the echo and keep the DB/event-hub
+// out of the unit test.
+mock.module("../../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: { type: string; [k: string]: unknown }) => {
+    broadcasts.push(msg);
+  },
+}));
+mock.module("../../persistence/conversation-crud.js", () => ({
+  recordConversationPersistedSeq: () => {},
+}));
+mock.module("../../runtime/assistant-stream-state.js", () => ({
+  getCurrentSeq: () => 0,
+}));
+mock.module("../../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationMessagesChanged: () => {},
 }));
 
 import { setConfig } from "../../__tests__/helpers/set-config.js";
@@ -65,6 +87,7 @@ interface FakeConversation {
   persistUserMessage: (opts: {
     content: string;
     requestId: string;
+    displayContent?: string;
     metadata?: Record<string, unknown>;
   }) => Promise<{ id: string }>;
   updateClient: (cb: unknown, reset?: boolean) => void;
@@ -85,7 +108,12 @@ function makeFakeConversation(opts: {
   const waitForIdleCalls: WaitForIdleCall[] = [];
   let persistCount = 0;
   let lastPersistOpts:
-    | { content: string; requestId: string; metadata?: Record<string, unknown> }
+    | {
+        content: string;
+        requestId: string;
+        displayContent?: string;
+        metadata?: Record<string, unknown>;
+      }
     | undefined;
   const conversation: FakeConversation = {
     conversationId: "conv-voice-bridge-test",
@@ -291,6 +319,60 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
     await startVoiceTurn(makeTurnOptions()); // content: CALL_OPENING_MARKER
 
     expect(fake.lastPersistOpts()?.metadata).toBeUndefined();
+  });
+});
+
+describe("startVoiceTurn surface-resume metadata", () => {
+  test("adopts the supplied requestId and persists/echoes displayContent", async () => {
+    broadcasts.length = 0;
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      // A real surface-resume turn: raw model-facing content + a friendly label
+      // + the accepted surface-action request id.
+      content: "[User action on table surface: archive]",
+      requestId: "surface-request-1",
+      displayContent: "Archive selected emails",
+    });
+
+    // The turn adopts the surface request id (so `currentRequestId` stays in
+    // `surfaceActionRequestIds`) rather than minting a fresh one.
+    expect(fake.lastPersistOpts()?.requestId).toBe("surface-request-1");
+    // The persisted row stores the friendly label; the model still receives the
+    // raw content.
+    expect(fake.lastPersistOpts()?.content).toBe(
+      "[User action on table surface: archive]",
+    );
+    expect(fake.lastPersistOpts()?.displayContent).toBe(
+      "Archive selected emails",
+    );
+
+    // The user echo carries the label, never the raw `[User action on …]`
+    // payload.
+    const echo = broadcasts.find((m) => m.type === "user_message_echo");
+    expect(echo).toBeDefined();
+    expect(echo?.text).toBe("Archive selected emails");
+    expect(echo?.requestId).toBe("surface-request-1");
+  });
+
+  test("a normal turn mints its own requestId and echoes raw content", async () => {
+    broadcasts.length = 0;
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what's the weather",
+    });
+
+    // No caller requestId → a fresh one is minted (not undefined).
+    expect(fake.lastPersistOpts()?.requestId).toBeString();
+    expect(fake.lastPersistOpts()?.displayContent).toBeUndefined();
+
+    const echo = broadcasts.find((m) => m.type === "user_message_echo");
+    expect(echo?.text).toBe("what's the weather");
   });
 });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -237,6 +237,15 @@ export interface VoiceTurnOptions {
    * still receives `content`. Undefined = persist/echo `content`.
    */
   displayContent?: string;
+  /**
+   * Completed interactive-surface id to restore as the turn's active surface.
+   * Set by a live-voice surface resume so `runAgentLoop` feeds it to
+   * `buildActiveSurfaceContext` and the model sees the active `dynamic_page`/app
+   * HTML + schema it just acted on — parity with the text path, which threads
+   * `activeSurfaceId` into `conversation.currentActiveSurfaceId`. Undefined =
+   * a normal STT turn with no active surface (left at the per-turn default).
+   */
+  activeSurfaceId?: string;
 }
 
 export interface VoiceTurnHandle {
@@ -989,6 +998,14 @@ export async function startVoiceTurn(
       // flag into subsequent non-voice turns on the same conversation.
       conversation.forcePromptSideEffects =
         !isGuardian && !usesLocalInteractiveApprovals;
+      // Restore the active-surface context for a surface-resume turn so
+      // `runAgentLoop` → `buildActiveSurfaceContext` re-injects the completed
+      // `dynamic_page`/app the user acted on (parity with the text path's
+      // `currentActiveSurfaceId`). Guarded so a normal STT turn leaves the field
+      // at its per-turn default (reset to undefined by the agent loop).
+      if (opts.activeSurfaceId !== undefined) {
+        conversation.currentActiveSurfaceId = opts.activeSurfaceId;
+      }
       await conversation.runAgentLoop(persistedContent, messageId, {
         onEvent: (msg: ServerMessage) => {
           if (msg.type === "error") {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -246,6 +246,16 @@ export interface VoiceTurnOptions {
    * a normal STT turn with no active surface (left at the per-turn default).
    */
   activeSurfaceId?: string;
+  /**
+   * Page to pair with `activeSurfaceId` for a surface-resume turn. Threaded
+   * into `conversation.currentPage` alongside `activeSurfaceId` so
+   * `buildActiveSurfaceContext` injects the right page — parity with the text
+   * path, which sets `currentPage` every turn. `runAgentLoop` clears
+   * `currentActiveSurfaceId` at turn end but not `currentPage`, so a resume
+   * must set it (to `undefined` when the surface action carries no page) to
+   * avoid pairing the resumed surface with a stale page from a prior turn.
+   */
+  currentPage?: string;
 }
 
 export interface VoiceTurnHandle {
@@ -1003,8 +1013,12 @@ export async function startVoiceTurn(
       // `dynamic_page`/app the user acted on (parity with the text path's
       // `currentActiveSurfaceId`). Guarded so a normal STT turn leaves the field
       // at its per-turn default (reset to undefined by the agent loop).
+      // `currentPage` is set alongside because the agent loop does not reset it
+      // between turns, so a resume must pair the surface with its own page
+      // (undefined when the action carries none) rather than a stale one.
       if (opts.activeSurfaceId !== undefined) {
         conversation.currentActiveSurfaceId = opts.activeSurfaceId;
+        conversation.currentPage = opts.currentPage;
       }
       await conversation.runAgentLoop(persistedContent, messageId, {
         onEvent: (msg: ServerMessage) => {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -221,6 +221,22 @@ export interface VoiceTurnOptions {
    * supplies its own `voiceControlPrompt`.
    */
   routingLeg?: VoiceRoutingLeg;
+  /**
+   * Request id to adopt for this turn instead of minting a fresh one. Set by a
+   * live-voice surface resume to the accepted surface-action request id, so the
+   * turn's `currentRequestId` stays inside the conversation's
+   * `surfaceActionRequestIds` set and surface-gated tools
+   * (`ToolContext.triggeredBySurfaceAction`) run. Undefined = mint one.
+   */
+  requestId?: string;
+  /**
+   * User-facing label persisted and echoed for this turn's user message in
+   * place of the model-facing `content`. Set by a live-voice surface resume so
+   * the transcript/history shows the friendly surface label (parity with the
+   * text path) rather than the raw `[User action on …]` payload. The agent loop
+   * still receives `content`. Undefined = persist/echo `content`.
+   */
+  displayContent?: string;
 }
 
 export interface VoiceTurnHandle {
@@ -596,12 +612,18 @@ export async function startVoiceTurn(
     }
   };
 
-  const requestId = uuidv7();
+  const requestId = opts.requestId ?? uuidv7();
   const turnId = crypto.randomUUID();
   const persistTurnUserMessage = async (): Promise<string> => {
     const persistResult = await conversation.persistUserMessage({
       content: persistedContent,
       requestId,
+      // Persist the user-facing label (when the caller supplied one) so
+      // `/messages` shows it after a refetch — the agent loop still receives
+      // `persistedContent`. Parity with the text path's `displayContent`.
+      ...(opts.displayContent !== undefined
+        ? { displayContent: opts.displayContent }
+        : {}),
       ...(isHiddenSyntheticPrompt ? { metadata: { hidden: true } } : {}),
     });
     return persistResult.id;
@@ -799,7 +821,10 @@ export async function startVoiceTurn(
   if (!isSyntheticVoicePrompt) {
     broadcastMessage({
       type: "user_message_echo",
-      text: persistedContent,
+      // Echo the user-facing label when supplied (surface resume), matching the
+      // persisted row and the text path — never the raw `[User action on …]`
+      // payload.
+      text: opts.displayContent ?? persistedContent,
       conversationId: opts.conversationId,
       messageId,
       requestId,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2475,6 +2475,7 @@ export async function handleSurfaceAction(
     voiceResumeHandler.resumeWithText(content, {
       ...(displayContent !== undefined ? { displayContent } : {}),
       requestId,
+      activeSurfaceId: surfaceId,
     });
     log.info(
       { surfaceId, actionId, requestId },

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2355,6 +2355,27 @@ export async function handleSurfaceAction(
   const onEvent = (msg: ServerMessage) =>
     broadcastMessage(msg, ctx.conversationId);
 
+  // A live-voice conversation resumes as a *spoken* turn: route the follow-up
+  // through the voice session instead of the silent text `processMessage`
+  // path, so completing e.g. an oauth_connect surface produces a spoken
+  // continuation that re-reads connection state at turn start (JARVIS-1286/7).
+  // This must be decided BEFORE the enqueue below: a busy conversation would
+  // otherwise push the completion onto the silent text queue and drain it via
+  // `processMessage`, never speaking it. `resumeWithText` serializes on the
+  // session's resume chain and waits for any in-flight turn to go idle, so it
+  // safely handles a busy session without touching the text queue.
+  // Attachments never travel this path (OAuth connect carries none); if any
+  // are present, fall back to the text path so the model still sees them.
+  const voiceResumeHandler = getVoiceResumeHandler(ctx.conversationId);
+  const routeToVoice =
+    voiceResumeHandler !== undefined && pendingAttachments.length === 0;
+  if (voiceResumeHandler && pendingAttachments.length > 0) {
+    log.warn(
+      { surfaceId, actionId, attachmentCount: pendingAttachments.length },
+      "Live-voice resume skipped: surface action carries attachments; falling back to text processMessage",
+    );
+  }
+
   log.info(
     {
       surfaceId,
@@ -2366,20 +2387,25 @@ export async function handleSurfaceAction(
         dataLength: a.data?.length ?? 0,
       })),
       contentPreview: content.slice(0, 200),
+      routeToVoice,
     },
     "Surface action follow-up: preparing to send message to model",
   );
 
-  const result = ctx.enqueueMessage({
-    content,
-    attachments: pendingAttachments,
-    onEvent,
-    requestId,
-    activeSurfaceId: surfaceId,
-    displayContent,
-    sourceActorPrincipalId,
-  });
-  if (result.rejected) {
+  // The voice path bypasses the queue entirely; the text path enqueues, which
+  // may reject (queue full) or queue behind an in-flight turn.
+  const result = routeToVoice
+    ? null
+    : ctx.enqueueMessage({
+        content,
+        attachments: pendingAttachments,
+        onEvent,
+        requestId,
+        activeSurfaceId: surfaceId,
+        displayContent,
+        sourceActorPrincipalId,
+      });
+  if (result?.rejected) {
     ctx.surfaceActionRequestIds.delete(requestId);
     return;
   }
@@ -2434,11 +2460,31 @@ export async function handleSurfaceAction(
       conversationId: ctx.conversationId,
     });
   }
-  if (result.queued) {
+  // Consume the pending-surface guard for every delivery path (voice, queued
+  // text, immediate text). The rejected path returned above without clearing
+  // it, so the surface stays active and retryable there.
+  if (!retainPending) {
+    ctx.pendingSurfaceActions.delete(surfaceId);
+  }
+
+  if (voiceResumeHandler && routeToVoice) {
+    // Reuse the accepted surface-action `requestId` (already in
+    // `ctx.surfaceActionRequestIds`) as the resumed turn's request id, so a
+    // tool gated on `triggeredBySurfaceAction` still sees `currentRequestId`
+    // in the set — parity with the text path, which passes it too.
+    voiceResumeHandler.resumeWithText(content, {
+      ...(displayContent !== undefined ? { displayContent } : {}),
+      requestId,
+    });
+    log.info(
+      { surfaceId, actionId, requestId },
+      "Surface action routed to live-voice spoken resume",
+    );
+    return;
+  }
+
+  if (result?.queued) {
     const position = ctx.getQueueDepth();
-    if (!retainPending) {
-      ctx.pendingSurfaceActions.delete(surfaceId);
-    }
     log.info(
       { surfaceId, actionId, requestId },
       "Surface action queued (conversation busy)",
@@ -2452,9 +2498,6 @@ export async function handleSurfaceAction(
     return;
   }
 
-  if (!retainPending) {
-    ctx.pendingSurfaceActions.delete(surfaceId);
-  }
   log.info(
     {
       surfaceId,
@@ -2464,34 +2507,6 @@ export async function handleSurfaceAction(
     },
     "Processing surface action as follow-up with attachments",
   );
-
-  // A live-voice conversation resumes as a *spoken* turn: route the follow-up
-  // through the voice session instead of the silent text `processMessage`
-  // path, so completing e.g. an oauth_connect surface produces a spoken
-  // continuation that re-reads connection state at turn start (JARVIS-1286/7).
-  // Attachments never travel this path (OAuth connect carries none); if any
-  // are present, fall back to `processMessage` so the model still sees them.
-  const voiceResumeHandler = getVoiceResumeHandler(ctx.conversationId);
-  if (voiceResumeHandler && pendingAttachments.length === 0) {
-    // Reuse the accepted surface-action `requestId` (already in
-    // `ctx.surfaceActionRequestIds`) as the resumed turn's request id, so a
-    // tool gated on `triggeredBySurfaceAction` still sees `currentRequestId`
-    // in the set — parity with the text path below, which passes it too.
-    voiceResumeHandler.resumeWithText(content, {
-      ...(displayContent !== undefined ? { displayContent } : {}),
-      ...(sourceActorPrincipalId !== undefined
-        ? { sourceActorPrincipalId }
-        : {}),
-      requestId,
-    });
-    return;
-  }
-  if (voiceResumeHandler && pendingAttachments.length > 0) {
-    log.warn(
-      { surfaceId, actionId, attachmentCount: pendingAttachments.length },
-      "Live-voice resume skipped: surface action carries attachments; falling back to text processMessage",
-    );
-  }
 
   ctx
     .processMessage({

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2453,7 +2453,10 @@ export async function handleSurfaceAction(
 
   // Echo the user's prompt to the client so it appears in the chat UI.
   // Deferred until after rejection check to avoid ghost messages.
-  if (shouldRelayPrompt && prompt) {
+  // Skipped on the voice-resume path: `startVoiceTurn` emits its own
+  // `user_message_echo` for the resumed turn, so relaying here as well would
+  // render two user bubbles for one surface click.
+  if (shouldRelayPrompt && prompt && !(voiceResumeHandler && routeToVoice)) {
     broadcastMessage({
       type: "user_message_echo",
       text: prompt,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -17,6 +17,7 @@ import {
   resolveEffectiveAppHtml,
   updateApp,
 } from "../apps/app-store.js";
+import { getVoiceResumeHandler } from "../live-voice/live-voice-resume-registry.js";
 import { recordActivationEvent } from "../onboarding/onboarding-events-store.js";
 import {
   getMessages,
@@ -2463,6 +2464,35 @@ export async function handleSurfaceAction(
     },
     "Processing surface action as follow-up with attachments",
   );
+
+  // A live-voice conversation resumes as a *spoken* turn: route the follow-up
+  // through the voice session instead of the silent text `processMessage`
+  // path, so completing e.g. an oauth_connect surface produces a spoken
+  // continuation that re-reads connection state at turn start (JARVIS-1286/7).
+  // Attachments never travel this path (OAuth connect carries none); if any
+  // are present, fall back to `processMessage` so the model still sees them.
+  const voiceResumeHandler = getVoiceResumeHandler(ctx.conversationId);
+  if (voiceResumeHandler && pendingAttachments.length === 0) {
+    // Reuse the accepted surface-action `requestId` (already in
+    // `ctx.surfaceActionRequestIds`) as the resumed turn's request id, so a
+    // tool gated on `triggeredBySurfaceAction` still sees `currentRequestId`
+    // in the set — parity with the text path below, which passes it too.
+    voiceResumeHandler.resumeWithText(content, {
+      ...(displayContent !== undefined ? { displayContent } : {}),
+      ...(sourceActorPrincipalId !== undefined
+        ? { sourceActorPrincipalId }
+        : {}),
+      requestId,
+    });
+    return;
+  }
+  if (voiceResumeHandler && pendingAttachments.length > 0) {
+    log.warn(
+      { surfaceId, actionId, attachmentCount: pendingAttachments.length },
+      "Live-voice resume skipped: surface action carries attachments; falling back to text processMessage",
+    );
+  }
+
   ctx
     .processMessage({
       content,

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -469,7 +469,7 @@ describe("LiveVoiceSession surface resume", () => {
     expect(getVoiceResumeHandler("conversation-123")).toBeUndefined();
   });
 
-  test("threads the surface-action requestId and displayContent into the resumed turn", async () => {
+  test("threads the surface-action requestId, displayContent, and activeSurfaceId into the resumed turn", async () => {
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
       options.callbacks?.assistant_text_delta?.({
         type: "assistant_text_delta",
@@ -489,22 +489,26 @@ describe("LiveVoiceSession surface resume", () => {
     session.resumeWithText("[User action on table surface: archive]", {
       displayContent: "Archive selected emails",
       requestId: "surface-request-1",
+      activeSurfaceId: "surface-1",
     });
     await waitFor(() => startVoiceTurn.mock.calls.length > 0);
 
     // The surface request id becomes the resumed turn's request id so
     // `currentRequestId` lands in `surfaceActionRequestIds` and surface-gated
-    // tools run; the display label rides along for the persisted/echoed row.
+    // tools run; the display label rides along for the persisted/echoed row;
+    // the active-surface id restores the completed surface's context for the
+    // resumed turn (parity with the text path).
     expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
       content: "[User action on table surface: archive]",
       requestId: "surface-request-1",
       displayContent: "Archive selected emails",
+      activeSurfaceId: "surface-1",
     });
 
     await session.close("client_end");
   });
 
-  test("a resume without opts mints no requestId or displayContent override", async () => {
+  test("a resume without opts mints no requestId, displayContent, or activeSurfaceId override", async () => {
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
       options.callbacks?.message_complete?.({
         type: "message_complete",
@@ -522,6 +526,7 @@ describe("LiveVoiceSession surface resume", () => {
     const opts = startVoiceTurn.mock.calls[0]?.[0];
     expect(opts?.requestId).toBeUndefined();
     expect(opts?.displayContent).toBeUndefined();
+    expect(opts?.activeSurfaceId).toBeUndefined();
 
     await session.close("client_end");
   });

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -8,6 +8,7 @@ import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
+import { getVoiceResumeHandler } from "../live-voice-resume-registry.js";
 import {
   LiveVoiceSession,
   type LiveVoiceTurnStarter,
@@ -396,5 +397,132 @@ describe("LiveVoiceSession assistant turn", () => {
       "stt_final",
       "thinking",
     ]);
+  });
+});
+
+describe("LiveVoiceSession surface resume", () => {
+  test("resumeWithText runs a spoken synthetic turn with no user transcript", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "You're connected. ",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-resume",
+      });
+      return { turnId: "bridge-resume-1", abort: mock() };
+    });
+    const { frames, session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    session.resumeWithText("[User connected Google: user@example.com]");
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      conversationId: "conversation-123",
+      content: "[User connected Google: user@example.com]",
+      isInbound: true,
+    });
+    const types = frames.map((frame) => frame.type);
+    // No user speech is echoed for a resume: no stt_final frame is emitted.
+    expect(types).not.toContain("stt_final");
+    expect(types).toEqual([
+      "ready",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+
+    await session.close("client_end");
+  });
+
+  test("registers a discoverable resume handler while active and clears it on close", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "Done.",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-resume",
+      });
+      return { turnId: "bridge-resume-1", abort: mock() };
+    });
+    const { frames, session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+
+    const handler = getVoiceResumeHandler("conversation-123");
+    expect(handler).toBeDefined();
+
+    handler?.resumeWithText("[User connected Google]");
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+
+    await session.close("client_end");
+    expect(getVoiceResumeHandler("conversation-123")).toBeUndefined();
+  });
+
+  test("threads the surface-action requestId and displayContent into the resumed turn", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.assistant_text_delta?.({
+        type: "assistant_text_delta",
+        text: "Archived. ",
+        conversationId: options.conversationId,
+      });
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-resume",
+      });
+      return { turnId: "bridge-resume-1", abort: mock() };
+    });
+    const { session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    session.resumeWithText("[User action on table surface: archive]", {
+      displayContent: "Archive selected emails",
+      requestId: "surface-request-1",
+    });
+    await waitFor(() => startVoiceTurn.mock.calls.length > 0);
+
+    // The surface request id becomes the resumed turn's request id so
+    // `currentRequestId` lands in `surfaceActionRequestIds` and surface-gated
+    // tools run; the display label rides along for the persisted/echoed row.
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      content: "[User action on table surface: archive]",
+      requestId: "surface-request-1",
+      displayContent: "Archive selected emails",
+    });
+
+    await session.close("client_end");
+  });
+
+  test("a resume without opts mints no requestId or displayContent override", async () => {
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.message_complete?.({
+        type: "message_complete",
+        conversationId: options.conversationId,
+        messageId: "assistant-message-resume",
+      });
+      return { turnId: "bridge-resume-1", abort: mock() };
+    });
+    const { session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    session.resumeWithText("[User connected Google]");
+    await waitFor(() => startVoiceTurn.mock.calls.length > 0);
+
+    const opts = startVoiceTurn.mock.calls[0]?.[0];
+    expect(opts?.requestId).toBeUndefined();
+    expect(opts?.displayContent).toBeUndefined();
+
+    await session.close("client_end");
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-resume-registry.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-resume-registry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getVoiceResumeHandler,
+  registerVoiceResumeHandler,
+  unregisterVoiceResumeHandler,
+  type VoiceResumeHandler,
+} from "../live-voice-resume-registry.js";
+
+function makeHandler(): VoiceResumeHandler {
+  return { resumeWithText: () => {} };
+}
+
+describe("live-voice resume registry", () => {
+  test("register makes a handler discoverable by conversation id", () => {
+    const conversationId = `conv-${crypto.randomUUID()}`;
+    const handler = makeHandler();
+
+    expect(getVoiceResumeHandler(conversationId)).toBeUndefined();
+    registerVoiceResumeHandler(conversationId, handler);
+    expect(getVoiceResumeHandler(conversationId)).toBe(handler);
+
+    unregisterVoiceResumeHandler(conversationId, handler);
+  });
+
+  test("register overwrites an existing handler for the same conversation", () => {
+    const conversationId = `conv-${crypto.randomUUID()}`;
+    const first = makeHandler();
+    const second = makeHandler();
+
+    registerVoiceResumeHandler(conversationId, first);
+    registerVoiceResumeHandler(conversationId, second);
+    expect(getVoiceResumeHandler(conversationId)).toBe(second);
+
+    unregisterVoiceResumeHandler(conversationId, second);
+  });
+
+  test("unregister deletes only when the stored handler is the one passed", () => {
+    const conversationId = `conv-${crypto.randomUUID()}`;
+    const current = makeHandler();
+    const stale = makeHandler();
+
+    registerVoiceResumeHandler(conversationId, current);
+
+    // A stale (older) session tearing down must not evict the current handler.
+    unregisterVoiceResumeHandler(conversationId, stale);
+    expect(getVoiceResumeHandler(conversationId)).toBe(current);
+
+    // The owning handler's unregister clears it.
+    unregisterVoiceResumeHandler(conversationId, current);
+    expect(getVoiceResumeHandler(conversationId)).toBeUndefined();
+  });
+});

--- a/assistant/src/live-voice/live-voice-resume-registry.ts
+++ b/assistant/src/live-voice/live-voice-resume-registry.ts
@@ -27,6 +27,12 @@
  * path so the transcript shows the friendly label, not the raw
  * `[User action on …]` payload.
  *
+ * `activeSurfaceId` (when supplied) is the completed surface's id. The resumed
+ * turn adopts it as `conversation.currentActiveSurfaceId` so `runAgentLoop`
+ * feeds it to `buildActiveSurfaceContext` and the model sees the active
+ * `dynamic_page`/app HTML + schema it just acted on — parity with the text
+ * path, which passes `activeSurfaceId` into `processMessage`.
+ *
  * Voice trust is not carried here: a live-voice turn's trust is established
  * once on the conversation at session adoption, so a resumed turn inherits the
  * same trust context as any speech turn.
@@ -34,6 +40,7 @@
 export interface VoiceResumeOptions {
   displayContent?: string;
   requestId?: string;
+  activeSurfaceId?: string;
 }
 
 export interface VoiceResumeHandler {

--- a/assistant/src/live-voice/live-voice-resume-registry.ts
+++ b/assistant/src/live-voice/live-voice-resume-registry.ts
@@ -1,0 +1,71 @@
+/**
+ * Per-conversation registry that lets an interactive surface completion resume
+ * a live-voice conversation as a *spoken* turn instead of a silent text turn.
+ *
+ * The live-voice session (producer) registers a {@link VoiceResumeHandler} once
+ * it adopts a stable conversation id, and the surface-action dispatcher
+ * (consumer, in `daemon/conversation-surfaces.ts`) looks one up before falling
+ * back to `processMessage`.
+ *
+ * This module deliberately imports nothing from `daemon/` or `calls/`: keeping
+ * it a pure registry lets both the producer and the consumer depend on it
+ * without forming a require cycle.
+ */
+
+export interface VoiceResumeHandler {
+  /**
+   * Run `content` as a spoken assistant turn on the live-voice session. The
+   * turn is synthetic (no user speech): it is not echoed as a user utterance
+   * and connection state is re-read at turn start.
+   *
+   * `requestId` (when supplied) is the accepted surface-action request id. The
+   * resumed turn adopts it as its own request id so `currentRequestId` lands in
+   * the conversation's `surfaceActionRequestIds` set — otherwise a tool gated on
+   * `ToolContext.triggeredBySurfaceAction` (e.g. archive-by-sender) would reject
+   * the resumed turn even though the user clicked the surface.
+   *
+   * `displayContent` (when supplied) is the user-facing label the resumed turn
+   * persists and echoes instead of the model-facing `content`, matching the
+   * text path so the transcript shows the friendly label, not the raw
+   * `[User action on …]` payload.
+   */
+  resumeWithText(
+    content: string,
+    opts?: {
+      displayContent?: string;
+      sourceActorPrincipalId?: string;
+      requestId?: string;
+    },
+  ): void;
+}
+
+const handlers = new Map<string, VoiceResumeHandler>();
+
+export function registerVoiceResumeHandler(
+  conversationId: string,
+  handler: VoiceResumeHandler,
+): void {
+  handlers.set(conversationId, handler);
+}
+
+/**
+ * Remove the handler for a conversation, but only when the stored handler is
+ * referentially the one passed. A newer session that adopted the same
+ * conversation id must not have its handler dropped by an older session's
+ * teardown (mirrors the identity-checked `pendingTurnTeardowns` guard in
+ * `calls/voice-session-bridge.ts`).
+ */
+export function unregisterVoiceResumeHandler(
+  conversationId: string,
+  handler: VoiceResumeHandler,
+): void {
+  if (handlers.get(conversationId) === handler) {
+    handlers.delete(conversationId);
+  }
+}
+
+export function getVoiceResumeHandler(
+  conversationId: string,
+): VoiceResumeHandler | undefined {
+  return handlers.get(conversationId);
+}

--- a/assistant/src/live-voice/live-voice-resume-registry.ts
+++ b/assistant/src/live-voice/live-voice-resume-registry.ts
@@ -12,31 +12,37 @@
  * without forming a require cycle.
  */
 
+/**
+ * Per-turn overrides carried from an interactive-surface completion into the
+ * resumed voice turn.
+ *
+ * `requestId` (when supplied) is the accepted surface-action request id. The
+ * resumed turn adopts it as its own request id so `currentRequestId` lands in
+ * the conversation's `surfaceActionRequestIds` set — otherwise a tool gated on
+ * `ToolContext.triggeredBySurfaceAction` (e.g. archive-by-sender) would reject
+ * the resumed turn even though the user clicked the surface.
+ *
+ * `displayContent` (when supplied) is the user-facing label the resumed turn
+ * persists and echoes instead of the model-facing `content`, matching the text
+ * path so the transcript shows the friendly label, not the raw
+ * `[User action on …]` payload.
+ *
+ * Voice trust is not carried here: a live-voice turn's trust is established
+ * once on the conversation at session adoption, so a resumed turn inherits the
+ * same trust context as any speech turn.
+ */
+export interface VoiceResumeOptions {
+  displayContent?: string;
+  requestId?: string;
+}
+
 export interface VoiceResumeHandler {
   /**
    * Run `content` as a spoken assistant turn on the live-voice session. The
    * turn is synthetic (no user speech): it is not echoed as a user utterance
    * and connection state is re-read at turn start.
-   *
-   * `requestId` (when supplied) is the accepted surface-action request id. The
-   * resumed turn adopts it as its own request id so `currentRequestId` lands in
-   * the conversation's `surfaceActionRequestIds` set — otherwise a tool gated on
-   * `ToolContext.triggeredBySurfaceAction` (e.g. archive-by-sender) would reject
-   * the resumed turn even though the user clicked the surface.
-   *
-   * `displayContent` (when supplied) is the user-facing label the resumed turn
-   * persists and echoes instead of the model-facing `content`, matching the
-   * text path so the transcript shows the friendly label, not the raw
-   * `[User action on …]` payload.
    */
-  resumeWithText(
-    content: string,
-    opts?: {
-      displayContent?: string;
-      sourceActorPrincipalId?: string;
-      requestId?: string;
-    },
-  ): void;
+  resumeWithText(content: string, opts?: VoiceResumeOptions): void;
 }
 
 const handlers = new Map<string, VoiceResumeHandler>();

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1566,14 +1566,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       },
       "Live voice resume requested from interactive surface completion",
     );
-    // The surface-action request id and user-facing label ride the turn down to
-    // `startVoiceTurn`: the id keeps `currentRequestId` inside the accepted
-    // `surfaceActionRequestIds` set (so surface-gated tools run), and the label
-    // is what the persisted user row / echo shows instead of the raw payload.
+    // The surface-action request id, user-facing label, and active-surface id
+    // ride the turn down to `startVoiceTurn`: the id keeps `currentRequestId`
+    // inside the accepted `surfaceActionRequestIds` set (so surface-gated tools
+    // run), the label is what the persisted user row / echo shows instead of the
+    // raw payload, and the active-surface id restores the completed
+    // `dynamic_page`/app context so the model doesn't run blind to what it acted
+    // on (parity with the text path).
     const resume: VoiceResumeOptions = {
       ...(opts?.requestId !== undefined ? { requestId: opts.requestId } : {}),
       ...(opts?.displayContent !== undefined
         ? { displayContent: opts.displayContent }
+        : {}),
+      ...(opts?.activeSurfaceId !== undefined
+        ? { activeSurfaceId: opts.activeSurfaceId }
         : {}),
     };
     this.resumeChain = this.resumeChain
@@ -1708,6 +1714,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         ...(resume?.requestId != null ? { requestId: resume.requestId } : {}),
         ...(resume?.displayContent != null
           ? { displayContent: resume.displayContent }
+          : {}),
+        ...(resume?.activeSurfaceId != null
+          ? { activeSurfaceId: resume.activeSurfaceId }
           : {}),
         callbacks: {
           assistant_text_delta: (msg) => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -55,6 +55,11 @@ import {
   type LiveVoiceTurnSeedMarks,
 } from "./live-voice-metrics.js";
 import {
+  registerVoiceResumeHandler,
+  unregisterVoiceResumeHandler,
+  type VoiceResumeHandler,
+} from "./live-voice-resume-registry.js";
+import {
   type LiveVoiceSession as LiveVoiceSessionContract,
   type LiveVoiceSessionCloseReason,
   type LiveVoiceSessionFactoryContext,
@@ -116,6 +121,18 @@ export type LiveVoiceCredentialReadinessResolver =
 export type LiveVoiceTurnStarter = (
   options: VoiceTurnOptions,
 ) => Promise<VoiceTurnHandle>;
+
+/**
+ * Per-turn overrides carried from an interactive-surface completion into the
+ * resumed voice turn. `requestId` is the accepted surface-action request id
+ * (keeps `currentRequestId` in the conversation's `surfaceActionRequestIds`
+ * set); `displayContent` is the user-facing label persisted/echoed in place of
+ * the model-facing content.
+ */
+interface ResumeTurnMetadata {
+  requestId?: string;
+  displayContent?: string;
+}
 
 export type LiveVoiceTtsStreamer = (
   options: LiveVoiceTtsOptions,
@@ -302,6 +319,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private currentUtterance: UtteranceCycle | null = null;
   private outboundFrames: Promise<void> = Promise.resolve();
   private activeAssistantTurn: ActiveAssistantTurn | null = null;
+  // Serializes surface-completion resumes so back-to-back resumes on the same
+  // conversation run one after another rather than clobbering each other.
+  private resumeChain: Promise<void> = Promise.resolve();
+  // Resolved whenever the active assistant turn clears, so a queued resume can
+  // wait for turn-idle instead of throwing CONVERSATION_BUSY.
+  private assistantTurnIdleWaiters: Array<() => void> = [];
+  // Stable handler reference for the resume registry: the same object is used
+  // for register (on start) and the identity-checked unregister (on close).
+  private readonly voiceResumeHandler: VoiceResumeHandler = {
+    resumeWithText: (content, opts) => this.resumeWithText(content, opts),
+  };
   private sessionEndMetricsEmitted = false;
   // Non-null iff the start frame requested turnDetection "server_vad".
   private readonly turnDetector: MediaTurnDetector | null;
@@ -445,6 +473,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // through the pending/pre-roll paths and flushes on arm. An arm failure
     // surfaces as a non-recoverable error frame instead of a start rejection.
     this.state = "active";
+    // The conversation id is stable now (adopted from the start frame); expose a
+    // resume handler so an interactive-surface completion on this conversation
+    // resumes as a spoken voice turn instead of a silent text turn.
+    registerVoiceResumeHandler(this.conversationId, this.voiceResumeHandler);
     void this.armUtterance().catch(() => {});
     this.metrics.markReady();
     await this.sendFrame({
@@ -488,6 +520,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
+    unregisterVoiceResumeHandler(this.conversationId, this.voiceResumeHandler);
+    this.resolveAssistantTurnIdleWaiters();
     this.turnDetector?.dispose();
     this.stopSessionTranscriber();
     await this.cancelAssistantTurn("session_closed");
@@ -504,29 +538,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // mode, again after every finalized turn (per-utterance phase tracks the
   // cycle).
   private async beginUtterance(): Promise<UtteranceStartResult> {
-    const utterance: UtteranceCycle = {
-      phase: "pending",
-      released: false,
-      assistantTurnStarted: false,
-      completed: false,
-      finalizeRequested: false,
-      transcriber: null,
-      pendingAudioChunks: [],
-      pendingAudioBytes: 0,
-      finalTranscriptSegments: [],
-      turnId: null,
-      userMessageId: null,
-      userAudioChunks: [],
-      metricsTurnStarted: false,
-      metricsTurnFinished: false,
-      stashedMetricsMarks: {
-        firstAudioAtMs: null,
-        firstPartialAtMs: null,
-        speechStartAtMs: null,
-        utteranceEndAtMs: null,
-        finalTranscriptAtMs: null,
-      },
-    };
+    const utterance = createUtteranceCycle();
     this.currentUtterance = utterance;
     // Speech parked while the previous cycle wound down belongs to this
     // cycle: buffer it before the transcriber arms, and capture the detector
@@ -1469,6 +1481,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
+    await this.startAssistantTurnForUtterance(utterance, content);
+  }
+
+  /**
+   * Build the {@link ActiveAssistantTurn}, announce it (`thinking`), and drive
+   * its first model leg from `content`. Shared by the STT turn-start path and
+   * the surface-completion resume path — a resume supplies a synthetic stub
+   * utterance rather than a transcribed one, but the turn machinery downstream
+   * is identical.
+   */
+  private async startAssistantTurnForUtterance(
+    utterance: UtteranceCycle,
+    content: string,
+    resume?: ResumeTurnMetadata,
+  ): Promise<void> {
     utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
     const turnId = this.ensureTurnId(utterance);
@@ -1493,7 +1520,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       assistantAudioChunks: [],
       assistantAudioMimeType: "audio/pcm",
     };
-    this.activeAssistantTurn = activeTurn;
+    this.setActiveAssistantTurn(activeTurn);
 
     await this.sendFrame({ type: "thinking", turnId });
     if (!this.isActiveAssistantTurn(token)) {
@@ -1522,7 +1549,80 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             frontDoor: true,
           }
         : { content },
+      resume,
     );
+  }
+
+  /**
+   * Resume the conversation as a spoken voice turn from supplied text (an
+   * interactive-surface completion, e.g. an OAuth connect). The turn is
+   * synthetic: no user audio is captured or archived, and no user transcript
+   * (`stt_final`) is emitted, so it does not surface as user speech. Registered
+   * per-conversation via {@link registerVoiceResumeHandler} and invoked by the
+   * surface-action dispatcher instead of the silent text `processMessage` path.
+   *
+   * Resumes serialize on {@link resumeChain} and wait for any in-flight turn to
+   * go idle rather than throwing CONVERSATION_BUSY.
+   */
+  resumeWithText(
+    content: string,
+    opts?: {
+      displayContent?: string;
+      sourceActorPrincipalId?: string;
+      requestId?: string;
+    },
+  ): void {
+    const trimmed = content.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    log.info(
+      {
+        conversationId: this.conversationId,
+        hasDisplayContent: opts?.displayContent != null,
+        sourceActorPrincipalId: opts?.sourceActorPrincipalId,
+        requestId: opts?.requestId,
+      },
+      "Live voice resume requested from interactive surface completion",
+    );
+    // The surface-action request id and user-facing label ride the turn down to
+    // `startVoiceTurn`: the id keeps `currentRequestId` inside the accepted
+    // `surfaceActionRequestIds` set (so surface-gated tools run), and the label
+    // is what the persisted user row / echo shows instead of the raw payload.
+    const resume: ResumeTurnMetadata = {
+      ...(opts?.requestId !== undefined ? { requestId: opts.requestId } : {}),
+      ...(opts?.displayContent !== undefined
+        ? { displayContent: opts.displayContent }
+        : {}),
+    };
+    this.resumeChain = this.resumeChain
+      .catch(() => {})
+      .then(() => this.runResumeTurn(trimmed, resume));
+    void this.resumeChain.catch(() => {});
+  }
+
+  private async runResumeTurn(
+    content: string,
+    resume?: ResumeTurnMetadata,
+  ): Promise<void> {
+    if (this.isClosedOrFailed || !this.startVoiceTurn) {
+      return;
+    }
+    await this.waitForAssistantTurnIdle();
+    if (this.isClosedOrFailed || this.activeAssistantTurn !== null) {
+      return;
+    }
+    // A turn-only synthetic utterance: the transcript is the supplied content
+    // and it carries no user audio, so the audio-archive step (which tolerates
+    // empty audio) records no user utterance. It is never installed as
+    // `currentUtterance`, so it doesn't disturb the transcriber listening for
+    // the next real utterance.
+    const utterance = createUtteranceCycle({
+      phase: "transcriber_closed",
+      released: true,
+      finalTranscriptSegments: [content],
+    });
+    await this.startAssistantTurnForUtterance(utterance, content, resume);
   }
 
   /**
@@ -1546,6 +1646,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       routingLeg?: VoiceRoutingLeg;
       frontDoor?: boolean;
     },
+    // Surface-resume metadata for the primary leg only. `escalateTurn` starts
+    // the escalated continuation leg without it: that leg persists an internal
+    // `[continue]` prompt, so it must neither reuse the surface request id nor
+    // show the surface's user-facing label.
+    resume?: ResumeTurnMetadata,
   ): Promise<void> {
     if (!this.startVoiceTurn) {
       return;
@@ -1619,6 +1724,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           ? { overrideProfile: leg.overrideProfile }
           : {}),
         ...(leg.routingLeg != null ? { routingLeg: leg.routingLeg } : {}),
+        ...(resume?.requestId != null ? { requestId: resume.requestId } : {}),
+        ...(resume?.displayContent != null
+          ? { displayContent: resume.displayContent }
+          : {}),
         callbacks: {
           assistant_text_delta: (msg) => {
             if (!this.isForwardingAssistantText(token)) {
@@ -1716,7 +1825,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       if (current.finalized) {
-        this.activeAssistantTurn = null;
+        this.setActiveAssistantTurn(null);
         return;
       }
       // The front-door leg may have handed off before its handle resolved;
@@ -1732,7 +1841,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
 
-      this.activeAssistantTurn = null;
+      this.setActiveAssistantTurn(null);
       await this.sendFrame({
         type: "error",
         code: LiveVoiceProtocolErrorCode.InvalidField,
@@ -1788,7 +1897,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async cancelAssistantTurn(reason: string): Promise<void> {
     const turn = this.activeAssistantTurn;
-    this.activeAssistantTurn = null;
+    this.setActiveAssistantTurn(null);
     if (turn) {
       turn.abortController.abort();
       turn.handle?.abort();
@@ -1806,6 +1915,37 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       await this.finalizePendingUtterance(utterance, reason);
     }
     this.scheduleRearmAfterTurn();
+  }
+
+  // Single choke point for the active-turn slot so a queued resume can observe
+  // the turn clearing (see waitForAssistantTurnIdle).
+  private setActiveAssistantTurn(turn: ActiveAssistantTurn | null): void {
+    this.activeAssistantTurn = turn;
+    if (turn === null) {
+      this.resolveAssistantTurnIdleWaiters();
+    }
+  }
+
+  private resolveAssistantTurnIdleWaiters(): void {
+    if (this.activeAssistantTurn !== null && !this.isClosedOrFailed) {
+      return;
+    }
+    const waiters = this.assistantTurnIdleWaiters;
+    if (waiters.length === 0) {
+      return;
+    }
+    this.assistantTurnIdleWaiters = [];
+    for (const resolve of waiters) {
+      resolve();
+    }
+  }
+
+  private async waitForAssistantTurnIdle(): Promise<void> {
+    while (this.activeAssistantTurn !== null && !this.isClosedOrFailed) {
+      await new Promise<void>((resolve) => {
+        this.assistantTurnIdleWaiters.push(resolve);
+      });
+    }
   }
 
   private isActiveAssistantTurn(token: symbol): boolean {
@@ -1890,7 +2030,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
         if (this.activeAssistantTurn?.token === token) {
           if (currentTurn.handle && currentTurn.finalized) {
-            this.activeAssistantTurn = null;
+            this.setActiveAssistantTurn(null);
           }
         }
 
@@ -2298,7 +2438,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.activeAssistantTurn?.token === turn.token &&
       turn.handle
     ) {
-      this.activeAssistantTurn = null;
+      this.setActiveAssistantTurn(null);
     }
 
     if (options.rearm ?? true) {
@@ -2519,6 +2659,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private get isClosed(): boolean {
     return this.state === "closed";
   }
+
+  private get isClosedOrFailed(): boolean {
+    return this.state === "closed" || this.state === "failed";
+  }
 }
 
 export function createLiveVoiceSession(
@@ -2668,6 +2812,38 @@ async function defaultArchiveLiveVoiceAudio(
   return input.role === "user"
     ? linkLiveVoiceUserUtteranceAudioToMessage(input)
     : linkLiveVoiceAssistantResponseAudioToMessage(input);
+}
+
+// Fresh utterance record with per-cycle defaults; `overrides` tailor it (e.g. a
+// synthetic resume cycle that is already `transcriber_closed`). Every call
+// allocates its own arrays/objects so cycles never share mutable buffers.
+function createUtteranceCycle(
+  overrides?: Partial<UtteranceCycle>,
+): UtteranceCycle {
+  return {
+    phase: "pending",
+    released: false,
+    assistantTurnStarted: false,
+    completed: false,
+    finalizeRequested: false,
+    transcriber: null,
+    pendingAudioChunks: [],
+    pendingAudioBytes: 0,
+    finalTranscriptSegments: [],
+    turnId: null,
+    userMessageId: null,
+    userAudioChunks: [],
+    metricsTurnStarted: false,
+    metricsTurnFinished: false,
+    stashedMetricsMarks: {
+      firstAudioAtMs: null,
+      firstPartialAtMs: null,
+      speechStartAtMs: null,
+      utteranceEndAtMs: null,
+      finalTranscriptAtMs: null,
+    },
+    ...overrides,
+  };
 }
 
 function toSeedMarks(stashed: StashedMetricsMarks): LiveVoiceTurnSeedMarks {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -58,6 +58,7 @@ import {
   registerVoiceResumeHandler,
   unregisterVoiceResumeHandler,
   type VoiceResumeHandler,
+  type VoiceResumeOptions,
 } from "./live-voice-resume-registry.js";
 import {
   type LiveVoiceSession as LiveVoiceSessionContract,
@@ -121,18 +122,6 @@ export type LiveVoiceCredentialReadinessResolver =
 export type LiveVoiceTurnStarter = (
   options: VoiceTurnOptions,
 ) => Promise<VoiceTurnHandle>;
-
-/**
- * Per-turn overrides carried from an interactive-surface completion into the
- * resumed voice turn. `requestId` is the accepted surface-action request id
- * (keeps `currentRequestId` in the conversation's `surfaceActionRequestIds`
- * set); `displayContent` is the user-facing label persisted/echoed in place of
- * the model-facing content.
- */
-interface ResumeTurnMetadata {
-  requestId?: string;
-  displayContent?: string;
-}
 
 export type LiveVoiceTtsStreamer = (
   options: LiveVoiceTtsOptions,
@@ -1494,7 +1483,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private async startAssistantTurnForUtterance(
     utterance: UtteranceCycle,
     content: string,
-    resume?: ResumeTurnMetadata,
+    resume?: VoiceResumeOptions,
   ): Promise<void> {
     utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
@@ -1564,14 +1553,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * Resumes serialize on {@link resumeChain} and wait for any in-flight turn to
    * go idle rather than throwing CONVERSATION_BUSY.
    */
-  resumeWithText(
-    content: string,
-    opts?: {
-      displayContent?: string;
-      sourceActorPrincipalId?: string;
-      requestId?: string;
-    },
-  ): void {
+  resumeWithText(content: string, opts?: VoiceResumeOptions): void {
     const trimmed = content.trim();
     if (trimmed.length === 0) {
       return;
@@ -1580,7 +1562,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       {
         conversationId: this.conversationId,
         hasDisplayContent: opts?.displayContent != null,
-        sourceActorPrincipalId: opts?.sourceActorPrincipalId,
         requestId: opts?.requestId,
       },
       "Live voice resume requested from interactive surface completion",
@@ -1589,7 +1570,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // `startVoiceTurn`: the id keeps `currentRequestId` inside the accepted
     // `surfaceActionRequestIds` set (so surface-gated tools run), and the label
     // is what the persisted user row / echo shows instead of the raw payload.
-    const resume: ResumeTurnMetadata = {
+    const resume: VoiceResumeOptions = {
       ...(opts?.requestId !== undefined ? { requestId: opts.requestId } : {}),
       ...(opts?.displayContent !== undefined
         ? { displayContent: opts.displayContent }
@@ -1603,7 +1584,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async runResumeTurn(
     content: string,
-    resume?: ResumeTurnMetadata,
+    resume?: VoiceResumeOptions,
   ): Promise<void> {
     if (this.isClosedOrFailed || !this.startVoiceTurn) {
       return;
@@ -1650,7 +1631,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // the escalated continuation leg without it: that leg persists an internal
     // `[continue]` prompt, so it must neither reuse the surface request id nor
     // show the surface's user-facing label.
-    resume?: ResumeTurnMetadata,
+    resume?: VoiceResumeOptions,
   ): Promise<void> {
     if (!this.startVoiceTurn) {
       return;

--- a/clients/web/.storybook/preview.tsx
+++ b/clients/web/.storybook/preview.tsx
@@ -11,6 +11,7 @@ import {
 import { create, themes } from "storybook/theming";
 import { addons } from "storybook/preview-api";
 import { GLOBALS_UPDATED } from "storybook/internal/core-events";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 import { useEffect, useState } from "react";
 import type { PropsWithChildren } from "react";
@@ -24,6 +25,13 @@ const themesAddon = themesAddonImport as unknown as () => ReturnType<
 >;
 
 import "./preview.css";
+
+// Single module-level client so stories sharing React Query hooks (e.g.
+// OAuthConnectSurface's useQueryClient) have a provider in context. Retries are
+// disabled so stories don't refetch on the backend-less Storybook environment.
+const storyQueryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
 
 const lightTheme = create({
   base: "light",
@@ -98,6 +106,11 @@ export default definePreview({
   addons: [docsAddon(), a11yAddon(), themesAddon()],
   tags: ["autodocs"],
   decorators: [
+    (Story) => (
+      <QueryClientProvider client={storyQueryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
     withThemeByDataAttribute<ReactRenderer>({
       themes: {
         light: "light",

--- a/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
@@ -1,10 +1,23 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  type QueryKey,
+} from "@tanstack/react-query";
+import type { ReactElement } from "react";
 
 mock.module("@/domains/chat/components/chat-markdown-message", () => ({
   ChatMarkdownMessage: ({ content }: { content: string }) => (
     <div>{content}</div>
   ),
+}));
+
+// The connections-cache invalidation resolves the platform-scoped assistant id
+// first; short-circuit it to the input so the invalidated key is deterministic
+// and no local-mode / gateway graph is exercised.
+mock.module("@/lib/local-platform-identity", () => ({
+  resolveLocalAssistantPlatformIdentity: async (id: string) => id,
 }));
 
 import { ChoiceSurface } from "@/domains/chat/components/surfaces/choice-surface";
@@ -14,6 +27,7 @@ import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router
 import type { ManagedOAuthConnectClient } from "@/domains/chat/api/managed-oauth";
 import type { OAuthConnection } from "@/generated/api/types.gen";
 import type { Surface } from "@/domains/chat/types/types";
+import { assistantsOauthConnectionsListQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 
 afterAll(() => {
   mock.restore();
@@ -30,6 +44,22 @@ function makeSurface(overrides: Partial<Surface>): Surface {
     data: {},
     ...overrides,
   };
+}
+
+/**
+ * Render inside a real QueryClient (OAuthConnectSurface calls `useQueryClient`),
+ * with `invalidateQueries` spied so the connections-cache refresh is assertable.
+ */
+function renderWithClient(ui: ReactElement) {
+  const queryClient = new QueryClient();
+  const invalidateQueries = mock((_arg?: { queryKey?: QueryKey }) =>
+    Promise.resolve(),
+  );
+  queryClient.invalidateQueries = invalidateQueries as never;
+  const result = render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+  return { ...result, queryClient, invalidateQueries };
 }
 
 describe("ChoiceSurface", () => {
@@ -195,7 +225,7 @@ describe("OAuthConnectSurface", () => {
       })),
     };
 
-    const { getByRole, queryByText } = render(
+    const { getByRole, queryByText } = renderWithClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -246,7 +276,7 @@ describe("OAuthConnectSurface", () => {
       connect: mock(async () => ({ status: "cancelled" as const })),
     };
 
-    const { getByText, queryByText } = render(
+    const { getByText, queryByText } = renderWithClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -279,7 +309,7 @@ describe("OAuthConnectSurface", () => {
       connect: mock(async () => ({ status: "cancelled" as const })),
     };
 
-    const { getByRole } = render(
+    const { getByRole } = renderWithClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -302,6 +332,108 @@ describe("OAuthConnectSurface", () => {
       providerKey: "linear",
       providerLabel: "Linear",
     });
+  });
+
+  test("refreshes the connections cache after a successful connect (still fires onAction)", async () => {
+    const onAction = mock(() => {});
+    const oauthClient: ManagedOAuthConnectClient = {
+      fetchProvider: mock(async () => null),
+      connect: mock(async () => ({
+        status: "connected" as const,
+        connection: {
+          id: "conn-1",
+          provider: "google",
+          status: "ACTIVE",
+          connected: true,
+          account_label: "user@example.com",
+          scopes_granted: [],
+          expires_at: null,
+        } as OAuthConnection,
+      })),
+    };
+
+    const { getByRole, invalidateQueries } = renderWithClient(
+      <OAuthConnectSurface
+        surface={makeSurface({
+          surfaceType: "oauth_connect",
+          data: { providerKey: "google", displayName: "Google" },
+        })}
+        assistantId="assistant-1"
+        oauthClient={oauthClient}
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Connect" }));
+
+    // The connections list query is keyed by the platform-scoped assistant id
+    // (mocked to the input here); a successful connect must invalidate it so a
+    // just-connected account repaints as connected wherever the list is mounted.
+    const expectedKey = assistantsOauthConnectionsListQueryKey({
+      path: { assistant_id: "assistant-1" },
+    });
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: expectedKey });
+      expect(onAction).toHaveBeenCalledWith(
+        "surface-1",
+        "connect",
+        expect.objectContaining({ status: "connected", providerKey: "google" }),
+      );
+    });
+  });
+
+  test("does not refresh the connections cache when the user cancels", async () => {
+    const oauthClient: ManagedOAuthConnectClient = {
+      fetchProvider: mock(async () => null),
+      connect: mock(async () => ({ status: "cancelled" as const })),
+    };
+
+    const { getByRole, invalidateQueries } = renderWithClient(
+      <OAuthConnectSurface
+        surface={makeSurface({
+          surfaceType: "oauth_connect",
+          data: { providerKey: "google", displayName: "Google" },
+        })}
+        assistantId="assistant-1"
+        oauthClient={oauthClient}
+        onAction={mock(() => {})}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => {
+      expect(oauthClient.connect).toHaveBeenCalledTimes(1);
+    });
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  test("does not refresh the connections cache on a connect error", async () => {
+    const oauthClient: ManagedOAuthConnectClient = {
+      fetchProvider: mock(async () => null),
+      connect: mock(async () => ({
+        status: "error" as const,
+        message: "Authorization failed.",
+      })),
+    };
+
+    const { getByRole, findByText, invalidateQueries } = renderWithClient(
+      <OAuthConnectSurface
+        surface={makeSurface({
+          surfaceType: "oauth_connect",
+          data: { providerKey: "google", displayName: "Google" },
+        })}
+        assistantId="assistant-1"
+        oauthClient={oauthClient}
+        onAction={mock(() => {})}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Connect" }));
+
+    // The error message surfaces once the flow settles.
+    expect(await findByText("Authorization failed.")).toBeTruthy();
+    expect(invalidateQueries).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@vellumai/design-library";
+import { useQueryClient } from "@tanstack/react-query";
 import {
     CheckCircle2,
     ExternalLink,
@@ -16,6 +17,8 @@ import {
     type ManagedOAuthProviderSummary,
 } from "@/domains/chat/api/managed-oauth";
 import type { Surface } from "@/domains/chat/types/types";
+import { assistantsOauthConnectionsListQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 
 interface OAuthConnectSurfaceData {
   providerKey?: string;
@@ -99,6 +102,7 @@ export function OAuthConnectSurface({
   assistantDisplayName,
   oauthClient = defaultManagedOAuthConnectClient,
 }: OAuthConnectSurfaceProps) {
+  const queryClient = useQueryClient();
   const data = surface.data as OAuthConnectSurfaceData;
   const providerKey = data.providerKey ?? "";
   const [provider, setProvider] = useState<ManagedOAuthProviderSummary | null>(
@@ -156,6 +160,20 @@ export function OAuthConnectSurface({
         accountLabel: result.connection?.account_label,
         scopesGranted: result.connection?.scopes_granted ?? [],
       });
+      // Invalidate the platform-assistant-scoped connections list so anywhere
+      // that query is mounted (e.g. the settings integrations page) refetches
+      // and reflects the just-connected account. Mirrors the settings connect
+      // hooks (use-oauth-connect). Best-effort: skip silently if the platform
+      // id can't resolve.
+      void resolveLocalAssistantPlatformIdentity(assistantId)
+        .then((platformAssistantId) => {
+          void queryClient.invalidateQueries({
+            queryKey: assistantsOauthConnectionsListQueryKey({
+              path: { assistant_id: platformAssistantId },
+            }),
+          });
+        })
+        .catch(() => {});
       return;
     }
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -30,6 +30,8 @@ import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
@@ -90,6 +92,43 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
   avatarQueryKey: (id: string) => ["assistantAvatar", id],
 }));
 
+// Stub the OAuth connect surface (managed-oauth + React Query graph): the room
+// only needs to mount it with the right props and let its Connect fire the
+// shared surface-action handler, so a button that echoes those props is enough.
+mock.module("@/domains/chat/components/surfaces/oauth-connect-surface", () => ({
+  OAuthConnectSurface: ({
+    surface,
+    assistantId,
+    assistantDisplayName,
+    onAction,
+  }: {
+    surface: { surfaceId: string };
+    assistantId: string | null;
+    assistantDisplayName?: string | null;
+    onAction: (surfaceId: string, actionId: string, data?: unknown) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="room-oauth-connect"
+      data-assistant-id={assistantId ?? ""}
+      data-assistant-name={assistantDisplayName ?? ""}
+      onClick={() => onAction(surface.surfaceId, "connect", {})}
+    >
+      Connect
+    </button>
+  ),
+}));
+
+// The room routes an in-room connect through the same imperative handler the
+// transcript uses; stub it so a click is assertable without the stream/turn
+// store side effects.
+const mockHandleSurfaceAction = mock(
+  (..._args: unknown[]): Promise<void> => Promise.resolve(),
+);
+mock.module("@/domains/chat/surface-actions", () => ({
+  handleSurfaceAction: (...args: unknown[]) => mockHandleSurfaceAction(...args),
+}));
+
 /** Minimal character components: one body/eye/color of each. */
 const CHARACTER_COMPONENTS = {
   bodyShapes: [
@@ -131,6 +170,7 @@ beforeEach(() => {
   controls.stop.mockClear();
   controls.release.mockClear();
   controls.interrupt.mockClear();
+  mockHandleSurfaceAction.mockClear();
   useLiveVoiceStore.getState().reset();
   useConversationStore
     .getState()
@@ -146,7 +186,44 @@ afterEach(() => {
   cleanup();
   useLiveVoiceStore.getState().reset();
   useConversationStore.getState().reset();
+  // Clear any seeded transcript / identity so the pending-surface slot never
+  // bleeds into another test's room.
+  useChatSessionStore.setState({ snapshot: null } as never);
+  useAssistantIdentityStore.getState().clearIdentity();
 });
+
+/**
+ * Seed a single assistant message carrying one `oauth_connect` surface into the
+ * transcript snapshot the room reads from.
+ */
+function seedOAuthConnectSurface(
+  overrides: { completed?: boolean } = {},
+): void {
+  useChatSessionStore.setState({
+    snapshot: {
+      messages: [
+        {
+          id: "assistant-msg-1",
+          role: "assistant",
+          surfaces: [
+            {
+              surfaceId: "oauth-1",
+              surfaceType: "oauth_connect",
+              data: { providerKey: "google", displayName: "Google" },
+              ...(overrides.completed ? { completed: true } : {}),
+            },
+          ],
+        },
+      ],
+      seq: 1,
+      processing: false,
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+      backgroundToolCompletions: [],
+    },
+  } as never);
+}
 
 const roomDialog = () =>
   screen.queryByRole("dialog", { name: "Voice session" });
@@ -594,5 +671,49 @@ describe("VoiceRoom — no push-to-talk / manual-release affordance (hands-free)
     render(<VoiceRoom />);
     expect(screen.queryByRole("button", { name: "Speak" })).toBeNull();
     expect(screen.queryByRole("button", { name: /Send now/ })).toBeNull();
+  });
+});
+
+describe("VoiceRoom — in-room OAuth connect card", () => {
+  const connectCard = () => screen.queryByTestId("room-oauth-connect");
+
+  test("renders no connect card when no oauth_connect surface is pending", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(roomDialog()).not.toBeNull();
+    expect(connectCard()).toBeNull();
+  });
+
+  test("mounts a clickable connect card for a pending oauth_connect surface, threading assistant props", () => {
+    // A live-voice turn's connect card is otherwise stranded behind the modal;
+    // the room re-hosts it so the user can actually connect.
+    useAssistantIdentityStore.getState().setIdentity("Aria", null);
+    seedOAuthConnectSurface();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    const card = connectCard();
+    expect(card).not.toBeNull();
+    expect((card as HTMLButtonElement).disabled).toBe(false);
+    // Wired like the transcript's SurfaceRouter: the session assistant + its
+    // display name.
+    expect(card!.getAttribute("data-assistant-id")).toBe(ASSISTANT_ID);
+    expect(card!.getAttribute("data-assistant-name")).toBe("Aria");
+  });
+
+  test("an in-room connect routes through the shared surface-action handler", () => {
+    seedOAuthConnectSurface();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    fireEvent.click(connectCard()!);
+    expect(mockHandleSurfaceAction).toHaveBeenCalledWith("oauth-1", "connect", {});
+  });
+
+  test("does not render a completed oauth_connect surface", () => {
+    seedOAuthConnectSurface({ completed: true });
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(connectCard()).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -39,7 +39,7 @@
  * is. The key handler attaches only while the room is mounted.
  */
 
-import { useEffect, type CSSProperties } from "react";
+import { useEffect, useMemo, type CSSProperties } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Captions, CaptionsOff, Mic, MicOff, Square, X } from "lucide-react";
 
@@ -54,8 +54,13 @@ import {
   stopLiveVoiceResponse,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { OAuthConnectSurface } from "@/domains/chat/components/surfaces/oauth-connect-surface";
+import { handleSurfaceAction } from "@/domains/chat/surface-actions";
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import type { Surface } from "@/domains/chat/types/types";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { AVATAR_ACCENT_CSS_VAR } from "@/hooks/use-avatar-accent-var";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { toneForBg } from "@/utils/surface-tone";
 
@@ -284,6 +289,13 @@ function VoiceRoomOverlay() {
           avatar and stays absent by default. */}
       <VoiceAmbientTranscript />
 
+      {/* A pending OAuth connect surface raised by the (voice) turn. The
+          transcript's own copy of this card is sealed behind the room's
+          `pointer-events-none blur-sm` cover (chat-layout), so a live-voice
+          turn that needs an account connected would strand the user — render a
+          live, clickable instance here inside the modal instead. */}
+      <VoiceRoomOAuthConnectSlot assistantId={assistantId} />
+
       {/* Room controls — captions toggle and the persistent exit. Rendered
           above all room chrome; ✕ is never gated behind avatar readiness, so
           ending works even mid-load / on failure. */}
@@ -436,5 +448,60 @@ function VoiceRoomOverlay() {
         {muted ? `Muted — ${stateLabel}` : stateLabel}
       </div>
     </motion.div>
+  );
+}
+
+/**
+ * The transcript surface the room re-hosts: the newest pending (not yet
+ * completed) `oauth_connect` card. Read from the same transcript state the
+ * chat body renders from, so completing it there (or from here — both go
+ * through {@link handleSurfaceAction}) drops it from both instances at once.
+ */
+function usePendingOAuthConnectSurface(): Surface | null {
+  const messages = useTranscriptMessages();
+  return useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const match = messages[i]?.surfaces?.find(
+        (s) => s.surfaceType === "oauth_connect" && !s.completed,
+      );
+      if (match) return match;
+    }
+    return null;
+  }, [messages]);
+}
+
+/**
+ * In-room mount of the active pending `oauth_connect` surface. The room is a
+ * `fixed inset-0` modal over the sealed (`pointer-events-none`) transcript, so
+ * the transcript's own card is invisible and unclickable during a session —
+ * this is the only reachable Connect button while voice is live. Wired exactly
+ * as {@link SurfaceRouter} wires it in the transcript (assistantId, the
+ * assistant display name, {@link handleSurfaceAction}), so a connect here is
+ * indistinguishable from one in the transcript. Renders nothing when no
+ * `oauth_connect` is pending.
+ */
+function VoiceRoomOAuthConnectSlot({
+  assistantId,
+}: {
+  assistantId: string | null;
+}) {
+  const surface = usePendingOAuthConnectSurface();
+  const assistantName = useAssistantIdentityStore.use.name();
+  if (!surface) return null;
+
+  return (
+    // The card floats above the room's centerpiece, clearing the bottom-corner
+    // session controls; only the card itself takes pointer events so the rest
+    // of the modal stays as it was.
+    <div className="pointer-events-none absolute inset-x-0 bottom-28 z-20 flex justify-center px-4">
+      <div className="pointer-events-auto w-full max-w-md">
+        <OAuthConnectSurface
+          surface={surface}
+          onAction={handleSurfaceAction}
+          assistantId={assistantId}
+          assistantDisplayName={assistantName?.trim() || undefined}
+        />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Closes the live-voice surface/OAuth seam. Live-voice turns bypass the text send path (`processMessage`), so an interactive `oauth_connect` surface raised during a voice turn yielded silently, its card rendered hidden behind the full-screen voice-room modal, and completion resumed as an unspoken text turn that never propagated the connection back into the live session.

- **Daemon:** a per-conversation resume registry + a live-voice session `resumeWithText` handler runs surface completion as a *spoken* voice turn (re-reading connection state); `handleSurfaceAction` routes to it when a live session owns the conversation, else falls back to the text path unchanged.
- **Client:** the pending `oauth_connect` card renders inside the voice-room modal (clickable Connect) and a successful surface connect invalidates the connections query cache.

Fixes JARVIS-1287 (voice no longer hangs/goes silent after connect) and addresses JARVIS-1286 (connect is reachable + reflected as connected during voice).

## Self-review result
GAPS FOUND → all fixed across 4 fix PRs over 3 remediation rounds; final re-review clean. Fixed: Storybook `QueryClientProvider`, a dead `sourceActorPrincipalId` param + resume-opts consolidation, busy-session completions routing to the silent text queue, and `activeSurfaceId`/`currentPage` context parity for `dynamic_page` resumes.

## PRs merged into feature branch
- #38090: Show the OAuth connect card in the voice room and refresh connections
- #38091: Resume interactive surfaces as spoken voice turns

### Fix PRs (self-review remediation)
- #38093: provide QueryClientProvider so OAuthConnectSurface stories render
- #38096: route busy-session surface resumes to voice, drop dead principal param, unify resume opts
- #38099: thread activeSurfaceId into voice surface resumes
- #38106: clear stale currentPage on voice surface resumes

## Deferred (optional follow-ups, not in this branch)
Spoken "ask" line when a surface is raised (needs a dedicated synthetic TTS turn), `open_url` popup de-dup, and the inline/structured double-mount guard — see the plan. Do only if QA still shows duplicate popups.

Part of plan: voice-seam-oauth.md