### PR TITLE
feat(memory): move memory_v2_activation_logs and memory_recall_logs to the memory DB

### DIFF
--- a/assistant/src/__tests__/memory-recall-log-store.test.ts
+++ b/assistant/src/__tests__/memory-recall-log-store.test.ts
@@ -1,8 +1,17 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+/**
+ * Tests for the memory recall-log store. The store reads and writes
+ * `memory_recall_logs` over the dedicated memory connection, so each test
+ * installs a fresh in-memory database into the `memory` singleton slot with
+ * the relocated table's schema.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { getDb } from "../persistence/db-connection.js";
-import { initializeDb } from "../persistence/db-init.js";
-import { memoryRecallLogs } from "../persistence/schema/index.js";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { clearStoredDb, setStoredDb } from "../persistence/db-singleton.js";
+import { ensureRecallLogsSchema } from "../persistence/migrations/337-move-memory-recall-logs-to-memory-db.js";
+import * as schema from "../persistence/schema/index.js";
 import {
   backfillMemoryRecallLogMessageId,
   getMemoryRecallLogByMessageIds,
@@ -10,18 +19,21 @@ import {
   recordMemoryRecallLog,
 } from "../plugins/defaults/memory/memory-recall-log-store.js";
 
-await initializeDb();
+let memorySqlite: Database;
 
-function resetTables(): void {
-  const db = getDb();
-  db.delete(memoryRecallLogs).run();
-}
+beforeEach(() => {
+  memorySqlite = new Database(":memory:");
+  ensureRecallLogsSchema(memorySqlite);
+  setStoredDb("memory", drizzle(memorySqlite, { schema }), () =>
+    memorySqlite.close(),
+  );
+});
+
+afterEach(() => {
+  clearStoredDb("memory");
+});
 
 describe("memory-recall-log-store", () => {
-  beforeEach(() => {
-    resetTables();
-  });
-
   test("round-trip: record → backfill messageId → query by messageId", () => {
     const conversationId = "conv-1";
     const messageId = "msg-1";
@@ -97,6 +109,28 @@ describe("memory-recall-log-store", () => {
     const result = getMemoryRecallLogByMessageIds([messageId]);
     expect(result).not.toBeNull();
     expect(result!.queryContext).toBeNull();
+  });
+
+  test("writes land in the memory connection", () => {
+    recordMemoryRecallLog({
+      conversationId: "conv-mem",
+      enabled: true,
+      degraded: false,
+      semanticHits: 1,
+      mergedCount: 1,
+      selectedCount: 1,
+      tier1Count: 1,
+      tier2Count: 0,
+      hybridSearchLatencyMs: 50,
+      sparseVectorUsed: false,
+      injectedTokens: 100,
+      latencyMs: 80,
+      topCandidatesJson: [],
+    });
+    const { n } = memorySqlite
+      .query(`SELECT COUNT(*) AS n FROM memory_recall_logs`)
+      .get() as { n: number };
+    expect(n).toBe(1);
   });
 
   test("returns null when no log exists for a messageId", () => {

--- a/assistant/src/persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.ts
@@ -1,0 +1,119 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_v2_activation_logs` from `main` into the memory DB.
+ * Full copy — the concept-frequency aggregator scans the entire history, so
+ * every row is worth preserving.
+ */
+export const ACTIVATION_LOGS_RELOCATION: RelocationSpec = {
+  table: "memory_v2_activation_logs",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "id",
+    "conversation_id",
+    "message_id",
+    "turn",
+    "mode",
+    "concepts_json",
+    "skills_json",
+    "config_json",
+    "created_at",
+  ],
+};
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS memory_v2_activation_logs (
+    id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    message_id TEXT,
+    turn INTEGER NOT NULL,
+    mode TEXT NOT NULL,
+    concepts_json TEXT NOT NULL,
+    skills_json TEXT NOT NULL,
+    config_json TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  )
+`;
+
+/**
+ * Create the `memory_v2_activation_logs` table and its indexes (mirroring
+ * migration 234) on the memory connection. Idempotent (`IF NOT EXISTS`) — the
+ * dedicated connection itself performs no DDL on open, so this migration owns
+ * the schema. Exported so tests can stand up the memory-side schema without
+ * running the full drain.
+ */
+export function ensureActivationLogsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(CREATE_TABLE);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v2_activation_logs_message_id
+      ON memory_v2_activation_logs (message_id)
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v2_activation_logs_conversation_id
+      ON memory_v2_activation_logs (conversation_id)
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v2_activation_logs_created_at
+      ON memory_v2_activation_logs (created_at)
+  `);
+}
+
+/**
+ * Move `memory_v2_activation_logs` — the per-turn v2 activation telemetry log
+ * — into the dedicated memory database (`assistant-memory.db`), alongside
+ * `memory_jobs` (migration 298) and `memory_v2_injection_events` (migration
+ * 326). One row is appended per activation pass, so housing the table with
+ * the other high-churn memory state keeps the main DB and its WAL out of
+ * that write path; the accessors in
+ * `plugins/defaults/memory/memory-v2-activation-log-store.ts` read/write it
+ * over the dedicated memory connection.
+ *
+ * Like migration 326 the move is incremental: create the table (and indexes)
+ * on the memory connection, rename any populated
+ * `main.memory_v2_activation_logs` aside to
+ * `memory_v2_activation_logs__relocating`, then drain it in awaited batches
+ * (see `helpers/relocation.ts`) per {@link ACTIVATION_LOGS_RELOCATION}.
+ *
+ * Registered with `dependsOn` on migrations 234 (creator) and 256 (whose
+ * backfill reads this table from `main`), so the move never outruns either
+ * on a database where they are still pending.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on
+ * a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveMemoryV2ActivationLogsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring memory_v2_activation_logs relocation",
+    );
+  }
+
+  ensureActivationLogsSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    ACTIVATION_LOGS_RELOCATION.table,
+  );
+
+  if (needsDrain) {
+    await drainStagedTable(raw, ACTIVATION_LOGS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/migrations/337-move-memory-recall-logs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/337-move-memory-recall-logs-to-memory-db.ts
@@ -1,0 +1,139 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_recall_logs` from `main` into the memory DB. Full copy
+ * — the inspector reads arbitrary historical turns, so every row is worth
+ * preserving. `query_context` was added by migration 211, so a legacy source
+ * may lack the column; the drain NULL-fills it.
+ */
+export const RECALL_LOGS_RELOCATION: RelocationSpec = {
+  table: "memory_recall_logs",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "id",
+    "conversation_id",
+    "message_id",
+    "enabled",
+    "degraded",
+    "provider",
+    "model",
+    "degradation_json",
+    "semantic_hits",
+    "merged_count",
+    "selected_count",
+    "tier1_count",
+    "tier2_count",
+    "hybrid_search_latency_ms",
+    "sparse_vector_used",
+    "injected_tokens",
+    "latency_ms",
+    "top_candidates_json",
+    "injected_text",
+    "reason",
+    "query_context",
+    "created_at",
+  ],
+};
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS memory_recall_logs (
+    id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    message_id TEXT,
+    enabled INTEGER NOT NULL,
+    degraded INTEGER NOT NULL,
+    provider TEXT,
+    model TEXT,
+    degradation_json TEXT,
+    semantic_hits INTEGER NOT NULL,
+    merged_count INTEGER NOT NULL,
+    selected_count INTEGER NOT NULL,
+    tier1_count INTEGER NOT NULL,
+    tier2_count INTEGER NOT NULL,
+    hybrid_search_latency_ms INTEGER NOT NULL,
+    sparse_vector_used INTEGER NOT NULL,
+    injected_tokens INTEGER NOT NULL,
+    latency_ms INTEGER NOT NULL,
+    top_candidates_json TEXT NOT NULL,
+    injected_text TEXT,
+    reason TEXT,
+    query_context TEXT,
+    created_at INTEGER NOT NULL
+  )
+`;
+
+/**
+ * Create the `memory_recall_logs` table and its indexes (mirroring migration
+ * 194, with the `query_context` column from migration 211 built in) on the
+ * memory connection. Idempotent (`IF NOT EXISTS`) — the dedicated connection
+ * itself performs no DDL on open, so this migration owns the schema. Exported
+ * so tests can stand up the memory-side schema without running the full
+ * drain.
+ */
+export function ensureRecallLogsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(CREATE_TABLE);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_recall_logs_message_id
+      ON memory_recall_logs (message_id)
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_recall_logs_conversation_id
+      ON memory_recall_logs (conversation_id)
+  `);
+}
+
+/**
+ * Move `memory_recall_logs` — the per-turn memory recall telemetry consumed
+ * by the inspector — into the dedicated memory database
+ * (`assistant-memory.db`), alongside the other relocated per-turn memory log
+ * tables. One row is appended per recall pass, so housing the table with the
+ * other high-churn memory state keeps the main DB and its WAL out of that
+ * write path; the accessors in
+ * `plugins/defaults/memory/memory-recall-log-store.ts` read/write it over the
+ * dedicated memory connection.
+ *
+ * Like migration 326 the move is incremental: create the table (and indexes)
+ * on the memory connection, rename any populated `main.memory_recall_logs`
+ * aside to `memory_recall_logs__relocating`, then drain it in awaited batches
+ * (see `helpers/relocation.ts`) per {@link RECALL_LOGS_RELOCATION}.
+ *
+ * Registered with `dependsOn` on migrations 194 (creator) and 211
+ * (`query_context` column), so the move never outruns either on a database
+ * where they are still pending.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on
+ * a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveMemoryRecallLogsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring memory_recall_logs relocation",
+    );
+  }
+
+  ensureRecallLogsSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(raw, RECALL_LOGS_RELOCATION.table);
+
+  if (needsDrain) {
+    await drainStagedTable(raw, RECALL_LOGS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -443,6 +443,8 @@ import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/332-move
 import { migrateCreateTelemetryEventsTable } from "./migrations/333-create-telemetry-events-table.js";
 import { migrateBackfillTelemetryEventsOutbox } from "./migrations/334-backfill-telemetry-events-outbox.js";
 import { migrateCollapseMemoryEmbedBacklog } from "./migrations/335-collapse-memory-embed-backlog.js";
+import { migrateMoveMemoryV2ActivationLogsToMemoryDb } from "./migrations/336-move-memory-v2-activation-logs-to-memory-db.js";
+import { migrateMoveMemoryRecallLogsToMemoryDb } from "./migrations/337-move-memory-recall-logs-to-memory-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1357,4 +1359,22 @@ export const migrationSteps: MigrationStep[] = [
   migrateCreateTelemetryEventsTable,
   migrateBackfillTelemetryEventsOutbox,
   migrateCollapseMemoryEmbedBacklog,
+  {
+    name: "migrateMoveMemoryV2ActivationLogsToMemoryDb",
+    run: migrateMoveMemoryV2ActivationLogsToMemoryDb,
+    // 256's backfill reads memory_v2_activation_logs from main, so the move
+    // must not run on a database where 256 is still pending.
+    dependsOn: [
+      "migrateMemoryV2ActivationLogs",
+      "migrateMemoryV2InjectionEvents",
+    ],
+  },
+  {
+    name: "migrateMoveMemoryRecallLogsToMemoryDb",
+    run: migrateMoveMemoryRecallLogsToMemoryDb,
+    dependsOn: [
+      "migrateCreateMemoryRecallLogs",
+      "migrateMemoryRecallLogsQueryContext",
+    ],
+  },
 ];

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -1375,6 +1375,7 @@ export const migrationSteps: MigrationStep[] = [
     dependsOn: [
       "migrateCreateMemoryRecallLogs",
       "migrateMemoryRecallLogsQueryContext",
+      "migrateDeletePrivateConversations",
     ],
   },
 ];

--- a/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
@@ -8,9 +8,10 @@
  *      the *main* WAL is exactly what this split exists to prevent.
  *   2. The main connection no longer ATTACHes the memory file: there is no
  *      `memory` schema on its `database_list`.
- *   3. The relocated memory tables (`memory_jobs`, `memory_v2_injection_events`)
- *      live in the dedicated memory connection, not in the main connection —
- *      proving the physical split.
+ *   3. The relocated memory tables (`memory_jobs`, `memory_v2_injection_events`,
+ *      `memory_v2_activation_logs`, `memory_recall_logs`) live in the dedicated
+ *      memory connection, not in the main connection — proving the physical
+ *      split.
  *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
  *      CLI backend, leaving the main DB untouched.
  */
@@ -52,26 +53,28 @@ describe("memory database connection", () => {
     expect(attached.some((e) => e.name === "memory")).toBe(false);
   });
 
-  test.each(["memory_jobs", "memory_v2_injection_events"])(
-    "%s lives in the memory connection, not main",
-    (table) => {
-      const inMemory = getMemorySqlite()!
-        .query<
-          { name: string },
-          [string]
-        >(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
-        .get(table);
-      expect(inMemory?.name).toBe(table);
+  test.each([
+    "memory_jobs",
+    "memory_v2_injection_events",
+    "memory_v2_activation_logs",
+    "memory_recall_logs",
+  ])("%s lives in the memory connection, not main", (table) => {
+    const inMemory = getMemorySqlite()!
+      .query<
+        { name: string },
+        [string]
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(table);
+    expect(inMemory?.name).toBe(table);
 
-      const inMain = getSqlite()
-        .query<
-          { name: string },
-          [string]
-        >(`SELECT name FROM main.sqlite_master WHERE name = ?`)
-        .get(table);
-      expect(inMain).toBeNull();
-    },
-  );
+    const inMain = getSqlite()
+      .query<
+        { name: string },
+        [string]
+      >(`SELECT name FROM main.sqlite_master WHERE name = ?`)
+      .get(table);
+    expect(inMain).toBeNull();
+  });
 
   test.if(sqlite3Available)(
     "runAsyncSqlite({ dbPath }) targets the given file, not the main DB",

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Degraded-mode coverage for the relocated per-turn memory log tables: with
+ * the dedicated memory database unavailable, writes are best-effort no-ops
+ * and reads return empty/zero results — nothing throws mid-turn.
+ *
+ * Unavailability is simulated by installing a connection with no underlying
+ * sqlite client into the `memory` singleton slot, so `getMemorySqlite()`
+ * resolves to null without mocking any module (module mocks would leak into
+ * other test files in the same run).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { DrizzleDb } from "../../../../persistence/db-connection.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import {
+  backfillMemoryRecallLogMessageId,
+  getMemoryRecallLogByMessageIds,
+  recordMemoryRecallLog,
+} from "../memory-recall-log-store.js";
+import {
+  backfillMemoryV2ActivationMessageId,
+  getMemoryV2ActivationLogByMessageIds,
+  recordMemoryV2ActivationLog,
+} from "../memory-v2-activation-log-store.js";
+import { getConceptFrequencySummary } from "../memory-v2-concept-frequency.js";
+import { extractOracleTurns } from "../v2/harness/oracle.js";
+import {
+  sampleConcepts,
+  sampleConfig,
+} from "./fixtures/memory-v2-activation-fixtures.js";
+
+// listPages returns [] for a workspace with no concepts directory.
+const WORKSPACE = "/tmp/memory-log-stores-degraded-nonexistent-workspace";
+
+beforeEach(() => {
+  setStoredDb("memory", { $client: null } as unknown as DrizzleDb, () => {});
+});
+
+afterEach(() => {
+  clearStoredDb("memory");
+});
+
+describe("memory log stores without a memory database", () => {
+  test("activation-log writes no-op and reads return null", () => {
+    expect(() =>
+      recordMemoryV2ActivationLog({
+        conversationId: "conv-1",
+        turn: 1,
+        mode: "per-turn",
+        concepts: sampleConcepts,
+        config: sampleConfig,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      backfillMemoryV2ActivationMessageId("conv-1", "msg-1"),
+    ).not.toThrow();
+    expect(getMemoryV2ActivationLogByMessageIds(["msg-1"])).toBeNull();
+  });
+
+  test("recall-log writes no-op and reads return null", () => {
+    expect(() =>
+      recordMemoryRecallLog({
+        conversationId: "conv-1",
+        enabled: true,
+        degraded: false,
+        semanticHits: 1,
+        mergedCount: 1,
+        selectedCount: 1,
+        tier1Count: 1,
+        tier2Count: 0,
+        hybridSearchLatencyMs: 50,
+        sparseVectorUsed: false,
+        injectedTokens: 100,
+        latencyMs: 80,
+        topCandidatesJson: [],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      backfillMemoryRecallLogMessageId("conv-1", "msg-1"),
+    ).not.toThrow();
+    expect(getMemoryRecallLogByMessageIds(["msg-1"])).toBeNull();
+  });
+
+  test("concept-frequency degrades to zero counts", async () => {
+    const result = await getConceptFrequencySummary(WORKSPACE);
+    expect(result.totals).toEqual({ logCount: 0, conceptOccurrences: 0 });
+    expect(result.concepts).toEqual([]);
+    expect(result.neverEvaluatedSlugs).toEqual([]);
+  });
+
+  test("oracle extraction returns no turns", () => {
+    expect(extractOracleTurns({} as DrizzleDb)).toEqual([]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-v2-activation-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-v2-activation-log-store.test.ts
@@ -1,8 +1,20 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+/**
+ * Tests for the memory v2 activation-log store. The store reads and writes
+ * `memory_v2_activation_logs` over the dedicated memory connection, so each
+ * test installs a fresh in-memory database into the `memory` singleton slot
+ * with the relocated table's schema (mirroring injection-events.test.ts).
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { getDb } from "../../../../persistence/db-connection.js";
-import { initializeDb } from "../../../../persistence/db-init.js";
-import { memoryV2ActivationLogs } from "../../../../persistence/schema/index.js";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import { ensureActivationLogsSchema } from "../../../../persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.js";
+import * as schema from "../../../../persistence/schema/index.js";
 import {
   backfillMemoryV2ActivationMessageId,
   getMemoryV2ActivationLogByMessageIds,
@@ -14,18 +26,35 @@ import {
   sampleConfig,
 } from "./fixtures/memory-v2-activation-fixtures.js";
 
-await initializeDb();
+let memorySqlite: Database;
 
-function resetTables(): void {
-  const db = getDb();
-  db.delete(memoryV2ActivationLogs).run();
+beforeEach(() => {
+  memorySqlite = new Database(":memory:");
+  ensureActivationLogsSchema(memorySqlite);
+  setStoredDb("memory", drizzle(memorySqlite, { schema }), () =>
+    memorySqlite.close(),
+  );
+});
+
+afterEach(() => {
+  clearStoredDb("memory");
+});
+
+interface LogRow {
+  message_id: string | null;
+  turn: number;
+  mode: string;
+}
+
+function allRows(): LogRow[] {
+  return memorySqlite
+    .query(
+      `SELECT message_id, turn, mode FROM memory_v2_activation_logs ORDER BY turn`,
+    )
+    .all() as LogRow[];
 }
 
 describe("memory-v2-activation-log-store", () => {
-  beforeEach(() => {
-    resetTables();
-  });
-
   test("round-trip: record → backfill messageId → query by messageId", () => {
     const conversationId = "conv-1";
     const messageId = "msg-1";
@@ -122,6 +151,20 @@ describe("memory-v2-activation-log-store", () => {
     expect(result).toBeNull();
   });
 
+  test("writes land in the memory connection", () => {
+    recordMemoryV2ActivationLog({
+      conversationId: "conv-mem",
+      turn: 1,
+      mode: "per-turn",
+      concepts: sampleConcepts,
+      config: sampleConfig,
+    });
+    const { n } = memorySqlite
+      .query(`SELECT COUNT(*) AS n FROM memory_v2_activation_logs`)
+      .get() as { n: number };
+    expect(n).toBe(1);
+  });
+
   test("backfill only updates rows with NULL messageId", () => {
     const conversationId = "conv-2";
 
@@ -143,11 +186,10 @@ describe("memory-v2-activation-log-store", () => {
     // First backfill: both rows should now have msg-a.
     backfillMemoryV2ActivationMessageId(conversationId, "msg-a");
 
-    const db = getDb();
-    const afterFirstBackfill = db.select().from(memoryV2ActivationLogs).all();
+    const afterFirstBackfill = allRows();
     expect(afterFirstBackfill).toHaveLength(2);
     for (const row of afterFirstBackfill) {
-      expect(row.messageId).toBe("msg-a");
+      expect(row.message_id).toBe("msg-a");
     }
 
     // Record a third row (messageId is NULL initially).
@@ -163,11 +205,10 @@ describe("memory-v2-activation-log-store", () => {
     // and must not overwrite the first two rows already set to msg-a.
     backfillMemoryV2ActivationMessageId(conversationId, "msg-b");
 
-    const afterSecondBackfill = db.select().from(memoryV2ActivationLogs).all();
-    const byTurn = new Map(afterSecondBackfill.map((r) => [r.turn, r]));
-    expect(byTurn.get(1)!.messageId).toBe("msg-a");
-    expect(byTurn.get(2)!.messageId).toBe("msg-a");
-    expect(byTurn.get(3)!.messageId).toBe("msg-b");
+    const byTurn = new Map(allRows().map((r) => [r.turn, r]));
+    expect(byTurn.get(1)!.message_id).toBe("msg-a");
+    expect(byTurn.get(2)!.message_id).toBe("msg-a");
+    expect(byTurn.get(3)!.message_id).toBe("msg-b");
   });
 
   test("backfill skips v3_shadow rows, leaving their messageId null", () => {
@@ -192,12 +233,10 @@ describe("memory-v2-activation-log-store", () => {
 
     backfillMemoryV2ActivationMessageId(conversationId, "msg-live");
 
-    const db = getDb();
-    const rows = db.select().from(memoryV2ActivationLogs).all();
-    const byMode = new Map(rows.map((r) => [r.mode, r]));
+    const byMode = new Map(allRows().map((r) => [r.mode, r]));
     // The live router row got stamped; the shadow row stayed null (not
     // mis-attributed to the live message).
-    expect(byMode.get("router")!.messageId).toBe("msg-live");
-    expect(byMode.get("v3_shadow")!.messageId).toBeNull();
+    expect(byMode.get("router")!.message_id).toBe("msg-live");
+    expect(byMode.get("v3_shadow")!.message_id).toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-v2-concept-frequency.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-v2-concept-frequency.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
 
 let listPagesImpl: (workspaceDir: string) => Promise<string[]> = async () => [];
 
@@ -6,9 +9,12 @@ mock.module("../v2/page-store.js", () => ({
   listPages: (workspaceDir: string) => listPagesImpl(workspaceDir),
 }));
 
-import { getDb } from "../../../../persistence/db-connection.js";
-import { initializeDb } from "../../../../persistence/db-init.js";
-import { memoryV2ActivationLogs } from "../../../../persistence/schema/index.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import { ensureActivationLogsSchema } from "../../../../persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.js";
+import * as schema from "../../../../persistence/schema/index.js";
 import {
   type MemoryV2ConceptRowRecord,
   recordMemoryV2ActivationLog,
@@ -16,7 +22,10 @@ import {
 import { getConceptFrequencySummary } from "../memory-v2-concept-frequency.js";
 import { sampleConfig } from "./fixtures/memory-v2-activation-fixtures.js";
 
-await initializeDb();
+// The store and aggregator resolve the dedicated memory connection through
+// the `memory` singleton slot — install a fresh in-memory DB there with the
+// relocated table's schema.
+let memorySqlite: Database;
 
 const WORKSPACE = "/tmp/memory-v2-concept-frequency-test";
 
@@ -41,14 +50,18 @@ function makeConcept(
   };
 }
 
-function resetTables(): void {
-  getDb().delete(memoryV2ActivationLogs).run();
-}
-
 describe("memory-v2-concept-frequency", () => {
   beforeEach(() => {
-    resetTables();
+    memorySqlite = new Database(":memory:");
+    ensureActivationLogsSchema(memorySqlite);
+    setStoredDb("memory", drizzle(memorySqlite, { schema }), () =>
+      memorySqlite.close(),
+    );
     listPagesImpl = async () => [];
+  });
+
+  afterEach(() => {
+    clearStoredDb("memory");
   });
 
   test("aggregates per-status counts across multiple turns", async () => {
@@ -185,7 +198,7 @@ describe("memory-v2-concept-frequency", () => {
       config: sampleConfig,
     });
     // Backdate the just-written row — recordMemoryV2ActivationLog uses Date.now().
-    getDb().update(memoryV2ActivationLogs).set({ createdAt: 1_000 }).run();
+    memorySqlite.exec(`UPDATE memory_v2_activation_logs SET created_at = 1000`);
 
     recordMemoryV2ActivationLog({
       conversationId: "conv-1",

--- a/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
@@ -28,6 +28,10 @@ const { MEMORY_JOBS_RELOCATION } =
   await import("../../../../persistence/migrations/298-move-memory-jobs-to-memory-db.js");
 const { INJECTION_EVENTS_RELOCATION } =
   await import("../../../../persistence/migrations/326-move-injection-events-to-memory-db.js");
+const { ACTIVATION_LOGS_RELOCATION } =
+  await import("../../../../persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.js");
+const { RECALL_LOGS_RELOCATION } =
+  await import("../../../../persistence/migrations/337-move-memory-recall-logs-to-memory-db.js");
 
 await initializeDb();
 
@@ -174,6 +178,120 @@ describe("memory_v2_injection_events drain", () => {
     expect(kept).toEqual([
       { id: 1, slug: "fresh-a" },
       { id: 2, slug: "fresh-b" },
+    ]);
+  });
+});
+
+describe("memory_v2_activation_logs drain", () => {
+  test("copies every row, drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Clean slate: empty live table, fresh populated staging table.
+    memory.exec(`DELETE FROM memory_v2_activation_logs`);
+    sqlite.exec(
+      `DROP TABLE IF EXISTS main."memory_v2_activation_logs__relocating"`,
+    );
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_v2_activation_logs__relocating" (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        message_id TEXT,
+        turn INTEGER NOT NULL,
+        mode TEXT NOT NULL,
+        concepts_json TEXT NOT NULL,
+        skills_json TEXT NOT NULL,
+        config_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    `);
+
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_v2_activation_logs__relocating"
+         (id, conversation_id, message_id, turn, mode,
+          concepts_json, skills_json, config_json, created_at)
+       VALUES (?, 'conv-1', ?, ?, 'router', '[]', '[]', '{}', ?)`,
+    );
+    insert.run("act-1", "msg-1", 1, 1_000);
+    insert.run("act-2", null, 2, 2_000);
+
+    await drainStagedTable(sqlite, ACTIVATION_LOGS_RELOCATION);
+
+    // Staging dropped; the full-copy spec preserved every row and column.
+    expect(existsInMain("memory_v2_activation_logs__relocating")).toBe(false);
+    const kept = memory
+      .query<
+        { id: string; message_id: string | null; turn: number },
+        []
+      >(`SELECT id, message_id, turn FROM memory_v2_activation_logs ORDER BY id`)
+      .all();
+    expect(kept).toEqual([
+      { id: "act-1", message_id: "msg-1", turn: 1 },
+      { id: "act-2", message_id: null, turn: 2 },
+    ]);
+  });
+});
+
+describe("memory_recall_logs drain", () => {
+  test("copies every row, NULL-fills query_context on a pre-211 source, drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Clean slate: empty live table, fresh populated staging table shaped
+    // like a legacy source that predates the query_context column.
+    memory.exec(`DELETE FROM memory_recall_logs`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."memory_recall_logs__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_recall_logs__relocating" (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        message_id TEXT,
+        enabled INTEGER NOT NULL,
+        degraded INTEGER NOT NULL,
+        provider TEXT,
+        model TEXT,
+        degradation_json TEXT,
+        semantic_hits INTEGER NOT NULL,
+        merged_count INTEGER NOT NULL,
+        selected_count INTEGER NOT NULL,
+        tier1_count INTEGER NOT NULL,
+        tier2_count INTEGER NOT NULL,
+        hybrid_search_latency_ms INTEGER NOT NULL,
+        sparse_vector_used INTEGER NOT NULL,
+        injected_tokens INTEGER NOT NULL,
+        latency_ms INTEGER NOT NULL,
+        top_candidates_json TEXT NOT NULL,
+        injected_text TEXT,
+        reason TEXT,
+        created_at INTEGER NOT NULL
+      )
+    `);
+
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_recall_logs__relocating"
+         (id, conversation_id, message_id, enabled, degraded, semantic_hits,
+          merged_count, selected_count, tier1_count, tier2_count,
+          hybrid_search_latency_ms, sparse_vector_used, injected_tokens,
+          latency_ms, top_candidates_json, created_at)
+       VALUES (?, 'conv-1', ?, 1, 0, 3, 2, 1, 1, 0, 100, 0, 300, 150, '[]', ?)`,
+    );
+    insert.run("rec-1", "msg-1", 1_000);
+    insert.run("rec-2", null, 2_000);
+
+    await drainStagedTable(sqlite, RECALL_LOGS_RELOCATION);
+
+    // Staging dropped; both rows copied with the absent legacy column
+    // NULL-filled.
+    expect(existsInMain("memory_recall_logs__relocating")).toBe(false);
+    const kept = memory
+      .query<
+        { id: string; message_id: string | null; query_context: string | null },
+        []
+      >(`SELECT id, message_id, query_context FROM memory_recall_logs ORDER BY id`)
+      .all();
+    expect(kept).toEqual([
+      { id: "rec-1", message_id: "msg-1", query_context: null },
+      { id: "rec-2", message_id: null, query_context: null },
     ]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/memory-recall-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/memory-recall-log-store.ts
@@ -1,8 +1,9 @@
-import { and, eq, inArray, isNull } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getDb } from "../../../persistence/db-connection.js";
-import { memoryRecallLogs } from "../../../persistence/schema/index.js";
+import { getLogger } from "./logging.js";
+import { memorySqliteOrNull } from "./memory-db.js";
+
+const log = getLogger("memory-recall-log-store");
 
 export interface RecordMemoryRecallLogParams {
   conversationId: string;
@@ -29,51 +30,74 @@ export interface RecordMemoryRecallLogParams {
 export function recordMemoryRecallLog(
   params: RecordMemoryRecallLogParams,
 ): void {
-  const db = getDb();
-  db.insert(memoryRecallLogs)
-    .values({
-      id: uuid(),
-      conversationId: params.conversationId,
-      messageId: null,
-      enabled: params.enabled ? 1 : 0,
-      degraded: params.degraded ? 1 : 0,
-      provider: params.provider ?? null,
-      model: params.model ?? null,
-      degradationJson: params.degradationJson
-        ? JSON.stringify(params.degradationJson)
-        : null,
-      semanticHits: params.semanticHits,
-      mergedCount: params.mergedCount,
-      selectedCount: params.selectedCount,
-      tier1Count: params.tier1Count,
-      tier2Count: params.tier2Count,
-      hybridSearchLatencyMs: params.hybridSearchLatencyMs,
-      sparseVectorUsed: params.sparseVectorUsed ? 1 : 0,
-      injectedTokens: params.injectedTokens,
-      latencyMs: params.latencyMs,
-      topCandidatesJson: JSON.stringify(params.topCandidatesJson),
-      injectedText: params.injectedText ?? null,
-      reason: params.reason ?? null,
-      queryContext: params.queryContext ?? null,
-      createdAt: Date.now(),
-    })
-    .run();
+  // Best-effort — telemetry writes must never abort the agent turn, so a
+  // degraded memory connection or a failed insert only logs a warning.
+  try {
+    const raw = memorySqliteOrNull("recordMemoryRecallLog");
+    if (!raw) {
+      return;
+    }
+    raw
+      .prepare(
+        `INSERT INTO memory_recall_logs (
+           id, conversation_id, message_id, enabled, degraded, provider,
+           model, degradation_json, semantic_hits, merged_count,
+           selected_count, tier1_count, tier2_count,
+           hybrid_search_latency_ms, sparse_vector_used, injected_tokens,
+           latency_ms, top_candidates_json, injected_text, reason,
+           query_context, created_at
+         ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        uuid(),
+        params.conversationId,
+        params.enabled ? 1 : 0,
+        params.degraded ? 1 : 0,
+        params.provider ?? null,
+        params.model ?? null,
+        params.degradationJson ? JSON.stringify(params.degradationJson) : null,
+        params.semanticHits,
+        params.mergedCount,
+        params.selectedCount,
+        params.tier1Count,
+        params.tier2Count,
+        params.hybridSearchLatencyMs,
+        params.sparseVectorUsed ? 1 : 0,
+        params.injectedTokens,
+        params.latencyMs,
+        JSON.stringify(params.topCandidatesJson),
+        params.injectedText ?? null,
+        params.reason ?? null,
+        params.queryContext ?? null,
+        Date.now(),
+      );
+  } catch (err) {
+    log.warn({ err }, "failed to record memory recall log; continuing");
+  }
 }
 
 export function backfillMemoryRecallLogMessageId(
   conversationId: string,
   messageId: string,
 ): void {
-  const db = getDb();
-  db.update(memoryRecallLogs)
-    .set({ messageId })
-    .where(
-      and(
-        eq(memoryRecallLogs.conversationId, conversationId),
-        isNull(memoryRecallLogs.messageId),
-      ),
-    )
-    .run();
+  try {
+    const raw = memorySqliteOrNull("backfillMemoryRecallLogMessageId");
+    if (!raw) {
+      return;
+    }
+    raw
+      .prepare(
+        `UPDATE memory_recall_logs
+           SET message_id = ?
+         WHERE conversation_id = ? AND message_id IS NULL`,
+      )
+      .run(messageId, conversationId);
+  } catch (err) {
+    log.warn(
+      { err },
+      "failed to backfill memory recall log messageId; continuing",
+    );
+  }
 }
 
 export interface MemoryRecallLog {
@@ -104,9 +128,13 @@ export interface MemoryRecallLog {
  * Entries already in inspector format pass through unchanged.
  */
 export function normalizeTopCandidates(raw: unknown): unknown {
-  if (!Array.isArray(raw)) return raw;
+  if (!Array.isArray(raw)) {
+    return raw;
+  }
   return raw.flatMap((entry: Record<string, unknown>) => {
-    if (!entry || typeof entry !== "object") return [];
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
 
     // Start with a shallow copy, then apply field renames
     const { key, finalScore, semantic, recency, kind: _kind, ...rest } = entry;
@@ -137,36 +165,71 @@ export function normalizeTopCandidates(raw: unknown): unknown {
   });
 }
 
+interface MemoryRecallLogRow {
+  enabled: number;
+  degraded: number;
+  provider: string | null;
+  model: string | null;
+  degradation_json: string | null;
+  semantic_hits: number;
+  merged_count: number;
+  selected_count: number;
+  tier1_count: number;
+  tier2_count: number;
+  hybrid_search_latency_ms: number;
+  sparse_vector_used: number;
+  injected_tokens: number;
+  latency_ms: number;
+  top_candidates_json: string;
+  injected_text: string | null;
+  reason: string | null;
+  query_context: string | null;
+}
+
 export function getMemoryRecallLogByMessageIds(
   messageIds: string[],
 ): MemoryRecallLog | null {
-  if (messageIds.length === 0) return null;
-  const db = getDb();
-  const rows = db
-    .select()
-    .from(memoryRecallLogs)
-    .where(inArray(memoryRecallLogs.messageId, messageIds))
-    .all();
-  if (rows.length === 0) return null;
-  const row = rows[0]!;
+  if (messageIds.length === 0) {
+    return null;
+  }
+  const raw = memorySqliteOrNull("getMemoryRecallLogByMessageIds");
+  if (!raw) {
+    return null;
+  }
+  const placeholders = messageIds.map(() => "?").join(",");
+  const row = raw
+    .query(
+      `SELECT enabled, degraded, provider, model, degradation_json,
+              semantic_hits, merged_count, selected_count, tier1_count,
+              tier2_count, hybrid_search_latency_ms, sparse_vector_used,
+              injected_tokens, latency_ms, top_candidates_json,
+              injected_text, reason, query_context
+         FROM memory_recall_logs
+        WHERE message_id IN (${placeholders})
+        LIMIT 1`,
+    )
+    .get(...messageIds) as MemoryRecallLogRow | null;
+  if (!row) {
+    return null;
+  }
   return {
     enabled: !!row.enabled,
     degraded: !!row.degraded,
     provider: row.provider,
     model: row.model,
-    degradation: row.degradationJson ? JSON.parse(row.degradationJson) : null,
-    semanticHits: row.semanticHits,
-    mergedCount: row.mergedCount,
-    selectedCount: row.selectedCount,
-    tier1Count: row.tier1Count,
-    tier2Count: row.tier2Count,
-    hybridSearchLatencyMs: row.hybridSearchLatencyMs,
-    sparseVectorUsed: !!row.sparseVectorUsed,
-    injectedTokens: row.injectedTokens,
-    latencyMs: row.latencyMs,
-    topCandidates: normalizeTopCandidates(JSON.parse(row.topCandidatesJson)),
-    injectedText: row.injectedText,
+    degradation: row.degradation_json ? JSON.parse(row.degradation_json) : null,
+    semanticHits: row.semantic_hits,
+    mergedCount: row.merged_count,
+    selectedCount: row.selected_count,
+    tier1Count: row.tier1_count,
+    tier2Count: row.tier2_count,
+    hybridSearchLatencyMs: row.hybrid_search_latency_ms,
+    sparseVectorUsed: !!row.sparse_vector_used,
+    injectedTokens: row.injected_tokens,
+    latencyMs: row.latency_ms,
+    topCandidates: normalizeTopCandidates(JSON.parse(row.top_candidates_json)),
+    injectedText: row.injected_text,
     reason: row.reason,
-    queryContext: row.queryContext,
+    queryContext: row.query_context,
   };
 }

--- a/assistant/src/plugins/defaults/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/memory-v2-activation-log-store.ts
@@ -1,8 +1,9 @@
-import { and, desc, eq, inArray, isNull, ne } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getDb } from "../../../persistence/db-connection.js";
-import { memoryV2ActivationLogs } from "../../../persistence/schema/index.js";
+import { getLogger } from "./logging.js";
+import { memorySqliteOrNull } from "./memory-db.js";
+
+const log = getLogger("memory-v2-activation-log-store");
 
 export interface MemoryV2ConceptRowRecord {
   slug: string;
@@ -139,45 +140,66 @@ export interface RecordMemoryV2ActivationLogParams {
 export function recordMemoryV2ActivationLog(
   params: RecordMemoryV2ActivationLogParams,
 ): void {
-  const db = getDb();
-  // Skills now live as concept rows under `slug: "skills/<id>"`, so the
-  // separate `skills_json` column is always written empty. The column itself
-  // remains in the schema for backwards-compat with prior log rows; the
-  // reader drops it. A future migration can DROP the column once those rows
-  // age out of relevance.
-  db.insert(memoryV2ActivationLogs)
-    .values({
-      id: uuid(),
-      conversationId: params.conversationId,
-      messageId: null,
-      turn: params.turn,
-      mode: params.mode,
-      conceptsJson: JSON.stringify(params.concepts),
-      skillsJson: "[]",
-      configJson: JSON.stringify(params.config),
-      createdAt: Date.now(),
-    })
-    .run();
+  // Best-effort — telemetry writes must never abort the agent turn, so a
+  // degraded memory connection or a failed insert only logs a warning.
+  try {
+    const raw = memorySqliteOrNull("recordMemoryV2ActivationLog");
+    if (!raw) {
+      return;
+    }
+    // Skills live as concept rows under `slug: "skills/<id>"`, so the
+    // separate `skills_json` column is always written empty. The column
+    // itself remains in the schema for backwards-compat with prior log rows;
+    // the reader drops it.
+    raw
+      .prepare(
+        `INSERT INTO memory_v2_activation_logs (
+           id, conversation_id, message_id, turn, mode,
+           concepts_json, skills_json, config_json, created_at
+         ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        uuid(),
+        params.conversationId,
+        params.turn,
+        params.mode,
+        JSON.stringify(params.concepts),
+        "[]",
+        JSON.stringify(params.config),
+        Date.now(),
+      );
+  } catch (err) {
+    log.warn({ err }, "failed to record memory v2 activation log; continuing");
+  }
 }
 
 export function backfillMemoryV2ActivationMessageId(
   conversationId: string,
   messageId: string,
 ): void {
-  const db = getDb();
   // `v3_shadow` rows are detached telemetry written outside the live turn with
   // a null messageId; they are not tied to any specific message. Excluding them
   // keeps their messageId null instead of stamping them with a later turn's id.
-  db.update(memoryV2ActivationLogs)
-    .set({ messageId })
-    .where(
-      and(
-        eq(memoryV2ActivationLogs.conversationId, conversationId),
-        isNull(memoryV2ActivationLogs.messageId),
-        ne(memoryV2ActivationLogs.mode, "v3_shadow"),
-      ),
-    )
-    .run();
+  try {
+    const raw = memorySqliteOrNull("backfillMemoryV2ActivationMessageId");
+    if (!raw) {
+      return;
+    }
+    raw
+      .prepare(
+        `UPDATE memory_v2_activation_logs
+           SET message_id = ?
+         WHERE conversation_id = ?
+           AND message_id IS NULL
+           AND mode != 'v3_shadow'`,
+      )
+      .run(messageId, conversationId);
+  } catch (err) {
+    log.warn(
+      { err },
+      "failed to backfill memory v2 activation messageId; continuing",
+    );
+  }
 }
 
 export interface MemoryV2ActivationLog {
@@ -191,18 +213,34 @@ export interface MemoryV2ActivationLog {
 export function getMemoryV2ActivationLogByMessageIds(
   messageIds: string[],
 ): MemoryV2ActivationLog | null {
-  if (messageIds.length === 0) return null;
-  const db = getDb();
-  const rows = db
-    .select()
-    .from(memoryV2ActivationLogs)
-    .where(inArray(memoryV2ActivationLogs.messageId, messageIds))
-    .orderBy(desc(memoryV2ActivationLogs.createdAt))
-    .all();
-  if (rows.length === 0) return null;
-  const row = rows[0]!;
+  if (messageIds.length === 0) {
+    return null;
+  }
+  const raw = memorySqliteOrNull("getMemoryV2ActivationLogByMessageIds");
+  if (!raw) {
+    return null;
+  }
+  const placeholders = messageIds.map(() => "?").join(",");
+  const row = raw
+    .query(
+      `SELECT conversation_id, turn, mode, concepts_json, config_json
+         FROM memory_v2_activation_logs
+        WHERE message_id IN (${placeholders})
+        ORDER BY created_at DESC
+        LIMIT 1`,
+    )
+    .get(...messageIds) as {
+    conversation_id: string;
+    turn: number;
+    mode: string;
+    concepts_json: string;
+    config_json: string;
+  } | null;
+  if (!row) {
+    return null;
+  }
   return {
-    conversationId: row.conversationId,
+    conversationId: row.conversation_id,
     turn: row.turn,
     mode: row.mode as
       | "context-load"
@@ -210,7 +248,7 @@ export function getMemoryV2ActivationLogByMessageIds(
       | "errored"
       | "router"
       | "v3_shadow",
-    concepts: JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[],
-    config: JSON.parse(row.configJson) as MemoryV2ConfigSnapshot,
+    concepts: JSON.parse(row.concepts_json) as MemoryV2ConceptRowRecord[],
+    config: JSON.parse(row.config_json) as MemoryV2ConfigSnapshot,
   };
 }

--- a/assistant/src/plugins/defaults/memory/memory-v2-concept-frequency.ts
+++ b/assistant/src/plugins/defaults/memory/memory-v2-concept-frequency.ts
@@ -1,4 +1,4 @@
-import { rawAll, rawGet } from "../../../persistence/raw-query.js";
+import { memorySqliteOrNull } from "./memory-db.js";
 import type { MemoryV2ConceptRowRecord } from "./memory-v2-activation-log-store.js";
 import { listPages } from "./v2/page-store.js";
 
@@ -67,43 +67,51 @@ export async function getConceptFrequencySummary(
   const sinceMs = filters.sinceMs ?? null;
 
   // Kick off the on-disk page walk in parallel with the (synchronous) SQL
-  // queries below — listPages does fs.readdir, rawAll/rawGet are sync.
+  // queries below — listPages does fs.readdir, the sqlite queries are sync.
   const onDiskSlugsPromise = listPages(workspaceDir);
 
-  const aggRows = rawAll<AggRow>(
-    "conceptFreq:summary:agg",
-    `SELECT
-       json_extract(c.value, '$.slug')   AS slug,
-       json_extract(c.value, '$.status') AS status,
-       COUNT(*)                          AS count,
-       MAX(l.created_at)                 AS last_seen
-     FROM memory_v2_activation_logs l, json_each(l.concepts_json) c
-     WHERE (? IS NULL OR l.conversation_id = ?)
-       AND (? IS NULL OR l.created_at >= ?)
-     GROUP BY slug, status`,
-    conversationId,
-    conversationId,
-    sinceMs,
-    sinceMs,
-  );
+  // Fail-soft: with the memory database unavailable the aggregation degrades
+  // to zero counts, so every on-disk page reads as never evaluated.
+  const raw = memorySqliteOrNull("getConceptFrequencySummary");
+  if (!raw) {
+    return {
+      filters: { conversationId, sinceMs },
+      totals: { logCount: 0, conceptOccurrences: 0 },
+      concepts: [],
+      neverEvaluatedSlugs: [...(await onDiskSlugsPromise)].sort(),
+    };
+  }
 
-  const logCountRow = rawGet<CountRow>(
-    "conceptFreq:summary:count",
-    `SELECT COUNT(*) AS count
-       FROM memory_v2_activation_logs
-       WHERE (? IS NULL OR conversation_id = ?)
-         AND (? IS NULL OR created_at >= ?)`,
-    conversationId,
-    conversationId,
-    sinceMs,
-    sinceMs,
-  );
+  const aggRows = raw
+    .query(
+      `SELECT
+         json_extract(c.value, '$.slug')   AS slug,
+         json_extract(c.value, '$.status') AS status,
+         COUNT(*)                          AS count,
+         MAX(l.created_at)                 AS last_seen
+       FROM memory_v2_activation_logs l, json_each(l.concepts_json) c
+       WHERE (? IS NULL OR l.conversation_id = ?)
+         AND (? IS NULL OR l.created_at >= ?)
+       GROUP BY slug, status`,
+    )
+    .all(conversationId, conversationId, sinceMs, sinceMs) as AggRow[];
+
+  const logCountRow = raw
+    .query(
+      `SELECT COUNT(*) AS count
+         FROM memory_v2_activation_logs
+         WHERE (? IS NULL OR conversation_id = ?)
+           AND (? IS NULL OR created_at >= ?)`,
+    )
+    .get(conversationId, conversationId, sinceMs, sinceMs) as CountRow | null;
 
   const bySlug = new Map<string, ConceptFrequencyRow>();
   let conceptOccurrences = 0;
 
   for (const row of aggRows) {
-    if (!row.slug) continue;
+    if (!row.slug) {
+      continue;
+    }
     let entry = bySlug.get(row.slug);
     if (!entry) {
       entry = {
@@ -152,7 +160,9 @@ export async function getConceptFrequencySummary(
 
   const neverEvaluatedSlugs: string[] = [];
   for (const slug of onDiskSlugs) {
-    if (!bySlug.has(slug)) neverEvaluatedSlugs.push(slug);
+    if (!bySlug.has(slug)) {
+      neverEvaluatedSlugs.push(slug);
+    }
   }
   neverEvaluatedSlugs.sort();
 

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/harness-compare.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/harness-compare.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../../../../../config/types.js";
-import { getDb } from "../../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../../persistence/db-init.js";
 import {
   conversations,
-  memoryV2ActivationLogs,
   messages,
 } from "../../../../../persistence/schema/index.js";
 import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
@@ -93,20 +95,23 @@ function insertRouterLog(
   createdAt: number,
 ): void {
   ensureConversation(conversationId);
-  getDb()
-    .insert(memoryV2ActivationLogs)
-    .values({
-      id: `log-${seq++}`,
+  // The activation log lives in the dedicated memory database.
+  getMemorySqlite()!
+    .prepare(
+      `INSERT INTO memory_v2_activation_logs (
+         id, conversation_id, message_id, turn, mode,
+         concepts_json, skills_json, config_json, created_at
+       ) VALUES (?, ?, ?, ?, 'router', ?, '[]', ?, ?)`,
+    )
+    .run(
+      `log-${seq++}`,
       conversationId,
       messageId,
       turn,
-      mode: "router",
-      conceptsJson: JSON.stringify(concepts),
-      skillsJson: "[]",
-      configJson: JSON.stringify(ZERO_CONFIG),
+      JSON.stringify(concepts),
+      JSON.stringify(ZERO_CONFIG),
       createdAt,
-    })
-    .run();
+    );
 }
 
 function stubRetriever(name: string, selected: string[]): Retriever {
@@ -120,9 +125,8 @@ function stubRetriever(name: string, selected: string[]): Retriever {
 }
 
 function reset(): void {
-  const db = getDb();
-  db.delete(memoryV2ActivationLogs).run();
-  db.delete(messages).run();
+  getMemorySqlite()!.exec(`DELETE FROM memory_v2_activation_logs`);
+  getDb().delete(messages).run();
 }
 
 /** Seed one router turn: user msg, assistant anchor, and the logged picks. */

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/harness-oracle.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/harness-oracle.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { getDb } from "../../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../../persistence/db-init.js";
 import {
   conversations,
-  memoryV2ActivationLogs,
   messages,
 } from "../../../../../persistence/schema/index.js";
 import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
@@ -63,20 +65,24 @@ function insertLog(opts: {
   createdAt: number;
 }): void {
   ensureConversation(opts.conversationId);
-  getDb()
-    .insert(memoryV2ActivationLogs)
-    .values({
-      id: `log-${seq++}`,
-      conversationId: opts.conversationId,
-      messageId: opts.messageId,
-      turn: opts.turn,
-      mode: opts.mode,
-      conceptsJson: JSON.stringify(opts.concepts),
-      skillsJson: "[]",
-      configJson: CONFIG_JSON,
-      createdAt: opts.createdAt,
-    })
-    .run();
+  // The activation log lives in the dedicated memory database.
+  getMemorySqlite()!
+    .prepare(
+      `INSERT INTO memory_v2_activation_logs (
+         id, conversation_id, message_id, turn, mode,
+         concepts_json, skills_json, config_json, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, '[]', ?, ?)`,
+    )
+    .run(
+      `log-${seq++}`,
+      opts.conversationId,
+      opts.messageId,
+      opts.turn,
+      opts.mode,
+      JSON.stringify(opts.concepts),
+      CONFIG_JSON,
+      opts.createdAt,
+    );
 }
 
 function insertMessage(
@@ -98,9 +104,8 @@ function insertMessage(
 }
 
 function reset(): void {
-  const db = getDb();
-  db.delete(memoryV2ActivationLogs).run();
-  db.delete(messages).run();
+  getMemorySqlite()!.exec(`DELETE FROM memory_v2_activation_logs`);
+  getDb().delete(messages).run();
 }
 
 describe("harness/oracle extractOracleTurns", () => {

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/harness-replay-input.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/harness-replay-input.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../../../../../config/types.js";
-import { getDb } from "../../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../../persistence/db-init.js";
 import {
   conversations,
-  memoryV2ActivationLogs,
   messages,
 } from "../../../../../persistence/schema/index.js";
 import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
@@ -93,20 +95,23 @@ function insertRouterLog(
   createdAt: number,
 ): void {
   ensureConversation(conversationId);
-  getDb()
-    .insert(memoryV2ActivationLogs)
-    .values({
-      id: `log-${seq++}`,
+  // The activation log lives in the dedicated memory database.
+  getMemorySqlite()!
+    .prepare(
+      `INSERT INTO memory_v2_activation_logs (
+         id, conversation_id, message_id, turn, mode,
+         concepts_json, skills_json, config_json, created_at
+       ) VALUES (?, ?, ?, ?, 'router', ?, '[]', ?, ?)`,
+    )
+    .run(
+      `log-${seq++}`,
       conversationId,
       messageId,
       turn,
-      mode: "router",
-      conceptsJson: JSON.stringify(concepts),
-      skillsJson: "[]",
-      configJson: JSON.stringify(ZERO_CONFIG),
+      JSON.stringify(concepts),
+      JSON.stringify(ZERO_CONFIG),
       createdAt,
-    })
-    .run();
+    );
 }
 
 function turnFor(
@@ -127,9 +132,8 @@ function turnFor(
 }
 
 function reset(): void {
-  const db = getDb();
-  db.delete(memoryV2ActivationLogs).run();
-  db.delete(messages).run();
+  getMemorySqlite()!.exec(`DELETE FROM memory_v2_activation_logs`);
+  getDb().delete(messages).run();
 }
 
 describe("harness/replay-input reconstructInput", () => {

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/injection.test.ts
@@ -184,8 +184,8 @@ mock.module("../cli-command-store.js", () => ({
 // Activation-log store mock
 // ---------------------------------------------------------------------------
 //
-// The real `recordMemoryV2ActivationLog` writes to the singleton
-// `getDb()` — but this test uses an isolated in-memory database, so we mock
+// The real `recordMemoryV2ActivationLog` writes to the memory-DB singleton
+// connection — but this test uses an isolated in-memory database, so we mock
 // the writer to capture calls in-process. `recordCalls` is the captured log
 // array; `recordShouldThrow` makes the next call throw to verify the caller
 // swallows the failure.
@@ -307,11 +307,24 @@ mock.module("../activation-store.js", () => ({
 
 let tmpWorkspace: string;
 let previousWorkspaceEnv: string | undefined;
+let memorySqlite: Database;
 
 beforeAll(() => {
   tmpWorkspace = mkdtempSync(join(tmpdir(), "memory-v2-injection-test-"));
   previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
   process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+  // The injection-events accessors resolve the dedicated memory connection
+  // through the `memory` singleton slot. Left alone, the slot either holds a
+  // connection cached by an earlier test file (that file's workspace) or
+  // lazily opens a schema-less DB under this file's temporary workspace —
+  // both order-dependent. Install a fresh in-memory DB with the relocated
+  // table's schema so this file is hermetic either way.
+  memorySqlite = new Database(":memory:");
+  ensureInjectionEventsSchema(memorySqlite);
+  setStoredDb("memory", drizzle(memorySqlite, { schema }), () =>
+    memorySqlite.close(),
+  );
 
   // Seed the v2 directory layout the migration would normally create.
   mkdirSync(join(tmpWorkspace, "memory", "concepts"), { recursive: true });
@@ -369,6 +382,9 @@ Long-form body content that should NOT appear in the injection block when the pa
 });
 
 afterAll(() => {
+  // Drop this file's in-memory memory-DB install so later test files reopen
+  // the connection from their own (restored) workspace path.
+  clearStoredDb("memory");
   if (previousWorkspaceEnv === undefined) {
     delete process.env.VELLUM_WORKSPACE_DIR;
   } else {
@@ -384,6 +400,10 @@ import type { SkillEntry } from "../types.js";
 
 const { getSqliteFrom } =
   await import("../../../../../persistence/db-connection.js");
+const { clearStoredDb, setStoredDb } =
+  await import("../../../../../persistence/db-singleton.js");
+const { ensureInjectionEventsSchema } =
+  await import("../../../../../persistence/migrations/326-move-injection-events-to-memory-db.js");
 const { migrateActivationState } =
   await import("../../../../../persistence/migrations/232-activation-state.js");
 const { migrateMemoryV2InjectionEvents } =

--- a/assistant/src/plugins/defaults/memory/v2/harness/oracle.ts
+++ b/assistant/src/plugins/defaults/memory/v2/harness/oracle.ts
@@ -15,13 +15,11 @@
  * always excluded.
  */
 
-import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import type { DrizzleDb } from "../../../../../persistence/db-connection.js";
-import {
-  memoryV2ActivationLogs,
-  messages,
-} from "../../../../../persistence/schema/index.js";
+import { messages } from "../../../../../persistence/schema/index.js";
+import { memorySqliteOrNull } from "../../memory-db.js";
 import type {
   MemoryV2ConceptRowRecord,
   MemoryV2ConfigSnapshot,
@@ -68,41 +66,51 @@ export function extractOracleTurns(
   } = options;
 
   const allowedStatuses = new Set<string>(["injected", "in_context"]);
-  if (includeNotInjected) allowedStatuses.add("not_injected");
-
-  const filters = [
-    eq(memoryV2ActivationLogs.mode, "router"),
-    isNotNull(memoryV2ActivationLogs.messageId),
-  ];
-  if (conversationIds && conversationIds.length > 0) {
-    filters.push(
-      inArray(memoryV2ActivationLogs.conversationId, conversationIds),
-    );
+  if (includeNotInjected) {
+    allowedStatuses.add("not_injected");
   }
 
-  const rows = db
-    .select({
-      conversationId: memoryV2ActivationLogs.conversationId,
-      messageId: memoryV2ActivationLogs.messageId,
-      turn: memoryV2ActivationLogs.turn,
-      conceptsJson: memoryV2ActivationLogs.conceptsJson,
-      configJson: memoryV2ActivationLogs.configJson,
-      createdAt: memoryV2ActivationLogs.createdAt,
-    })
-    .from(memoryV2ActivationLogs)
-    .where(and(...filters))
-    .orderBy(
-      strategy === "random"
-        ? sql`RANDOM()`
-        : desc(memoryV2ActivationLogs.createdAt),
+  // The activation log lives in the dedicated memory database; the anchor
+  // lookup below stays on the main connection (`messages`). Fail-soft: no
+  // memory connection means no oracle turns.
+  const memoryRaw = memorySqliteOrNull("extractOracleTurns");
+  if (!memoryRaw) {
+    return [];
+  }
+
+  const params: (string | number)[] = [];
+  let where = `mode = 'router' AND message_id IS NOT NULL`;
+  if (conversationIds && conversationIds.length > 0) {
+    where += ` AND conversation_id IN (${conversationIds.map(() => "?").join(",")})`;
+    params.push(...conversationIds);
+  }
+  const orderBy = strategy === "random" ? "RANDOM()" : "created_at DESC";
+  params.push(limit);
+
+  const rows = memoryRaw
+    .query(
+      `SELECT conversation_id, message_id, turn, concepts_json, config_json,
+              created_at
+         FROM memory_v2_activation_logs
+        WHERE ${where}
+        ORDER BY ${orderBy}
+        LIMIT ?`,
     )
-    .limit(limit)
-    .all();
+    .all(...params) as Array<{
+    conversation_id: string;
+    message_id: string | null;
+    turn: number;
+    concepts_json: string;
+    config_json: string;
+    created_at: number;
+  }>;
 
   const turns: OracleTurn[] = [];
   for (const row of rows) {
-    const messageId = row.messageId;
-    if (messageId == null) continue;
+    const messageId = row.message_id;
+    if (messageId == null) {
+      continue;
+    }
 
     const anchor = db
       .select({ createdAt: messages.createdAt })
@@ -111,13 +119,15 @@ export function extractOracleTurns(
       .limit(1)
       .all();
     const anchorRow = anchor[0];
-    if (!anchorRow) continue;
+    if (!anchorRow) {
+      continue;
+    }
 
     let concepts: MemoryV2ConceptRowRecord[];
     let loggedConfig: MemoryV2ConfigSnapshot;
     try {
-      concepts = JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[];
-      loggedConfig = JSON.parse(row.configJson) as MemoryV2ConfigSnapshot;
+      concepts = JSON.parse(row.concepts_json) as MemoryV2ConceptRowRecord[];
+      loggedConfig = JSON.parse(row.config_json) as MemoryV2ConfigSnapshot;
     } catch {
       continue;
     }
@@ -125,22 +135,30 @@ export function extractOracleTurns(
     const seen = new Set<string>();
     const groundTruthSlugs: string[] = [];
     for (const concept of concepts) {
-      if (!allowedStatuses.has(concept.status)) continue;
-      if (pageExists && !pageExists(concept.slug)) continue;
-      if (seen.has(concept.slug)) continue;
+      if (!allowedStatuses.has(concept.status)) {
+        continue;
+      }
+      if (pageExists && !pageExists(concept.slug)) {
+        continue;
+      }
+      if (seen.has(concept.slug)) {
+        continue;
+      }
       seen.add(concept.slug);
       groundTruthSlugs.push(concept.slug);
     }
-    if (groundTruthSlugs.length === 0) continue;
+    if (groundTruthSlugs.length === 0) {
+      continue;
+    }
 
     turns.push({
-      conversationId: row.conversationId,
+      conversationId: row.conversation_id,
       turn: row.turn,
       anchorMessageId: messageId,
       anchorCreatedAt: anchorRow.createdAt,
       groundTruthSlugs,
       loggedConfig,
-      createdAt: row.createdAt,
+      createdAt: row.created_at,
     });
   }
 

--- a/assistant/src/plugins/defaults/memory/v2/harness/replay-input.ts
+++ b/assistant/src/plugins/defaults/memory/v2/harness/replay-input.ts
@@ -21,14 +21,12 @@
  */
 
 import type { ContentBlock } from "@vellumai/plugin-api";
-import { and, asc, desc, eq, lt, lte } from "drizzle-orm";
+import { and, desc, eq, lte } from "drizzle-orm";
 
 import type { AssistantConfig } from "../../../../../config/types.js";
 import type { DrizzleDb } from "../../../../../persistence/db-connection.js";
-import {
-  memoryV2ActivationLogs,
-  messages,
-} from "../../../../../persistence/schema/index.js";
+import { messages } from "../../../../../persistence/schema/index.js";
+import { memorySqliteOrNull } from "../../memory-db.js";
 import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
 import { loadNowText } from "../now-text.js";
 import type { RouterTurnPair } from "../router.js";
@@ -143,9 +141,13 @@ export async function reconstructInput(
     .all();
 
   const anchorPos = recent.findIndex((m) => m.id === turn.anchorMessageId);
-  if (anchorPos < 0) return null;
+  if (anchorPos < 0) {
+    return null;
+  }
   const beforeAnchor = recent.slice(anchorPos + 1);
-  if (beforeAnchor.length === 0) return null;
+  if (beforeAnchor.length === 0) {
+    return null;
+  }
 
   const plain: PlainMessage[] = beforeAnchor
     .slice()
@@ -154,7 +156,6 @@ export async function reconstructInput(
 
   const recentTurnPairs = extractRecentTurnPairs(plain, windowPairs);
   const priorEverInjected = reconstructPriorEverInjected(
-    db,
     turn.conversationId,
     turn.turn,
   );
@@ -197,38 +198,41 @@ const PRIOR_STATUSES = new Set<string>([
  * Union of slugs injected on earlier `mode='router'` turns in this conversation
  * (turn < `currentTurn`), each tagged with the earliest turn it appeared on —
  * the harness analogue of the running `everInjected` list production maintains.
+ * The activation log lives in the dedicated memory database; without that
+ * connection the prior state degrades to empty.
  */
 function reconstructPriorEverInjected(
-  db: DrizzleDb,
   conversationId: string,
   currentTurn: number,
 ): EverInjectedEntry[] {
-  const rows = db
-    .select({
-      turn: memoryV2ActivationLogs.turn,
-      conceptsJson: memoryV2ActivationLogs.conceptsJson,
-    })
-    .from(memoryV2ActivationLogs)
-    .where(
-      and(
-        eq(memoryV2ActivationLogs.conversationId, conversationId),
-        eq(memoryV2ActivationLogs.mode, "router"),
-        lt(memoryV2ActivationLogs.turn, currentTurn),
-      ),
+  const raw = memorySqliteOrNull("reconstructPriorEverInjected");
+  if (!raw) {
+    return [];
+  }
+  const rows = raw
+    .query(
+      `SELECT turn, concepts_json
+         FROM memory_v2_activation_logs
+        WHERE conversation_id = ? AND mode = 'router' AND turn < ?
+        ORDER BY turn ASC`,
     )
-    .orderBy(asc(memoryV2ActivationLogs.turn))
-    .all();
+    .all(conversationId, currentTurn) as Array<{
+    turn: number;
+    concepts_json: string;
+  }>;
 
   const firstTurnBySlug = new Map<string, number>();
   for (const row of rows) {
     let concepts: MemoryV2ConceptRowRecord[];
     try {
-      concepts = JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[];
+      concepts = JSON.parse(row.concepts_json) as MemoryV2ConceptRowRecord[];
     } catch {
       continue;
     }
     for (const concept of concepts) {
-      if (!PRIOR_STATUSES.has(concept.status)) continue;
+      if (!PRIOR_STATUSES.has(concept.status)) {
+        continue;
+      }
       if (!firstTurnBySlug.has(concept.slug)) {
         firstTurnBySlug.set(concept.slug, row.turn);
       }

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -53,13 +53,16 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
 import { loadRawConfig } from "../../../config/loader.js";
 import { LLMConfigBase } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
-import { getDb, getLogsDb } from "../../../persistence/db-connection.js";
+import {
+  getDb,
+  getLogsDb,
+  getMemorySqlite,
+} from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import {
   conversationKeys,
   conversations,
   llmRequestLogs,
-  memoryV2ActivationLogs,
   messages,
   providerConnections,
 } from "../../../persistence/schema/index.js";
@@ -106,7 +109,7 @@ function dispatchConversationLlmContext(queryParams: Record<string, string>) {
 function clearTables(): void {
   const db = getDb();
   getLogsDb()!.delete(llmRequestLogs).run();
-  db.delete(memoryV2ActivationLogs).run();
+  getMemorySqlite()!.exec(`DELETE FROM memory_v2_activation_logs`);
   db.delete(messages).run();
   db.delete(conversationKeys).run();
   db.delete(conversations).run();


### PR DESCRIPTION
## Summary
- Relocate the two per-turn memory log tables into assistant-memory.db via the staged-drain playbook (migrations 336/337), declaring dependsOn on their creator/backfill steps.
- Repoint the activation-log and recall-log stores, concept-frequency reader, harness, and debug route at the memory connection, fail-soft.

Part of plan: memory-db-wave1.md (PR 2 of 3)