### PR TITLE
fix(web): show the full message id in the LLM Context Inspector

### DIFF
--- a/clients/web/src/domains/chat/inspector/inspect-page.test.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.test.tsx
@@ -483,7 +483,7 @@ describe("InspectPage — dual-mode chrome", () => {
     expect(html).not.toContain("View all conversation calls");
   });
 
-  test("message mode renders the scoped subtitle, short id, and keeps the filter dropdown", () => {
+  test("message mode renders the scoped subtitle, full id, and keeps the filter dropdown", () => {
     paramsStub = { conversationId: "conv-1" };
     searchParamsMap.set("messageId", "msg-abcdef-1234567890");
     contextStub = {
@@ -505,7 +505,7 @@ describe("InspectPage — dual-mode chrome", () => {
     const html = renderInspector();
 
     expect(html).toContain("Scoped to one message");
-    expect(html).toContain("msg-abcd"); // shortMessageId
+    expect(html).toContain("msg-abcdef-1234567890");
     // The dropdown stays visible in message mode; selecting "All
     // messages" returns to conversation mode.
     expect(html).toContain("Filter to message:");

--- a/clients/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.tsx
@@ -446,14 +446,14 @@ function ScopeSubtitle({
         style={{ color: "var(--content-secondary)" }}
       >
         <span
-          className="inline-flex items-center gap-1"
+          className="inline-flex flex-wrap items-center gap-1"
           style={{ color: "var(--content-default)" }}
         >
           <MessageSquare size={12} aria-hidden />
           {turnPosition
             ? `Scoped to turn ${turnPosition.index} of ${turnPosition.count} · `
             : "Scoped to one message · "}
-          <code>{shortMessageId(messageId)}</code>
+          <code>{messageId}</code>
         </span>
       </p>
     );
@@ -492,7 +492,7 @@ function ScopeControls({
     if (messageId && !built.some((opt) => opt.value === messageId)) {
       built.push({
         value: messageId,
-        label: `Message ${shortMessageId(messageId)}`,
+        label: `Message ${messageId}`,
       });
     }
     return built;
@@ -579,10 +579,6 @@ function previewContent(content: string | undefined | null): string {
   const collapsed = content.replace(/\s+/g, " ").trim();
   if (collapsed.length <= 60) return collapsed;
   return `${collapsed.slice(0, 57)}…`;
-}
-
-function shortMessageId(messageId: string): string {
-  return messageId.length > 12 ? `${messageId.slice(0, 8)}…` : messageId;
 }
 
 interface TurnPosition {


### PR DESCRIPTION
## Summary
- The LLM Context Inspector's scope subtitle ("Scoped to turn N of M · …") rendered the scoped message id through `shortMessageId()`, truncating it to 8 characters (e.g. `019f6446…`); it now renders the full id so it can be read and copied.
- The fallback "Message <id>" option in the message-filter dropdown gets the same treatment, and the now-unused `shortMessageId()` helper is deleted.
- The subtitle span gains `flex-wrap` so the full UUID wraps below the turn label on narrow phone viewports instead of overflowing.

## Original prompt
From a screenshot of the LLM Context Inspector header showing "Scoped to turn 18 of 18 · 019f6446…": the inspector shouldn't truncate the UUID there — it should show the full UUID.