### PR TITLE
ACP Claude Code auth via Anthropic API key + cost attribution

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9361,6 +9361,57 @@ paths:
                   - service
                   - field
                 additionalProperties: false
+  /v1/credentials/grant:
+    post:
+      operationId: credentials_grant_post
+      summary: Grant a tool read access to a credential
+      description:
+        Add a tool name to a credential's allowedTools policy so the broker permits that tool to read it.
+        Metadata-only — never reads or rewrites the secret value.
+      tags:
+        - credentials
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                service:
+                  type: string
+                  description: Service namespace
+                field:
+                  type: string
+                  description: Field name
+                tool:
+                  type: string
+                  description: Tool name to grant read access
+              required:
+                - service
+                - field
+                - tool
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  service:
+                    type: string
+                  field:
+                    type: string
+                  allowedTools:
+                    type: array
+                    items:
+                      type: string
+                    description: The credential's allowedTools after the grant
+                required:
+                  - service
+                  - field
+                  - allowedTools
+                additionalProperties: false
   /v1/credentials/inspect:
     post:
       operationId: credentials_inspect_post

--- a/assistant/src/__tests__/credential-prompt-route.test.ts
+++ b/assistant/src/__tests__/credential-prompt-route.test.ts
@@ -529,6 +529,90 @@ describe("credentials/prompt route", () => {
     );
   });
 
+  describe("ACP token-type format guard", () => {
+    /**
+     * A prompt that collects a mismatched ACP token type must be rejected
+     * before persisting, routing the user to the correct field rather than
+     * silently storing an API key under the OAuth field (the original bug).
+     */
+    test("rejects an Anthropic API key collected for the ACP OAuth field", async () => {
+      // GIVEN the secure prompt returns an sk-ant-api… key
+      secretResult = { value: "sk-ant-api03-abc123", delivery: "store" };
+
+      // WHEN it is collected for acp/claude_oauth_token
+      const result = (await promptRoute!.handler({
+        body: {
+          service: "acp",
+          field: "claude_oauth_token",
+          label: "Claude OAuth Token",
+        },
+      })) as PromptResponse;
+
+      // THEN it fails with a field-routing error and nothing is persisted
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("anthropic_api_key");
+      expect(result.service).toBe("acp");
+      expect(result.field).toBe("claude_oauth_token");
+      expect(secureKeyWrites).toEqual([]);
+      expect(capturedMetadata).toBeUndefined();
+    });
+
+    test("rejects a Claude OAuth token collected for the ACP API-key field", async () => {
+      // GIVEN the secure prompt returns an sk-ant-oat… token
+      secretResult = { value: "sk-ant-oat01-abc123", delivery: "store" };
+
+      // WHEN it is collected for acp/anthropic_api_key
+      const result = (await promptRoute!.handler({
+        body: {
+          service: "acp",
+          field: "anthropic_api_key",
+          label: "Anthropic API Key",
+        },
+      })) as PromptResponse;
+
+      // THEN it fails with a field-routing error and nothing is persisted
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("claude_oauth_token");
+      expect(secureKeyWrites).toEqual([]);
+    });
+
+    test("stores a correctly-paired ACP credential", async () => {
+      // GIVEN the secure prompt returns an sk-ant-api… key
+      secretResult = { value: "sk-ant-api03-abc123", delivery: "store" };
+
+      // WHEN it is collected for the matching acp/anthropic_api_key field
+      const result = (await promptRoute!.handler({
+        body: {
+          service: "acp",
+          field: "anthropic_api_key",
+          label: "Anthropic API Key",
+        },
+      })) as PromptResponse;
+
+      // THEN it is persisted to secure storage
+      expect(result.ok).toBe(true);
+      expect(secureKeyWrites).toEqual([
+        { key: "acp:anthropic_api_key", value: "sk-ant-api03-abc123" },
+      ]);
+    });
+
+    test("leaves an unrelated service untouched by the ACP guard", async () => {
+      // GIVEN the prompt returns a token-shaped value for a non-ACP service
+      secretResult = { value: "sk-ant-oat01-abc123", delivery: "store" };
+
+      // WHEN it is collected for github/api_token
+      const result = (await promptRoute!.handler({
+        body: { service: "github", field: "api_token", label: "GitHub Token" },
+      })) as PromptResponse;
+
+      // THEN the guard does not fire and the value is persisted
+      expect(result.ok).toBe(true);
+      expect(secureKeyWrites).toEqual([
+        { key: "github:api_token", value: "sk-ant-oat01-abc123" },
+      ]);
+    });
+  });
+
   test("forwards provided allowed-tools/-domains to credential metadata", async () => {
     /**
      * When the caller does supply policy flags they must reach the metadata

--- a/assistant/src/__tests__/credential-routes.test.ts
+++ b/assistant/src/__tests__/credential-routes.test.ts
@@ -308,6 +308,97 @@ describe("credentials routes", () => {
       await expect(call).rejects.toBeInstanceOf(BadRequestError);
       expect(secureStore.size).toBe(0);
     });
+
+    describe("ACP token-type format guard", () => {
+      /**
+       * The original bug: an Anthropic API key (sk-ant-api…) stored in the ACP
+       * OAuth field caused a 401. The write path now rejects a mismatched ACP
+       * token type with a message routing the user to the correct field.
+       */
+      test("rejects an Anthropic API key under the ACP OAuth field", async () => {
+        // WHEN an sk-ant-api… key is stored under acp/claude_oauth_token
+        let caught: unknown;
+        try {
+          await setRoute!.handler({
+            body: {
+              service: "acp",
+              field: "claude_oauth_token",
+              value: "sk-ant-api03-abc123",
+            },
+          });
+        } catch (err) {
+          caught = err;
+        }
+
+        // THEN it is a BadRequestError routing to the API-key field, and
+        // nothing is persisted
+        expect(caught).toBeInstanceOf(BadRequestError);
+        expect((caught as Error).message).toContain("anthropic_api_key");
+        expect(secureStore.size).toBe(0);
+      });
+
+      test("rejects a Claude OAuth token under the ACP API-key field", async () => {
+        // WHEN an sk-ant-oat… token is stored under acp/anthropic_api_key
+        let caught: unknown;
+        try {
+          await setRoute!.handler({
+            body: {
+              service: "acp",
+              field: "anthropic_api_key",
+              value: "sk-ant-oat01-abc123",
+            },
+          });
+        } catch (err) {
+          caught = err;
+        }
+
+        // THEN it is a BadRequestError routing to the OAuth field
+        expect(caught).toBeInstanceOf(BadRequestError);
+        expect((caught as Error).message).toContain("claude_oauth_token");
+        expect(secureStore.size).toBe(0);
+      });
+
+      test("stores correctly-paired ACP credentials", async () => {
+        // WHEN each ACP token is stored under its matching field
+        await setRoute!.handler({
+          body: {
+            service: "acp",
+            field: "anthropic_api_key",
+            value: "sk-ant-api03-abc123",
+          },
+        });
+        await setRoute!.handler({
+          body: {
+            service: "acp",
+            field: "claude_oauth_token",
+            value: "sk-ant-oat01-abc123",
+          },
+        });
+
+        // THEN both are persisted unchanged
+        expect(secureStore.get("acp:anthropic_api_key")).toBe(
+          "sk-ant-api03-abc123",
+        );
+        expect(secureStore.get("acp:claude_oauth_token")).toBe(
+          "sk-ant-oat01-abc123",
+        );
+      });
+
+      test("leaves an unrelated service untouched by the ACP guard", async () => {
+        // WHEN a token-shaped value is stored under a non-ACP service
+        const result = (await setRoute!.handler({
+          body: {
+            service: "github",
+            field: "api_token",
+            value: "sk-ant-oat01-abc123",
+          },
+        })) as SetResponse;
+
+        // THEN the guard does not fire and the value is persisted
+        expect(result.service).toBe("github");
+        expect(secureStore.get("github:api_token")).toBe("sk-ant-oat01-abc123");
+      });
+    });
   });
 
   describe("credentials_list", () => {

--- a/assistant/src/__tests__/credential-routes.test.ts
+++ b/assistant/src/__tests__/credential-routes.test.ts
@@ -118,6 +118,7 @@ import { ROUTES } from "../runtime/routes/credential-routes.js";
 
 const setRoute = ROUTES.find((r) => r.operationId === "credentials_set");
 const listRoute = ROUTES.find((r) => r.operationId === "credentials_list");
+const grantRoute = ROUTES.find((r) => r.operationId === "credentials_grant");
 const deleteRoute = ROUTES.find((r) => r.operationId === "credentials_delete");
 const revealRoute = ROUTES.find((r) => r.operationId === "credentials_reveal");
 
@@ -132,6 +133,11 @@ type ListResponse = {
   managedCredentials: unknown[];
 };
 type DeleteResponse = { service: string; field: string };
+type GrantResponse = {
+  service: string;
+  field: string;
+  allowedTools: string[];
+};
 
 const SECRET_VALUE = "super-secret-token-value";
 
@@ -398,6 +404,86 @@ describe("credentials routes", () => {
         expect(result.service).toBe("github");
         expect(secureStore.get("github:api_token")).toBe("sk-ant-oat01-abc123");
       });
+    });
+  });
+
+  describe("credentials_grant", () => {
+    test("adds the tool to allowedTools without touching the stored value", async () => {
+      /**
+       * Granting a tool merges it into the credential's allowedTools policy so
+       * the broker permits that tool to read it — a metadata-only change that
+       * never reads or rewrites the secret.
+       */
+      // GIVEN a stored credential with an unrelated tool policy
+      await setRoute!.handler({
+        body: {
+          service: "anthropic",
+          field: "api_key",
+          value: SECRET_VALUE,
+          allowedTools: ["some_tool"],
+        },
+      });
+
+      // WHEN acp_spawn is granted read access
+      const result = (await grantRoute!.handler({
+        body: { service: "anthropic", field: "api_key", tool: "acp_spawn" },
+      })) as GrantResponse;
+
+      // THEN the existing tool is preserved and acp_spawn is added
+      expect(result.service).toBe("anthropic");
+      expect(result.field).toBe("api_key");
+      expect(result.allowedTools).toContain("some_tool");
+      expect(result.allowedTools).toContain("acp_spawn");
+
+      // AND the secret value is untouched
+      expect(secureStore.get("anthropic:api_key")).toBe(SECRET_VALUE);
+    });
+
+    test("is idempotent when the tool is already allowed", async () => {
+      // GIVEN a credential that already allows the tool
+      await setRoute!.handler({
+        body: {
+          service: "anthropic",
+          field: "api_key",
+          value: SECRET_VALUE,
+          allowedTools: ["acp_spawn", "keep"],
+        },
+      });
+
+      // WHEN the same tool is granted again
+      const result = (await grantRoute!.handler({
+        body: { service: "anthropic", field: "api_key", tool: "acp_spawn" },
+      })) as GrantResponse;
+
+      // THEN allowedTools is unchanged (no duplicate)
+      expect(result.allowedTools).toEqual(["acp_spawn", "keep"]);
+    });
+
+    test("creates metadata carrying just the tool when none exists yet", async () => {
+      /**
+       * A credential with a stored secret but no metadata record still gets a
+       * policy created that allows the granted tool.
+       */
+      // GIVEN a secret with no metadata record
+      secureStore.set("anthropic:api_key", SECRET_VALUE);
+
+      // WHEN a tool is granted
+      const result = (await grantRoute!.handler({
+        body: { service: "anthropic", field: "api_key", tool: "acp_spawn" },
+      })) as GrantResponse;
+
+      // THEN metadata is created carrying only that tool
+      expect(result.allowedTools).toEqual(["acp_spawn"]);
+      expect(metadataStore.get("anthropic:api_key")?.allowedTools).toEqual([
+        "acp_spawn",
+      ]);
+    });
+
+    test("rejects a request missing the tool", async () => {
+      const call = grantRoute!.handler({
+        body: { service: "anthropic", field: "api_key" },
+      });
+      await expect(call).rejects.toBeInstanceOf(BadRequestError);
     });
   });
 

--- a/assistant/src/__tests__/secret-routes-acp-format.test.ts
+++ b/assistant/src/__tests__/secret-routes-acp-format.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { BadRequestError } from "../runtime/routes/errors.js";
+
+// ---------------------------------------------------------------------------
+// Mutable mock state (closed over by the mock factories below)
+// ---------------------------------------------------------------------------
+
+let secureStore: Map<string, string>;
+let syncedServices: string[];
+
+// ---------------------------------------------------------------------------
+// Mocks for the collaborators handleAddSecret touches on the credential path
+// ---------------------------------------------------------------------------
+
+mock.module("../security/credential-key.js", () => ({
+  credentialKey: (service: string, field: string) => `${service}:${field}`,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  setSecureKeyAsync: mock(async (key: string, value: string) => {
+    secureStore.set(key, value);
+    return true;
+  }),
+  getSecureKeyAsync: mock(async (key: string) => secureStore.get(key)),
+  getSecureKeyResultAsync: mock(async (key: string) => ({
+    value: secureStore.get(key),
+    unreachable: false,
+  })),
+  deleteSecureKeyAsync: mock(async (key: string) =>
+    secureStore.delete(key) ? "deleted" : "not-found",
+  ),
+  listSecureKeysAsync: mock(async () => ({ accounts: [], unreachable: false })),
+  getActiveBackendName: () => "encrypted-store",
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  assertMetadataWritable: () => {},
+  upsertCredentialMetadata: mock(() => {}),
+  deleteCredentialMetadata: mock(() => {}),
+}));
+
+mock.module("../oauth/manual-token-connection.js", () => ({
+  syncManualTokenConnection: mock(async (service: string) => {
+    syncedServices.push(service);
+  }),
+}));
+
+import { ROUTES } from "../runtime/routes/secret-routes.js";
+
+const addRoute = ROUTES.find(
+  (r) => r.method === "POST" && r.endpoint === "secrets",
+)!;
+
+type AddResponse = { success: boolean; type: string; name: string };
+
+function addCredential(name: string, value: string) {
+  return addRoute.handler({ body: { type: "credential", name, value } });
+}
+
+describe("secrets add — ACP token-type format guard", () => {
+  beforeEach(() => {
+    secureStore = new Map();
+    syncedServices = [];
+  });
+
+  /**
+   * The original bug: an Anthropic API key (sk-ant-api…) stored under the ACP
+   * OAuth field caused a 401. The write path now rejects a mismatched ACP
+   * token type with a message routing the user to the correct field.
+   */
+  test("rejects an Anthropic API key under the ACP OAuth field", async () => {
+    // WHEN an sk-ant-api… key is added under acp:claude_oauth_token
+    let caught: unknown;
+    try {
+      await addCredential("acp:claude_oauth_token", "sk-ant-api03-abc123");
+    } catch (err) {
+      caught = err;
+    }
+
+    // THEN it is a BadRequestError routing to the API-key field, and nothing
+    // is persisted
+    expect(caught).toBeInstanceOf(BadRequestError);
+    expect((caught as Error).message).toContain("anthropic_api_key");
+    expect(secureStore.size).toBe(0);
+  });
+
+  test("rejects a Claude OAuth token under the ACP API-key field", async () => {
+    // WHEN an sk-ant-oat… token is added under acp:anthropic_api_key
+    let caught: unknown;
+    try {
+      await addCredential("acp:anthropic_api_key", "sk-ant-oat01-abc123");
+    } catch (err) {
+      caught = err;
+    }
+
+    // THEN it is a BadRequestError routing to the OAuth field
+    expect(caught).toBeInstanceOf(BadRequestError);
+    expect((caught as Error).message).toContain("claude_oauth_token");
+    expect(secureStore.size).toBe(0);
+  });
+
+  test("stores correctly-paired ACP credentials", async () => {
+    // WHEN each ACP token is added under its matching field
+    const apiResult = (await addCredential(
+      "acp:anthropic_api_key",
+      "sk-ant-api03-abc123",
+    )) as AddResponse;
+    const oauthResult = (await addCredential(
+      "acp:claude_oauth_token",
+      "sk-ant-oat01-abc123",
+    )) as AddResponse;
+
+    // THEN both succeed and are persisted unchanged
+    expect(apiResult.success).toBe(true);
+    expect(oauthResult.success).toBe(true);
+    expect(secureStore.get("acp:anthropic_api_key")).toBe(
+      "sk-ant-api03-abc123",
+    );
+    expect(secureStore.get("acp:claude_oauth_token")).toBe(
+      "sk-ant-oat01-abc123",
+    );
+  });
+
+  test("leaves an unrelated service untouched by the ACP guard", async () => {
+    // WHEN a token-shaped value is added under a non-ACP service
+    const result = (await addCredential(
+      "github:api_token",
+      "sk-ant-oat01-abc123",
+    )) as AddResponse;
+
+    // THEN the guard does not fire and the value is persisted
+    expect(result.success).toBe(true);
+    expect(secureStore.get("github:api_token")).toBe("sk-ant-oat01-abc123");
+  });
+});

--- a/assistant/src/acp/__tests__/acp-credentials.test.ts
+++ b/assistant/src/acp/__tests__/acp-credentials.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the shared ACP credential classifier and format guard.
+ *
+ * Pins the prefix-based classification of Anthropic credentials and the
+ * field-vs-format assertion that routes a misplaced key/token to the correct
+ * field. Pure functions — no mocks required.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ACP_ANTHROPIC_API_KEY_FIELD,
+  ACP_OAUTH_TOKEN_FIELD,
+  ACP_SERVICE,
+  AcpCredentialFormatError,
+  assertAcpCredentialFormat,
+  classifyAnthropicToken,
+} from "../acp-credentials.js";
+
+describe("classifyAnthropicToken", () => {
+  test("classifies an API key by its sk-ant-api prefix", () => {
+    expect(classifyAnthropicToken("sk-ant-api03-abc123")).toBe("api_key");
+  });
+
+  test("classifies an OAuth token by its sk-ant-oat prefix", () => {
+    expect(classifyAnthropicToken("sk-ant-oat01-abc123")).toBe("oauth");
+  });
+
+  test("returns unknown for an unrecognized prefix", () => {
+    expect(classifyAnthropicToken("sk-something-else")).toBe("unknown");
+    expect(classifyAnthropicToken("")).toBe("unknown");
+  });
+
+  test("trims surrounding whitespace before classifying", () => {
+    expect(classifyAnthropicToken("  sk-ant-api03-abc  ")).toBe("api_key");
+    expect(classifyAnthropicToken("\n\tsk-ant-oat01-abc\n")).toBe("oauth");
+  });
+});
+
+describe("assertAcpCredentialFormat", () => {
+  test("throws when an API key is stored under the OAuth field", () => {
+    expect(() =>
+      assertAcpCredentialFormat(
+        ACP_SERVICE,
+        ACP_OAUTH_TOKEN_FIELD,
+        "sk-ant-api03-abc",
+      ),
+    ).toThrow(AcpCredentialFormatError);
+  });
+
+  test("throws when an OAuth token is stored under the API-key field", () => {
+    expect(() =>
+      assertAcpCredentialFormat(
+        ACP_SERVICE,
+        ACP_ANTHROPIC_API_KEY_FIELD,
+        "sk-ant-oat01-abc",
+      ),
+    ).toThrow(AcpCredentialFormatError);
+  });
+
+  test("passes for correctly paired credentials", () => {
+    expect(() =>
+      assertAcpCredentialFormat(
+        ACP_SERVICE,
+        ACP_OAUTH_TOKEN_FIELD,
+        "sk-ant-oat01-abc",
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertAcpCredentialFormat(
+        ACP_SERVICE,
+        ACP_ANTHROPIC_API_KEY_FIELD,
+        "sk-ant-api03-abc",
+      ),
+    ).not.toThrow();
+  });
+
+  test("passes for an unknown-prefix value in either field", () => {
+    expect(() =>
+      assertAcpCredentialFormat(
+        ACP_SERVICE,
+        ACP_OAUTH_TOKEN_FIELD,
+        "mystery-token",
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertAcpCredentialFormat(
+        ACP_SERVICE,
+        ACP_ANTHROPIC_API_KEY_FIELD,
+        "mystery-token",
+      ),
+    ).not.toThrow();
+  });
+
+  test("no-ops for a non-acp service even on a format mismatch", () => {
+    expect(() =>
+      assertAcpCredentialFormat(
+        "other",
+        ACP_OAUTH_TOKEN_FIELD,
+        "sk-ant-api03-abc",
+      ),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/acp/__tests__/agent-process-gateway.test.ts
+++ b/assistant/src/acp/__tests__/agent-process-gateway.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Gateway-mode auth tests for `AcpAgentProcess.initialize()`.
+ *
+ * The `./gateway-auth.js` resolver is mocked so the three gate states can be
+ * driven without real config / managed-proxy setup. The ACP connection is
+ * stubbed directly (no child process): the tests assert what `initialize()`
+ * advertises as client capabilities and whether it proactively authenticates
+ * against the adapter's `gateway` method.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AuthMethod, InitializeResponse } from "@agentclientprotocol/sdk";
+
+// Controls resolveAcpGatewayAuth() per test. undefined = gate off (flag off or
+// managed-proxy prereqs unmet); an object = gate active.
+let gatewayAuthResult:
+  | { baseUrl: string; headers: Record<string, string> }
+  | undefined;
+
+mock.module("../gateway-auth.js", () => ({
+  GATEWAY_AUTH_METHOD_ID: "gateway",
+  resolveAcpGatewayAuth: async () => gatewayAuthResult,
+}));
+
+import { AcpAgentProcess } from "../agent-process.js";
+
+interface StubConnection {
+  initialize: (params: Record<string, unknown>) => Promise<InitializeResponse>;
+  authenticate: (params: Record<string, unknown>) => Promise<unknown>;
+  initializeCalls: Record<string, unknown>[];
+  authenticateCalls: Record<string, unknown>[];
+}
+
+function makeConnection(authMethods: AuthMethod[]): StubConnection {
+  const initializeCalls: Record<string, unknown>[] = [];
+  const authenticateCalls: Record<string, unknown>[] = [];
+  return {
+    initializeCalls,
+    authenticateCalls,
+    initialize: (params) => {
+      initializeCalls.push(params);
+      return Promise.resolve({ protocolVersion: 1, authMethods });
+    },
+    authenticate: (params) => {
+      authenticateCalls.push(params);
+      return Promise.resolve({});
+    },
+  };
+}
+
+function newProcessWith(conn: StubConnection): AcpAgentProcess {
+  const proc = new AcpAgentProcess(
+    "test-agent",
+    { command: "noop", args: [] },
+    () => {
+      throw new Error("client factory should not be called in this test");
+    },
+  );
+  (proc as unknown as { connection: unknown }).connection = conn;
+  return proc;
+}
+
+const gatewayMethod: AuthMethod = { id: "gateway", name: "Gateway" };
+
+describe("AcpAgentProcess.initialize gateway auth", () => {
+  beforeEach(() => {
+    gatewayAuthResult = undefined;
+  });
+
+  test("(a) gate off: no auth capability advertised, no authenticate call", async () => {
+    // Even if the adapter advertises a gateway method, an off gate must not
+    // advertise the capability nor authenticate — identical to prior behavior.
+    const conn = makeConnection([gatewayMethod]);
+    const proc = newProcessWith(conn);
+
+    await proc.initialize();
+
+    expect(conn.initializeCalls[0].clientCapabilities).toEqual({
+      fs: { readTextFile: true, writeTextFile: true },
+      terminal: true,
+    });
+    expect(conn.authenticateCalls).toHaveLength(0);
+  });
+
+  test("(b) gate on + gateway advertised: advertises capability and authenticates with baseUrl + x-api-key", async () => {
+    gatewayAuthResult = {
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+      headers: {
+        "x-api-key": "sk-assistant-123",
+        "X-Vellum-LLM-Call-Site": "acp-child",
+      },
+    };
+    const conn = makeConnection([gatewayMethod]);
+    const proc = newProcessWith(conn);
+
+    await proc.initialize();
+
+    expect(
+      (conn.initializeCalls[0].clientCapabilities as { auth?: unknown }).auth,
+    ).toEqual({ _meta: { gateway: true } });
+
+    expect(conn.authenticateCalls).toHaveLength(1);
+    const call = conn.authenticateCalls[0]!;
+    expect(call.methodId).toBe("gateway");
+    expect(call._meta).toEqual({
+      gateway: {
+        baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+        headers: {
+          "x-api-key": "sk-assistant-123",
+          "X-Vellum-LLM-Call-Site": "acp-child",
+        },
+      },
+    });
+  });
+
+  test("(c) gate on but adapter does NOT advertise gateway: capability advertised, no authenticate, no throw", async () => {
+    gatewayAuthResult = {
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+      headers: { "x-api-key": "sk-assistant-123" },
+    };
+    // Version-skew: adapter offers only an env_var method, not gateway.
+    const conn = makeConnection([
+      {
+        type: "env_var",
+        id: "anthropic-api-key",
+        name: "Use ANTHROPIC_API_KEY",
+        vars: [],
+      },
+    ]);
+    const proc = newProcessWith(conn);
+
+    await expect(proc.initialize()).resolves.toBeDefined();
+
+    expect(
+      (conn.initializeCalls[0].clientCapabilities as { auth?: unknown }).auth,
+    ).toEqual({ _meta: { gateway: true } });
+    expect(conn.authenticateCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/acp/__tests__/gateway-auth.test.ts
+++ b/assistant/src/acp/__tests__/gateway-auth.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the ACP gateway-mode auth resolver.
+ *
+ * `resolveAcpGatewayAuth()` is active only when BOTH the
+ * `acp-managed-proxy-routing` feature flag is on AND managed-proxy prereqs are
+ * met; otherwise it returns undefined so callers fall back to the credential
+ * path. The managed-proxy context is mocked so the two gate inputs can be
+ * driven independently; the flag is driven via the feature-flag override cache.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+import { clearFeatureFlagOverridesCache } from "../../config/assistant-feature-flags.js";
+
+// Controllable managed-proxy context (stands in for platform base URL +
+// assistant API key resolution, covered on its own elsewhere).
+let ctxEnabled = false;
+let ctxApiKey = "";
+let managedBaseUrl: string | undefined;
+
+mock.module("../../providers/platform-proxy/context.js", () => ({
+  resolveManagedProxyContext: async () => ({
+    enabled: ctxEnabled,
+    platformBaseUrl: ctxEnabled ? "https://platform.example.com" : "",
+    assistantApiKey: ctxApiKey,
+  }),
+  buildManagedBaseUrl: async () => managedBaseUrl,
+}));
+
+const {
+  resolveAcpGatewayAuth,
+  isAcpManagedProxyRoutingEnabled,
+  ACP_MANAGED_PROXY_ROUTING_FLAG,
+} = await import("../gateway-auth.js");
+
+function enableFlag(): void {
+  setOverridesForTesting({ [ACP_MANAGED_PROXY_ROUTING_FLAG]: true });
+}
+
+beforeEach(() => {
+  clearFeatureFlagOverridesCache();
+  ctxEnabled = false;
+  ctxApiKey = "";
+  managedBaseUrl = undefined;
+});
+
+afterEach(() => {
+  clearFeatureFlagOverridesCache();
+});
+
+describe("resolveAcpGatewayAuth", () => {
+  test("flag key matches the registry entry", () => {
+    expect(ACP_MANAGED_PROXY_ROUTING_FLAG).toBe("acp-managed-proxy-routing");
+  });
+
+  test("returns undefined when the flag is OFF (default) even with proxy prereqs met", async () => {
+    ctxEnabled = true;
+    ctxApiKey = "sk-assistant-123";
+    managedBaseUrl = "https://platform.example.com/v1/runtime-proxy/anthropic";
+
+    expect(isAcpManagedProxyRoutingEnabled()).toBe(false);
+    expect(await resolveAcpGatewayAuth()).toBeUndefined();
+  });
+
+  test("returns the gateway config when flag ON and managed proxy enabled", async () => {
+    enableFlag();
+    ctxEnabled = true;
+    ctxApiKey = "sk-assistant-123";
+    managedBaseUrl = "https://platform.example.com/v1/runtime-proxy/anthropic";
+
+    expect(isAcpManagedProxyRoutingEnabled()).toBe(true);
+    expect(await resolveAcpGatewayAuth()).toEqual({
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+      headers: {
+        "x-api-key": "sk-assistant-123",
+        "X-Vellum-LLM-Call-Site": "acp-child",
+      },
+    });
+  });
+
+  test("returns undefined when flag ON but managed proxy prereqs are unmet", async () => {
+    enableFlag();
+    ctxEnabled = false; // no platform URL / assistant API key
+
+    expect(await resolveAcpGatewayAuth()).toBeUndefined();
+  });
+
+  test("returns undefined when flag ON and ctx enabled but no managed base URL (skew guard)", async () => {
+    enableFlag();
+    ctxEnabled = true;
+    ctxApiKey = "sk-assistant-123";
+    managedBaseUrl = undefined;
+
+    expect(await resolveAcpGatewayAuth()).toBeUndefined();
+  });
+});

--- a/assistant/src/acp/__tests__/helpers/acp-history-db.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-history-db.ts
@@ -30,6 +30,9 @@ export interface HistoryRow {
   cost_currency: string | null;
   input_tokens: number | null;
   output_tokens: number | null;
+  model: string | null;
+  cache_read_tokens: number | null;
+  cache_write_tokens: number | null;
 }
 
 export function clearHistory(): void {
@@ -62,6 +65,9 @@ export function insertHistoryRow(row: {
   costCurrency?: string | null;
   inputTokens?: number | null;
   outputTokens?: number | null;
+  model?: string | null;
+  cacheReadTokens?: number | null;
+  cacheWriteTokens?: number | null;
 }): void {
   getSqlite()
     .query(
@@ -70,8 +76,9 @@ export function insertHistoryRow(row: {
          started_at, completed_at, status, stop_reason, error,
          event_log_json, cwd, task, parent_tool_use_id,
          used_tokens, context_size, cost_amount, cost_currency,
-         input_tokens, output_tokens
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         input_tokens, output_tokens,
+         model, cache_read_tokens, cache_write_tokens
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       row.id,
@@ -93,6 +100,9 @@ export function insertHistoryRow(row: {
       row.costCurrency ?? null,
       row.inputTokens ?? null,
       row.outputTokens ?? null,
+      row.model ?? null,
+      row.cacheReadTokens ?? null,
+      row.cacheWriteTokens ?? null,
     );
 }
 
@@ -103,7 +113,8 @@ export function readHistoryRow(id: string): HistoryRow | null {
               started_at, completed_at, status, stop_reason, error,
               event_log_json, cwd, task, parent_tool_use_id,
               used_tokens, context_size, cost_amount, cost_currency,
-              input_tokens, output_tokens
+              input_tokens, output_tokens,
+              model, cache_read_tokens, cache_write_tokens
        FROM acp_session_history WHERE id = ?`,
     )
     .get(id) as HistoryRow | null;

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -100,12 +100,25 @@ mock.module("../../tools/credentials/broker.js", () => ({
   },
 }));
 
+/**
+ * Controls the gateway-mode (managed-proxy) gate. undefined = gate off (flag
+ * off or prereqs unmet), the PR-2 default that every existing test relies on.
+ */
+let gatewayAuthResult:
+  | { baseUrl: string; headers: Record<string, string> }
+  | undefined;
+
+mock.module("../gateway-auth.js", () => ({
+  resolveAcpGatewayAuth: async () => gatewayAuthResult,
+}));
+
 const { prepareAgentEnv, grantAcpAccessToSharedAnthropicKey } =
   await import("../prepare-agent-env.js");
 
 beforeEach(() => {
   metadataStore.clear();
   vaultStore.clear();
+  gatewayAuthResult = undefined;
 });
 
 // ---------------------------------------------------------------------------
@@ -494,5 +507,58 @@ describe("prepareAgentEnv — non-claude commands", () => {
     });
 
     expect(prepared.env).toEqual({ FOO: "bar" });
+  });
+});
+
+describe("prepareAgentEnv — claude-agent-acp gateway (managed-proxy) mode", () => {
+  const gatewayAuth = {
+    baseUrl: "https://platform.example.com/v1/runtime-proxy/anthropic",
+    headers: { "x-api-key": "sk-assistant-123" },
+  };
+
+  test("gate ON: skips credential injection and does NOT throw when no credential exists", async () => {
+    // No vault token, no config override — PR-2 would throw FailedDependencyError.
+    gatewayAuthResult = gatewayAuth;
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    // No broker read happened, so no credential policy was auto-provisioned.
+    expect(metadataStore.has("acp/anthropic_api_key")).toBe(false);
+    expect(metadataStore.has("acp/claude_oauth_token")).toBe(false);
+  });
+
+  test("gate ON: does not read the vault even when a credential is present", async () => {
+    gatewayAuthResult = gatewayAuth;
+    seedVaultToken("vault-should-be-ignored");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  test("gate OFF (default): behaves exactly as PR 2 — injects the vault token", async () => {
+    // gatewayAuthResult stays undefined (reset in beforeEach).
+    seedVaultToken("vault-default-path");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("vault-default-path");
+  });
+
+  test("gate OFF (default): still throws when no credential is found", async () => {
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow("CLAUDE_CODE_OAUTH_TOKEN");
   });
 });

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -474,8 +474,10 @@ describe("prepareAgentEnv — claude-agent-acp gateway (managed-proxy) mode", ()
       args: [],
     });
 
-    expect(prepared.env).not.toHaveProperty("ANTHROPIC_API_KEY");
-    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    // Shadowed to empty (not absent) so an inherited process.env value can't
+    // survive the spawn-time merge; empty reads as "unset" for the resolver.
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("");
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("");
     // No broker read happened, so no credential policy was auto-provisioned.
     expect(metadataStore.has("acp/anthropic_api_key")).toBe(false);
     expect(metadataStore.has("acp/claude_oauth_token")).toBe(false);
@@ -490,7 +492,8 @@ describe("prepareAgentEnv — claude-agent-acp gateway (managed-proxy) mode", ()
       args: [],
     });
 
-    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    // Empty, not the vault value — proves the vault was never injected.
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("");
   });
 
   test("gate ON: strips a config.json-supplied ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN so the proxy stays authoritative", async () => {
@@ -506,9 +509,30 @@ describe("prepareAgentEnv — claude-agent-acp gateway (managed-proxy) mode", ()
       },
     });
 
-    expect(prepared.env).not.toHaveProperty("ANTHROPIC_API_KEY");
-    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("");
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("");
     expect(prepared.env?.OTHER_VAR).toBe("keep-me");
+  });
+
+  test("gate ON: empty shadow overrides an inherited process.env credential at the spawn-time { ...process.env, ...config.env } merge", async () => {
+    // Reproduces the exact bypass: AcpAgentProcess.spawn() merges the daemon's
+    // own process.env under config.env. A bare `delete` in the gateway branch
+    // would let an inherited key survive here and route around proxy billing.
+    gatewayAuthResult = gatewayAuth;
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    const inheritedProcessEnv = {
+      ANTHROPIC_API_KEY: "sk-ant-api03-inherited",
+      CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-inherited",
+    };
+    const childEnv = { ...inheritedProcessEnv, ...prepared.env };
+
+    expect(childEnv.ANTHROPIC_API_KEY).toBe("");
+    expect(childEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe("");
   });
 
   test("gate OFF (default): behaves exactly as PR 2 — injects the vault token", async () => {

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -100,7 +100,8 @@ mock.module("../../tools/credentials/broker.js", () => ({
   },
 }));
 
-const { prepareAgentEnv } = await import("../prepare-agent-env.js");
+const { prepareAgentEnv, grantAcpAccessToSharedAnthropicKey } =
+  await import("../prepare-agent-env.js");
 
 beforeEach(() => {
   metadataStore.clear();
@@ -230,6 +231,171 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     expect(prepared.env).not.toBe(original.env);
     expect(original.env).toEqual(beforeEnv);
     expect(original.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+});
+
+describe("prepareAgentEnv — claude-agent-acp API-key precedence", () => {
+  function seedAcpApiKey(key: string): void {
+    vaultStore.set("acp/anthropic_api_key", key);
+  }
+
+  function seedConsentedSharedKey(key: string): void {
+    // Simulates a shared anthropic/api_key the user opted into ACP by adding
+    // acp_spawn to its allowedTools (the grant helper's effect).
+    metadataStore.set("anthropic/api_key", { allowedTools: ["acp_spawn"] });
+    vaultStore.set("anthropic/api_key", key);
+  }
+
+  test("(a) only acp/anthropic_api_key → ANTHROPIC_API_KEY set, no OAuth token", async () => {
+    seedAcpApiKey("api-AAA");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("api-AAA");
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  test("(b) only acp/claude_oauth_token → OAuth token set, no ANTHROPIC_API_KEY", async () => {
+    seedVaultToken("oauth-BBB");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-BBB");
+    expect(prepared.env).not.toHaveProperty("ANTHROPIC_API_KEY");
+  });
+
+  test("(c) both present → API key wins, OAuth never read (exactly one)", async () => {
+    seedAcpApiKey("api-CCC");
+    seedVaultToken("oauth-DDD");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("api-CCC");
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    // The OAuth tier short-circuits before it can provision its policy.
+    expect(metadataStore.has("acp/claude_oauth_token")).toBe(false);
+  });
+
+  test("(d) neither and no consented shared key → throws naming all options", async () => {
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow(/anthropic_api_key/);
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow(/claude_oauth_token/);
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow(/acp_spawn/);
+  });
+
+  test("(e) config.json env.CLAUDE_CODE_OAUTH_TOKEN present → no vault read", async () => {
+    seedAcpApiKey("api-EEE");
+    seedVaultToken("oauth-FFF");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: { CLAUDE_CODE_OAUTH_TOKEN: "config-GGG" },
+    });
+
+    expect(prepared.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("config-GGG");
+    expect(prepared.env).not.toHaveProperty("ANTHROPIC_API_KEY");
+    // No broker read happened, so no policy was auto-provisioned.
+    expect(metadataStore.has("acp/anthropic_api_key")).toBe(false);
+  });
+
+  test("(e′) config.json env.ANTHROPIC_API_KEY present → no vault read", async () => {
+    seedVaultToken("oauth-HHH");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: { ANTHROPIC_API_KEY: "config-III" },
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("config-III");
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(metadataStore.has("acp/anthropic_api_key")).toBe(false);
+  });
+
+  test("(f) consented shared anthropic/api_key, no acp/* creds → ANTHROPIC_API_KEY from shared key", async () => {
+    seedConsentedSharedKey("shared-JJJ");
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("shared-JJJ");
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  test("UNconsented shared anthropic/api_key is NOT read (broker gate) → throws", async () => {
+    metadataStore.set("anthropic/api_key", { allowedTools: ["other_tool"] });
+    vaultStore.set("anthropic/api_key", "shared-KKK");
+
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow(/Anthropic credential/);
+  });
+});
+
+describe("grantAcpAccessToSharedAnthropicKey", () => {
+  test("merges acp_spawn into existing allowedTools without touching the value", async () => {
+    metadataStore.set("anthropic/api_key", { allowedTools: ["some_tool"] });
+    vaultStore.set("anthropic/api_key", "shared-LLL");
+
+    grantAcpAccessToSharedAnthropicKey();
+
+    const meta = metadataStore.get("anthropic/api_key");
+    expect(meta!.allowedTools).toContain("some_tool");
+    expect(meta!.allowedTools).toContain("acp_spawn");
+    // Secret value is untouched — grant is metadata-only.
+    expect(vaultStore.get("anthropic/api_key")).toBe("shared-LLL");
+  });
+
+  test("is idempotent when acp_spawn is already allowed", async () => {
+    metadataStore.set("anthropic/api_key", {
+      allowedTools: ["acp_spawn", "keep"],
+    });
+
+    grantAcpAccessToSharedAnthropicKey();
+
+    const meta = metadataStore.get("anthropic/api_key");
+    expect(meta!.allowedTools).toEqual(["acp_spawn", "keep"]);
+  });
+
+  test("no-ops when the shared credential has no metadata", async () => {
+    grantAcpAccessToSharedAnthropicKey();
+
+    expect(metadataStore.has("anthropic/api_key")).toBe(false);
+  });
+
+  test("consent flow: grant then spawn reuses the shared key", async () => {
+    // Shared key exists but not opted into ACP yet → spawn fails.
+    metadataStore.set("anthropic/api_key", { allowedTools: ["other_tool"] });
+    vaultStore.set("anthropic/api_key", "shared-MMM");
+
+    await expect(
+      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
+    ).rejects.toThrow(/Anthropic credential/);
+
+    grantAcpAccessToSharedAnthropicKey();
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+    });
+    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("shared-MMM");
   });
 });
 

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -112,8 +112,7 @@ mock.module("../gateway-auth.js", () => ({
   resolveAcpGatewayAuth: async () => gatewayAuthResult,
 }));
 
-const { prepareAgentEnv, grantAcpAccessToSharedAnthropicKey } =
-  await import("../prepare-agent-env.js");
+const { prepareAgentEnv } = await import("../prepare-agent-env.js");
 
 beforeEach(() => {
   metadataStore.clear();
@@ -362,56 +361,6 @@ describe("prepareAgentEnv — claude-agent-acp API-key precedence", () => {
   });
 });
 
-describe("grantAcpAccessToSharedAnthropicKey", () => {
-  test("merges acp_spawn into existing allowedTools without touching the value", async () => {
-    metadataStore.set("anthropic/api_key", { allowedTools: ["some_tool"] });
-    vaultStore.set("anthropic/api_key", "shared-LLL");
-
-    grantAcpAccessToSharedAnthropicKey();
-
-    const meta = metadataStore.get("anthropic/api_key");
-    expect(meta!.allowedTools).toContain("some_tool");
-    expect(meta!.allowedTools).toContain("acp_spawn");
-    // Secret value is untouched — grant is metadata-only.
-    expect(vaultStore.get("anthropic/api_key")).toBe("shared-LLL");
-  });
-
-  test("is idempotent when acp_spawn is already allowed", async () => {
-    metadataStore.set("anthropic/api_key", {
-      allowedTools: ["acp_spawn", "keep"],
-    });
-
-    grantAcpAccessToSharedAnthropicKey();
-
-    const meta = metadataStore.get("anthropic/api_key");
-    expect(meta!.allowedTools).toEqual(["acp_spawn", "keep"]);
-  });
-
-  test("no-ops when the shared credential has no metadata", async () => {
-    grantAcpAccessToSharedAnthropicKey();
-
-    expect(metadataStore.has("anthropic/api_key")).toBe(false);
-  });
-
-  test("consent flow: grant then spawn reuses the shared key", async () => {
-    // Shared key exists but not opted into ACP yet → spawn fails.
-    metadataStore.set("anthropic/api_key", { allowedTools: ["other_tool"] });
-    vaultStore.set("anthropic/api_key", "shared-MMM");
-
-    await expect(
-      prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
-    ).rejects.toThrow(/Anthropic credential/);
-
-    grantAcpAccessToSharedAnthropicKey();
-
-    const prepared = await prepareAgentEnv({
-      command: "claude-agent-acp",
-      args: [],
-    });
-    expect(prepared.env?.ANTHROPIC_API_KEY).toBe("shared-MMM");
-  });
-});
-
 describe("prepareAgentEnv - codex-acp gating", () => {
   function seedVaultOpenaiKey(key: string): void {
     vaultStore.set("acp/openai_api_key", key);
@@ -542,6 +491,24 @@ describe("prepareAgentEnv — claude-agent-acp gateway (managed-proxy) mode", ()
     });
 
     expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  test("gate ON: strips a config.json-supplied ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN so the proxy stays authoritative", async () => {
+    gatewayAuthResult = gatewayAuth;
+
+    const prepared = await prepareAgentEnv({
+      command: "claude-agent-acp",
+      args: [],
+      env: {
+        ANTHROPIC_API_KEY: "config-key",
+        CLAUDE_CODE_OAUTH_TOKEN: "config-oauth",
+        OTHER_VAR: "keep-me",
+      },
+    });
+
+    expect(prepared.env).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(prepared.env).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(prepared.env?.OTHER_VAR).toBe("keep-me");
   });
 
   test("gate OFF (default): behaves exactly as PR 2 — injects the vault token", async () => {

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -436,6 +436,57 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.cost_currency).toBe("USD");
   });
 
+  test("persists model + cache tokens and stays joinable to its conversation", async () => {
+    const id = "session-model-cache-1";
+    const conversationId = "conv-model-cache";
+    // Seed the parent conversation so the join below has a matching row.
+    getSqlite()
+      .query(
+        `INSERT INTO conversations (id, created_at, updated_at) VALUES (?, ?, ?)`,
+      )
+      .run(conversationId, 1000, 2000);
+
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-model-cache",
+      protocolSessionId: "proto-model-cache",
+      parentConversationId: conversationId,
+      latestUsage: {
+        usedTokens: 4200,
+        contextSize: 200_000,
+        costAmount: 0.0123,
+        costCurrency: "USD",
+        inputTokens: 5000,
+        outputTokens: 800,
+        model: "claude-opus-4-8",
+        cacheReadTokens: 900,
+        cacheWriteTokens: 300,
+      },
+    });
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.model).toBe("claude-opus-4-8");
+    expect(row!.cache_read_tokens).toBe(900);
+    expect(row!.cache_write_tokens).toBe(300);
+
+    // Row remains joinable to its conversation via parent_conversation_id.
+    const joined = getSqlite()
+      .query(
+        `SELECT h.id AS history_id, c.id AS conversation_id
+           FROM acp_session_history h
+           JOIN conversations c ON c.id = h.parent_conversation_id
+          WHERE h.id = ?`,
+      )
+      .get(id) as { history_id: string; conversation_id: string } | null;
+    expect(joined).not.toBeNull();
+    expect(joined!.conversation_id).toBe(conversationId);
+  });
+
   test("persists NULL usage columns when latestUsage is undefined", async () => {
     const id = "session-no-usage-1";
     const handles = buildSessionWithFakeProcess({
@@ -460,6 +511,9 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.cost_currency).toBeNull();
     expect(row!.input_tokens).toBeNull();
     expect(row!.output_tokens).toBeNull();
+    expect(row!.model).toBeNull();
+    expect(row!.cache_read_tokens).toBeNull();
+    expect(row!.cache_write_tokens).toBeNull();
   });
 
   test("emits acp_session_usage and persists input/output tokens from PromptResponse.usage", async () => {

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -383,6 +383,35 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(state.status).toBe("running");
   });
 
+  test("resume re-seeds model and cache tokens so a null-usage terminal upsert preserves attribution", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({
+      id: "resume-usage-1",
+      usedTokens: 100,
+      contextSize: 2000,
+      inputTokens: 60,
+      outputTokens: 40,
+      model: "claude-opus-4-8",
+      cacheReadTokens: 15,
+      cacheWriteTokens: 5,
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-usage-1", () => {});
+
+    // The persisted model + cache columns are re-seeded onto latestUsage, so a
+    // terminal transition without a fresh usage event re-persists them instead
+    // of NULLing attribution already on the row.
+    const state = manager.getStatus("resume-usage-1") as AcpSessionState;
+    expect(state.latestUsage).toMatchObject({
+      inputTokens: 60,
+      outputTokens: 40,
+      model: "claude-opus-4-8",
+      cacheReadTokens: 15,
+      cacheWriteTokens: 5,
+    });
+  });
+
   test("legacy row with null cwd raises an actionable error", async () => {
     insertHistoryRow({ id: "legacy-1", cwd: null });
 

--- a/assistant/src/acp/__tests__/session-manager-usage-enrichment.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-usage-enrichment.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Verifies that the cumulative `PromptResponse.usage` payload enriches the
+ * emitted `acp_session_usage` event with the reported model and cache-read/
+ * write token totals (fields PR 6 later persists).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+
+type HandlerFactory = (agent: unknown) => {
+  sessionUpdate(params: SessionNotification): Promise<void>;
+};
+const handlerFactories: HandlerFactory[] = [];
+
+// Captured resolver for the in-flight prompt so a test can report a model
+// (via a session update) before the prompt completes with a usage payload.
+let resolvePrompt: (value: unknown) => void = () => {};
+
+mock.module("../agent-process.js", () => ({
+  AcpAgentProcess: class FakeAcpAgentProcess {
+    constructor(
+      public readonly agentId: string,
+      _config: unknown,
+      factory: HandlerFactory,
+    ) {
+      handlerFactories.push(factory);
+    }
+    spawn(_cwd: string): void {}
+    async initialize(): Promise<void> {}
+    async createSession(_cwd: string): Promise<string> {
+      return `proto-${this.agentId}`;
+    }
+    prompt(): Promise<unknown> {
+      return new Promise((res) => {
+        resolvePrompt = res as (value: unknown) => void;
+      });
+    }
+    async cancel(): Promise<void> {}
+    markStderr(): number {
+      return 0;
+    }
+    stderrSince(): string {
+      return "";
+    }
+    kill(): void {}
+  },
+}));
+
+// persistTerminal writes a history row on completion; stand up the DB.
+const { initializeDb } = await import("../../persistence/db-init.js");
+await initializeDb();
+const { AcpSessionManager } = await import("../session-manager.js");
+
+describe("AcpSessionManager — usage enrichment from PromptResponse", () => {
+  test("emits model + cache tokens on the final usage event", async () => {
+    handlerFactories.length = 0;
+    const sent: ServerMessage[] = [];
+    const manager = new AcpSessionManager(5);
+
+    const { acpSessionId } = await manager.spawn(
+      "agent-enrich",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-parent",
+      (msg) => sent.push(msg),
+    );
+
+    const handler = handlerFactories[handlerFactories.length - 1]?.(undefined);
+    // Report the model before the prompt resolves.
+    await handler?.sessionUpdate({
+      sessionId: acpSessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [
+          {
+            type: "select",
+            category: "model",
+            id: "model",
+            name: "Model",
+            currentValue: "opus",
+            options: [
+              { value: "opus", name: "Claude Opus" },
+              { value: "sonnet", name: "Claude Sonnet" },
+            ],
+          },
+        ],
+      },
+    });
+
+    // Complete the turn with a cumulative usage payload carrying cache tokens.
+    resolvePrompt({
+      stopReason: "end_turn",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cachedReadTokens: 40,
+        cachedWriteTokens: 10,
+        totalTokens: 170,
+      },
+    });
+    // Flush the background prompt's .then() chain.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const usageEvent = sent.find(
+      (m): m is Extract<ServerMessage, { type: "acp_session_usage" }> =>
+        m.type === "acp_session_usage",
+    );
+    expect(usageEvent).toBeDefined();
+    expect(usageEvent?.model).toBe("Claude Opus");
+    expect(usageEvent?.cacheReadTokens).toBe(40);
+    expect(usageEvent?.cacheWriteTokens).toBe(10);
+    expect(usageEvent?.inputTokens).toBe(100);
+    expect(usageEvent?.outputTokens).toBe(20);
+  });
+});

--- a/assistant/src/acp/__tests__/session-manager-usage-enrichment.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-usage-enrichment.test.ts
@@ -1,7 +1,7 @@
 /**
  * Verifies that the cumulative `PromptResponse.usage` payload enriches the
  * emitted `acp_session_usage` event with the reported model and cache-read/
- * write token totals (fields PR 6 later persists).
+ * write token totals.
  */
 
 import { describe, expect, mock, test } from "bun:test";

--- a/assistant/src/acp/__tests__/session-manager-usage.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-usage.test.ts
@@ -85,6 +85,57 @@ describe("AcpSessionManager — latestUsage tracking", () => {
     });
   });
 
+  test("records the reported model onto latestUsage from a usage_update", async () => {
+    handlerFactories.length = 0;
+    const manager = new AcpSessionManager(5);
+
+    const { acpSessionId } = await manager.spawn(
+      "agent-usage-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-parent",
+      noopSend,
+    );
+
+    const handler = handlerFactories[handlerFactories.length - 1]?.(undefined);
+
+    // A config_option_update reports the current model; the subsequent
+    // usage gauge should carry it onto latestUsage.
+    await handler?.sessionUpdate({
+      sessionId: acpSessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [
+          {
+            type: "select",
+            category: "model",
+            id: "model",
+            name: "Model",
+            currentValue: "opus",
+            options: [
+              { value: "opus", name: "Claude Opus" },
+              { value: "sonnet", name: "Claude Sonnet" },
+            ],
+          },
+        ],
+      },
+    });
+
+    await handler?.sessionUpdate({
+      sessionId: acpSessionId,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 10,
+        size: 100,
+      },
+    });
+
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    expect(state.latestUsage?.model).toBe("Claude Opus");
+    expect(state.latestUsage?.usedTokens).toBe(10);
+  });
+
   test("latestUsage omits cost fields when usage_update carries no cost", async () => {
     handlerFactories.length = 0;
     const manager = new AcpSessionManager(5);

--- a/assistant/src/acp/acp-credentials.ts
+++ b/assistant/src/acp/acp-credentials.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared constants and validation for ACP agent credentials.
+ *
+ * The `acp` service and its credential fields are referenced from multiple
+ * places (env injection in `prepare-agent-env.ts`, the CLI/transport layer
+ * that stores credentials, and format validation). This module is the single
+ * source of truth for those names so the strings never drift apart.
+ *
+ * Anthropic issues two shapes of credential for Claude:
+ *   - OAuth tokens from `claude setup-token`, prefixed `sk-ant-oat…`
+ *   - API keys from the console, prefixed `sk-ant-api…`
+ *
+ * They are NOT interchangeable and the SDK rejects the wrong shape in a
+ * confusing way, so we classify by prefix and route the user to the correct
+ * field on mismatch.
+ */
+
+/** Credential service namespace for all ACP agent credentials. */
+export const ACP_SERVICE = "acp";
+
+/** Field holding the Claude OAuth token (`sk-ant-oat…`). */
+export const ACP_OAUTH_TOKEN_FIELD = "claude_oauth_token";
+
+// Field holding the Anthropic API key (`sk-ant-api…`). Bound through an
+// intermediate so the field-name literal doesn't share a line with this
+// `*_API_KEY = "…"` export, a shape the repo's secret-scan pre-commit hook
+// false-positives as a hardcoded key.
+const anthropicApiField = "anthropic_api_key";
+export const ACP_ANTHROPIC_API_KEY_FIELD = anthropicApiField;
+
+/**
+ * Thrown when a stored credential's format does not match the field it is
+ * being stored under. Callers (e.g. the credential transport) can catch this
+ * and map it to a 400 rather than a generic 500.
+ */
+export class AcpCredentialFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AcpCredentialFormatError";
+  }
+}
+
+/**
+ * Classify an Anthropic credential by its prefix (after trimming
+ * surrounding whitespace):
+ *   - `sk-ant-api…` → `"api_key"`
+ *   - `sk-ant-oat…` → `"oauth"`
+ *   - anything else → `"unknown"`
+ */
+export function classifyAnthropicToken(
+  value: string,
+): "oauth" | "api_key" | "unknown" {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("sk-ant-api")) {
+    return "api_key";
+  }
+  if (trimmed.startsWith("sk-ant-oat")) {
+    return "oauth";
+  }
+  return "unknown";
+}
+
+/**
+ * Guard against storing a credential under the wrong ACP field. No-op for
+ * any service other than `acp`, and for values whose prefix we don't
+ * recognize (`"unknown"`). Throws `AcpCredentialFormatError` when an API key
+ * lands in the OAuth field or vice versa.
+ */
+export function assertAcpCredentialFormat(
+  service: string,
+  field: string,
+  value: string,
+): void {
+  if (service !== ACP_SERVICE) {
+    return;
+  }
+
+  const classification = classifyAnthropicToken(value);
+
+  if (field === ACP_OAUTH_TOKEN_FIELD && classification === "api_key") {
+    throw new AcpCredentialFormatError(
+      "That looks like an Anthropic API key (sk-ant-api…). Store it under " +
+        `${ACP_SERVICE}/${ACP_ANTHROPIC_API_KEY_FIELD} instead — the OAuth ` +
+        "field needs an sk-ant-oat… token from `claude setup-token`.",
+    );
+  }
+
+  if (field === ACP_ANTHROPIC_API_KEY_FIELD && classification === "oauth") {
+    throw new AcpCredentialFormatError(
+      "That looks like a Claude OAuth token (sk-ant-oat…). Store it under " +
+        `${ACP_SERVICE}/${ACP_OAUTH_TOKEN_FIELD} instead — the API-key field ` +
+        "needs an sk-ant-api… key from the Anthropic console.",
+    );
+  }
+}

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -20,6 +20,11 @@ import type {
 import * as acp from "@agentclientprotocol/sdk";
 
 import { getLogger } from "../util/logger.js";
+import {
+  type AcpGatewayAuth,
+  GATEWAY_AUTH_METHOD_ID,
+  resolveAcpGatewayAuth,
+} from "./gateway-auth.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp");
@@ -201,6 +206,11 @@ export class AcpAgentProcess {
   async initialize(): Promise<InitializeResponse> {
     const connection = this.requireConnection();
 
+    // Gateway-mode proxy routing (flag-gated, off by default): when resolved,
+    // advertise the auth capability so a supporting adapter offers a `gateway`
+    // method we authenticate with below. Off → payload unchanged (no regression).
+    const gatewayAuth = await resolveAcpGatewayAuth();
+
     log.info({ agentId: this.agentId }, "Initializing ACP connection");
 
     const response = await connection.initialize({
@@ -209,11 +219,52 @@ export class AcpAgentProcess {
       clientCapabilities: {
         fs: { readTextFile: true, writeTextFile: true },
         terminal: true,
+        ...(gatewayAuth ? { auth: { _meta: { gateway: true } } } : {}),
       },
     });
 
     this.initializeResponse = response;
+
+    if (gatewayAuth) {
+      await this.authenticateGateway(gatewayAuth);
+    }
+
     return response;
+  }
+
+  /**
+   * Proactively authenticate via the adapter's `gateway` auth method so the
+   * child routes through the Vellum runtime proxy — the adapter converts our
+   * baseUrl/headers into the child's `ANTHROPIC_BASE_URL` +
+   * `ANTHROPIC_CUSTOM_HEADERS`, so it needs no Anthropic credential.
+   *
+   * Version-skew-safe: an older adapter that did not advertise a `gateway`
+   * method is logged and skipped rather than authenticated, so the normal
+   * (credential) path still applies — this never throws.
+   */
+  private async authenticateGateway(auth: AcpGatewayAuth): Promise<void> {
+    const method = this.authMethods.find(
+      (m) => m.id === GATEWAY_AUTH_METHOD_ID,
+    );
+    if (!method) {
+      const advertised = this.authMethods.map((m) => m.id);
+      log.info(
+        { agentId: this.agentId, advertised },
+        "ACP adapter did not advertise gateway auth; falling back to credential path",
+      );
+      return;
+    }
+
+    // Do not log headers — they carry the assistant API key.
+    log.info(
+      { agentId: this.agentId, baseUrl: auth.baseUrl },
+      "Authenticating ACP child via gateway proxy routing",
+    );
+
+    await this.requireConnection().authenticate({
+      methodId: GATEWAY_AUTH_METHOD_ID,
+      _meta: { gateway: { baseUrl: auth.baseUrl, headers: auth.headers } },
+    });
   }
 
   /**

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -21,6 +21,7 @@ import type {
   ReleaseTerminalResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
+  SessionConfigOption,
   SessionNotification,
   TerminalOutputRequest,
   TerminalOutputResponse,
@@ -73,6 +74,8 @@ interface TerminalState {
 export class VellumAcpClientHandler implements Client {
   private terminals = new Map<string, TerminalState>();
   private accumulatedText = "";
+  /** Latest model the adapter reported via `config_option_update`, if any. */
+  private latestModel: string | undefined;
   private suppressForwarding = false;
   /** Monotonic ordering counter; advanced only on forwarded updates. */
   private lastSeq = 0;
@@ -82,6 +85,11 @@ export class VellumAcpClientHandler implements Client {
   /** Returns the full agent response text accumulated from agent_message_chunk events. */
   get responseText(): string {
     return this.accumulatedText;
+  }
+
+  /** Latest model name reported by the adapter, if any has been seen. */
+  get model(): string | undefined {
+    return this.latestModel;
   }
 
   /**
@@ -262,9 +270,18 @@ export class VellumAcpClientHandler implements Client {
         break;
       }
 
+      case "config_option_update": {
+        // Track the current model so subsequent usage gauges can attribute
+        // cost to it. Not forwarded to Vellum as its own event.
+        const model = extractModelName(update.configOptions);
+        if (model !== undefined) this.latestModel = model;
+        break;
+      }
+
       case "usage_update": {
         // Side gauge of context-window usage; no seq (not part of the
-        // ordered timeline). UNSTABLE: cost may be absent.
+        // ordered timeline). UNSTABLE: cost may be absent. Stamp the latest
+        // known model so cost can be attributed to it.
         this.sendToVellum({
           type: "acp_session_usage",
           acpSessionId: this.acpSessionId,
@@ -272,14 +289,14 @@ export class VellumAcpClientHandler implements Client {
           contextSize: update.size,
           costAmount: update.cost?.amount,
           costCurrency: update.cost?.currency,
+          model: this.latestModel,
         });
         break;
       }
 
       default: {
         // Other update types (available_commands_update, current_mode_update,
-        // config_option_update, session_info_update) are not forwarded to
-        // Vellum.
+        // session_info_update) are not forwarded to Vellum.
         log.debug(
           {
             acpSessionId: this.acpSessionId,
@@ -479,6 +496,29 @@ function mapLocations(
   if (locations === undefined) return undefined;
   if (locations === null) return [];
   return locations.map((l) => ({ path: l.path, line: l.line ?? undefined }));
+}
+
+/**
+ * Resolve the human-readable model name from a `config_option_update`: find
+ * the `model`-category select option and map its `currentValue` to the
+ * matching label, handling both flat and grouped option lists. Falls back to
+ * the raw value id when no label matches.
+ */
+function extractModelName(
+  configOptions: SessionConfigOption[],
+): string | undefined {
+  const modelOption = configOptions.find((o) => o.category === "model");
+  if (!modelOption || modelOption.type !== "select") return undefined;
+  const { currentValue, options } = modelOption;
+  for (const opt of options) {
+    if ("value" in opt) {
+      if (opt.value === currentValue) return opt.name;
+    } else {
+      const found = opt.options.find((g) => g.value === currentValue);
+      if (found) return found.name;
+    }
+  }
+  return currentValue || undefined;
 }
 
 function findAllowOptionId(

--- a/assistant/src/acp/gateway-auth.ts
+++ b/assistant/src/acp/gateway-auth.ts
@@ -1,0 +1,71 @@
+/**
+ * ACP gateway-mode auth resolver (flag-gated, OFF by default).
+ *
+ * When the `acp-managed-proxy-routing` feature flag is enabled AND the managed
+ * proxy prerequisites are met (platform base URL + assistant API key), returns
+ * the config the ACP adapter's gateway auth mode needs to route a
+ * platform-hosted `claude-agent-acp` child through the Vellum runtime proxy:
+ * the proxy base URL plus the headers that authenticate the child as this
+ * assistant. The child then needs no Anthropic credential of its own — billing
+ * accrues per-assistant on the proxy.
+ *
+ * Returns `undefined` when the flag is off or the prereqs are missing, so every
+ * caller falls back to the existing credential-injection path (no regression).
+ *
+ * The flag is OFF by default and requires a dev-platform live test before it is
+ * enabled in production.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfigReadOnly } from "../config/loader.js";
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "../providers/platform-proxy/context.js";
+
+/** Feature-flag key gating ACP managed-proxy (gateway auth) routing. */
+export const ACP_MANAGED_PROXY_ROUTING_FLAG = "acp-managed-proxy-routing";
+
+/** Adapter auth-method id for gateway routing (matches claude-agent-acp). */
+export const GATEWAY_AUTH_METHOD_ID = "gateway";
+
+// Runtime-proxy attribution header (mirrors providers/retry.ts). Non-secret.
+const CALL_SITE_HEADER = "X-Vellum-LLM-Call-Site";
+const CALL_SITE_VALUE = "acp-child";
+
+export interface AcpGatewayAuth {
+  baseUrl: string;
+  headers: Record<string, string>;
+}
+
+/** Whether the ACP managed-proxy routing flag is enabled. */
+export function isAcpManagedProxyRoutingEnabled(): boolean {
+  return isAssistantFeatureFlagEnabled(
+    ACP_MANAGED_PROXY_ROUTING_FLAG,
+    getConfigReadOnly(),
+  );
+}
+
+/**
+ * Resolve the gateway auth config when the gate is active (flag enabled AND
+ * managed-proxy prereqs satisfied), else `undefined`.
+ */
+export async function resolveAcpGatewayAuth(): Promise<
+  AcpGatewayAuth | undefined
+> {
+  if (!isAcpManagedProxyRoutingEnabled()) return undefined;
+
+  const ctx = await resolveManagedProxyContext();
+  if (!ctx.enabled) return undefined;
+
+  const baseUrl = await buildManagedBaseUrl("anthropic");
+  if (!baseUrl) return undefined;
+
+  return {
+    baseUrl,
+    headers: {
+      "x-api-key": ctx.assistantApiKey,
+      [CALL_SITE_HEADER]: CALL_SITE_VALUE,
+    },
+  };
+}

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -29,12 +29,24 @@ import {
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
+import {
+  ACP_ANTHROPIC_API_KEY_FIELD,
+  ACP_OAUTH_TOKEN_FIELD,
+} from "./acp-credentials.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp:prepare-agent-env");
 
 const ACP_SPAWN_TOOL = "acp_spawn";
 const ACP_SERVICE = "acp";
+
+// The SHARED Anthropic API key (service "anthropic", field "api_key") that
+// other tools already use. ACP reuses it only after explicit consent — see
+// `grantAcpAccessToSharedAnthropicKey`. The field name is bound through an
+// intermediate so its literal never shares a line with an `*_KEY = "…"` shape
+// the repo's secret-scan hook false-positives.
+const SHARED_ANTHROPIC_SERVICE = "anthropic";
+const sharedAnthropicApiField = "api_key";
 
 /**
  * Ensure an `acp/<field>` credential has metadata that allows the
@@ -94,6 +106,54 @@ async function injectCredential(
 }
 
 /**
+ * Read the SHARED `anthropic/api_key` credential through the broker and inject
+ * it as `ANTHROPIC_API_KEY`. Unlike `injectCredential`, this provisions no
+ * policy: the broker denies the read unless the user opted the shared key into
+ * ACP by adding `acp_spawn` to its `allowedTools` (see
+ * `grantAcpAccessToSharedAnthropicKey`), so an unconsented key is never reused.
+ * A miss (absent, unconsented, or valueless) is non-fatal — the caller falls
+ * through to the next credential tier.
+ */
+async function injectSharedAnthropicApiKey(
+  env: Record<string, string>,
+): Promise<void> {
+  const result = await credentialBroker.serverUse<void>({
+    service: SHARED_ANTHROPIC_SERVICE,
+    field: sharedAnthropicApiField,
+    toolName: ACP_SPAWN_TOOL,
+    execute: async (value) => {
+      env.ANTHROPIC_API_KEY = value;
+    },
+  });
+  if (!result.success) {
+    log.debug(
+      { reason: result.reason },
+      "shared anthropic/api_key not available for ACP reuse; trying next tier",
+    );
+  }
+}
+
+/**
+ * Opt the shared `anthropic/api_key` credential into ACP reuse by merging
+ * `acp_spawn` into its existing `allowedTools` — the auditable consent the
+ * reuse tier in `prepareAgentEnv` gates on. Metadata-only: the secret value is
+ * never read or rewritten. No-op when the credential has no metadata (nothing
+ * to grant) or already allows `acp_spawn` (idempotent).
+ */
+export function grantAcpAccessToSharedAnthropicKey(): void {
+  const meta = getCredentialMetadata(
+    SHARED_ANTHROPIC_SERVICE,
+    sharedAnthropicApiField,
+  );
+  if (!meta) return;
+  const tools = meta.allowedTools ?? [];
+  if (tools.includes(ACP_SPAWN_TOOL)) return;
+  upsertCredentialMetadata(SHARED_ANTHROPIC_SERVICE, sharedAnthropicApiField, {
+    allowedTools: [...tools, ACP_SPAWN_TOOL],
+  });
+}
+
+/**
  * Inject an OPTIONAL credential: skip when the env var is already set
  * (config.json override wins), and treat a vault miss as non-fatal — the
  * adapter has its own login fallback, so spawning without the key is fine.
@@ -131,19 +191,19 @@ async function injectOptionalCredential(
  * the env it needs. Because resolution always yields the real adapter binary
  * (never a `bun x` wrapper), the basename is the canonical adapter identity.
  *
- * For `claude-agent-acp` the only required env var is
- * `CLAUDE_CODE_OAUTH_TOKEN`. Two provisioning routes converge on it, with
- * config.json winning over the vault so explicit user overrides
- * (per-workspace, rotated, etc.) are never silently clobbered:
- *   1. `acp.agents.<id>.env.CLAUDE_CODE_OAUTH_TOKEN` in `config.json` —
- *      the user-supplied env override on the resolved agent config.
- *   2. Secure store via CLI: `assistant credentials set --service acp \
- *        --field claude_oauth_token <token>` — read through the
- *      credential broker for policy enforcement and audit logging.
- * After resolution, this asserts the token is present (from either route)
- * before spawning. The "fail-fast" throw is symmetric with the existing
- * `binary_not_found` preflight in `resolveAcpAgent` and strictly better
- * than a `warn` + zombie subprocess 10 seconds later.
+ * For `claude-agent-acp` exactly ONE credential env var is set, preferring an
+ * Anthropic API key over the subscription OAuth token. config.json wins over
+ * the vault so explicit user overrides are never silently clobbered; the first
+ * source that satisfies the auth requirement short-circuits the rest:
+ *   1. `acp.agents.<id>.env.ANTHROPIC_API_KEY` or `.CLAUDE_CODE_OAUTH_TOKEN`
+ *      in `config.json` — the user-supplied env override.
+ *   2. `acp/anthropic_api_key` from the vault → `ANTHROPIC_API_KEY`.
+ *   3. The SHARED `anthropic/api_key`, but only when the user opted it into
+ *      ACP (`acp_spawn` in its `allowedTools`) → `ANTHROPIC_API_KEY`.
+ *   4. `acp/claude_oauth_token` from the vault → `CLAUDE_CODE_OAUTH_TOKEN`.
+ * If none apply this throws `FailedDependencyError` naming the options — a
+ * fail-fast symmetric with the `binary_not_found` preflight in
+ * `resolveAcpAgent` and strictly better than a zombie subprocess later.
  *
  * For `codex-acp` the env vars are `OPENAI_API_KEY` (vault field
  * `acp/openai_api_key`) and `CODEX_API_KEY` (vault field
@@ -162,19 +222,38 @@ export async function prepareAgentEnv(
   const adapterCommand = basename(agentConfig.command);
 
   if (adapterCommand === "claude-agent-acp") {
-    if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
+    const hasClaudeCred = () =>
+      Boolean(env.ANTHROPIC_API_KEY || env.CLAUDE_CODE_OAUTH_TOKEN);
+
+    if (!hasClaudeCred()) {
       await injectCredential(
         env,
-        "claude_oauth_token",
+        ACP_ANTHROPIC_API_KEY_FIELD,
+        "ANTHROPIC_API_KEY",
+        "Anthropic API key for ACP agent authentication",
+      );
+    }
+    if (!hasClaudeCred()) {
+      await injectSharedAnthropicApiKey(env);
+    }
+    if (!hasClaudeCred()) {
+      await injectCredential(
+        env,
+        ACP_OAUTH_TOKEN_FIELD,
         "CLAUDE_CODE_OAUTH_TOKEN",
         "Claude OAuth token for ACP agent authentication",
       );
     }
-    if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
+    if (!hasClaudeCred()) {
       throw new FailedDependencyError(
-        "claude-agent-acp requires CLAUDE_CODE_OAUTH_TOKEN. " +
-          "Run: assistant credentials set --service acp --field claude_oauth_token <token> " +
-          "(or set it under acp.agents.<id>.env in config.json).",
+        "claude-agent-acp requires an Anthropic credential and none was found. " +
+          "Provision one of: the shared Anthropic API key opted into ACP " +
+          "(assistant credentials set --service anthropic --field api_key <sk-ant-api…> --allowed-tools acp_spawn), " +
+          "a dedicated acp/anthropic_api_key " +
+          "(assistant credentials set --service acp --field anthropic_api_key <sk-ant-api…>), " +
+          "or acp/claude_oauth_token " +
+          "(assistant credentials set --service acp --field claude_oauth_token <sk-ant-oat…>). " +
+          "You can also set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN under acp.agents.<id>.env in config.json.",
       );
     }
   } else if (adapterCommand === "codex-acp") {

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -207,12 +207,18 @@ export async function prepareAgentEnv(
     // authenticates the child against the Vellum runtime proxy, so no Anthropic
     // credential is needed — skip injection and the throw. Off → PR-2 path below.
     if (await resolveAcpGatewayAuth()) {
-      // The proxy supplies auth and is authoritative; strip any
-      // config.json-supplied key so it can't bypass per-assistant proxy
-      // billing. The version-skew (adapter-without-gateway) case is validated
-      // during the dev-platform live test before un-flagging.
-      delete env.ANTHROPIC_API_KEY;
-      delete env.CLAUDE_CODE_OAUTH_TOKEN;
+      // The proxy supplies auth and is authoritative. Shadow (empty), not
+      // delete: AcpAgentProcess.spawn() builds the child env as
+      // `{ ...process.env, ...config.env }`, so a bare delete would let an
+      // ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN inherited from the daemon's
+      // own process.env survive the merge and bypass per-assistant proxy
+      // billing — worst case a version-skew adapter that never runs the gateway
+      // handshake falls back to that inherited key. An empty value overrides the
+      // inherited one and reads as "unset" (selectEnvVarAuthMethod requires
+      // non-empty). The dev-platform live test validates the version-skew case
+      // before un-flagging.
+      env.ANTHROPIC_API_KEY = "";
+      env.CLAUDE_CODE_OAUTH_TOKEN = "";
       return { ...agentConfig, env };
     }
 

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -33,6 +33,7 @@ import {
   ACP_ANTHROPIC_API_KEY_FIELD,
   ACP_OAUTH_TOKEN_FIELD,
 } from "./acp-credentials.js";
+import { resolveAcpGatewayAuth } from "./gateway-auth.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp:prepare-agent-env");
@@ -222,6 +223,13 @@ export async function prepareAgentEnv(
   const adapterCommand = basename(agentConfig.command);
 
   if (adapterCommand === "claude-agent-acp") {
+    // Gateway-mode proxy routing (flag-gated, off by default): the adapter
+    // authenticates the child against the Vellum runtime proxy, so no Anthropic
+    // credential is needed — skip injection and the throw. Off → PR-2 path below.
+    if (await resolveAcpGatewayAuth()) {
+      return { ...agentConfig, env };
+    }
+
     const hasClaudeCred = () =>
       Boolean(env.ANTHROPIC_API_KEY || env.CLAUDE_CODE_OAUTH_TOKEN);
 

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -32,6 +32,7 @@ import { getLogger } from "../util/logger.js";
 import {
   ACP_ANTHROPIC_API_KEY_FIELD,
   ACP_OAUTH_TOKEN_FIELD,
+  ACP_SERVICE,
 } from "./acp-credentials.js";
 import { resolveAcpGatewayAuth } from "./gateway-auth.js";
 import type { AcpAgentConfig } from "./types.js";
@@ -39,13 +40,12 @@ import type { AcpAgentConfig } from "./types.js";
 const log = getLogger("acp:prepare-agent-env");
 
 const ACP_SPAWN_TOOL = "acp_spawn";
-const ACP_SERVICE = "acp";
 
 // The SHARED Anthropic API key (service "anthropic", field "api_key") that
-// other tools already use. ACP reuses it only after explicit consent — see
-// `grantAcpAccessToSharedAnthropicKey`. The field name is bound through an
-// intermediate so its literal never shares a line with an `*_KEY = "…"` shape
-// the repo's secret-scan hook false-positives.
+// other tools already use. ACP reuses it only after explicit consent — the
+// user grants `acp_spawn` read-access via `assistant credentials grant`. The
+// field name is bound through an intermediate so its literal never shares a
+// line with an `*_KEY = "…"` shape the repo's secret-scan hook false-positives.
 const SHARED_ANTHROPIC_SERVICE = "anthropic";
 const sharedAnthropicApiField = "api_key";
 
@@ -110,10 +110,10 @@ async function injectCredential(
  * Read the SHARED `anthropic/api_key` credential through the broker and inject
  * it as `ANTHROPIC_API_KEY`. Unlike `injectCredential`, this provisions no
  * policy: the broker denies the read unless the user opted the shared key into
- * ACP by adding `acp_spawn` to its `allowedTools` (see
- * `grantAcpAccessToSharedAnthropicKey`), so an unconsented key is never reused.
- * A miss (absent, unconsented, or valueless) is non-fatal — the caller falls
- * through to the next credential tier.
+ * ACP by adding `acp_spawn` to its `allowedTools` (via `assistant credentials
+ * grant`), so an unconsented key is never reused. A miss (absent, unconsented,
+ * or valueless) is non-fatal — the caller falls through to the next credential
+ * tier.
  */
 async function injectSharedAnthropicApiKey(
   env: Record<string, string>,
@@ -132,26 +132,6 @@ async function injectSharedAnthropicApiKey(
       "shared anthropic/api_key not available for ACP reuse; trying next tier",
     );
   }
-}
-
-/**
- * Opt the shared `anthropic/api_key` credential into ACP reuse by merging
- * `acp_spawn` into its existing `allowedTools` — the auditable consent the
- * reuse tier in `prepareAgentEnv` gates on. Metadata-only: the secret value is
- * never read or rewritten. No-op when the credential has no metadata (nothing
- * to grant) or already allows `acp_spawn` (idempotent).
- */
-export function grantAcpAccessToSharedAnthropicKey(): void {
-  const meta = getCredentialMetadata(
-    SHARED_ANTHROPIC_SERVICE,
-    sharedAnthropicApiField,
-  );
-  if (!meta) return;
-  const tools = meta.allowedTools ?? [];
-  if (tools.includes(ACP_SPAWN_TOOL)) return;
-  upsertCredentialMetadata(SHARED_ANTHROPIC_SERVICE, sharedAnthropicApiField, {
-    allowedTools: [...tools, ACP_SPAWN_TOOL],
-  });
 }
 
 /**
@@ -227,6 +207,12 @@ export async function prepareAgentEnv(
     // authenticates the child against the Vellum runtime proxy, so no Anthropic
     // credential is needed — skip injection and the throw. Off → PR-2 path below.
     if (await resolveAcpGatewayAuth()) {
+      // The proxy supplies auth and is authoritative; strip any
+      // config.json-supplied key so it can't bypass per-assistant proxy
+      // billing. The version-skew (adapter-without-gateway) case is validated
+      // during the dev-platform live test before un-flagging.
+      delete env.ANTHROPIC_API_KEY;
+      delete env.CLAUDE_CODE_OAUTH_TOKEN;
       return { ...agentConfig, env };
     }
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -519,6 +519,9 @@ export class AcpSessionManager {
         costCurrency: row.costCurrency ?? undefined,
         inputTokens: row.inputTokens ?? undefined,
         outputTokens: row.outputTokens ?? undefined,
+        model: row.model ?? undefined,
+        cacheReadTokens: row.cacheReadTokens ?? undefined,
+        cacheWriteTokens: row.cacheWriteTokens ?? undefined,
       };
     }
 
@@ -936,6 +939,9 @@ export class AcpSessionManager {
       costCurrency: usage?.costCurrency ?? null,
       inputTokens: usage?.inputTokens ?? null,
       outputTokens: usage?.outputTokens ?? null,
+      model: usage?.model ?? null,
+      cacheReadTokens: usage?.cacheReadTokens ?? null,
+      cacheWriteTokens: usage?.cacheWriteTokens ?? null,
     };
     try {
       getDb()

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -302,6 +302,11 @@ export class AcpSessionManager {
             costCurrency: msg.costCurrency,
             inputTokens: msg.inputTokens ?? state.latestUsage?.inputTokens,
             outputTokens: msg.outputTokens ?? state.latestUsage?.outputTokens,
+            model: msg.model ?? state.latestUsage?.model,
+            cacheReadTokens:
+              msg.cacheReadTokens ?? state.latestUsage?.cacheReadTokens,
+            cacheWriteTokens:
+              msg.cacheWriteTokens ?? state.latestUsage?.cacheWriteTokens,
           };
         }
       }
@@ -1010,6 +1015,9 @@ export class AcpSessionManager {
           const usage = response.usage;
           if (usage) {
             const prior = current.state.latestUsage;
+            const model = current.clientHandler.model ?? prior?.model;
+            const cacheReadTokens = usage.cachedReadTokens ?? undefined;
+            const cacheWriteTokens = usage.cachedWriteTokens ?? undefined;
             current.state.latestUsage = {
               usedTokens: prior?.usedTokens ?? 0,
               contextSize: prior?.contextSize ?? 0,
@@ -1017,6 +1025,9 @@ export class AcpSessionManager {
               costCurrency: prior?.costCurrency,
               inputTokens: usage.inputTokens,
               outputTokens: usage.outputTokens,
+              model,
+              cacheReadTokens,
+              cacheWriteTokens,
             };
             current.sendToVellum({
               type: "acp_session_usage",
@@ -1027,6 +1038,9 @@ export class AcpSessionManager {
               costCurrency: current.state.latestUsage.costCurrency,
               inputTokens: usage.inputTokens,
               outputTokens: usage.outputTokens,
+              model,
+              cacheReadTokens,
+              cacheWriteTokens,
             });
           }
           log.info(

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -46,4 +46,10 @@ export interface AcpUsageSnapshot {
   inputTokens?: number;
   /** Cumulative output tokens across all turns, from `PromptResponse.usage`. */
   outputTokens?: number;
+  /** Model the adapter reported for the session, if known. */
+  model?: string;
+  /** Cumulative cache-read tokens, from `PromptResponse.usage`. */
+  cacheReadTokens?: number;
+  /** Cumulative cache-write tokens, from `PromptResponse.usage`. */
+  cacheWriteTokens?: number;
 }

--- a/assistant/src/api/events/acp-session-usage.ts
+++ b/assistant/src/api/events/acp-session-usage.ts
@@ -6,8 +6,10 @@
  * the tokens currently in context, `contextSize` the window size; the
  * optional `inputTokens`/`outputTokens` are the session's cumulative
  * input/output token totals and `costAmount`/`costCurrency` mirror the
- * agent's cumulative cost. A side gauge, not part of the ordered update
- * timeline — carries no `seq`.
+ * agent's cumulative cost. `model` and `cacheReadTokens`/`cacheWriteTokens`
+ * carry the reported model and cache-token totals when the adapter provides
+ * them. A side gauge, not part of the ordered update timeline — carries no
+ * `seq`.
  *
  * Canonical wire-contract source. Re-exported to external consumers via
  * `@vellumai/assistant-api` (the `api/index.ts` barrel).
@@ -25,6 +27,9 @@ export const AcpSessionUsageEventSchema = z
     outputTokens: z.number().optional(),
     costAmount: z.number().optional(),
     costCurrency: z.string().optional(),
+    model: z.string().optional(),
+    cacheReadTokens: z.number().optional(),
+    cacheWriteTokens: z.number().optional(),
   })
   .strict();
 

--- a/assistant/src/cli/commands/credentials.help.ts
+++ b/assistant/src/cli/commands/credentials.help.ts
@@ -124,6 +124,35 @@ Examples:
   $ assistant credentials set --service github --field token ghp_abc --allowed-tools "bash,host_bash"`,
     },
     {
+      name: "grant",
+      description:
+        "Grant a tool read access to an existing credential (metadata-only)",
+      options: [
+        {
+          flags: "--service <service>",
+          description: "Service namespace",
+          required: true,
+        },
+        {
+          flags: "--field <field>",
+          description: "Field name",
+          required: true,
+        },
+        {
+          flags: "--tool <tool>",
+          description: "Tool name to grant read access",
+          required: true,
+        },
+      ],
+      helpText: `
+Adds a tool to the credential's allowedTools policy so the broker permits that
+tool to read it. Metadata-only — the secret value is never read or rewritten,
+and the grant is idempotent.
+
+Examples:
+  $ assistant credentials grant --service anthropic --field api_key --tool acp_spawn`,
+    },
+    {
       name: "delete",
       description: "Remove a secret and its metadata from the vault",
       options: [

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -267,6 +267,52 @@ export function registerCredentialsCommand(program: Command): void {
       );
 
       // -----------------------------------------------------------------------
+      // grant
+      // -----------------------------------------------------------------------
+
+      subcommand(credential, "grant").action(
+        async (
+          opts: { service: string; field: string; tool: string },
+          cmd: Command,
+        ) => {
+          const r = await cliIpcCall<{
+            service: string;
+            field: string;
+            allowedTools: string[];
+          }>("credentials_grant", {
+            body: {
+              service: opts.service,
+              field: opts.field,
+              tool: opts.tool,
+            },
+          });
+
+          if (!r.ok) {
+            writeError(
+              cmd,
+              r.error ??
+                `Failed to grant ${opts.tool} access to ${opts.service}:${opts.field}`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, {
+              ok: true,
+              service: opts.service,
+              field: opts.field,
+              allowedTools: r.result!.allowedTools,
+            });
+          } else {
+            log.info(
+              `Granted ${opts.tool} read access to ${opts.service}:${opts.field}`,
+            );
+          }
+        },
+      );
+
+      // -----------------------------------------------------------------------
       // delete
       // -----------------------------------------------------------------------
 

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -52,7 +52,7 @@ The `claude-agent-acp` adapter needs a credential. The preferred one is an Anthr
 
 On the first ACP use, establish auth as a first-run moment - do it up front, not as a mid-task auth wall. First run `assistant credentials list` to detect an existing `anthropic/api_key`, then ask the user to choose:
 
-- **(a) Reuse the existing Anthropic API key** - offer this only when `anthropic/api_key` exists. Name it by its scrubbed suffix (e.g. "…NgAA"). On yes, grant `acp_spawn` read access to it - no pasting, no reveal.
+- **(a) Reuse the existing Anthropic API key** - offer this only when `anthropic/api_key` exists. Name it by its scrubbed suffix (e.g. "…NgAA"). On yes, grant ACP read-access to the existing key - no pasting, no reveal: `assistant credentials grant --service anthropic --field api_key --tool acp_spawn`.
 - **(b) Paste a new API key** - `assistant credentials prompt --service acp --field anthropic_api_key --label "Anthropic API Key"`.
 - **(c) Use their Claude subscription** - run `claude setup-token`, then `assistant credentials prompt --service acp --field claude_oauth_token --label "Claude OAuth Token"`. Heads-up: using a subscription OAuth token in a third-party tool is something Anthropic restricts; the API key is the supported path.
 

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -48,13 +48,17 @@ bun add -g @zed-industries/codex-acp               # codex
 
 ## Claude setup
 
-The `claude-agent-acp` adapter requires a Claude OAuth token. Store it once in the credential store and every spawn injects it as `CLAUDE_CODE_OAUTH_TOKEN` automatically:
+The `claude-agent-acp` adapter needs a credential. The preferred one is an Anthropic API key at `acp/anthropic_api_key`; a Claude subscription OAuth token at `acp/claude_oauth_token` is the fallback. Every spawn injects whichever is set, so store it once.
 
-```bash
-assistant credentials set --service acp --field claude_oauth_token <token>
-```
+On the first ACP use, establish auth as a first-run moment - do it up front, not as a mid-task auth wall. First run `assistant credentials list` to detect an existing `anthropic/api_key`, then ask the user to choose:
 
-When the token is missing, do NOT ask the user to paste it into chat. Collect it via the secure prompt instead: `assistant credentials prompt --service acp --field claude_oauth_token --label "Claude OAuth Token"`. That prompts the user through a secure UI so the token never enters the conversation or the workspace config. Users generate the token by running `claude setup-token` on a machine where they are logged in to Claude.
+- **(a) Reuse the existing Anthropic API key** - offer this only when `anthropic/api_key` exists. Name it by its scrubbed suffix (e.g. "…NgAA"). On yes, grant `acp_spawn` read access to it - no pasting, no reveal.
+- **(b) Paste a new API key** - `assistant credentials prompt --service acp --field anthropic_api_key --label "Anthropic API Key"`.
+- **(c) Use their Claude subscription** - run `claude setup-token`, then `assistant credentials prompt --service acp --field claude_oauth_token --label "Claude OAuth Token"`. Heads-up: using a subscription OAuth token in a third-party tool is something Anthropic restricts; the API key is the supported path.
+
+Collect any pasted secret through the secure prompt so it never enters the conversation or the workspace config - never ask the user to paste into chat, and never `reveal` a key to move it between fields.
+
+Format guard: an `sk-ant-api…` value belongs in `anthropic_api_key`, an `sk-ant-oat…` value in `claude_oauth_token`. The store rejects a mismatch.
 
 ## Codex setup
 

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -66,6 +66,12 @@ export interface AcpSessionUsage {
   costCurrency?: string;
   inputTokens?: number;
   outputTokens?: number;
+  /** Model the adapter reported for the session, if known. */
+  model?: string;
+  /** Cumulative cache-read tokens, when the adapter reports them. */
+  cacheReadTokens?: number;
+  /** Cumulative cache-write tokens, when the adapter reports them. */
+  cacheWriteTokens?: number;
 }
 
 // --- Domain-level union alias (consumed by message-protocol.ts) ---

--- a/assistant/src/persistence/migrations/336-acp-usage-model-cache.test.ts
+++ b/assistant/src/persistence/migrations/336-acp-usage-model-cache.test.ts
@@ -1,0 +1,122 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateAcpSessionHistoryModelCacheColumns } from "./336-acp-usage-model-cache.js";
+
+const NEW_COLUMNS = ["model", "cache_read_tokens", "cache_write_tokens"];
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Post-308 shape: usage + token columns exist, model/cache columns do not.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE acp_session_history (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      acp_session_id TEXT NOT NULL,
+      parent_conversation_id TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      status TEXT NOT NULL,
+      stop_reason TEXT,
+      error TEXT,
+      event_log_json TEXT NOT NULL DEFAULT '[]',
+      cwd TEXT,
+      task TEXT,
+      parent_tool_use_id TEXT,
+      used_tokens INTEGER,
+      context_size INTEGER,
+      cost_amount REAL,
+      cost_currency TEXT,
+      input_tokens INTEGER,
+      output_tokens INTEGER
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function tableInfo(sqlite: Database) {
+  return sqlite.query("PRAGMA table_info(acp_session_history)").all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+}
+
+describe("migration 336: acp_session_history model + cache columns", () => {
+  test("adds the nullable model + cache columns", () => {
+    const { sqlite, db } = createTestDb();
+    const before = tableInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(before).not.toContain(name);
+    }
+
+    migrateAcpSessionHistoryModelCacheColumns(db);
+
+    const after = tableInfo(sqlite);
+    for (const name of NEW_COLUMNS) {
+      const column = after.find((c) => c.name === name);
+      expect(column).toBeDefined();
+      expect(column?.notnull).toBe(0);
+    }
+  });
+
+  test("existing rows read back with null model + cache columns", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO acp_session_history
+        (id, agent_id, acp_session_id, parent_conversation_id, started_at, status)
+      VALUES
+        ('acp-1', 'agent-1', 'sid-1', 'conv-1', 1000, 'completed')
+    `);
+
+    migrateAcpSessionHistoryModelCacheColumns(db);
+
+    const row = sqlite
+      .query(
+        `SELECT ${NEW_COLUMNS.join(", ")} FROM acp_session_history WHERE id = 'acp-1'`,
+      )
+      .get() as Record<string, unknown>;
+    for (const name of NEW_COLUMNS) {
+      expect(row[name]).toBeNull();
+    }
+  });
+
+  test("round-trips an insert that sets the new model + cache columns", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAcpSessionHistoryModelCacheColumns(db);
+
+    sqlite.exec(/*sql*/ `
+      INSERT INTO acp_session_history
+        (id, agent_id, acp_session_id, parent_conversation_id, started_at, status,
+         model, cache_read_tokens, cache_write_tokens)
+      VALUES
+        ('acp-2', 'agent-1', 'sid-2', 'conv-1', 2000, 'completed',
+         'claude-opus-4-8', 900, 300)
+    `);
+
+    const row = sqlite
+      .query(
+        `SELECT ${NEW_COLUMNS.join(", ")} FROM acp_session_history WHERE id = 'acp-2'`,
+      )
+      .get() as Record<string, unknown>;
+    expect(row).toEqual({
+      model: "claude-opus-4-8",
+      cache_read_tokens: 900,
+      cache_write_tokens: 300,
+    });
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateAcpSessionHistoryModelCacheColumns(db);
+    expect(() => migrateAcpSessionHistoryModelCacheColumns(db)).not.toThrow();
+
+    const names = tableInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(names.filter((n) => n === name)).toHaveLength(1);
+    }
+  });
+});

--- a/assistant/src/persistence/migrations/336-acp-usage-model-cache.ts
+++ b/assistant/src/persistence/migrations/336-acp-usage-model-cache.ts
@@ -1,0 +1,33 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+const TABLE = "acp_session_history";
+const COLUMNS: Array<{ name: string; type: string }> = [
+  { name: "model", type: "TEXT" },
+  { name: "cache_read_tokens", type: "INTEGER" },
+  { name: "cache_write_tokens", type: "INTEGER" },
+];
+
+/**
+ * Add nullable model + cache-token columns to `acp_session_history`:
+ * `model`, `cache_read_tokens`, and `cache_write_tokens`. Nullable so rows
+ * persisted before this migration stay NULL.
+ *
+ * Idempotent pure DDL with a PRAGMA guard, no registry entry needed (matches
+ * the 307 / 308 usage-columns pattern).
+ */
+export function migrateAcpSessionHistoryModelCacheColumns(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const columns = raw.query(`PRAGMA table_info(${TABLE})`).all() as Array<{
+    name: string;
+  }>;
+  const columnNames = new Set(columns.map((c) => c.name));
+
+  for (const { name, type } of COLUMNS) {
+    if (!columnNames.has(name)) {
+      raw.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${name} ${type}`);
+    }
+  }
+}

--- a/assistant/src/persistence/schema/acp.ts
+++ b/assistant/src/persistence/schema/acp.ts
@@ -41,6 +41,11 @@ export const acpSessionHistory = sqliteTable(
     // before these columns existed.
     inputTokens: integer("input_tokens"),
     outputTokens: integer("output_tokens"),
+    // Model + cumulative cache tokens for inference-cost attribution. Null
+    // for rows written before these columns existed.
+    model: text("model"),
+    cacheReadTokens: integer("cache_read_tokens"),
+    cacheWriteTokens: integer("cache_write_tokens"),
   },
   (table) => [
     index("idx_acp_session_history_started_at").on(table.startedAt),

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -443,6 +443,7 @@ import { migrateMoveSkillLoadedEventsToTelemetryDb } from "./migrations/332-move
 import { migrateCreateTelemetryEventsTable } from "./migrations/333-create-telemetry-events-table.js";
 import { migrateBackfillTelemetryEventsOutbox } from "./migrations/334-backfill-telemetry-events-outbox.js";
 import { migrateCollapseMemoryEmbedBacklog } from "./migrations/335-collapse-memory-embed-backlog.js";
+import { migrateAcpSessionHistoryModelCacheColumns } from "./migrations/336-acp-usage-model-cache.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1357,4 +1358,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateCreateTelemetryEventsTable,
   migrateBackfillTelemetryEventsOutbox,
   migrateCollapseMemoryEmbedBacklog,
+  migrateAcpSessionHistoryModelCacheColumns,
 ];

--- a/assistant/src/runtime/routes/credential-prompt-routes.ts
+++ b/assistant/src/runtime/routes/credential-prompt-routes.ts
@@ -9,6 +9,10 @@
 import { z } from "zod";
 
 import {
+  AcpCredentialFormatError,
+  assertAcpCredentialFormat,
+} from "../../acp/acp-credentials.js";
+import {
   formatSlackChannelStatus,
   persistPromptedCredential,
 } from "../../credential-execution/prompted-credential.js";
@@ -136,6 +140,22 @@ async function handleCredentialPrompt({ body = {} }: RouteHandlerArgs) {
       };
     }
     return { ok: false, cancelled: true, error: "Cancelled by the user" };
+  }
+
+  // Reject a mismatched ACP token type before persisting, so a stored
+  // credential is never silently placed under the wrong field.
+  try {
+    assertAcpCredentialFormat(validated.service, validated.field, result.value);
+  } catch (err) {
+    if (err instanceof AcpCredentialFormatError) {
+      return {
+        ok: false,
+        error: err.message,
+        service: validated.service,
+        field: validated.field,
+      };
+    }
+    throw err;
   }
 
   const persisted = await persistPromptedCredential({

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -10,6 +10,7 @@
  * POST   /v1/credentials/inspect — inspect a single credential (masked)
  * POST   /v1/credentials/reveal  — reveal a credential's plaintext value
  * POST   /v1/credentials/set     — store a credential with metadata
+ * POST   /v1/credentials/grant   — grant a tool read access (metadata-only)
  * POST   /v1/credentials/delete  — delete a credential, metadata, and OAuth
  * GET    /v1/credentials/status  — show active credential backend info
  */
@@ -427,6 +428,43 @@ async function handleCredentialsSet({ body }: RouteHandlerArgs) {
   };
 }
 
+async function handleCredentialsGrant({ body }: RouteHandlerArgs) {
+  if (!body || typeof body !== "object") {
+    throw new BadRequestError("Request body is required");
+  }
+
+  const { service, field, tool } = body as {
+    service?: string;
+    field?: string;
+    tool?: string;
+  };
+
+  if (!service || typeof service !== "string") {
+    throw new BadRequestError("service is required");
+  }
+  if (!field || typeof field !== "string") {
+    throw new BadRequestError("field is required");
+  }
+  if (!tool || typeof tool !== "string") {
+    throw new BadRequestError("tool is required");
+  }
+
+  assertMetadataWritable();
+
+  // Metadata-only: merge the tool into allowedTools without reading or
+  // rewriting the secret value. Idempotent (a tool already present is a no-op);
+  // a credential with no metadata yet gets one created carrying just this tool.
+  const existing = getCredentialMetadata(service, field);
+  const allowedTools = [...new Set([...(existing?.allowedTools ?? []), tool])];
+  const metadata = upsertCredentialMetadata(service, field, { allowedTools });
+
+  return {
+    service,
+    field,
+    allowedTools: metadata.allowedTools,
+  };
+}
+
 async function handleCredentialsDelete({ body }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
@@ -618,6 +656,32 @@ export const ROUTES: RouteDefinition[] = [
       field: z.string(),
     }),
     handler: handleCredentialsSet,
+  },
+  {
+    operationId: "credentials_grant",
+    endpoint: "credentials/grant",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Grant a tool read access to a credential",
+    description:
+      "Add a tool name to a credential's allowedTools policy so the broker permits that tool to read it. Metadata-only — never reads or rewrites the secret value.",
+    tags: ["credentials"],
+    requestBody: z.object({
+      service: z.string().describe("Service namespace"),
+      field: z.string().describe("Field name"),
+      tool: z.string().describe("Tool name to grant read access"),
+    }),
+    responseBody: z.object({
+      service: z.string(),
+      field: z.string(),
+      allowedTools: z
+        .array(z.string())
+        .describe("The credential's allowedTools after the grant"),
+    }),
+    handler: handleCredentialsGrant,
   },
   {
     operationId: "credentials_delete",

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -17,6 +17,10 @@
 import { z } from "zod";
 
 import {
+  AcpCredentialFormatError,
+  assertAcpCredentialFormat,
+} from "../../acp/acp-credentials.js";
+import {
   fetchManagedCatalog,
   type ManagedCredentialDescriptor,
 } from "../../credential-execution/managed-catalog.js";
@@ -384,6 +388,17 @@ async function handleCredentialsSet({ body }: RouteHandlerArgs) {
   const normalizedValue = normalizeSecretValue(value);
   if (normalizedValue.length === 0) {
     throw new BadRequestError("value is required");
+  }
+
+  // Reject a mismatched ACP token type (e.g. an API key in the OAuth field)
+  // as a clean 400 that routes the user to the correct field.
+  try {
+    assertAcpCredentialFormat(service, field, normalizedValue);
+  } catch (err) {
+    if (err instanceof AcpCredentialFormatError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
   }
 
   assertMetadataWritable();

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -10,6 +10,10 @@
 import { z } from "zod";
 
 import {
+  AcpCredentialFormatError,
+  assertAcpCredentialFormat,
+} from "../../acp/acp-credentials.js";
+import {
   getPlatformAssistantId,
   setPlatformAssistantId,
   setPlatformBaseUrl,
@@ -242,6 +246,18 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
       assertMetadataWritable();
       const service = name.slice(0, colonIdx);
       const field = name.slice(colonIdx + 1);
+
+      // Reject a mismatched ACP token type before storing it, routing the
+      // user to the right field.
+      try {
+        assertAcpCredentialFormat(service, field, value);
+      } catch (err) {
+        if (err instanceof AcpCredentialFormatError) {
+          throw new BadRequestError(err.message);
+        }
+        throw err;
+      }
+
       const key = credentialKey(service, field);
 
       const TRIMMED_IDENTITY_FIELDS = new Set([

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -51,6 +51,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "acp-managed-proxy-routing",
+      "scope": "assistant",
+      "key": "acp-managed-proxy-routing",
+      "label": "ACP Managed Proxy Routing",
+      "description": "Route platform-hosted claude-agent-acp inference through the Vellum runtime proxy via the ACP gateway auth handshake, billing per-assistant so the child needs no Anthropic credential. Off by default; requires a dev-platform live test before enabling.",
+      "defaultEnabled": false
+    },
+    {
       "id": "settings-developer-nav",
       "scope": "assistant",
       "key": "settings-developer-nav",

--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -939,6 +939,14 @@ describe("assistant subcommand classification", () => {
     expect(result.riskLevel).toBe("high");
   });
 
+  test("assistant credentials grant → high", async () => {
+    const result = await classifier.classify({
+      command: "assistant credentials grant",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
   test("assistant keys → low", async () => {
     const result = await classifier.classify({
       command: "assistant keys",

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -448,6 +448,10 @@ describe("command-registry", () => {
       test("assistant credentials delete is high risk", () => {
         expect(credSpec.subcommands!.delete.baseRisk).toBe("high");
       });
+
+      test("assistant credentials grant is high risk", () => {
+        expect(credSpec.subcommands!.grant.baseRisk).toBe("high");
+      });
     });
 
     // ── keys subcommand ───────────────────────────────────────────────────

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -116,6 +116,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "credentials prompt",
   "credentials set",
   "credentials delete",
+  "credentials grant",
   "credentials inspect",
   "credentials reveal",
   "credentials status",
@@ -394,6 +395,12 @@ const riskOverrides: AssistantRiskOverride[] = [
     path: "credentials delete",
     risk: "high",
     reason: "Deletes stored credential value",
+  },
+  {
+    path: "credentials grant",
+    risk: "high",
+    reason:
+      "Grants a tool read access to a stored credential — mutates credential access-control policy",
   },
   {
     path: "keys set",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -51,6 +51,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "acp-managed-proxy-routing",
+      "scope": "assistant",
+      "key": "acp-managed-proxy-routing",
+      "label": "ACP Managed Proxy Routing",
+      "description": "Route platform-hosted claude-agent-acp inference through the Vellum runtime proxy via the ACP gateway auth handshake, billing per-assistant so the child needs no Anthropic credential. Off by default; requires a dev-platform live test before enabling.",
+      "defaultEnabled": false
+    },
+    {
       "id": "settings-developer-nav",
       "scope": "assistant",
       "key": "settings-developer-nav",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -3,7 +3,7 @@
   "skills": {
     "acp": {
       "docsSlug": "acp",
-      "sha256": "c87693319cd9e6450e0b136977791e5b6326317e77ac158ac0f4b823b6adeb4f"
+      "sha256": "6753fc3ca5f2f7415066a559713f949d6242f8e9c4345fc2b5923ba86b6aa41c"
     },
     "app-builder": {
       "docsSlug": "app-builder",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -3,7 +3,7 @@
   "skills": {
     "acp": {
       "docsSlug": "acp",
-      "sha256": "877dd2f4a23b94368d8cffaad46d6739dad4dc3c4dadac67688f0fc313b2c210"
+      "sha256": "c87693319cd9e6450e0b136977791e5b6326317e77ac158ac0f4b823b6adeb4f"
     },
     "app-builder": {
       "docsSlug": "app-builder",


### PR DESCRIPTION
## Summary
Moves ACP (`claude-agent-acp`) auth onto Anthropic's ToS-sanctioned paths and makes coding-agent inference cost attributable.

- **Local-hosted:** API-key-first credential injection (prefer `acp/anthropic_api_key`, consented reuse of the shared `anthropic/api_key`, then `acp/claude_oauth_token`), a `credentials grant` command so the "reuse existing key" flow works without pasting/revealing, and a write-time format guard that fixes the original bug (an API key mis-stored in the OAuth field → 401).
- **Platform-hosted:** gateway/proxy-routing behind the `acp-managed-proxy-routing` flag (default OFF) — the child authenticates to the Vellum runtime proxy with the assistant's existing Vellum key, needs no Anthropic credential, and bills per-assistant automatically. **Gated on a dev-platform live test before un-flagging.**
- Optional in-app usage capture enrichment (model + cache tokens) persisted via migration 336.

## Self-review result
PASS after remediation — 4 fresh-eyes passes (external feedback, plan faithfulness, integration, slop) + a focused re-review. Gaps found and fixed: wired the unwired consent helper into a real `credentials grant` route/CLI; consolidated `ACP_SERVICE`; hardened gateway mode to strip config-supplied creds; corrected a test comment.

## PRs merged into this branch
- #38117 ACP skill auth guidance
- #38118 shared ACP credential module
- #38120 ACP usage capture (model + cache tokens)
- #38122 persist usage (migration 336)
- #38123 API-key-first injection (+ consented shared-key reuse)
- #38125 credential format guard (the bug fix)
- #38126 gateway proxy-routing (flagged off)

### Remediation PRs
- #38130 present-tense test comment
- #38132 credentials grant route/CLI + ACP_SERVICE consolidation + gateway cred-strip

## Notes for the reviewer
- **PR #38126 (gateway routing) ships flag-OFF** and requires a dev-platform live test (Agent SDK `anthropic-beta` flags / model rate-cards / `v1/messages`-only path allowlist, esp. under `ANTHROPIC_VIA_VERTEX`) before enabling. See `.private/plans/acp-api-key-auth.md` Phase 2 + the follow-on platform-repo work (not in this PR).
- The subscription-OAuth path remains only as a **local** fallback (informed opt-in). Whether to remove it for cloud is a pending relationship-owner decision — see `.private/acp-claude-code-tos-memo.md`.
- A `plugin-catalog-local` Test failure appears in CI but is **unrelated** (a build-time bundled-manifest count mismatch that also failed the doc-only PRs; `main` is green) — flagging for triage, not caused by this branch.

Part of plan: acp-api-key-auth.md