### PR TITLE
feat(acp): capture model + cache tokens in ACP session usage

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-usage-enrichment.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-usage-enrichment.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Verifies that the cumulative `PromptResponse.usage` payload enriches the
+ * emitted `acp_session_usage` event with the reported model and cache-read/
+ * write token totals (fields PR 6 later persists).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+
+type HandlerFactory = (agent: unknown) => {
+  sessionUpdate(params: SessionNotification): Promise<void>;
+};
+const handlerFactories: HandlerFactory[] = [];
+
+// Captured resolver for the in-flight prompt so a test can report a model
+// (via a session update) before the prompt completes with a usage payload.
+let resolvePrompt: (value: unknown) => void = () => {};
+
+mock.module("../agent-process.js", () => ({
+  AcpAgentProcess: class FakeAcpAgentProcess {
+    constructor(
+      public readonly agentId: string,
+      _config: unknown,
+      factory: HandlerFactory,
+    ) {
+      handlerFactories.push(factory);
+    }
+    spawn(_cwd: string): void {}
+    async initialize(): Promise<void> {}
+    async createSession(_cwd: string): Promise<string> {
+      return `proto-${this.agentId}`;
+    }
+    prompt(): Promise<unknown> {
+      return new Promise((res) => {
+        resolvePrompt = res as (value: unknown) => void;
+      });
+    }
+    async cancel(): Promise<void> {}
+    markStderr(): number {
+      return 0;
+    }
+    stderrSince(): string {
+      return "";
+    }
+    kill(): void {}
+  },
+}));
+
+// persistTerminal writes a history row on completion; stand up the DB.
+const { initializeDb } = await import("../../persistence/db-init.js");
+await initializeDb();
+const { AcpSessionManager } = await import("../session-manager.js");
+
+describe("AcpSessionManager — usage enrichment from PromptResponse", () => {
+  test("emits model + cache tokens on the final usage event", async () => {
+    handlerFactories.length = 0;
+    const sent: ServerMessage[] = [];
+    const manager = new AcpSessionManager(5);
+
+    const { acpSessionId } = await manager.spawn(
+      "agent-enrich",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-parent",
+      (msg) => sent.push(msg),
+    );
+
+    const handler = handlerFactories[handlerFactories.length - 1]?.(undefined);
+    // Report the model before the prompt resolves.
+    await handler?.sessionUpdate({
+      sessionId: acpSessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [
+          {
+            type: "select",
+            category: "model",
+            id: "model",
+            name: "Model",
+            currentValue: "opus",
+            options: [
+              { value: "opus", name: "Claude Opus" },
+              { value: "sonnet", name: "Claude Sonnet" },
+            ],
+          },
+        ],
+      },
+    });
+
+    // Complete the turn with a cumulative usage payload carrying cache tokens.
+    resolvePrompt({
+      stopReason: "end_turn",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cachedReadTokens: 40,
+        cachedWriteTokens: 10,
+        totalTokens: 170,
+      },
+    });
+    // Flush the background prompt's .then() chain.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const usageEvent = sent.find(
+      (m): m is Extract<ServerMessage, { type: "acp_session_usage" }> =>
+        m.type === "acp_session_usage",
+    );
+    expect(usageEvent).toBeDefined();
+    expect(usageEvent?.model).toBe("Claude Opus");
+    expect(usageEvent?.cacheReadTokens).toBe(40);
+    expect(usageEvent?.cacheWriteTokens).toBe(10);
+    expect(usageEvent?.inputTokens).toBe(100);
+    expect(usageEvent?.outputTokens).toBe(20);
+  });
+});

--- a/assistant/src/acp/__tests__/session-manager-usage.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-usage.test.ts
@@ -85,6 +85,57 @@ describe("AcpSessionManager — latestUsage tracking", () => {
     });
   });
 
+  test("records the reported model onto latestUsage from a usage_update", async () => {
+    handlerFactories.length = 0;
+    const manager = new AcpSessionManager(5);
+
+    const { acpSessionId } = await manager.spawn(
+      "agent-usage-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-parent",
+      noopSend,
+    );
+
+    const handler = handlerFactories[handlerFactories.length - 1]?.(undefined);
+
+    // A config_option_update reports the current model; the subsequent
+    // usage gauge should carry it onto latestUsage.
+    await handler?.sessionUpdate({
+      sessionId: acpSessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [
+          {
+            type: "select",
+            category: "model",
+            id: "model",
+            name: "Model",
+            currentValue: "opus",
+            options: [
+              { value: "opus", name: "Claude Opus" },
+              { value: "sonnet", name: "Claude Sonnet" },
+            ],
+          },
+        ],
+      },
+    });
+
+    await handler?.sessionUpdate({
+      sessionId: acpSessionId,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 10,
+        size: 100,
+      },
+    });
+
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    expect(state.latestUsage?.model).toBe("Claude Opus");
+    expect(state.latestUsage?.usedTokens).toBe(10);
+  });
+
   test("latestUsage omits cost fields when usage_update carries no cost", async () => {
     handlerFactories.length = 0;
     const manager = new AcpSessionManager(5);

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -21,6 +21,7 @@ import type {
   ReleaseTerminalResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
+  SessionConfigOption,
   SessionNotification,
   TerminalOutputRequest,
   TerminalOutputResponse,
@@ -73,6 +74,8 @@ interface TerminalState {
 export class VellumAcpClientHandler implements Client {
   private terminals = new Map<string, TerminalState>();
   private accumulatedText = "";
+  /** Latest model the adapter reported via `config_option_update`, if any. */
+  private latestModel: string | undefined;
   private suppressForwarding = false;
   /** Monotonic ordering counter; advanced only on forwarded updates. */
   private lastSeq = 0;
@@ -82,6 +85,11 @@ export class VellumAcpClientHandler implements Client {
   /** Returns the full agent response text accumulated from agent_message_chunk events. */
   get responseText(): string {
     return this.accumulatedText;
+  }
+
+  /** Latest model name reported by the adapter, if any has been seen. */
+  get model(): string | undefined {
+    return this.latestModel;
   }
 
   /**
@@ -262,9 +270,18 @@ export class VellumAcpClientHandler implements Client {
         break;
       }
 
+      case "config_option_update": {
+        // Track the current model so subsequent usage gauges can attribute
+        // cost to it. Not forwarded to Vellum as its own event.
+        const model = extractModelName(update.configOptions);
+        if (model !== undefined) this.latestModel = model;
+        break;
+      }
+
       case "usage_update": {
         // Side gauge of context-window usage; no seq (not part of the
-        // ordered timeline). UNSTABLE: cost may be absent.
+        // ordered timeline). UNSTABLE: cost may be absent. Stamp the latest
+        // known model so cost can be attributed to it.
         this.sendToVellum({
           type: "acp_session_usage",
           acpSessionId: this.acpSessionId,
@@ -272,14 +289,14 @@ export class VellumAcpClientHandler implements Client {
           contextSize: update.size,
           costAmount: update.cost?.amount,
           costCurrency: update.cost?.currency,
+          model: this.latestModel,
         });
         break;
       }
 
       default: {
         // Other update types (available_commands_update, current_mode_update,
-        // config_option_update, session_info_update) are not forwarded to
-        // Vellum.
+        // session_info_update) are not forwarded to Vellum.
         log.debug(
           {
             acpSessionId: this.acpSessionId,
@@ -479,6 +496,29 @@ function mapLocations(
   if (locations === undefined) return undefined;
   if (locations === null) return [];
   return locations.map((l) => ({ path: l.path, line: l.line ?? undefined }));
+}
+
+/**
+ * Resolve the human-readable model name from a `config_option_update`: find
+ * the `model`-category select option and map its `currentValue` to the
+ * matching label, handling both flat and grouped option lists. Falls back to
+ * the raw value id when no label matches.
+ */
+function extractModelName(
+  configOptions: SessionConfigOption[],
+): string | undefined {
+  const modelOption = configOptions.find((o) => o.category === "model");
+  if (!modelOption || modelOption.type !== "select") return undefined;
+  const { currentValue, options } = modelOption;
+  for (const opt of options) {
+    if ("value" in opt) {
+      if (opt.value === currentValue) return opt.name;
+    } else {
+      const found = opt.options.find((g) => g.value === currentValue);
+      if (found) return found.name;
+    }
+  }
+  return currentValue || undefined;
 }
 
 function findAllowOptionId(

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -302,6 +302,11 @@ export class AcpSessionManager {
             costCurrency: msg.costCurrency,
             inputTokens: msg.inputTokens ?? state.latestUsage?.inputTokens,
             outputTokens: msg.outputTokens ?? state.latestUsage?.outputTokens,
+            model: msg.model ?? state.latestUsage?.model,
+            cacheReadTokens:
+              msg.cacheReadTokens ?? state.latestUsage?.cacheReadTokens,
+            cacheWriteTokens:
+              msg.cacheWriteTokens ?? state.latestUsage?.cacheWriteTokens,
           };
         }
       }
@@ -1010,6 +1015,9 @@ export class AcpSessionManager {
           const usage = response.usage;
           if (usage) {
             const prior = current.state.latestUsage;
+            const model = current.clientHandler.model ?? prior?.model;
+            const cacheReadTokens = usage.cachedReadTokens ?? undefined;
+            const cacheWriteTokens = usage.cachedWriteTokens ?? undefined;
             current.state.latestUsage = {
               usedTokens: prior?.usedTokens ?? 0,
               contextSize: prior?.contextSize ?? 0,
@@ -1017,6 +1025,9 @@ export class AcpSessionManager {
               costCurrency: prior?.costCurrency,
               inputTokens: usage.inputTokens,
               outputTokens: usage.outputTokens,
+              model,
+              cacheReadTokens,
+              cacheWriteTokens,
             };
             current.sendToVellum({
               type: "acp_session_usage",
@@ -1027,6 +1038,9 @@ export class AcpSessionManager {
               costCurrency: current.state.latestUsage.costCurrency,
               inputTokens: usage.inputTokens,
               outputTokens: usage.outputTokens,
+              model,
+              cacheReadTokens,
+              cacheWriteTokens,
             });
           }
           log.info(

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -46,4 +46,10 @@ export interface AcpUsageSnapshot {
   inputTokens?: number;
   /** Cumulative output tokens across all turns, from `PromptResponse.usage`. */
   outputTokens?: number;
+  /** Model the adapter reported for the session, if known. */
+  model?: string;
+  /** Cumulative cache-read tokens, from `PromptResponse.usage`. */
+  cacheReadTokens?: number;
+  /** Cumulative cache-write tokens, from `PromptResponse.usage`. */
+  cacheWriteTokens?: number;
 }

--- a/assistant/src/api/events/acp-session-usage.ts
+++ b/assistant/src/api/events/acp-session-usage.ts
@@ -6,8 +6,10 @@
  * the tokens currently in context, `contextSize` the window size; the
  * optional `inputTokens`/`outputTokens` are the session's cumulative
  * input/output token totals and `costAmount`/`costCurrency` mirror the
- * agent's cumulative cost. A side gauge, not part of the ordered update
- * timeline — carries no `seq`.
+ * agent's cumulative cost. `model` and `cacheReadTokens`/`cacheWriteTokens`
+ * carry the reported model and cache-token totals when the adapter provides
+ * them. A side gauge, not part of the ordered update timeline — carries no
+ * `seq`.
  *
  * Canonical wire-contract source. Re-exported to external consumers via
  * `@vellumai/assistant-api` (the `api/index.ts` barrel).
@@ -25,6 +27,9 @@ export const AcpSessionUsageEventSchema = z
     outputTokens: z.number().optional(),
     costAmount: z.number().optional(),
     costCurrency: z.string().optional(),
+    model: z.string().optional(),
+    cacheReadTokens: z.number().optional(),
+    cacheWriteTokens: z.number().optional(),
   })
   .strict();
 

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -66,6 +66,12 @@ export interface AcpSessionUsage {
   costCurrency?: string;
   inputTokens?: number;
   outputTokens?: number;
+  /** Model the adapter reported for the session, if known. */
+  model?: string;
+  /** Cumulative cache-read tokens, when the adapter reports them. */
+  cacheReadTokens?: number;
+  /** Cumulative cache-write tokens, when the adapter reports them. */
+  cacheWriteTokens?: number;
 }
 
 // --- Domain-level union alias (consumed by message-protocol.ts) ---


### PR DESCRIPTION
## Summary
- AcpSessionUsage + zod schema gain optional model, cacheReadTokens, cacheWriteTokens
- client-handler + session-manager capture model name and cache tokens into latestUsage
- Tests for the new fields; existing fields unchanged (back-compat)

Part of plan: acp-api-key-auth.md (PR 5 of 7)