### PR TITLE
feat(web): sidebar TipCard component and useTipCard orchestration hook

### DIFF
--- a/clients/web/src/components/tips/sidebar-tip-card.tsx
+++ b/clients/web/src/components/tips/sidebar-tip-card.tsx
@@ -1,0 +1,26 @@
+/**
+ * Connected proactive tip card — the single component the sidebar mounts.
+ * `useTipCard` owns every gate and returns `tip: null` when nothing should
+ * show, so this renders nothing until a tip is due.
+ */
+
+import { useTipCard } from "@/hooks/use-tip-card";
+
+import { TipCard } from "./tip-card";
+
+export function SidebarTipCard() {
+  const { tip, onDismiss, onLearnMore, onDontShowAgain } = useTipCard();
+
+  if (!tip) {
+    return null;
+  }
+
+  return (
+    <TipCard
+      tip={tip}
+      onDismiss={onDismiss}
+      onLearnMore={onLearnMore}
+      onDontShowAgain={onDontShowAgain}
+    />
+  );
+}

--- a/clients/web/src/components/tips/tip-card.test.tsx
+++ b/clients/web/src/components/tips/tip-card.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for `TipCard` — the presentational tip card. The design-library
+ * `Notice` is mocked to a minimal stand-in exposing the same contract
+ * (children, actions, tone, onDismiss), mirroring `nudge-chat-banner.test.tsx`;
+ * the card renders inside a `MemoryRouter` (it emits a react-router `<Link>`
+ * and navigates on "Don't show again"), via `@testing-library/react` on
+ * happy-dom.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { type ReactNode } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router";
+
+import { routes } from "@/utils/routes";
+import type { Tip } from "@/utils/tips-catalog";
+
+mock.module("@vellumai/design-library", () => ({
+  Notice: ({
+    children,
+    actions,
+    tone,
+    onDismiss,
+  }: {
+    children?: ReactNode;
+    actions?: ReactNode;
+    tone?: string;
+    onDismiss?: () => void;
+  }) => (
+    <div data-testid="notice" data-tone={tone}>
+      {children}
+      {actions ? <div data-testid="notice-actions">{actions}</div> : null}
+      {onDismiss ? (
+        <button type="button" aria-label="Dismiss" onClick={onDismiss} />
+      ) : null}
+    </div>
+  ),
+}));
+
+const { TipCard } = await import("@/components/tips/tip-card");
+
+const LINKED_TIP: Tip = {
+  id: "what-are-skills",
+  kind: "info",
+  source: "curated",
+  body: "Skills are how I learn new abilities.",
+  learnMore: { label: "Browse skills", to: routes.skills.root },
+};
+
+const PLAIN_TIP: Tip = {
+  id: "app-builder",
+  kind: "info",
+  source: "curated",
+  body: "Ask me to build you a tracker or dashboard.",
+};
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+function renderCard(
+  tip: Tip,
+  handlers?: Partial<{
+    onDismiss: () => void;
+    onLearnMore: () => void;
+    onDontShowAgain: () => void;
+  }>,
+) {
+  return render(
+    <MemoryRouter initialEntries={[routes.assistant]}>
+      <TipCard
+        tip={tip}
+        onDismiss={handlers?.onDismiss ?? (() => {})}
+        onLearnMore={handlers?.onLearnMore ?? (() => {})}
+        onDontShowAgain={handlers?.onDontShowAgain ?? (() => {})}
+      />
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TipCard", () => {
+  test("renders the tip body in a hint-tone notice", () => {
+    const { getByText, getByTestId } = renderCard(LINKED_TIP);
+
+    expect(getByText(LINKED_TIP.body)).not.toBeNull();
+    expect(getByTestId("notice").getAttribute("data-tone")).toBe("hint");
+  });
+
+  test("renders the learn-more link with the catalog label and target", () => {
+    const onLearnMore = mock(() => {});
+    const { getByText } = renderCard(LINKED_TIP, { onLearnMore });
+
+    const link = getByText("Browse skills").closest("a");
+    expect(link?.getAttribute("href")).toBe(routes.skills.root);
+
+    fireEvent.click(getByText("Browse skills"));
+    expect(onLearnMore).toHaveBeenCalledTimes(1);
+  });
+
+  test("omits the learn-more link for tips without one", () => {
+    const { container, getByText } = renderCard(PLAIN_TIP);
+
+    expect(container.querySelector("a")).toBeNull();
+    expect(getByText("Don't show again")).not.toBeNull();
+  });
+
+  test("forwards dismissal through the Notice close affordance", () => {
+    const onDismiss = mock(() => {});
+    const { getByLabelText } = renderCard(LINKED_TIP, { onDismiss });
+
+    fireEvent.click(getByLabelText("Dismiss"));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test("don't show again fires the callback and navigates to Settings General", () => {
+    const onDontShowAgain = mock(() => {});
+    const { getByText, getByTestId } = renderCard(LINKED_TIP, {
+      onDontShowAgain,
+    });
+
+    fireEvent.click(getByText("Don't show again"));
+
+    expect(onDontShowAgain).toHaveBeenCalledTimes(1);
+    expect(getByTestId("location").textContent).toBe(routes.settings.general);
+  });
+});

--- a/clients/web/src/components/tips/tip-card.tsx
+++ b/clients/web/src/components/tips/tip-card.tsx
@@ -1,0 +1,66 @@
+/**
+ * Presentational proactive tip card — props in, callbacks out. All gating,
+ * selection, persistence, and telemetry live in `useTipCard`
+ * (`hooks/use-tip-card.ts`); this component only renders the tip it is given.
+ *
+ * Sized for the narrow sidebar: the Notice row wraps so the actions land on
+ * their own line under the body instead of crushing it.
+ */
+
+import { Link, useNavigate } from "react-router";
+
+import { Notice } from "@vellumai/design-library";
+
+import { routes } from "@/utils/routes";
+import type { Tip } from "@/utils/tips-catalog";
+
+export interface TipCardProps {
+  tip: Tip;
+  onDismiss: () => void;
+  onLearnMore: () => void;
+  onDontShowAgain: () => void;
+}
+
+export function TipCard({
+  tip,
+  onDismiss,
+  onLearnMore,
+  onDontShowAgain,
+}: TipCardProps) {
+  const navigate = useNavigate();
+
+  return (
+    <Notice
+      tone="hint"
+      onDismiss={onDismiss}
+      className="flex-wrap gap-2 p-2.5"
+      actions={
+        <>
+          {tip.learnMore ? (
+            <Link
+              data-slot="tip-card-learn-more"
+              to={tip.learnMore.to}
+              onClick={onLearnMore}
+              className="text-body-small-default whitespace-nowrap text-[color:var(--content-secondary)] hover:text-[color:var(--content-emphasised)] hover:underline"
+            >
+              {tip.learnMore.label}
+            </Link>
+          ) : null}
+          <button
+            type="button"
+            data-slot="tip-card-dont-show-again"
+            onClick={() => {
+              onDontShowAgain();
+              navigate(routes.settings.general);
+            }}
+            className="text-body-small-default cursor-pointer whitespace-nowrap text-[color:var(--content-tertiary)] hover:text-[color:var(--content-secondary)] hover:underline"
+          >
+            Don&apos;t show again
+          </button>
+        </>
+      }
+    >
+      {tip.body}
+    </Notice>
+  );
+}

--- a/clients/web/src/hooks/use-tip-card.test.ts
+++ b/clients/web/src/hooks/use-tip-card.test.ts
@@ -22,7 +22,9 @@ const { useClientFeatureFlagStore } = await import(
   "@/stores/client-feature-flag-store"
 );
 const { TIPS_CATALOG } = await import("@/utils/tips-catalog");
-const { TIPS_MIN_ACCOUNT_AGE_MS } = await import("@/utils/tips-selection");
+const { TIP_ROTATION_INTERVAL_MS, TIPS_MIN_ACCOUNT_AGE_MS } = await import(
+  "@/utils/tips-selection"
+);
 const {
   recordTipDismissed,
   tipRecordsStorage,
@@ -31,6 +33,9 @@ const {
 } = await import("@/utils/tips-storage");
 
 const FIRST_TIP_ID = TIPS_CATALOG[0].id;
+// Successor on web once the first tip is dismissed: next tip that passes
+// gates in this environment (no Electron, no flags, no plugins surface).
+const SECOND_UNGATED_TIP_ID = TIPS_CATALOG.filter((tip) => !tip.gates)[1].id;
 
 function setFlag(value: "on" | "off") {
   useClientFeatureFlagStore.getState().setStringFlags({ proactiveTips: value });
@@ -150,6 +155,47 @@ describe("useTipCard selection and impressions", () => {
       useAssistantFeatureFlagStore.getState().setFlags({ voiceMode: true });
     });
     expect(result.current.tip?.id).toBe("voice-mode");
+  });
+});
+
+describe("useTipCard rotation", () => {
+  test("shows a dismissed tip's successor when the window elapses while mounted", async () => {
+    openAllGates();
+    const { result } = renderHook(() => useTipCard());
+    expect(result.current.tip?.id).toBe(FIRST_TIP_ID);
+
+    act(() => {
+      result.current.onDismiss();
+    });
+    expect(result.current.tip).toBeNull();
+
+    // Rewind the stamped record so the rotation boundary (lastShownAt +
+    // window) lands ~40ms of real time from now; the hook reschedules its
+    // boundary timer off the records change. Bun's setSystemTime doesn't
+    // advance setTimeout, so the test rides a short real timer instead.
+    act(() => {
+      const record = tipRecordsStorage.load()[FIRST_TIP_ID];
+      tipRecordsStorage.save({
+        [FIRST_TIP_ID]: {
+          ...record,
+          shownCount: record?.shownCount ?? 1,
+          lastShownAt: Date.now() - TIP_ROTATION_INTERVAL_MS + 40,
+        },
+      });
+    });
+    // Still within the window: the slot stays blank until the boundary.
+    expect(result.current.tip).toBeNull();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    });
+
+    // No remount: the boundary timer refreshed the clock and the successor
+    // took the slot (and stamped its own impression).
+    expect(result.current.tip?.id).toBe(SECOND_UNGATED_TIP_ID);
+    expect(
+      tipRecordsStorage.load()[SECOND_UNGATED_TIP_ID]?.lastShownAt,
+    ).toBeGreaterThan(0);
   });
 });
 

--- a/clients/web/src/hooks/use-tip-card.test.ts
+++ b/clients/web/src/hooks/use-tip-card.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for `useTipCard` — the orchestration hook behind the sidebar tip
+ * card. Gates (flag, preference, banner exclusivity, new-user grace) are
+ * driven through the real stores/storage; only telemetry is mocked so
+ * emissions can be asserted without the onboarding funnel pipeline.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+const emitTipEvent = mock(() => {});
+mock.module("@/utils/tips-telemetry", () => ({ emitTipEvent }));
+
+const { useTipCard } = await import("@/hooks/use-tip-card");
+const { useAssistantFeatureFlagStore } = await import(
+  "@/stores/assistant-feature-flag-store"
+);
+const { useBannerVisibilityStore } = await import(
+  "@/stores/banner-visibility-store"
+);
+const { useClientFeatureFlagStore } = await import(
+  "@/stores/client-feature-flag-store"
+);
+const { TIPS_CATALOG } = await import("@/utils/tips-catalog");
+const { TIPS_MIN_ACCOUNT_AGE_MS } = await import("@/utils/tips-selection");
+const {
+  recordTipDismissed,
+  tipRecordsStorage,
+  tipsEnabledStorage,
+  tipsFirstSeenAtStorage,
+} = await import("@/utils/tips-storage");
+
+const FIRST_TIP_ID = TIPS_CATALOG[0].id;
+
+function setFlag(value: "on" | "off") {
+  useClientFeatureFlagStore.getState().setStringFlags({ proactiveTips: value });
+}
+
+/** Stamp first-seen far enough in the past that the new-user grace has run. */
+function stampAgedFirstSeen() {
+  tipsFirstSeenAtStorage.save(Date.now() - TIPS_MIN_ACCOUNT_AGE_MS - 60_000);
+}
+
+/** Flag on + aged first-seen — tips enabled is the storage default (true). */
+function openAllGates() {
+  setFlag("on");
+  stampAgedFirstSeen();
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  setFlag("off");
+  useAssistantFeatureFlagStore.getState().resetForAssistantSwitch();
+  useBannerVisibilityStore.setState({ visibleBannerCount: 0 });
+  emitTipEvent.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("useTipCard gates", () => {
+  test("returns null while the proactive-tips flag is off", () => {
+    stampAgedFirstSeen();
+
+    const { result } = renderHook(() => useTipCard());
+
+    expect(result.current.tip).toBeNull();
+    expect(emitTipEvent).not.toHaveBeenCalled();
+  });
+
+  test("returns null when the user disabled tips", () => {
+    openAllGates();
+    tipsEnabledStorage.save(false);
+
+    const { result } = renderHook(() => useTipCard());
+
+    expect(result.current.tip).toBeNull();
+    expect(emitTipEvent).not.toHaveBeenCalled();
+  });
+
+  test("hides while a nudge banner is visible and reappears when it unregisters", () => {
+    openAllGates();
+    act(() => {
+      useBannerVisibilityStore.getState().registerVisibleBanner();
+    });
+
+    const { result } = renderHook(() => useTipCard());
+    expect(result.current.tip).toBeNull();
+
+    act(() => {
+      useBannerVisibilityStore.getState().unregisterVisibleBanner();
+    });
+    expect(result.current.tip?.id).toBe(FIRST_TIP_ID);
+  });
+
+  test("returns null during the new-user grace and stamps first-seen", () => {
+    setFlag("on");
+
+    const { result } = renderHook(() => useTipCard());
+
+    expect(result.current.tip).toBeNull();
+    expect(tipsFirstSeenAtStorage.load()).toBeGreaterThan(0);
+    expect(emitTipEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("useTipCard selection and impressions", () => {
+  test("selects the first catalog tip and records the impression", () => {
+    openAllGates();
+
+    const { result } = renderHook(() => useTipCard());
+
+    expect(result.current.tip?.id).toBe(FIRST_TIP_ID);
+    const record = tipRecordsStorage.load()[FIRST_TIP_ID];
+    expect(record?.lastShownAt).toBeGreaterThan(0);
+    expect(record?.shownCount).toBe(1);
+    expect(emitTipEvent).toHaveBeenCalledTimes(1);
+    expect(emitTipEvent).toHaveBeenCalledWith(FIRST_TIP_ID, "impression", "on");
+  });
+
+  test("emits the impression at most once per rotation window across remounts", () => {
+    openAllGates();
+
+    const first = renderHook(() => useTipCard());
+    expect(emitTipEvent).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    const second = renderHook(() => useTipCard());
+    expect(second.result.current.tip?.id).toBe(FIRST_TIP_ID);
+    expect(emitTipEvent).toHaveBeenCalledTimes(1);
+    expect(tipRecordsStorage.load()[FIRST_TIP_ID]?.shownCount).toBe(1);
+  });
+
+  test("excludes gated tips whose requirements fail and includes them when met", () => {
+    openAllGates();
+    // Exhaust every ungated tip; on web the electron/flag/plugins-gated
+    // remainder must all be filtered out, leaving nothing to show.
+    const now = Date.now();
+    for (const tip of TIPS_CATALOG.filter((entry) => !entry.gates)) {
+      recordTipDismissed(tip.id, now);
+    }
+
+    const { result } = renderHook(() => useTipCard());
+    expect(result.current.tip).toBeNull();
+
+    // Turning the gating assistant flag on makes the voice tip eligible.
+    act(() => {
+      useAssistantFeatureFlagStore.getState().setFlags({ voiceMode: true });
+    });
+    expect(result.current.tip?.id).toBe("voice-mode");
+  });
+});
+
+describe("useTipCard actions", () => {
+  test("dismiss stamps the record, emits, and blanks the slot for the window", () => {
+    openAllGates();
+    const { result } = renderHook(() => useTipCard());
+    emitTipEvent.mockClear();
+
+    act(() => {
+      result.current.onDismiss();
+    });
+
+    expect(result.current.tip).toBeNull();
+    expect(tipRecordsStorage.load()[FIRST_TIP_ID]?.dismissedAt).toBeGreaterThan(
+      0,
+    );
+    expect(emitTipEvent).toHaveBeenCalledTimes(1);
+    expect(emitTipEvent).toHaveBeenCalledWith(FIRST_TIP_ID, "dismiss", "on");
+  });
+
+  test("learn more emits without hiding the tip", () => {
+    openAllGates();
+    const { result } = renderHook(() => useTipCard());
+    emitTipEvent.mockClear();
+
+    act(() => {
+      result.current.onLearnMore();
+    });
+
+    expect(result.current.tip?.id).toBe(FIRST_TIP_ID);
+    expect(emitTipEvent).toHaveBeenCalledTimes(1);
+    expect(emitTipEvent).toHaveBeenCalledWith(FIRST_TIP_ID, "learn_more", "on");
+  });
+
+  test("don't show again disables tips and emits", () => {
+    openAllGates();
+    const { result } = renderHook(() => useTipCard());
+    emitTipEvent.mockClear();
+
+    act(() => {
+      result.current.onDontShowAgain();
+    });
+
+    expect(result.current.tip).toBeNull();
+    expect(tipsEnabledStorage.load()).toBe(false);
+    expect(emitTipEvent).toHaveBeenCalledTimes(1);
+    expect(emitTipEvent).toHaveBeenCalledWith(
+      FIRST_TIP_ID,
+      "dont_show_again",
+      "on",
+    );
+  });
+});

--- a/clients/web/src/hooks/use-tip-card.ts
+++ b/clients/web/src/hooks/use-tip-card.ts
@@ -86,10 +86,10 @@ export function useTipCard(): UseTipCardResult {
 
   const variant = clientFlagState.stringFlags.proactiveTips ?? "off";
 
-  // Mount-time clock snapshot: reading Date.now() during render is impure
-  // (react-hooks/purity). Selection precision within a mount doesn't matter
-  // for a 24h rotation window; the effects below read the live clock.
-  const [now] = useState(() => Date.now());
+  // Clock state for selection: reading Date.now() during render is impure
+  // (react-hooks/purity), so renders see a snapshot that the rotation-boundary
+  // timer below refreshes whenever the selection outcome can change.
+  const [now, setNow] = useState(() => Date.now());
   const [ageEligible, setAgeEligible] = useState(false);
 
   useEffect(() => {
@@ -113,6 +113,35 @@ export function useTipCard(): UseTipCardResult {
     const timer = setTimeout(() => setAgeEligible(true), remaining);
     return () => clearTimeout(timer);
   }, [firstSeenAt]);
+
+  // Refresh the clock when a rotation window elapses mid-session, so a pinned
+  // tip rotates (or a dismissed tip's successor appears) without a remount.
+  // Selection keys rotation on lastShownAt only, so the next boundary is the
+  // earliest future lastShownAt + window. `now` is a dependency so an
+  // early-firing timer reschedules itself for the remaining delay.
+  useEffect(() => {
+    let nextBoundary = Infinity;
+    for (const record of Object.values(records)) {
+      if (record.lastShownAt === undefined) {
+        continue;
+      }
+      const boundary = record.lastShownAt + TIP_ROTATION_INTERVAL_MS;
+      if (boundary > now && boundary < nextBoundary) {
+        nextBoundary = boundary;
+      }
+    }
+    if (nextBoundary === Infinity) {
+      return;
+    }
+    // Clamp: a skewed lastShownAt could push the delay past setTimeout's
+    // ~24.8-day ceiling; an early fire simply reschedules.
+    const delay = Math.min(
+      Math.max(nextBoundary - Date.now(), 0),
+      TIP_ROTATION_INTERVAL_MS,
+    );
+    const timer = setTimeout(() => setNow(Date.now()), delay);
+    return () => clearTimeout(timer);
+  }, [records, now]);
 
   const gatesOpen =
     variant === "on" && tipsEnabled && !bannerVisible && ageEligible;

--- a/clients/web/src/hooks/use-tip-card.ts
+++ b/clients/web/src/hooks/use-tip-card.ts
@@ -1,0 +1,177 @@
+/**
+ * Orchestration for the proactive tip card: evaluates the surface gates
+ * (feature flag, "show tips" preference, nudge-banner exclusivity, new-user
+ * grace), filters the tips catalog by per-tip gates, selects the current tip
+ * via the cadence policy, and owns persistence + telemetry for impressions
+ * and user actions.
+ *
+ * Rendering lives in `TipCard` (`components/tips/tip-card.tsx`); this hook
+ * returns `tip: null` whenever nothing should show.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { useSupportsPluginsSurface } from "@/lib/backwards-compat/plugins-surface";
+import { isElectron } from "@/runtime/is-electron";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { useBannerVisible } from "@/stores/banner-visibility-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { TIPS_CATALOG, type Tip } from "@/utils/tips-catalog";
+import {
+  selectCurrentTip,
+  TIP_ROTATION_INTERVAL_MS,
+  TIPS_MIN_ACCOUNT_AGE_MS,
+} from "@/utils/tips-selection";
+import {
+  ensureTipsFirstSeenAt,
+  recordTipDismissed,
+  recordTipShown,
+  tipRecordsStorage,
+  tipsEnabledStorage,
+  tipsFirstSeenAtStorage,
+} from "@/utils/tips-storage";
+import { emitTipEvent } from "@/utils/tips-telemetry";
+
+interface TipGateContext {
+  electron: boolean;
+  pluginsSurface: boolean;
+  clientFlags: Record<string, boolean>;
+  assistantFlags: Record<string, boolean>;
+}
+
+function tipPassesGates(tip: Tip, ctx: TipGateContext): boolean {
+  const gates = tip.gates;
+  if (!gates) {
+    return true;
+  }
+  if (gates.requiresElectron && !ctx.electron) {
+    return false;
+  }
+  if (
+    gates.requiresClientFlag &&
+    ctx.clientFlags[gates.requiresClientFlag] !== true
+  ) {
+    return false;
+  }
+  if (
+    gates.requiresAssistantFlag &&
+    ctx.assistantFlags[gates.requiresAssistantFlag] !== true
+  ) {
+    return false;
+  }
+  if (gates.requiresPluginsSurface && !ctx.pluginsSurface) {
+    return false;
+  }
+  return true;
+}
+
+export interface UseTipCardResult {
+  /** The tip to render, or `null` when no tip should show. */
+  tip: Tip | null;
+  onDismiss: () => void;
+  onLearnMore: () => void;
+  onDontShowAgain: () => void;
+}
+
+export function useTipCard(): UseTipCardResult {
+  // Whole-store subscriptions: tip gates reference flags by dynamic key, so
+  // per-key selectors can't be used (same pattern as the feature-flags panel).
+  const clientFlagState = useClientFeatureFlagStore();
+  const assistantFlagState = useAssistantFeatureFlagStore();
+  const bannerVisible = useBannerVisible();
+  const supportsPluginsSurface = useSupportsPluginsSurface();
+  const tipsEnabled = tipsEnabledStorage.useValue();
+  const records = tipRecordsStorage.useValue();
+  const firstSeenAt = tipsFirstSeenAtStorage.useValue();
+
+  const variant = clientFlagState.stringFlags.proactiveTips ?? "off";
+
+  // Mount-time clock snapshot: reading Date.now() during render is impure
+  // (react-hooks/purity). Selection precision within a mount doesn't matter
+  // for a 24h rotation window; the effects below read the live clock.
+  const [now] = useState(() => Date.now());
+  const [ageEligible, setAgeEligible] = useState(false);
+
+  useEffect(() => {
+    ensureTipsFirstSeenAt();
+  }, []);
+
+  // Flip eligibility mid-session once the age threshold elapses. For a 24h
+  // gate this rarely fires in-session; the recompute below runs again on the
+  // user's next visit, which is the real trigger.
+  useEffect(() => {
+    if (firstSeenAt === 0) {
+      setAgeEligible(false);
+      return;
+    }
+    const remaining = TIPS_MIN_ACCOUNT_AGE_MS - (Date.now() - firstSeenAt);
+    if (remaining <= 0) {
+      setAgeEligible(true);
+      return;
+    }
+    setAgeEligible(false);
+    const timer = setTimeout(() => setAgeEligible(true), remaining);
+    return () => clearTimeout(timer);
+  }, [firstSeenAt]);
+
+  const gatesOpen =
+    variant === "on" && tipsEnabled && !bannerVisible && ageEligible;
+
+  const eligibleCatalog = TIPS_CATALOG.filter((tip) =>
+    tipPassesGates(tip, {
+      electron: isElectron(),
+      pluginsSurface: supportsPluginsSurface,
+      clientFlags: clientFlagState,
+      assistantFlags: assistantFlagState,
+    }),
+  );
+
+  const tip = gatesOpen
+    ? selectCurrentTip(eligibleCatalog, records, now)
+    : null;
+  const tipId = tip?.id ?? null;
+
+  // Impression stamping is driven off the persisted record (not component
+  // lifecycle), so remounts and re-renders within a rotation window never
+  // double-count: a tip already shown within the window is skipped.
+  useEffect(() => {
+    if (tipId === null) {
+      return;
+    }
+    const shownAt = Date.now();
+    const record = tipRecordsStorage.load()[tipId];
+    const shownWithinWindow =
+      record?.lastShownAt !== undefined &&
+      shownAt - record.lastShownAt < TIP_ROTATION_INTERVAL_MS;
+    if (shownWithinWindow) {
+      return;
+    }
+    recordTipShown(tipId, shownAt);
+    emitTipEvent(tipId, "impression", variant);
+  }, [tipId, variant]);
+
+  const onDismiss = useCallback(() => {
+    if (tipId === null) {
+      return;
+    }
+    recordTipDismissed(tipId, Date.now());
+    emitTipEvent(tipId, "dismiss", variant);
+  }, [tipId, variant]);
+
+  const onLearnMore = useCallback(() => {
+    if (tipId === null) {
+      return;
+    }
+    emitTipEvent(tipId, "learn_more", variant);
+  }, [tipId, variant]);
+
+  const onDontShowAgain = useCallback(() => {
+    if (tipId === null) {
+      return;
+    }
+    tipsEnabledStorage.save(false);
+    emitTipEvent(tipId, "dont_show_again", variant);
+  }, [tipId, variant]);
+
+  return { tip, onDismiss, onLearnMore, onDontShowAgain };
+}


### PR DESCRIPTION
## Summary
- Presentational TipCard (Notice hint tone, Learn more link, Don't-show-again → Settings)
- useTipCard hook: flag/enabled/banner-exclusivity/new-user-grace gates, catalog gate filtering, cadence selection, impression/dismiss telemetry
- SidebarTipCard one-line composition for the sidebar slot (next PR)

Part of plan: proactive-tips-v1.md (PR 5 of 7)