### PR TITLE
feat(memory): move memory_v3_selections and activation_sessions to the memory DB

### DIFF
--- a/assistant/src/__tests__/activation-early-marking.test.ts
+++ b/assistant/src/__tests__/activation-early-marking.test.ts
@@ -25,9 +25,8 @@ const { isActivationSession } =
   await import("../plugins/defaults/memory/activation-session-store.js");
 const { ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE } =
   await import("../telemetry/activation-funnel.js");
-const { getDb } = await import("../persistence/db-connection.js");
+const { getMemorySqlite } = await import("../persistence/db-connection.js");
 const { initializeDb } = await import("../persistence/db-init.js");
-const { activationSessions } = await import("../persistence/schema/index.js");
 
 await initializeDb();
 
@@ -44,7 +43,7 @@ function seedGenericBootstrap(): void {
 
 describe("applyBootstrapTemplate — early activation marking", () => {
   beforeEach(() => {
-    getDb().delete(activationSessions).run();
+    getMemorySqlite()!.exec("DELETE FROM activation_sessions");
   });
 
   test("marks the conversation when the activation-rail template is applied", () => {
@@ -71,8 +70,10 @@ describe("applyBootstrapTemplate — early activation marking", () => {
     applyBootstrapTemplate(ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE);
 
     // Nothing to assert by id; confirm the table stayed empty.
-    const rows = getDb().select().from(activationSessions).all();
-    expect(rows.length).toBe(0);
+    const { n } = getMemorySqlite()!
+      .query("SELECT COUNT(*) AS n FROM activation_sessions")
+      .get() as { n: number };
+    expect(n).toBe(0);
   });
 
   test("does not mark when BOOTSTRAP.md is customized to something else", () => {

--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -27,12 +27,12 @@ const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
 
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type { SurfaceType, UiSurfaceShow } from "../daemon/message-protocol.js";
-import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
-import { initializeDb } from "../persistence/db-init.js";
 import {
-  activationSessions,
-  telemetryEvents,
-} from "../persistence/schema/index.js";
+  getMemorySqlite,
+  getTelemetryDb,
+} from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
 import {
   isActivationSession,
   markActivationSession,
@@ -93,7 +93,7 @@ function makeContext(
 
 function resetTables(): void {
   getTelemetryDb()!.delete(telemetryEvents).run();
-  getDb().delete(activationSessions).run();
+  getMemorySqlite()!.exec("DELETE FROM activation_sessions");
 }
 
 /** Render a choice surface tagged (or not) with an activation_moment. */

--- a/assistant/src/persistence/migrations/338-move-memory-v3-selections-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/338-move-memory-v3-selections-to-memory-db.ts
@@ -1,0 +1,110 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_v3_selections` from `main` into the memory DB. Every
+ * row is copied: the hot-set and learned-edge lanes score decayed selection
+ * frequency over the full log, so there is no age cutoff a purge could lean
+ * on. The column list covers migration 268's originals plus the nullable
+ * columns migration 283 added — a source staged before 283 ran simply
+ * NULL-fills them during the copy.
+ */
+export const MEMORY_V3_SELECTIONS_RELOCATION: RelocationSpec = {
+  table: "memory_v3_selections",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "conversation_id",
+    "turn",
+    "slug",
+    "source",
+    "pinned",
+    "created_at",
+    "message_id",
+    "section_ordinal",
+    "section_title",
+  ],
+};
+
+/**
+ * Create the `memory_v3_selections` table and its indexes on the memory
+ * connection. Idempotent (`IF NOT EXISTS`) — the dedicated connection itself
+ * performs no DDL on open, so this migration owns the schema. Exported so
+ * tests can stand up the memory-side schema without running the full drain.
+ */
+export function ensureMemoryV3SelectionsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_v3_selections (
+      conversation_id TEXT NOT NULL,
+      turn INTEGER NOT NULL,
+      slug TEXT NOT NULL,
+      source TEXT NOT NULL,
+      pinned INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      message_id TEXT,
+      section_ordinal INTEGER,
+      section_title TEXT,
+      PRIMARY KEY (conversation_id, turn, slug)
+    )
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v3_selections_conv
+      ON memory_v3_selections (conversation_id, turn DESC)
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v3_selections_message
+      ON memory_v3_selections (message_id)
+  `);
+}
+
+/**
+ * Move `memory_v3_selections` — the per-turn v3 selection log feeding the
+ * hot-set, learned-edge, prune, and inspector readers — into the dedicated
+ * memory database (`assistant-memory.db`), alongside `memory_jobs` (298) and
+ * `memory_v2_injection_events` (326). The log gains rows on every v3 turn;
+ * housing it with the other high-churn memory state keeps the main DB and its
+ * WAL out of that write path.
+ *
+ * Like migration 326 the move is incremental: create the table (and indexes)
+ * on the memory connection, rename any populated `main.memory_v3_selections`
+ * aside to `memory_v3_selections__relocating`, then drain it in awaited
+ * batches per {@link MEMORY_V3_SELECTIONS_RELOCATION}. On a fresh install the
+ * main-side table created by migration 268 is empty, so staging just drops it.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on
+ * a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveMemoryV3SelectionsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring memory_v3_selections relocation",
+    );
+  }
+
+  ensureMemoryV3SelectionsSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    MEMORY_V3_SELECTIONS_RELOCATION.table,
+  );
+
+  if (needsDrain) {
+    await drainStagedTable(raw, MEMORY_V3_SELECTIONS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
@@ -1,0 +1,79 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `activation_sessions` from `main` into the memory DB. Every
+ * row is copied: the table is one row per activation-rail conversation, read
+ * by the activation funnel for the conversation's whole lifetime.
+ */
+export const ACTIVATION_SESSIONS_RELOCATION: RelocationSpec = {
+  table: "activation_sessions",
+  targetDbPath: getMemoryDbPath,
+  columns: ["conversation_id", "created_at"],
+};
+
+/**
+ * Create the `activation_sessions` table on the memory connection. Idempotent
+ * (`IF NOT EXISTS`) — the dedicated connection itself performs no DDL on open,
+ * so this migration owns the schema. Exported so tests can stand up the
+ * memory-side schema without running the full drain.
+ */
+export function ensureActivationSessionsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS activation_sessions (
+      conversation_id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL
+    )
+  `);
+}
+
+/**
+ * Move `activation_sessions` — the per-conversation activation-rail marker
+ * behind the activation funnel telemetry — into the dedicated memory database
+ * (`assistant-memory.db`), joining the memory plugin's other relocated state
+ * so its store reads/writes ride the memory connection.
+ *
+ * Like migration 326 the move is incremental: create the table on the memory
+ * connection, rename any populated `main.activation_sessions` aside to
+ * `activation_sessions__relocating`, then drain it in awaited batches per
+ * {@link ACTIVATION_SESSIONS_RELOCATION}. On a fresh install the main-side
+ * table created by migration 274 is empty, so staging just drops it.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on
+ * a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveActivationSessionsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring activation_sessions relocation",
+    );
+  }
+
+  ensureActivationSessionsSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    ACTIVATION_SESSIONS_RELOCATION.table,
+  );
+
+  if (needsDrain) {
+    await drainStagedTable(raw, ACTIVATION_SESSIONS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -443,6 +443,8 @@ import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/332-move
 import { migrateCreateTelemetryEventsTable } from "./migrations/333-create-telemetry-events-table.js";
 import { migrateBackfillTelemetryEventsOutbox } from "./migrations/334-backfill-telemetry-events-outbox.js";
 import { migrateCollapseMemoryEmbedBacklog } from "./migrations/335-collapse-memory-embed-backlog.js";
+import { migrateMoveMemoryV3SelectionsToMemoryDb } from "./migrations/338-move-memory-v3-selections-to-memory-db.js";
+import { migrateMoveActivationSessionsToMemoryDb } from "./migrations/339-move-activation-sessions-to-memory-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1357,4 +1359,17 @@ export const migrationSteps: MigrationStep[] = [
   migrateCreateTelemetryEventsTable,
   migrateBackfillTelemetryEventsOutbox,
   migrateCollapseMemoryEmbedBacklog,
+  {
+    name: "migrateMoveMemoryV3SelectionsToMemoryDb",
+    run: migrateMoveMemoryV3SelectionsToMemoryDb,
+    dependsOn: [
+      "migrateAddMemoryV3Selections",
+      "migrateMemoryV3SelectionsMessageIdAndSections",
+    ],
+  },
+  {
+    name: "migrateMoveActivationSessionsToMemoryDb",
+    run: migrateMoveActivationSessionsToMemoryDb,
+    dependsOn: ["createActivationSessionsTable"],
+  },
 ];

--- a/assistant/src/plugins/defaults/memory/__tests__/activation-session-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/activation-session-store.test.ts
@@ -1,8 +1,15 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { getDb } from "../../../../persistence/db-connection.js";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getMemorySqlite } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
-import { activationSessions } from "../../../../persistence/schema/index.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import * as schema from "../../../../persistence/schema/index.js";
 import {
   isActivationSession,
   markActivationSession,
@@ -12,7 +19,7 @@ await initializeDb();
 
 describe("activation-session-store", () => {
   beforeEach(() => {
-    getDb().delete(activationSessions).run();
+    getMemorySqlite()!.exec("DELETE FROM activation_sessions");
   });
 
   test("marks a conversation and reports it as an activation session", () => {
@@ -28,7 +35,42 @@ describe("activation-session-store", () => {
     markActivationSession("c1");
     markActivationSession("c1");
     expect(isActivationSession("c1")).toBe(true);
-    const rows = getDb().select().from(activationSessions).all();
-    expect(rows.length).toBe(1);
+    const { n } = getMemorySqlite()!
+      .query("SELECT COUNT(*) AS n FROM activation_sessions")
+      .get() as { n: number };
+    expect(n).toBe(1);
+  });
+
+  test("rows land in the memory database, not main", () => {
+    markActivationSession("c-placement");
+    const inMemory = getMemorySqlite()!
+      .query(
+        "SELECT conversation_id FROM activation_sessions WHERE conversation_id = 'c-placement'",
+      )
+      .get() as { conversation_id: string } | null;
+    expect(inMemory?.conversation_id).toBe("c-placement");
+  });
+});
+
+describe("activation-session-store — degraded memory database", () => {
+  // Install a memory DB WITHOUT the activation_sessions table: the store's
+  // catch paths must swallow the failure (write no-ops, read reports false)
+  // rather than throw into the turn.
+  let brokenSqlite: Database;
+
+  beforeEach(() => {
+    brokenSqlite = new Database(":memory:");
+    setStoredDb("memory", drizzle(brokenSqlite, { schema }), () =>
+      brokenSqlite.close(),
+    );
+  });
+
+  afterEach(() => {
+    clearStoredDb("memory");
+  });
+
+  test("mark is a no-op and read reports false", () => {
+    expect(() => markActivationSession("c1")).not.toThrow();
+    expect(isActivationSession("c1")).toBe(false);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
@@ -8,9 +8,10 @@
  *      the *main* WAL is exactly what this split exists to prevent.
  *   2. The main connection no longer ATTACHes the memory file: there is no
  *      `memory` schema on its `database_list`.
- *   3. The relocated memory tables (`memory_jobs`, `memory_v2_injection_events`)
- *      live in the dedicated memory connection, not in the main connection —
- *      proving the physical split.
+ *   3. The relocated memory tables (`memory_jobs`, `memory_v2_injection_events`,
+ *      `memory_v3_selections`, `activation_sessions`) live in the dedicated
+ *      memory connection, not in the main connection — proving the physical
+ *      split.
  *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
  *      CLI backend, leaving the main DB untouched.
  */
@@ -52,26 +53,28 @@ describe("memory database connection", () => {
     expect(attached.some((e) => e.name === "memory")).toBe(false);
   });
 
-  test.each(["memory_jobs", "memory_v2_injection_events"])(
-    "%s lives in the memory connection, not main",
-    (table) => {
-      const inMemory = getMemorySqlite()!
-        .query<
-          { name: string },
-          [string]
-        >(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
-        .get(table);
-      expect(inMemory?.name).toBe(table);
+  test.each([
+    "memory_jobs",
+    "memory_v2_injection_events",
+    "memory_v3_selections",
+    "activation_sessions",
+  ])("%s lives in the memory connection, not main", (table) => {
+    const inMemory = getMemorySqlite()!
+      .query<
+        { name: string },
+        [string]
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(table);
+    expect(inMemory?.name).toBe(table);
 
-      const inMain = getSqlite()
-        .query<
-          { name: string },
-          [string]
-        >(`SELECT name FROM main.sqlite_master WHERE name = ?`)
-        .get(table);
-      expect(inMain).toBeNull();
-    },
-  );
+    const inMain = getSqlite()
+      .query<
+        { name: string },
+        [string]
+      >(`SELECT name FROM main.sqlite_master WHERE name = ?`)
+      .get(table);
+    expect(inMain).toBeNull();
+  });
 
   test.if(sqlite3Available)(
     "runAsyncSqlite({ dbPath }) targets the given file, not the main DB",

--- a/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
@@ -28,6 +28,10 @@ const { MEMORY_JOBS_RELOCATION } =
   await import("../../../../persistence/migrations/298-move-memory-jobs-to-memory-db.js");
 const { INJECTION_EVENTS_RELOCATION } =
   await import("../../../../persistence/migrations/326-move-injection-events-to-memory-db.js");
+const { MEMORY_V3_SELECTIONS_RELOCATION } =
+  await import("../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js");
+const { ACTIVATION_SESSIONS_RELOCATION } =
+  await import("../../../../persistence/migrations/339-move-activation-sessions-to-memory-db.js");
 
 await initializeDb();
 
@@ -174,6 +178,162 @@ describe("memory_v2_injection_events drain", () => {
     expect(kept).toEqual([
       { id: 1, slug: "fresh-a" },
       { id: 2, slug: "fresh-b" },
+    ]);
+  });
+});
+
+describe("memory_v3_selections drain", () => {
+  test("copies every row (full copy) and drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Clean slate: empty live table, fresh populated staging table with the
+    // full post-283 column set.
+    memory.exec(`DELETE FROM memory_v3_selections`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."memory_v3_selections__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_v3_selections__relocating" (
+        conversation_id TEXT NOT NULL,
+        turn INTEGER NOT NULL,
+        slug TEXT NOT NULL,
+        source TEXT NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        message_id TEXT,
+        section_ordinal INTEGER,
+        section_title TEXT,
+        PRIMARY KEY (conversation_id, turn, slug)
+      )
+    `);
+
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_v3_selections__relocating"
+         (conversation_id, turn, slug, source, pinned, created_at,
+          message_id, section_ordinal, section_title)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run("conv-1", 1, "page-a", "needle", 0, 1_000, "msg-1", 2, "Head");
+    insert.run("conv-1", 2, "page-b", "core", 1, 2_000, null, null, null);
+
+    await drainStagedTable(sqlite, MEMORY_V3_SELECTIONS_RELOCATION);
+
+    expect(existsInMain("memory_v3_selections__relocating")).toBe(false);
+
+    // Both rows landed intact, secondary attributes included.
+    const kept = memory
+      .query(
+        `SELECT conversation_id, turn, slug, source, pinned, created_at,
+                message_id, section_ordinal, section_title
+           FROM memory_v3_selections WHERE conversation_id = 'conv-1'
+           ORDER BY turn`,
+      )
+      .all();
+    expect(kept).toEqual([
+      {
+        conversation_id: "conv-1",
+        turn: 1,
+        slug: "page-a",
+        source: "needle",
+        pinned: 0,
+        created_at: 1_000,
+        message_id: "msg-1",
+        section_ordinal: 2,
+        section_title: "Head",
+      },
+      {
+        conversation_id: "conv-1",
+        turn: 2,
+        slug: "page-b",
+        source: "core",
+        pinned: 1,
+        created_at: 2_000,
+        message_id: null,
+        section_ordinal: null,
+        section_title: null,
+      },
+    ]);
+  });
+
+  test("a pre-283 legacy source NULL-fills the missing columns", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Staging table shaped like migration 268's original schema — no
+    // message_id / section_ordinal / section_title columns.
+    memory.exec(`DELETE FROM memory_v3_selections`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."memory_v3_selections__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_v3_selections__relocating" (
+        conversation_id TEXT NOT NULL,
+        turn INTEGER NOT NULL,
+        slug TEXT NOT NULL,
+        source TEXT NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (conversation_id, turn, slug)
+      )
+    `);
+    sqlite
+      .prepare(
+        `INSERT INTO main."memory_v3_selections__relocating"
+           (conversation_id, turn, slug, source, pinned, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run("conv-legacy", 7, "page-old", "needle", 0, 5_000);
+
+    await drainStagedTable(sqlite, MEMORY_V3_SELECTIONS_RELOCATION);
+
+    expect(existsInMain("memory_v3_selections__relocating")).toBe(false);
+
+    const row = memory
+      .query(
+        `SELECT slug, created_at, message_id, section_ordinal, section_title
+           FROM memory_v3_selections WHERE conversation_id = 'conv-legacy'`,
+      )
+      .get();
+    expect(row).toEqual({
+      slug: "page-old",
+      created_at: 5_000,
+      message_id: null,
+      section_ordinal: null,
+      section_title: null,
+    });
+  });
+});
+
+describe("activation_sessions drain", () => {
+  test("copies every row and drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    memory.exec(`DELETE FROM activation_sessions`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."activation_sessions__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."activation_sessions__relocating" (
+        conversation_id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    const insert = sqlite.prepare(
+      `INSERT INTO main."activation_sessions__relocating"
+         (conversation_id, created_at) VALUES (?, ?)`,
+    );
+    insert.run("conv-a", 1_000);
+    insert.run("conv-b", 2_000);
+
+    await drainStagedTable(sqlite, ACTIVATION_SESSIONS_RELOCATION);
+
+    expect(existsInMain("activation_sessions__relocating")).toBe(false);
+
+    const kept = memory
+      .query(
+        `SELECT conversation_id, created_at FROM activation_sessions
+           ORDER BY conversation_id`,
+      )
+      .all();
+    expect(kept).toEqual([
+      { conversation_id: "conv-a", created_at: 1_000 },
+      { conversation_id: "conv-b", created_at: 2_000 },
     ]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/activation-session-store.ts
+++ b/assistant/src/plugins/defaults/memory/activation-session-store.ts
@@ -1,41 +1,48 @@
-import { eq } from "drizzle-orm";
-
-import { getDb } from "../../../persistence/db-connection.js";
-import { activationSessions } from "../../../persistence/schema/index.js";
 import { getLogger } from "./logging.js";
+import { memorySqliteOrNull } from "./memory-db.js";
 
 const log = getLogger("activation-session-store");
 
 /**
  * Mark a conversation as an activation-rail session. Idempotent (the row's
- * primary key is the conversation id) and best-effort: a write failure is
- * logged and swallowed so it never blocks the turn that triggered it.
+ * primary key is the conversation id) and best-effort: an unavailable memory
+ * database or a write failure is logged and swallowed so it never blocks the
+ * turn that triggered it.
  */
 export function markActivationSession(conversationId: string): void {
   try {
-    getDb()
-      .insert(activationSessions)
-      .values({ conversationId, createdAt: Date.now() })
-      .onConflictDoNothing()
-      .run();
+    const raw = memorySqliteOrNull("markActivationSession");
+    if (!raw) {
+      return;
+    }
+    raw
+      .query(
+        /*sql*/ `INSERT OR IGNORE INTO activation_sessions (conversation_id, created_at) VALUES (?, ?)`,
+      )
+      .run(conversationId, Date.now());
   } catch (err) {
     log.warn({ err, conversationId }, "Failed to mark activation session");
   }
 }
 
 /**
- * Whether the given conversation was started on the activation rail. Best-effort:
- * a read failure is logged and treated as "not an activation session".
+ * Whether the given conversation was started on the activation rail.
+ * Best-effort: an unavailable memory database or a read failure is logged and
+ * treated as "not an activation session".
  */
 export function isActivationSession(conversationId: string): boolean {
   try {
-    const row = getDb()
-      .select({ conversationId: activationSessions.conversationId })
-      .from(activationSessions)
-      .where(eq(activationSessions.conversationId, conversationId))
-      .limit(1)
-      .get();
-    return row !== undefined;
+    const raw = memorySqliteOrNull("isActivationSession");
+    if (!raw) {
+      return false;
+    }
+    return (
+      raw
+        .query(
+          /*sql*/ `SELECT 1 FROM activation_sessions WHERE conversation_id = ?`,
+        )
+        .get(conversationId) != null
+    );
   } catch (err) {
     log.warn({ err, conversationId }, "Failed to read activation session");
     return false;

--- a/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
@@ -17,7 +17,6 @@
 
 import { isMemoryV3Live } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
-import { getDb } from "../../../../persistence/db-connection.js";
 import { getWorkspaceDir } from "../paths.js";
 import { getPageIndex, type PageIndexEntry } from "../v2/page-index.js";
 import { readPage, renderPageContent } from "../v2/page-store.js";
@@ -289,21 +288,15 @@ export async function getMemoryGraph(
   // little extra edge noise) is a fair trade. Floors keep the thresholds sane
   // even when the retrieval config is aggressive or disables the lane.
   const learned = config.memory.v3.learnedEdges;
-  const learnedGraph = computeLearnedEdgeGraph(
-    { db: getDb() },
-    {
-      halfLifeMs: learned.halfLifeDays * DAY_MS,
-      minCount: Math.max(1, learned.minCount * GRAPH_LEARNED_MIN_COUNT_FACTOR),
-      npmiFloor: Math.max(
-        0,
-        learned.npmiFloor * GRAPH_LEARNED_NPMI_FLOOR_FACTOR,
-      ),
-      maxPerPage: Math.max(learned.maxPerPage, GRAPH_LEARNED_MIN_MAX_PER_PAGE),
-      now: Date.now(),
-      windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
-      knownSlugs: new Set(entries.map((e) => e.slug)),
-    },
-  );
+  const learnedGraph = computeLearnedEdgeGraph({
+    halfLifeMs: learned.halfLifeDays * DAY_MS,
+    minCount: Math.max(1, learned.minCount * GRAPH_LEARNED_MIN_COUNT_FACTOR),
+    npmiFloor: Math.max(0, learned.npmiFloor * GRAPH_LEARNED_NPMI_FLOOR_FACTOR),
+    maxPerPage: Math.max(learned.maxPerPage, GRAPH_LEARNED_MIN_MAX_PER_PAGE),
+    now: Date.now(),
+    windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
+    knownSlugs: new Set(entries.map((e) => e.slug)),
+  });
 
   const assembled = assembleMemoryGraph({
     entries,

--- a/assistant/src/plugins/defaults/memory/memory-db.ts
+++ b/assistant/src/plugins/defaults/memory/memory-db.ts
@@ -6,7 +6,8 @@ const log = getLogger("memory-db");
 /**
  * The plugin's accessor for the dedicated memory database
  * (`assistant-memory.db`), where the memory plugin's relocated tables live
- * (`memory_v2_injection_events`, with more to follow).
+ * (`memory_v2_injection_events`, `memory_v3_selections`,
+ * `activation_sessions`, with more to follow).
  *
  * Fail-soft: returns `null` when the file cannot be opened, logging a warn
  * tagged with the calling context. Callers degrade rather than throw — the

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -58,9 +58,8 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
 import { stripSpotlightInjections } from "../../../../../context/strip-injections.js";
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import { unwrapMemoryBlock, wrapMemoryBlock } from "../../memory-marker.js";
 import type { PageIndexEntry } from "../../v2/page-index.js";
@@ -129,13 +128,17 @@ mock.module("../dense.js", () => ({
 }));
 
 let testSqlite: Database;
+// Selection rows live on the dedicated memory connection, resolved via
+// `getMemorySqlite` — stubbed to a second in-memory DB carrying the relocated
+// table's schema. Messages and the everInjected store stay in main.
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3EverInjected(db);
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   // Minimal `messages` shape — metadata persistence, the prune valve's
   // v3-ownership scan, and the restart rehydration read only these columns.
   testSqlite.run(/*sql*/ `
@@ -159,6 +162,8 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
       : realDbConnection.getSqliteFrom(
           db as Parameters<typeof realDbConnection.getSqliteFrom>[0],
         ),
+  getMemorySqlite: () =>
+    carryMockActive ? memorySqlite : realDbConnection.getMemorySqlite(),
 }));
 
 /** Mutable prune config: `null` until the script opens the valve window. */
@@ -276,7 +281,7 @@ async function scriptedObserveTurn(conversationId: string, turnIndex: number) {
     turnIndex,
     realShadowPlugin.attributeSelections(result),
   );
-  testSqlite
+  memorySqlite
     .query(
       /*sql*/ `
       UPDATE memory_v3_selections SET created_at = ?
@@ -405,7 +410,7 @@ async function buildFixtureLanes(): Promise<FixtureLanes> {
 
   // Seed a selections history (a PRIOR conversation) making three slugs hot,
   // with distinct frecency so the hot order is deterministic.
-  const seed = testSqlite.query(/*sql*/ `
+  const seed = memorySqlite.query(/*sql*/ `
     INSERT INTO memory_v3_selections
       (conversation_id, turn, slug, source, pinned, created_at)
     VALUES (?, ?, ?, 'needle', 0, ?)
@@ -439,15 +444,12 @@ async function buildFixtureLanes(): Promise<FixtureLanes> {
   const coreSlugs = loadCoreSet(workspaceDir).filter((slug) =>
     sectionIndex.byArticle.has(slug),
   );
-  const hotSlugs = computeHotSet(
-    { db: testDb },
-    {
-      k: 3,
-      halfLifeMs: 14 * DAY_MS,
-      now: BASE,
-      excludeSlugs: new Set(coreSlugs),
-    },
-  )
+  const hotSlugs = computeHotSet({
+    k: 3,
+    halfLifeMs: 14 * DAY_MS,
+    now: BASE,
+    excludeSlugs: new Set(coreSlugs),
+  })
     .map((entry) => entry.slug)
     .filter((slug) => sectionIndex.byArticle.has(slug));
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -29,9 +29,8 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import type { InjectionBlock } from "../../../../types.js";
 import { unwrapMemoryBlock } from "../../memory-marker.js";
@@ -89,14 +88,17 @@ mock.module("../../../../../util/logger.js", () => ({
 }));
 
 let testSqlite: Database;
+// The prune valve's recency ranking reads `memory_v3_selections` over the
+// dedicated memory connection, resolved via `getMemorySqlite` — stubbed to a
+// second in-memory DB carrying the relocated table's schema.
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3EverInjected(db);
-  // The prune valve's recency ranking reads `memory_v3_selections`.
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   // The prune valve plans only against slugs whose card sections are
   // locatable in persisted `memoryV3InjectedBlock` rows
   // (`collectPersistedV3Cards`) — minimal `messages` shape it reads.
@@ -122,6 +124,8 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
       : realDbConnection.getSqliteFrom(
           db as Parameters<typeof realDbConnection.getSqliteFrom>[0],
         ),
+  getMemorySqlite: () =>
+    injectionMockActive ? memorySqlite : realDbConnection.getMemorySqlite(),
 }));
 
 // The injector reads `memory.enabled` / `memory.v3.live` / `memory.v3.spotlight`

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
@@ -25,8 +25,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 
 const realFlags = {
@@ -41,16 +40,20 @@ let storeMockActive = false;
 let liveEnabled = false;
 
 let testSqlite: Database;
+// Selection rows live on the dedicated memory connection, resolved via
+// `getMemorySqlite` — stubbed to a second in-memory DB carrying the relocated
+// table's schema. The fork-source fallback still reads `messages` from main.
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
   // The fork-source fallback reads `messages.metadata.forkSourceMessageId`; the
   // inspector store touches only these two columns, so a minimal table suffices.
   testSqlite.exec(`CREATE TABLE messages (id TEXT PRIMARY KEY, metadata TEXT)`);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   return db;
 }
 
@@ -66,7 +69,7 @@ function seed(
   }>,
   messageId: string | null = null,
 ): void {
-  const stmt = testSqlite.query(
+  const stmt = memorySqlite.query(
     `INSERT INTO memory_v3_selections
        (conversation_id, turn, slug, source, pinned, created_at,
         message_id, section_ordinal, section_title)
@@ -118,6 +121,8 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
     storeMockActive
       ? testSqlite
       : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+  getMemorySqlite: () =>
+    storeMockActive ? memorySqlite : realDb.getMemorySqlite(),
 }));
 
 mock.module("../page-content.js", () => ({

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -33,8 +33,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Message, Provider, ProviderResponse } from "@vellumai/plugin-api";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import type { PageIndexEntry } from "../../v2/page-index.js";
 import { renderCard } from "../card.js";
@@ -96,19 +95,21 @@ mock.module("../dense.js", () => ({
       : realDense.denseLaneScored(...args),
 }));
 
-// In-memory selections DB. `summarizeSelections` reads via getDb/getSqliteFrom;
-// the writer below writes through the same handles.
+// In-memory selections DB. Selection rows live on the dedicated memory
+// connection — `writeSelections` writes and `summarizeSelections` reads via
+// `getMemorySqlite`, stubbed to a DB carrying the relocated table's schema.
 const realDb = {
   ...(await import("../../../../../persistence/db-connection.js")),
 };
 let testSqlite: Database;
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   return db;
 }
 mock.module("../../../../../persistence/db-connection.js", () => ({
@@ -118,6 +119,7 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
     mockActive
       ? testSqlite
       : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+  getMemorySqlite: () => (mockActive ? memorySqlite : realDb.getMemorySqlite()),
 }));
 
 const { orchestrate } = await import("../orchestrate.js");
@@ -285,7 +287,7 @@ function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
 
 /** Read back every logged selection source for a turn, in row order. */
 function loggedSources(turn: number): Array<{ slug: Slug; source: string }> {
-  return testSqlite
+  return memorySqlite
     .query(
       `SELECT slug, source FROM memory_v3_selections
          WHERE conversation_id = ? AND turn = ? ORDER BY rowid`,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -28,9 +28,8 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
 import { MemoryV3GateSchema } from "../../../../../config/schemas/memory-v3.js";
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import type { HotSetEntry, HotSetOptions } from "../hot-set.js";
 import type { OrchestrateResult } from "../orchestrate.js";
@@ -170,17 +169,20 @@ let hotSetOpts: HotSetOptions | null = null;
 // page body.
 let capturedPageBody: ((slug: string) => Promise<string>) | null = null;
 
-// Shared in-memory DB so writes are observable from the test.
+// Shared in-memory DBs so writes are observable from the test. Selection rows
+// live on the dedicated memory connection (`memorySqlite`, resolved through
+// the stubbed `getMemorySqlite`); the everInjected store stays in main.
 let testSqlite: Database;
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
   // The live injector's net-new dedup reads/writes the everInjected store.
   migrateAddMemoryV3EverInjected(db);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   return db;
 }
 
@@ -258,7 +260,7 @@ mock.module("../hot-set.js", () => ({
     ...args: Parameters<typeof realHotSet.computeHotSet>
   ): HotSetEntry[] => {
     if (!shadowMockActive) return realHotSet.computeHotSet(...args);
-    hotSetOpts = args[1];
+    hotSetOpts = args[0];
     return hotSetResult;
   },
 }));
@@ -273,6 +275,7 @@ mock.module("../../../../../persistence/conversation-crud.js", () => ({
 mock.module("../../../../../persistence/db-connection.js", () => ({
   getDb: () => testDb,
   getSqliteFrom: () => testSqlite,
+  getMemorySqlite: () => memorySqlite,
 }));
 
 mock.module("../../v2/page-index.js", () => ({
@@ -464,7 +467,7 @@ afterAll(() => {
 });
 
 function readRows() {
-  return testSqlite
+  return memorySqlite
     .query(
       `SELECT slug, source, pinned FROM memory_v3_selections ORDER BY slug`,
     )

--- a/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
@@ -1,31 +1,51 @@
 /**
  * Tests for the frecency hot-set lane (`hot-set.ts`) and its config schema.
  *
- * `computeHotSet` takes the db handle directly (no module mocks needed):
- * each test seeds an in-memory SQLite db with `memory_v3_selections` rows
- * (via the real migration) and asserts the decayed-frequency ranking.
+ * `computeHotSet` reads `memory_v3_selections` over the dedicated memory
+ * connection: each test installs an in-memory SQLite db into the `memory`
+ * singleton slot (where the accessor resolves its connection), seeds it with
+ * selection rows, and asserts the decayed-frequency ranking.
  */
 
 import { Database } from "bun:sqlite";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { MemoryV3ConfigSchema } from "../../../../config/schemas/memory-v3.js";
-import { migrateAddMemoryV3Selections } from "../../../../persistence/migrations/268-add-memory-v3-selections.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../persistence/schema/index.js";
 import { computeHotSet, type HotSetOptions } from "./hot-set.js";
 
 const HALF_LIFE_MS = 1000;
 const NOW = 100_000;
 
+// Fail-soft seam: `mock.module` is process-global and leaks into sibling
+// files in a directory run, so the stub DELEGATES to the real accessor unless
+// a test flips `memoryDbUnavailable`.
+const realMemoryDb = { ...(await import("../memory-db.js")) };
+let memoryDbUnavailable = false;
+mock.module("../memory-db.js", () => ({
+  ...realMemoryDb,
+  memorySqliteOrNull: (context: string) =>
+    memoryDbUnavailable ? null : realMemoryDb.memorySqliteOrNull(context),
+}));
+
 let sqlite: Database;
-let db: ReturnType<typeof drizzle<typeof schema>>;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
-  db = drizzle(sqlite, { schema });
-  migrateAddMemoryV3Selections(db);
+  ensureMemoryV3SelectionsSchema(sqlite);
+  setStoredDb("memory", drizzle(sqlite, { schema }), () => sqlite.close());
+});
+
+afterEach(() => {
+  memoryDbUnavailable = false;
+  clearStoredDb("memory");
 });
 
 let nextTurn = 0;
@@ -40,16 +60,13 @@ function seed(slug: string, createdAts: number[]): void {
 }
 
 function hotSet(overrides: Partial<HotSetOptions> = {}) {
-  return computeHotSet(
-    { db },
-    {
-      k: 10,
-      halfLifeMs: HALF_LIFE_MS,
-      now: NOW,
-      excludeSlugs: new Set<string>(),
-      ...overrides,
-    },
-  );
+  return computeHotSet({
+    k: 10,
+    halfLifeMs: HALF_LIFE_MS,
+    now: NOW,
+    excludeSlugs: new Set<string>(),
+    ...overrides,
+  });
 }
 
 describe("computeHotSet", () => {
@@ -110,6 +127,12 @@ describe("computeHotSet", () => {
   test("future-dated rows are clamped to weight 1", () => {
     seed("page-a", [NOW + 50 * HALF_LIFE_MS]);
     expect(hotSet()[0]!.score).toBeCloseTo(1, 10);
+  });
+
+  test("degrades to an empty hot set when the memory database is unavailable", () => {
+    seed("page-a", [NOW]);
+    memoryDbUnavailable = true;
+    expect(hotSet()).toEqual([]);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
@@ -24,17 +24,6 @@ import { computeHotSet, type HotSetOptions } from "./hot-set.js";
 const HALF_LIFE_MS = 1000;
 const NOW = 100_000;
 
-// Fail-soft seam: `mock.module` is process-global and leaks into sibling
-// files in a directory run, so the stub DELEGATES to the real accessor unless
-// a test flips `memoryDbUnavailable`.
-const realMemoryDb = { ...(await import("../memory-db.js")) };
-let memoryDbUnavailable = false;
-mock.module("../memory-db.js", () => ({
-  ...realMemoryDb,
-  memorySqliteOrNull: (context: string) =>
-    memoryDbUnavailable ? null : realMemoryDb.memorySqliteOrNull(context),
-}));
-
 let sqlite: Database;
 
 beforeEach(() => {
@@ -44,7 +33,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  memoryDbUnavailable = false;
   clearStoredDb("memory");
 });
 
@@ -131,7 +119,14 @@ describe("computeHotSet", () => {
 
   test("degrades to an empty hot set when the memory database is unavailable", () => {
     seed("page-a", [NOW]);
-    memoryDbUnavailable = true;
+    // Simulate unavailability through the singleton slot instead of
+    // `mock.module`, which is process-global and leaks into sibling test
+    // files. The accessor extracts the raw connection from the stored
+    // handle's `$client`, so a handle without one makes `getMemorySqlite()`
+    // resolve to null, the same contract computeHotSet sees when the
+    // dedicated open fails.
+    clearStoredDb("memory");
+    setStoredDb("memory", { $client: null }, () => {});
     expect(hotSet()).toEqual([]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/hot-set.ts
+++ b/assistant/src/plugins/defaults/memory/v3/hot-set.ts
@@ -14,16 +14,8 @@
  * the hot lane never duplicates core.
  */
 
-import {
-  type DrizzleDb,
-  getSqliteFrom,
-} from "../../../../persistence/db-connection.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import type { Slug } from "./types.js";
-
-export interface HotSetDeps {
-  /** Handle to the database containing `memory_v3_selections`. */
-  db: DrizzleDb;
-}
 
 export interface HotSetOptions {
   /** Maximum number of slugs returned. */
@@ -52,15 +44,21 @@ interface SelectionAgeRow {
  * Deterministic for fixed inputs: ties break score desc, then slug asc. The
  * decay sum runs in TS over `(slug, created_at)` pairs — the selections table
  * is small enough that reading it directly beats pushing the math into SQL.
+ *
+ * Reads `memory_v3_selections` over the dedicated memory connection.
+ * Fail-soft: an unavailable memory database yields an empty hot set — the
+ * lane simply contributes nothing to the stable prefix.
  */
-export function computeHotSet(
-  deps: HotSetDeps,
-  opts: HotSetOptions,
-): HotSetEntry[] {
+export function computeHotSet(opts: HotSetOptions): HotSetEntry[] {
   const { k, halfLifeMs, now, excludeSlugs } = opts;
   if (k <= 0) return [];
 
-  const rows = getSqliteFrom(deps.db)
+  const raw = memorySqliteOrNull("computeHotSet");
+  if (!raw) {
+    return [];
+  }
+
+  const rows = raw
     .query(
       /*sql*/ `
       SELECT slug, created_at FROM memory_v3_selections

--- a/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
@@ -1,18 +1,23 @@
 /**
  * Tests for the learned-edge lane (`learned-edges.ts`).
  *
- * `computeLearnedEdgeGraph` takes the db handle directly (no module mocks):
- * each test seeds an in-memory SQLite db with `memory_v3_selections` rows
- * (via the real migration) and asserts the NPMI association graph. Rows
+ * `computeLearnedEdgeGraph` reads `memory_v3_selections` over the dedicated
+ * memory connection: each test installs an in-memory SQLite db into the
+ * `memory` singleton slot (where the accessor resolves its connection), seeds
+ * it with selection rows, and asserts the NPMI association graph. Rows
  * sharing a `(conversation_id, created_at)` form one selector call.
  */
 
 import { Database } from "bun:sqlite";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { migrateAddMemoryV3Selections } from "../../../../persistence/migrations/268-add-memory-v3-selections.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../persistence/schema/index.js";
 import {
   computeLearnedEdgeGraph,
@@ -23,12 +28,15 @@ const HALF_LIFE_MS = 1_000_000;
 const NOW = 100_000;
 
 let sqlite: Database;
-let db: ReturnType<typeof drizzle<typeof schema>>;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
-  db = drizzle(sqlite, { schema });
-  migrateAddMemoryV3Selections(db);
+  ensureMemoryV3SelectionsSchema(sqlite);
+  setStoredDb("memory", drizzle(sqlite, { schema }), () => sqlite.close());
+});
+
+afterEach(() => {
+  clearStoredDb("memory");
 });
 
 let nextTurn = 0;
@@ -44,25 +52,22 @@ function seedCall(slugs: string[], createdAt = NOW, conv = "conv-1"): void {
 }
 
 function graphOf(overrides: Partial<LearnedEdgesOptions> = {}) {
-  return computeLearnedEdgeGraph(
-    { db },
-    {
-      halfLifeMs: HALF_LIFE_MS,
-      minCount: 2,
-      npmiFloor: 0.2,
-      maxPerPage: 6,
-      now: NOW,
-      windowMs: NOW,
-      knownSlugs: new Set([
-        "page-a",
-        "page-b",
-        "page-c",
-        "page-d",
-        "skills/widget",
-      ]),
-      ...overrides,
-    },
-  );
+  return computeLearnedEdgeGraph({
+    halfLifeMs: HALF_LIFE_MS,
+    minCount: 2,
+    npmiFloor: 0.2,
+    maxPerPage: 6,
+    now: NOW,
+    windowMs: NOW,
+    knownSlugs: new Set([
+      "page-a",
+      "page-b",
+      "page-c",
+      "page-d",
+      "skills/widget",
+    ]),
+    ...overrides,
+  });
 }
 
 const peersOf = (

--- a/assistant/src/plugins/defaults/memory/v3/learned-edges.ts
+++ b/assistant/src/plugins/defaults/memory/v3/learned-edges.ts
@@ -38,17 +38,9 @@
  * the persistence; nothing else is stored.
  */
 
-import {
-  type DrizzleDb,
-  getSqliteFrom,
-} from "../../../../persistence/db-connection.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import type { EdgeGraph } from "./edge.js";
 import type { Slug } from "./types.js";
-
-export interface LearnedEdgesDeps {
-  /** Handle to the database containing `memory_v3_selections`. */
-  db: DrizzleDb;
-}
 
 export interface LearnedEdgesOptions {
   /** Decay half-life in milliseconds: a selector call this old contributes
@@ -86,11 +78,12 @@ interface SelectionRow {
  * Deterministic for fixed inputs: per-page neighbors order by NPMI desc, then
  * peer slug asc. Symmetric by construction — an edge contributes to BOTH
  * endpoints' neighbor lists (each independently subject to `maxPerPage`).
+ *
+ * Reads `memory_v3_selections` over the dedicated memory connection.
+ * Fail-soft: an unavailable memory database yields an empty graph — the lane
+ * simply surfaces no learned associations.
  */
-export function computeLearnedEdgeGraph(
-  deps: LearnedEdgesDeps,
-  opts: LearnedEdgesOptions,
-): EdgeGraph {
+export function computeLearnedEdgeGraph(opts: LearnedEdgesOptions): EdgeGraph {
   const { halfLifeMs, minCount, npmiFloor, maxPerPage, now, windowMs } = opts;
   const empty: EdgeGraph = {
     adjacency: new Map(),
@@ -99,7 +92,12 @@ export function computeLearnedEdgeGraph(
   };
   if (maxPerPage <= 0) return empty;
 
-  const rows = getSqliteFrom(deps.db)
+  const raw = memorySqliteOrNull("computeLearnedEdgeGraph");
+  if (!raw) {
+    return empty;
+  }
+
+  const rows = raw
     .query(
       /*sql*/ `
       SELECT conversation_id, slug, created_at FROM memory_v3_selections

--- a/assistant/src/plugins/defaults/memory/v3/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.test.ts
@@ -31,8 +31,8 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Message } from "@vellumai/plugin-api";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { migrateAddMemoryV3Selections } from "../../../../persistence/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../persistence/schema/index.js";
 import { wrapMemoryBlock } from "../memory-marker.js";
 
@@ -48,12 +48,15 @@ let pruneConfig: {
 } | null = null;
 
 let testSqlite: Database;
+// `planPrune`'s recency ranking reads `memory_v3_selections` over the
+// dedicated memory connection, resolved via `getMemorySqlite` — stubbed to a
+// second in-memory DB carrying the relocated table's schema.
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3EverInjected(db);
-  migrateAddMemoryV3Selections(db);
   // Minimal `messages` shape — `collectPersistedV3Cards` reads only
   // `conversation_id` and `metadata`.
   testSqlite.run(/*sql*/ `
@@ -66,6 +69,8 @@ function makeDb() {
       created_at INTEGER NOT NULL
     )
   `);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   return db;
 }
 
@@ -76,6 +81,8 @@ mock.module("../../../../persistence/db-connection.js", () => ({
     pruneMockActive
       ? testSqlite
       : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+  getMemorySqlite: () =>
+    pruneMockActive ? memorySqlite : realDb.getMemorySqlite(),
 }));
 
 // Memory code resolves its config through the plugin's own accessor
@@ -120,7 +127,7 @@ function insertSelection(
   slug: string,
   createdAt: number,
 ): void {
-  testSqlite
+  memorySqlite
     .query(
       /*sql*/ `
       INSERT OR REPLACE INTO memory_v3_selections

--- a/assistant/src/plugins/defaults/memory/v3/prune.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.ts
@@ -63,6 +63,7 @@ import type { ContentBlock, Message } from "@vellumai/plugin-api";
 import { getDb, getSqliteFrom } from "../../../../persistence/db-connection.js";
 import { getMemoryConfig } from "../config.js";
 import { getLogger } from "../logging.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import { unwrapMemoryBlock, wrapMemoryBlock } from "../memory-marker.js";
 import {
   INJECTED_CONCEPT_HEADER_REGEX,
@@ -210,12 +211,14 @@ export interface PruneDeps {
  *
  * The footprint and the candidates both range over the ACTIVE injected slugs.
  * Candidates are ranked by last selection recency — `MAX(created_at)` per
- * slug from `memory_v3_selections`, falling back to the store's `injected_at`
- * for slugs with no selection rows (e.g. rows copied by a full fork) — taken
- * oldest-first until the footprint is at `targetResidentBytes`. Core/hot lane
- * members are exempt, and zero-byte rows (capability slugs, truncated-fork
- * seeds: dedup-only, no byte accounting) are skipped — pruning them frees
- * nothing while discarding inherited context.
+ * slug from `memory_v3_selections` (read over the dedicated memory
+ * connection; an unavailable memory database reads as no selection rows),
+ * falling back to the store's `injected_at` for slugs with no selection rows
+ * (e.g. rows copied by a full fork) — taken oldest-first until the footprint
+ * is at `targetResidentBytes`. Core/hot lane members are exempt, and
+ * zero-byte rows (capability slugs, truncated-fork seeds: dedup-only, no byte
+ * accounting) are skipped — pruning them frees nothing while discarding
+ * inherited context.
  */
 export function planPrune(
   deps: PruneDeps,
@@ -225,15 +228,18 @@ export function planPrune(
   const resident = activeEntries.reduce((sum, e) => sum + e.bytes, 0);
   if (resident <= deps.maxResidentBytes) return null;
 
-  const selectionRows = getSqliteFrom(getDb())
-    .query(
-      /*sql*/ `
+  const memoryRaw = memorySqliteOrNull("planPrune");
+  const selectionRows = memoryRaw
+    ? (memoryRaw
+        .query(
+          /*sql*/ `
       SELECT slug, MAX(created_at) AS lastSelectedAt FROM memory_v3_selections
       WHERE conversation_id = ?
       GROUP BY slug
     `,
-    )
-    .all(conversationId) as Array<{ slug: string; lastSelectedAt: number }>;
+        )
+        .all(conversationId) as Array<{ slug: string; lastSelectedAt: number }>)
+    : [];
   const lastSelectedAt = new Map(
     selectionRows.map((row) => [row.slug, row.lastSelectedAt]),
   );

--- a/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
@@ -20,6 +20,7 @@ import type { MemoryV3SelectionLog } from "../../../../api/responses/memory-v3-s
 import { getConfig } from "../../../../config/loader.js";
 import { isMemoryV3Live } from "../../../../config/memory-v3-gate.js";
 import { getDb, getSqliteFrom } from "../../../../persistence/db-connection.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import { getWorkspaceDir } from "../paths.js";
 import { readPage } from "../v2/page-store.js";
 import { capabilityOrDiskBody } from "./capabilities.js";
@@ -46,7 +47,11 @@ interface SelectionRow {
 const SELECTION_COLUMNS = `turn, slug, source, pinned, section_ordinal, section_title`;
 
 function rowsForTurn(conversationId: string, turn: number): SelectionRow[] {
-  return getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("rowsForTurn");
+  if (!raw) {
+    return [];
+  }
+  return raw
     .query(
       /*sql*/ `
       SELECT ${SELECTION_COLUMNS} FROM memory_v3_selections
@@ -59,8 +64,12 @@ function rowsForTurn(conversationId: string, turn: number): SelectionRow[] {
 
 function rowsForMessageIds(messageIds: string[]): SelectionRow[] {
   if (messageIds.length === 0) return [];
+  const raw = memorySqliteOrNull("rowsForMessageIds");
+  if (!raw) {
+    return [];
+  }
   const placeholders = messageIds.map(() => "?").join(", ");
-  return getSqliteFrom(getDb())
+  return raw
     .query(
       /*sql*/ `
       SELECT ${SELECTION_COLUMNS} FROM memory_v3_selections
@@ -249,18 +258,21 @@ function isSelectionSource(source: string): source is SelectionSource {
 }
 
 export function summarizeSelections(conversationId: string): SelectionSummary {
-  const rows = getSqliteFrom(getDb())
-    .query(
-      /*sql*/ `
+  const raw = memorySqliteOrNull("summarizeSelections");
+  const rows = raw
+    ? (raw
+        .query(
+          /*sql*/ `
       SELECT turn, slug, source FROM memory_v3_selections
       WHERE conversation_id = ?
     `,
-    )
-    .all(conversationId) as Array<{
-    turn: number;
-    slug: string;
-    source: string;
-  }>;
+        )
+        .all(conversationId) as Array<{
+        turn: number;
+        slug: string;
+        source: string;
+      }>)
+    : [];
 
   const bySource = Object.fromEntries(
     SELECTION_SOURCES.map((source) => [source, 0]),

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -30,9 +30,9 @@ import {
 
 import { getConfig } from "../../../../config/loader.js";
 import type { AssistantConfig } from "../../../../config/schema.js";
-import { getDb, getSqliteFrom } from "../../../../persistence/db-connection.js";
 import { stripCommentLines } from "../host-utils.js";
 import { getLogger } from "../logging.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../paths.js";
 import { getPageIndex } from "../v2/page-index.js";
 import { readPage, renderPageContent } from "../v2/page-store.js";
@@ -229,15 +229,12 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   const coreSlugs = loadCoreSet(getWorkspaceDir()).filter((slug) =>
     sectionIndex.byArticle.has(slug),
   );
-  const hotSlugs = computeHotSet(
-    { db: getDb() },
-    {
-      k: tuning.hotSetK,
-      halfLifeMs: config.memory.v3.hotSet.halfLifeDays * DAY_MS,
-      now: Date.now(),
-      excludeSlugs: new Set(coreSlugs),
-    },
-  )
+  const hotSlugs = computeHotSet({
+    k: tuning.hotSetK,
+    halfLifeMs: config.memory.v3.hotSet.halfLifeDays * DAY_MS,
+    now: Date.now(),
+    excludeSlugs: new Set(coreSlugs),
+  })
     .map((entry) => entry.slug)
     .filter((slug) => sectionIndex.byArticle.has(slug));
 
@@ -320,18 +317,15 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   const learned = config.memory.v3.learnedEdges;
   const learnedGraph =
     tuning.learnedEdgesCap > 0 && learned.maxPerPage > 0
-      ? computeLearnedEdgeGraph(
-          { db: getDb() },
-          {
-            halfLifeMs: learned.halfLifeDays * DAY_MS,
-            minCount: learned.minCount,
-            npmiFloor: learned.npmiFloor,
-            maxPerPage: learned.maxPerPage,
-            now: Date.now(),
-            windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
-            knownSlugs: new Set(sectionIndex.byArticle.keys()),
-          },
-        )
+      ? computeLearnedEdgeGraph({
+          halfLifeMs: learned.halfLifeDays * DAY_MS,
+          minCount: learned.minCount,
+          npmiFloor: learned.npmiFloor,
+          maxPerPage: learned.maxPerPage,
+          now: Date.now(),
+          windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
+          knownSlugs: new Set(sectionIndex.byArticle.keys()),
+        })
       : undefined;
   // Ensuring the dense collection is best-effort: the needle + edge lanes and
   // the core/hot prefix are in-memory and independent of Qdrant, so a Qdrant outage
@@ -530,7 +524,11 @@ export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
   });
 }
 
-/** Write the attributed selection rows to `memory_v3_selections`. */
+/**
+ * Write the attributed selection rows to `memory_v3_selections` over the
+ * dedicated memory connection. Best-effort: an unavailable memory database
+ * drops the turn's log rows rather than affecting the turn.
+ */
 export function writeSelections(
   conversationId: string,
   turn: number,
@@ -539,7 +537,10 @@ export function writeSelections(
   if (rows.length === 0) {
     return;
   }
-  const raw = getSqliteFrom(getDb());
+  const raw = memorySqliteOrNull("writeSelections");
+  if (!raw) {
+    return;
+  }
   // PK is (conversation_id, turn, slug); OR REPLACE keeps the write
   // idempotent if the same turn is observed twice (e.g. a retried turn).
   // `message_id` is written NULL here (the assistant message does not exist at
@@ -579,7 +580,11 @@ export function backfillMemoryV3SelectionMessageId(
   conversationId: string,
   assistantMessageId: string,
 ): void {
-  getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("backfillMemoryV3SelectionMessageId");
+  if (!raw) {
+    return;
+  }
+  raw
     .query(
       /*sql*/ `UPDATE memory_v3_selections SET message_id = ?
                WHERE conversation_id = ? AND message_id IS NULL`,


### PR DESCRIPTION
## Summary
- Relocate memory_v3_selections and activation_sessions into assistant-memory.db via the staged-drain playbook (migrations 338/339), declaring dependsOn on their creator steps.
- Repoint the v3 selection/hot-set/prune/learned-edges modules and the activation-session store at the memory connection, fail-soft.

Part of plan: memory-db-wave1.md (PR 3 of 3)