### PR TITLE
fix(web): restore updateConfig in initial-connect retry controls

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -894,6 +894,7 @@ export function useLiveVoice(
                 release,
                 interrupt,
                 setMuted,
+                updateConfig,
               });
               console.warn(
                 `live-voice: initial connect failed (${err.reason}); retrying ` +


### PR DESCRIPTION
## Summary

`clients/web` typecheck is broken on `main`: `use-live-voice.ts:892` passes a controls object missing the `updateConfig` member that `LiveVoiceSessionControls` requires (added in #38089).

The v0.10.9 release merge (#38094) reintroduced the initial-connect retry `setControls` block without it — the other two `setControls` sites (lines ~569 and ~954) have it. The breakage went unnoticed because the CI Main Web run for the merge commit was cancelled and subsequent pushes didn't touch web paths, so the path-filtered workflow never re-ran.

One-line fix: add `updateConfig` to the retry-path controls, matching the other two call sites.

## Verification

`bunx tsc --noEmit` in `clients/web`: fails on main with exactly this one error; clean with this fix.

This also unblocks the web Type Check on any PR branched from current main (e.g. #37740).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->