### PR TITLE
feat(web): tips catalog, timestamp-record storage, selection policy, telemetry

### DIFF
--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -124,6 +124,11 @@ export interface OnboardingFunnelStepCompletedOptions {
   funnelVersion?: string;
   /** Completed vs skipped; omitted when the funnel doesn't distinguish. */
   outcome?: OnboardingFunnelStepOutcome;
+  /**
+   * Emitted `screen` when it differs from the step name — e.g. the tips
+   * funnel puts the tip id in `screen` and the action in `step_name`.
+   */
+  screen?: string;
 }
 
 export interface OnboardingFunnelEvent {
@@ -212,7 +217,7 @@ export function buildOnboardingFunnelEvent(
     type: "onboarding",
     daemon_event_id: crypto.randomUUID(),
     recorded_at: now,
-    screen: screen.stepName,
+    screen: options.screen ?? screen.stepName,
     session_id: getOnboardingFunnelSessionId(),
     step_name: screen.stepName,
     step_index: screen.stepIndex,

--- a/clients/web/src/utils/tips-catalog.test.ts
+++ b/clients/web/src/utils/tips-catalog.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+
+import { routes } from "@/utils/routes";
+import { TIPS_CATALOG } from "@/utils/tips-catalog";
+
+/** Every string leaf of the routes registry (route constants, not builders). */
+function collectRoutePaths(node: unknown, into: Set<string>): Set<string> {
+  if (typeof node === "string") {
+    into.add(node);
+  } else if (node && typeof node === "object") {
+    for (const value of Object.values(node)) {
+      collectRoutePaths(value, into);
+    }
+  }
+  return into;
+}
+
+describe("TIPS_CATALOG", () => {
+  it("has a unique id per tip", () => {
+    const ids = TIPS_CATALOG.map((tip) => tip.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("contains only info tips from the curated source", () => {
+    for (const tip of TIPS_CATALOG) {
+      expect(tip.kind).toBe("info");
+      expect(tip.source).toBe("curated");
+    }
+  });
+
+  it("points every learnMore link at a real route constant", () => {
+    const routePaths = collectRoutePaths(routes, new Set<string>());
+    for (const tip of TIPS_CATALOG) {
+      if (!tip.learnMore) {
+        continue;
+      }
+      expect(routePaths.has(tip.learnMore.to)).toBe(true);
+      expect(tip.learnMore.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps tip copy short enough for the sidebar", () => {
+    for (const tip of TIPS_CATALOG) {
+      expect(tip.body.length).toBeGreaterThan(0);
+      expect(tip.body.length).toBeLessThanOrEqual(120);
+    }
+  });
+});

--- a/clients/web/src/utils/tips-catalog.test.ts
+++ b/clients/web/src/utils/tips-catalog.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
+import {
+  getFlagDefinition,
+  scopeIncludes,
+} from "@/lib/feature-flags/feature-flag-catalog";
 import { routes } from "@/utils/routes";
 import { TIPS_CATALOG } from "@/utils/tips-catalog";
 
@@ -43,6 +47,26 @@ describe("TIPS_CATALOG", () => {
     for (const tip of TIPS_CATALOG) {
       expect(tip.body.length).toBeGreaterThan(0);
       expect(tip.body.length).toBeLessThanOrEqual(120);
+    }
+  });
+
+  it("gates flag-gated tips on a registry flag with the matching scope", () => {
+    for (const tip of TIPS_CATALOG) {
+      const checks = [
+        { storeKey: tip.gates?.requiresClientFlag, scope: "client" as const },
+        {
+          storeKey: tip.gates?.requiresAssistantFlag,
+          scope: "assistant" as const,
+        },
+      ];
+      for (const { storeKey, scope } of checks) {
+        if (!storeKey) {
+          continue;
+        }
+        const definition = getFlagDefinition(storeKey);
+        expect(definition).toBeDefined();
+        expect(scopeIncludes(definition!.scope, scope)).toBe(true);
+      }
     }
   });
 });

--- a/clients/web/src/utils/tips-catalog.ts
+++ b/clients/web/src/utils/tips-catalog.ts
@@ -13,8 +13,13 @@ export type TipSource = "curated"; // future: "assistant"
 export interface TipGates {
   /** Only show inside the Electron desktop shell. */
   requiresElectron?: boolean;
-  /** Client feature-flag store key (camelCase, e.g. "voiceMode") that must be on. */
+  /** Client feature-flag store key (camelCase, e.g. "quickInput") that must be on. */
   requiresClientFlag?: string;
+  /**
+   * Assistant feature-flag store key (camelCase, e.g. "voiceMode") that must be
+   * on — resolved via useAssistantFeatureFlagStore by the consuming hook.
+   */
+  requiresAssistantFlag?: string;
   /** Requires the plugins surface — a daemon-version gate resolved by the consuming hook. */
   requiresPluginsSurface?: boolean;
 }
@@ -80,7 +85,7 @@ export const TIPS_CATALOG: readonly Tip[] = [
     kind: "info",
     source: "curated",
     body: "You can talk to me — voice mode is in the top right.",
-    gates: { requiresClientFlag: "voiceMode" },
+    gates: { requiresAssistantFlag: "voiceMode" },
   },
   {
     id: "computer-use",

--- a/clients/web/src/utils/tips-catalog.ts
+++ b/clients/web/src/utils/tips-catalog.ts
@@ -1,0 +1,118 @@
+/**
+ * Curated catalog of proactive tips — short feature-discovery blurbs surfaced
+ * one at a time in the sidebar. Pure data: the consuming hook evaluates
+ * `gates` and the selection policy (`tips-selection.ts`) decides which tip
+ * shows when.
+ */
+
+import { routes } from "@/utils/routes";
+
+export type TipKind = "info"; // future: "action"
+export type TipSource = "curated"; // future: "assistant"
+
+export interface TipGates {
+  /** Only show inside the Electron desktop shell. */
+  requiresElectron?: boolean;
+  /** Client feature-flag store key (camelCase, e.g. "voiceMode") that must be on. */
+  requiresClientFlag?: string;
+  /** Requires the plugins surface — a daemon-version gate resolved by the consuming hook. */
+  requiresPluginsSurface?: boolean;
+}
+
+export interface Tip {
+  id: string;
+  kind: TipKind;
+  source: TipSource;
+  body: string;
+  /** Route path only — navigation must never be state-changing. */
+  learnMore?: { label: string; to: string };
+  gates?: TipGates;
+}
+
+export const TIPS_CATALOG: readonly Tip[] = [
+  {
+    id: "what-are-skills",
+    kind: "info",
+    source: "curated",
+    body: "Skills are how I learn new abilities — there's a catalog of skills you can install.",
+    learnMore: { label: "Browse skills", to: routes.skills.root },
+  },
+  {
+    id: "what-are-plugins",
+    kind: "info",
+    source: "curated",
+    body: "Plugins change how I behave — from a personal-finance copilot to a mode that lives in your MacBook notch.",
+    learnMore: { label: "Browse plugins", to: routes.plugins },
+    gates: { requiresPluginsSurface: true },
+  },
+  {
+    id: "app-builder",
+    kind: "info",
+    source: "curated",
+    body: "Ask me to build you a tracker, dashboard, or calculator — I keep them in your Library.",
+  },
+  {
+    id: "document-editor",
+    kind: "info",
+    source: "curated",
+    body: "I can draft long-form docs in a real editor you can comment on.",
+  },
+  {
+    id: "image-studio",
+    kind: "info",
+    source: "curated",
+    body: "I can create and edit images — backgrounds, retouching, restyling.",
+  },
+  {
+    id: "subagents-workflows",
+    kind: "info",
+    source: "curated",
+    body: "Big job? I can split it across a fleet of parallel background agents.",
+  },
+  {
+    id: "memory-aware",
+    kind: "info",
+    source: "curated",
+    body: "I remember our conversations — ask me what I know about you.",
+  },
+  {
+    id: "voice-mode",
+    kind: "info",
+    source: "curated",
+    body: "You can talk to me — voice mode is in the top right.",
+    gates: { requiresClientFlag: "voiceMode" },
+  },
+  {
+    id: "computer-use",
+    kind: "info",
+    source: "curated",
+    body: "On this Mac I can control apps and the desktop for you.",
+    gates: { requiresElectron: true },
+  },
+  {
+    id: "quick-input",
+    kind: "info",
+    source: "curated",
+    body: "Press Cmd+Shift+/ anywhere to send me a quick message.",
+    gates: { requiresElectron: true, requiresClientFlag: "quickInput" },
+  },
+  {
+    id: "personalize-me",
+    kind: "info",
+    source: "curated",
+    body: "You can give me a custom avatar, sounds, and theme.",
+    learnMore: { label: "Personalize", to: routes.identity },
+  },
+  {
+    id: "import-chatgpt",
+    kind: "info",
+    source: "curated",
+    body: "Coming from ChatGPT? I can import your history so I know you from day one.",
+  },
+  {
+    id: "daily-schedule",
+    kind: "info",
+    source: "curated",
+    body: "I can run things on a schedule — try a daily briefing or a weekly summary.",
+  },
+];

--- a/clients/web/src/utils/tips-selection.test.ts
+++ b/clients/web/src/utils/tips-selection.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Tip } from "@/utils/tips-catalog";
+import type { TipRecord } from "@/utils/tips-storage";
+import {
+  isTipEligible,
+  selectCurrentTip,
+  TIP_ROTATION_INTERVAL_MS,
+} from "@/utils/tips-selection";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 10 * DAY;
+
+function tip(id: string): Tip {
+  return { id, kind: "info", source: "curated", body: `body of ${id}` };
+}
+
+const catalog: readonly Tip[] = [tip("one"), tip("two"), tip("three")];
+
+describe("isTipEligible", () => {
+  it("treats a missing record as eligible", () => {
+    expect(isTipEligible(tip("one"), undefined, NOW)).toBe(true);
+  });
+
+  it("treats an undismissed record as eligible regardless of showings", () => {
+    expect(
+      isTipEligible(tip("one"), { lastShownAt: NOW - 2 * DAY, shownCount: 3 }, NOW),
+    ).toBe(true);
+  });
+
+  it("never re-admits a dismissed tip", () => {
+    expect(
+      isTipEligible(tip("one"), { dismissedAt: NOW - 100 * DAY, shownCount: 1 }, NOW),
+    ).toBe(false);
+  });
+});
+
+describe("selectCurrentTip", () => {
+  it("shows the first tip in catalog order to a fresh user", () => {
+    expect(selectCurrentTip(catalog, {}, NOW)?.id).toBe("one");
+  });
+
+  it("keeps the same tip for the rest of its rotation window", () => {
+    const records = {
+      one: { lastShownAt: NOW - TIP_ROTATION_INTERVAL_MS + 1, shownCount: 1 },
+    };
+    expect(selectCurrentTip(catalog, records, NOW)?.id).toBe("one");
+  });
+
+  it("re-selects an undismissed tip once its window has elapsed", () => {
+    const records = { one: { lastShownAt: NOW - DAY - 1, shownCount: 1 } };
+    expect(selectCurrentTip(catalog, records, NOW)?.id).toBe("one");
+  });
+
+  it("shows nothing for the rest of the window after a dismissal", () => {
+    const records = {
+      one: { dismissedAt: NOW - 1, lastShownAt: NOW - 60_000, shownCount: 1 },
+    };
+    expect(selectCurrentTip(catalog, records, NOW)).toBeNull();
+  });
+
+  it("advances to the next tip on the next window after a dismissal", () => {
+    const records = {
+      one: { dismissedAt: NOW - DAY - 1, lastShownAt: NOW - DAY - 1, shownCount: 1 },
+    };
+    expect(selectCurrentTip(catalog, records, NOW)?.id).toBe("two");
+  });
+
+  it("enforces at most one tip per window across different tips", () => {
+    // Tip two was shown then dismissed within the current window; tip one was
+    // dismissed long ago. Nothing shows until the window elapses.
+    const records = {
+      one: { dismissedAt: NOW - 5 * DAY, lastShownAt: NOW - 5 * DAY, shownCount: 1 },
+      two: { dismissedAt: NOW - 1, lastShownAt: NOW - 60_000, shownCount: 1 },
+    };
+    expect(selectCurrentTip(catalog, records, NOW)).toBeNull();
+    expect(
+      selectCurrentTip(catalog, records, NOW + TIP_ROTATION_INTERVAL_MS)?.id,
+    ).toBe("three");
+  });
+
+  it("advances immediately past a tip dismissed without ever being shown", () => {
+    const records = { one: { dismissedAt: NOW - 1, shownCount: 0 } };
+    expect(selectCurrentTip(catalog, records, NOW)?.id).toBe("two");
+  });
+
+  it("returns null forever once every tip is dismissed", () => {
+    const records: Record<string, TipRecord> = {};
+    for (const entry of catalog) {
+      records[entry.id] = { dismissedAt: NOW - 30 * DAY, shownCount: 1 };
+    }
+    expect(selectCurrentTip(catalog, records, NOW)).toBeNull();
+    expect(selectCurrentTip(catalog, records, NOW + 365 * DAY)).toBeNull();
+  });
+
+  it("treats partial records with no lastShownAt as unseen", () => {
+    const records = { one: { shownCount: 2 } };
+    expect(selectCurrentTip(catalog, records, NOW)?.id).toBe("one");
+  });
+
+  it("ignores records for tips no longer in the catalog", () => {
+    const records = { retired: { dismissedAt: NOW - 5 * DAY, shownCount: 1 } };
+    expect(selectCurrentTip(catalog, records, NOW)?.id).toBe("one");
+  });
+
+  it("holds the window even when the current tip's record id left the catalog", () => {
+    // A stale record shown within the window still counts toward ≤1 tip/window.
+    const records = { retired: { lastShownAt: NOW - 60_000, shownCount: 1 } };
+    expect(selectCurrentTip(catalog, records, NOW)).toBeNull();
+  });
+
+  it("returns null for an empty catalog", () => {
+    expect(selectCurrentTip([], {}, NOW)).toBeNull();
+  });
+});

--- a/clients/web/src/utils/tips-selection.ts
+++ b/clients/web/src/utils/tips-selection.ts
@@ -1,0 +1,75 @@
+/**
+ * Cadence policy for proactive tips, as pure functions: which tip (if any)
+ * shows at a given instant. Callers always pass `now` — nothing here reads
+ * the clock — and gates are NOT evaluated here (the consuming hook filters
+ * the catalog first).
+ *
+ * v1 policy: a shown tip persists for its rotation window; at most one tip
+ * per window in total; a dismissal advances to the next tip only once the
+ * window elapses; a dismissed tip is never reshown.
+ */
+
+import type { Tip } from "@/utils/tips-catalog";
+import type { TipRecord } from "@/utils/tips-storage";
+
+/** New-user grace: no tips until the account is at least this old. */
+export const TIPS_MIN_ACCOUNT_AGE_MS = 24 * 60 * 60 * 1000;
+
+/** A shown tip holds the slot this long; the next tip waits it out. */
+export const TIP_ROTATION_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+function isWithinRotationWindow(
+  lastShownAt: number | undefined,
+  now: number,
+): boolean {
+  return lastShownAt !== undefined && now - lastShownAt < TIP_ROTATION_INTERVAL_MS;
+}
+
+/**
+ * Whether a tip may still be shown. v1: dismissed means never again — the
+ * unused `tip`/`now` parameters are the seam for tunable reshow thresholds
+ * later (records are timestamps for exactly that reason).
+ */
+export function isTipEligible(
+  _tip: Tip,
+  record: TipRecord | undefined,
+  _now: number,
+): boolean {
+  return record?.dismissedAt === undefined;
+}
+
+/**
+ * Pick the tip to display at `now`, or `null` when none should show.
+ *
+ * 1. A tip shown within the rotation window and not dismissed persists.
+ * 2. Otherwise, if ANY tip was shown within the window (e.g. it was just
+ *    dismissed), nothing shows — the next tip waits for the next window.
+ * 3. Otherwise the first eligible tip in catalog order shows. Missing or
+ *    partial records are treated as unseen.
+ */
+export function selectCurrentTip(
+  catalog: readonly Tip[],
+  records: Record<string, TipRecord>,
+  now: number,
+): Tip | null {
+  for (const tip of catalog) {
+    const record = records[tip.id];
+    if (
+      isTipEligible(tip, record, now) &&
+      isWithinRotationWindow(record?.lastShownAt, now)
+    ) {
+      return tip;
+    }
+  }
+
+  const anyShownWithinWindow = Object.values(records).some((record) =>
+    isWithinRotationWindow(record.lastShownAt, now),
+  );
+  if (anyShownWithinWindow) {
+    return null;
+  }
+
+  return (
+    catalog.find((tip) => isTipEligible(tip, records[tip.id], now)) ?? null
+  );
+}

--- a/clients/web/src/utils/tips-storage.test.ts
+++ b/clients/web/src/utils/tips-storage.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import {
+  ensureTipsFirstSeenAt,
+  recordTipDismissed,
+  recordTipShown,
+  tipRecordsStorage,
+  tipsEnabledStorage,
+  tipsFirstSeenAtStorage,
+} from "@/utils/tips-storage";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("tipRecordsStorage", () => {
+  it("falls back to an empty record when nothing is stored", () => {
+    expect(tipRecordsStorage.load()).toEqual({});
+  });
+
+  it("round-trips tip records", () => {
+    const records = {
+      "what-are-skills": { lastShownAt: 111, shownCount: 2 },
+      "voice-mode": { dismissedAt: 222, lastShownAt: 200, shownCount: 1 },
+    };
+    tipRecordsStorage.save(records);
+    expect(tipRecordsStorage.load()).toEqual(records);
+  });
+
+  it("falls back on malformed persisted values", () => {
+    localStorage.setItem(tipRecordsStorage.key, "not json");
+    expect(tipRecordsStorage.load()).toEqual({});
+
+    localStorage.setItem(tipRecordsStorage.key, JSON.stringify([1, 2]));
+    expect(tipRecordsStorage.load()).toEqual({});
+  });
+
+  it("drops malformed entries but keeps valid ones", () => {
+    localStorage.setItem(
+      tipRecordsStorage.key,
+      JSON.stringify({
+        good: { shownCount: 1, lastShownAt: 5 },
+        badCount: { shownCount: "many" },
+        badTimestamp: { shownCount: 1, dismissedAt: "yesterday" },
+        notAnObject: 7,
+      }),
+    );
+    expect(tipRecordsStorage.load()).toEqual({
+      good: { shownCount: 1, lastShownAt: 5 },
+    });
+  });
+});
+
+describe("tipsEnabledStorage", () => {
+  it("defaults to enabled and round-trips", () => {
+    expect(tipsEnabledStorage.load()).toBe(true);
+    tipsEnabledStorage.save(false);
+    expect(tipsEnabledStorage.load()).toBe(false);
+  });
+
+  it("falls back to enabled on malformed values", () => {
+    localStorage.setItem(tipsEnabledStorage.key, "yes");
+    expect(tipsEnabledStorage.load()).toBe(true);
+  });
+});
+
+describe("tipsFirstSeenAtStorage", () => {
+  it("defaults to 0 and rejects malformed values", () => {
+    expect(tipsFirstSeenAtStorage.load()).toBe(0);
+
+    localStorage.setItem(tipsFirstSeenAtStorage.key, "not-a-number");
+    expect(tipsFirstSeenAtStorage.load()).toBe(0);
+
+    localStorage.setItem(tipsFirstSeenAtStorage.key, "-5");
+    expect(tipsFirstSeenAtStorage.load()).toBe(0);
+  });
+});
+
+describe("ensureTipsFirstSeenAt", () => {
+  it("stamps once and is idempotent", () => {
+    const before = Date.now();
+    ensureTipsFirstSeenAt();
+    const stamped = tipsFirstSeenAtStorage.load();
+    expect(stamped).toBeGreaterThanOrEqual(before);
+
+    ensureTipsFirstSeenAt();
+    expect(tipsFirstSeenAtStorage.load()).toBe(stamped);
+  });
+
+  it("does not overwrite an existing stamp", () => {
+    tipsFirstSeenAtStorage.save(123);
+    ensureTipsFirstSeenAt();
+    expect(tipsFirstSeenAtStorage.load()).toBe(123);
+  });
+});
+
+describe("recordTipShown", () => {
+  it("creates a record and bumps lastShownAt + shownCount", () => {
+    recordTipShown("app-builder", 1_000);
+    expect(tipRecordsStorage.load()["app-builder"]).toEqual({
+      lastShownAt: 1_000,
+      shownCount: 1,
+    });
+
+    recordTipShown("app-builder", 2_000);
+    expect(tipRecordsStorage.load()["app-builder"]).toEqual({
+      lastShownAt: 2_000,
+      shownCount: 2,
+    });
+  });
+
+  it("preserves a prior dismissal and other tips' records", () => {
+    recordTipDismissed("memory-aware", 500);
+    recordTipShown("app-builder", 1_000);
+    recordTipShown("memory-aware", 2_000);
+
+    expect(tipRecordsStorage.load()).toEqual({
+      "app-builder": { lastShownAt: 1_000, shownCount: 1 },
+      "memory-aware": { dismissedAt: 500, lastShownAt: 2_000, shownCount: 1 },
+    });
+  });
+});
+
+describe("recordTipDismissed", () => {
+  it("stamps dismissedAt on an unseen tip with a zero shownCount", () => {
+    recordTipDismissed("image-studio", 3_000);
+    expect(tipRecordsStorage.load()["image-studio"]).toEqual({
+      dismissedAt: 3_000,
+      shownCount: 0,
+    });
+  });
+
+  it("preserves lastShownAt and shownCount from prior showings", () => {
+    recordTipShown("image-studio", 1_000);
+    recordTipDismissed("image-studio", 3_000);
+    expect(tipRecordsStorage.load()["image-studio"]).toEqual({
+      dismissedAt: 3_000,
+      lastShownAt: 1_000,
+      shownCount: 1,
+    });
+  });
+});

--- a/clients/web/src/utils/tips-storage.ts
+++ b/clients/web/src/utils/tips-storage.ts
@@ -66,7 +66,7 @@ function parseTimestamp(raw: string): number | null {
 export const tipRecordsStorage = createStorageAccessor<
   Record<string, TipRecord>
 >({
-  key: "app.tips.records",
+  key: "device:tips:records",
   scope: "device",
   parse: parseTipRecords,
   serialize: JSON.stringify,
@@ -75,7 +75,7 @@ export const tipRecordsStorage = createStorageAccessor<
 
 /** Master switch — the Settings "show tips" toggle writes here. */
 export const tipsEnabledStorage = createStorageAccessor<boolean>({
-  key: "app.tips.enabled",
+  key: "device:tips:enabled",
   scope: "device",
   parse: parseBool,
   serialize: String,
@@ -84,7 +84,7 @@ export const tipsEnabledStorage = createStorageAccessor<boolean>({
 
 /** Epoch ms of the first time the tips feature observed this user. 0 = not yet. */
 export const tipsFirstSeenAtStorage = createStorageAccessor<number>({
-  key: "app.tips.firstSeenAt",
+  key: "device:tips:first_seen_at",
   scope: "device",
   parse: parseTimestamp,
   serialize: String,

--- a/clients/web/src/utils/tips-storage.ts
+++ b/clients/web/src/utils/tips-storage.ts
@@ -1,0 +1,125 @@
+/**
+ * Persistence for the proactive tips feature.
+ *
+ * Per-tip state is a timestamp record (never booleans) so reshow thresholds
+ * stay tunable later without a storage migration. All keys are device-scoped:
+ * tips describe what this browser has already been told, not account state.
+ */
+
+import { createStorageAccessor } from "@/utils/typed-storage";
+
+export interface TipRecord {
+  dismissedAt?: number;
+  lastShownAt?: number;
+  shownCount: number;
+}
+
+function isOptionalTimestamp(value: unknown): value is number | undefined {
+  return (
+    value === undefined || (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+function isValidTipRecord(value: unknown): value is TipRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.shownCount === "number" &&
+    Number.isFinite(record.shownCount) &&
+    isOptionalTimestamp(record.dismissedAt) &&
+    isOptionalTimestamp(record.lastShownAt)
+  );
+}
+
+function parseTipRecords(raw: string): Record<string, TipRecord> | null {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const result: Record<string, TipRecord> = {};
+  for (const [tipId, value] of Object.entries(parsed)) {
+    if (isValidTipRecord(value)) {
+      result[tipId] = value;
+    }
+  }
+  return result;
+}
+
+function parseBool(raw: string): boolean | null {
+  if (raw === "true") {
+    return true;
+  }
+  if (raw === "false") {
+    return false;
+  }
+  return null;
+}
+
+function parseTimestamp(raw: string): number | null {
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+/** Per-tip timestamp records, keyed by tip id. */
+export const tipRecordsStorage = createStorageAccessor<
+  Record<string, TipRecord>
+>({
+  key: "app.tips.records",
+  scope: "device",
+  parse: parseTipRecords,
+  serialize: JSON.stringify,
+  fallback: {},
+});
+
+/** Master switch — the Settings "show tips" toggle writes here. */
+export const tipsEnabledStorage = createStorageAccessor<boolean>({
+  key: "app.tips.enabled",
+  scope: "device",
+  parse: parseBool,
+  serialize: String,
+  fallback: true,
+});
+
+/** Epoch ms of the first time the tips feature observed this user. 0 = not yet. */
+export const tipsFirstSeenAtStorage = createStorageAccessor<number>({
+  key: "app.tips.firstSeenAt",
+  scope: "device",
+  parse: parseTimestamp,
+  serialize: String,
+  fallback: 0,
+});
+
+/** Stamp the first-seen timestamp once. Idempotent: later calls are no-ops. */
+export function ensureTipsFirstSeenAt(): void {
+  if (tipsFirstSeenAtStorage.load() === 0) {
+    tipsFirstSeenAtStorage.save(Date.now());
+  }
+}
+
+export function recordTipShown(tipId: string, now: number): void {
+  const records = tipRecordsStorage.load();
+  const existing = records[tipId];
+  tipRecordsStorage.save({
+    ...records,
+    [tipId]: {
+      ...existing,
+      lastShownAt: now,
+      shownCount: (existing?.shownCount ?? 0) + 1,
+    },
+  });
+}
+
+export function recordTipDismissed(tipId: string, now: number): void {
+  const records = tipRecordsStorage.load();
+  const existing = records[tipId];
+  tipRecordsStorage.save({
+    ...records,
+    [tipId]: {
+      ...existing,
+      dismissedAt: now,
+      shownCount: existing?.shownCount ?? 0,
+    },
+  });
+}

--- a/clients/web/src/utils/tips-telemetry.test.ts
+++ b/clients/web/src/utils/tips-telemetry.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Exercises the real funnel pipeline (fetch-level mock rather than
+ * `mock.module`, which is process-global) so the payload mapping — screen =
+ * tip id, step_name = action — and the consent gate are asserted end-to-end.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import { emitTipEvent, TIPS_FUNNEL_VERSION } from "@/utils/tips-telemetry";
+
+const originalFetch = globalThis.fetch;
+
+function installFetchMock() {
+  const fetchMock = mock(
+    async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response("{}", { status: 200 }),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function eventFromCall(
+  fetchMock: ReturnType<typeof installFetchMock>,
+  callIndex: number,
+): Record<string, unknown> {
+  const calls = fetchMock.mock.calls as Array<
+    [RequestInfo | URL, RequestInit | undefined]
+  >;
+  const payload = JSON.parse(calls[callIndex]?.[1]?.body as string) as {
+    events: Array<Record<string, unknown>>;
+  };
+  return payload.events[0] ?? {};
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+  localStorage.setItem("device:share_analytics", "true");
+  useOnboardingStore.setState({ shareAnalytics: true });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("emitTipEvent", () => {
+  it("maps the tip id to screen and the action to step_name", () => {
+    const fetchMock = installFetchMock();
+
+    emitTipEvent("what-are-skills", "impression", "control");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calls = fetchMock.mock.calls as Array<
+      [RequestInfo | URL, RequestInit | undefined]
+    >;
+    expect(calls[0]?.[0]).toBe("/v1/telemetry/ingest/");
+    expect(eventFromCall(fetchMock, 0)).toMatchObject({
+      type: "onboarding",
+      screen: "what-are-skills",
+      step_name: "impression",
+      step_index: 0,
+      funnel_version: TIPS_FUNNEL_VERSION,
+      ab_variant: "control",
+    });
+  });
+
+  it("gives each action a distinct step_name and index", () => {
+    const fetchMock = installFetchMock();
+
+    emitTipEvent("voice-mode", "impression", "control");
+    emitTipEvent("voice-mode", "learn_more", "control");
+    emitTipEvent("voice-mode", "dismiss", "control");
+    emitTipEvent("voice-mode", "dont_show_again", "control");
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(eventFromCall(fetchMock, 0)).toMatchObject({
+      step_name: "impression",
+      step_index: 0,
+    });
+    expect(eventFromCall(fetchMock, 1)).toMatchObject({
+      step_name: "learn_more",
+      step_index: 1,
+    });
+    expect(eventFromCall(fetchMock, 2)).toMatchObject({
+      step_name: "dismiss",
+      step_index: 2,
+    });
+    expect(eventFromCall(fetchMock, 3)).toMatchObject({
+      step_name: "dont_show_again",
+      step_index: 3,
+    });
+  });
+
+  it("stamps the caller's variant on every event", () => {
+    const fetchMock = installFetchMock();
+
+    emitTipEvent("app-builder", "dismiss", "pared_down");
+
+    expect(eventFromCall(fetchMock, 0)).toMatchObject({
+      screen: "app-builder",
+      ab_variant: "pared_down",
+    });
+  });
+
+  it("does not emit when analytics sharing is opted out", () => {
+    useOnboardingStore.setState({ shareAnalytics: false });
+    const fetchMock = installFetchMock();
+
+    emitTipEvent("what-are-skills", "impression", "control");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/utils/tips-telemetry.ts
+++ b/clients/web/src/utils/tips-telemetry.ts
@@ -1,0 +1,44 @@
+/**
+ * Telemetry for proactive tips, riding the existing onboarding funnel
+ * pipeline: same event shape, ingest path, and analytics-consent gating
+ * (`readShareAnalytics()` inside the base emitter). Each event lands with
+ * `funnel_version: "proactive-tips-v1"`, `screen` = tip id, and
+ * `step_name` = the action taken.
+ */
+
+import {
+  emitOnboardingFunnelStepCompleted,
+  type OnboardingFunnelVariant,
+} from "@/domains/onboarding/funnel-events";
+
+export const TIPS_FUNNEL_VERSION = "proactive-tips-v1";
+
+export type TipTelemetryAction =
+  | "impression"
+  | "dismiss"
+  | "learn_more"
+  | "dont_show_again";
+
+const ACTION_STEP_INDICES: Record<TipTelemetryAction, number> = {
+  impression: 0,
+  learn_more: 1,
+  dismiss: 2,
+  dont_show_again: 3,
+};
+
+export function emitTipEvent(
+  tipId: string,
+  action: TipTelemetryAction,
+  variant: string,
+): void {
+  emitOnboardingFunnelStepCompleted(
+    { stepName: action, stepIndex: ACTION_STEP_INDICES[action] },
+    {
+      funnelVersion: TIPS_FUNNEL_VERSION,
+      screen: tipId,
+      // The ingest stores ab_variant as an open string; the union type on the
+      // base emitter documents the pre-chat A/B arms.
+      variant: variant as OnboardingFunnelVariant,
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Curated 13-tip info catalog with extensible kind/source/gates schema
- Timestamp-record storage (dismissedAt/lastShownAt/shownCount) + enabled + firstSeenAt accessors
- Pure cadence policy: once-a-day per tip, next-day advancement after dismiss, never-reshow-dismissed (tunable seam)
- Funnel telemetry emitter (proactive-tips-v1 funnel, consent-gated via existing pipeline)
- Small additive change to `funnel-events.ts`: optional `screen` override on the emit options, because the base builder hardwires `screen` = `step_name` and the tips funnel needs `screen` = tip id with `step_name` = action

Part of plan: proactive-tips-v1.md (PR 3 of 7)