### PR TITLE
Memory-DB cutover Wave 1: move per-turn log tables + migration dependsOn guard

### DIFF
--- a/assistant/src/__tests__/activation-early-marking.test.ts
+++ b/assistant/src/__tests__/activation-early-marking.test.ts
@@ -25,9 +25,8 @@ const { isActivationSession } =
   await import("../plugins/defaults/memory/activation-session-store.js");
 const { ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE } =
   await import("../telemetry/activation-funnel.js");
-const { getDb } = await import("../persistence/db-connection.js");
+const { getMemorySqlite } = await import("../persistence/db-connection.js");
 const { initializeDb } = await import("../persistence/db-init.js");
-const { activationSessions } = await import("../persistence/schema/index.js");
 
 await initializeDb();
 
@@ -44,7 +43,7 @@ function seedGenericBootstrap(): void {
 
 describe("applyBootstrapTemplate — early activation marking", () => {
   beforeEach(() => {
-    getDb().delete(activationSessions).run();
+    getMemorySqlite()!.exec("DELETE FROM activation_sessions");
   });
 
   test("marks the conversation when the activation-rail template is applied", () => {
@@ -71,8 +70,10 @@ describe("applyBootstrapTemplate — early activation marking", () => {
     applyBootstrapTemplate(ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE);
 
     // Nothing to assert by id; confirm the table stayed empty.
-    const rows = getDb().select().from(activationSessions).all();
-    expect(rows.length).toBe(0);
+    const { n } = getMemorySqlite()!
+      .query("SELECT COUNT(*) AS n FROM activation_sessions")
+      .get() as { n: number };
+    expect(n).toBe(0);
   });
 
   test("does not mark when BOOTSTRAP.md is customized to something else", () => {

--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -27,12 +27,12 @@ const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
 
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type { SurfaceType, UiSurfaceShow } from "../daemon/message-protocol.js";
-import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
-import { initializeDb } from "../persistence/db-init.js";
 import {
-  activationSessions,
-  telemetryEvents,
-} from "../persistence/schema/index.js";
+  getMemorySqlite,
+  getTelemetryDb,
+} from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { telemetryEvents } from "../persistence/schema/index.js";
 import {
   isActivationSession,
   markActivationSession,
@@ -93,7 +93,7 @@ function makeContext(
 
 function resetTables(): void {
   getTelemetryDb()!.delete(telemetryEvents).run();
-  getDb().delete(activationSessions).run();
+  getMemorySqlite()!.exec("DELETE FROM activation_sessions");
 }
 
 /** Render a choice surface tagged (or not) with an activation_moment. */

--- a/assistant/src/__tests__/memory-recall-log-store.test.ts
+++ b/assistant/src/__tests__/memory-recall-log-store.test.ts
@@ -1,8 +1,17 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+/**
+ * Tests for the memory recall-log store. The store reads and writes
+ * `memory_recall_logs` over the dedicated memory connection, so each test
+ * installs a fresh in-memory database into the `memory` singleton slot with
+ * the relocated table's schema.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { getDb } from "../persistence/db-connection.js";
-import { initializeDb } from "../persistence/db-init.js";
-import { memoryRecallLogs } from "../persistence/schema/index.js";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { clearStoredDb, setStoredDb } from "../persistence/db-singleton.js";
+import { ensureRecallLogsSchema } from "../persistence/migrations/337-move-memory-recall-logs-to-memory-db.js";
+import * as schema from "../persistence/schema/index.js";
 import {
   backfillMemoryRecallLogMessageId,
   getMemoryRecallLogByMessageIds,
@@ -10,18 +19,21 @@ import {
   recordMemoryRecallLog,
 } from "../plugins/defaults/memory/memory-recall-log-store.js";
 
-await initializeDb();
+let memorySqlite: Database;
 
-function resetTables(): void {
-  const db = getDb();
-  db.delete(memoryRecallLogs).run();
-}
+beforeEach(() => {
+  memorySqlite = new Database(":memory:");
+  ensureRecallLogsSchema(memorySqlite);
+  setStoredDb("memory", drizzle(memorySqlite, { schema }), () =>
+    memorySqlite.close(),
+  );
+});
+
+afterEach(() => {
+  clearStoredDb("memory");
+});
 
 describe("memory-recall-log-store", () => {
-  beforeEach(() => {
-    resetTables();
-  });
-
   test("round-trip: record → backfill messageId → query by messageId", () => {
     const conversationId = "conv-1";
     const messageId = "msg-1";
@@ -97,6 +109,28 @@ describe("memory-recall-log-store", () => {
     const result = getMemoryRecallLogByMessageIds([messageId]);
     expect(result).not.toBeNull();
     expect(result!.queryContext).toBeNull();
+  });
+
+  test("writes land in the memory connection", () => {
+    recordMemoryRecallLog({
+      conversationId: "conv-mem",
+      enabled: true,
+      degraded: false,
+      semanticHits: 1,
+      mergedCount: 1,
+      selectedCount: 1,
+      tier1Count: 1,
+      tier2Count: 0,
+      hybridSearchLatencyMs: 50,
+      sparseVectorUsed: false,
+      injectedTokens: 100,
+      latencyMs: 80,
+      topCandidatesJson: [],
+    });
+    const { n } = memorySqlite
+      .query(`SELECT COUNT(*) AS n FROM memory_recall_logs`)
+      .get() as { n: number };
+    expect(n).toBe(1);
   });
 
   test("returns null when no log exists for a messageId", () => {

--- a/assistant/src/persistence/migrations/298-move-memory-jobs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/298-move-memory-jobs-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -94,35 +89,16 @@ function createIndexes(raw: Database) {
  * The jobs store reads/writes the queue over the dedicated memory connection
  * (see `getMemoryDb()`).
  *
- * Like the `llm_request_logs` move (migration 297) this is incremental: create
- * the table (and indexes) on the memory connection, rename any populated
- * `main.memory_jobs` aside to `memory_jobs__relocating`, then drain it in
- * awaited batches (see `helpers/relocation.ts`) per {@link MEMORY_JOBS_RELOCATION}.
- *
  * Because the drain is awaited as part of this step, the pending/running jobs
  * are in their new home before the memory jobs worker starts later in daemon
  * startup — the worker never observes a transiently empty queue.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on a
- * later boot — never renaming the source aside without a target to write to,
- * and never marking the relocation done while it has not happened. The throw is
- * caught per-step by the runner, so startup is not aborted.
  */
 export async function migrateMoveMemoryJobsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_jobs relocation",
-    );
-  }
-
-  ensureMemoryJobsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(raw, MEMORY_JOBS_RELOCATION.table);
-
-  if (needsDrain) await drainStagedTable(raw, MEMORY_JOBS_RELOCATION);
+  await runMemoryTableRelocation(
+    database,
+    MEMORY_JOBS_RELOCATION,
+    ensureMemoryJobsSchema,
+  );
 }

--- a/assistant/src/persistence/migrations/326-move-injection-events-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/326-move-injection-events-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -69,36 +64,15 @@ export function ensureInjectionEventsSchema(memoryRaw: Database): void {
  * accessors in `plugins/defaults/memory/v2/injection-events.ts` read/write it
  * over the dedicated memory connection (see `getMemoryDb()`).
  *
- * Like migrations 297/298 the move is incremental: create the table (and
- * indexes) on the memory connection, rename any populated
- * `main.memory_v2_injection_events` aside to
- * `memory_v2_injection_events__relocating`, then drain it in awaited batches
- * (see `helpers/relocation.ts`) per {@link INJECTION_EVENTS_RELOCATION}. On a
- * fresh install the main-side table created by migration 256 is empty, so
- * staging just drops it.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
+ * On a fresh install the main-side table created by migration 256 is empty,
+ * so staging just drops it.
  */
 export async function migrateMoveInjectionEventsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_v2_injection_events relocation",
-    );
-  }
-
-  ensureInjectionEventsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(
-    raw,
-    INJECTION_EVENTS_RELOCATION.table,
+  await runMemoryTableRelocation(
+    database,
+    INJECTION_EVENTS_RELOCATION,
+    ensureInjectionEventsSchema,
   );
-
-  if (needsDrain) await drainStagedTable(raw, INJECTION_EVENTS_RELOCATION);
 }

--- a/assistant/src/persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.ts
@@ -1,0 +1,119 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_v2_activation_logs` from `main` into the memory DB.
+ * Full copy — the concept-frequency aggregator scans the entire history, so
+ * every row is worth preserving.
+ */
+export const ACTIVATION_LOGS_RELOCATION: RelocationSpec = {
+  table: "memory_v2_activation_logs",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "id",
+    "conversation_id",
+    "message_id",
+    "turn",
+    "mode",
+    "concepts_json",
+    "skills_json",
+    "config_json",
+    "created_at",
+  ],
+};
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS memory_v2_activation_logs (
+    id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    message_id TEXT,
+    turn INTEGER NOT NULL,
+    mode TEXT NOT NULL,
+    concepts_json TEXT NOT NULL,
+    skills_json TEXT NOT NULL,
+    config_json TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  )
+`;
+
+/**
+ * Create the `memory_v2_activation_logs` table and its indexes (mirroring
+ * migration 234) on the memory connection. Idempotent (`IF NOT EXISTS`) — the
+ * dedicated connection itself performs no DDL on open, so this migration owns
+ * the schema. Exported so tests can stand up the memory-side schema without
+ * running the full drain.
+ */
+export function ensureActivationLogsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(CREATE_TABLE);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v2_activation_logs_message_id
+      ON memory_v2_activation_logs (message_id)
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v2_activation_logs_conversation_id
+      ON memory_v2_activation_logs (conversation_id)
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v2_activation_logs_created_at
+      ON memory_v2_activation_logs (created_at)
+  `);
+}
+
+/**
+ * Move `memory_v2_activation_logs` — the per-turn v2 activation telemetry log
+ * — into the dedicated memory database (`assistant-memory.db`), alongside
+ * `memory_jobs` (migration 298) and `memory_v2_injection_events` (migration
+ * 326). One row is appended per activation pass, so housing the table with
+ * the other high-churn memory state keeps the main DB and its WAL out of
+ * that write path; the accessors in
+ * `plugins/defaults/memory/memory-v2-activation-log-store.ts` read/write it
+ * over the dedicated memory connection.
+ *
+ * Like migration 326 the move is incremental: create the table (and indexes)
+ * on the memory connection, rename any populated
+ * `main.memory_v2_activation_logs` aside to
+ * `memory_v2_activation_logs__relocating`, then drain it in awaited batches
+ * (see `helpers/relocation.ts`) per {@link ACTIVATION_LOGS_RELOCATION}.
+ *
+ * Registered with `dependsOn` on migrations 234 (creator) and 256 (whose
+ * backfill reads this table from `main`), so the move never outruns either
+ * on a database where they are still pending.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on
+ * a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveMemoryV2ActivationLogsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring memory_v2_activation_logs relocation",
+    );
+  }
+
+  ensureActivationLogsSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    ACTIVATION_LOGS_RELOCATION.table,
+  );
+
+  if (needsDrain) {
+    await drainStagedTable(raw, ACTIVATION_LOGS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -80,40 +75,16 @@ export function ensureActivationLogsSchema(memoryRaw: Database): void {
  * `plugins/defaults/memory/memory-v2-activation-log-store.ts` read/write it
  * over the dedicated memory connection.
  *
- * Like migration 326 the move is incremental: create the table (and indexes)
- * on the memory connection, rename any populated
- * `main.memory_v2_activation_logs` aside to
- * `memory_v2_activation_logs__relocating`, then drain it in awaited batches
- * (see `helpers/relocation.ts`) per {@link ACTIVATION_LOGS_RELOCATION}.
- *
  * Registered with `dependsOn` on migrations 234 (creator) and 256 (whose
  * backfill reads this table from `main`), so the move never outruns either
  * on a database where they are still pending.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
  */
 export async function migrateMoveMemoryV2ActivationLogsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_v2_activation_logs relocation",
-    );
-  }
-
-  ensureActivationLogsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(
-    raw,
-    ACTIVATION_LOGS_RELOCATION.table,
+  await runMemoryTableRelocation(
+    database,
+    ACTIVATION_LOGS_RELOCATION,
+    ensureActivationLogsSchema,
   );
-
-  if (needsDrain) {
-    await drainStagedTable(raw, ACTIVATION_LOGS_RELOCATION);
-  }
 }

--- a/assistant/src/persistence/migrations/337-move-memory-recall-logs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/337-move-memory-recall-logs-to-memory-db.ts
@@ -1,0 +1,139 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_recall_logs` from `main` into the memory DB. Full copy
+ * — the inspector reads arbitrary historical turns, so every row is worth
+ * preserving. `query_context` was added by migration 211, so a legacy source
+ * may lack the column; the drain NULL-fills it.
+ */
+export const RECALL_LOGS_RELOCATION: RelocationSpec = {
+  table: "memory_recall_logs",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "id",
+    "conversation_id",
+    "message_id",
+    "enabled",
+    "degraded",
+    "provider",
+    "model",
+    "degradation_json",
+    "semantic_hits",
+    "merged_count",
+    "selected_count",
+    "tier1_count",
+    "tier2_count",
+    "hybrid_search_latency_ms",
+    "sparse_vector_used",
+    "injected_tokens",
+    "latency_ms",
+    "top_candidates_json",
+    "injected_text",
+    "reason",
+    "query_context",
+    "created_at",
+  ],
+};
+
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS memory_recall_logs (
+    id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    message_id TEXT,
+    enabled INTEGER NOT NULL,
+    degraded INTEGER NOT NULL,
+    provider TEXT,
+    model TEXT,
+    degradation_json TEXT,
+    semantic_hits INTEGER NOT NULL,
+    merged_count INTEGER NOT NULL,
+    selected_count INTEGER NOT NULL,
+    tier1_count INTEGER NOT NULL,
+    tier2_count INTEGER NOT NULL,
+    hybrid_search_latency_ms INTEGER NOT NULL,
+    sparse_vector_used INTEGER NOT NULL,
+    injected_tokens INTEGER NOT NULL,
+    latency_ms INTEGER NOT NULL,
+    top_candidates_json TEXT NOT NULL,
+    injected_text TEXT,
+    reason TEXT,
+    query_context TEXT,
+    created_at INTEGER NOT NULL
+  )
+`;
+
+/**
+ * Create the `memory_recall_logs` table and its indexes (mirroring migration
+ * 194, with the `query_context` column from migration 211 built in) on the
+ * memory connection. Idempotent (`IF NOT EXISTS`) — the dedicated connection
+ * itself performs no DDL on open, so this migration owns the schema. Exported
+ * so tests can stand up the memory-side schema without running the full
+ * drain.
+ */
+export function ensureRecallLogsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(CREATE_TABLE);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_recall_logs_message_id
+      ON memory_recall_logs (message_id)
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_recall_logs_conversation_id
+      ON memory_recall_logs (conversation_id)
+  `);
+}
+
+/**
+ * Move `memory_recall_logs` — the per-turn memory recall telemetry consumed
+ * by the inspector — into the dedicated memory database
+ * (`assistant-memory.db`), alongside the other relocated per-turn memory log
+ * tables. One row is appended per recall pass, so housing the table with the
+ * other high-churn memory state keeps the main DB and its WAL out of that
+ * write path; the accessors in
+ * `plugins/defaults/memory/memory-recall-log-store.ts` read/write it over the
+ * dedicated memory connection.
+ *
+ * Like migration 326 the move is incremental: create the table (and indexes)
+ * on the memory connection, rename any populated `main.memory_recall_logs`
+ * aside to `memory_recall_logs__relocating`, then drain it in awaited batches
+ * (see `helpers/relocation.ts`) per {@link RECALL_LOGS_RELOCATION}.
+ *
+ * Registered with `dependsOn` on migrations 194 (creator) and 211
+ * (`query_context` column), so the move never outruns either on a database
+ * where they are still pending.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on
+ * a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveMemoryRecallLogsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring memory_recall_logs relocation",
+    );
+  }
+
+  ensureRecallLogsSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(raw, RECALL_LOGS_RELOCATION.table);
+
+  if (needsDrain) {
+    await drainStagedTable(raw, RECALL_LOGS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/migrations/337-move-memory-recall-logs-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/337-move-memory-recall-logs-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -104,36 +99,16 @@ export function ensureRecallLogsSchema(memoryRaw: Database): void {
  * `plugins/defaults/memory/memory-recall-log-store.ts` read/write it over the
  * dedicated memory connection.
  *
- * Like migration 326 the move is incremental: create the table (and indexes)
- * on the memory connection, rename any populated `main.memory_recall_logs`
- * aside to `memory_recall_logs__relocating`, then drain it in awaited batches
- * (see `helpers/relocation.ts`) per {@link RECALL_LOGS_RELOCATION}.
- *
  * Registered with `dependsOn` on migrations 194 (creator) and 211
  * (`query_context` column), so the move never outruns either on a database
  * where they are still pending.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
  */
 export async function migrateMoveMemoryRecallLogsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_recall_logs relocation",
-    );
-  }
-
-  ensureRecallLogsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(raw, RECALL_LOGS_RELOCATION.table);
-
-  if (needsDrain) {
-    await drainStagedTable(raw, RECALL_LOGS_RELOCATION);
-  }
+  await runMemoryTableRelocation(
+    database,
+    RECALL_LOGS_RELOCATION,
+    ensureRecallLogsSchema,
+  );
 }

--- a/assistant/src/persistence/migrations/338-move-memory-v3-selections-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/338-move-memory-v3-selections-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -75,36 +70,15 @@ export function ensureMemoryV3SelectionsSchema(memoryRaw: Database): void {
  * housing it with the other high-churn memory state keeps the main DB and its
  * WAL out of that write path.
  *
- * Like migration 326 the move is incremental: create the table (and indexes)
- * on the memory connection, rename any populated `main.memory_v3_selections`
- * aside to `memory_v3_selections__relocating`, then drain it in awaited
- * batches per {@link MEMORY_V3_SELECTIONS_RELOCATION}. On a fresh install the
- * main-side table created by migration 268 is empty, so staging just drops it.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
+ * On a fresh install the main-side table created by migration 268 is empty,
+ * so staging just drops it.
  */
 export async function migrateMoveMemoryV3SelectionsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring memory_v3_selections relocation",
-    );
-  }
-
-  ensureMemoryV3SelectionsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(
-    raw,
-    MEMORY_V3_SELECTIONS_RELOCATION.table,
+  await runMemoryTableRelocation(
+    database,
+    MEMORY_V3_SELECTIONS_RELOCATION,
+    ensureMemoryV3SelectionsSchema,
   );
-
-  if (needsDrain) {
-    await drainStagedTable(raw, MEMORY_V3_SELECTIONS_RELOCATION);
-  }
 }

--- a/assistant/src/persistence/migrations/338-move-memory-v3-selections-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/338-move-memory-v3-selections-to-memory-db.ts
@@ -1,0 +1,110 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_v3_selections` from `main` into the memory DB. Every
+ * row is copied: the hot-set and learned-edge lanes score decayed selection
+ * frequency over the full log, so there is no age cutoff a purge could lean
+ * on. The column list covers migration 268's originals plus the nullable
+ * columns migration 283 added — a source staged before 283 ran simply
+ * NULL-fills them during the copy.
+ */
+export const MEMORY_V3_SELECTIONS_RELOCATION: RelocationSpec = {
+  table: "memory_v3_selections",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "conversation_id",
+    "turn",
+    "slug",
+    "source",
+    "pinned",
+    "created_at",
+    "message_id",
+    "section_ordinal",
+    "section_title",
+  ],
+};
+
+/**
+ * Create the `memory_v3_selections` table and its indexes on the memory
+ * connection. Idempotent (`IF NOT EXISTS`) — the dedicated connection itself
+ * performs no DDL on open, so this migration owns the schema. Exported so
+ * tests can stand up the memory-side schema without running the full drain.
+ */
+export function ensureMemoryV3SelectionsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_v3_selections (
+      conversation_id TEXT NOT NULL,
+      turn INTEGER NOT NULL,
+      slug TEXT NOT NULL,
+      source TEXT NOT NULL,
+      pinned INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      message_id TEXT,
+      section_ordinal INTEGER,
+      section_title TEXT,
+      PRIMARY KEY (conversation_id, turn, slug)
+    )
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v3_selections_conv
+      ON memory_v3_selections (conversation_id, turn DESC)
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v3_selections_message
+      ON memory_v3_selections (message_id)
+  `);
+}
+
+/**
+ * Move `memory_v3_selections` — the per-turn v3 selection log feeding the
+ * hot-set, learned-edge, prune, and inspector readers — into the dedicated
+ * memory database (`assistant-memory.db`), alongside `memory_jobs` (298) and
+ * `memory_v2_injection_events` (326). The log gains rows on every v3 turn;
+ * housing it with the other high-churn memory state keeps the main DB and its
+ * WAL out of that write path.
+ *
+ * Like migration 326 the move is incremental: create the table (and indexes)
+ * on the memory connection, rename any populated `main.memory_v3_selections`
+ * aside to `memory_v3_selections__relocating`, then drain it in awaited
+ * batches per {@link MEMORY_V3_SELECTIONS_RELOCATION}. On a fresh install the
+ * main-side table created by migration 268 is empty, so staging just drops it.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on
+ * a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveMemoryV3SelectionsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring memory_v3_selections relocation",
+    );
+  }
+
+  ensureMemoryV3SelectionsSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    MEMORY_V3_SELECTIONS_RELOCATION.table,
+  );
+
+  if (needsDrain) {
+    await drainStagedTable(raw, MEMORY_V3_SELECTIONS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
@@ -1,0 +1,79 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+import {
+  drainStagedTable,
+  type RelocationSpec,
+  stageTableForRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `activation_sessions` from `main` into the memory DB. Every
+ * row is copied: the table is one row per activation-rail conversation, read
+ * by the activation funnel for the conversation's whole lifetime.
+ */
+export const ACTIVATION_SESSIONS_RELOCATION: RelocationSpec = {
+  table: "activation_sessions",
+  targetDbPath: getMemoryDbPath,
+  columns: ["conversation_id", "created_at"],
+};
+
+/**
+ * Create the `activation_sessions` table on the memory connection. Idempotent
+ * (`IF NOT EXISTS`) — the dedicated connection itself performs no DDL on open,
+ * so this migration owns the schema. Exported so tests can stand up the
+ * memory-side schema without running the full drain.
+ */
+export function ensureActivationSessionsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS activation_sessions (
+      conversation_id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL
+    )
+  `);
+}
+
+/**
+ * Move `activation_sessions` — the per-conversation activation-rail marker
+ * behind the activation funnel telemetry — into the dedicated memory database
+ * (`assistant-memory.db`), joining the memory plugin's other relocated state
+ * so its store reads/writes ride the memory connection.
+ *
+ * Like migration 326 the move is incremental: create the table on the memory
+ * connection, rename any populated `main.activation_sessions` aside to
+ * `activation_sessions__relocating`, then drain it in awaited batches per
+ * {@link ACTIVATION_SESSIONS_RELOCATION}. On a fresh install the main-side
+ * table created by migration 274 is empty, so staging just drops it.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on
+ * a later boot — never renaming the source aside without a target to write
+ * to. The throw is caught per-step by the runner, so startup is not aborted.
+ */
+export async function migrateMoveActivationSessionsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring activation_sessions relocation",
+    );
+  }
+
+  ensureActivationSessionsSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(
+    raw,
+    ACTIVATION_SESSIONS_RELOCATION.table,
+  );
+
+  if (needsDrain) {
+    await drainStagedTable(raw, ACTIVATION_SESSIONS_RELOCATION);
+  }
+}

--- a/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
@@ -26,10 +26,9 @@ export const ACTIVATION_SESSIONS_RELOCATION: RelocationSpec = {
 /**
  * Create the `activation_sessions` table on the memory connection. Idempotent
  * (`IF NOT EXISTS`) — the dedicated connection itself performs no DDL on open,
- * so this migration owns the schema. Exported so tests can stand up the
- * memory-side schema without running the full drain.
+ * so this migration owns the schema.
  */
-export function ensureActivationSessionsSchema(memoryRaw: Database): void {
+function ensureActivationSessionsSchema(memoryRaw: Database): void {
   memoryRaw.exec(/*sql*/ `
     CREATE TABLE IF NOT EXISTS activation_sessions (
       conversation_id TEXT PRIMARY KEY,

--- a/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/339-move-activation-sessions-to-memory-db.ts
@@ -1,15 +1,10 @@
 import type { Database } from "bun:sqlite";
 
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
 import {
-  type DrizzleDb,
-  getMemorySqlite,
-  getSqliteFrom,
-} from "../db-connection.js";
-import {
-  drainStagedTable,
   type RelocationSpec,
-  stageTableForRelocation,
+  runMemoryTableRelocation,
 } from "./helpers/relocation.js";
 
 /**
@@ -43,36 +38,15 @@ function ensureActivationSessionsSchema(memoryRaw: Database): void {
  * (`assistant-memory.db`), joining the memory plugin's other relocated state
  * so its store reads/writes ride the memory connection.
  *
- * Like migration 326 the move is incremental: create the table on the memory
- * connection, rename any populated `main.activation_sessions` aside to
- * `activation_sessions__relocating`, then drain it in awaited batches per
- * {@link ACTIVATION_SESSIONS_RELOCATION}. On a fresh install the main-side
- * table created by migration 274 is empty, so staging just drops it.
- *
- * Throws (rather than returning) if the memory database cannot be opened, so
- * the runner records the step as failed instead of applied and retries it on
- * a later boot — never renaming the source aside without a target to write
- * to. The throw is caught per-step by the runner, so startup is not aborted.
+ * On a fresh install the main-side table created by migration 274 is empty,
+ * so staging just drops it.
  */
 export async function migrateMoveActivationSessionsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const memoryRaw = getMemorySqlite();
-  if (!memoryRaw) {
-    throw new Error(
-      "memory database unavailable — deferring activation_sessions relocation",
-    );
-  }
-
-  ensureActivationSessionsSchema(memoryRaw);
-
-  const raw = getSqliteFrom(database);
-  const needsDrain = stageTableForRelocation(
-    raw,
-    ACTIVATION_SESSIONS_RELOCATION.table,
+  await runMemoryTableRelocation(
+    database,
+    ACTIVATION_SESSIONS_RELOCATION,
+    ensureActivationSessionsSchema,
   );
-
-  if (needsDrain) {
-    await drainStagedTable(raw, ACTIVATION_SESSIONS_RELOCATION);
-  }
 }

--- a/assistant/src/persistence/migrations/helpers/relocation.ts
+++ b/assistant/src/persistence/migrations/helpers/relocation.ts
@@ -6,6 +6,11 @@ import {
   parseChangesFromStdout,
   runAsyncSqlite,
 } from "../../db-async-query.js";
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../../db-connection.js";
 
 const log = getLogger("memory-db");
 
@@ -145,7 +150,9 @@ export async function drainStagedTable(
   const staging = `${table}${RELOCATING_SUFFIX}`;
 
   // Nothing to do once the staging table is gone (drain finished previously).
-  if (!tableExistsInMain(raw, staging)) return;
+  if (!tableExistsInMain(raw, staging)) {
+    return;
+  }
 
   // Build a select list from the staging table's actual columns: apply any
   // per-column transform, copy a present column verbatim, NULL-fill an absent
@@ -227,4 +234,40 @@ export async function drainStagedTable(
     );
   }
   log.info({ table }, "relocation: complete — staging dropped");
+}
+
+/**
+ * Run one memory-table relocation end to end: ensure the table's schema on the
+ * memory connection, stage `main.<table>` aside via
+ * {@link stageTableForRelocation}, then drain the staged rows into the memory
+ * DB in awaited batches via {@link drainStagedTable} per the spec. Because the
+ * drain is awaited as part of the migration step, later startup work observes
+ * the finished move.
+ *
+ * Throws (rather than returning) if the memory database cannot be opened, so
+ * the runner records the step as failed instead of applied and retries it on a
+ * later boot — never renaming the source aside without a target to write to,
+ * and never marking the relocation done while it has not happened. The throw
+ * is caught per-step by the runner, so startup is not aborted.
+ */
+export async function runMemoryTableRelocation(
+  database: DrizzleDb,
+  spec: RelocationSpec,
+  ensureSchema: (memoryRaw: Database) => void,
+): Promise<void> {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      `memory database unavailable — deferring ${spec.table} relocation`,
+    );
+  }
+
+  ensureSchema(memoryRaw);
+
+  const raw = getSqliteFrom(database);
+  const needsDrain = stageTableForRelocation(raw, spec.table);
+
+  if (needsDrain) {
+    await drainStagedTable(raw, spec);
+  }
 }

--- a/assistant/src/persistence/schema/infrastructure.ts
+++ b/assistant/src/persistence/schema/infrastructure.ts
@@ -170,6 +170,10 @@ export const llmRequestLogs = sqliteTable(
   ],
 );
 
+// Per-turn diagnostics for memory recall, recording hit counts, latency,
+// and the injected text. Lives in the dedicated memory database
+// (`assistant-memory.db`), not main — access it via the memory connection
+// (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryRecallLogs = sqliteTable(
   "memory_recall_logs",
   {
@@ -202,6 +206,9 @@ export const memoryRecallLogs = sqliteTable(
   ],
 );
 
+// Per-turn log of memory-v2 concept/skill activations. Lives in the
+// dedicated memory database (`assistant-memory.db`), not main — access it
+// via the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryV2ActivationLogs = sqliteTable(
   "memory_v2_activation_logs",
   {
@@ -277,6 +284,8 @@ export const llmUsageEvents = sqliteTable(
 // One row per conversation started on the activation-rail bootstrap template.
 // Lets the activation funnel telemetry scope its events to activation
 // conversations without inspecting the bootstrap template at emit time.
+// Lives in the dedicated memory database (`assistant-memory.db`), not main —
+// access it via the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const activationSessions = sqliteTable("activation_sessions", {
   conversationId: text("conversation_id").primaryKey(),
   createdAt: integer("created_at").notNull(),

--- a/assistant/src/persistence/schema/memory-core.ts
+++ b/assistant/src/persistence/schema/memory-core.ts
@@ -72,6 +72,9 @@ export const memoryEmbeddings = sqliteTable(
   ],
 );
 
+// Background job queue for the memory plugin. Lives in the dedicated memory
+// database (`assistant-memory.db`), not main — access it via the memory
+// connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryJobs = sqliteTable("memory_jobs", {
   id: text("id").primaryKey(),
   type: text("type").notNull(),

--- a/assistant/src/persistence/schema/memory-injection.ts
+++ b/assistant/src/persistence/schema/memory-injection.ts
@@ -44,6 +44,8 @@ export const memoryV3EverInjected = sqliteTable(
 );
 
 // Per-turn log of which memory-v3 cards were selected, with lane attribution.
+// Lives in the dedicated memory database (`assistant-memory.db`), not main —
+// access it via the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryV3Selections = sqliteTable(
   "memory_v3_selections",
   {

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -445,6 +445,8 @@ import { migrateBackfillTelemetryEventsOutbox } from "./migrations/334-backfill-
 import { migrateCollapseMemoryEmbedBacklog } from "./migrations/335-collapse-memory-embed-backlog.js";
 import { migrateMoveMemoryV2ActivationLogsToMemoryDb } from "./migrations/336-move-memory-v2-activation-logs-to-memory-db.js";
 import { migrateMoveMemoryRecallLogsToMemoryDb } from "./migrations/337-move-memory-recall-logs-to-memory-db.js";
+import { migrateMoveMemoryV3SelectionsToMemoryDb } from "./migrations/338-move-memory-v3-selections-to-memory-db.js";
+import { migrateMoveActivationSessionsToMemoryDb } from "./migrations/339-move-activation-sessions-to-memory-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1377,5 +1379,18 @@ export const migrationSteps: MigrationStep[] = [
       "migrateMemoryRecallLogsQueryContext",
       "migrateDeletePrivateConversations",
     ],
+  },
+  {
+    name: "migrateMoveMemoryV3SelectionsToMemoryDb",
+    run: migrateMoveMemoryV3SelectionsToMemoryDb,
+    dependsOn: [
+      "migrateAddMemoryV3Selections",
+      "migrateMemoryV3SelectionsMessageIdAndSections",
+    ],
+  },
+  {
+    name: "migrateMoveActivationSessionsToMemoryDb",
+    run: migrateMoveActivationSessionsToMemoryDb,
+    dependsOn: ["createActivationSessionsTable"],
   },
 ];

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -443,6 +443,8 @@ import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/332-move
 import { migrateCreateTelemetryEventsTable } from "./migrations/333-create-telemetry-events-table.js";
 import { migrateBackfillTelemetryEventsOutbox } from "./migrations/334-backfill-telemetry-events-outbox.js";
 import { migrateCollapseMemoryEmbedBacklog } from "./migrations/335-collapse-memory-embed-backlog.js";
+import { migrateMoveMemoryV2ActivationLogsToMemoryDb } from "./migrations/336-move-memory-v2-activation-logs-to-memory-db.js";
+import { migrateMoveMemoryRecallLogsToMemoryDb } from "./migrations/337-move-memory-recall-logs-to-memory-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1357,4 +1359,23 @@ export const migrationSteps: MigrationStep[] = [
   migrateCreateTelemetryEventsTable,
   migrateBackfillTelemetryEventsOutbox,
   migrateCollapseMemoryEmbedBacklog,
+  {
+    name: "migrateMoveMemoryV2ActivationLogsToMemoryDb",
+    run: migrateMoveMemoryV2ActivationLogsToMemoryDb,
+    // 256's backfill reads memory_v2_activation_logs from main, so the move
+    // must not run on a database where 256 is still pending.
+    dependsOn: [
+      "migrateMemoryV2ActivationLogs",
+      "migrateMemoryV2InjectionEvents",
+    ],
+  },
+  {
+    name: "migrateMoveMemoryRecallLogsToMemoryDb",
+    run: migrateMoveMemoryRecallLogsToMemoryDb,
+    dependsOn: [
+      "migrateCreateMemoryRecallLogs",
+      "migrateMemoryRecallLogsQueryContext",
+      "migrateDeletePrivateConversations",
+    ],
+  },
 ];

--- a/assistant/src/plugins/defaults/memory/__tests__/activation-session-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/activation-session-store.test.ts
@@ -1,8 +1,15 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { getDb } from "../../../../persistence/db-connection.js";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getMemorySqlite } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
-import { activationSessions } from "../../../../persistence/schema/index.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import * as schema from "../../../../persistence/schema/index.js";
 import {
   isActivationSession,
   markActivationSession,
@@ -12,7 +19,7 @@ await initializeDb();
 
 describe("activation-session-store", () => {
   beforeEach(() => {
-    getDb().delete(activationSessions).run();
+    getMemorySqlite()!.exec("DELETE FROM activation_sessions");
   });
 
   test("marks a conversation and reports it as an activation session", () => {
@@ -28,7 +35,42 @@ describe("activation-session-store", () => {
     markActivationSession("c1");
     markActivationSession("c1");
     expect(isActivationSession("c1")).toBe(true);
-    const rows = getDb().select().from(activationSessions).all();
-    expect(rows.length).toBe(1);
+    const { n } = getMemorySqlite()!
+      .query("SELECT COUNT(*) AS n FROM activation_sessions")
+      .get() as { n: number };
+    expect(n).toBe(1);
+  });
+
+  test("rows land in the memory database, not main", () => {
+    markActivationSession("c-placement");
+    const inMemory = getMemorySqlite()!
+      .query(
+        "SELECT conversation_id FROM activation_sessions WHERE conversation_id = 'c-placement'",
+      )
+      .get() as { conversation_id: string } | null;
+    expect(inMemory?.conversation_id).toBe("c-placement");
+  });
+});
+
+describe("activation-session-store — degraded memory database", () => {
+  // Install a memory DB WITHOUT the activation_sessions table: the store's
+  // catch paths must swallow the failure (write no-ops, read reports false)
+  // rather than throw into the turn.
+  let brokenSqlite: Database;
+
+  beforeEach(() => {
+    brokenSqlite = new Database(":memory:");
+    setStoredDb("memory", drizzle(brokenSqlite, { schema }), () =>
+      brokenSqlite.close(),
+    );
+  });
+
+  afterEach(() => {
+    clearStoredDb("memory");
+  });
+
+  test("mark is a no-op and read reports false", () => {
+    expect(() => markActivationSession("c1")).not.toThrow();
+    expect(isActivationSession("c1")).toBe(false);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
@@ -9,7 +9,8 @@
  *   2. The main connection no longer ATTACHes the memory file: there is no
  *      `memory` schema on its `database_list`.
  *   3. The relocated memory tables (`memory_jobs`, `memory_v2_injection_events`,
- *      `memory_v2_activation_logs`, `memory_recall_logs`) live in the dedicated
+ *      `memory_v2_activation_logs`, `memory_recall_logs`,
+ *      `memory_v3_selections`, `activation_sessions`) live in the dedicated
  *      memory connection, not in the main connection — proving the physical
  *      split.
  *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
@@ -58,6 +59,8 @@ describe("memory database connection", () => {
     "memory_v2_injection_events",
     "memory_v2_activation_logs",
     "memory_recall_logs",
+    "memory_v3_selections",
+    "activation_sessions",
   ])("%s lives in the memory connection, not main", (table) => {
     const inMemory = getMemorySqlite()!
       .query<

--- a/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
@@ -8,9 +8,10 @@
  *      the *main* WAL is exactly what this split exists to prevent.
  *   2. The main connection no longer ATTACHes the memory file: there is no
  *      `memory` schema on its `database_list`.
- *   3. The relocated memory tables (`memory_jobs`, `memory_v2_injection_events`)
- *      live in the dedicated memory connection, not in the main connection —
- *      proving the physical split.
+ *   3. The relocated memory tables (`memory_jobs`, `memory_v2_injection_events`,
+ *      `memory_v2_activation_logs`, `memory_recall_logs`) live in the dedicated
+ *      memory connection, not in the main connection — proving the physical
+ *      split.
  *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
  *      CLI backend, leaving the main DB untouched.
  */
@@ -52,26 +53,28 @@ describe("memory database connection", () => {
     expect(attached.some((e) => e.name === "memory")).toBe(false);
   });
 
-  test.each(["memory_jobs", "memory_v2_injection_events"])(
-    "%s lives in the memory connection, not main",
-    (table) => {
-      const inMemory = getMemorySqlite()!
-        .query<
-          { name: string },
-          [string]
-        >(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
-        .get(table);
-      expect(inMemory?.name).toBe(table);
+  test.each([
+    "memory_jobs",
+    "memory_v2_injection_events",
+    "memory_v2_activation_logs",
+    "memory_recall_logs",
+  ])("%s lives in the memory connection, not main", (table) => {
+    const inMemory = getMemorySqlite()!
+      .query<
+        { name: string },
+        [string]
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(table);
+    expect(inMemory?.name).toBe(table);
 
-      const inMain = getSqlite()
-        .query<
-          { name: string },
-          [string]
-        >(`SELECT name FROM main.sqlite_master WHERE name = ?`)
-        .get(table);
-      expect(inMain).toBeNull();
-    },
-  );
+    const inMain = getSqlite()
+      .query<
+        { name: string },
+        [string]
+      >(`SELECT name FROM main.sqlite_master WHERE name = ?`)
+      .get(table);
+    expect(inMain).toBeNull();
+  });
 
   test.if(sqlite3Available)(
     "runAsyncSqlite({ dbPath }) targets the given file, not the main DB",

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
@@ -8,13 +8,18 @@
  * resolves to null without mocking any module (module mocks would leak into
  * other test files in the same run).
  */
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import type { DrizzleDb } from "../../../../persistence/db-connection.js";
 import {
   clearStoredDb,
   setStoredDb,
 } from "../../../../persistence/db-singleton.js";
+import { migrateAddMemoryV3EverInjected } from "../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
+import * as schema from "../../../../persistence/schema/index.js";
 import {
   backfillMemoryRecallLogMessageId,
   getMemoryRecallLogByMessageIds,
@@ -27,6 +32,8 @@ import {
 } from "../memory-v2-activation-log-store.js";
 import { getConceptFrequencySummary } from "../memory-v2-concept-frequency.js";
 import { extractOracleTurns } from "../v2/harness/oracle.js";
+import { recordInjected } from "../v3/ever-injected-store.js";
+import { planPrune } from "../v3/prune.js";
 import {
   sampleConcepts,
   sampleConfig,
@@ -93,5 +100,49 @@ describe("memory log stores without a memory database", () => {
 
   test("oracle extraction returns no turns", () => {
     expect(extractOracleTurns({} as DrizzleDb)).toEqual([]);
+  });
+});
+
+describe("memory-v3 prune valve without a memory database", () => {
+  // The valve's candidate accounting (`memory_v3_ever_injected`) lives in the
+  // MAIN database, which stays available — install a schema-bearing in-memory
+  // main DB into the `main` singleton slot so only the memory connection
+  // (degraded by the outer beforeEach) is down.
+  let mainSqlite: Database;
+
+  beforeEach(() => {
+    mainSqlite = new Database(":memory:");
+    const mainDb = drizzle(mainSqlite, { schema });
+    migrateAddMemoryV3EverInjected(mainDb);
+    setStoredDb("main", mainDb, () => mainSqlite.close());
+  });
+
+  afterEach(() => {
+    clearStoredDb("main");
+  });
+
+  test("planPrune falls back to injected_at recency without throwing", () => {
+    // With the memory DB unavailable the selection-recency read degrades to
+    // no rows, so every candidate ranks by its injected_at fallback.
+    recordInjected(
+      "conv-degraded-prune",
+      [{ slug: "domain-a/page-old", bytes: 600 }],
+      1_000,
+    );
+    recordInjected(
+      "conv-degraded-prune",
+      [{ slug: "domain-a/page-new", bytes: 500 }],
+      2_000,
+    );
+
+    const plan = planPrune(
+      {
+        maxResidentBytes: 1_000,
+        targetResidentBytes: 500,
+        exemptSlugs: new Set(),
+      },
+      "conv-degraded-prune",
+    );
+    expect(plan).toEqual({ slugs: ["domain-a/page-old"], bytesFreed: 600 });
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Degraded-mode coverage for the relocated per-turn memory log tables: with
+ * the dedicated memory database unavailable, writes are best-effort no-ops
+ * and reads return empty/zero results — nothing throws mid-turn.
+ *
+ * Unavailability is simulated by installing a connection with no underlying
+ * sqlite client into the `memory` singleton slot, so `getMemorySqlite()`
+ * resolves to null without mocking any module (module mocks would leak into
+ * other test files in the same run).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { DrizzleDb } from "../../../../persistence/db-connection.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import {
+  backfillMemoryRecallLogMessageId,
+  getMemoryRecallLogByMessageIds,
+  recordMemoryRecallLog,
+} from "../memory-recall-log-store.js";
+import {
+  backfillMemoryV2ActivationMessageId,
+  getMemoryV2ActivationLogByMessageIds,
+  recordMemoryV2ActivationLog,
+} from "../memory-v2-activation-log-store.js";
+import { getConceptFrequencySummary } from "../memory-v2-concept-frequency.js";
+import { extractOracleTurns } from "../v2/harness/oracle.js";
+import {
+  sampleConcepts,
+  sampleConfig,
+} from "./fixtures/memory-v2-activation-fixtures.js";
+
+// listPages returns [] for a workspace with no concepts directory.
+const WORKSPACE = "/tmp/memory-log-stores-degraded-nonexistent-workspace";
+
+beforeEach(() => {
+  setStoredDb("memory", { $client: null } as unknown as DrizzleDb, () => {});
+});
+
+afterEach(() => {
+  clearStoredDb("memory");
+});
+
+describe("memory log stores without a memory database", () => {
+  test("activation-log writes no-op and reads return null", () => {
+    expect(() =>
+      recordMemoryV2ActivationLog({
+        conversationId: "conv-1",
+        turn: 1,
+        mode: "per-turn",
+        concepts: sampleConcepts,
+        config: sampleConfig,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      backfillMemoryV2ActivationMessageId("conv-1", "msg-1"),
+    ).not.toThrow();
+    expect(getMemoryV2ActivationLogByMessageIds(["msg-1"])).toBeNull();
+  });
+
+  test("recall-log writes no-op and reads return null", () => {
+    expect(() =>
+      recordMemoryRecallLog({
+        conversationId: "conv-1",
+        enabled: true,
+        degraded: false,
+        semanticHits: 1,
+        mergedCount: 1,
+        selectedCount: 1,
+        tier1Count: 1,
+        tier2Count: 0,
+        hybridSearchLatencyMs: 50,
+        sparseVectorUsed: false,
+        injectedTokens: 100,
+        latencyMs: 80,
+        topCandidatesJson: [],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      backfillMemoryRecallLogMessageId("conv-1", "msg-1"),
+    ).not.toThrow();
+    expect(getMemoryRecallLogByMessageIds(["msg-1"])).toBeNull();
+  });
+
+  test("concept-frequency degrades to zero counts", async () => {
+    const result = await getConceptFrequencySummary(WORKSPACE);
+    expect(result.totals).toEqual({ logCount: 0, conceptOccurrences: 0 });
+    expect(result.concepts).toEqual([]);
+    expect(result.neverEvaluatedSlugs).toEqual([]);
+  });
+
+  test("oracle extraction returns no turns", () => {
+    expect(extractOracleTurns({} as DrizzleDb)).toEqual([]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-v2-activation-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-v2-activation-log-store.test.ts
@@ -1,8 +1,20 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+/**
+ * Tests for the memory v2 activation-log store. The store reads and writes
+ * `memory_v2_activation_logs` over the dedicated memory connection, so each
+ * test installs a fresh in-memory database into the `memory` singleton slot
+ * with the relocated table's schema (mirroring injection-events.test.ts).
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { getDb } from "../../../../persistence/db-connection.js";
-import { initializeDb } from "../../../../persistence/db-init.js";
-import { memoryV2ActivationLogs } from "../../../../persistence/schema/index.js";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import { ensureActivationLogsSchema } from "../../../../persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.js";
+import * as schema from "../../../../persistence/schema/index.js";
 import {
   backfillMemoryV2ActivationMessageId,
   getMemoryV2ActivationLogByMessageIds,
@@ -14,18 +26,35 @@ import {
   sampleConfig,
 } from "./fixtures/memory-v2-activation-fixtures.js";
 
-await initializeDb();
+let memorySqlite: Database;
 
-function resetTables(): void {
-  const db = getDb();
-  db.delete(memoryV2ActivationLogs).run();
+beforeEach(() => {
+  memorySqlite = new Database(":memory:");
+  ensureActivationLogsSchema(memorySqlite);
+  setStoredDb("memory", drizzle(memorySqlite, { schema }), () =>
+    memorySqlite.close(),
+  );
+});
+
+afterEach(() => {
+  clearStoredDb("memory");
+});
+
+interface LogRow {
+  message_id: string | null;
+  turn: number;
+  mode: string;
+}
+
+function allRows(): LogRow[] {
+  return memorySqlite
+    .query(
+      `SELECT message_id, turn, mode FROM memory_v2_activation_logs ORDER BY turn`,
+    )
+    .all() as LogRow[];
 }
 
 describe("memory-v2-activation-log-store", () => {
-  beforeEach(() => {
-    resetTables();
-  });
-
   test("round-trip: record → backfill messageId → query by messageId", () => {
     const conversationId = "conv-1";
     const messageId = "msg-1";
@@ -122,6 +151,20 @@ describe("memory-v2-activation-log-store", () => {
     expect(result).toBeNull();
   });
 
+  test("writes land in the memory connection", () => {
+    recordMemoryV2ActivationLog({
+      conversationId: "conv-mem",
+      turn: 1,
+      mode: "per-turn",
+      concepts: sampleConcepts,
+      config: sampleConfig,
+    });
+    const { n } = memorySqlite
+      .query(`SELECT COUNT(*) AS n FROM memory_v2_activation_logs`)
+      .get() as { n: number };
+    expect(n).toBe(1);
+  });
+
   test("backfill only updates rows with NULL messageId", () => {
     const conversationId = "conv-2";
 
@@ -143,11 +186,10 @@ describe("memory-v2-activation-log-store", () => {
     // First backfill: both rows should now have msg-a.
     backfillMemoryV2ActivationMessageId(conversationId, "msg-a");
 
-    const db = getDb();
-    const afterFirstBackfill = db.select().from(memoryV2ActivationLogs).all();
+    const afterFirstBackfill = allRows();
     expect(afterFirstBackfill).toHaveLength(2);
     for (const row of afterFirstBackfill) {
-      expect(row.messageId).toBe("msg-a");
+      expect(row.message_id).toBe("msg-a");
     }
 
     // Record a third row (messageId is NULL initially).
@@ -163,11 +205,10 @@ describe("memory-v2-activation-log-store", () => {
     // and must not overwrite the first two rows already set to msg-a.
     backfillMemoryV2ActivationMessageId(conversationId, "msg-b");
 
-    const afterSecondBackfill = db.select().from(memoryV2ActivationLogs).all();
-    const byTurn = new Map(afterSecondBackfill.map((r) => [r.turn, r]));
-    expect(byTurn.get(1)!.messageId).toBe("msg-a");
-    expect(byTurn.get(2)!.messageId).toBe("msg-a");
-    expect(byTurn.get(3)!.messageId).toBe("msg-b");
+    const byTurn = new Map(allRows().map((r) => [r.turn, r]));
+    expect(byTurn.get(1)!.message_id).toBe("msg-a");
+    expect(byTurn.get(2)!.message_id).toBe("msg-a");
+    expect(byTurn.get(3)!.message_id).toBe("msg-b");
   });
 
   test("backfill skips v3_shadow rows, leaving their messageId null", () => {
@@ -192,12 +233,10 @@ describe("memory-v2-activation-log-store", () => {
 
     backfillMemoryV2ActivationMessageId(conversationId, "msg-live");
 
-    const db = getDb();
-    const rows = db.select().from(memoryV2ActivationLogs).all();
-    const byMode = new Map(rows.map((r) => [r.mode, r]));
+    const byMode = new Map(allRows().map((r) => [r.mode, r]));
     // The live router row got stamped; the shadow row stayed null (not
     // mis-attributed to the live message).
-    expect(byMode.get("router")!.messageId).toBe("msg-live");
-    expect(byMode.get("v3_shadow")!.messageId).toBeNull();
+    expect(byMode.get("router")!.message_id).toBe("msg-live");
+    expect(byMode.get("v3_shadow")!.message_id).toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-v2-concept-frequency.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-v2-concept-frequency.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
 
 let listPagesImpl: (workspaceDir: string) => Promise<string[]> = async () => [];
 
@@ -6,9 +9,12 @@ mock.module("../v2/page-store.js", () => ({
   listPages: (workspaceDir: string) => listPagesImpl(workspaceDir),
 }));
 
-import { getDb } from "../../../../persistence/db-connection.js";
-import { initializeDb } from "../../../../persistence/db-init.js";
-import { memoryV2ActivationLogs } from "../../../../persistence/schema/index.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import { ensureActivationLogsSchema } from "../../../../persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.js";
+import * as schema from "../../../../persistence/schema/index.js";
 import {
   type MemoryV2ConceptRowRecord,
   recordMemoryV2ActivationLog,
@@ -16,7 +22,10 @@ import {
 import { getConceptFrequencySummary } from "../memory-v2-concept-frequency.js";
 import { sampleConfig } from "./fixtures/memory-v2-activation-fixtures.js";
 
-await initializeDb();
+// The store and aggregator resolve the dedicated memory connection through
+// the `memory` singleton slot — install a fresh in-memory DB there with the
+// relocated table's schema.
+let memorySqlite: Database;
 
 const WORKSPACE = "/tmp/memory-v2-concept-frequency-test";
 
@@ -41,14 +50,18 @@ function makeConcept(
   };
 }
 
-function resetTables(): void {
-  getDb().delete(memoryV2ActivationLogs).run();
-}
-
 describe("memory-v2-concept-frequency", () => {
   beforeEach(() => {
-    resetTables();
+    memorySqlite = new Database(":memory:");
+    ensureActivationLogsSchema(memorySqlite);
+    setStoredDb("memory", drizzle(memorySqlite, { schema }), () =>
+      memorySqlite.close(),
+    );
     listPagesImpl = async () => [];
+  });
+
+  afterEach(() => {
+    clearStoredDb("memory");
   });
 
   test("aggregates per-status counts across multiple turns", async () => {
@@ -185,7 +198,7 @@ describe("memory-v2-concept-frequency", () => {
       config: sampleConfig,
     });
     // Backdate the just-written row — recordMemoryV2ActivationLog uses Date.now().
-    getDb().update(memoryV2ActivationLogs).set({ createdAt: 1_000 }).run();
+    memorySqlite.exec(`UPDATE memory_v2_activation_logs SET created_at = 1000`);
 
     recordMemoryV2ActivationLog({
       conversationId: "conv-1",

--- a/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
@@ -28,6 +28,10 @@ const { MEMORY_JOBS_RELOCATION } =
   await import("../../../../persistence/migrations/298-move-memory-jobs-to-memory-db.js");
 const { INJECTION_EVENTS_RELOCATION } =
   await import("../../../../persistence/migrations/326-move-injection-events-to-memory-db.js");
+const { ACTIVATION_LOGS_RELOCATION } =
+  await import("../../../../persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.js");
+const { RECALL_LOGS_RELOCATION } =
+  await import("../../../../persistence/migrations/337-move-memory-recall-logs-to-memory-db.js");
 
 await initializeDb();
 
@@ -174,6 +178,120 @@ describe("memory_v2_injection_events drain", () => {
     expect(kept).toEqual([
       { id: 1, slug: "fresh-a" },
       { id: 2, slug: "fresh-b" },
+    ]);
+  });
+});
+
+describe("memory_v2_activation_logs drain", () => {
+  test("copies every row, drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Clean slate: empty live table, fresh populated staging table.
+    memory.exec(`DELETE FROM memory_v2_activation_logs`);
+    sqlite.exec(
+      `DROP TABLE IF EXISTS main."memory_v2_activation_logs__relocating"`,
+    );
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_v2_activation_logs__relocating" (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        message_id TEXT,
+        turn INTEGER NOT NULL,
+        mode TEXT NOT NULL,
+        concepts_json TEXT NOT NULL,
+        skills_json TEXT NOT NULL,
+        config_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    `);
+
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_v2_activation_logs__relocating"
+         (id, conversation_id, message_id, turn, mode,
+          concepts_json, skills_json, config_json, created_at)
+       VALUES (?, 'conv-1', ?, ?, 'router', '[]', '[]', '{}', ?)`,
+    );
+    insert.run("act-1", "msg-1", 1, 1_000);
+    insert.run("act-2", null, 2, 2_000);
+
+    await drainStagedTable(sqlite, ACTIVATION_LOGS_RELOCATION);
+
+    // Staging dropped; the full-copy spec preserved every row and column.
+    expect(existsInMain("memory_v2_activation_logs__relocating")).toBe(false);
+    const kept = memory
+      .query<
+        { id: string; message_id: string | null; turn: number },
+        []
+      >(`SELECT id, message_id, turn FROM memory_v2_activation_logs ORDER BY id`)
+      .all();
+    expect(kept).toEqual([
+      { id: "act-1", message_id: "msg-1", turn: 1 },
+      { id: "act-2", message_id: null, turn: 2 },
+    ]);
+  });
+});
+
+describe("memory_recall_logs drain", () => {
+  test("copies every row, NULL-fills query_context on a pre-211 source, drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Clean slate: empty live table, fresh populated staging table shaped
+    // like a legacy source that predates the query_context column.
+    memory.exec(`DELETE FROM memory_recall_logs`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."memory_recall_logs__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_recall_logs__relocating" (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        message_id TEXT,
+        enabled INTEGER NOT NULL,
+        degraded INTEGER NOT NULL,
+        provider TEXT,
+        model TEXT,
+        degradation_json TEXT,
+        semantic_hits INTEGER NOT NULL,
+        merged_count INTEGER NOT NULL,
+        selected_count INTEGER NOT NULL,
+        tier1_count INTEGER NOT NULL,
+        tier2_count INTEGER NOT NULL,
+        hybrid_search_latency_ms INTEGER NOT NULL,
+        sparse_vector_used INTEGER NOT NULL,
+        injected_tokens INTEGER NOT NULL,
+        latency_ms INTEGER NOT NULL,
+        top_candidates_json TEXT NOT NULL,
+        injected_text TEXT,
+        reason TEXT,
+        created_at INTEGER NOT NULL
+      )
+    `);
+
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_recall_logs__relocating"
+         (id, conversation_id, message_id, enabled, degraded, semantic_hits,
+          merged_count, selected_count, tier1_count, tier2_count,
+          hybrid_search_latency_ms, sparse_vector_used, injected_tokens,
+          latency_ms, top_candidates_json, created_at)
+       VALUES (?, 'conv-1', ?, 1, 0, 3, 2, 1, 1, 0, 100, 0, 300, 150, '[]', ?)`,
+    );
+    insert.run("rec-1", "msg-1", 1_000);
+    insert.run("rec-2", null, 2_000);
+
+    await drainStagedTable(sqlite, RECALL_LOGS_RELOCATION);
+
+    // Staging dropped; both rows copied with the absent legacy column
+    // NULL-filled.
+    expect(existsInMain("memory_recall_logs__relocating")).toBe(false);
+    const kept = memory
+      .query<
+        { id: string; message_id: string | null; query_context: string | null },
+        []
+      >(`SELECT id, message_id, query_context FROM memory_recall_logs ORDER BY id`)
+      .all();
+    expect(kept).toEqual([
+      { id: "rec-1", message_id: "msg-1", query_context: null },
+      { id: "rec-2", message_id: null, query_context: null },
     ]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
@@ -32,6 +32,10 @@ const { ACTIVATION_LOGS_RELOCATION } =
   await import("../../../../persistence/migrations/336-move-memory-v2-activation-logs-to-memory-db.js");
 const { RECALL_LOGS_RELOCATION } =
   await import("../../../../persistence/migrations/337-move-memory-recall-logs-to-memory-db.js");
+const { MEMORY_V3_SELECTIONS_RELOCATION } =
+  await import("../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js");
+const { ACTIVATION_SESSIONS_RELOCATION } =
+  await import("../../../../persistence/migrations/339-move-activation-sessions-to-memory-db.js");
 
 await initializeDb();
 
@@ -178,6 +182,162 @@ describe("memory_v2_injection_events drain", () => {
     expect(kept).toEqual([
       { id: 1, slug: "fresh-a" },
       { id: 2, slug: "fresh-b" },
+    ]);
+  });
+});
+
+describe("memory_v3_selections drain", () => {
+  test("copies every row (full copy) and drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Clean slate: empty live table, fresh populated staging table with the
+    // full post-283 column set.
+    memory.exec(`DELETE FROM memory_v3_selections`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."memory_v3_selections__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_v3_selections__relocating" (
+        conversation_id TEXT NOT NULL,
+        turn INTEGER NOT NULL,
+        slug TEXT NOT NULL,
+        source TEXT NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        message_id TEXT,
+        section_ordinal INTEGER,
+        section_title TEXT,
+        PRIMARY KEY (conversation_id, turn, slug)
+      )
+    `);
+
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_v3_selections__relocating"
+         (conversation_id, turn, slug, source, pinned, created_at,
+          message_id, section_ordinal, section_title)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run("conv-1", 1, "page-a", "needle", 0, 1_000, "msg-1", 2, "Head");
+    insert.run("conv-1", 2, "page-b", "core", 1, 2_000, null, null, null);
+
+    await drainStagedTable(sqlite, MEMORY_V3_SELECTIONS_RELOCATION);
+
+    expect(existsInMain("memory_v3_selections__relocating")).toBe(false);
+
+    // Both rows landed intact, secondary attributes included.
+    const kept = memory
+      .query(
+        `SELECT conversation_id, turn, slug, source, pinned, created_at,
+                message_id, section_ordinal, section_title
+           FROM memory_v3_selections WHERE conversation_id = 'conv-1'
+           ORDER BY turn`,
+      )
+      .all();
+    expect(kept).toEqual([
+      {
+        conversation_id: "conv-1",
+        turn: 1,
+        slug: "page-a",
+        source: "needle",
+        pinned: 0,
+        created_at: 1_000,
+        message_id: "msg-1",
+        section_ordinal: 2,
+        section_title: "Head",
+      },
+      {
+        conversation_id: "conv-1",
+        turn: 2,
+        slug: "page-b",
+        source: "core",
+        pinned: 1,
+        created_at: 2_000,
+        message_id: null,
+        section_ordinal: null,
+        section_title: null,
+      },
+    ]);
+  });
+
+  test("a pre-283 legacy source NULL-fills the missing columns", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Staging table shaped like migration 268's original schema — no
+    // message_id / section_ordinal / section_title columns.
+    memory.exec(`DELETE FROM memory_v3_selections`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."memory_v3_selections__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_v3_selections__relocating" (
+        conversation_id TEXT NOT NULL,
+        turn INTEGER NOT NULL,
+        slug TEXT NOT NULL,
+        source TEXT NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (conversation_id, turn, slug)
+      )
+    `);
+    sqlite
+      .prepare(
+        `INSERT INTO main."memory_v3_selections__relocating"
+           (conversation_id, turn, slug, source, pinned, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run("conv-legacy", 7, "page-old", "needle", 0, 5_000);
+
+    await drainStagedTable(sqlite, MEMORY_V3_SELECTIONS_RELOCATION);
+
+    expect(existsInMain("memory_v3_selections__relocating")).toBe(false);
+
+    const row = memory
+      .query(
+        `SELECT slug, created_at, message_id, section_ordinal, section_title
+           FROM memory_v3_selections WHERE conversation_id = 'conv-legacy'`,
+      )
+      .get();
+    expect(row).toEqual({
+      slug: "page-old",
+      created_at: 5_000,
+      message_id: null,
+      section_ordinal: null,
+      section_title: null,
+    });
+  });
+});
+
+describe("activation_sessions drain", () => {
+  test("copies every row and drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    memory.exec(`DELETE FROM activation_sessions`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."activation_sessions__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."activation_sessions__relocating" (
+        conversation_id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    const insert = sqlite.prepare(
+      `INSERT INTO main."activation_sessions__relocating"
+         (conversation_id, created_at) VALUES (?, ?)`,
+    );
+    insert.run("conv-a", 1_000);
+    insert.run("conv-b", 2_000);
+
+    await drainStagedTable(sqlite, ACTIVATION_SESSIONS_RELOCATION);
+
+    expect(existsInMain("activation_sessions__relocating")).toBe(false);
+
+    const kept = memory
+      .query(
+        `SELECT conversation_id, created_at FROM activation_sessions
+           ORDER BY conversation_id`,
+      )
+      .all();
+    expect(kept).toEqual([
+      { conversation_id: "conv-a", created_at: 1_000 },
+      { conversation_id: "conv-b", created_at: 2_000 },
     ]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/activation-session-store.ts
+++ b/assistant/src/plugins/defaults/memory/activation-session-store.ts
@@ -1,41 +1,48 @@
-import { eq } from "drizzle-orm";
-
-import { getDb } from "../../../persistence/db-connection.js";
-import { activationSessions } from "../../../persistence/schema/index.js";
 import { getLogger } from "./logging.js";
+import { memorySqliteOrNull } from "./memory-db.js";
 
 const log = getLogger("activation-session-store");
 
 /**
  * Mark a conversation as an activation-rail session. Idempotent (the row's
- * primary key is the conversation id) and best-effort: a write failure is
- * logged and swallowed so it never blocks the turn that triggered it.
+ * primary key is the conversation id) and best-effort: an unavailable memory
+ * database or a write failure is logged and swallowed so it never blocks the
+ * turn that triggered it.
  */
 export function markActivationSession(conversationId: string): void {
   try {
-    getDb()
-      .insert(activationSessions)
-      .values({ conversationId, createdAt: Date.now() })
-      .onConflictDoNothing()
-      .run();
+    const raw = memorySqliteOrNull("markActivationSession");
+    if (!raw) {
+      return;
+    }
+    raw
+      .query(
+        /*sql*/ `INSERT OR IGNORE INTO activation_sessions (conversation_id, created_at) VALUES (?, ?)`,
+      )
+      .run(conversationId, Date.now());
   } catch (err) {
     log.warn({ err, conversationId }, "Failed to mark activation session");
   }
 }
 
 /**
- * Whether the given conversation was started on the activation rail. Best-effort:
- * a read failure is logged and treated as "not an activation session".
+ * Whether the given conversation was started on the activation rail.
+ * Best-effort: an unavailable memory database or a read failure is logged and
+ * treated as "not an activation session".
  */
 export function isActivationSession(conversationId: string): boolean {
   try {
-    const row = getDb()
-      .select({ conversationId: activationSessions.conversationId })
-      .from(activationSessions)
-      .where(eq(activationSessions.conversationId, conversationId))
-      .limit(1)
-      .get();
-    return row !== undefined;
+    const raw = memorySqliteOrNull("isActivationSession");
+    if (!raw) {
+      return false;
+    }
+    return (
+      raw
+        .query(
+          /*sql*/ `SELECT 1 FROM activation_sessions WHERE conversation_id = ?`,
+        )
+        .get(conversationId) != null
+    );
   } catch (err) {
     log.warn({ err, conversationId }, "Failed to read activation session");
     return false;

--- a/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
@@ -17,7 +17,6 @@
 
 import { isMemoryV3Live } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
-import { getDb } from "../../../../persistence/db-connection.js";
 import { getWorkspaceDir } from "../paths.js";
 import { getPageIndex, type PageIndexEntry } from "../v2/page-index.js";
 import { readPage, renderPageContent } from "../v2/page-store.js";
@@ -278,21 +277,15 @@ export async function getMemoryGraph(
   // little extra edge noise) is a fair trade. Floors keep the thresholds sane
   // even when the retrieval config is aggressive or disables the lane.
   const learned = config.memory.v3.learnedEdges;
-  const learnedGraph = computeLearnedEdgeGraph(
-    { db: getDb() },
-    {
-      halfLifeMs: learned.halfLifeDays * DAY_MS,
-      minCount: Math.max(1, learned.minCount * GRAPH_LEARNED_MIN_COUNT_FACTOR),
-      npmiFloor: Math.max(
-        0,
-        learned.npmiFloor * GRAPH_LEARNED_NPMI_FLOOR_FACTOR,
-      ),
-      maxPerPage: Math.max(learned.maxPerPage, GRAPH_LEARNED_MIN_MAX_PER_PAGE),
-      now: Date.now(),
-      windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
-      knownSlugs: new Set(entries.map((e) => e.slug)),
-    },
-  );
+  const learnedGraph = computeLearnedEdgeGraph({
+    halfLifeMs: learned.halfLifeDays * DAY_MS,
+    minCount: Math.max(1, learned.minCount * GRAPH_LEARNED_MIN_COUNT_FACTOR),
+    npmiFloor: Math.max(0, learned.npmiFloor * GRAPH_LEARNED_NPMI_FLOOR_FACTOR),
+    maxPerPage: Math.max(learned.maxPerPage, GRAPH_LEARNED_MIN_MAX_PER_PAGE),
+    now: Date.now(),
+    windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
+    knownSlugs: new Set(entries.map((e) => e.slug)),
+  });
 
   const assembled = assembleMemoryGraph({
     entries,

--- a/assistant/src/plugins/defaults/memory/memory-db.ts
+++ b/assistant/src/plugins/defaults/memory/memory-db.ts
@@ -6,7 +6,8 @@ const log = getLogger("memory-db");
 /**
  * The plugin's accessor for the dedicated memory database
  * (`assistant-memory.db`), where the memory plugin's relocated tables live
- * (`memory_v2_injection_events`, with more to follow).
+ * (`memory_v2_injection_events`, `memory_v3_selections`,
+ * `activation_sessions`, with more to follow).
  *
  * Fail-soft: returns `null` when the file cannot be opened, logging a warn
  * tagged with the calling context. Callers degrade rather than throw — the

--- a/assistant/src/plugins/defaults/memory/memory-db.ts
+++ b/assistant/src/plugins/defaults/memory/memory-db.ts
@@ -5,9 +5,9 @@ const log = getLogger("memory-db");
 
 /**
  * The plugin's accessor for the dedicated memory database
- * (`assistant-memory.db`), where the memory plugin's relocated tables live
- * (`memory_v2_injection_events`, `memory_v3_selections`,
- * `activation_sessions`, with more to follow).
+ * (`assistant-memory.db`), where the memory plugin's relocated tables live.
+ * The `move-*-to-memory-db` migrations in `persistence/migrations/` define
+ * the current set of relocated tables.
  *
  * Fail-soft: returns `null` when the file cannot be opened, logging a warn
  * tagged with the calling context. Callers degrade rather than throw — the

--- a/assistant/src/plugins/defaults/memory/memory-recall-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/memory-recall-log-store.ts
@@ -1,8 +1,9 @@
-import { and, eq, inArray, isNull } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getDb } from "../../../persistence/db-connection.js";
-import { memoryRecallLogs } from "../../../persistence/schema/index.js";
+import { getLogger } from "./logging.js";
+import { memorySqliteOrNull } from "./memory-db.js";
+
+const log = getLogger("memory-recall-log-store");
 
 export interface RecordMemoryRecallLogParams {
   conversationId: string;
@@ -29,51 +30,74 @@ export interface RecordMemoryRecallLogParams {
 export function recordMemoryRecallLog(
   params: RecordMemoryRecallLogParams,
 ): void {
-  const db = getDb();
-  db.insert(memoryRecallLogs)
-    .values({
-      id: uuid(),
-      conversationId: params.conversationId,
-      messageId: null,
-      enabled: params.enabled ? 1 : 0,
-      degraded: params.degraded ? 1 : 0,
-      provider: params.provider ?? null,
-      model: params.model ?? null,
-      degradationJson: params.degradationJson
-        ? JSON.stringify(params.degradationJson)
-        : null,
-      semanticHits: params.semanticHits,
-      mergedCount: params.mergedCount,
-      selectedCount: params.selectedCount,
-      tier1Count: params.tier1Count,
-      tier2Count: params.tier2Count,
-      hybridSearchLatencyMs: params.hybridSearchLatencyMs,
-      sparseVectorUsed: params.sparseVectorUsed ? 1 : 0,
-      injectedTokens: params.injectedTokens,
-      latencyMs: params.latencyMs,
-      topCandidatesJson: JSON.stringify(params.topCandidatesJson),
-      injectedText: params.injectedText ?? null,
-      reason: params.reason ?? null,
-      queryContext: params.queryContext ?? null,
-      createdAt: Date.now(),
-    })
-    .run();
+  // Best-effort — telemetry writes must never abort the agent turn, so a
+  // degraded memory connection or a failed insert only logs a warning.
+  try {
+    const raw = memorySqliteOrNull("recordMemoryRecallLog");
+    if (!raw) {
+      return;
+    }
+    raw
+      .prepare(
+        `INSERT INTO memory_recall_logs (
+           id, conversation_id, message_id, enabled, degraded, provider,
+           model, degradation_json, semantic_hits, merged_count,
+           selected_count, tier1_count, tier2_count,
+           hybrid_search_latency_ms, sparse_vector_used, injected_tokens,
+           latency_ms, top_candidates_json, injected_text, reason,
+           query_context, created_at
+         ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        uuid(),
+        params.conversationId,
+        params.enabled ? 1 : 0,
+        params.degraded ? 1 : 0,
+        params.provider ?? null,
+        params.model ?? null,
+        params.degradationJson ? JSON.stringify(params.degradationJson) : null,
+        params.semanticHits,
+        params.mergedCount,
+        params.selectedCount,
+        params.tier1Count,
+        params.tier2Count,
+        params.hybridSearchLatencyMs,
+        params.sparseVectorUsed ? 1 : 0,
+        params.injectedTokens,
+        params.latencyMs,
+        JSON.stringify(params.topCandidatesJson),
+        params.injectedText ?? null,
+        params.reason ?? null,
+        params.queryContext ?? null,
+        Date.now(),
+      );
+  } catch (err) {
+    log.warn({ err }, "failed to record memory recall log; continuing");
+  }
 }
 
 export function backfillMemoryRecallLogMessageId(
   conversationId: string,
   messageId: string,
 ): void {
-  const db = getDb();
-  db.update(memoryRecallLogs)
-    .set({ messageId })
-    .where(
-      and(
-        eq(memoryRecallLogs.conversationId, conversationId),
-        isNull(memoryRecallLogs.messageId),
-      ),
-    )
-    .run();
+  try {
+    const raw = memorySqliteOrNull("backfillMemoryRecallLogMessageId");
+    if (!raw) {
+      return;
+    }
+    raw
+      .prepare(
+        `UPDATE memory_recall_logs
+           SET message_id = ?
+         WHERE conversation_id = ? AND message_id IS NULL`,
+      )
+      .run(messageId, conversationId);
+  } catch (err) {
+    log.warn(
+      { err },
+      "failed to backfill memory recall log messageId; continuing",
+    );
+  }
 }
 
 export interface MemoryRecallLog {
@@ -104,9 +128,13 @@ export interface MemoryRecallLog {
  * Entries already in inspector format pass through unchanged.
  */
 export function normalizeTopCandidates(raw: unknown): unknown {
-  if (!Array.isArray(raw)) return raw;
+  if (!Array.isArray(raw)) {
+    return raw;
+  }
   return raw.flatMap((entry: Record<string, unknown>) => {
-    if (!entry || typeof entry !== "object") return [];
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
 
     // Start with a shallow copy, then apply field renames
     const { key, finalScore, semantic, recency, kind: _kind, ...rest } = entry;
@@ -137,36 +165,71 @@ export function normalizeTopCandidates(raw: unknown): unknown {
   });
 }
 
+interface MemoryRecallLogRow {
+  enabled: number;
+  degraded: number;
+  provider: string | null;
+  model: string | null;
+  degradation_json: string | null;
+  semantic_hits: number;
+  merged_count: number;
+  selected_count: number;
+  tier1_count: number;
+  tier2_count: number;
+  hybrid_search_latency_ms: number;
+  sparse_vector_used: number;
+  injected_tokens: number;
+  latency_ms: number;
+  top_candidates_json: string;
+  injected_text: string | null;
+  reason: string | null;
+  query_context: string | null;
+}
+
 export function getMemoryRecallLogByMessageIds(
   messageIds: string[],
 ): MemoryRecallLog | null {
-  if (messageIds.length === 0) return null;
-  const db = getDb();
-  const rows = db
-    .select()
-    .from(memoryRecallLogs)
-    .where(inArray(memoryRecallLogs.messageId, messageIds))
-    .all();
-  if (rows.length === 0) return null;
-  const row = rows[0]!;
+  if (messageIds.length === 0) {
+    return null;
+  }
+  const raw = memorySqliteOrNull("getMemoryRecallLogByMessageIds");
+  if (!raw) {
+    return null;
+  }
+  const placeholders = messageIds.map(() => "?").join(",");
+  const row = raw
+    .query(
+      `SELECT enabled, degraded, provider, model, degradation_json,
+              semantic_hits, merged_count, selected_count, tier1_count,
+              tier2_count, hybrid_search_latency_ms, sparse_vector_used,
+              injected_tokens, latency_ms, top_candidates_json,
+              injected_text, reason, query_context
+         FROM memory_recall_logs
+        WHERE message_id IN (${placeholders})
+        LIMIT 1`,
+    )
+    .get(...messageIds) as MemoryRecallLogRow | null;
+  if (!row) {
+    return null;
+  }
   return {
     enabled: !!row.enabled,
     degraded: !!row.degraded,
     provider: row.provider,
     model: row.model,
-    degradation: row.degradationJson ? JSON.parse(row.degradationJson) : null,
-    semanticHits: row.semanticHits,
-    mergedCount: row.mergedCount,
-    selectedCount: row.selectedCount,
-    tier1Count: row.tier1Count,
-    tier2Count: row.tier2Count,
-    hybridSearchLatencyMs: row.hybridSearchLatencyMs,
-    sparseVectorUsed: !!row.sparseVectorUsed,
-    injectedTokens: row.injectedTokens,
-    latencyMs: row.latencyMs,
-    topCandidates: normalizeTopCandidates(JSON.parse(row.topCandidatesJson)),
-    injectedText: row.injectedText,
+    degradation: row.degradation_json ? JSON.parse(row.degradation_json) : null,
+    semanticHits: row.semantic_hits,
+    mergedCount: row.merged_count,
+    selectedCount: row.selected_count,
+    tier1Count: row.tier1_count,
+    tier2Count: row.tier2_count,
+    hybridSearchLatencyMs: row.hybrid_search_latency_ms,
+    sparseVectorUsed: !!row.sparse_vector_used,
+    injectedTokens: row.injected_tokens,
+    latencyMs: row.latency_ms,
+    topCandidates: normalizeTopCandidates(JSON.parse(row.top_candidates_json)),
+    injectedText: row.injected_text,
     reason: row.reason,
-    queryContext: row.queryContext,
+    queryContext: row.query_context,
   };
 }

--- a/assistant/src/plugins/defaults/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/memory-v2-activation-log-store.ts
@@ -1,8 +1,9 @@
-import { and, desc, eq, inArray, isNull, ne } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getDb } from "../../../persistence/db-connection.js";
-import { memoryV2ActivationLogs } from "../../../persistence/schema/index.js";
+import { getLogger } from "./logging.js";
+import { memorySqliteOrNull } from "./memory-db.js";
+
+const log = getLogger("memory-v2-activation-log-store");
 
 export interface MemoryV2ConceptRowRecord {
   slug: string;
@@ -139,45 +140,66 @@ export interface RecordMemoryV2ActivationLogParams {
 export function recordMemoryV2ActivationLog(
   params: RecordMemoryV2ActivationLogParams,
 ): void {
-  const db = getDb();
-  // Skills now live as concept rows under `slug: "skills/<id>"`, so the
-  // separate `skills_json` column is always written empty. The column itself
-  // remains in the schema for backwards-compat with prior log rows; the
-  // reader drops it. A future migration can DROP the column once those rows
-  // age out of relevance.
-  db.insert(memoryV2ActivationLogs)
-    .values({
-      id: uuid(),
-      conversationId: params.conversationId,
-      messageId: null,
-      turn: params.turn,
-      mode: params.mode,
-      conceptsJson: JSON.stringify(params.concepts),
-      skillsJson: "[]",
-      configJson: JSON.stringify(params.config),
-      createdAt: Date.now(),
-    })
-    .run();
+  // Best-effort — telemetry writes must never abort the agent turn, so a
+  // degraded memory connection or a failed insert only logs a warning.
+  try {
+    const raw = memorySqliteOrNull("recordMemoryV2ActivationLog");
+    if (!raw) {
+      return;
+    }
+    // Skills live as concept rows under `slug: "skills/<id>"`, so the
+    // separate `skills_json` column is always written empty. The column
+    // itself remains in the schema for backwards-compat with prior log rows;
+    // the reader drops it.
+    raw
+      .prepare(
+        `INSERT INTO memory_v2_activation_logs (
+           id, conversation_id, message_id, turn, mode,
+           concepts_json, skills_json, config_json, created_at
+         ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        uuid(),
+        params.conversationId,
+        params.turn,
+        params.mode,
+        JSON.stringify(params.concepts),
+        "[]",
+        JSON.stringify(params.config),
+        Date.now(),
+      );
+  } catch (err) {
+    log.warn({ err }, "failed to record memory v2 activation log; continuing");
+  }
 }
 
 export function backfillMemoryV2ActivationMessageId(
   conversationId: string,
   messageId: string,
 ): void {
-  const db = getDb();
   // `v3_shadow` rows are detached telemetry written outside the live turn with
   // a null messageId; they are not tied to any specific message. Excluding them
   // keeps their messageId null instead of stamping them with a later turn's id.
-  db.update(memoryV2ActivationLogs)
-    .set({ messageId })
-    .where(
-      and(
-        eq(memoryV2ActivationLogs.conversationId, conversationId),
-        isNull(memoryV2ActivationLogs.messageId),
-        ne(memoryV2ActivationLogs.mode, "v3_shadow"),
-      ),
-    )
-    .run();
+  try {
+    const raw = memorySqliteOrNull("backfillMemoryV2ActivationMessageId");
+    if (!raw) {
+      return;
+    }
+    raw
+      .prepare(
+        `UPDATE memory_v2_activation_logs
+           SET message_id = ?
+         WHERE conversation_id = ?
+           AND message_id IS NULL
+           AND mode != 'v3_shadow'`,
+      )
+      .run(messageId, conversationId);
+  } catch (err) {
+    log.warn(
+      { err },
+      "failed to backfill memory v2 activation messageId; continuing",
+    );
+  }
 }
 
 export interface MemoryV2ActivationLog {
@@ -191,18 +213,34 @@ export interface MemoryV2ActivationLog {
 export function getMemoryV2ActivationLogByMessageIds(
   messageIds: string[],
 ): MemoryV2ActivationLog | null {
-  if (messageIds.length === 0) return null;
-  const db = getDb();
-  const rows = db
-    .select()
-    .from(memoryV2ActivationLogs)
-    .where(inArray(memoryV2ActivationLogs.messageId, messageIds))
-    .orderBy(desc(memoryV2ActivationLogs.createdAt))
-    .all();
-  if (rows.length === 0) return null;
-  const row = rows[0]!;
+  if (messageIds.length === 0) {
+    return null;
+  }
+  const raw = memorySqliteOrNull("getMemoryV2ActivationLogByMessageIds");
+  if (!raw) {
+    return null;
+  }
+  const placeholders = messageIds.map(() => "?").join(",");
+  const row = raw
+    .query(
+      `SELECT conversation_id, turn, mode, concepts_json, config_json
+         FROM memory_v2_activation_logs
+        WHERE message_id IN (${placeholders})
+        ORDER BY created_at DESC
+        LIMIT 1`,
+    )
+    .get(...messageIds) as {
+    conversation_id: string;
+    turn: number;
+    mode: string;
+    concepts_json: string;
+    config_json: string;
+  } | null;
+  if (!row) {
+    return null;
+  }
   return {
-    conversationId: row.conversationId,
+    conversationId: row.conversation_id,
     turn: row.turn,
     mode: row.mode as
       | "context-load"
@@ -210,7 +248,7 @@ export function getMemoryV2ActivationLogByMessageIds(
       | "errored"
       | "router"
       | "v3_shadow",
-    concepts: JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[],
-    config: JSON.parse(row.configJson) as MemoryV2ConfigSnapshot,
+    concepts: JSON.parse(row.concepts_json) as MemoryV2ConceptRowRecord[],
+    config: JSON.parse(row.config_json) as MemoryV2ConfigSnapshot,
   };
 }

--- a/assistant/src/plugins/defaults/memory/memory-v2-concept-frequency.ts
+++ b/assistant/src/plugins/defaults/memory/memory-v2-concept-frequency.ts
@@ -1,4 +1,4 @@
-import { rawAll, rawGet } from "../../../persistence/raw-query.js";
+import { memorySqliteOrNull } from "./memory-db.js";
 import type { MemoryV2ConceptRowRecord } from "./memory-v2-activation-log-store.js";
 import { listPages } from "./v2/page-store.js";
 
@@ -67,43 +67,51 @@ export async function getConceptFrequencySummary(
   const sinceMs = filters.sinceMs ?? null;
 
   // Kick off the on-disk page walk in parallel with the (synchronous) SQL
-  // queries below — listPages does fs.readdir, rawAll/rawGet are sync.
+  // queries below — listPages does fs.readdir, the sqlite queries are sync.
   const onDiskSlugsPromise = listPages(workspaceDir);
 
-  const aggRows = rawAll<AggRow>(
-    "conceptFreq:summary:agg",
-    `SELECT
-       json_extract(c.value, '$.slug')   AS slug,
-       json_extract(c.value, '$.status') AS status,
-       COUNT(*)                          AS count,
-       MAX(l.created_at)                 AS last_seen
-     FROM memory_v2_activation_logs l, json_each(l.concepts_json) c
-     WHERE (? IS NULL OR l.conversation_id = ?)
-       AND (? IS NULL OR l.created_at >= ?)
-     GROUP BY slug, status`,
-    conversationId,
-    conversationId,
-    sinceMs,
-    sinceMs,
-  );
+  // Fail-soft: with the memory database unavailable the aggregation degrades
+  // to zero counts, so every on-disk page reads as never evaluated.
+  const raw = memorySqliteOrNull("getConceptFrequencySummary");
+  if (!raw) {
+    return {
+      filters: { conversationId, sinceMs },
+      totals: { logCount: 0, conceptOccurrences: 0 },
+      concepts: [],
+      neverEvaluatedSlugs: [...(await onDiskSlugsPromise)].sort(),
+    };
+  }
 
-  const logCountRow = rawGet<CountRow>(
-    "conceptFreq:summary:count",
-    `SELECT COUNT(*) AS count
-       FROM memory_v2_activation_logs
-       WHERE (? IS NULL OR conversation_id = ?)
-         AND (? IS NULL OR created_at >= ?)`,
-    conversationId,
-    conversationId,
-    sinceMs,
-    sinceMs,
-  );
+  const aggRows = raw
+    .query(
+      `SELECT
+         json_extract(c.value, '$.slug')   AS slug,
+         json_extract(c.value, '$.status') AS status,
+         COUNT(*)                          AS count,
+         MAX(l.created_at)                 AS last_seen
+       FROM memory_v2_activation_logs l, json_each(l.concepts_json) c
+       WHERE (? IS NULL OR l.conversation_id = ?)
+         AND (? IS NULL OR l.created_at >= ?)
+       GROUP BY slug, status`,
+    )
+    .all(conversationId, conversationId, sinceMs, sinceMs) as AggRow[];
+
+  const logCountRow = raw
+    .query(
+      `SELECT COUNT(*) AS count
+         FROM memory_v2_activation_logs
+         WHERE (? IS NULL OR conversation_id = ?)
+           AND (? IS NULL OR created_at >= ?)`,
+    )
+    .get(conversationId, conversationId, sinceMs, sinceMs) as CountRow | null;
 
   const bySlug = new Map<string, ConceptFrequencyRow>();
   let conceptOccurrences = 0;
 
   for (const row of aggRows) {
-    if (!row.slug) continue;
+    if (!row.slug) {
+      continue;
+    }
     let entry = bySlug.get(row.slug);
     if (!entry) {
       entry = {
@@ -152,7 +160,9 @@ export async function getConceptFrequencySummary(
 
   const neverEvaluatedSlugs: string[] = [];
   for (const slug of onDiskSlugs) {
-    if (!bySlug.has(slug)) neverEvaluatedSlugs.push(slug);
+    if (!bySlug.has(slug)) {
+      neverEvaluatedSlugs.push(slug);
+    }
   }
   neverEvaluatedSlugs.sort();
 

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/harness-compare.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/harness-compare.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../../../../../config/types.js";
-import { getDb } from "../../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../../persistence/db-init.js";
 import {
   conversations,
-  memoryV2ActivationLogs,
   messages,
 } from "../../../../../persistence/schema/index.js";
 import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
@@ -93,20 +95,23 @@ function insertRouterLog(
   createdAt: number,
 ): void {
   ensureConversation(conversationId);
-  getDb()
-    .insert(memoryV2ActivationLogs)
-    .values({
-      id: `log-${seq++}`,
+  // The activation log lives in the dedicated memory database.
+  getMemorySqlite()!
+    .prepare(
+      `INSERT INTO memory_v2_activation_logs (
+         id, conversation_id, message_id, turn, mode,
+         concepts_json, skills_json, config_json, created_at
+       ) VALUES (?, ?, ?, ?, 'router', ?, '[]', ?, ?)`,
+    )
+    .run(
+      `log-${seq++}`,
       conversationId,
       messageId,
       turn,
-      mode: "router",
-      conceptsJson: JSON.stringify(concepts),
-      skillsJson: "[]",
-      configJson: JSON.stringify(ZERO_CONFIG),
+      JSON.stringify(concepts),
+      JSON.stringify(ZERO_CONFIG),
       createdAt,
-    })
-    .run();
+    );
 }
 
 function stubRetriever(name: string, selected: string[]): Retriever {
@@ -120,9 +125,8 @@ function stubRetriever(name: string, selected: string[]): Retriever {
 }
 
 function reset(): void {
-  const db = getDb();
-  db.delete(memoryV2ActivationLogs).run();
-  db.delete(messages).run();
+  getMemorySqlite()!.exec(`DELETE FROM memory_v2_activation_logs`);
+  getDb().delete(messages).run();
 }
 
 /** Seed one router turn: user msg, assistant anchor, and the logged picks. */

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/harness-oracle.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/harness-oracle.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { getDb } from "../../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../../persistence/db-init.js";
 import {
   conversations,
-  memoryV2ActivationLogs,
   messages,
 } from "../../../../../persistence/schema/index.js";
 import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
@@ -63,20 +65,24 @@ function insertLog(opts: {
   createdAt: number;
 }): void {
   ensureConversation(opts.conversationId);
-  getDb()
-    .insert(memoryV2ActivationLogs)
-    .values({
-      id: `log-${seq++}`,
-      conversationId: opts.conversationId,
-      messageId: opts.messageId,
-      turn: opts.turn,
-      mode: opts.mode,
-      conceptsJson: JSON.stringify(opts.concepts),
-      skillsJson: "[]",
-      configJson: CONFIG_JSON,
-      createdAt: opts.createdAt,
-    })
-    .run();
+  // The activation log lives in the dedicated memory database.
+  getMemorySqlite()!
+    .prepare(
+      `INSERT INTO memory_v2_activation_logs (
+         id, conversation_id, message_id, turn, mode,
+         concepts_json, skills_json, config_json, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, '[]', ?, ?)`,
+    )
+    .run(
+      `log-${seq++}`,
+      opts.conversationId,
+      opts.messageId,
+      opts.turn,
+      opts.mode,
+      JSON.stringify(opts.concepts),
+      CONFIG_JSON,
+      opts.createdAt,
+    );
 }
 
 function insertMessage(
@@ -98,9 +104,8 @@ function insertMessage(
 }
 
 function reset(): void {
-  const db = getDb();
-  db.delete(memoryV2ActivationLogs).run();
-  db.delete(messages).run();
+  getMemorySqlite()!.exec(`DELETE FROM memory_v2_activation_logs`);
+  getDb().delete(messages).run();
 }
 
 describe("harness/oracle extractOracleTurns", () => {

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/harness-replay-input.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/harness-replay-input.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../../../../../config/types.js";
-import { getDb } from "../../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../../persistence/db-init.js";
 import {
   conversations,
-  memoryV2ActivationLogs,
   messages,
 } from "../../../../../persistence/schema/index.js";
 import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
@@ -93,20 +95,23 @@ function insertRouterLog(
   createdAt: number,
 ): void {
   ensureConversation(conversationId);
-  getDb()
-    .insert(memoryV2ActivationLogs)
-    .values({
-      id: `log-${seq++}`,
+  // The activation log lives in the dedicated memory database.
+  getMemorySqlite()!
+    .prepare(
+      `INSERT INTO memory_v2_activation_logs (
+         id, conversation_id, message_id, turn, mode,
+         concepts_json, skills_json, config_json, created_at
+       ) VALUES (?, ?, ?, ?, 'router', ?, '[]', ?, ?)`,
+    )
+    .run(
+      `log-${seq++}`,
       conversationId,
       messageId,
       turn,
-      mode: "router",
-      conceptsJson: JSON.stringify(concepts),
-      skillsJson: "[]",
-      configJson: JSON.stringify(ZERO_CONFIG),
+      JSON.stringify(concepts),
+      JSON.stringify(ZERO_CONFIG),
       createdAt,
-    })
-    .run();
+    );
 }
 
 function turnFor(
@@ -127,9 +132,8 @@ function turnFor(
 }
 
 function reset(): void {
-  const db = getDb();
-  db.delete(memoryV2ActivationLogs).run();
-  db.delete(messages).run();
+  getMemorySqlite()!.exec(`DELETE FROM memory_v2_activation_logs`);
+  getDb().delete(messages).run();
 }
 
 describe("harness/replay-input reconstructInput", () => {

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/injection.test.ts
@@ -184,8 +184,8 @@ mock.module("../cli-command-store.js", () => ({
 // Activation-log store mock
 // ---------------------------------------------------------------------------
 //
-// The real `recordMemoryV2ActivationLog` writes to the singleton
-// `getDb()` — but this test uses an isolated in-memory database, so we mock
+// The real `recordMemoryV2ActivationLog` writes to the memory-DB singleton
+// connection — but this test uses an isolated in-memory database, so we mock
 // the writer to capture calls in-process. `recordCalls` is the captured log
 // array; `recordShouldThrow` makes the next call throw to verify the caller
 // swallows the failure.
@@ -307,11 +307,24 @@ mock.module("../activation-store.js", () => ({
 
 let tmpWorkspace: string;
 let previousWorkspaceEnv: string | undefined;
+let memorySqlite: Database;
 
 beforeAll(() => {
   tmpWorkspace = mkdtempSync(join(tmpdir(), "memory-v2-injection-test-"));
   previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
   process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+  // The injection-events accessors resolve the dedicated memory connection
+  // through the `memory` singleton slot. Left alone, the slot either holds a
+  // connection cached by an earlier test file (that file's workspace) or
+  // lazily opens a schema-less DB under this file's temporary workspace —
+  // both order-dependent. Install a fresh in-memory DB with the relocated
+  // table's schema so this file is hermetic either way.
+  memorySqlite = new Database(":memory:");
+  ensureInjectionEventsSchema(memorySqlite);
+  setStoredDb("memory", drizzle(memorySqlite, { schema }), () =>
+    memorySqlite.close(),
+  );
 
   // Seed the v2 directory layout the migration would normally create.
   mkdirSync(join(tmpWorkspace, "memory", "concepts"), { recursive: true });
@@ -369,6 +382,9 @@ Long-form body content that should NOT appear in the injection block when the pa
 });
 
 afterAll(() => {
+  // Drop this file's in-memory memory-DB install so later test files reopen
+  // the connection from their own (restored) workspace path.
+  clearStoredDb("memory");
   if (previousWorkspaceEnv === undefined) {
     delete process.env.VELLUM_WORKSPACE_DIR;
   } else {
@@ -384,6 +400,10 @@ import type { SkillEntry } from "../types.js";
 
 const { getSqliteFrom } =
   await import("../../../../../persistence/db-connection.js");
+const { clearStoredDb, setStoredDb } =
+  await import("../../../../../persistence/db-singleton.js");
+const { ensureInjectionEventsSchema } =
+  await import("../../../../../persistence/migrations/326-move-injection-events-to-memory-db.js");
 const { migrateActivationState } =
   await import("../../../../../persistence/migrations/232-activation-state.js");
 const { migrateMemoryV2InjectionEvents } =

--- a/assistant/src/plugins/defaults/memory/v2/harness/oracle.ts
+++ b/assistant/src/plugins/defaults/memory/v2/harness/oracle.ts
@@ -15,13 +15,11 @@
  * always excluded.
  */
 
-import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import type { DrizzleDb } from "../../../../../persistence/db-connection.js";
-import {
-  memoryV2ActivationLogs,
-  messages,
-} from "../../../../../persistence/schema/index.js";
+import { messages } from "../../../../../persistence/schema/index.js";
+import { memorySqliteOrNull } from "../../memory-db.js";
 import type {
   MemoryV2ConceptRowRecord,
   MemoryV2ConfigSnapshot,
@@ -68,41 +66,51 @@ export function extractOracleTurns(
   } = options;
 
   const allowedStatuses = new Set<string>(["injected", "in_context"]);
-  if (includeNotInjected) allowedStatuses.add("not_injected");
-
-  const filters = [
-    eq(memoryV2ActivationLogs.mode, "router"),
-    isNotNull(memoryV2ActivationLogs.messageId),
-  ];
-  if (conversationIds && conversationIds.length > 0) {
-    filters.push(
-      inArray(memoryV2ActivationLogs.conversationId, conversationIds),
-    );
+  if (includeNotInjected) {
+    allowedStatuses.add("not_injected");
   }
 
-  const rows = db
-    .select({
-      conversationId: memoryV2ActivationLogs.conversationId,
-      messageId: memoryV2ActivationLogs.messageId,
-      turn: memoryV2ActivationLogs.turn,
-      conceptsJson: memoryV2ActivationLogs.conceptsJson,
-      configJson: memoryV2ActivationLogs.configJson,
-      createdAt: memoryV2ActivationLogs.createdAt,
-    })
-    .from(memoryV2ActivationLogs)
-    .where(and(...filters))
-    .orderBy(
-      strategy === "random"
-        ? sql`RANDOM()`
-        : desc(memoryV2ActivationLogs.createdAt),
+  // The activation log lives in the dedicated memory database; the anchor
+  // lookup below stays on the main connection (`messages`). Fail-soft: no
+  // memory connection means no oracle turns.
+  const memoryRaw = memorySqliteOrNull("extractOracleTurns");
+  if (!memoryRaw) {
+    return [];
+  }
+
+  const params: (string | number)[] = [];
+  let where = `mode = 'router' AND message_id IS NOT NULL`;
+  if (conversationIds && conversationIds.length > 0) {
+    where += ` AND conversation_id IN (${conversationIds.map(() => "?").join(",")})`;
+    params.push(...conversationIds);
+  }
+  const orderBy = strategy === "random" ? "RANDOM()" : "created_at DESC";
+  params.push(limit);
+
+  const rows = memoryRaw
+    .query(
+      `SELECT conversation_id, message_id, turn, concepts_json, config_json,
+              created_at
+         FROM memory_v2_activation_logs
+        WHERE ${where}
+        ORDER BY ${orderBy}
+        LIMIT ?`,
     )
-    .limit(limit)
-    .all();
+    .all(...params) as Array<{
+    conversation_id: string;
+    message_id: string | null;
+    turn: number;
+    concepts_json: string;
+    config_json: string;
+    created_at: number;
+  }>;
 
   const turns: OracleTurn[] = [];
   for (const row of rows) {
-    const messageId = row.messageId;
-    if (messageId == null) continue;
+    const messageId = row.message_id;
+    if (messageId == null) {
+      continue;
+    }
 
     const anchor = db
       .select({ createdAt: messages.createdAt })
@@ -111,13 +119,15 @@ export function extractOracleTurns(
       .limit(1)
       .all();
     const anchorRow = anchor[0];
-    if (!anchorRow) continue;
+    if (!anchorRow) {
+      continue;
+    }
 
     let concepts: MemoryV2ConceptRowRecord[];
     let loggedConfig: MemoryV2ConfigSnapshot;
     try {
-      concepts = JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[];
-      loggedConfig = JSON.parse(row.configJson) as MemoryV2ConfigSnapshot;
+      concepts = JSON.parse(row.concepts_json) as MemoryV2ConceptRowRecord[];
+      loggedConfig = JSON.parse(row.config_json) as MemoryV2ConfigSnapshot;
     } catch {
       continue;
     }
@@ -125,22 +135,30 @@ export function extractOracleTurns(
     const seen = new Set<string>();
     const groundTruthSlugs: string[] = [];
     for (const concept of concepts) {
-      if (!allowedStatuses.has(concept.status)) continue;
-      if (pageExists && !pageExists(concept.slug)) continue;
-      if (seen.has(concept.slug)) continue;
+      if (!allowedStatuses.has(concept.status)) {
+        continue;
+      }
+      if (pageExists && !pageExists(concept.slug)) {
+        continue;
+      }
+      if (seen.has(concept.slug)) {
+        continue;
+      }
       seen.add(concept.slug);
       groundTruthSlugs.push(concept.slug);
     }
-    if (groundTruthSlugs.length === 0) continue;
+    if (groundTruthSlugs.length === 0) {
+      continue;
+    }
 
     turns.push({
-      conversationId: row.conversationId,
+      conversationId: row.conversation_id,
       turn: row.turn,
       anchorMessageId: messageId,
       anchorCreatedAt: anchorRow.createdAt,
       groundTruthSlugs,
       loggedConfig,
-      createdAt: row.createdAt,
+      createdAt: row.created_at,
     });
   }
 

--- a/assistant/src/plugins/defaults/memory/v2/harness/replay-input.ts
+++ b/assistant/src/plugins/defaults/memory/v2/harness/replay-input.ts
@@ -21,14 +21,12 @@
  */
 
 import type { ContentBlock } from "@vellumai/plugin-api";
-import { and, asc, desc, eq, lt, lte } from "drizzle-orm";
+import { and, desc, eq, lte } from "drizzle-orm";
 
 import type { AssistantConfig } from "../../../../../config/types.js";
 import type { DrizzleDb } from "../../../../../persistence/db-connection.js";
-import {
-  memoryV2ActivationLogs,
-  messages,
-} from "../../../../../persistence/schema/index.js";
+import { messages } from "../../../../../persistence/schema/index.js";
+import { memorySqliteOrNull } from "../../memory-db.js";
 import type { MemoryV2ConceptRowRecord } from "../../memory-v2-activation-log-store.js";
 import { loadNowText } from "../now-text.js";
 import type { RouterTurnPair } from "../router.js";
@@ -143,9 +141,13 @@ export async function reconstructInput(
     .all();
 
   const anchorPos = recent.findIndex((m) => m.id === turn.anchorMessageId);
-  if (anchorPos < 0) return null;
+  if (anchorPos < 0) {
+    return null;
+  }
   const beforeAnchor = recent.slice(anchorPos + 1);
-  if (beforeAnchor.length === 0) return null;
+  if (beforeAnchor.length === 0) {
+    return null;
+  }
 
   const plain: PlainMessage[] = beforeAnchor
     .slice()
@@ -154,7 +156,6 @@ export async function reconstructInput(
 
   const recentTurnPairs = extractRecentTurnPairs(plain, windowPairs);
   const priorEverInjected = reconstructPriorEverInjected(
-    db,
     turn.conversationId,
     turn.turn,
   );
@@ -197,38 +198,41 @@ const PRIOR_STATUSES = new Set<string>([
  * Union of slugs injected on earlier `mode='router'` turns in this conversation
  * (turn < `currentTurn`), each tagged with the earliest turn it appeared on —
  * the harness analogue of the running `everInjected` list production maintains.
+ * The activation log lives in the dedicated memory database; without that
+ * connection the prior state degrades to empty.
  */
 function reconstructPriorEverInjected(
-  db: DrizzleDb,
   conversationId: string,
   currentTurn: number,
 ): EverInjectedEntry[] {
-  const rows = db
-    .select({
-      turn: memoryV2ActivationLogs.turn,
-      conceptsJson: memoryV2ActivationLogs.conceptsJson,
-    })
-    .from(memoryV2ActivationLogs)
-    .where(
-      and(
-        eq(memoryV2ActivationLogs.conversationId, conversationId),
-        eq(memoryV2ActivationLogs.mode, "router"),
-        lt(memoryV2ActivationLogs.turn, currentTurn),
-      ),
+  const raw = memorySqliteOrNull("reconstructPriorEverInjected");
+  if (!raw) {
+    return [];
+  }
+  const rows = raw
+    .query(
+      `SELECT turn, concepts_json
+         FROM memory_v2_activation_logs
+        WHERE conversation_id = ? AND mode = 'router' AND turn < ?
+        ORDER BY turn ASC`,
     )
-    .orderBy(asc(memoryV2ActivationLogs.turn))
-    .all();
+    .all(conversationId, currentTurn) as Array<{
+    turn: number;
+    concepts_json: string;
+  }>;
 
   const firstTurnBySlug = new Map<string, number>();
   for (const row of rows) {
     let concepts: MemoryV2ConceptRowRecord[];
     try {
-      concepts = JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[];
+      concepts = JSON.parse(row.concepts_json) as MemoryV2ConceptRowRecord[];
     } catch {
       continue;
     }
     for (const concept of concepts) {
-      if (!PRIOR_STATUSES.has(concept.status)) continue;
+      if (!PRIOR_STATUSES.has(concept.status)) {
+        continue;
+      }
       if (!firstTurnBySlug.has(concept.slug)) {
         firstTurnBySlug.set(concept.slug, row.turn);
       }

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -58,9 +58,8 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
 import { stripSpotlightInjections } from "../../../../../context/strip-injections.js";
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import { unwrapMemoryBlock, wrapMemoryBlock } from "../../memory-marker.js";
 import type { PageIndexEntry } from "../../v2/page-index.js";
@@ -129,13 +128,17 @@ mock.module("../dense.js", () => ({
 }));
 
 let testSqlite: Database;
+// Selection rows live on the dedicated memory connection, resolved via
+// `getMemorySqlite` — stubbed to a second in-memory DB carrying the relocated
+// table's schema. Messages and the everInjected store stay in main.
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3EverInjected(db);
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   // Minimal `messages` shape — metadata persistence, the prune valve's
   // v3-ownership scan, and the restart rehydration read only these columns.
   testSqlite.run(/*sql*/ `
@@ -159,6 +162,8 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
       : realDbConnection.getSqliteFrom(
           db as Parameters<typeof realDbConnection.getSqliteFrom>[0],
         ),
+  getMemorySqlite: () =>
+    carryMockActive ? memorySqlite : realDbConnection.getMemorySqlite(),
 }));
 
 /** Mutable prune config: `null` until the script opens the valve window. */
@@ -276,7 +281,7 @@ async function scriptedObserveTurn(conversationId: string, turnIndex: number) {
     turnIndex,
     realShadowPlugin.attributeSelections(result),
   );
-  testSqlite
+  memorySqlite
     .query(
       /*sql*/ `
       UPDATE memory_v3_selections SET created_at = ?
@@ -405,7 +410,7 @@ async function buildFixtureLanes(): Promise<FixtureLanes> {
 
   // Seed a selections history (a PRIOR conversation) making three slugs hot,
   // with distinct frecency so the hot order is deterministic.
-  const seed = testSqlite.query(/*sql*/ `
+  const seed = memorySqlite.query(/*sql*/ `
     INSERT INTO memory_v3_selections
       (conversation_id, turn, slug, source, pinned, created_at)
     VALUES (?, ?, ?, 'needle', 0, ?)
@@ -439,15 +444,12 @@ async function buildFixtureLanes(): Promise<FixtureLanes> {
   const coreSlugs = loadCoreSet(workspaceDir).filter((slug) =>
     sectionIndex.byArticle.has(slug),
   );
-  const hotSlugs = computeHotSet(
-    { db: testDb },
-    {
-      k: 3,
-      halfLifeMs: 14 * DAY_MS,
-      now: BASE,
-      excludeSlugs: new Set(coreSlugs),
-    },
-  )
+  const hotSlugs = computeHotSet({
+    k: 3,
+    halfLifeMs: 14 * DAY_MS,
+    now: BASE,
+    excludeSlugs: new Set(coreSlugs),
+  })
     .map((entry) => entry.slug)
     .filter((slug) => sectionIndex.byArticle.has(slug));
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -29,9 +29,8 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import type { InjectionBlock } from "../../../../types.js";
 import { unwrapMemoryBlock } from "../../memory-marker.js";
@@ -89,14 +88,17 @@ mock.module("../../../../../util/logger.js", () => ({
 }));
 
 let testSqlite: Database;
+// The prune valve's recency ranking reads `memory_v3_selections` over the
+// dedicated memory connection, resolved via `getMemorySqlite` — stubbed to a
+// second in-memory DB carrying the relocated table's schema.
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3EverInjected(db);
-  // The prune valve's recency ranking reads `memory_v3_selections`.
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   // The prune valve plans only against slugs whose card sections are
   // locatable in persisted `memoryV3InjectedBlock` rows
   // (`collectPersistedV3Cards`) — minimal `messages` shape it reads.
@@ -122,6 +124,8 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
       : realDbConnection.getSqliteFrom(
           db as Parameters<typeof realDbConnection.getSqliteFrom>[0],
         ),
+  getMemorySqlite: () =>
+    injectionMockActive ? memorySqlite : realDbConnection.getMemorySqlite(),
 }));
 
 // The injector reads `memory.enabled` / `memory.v3.live` / `memory.v3.spotlight`

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
@@ -25,8 +25,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 
 const realFlags = {
@@ -41,16 +40,20 @@ let storeMockActive = false;
 let liveEnabled = false;
 
 let testSqlite: Database;
+// Selection rows live on the dedicated memory connection, resolved via
+// `getMemorySqlite` — stubbed to a second in-memory DB carrying the relocated
+// table's schema. The fork-source fallback still reads `messages` from main.
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
   // The fork-source fallback reads `messages.metadata.forkSourceMessageId`; the
   // inspector store touches only these two columns, so a minimal table suffices.
   testSqlite.exec(`CREATE TABLE messages (id TEXT PRIMARY KEY, metadata TEXT)`);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   return db;
 }
 
@@ -66,7 +69,7 @@ function seed(
   }>,
   messageId: string | null = null,
 ): void {
-  const stmt = testSqlite.query(
+  const stmt = memorySqlite.query(
     `INSERT INTO memory_v3_selections
        (conversation_id, turn, slug, source, pinned, created_at,
         message_id, section_ordinal, section_title)
@@ -118,6 +121,8 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
     storeMockActive
       ? testSqlite
       : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+  getMemorySqlite: () =>
+    storeMockActive ? memorySqlite : realDb.getMemorySqlite(),
 }));
 
 mock.module("../page-content.js", () => ({

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
@@ -38,6 +38,9 @@ const realPageContent = { ...(await import("../page-content.js")) };
 
 let storeMockActive = false;
 let liveEnabled = false;
+// When false, the stubbed `getMemorySqlite` resolves to null — the contract
+// the store sees when the dedicated memory database cannot be opened.
+let memoryDbAvailable = true;
 
 let testSqlite: Database;
 // Selection rows live on the dedicated memory connection, resolved via
@@ -122,7 +125,11 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
       ? testSqlite
       : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
   getMemorySqlite: () =>
-    storeMockActive ? memorySqlite : realDb.getMemorySqlite(),
+    storeMockActive
+      ? memoryDbAvailable
+        ? memorySqlite
+        : null
+      : realDb.getMemorySqlite(),
 }));
 
 mock.module("../page-content.js", () => ({
@@ -148,6 +155,7 @@ const {
 beforeEach(() => {
   storeMockActive = true;
   liveEnabled = false;
+  memoryDbAvailable = true;
   // The inspector's `live` flag comes from `isMemoryV3Live(getConfig())`,
   // which reads `memory.v3.live` — seed it for real.
   setConfig("memory", { v3: { live: false } });
@@ -352,6 +360,23 @@ describe("getMemoryV3SelectionForInspectorByMessageIds", () => {
       await getMemoryV3SelectionForInspectorByMessageIds(["fork-msg"]),
     ).toBeNull();
   });
+
+  test("returns null when the memory database is unavailable", async () => {
+    // Rows exist for both lookup keys, but with the memory connection down
+    // both inspector reads (including the fork-fallback walk, which still
+    // touches the main-DB `messages` table) must degrade to null, not throw.
+    seed(
+      "conv-deg",
+      1,
+      [{ slug: "domain-a/page-1", source: "needle" }],
+      "msg-deg",
+    );
+    memoryDbAvailable = false;
+    expect(await getMemoryV3SelectionForInspector("conv-deg", 1)).toBeNull();
+    expect(
+      await getMemoryV3SelectionForInspectorByMessageIds(["msg-deg"]),
+    ).toBeNull();
+  });
 });
 
 describe("summarizeSelections", () => {
@@ -388,6 +413,28 @@ describe("summarizeSelections", () => {
 
   test("returns zeroed counts for a conversation with no rows", () => {
     expect(summarizeSelections("conv-none")).toEqual({
+      bySource: {
+        core: 0,
+        hot: 0,
+        fresh: 0,
+        needle: 0,
+        dense: 0,
+        edge: 0,
+        reply: 0,
+        learned: 0,
+        entity: 0,
+      },
+      turns: 0,
+      distinctSlugs: 0,
+    });
+  });
+
+  test("returns zeroed results when the memory database is unavailable", () => {
+    // Rows exist, but with the memory connection down the summary must
+    // degrade to zeroes rather than throw.
+    seed("conv-deg", 1, [{ slug: "domain-a/page-1", source: "needle" }]);
+    memoryDbAvailable = false;
+    expect(summarizeSelections("conv-deg")).toEqual({
       bySource: {
         core: 0,
         hot: 0,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -33,8 +33,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Message, Provider, ProviderResponse } from "@vellumai/plugin-api";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import type { PageIndexEntry } from "../../v2/page-index.js";
 import { renderCard } from "../card.js";
@@ -96,19 +95,21 @@ mock.module("../dense.js", () => ({
       : realDense.denseLaneScored(...args),
 }));
 
-// In-memory selections DB. `summarizeSelections` reads via getDb/getSqliteFrom;
-// the writer below writes through the same handles.
+// In-memory selections DB. Selection rows live on the dedicated memory
+// connection — `writeSelections` writes and `summarizeSelections` reads via
+// `getMemorySqlite`, stubbed to a DB carrying the relocated table's schema.
 const realDb = {
   ...(await import("../../../../../persistence/db-connection.js")),
 };
 let testSqlite: Database;
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   return db;
 }
 mock.module("../../../../../persistence/db-connection.js", () => ({
@@ -118,6 +119,7 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
     mockActive
       ? testSqlite
       : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+  getMemorySqlite: () => (mockActive ? memorySqlite : realDb.getMemorySqlite()),
 }));
 
 const { orchestrate } = await import("../orchestrate.js");
@@ -285,7 +287,7 @@ function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
 
 /** Read back every logged selection source for a turn, in row order. */
 function loggedSources(turn: number): Array<{ slug: Slug; source: string }> {
-  return testSqlite
+  return memorySqlite
     .query(
       `SELECT slug, source FROM memory_v3_selections
          WHERE conversation_id = ? AND turn = ? ORDER BY rowid`,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -28,9 +28,8 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
 import { MemoryV3GateSchema } from "../../../../../config/schemas/memory-v3.js";
-import { migrateAddMemoryV3Selections } from "../../../../../persistence/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
-import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../../persistence/migrations/283-memory-v3-selections-message-id-and-sections.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import type { HotSetEntry, HotSetOptions } from "../hot-set.js";
 import type { OrchestrateResult } from "../orchestrate.js";
@@ -170,17 +169,20 @@ let hotSetOpts: HotSetOptions | null = null;
 // page body.
 let capturedPageBody: ((slug: string) => Promise<string>) | null = null;
 
-// Shared in-memory DB so writes are observable from the test.
+// Shared in-memory DBs so writes are observable from the test. Selection rows
+// live on the dedicated memory connection (`memorySqlite`, resolved through
+// the stubbed `getMemorySqlite`); the everInjected store stays in main.
 let testSqlite: Database;
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3Selections(db);
-  migrateMemoryV3SelectionsMessageIdAndSections(db);
   // The live injector's net-new dedup reads/writes the everInjected store.
   migrateAddMemoryV3EverInjected(db);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   return db;
 }
 
@@ -258,7 +260,7 @@ mock.module("../hot-set.js", () => ({
     ...args: Parameters<typeof realHotSet.computeHotSet>
   ): HotSetEntry[] => {
     if (!shadowMockActive) return realHotSet.computeHotSet(...args);
-    hotSetOpts = args[1];
+    hotSetOpts = args[0];
     return hotSetResult;
   },
 }));
@@ -273,6 +275,7 @@ mock.module("../../../../../persistence/conversation-crud.js", () => ({
 mock.module("../../../../../persistence/db-connection.js", () => ({
   getDb: () => testDb,
   getSqliteFrom: () => testSqlite,
+  getMemorySqlite: () => memorySqlite,
 }));
 
 mock.module("../../v2/page-index.js", () => ({
@@ -464,7 +467,7 @@ afterAll(() => {
 });
 
 function readRows() {
-  return testSqlite
+  return memorySqlite
     .query(
       `SELECT slug, source, pinned FROM memory_v3_selections ORDER BY slug`,
     )

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -174,6 +174,9 @@ let capturedPageBody: ((slug: string) => Promise<string>) | null = null;
 // the stubbed `getMemorySqlite`); the everInjected store stays in main.
 let testSqlite: Database;
 let memorySqlite: Database;
+// When false, the stubbed `getMemorySqlite` resolves to null — the contract
+// the plugin sees when the dedicated memory database cannot be opened.
+let memoryDbAvailable = true;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
@@ -275,7 +278,7 @@ mock.module("../../../../../persistence/conversation-crud.js", () => ({
 mock.module("../../../../../persistence/db-connection.js", () => ({
   getDb: () => testDb,
   getSqliteFrom: () => testSqlite,
-  getMemorySqlite: () => memorySqlite,
+  getMemorySqlite: () => (memoryDbAvailable ? memorySqlite : null),
 }));
 
 mock.module("../../v2/page-index.js", () => ({
@@ -449,6 +452,8 @@ const {
   resetShadowLanesForTests,
   invalidateLanes,
   attributeSelections,
+  writeSelections,
+  backfillMemoryV3SelectionMessageId,
 } = await import("../shadow-plugin.js");
 const { memoryV3Injector, resetMemoryV3InjectorStateForTests } =
   await import("../injector.js");
@@ -478,6 +483,7 @@ beforeEach(() => {
   shadowMockActive = true;
   liveEnabled = false;
   memoryEnabled = true;
+  memoryDbAvailable = true;
   learnedEdgesCap = 0;
   extraRealConceptPages = 0;
   selectorEnabledCfg = false;
@@ -532,6 +538,28 @@ describe("memory-v3 engine", () => {
 
     expect(orchestrateSpy).not.toHaveBeenCalled();
     expect(sectionBuilds).toBe(0);
+    expect(readRows()).toHaveLength(0);
+  });
+
+  test("selection writes and the message-id backfill no-op when the memory database is unavailable", () => {
+    memoryDbAvailable = false;
+    expect(() =>
+      writeSelections("conv-1", 1, [
+        {
+          slug: "page-1",
+          source: "needle",
+          pinned: 0,
+          sectionOrdinal: null,
+          sectionTitle: null,
+        },
+      ]),
+    ).not.toThrow();
+    expect(() =>
+      backfillMemoryV3SelectionMessageId("conv-1", "m-1"),
+    ).not.toThrow();
+
+    // Nothing landed while the connection was down.
+    memoryDbAvailable = true;
     expect(readRows()).toHaveLength(0);
   });
 

--- a/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
@@ -1,18 +1,23 @@
 /**
  * Tests for the frecency hot-set lane (`hot-set.ts`) and its config schema.
  *
- * `computeHotSet` takes the db handle directly (no module mocks needed):
- * each test seeds an in-memory SQLite db with `memory_v3_selections` rows
- * (via the real migration) and asserts the decayed-frequency ranking.
+ * `computeHotSet` reads `memory_v3_selections` over the dedicated memory
+ * connection: each test installs an in-memory SQLite db into the `memory`
+ * singleton slot (where the accessor resolves its connection), seeds it with
+ * selection rows, and asserts the decayed-frequency ranking.
  */
 
 import { Database } from "bun:sqlite";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { MemoryV3ConfigSchema } from "../../../../config/schemas/memory-v3.js";
-import { migrateAddMemoryV3Selections } from "../../../../persistence/migrations/268-add-memory-v3-selections.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../persistence/schema/index.js";
 import { computeHotSet, type HotSetOptions } from "./hot-set.js";
 
@@ -20,12 +25,15 @@ const HALF_LIFE_MS = 1000;
 const NOW = 100_000;
 
 let sqlite: Database;
-let db: ReturnType<typeof drizzle<typeof schema>>;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
-  db = drizzle(sqlite, { schema });
-  migrateAddMemoryV3Selections(db);
+  ensureMemoryV3SelectionsSchema(sqlite);
+  setStoredDb("memory", drizzle(sqlite, { schema }), () => sqlite.close());
+});
+
+afterEach(() => {
+  clearStoredDb("memory");
 });
 
 let nextTurn = 0;
@@ -40,16 +48,13 @@ function seed(slug: string, createdAts: number[]): void {
 }
 
 function hotSet(overrides: Partial<HotSetOptions> = {}) {
-  return computeHotSet(
-    { db },
-    {
-      k: 10,
-      halfLifeMs: HALF_LIFE_MS,
-      now: NOW,
-      excludeSlugs: new Set<string>(),
-      ...overrides,
-    },
-  );
+  return computeHotSet({
+    k: 10,
+    halfLifeMs: HALF_LIFE_MS,
+    now: NOW,
+    excludeSlugs: new Set<string>(),
+    ...overrides,
+  });
 }
 
 describe("computeHotSet", () => {
@@ -110,6 +115,19 @@ describe("computeHotSet", () => {
   test("future-dated rows are clamped to weight 1", () => {
     seed("page-a", [NOW + 50 * HALF_LIFE_MS]);
     expect(hotSet()[0]!.score).toBeCloseTo(1, 10);
+  });
+
+  test("degrades to an empty hot set when the memory database is unavailable", () => {
+    seed("page-a", [NOW]);
+    // Simulate unavailability through the singleton slot instead of
+    // `mock.module`, which is process-global and leaks into sibling test
+    // files. The accessor extracts the raw connection from the stored
+    // handle's `$client`, so a handle without one makes `getMemorySqlite()`
+    // resolve to null, the same contract computeHotSet sees when the
+    // dedicated open fails.
+    clearStoredDb("memory");
+    setStoredDb("memory", { $client: null }, () => {});
+    expect(hotSet()).toEqual([]);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/v3/hot-set.ts
+++ b/assistant/src/plugins/defaults/memory/v3/hot-set.ts
@@ -14,16 +14,8 @@
  * the hot lane never duplicates core.
  */
 
-import {
-  type DrizzleDb,
-  getSqliteFrom,
-} from "../../../../persistence/db-connection.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import type { Slug } from "./types.js";
-
-export interface HotSetDeps {
-  /** Handle to the database containing `memory_v3_selections`. */
-  db: DrizzleDb;
-}
 
 export interface HotSetOptions {
   /** Maximum number of slugs returned. */
@@ -52,15 +44,21 @@ interface SelectionAgeRow {
  * Deterministic for fixed inputs: ties break score desc, then slug asc. The
  * decay sum runs in TS over `(slug, created_at)` pairs — the selections table
  * is small enough that reading it directly beats pushing the math into SQL.
+ *
+ * Reads `memory_v3_selections` over the dedicated memory connection.
+ * Fail-soft: an unavailable memory database yields an empty hot set — the
+ * lane simply contributes nothing to the stable prefix.
  */
-export function computeHotSet(
-  deps: HotSetDeps,
-  opts: HotSetOptions,
-): HotSetEntry[] {
+export function computeHotSet(opts: HotSetOptions): HotSetEntry[] {
   const { k, halfLifeMs, now, excludeSlugs } = opts;
   if (k <= 0) return [];
 
-  const rows = getSqliteFrom(deps.db)
+  const raw = memorySqliteOrNull("computeHotSet");
+  if (!raw) {
+    return [];
+  }
+
+  const rows = raw
     .query(
       /*sql*/ `
       SELECT slug, created_at FROM memory_v3_selections

--- a/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
@@ -185,4 +185,19 @@ describe("computeLearnedEdgeGraph", () => {
     const graph = graphOf({ windowMs: 10_000 });
     expect(graph.adjacency.size).toBe(0);
   });
+
+  test("degrades to an empty graph when the memory database is unavailable", () => {
+    // Simulate unavailability through the singleton slot instead of
+    // `mock.module`, which is process-global and leaks into sibling test
+    // files. The accessor extracts the raw connection from the stored
+    // handle's `$client`, so a handle without one makes `getMemorySqlite()`
+    // resolve to null, the same contract computeLearnedEdgeGraph sees when
+    // the dedicated open fails.
+    clearStoredDb("memory");
+    setStoredDb("memory", { $client: null }, () => {});
+
+    const graph = graphOf();
+    expect(graph.adjacency.size).toBe(0);
+    expect(graph.hubs.size).toBe(0);
+  });
 });

--- a/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
@@ -1,18 +1,23 @@
 /**
  * Tests for the learned-edge lane (`learned-edges.ts`).
  *
- * `computeLearnedEdgeGraph` takes the db handle directly (no module mocks):
- * each test seeds an in-memory SQLite db with `memory_v3_selections` rows
- * (via the real migration) and asserts the NPMI association graph. Rows
+ * `computeLearnedEdgeGraph` reads `memory_v3_selections` over the dedicated
+ * memory connection: each test installs an in-memory SQLite db into the
+ * `memory` singleton slot (where the accessor resolves its connection), seeds
+ * it with selection rows, and asserts the NPMI association graph. Rows
  * sharing a `(conversation_id, created_at)` form one selector call.
  */
 
 import { Database } from "bun:sqlite";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { migrateAddMemoryV3Selections } from "../../../../persistence/migrations/268-add-memory-v3-selections.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../persistence/schema/index.js";
 import {
   computeLearnedEdgeGraph,
@@ -23,12 +28,15 @@ const HALF_LIFE_MS = 1_000_000;
 const NOW = 100_000;
 
 let sqlite: Database;
-let db: ReturnType<typeof drizzle<typeof schema>>;
 
 beforeEach(() => {
   sqlite = new Database(":memory:");
-  db = drizzle(sqlite, { schema });
-  migrateAddMemoryV3Selections(db);
+  ensureMemoryV3SelectionsSchema(sqlite);
+  setStoredDb("memory", drizzle(sqlite, { schema }), () => sqlite.close());
+});
+
+afterEach(() => {
+  clearStoredDb("memory");
 });
 
 let nextTurn = 0;
@@ -44,25 +52,22 @@ function seedCall(slugs: string[], createdAt = NOW, conv = "conv-1"): void {
 }
 
 function graphOf(overrides: Partial<LearnedEdgesOptions> = {}) {
-  return computeLearnedEdgeGraph(
-    { db },
-    {
-      halfLifeMs: HALF_LIFE_MS,
-      minCount: 2,
-      npmiFloor: 0.2,
-      maxPerPage: 6,
-      now: NOW,
-      windowMs: NOW,
-      knownSlugs: new Set([
-        "page-a",
-        "page-b",
-        "page-c",
-        "page-d",
-        "skills/widget",
-      ]),
-      ...overrides,
-    },
-  );
+  return computeLearnedEdgeGraph({
+    halfLifeMs: HALF_LIFE_MS,
+    minCount: 2,
+    npmiFloor: 0.2,
+    maxPerPage: 6,
+    now: NOW,
+    windowMs: NOW,
+    knownSlugs: new Set([
+      "page-a",
+      "page-b",
+      "page-c",
+      "page-d",
+      "skills/widget",
+    ]),
+    ...overrides,
+  });
 }
 
 const peersOf = (

--- a/assistant/src/plugins/defaults/memory/v3/learned-edges.ts
+++ b/assistant/src/plugins/defaults/memory/v3/learned-edges.ts
@@ -38,17 +38,9 @@
  * the persistence; nothing else is stored.
  */
 
-import {
-  type DrizzleDb,
-  getSqliteFrom,
-} from "../../../../persistence/db-connection.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import type { EdgeGraph } from "./edge.js";
 import type { Slug } from "./types.js";
-
-export interface LearnedEdgesDeps {
-  /** Handle to the database containing `memory_v3_selections`. */
-  db: DrizzleDb;
-}
 
 export interface LearnedEdgesOptions {
   /** Decay half-life in milliseconds: a selector call this old contributes
@@ -86,11 +78,12 @@ interface SelectionRow {
  * Deterministic for fixed inputs: per-page neighbors order by NPMI desc, then
  * peer slug asc. Symmetric by construction — an edge contributes to BOTH
  * endpoints' neighbor lists (each independently subject to `maxPerPage`).
+ *
+ * Reads `memory_v3_selections` over the dedicated memory connection.
+ * Fail-soft: an unavailable memory database yields an empty graph — the lane
+ * simply surfaces no learned associations.
  */
-export function computeLearnedEdgeGraph(
-  deps: LearnedEdgesDeps,
-  opts: LearnedEdgesOptions,
-): EdgeGraph {
+export function computeLearnedEdgeGraph(opts: LearnedEdgesOptions): EdgeGraph {
   const { halfLifeMs, minCount, npmiFloor, maxPerPage, now, windowMs } = opts;
   const empty: EdgeGraph = {
     adjacency: new Map(),
@@ -99,7 +92,12 @@ export function computeLearnedEdgeGraph(
   };
   if (maxPerPage <= 0) return empty;
 
-  const rows = getSqliteFrom(deps.db)
+  const raw = memorySqliteOrNull("computeLearnedEdgeGraph");
+  if (!raw) {
+    return empty;
+  }
+
+  const rows = raw
     .query(
       /*sql*/ `
       SELECT conversation_id, slug, created_at FROM memory_v3_selections

--- a/assistant/src/plugins/defaults/memory/v3/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.test.ts
@@ -31,8 +31,8 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Message } from "@vellumai/plugin-api";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { migrateAddMemoryV3Selections } from "../../../../persistence/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../persistence/schema/index.js";
 import { wrapMemoryBlock } from "../memory-marker.js";
 
@@ -48,12 +48,15 @@ let pruneConfig: {
 } | null = null;
 
 let testSqlite: Database;
+// `planPrune`'s recency ranking reads `memory_v3_selections` over the
+// dedicated memory connection, resolved via `getMemorySqlite` — stubbed to a
+// second in-memory DB carrying the relocated table's schema.
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3EverInjected(db);
-  migrateAddMemoryV3Selections(db);
   // Minimal `messages` shape — `collectPersistedV3Cards` reads only
   // `conversation_id` and `metadata`.
   testSqlite.run(/*sql*/ `
@@ -66,6 +69,8 @@ function makeDb() {
       created_at INTEGER NOT NULL
     )
   `);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
   return db;
 }
 
@@ -76,6 +81,8 @@ mock.module("../../../../persistence/db-connection.js", () => ({
     pruneMockActive
       ? testSqlite
       : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+  getMemorySqlite: () =>
+    pruneMockActive ? memorySqlite : realDb.getMemorySqlite(),
 }));
 
 // Memory code resolves its config through the plugin's own accessor
@@ -120,7 +127,7 @@ function insertSelection(
   slug: string,
   createdAt: number,
 ): void {
-  testSqlite
+  memorySqlite
     .query(
       /*sql*/ `
       INSERT OR REPLACE INTO memory_v3_selections

--- a/assistant/src/plugins/defaults/memory/v3/prune.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.ts
@@ -63,6 +63,7 @@ import type { ContentBlock, Message } from "@vellumai/plugin-api";
 import { getDb, getSqliteFrom } from "../../../../persistence/db-connection.js";
 import { getMemoryConfig } from "../config.js";
 import { getLogger } from "../logging.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import { unwrapMemoryBlock, wrapMemoryBlock } from "../memory-marker.js";
 import {
   INJECTED_CONCEPT_HEADER_REGEX,
@@ -210,12 +211,14 @@ export interface PruneDeps {
  *
  * The footprint and the candidates both range over the ACTIVE injected slugs.
  * Candidates are ranked by last selection recency — `MAX(created_at)` per
- * slug from `memory_v3_selections`, falling back to the store's `injected_at`
- * for slugs with no selection rows (e.g. rows copied by a full fork) — taken
- * oldest-first until the footprint is at `targetResidentBytes`. Core/hot lane
- * members are exempt, and zero-byte rows (capability slugs, truncated-fork
- * seeds: dedup-only, no byte accounting) are skipped — pruning them frees
- * nothing while discarding inherited context.
+ * slug from `memory_v3_selections` (read over the dedicated memory
+ * connection; an unavailable memory database reads as no selection rows),
+ * falling back to the store's `injected_at` for slugs with no selection rows
+ * (e.g. rows copied by a full fork) — taken oldest-first until the footprint
+ * is at `targetResidentBytes`. Core/hot lane members are exempt, and
+ * zero-byte rows (capability slugs, truncated-fork seeds: dedup-only, no byte
+ * accounting) are skipped — pruning them frees nothing while discarding
+ * inherited context.
  */
 export function planPrune(
   deps: PruneDeps,
@@ -225,15 +228,18 @@ export function planPrune(
   const resident = activeEntries.reduce((sum, e) => sum + e.bytes, 0);
   if (resident <= deps.maxResidentBytes) return null;
 
-  const selectionRows = getSqliteFrom(getDb())
-    .query(
-      /*sql*/ `
+  const memoryRaw = memorySqliteOrNull("planPrune");
+  const selectionRows = memoryRaw
+    ? (memoryRaw
+        .query(
+          /*sql*/ `
       SELECT slug, MAX(created_at) AS lastSelectedAt FROM memory_v3_selections
       WHERE conversation_id = ?
       GROUP BY slug
     `,
-    )
-    .all(conversationId) as Array<{ slug: string; lastSelectedAt: number }>;
+        )
+        .all(conversationId) as Array<{ slug: string; lastSelectedAt: number }>)
+    : [];
   const lastSelectedAt = new Map(
     selectionRows.map((row) => [row.slug, row.lastSelectedAt]),
   );

--- a/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
@@ -20,6 +20,7 @@ import type { MemoryV3SelectionLog } from "../../../../api/responses/memory-v3-s
 import { getConfig } from "../../../../config/loader.js";
 import { isMemoryV3Live } from "../../../../config/memory-v3-gate.js";
 import { getDb, getSqliteFrom } from "../../../../persistence/db-connection.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import { getWorkspaceDir } from "../paths.js";
 import { readPage } from "../v2/page-store.js";
 import { capabilityOrDiskBody } from "./capabilities.js";
@@ -46,7 +47,11 @@ interface SelectionRow {
 const SELECTION_COLUMNS = `turn, slug, source, pinned, section_ordinal, section_title`;
 
 function rowsForTurn(conversationId: string, turn: number): SelectionRow[] {
-  return getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("rowsForTurn");
+  if (!raw) {
+    return [];
+  }
+  return raw
     .query(
       /*sql*/ `
       SELECT ${SELECTION_COLUMNS} FROM memory_v3_selections
@@ -59,8 +64,12 @@ function rowsForTurn(conversationId: string, turn: number): SelectionRow[] {
 
 function rowsForMessageIds(messageIds: string[]): SelectionRow[] {
   if (messageIds.length === 0) return [];
+  const raw = memorySqliteOrNull("rowsForMessageIds");
+  if (!raw) {
+    return [];
+  }
   const placeholders = messageIds.map(() => "?").join(", ");
-  return getSqliteFrom(getDb())
+  return raw
     .query(
       /*sql*/ `
       SELECT ${SELECTION_COLUMNS} FROM memory_v3_selections
@@ -249,18 +258,21 @@ function isSelectionSource(source: string): source is SelectionSource {
 }
 
 export function summarizeSelections(conversationId: string): SelectionSummary {
-  const rows = getSqliteFrom(getDb())
-    .query(
-      /*sql*/ `
+  const raw = memorySqliteOrNull("summarizeSelections");
+  const rows = raw
+    ? (raw
+        .query(
+          /*sql*/ `
       SELECT turn, slug, source FROM memory_v3_selections
       WHERE conversation_id = ?
     `,
-    )
-    .all(conversationId) as Array<{
-    turn: number;
-    slug: string;
-    source: string;
-  }>;
+        )
+        .all(conversationId) as Array<{
+        turn: number;
+        slug: string;
+        source: string;
+      }>)
+    : [];
 
   const bySource = Object.fromEntries(
     SELECTION_SOURCES.map((source) => [source, 0]),

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -526,8 +526,8 @@ export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
 
 /**
  * Write the attributed selection rows to `memory_v3_selections` over the
- * dedicated memory connection. Best-effort: an unavailable memory database
- * drops the turn's log rows rather than affecting the turn.
+ * dedicated memory connection. Best-effort: an unavailable memory database or
+ * a failed write drops the turn's log rows rather than affecting the turn.
  */
 export function writeSelections(
   conversationId: string,
@@ -537,33 +537,37 @@ export function writeSelections(
   if (rows.length === 0) {
     return;
   }
-  const raw = memorySqliteOrNull("writeSelections");
-  if (!raw) {
-    return;
-  }
-  // PK is (conversation_id, turn, slug); OR REPLACE keeps the write
-  // idempotent if the same turn is observed twice (e.g. a retried turn).
-  // `message_id` is written NULL here (the assistant message does not exist at
-  // injection time) and stamped at turn end by
-  // `backfillMemoryV3SelectionMessageId`.
-  const stmt = raw.query(/*sql*/ `
-    INSERT OR REPLACE INTO memory_v3_selections (
-      conversation_id, turn, slug, source, pinned, created_at,
-      message_id, section_ordinal, section_title
-    ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
-  `);
-  const now = Date.now();
-  for (const row of rows) {
-    stmt.run(
-      conversationId,
-      turn,
-      row.slug,
-      row.source,
-      row.pinned,
-      now,
-      row.sectionOrdinal,
-      row.sectionTitle,
-    );
+  try {
+    const raw = memorySqliteOrNull("writeSelections");
+    if (!raw) {
+      return;
+    }
+    // PK is (conversation_id, turn, slug); OR REPLACE keeps the write
+    // idempotent if the same turn is observed twice (e.g. a retried turn).
+    // `message_id` is written NULL here (the assistant message does not exist
+    // at injection time) and stamped at turn end by
+    // `backfillMemoryV3SelectionMessageId`.
+    const stmt = raw.query(/*sql*/ `
+      INSERT OR REPLACE INTO memory_v3_selections (
+        conversation_id, turn, slug, source, pinned, created_at,
+        message_id, section_ordinal, section_title
+      ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
+    `);
+    const now = Date.now();
+    for (const row of rows) {
+      stmt.run(
+        conversationId,
+        turn,
+        row.slug,
+        row.source,
+        row.pinned,
+        now,
+        row.sectionOrdinal,
+        row.sectionTitle,
+      );
+    }
+  } catch (err) {
+    log.warn({ err }, "failed to write memory-v3 selections; continuing");
   }
 }
 
@@ -580,16 +584,23 @@ export function backfillMemoryV3SelectionMessageId(
   conversationId: string,
   assistantMessageId: string,
 ): void {
-  const raw = memorySqliteOrNull("backfillMemoryV3SelectionMessageId");
-  if (!raw) {
-    return;
+  try {
+    const raw = memorySqliteOrNull("backfillMemoryV3SelectionMessageId");
+    if (!raw) {
+      return;
+    }
+    raw
+      .query(
+        /*sql*/ `UPDATE memory_v3_selections SET message_id = ?
+                 WHERE conversation_id = ? AND message_id IS NULL`,
+      )
+      .run(assistantMessageId, conversationId);
+  } catch (err) {
+    log.warn(
+      { err },
+      "failed to backfill memory-v3 selection messageId; continuing",
+    );
   }
-  raw
-    .query(
-      /*sql*/ `UPDATE memory_v3_selections SET message_id = ?
-               WHERE conversation_id = ? AND message_id IS NULL`,
-    )
-    .run(assistantMessageId, conversationId);
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -30,9 +30,9 @@ import {
 
 import { getConfig } from "../../../../config/loader.js";
 import type { AssistantConfig } from "../../../../config/schema.js";
-import { getDb, getSqliteFrom } from "../../../../persistence/db-connection.js";
 import { stripCommentLines } from "../host-utils.js";
 import { getLogger } from "../logging.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../paths.js";
 import { getPageIndex } from "../v2/page-index.js";
 import { readPage, renderPageContent } from "../v2/page-store.js";
@@ -229,15 +229,12 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   const coreSlugs = loadCoreSet(getWorkspaceDir()).filter((slug) =>
     sectionIndex.byArticle.has(slug),
   );
-  const hotSlugs = computeHotSet(
-    { db: getDb() },
-    {
-      k: tuning.hotSetK,
-      halfLifeMs: config.memory.v3.hotSet.halfLifeDays * DAY_MS,
-      now: Date.now(),
-      excludeSlugs: new Set(coreSlugs),
-    },
-  )
+  const hotSlugs = computeHotSet({
+    k: tuning.hotSetK,
+    halfLifeMs: config.memory.v3.hotSet.halfLifeDays * DAY_MS,
+    now: Date.now(),
+    excludeSlugs: new Set(coreSlugs),
+  })
     .map((entry) => entry.slug)
     .filter((slug) => sectionIndex.byArticle.has(slug));
 
@@ -320,18 +317,15 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   const learned = config.memory.v3.learnedEdges;
   const learnedGraph =
     tuning.learnedEdgesCap > 0 && learned.maxPerPage > 0
-      ? computeLearnedEdgeGraph(
-          { db: getDb() },
-          {
-            halfLifeMs: learned.halfLifeDays * DAY_MS,
-            minCount: learned.minCount,
-            npmiFloor: learned.npmiFloor,
-            maxPerPage: learned.maxPerPage,
-            now: Date.now(),
-            windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
-            knownSlugs: new Set(sectionIndex.byArticle.keys()),
-          },
-        )
+      ? computeLearnedEdgeGraph({
+          halfLifeMs: learned.halfLifeDays * DAY_MS,
+          minCount: learned.minCount,
+          npmiFloor: learned.npmiFloor,
+          maxPerPage: learned.maxPerPage,
+          now: Date.now(),
+          windowMs: LEARNED_EDGES_WINDOW_DAYS * DAY_MS,
+          knownSlugs: new Set(sectionIndex.byArticle.keys()),
+        })
       : undefined;
   // Ensuring the dense collection is best-effort: the needle + edge lanes and
   // the core/hot prefix are in-memory and independent of Qdrant, so a Qdrant outage
@@ -530,7 +524,11 @@ export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
   });
 }
 
-/** Write the attributed selection rows to `memory_v3_selections`. */
+/**
+ * Write the attributed selection rows to `memory_v3_selections` over the
+ * dedicated memory connection. Best-effort: an unavailable memory database
+ * drops the turn's log rows rather than affecting the turn.
+ */
 export function writeSelections(
   conversationId: string,
   turn: number,
@@ -539,7 +537,10 @@ export function writeSelections(
   if (rows.length === 0) {
     return;
   }
-  const raw = getSqliteFrom(getDb());
+  const raw = memorySqliteOrNull("writeSelections");
+  if (!raw) {
+    return;
+  }
   // PK is (conversation_id, turn, slug); OR REPLACE keeps the write
   // idempotent if the same turn is observed twice (e.g. a retried turn).
   // `message_id` is written NULL here (the assistant message does not exist at
@@ -579,7 +580,11 @@ export function backfillMemoryV3SelectionMessageId(
   conversationId: string,
   assistantMessageId: string,
 ): void {
-  getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("backfillMemoryV3SelectionMessageId");
+  if (!raw) {
+    return;
+  }
+  raw
     .query(
       /*sql*/ `UPDATE memory_v3_selections SET message_id = ?
                WHERE conversation_id = ? AND message_id IS NULL`,

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -53,13 +53,16 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
 import { loadRawConfig } from "../../../config/loader.js";
 import { LLMConfigBase } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
-import { getDb, getLogsDb } from "../../../persistence/db-connection.js";
+import {
+  getDb,
+  getLogsDb,
+  getMemorySqlite,
+} from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import {
   conversationKeys,
   conversations,
   llmRequestLogs,
-  memoryV2ActivationLogs,
   messages,
   providerConnections,
 } from "../../../persistence/schema/index.js";
@@ -106,7 +109,7 @@ function dispatchConversationLlmContext(queryParams: Record<string, string>) {
 function clearTables(): void {
   const db = getDb();
   getLogsDb()!.delete(llmRequestLogs).run();
-  db.delete(memoryV2ActivationLogs).run();
+  getMemorySqlite()!.exec(`DELETE FROM memory_v2_activation_logs`);
   db.delete(messages).run();
   db.delete(conversationKeys).run();
   db.delete(conversations).run();


### PR DESCRIPTION
## Summary
- Migrations 336-339 relocate `memory_v2_activation_logs`, `memory_recall_logs`, `memory_v3_selections`, and `activation_sessions` from `assistant.db` into `assistant-memory.db` via the staged-drain playbook, full copy, each declaring `dependsOn` on every earlier migration that touches its table (enforced by the runner guard from #38251).
- All readers and writers of the four tables now go through the memory connection, fail-soft, and the six move-* migrations share one relocation runner.

Part of ATL-1001.

## PRs merged into this branch
- #38110 move activation + recall logs
- #38109 move v3 selections + activation sessions
- #38114, #38115, #38116, #38119 review fixes (docs, shared relocation runner, test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)