### PR TITLE
fix: post-review docs and best-effort alignment for wave-1 table moves

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -235,7 +235,7 @@ export async function runDaemon(): Promise<void> {
     } else {
       setDbMigrationFailed();
       log.error(
-        "Daemon startup: DB opened but one or more migrations failed — /readyz will remain unready",
+        "Daemon startup: DB opened but one or more migrations failed or were deferred — /readyz will remain unready",
       );
     }
     // Migrations have settled (successfully or in the failed degraded mode),

--- a/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
@@ -26,10 +26,9 @@ export const ACTIVATION_SESSIONS_RELOCATION: RelocationSpec = {
 /**
  * Create the `activation_sessions` table on the memory connection. Idempotent
  * (`IF NOT EXISTS`) — the dedicated connection itself performs no DDL on open,
- * so this migration owns the schema. Exported so tests can stand up the
- * memory-side schema without running the full drain.
+ * so this migration owns the schema.
  */
-export function ensureActivationSessionsSchema(memoryRaw: Database): void {
+function ensureActivationSessionsSchema(memoryRaw: Database): void {
   memoryRaw.exec(/*sql*/ `
     CREATE TABLE IF NOT EXISTS activation_sessions (
       conversation_id TEXT PRIMARY KEY,

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -170,6 +170,10 @@ export const llmRequestLogs = sqliteTable(
   ],
 );
 
+// Per-turn diagnostics for memory recall, recording hit counts, latency,
+// and the injected text. Lives in the dedicated memory database
+// (`assistant-memory.db`), not main — access it via the memory connection
+// (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryRecallLogs = sqliteTable(
   "memory_recall_logs",
   {
@@ -202,6 +206,9 @@ export const memoryRecallLogs = sqliteTable(
   ],
 );
 
+// Per-turn log of memory-v2 concept/skill activations. Lives in the
+// dedicated memory database (`assistant-memory.db`), not main — access it
+// via the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryV2ActivationLogs = sqliteTable(
   "memory_v2_activation_logs",
   {
@@ -277,6 +284,8 @@ export const llmUsageEvents = sqliteTable(
 // One row per conversation started on the activation-rail bootstrap template.
 // Lets the activation funnel telemetry scope its events to activation
 // conversations without inspecting the bootstrap template at emit time.
+// Lives in the dedicated memory database (`assistant-memory.db`), not main —
+// access it via the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const activationSessions = sqliteTable("activation_sessions", {
   conversationId: text("conversation_id").primaryKey(),
   createdAt: integer("created_at").notNull(),

--- a/assistant/src/persistence/schema/memory-injection.ts
+++ b/assistant/src/persistence/schema/memory-injection.ts
@@ -44,6 +44,8 @@ export const memoryV3EverInjected = sqliteTable(
 );
 
 // Per-turn log of which memory-v3 cards were selected, with lane attribution.
+// Lives in the dedicated memory database (`assistant-memory.db`), not main —
+// access it via the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryV3Selections = sqliteTable(
   "memory_v3_selections",
   {

--- a/assistant/src/plugins/defaults/memory/memory-db.ts
+++ b/assistant/src/plugins/defaults/memory/memory-db.ts
@@ -5,9 +5,9 @@ const log = getLogger("memory-db");
 
 /**
  * The plugin's accessor for the dedicated memory database
- * (`assistant-memory.db`), where the memory plugin's relocated tables live
- * (`memory_v2_injection_events`, `memory_v3_selections`,
- * `activation_sessions`, with more to follow).
+ * (`assistant-memory.db`), where the memory plugin's relocated tables live.
+ * The `move-*-to-memory-db` migrations in `persistence/migrations/` define
+ * the current set of relocated tables.
  *
  * Fail-soft: returns `null` when the file cannot be opened, logging a warn
  * tagged with the calling context. Callers degrade rather than throw — the

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -526,8 +526,8 @@ export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
 
 /**
  * Write the attributed selection rows to `memory_v3_selections` over the
- * dedicated memory connection. Best-effort: an unavailable memory database
- * drops the turn's log rows rather than affecting the turn.
+ * dedicated memory connection. Best-effort: an unavailable memory database or
+ * a failed write drops the turn's log rows rather than affecting the turn.
  */
 export function writeSelections(
   conversationId: string,
@@ -537,33 +537,37 @@ export function writeSelections(
   if (rows.length === 0) {
     return;
   }
-  const raw = memorySqliteOrNull("writeSelections");
-  if (!raw) {
-    return;
-  }
-  // PK is (conversation_id, turn, slug); OR REPLACE keeps the write
-  // idempotent if the same turn is observed twice (e.g. a retried turn).
-  // `message_id` is written NULL here (the assistant message does not exist at
-  // injection time) and stamped at turn end by
-  // `backfillMemoryV3SelectionMessageId`.
-  const stmt = raw.query(/*sql*/ `
-    INSERT OR REPLACE INTO memory_v3_selections (
-      conversation_id, turn, slug, source, pinned, created_at,
-      message_id, section_ordinal, section_title
-    ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
-  `);
-  const now = Date.now();
-  for (const row of rows) {
-    stmt.run(
-      conversationId,
-      turn,
-      row.slug,
-      row.source,
-      row.pinned,
-      now,
-      row.sectionOrdinal,
-      row.sectionTitle,
-    );
+  try {
+    const raw = memorySqliteOrNull("writeSelections");
+    if (!raw) {
+      return;
+    }
+    // PK is (conversation_id, turn, slug); OR REPLACE keeps the write
+    // idempotent if the same turn is observed twice (e.g. a retried turn).
+    // `message_id` is written NULL here (the assistant message does not exist
+    // at injection time) and stamped at turn end by
+    // `backfillMemoryV3SelectionMessageId`.
+    const stmt = raw.query(/*sql*/ `
+      INSERT OR REPLACE INTO memory_v3_selections (
+        conversation_id, turn, slug, source, pinned, created_at,
+        message_id, section_ordinal, section_title
+      ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
+    `);
+    const now = Date.now();
+    for (const row of rows) {
+      stmt.run(
+        conversationId,
+        turn,
+        row.slug,
+        row.source,
+        row.pinned,
+        now,
+        row.sectionOrdinal,
+        row.sectionTitle,
+      );
+    }
+  } catch (err) {
+    log.warn({ err }, "failed to write memory-v3 selections; continuing");
   }
 }
 
@@ -580,16 +584,23 @@ export function backfillMemoryV3SelectionMessageId(
   conversationId: string,
   assistantMessageId: string,
 ): void {
-  const raw = memorySqliteOrNull("backfillMemoryV3SelectionMessageId");
-  if (!raw) {
-    return;
+  try {
+    const raw = memorySqliteOrNull("backfillMemoryV3SelectionMessageId");
+    if (!raw) {
+      return;
+    }
+    raw
+      .query(
+        /*sql*/ `UPDATE memory_v3_selections SET message_id = ?
+                 WHERE conversation_id = ? AND message_id IS NULL`,
+      )
+      .run(assistantMessageId, conversationId);
+  } catch (err) {
+    log.warn(
+      { err },
+      "failed to backfill memory-v3 selection messageId; continuing",
+    );
   }
-  raw
-    .query(
-      /*sql*/ `UPDATE memory_v3_selections SET message_id = ?
-               WHERE conversation_id = ? AND message_id IS NULL`,
-    )
-    .run(assistantMessageId, conversationId);
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for memory-db-wave1.md: memory-DB location notes on the moved tables' drizzle definitions, de-staled memory-db.ts docstring, removed a dead schema-ensure export, aligned shadow-plugin writes with their best-effort contract, and corrected the migration-failure lifecycle log wording.