### PR TITLE
feat(acp): persist model + cache tokens on acp_session_history

### DIFF
--- a/assistant/src/acp/__tests__/helpers/acp-history-db.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-history-db.ts
@@ -30,6 +30,9 @@ export interface HistoryRow {
   cost_currency: string | null;
   input_tokens: number | null;
   output_tokens: number | null;
+  model: string | null;
+  cache_read_tokens: number | null;
+  cache_write_tokens: number | null;
 }
 
 export function clearHistory(): void {
@@ -62,6 +65,9 @@ export function insertHistoryRow(row: {
   costCurrency?: string | null;
   inputTokens?: number | null;
   outputTokens?: number | null;
+  model?: string | null;
+  cacheReadTokens?: number | null;
+  cacheWriteTokens?: number | null;
 }): void {
   getSqlite()
     .query(
@@ -70,8 +76,9 @@ export function insertHistoryRow(row: {
          started_at, completed_at, status, stop_reason, error,
          event_log_json, cwd, task, parent_tool_use_id,
          used_tokens, context_size, cost_amount, cost_currency,
-         input_tokens, output_tokens
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         input_tokens, output_tokens,
+         model, cache_read_tokens, cache_write_tokens
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       row.id,
@@ -93,6 +100,9 @@ export function insertHistoryRow(row: {
       row.costCurrency ?? null,
       row.inputTokens ?? null,
       row.outputTokens ?? null,
+      row.model ?? null,
+      row.cacheReadTokens ?? null,
+      row.cacheWriteTokens ?? null,
     );
 }
 
@@ -103,7 +113,8 @@ export function readHistoryRow(id: string): HistoryRow | null {
               started_at, completed_at, status, stop_reason, error,
               event_log_json, cwd, task, parent_tool_use_id,
               used_tokens, context_size, cost_amount, cost_currency,
-              input_tokens, output_tokens
+              input_tokens, output_tokens,
+              model, cache_read_tokens, cache_write_tokens
        FROM acp_session_history WHERE id = ?`,
     )
     .get(id) as HistoryRow | null;

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -436,6 +436,57 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.cost_currency).toBe("USD");
   });
 
+  test("persists model + cache tokens and stays joinable to its conversation", async () => {
+    const id = "session-model-cache-1";
+    const conversationId = "conv-model-cache";
+    // Seed the parent conversation so the join below has a matching row.
+    getSqlite()
+      .query(
+        `INSERT INTO conversations (id, created_at, updated_at) VALUES (?, ?, ?)`,
+      )
+      .run(conversationId, 1000, 2000);
+
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-model-cache",
+      protocolSessionId: "proto-model-cache",
+      parentConversationId: conversationId,
+      latestUsage: {
+        usedTokens: 4200,
+        contextSize: 200_000,
+        costAmount: 0.0123,
+        costCurrency: "USD",
+        inputTokens: 5000,
+        outputTokens: 800,
+        model: "claude-opus-4-8",
+        cacheReadTokens: 900,
+        cacheWriteTokens: 300,
+      },
+    });
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.model).toBe("claude-opus-4-8");
+    expect(row!.cache_read_tokens).toBe(900);
+    expect(row!.cache_write_tokens).toBe(300);
+
+    // Row remains joinable to its conversation via parent_conversation_id.
+    const joined = getSqlite()
+      .query(
+        `SELECT h.id AS history_id, c.id AS conversation_id
+           FROM acp_session_history h
+           JOIN conversations c ON c.id = h.parent_conversation_id
+          WHERE h.id = ?`,
+      )
+      .get(id) as { history_id: string; conversation_id: string } | null;
+    expect(joined).not.toBeNull();
+    expect(joined!.conversation_id).toBe(conversationId);
+  });
+
   test("persists NULL usage columns when latestUsage is undefined", async () => {
     const id = "session-no-usage-1";
     const handles = buildSessionWithFakeProcess({
@@ -460,6 +511,9 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.cost_currency).toBeNull();
     expect(row!.input_tokens).toBeNull();
     expect(row!.output_tokens).toBeNull();
+    expect(row!.model).toBeNull();
+    expect(row!.cache_read_tokens).toBeNull();
+    expect(row!.cache_write_tokens).toBeNull();
   });
 
   test("emits acp_session_usage and persists input/output tokens from PromptResponse.usage", async () => {

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -383,6 +383,35 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(state.status).toBe("running");
   });
 
+  test("resume re-seeds model and cache tokens so a null-usage terminal upsert preserves attribution", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({
+      id: "resume-usage-1",
+      usedTokens: 100,
+      contextSize: 2000,
+      inputTokens: 60,
+      outputTokens: 40,
+      model: "claude-opus-4-8",
+      cacheReadTokens: 15,
+      cacheWriteTokens: 5,
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-usage-1", () => {});
+
+    // The persisted model + cache columns are re-seeded onto latestUsage, so a
+    // terminal transition without a fresh usage event re-persists them instead
+    // of NULLing attribution already on the row.
+    const state = manager.getStatus("resume-usage-1") as AcpSessionState;
+    expect(state.latestUsage).toMatchObject({
+      inputTokens: 60,
+      outputTokens: 40,
+      model: "claude-opus-4-8",
+      cacheReadTokens: 15,
+      cacheWriteTokens: 5,
+    });
+  });
+
   test("legacy row with null cwd raises an actionable error", async () => {
     insertHistoryRow({ id: "legacy-1", cwd: null });
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -936,6 +936,9 @@ export class AcpSessionManager {
       costCurrency: usage?.costCurrency ?? null,
       inputTokens: usage?.inputTokens ?? null,
       outputTokens: usage?.outputTokens ?? null,
+      model: usage?.model ?? null,
+      cacheReadTokens: usage?.cacheReadTokens ?? null,
+      cacheWriteTokens: usage?.cacheWriteTokens ?? null,
     };
     try {
       getDb()

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -519,6 +519,9 @@ export class AcpSessionManager {
         costCurrency: row.costCurrency ?? undefined,
         inputTokens: row.inputTokens ?? undefined,
         outputTokens: row.outputTokens ?? undefined,
+        model: row.model ?? undefined,
+        cacheReadTokens: row.cacheReadTokens ?? undefined,
+        cacheWriteTokens: row.cacheWriteTokens ?? undefined,
       };
     }
 

--- a/assistant/src/persistence/migrations/336-acp-usage-model-cache.test.ts
+++ b/assistant/src/persistence/migrations/336-acp-usage-model-cache.test.ts
@@ -1,0 +1,122 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateAcpSessionHistoryModelCacheColumns } from "./336-acp-usage-model-cache.js";
+
+const NEW_COLUMNS = ["model", "cache_read_tokens", "cache_write_tokens"];
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Post-308 shape: usage + token columns exist, model/cache columns do not.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE acp_session_history (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      acp_session_id TEXT NOT NULL,
+      parent_conversation_id TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      status TEXT NOT NULL,
+      stop_reason TEXT,
+      error TEXT,
+      event_log_json TEXT NOT NULL DEFAULT '[]',
+      cwd TEXT,
+      task TEXT,
+      parent_tool_use_id TEXT,
+      used_tokens INTEGER,
+      context_size INTEGER,
+      cost_amount REAL,
+      cost_currency TEXT,
+      input_tokens INTEGER,
+      output_tokens INTEGER
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function tableInfo(sqlite: Database) {
+  return sqlite.query("PRAGMA table_info(acp_session_history)").all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+}
+
+describe("migration 336: acp_session_history model + cache columns", () => {
+  test("adds the nullable model + cache columns", () => {
+    const { sqlite, db } = createTestDb();
+    const before = tableInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(before).not.toContain(name);
+    }
+
+    migrateAcpSessionHistoryModelCacheColumns(db);
+
+    const after = tableInfo(sqlite);
+    for (const name of NEW_COLUMNS) {
+      const column = after.find((c) => c.name === name);
+      expect(column).toBeDefined();
+      expect(column?.notnull).toBe(0);
+    }
+  });
+
+  test("existing rows read back with null model + cache columns", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO acp_session_history
+        (id, agent_id, acp_session_id, parent_conversation_id, started_at, status)
+      VALUES
+        ('acp-1', 'agent-1', 'sid-1', 'conv-1', 1000, 'completed')
+    `);
+
+    migrateAcpSessionHistoryModelCacheColumns(db);
+
+    const row = sqlite
+      .query(
+        `SELECT ${NEW_COLUMNS.join(", ")} FROM acp_session_history WHERE id = 'acp-1'`,
+      )
+      .get() as Record<string, unknown>;
+    for (const name of NEW_COLUMNS) {
+      expect(row[name]).toBeNull();
+    }
+  });
+
+  test("round-trips an insert that sets the new model + cache columns", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAcpSessionHistoryModelCacheColumns(db);
+
+    sqlite.exec(/*sql*/ `
+      INSERT INTO acp_session_history
+        (id, agent_id, acp_session_id, parent_conversation_id, started_at, status,
+         model, cache_read_tokens, cache_write_tokens)
+      VALUES
+        ('acp-2', 'agent-1', 'sid-2', 'conv-1', 2000, 'completed',
+         'claude-opus-4-8', 900, 300)
+    `);
+
+    const row = sqlite
+      .query(
+        `SELECT ${NEW_COLUMNS.join(", ")} FROM acp_session_history WHERE id = 'acp-2'`,
+      )
+      .get() as Record<string, unknown>;
+    expect(row).toEqual({
+      model: "claude-opus-4-8",
+      cache_read_tokens: 900,
+      cache_write_tokens: 300,
+    });
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateAcpSessionHistoryModelCacheColumns(db);
+    expect(() => migrateAcpSessionHistoryModelCacheColumns(db)).not.toThrow();
+
+    const names = tableInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(names.filter((n) => n === name)).toHaveLength(1);
+    }
+  });
+});

--- a/assistant/src/persistence/migrations/336-acp-usage-model-cache.ts
+++ b/assistant/src/persistence/migrations/336-acp-usage-model-cache.ts
@@ -1,0 +1,33 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+const TABLE = "acp_session_history";
+const COLUMNS: Array<{ name: string; type: string }> = [
+  { name: "model", type: "TEXT" },
+  { name: "cache_read_tokens", type: "INTEGER" },
+  { name: "cache_write_tokens", type: "INTEGER" },
+];
+
+/**
+ * Add nullable model + cache-token columns to `acp_session_history`:
+ * `model`, `cache_read_tokens`, and `cache_write_tokens`. Nullable so rows
+ * persisted before this migration stay NULL.
+ *
+ * Idempotent pure DDL with a PRAGMA guard, no registry entry needed (matches
+ * the 307 / 308 usage-columns pattern).
+ */
+export function migrateAcpSessionHistoryModelCacheColumns(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const columns = raw.query(`PRAGMA table_info(${TABLE})`).all() as Array<{
+    name: string;
+  }>;
+  const columnNames = new Set(columns.map((c) => c.name));
+
+  for (const { name, type } of COLUMNS) {
+    if (!columnNames.has(name)) {
+      raw.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${name} ${type}`);
+    }
+  }
+}

--- a/assistant/src/persistence/schema/acp.ts
+++ b/assistant/src/persistence/schema/acp.ts
@@ -41,6 +41,11 @@ export const acpSessionHistory = sqliteTable(
     // before these columns existed.
     inputTokens: integer("input_tokens"),
     outputTokens: integer("output_tokens"),
+    // Model + cumulative cache tokens for inference-cost attribution. Null
+    // for rows written before these columns existed.
+    model: text("model"),
+    cacheReadTokens: integer("cache_read_tokens"),
+    cacheWriteTokens: integer("cache_write_tokens"),
   },
   (table) => [
     index("idx_acp_session_history_started_at").on(table.startedAt),

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -443,6 +443,7 @@ import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/332-move
 import { migrateCreateTelemetryEventsTable } from "./migrations/333-create-telemetry-events-table.js";
 import { migrateBackfillTelemetryEventsOutbox } from "./migrations/334-backfill-telemetry-events-outbox.js";
 import { migrateCollapseMemoryEmbedBacklog } from "./migrations/335-collapse-memory-embed-backlog.js";
+import { migrateAcpSessionHistoryModelCacheColumns } from "./migrations/336-acp-usage-model-cache.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1357,4 +1358,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateCreateTelemetryEventsTable,
   migrateBackfillTelemetryEventsOutbox,
   migrateCollapseMemoryEmbedBacklog,
+  migrateAcpSessionHistoryModelCacheColumns,
 ];


### PR DESCRIPTION
## Summary
- Migration + schema add nullable model, cache_read_tokens, cache_write_tokens to acp_session_history
- persistTerminal() writes the new latestUsage fields (from PR 5)
- Test asserts persistence + conversation joinability; existing rows unaffected

Part of plan: acp-api-key-auth.md (PR 6 of 7)