### PR TITLE
fix(credentials): reject mismatched ACP token types at write time

### DIFF
--- a/assistant/src/__tests__/credential-prompt-route.test.ts
+++ b/assistant/src/__tests__/credential-prompt-route.test.ts
@@ -529,6 +529,90 @@ describe("credentials/prompt route", () => {
     );
   });
 
+  describe("ACP token-type format guard", () => {
+    /**
+     * A prompt that collects a mismatched ACP token type must be rejected
+     * before persisting, routing the user to the correct field rather than
+     * silently storing an API key under the OAuth field (the original bug).
+     */
+    test("rejects an Anthropic API key collected for the ACP OAuth field", async () => {
+      // GIVEN the secure prompt returns an sk-ant-api… key
+      secretResult = { value: "sk-ant-api03-abc123", delivery: "store" };
+
+      // WHEN it is collected for acp/claude_oauth_token
+      const result = (await promptRoute!.handler({
+        body: {
+          service: "acp",
+          field: "claude_oauth_token",
+          label: "Claude OAuth Token",
+        },
+      })) as PromptResponse;
+
+      // THEN it fails with a field-routing error and nothing is persisted
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("anthropic_api_key");
+      expect(result.service).toBe("acp");
+      expect(result.field).toBe("claude_oauth_token");
+      expect(secureKeyWrites).toEqual([]);
+      expect(capturedMetadata).toBeUndefined();
+    });
+
+    test("rejects a Claude OAuth token collected for the ACP API-key field", async () => {
+      // GIVEN the secure prompt returns an sk-ant-oat… token
+      secretResult = { value: "sk-ant-oat01-abc123", delivery: "store" };
+
+      // WHEN it is collected for acp/anthropic_api_key
+      const result = (await promptRoute!.handler({
+        body: {
+          service: "acp",
+          field: "anthropic_api_key",
+          label: "Anthropic API Key",
+        },
+      })) as PromptResponse;
+
+      // THEN it fails with a field-routing error and nothing is persisted
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("claude_oauth_token");
+      expect(secureKeyWrites).toEqual([]);
+    });
+
+    test("stores a correctly-paired ACP credential", async () => {
+      // GIVEN the secure prompt returns an sk-ant-api… key
+      secretResult = { value: "sk-ant-api03-abc123", delivery: "store" };
+
+      // WHEN it is collected for the matching acp/anthropic_api_key field
+      const result = (await promptRoute!.handler({
+        body: {
+          service: "acp",
+          field: "anthropic_api_key",
+          label: "Anthropic API Key",
+        },
+      })) as PromptResponse;
+
+      // THEN it is persisted to secure storage
+      expect(result.ok).toBe(true);
+      expect(secureKeyWrites).toEqual([
+        { key: "acp:anthropic_api_key", value: "sk-ant-api03-abc123" },
+      ]);
+    });
+
+    test("leaves an unrelated service untouched by the ACP guard", async () => {
+      // GIVEN the prompt returns a token-shaped value for a non-ACP service
+      secretResult = { value: "sk-ant-oat01-abc123", delivery: "store" };
+
+      // WHEN it is collected for github/api_token
+      const result = (await promptRoute!.handler({
+        body: { service: "github", field: "api_token", label: "GitHub Token" },
+      })) as PromptResponse;
+
+      // THEN the guard does not fire and the value is persisted
+      expect(result.ok).toBe(true);
+      expect(secureKeyWrites).toEqual([
+        { key: "github:api_token", value: "sk-ant-oat01-abc123" },
+      ]);
+    });
+  });
+
   test("forwards provided allowed-tools/-domains to credential metadata", async () => {
     /**
      * When the caller does supply policy flags they must reach the metadata

--- a/assistant/src/__tests__/credential-routes.test.ts
+++ b/assistant/src/__tests__/credential-routes.test.ts
@@ -308,6 +308,97 @@ describe("credentials routes", () => {
       await expect(call).rejects.toBeInstanceOf(BadRequestError);
       expect(secureStore.size).toBe(0);
     });
+
+    describe("ACP token-type format guard", () => {
+      /**
+       * The original bug: an Anthropic API key (sk-ant-api…) stored in the ACP
+       * OAuth field caused a 401. The write path now rejects a mismatched ACP
+       * token type with a message routing the user to the correct field.
+       */
+      test("rejects an Anthropic API key under the ACP OAuth field", async () => {
+        // WHEN an sk-ant-api… key is stored under acp/claude_oauth_token
+        let caught: unknown;
+        try {
+          await setRoute!.handler({
+            body: {
+              service: "acp",
+              field: "claude_oauth_token",
+              value: "sk-ant-api03-abc123",
+            },
+          });
+        } catch (err) {
+          caught = err;
+        }
+
+        // THEN it is a BadRequestError routing to the API-key field, and
+        // nothing is persisted
+        expect(caught).toBeInstanceOf(BadRequestError);
+        expect((caught as Error).message).toContain("anthropic_api_key");
+        expect(secureStore.size).toBe(0);
+      });
+
+      test("rejects a Claude OAuth token under the ACP API-key field", async () => {
+        // WHEN an sk-ant-oat… token is stored under acp/anthropic_api_key
+        let caught: unknown;
+        try {
+          await setRoute!.handler({
+            body: {
+              service: "acp",
+              field: "anthropic_api_key",
+              value: "sk-ant-oat01-abc123",
+            },
+          });
+        } catch (err) {
+          caught = err;
+        }
+
+        // THEN it is a BadRequestError routing to the OAuth field
+        expect(caught).toBeInstanceOf(BadRequestError);
+        expect((caught as Error).message).toContain("claude_oauth_token");
+        expect(secureStore.size).toBe(0);
+      });
+
+      test("stores correctly-paired ACP credentials", async () => {
+        // WHEN each ACP token is stored under its matching field
+        await setRoute!.handler({
+          body: {
+            service: "acp",
+            field: "anthropic_api_key",
+            value: "sk-ant-api03-abc123",
+          },
+        });
+        await setRoute!.handler({
+          body: {
+            service: "acp",
+            field: "claude_oauth_token",
+            value: "sk-ant-oat01-abc123",
+          },
+        });
+
+        // THEN both are persisted unchanged
+        expect(secureStore.get("acp:anthropic_api_key")).toBe(
+          "sk-ant-api03-abc123",
+        );
+        expect(secureStore.get("acp:claude_oauth_token")).toBe(
+          "sk-ant-oat01-abc123",
+        );
+      });
+
+      test("leaves an unrelated service untouched by the ACP guard", async () => {
+        // WHEN a token-shaped value is stored under a non-ACP service
+        const result = (await setRoute!.handler({
+          body: {
+            service: "github",
+            field: "api_token",
+            value: "sk-ant-oat01-abc123",
+          },
+        })) as SetResponse;
+
+        // THEN the guard does not fire and the value is persisted
+        expect(result.service).toBe("github");
+        expect(secureStore.get("github:api_token")).toBe("sk-ant-oat01-abc123");
+      });
+    });
   });
 
   describe("credentials_list", () => {

--- a/assistant/src/__tests__/secret-routes-acp-format.test.ts
+++ b/assistant/src/__tests__/secret-routes-acp-format.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { BadRequestError } from "../runtime/routes/errors.js";
+
+// ---------------------------------------------------------------------------
+// Mutable mock state (closed over by the mock factories below)
+// ---------------------------------------------------------------------------
+
+let secureStore: Map<string, string>;
+let syncedServices: string[];
+
+// ---------------------------------------------------------------------------
+// Mocks for the collaborators handleAddSecret touches on the credential path
+// ---------------------------------------------------------------------------
+
+mock.module("../security/credential-key.js", () => ({
+  credentialKey: (service: string, field: string) => `${service}:${field}`,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  setSecureKeyAsync: mock(async (key: string, value: string) => {
+    secureStore.set(key, value);
+    return true;
+  }),
+  getSecureKeyAsync: mock(async (key: string) => secureStore.get(key)),
+  getSecureKeyResultAsync: mock(async (key: string) => ({
+    value: secureStore.get(key),
+    unreachable: false,
+  })),
+  deleteSecureKeyAsync: mock(async (key: string) =>
+    secureStore.delete(key) ? "deleted" : "not-found",
+  ),
+  listSecureKeysAsync: mock(async () => ({ accounts: [], unreachable: false })),
+  getActiveBackendName: () => "encrypted-store",
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  assertMetadataWritable: () => {},
+  upsertCredentialMetadata: mock(() => {}),
+  deleteCredentialMetadata: mock(() => {}),
+}));
+
+mock.module("../oauth/manual-token-connection.js", () => ({
+  syncManualTokenConnection: mock(async (service: string) => {
+    syncedServices.push(service);
+  }),
+}));
+
+import { ROUTES } from "../runtime/routes/secret-routes.js";
+
+const addRoute = ROUTES.find(
+  (r) => r.method === "POST" && r.endpoint === "secrets",
+)!;
+
+type AddResponse = { success: boolean; type: string; name: string };
+
+function addCredential(name: string, value: string) {
+  return addRoute.handler({ body: { type: "credential", name, value } });
+}
+
+describe("secrets add — ACP token-type format guard", () => {
+  beforeEach(() => {
+    secureStore = new Map();
+    syncedServices = [];
+  });
+
+  /**
+   * The original bug: an Anthropic API key (sk-ant-api…) stored under the ACP
+   * OAuth field caused a 401. The write path now rejects a mismatched ACP
+   * token type with a message routing the user to the correct field.
+   */
+  test("rejects an Anthropic API key under the ACP OAuth field", async () => {
+    // WHEN an sk-ant-api… key is added under acp:claude_oauth_token
+    let caught: unknown;
+    try {
+      await addCredential("acp:claude_oauth_token", "sk-ant-api03-abc123");
+    } catch (err) {
+      caught = err;
+    }
+
+    // THEN it is a BadRequestError routing to the API-key field, and nothing
+    // is persisted
+    expect(caught).toBeInstanceOf(BadRequestError);
+    expect((caught as Error).message).toContain("anthropic_api_key");
+    expect(secureStore.size).toBe(0);
+  });
+
+  test("rejects a Claude OAuth token under the ACP API-key field", async () => {
+    // WHEN an sk-ant-oat… token is added under acp:anthropic_api_key
+    let caught: unknown;
+    try {
+      await addCredential("acp:anthropic_api_key", "sk-ant-oat01-abc123");
+    } catch (err) {
+      caught = err;
+    }
+
+    // THEN it is a BadRequestError routing to the OAuth field
+    expect(caught).toBeInstanceOf(BadRequestError);
+    expect((caught as Error).message).toContain("claude_oauth_token");
+    expect(secureStore.size).toBe(0);
+  });
+
+  test("stores correctly-paired ACP credentials", async () => {
+    // WHEN each ACP token is added under its matching field
+    const apiResult = (await addCredential(
+      "acp:anthropic_api_key",
+      "sk-ant-api03-abc123",
+    )) as AddResponse;
+    const oauthResult = (await addCredential(
+      "acp:claude_oauth_token",
+      "sk-ant-oat01-abc123",
+    )) as AddResponse;
+
+    // THEN both succeed and are persisted unchanged
+    expect(apiResult.success).toBe(true);
+    expect(oauthResult.success).toBe(true);
+    expect(secureStore.get("acp:anthropic_api_key")).toBe(
+      "sk-ant-api03-abc123",
+    );
+    expect(secureStore.get("acp:claude_oauth_token")).toBe(
+      "sk-ant-oat01-abc123",
+    );
+  });
+
+  test("leaves an unrelated service untouched by the ACP guard", async () => {
+    // WHEN a token-shaped value is added under a non-ACP service
+    const result = (await addCredential(
+      "github:api_token",
+      "sk-ant-oat01-abc123",
+    )) as AddResponse;
+
+    // THEN the guard does not fire and the value is persisted
+    expect(result.success).toBe(true);
+    expect(secureStore.get("github:api_token")).toBe("sk-ant-oat01-abc123");
+  });
+});

--- a/assistant/src/runtime/routes/credential-prompt-routes.ts
+++ b/assistant/src/runtime/routes/credential-prompt-routes.ts
@@ -9,6 +9,10 @@
 import { z } from "zod";
 
 import {
+  AcpCredentialFormatError,
+  assertAcpCredentialFormat,
+} from "../../acp/acp-credentials.js";
+import {
   formatSlackChannelStatus,
   persistPromptedCredential,
 } from "../../credential-execution/prompted-credential.js";
@@ -136,6 +140,22 @@ async function handleCredentialPrompt({ body = {} }: RouteHandlerArgs) {
       };
     }
     return { ok: false, cancelled: true, error: "Cancelled by the user" };
+  }
+
+  // Reject a mismatched ACP token type before persisting, so a stored
+  // credential is never silently placed under the wrong field.
+  try {
+    assertAcpCredentialFormat(validated.service, validated.field, result.value);
+  } catch (err) {
+    if (err instanceof AcpCredentialFormatError) {
+      return {
+        ok: false,
+        error: err.message,
+        service: validated.service,
+        field: validated.field,
+      };
+    }
+    throw err;
   }
 
   const persisted = await persistPromptedCredential({

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -17,6 +17,10 @@
 import { z } from "zod";
 
 import {
+  AcpCredentialFormatError,
+  assertAcpCredentialFormat,
+} from "../../acp/acp-credentials.js";
+import {
   fetchManagedCatalog,
   type ManagedCredentialDescriptor,
 } from "../../credential-execution/managed-catalog.js";
@@ -384,6 +388,17 @@ async function handleCredentialsSet({ body }: RouteHandlerArgs) {
   const normalizedValue = normalizeSecretValue(value);
   if (normalizedValue.length === 0) {
     throw new BadRequestError("value is required");
+  }
+
+  // Reject a mismatched ACP token type (e.g. an API key in the OAuth field)
+  // as a clean 400 that routes the user to the correct field.
+  try {
+    assertAcpCredentialFormat(service, field, normalizedValue);
+  } catch (err) {
+    if (err instanceof AcpCredentialFormatError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
   }
 
   assertMetadataWritable();

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -10,6 +10,10 @@
 import { z } from "zod";
 
 import {
+  AcpCredentialFormatError,
+  assertAcpCredentialFormat,
+} from "../../acp/acp-credentials.js";
+import {
   getPlatformAssistantId,
   setPlatformAssistantId,
   setPlatformBaseUrl,
@@ -242,6 +246,18 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
       assertMetadataWritable();
       const service = name.slice(0, colonIdx);
       const field = name.slice(colonIdx + 1);
+
+      // Reject a mismatched ACP token type before storing it, routing the
+      // user to the right field.
+      try {
+        assertAcpCredentialFormat(service, field, value);
+      } catch (err) {
+        if (err instanceof AcpCredentialFormatError) {
+          throw new BadRequestError(err.message);
+        }
+        throw err;
+      }
+
       const key = credentialKey(service, field);
 
       const TRIMMED_IDENTITY_FIELDS = new Set([


### PR DESCRIPTION
## Summary
- Wire assertAcpCredentialFormat into all three credential write paths (credentials/set, secrets add, credentials/prompt)
- Rejects sk-ant-api… in acp/claude_oauth_token and sk-ant-oat… in acp/anthropic_api_key with a field-routing message
- Fixes the original bug report; non-ACP creds unaffected

Part of plan: acp-api-key-auth.md (PR 3 of 7)