### PR TITLE
fix(acp): invocable credentials grant + ACP_SERVICE consolidation + gateway cred strip

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9358,6 +9358,57 @@ paths:
                   - service
                   - field
                 additionalProperties: false
+  /v1/credentials/grant:
+    post:
+      operationId: credentials_grant_post
+      summary: Grant a tool read access to a credential
+      description:
+        Add a tool name to a credential's allowedTools policy so the broker permits that tool to read it.
+        Metadata-only — never reads or rewrites the secret value.
+      tags:
+        - credentials
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                service:
+                  type: string
+                  description: Service namespace
+                field:
+                  type: string
+                  description: Field name
+                tool:
+                  type: string
+                  description: Tool name to grant read access
+              required:
+                - service
+                - field
+                - tool
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  service:
+                    type: string
+                  field:
+                    type: string
+                  allowedTools:
+                    type: array
+                    items:
+                      type: string
+                    description: The credential's allowedTools after the grant
+                required:
+                  - service
+                  - field
+                  - allowedTools
+                additionalProperties: false
   /v1/credentials/inspect:
     post:
       operationId: credentials_inspect_post

--- a/assistant/src/__tests__/credential-routes.test.ts
+++ b/assistant/src/__tests__/credential-routes.test.ts
@@ -118,6 +118,7 @@ import { ROUTES } from "../runtime/routes/credential-routes.js";
 
 const setRoute = ROUTES.find((r) => r.operationId === "credentials_set");
 const listRoute = ROUTES.find((r) => r.operationId === "credentials_list");
+const grantRoute = ROUTES.find((r) => r.operationId === "credentials_grant");
 const deleteRoute = ROUTES.find((r) => r.operationId === "credentials_delete");
 const revealRoute = ROUTES.find((r) => r.operationId === "credentials_reveal");
 
@@ -132,6 +133,11 @@ type ListResponse = {
   managedCredentials: unknown[];
 };
 type DeleteResponse = { service: string; field: string };
+type GrantResponse = {
+  service: string;
+  field: string;
+  allowedTools: string[];
+};
 
 const SECRET_VALUE = "super-secret-token-value";
 
@@ -398,6 +404,86 @@ describe("credentials routes", () => {
         expect(result.service).toBe("github");
         expect(secureStore.get("github:api_token")).toBe("sk-ant-oat01-abc123");
       });
+    });
+  });
+
+  describe("credentials_grant", () => {
+    test("adds the tool to allowedTools without touching the stored value", async () => {
+      /**
+       * Granting a tool merges it into the credential's allowedTools policy so
+       * the broker permits that tool to read it — a metadata-only change that
+       * never reads or rewrites the secret.
+       */
+      // GIVEN a stored credential with an unrelated tool policy
+      await setRoute!.handler({
+        body: {
+          service: "anthropic",
+          field: "api_key",
+          value: SECRET_VALUE,
+          allowedTools: ["some_tool"],
+        },
+      });
+
+      // WHEN acp_spawn is granted read access
+      const result = (await grantRoute!.handler({
+        body: { service: "anthropic", field: "api_key", tool: "acp_spawn" },
+      })) as GrantResponse;
+
+      // THEN the existing tool is preserved and acp_spawn is added
+      expect(result.service).toBe("anthropic");
+      expect(result.field).toBe("api_key");
+      expect(result.allowedTools).toContain("some_tool");
+      expect(result.allowedTools).toContain("acp_spawn");
+
+      // AND the secret value is untouched
+      expect(secureStore.get("anthropic:api_key")).toBe(SECRET_VALUE);
+    });
+
+    test("is idempotent when the tool is already allowed", async () => {
+      // GIVEN a credential that already allows the tool
+      await setRoute!.handler({
+        body: {
+          service: "anthropic",
+          field: "api_key",
+          value: SECRET_VALUE,
+          allowedTools: ["acp_spawn", "keep"],
+        },
+      });
+
+      // WHEN the same tool is granted again
+      const result = (await grantRoute!.handler({
+        body: { service: "anthropic", field: "api_key", tool: "acp_spawn" },
+      })) as GrantResponse;
+
+      // THEN allowedTools is unchanged (no duplicate)
+      expect(result.allowedTools).toEqual(["acp_spawn", "keep"]);
+    });
+
+    test("creates metadata carrying just the tool when none exists yet", async () => {
+      /**
+       * A credential with a stored secret but no metadata record still gets a
+       * policy created that allows the granted tool.
+       */
+      // GIVEN a secret with no metadata record
+      secureStore.set("anthropic:api_key", SECRET_VALUE);
+
+      // WHEN a tool is granted
+      const result = (await grantRoute!.handler({
+        body: { service: "anthropic", field: "api_key", tool: "acp_spawn" },
+      })) as GrantResponse;
+
+      // THEN metadata is created carrying only that tool
+      expect(result.allowedTools).toEqual(["acp_spawn"]);
+      expect(metadataStore.get("anthropic:api_key")?.allowedTools).toEqual([
+        "acp_spawn",
+      ]);
+    });
+
+    test("rejects a request missing the tool", async () => {
+      const call = grantRoute!.handler({
+        body: { service: "anthropic", field: "api_key" },
+      });
+      await expect(call).rejects.toBeInstanceOf(BadRequestError);
     });
   });
 

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -112,8 +112,7 @@ mock.module("../gateway-auth.js", () => ({
   resolveAcpGatewayAuth: async () => gatewayAuthResult,
 }));
 
-const { prepareAgentEnv, grantAcpAccessToSharedAnthropicKey } =
-  await import("../prepare-agent-env.js");
+const { prepareAgentEnv } = await import("../prepare-agent-env.js");
 
 beforeEach(() => {
   metadataStore.clear();
@@ -362,56 +361,6 @@ describe("prepareAgentEnv — claude-agent-acp API-key precedence", () => {
   });
 });
 
-describe("grantAcpAccessToSharedAnthropicKey", () => {
-  test("merges acp_spawn into existing allowedTools without touching the value", async () => {
-    metadataStore.set("anthropic/api_key", { allowedTools: ["some_tool"] });
-    vaultStore.set("anthropic/api_key", "shared-LLL");
-
-    grantAcpAccessToSharedAnthropicKey();
-
-    const meta = metadataStore.get("anthropic/api_key");
-    expect(meta!.allowedTools).toContain("some_tool");
-    expect(meta!.allowedTools).toContain("acp_spawn");
-    // Secret value is untouched — grant is metadata-only.
-    expect(vaultStore.get("anthropic/api_key")).toBe("shared-LLL");
-  });
-
-  test("is idempotent when acp_spawn is already allowed", async () => {
-    metadataStore.set("anthropic/api_key", {
-      allowedTools: ["acp_spawn", "keep"],
-    });
-
-    grantAcpAccessToSharedAnthropicKey();
-
-    const meta = metadataStore.get("anthropic/api_key");
-    expect(meta!.allowedTools).toEqual(["acp_spawn", "keep"]);
-  });
-
-  test("no-ops when the shared credential has no metadata", async () => {
-    grantAcpAccessToSharedAnthropicKey();
-
-    expect(metadataStore.has("anthropic/api_key")).toBe(false);
-  });
-
-  test("consent flow: grant then spawn reuses the shared key", async () => {
-    // Shared key exists but not opted into ACP yet → spawn fails.
-    metadataStore.set("anthropic/api_key", { allowedTools: ["other_tool"] });
-    vaultStore.set("anthropic/api_key", "shared-MMM");
-
-    await expect(
-      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
-    ).rejects.toThrow(/Anthropic credential/);
-
-    grantAcpAccessToSharedAnthropicKey();
-
-    const prepared = await prepareAgentEnv({
-      command: "claude-agent-acp",
-      args: [],
-    });
-    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("shared-MMM");
-  });
-});
-
 describe("prepareAgentEnv - codex-acp gating", () => {
   function seedVaultOpenaiKey(key: string): void {
     vaultStore.set("acp/openai_api_key", key);
@@ -542,6 +491,24 @@ describe("prepareAgentEnv — claude-agent-acp gateway (managed-proxy) mode", ()
     });
 
     expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  test("gate ON: strips a config.json-supplied ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN so the proxy stays authoritative", async () => {
+    gatewayAuthResult = gatewayAuth;
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: {
+        ANTHROPIC_API_KEY: "config-key",
+        CLAUDE_CODE_OAUTH_TOKEN: "config-oauth",
+        OTHER_VAR: "keep-me",
+      },
+    });
+
+    expect(prepared.env).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(prepared.env?.OTHER_VAR).toBe("keep-me");
   });
 
   test("gate OFF (default): behaves exactly as PR 2 — injects the vault token", async () => {

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -32,6 +32,7 @@ import { getLogger } from "../util/logger.js";
 import {
   ACP_ANTHROPIC_API_KEY_FIELD,
   ACP_OAUTH_TOKEN_FIELD,
+  ACP_SERVICE,
 } from "./acp-credentials.js";
 import { resolveAcpGatewayAuth } from "./gateway-auth.js";
 import type { AcpAgentConfig } from "./types.js";
@@ -39,13 +40,12 @@ import type { AcpAgentConfig } from "./types.js";
 const log = getLogger("acp:prepare-agent-env");
 
 const ACP_SPAWN_TOOL = "acp_spawn";
-const ACP_SERVICE = "acp";
 
 // The SHARED Anthropic API key (service "anthropic", field "api_key") that
-// other tools already use. ACP reuses it only after explicit consent — see
-// `grantAcpAccessToSharedAnthropicKey`. The field name is bound through an
-// intermediate so its literal never shares a line with an `*_KEY = "…"` shape
-// the repo's secret-scan hook false-positives.
+// other tools already use. ACP reuses it only after explicit consent — the
+// user grants `acp_spawn` read-access via `assistant credentials grant`. The
+// field name is bound through an intermediate so its literal never shares a
+// line with an `*_KEY = "…"` shape the repo's secret-scan hook false-positives.
 const SHARED_ANTHROPIC_SERVICE = "anthropic";
 const sharedAnthropicApiField = "api_key";
 
@@ -110,10 +110,10 @@ async function injectCredential(
  * Read the SHARED `anthropic/api_key` credential through the broker and inject
  * it as `ANTHROPIC_API_KEY`. Unlike `injectCredential`, this provisions no
  * policy: the broker denies the read unless the user opted the shared key into
- * ACP by adding `acp_spawn` to its `allowedTools` (see
- * `grantAcpAccessToSharedAnthropicKey`), so an unconsented key is never reused.
- * A miss (absent, unconsented, or valueless) is non-fatal — the caller falls
- * through to the next credential tier.
+ * ACP by adding `acp_spawn` to its `allowedTools` (via `assistant credentials
+ * grant`), so an unconsented key is never reused. A miss (absent, unconsented,
+ * or valueless) is non-fatal — the caller falls through to the next credential
+ * tier.
  */
 async function injectSharedAnthropicApiKey(
   env: Record<string, string>,
@@ -132,26 +132,6 @@ async function injectSharedAnthropicApiKey(
       "shared anthropic/api_key not available for ACP reuse; trying next tier",
     );
   }
-}
-
-/**
- * Opt the shared `anthropic/api_key` credential into ACP reuse by merging
- * `acp_spawn` into its existing `allowedTools` — the auditable consent the
- * reuse tier in `prepareAgentEnv` gates on. Metadata-only: the secret value is
- * never read or rewritten. No-op when the credential has no metadata (nothing
- * to grant) or already allows `acp_spawn` (idempotent).
- */
-export function grantAcpAccessToSharedAnthropicKey(): void {
-  const meta = getCredentialMetadata(
-    SHARED_ANTHROPIC_SERVICE,
-    sharedAnthropicApiField,
-  );
-  if (!meta) return;
-  const tools = meta.allowedTools ?? [];
-  if (tools.includes(ACP_SPAWN_TOOL)) return;
-  upsertCredentialMetadata(SHARED_ANTHROPIC_SERVICE, sharedAnthropicApiField, {
-    allowedTools: [...tools, ACP_SPAWN_TOOL],
-  });
 }
 
 /**
@@ -227,6 +207,12 @@ export async function prepareAgentEnv(
     // authenticates the child against the Vellum runtime proxy, so no Anthropic
     // credential is needed — skip injection and the throw. Off → PR-2 path below.
     if (await resolveAcpGatewayAuth()) {
+      // The proxy supplies auth and is authoritative; strip any
+      // config.json-supplied key so it can't bypass per-assistant proxy
+      // billing. The version-skew (adapter-without-gateway) case is validated
+      // during the dev-platform live test before un-flagging.
+      delete env.ANTHROPIC_API_KEY;
+      delete env.CLAUDE_CODE_OAUTH_TOKEN;
       return { ...agentConfig, env };
     }
 

--- a/assistant/src/cli/commands/credentials.help.ts
+++ b/assistant/src/cli/commands/credentials.help.ts
@@ -124,6 +124,35 @@ Examples:
   $ assistant credentials set --service github --field token ghp_abc --allowed-tools "bash,host_bash"`,
     },
     {
+      name: "grant",
+      description:
+        "Grant a tool read access to an existing credential (metadata-only)",
+      options: [
+        {
+          flags: "--service <service>",
+          description: "Service namespace",
+          required: true,
+        },
+        {
+          flags: "--field <field>",
+          description: "Field name",
+          required: true,
+        },
+        {
+          flags: "--tool <tool>",
+          description: "Tool name to grant read access",
+          required: true,
+        },
+      ],
+      helpText: `
+Adds a tool to the credential's allowedTools policy so the broker permits that
+tool to read it. Metadata-only — the secret value is never read or rewritten,
+and the grant is idempotent.
+
+Examples:
+  $ assistant credentials grant --service anthropic --field api_key --tool acp_spawn`,
+    },
+    {
       name: "delete",
       description: "Remove a secret and its metadata from the vault",
       options: [

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -267,6 +267,52 @@ export function registerCredentialsCommand(program: Command): void {
       );
 
       // -----------------------------------------------------------------------
+      // grant
+      // -----------------------------------------------------------------------
+
+      subcommand(credential, "grant").action(
+        async (
+          opts: { service: string; field: string; tool: string },
+          cmd: Command,
+        ) => {
+          const r = await cliIpcCall<{
+            service: string;
+            field: string;
+            allowedTools: string[];
+          }>("credentials_grant", {
+            body: {
+              service: opts.service,
+              field: opts.field,
+              tool: opts.tool,
+            },
+          });
+
+          if (!r.ok) {
+            writeError(
+              cmd,
+              r.error ??
+                `Failed to grant ${opts.tool} access to ${opts.service}:${opts.field}`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, {
+              ok: true,
+              service: opts.service,
+              field: opts.field,
+              allowedTools: r.result!.allowedTools,
+            });
+          } else {
+            log.info(
+              `Granted ${opts.tool} read access to ${opts.service}:${opts.field}`,
+            );
+          }
+        },
+      );
+
+      // -----------------------------------------------------------------------
       // delete
       // -----------------------------------------------------------------------
 

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -52,7 +52,7 @@ The `claude-agent-acp` adapter needs a credential. The preferred one is an Anthr
 
 On the first ACP use, establish auth as a first-run moment - do it up front, not as a mid-task auth wall. First run `assistant credentials list` to detect an existing `anthropic/api_key`, then ask the user to choose:
 
-- **(a) Reuse the existing Anthropic API key** - offer this only when `anthropic/api_key` exists. Name it by its scrubbed suffix (e.g. "…NgAA"). On yes, grant `acp_spawn` read access to it - no pasting, no reveal.
+- **(a) Reuse the existing Anthropic API key** - offer this only when `anthropic/api_key` exists. Name it by its scrubbed suffix (e.g. "…NgAA"). On yes, grant ACP read-access to the existing key - no pasting, no reveal: `assistant credentials grant --service anthropic --field api_key --tool acp_spawn`.
 - **(b) Paste a new API key** - `assistant credentials prompt --service acp --field anthropic_api_key --label "Anthropic API Key"`.
 - **(c) Use their Claude subscription** - run `claude setup-token`, then `assistant credentials prompt --service acp --field claude_oauth_token --label "Claude OAuth Token"`. Heads-up: using a subscription OAuth token in a third-party tool is something Anthropic restricts; the API key is the supported path.
 

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -10,6 +10,7 @@
  * POST   /v1/credentials/inspect — inspect a single credential (masked)
  * POST   /v1/credentials/reveal  — reveal a credential's plaintext value
  * POST   /v1/credentials/set     — store a credential with metadata
+ * POST   /v1/credentials/grant   — grant a tool read access (metadata-only)
  * POST   /v1/credentials/delete  — delete a credential, metadata, and OAuth
  * GET    /v1/credentials/status  — show active credential backend info
  */
@@ -427,6 +428,43 @@ async function handleCredentialsSet({ body }: RouteHandlerArgs) {
   };
 }
 
+async function handleCredentialsGrant({ body }: RouteHandlerArgs) {
+  if (!body || typeof body !== "object") {
+    throw new BadRequestError("Request body is required");
+  }
+
+  const { service, field, tool } = body as {
+    service?: string;
+    field?: string;
+    tool?: string;
+  };
+
+  if (!service || typeof service !== "string") {
+    throw new BadRequestError("service is required");
+  }
+  if (!field || typeof field !== "string") {
+    throw new BadRequestError("field is required");
+  }
+  if (!tool || typeof tool !== "string") {
+    throw new BadRequestError("tool is required");
+  }
+
+  assertMetadataWritable();
+
+  // Metadata-only: merge the tool into allowedTools without reading or
+  // rewriting the secret value. Idempotent (a tool already present is a no-op);
+  // a credential with no metadata yet gets one created carrying just this tool.
+  const existing = getCredentialMetadata(service, field);
+  const allowedTools = [...new Set([...(existing?.allowedTools ?? []), tool])];
+  const metadata = upsertCredentialMetadata(service, field, { allowedTools });
+
+  return {
+    service,
+    field,
+    allowedTools: metadata.allowedTools,
+  };
+}
+
 async function handleCredentialsDelete({ body }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
@@ -618,6 +656,32 @@ export const ROUTES: RouteDefinition[] = [
       field: z.string(),
     }),
     handler: handleCredentialsSet,
+  },
+  {
+    operationId: "credentials_grant",
+    endpoint: "credentials/grant",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Grant a tool read access to a credential",
+    description:
+      "Add a tool name to a credential's allowedTools policy so the broker permits that tool to read it. Metadata-only — never reads or rewrites the secret value.",
+    tags: ["credentials"],
+    requestBody: z.object({
+      service: z.string().describe("Service namespace"),
+      field: z.string().describe("Field name"),
+      tool: z.string().describe("Tool name to grant read access"),
+    }),
+    responseBody: z.object({
+      service: z.string(),
+      field: z.string(),
+      allowedTools: z
+        .array(z.string())
+        .describe("The credential's allowedTools after the grant"),
+    }),
+    handler: handleCredentialsGrant,
   },
   {
     operationId: "credentials_delete",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -3,7 +3,7 @@
   "skills": {
     "acp": {
       "docsSlug": "acp",
-      "sha256": "c87693319cd9e6450e0b136977791e5b6326317e77ac158ac0f4b823b6adeb4f"
+      "sha256": "6753fc3ca5f2f7415066a559713f949d6242f8e9c4345fc2b5923ba86b6aa41c"
     },
     "app-builder": {
       "docsSlug": "app-builder",


### PR DESCRIPTION
## Summary
Addresses self-review gaps for plan acp-api-key-auth:
- Adds a generic `credentials grant` route + CLI (metadata-only allowedTools merge) so the ACP 'reuse existing anthropic/api_key' flow is executable; removes the now-redundant unwired grantAcpAccessToSharedAnthropicKey helper; SKILL.md option (a) gets the exact command
- Imports ACP_SERVICE from acp-credentials.ts instead of a local redeclaration
- Gateway mode strips config-supplied ANTHROPIC_API_KEY/CLAUDE_CODE_OAUTH_TOKEN so the proxy is authoritative

🤖 Generated with [Claude Code](https://claude.com/claude-code)