### PR TITLE
feat(acp): gateway-mode proxy routing for platform-hosted (flagged off)

### DIFF
--- a/assistant/src/acp/__tests__/agent-process-gateway.test.ts
+++ b/assistant/src/acp/__tests__/agent-process-gateway.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Gateway-mode auth tests for `AcpAgentProcess.initialize()`.
+ *
+ * The `./gateway-auth.js` resolver is mocked so the three gate states can be
+ * driven without real config / managed-proxy setup. The ACP connection is
+ * stubbed directly (no child process): the tests assert what `initialize()`
+ * advertises as client capabilities and whether it proactively authenticates
+ * against the adapter's `gateway` method.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AuthMethod, InitializeResponse } from "@agentclientprotocol/sdk";
+
+// Controls resolveAcpGatewayAuth() per test. undefined = gate off (flag off or
+// managed-proxy prereqs unmet); an object = gate active.
+let gatewayAuthResult:
+  | { baseUrl: string; headers: Record<string, string> }
+  | undefined;
+
+mock.module("../gateway-auth.js", () => ({
+  GATEWAY_AUTH_METHOD_ID: "gateway",
+  resolveAcpGatewayAuth: async () => gatewayAuthResult,
+}));
+
+import { AcpAgentProcess } from "../agent-process.js";
+
+interface StubConnection {
+  initialize: (params: Record<string, unknown>) => Promise<InitializeResponse>;
+  authenticate: (params: Record<string, unknown>) => Promise<unknown>;
+  initializeCalls: Record<string, unknown>[];
+  authenticateCalls: Record<string, unknown>[];
+}
+
+function makeConnection(authMethods: AuthMethod[]): StubConnection {
+  const initializeCalls: Record<string, unknown>[] = [];
+  const authenticateCalls: Record<string, unknown>[] = [];
+  return {
+    initializeCalls,
+    authenticateCalls,
+    initialize: (params) => {
+      initializeCalls.push(params);
+      return Promise.resolve({ protocolVersion: 1, authMethods });
+    },
+    authenticate: (params) => {
+      authenticateCalls.push(params);
+      return Promise.resolve({});
+    },
+  };
+}
+
+function newProcessWith(conn: StubConnection): AcpAgentProcess {
+  const proc = new AcpAgentProcess(
+    "test-agent",
+    { command: "noop", args: [] },
+    () => {
+      throw new Error("client factory should not be called in this test");
+    },
+  );
+  (proc as unknown as { connection: unknown }).connection = conn;
+  return proc;
+}
+
+const gatewayMethod: AuthMethod = { id: "gateway", name: "Gateway" };
+
+describe("AcpAgentProcess.initialize gateway auth", () => {
+  beforeEach(() => {
+    gatewayAuthResult = undefined;
+  });
+
+  test("(a) gate off: no auth capability advertised, no authenticate call", async () => {
+    // Even if the adapter advertises a gateway method, an off gate must not
+    // advertise the capability nor authenticate — identical to prior behavior.
+    const conn = makeConnection([gatewayMethod]);
+    const proc = newProcessWith(conn);
+
+    await proc.initialize();
+
+    expect(conn.initializeCalls[0].clientCapabilities).toEqual({
+      fs: { readTextFile: true, writeTextFile: true },
+      terminal: true,
+    });
+    expect(conn.authenticateCalls).toHaveLength(0);
+  });
+
+  test("(b) gate on + gateway advertised: advertises capability and authenticates with baseUrl + x-api-key", async () => {
+    gatewayAuthResult = {
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+      headers: {
+        "x-api-key": "sk-assistant-123",
+        "X-Vellum-LLM-Call-Site": "acp-child",
+      },
+    };
+    const conn = makeConnection([gatewayMethod]);
+    const proc = newProcessWith(conn);
+
+    await proc.initialize();
+
+    expect(
+      (conn.initializeCalls[0].clientCapabilities as { auth?: unknown }).auth,
+    ).toEqual({ _meta: { gateway: true } });
+
+    expect(conn.authenticateCalls).toHaveLength(1);
+    const call = conn.authenticateCalls[0]!;
+    expect(call.methodId).toBe("gateway");
+    expect(call._meta).toEqual({
+      gateway: {
+        baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+        headers: {
+          "x-api-key": "sk-assistant-123",
+          "X-Vellum-LLM-Call-Site": "acp-child",
+        },
+      },
+    });
+  });
+
+  test("(c) gate on but adapter does NOT advertise gateway: capability advertised, no authenticate, no throw", async () => {
+    gatewayAuthResult = {
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+      headers: { "x-api-key": "sk-assistant-123" },
+    };
+    // Version-skew: adapter offers only an env_var method, not gateway.
+    const conn = makeConnection([
+      {
+        type: "env_var",
+        id: "anthropic-api-key",
+        name: "Use ANTHROPIC_API_KEY",
+        vars: [],
+      },
+    ]);
+    const proc = newProcessWith(conn);
+
+    await expect(proc.initialize()).resolves.toBeDefined();
+
+    expect(
+      (conn.initializeCalls[0].clientCapabilities as { auth?: unknown }).auth,
+    ).toEqual({ _meta: { gateway: true } });
+    expect(conn.authenticateCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/acp/__tests__/gateway-auth.test.ts
+++ b/assistant/src/acp/__tests__/gateway-auth.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the ACP gateway-mode auth resolver.
+ *
+ * `resolveAcpGatewayAuth()` is active only when BOTH the
+ * `acp-managed-proxy-routing` feature flag is on AND managed-proxy prereqs are
+ * met; otherwise it returns undefined so callers fall back to the credential
+ * path. The managed-proxy context is mocked so the two gate inputs can be
+ * driven independently; the flag is driven via the feature-flag override cache.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+import { clearFeatureFlagOverridesCache } from "../../config/assistant-feature-flags.js";
+
+// Controllable managed-proxy context (stands in for platform base URL +
+// assistant API key resolution, covered on its own elsewhere).
+let ctxEnabled = false;
+let ctxApiKey = "";
+let managedBaseUrl: string | undefined;
+
+mock.module("../../providers/platform-proxy/context.js", () => ({
+  resolveManagedProxyContext: async () => ({
+    enabled: ctxEnabled,
+    platformBaseUrl: ctxEnabled ? "https://platform.example.com" : "",
+    assistantApiKey: ctxApiKey,
+  }),
+  buildManagedBaseUrl: async () => managedBaseUrl,
+}));
+
+const {
+  resolveAcpGatewayAuth,
+  isAcpManagedProxyRoutingEnabled,
+  ACP_MANAGED_PROXY_ROUTING_FLAG,
+} = await import("../gateway-auth.js");
+
+function enableFlag(): void {
+  setOverridesForTesting({ [ACP_MANAGED_PROXY_ROUTING_FLAG]: true });
+}
+
+beforeEach(() => {
+  clearFeatureFlagOverridesCache();
+  ctxEnabled = false;
+  ctxApiKey = "";
+  managedBaseUrl = undefined;
+});
+
+afterEach(() => {
+  clearFeatureFlagOverridesCache();
+});
+
+describe("resolveAcpGatewayAuth", () => {
+  test("flag key matches the registry entry", () => {
+    expect(ACP_MANAGED_PROXY_ROUTING_FLAG).toBe("acp-managed-proxy-routing");
+  });
+
+  test("returns undefined when the flag is OFF (default) even with proxy prereqs met", async () => {
+    ctxEnabled = true;
+    ctxApiKey = "sk-assistant-123";
+    managedBaseUrl = "https://platform.example.com/v1/runtime-proxy/anthropic";
+
+    expect(isAcpManagedProxyRoutingEnabled()).toBe(false);
+    expect(await resolveAcpGatewayAuth()).toBeUndefined();
+  });
+
+  test("returns the gateway config when flag ON and managed proxy enabled", async () => {
+    enableFlag();
+    ctxEnabled = true;
+    ctxApiKey = "sk-assistant-123";
+    managedBaseUrl = "https://platform.example.com/v1/runtime-proxy/anthropic";
+
+    expect(isAcpManagedProxyRoutingEnabled()).toBe(true);
+    expect(await resolveAcpGatewayAuth()).toEqual({
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+      headers: {
+        "x-api-key": "sk-assistant-123",
+        "X-Vellum-LLM-Call-Site": "acp-child",
+      },
+    });
+  });
+
+  test("returns undefined when flag ON but managed proxy prereqs are unmet", async () => {
+    enableFlag();
+    ctxEnabled = false; // no platform URL / assistant API key
+
+    expect(await resolveAcpGatewayAuth()).toBeUndefined();
+  });
+
+  test("returns undefined when flag ON and ctx enabled but no managed base URL (skew guard)", async () => {
+    enableFlag();
+    ctxEnabled = true;
+    ctxApiKey = "sk-assistant-123";
+    managedBaseUrl = undefined;
+
+    expect(await resolveAcpGatewayAuth()).toBeUndefined();
+  });
+});

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -100,12 +100,25 @@ mock.module("../../tools/credentials/broker.js", () => ({
   },
 }));
 
+/**
+ * Controls the gateway-mode (managed-proxy) gate. undefined = gate off (flag
+ * off or prereqs unmet), the PR-2 default that every existing test relies on.
+ */
+let gatewayAuthResult:
+  | { baseUrl: string; headers: Record<string, string> }
+  | undefined;
+
+mock.module("../gateway-auth.js", () => ({
+  resolveAcpGatewayAuth: async () => gatewayAuthResult,
+}));
+
 const { prepareAgentEnv, grantAcpAccessToSharedAnthropicKey } =
   await import("../prepare-agent-env.js");
 
 beforeEach(() => {
   metadataStore.clear();
   vaultStore.clear();
+  gatewayAuthResult = undefined;
 });
 
 // ---------------------------------------------------------------------------
@@ -494,5 +507,58 @@ describe("prepareAgentEnv — non-claude commands", () => {
     });
 
     expect(prepared.env).toEqual({ FOO: "bar" });
+  });
+});
+
+describe("prepareAgentEnv — claude-agent-acp gateway (managed-proxy) mode", () => {
+  const gatewayAuth = {
+    baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+    headers: { "x-api-key": "sk-assistant-123" },
+  };
+
+  test("gate ON: skips credential injection and does NOT throw when no credential exists", async () => {
+    // No vault token, no config override — PR-2 would throw FailedDependencyError.
+    gatewayAuthResult = gatewayAuth;
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    // No broker read happened, so no credential policy was auto-provisioned.
+    expect(metadataStore.has("acp/anthropic_api_key")).toBe(false);
+    expect(metadataStore.has("acp/claude_oauth_token")).toBe(false);
+  });
+
+  test("gate ON: does not read the vault even when a credential is present", async () => {
+    gatewayAuthResult = gatewayAuth;
+    seedVaultToken("vault-should-be-ignored");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  test("gate OFF (default): behaves exactly as PR 2 — injects the vault token", async () => {
+    // gatewayAuthResult stays undefined (reset in beforeEach).
+    seedVaultToken("vault-default-path");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-default-path");
+  });
+
+  test("gate OFF (default): still throws when no credential is found", async () => {
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow("CLAUDE_CODE_OAUTH_TOKEN");
   });
 });

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -20,6 +20,11 @@ import type {
 import * as acp from "@agentclientprotocol/sdk";
 
 import { getLogger } from "../util/logger.js";
+import {
+  type AcpGatewayAuth,
+  GATEWAY_AUTH_METHOD_ID,
+  resolveAcpGatewayAuth,
+} from "./gateway-auth.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp");
@@ -201,6 +206,11 @@ export class AcpAgentProcess {
   async initialize(): Promise<InitializeResponse> {
     const connection = this.requireConnection();
 
+    // Gateway-mode proxy routing (flag-gated, off by default): when resolved,
+    // advertise the auth capability so a supporting adapter offers a `gateway`
+    // method we authenticate with below. Off → payload unchanged (no regression).
+    const gatewayAuth = await resolveAcpGatewayAuth();
+
     log.info({ agentId: this.agentId }, "Initializing ACP connection");
 
     const response = await connection.initialize({
@@ -209,11 +219,52 @@ export class AcpAgentProcess {
       clientCapabilities: {
         fs: { readTextFile: true, writeTextFile: true },
         terminal: true,
+        ...(gatewayAuth ? { auth: { _meta: { gateway: true } } } : {}),
       },
     });
 
     this.initializeResponse = response;
+
+    if (gatewayAuth) {
+      await this.authenticateGateway(gatewayAuth);
+    }
+
     return response;
+  }
+
+  /**
+   * Proactively authenticate via the adapter's `gateway` auth method so the
+   * child routes through the Vellum runtime proxy — the adapter converts our
+   * baseUrl/headers into the child's `ANTHROPIC_BASE_URL` +
+   * `ANTHROPIC_CUSTOM_HEADERS`, so it needs no Anthropic credential.
+   *
+   * Version-skew-safe: an older adapter that did not advertise a `gateway`
+   * method is logged and skipped rather than authenticated, so the normal
+   * (credential) path still applies — this never throws.
+   */
+  private async authenticateGateway(auth: AcpGatewayAuth): Promise<void> {
+    const method = this.authMethods.find(
+      (m) => m.id === GATEWAY_AUTH_METHOD_ID,
+    );
+    if (!method) {
+      const advertised = this.authMethods.map((m) => m.id);
+      log.info(
+        { agentId: this.agentId, advertised },
+        "ACP adapter did not advertise gateway auth; falling back to credential path",
+      );
+      return;
+    }
+
+    // Do not log headers — they carry the assistant API key.
+    log.info(
+      { agentId: this.agentId, baseUrl: auth.baseUrl },
+      "Authenticating ACP child via gateway proxy routing",
+    );
+
+    await this.requireConnection().authenticate({
+      methodId: GATEWAY_AUTH_METHOD_ID,
+      _meta: { gateway: { baseUrl: auth.baseUrl, headers: auth.headers } },
+    });
   }
 
   /**

--- a/assistant/src/acp/gateway-auth.ts
+++ b/assistant/src/acp/gateway-auth.ts
@@ -1,0 +1,71 @@
+/**
+ * ACP gateway-mode auth resolver (flag-gated, OFF by default).
+ *
+ * When the `acp-managed-proxy-routing` feature flag is enabled AND the managed
+ * proxy prerequisites are met (platform base URL + assistant API key), returns
+ * the config the ACP adapter's gateway auth mode needs to route a
+ * platform-hosted `claude-agent-acp` child through the Vellum runtime proxy:
+ * the proxy base URL plus the headers that authenticate the child as this
+ * assistant. The child then needs no Anthropic credential of its own — billing
+ * accrues per-assistant on the proxy.
+ *
+ * Returns `undefined` when the flag is off or the prereqs are missing, so every
+ * caller falls back to the existing credential-injection path (no regression).
+ *
+ * The flag is OFF by default and requires a dev-platform live test before it is
+ * enabled in production.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfigReadOnly } from "../config/loader.js";
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "../providers/platform-proxy/context.js";
+
+/** Feature-flag key gating ACP managed-proxy (gateway auth) routing. */
+export const ACP_MANAGED_PROXY_ROUTING_FLAG = "acp-managed-proxy-routing";
+
+/** Adapter auth-method id for gateway routing (matches claude-agent-acp). */
+export const GATEWAY_AUTH_METHOD_ID = "gateway";
+
+// Runtime-proxy attribution header (mirrors providers/retry.ts). Non-secret.
+const CALL_SITE_HEADER = "X-Vellum-LLM-Call-Site";
+const CALL_SITE_VALUE = "acp-child";
+
+export interface AcpGatewayAuth {
+  baseUrl: string;
+  headers: Record<string, string>;
+}
+
+/** Whether the ACP managed-proxy routing flag is enabled. */
+export function isAcpManagedProxyRoutingEnabled(): boolean {
+  return isAssistantFeatureFlagEnabled(
+    ACP_MANAGED_PROXY_ROUTING_FLAG,
+    getConfigReadOnly(),
+  );
+}
+
+/**
+ * Resolve the gateway auth config when the gate is active (flag enabled AND
+ * managed-proxy prereqs satisfied), else `undefined`.
+ */
+export async function resolveAcpGatewayAuth(): Promise<
+  AcpGatewayAuth | undefined
+> {
+  if (!isAcpManagedProxyRoutingEnabled()) return undefined;
+
+  const ctx = await resolveManagedProxyContext();
+  if (!ctx.enabled) return undefined;
+
+  const baseUrl = await buildManagedBaseUrl("anthropic");
+  if (!baseUrl) return undefined;
+
+  return {
+    baseUrl,
+    headers: {
+      "x-api-key": ctx.assistantApiKey,
+      [CALL_SITE_HEADER]: CALL_SITE_VALUE,
+    },
+  };
+}

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -33,6 +33,7 @@ import {
   ACP_ANTHROPIC_API_KEY_FIELD,
   ACP_OAUTH_TOKEN_FIELD,
 } from "./acp-credentials.js";
+import { resolveAcpGatewayAuth } from "./gateway-auth.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp:prepare-agent-env");
@@ -222,6 +223,13 @@ export async function prepareAgentEnv(
   const adapterCommand = basename(agentConfig.command);
 
   if (adapterCommand === "claude-agent-acp") {
+    // Gateway-mode proxy routing (flag-gated, off by default): the adapter
+    // authenticates the child against the Vellum runtime proxy, so no Anthropic
+    // credential is needed — skip injection and the throw. Off → PR-2 path below.
+    if (await resolveAcpGatewayAuth()) {
+      return { ...agentConfig, env };
+    }
+
     const hasClaudeCred = () =>
       Boolean(env.ANTHROPIC_API_KEY || env.CLAUDE_CODE_OAUTH_TOKEN);
 

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -51,6 +51,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "acp-managed-proxy-routing",
+      "scope": "assistant",
+      "key": "acp-managed-proxy-routing",
+      "label": "ACP Managed Proxy Routing",
+      "description": "Route platform-hosted claude-agent-acp inference through the Vellum runtime proxy via the ACP gateway auth handshake, billing per-assistant so the child needs no Anthropic credential. Off by default; requires a dev-platform live test before enabling.",
+      "defaultEnabled": false
+    },
+    {
       "id": "settings-developer-nav",
       "scope": "assistant",
       "key": "settings-developer-nav",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -51,6 +51,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "acp-managed-proxy-routing",
+      "scope": "assistant",
+      "key": "acp-managed-proxy-routing",
+      "label": "ACP Managed Proxy Routing",
+      "description": "Route platform-hosted claude-agent-acp inference through the Vellum runtime proxy via the ACP gateway auth handshake, billing per-assistant so the child needs no Anthropic credential. Off by default; requires a dev-platform live test before enabling.",
+      "defaultEnabled": false
+    },
+    {
       "id": "settings-developer-nav",
       "scope": "assistant",
       "key": "settings-developer-nav",


### PR DESCRIPTION
## Summary
- Behind a flag (off by default): route platform-hosted claude-agent-acp through the Vellum runtime proxy via the adapter's gateway auth mode
- agent-process advertises auth._meta.gateway + sends authenticate({methodId:gateway}) with the proxy baseUrl + assistant x-api-key; version-skew-safe fallback
- prepare-agent-env skips credential injection/throw in gateway mode; PR 2 behavior unchanged when off
- Requires a dev-platform live test before enabling

Part of plan: acp-api-key-auth.md (PR 7 of 7)