### PR TITLE
docs(acp): present-tense test comment in session-manager-usage-enrichment.test.ts

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-usage-enrichment.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-usage-enrichment.test.ts
@@ -1,7 +1,7 @@
 /**
  * Verifies that the cumulative `PromptResponse.usage` payload enriches the
  * emitted `acp_session_usage` event with the reported model and cache-read/
- * write token totals (fields PR 6 later persists).
+ * write token totals.
  */
 
 import { describe, expect, mock, test } from "bun:test";


### PR DESCRIPTION
## Summary
Rewrites a test comment that referenced 'PR 6' to describe current behavior only, per the repo's no-PR-history-in-comments rule.

Addresses a self-review finding for plan acp-api-key-auth.