### PR TITLE
fix(marketplace): undo v0.10.9 release-merge regression in plugins manifest

### DIFF
--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -97,81 +97,6 @@
       "license": "MIT"
     },
     {
-      "name": "agent-wrapped",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/agent-wrapped",
-        "ref": "1bfa2b9c0735662e4c493955a414b6b62136a380"
-      },
-      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
-      "category": "creative",
-      "license": "MIT",
-      "submittedBy": "marina",
-      "homepage": "https://agent-wrapped.com"
-    },
-    {
-      "name": "ai-hero-engineer-kit",
-      "source": {
-        "source": "github",
-        "repo": "marinatrajk/ai-hero-engineer-kit",
-        "ref": "18d33c62b15a3e2cc22dc070723fe3077749dcec"
-      },
-      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
-      "category": "developer",
-      "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
-      "license": "MIT"
-    },
-    {
-      "name": "amex-perk-reminder",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/amex-perk-reminder",
-        "ref": "48649b3e9f5c37153c7a8b2887a740eadd7c0b1e"
-      },
-      "description": "Track every credit on the Amex cards you hold (Platinum, Gold, Business Platinum, Delta Gold/Platinum/Reserve) with status-aware reminders before any window closes.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/AnitaKirkovska/amex-perk-reminder",
-      "license": "MIT"
-    },
-    {
-      "name": "astrology-horoscope",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/astrology-horoscope",
-        "ref": "d226ce2e0a021e12cbf89ca7313f7c76a0bd8e39"
-      },
-      "description": "Western tropical natal chart and transit computation. Local ephemeris (astronomy-engine, no API keys) for planet positions, ascendant/midheaven, whole-sign houses, and aspects, plus a natal-reading skill that interprets the raw chart into a readable report.",
-      "category": "hobby",
-      "homepage": "https://github.com/vellum-ai/astrology-horoscope",
-      "license": "MIT"
-    },
-    {
-      "name": "caveman",
-      "source": {
-        "source": "github",
-        "repo": "JuliusBrussee/caveman",
-        "ref": "63a91ecadbf4c4719a4602a5abb00883f9966034"
-      },
-      "description": "Ultra-compressed communication mode that strips filler words to cut token usage.",
-      "category": "productivity",
-      "homepage": "https://github.com/JuliusBrussee/caveman",
-      "license": "MIT",
-      "icon": "\ud83e\uddb4"
-    },
-    {
-      "name": "coffee-aficionado",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/coffee-aficionado",
-        "ref": "facd5a03979605edc894ea61e9a45f7b6a53214a"
-      },
-      "description": "Find great coffee beans and machines matched to your taste profile, budget, and kitchen. Persistent memory learns your preferences over time.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/vellum-ai/coffee-aficionado",
-      "license": "MIT",
-      "icon": "\u2615"
-    },
-    {
       "name": "cofounder",
       "source": {
         "source": "github",
@@ -181,7 +106,8 @@
       "description": "AI co-founder that remembers your company context, challenges your thinking, and tracks your decisions.",
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/cofounder",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "🤝"
     },
     {
       "name": "cognee",
@@ -262,66 +188,6 @@
       "icon": "🔍"
     },
     {
-      "name": "dynamic-notch",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/dynamic-notch",
-        "ref": "9729c3685d60d00d1de73a183b03122b9fa1f8f4"
-      },
-      "description": "Put your Vellum assistant inside your MacBook's notch: click to chat, hold Ctrl+Option to talk, and get a floating task bulb while it works, with live-streamed replies and per-sentence voice.",
-      "category": "interface",
-      "homepage": "https://github.com/AnitaKirkovska/dynamic-notch",
-      "license": "MIT"
-    },
-    {
-      "name": "family-briefing",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/family-briefing",
-        "ref": "145f341db7d06ffa81e2052033f187679b8bda4d"
-      },
-      "description": "Daily morning briefing for parents: merges family calendars, triages school emails, and detects scheduling conflicts.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/family-briefing",
-      "license": "MIT"
-    },
-    {
-      "name": "fitness-companion",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/fitness-companion",
-        "ref": "fe4e02e2b514207a37f2a7e9f9c500ec8a73edcb"
-      },
-      "description": "Fitness and nutrition companion. Logs meals, workouts, and weight; looks up nutrition data from OpenFoodFacts; calculates macro targets; and injects daily fitness context into every conversation.",
-      "category": "health",
-      "homepage": "https://github.com/vellum-ai/fitness-companion",
-      "license": "MIT"
-    },
-    {
-      "name": "git-workflow",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/git-workflow",
-        "ref": "829407aa93b63b8bca4717624533f2fc7f702a5d"
-      },
-      "description": "Git workflow tools and multi-perspective code review: branch management, push, stash, PR creation/review/merge/checkout, diffs, logs, changelog generation, and parallel subagent code review with confidence scoring.",
-      "category": "developer",
-      "homepage": "https://github.com/vellum-ai/git-workflow",
-      "license": "MIT"
-    },
-    {
-      "name": "google-drive-search",
-      "source": {
-        "source": "github",
-        "repo": "ZeebBoyBlue/google-drive-search",
-        "ref": "ddd5013477cc1ec8d1fb174db6b599dbfe1cca21"
-      },
-      "description": "Local full-text search across your Google Drive. Indexes file metadata and document content into SQLite FTS5 for instant, private search.",
-      "category": "productivity",
-      "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
-      "license": "Apache-2.0"
-    },
-    {
       "name": "influencer-marketing",
       "source": {
         "source": "github",
@@ -336,186 +202,6 @@
     },
     {
       "name": "kitchen-companion",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/kitchen-companion",
-        "ref": "b6ebdda6992dfa1fd2186a600a642f538fb64584"
-      },
-      "description": "Full kitchen companion. Scan your fridge with a photo to stock a pantry inventory and get 3 makeable-now recipes, get alerts before food expires, clip recipes from any URL into a clean format, and generate meal plans with grocery lists from what you actually have.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/vellum-ai/kitchen-companion",
-      "license": "MIT"
-    },
-    {
-      "name": "level-up",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/level-up",
-        "ref": "d3cbb50f8aba1f8320cd2d59ea3a85d0a4e9210b"
-      },
-      "description": "Surfaces a first-class \"Level Up\" diff card whenever the assistant edits its own skills or plugins, so you can see how it improved itself after the fact.",
-      "category": "developer",
-      "homepage": "https://github.com/vellum-ai/level-up",
-      "license": "MIT"
-    },
-    {
-      "name": "marketing-expert",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/marketing-expert",
-        "ref": "6a85ee33e184c2be56ed63cd5681d1287a941eff"
-      },
-      "description": "Acts as a full-stack marketing expert for any business (B2B or B2C): an on-demand persona plus playbook skills (positioning, demand planning, launches, content & copywriting, brand voice, email sequences, SEO & GEO, competitive teardown, board reporting) and deterministic funnel/positioning/GTM/competitive tools.",
-      "category": "marketing",
-      "homepage": "https://github.com/vellum-ai/marketing-expert",
-      "license": "MIT"
-    },
-    {
-      "name": "model-router",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/model-router",
-        "ref": "605100d27b5333b243ada5a29fcb324e2217d336"
-      },
-      "description": "Routes each user-facing message to one of your workspace's inference profiles, so model selection can vary per call instead of staying pinned to a single profile.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/model-router",
-      "license": "MIT"
-    },
-    {
-      "name": "motion-design",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/motion-design",
-        "ref": "9cdc798c26e0141dcdf6887d7707559c38bfe00e"
-      },
-      "description": "Teaches the assistant to build polished UI animations with Motion (motion.dev) for React: animated product mockups, chat replays, typing effects, and staggered reveals, with a complete animated chat example included.",
-      "category": "creative",
-      "homepage": "https://github.com/vellum-ai/motion-design",
-      "license": "MIT"
-    },
-    {
-      "name": "originkit",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/originkit",
-        "ref": "9aa260c2561ad9e765832dc342e9bbb5138858a4"
-      },
-      "description": "Browse and import animated UI components from Originkit, a free library of 50 animated components. Browse by category or search term without an API key; fetch component source code (React, Next.js, Vite, Framer) with a free key from originkit.dev.",
-      "category": "productivity",
-      "homepage": "https://github.com/vellum-ai/originkit",
-      "license": "MIT"
-    },
-    {
-      "name": "personal-finance",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/personal-finance",
-        "ref": "f8f9bfba3d86c943001da894b920e7e867507dd4"
-      },
-      "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/personal-finance",
-      "license": "MIT"
-    },
-    {
-      "name": "plant-doctor",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/plant-doctor",
-        "ref": "1115ac07a5b7f731600f037b743e011a84bd0597"
-      },
-      "description": "Diagnose plants from photos. Identifies the species, assesses health with visible evidence, and returns a care plan. Named plants get a persistent checkup history so you can track whether they are improving.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/vellum-ai/plant-doctor",
-      "license": "MIT"
-    },
-    {
-      "name": "polyglot",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/polyglot",
-        "ref": "ab607b7c60b64b0ac5c6bf01609840a004cfd002"
-      },
-      "description": "Ambient language acquisition through your assistant. Three graduated modes (practice, ambient, immersive) weave a target language into your real conversations, with SM-2 spaced repetition, error-pattern tracking, and CEFR level history.",
-      "category": "education",
-      "homepage": "https://github.com/vellum-ai/polyglot",
-      "license": "MIT"
-    },
-    {
-      "name": "proactive-slacks",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/proactive-slacks",
-        "ref": "a5dd35699455ae7a2db3d2243511a8c7edc49aea"
-      },
-      "description": "Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
-      "license": "MIT"
-    },
-    {
-      "name": "reading-pal",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/reading-pal",
-        "ref": "5219474719e67db7ea64848f6bd2a0b7312e4f27"
-      },
-      "description": "Your reading life in one plugin. Track your TBR pile, get guilt-tripped about your backlog, find your next read, and sync from Goodreads.",
-      "category": "hobby",
-      "homepage": "https://github.com/vellum-ai/reading-pal",
-      "license": "MIT"
-    },
-    {
-      "name": "simple-memory",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/simple-memory",
-        "ref": "ed09a4c01bf18e4ac8859faee94cb65c7cbd1ca3"
-      },
-      "description": "Reference memory plugin that exercises the full plugin API with low-cost variants of Vellum's memory defaults.",
-      "category": "memory",
-      "homepage": "https://github.com/vellum-ai/simple-memory",
-      "license": "MIT"
-    },
-    {
-      "name": "smb-inbox-brief",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/smb-inbox-brief",
-        "ref": "8e298bd8ded5e0e16c5160edcd547eda1e4d222f"
-      },
-      "description": "Find urgent replies, overdue invoices, quotes, and customer follow-ups before they slip. Scans email, logs business items, delivers urgency-ranked daily briefs.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
-      "license": "MIT"
-    },
-    {
-      "name": "tennis-companion",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/tennis-companion",
-        "ref": "1c6d2bd448ee7b5285d37cfee4e0e413522746d1"
-      },
-      "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
-      "category": "health",
-      "homepage": "https://github.com/vellum-ai/tennis-companion",
-      "license": "MIT"
-    },
-    {
-      "name": "travel-planner",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/travel-planner",
-        "ref": "10c2c4878b017997cb6766b8204b9803c56bc6cf"
-      },
-      "description": "A travel EA for your assistant. Remembers how you travel (carrier, miles, hotel budget, card benefits), keeps per-trip records, watches Gmail for booking changes, syncs your calendar, and emails an EA-style trip brief 48 hours before departure.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/AnitaKirkovska/travel-planner",
-      "license": "MIT"
-    },
-    {
-      "name": "vellum-client-qa",
       "source": {
         "source": "github",
         "repo": "vellum-ai/kitchen-companion",
@@ -580,6 +266,149 @@
       "icon": "🎬"
     },
     {
+      "name": "originkit",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/originkit",
+        "ref": "9aa260c2561ad9e765832dc342e9bbb5138858a4"
+      },
+      "description": "Browse and import animated UI components from Originkit, a free library of 50 animated components. Browse by category or search term without an API key; fetch component source code (React, Next.js, Vite, Framer) with a free key from originkit.dev.",
+      "category": "productivity",
+      "homepage": "https://github.com/vellum-ai/originkit",
+      "license": "MIT",
+      "icon": "🧱"
+    },
+    {
+      "name": "personal-finance",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/personal-finance",
+        "ref": "f8f9bfba3d86c943001da894b920e7e867507dd4"
+      },
+      "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
+      "category": "productivity",
+      "homepage": "https://github.com/AnitaKirkovska/personal-finance",
+      "license": "MIT",
+      "icon": "💰"
+    },
+    {
+      "name": "plant-doctor",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/plant-doctor",
+        "ref": "1115ac07a5b7f731600f037b743e011a84bd0597"
+      },
+      "description": "Diagnose plants from photos. Identifies the species, assesses health with visible evidence, and returns a care plan. Named plants get a persistent checkup history so you can track whether they are improving.",
+      "category": "lifestyle",
+      "homepage": "https://github.com/vellum-ai/plant-doctor",
+      "license": "MIT",
+      "icon": "🪴"
+    },
+    {
+      "name": "polyglot",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/polyglot",
+        "ref": "ab607b7c60b64b0ac5c6bf01609840a004cfd002"
+      },
+      "description": "Ambient language acquisition through your assistant. Three graduated modes (practice, ambient, immersive) weave a target language into your real conversations, with SM-2 spaced repetition, error-pattern tracking, and CEFR level history.",
+      "category": "education",
+      "homepage": "https://github.com/vellum-ai/polyglot",
+      "license": "MIT",
+      "icon": "🗣️"
+    },
+    {
+      "name": "proactive-slacks",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/proactive-slacks",
+        "ref": "a5dd35699455ae7a2db3d2243511a8c7edc49aea"
+      },
+      "description": "Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.",
+      "category": "productivity",
+      "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
+      "license": "MIT",
+      "icon": "💬"
+    },
+    {
+      "name": "reading-pal",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/reading-pal",
+        "ref": "5219474719e67db7ea64848f6bd2a0b7312e4f27"
+      },
+      "description": "Your reading life in one plugin. Track your TBR pile, get guilt-tripped about your backlog, find your next read, and sync from Goodreads.",
+      "category": "hobby",
+      "homepage": "https://github.com/vellum-ai/reading-pal",
+      "license": "MIT",
+      "icon": "📚"
+    },
+    {
+      "name": "simple-memory",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/simple-memory",
+        "ref": "ed09a4c01bf18e4ac8859faee94cb65c7cbd1ca3"
+      },
+      "description": "Reference memory plugin that exercises the full plugin API with low-cost variants of Vellum's memory defaults.",
+      "category": "memory",
+      "homepage": "https://github.com/vellum-ai/simple-memory",
+      "license": "MIT",
+      "icon": "🧠"
+    },
+    {
+      "name": "smb-inbox-brief",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/smb-inbox-brief",
+        "ref": "8e298bd8ded5e0e16c5160edcd547eda1e4d222f"
+      },
+      "description": "Find urgent replies, overdue invoices, quotes, and customer follow-ups before they slip. Scans email, logs business items, delivers urgency-ranked daily briefs.",
+      "category": "productivity",
+      "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
+      "license": "MIT",
+      "icon": "📧"
+    },
+    {
+      "name": "tennis-companion",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/tennis-companion",
+        "ref": "1c6d2bd448ee7b5285d37cfee4e0e413522746d1"
+      },
+      "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
+      "category": "health",
+      "homepage": "https://github.com/vellum-ai/tennis-companion",
+      "license": "MIT",
+      "icon": "🎾"
+    },
+    {
+      "name": "travel-planner",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/travel-planner",
+        "ref": "10c2c4878b017997cb6766b8204b9803c56bc6cf"
+      },
+      "description": "A travel EA for your assistant. Remembers how you travel (carrier, miles, hotel budget, card benefits), keeps per-trip records, watches Gmail for booking changes, syncs your calendar, and emails an EA-style trip brief 48 hours before departure.",
+      "category": "lifestyle",
+      "homepage": "https://github.com/AnitaKirkovska/travel-planner",
+      "license": "MIT",
+      "icon": "✈️"
+    },
+    {
+      "name": "vellum-client-qa",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/vellum-client-qa",
+        "ref": "4f559d865eaa04b68285f8e4fae4a05fc18fe88f"
+      },
+      "description": "Cross-platform QA rig for vellum-assistant clients: mock the platform backend, boot the real chat UI, and verify feature branches in headless Chromium (web), an iOS simulator, or Electron with screenshot and video proof.",
+      "category": "developer",
+      "homepage": "https://github.com/vellum-ai/vellum-client-qa",
+      "license": "MIT",
+      "icon": "🧪"
+    },
+    {
       "name": "writing-coach",
       "source": {
         "source": "github",
@@ -589,7 +418,8 @@
       "description": "A writing coach in your pocket. Daily prompts that escalate with your streak, savage-but-constructive draft roasts, query letter critiques, and a word count enforcer that guilt-trips you when you skip.",
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/writing-coach",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "✍️"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -97,81 +97,6 @@
       "license": "MIT"
     },
     {
-      "name": "agent-wrapped",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/agent-wrapped",
-        "ref": "1bfa2b9c0735662e4c493955a414b6b62136a380"
-      },
-      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
-      "category": "creative",
-      "license": "MIT",
-      "submittedBy": "marina",
-      "homepage": "https://agent-wrapped.com"
-    },
-    {
-      "name": "ai-hero-engineer-kit",
-      "source": {
-        "source": "github",
-        "repo": "marinatrajk/ai-hero-engineer-kit",
-        "ref": "18d33c62b15a3e2cc22dc070723fe3077749dcec"
-      },
-      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
-      "category": "developer",
-      "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
-      "license": "MIT"
-    },
-    {
-      "name": "amex-perk-reminder",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/amex-perk-reminder",
-        "ref": "48649b3e9f5c37153c7a8b2887a740eadd7c0b1e"
-      },
-      "description": "Track every credit on the Amex cards you hold (Platinum, Gold, Business Platinum, Delta Gold/Platinum/Reserve) with status-aware reminders before any window closes.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/AnitaKirkovska/amex-perk-reminder",
-      "license": "MIT"
-    },
-    {
-      "name": "astrology-horoscope",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/astrology-horoscope",
-        "ref": "d226ce2e0a021e12cbf89ca7313f7c76a0bd8e39"
-      },
-      "description": "Western tropical natal chart and transit computation. Local ephemeris (astronomy-engine, no API keys) for planet positions, ascendant/midheaven, whole-sign houses, and aspects, plus a natal-reading skill that interprets the raw chart into a readable report.",
-      "category": "hobby",
-      "homepage": "https://github.com/vellum-ai/astrology-horoscope",
-      "license": "MIT"
-    },
-    {
-      "name": "caveman",
-      "source": {
-        "source": "github",
-        "repo": "JuliusBrussee/caveman",
-        "ref": "63a91ecadbf4c4719a4602a5abb00883f9966034"
-      },
-      "description": "Ultra-compressed communication mode that strips filler words to cut token usage.",
-      "category": "productivity",
-      "homepage": "https://github.com/JuliusBrussee/caveman",
-      "license": "MIT",
-      "icon": "\ud83e\uddb4"
-    },
-    {
-      "name": "coffee-aficionado",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/coffee-aficionado",
-        "ref": "facd5a03979605edc894ea61e9a45f7b6a53214a"
-      },
-      "description": "Find great coffee beans and machines matched to your taste profile, budget, and kitchen. Persistent memory learns your preferences over time.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/vellum-ai/coffee-aficionado",
-      "license": "MIT",
-      "icon": "\u2615"
-    },
-    {
       "name": "cofounder",
       "source": {
         "source": "github",
@@ -181,7 +106,8 @@
       "description": "AI co-founder that remembers your company context, challenges your thinking, and tracks your decisions.",
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/cofounder",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "🤝"
     },
     {
       "name": "cognee",
@@ -262,66 +188,6 @@
       "icon": "🔍"
     },
     {
-      "name": "dynamic-notch",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/dynamic-notch",
-        "ref": "9729c3685d60d00d1de73a183b03122b9fa1f8f4"
-      },
-      "description": "Put your Vellum assistant inside your MacBook's notch: click to chat, hold Ctrl+Option to talk, and get a floating task bulb while it works, with live-streamed replies and per-sentence voice.",
-      "category": "interface",
-      "homepage": "https://github.com/AnitaKirkovska/dynamic-notch",
-      "license": "MIT"
-    },
-    {
-      "name": "family-briefing",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/family-briefing",
-        "ref": "145f341db7d06ffa81e2052033f187679b8bda4d"
-      },
-      "description": "Daily morning briefing for parents: merges family calendars, triages school emails, and detects scheduling conflicts.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/family-briefing",
-      "license": "MIT"
-    },
-    {
-      "name": "fitness-companion",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/fitness-companion",
-        "ref": "fe4e02e2b514207a37f2a7e9f9c500ec8a73edcb"
-      },
-      "description": "Fitness and nutrition companion. Logs meals, workouts, and weight; looks up nutrition data from OpenFoodFacts; calculates macro targets; and injects daily fitness context into every conversation.",
-      "category": "health",
-      "homepage": "https://github.com/vellum-ai/fitness-companion",
-      "license": "MIT"
-    },
-    {
-      "name": "git-workflow",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/git-workflow",
-        "ref": "829407aa93b63b8bca4717624533f2fc7f702a5d"
-      },
-      "description": "Git workflow tools and multi-perspective code review: branch management, push, stash, PR creation/review/merge/checkout, diffs, logs, changelog generation, and parallel subagent code review with confidence scoring.",
-      "category": "developer",
-      "homepage": "https://github.com/vellum-ai/git-workflow",
-      "license": "MIT"
-    },
-    {
-      "name": "google-drive-search",
-      "source": {
-        "source": "github",
-        "repo": "ZeebBoyBlue/google-drive-search",
-        "ref": "ddd5013477cc1ec8d1fb174db6b599dbfe1cca21"
-      },
-      "description": "Local full-text search across your Google Drive. Indexes file metadata and document content into SQLite FTS5 for instant, private search.",
-      "category": "productivity",
-      "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
-      "license": "Apache-2.0"
-    },
-    {
       "name": "influencer-marketing",
       "source": {
         "source": "github",
@@ -336,186 +202,6 @@
     },
     {
       "name": "kitchen-companion",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/kitchen-companion",
-        "ref": "b6ebdda6992dfa1fd2186a600a642f538fb64584"
-      },
-      "description": "Full kitchen companion. Scan your fridge with a photo to stock a pantry inventory and get 3 makeable-now recipes, get alerts before food expires, clip recipes from any URL into a clean format, and generate meal plans with grocery lists from what you actually have.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/vellum-ai/kitchen-companion",
-      "license": "MIT"
-    },
-    {
-      "name": "level-up",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/level-up",
-        "ref": "d3cbb50f8aba1f8320cd2d59ea3a85d0a4e9210b"
-      },
-      "description": "Surfaces a first-class \"Level Up\" diff card whenever the assistant edits its own skills or plugins, so you can see how it improved itself after the fact.",
-      "category": "developer",
-      "homepage": "https://github.com/vellum-ai/level-up",
-      "license": "MIT"
-    },
-    {
-      "name": "marketing-expert",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/marketing-expert",
-        "ref": "6a85ee33e184c2be56ed63cd5681d1287a941eff"
-      },
-      "description": "Acts as a full-stack marketing expert for any business (B2B or B2C): an on-demand persona plus playbook skills (positioning, demand planning, launches, content & copywriting, brand voice, email sequences, SEO & GEO, competitive teardown, board reporting) and deterministic funnel/positioning/GTM/competitive tools.",
-      "category": "marketing",
-      "homepage": "https://github.com/vellum-ai/marketing-expert",
-      "license": "MIT"
-    },
-    {
-      "name": "model-router",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/model-router",
-        "ref": "605100d27b5333b243ada5a29fcb324e2217d336"
-      },
-      "description": "Routes each user-facing message to one of your workspace's inference profiles, so model selection can vary per call instead of staying pinned to a single profile.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/model-router",
-      "license": "MIT"
-    },
-    {
-      "name": "motion-design",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/motion-design",
-        "ref": "9cdc798c26e0141dcdf6887d7707559c38bfe00e"
-      },
-      "description": "Teaches the assistant to build polished UI animations with Motion (motion.dev) for React: animated product mockups, chat replays, typing effects, and staggered reveals, with a complete animated chat example included.",
-      "category": "creative",
-      "homepage": "https://github.com/vellum-ai/motion-design",
-      "license": "MIT"
-    },
-    {
-      "name": "originkit",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/originkit",
-        "ref": "9aa260c2561ad9e765832dc342e9bbb5138858a4"
-      },
-      "description": "Browse and import animated UI components from Originkit, a free library of 50 animated components. Browse by category or search term without an API key; fetch component source code (React, Next.js, Vite, Framer) with a free key from originkit.dev.",
-      "category": "productivity",
-      "homepage": "https://github.com/vellum-ai/originkit",
-      "license": "MIT"
-    },
-    {
-      "name": "personal-finance",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/personal-finance",
-        "ref": "f8f9bfba3d86c943001da894b920e7e867507dd4"
-      },
-      "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/personal-finance",
-      "license": "MIT"
-    },
-    {
-      "name": "plant-doctor",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/plant-doctor",
-        "ref": "1115ac07a5b7f731600f037b743e011a84bd0597"
-      },
-      "description": "Diagnose plants from photos. Identifies the species, assesses health with visible evidence, and returns a care plan. Named plants get a persistent checkup history so you can track whether they are improving.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/vellum-ai/plant-doctor",
-      "license": "MIT"
-    },
-    {
-      "name": "polyglot",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/polyglot",
-        "ref": "ab607b7c60b64b0ac5c6bf01609840a004cfd002"
-      },
-      "description": "Ambient language acquisition through your assistant. Three graduated modes (practice, ambient, immersive) weave a target language into your real conversations, with SM-2 spaced repetition, error-pattern tracking, and CEFR level history.",
-      "category": "education",
-      "homepage": "https://github.com/vellum-ai/polyglot",
-      "license": "MIT"
-    },
-    {
-      "name": "proactive-slacks",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/proactive-slacks",
-        "ref": "a5dd35699455ae7a2db3d2243511a8c7edc49aea"
-      },
-      "description": "Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
-      "license": "MIT"
-    },
-    {
-      "name": "reading-pal",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/reading-pal",
-        "ref": "5219474719e67db7ea64848f6bd2a0b7312e4f27"
-      },
-      "description": "Your reading life in one plugin. Track your TBR pile, get guilt-tripped about your backlog, find your next read, and sync from Goodreads.",
-      "category": "hobby",
-      "homepage": "https://github.com/vellum-ai/reading-pal",
-      "license": "MIT"
-    },
-    {
-      "name": "simple-memory",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/simple-memory",
-        "ref": "ed09a4c01bf18e4ac8859faee94cb65c7cbd1ca3"
-      },
-      "description": "Reference memory plugin that exercises the full plugin API with low-cost variants of Vellum's memory defaults.",
-      "category": "memory",
-      "homepage": "https://github.com/vellum-ai/simple-memory",
-      "license": "MIT"
-    },
-    {
-      "name": "smb-inbox-brief",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/smb-inbox-brief",
-        "ref": "8e298bd8ded5e0e16c5160edcd547eda1e4d222f"
-      },
-      "description": "Find urgent replies, overdue invoices, quotes, and customer follow-ups before they slip. Scans email, logs business items, delivers urgency-ranked daily briefs.",
-      "category": "productivity",
-      "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
-      "license": "MIT"
-    },
-    {
-      "name": "tennis-companion",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/tennis-companion",
-        "ref": "1c6d2bd448ee7b5285d37cfee4e0e413522746d1"
-      },
-      "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
-      "category": "health",
-      "homepage": "https://github.com/vellum-ai/tennis-companion",
-      "license": "MIT"
-    },
-    {
-      "name": "travel-planner",
-      "source": {
-        "source": "github",
-        "repo": "AnitaKirkovska/travel-planner",
-        "ref": "10c2c4878b017997cb6766b8204b9803c56bc6cf"
-      },
-      "description": "A travel EA for your assistant. Remembers how you travel (carrier, miles, hotel budget, card benefits), keeps per-trip records, watches Gmail for booking changes, syncs your calendar, and emails an EA-style trip brief 48 hours before departure.",
-      "category": "lifestyle",
-      "homepage": "https://github.com/AnitaKirkovska/travel-planner",
-      "license": "MIT"
-    },
-    {
-      "name": "vellum-client-qa",
       "source": {
         "source": "github",
         "repo": "vellum-ai/kitchen-companion",
@@ -580,6 +266,149 @@
       "icon": "🎬"
     },
     {
+      "name": "originkit",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/originkit",
+        "ref": "9aa260c2561ad9e765832dc342e9bbb5138858a4"
+      },
+      "description": "Browse and import animated UI components from Originkit, a free library of 50 animated components. Browse by category or search term without an API key; fetch component source code (React, Next.js, Vite, Framer) with a free key from originkit.dev.",
+      "category": "productivity",
+      "homepage": "https://github.com/vellum-ai/originkit",
+      "license": "MIT",
+      "icon": "🧱"
+    },
+    {
+      "name": "personal-finance",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/personal-finance",
+        "ref": "f8f9bfba3d86c943001da894b920e7e867507dd4"
+      },
+      "description": "Track expenses, income, recurring bills, and savings funds from your assistant. Multi-currency, receipt OCR, Plaid bank sync, and financial summaries. All data stored locally in SQLite.",
+      "category": "productivity",
+      "homepage": "https://github.com/AnitaKirkovska/personal-finance",
+      "license": "MIT",
+      "icon": "💰"
+    },
+    {
+      "name": "plant-doctor",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/plant-doctor",
+        "ref": "1115ac07a5b7f731600f037b743e011a84bd0597"
+      },
+      "description": "Diagnose plants from photos. Identifies the species, assesses health with visible evidence, and returns a care plan. Named plants get a persistent checkup history so you can track whether they are improving.",
+      "category": "lifestyle",
+      "homepage": "https://github.com/vellum-ai/plant-doctor",
+      "license": "MIT",
+      "icon": "🪴"
+    },
+    {
+      "name": "polyglot",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/polyglot",
+        "ref": "ab607b7c60b64b0ac5c6bf01609840a004cfd002"
+      },
+      "description": "Ambient language acquisition through your assistant. Three graduated modes (practice, ambient, immersive) weave a target language into your real conversations, with SM-2 spaced repetition, error-pattern tracking, and CEFR level history.",
+      "category": "education",
+      "homepage": "https://github.com/vellum-ai/polyglot",
+      "license": "MIT",
+      "icon": "🗣️"
+    },
+    {
+      "name": "proactive-slacks",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/proactive-slacks",
+        "ref": "a5dd35699455ae7a2db3d2243511a8c7edc49aea"
+      },
+      "description": "Let your assistant reach you on Slack on purpose. Route notifications by topic to the right channel at the right volume, with heartbeat-based change detection so it only pings when something actually changed.",
+      "category": "productivity",
+      "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
+      "license": "MIT",
+      "icon": "💬"
+    },
+    {
+      "name": "reading-pal",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/reading-pal",
+        "ref": "5219474719e67db7ea64848f6bd2a0b7312e4f27"
+      },
+      "description": "Your reading life in one plugin. Track your TBR pile, get guilt-tripped about your backlog, find your next read, and sync from Goodreads.",
+      "category": "hobby",
+      "homepage": "https://github.com/vellum-ai/reading-pal",
+      "license": "MIT",
+      "icon": "📚"
+    },
+    {
+      "name": "simple-memory",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/simple-memory",
+        "ref": "ed09a4c01bf18e4ac8859faee94cb65c7cbd1ca3"
+      },
+      "description": "Reference memory plugin that exercises the full plugin API with low-cost variants of Vellum's memory defaults.",
+      "category": "memory",
+      "homepage": "https://github.com/vellum-ai/simple-memory",
+      "license": "MIT",
+      "icon": "🧠"
+    },
+    {
+      "name": "smb-inbox-brief",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/smb-inbox-brief",
+        "ref": "8e298bd8ded5e0e16c5160edcd547eda1e4d222f"
+      },
+      "description": "Find urgent replies, overdue invoices, quotes, and customer follow-ups before they slip. Scans email, logs business items, delivers urgency-ranked daily briefs.",
+      "category": "productivity",
+      "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
+      "license": "MIT",
+      "icon": "📧"
+    },
+    {
+      "name": "tennis-companion",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/tennis-companion",
+        "ref": "1c6d2bd448ee7b5285d37cfee4e0e413522746d1"
+      },
+      "description": "Tennis journal, drill sessions, court finder, and progress tracking. Log matches with opponent tendencies, generate 30-minute practice sessions with progressions, find nearby courts via OpenStreetMap, and track win rate by surface and conditions.",
+      "category": "health",
+      "homepage": "https://github.com/vellum-ai/tennis-companion",
+      "license": "MIT",
+      "icon": "🎾"
+    },
+    {
+      "name": "travel-planner",
+      "source": {
+        "source": "github",
+        "repo": "AnitaKirkovska/travel-planner",
+        "ref": "10c2c4878b017997cb6766b8204b9803c56bc6cf"
+      },
+      "description": "A travel EA for your assistant. Remembers how you travel (carrier, miles, hotel budget, card benefits), keeps per-trip records, watches Gmail for booking changes, syncs your calendar, and emails an EA-style trip brief 48 hours before departure.",
+      "category": "lifestyle",
+      "homepage": "https://github.com/AnitaKirkovska/travel-planner",
+      "license": "MIT",
+      "icon": "✈️"
+    },
+    {
+      "name": "vellum-client-qa",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/vellum-client-qa",
+        "ref": "4f559d865eaa04b68285f8e4fae4a05fc18fe88f"
+      },
+      "description": "Cross-platform QA rig for vellum-assistant clients: mock the platform backend, boot the real chat UI, and verify feature branches in headless Chromium (web), an iOS simulator, or Electron with screenshot and video proof.",
+      "category": "developer",
+      "homepage": "https://github.com/vellum-ai/vellum-client-qa",
+      "license": "MIT",
+      "icon": "🧪"
+    },
+    {
       "name": "writing-coach",
       "source": {
         "source": "github",
@@ -589,7 +418,8 @@
       "description": "A writing coach in your pocket. Daily prompts that escalate with your streak, savage-but-constructive draft roasts, query letter critiques, and a word count enforcer that guilt-trips you when you skip.",
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/writing-coach",
-      "license": "MIT"
+      "license": "MIT",
+      "icon": "✍️"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Assistant CI has been red on `main` since the v0.10.9 release merge (#38094): `plugin-catalog-local.test.ts` expects one catalog match per manifest entry, but the merge left `plugins/marketplace.json` with 47 entries for 32 unique plugins.

The merge replaced the manifest with stale release-branch content interleaved with current entries:
- **15 duplicated plugins** — and since the catalog keeps the *first* occurrence per name, several dupes shadow the newer entry, so the served catalog regressed to stale pins (e.g. `agent-wrapped` lost its #38087 repin).
- **14 singletons lost their curated icons** from #38079 / #38084 (e.g. `cofounder`, `kitchen-companion`, `simple-memory`).

## Fix

Restore `plugins/marketplace.json` to its pre-merge state (`98db61e0be` — same 32-plugin set, curated icons, current pins; verified the name sets are identical, so no plugin is added or removed) and re-run `meta/sync-bundled-copies.ts` to regenerate `assistant/src/cli/lib/bundled-marketplace.json`.

## Verification

- `bun test src/cli/lib/__tests__/plugin-catalog-local.test.ts`: 4 pass / 0 fail (was 3/1).
- Manifest and bundled copy both back to 32 entries, 32 unique.

Sibling main-CI fix: #38111 (web typecheck, also broken by the same release merge). Together they unblock CI for PRs branched from current main (e.g. #37740).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->