### PR TITLE
docs(schema): note memory_jobs lives in the memory database

### DIFF
--- a/assistant/src/persistence/schema/memory-core.ts
+++ b/assistant/src/persistence/schema/memory-core.ts
@@ -72,6 +72,9 @@ export const memoryEmbeddings = sqliteTable(
   ],
 );
 
+// Background job queue for the memory plugin. Lives in the dedicated memory
+// database (`assistant-memory.db`), not main — access it via the memory
+// connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryJobs = sqliteTable("memory_jobs", {
   id: text("id").primaryKey(),
   type: text("type").notNull(),


### PR DESCRIPTION
## Summary
The five other relocated memory tables' drizzle definitions carry a location note pointing readers at the memory connection; memory_jobs (moved by migration 298) was the one missing it.