### PR TITLE
test: cover deferral readiness gating and v3 degraded paths

### DIFF
--- a/assistant/src/persistence/__tests__/db-init-migrations-ok.test.ts
+++ b/assistant/src/persistence/__tests__/db-init-migrations-ok.test.ts
@@ -11,10 +11,36 @@
 import { describe, expect, test } from "bun:test";
 
 import { initializeDb } from "../db-init.js";
+import { migrationSteps } from "../steps.js";
 
 describe("initializeDb — migrationsOk return contract", () => {
   test("resolves to { migrationsOk: true } on a clean init", async () => {
     const result = await initializeDb();
     expect(result).toEqual({ migrationsOk: true });
+  });
+
+  test("resolves to { migrationsOk: false } when a step is deferred", async () => {
+    // initializeDb reads the shared migrationSteps array, so appending a step
+    // whose dependsOn names a checkpoint that can never exist exercises the
+    // real deferral path end-to-end. The step is deferred (never run, never
+    // checkpointed), so removing it in finally leaves the ledger untouched.
+    const syntheticStep = {
+      name: "dbInitTestSyntheticDeferredStep",
+      run: () => {
+        throw new Error("deferred step must not run");
+      },
+      dependsOn: ["dbInitTestMissingPrerequisite"],
+    };
+    migrationSteps.push(syntheticStep);
+    try {
+      const result = await initializeDb();
+      expect(result).toEqual({ migrationsOk: false });
+    } finally {
+      migrationSteps.splice(migrationSteps.indexOf(syntheticStep), 1);
+    }
+
+    // The deferred step wrote nothing to the ledger, so a clean re-init
+    // reports ready again.
+    expect(await initializeDb()).toEqual({ migrationsOk: true });
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
@@ -8,13 +8,18 @@
  * resolves to null without mocking any module (module mocks would leak into
  * other test files in the same run).
  */
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import type { DrizzleDb } from "../../../../persistence/db-connection.js";
 import {
   clearStoredDb,
   setStoredDb,
 } from "../../../../persistence/db-singleton.js";
+import { migrateAddMemoryV3EverInjected } from "../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
+import * as schema from "../../../../persistence/schema/index.js";
 import {
   backfillMemoryRecallLogMessageId,
   getMemoryRecallLogByMessageIds,
@@ -27,6 +32,8 @@ import {
 } from "../memory-v2-activation-log-store.js";
 import { getConceptFrequencySummary } from "../memory-v2-concept-frequency.js";
 import { extractOracleTurns } from "../v2/harness/oracle.js";
+import { recordInjected } from "../v3/ever-injected-store.js";
+import { planPrune } from "../v3/prune.js";
 import {
   sampleConcepts,
   sampleConfig,
@@ -93,5 +100,49 @@ describe("memory log stores without a memory database", () => {
 
   test("oracle extraction returns no turns", () => {
     expect(extractOracleTurns({} as DrizzleDb)).toEqual([]);
+  });
+});
+
+describe("memory-v3 prune valve without a memory database", () => {
+  // The valve's candidate accounting (`memory_v3_ever_injected`) lives in the
+  // MAIN database, which stays available — install a schema-bearing in-memory
+  // main DB into the `main` singleton slot so only the memory connection
+  // (degraded by the outer beforeEach) is down.
+  let mainSqlite: Database;
+
+  beforeEach(() => {
+    mainSqlite = new Database(":memory:");
+    const mainDb = drizzle(mainSqlite, { schema });
+    migrateAddMemoryV3EverInjected(mainDb);
+    setStoredDb("main", mainDb, () => mainSqlite.close());
+  });
+
+  afterEach(() => {
+    clearStoredDb("main");
+  });
+
+  test("planPrune falls back to injected_at recency without throwing", () => {
+    // With the memory DB unavailable the selection-recency read degrades to
+    // no rows, so every candidate ranks by its injected_at fallback.
+    recordInjected(
+      "conv-degraded-prune",
+      [{ slug: "domain-a/page-old", bytes: 600 }],
+      1_000,
+    );
+    recordInjected(
+      "conv-degraded-prune",
+      [{ slug: "domain-a/page-new", bytes: 500 }],
+      2_000,
+    );
+
+    const plan = planPrune(
+      {
+        maxResidentBytes: 1_000,
+        targetResidentBytes: 500,
+        exemptSlugs: new Set(),
+      },
+      "conv-degraded-prune",
+    );
+    expect(plan).toEqual({ slugs: ["domain-a/page-old"], bytesFreed: 600 });
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
@@ -38,6 +38,9 @@ const realPageContent = { ...(await import("../page-content.js")) };
 
 let storeMockActive = false;
 let liveEnabled = false;
+// When false, the stubbed `getMemorySqlite` resolves to null — the contract
+// the store sees when the dedicated memory database cannot be opened.
+let memoryDbAvailable = true;
 
 let testSqlite: Database;
 // Selection rows live on the dedicated memory connection, resolved via
@@ -122,7 +125,11 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
       ? testSqlite
       : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
   getMemorySqlite: () =>
-    storeMockActive ? memorySqlite : realDb.getMemorySqlite(),
+    storeMockActive
+      ? memoryDbAvailable
+        ? memorySqlite
+        : null
+      : realDb.getMemorySqlite(),
 }));
 
 mock.module("../page-content.js", () => ({
@@ -148,6 +155,7 @@ const {
 beforeEach(() => {
   storeMockActive = true;
   liveEnabled = false;
+  memoryDbAvailable = true;
   // The inspector's `live` flag comes from `isMemoryV3Live(getConfig())`,
   // which reads `memory.v3.live` — seed it for real.
   setConfig("memory", { v3: { live: false } });
@@ -352,6 +360,23 @@ describe("getMemoryV3SelectionForInspectorByMessageIds", () => {
       await getMemoryV3SelectionForInspectorByMessageIds(["fork-msg"]),
     ).toBeNull();
   });
+
+  test("returns null when the memory database is unavailable", async () => {
+    // Rows exist for both lookup keys, but with the memory connection down
+    // both inspector reads (including the fork-fallback walk, which still
+    // touches the main-DB `messages` table) must degrade to null, not throw.
+    seed(
+      "conv-deg",
+      1,
+      [{ slug: "domain-a/page-1", source: "needle" }],
+      "msg-deg",
+    );
+    memoryDbAvailable = false;
+    expect(await getMemoryV3SelectionForInspector("conv-deg", 1)).toBeNull();
+    expect(
+      await getMemoryV3SelectionForInspectorByMessageIds(["msg-deg"]),
+    ).toBeNull();
+  });
 });
 
 describe("summarizeSelections", () => {
@@ -388,6 +413,28 @@ describe("summarizeSelections", () => {
 
   test("returns zeroed counts for a conversation with no rows", () => {
     expect(summarizeSelections("conv-none")).toEqual({
+      bySource: {
+        core: 0,
+        hot: 0,
+        fresh: 0,
+        needle: 0,
+        dense: 0,
+        edge: 0,
+        reply: 0,
+        learned: 0,
+        entity: 0,
+      },
+      turns: 0,
+      distinctSlugs: 0,
+    });
+  });
+
+  test("returns zeroed results when the memory database is unavailable", () => {
+    // Rows exist, but with the memory connection down the summary must
+    // degrade to zeroes rather than throw.
+    seed("conv-deg", 1, [{ slug: "domain-a/page-1", source: "needle" }]);
+    memoryDbAvailable = false;
+    expect(summarizeSelections("conv-deg")).toEqual({
       bySource: {
         core: 0,
         hot: 0,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -174,6 +174,9 @@ let capturedPageBody: ((slug: string) => Promise<string>) | null = null;
 // the stubbed `getMemorySqlite`); the everInjected store stays in main.
 let testSqlite: Database;
 let memorySqlite: Database;
+// When false, the stubbed `getMemorySqlite` resolves to null — the contract
+// the plugin sees when the dedicated memory database cannot be opened.
+let memoryDbAvailable = true;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
@@ -275,7 +278,7 @@ mock.module("../../../../../persistence/conversation-crud.js", () => ({
 mock.module("../../../../../persistence/db-connection.js", () => ({
   getDb: () => testDb,
   getSqliteFrom: () => testSqlite,
-  getMemorySqlite: () => memorySqlite,
+  getMemorySqlite: () => (memoryDbAvailable ? memorySqlite : null),
 }));
 
 mock.module("../../v2/page-index.js", () => ({
@@ -449,6 +452,8 @@ const {
   resetShadowLanesForTests,
   invalidateLanes,
   attributeSelections,
+  writeSelections,
+  backfillMemoryV3SelectionMessageId,
 } = await import("../shadow-plugin.js");
 const { memoryV3Injector, resetMemoryV3InjectorStateForTests } =
   await import("../injector.js");
@@ -478,6 +483,7 @@ beforeEach(() => {
   shadowMockActive = true;
   liveEnabled = false;
   memoryEnabled = true;
+  memoryDbAvailable = true;
   learnedEdgesCap = 0;
   extraRealConceptPages = 0;
   selectorEnabledCfg = false;
@@ -532,6 +538,28 @@ describe("memory-v3 engine", () => {
 
     expect(orchestrateSpy).not.toHaveBeenCalled();
     expect(sectionBuilds).toBe(0);
+    expect(readRows()).toHaveLength(0);
+  });
+
+  test("selection writes and the message-id backfill no-op when the memory database is unavailable", () => {
+    memoryDbAvailable = false;
+    expect(() =>
+      writeSelections("conv-1", 1, [
+        {
+          slug: "page-1",
+          source: "needle",
+          pinned: 0,
+          sectionOrdinal: null,
+          sectionTitle: null,
+        },
+      ]),
+    ).not.toThrow();
+    expect(() =>
+      backfillMemoryV3SelectionMessageId("conv-1", "m-1"),
+    ).not.toThrow();
+
+    // Nothing landed while the connection was down.
+    memoryDbAvailable = true;
     expect(readRows()).toHaveLength(0);
   });
 

--- a/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
@@ -185,4 +185,19 @@ describe("computeLearnedEdgeGraph", () => {
     const graph = graphOf({ windowMs: 10_000 });
     expect(graph.adjacency.size).toBe(0);
   });
+
+  test("degrades to an empty graph when the memory database is unavailable", () => {
+    // Simulate unavailability through the singleton slot instead of
+    // `mock.module`, which is process-global and leaks into sibling test
+    // files. The accessor extracts the raw connection from the stored
+    // handle's `$client`, so a handle without one makes `getMemorySqlite()`
+    // resolve to null, the same contract computeLearnedEdgeGraph sees when
+    // the dedicated open fails.
+    clearStoredDb("memory");
+    setStoredDb("memory", { $client: null }, () => {});
+
+    const graph = graphOf();
+    expect(graph.adjacency.size).toBe(0);
+    expect(graph.hubs.size).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
Fixes review gaps for memory-db-wave1.md: initializeDb now has a test pinning migrationsOk=false on a deferred step, and learned-edges, prune, selection-log-store, and shadow-plugin have memory-DB-unavailable degradation tests.