### PR TITLE
feat(web): shared banner-visibility store for nudge/tip mutual exclusivity

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -12,12 +12,16 @@
  * `ChatBody` itself.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { type ButtonHTMLAttributes, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { ChatBodyProps } from "@/domains/chat/components/chat-body";
+import {
+  isBannerVisible,
+  useBannerVisibilityStore,
+} from "@/stores/banner-visibility-store";
 
 // Stub child components that require browser APIs or complex hooks.
 // NOTE: Do NOT mock chat-scroll-area itself — that leaks across test
@@ -293,6 +297,83 @@ describe("ChatBody — banner overlay suppression (LUM-1566)", () => {
       globalThis.ResizeObserver = originalResizeObserver;
       cleanup();
     }
+  });
+});
+
+describe("ChatBody — banner-visibility store mirroring", () => {
+  // The shared store must reflect the banner actually being MOUNTED
+  // (bannerSlot provided AND not on the empty state), not merely a
+  // candidate slot existing — a sidebar tip hides itself while the store
+  // reports a visible banner. Count-based register/unregister keeps
+  // concurrent instances (main chat + app-editing side panel) from
+  // clobbering each other.
+  const bannerSlot = <div data-testid="banner">BANNER_CONTENT</div>;
+  const visible = () =>
+    isBannerVisible(useBannerVisibilityStore.getState().visibleBannerCount);
+
+  beforeEach(() => {
+    useBannerVisibilityStore.setState({ visibleBannerCount: 0 });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("registers while the banner overlay is mounted, unregisters on unmount", () => {
+    const { unmount } = render(<ChatBody {...baseProps({ bannerSlot })} />);
+    expect(visible()).toBe(true);
+
+    unmount();
+    expect(visible()).toBe(false);
+  });
+
+  test("does NOT register on the empty state even when bannerSlot is provided", () => {
+    render(<ChatBody {...withEmptyState({ bannerSlot })} />);
+    expect(visible()).toBe(false);
+  });
+
+  test("does NOT register without a bannerSlot (side panel passes undefined)", () => {
+    render(<ChatBody {...baseProps({ variant: "side-panel" })} />);
+    expect(visible()).toBe(false);
+  });
+
+  test("empty→active transition flips the store as the banner mounts/unmounts", () => {
+    const { rerender } = render(
+      <ChatBody {...withEmptyState({ bannerSlot })} />,
+    );
+    expect(visible()).toBe(false);
+
+    rerender(<ChatBody {...baseProps({ bannerSlot })} />);
+    expect(visible()).toBe(true);
+
+    rerender(<ChatBody {...withEmptyState({ bannerSlot })} />);
+    expect(visible()).toBe(false);
+  });
+
+  test("a bannerless second instance does not clobber the first's visibility", () => {
+    const main = render(<ChatBody {...baseProps({ bannerSlot })} />);
+    const sidePanel = render(
+      <ChatBody {...baseProps({ variant: "side-panel" })} />,
+    );
+    expect(visible()).toBe(true);
+
+    sidePanel.unmount();
+    expect(visible()).toBe(true);
+
+    main.unmount();
+    expect(visible()).toBe(false);
+  });
+
+  test("stays visible until every banner-rendering instance unmounts", () => {
+    const first = render(<ChatBody {...baseProps({ bannerSlot })} />);
+    const second = render(<ChatBody {...baseProps({ bannerSlot })} />);
+    expect(useBannerVisibilityStore.getState().visibleBannerCount).toBe(2);
+
+    first.unmount();
+    expect(visible()).toBe(true);
+
+    second.unmount();
+    expect(visible()).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -1,4 +1,5 @@
 import {
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -8,6 +9,7 @@ import {
 
 import { Paperclip, X } from "lucide-react";
 
+import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
 import { QuestionPromptSlot } from "@/domains/chat/components/question-prompt-slot";
 import { StagedQuotesStrip } from "@/domains/chat/components/staged-quotes-strip";
 import {
@@ -44,10 +46,11 @@ import { Button, Notice, type NoticeTone } from "@vellumai/design-library";
  * as optional slot props or a `variant` enum, so the composer itself is
  * a single mounted instance across both paths (LUM-1516).
  *
- * The component is purely presentational: all state, handlers, and
- * derived flags are owned by the parent page. This keeps the chat-body
- * surface framework-agnostic and free of routing or page-level
- * concerns.
+ * The component is presentational: all state, handlers, and derived
+ * flags are owned by the parent page (its one side effect reports
+ * mounted-banner visibility to the shared banner-visibility store).
+ * This keeps the chat-body surface framework-agnostic and free of
+ * routing or page-level concerns.
  */
 export interface ChatBodyDragHandlers {
   onDragEnter: DragEventHandler<HTMLDivElement>;
@@ -121,6 +124,8 @@ export interface ChatBodyProps {
    * Optional pre-rendered banner stack (mobile-app nudge / GitHub / Discord)
    * rendered alongside the scroll-to-latest button in the absolute-positioned
    * overlay above the composer. Omitted by the app-editing side panel.
+   * While mounted (non-empty state), visibility is mirrored into the shared
+   * banner-visibility store so tip surfaces can stay mutually exclusive.
    */
   bannerSlot?: ReactNode;
 
@@ -260,12 +265,26 @@ export function ChatBody({
   // user sends a message and the empty state clears. `showScrollToLatest`
   // is already false on the empty state (gated on `messages.length > 0`
   // at the call site), so this only affects `bannerSlot`.
-  const hasOverlay =
-    !isEmptyState && (showScrollToLatest || Boolean(bannerSlot));
+  const bannerRendered = !isEmptyState && Boolean(bannerSlot);
+  const hasOverlay = bannerRendered || (!isEmptyState && showScrollToLatest);
   const bottomOverlayReservePx =
-    !isEmptyState && bannerSlot && bottomBannerOverlayHeight > 0
+    bannerRendered && bottomBannerOverlayHeight > 0
       ? bottomBannerOverlayHeight
       : undefined;
+
+  // Mirror the mounted banner — not the candidate slot — into the shared
+  // store so tip surfaces stay mutually exclusive with nudge banners.
+  // Register/unregister (a count) tolerates concurrent instances (main +
+  // side panel) without a last-write-wins race.
+  const registerVisibleBanner =
+    useBannerVisibilityStore.use.registerVisibleBanner();
+  const unregisterVisibleBanner =
+    useBannerVisibilityStore.use.unregisterVisibleBanner();
+  useEffect(() => {
+    if (!bannerRendered) return;
+    registerVisibleBanner();
+    return unregisterVisibleBanner;
+  }, [bannerRendered, registerVisibleBanner, unregisterVisibleBanner]);
 
   // Composer stack — stays at the same tree position across the empty→active
   // transition so React preserves its state (focus, draft text, attachments)

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -1,5 +1,4 @@
 import {
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -275,12 +274,13 @@ export function ChatBody({
   // Mirror the mounted banner — not the candidate slot — into the shared
   // store so tip surfaces stay mutually exclusive with nudge banners.
   // Register/unregister (a count) tolerates concurrent instances (main +
-  // side panel) without a last-write-wins race.
+  // side panel) without a last-write-wins race. Layout effect so consumers
+  // see the update before paint and never render a frame over the banner.
   const registerVisibleBanner =
     useBannerVisibilityStore.use.registerVisibleBanner();
   const unregisterVisibleBanner =
     useBannerVisibilityStore.use.unregisterVisibleBanner();
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!bannerRendered) return;
     registerVisibleBanner();
     return unregisterVisibleBanner;

--- a/clients/web/src/domains/chat/hooks/use-chat-banner-slots.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-banner-slots.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests that `useChatBannerSlots` mirrors "a nudge banner is currently
+ * visible" into the shared banner-visibility store — the mutual-exclusivity
+ * contract the sidebar tip reads to avoid rendering alongside a banner.
+ *
+ * The banner components and queued drawer are stubbed via `mock.module` so
+ * the test stays focused on the slot/visibility logic.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+// --- Mocks ----------------------------------------------------------------
+
+mock.module("@/components/nudges/discord-nudge-banner", () => ({
+  DiscordNudgeBanner: () => null,
+}));
+mock.module("@/components/nudges/github-nudge-banner", () => ({
+  GitHubNudgeBanner: () => null,
+}));
+mock.module("@/components/nudges/ios-app-banner", () => ({
+  IOSAppBanner: () => null,
+}));
+mock.module("@/components/nudges/macos-app-banner", () => ({
+  MacOSAppBanner: () => null,
+}));
+mock.module("@/domains/chat/components/queued-messages-drawer", () => ({
+  QueuedMessagesDrawer: () => null,
+}));
+
+import { useChatBannerSlots } from "@/domains/chat/hooks/use-chat-banner-slots";
+import type { UseChatBannerSlotsParams } from "@/domains/chat/hooks/use-chat-banner-slots";
+import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
+
+// --- Fixtures ---------------------------------------------------------------
+
+type Nudges = UseChatBannerSlotsParams["nudges"];
+
+const noop = () => {};
+
+function makeNudges(overrides: Partial<Nudges> = {}): Nudges {
+  return {
+    isOnIOS: false,
+    isOnMacOS: true,
+    isOnNudgePlatform: true,
+    nudge: {
+      bannerShouldShow: false,
+      handleDownload: noop,
+      handleBannerDismiss: noop,
+    },
+    showBanner: false,
+    githubNudge: {
+      bannerShouldShow: false,
+      handleStar: noop,
+      handleBannerDismiss: noop,
+    },
+    showGitHubBanner: false,
+    discordNudge: {
+      bannerShouldShow: false,
+      handleJoin: noop,
+      handleBannerDismiss: noop,
+    },
+    showDiscordBanner: false,
+    ...overrides,
+  };
+}
+
+function makeParams(nudges: Nudges): UseChatBannerSlotsParams {
+  return {
+    nudges,
+    queuedMessages: [],
+    onCancelQueuedMessage: noop,
+    onCancelAllQueued: noop,
+    onSteerMessage: noop,
+    onEditQueueTail: noop,
+    queueSteering: false,
+  };
+}
+
+const bannerVisible = () =>
+  useBannerVisibilityStore.getState().bannerVisible;
+
+beforeEach(() => {
+  useBannerVisibilityStore.setState({ bannerVisible: false });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// --- Tests ------------------------------------------------------------------
+
+describe("useChatBannerSlots — banner-visibility mirroring", () => {
+  test("no banner showing → slot null, store stays false", () => {
+    const { result } = renderHook(useChatBannerSlots, {
+      initialProps: makeParams(makeNudges()),
+    });
+    expect(result.current.mainBannerSlot).toBeNull();
+    expect(bannerVisible()).toBe(false);
+  });
+
+  const flags = ["showBanner", "showGitHubBanner", "showDiscordBanner"] as const;
+  for (const flag of flags) {
+    test(`${flag} → slot renders, store flips true`, () => {
+      const { result } = renderHook(useChatBannerSlots, {
+        initialProps: makeParams(makeNudges({ [flag]: true })),
+      });
+      expect(result.current.mainBannerSlot).not.toBeNull();
+      expect(bannerVisible()).toBe(true);
+    });
+  }
+
+  test("banner hiding flips the store back to false", () => {
+    const { rerender } = renderHook(useChatBannerSlots, {
+      initialProps: makeParams(makeNudges({ showBanner: true })),
+    });
+    expect(bannerVisible()).toBe(true);
+
+    rerender(makeParams(makeNudges()));
+    expect(bannerVisible()).toBe(false);
+  });
+
+  test("unmount resets the store to false", () => {
+    const { unmount } = renderHook(useChatBannerSlots, {
+      initialProps: makeParams(makeNudges({ showGitHubBanner: true })),
+    });
+    expect(bannerVisible()).toBe(true);
+
+    unmount();
+    expect(bannerVisible()).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-chat-banner-slots.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-banner-slots.test.tsx
@@ -1,13 +1,14 @@
 /**
- * Tests that `useChatBannerSlots` mirrors "a nudge banner is currently
- * visible" into the shared banner-visibility store — the mutual-exclusivity
- * contract the sidebar tip reads to avoid rendering alongside a banner.
+ * Tests that `useChatBannerSlots` builds the main banner slot from the nudge
+ * flags. Banner *visibility* is mirrored into the shared store by `ChatBody`
+ * (which owns the actual mount conditions), not by this hook — see
+ * `chat-body.test.tsx`.
  *
  * The banner components and queued drawer are stubbed via `mock.module` so
- * the test stays focused on the slot/visibility logic.
+ * the test stays focused on the slot construction logic.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
 // --- Mocks ----------------------------------------------------------------
@@ -30,7 +31,6 @@ mock.module("@/domains/chat/components/queued-messages-drawer", () => ({
 
 import { useChatBannerSlots } from "@/domains/chat/hooks/use-chat-banner-slots";
 import type { UseChatBannerSlotsParams } from "@/domains/chat/hooks/use-chat-banner-slots";
-import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
 
 // --- Fixtures ---------------------------------------------------------------
 
@@ -77,56 +77,37 @@ function makeParams(nudges: Nudges): UseChatBannerSlotsParams {
   };
 }
 
-const bannerVisible = () =>
-  useBannerVisibilityStore.getState().bannerVisible;
-
-beforeEach(() => {
-  useBannerVisibilityStore.setState({ bannerVisible: false });
-});
-
 afterEach(() => {
   cleanup();
 });
 
 // --- Tests ------------------------------------------------------------------
 
-describe("useChatBannerSlots — banner-visibility mirroring", () => {
-  test("no banner showing → slot null, store stays false", () => {
+describe("useChatBannerSlots — banner slot construction", () => {
+  test("no nudge flag set → mainBannerSlot is null", () => {
     const { result } = renderHook(useChatBannerSlots, {
       initialProps: makeParams(makeNudges()),
     });
     expect(result.current.mainBannerSlot).toBeNull();
-    expect(bannerVisible()).toBe(false);
   });
 
   const flags = ["showBanner", "showGitHubBanner", "showDiscordBanner"] as const;
   for (const flag of flags) {
-    test(`${flag} → slot renders, store flips true`, () => {
+    test(`${flag} → mainBannerSlot renders`, () => {
       const { result } = renderHook(useChatBannerSlots, {
         initialProps: makeParams(makeNudges({ [flag]: true })),
       });
       expect(result.current.mainBannerSlot).not.toBeNull();
-      expect(bannerVisible()).toBe(true);
     });
   }
 
-  test("banner hiding flips the store back to false", () => {
-    const { rerender } = renderHook(useChatBannerSlots, {
+  test("clearing the flag drops the slot back to null", () => {
+    const { result, rerender } = renderHook(useChatBannerSlots, {
       initialProps: makeParams(makeNudges({ showBanner: true })),
     });
-    expect(bannerVisible()).toBe(true);
+    expect(result.current.mainBannerSlot).not.toBeNull();
 
     rerender(makeParams(makeNudges()));
-    expect(bannerVisible()).toBe(false);
-  });
-
-  test("unmount resets the store to false", () => {
-    const { unmount } = renderHook(useChatBannerSlots, {
-      initialProps: makeParams(makeNudges({ showGitHubBanner: true })),
-    });
-    expect(bannerVisible()).toBe(true);
-
-    unmount();
-    expect(bannerVisible()).toBe(false);
+    expect(result.current.mainBannerSlot).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-chat-banner-slots.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-banner-slots.tsx
@@ -6,8 +6,9 @@
  * testable independently and the orchestrator stays focused on wiring.
  */
 
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, useEffect, useMemo } from "react";
 
+import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
 import { DiscordNudgeBanner } from "@/components/nudges/discord-nudge-banner";
 import { GitHubNudgeBanner } from "@/components/nudges/github-nudge-banner";
 import { IOSAppBanner } from "@/components/nudges/ios-app-banner";
@@ -94,6 +95,15 @@ export function useChatBannerSlots({
     }
     return null;
   }, [showBanner, isOnIOS, nudge, showGitHubBanner, githubNudge, showDiscordBanner, discordNudge]);
+
+  // Mirror banner visibility into the shared store so the sidebar tip can
+  // stay mutually exclusive with nudge banners.
+  const bannerVisible = mainBannerSlot !== null;
+  useEffect(() => {
+    const { setBannerVisible } = useBannerVisibilityStore.getState();
+    setBannerVisible(bannerVisible);
+    return () => setBannerVisible(false);
+  }, [bannerVisible]);
 
   const mainQueuedDrawerSlot = useMemo((): ReactNode => (
     <QueuedMessagesDrawer

--- a/clients/web/src/domains/chat/hooks/use-chat-banner-slots.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-banner-slots.tsx
@@ -6,9 +6,8 @@
  * testable independently and the orchestrator stays focused on wiring.
  */
 
-import { type ReactNode, useEffect, useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 
-import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
 import { DiscordNudgeBanner } from "@/components/nudges/discord-nudge-banner";
 import { GitHubNudgeBanner } from "@/components/nudges/github-nudge-banner";
 import { IOSAppBanner } from "@/components/nudges/ios-app-banner";
@@ -95,15 +94,6 @@ export function useChatBannerSlots({
     }
     return null;
   }, [showBanner, isOnIOS, nudge, showGitHubBanner, githubNudge, showDiscordBanner, discordNudge]);
-
-  // Mirror banner visibility into the shared store so the sidebar tip can
-  // stay mutually exclusive with nudge banners.
-  const bannerVisible = mainBannerSlot !== null;
-  useEffect(() => {
-    const { setBannerVisible } = useBannerVisibilityStore.getState();
-    setBannerVisible(bannerVisible);
-    return () => setBannerVisible(false);
-  }, [bannerVisible]);
 
   const mainQueuedDrawerSlot = useMemo((): ReactNode => (
     <QueuedMessagesDrawer

--- a/clients/web/src/stores/banner-visibility-store.test.ts
+++ b/clients/web/src/stores/banner-visibility-store.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+
+import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
+
+beforeEach(() => {
+  useBannerVisibilityStore.setState({ bannerVisible: false });
+});
+
+describe("useBannerVisibilityStore", () => {
+  it("initial state is false", () => {
+    expect(useBannerVisibilityStore.getState().bannerVisible).toBe(false);
+  });
+
+  it("setBannerVisible(true) flips the flag", () => {
+    useBannerVisibilityStore.getState().setBannerVisible(true);
+    expect(useBannerVisibilityStore.getState().bannerVisible).toBe(true);
+  });
+
+  it("setBannerVisible(false) flips back", () => {
+    useBannerVisibilityStore.getState().setBannerVisible(true);
+    useBannerVisibilityStore.getState().setBannerVisible(false);
+    expect(useBannerVisibilityStore.getState().bannerVisible).toBe(false);
+  });
+
+  it("setting the same value is a no-op (no state churn)", () => {
+    let notifications = 0;
+    const unsubscribe = useBannerVisibilityStore.subscribe(() => {
+      notifications++;
+    });
+    useBannerVisibilityStore.getState().setBannerVisible(false);
+    expect(notifications).toBe(0);
+    useBannerVisibilityStore.getState().setBannerVisible(true);
+    useBannerVisibilityStore.getState().setBannerVisible(true);
+    expect(notifications).toBe(1);
+    unsubscribe();
+  });
+});

--- a/clients/web/src/stores/banner-visibility-store.test.ts
+++ b/clients/web/src/stores/banner-visibility-store.test.ts
@@ -1,37 +1,64 @@
 import { describe, it, expect, beforeEach } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
 
-import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
+import {
+  isBannerVisible,
+  useBannerVisibilityStore,
+  useBannerVisible,
+} from "@/stores/banner-visibility-store";
+
+const visible = () =>
+  isBannerVisible(useBannerVisibilityStore.getState().visibleBannerCount);
 
 beforeEach(() => {
-  useBannerVisibilityStore.setState({ bannerVisible: false });
+  useBannerVisibilityStore.setState({ visibleBannerCount: 0 });
 });
 
 describe("useBannerVisibilityStore", () => {
-  it("initial state is false", () => {
-    expect(useBannerVisibilityStore.getState().bannerVisible).toBe(false);
+  it("starts with no visible banners", () => {
+    expect(useBannerVisibilityStore.getState().visibleBannerCount).toBe(0);
+    expect(visible()).toBe(false);
   });
 
-  it("setBannerVisible(true) flips the flag", () => {
-    useBannerVisibilityStore.getState().setBannerVisible(true);
-    expect(useBannerVisibilityStore.getState().bannerVisible).toBe(true);
+  it("register/unregister round-trips the visibility", () => {
+    useBannerVisibilityStore.getState().registerVisibleBanner();
+    expect(visible()).toBe(true);
+    useBannerVisibilityStore.getState().unregisterVisibleBanner();
+    expect(visible()).toBe(false);
   });
 
-  it("setBannerVisible(false) flips back", () => {
-    useBannerVisibilityStore.getState().setBannerVisible(true);
-    useBannerVisibilityStore.getState().setBannerVisible(false);
-    expect(useBannerVisibilityStore.getState().bannerVisible).toBe(false);
+  it("stays visible until every registrant unregisters (concurrent instances)", () => {
+    const { registerVisibleBanner, unregisterVisibleBanner } =
+      useBannerVisibilityStore.getState();
+    registerVisibleBanner();
+    registerVisibleBanner();
+    expect(useBannerVisibilityStore.getState().visibleBannerCount).toBe(2);
+
+    unregisterVisibleBanner();
+    expect(visible()).toBe(true);
+    unregisterVisibleBanner();
+    expect(visible()).toBe(false);
   });
 
-  it("setting the same value is a no-op (no state churn)", () => {
-    let notifications = 0;
-    const unsubscribe = useBannerVisibilityStore.subscribe(() => {
-      notifications++;
-    });
-    useBannerVisibilityStore.getState().setBannerVisible(false);
-    expect(notifications).toBe(0);
-    useBannerVisibilityStore.getState().setBannerVisible(true);
-    useBannerVisibilityStore.getState().setBannerVisible(true);
-    expect(notifications).toBe(1);
-    unsubscribe();
+  it("unregister at zero clamps — the count never goes negative", () => {
+    useBannerVisibilityStore.getState().unregisterVisibleBanner();
+    expect(useBannerVisibilityStore.getState().visibleBannerCount).toBe(0);
+
+    // A later register must still flip visibility on.
+    useBannerVisibilityStore.getState().registerVisibleBanner();
+    expect(visible()).toBe(true);
+  });
+});
+
+describe("useBannerVisible", () => {
+  it("reactively derives count > 0", () => {
+    const { result } = renderHook(useBannerVisible);
+    expect(result.current).toBe(false);
+
+    act(() => useBannerVisibilityStore.getState().registerVisibleBanner());
+    expect(result.current).toBe(true);
+
+    act(() => useBannerVisibilityStore.getState().unregisterVisibleBanner());
+    expect(result.current).toBe(false);
   });
 });

--- a/clients/web/src/stores/banner-visibility-store.ts
+++ b/clients/web/src/stores/banner-visibility-store.ts
@@ -1,0 +1,49 @@
+/**
+ * Zustand store tracking whether a composer nudge banner is currently
+ * visible. Contract for mutual exclusivity: a sidebar tip must never render
+ * while a composer nudge banner is showing, so tip surfaces read
+ * `bannerVisible` and hide themselves when it's true.
+ *
+ * Not persisted — visibility is derived live by `use-chat-banner-slots`.
+ *
+ * Reference: {@link https://zustand.docs.pmnd.rs/}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+// ---------------------------------------------------------------------------
+// State & Actions
+// ---------------------------------------------------------------------------
+
+export interface BannerVisibilityState {
+  bannerVisible: boolean;
+}
+
+export interface BannerVisibilityActions {
+  setBannerVisible: (value: boolean) => void;
+}
+
+export type BannerVisibilityStore = BannerVisibilityState &
+  BannerVisibilityActions;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const useBannerVisibilityStoreBase = create<BannerVisibilityStore>()(
+  (set, get) => ({
+    bannerVisible: false,
+
+    setBannerVisible: (value) => {
+      if (get().bannerVisible !== value) {
+        set({ bannerVisible: value });
+      }
+    },
+  }),
+);
+
+export const useBannerVisibilityStore = createSelectors(
+  useBannerVisibilityStoreBase,
+);

--- a/clients/web/src/stores/banner-visibility-store.ts
+++ b/clients/web/src/stores/banner-visibility-store.ts
@@ -1,10 +1,15 @@
 /**
  * Zustand store tracking whether a composer nudge banner is currently
- * visible. Contract for mutual exclusivity: a sidebar tip must never render
+ * rendered. Contract for mutual exclusivity: a sidebar tip must never render
  * while a composer nudge banner is showing, so tip surfaces read
- * `bannerVisible` and hide themselves when it's true.
+ * {@link useBannerVisible} and hide themselves while it's true.
  *
- * Not persisted — visibility is derived live by `use-chat-banner-slots`.
+ * Each `ChatBody` instance that actually mounts its banner overlay registers
+ * here for the duration. A count (not a boolean) tolerates concurrent
+ * instances — main chat plus the app-editing side panel — without a
+ * last-write-wins race, mirroring `edge-swipe-arbiter-store`.
+ *
+ * Not persisted — visibility is live render state.
  *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
@@ -18,11 +23,13 @@ import { createSelectors } from "@/utils/create-selectors";
 // ---------------------------------------------------------------------------
 
 export interface BannerVisibilityState {
-  bannerVisible: boolean;
+  /** Number of currently mounted nudge banner overlays. */
+  visibleBannerCount: number;
 }
 
 export interface BannerVisibilityActions {
-  setBannerVisible: (value: boolean) => void;
+  registerVisibleBanner: () => void;
+  unregisterVisibleBanner: () => void;
 }
 
 export type BannerVisibilityStore = BannerVisibilityState &
@@ -32,18 +39,29 @@ export type BannerVisibilityStore = BannerVisibilityState &
 // Store
 // ---------------------------------------------------------------------------
 
-const useBannerVisibilityStoreBase = create<BannerVisibilityStore>()(
-  (set, get) => ({
-    bannerVisible: false,
+const useBannerVisibilityStoreBase = create<BannerVisibilityStore>()((set) => ({
+  visibleBannerCount: 0,
 
-    setBannerVisible: (value) => {
-      if (get().bannerVisible !== value) {
-        set({ bannerVisible: value });
-      }
-    },
-  }),
-);
+  registerVisibleBanner: () =>
+    set((state) => ({ visibleBannerCount: state.visibleBannerCount + 1 })),
+  unregisterVisibleBanner: () =>
+    set((state) => ({
+      visibleBannerCount: Math.max(0, state.visibleBannerCount - 1),
+    })),
+}));
 
 export const useBannerVisibilityStore = createSelectors(
   useBannerVisibilityStoreBase,
 );
+
+// ---------------------------------------------------------------------------
+// Derivation
+// ---------------------------------------------------------------------------
+
+/** Pure predicate — true while any nudge banner is mounted. */
+export const isBannerVisible = (visibleBannerCount: number) =>
+  visibleBannerCount > 0;
+
+/** Reactive read for components (e.g. tip surfaces). */
+export const useBannerVisible = () =>
+  isBannerVisible(useBannerVisibilityStore.use.visibleBannerCount());


### PR DESCRIPTION
## Summary
- Adds a tiny non-persisted Zustand banner-visibility store (src/stores)
- use-chat-banner-slots mirrors current banner visibility into it so the upcoming sidebar tip can stay mutually exclusive with nudge banners

Part of plan: proactive-tips-v1.md (PR 4 of 7)