### PR TITLE
feat(design-library): add hint tone to Notice

### DIFF
--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -3,6 +3,7 @@ import {
   CircleCheck,
   CloudOff,
   Info,
+  Lightbulb,
   LoaderCircle,
   Moon,
   TriangleAlert,
@@ -109,6 +110,13 @@ const STATUS_TONE_CLASSES: Record<NoticeTone, StatusToneClasses> = {
     icon: "text-[color:var(--content-secondary)]",
     action: "[--status-banner-action-color:var(--content-secondary)]",
     DefaultIcon: null,
+  },
+  hint: {
+    container: "bg-[var(--system-info-weak)]",
+    content: "text-[color:var(--system-info-strong)]",
+    icon: "text-[color:var(--system-info-strong)]",
+    action: "[--status-banner-action-color:var(--system-info-strong)]",
+    DefaultIcon: Lightbulb,
   },
 };
 

--- a/packages/design-library/src/components/notice.stories.tsx
+++ b/packages/design-library/src/components/notice.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof Notice> = {
   argTypes: {
     tone: {
       control: "select",
-      options: ["info", "success", "warning", "error", "neutral"],
+      options: ["info", "success", "warning", "error", "neutral", "hint"],
     },
     onDismiss: { action: "dismissed" },
   },
@@ -57,6 +57,14 @@ export const Error: Story = {
   },
 };
 
+export const Hint: Story = {
+  args: {
+    tone: "hint",
+    title: "Tip",
+    children: "This is a helpful hint.",
+  },
+};
+
 export const Neutral: Story = {
   args: {
     tone: "neutral",
@@ -98,7 +106,7 @@ export const BodyOnly: Story = {
 export const AllTones: Story = {
   render: () => (
     <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
-      {(["info", "success", "warning", "error", "neutral"] as const).map((tone) => (
+      {(["info", "success", "warning", "error", "neutral", "hint"] as const).map((tone) => (
         <Notice key={tone} tone={tone} title={tone}>
           Example {tone} notice.
         </Notice>

--- a/packages/design-library/src/components/notice.test.tsx
+++ b/packages/design-library/src/components/notice.test.tsx
@@ -28,3 +28,24 @@ describe("Notice — error tone icon", () => {
     expect(html).not.toContain("lucide-triangle-alert");
   });
 });
+
+describe("Notice — hint tone", () => {
+  test("renders the Lightbulb icon and hint container classes", () => {
+    const html = renderToStaticMarkup(
+      <Notice tone="hint">Try keyboard shortcuts.</Notice>,
+    );
+
+    expect(html).toContain("lucide-lightbulb");
+    expect(html).toContain("var(--system-info-weak)");
+  });
+
+  test("icon={null} suppresses the default hint Lightbulb", () => {
+    const html = renderToStaticMarkup(
+      <Notice tone="hint" icon={null}>
+        Try keyboard shortcuts.
+      </Notice>,
+    );
+
+    expect(html).not.toContain("lucide-lightbulb");
+  });
+});

--- a/packages/design-library/src/components/notice.tsx
+++ b/packages/design-library/src/components/notice.tsx
@@ -2,6 +2,7 @@ import {
   CircleAlert,
   CircleCheck,
   Info,
+  Lightbulb,
   TriangleAlert,
   X,
   type LucideIcon,
@@ -11,7 +12,7 @@ import { type ComponentProps, type ReactNode } from "react";
 import { cn } from "../utils/cn";
 import { Typography } from "./typography";
 
-export type NoticeTone = "info" | "success" | "warning" | "error" | "neutral";
+export type NoticeTone = "info" | "success" | "warning" | "error" | "neutral" | "hint";
 
 export interface NoticeProps
   extends Omit<ComponentProps<"div">, "title" | "role"> {
@@ -58,6 +59,12 @@ const TONE_CLASSES: Record<NoticeTone, ToneClasses> = {
     container: "bg-[var(--surface-overlay)] border-[var(--border-base)]",
     icon: "text-[color:var(--content-secondary)]",
     DefaultIcon: null,
+  },
+  hint: {
+    container:
+      "bg-[var(--system-info-weak)] border-[color-mix(in_srgb,var(--system-info-strong)_25%,transparent)]",
+    icon: "text-[color:var(--system-info-strong)]",
+    DefaultIcon: Lightbulb,
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds a `hint` tone to the design-library Notice component using the `--system-info-*` semantic tokens, with Lightbulb default icon
- Stories + tests updated (Hint story, AllTones, icon/container assertions)

Part of plan: proactive-tips-v1.md (PR 1 of 7)