### PR TITLE
feat(web): Show tips toggle in Settings → General

### DIFF
--- a/clients/web/src/domains/settings/components/show-tips-card.test.tsx
+++ b/clients/web/src/domains/settings/components/show-tips-card.test.tsx
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { tipsEnabledStorage } from "@/utils/tips-storage";
+
+import { ShowTipsCard } from "./show-tips-card";
+
+function setProactiveTipsFlag(value: "off" | "on") {
+  act(() => {
+    useClientFeatureFlagStore
+      .getState()
+      .setStringFlags({ proactiveTips: value });
+  });
+}
+
+beforeEach(() => {
+  tipsEnabledStorage.remove();
+  setProactiveTipsFlag("off");
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ShowTipsCard", () => {
+  test("renders nothing when the proactive-tips flag is off", () => {
+    render(<ShowTipsCard />);
+
+    expect(screen.queryByRole("switch", { name: "Show tips" })).toBeNull();
+  });
+
+  test("renders on by default when the flag is on (storage fallback)", () => {
+    setProactiveTipsFlag("on");
+    render(<ShowTipsCard />);
+
+    const toggle = screen.getByRole("switch", { name: "Show tips" });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
+
+  test("reflects a stored disabled value", () => {
+    setProactiveTipsFlag("on");
+    tipsEnabledStorage.save(false);
+    render(<ShowTipsCard />);
+
+    const toggle = screen.getByRole("switch", { name: "Show tips" });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+  });
+
+  test("clicking the toggle writes the new value to storage", () => {
+    setProactiveTipsFlag("on");
+    render(<ShowTipsCard />);
+
+    const toggle = screen.getByRole("switch", { name: "Show tips" });
+    fireEvent.click(toggle);
+
+    expect(tipsEnabledStorage.load()).toBe(false);
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+
+    fireEvent.click(toggle);
+
+    expect(tipsEnabledStorage.load()).toBe(true);
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
+
+  test("reacts to storage writes made outside the component", () => {
+    setProactiveTipsFlag("on");
+    render(<ShowTipsCard />);
+
+    act(() => {
+      tipsEnabledStorage.save(false);
+    });
+
+    const toggle = screen.getByRole("switch", { name: "Show tips" });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+  });
+});

--- a/clients/web/src/domains/settings/components/show-tips-card.tsx
+++ b/clients/web/src/domains/settings/components/show-tips-card.tsx
@@ -1,0 +1,32 @@
+import { DetailCard } from "@/components/detail-card";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { tipsEnabledStorage } from "@/utils/tips-storage";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+export function ShowTipsCard() {
+  const proactiveTips =
+    useClientFeatureFlagStore.use.stringFlags().proactiveTips;
+  const enabled = tipsEnabledStorage.useValue();
+
+  if (proactiveTips !== "on") {
+    return null;
+  }
+
+  return (
+    <DetailCard
+      title="Tips"
+      subtitle="Occasional tips in the sidebar that highlight features you haven't tried yet."
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-body-medium-lighter text-[var(--content-default)]">
+          Show tips
+        </div>
+        <Toggle
+          checked={enabled}
+          onChange={tipsEnabledStorage.save}
+          aria-label="Show tips"
+        />
+      </div>
+    </DetailCard>
+  );
+}

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -21,6 +21,7 @@ import { PreferencesModal } from "@/domains/settings/components/preferences-moda
 import { PreviewReleaseChannel } from "@/domains/settings/components/preview-release-channel";
 import { ResizeCard } from "@/domains/settings/components/resize-card";
 import { RetireAssistant } from "@/domains/settings/components/retire-assistant";
+import { ShowTipsCard } from "@/domains/settings/components/show-tips-card";
 import { TimezoneSection } from "@/domains/settings/components/timezone-section";
 import { UpdateWindowModal } from "@/domains/settings/components/update-window-modal";
 import { TwoFactorSection } from "@/domains/settings/security/two-factor-section";
@@ -284,6 +285,8 @@ export function GeneralPage() {
       )}
 
       <AppearanceCard />
+
+      <ShowTipsCard />
 
       {infraGate === "full" && assistant && (
         <ResizeCard


### PR DESCRIPTION
## Summary
- Adds a flag-gated Tips card with a reactive Show-tips Toggle to Settings → General, backed by tipsEnabledStorage
- Target of the sidebar tip card's Don't-show-again link (PR 5)

Part of plan: proactive-tips-v1.md (PR 7 of 7)