### PR TITLE
feat(plugin-api): add authedFetch for credential-backed HTTP

### DIFF
--- a/assistant/src/__tests__/plugin-api-authed-fetch.test.ts
+++ b/assistant/src/__tests__/plugin-api-authed-fetch.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for plugin-api `authedFetch`.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentialKey } from "../security/credential-key.js";
+import type { CredentialMetadata } from "../tools/credentials/metadata-store.js";
+import type { CredentialInjectionTemplate } from "../tools/credentials/policy-types.js";
+import type { ResolvedCredential } from "../tools/credentials/resolve.js";
+import { AUTHED_FETCH_CAPABILITY } from "../tools/credentials/tool-policy.js";
+
+let resolveByIdResults = new Map<string, ResolvedCredential | undefined>();
+let resolveByServiceFieldResults = new Map<
+  string,
+  ResolvedCredential | undefined
+>();
+let credentialMetadataList: CredentialMetadata[] = [];
+let secureKeyValues = new Map<string, string | undefined>();
+
+mock.module("../tools/credentials/resolve.js", () => ({
+  resolveById: (credentialId: string) => resolveByIdResults.get(credentialId),
+  resolveByServiceField: (service: string, field: string) =>
+    resolveByServiceFieldResults.get(`${service}:${field}`),
+  resolveCredentialRef: (ref: string) => {
+    const byId = resolveByIdResults.get(ref);
+    if (byId) {
+      return byId;
+    }
+    const slashIndex = ref.indexOf("/");
+    if (slashIndex <= 0 || slashIndex >= ref.length - 1) {
+      return undefined;
+    }
+    if (ref.indexOf("/", slashIndex + 1) !== -1) {
+      return undefined;
+    }
+    const service = ref.slice(0, slashIndex);
+    const field = ref.slice(slashIndex + 1);
+    return resolveByServiceFieldResults.get(`${service}:${field}`);
+  },
+  resolveForDomain: () => [],
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  listCredentialMetadata: () => credentialMetadataList,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: (account: string) =>
+    Promise.resolve(secureKeyValues.get(account)),
+}));
+
+import { PLUGIN_API_EXPORTS } from "../embedded/plugin-api.js";
+import { authedFetch, AuthedFetchError } from "../plugin-api/authed-fetch.js";
+import * as pluginApi from "../plugin-api/index.js";
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  resolveByIdResults = new Map();
+  resolveByServiceFieldResults = new Map();
+  credentialMetadataList = [];
+  secureKeyValues = new Map();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function stubFetch(
+  impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+): void {
+  // typeof fetch also requires Fetch.preconnect; tests only stub the call.
+  globalThis.fetch = impl as unknown as typeof fetch;
+}
+
+function makeTemplate(
+  hostPattern: string,
+  headerName = "Authorization",
+  valuePrefix = "Bearer ",
+): CredentialInjectionTemplate {
+  return { hostPattern, injectionType: "header", headerName, valuePrefix };
+}
+
+function makeResolved(
+  credentialId: string,
+  templates: CredentialInjectionTemplate[],
+  options: {
+    service?: string;
+    field?: string;
+    allowedTools?: string[];
+  } = {},
+): ResolvedCredential {
+  const service = options.service ?? "acme";
+  const field = options.field ?? "api_key";
+  const allowedTools = options.allowedTools ?? [AUTHED_FETCH_CAPABILITY];
+  const metadata: CredentialMetadata = {
+    credentialId,
+    service,
+    field,
+    allowedTools,
+    allowedDomains: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    injectionTemplates: templates,
+  };
+  return {
+    credentialId,
+    service,
+    field,
+    storageKey: credentialKey(service, field),
+    injectionTemplates: templates,
+    metadata,
+  };
+}
+
+function registerCredential(
+  resolved: ResolvedCredential,
+  secret: string,
+): void {
+  resolveByIdResults.set(resolved.credentialId, resolved);
+  resolveByServiceFieldResults.set(
+    `${resolved.service}:${resolved.field}`,
+    resolved,
+  );
+  credentialMetadataList.push(resolved.metadata);
+  secureKeyValues.set(resolved.storageKey, secret);
+}
+
+describe("authedFetch", () => {
+  test("injects Authorization header from matching credential", async () => {
+    const tpl = makeTemplate("api.acme.test");
+    const resolved = makeResolved("cred-1", [tpl]);
+    registerCredential(resolved, "secret-token");
+
+    let capturedHeaders: Headers | undefined;
+    stubFetch(async (_input, init) => {
+      capturedHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    const response = await authedFetch("https://api.acme.test/v1/items");
+    expect(response.status).toBe(200);
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer secret-token");
+  });
+
+  test("overwrites a caller-provided header of the same name", async () => {
+    const tpl = makeTemplate("api.acme.test");
+    const resolved = makeResolved("cred-1", [tpl]);
+    registerCredential(resolved, "secret-token");
+
+    let capturedHeaders: Headers | undefined;
+    stubFetch(async (_input, init) => {
+      capturedHeaders = new Headers(init?.headers);
+      return new Response("", { status: 204 });
+    });
+
+    await authedFetch("https://api.acme.test/x", {
+      headers: { Authorization: "Bearer caller-value" },
+    });
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer secret-token");
+  });
+
+  test("denies when allowedTools does not include authedFetch", async () => {
+    const tpl = makeTemplate("api.acme.test");
+    const resolved = makeResolved("cred-1", [tpl], { allowedTools: ["bash"] });
+    registerCredential(resolved, "secret-token");
+
+    stubFetch(async () => {
+      throw new Error("fetch must not be called");
+    });
+
+    await expect(authedFetch("https://api.acme.test/v1")).rejects.toMatchObject(
+      {
+        code: "POLICY_DENIED",
+        name: "AuthedFetchError",
+      },
+    );
+  });
+
+  test("throws AMBIGUOUS_CREDENTIAL when two credentials match", async () => {
+    const tpl = makeTemplate("*.acme.test");
+    registerCredential(makeResolved("cred-a", [tpl], { field: "a" }), "a");
+    registerCredential(
+      makeResolved("cred-b", [tpl], { field: "b", service: "acme" }),
+      "b",
+    );
+
+    stubFetch(async () => {
+      throw new Error("fetch must not be called");
+    });
+
+    await expect(authedFetch("https://api.acme.test/v1")).rejects.toMatchObject(
+      {
+        code: "AMBIGUOUS_CREDENTIAL",
+      },
+    );
+  });
+
+  test("options.credential disambiguates among matches", async () => {
+    const tpl = makeTemplate("*.acme.test");
+    registerCredential(
+      makeResolved("cred-a", [tpl], { field: "a" }),
+      "token-a",
+    );
+    registerCredential(
+      makeResolved("cred-b", [tpl], { field: "b", service: "acme" }),
+      "token-b",
+    );
+
+    let capturedHeaders: Headers | undefined;
+    stubFetch(async (_input, init) => {
+      capturedHeaders = new Headers(init?.headers);
+      return new Response("", { status: 200 });
+    });
+
+    await authedFetch("https://api.acme.test/v1", undefined, {
+      credential: "acme/b",
+    });
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer token-b");
+  });
+
+  test("throws NO_CREDENTIAL when no template matches", async () => {
+    const tpl = makeTemplate("other.test");
+    registerCredential(makeResolved("cred-1", [tpl]), "secret");
+
+    stubFetch(async () => {
+      throw new Error("fetch must not be called");
+    });
+
+    await expect(
+      authedFetch("https://api.acme.test/v1"),
+    ).rejects.toBeInstanceOf(AuthedFetchError);
+    await expect(authedFetch("https://api.acme.test/v1")).rejects.toMatchObject(
+      {
+        code: "NO_CREDENTIAL",
+      },
+    );
+  });
+
+  test("throws NO_HEADER_TEMPLATE when only query injection matches", async () => {
+    const queryTpl: CredentialInjectionTemplate = {
+      hostPattern: "api.acme.test",
+      injectionType: "query",
+      queryParamName: "key",
+    };
+    const resolved = makeResolved("cred-1", [queryTpl]);
+    registerCredential(resolved, "secret");
+
+    stubFetch(async () => {
+      throw new Error("fetch must not be called");
+    });
+
+    await expect(
+      authedFetch("https://api.acme.test/v1", undefined, {
+        credential: "cred-1",
+      }),
+    ).rejects.toMatchObject({ code: "NO_HEADER_TEMPLATE" });
+  });
+});
+
+describe("plugin-api authedFetch export", () => {
+  test("authedFetch is exported as a runtime value", () => {
+    expect(typeof pluginApi.authedFetch).toBe("function");
+  });
+
+  test("authedFetch is in the shim-rebound runtime surface", () => {
+    expect(PLUGIN_API_EXPORTS).toContain("authedFetch");
+  });
+});

--- a/assistant/src/__tests__/plugin-api-authed-fetch.test.ts
+++ b/assistant/src/__tests__/plugin-api-authed-fetch.test.ts
@@ -88,6 +88,7 @@ function makeResolved(
     service?: string;
     field?: string;
     allowedTools?: string[];
+    allowedDomains?: string[];
   } = {},
 ): ResolvedCredential {
   const service = options.service ?? "acme";
@@ -98,7 +99,7 @@ function makeResolved(
     service,
     field,
     allowedTools,
-    allowedDomains: [],
+    allowedDomains: options.allowedDomains ?? [],
     createdAt: Date.now(),
     updatedAt: Date.now(),
     injectionTemplates: templates,
@@ -160,7 +161,7 @@ describe("authedFetch", () => {
     expect(capturedHeaders?.get("Authorization")).toBe("Bearer secret-token");
   });
 
-  test("denies when allowedTools does not include authedFetch", async () => {
+  test("skips credentials without authedFetch when auto-matching", async () => {
     const tpl = makeTemplate("api.acme.test");
     const resolved = makeResolved("cred-1", [tpl], { allowedTools: ["bash"] });
     registerCredential(resolved, "secret-token");
@@ -171,10 +172,73 @@ describe("authedFetch", () => {
 
     await expect(authedFetch("https://api.acme.test/v1")).rejects.toMatchObject(
       {
-        code: "POLICY_DENIED",
+        code: "NO_CREDENTIAL",
         name: "AuthedFetchError",
       },
     );
+  });
+
+  test("denies pinned credential when allowedTools lacks authedFetch", async () => {
+    const tpl = makeTemplate("api.acme.test");
+    const resolved = makeResolved("cred-1", [tpl], { allowedTools: ["bash"] });
+    registerCredential(resolved, "secret-token");
+
+    stubFetch(async () => {
+      throw new Error("fetch must not be called");
+    });
+
+    await expect(
+      authedFetch("https://api.acme.test/v1", undefined, {
+        credential: "cred-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "POLICY_DENIED",
+      name: "AuthedFetchError",
+    });
+  });
+
+  test("denies credentials with allowedDomains (browser-scoped)", async () => {
+    const tpl = makeTemplate("api.acme.test");
+    registerCredential(
+      makeResolved("cred-1", [tpl], {
+        allowedDomains: ["api.acme.test"],
+      }),
+      "secret-token",
+    );
+
+    stubFetch(async () => {
+      throw new Error("fetch must not be called");
+    });
+
+    await expect(
+      authedFetch("https://api.acme.test/v1", undefined, {
+        credential: "cred-1",
+      }),
+    ).rejects.toMatchObject({ code: "POLICY_DENIED" });
+  });
+
+  test("ignores proxy-only sibling when selecting an authedFetch credential", async () => {
+    const tpl = makeTemplate("*.acme.test");
+    registerCredential(
+      makeResolved("cred-proxy", [tpl], {
+        field: "proxy_key",
+        allowedTools: ["bash"],
+      }),
+      "proxy-secret",
+    );
+    registerCredential(
+      makeResolved("cred-fetch", [tpl], { field: "api_key" }),
+      "fetch-secret",
+    );
+
+    let capturedHeaders: Headers | undefined;
+    stubFetch(async (_input, init) => {
+      capturedHeaders = new Headers(init?.headers);
+      return new Response("", { status: 200 });
+    });
+
+    await authedFetch("https://api.acme.test/v1");
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer fetch-secret");
   });
 
   test("throws AMBIGUOUS_CREDENTIAL when two credentials match", async () => {

--- a/assistant/src/plugin-api/authed-fetch.ts
+++ b/assistant/src/plugin-api/authed-fetch.ts
@@ -1,0 +1,275 @@
+/**
+ * Authenticated fetch for plugin authors.
+ *
+ * Resolves a credential by matching the request hostname against each
+ * credential's `injectionTemplates.hostPattern` (same matching rules as the
+ * script-proxy MITM path), checks that the credential allows the
+ * `authedFetch` capability, builds the injected header value (never exposing
+ * the plaintext to the caller), then performs a normal `fetch`.
+ */
+
+import { evaluateRequest } from "../outbound-proxy/policy.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { buildInjectedValue } from "../tools/credentials/injection.js";
+import { listCredentialMetadata } from "../tools/credentials/metadata-store.js";
+import type { CredentialInjectionTemplate } from "../tools/credentials/policy-types.js";
+import {
+  resolveById,
+  resolveCredentialRef,
+} from "../tools/credentials/resolve.js";
+import {
+  AUTHED_FETCH_CAPABILITY,
+  isToolAllowed,
+} from "../tools/credentials/tool-policy.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("plugin-api:authed-fetch");
+
+// ---------------------------------------------------------------------------
+// Public options / errors
+// ---------------------------------------------------------------------------
+
+export interface AuthedFetchOptions {
+  /**
+   * Pin a credential by opaque id or `service/field`. When omitted, every
+   * credential with injection templates is considered and the best
+   * hostPattern match wins (ambiguity throws).
+   */
+  credential?: string;
+}
+
+export type AuthedFetchErrorCode =
+  | "MISSING_URL"
+  | "NO_CREDENTIAL"
+  | "AMBIGUOUS_CREDENTIAL"
+  | "POLICY_DENIED"
+  | "NO_HEADER_TEMPLATE"
+  | "SECRET_UNAVAILABLE"
+  | "COMPOSE_FAILED";
+
+export class AuthedFetchError extends Error {
+  readonly code: AuthedFetchErrorCode;
+
+  constructor(code: AuthedFetchErrorCode, message: string) {
+    super(message);
+    this.name = "AuthedFetchError";
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+function resolveRequestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof URL) {
+    return input;
+  }
+  if (typeof input === "string") {
+    return new URL(input);
+  }
+  // Request object — prefer its URL; `init` cannot override Request.url.
+  return new URL(input.url);
+}
+
+function collectTemplates(credentialPin?: string): {
+  credentialIds: string[];
+  templates: Map<string, CredentialInjectionTemplate[]>;
+} {
+  const templates = new Map<string, CredentialInjectionTemplate[]>();
+  const credentialIds: string[] = [];
+
+  if (credentialPin !== undefined) {
+    const resolved = resolveCredentialRef(credentialPin);
+    if (!resolved) {
+      throw new AuthedFetchError(
+        "NO_CREDENTIAL",
+        `Unknown credential reference "${credentialPin}". Use \`assistant credentials list\` to see available credentials.`,
+      );
+    }
+    if (resolved.injectionTemplates.length === 0) {
+      throw new AuthedFetchError(
+        "NO_HEADER_TEMPLATE",
+        `Credential ${resolved.service}/${resolved.field} has no injection templates.`,
+      );
+    }
+    const hasHeader = resolved.injectionTemplates.some(
+      (template) => template.injectionType === "header" && template.headerName,
+    );
+    if (!hasHeader) {
+      throw new AuthedFetchError(
+        "NO_HEADER_TEMPLATE",
+        `Credential ${resolved.service}/${resolved.field} has no header injection template (query injection is not supported by authedFetch).`,
+      );
+    }
+    credentialIds.push(resolved.credentialId);
+    templates.set(resolved.credentialId, resolved.injectionTemplates);
+    return { credentialIds, templates };
+  }
+
+  for (const meta of listCredentialMetadata()) {
+    const tpls = meta.injectionTemplates ?? [];
+    if (tpls.length === 0) {
+      continue;
+    }
+    credentialIds.push(meta.credentialId);
+    templates.set(meta.credentialId, tpls);
+  }
+
+  return { credentialIds, templates };
+}
+
+function mergeHeaders(
+  existing: HeadersInit | undefined,
+  headerName: string,
+  headerValue: string,
+): Headers {
+  const headers = new Headers(existing);
+  headers.set(headerName, headerValue);
+  return headers;
+}
+
+/**
+ * Fetch with credential header injection.
+ *
+ * Injected header values overwrite a caller-provided header of the same name
+ * (matches script-proxy MITM rewrite behavior).
+ */
+export async function authedFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  options?: AuthedFetchOptions,
+): Promise<Response> {
+  let url: URL;
+  try {
+    url = resolveRequestUrl(input);
+  } catch {
+    throw new AuthedFetchError(
+      "MISSING_URL",
+      "authedFetch requires a valid absolute URL",
+    );
+  }
+
+  const hostname = url.hostname;
+  if (!hostname) {
+    throw new AuthedFetchError(
+      "MISSING_URL",
+      "authedFetch requires a URL with a hostname",
+    );
+  }
+
+  const { credentialIds, templates } = collectTemplates(options?.credential);
+
+  const decision = evaluateRequest(
+    hostname,
+    url.pathname || "/",
+    credentialIds,
+    templates,
+  );
+
+  if (decision.kind === "ambiguous") {
+    const labels = decision.candidates
+      .map((candidate) => {
+        const resolved = resolveById(candidate.credentialId);
+        const name = resolved
+          ? `${resolved.service}/${resolved.field}`
+          : candidate.credentialId;
+        return `${name} (${candidate.template.hostPattern})`;
+      })
+      .join(", ");
+    throw new AuthedFetchError(
+      "AMBIGUOUS_CREDENTIAL",
+      `Multiple credentials match host "${hostname}": ${labels}. Pass options.credential to disambiguate.`,
+    );
+  }
+
+  if (decision.kind !== "matched") {
+    throw new AuthedFetchError(
+      "NO_CREDENTIAL",
+      `No credential with a header injection template matches host "${hostname}".` +
+        (options?.credential
+          ? ` Pinned credential "${options.credential}" did not match.`
+          : " Add injection templates or pass options.credential."),
+    );
+  }
+
+  const { credentialId, template } = decision;
+
+  if (template.injectionType !== "header" || !template.headerName) {
+    throw new AuthedFetchError(
+      "NO_HEADER_TEMPLATE",
+      `Matched credential for host "${hostname}" has no header injection template (query injection is not supported by authedFetch).`,
+    );
+  }
+
+  const resolved = resolveById(credentialId);
+  if (!resolved) {
+    throw new AuthedFetchError(
+      "NO_CREDENTIAL",
+      `Credential ${credentialId} could not be resolved after match`,
+    );
+  }
+
+  if (!isToolAllowed(AUTHED_FETCH_CAPABILITY, resolved.metadata.allowedTools)) {
+    const tools = resolved.metadata.allowedTools ?? [];
+    throw new AuthedFetchError(
+      "POLICY_DENIED",
+      `Credential ${resolved.service}/${resolved.field} does not allow "${AUTHED_FETCH_CAPABILITY}".` +
+        (tools.length === 0
+          ? " No tools are currently allowed — update allowed_tools via `assistant credentials set`."
+          : ` Allowed tools: ${tools.join(", ")}.`),
+    );
+  }
+
+  const secret = await getSecureKeyAsync(resolved.storageKey);
+  if (!secret) {
+    throw new AuthedFetchError(
+      "SECRET_UNAVAILABLE",
+      `Credential metadata exists but no stored value for ${resolved.service}/${resolved.field}`,
+    );
+  }
+
+  const headerValue = await buildInjectedValue(template, secret);
+  if (!headerValue) {
+    throw new AuthedFetchError(
+      "COMPOSE_FAILED",
+      `Failed to compose injected value for ${resolved.service}/${resolved.field} (composeWith credential missing)`,
+    );
+  }
+
+  const callerHeaders =
+    init?.headers ??
+    (typeof input !== "string" && !(input instanceof URL) && "headers" in input
+      ? input.headers
+      : undefined);
+
+  const headers = mergeHeaders(callerHeaders, template.headerName, headerValue);
+
+  log.info(
+    {
+      hostname,
+      credentialId,
+      service: resolved.service,
+      field: resolved.field,
+      headerName: template.headerName,
+      method: init?.method ?? "GET",
+    },
+    "Starting authedFetch",
+  );
+
+  const response = await fetch(input, {
+    ...init,
+    headers,
+  });
+
+  log.info(
+    {
+      hostname,
+      credentialId,
+      status: response.status,
+    },
+    "Completed authedFetch",
+  );
+
+  return response;
+}

--- a/assistant/src/plugin-api/authed-fetch.ts
+++ b/assistant/src/plugin-api/authed-fetch.ts
@@ -16,6 +16,7 @@ import type { CredentialInjectionTemplate } from "../tools/credentials/policy-ty
 import {
   resolveById,
   resolveCredentialRef,
+  type ResolvedCredential,
 } from "../tools/credentials/resolve.js";
 import {
   AUTHED_FETCH_CAPABILITY,
@@ -60,6 +61,45 @@ export class AuthedFetchError extends Error {
 // ---------------------------------------------------------------------------
 // Implementation
 // ---------------------------------------------------------------------------
+
+/**
+ * Server-side use mirrors CredentialBroker.serverUseById: capability must
+ * allow authedFetch, and domain-scoped (browser) credentials are rejected.
+ */
+function assertCredentialUsableForAuthedFetch(
+  resolved: ResolvedCredential,
+): void {
+  if (!isToolAllowed(AUTHED_FETCH_CAPABILITY, resolved.metadata.allowedTools)) {
+    const tools = resolved.metadata.allowedTools ?? [];
+    throw new AuthedFetchError(
+      "POLICY_DENIED",
+      `Credential ${resolved.service}/${resolved.field} does not allow "${AUTHED_FETCH_CAPABILITY}".` +
+        (tools.length === 0
+          ? " No tools are currently allowed — update allowed_tools via `assistant credentials set`."
+          : ` Allowed tools: ${tools.join(", ")}.`),
+    );
+  }
+
+  const domains = resolved.metadata.allowedDomains ?? [];
+  if (domains.length > 0) {
+    throw new AuthedFetchError(
+      "POLICY_DENIED",
+      `Credential ${resolved.service}/${resolved.field} has domain restrictions ` +
+        `(${domains.join(", ")}) and cannot be used server-side. ` +
+        "Remove domain restrictions or use a separate credential without domain policy.",
+    );
+  }
+}
+
+function isMetadataUsableForAuthedFetch(meta: {
+  allowedTools?: string[];
+  allowedDomains?: string[];
+}): boolean {
+  if (!isToolAllowed(AUTHED_FETCH_CAPABILITY, meta.allowedTools ?? [])) {
+    return false;
+  }
+  return (meta.allowedDomains ?? []).length === 0;
+}
 
 function resolveRequestUrl(input: RequestInfo | URL): URL {
   if (input instanceof URL) {
@@ -110,6 +150,11 @@ function collectTemplates(credentialPin?: string): {
   for (const meta of listCredentialMetadata()) {
     const tpls = meta.injectionTemplates ?? [];
     if (tpls.length === 0) {
+      continue;
+    }
+    // Exclude credentials that cannot authorize this path so they cannot
+    // shadow a usable match (ambiguous / policy-denied on a bad candidate).
+    if (!isMetadataUsableForAuthedFetch(meta)) {
       continue;
     }
     credentialIds.push(meta.credentialId);
@@ -210,16 +255,7 @@ export async function authedFetch(
     );
   }
 
-  if (!isToolAllowed(AUTHED_FETCH_CAPABILITY, resolved.metadata.allowedTools)) {
-    const tools = resolved.metadata.allowedTools ?? [];
-    throw new AuthedFetchError(
-      "POLICY_DENIED",
-      `Credential ${resolved.service}/${resolved.field} does not allow "${AUTHED_FETCH_CAPABILITY}".` +
-        (tools.length === 0
-          ? " No tools are currently allowed — update allowed_tools via `assistant credentials set`."
-          : ` Allowed tools: ${tools.join(", ")}.`),
-    );
-  }
+  assertCredentialUsableForAuthedFetch(resolved);
 
   const secret = await getSecureKeyAsync(resolved.storageKey);
   if (!secret) {

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -244,6 +244,16 @@ export {
 export type { SynthesizeTextOptions } from "../tts/synthesize-text.js";
 export { synthesizeText, TtsSynthesisError } from "../tts/synthesize-text.js";
 export type { TtsSynthesisResult } from "../tts/types.js";
+// Authenticated HTTP for plugin tools: fetch-compatible helper that matches a
+// credential by injectionTemplates.hostPattern (optional options.credential
+// pin), requires "authedFetch" in the credential's allowedTools, injects the
+// auth header from the secret store, then calls fetch. Secrets never leave
+// the helper return value.
+export type {
+  AuthedFetchErrorCode,
+  AuthedFetchOptions,
+} from "./authed-fetch.js";
+export { authedFetch, AuthedFetchError } from "./authed-fetch.js";
 // Conversation agent-loop turn — run a full conversation turn (persist user
 // message, execute the agent loop with history/tools/compaction/injections,
 // return the assistant's full content-block response). Accepts ContentBlock[]

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -1,6 +1,7 @@
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import type * as wire from "./telemetry-wire.generated.js";
+import { telemetryEventSchema } from "./telemetry-wire.generated.js";
 import type { TurnOutcome } from "./turn-outcome.js";
 
 /** Base fields present on every telemetry event. */

--- a/assistant/src/tools/credentials/injection.ts
+++ b/assistant/src/tools/credentials/injection.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared credential value injection helpers used by the script-proxy MITM
+ * path and by plugin-api `authedFetch`.
+ */
+
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
+import type { CredentialInjectionTemplate } from "./policy-types.js";
+import { resolveByServiceField } from "./resolve.js";
+
+/**
+ * Build the final header (or query) value for a matched credential injection
+ * template. Handles optional composition with a second credential and value
+ * transforms. Returns null if any referenced credential cannot be resolved.
+ */
+export async function buildInjectedValue(
+  tpl: CredentialInjectionTemplate,
+  primaryValue: string,
+): Promise<string | null> {
+  let value = primaryValue;
+
+  if (tpl.composeWith) {
+    const composed = resolveByServiceField(
+      tpl.composeWith.service,
+      tpl.composeWith.field,
+    );
+    if (!composed) {
+      return null;
+    }
+    const composedValue = await getSecureKeyAsync(composed.storageKey);
+    if (!composedValue) {
+      return null;
+    }
+    value = `${value}${tpl.composeWith.separator}${composedValue}`;
+  }
+
+  if (tpl.valueTransform === "base64") {
+    value = Buffer.from(value).toString("base64");
+  }
+
+  return (tpl.valuePrefix ?? "") + value;
+}

--- a/assistant/src/tools/credentials/tool-policy.ts
+++ b/assistant/src/tools/credentials/tool-policy.ts
@@ -15,6 +15,13 @@
 export const BROWSER_FILL_CAPABILITY = "assistant_browser_fill_credential";
 
 /**
+ * Canonical capability key for in-process authenticated HTTP via
+ * `@vellumai/plugin-api` `authedFetch`. Credentials must list this literal
+ * in `allowedTools` for `authedFetch` to inject their headers.
+ */
+export const AUTHED_FETCH_CAPABILITY = "authedFetch";
+
+/**
  * Legacy tool names that map to canonical capability keys.
  *
  * Credentials stored with `browser_fill_credential` in their

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -38,11 +38,11 @@ import {
   type HostMatchKind,
   matchHostPattern,
 } from "../../credentials/host-pattern-match.js";
+import { buildInjectedValue } from "../../credentials/injection.js";
 import { listCredentialMetadata } from "../../credentials/metadata-store.js";
 import type { CredentialInjectionTemplate } from "../../credentials/policy-types.js";
 import {
   resolveById,
-  resolveByServiceField,
   type ResolvedCredential,
 } from "../../credentials/resolve.js";
 
@@ -132,35 +132,6 @@ function isAllowedHost(hostname: string): boolean {
 // ---------------------------------------------------------------------------
 // Credential helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Build the final header value for a matched credential injection template.
- * Handles optional composition with a second credential and value transforms.
- * Returns null if any referenced credential cannot be resolved.
- */
-async function buildInjectedValue(
-  tpl: CredentialInjectionTemplate,
-  primaryValue: string,
-): Promise<string | null> {
-  let value = primaryValue;
-
-  if (tpl.composeWith) {
-    const composed = resolveByServiceField(
-      tpl.composeWith.service,
-      tpl.composeWith.field,
-    );
-    if (!composed) return null;
-    const composedValue = await getSecureKeyAsync(composed.storageKey);
-    if (!composedValue) return null;
-    value = `${value}${tpl.composeWith.separator}${composedValue}`;
-  }
-
-  if (tpl.valueTransform === "base64") {
-    value = Buffer.from(value).toString("base64");
-  }
-
-  return (tpl.valuePrefix ?? "") + value;
-}
 
 /**
  * Resolve injection templates for a credential.


### PR DESCRIPTION
## Prompt / plan
Plugins often store API tokens in their own config so tools can call third-party APIs. That puts secrets in plaintext next to plugin state: the model can read them, and other plugins/tools can reach them too.

This PR adds `@vellumai/plugin-api` `authedFetch` — a fetch-compatible helper that resolves a credential by `injectionTemplates.hostPattern` (optional `options.credential` pin), requires `"authedFetch"` in the credential's `allowedTools`, injects the auth header in-process via the secret store, then calls `fetch`. The plaintext secret never returns to the plugin.

Shared `buildInjectedValue` lives in `tools/credentials/injection.ts` so script-proxy MITM and `authedFetch` stay on one injection path. Capability constant: `AUTHED_FETCH_CAPABILITY = "authedFetch"`.

v1: header injection only (query deferred). No CES RPC `make_authenticated_request`, no ToolContext method, no auto-backfill of `"authedFetch"` onto existing credentials — callers opt in via `assistant credentials set`.

Also includes a small fix in `telemetry/types.ts`: value-import `telemetryEventSchema` (was used without import; blocked typecheck).

## Test plan
- [x] `cd assistant && bun test src/__tests__/plugin-api-authed-fetch.test.ts` (header inject, overwrite, policy deny, ambiguity, credential pin, query-only reject, export presence)
- [x] `cd assistant && bunx tsc --noEmit`
- [ ] Manual: create credential with header `injectionTemplates` + `allowedTools` including `authedFetch`; call `authedFetch` from a plugin tool and confirm Authorization is set and the secret is not returned
- [ ] Manual: same credential without `authedFetch` in `allowedTools` → `POLICY_DENIED`

## Risk
Low–medium. New surface only; existing credentials without `"authedFetch"` are unchanged. Secrets are materialized in daemon process like today's script-proxy MITM (same trust tier), not exposed on the plugin-api return path.