### PR TITLE
refactor(migrations): share the memory-table relocation runner across movers

### DIFF
--- a/assistant/src/persistence/migrations/298-move-memory-jobs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/298-move-memory-jobs-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -94,35 +89,16 @@ function createIndexes(raw: Database) {
  * The jobs store reads/writes the queue over the dedicated memory connection
  * (see `getMemoryDb()`).
  *
- * Like the `llm_request_logs` move (migration 297) this is incremental: create
- * the table (and indexes) on the memory connection, rename any populated
- * `main.memory_jobs` aside to `memory_jobs__relocating`, then drain it in
- * awaited batches (see `helpers/relocation.ts`) per {@link MEMORY_JOBS_RELOCATION}.
- *
  * Because the drain is awaited as part of this step, the pending/running jobs
  * are in their new home before the memory jobs worker starts later in daemon
  * startup — the worker never observes a transiently empty queue.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on a
- * later boot — never renaming the source aside without a target to write to,
- * and never marking the relocation done while it has not happened. The throw is
- * caught per-step by the runner, so startup is not aborted.
  */
 export async function migrateMoveMemoryJobsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_jobs relocation",
-    );
-  }
-
-  ensureMemoryJobsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(raw, MEMORY_JOBS_RELOCATION.table);
-
-  if (needsDrain) await drainStagedTable(raw, MEMORY_JOBS_RELOCATION);
+  await runMemoryTableRelocation(
+    database,
+    MEMORY_JOBS_RELOCATION,
+    ensureMemoryJobsSchema,
+  );
 }

--- a/assistant/src/persistence/migrations/326-move-injection-events-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/326-move-injection-events-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -69,36 +64,15 @@ export function ensureInjectionEventsSchema(memoryRaw: Database): void {
  * accessors in `plugins/defaults/memory/v2/injection-events.ts` read/write it
  * over the dedicated memory connection (see `getMemoryDb()`).
  *
- * Like migrations 297/298 the move is incremental: create the table (and
- * indexes) on the memory connection, rename any populated
- * `main.memory_v2_injection_events` aside to
- * `memory_v2_injection_events__relocating`, then drain it in awaited batches
- * (see `helpers/relocation.ts`) per {@link INJECTION_EVENTS_RELOCATION}. On a
- * fresh install the main-side table created by migration 256 is empty, so
- * staging just drops it.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
+ * On a fresh install the main-side table created by migration 256 is empty,
+ * so staging just drops it.
  */
 export async function migrateMoveInjectionEventsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_v2_injection_events relocation",
-    );
-  }
-
-  ensureInjectionEventsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(
-    raw,
-    INJECTION_EVENTS_RELOCATION.table,
+  await runMemoryTableRelocation(
+    database,
+    INJECTION_EVENTS_RELOCATION,
+    ensureInjectionEventsSchema,
   );
-
-  if (needsDrain) await drainStagedTable(raw, INJECTION_EVENTS_RELOCATION);
 }

--- a/assistant/src/persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -80,40 +75,16 @@ export function ensureActivationLogsSchema(memoryRaw: Database): void {
  * `plugins/defaults/memory/memory-v2-activation-log-store.ts` read/write it
  * over the dedicated memory connection.
  *
- * Like migration 326 the move is incremental: create the table (and indexes)
- * on the memory connection, rename any populated
- * `main.memory_v2_activation_logs` aside to
- * `memory_v2_activation_logs__relocating`, then drain it in awaited batches
- * (see `helpers/relocation.ts`) per {@link ACTIVATION_LOGS_RELOCATION}.
- *
  * Registered with `dependsOn` on migrations 234 (creator) and 256 (whose
  * backfill reads this table from `main`), so the move never outruns either
  * on a database where they are still pending.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
  */
 export async function migrateMoveMemoryV2ActivationLogsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_v2_activation_logs relocation",
-    );
-  }
-
-  ensureActivationLogsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(
-    raw,
-    ACTIVATION_LOGS_RELOCATION.table,
+  await runMemoryTableRelocation(
+    database,
+    ACTIVATION_LOGS_RELOCATION,
+    ensureActivationLogsSchema,
   );
-
-  if (needsDrain) {
-    await drainStagedTable(raw, ACTIVATION_LOGS_RELOCATION);
-  }
 }

--- a/assistant/src/persistence/migrations/337-move-memory-recall-logs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/337-move-memory-recall-logs-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -104,36 +99,16 @@ export function ensureRecallLogsSchema(memoryRaw: Database): void {
  * `plugins/defaults/memory/memory-recall-log-store.ts` read/write it over the
  * dedicated memory connection.
  *
- * Like migration 326 the move is incremental: create the table (and indexes)
- * on the memory connection, rename any populated `main.memory_recall_logs`
- * aside to `memory_recall_logs__relocating`, then drain it in awaited batches
- * (see `helpers/relocation.ts`) per {@link RECALL_LOGS_RELOCATION}.
- *
  * Registered with `dependsOn` on migrations 194 (creator) and 211
  * (`query_context` column), so the move never outruns either on a database
  * where they are still pending.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
  */
 export async function migrateMoveMemoryRecallLogsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_recall_logs relocation",
-    );
-  }
-
-  ensureRecallLogsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(raw, RECALL_LOGS_RELOCATION.table);
-
-  if (needsDrain) {
-    await drainStagedTable(raw, RECALL_LOGS_RELOCATION);
-  }
+  await runMemoryTableRelocation(
+    database,
+    RECALL_LOGS_RELOCATION,
+    ensureRecallLogsSchema,
+  );
 }

--- a/assistant/src/persistence/migrations/338-move-memory-v3-selections-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/338-move-memory-v3-selections-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -75,36 +70,15 @@ export function ensureMemoryV3SelectionsSchema(memoryRaw: Database): void {
  * housing it with the other high-churn memory state keeps the main DB and its
  * WAL out of that write path.
  *
- * Like migration 326 the move is incremental: create the table (and indexes)
- * on the memory connection, rename any populated `main.memory_v3_selections`
- * aside to `memory_v3_selections__relocating`, then drain it in awaited
- * batches per {@link MEMORY_V3_SELECTIONS_RELOCATION}. On a fresh install the
- * main-side table created by migration 268 is empty, so staging just drops it.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
+ * On a fresh install the main-side table created by migration 268 is empty,
+ * so staging just drops it.
  */
 export async function migrateMoveMemoryV3SelectionsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_v3_selections relocation",
-    );
-  }
-
-  ensureMemoryV3SelectionsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(
-    raw,
-    MEMORY_V3_SELECTIONS_RELOCATION.table,
+  await runMemoryTableRelocation(
+    database,
+    MEMORY_V3_SELECTIONS_RELOCATION,
+    ensureMemoryV3SelectionsSchema,
   );
-
-  if (needsDrain) {
-    await drainStagedTable(raw, MEMORY_V3_SELECTIONS_RELOCATION);
-  }
 }

--- a/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -44,36 +39,15 @@ export function ensureActivationSessionsSchema(memoryRaw: Database): void {
  * (`assistant-memory.db`), joining the memory plugin's other relocated state
  * so its store reads/writes ride the memory connection.
  *
- * Like migration 326 the move is incremental: create the table on the memory
- * connection, rename any populated `main.activation_sessions` aside to
- * `activation_sessions__relocating`, then drain it in awaited batches per
- * {@link ACTIVATION_SESSIONS_RELOCATION}. On a fresh install the main-side
- * table created by migration 274 is empty, so staging just drops it.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
+ * On a fresh install the main-side table created by migration 274 is empty,
+ * so staging just drops it.
  */
 export async function migrateMoveActivationSessionsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring activation_sessions relocation",
-    );
-  }
-
-  ensureActivationSessionsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(
-    raw,
-    ACTIVATION_SESSIONS_RELOCATION.table,
+  await runMemoryTableRelocation(
+    database,
+    ACTIVATION_SESSIONS_RELOCATION,
+    ensureActivationSessionsSchema,
   );
-
-  if (needsDrain) {
-    await drainStagedTable(raw, ACTIVATION_SESSIONS_RELOCATION);
-  }
 }

--- a/assistant/src/persistence/migrations/helpers/relocation.ts
+++ b/assistant/src/persistence/migrations/helpers/relocation.ts
@@ -6,6 +6,11 @@ import {
   parseChangesFromStdout,
   runAsyncSqlite,
 } from "../../db-async-query.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../../db-connection.js";
 
 const log = getLogger("memory-db");
 
@@ -145,7 +150,9 @@ export async function drainStagedTable(
   const staging = `${table}${RELOCATING_SUFFIX}`;
 
   // Nothing to do once the staging table is gone (drain finished previously).
-  if (!tableExistsInMain(raw, staging)) return;
+  if (!tableExistsInMain(raw, staging)) {
+    return;
+  }
 
   // Build a select list from the staging table's actual columns: apply any
   // per-column transform, copy a present column verbatim, NULL-fill an absent
@@ -227,4 +234,40 @@ export async function drainStagedTable(
     );
   }
   log.info({ table }, "relocation: complete — staging dropped");
+}
+
+/**
+ * Run one memory-table relocation end to end: ensure the table's schema on the
+ * memory connection, stage `main.<table>` aside via
+ * {@link stageTableForRelocation}, then drain the staged rows into the memory
+ * DB in awaited batches via {@link drainStagedTable} per the spec. Because the
+ * drain is awaited as part of the migration step, later startup work observes
+ * the finished move.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on a
+ * later boot — never renaming the source aside without a target to write to,
+ * and never marking the relocation done while it has not happened. The throw
+ * is caught per-step by the runner, so startup is not aborted.
+ */
+export async function runMemoryTableRelocation(
+  database: DrizzleDb,
+  spec: RelocationSpec,
+  ensureSchema: (memoryRaw: Database) => void,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      `memory database unavailable — deferring ${spec.table} relocation`,
+    );
+  }
+
+  ensureSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(raw, spec.table);
+
+  if (needsDrain) {
+    await drainStagedTable(raw, spec);
+  }
 }


### PR DESCRIPTION
## Summary
Fixes a review gap for memory-db-wave1.md: the six move-*-to-memory-db migrations shared a byte-identical runner body; it now lives once in helpers/relocation.ts and each migration is its schema, its spec, and one call.