### PR TITLE
feat(web): render TipCard above the Preferences footer in the sidebar

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -71,6 +71,7 @@ import { requestComposerFocus } from "./composer-focus";
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { RuntimeUpgradeBanner } from "@/components/runtime-upgrade-banner";
 import { StatusBanner } from "@/components/status-banner";
+import { SidebarTipCard } from "@/components/tips/sidebar-tip-card";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
 import { useCommandPaletteOrchestrator } from "@/domains/chat/hooks/use-command-palette-orchestrator";
@@ -724,6 +725,7 @@ export function ChatLayout() {
           triggerVariant={args.variant === "overlay" ? "pill" : "item"}
         />
       }
+      tipCard={<SidebarTipCard />}
       onClose={args.onClose}
     />
   );

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -330,6 +331,129 @@ describe("AssistantSideMenu · tipCard slot", () => {
     const html = renderMenu({ conversations, variant: "overlay" });
 
     expect(html).not.toContain("empty:hidden");
+  });
+});
+
+describe("AssistantSideMenu · overlay bottom scroll reserve", () => {
+  const conversations = [
+    makeConversation({ conversationId: "a", title: "Alpha" }),
+  ];
+
+  const sliceBodyOpeningTag = (html: string): string => {
+    const slotIndex = html.indexOf('data-slot="side-menu-body"');
+    expect(slotIndex).toBeGreaterThanOrEqual(0);
+    const open = html.lastIndexOf("<div", slotIndex);
+    const close = html.indexOf(">", slotIndex);
+    return html.slice(open, close + 1);
+  };
+
+  test("overlay static markup keeps the pb-24 fallback (layout effects don't run in static rendering)", () => {
+    const tag = sliceBodyOpeningTag(
+      renderMenu({ conversations, variant: "overlay", includeTipCard: true }),
+    );
+
+    expect(tag).toContain("pb-24");
+    expect(tag).not.toContain("padding-bottom");
+  });
+
+  test("rail body reserves no bottom padding", () => {
+    const tag = sliceBodyOpeningTag(renderMenu({ conversations }));
+
+    expect(tag).not.toContain("pb-24");
+    expect(tag).not.toContain("padding-bottom");
+  });
+
+  test("reserves the measured floating-column height once mounted", async () => {
+    const originalGetBoundingClientRect =
+      HTMLElement.prototype.getBoundingClientRect;
+    const originalResizeObserver = globalThis.ResizeObserver;
+    let measuredHeight = 132;
+    let resizeCallback: ResizeObserverCallback | null = null;
+
+    // Only the floating-column ref is measured by the reserve effect, so
+    // matching by tip descendant is safe — ancestors are never measured.
+    HTMLElement.prototype.getBoundingClientRect =
+      function getBoundingClientRect() {
+        if (this.querySelector('[data-testid="overlay-tip"]')) {
+          return {
+            bottom: measuredHeight,
+            height: measuredHeight,
+            left: 0,
+            right: 0,
+            top: 0,
+            width: 0,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          };
+        }
+        return originalGetBoundingClientRect.call(this);
+      };
+    // Other components in the tree construct their own ResizeObservers, so
+    // capture the callback of the one observing the floating column rather
+    // than whichever was constructed last.
+    globalThis.ResizeObserver = class {
+      callback: ResizeObserverCallback;
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+      }
+      observe(target: Element) {
+        if (target.querySelector('[data-testid="overlay-tip"]')) {
+          resizeCallback = this.callback;
+        }
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      const { container } = render(
+        createElement(AssistantSideMenu, {
+          assistantId: "asst-1",
+          collapsed: false,
+          variant: "overlay",
+          conversations,
+          onSelectConversation: () => {},
+          onStartNewConversation: () => {},
+          footerAction: createElement("span", null, "Preferences"),
+          tipCard: createElement(
+            "span",
+            { "data-testid": "overlay-tip" },
+            "TipSentinel",
+          ),
+        }),
+      );
+
+      // happy-dom's CSSStyleDeclaration drops values containing `env()`,
+      // so the composed `padding-bottom` calc is unobservable here; the
+      // measured height feeding it is asserted via its custom property,
+      // which happy-dom stores verbatim.
+      const measuredReserve = () => {
+        const body = container.querySelector<HTMLElement>(
+          '[data-slot="side-menu-body"]',
+        );
+        return body?.style.getPropertyValue("--overlay-bottom-column-h") ?? "";
+      };
+
+      await waitFor(() => {
+        expect(measuredReserve()).toBe("132px");
+      });
+
+      // Tip dismissal / copy-length changes resize the column; the
+      // reserve tracks the new height through the ResizeObserver.
+      measuredHeight = 56;
+      act(() => {
+        resizeCallback?.([], {} as ResizeObserver);
+      });
+      await waitFor(() => {
+        expect(measuredReserve()).toBe("56px");
+      });
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect =
+        originalGetBoundingClientRect;
+      globalThis.ResizeObserver = originalResizeObserver;
+      cleanup();
+    }
   });
 });
 

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -50,6 +50,7 @@ function renderMenu(props: {
   collapsed?: boolean;
   variant?: "rail" | "overlay";
   includeFooterAction?: boolean;
+  includeTipCard?: boolean;
 }): string {
   const includeFooterAction = props.includeFooterAction ?? true;
   return renderToStaticMarkup(
@@ -62,6 +63,9 @@ function renderMenu(props: {
       onSelectConversation: () => {},
       footerAction: includeFooterAction
         ? createElement("span", null, "Preferences")
+        : undefined,
+      tipCard: props.includeTipCard
+        ? createElement("span", null, "TipSentinel")
         : undefined,
     }),
   );
@@ -259,6 +263,73 @@ describe("AssistantSideMenu · footer slot behavior", () => {
     const html = renderMenu({ conversations, includeFooterAction: false });
 
     expect(html).not.toContain("Preferences");
+    expect(html).not.toContain('data-slot="side-menu-footer"');
+  });
+});
+
+describe("AssistantSideMenu · tipCard slot", () => {
+  const conversations = [
+    makeConversation({ conversationId: "a", title: "Alpha" }),
+  ];
+
+  test("renders the tip card in the rail footer above the footer action", () => {
+    const html = renderMenu({ conversations, includeTipCard: true });
+
+    const footerIndex = html.indexOf('data-slot="side-menu-footer"');
+    const tipIndex = html.indexOf("TipSentinel");
+    const actionIndex = html.indexOf("Preferences");
+    expect(footerIndex).toBeGreaterThanOrEqual(0);
+    expect(tipIndex).toBeGreaterThan(footerIndex);
+    expect(actionIndex).toBeGreaterThan(tipIndex);
+  });
+
+  test("hides the tip card on the collapsed rail", () => {
+    const html = renderMenu({
+      conversations,
+      collapsed: true,
+      includeTipCard: true,
+    });
+
+    expect(html).not.toContain("TipSentinel");
+    // The footer action still renders when collapsed.
+    expect(html).toContain("Preferences");
+  });
+
+  test("renders the footer when only the tip card is provided", () => {
+    const html = renderMenu({
+      conversations,
+      includeFooterAction: false,
+      includeTipCard: true,
+    });
+
+    expect(html).toContain('data-slot="side-menu-footer"');
+    expect(html).toContain("TipSentinel");
+    expect(html).not.toContain("Preferences");
+  });
+
+  test("renders the tip card in the overlay floating container above the action pills", () => {
+    const html = renderMenu({
+      conversations,
+      variant: "overlay",
+      includeTipCard: true,
+    });
+
+    const tipIndex = html.indexOf("TipSentinel");
+    const actionIndex = html.indexOf("Preferences");
+    expect(tipIndex).toBeGreaterThanOrEqual(0);
+    expect(actionIndex).toBeGreaterThan(tipIndex);
+    // The wrapper re-enables pointer events inside the pointer-events-none
+    // container and collapses when the tip card renders null.
+    const wrapperOpen = html.lastIndexOf("<div", tipIndex);
+    const wrapper = html.slice(wrapperOpen, tipIndex);
+    expect(wrapper).toContain("pointer-events-auto");
+    expect(wrapper).toContain("empty:hidden");
+  });
+
+  test("omits the tip wrapper from the overlay when no tip card is provided", () => {
+    const html = renderMenu({ conversations, variant: "overlay" });
+
+    expect(html).not.toContain("empty:hidden");
   });
 });
 

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -8,7 +8,14 @@ import {
     SquarePen,
     X,
 } from "lucide-react";
-import { useCallback, type ReactNode } from "react";
+import {
+    useCallback,
+    useLayoutEffect,
+    useRef,
+    useState,
+    type CSSProperties,
+    type ReactNode,
+} from "react";
 
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 
@@ -186,6 +193,45 @@ export function AssistantSideMenu({
   const pinnedApps = usePinnedAppsStore.use.pinnedApps();
 
   const isCollapsedRail = collapsed && variant === "rail";
+
+  // --- Overlay bottom reserve ---
+  // The overlay's floating bottom column (tip card + action pills) covers the
+  // scrollable body, so the body reserves matching bottom padding to keep the
+  // last conversation rows scrollable clear of it. Measured (not static)
+  // because the tip card appears/disappears and its copy length varies.
+  const overlayBottomColumnRef = useRef<HTMLDivElement | null>(null);
+  const [overlayBottomColumnHeight, setOverlayBottomColumnHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    if (variant !== "overlay") {
+      setOverlayBottomColumnHeight(0);
+      return;
+    }
+
+    const el = overlayBottomColumnRef.current;
+    if (!el) {
+      return;
+    }
+
+    const updateHeight = () => {
+      const nextHeight = Math.ceil(el.getBoundingClientRect().height);
+      setOverlayBottomColumnHeight((currentHeight) =>
+        currentHeight === nextHeight ? currentHeight : nextHeight,
+      );
+    };
+
+    updateHeight();
+
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(el);
+    return () => observer.disconnect();
+    // `tipCard` re-runs the initial measure on card mount/unmount as a
+    // fallback for environments without ResizeObserver.
+  }, [variant, tipCard]);
 
   // --- Drag-reorder (Pinned + custom groups; sections sorted by displayOrder) ---
 
@@ -368,10 +414,23 @@ export function AssistantSideMenu({
         <SideMenu.Body
           className={
             variant === "overlay"
-              /* pb-24 keeps the last rows scrollable clear of the floating
-                 action pills. */
+              /* pb-24 approximates the floating-column reserve until the
+                 measured inline padding below takes over (layout effects
+                 don't run in static/server markup). */
               ? "gap-4 pt-3 pb-24 max-md:pt-4"
               : "gap-4 pt-3 max-md:pt-4"
+          }
+          style={
+            variant === "overlay" && overlayBottomColumnHeight > 0
+              ? {
+                  /* The floating column overlaps the scrollport by its own
+                     height + the safe-area inset (its 1rem bottom offset
+                     cancels against the root's p-4); + 1rem breathing gap. */
+                  "--overlay-bottom-column-h": `${overlayBottomColumnHeight}px`,
+                  paddingBottom:
+                    "calc(var(--overlay-bottom-column-h) + 1rem + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))",
+                } as CSSProperties
+              : undefined
           }
         >
           {variant === "overlay" ? builtInNav : null}
@@ -525,6 +584,7 @@ export function AssistantSideMenu({
              while letting their drop shadows fade out naturally instead of
              being clipped at a safe-area boundary. */
           <div
+            ref={overlayBottomColumnRef}
             className="pointer-events-none absolute inset-x-4 z-10 flex flex-col gap-4"
             style={{
               bottom:

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -59,6 +59,11 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   activeAppId?: string;
   onStartNewConversation?: () => void;
   footerAction?: ReactNode;
+  /**
+   * Rendered above `footerAction` in the rail footer (hidden when collapsed)
+   * and above the floating action pills on the overlay.
+   */
+  tipCard?: ReactNode;
   onClose?: () => void;
 
   onPinConversation?: (conversation: Conversation) => void;
@@ -121,6 +126,7 @@ function SearchButton() {
  *                        (Slack, Telegram, WhatsApp, …)
  *   Footer
  *     • ───────────────
+ *     • caller-provided tip card (SidebarTipCard) — hidden on the collapsed rail
  *     • caller-provided action (PreferencesMenu)
  *
  * The conversation rows, row lists, and collapsible sections are
@@ -149,6 +155,7 @@ export function AssistantSideMenu({
   activeAppId,
   onStartNewConversation,
   footerAction,
+  tipCard,
   onPinConversation,
   onReorderConversations,
   onRenameConversation,
@@ -177,6 +184,8 @@ export function AssistantSideMenu({
   });
 
   const pinnedApps = usePinnedAppsStore.use.pinnedApps();
+
+  const isCollapsedRail = collapsed && variant === "rail";
 
   // --- Drag-reorder (Pinned + custom groups; sections sorted by displayOrder) ---
 
@@ -366,7 +375,7 @@ export function AssistantSideMenu({
           }
         >
           {variant === "overlay" ? builtInNav : null}
-          {collapsed && variant === "rail" ? (
+          {isCollapsedRail ? (
             <div className="flex flex-col items-center gap-2">
               {headerActions}
               {sidebar.pinned.length > 0 ? (
@@ -508,41 +517,50 @@ export function AssistantSideMenu({
         {variant === "overlay" ? (
           /* Overlay: the footer bar is replaced by floating action pills so
              the primary actions sit in the thumb zone without spending two
-             fixed rows (Figma 6764:6745). `pointer-events-none` on the row
-             keeps the list scrollable between/around the pills. The row
-             offsets itself by the bottom safe-area inset because the
-             overlay sheet runs full-bleed to the physical screen edge —
-             this keeps the pills above the home indicator while letting
-             their drop shadows fade out naturally instead of being clipped
-             at a safe-area boundary. */
+             fixed rows (Figma 6764:6745). `pointer-events-none` on the
+             container keeps the list scrollable between/around the pills.
+             The container offsets itself by the bottom safe-area inset
+             because the overlay sheet runs full-bleed to the physical
+             screen edge — this keeps the pills above the home indicator
+             while letting their drop shadows fade out naturally instead of
+             being clipped at a safe-area boundary. */
           <div
-            className="pointer-events-none absolute inset-x-4 z-10 flex items-center justify-center gap-4"
+            className="pointer-events-none absolute inset-x-4 z-10 flex flex-col gap-4"
             style={{
               bottom:
                 "calc(1rem + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))",
             }}
           >
-            {footerAction ? (
-              <div className="pointer-events-auto flex-1">{footerAction}</div>
+            {/* `empty:hidden` collapses the row when the tip card renders
+               null, so the column gap adds no phantom spacing. */}
+            {tipCard ? (
+              <div className="pointer-events-auto empty:hidden">{tipCard}</div>
             ) : null}
-            {onStartNewConversation ? (
-              <Button
-                variant="primary"
-                className="pointer-events-auto h-10 flex-1 rounded-full px-4 shadow-[var(--shadow-lg)]"
-                leftIcon={<SquarePen />}
-                onClick={() => {
-                  onStartNewConversation();
-                  onClose?.();
-                }}
-              >
-                New Chat
-              </Button>
-            ) : null}
+            <div className="flex items-center justify-center gap-4">
+              {footerAction ? (
+                <div className="pointer-events-auto flex-1">{footerAction}</div>
+              ) : null}
+              {onStartNewConversation ? (
+                <Button
+                  variant="primary"
+                  className="pointer-events-auto h-10 flex-1 rounded-full px-4 shadow-[var(--shadow-lg)]"
+                  leftIcon={<SquarePen />}
+                  onClick={() => {
+                    onStartNewConversation();
+                    onClose?.();
+                  }}
+                >
+                  New Chat
+                </Button>
+              ) : null}
+            </div>
           </div>
-        ) : footerAction ? (
+        ) : footerAction || tipCard ? (
           <SideMenu.Footer>
-            {/* The collapsed rail drops the footer divider (per design). */}
-            {collapsed && variant === "rail" ? null : <SideMenu.Separator />}
+            {/* The collapsed rail drops the footer divider and tip card
+               (per design). */}
+            {isCollapsedRail ? null : <SideMenu.Separator />}
+            {isCollapsedRail ? null : tipCard}
             {footerAction}
           </SideMenu.Footer>
         ) : null}


### PR DESCRIPTION
## Summary
- Adds a tipCard slot to AssistantSideMenu: rail footer above Preferences (hidden when collapsed), overlay drawer above the action pills
- ChatLayout mounts SidebarTipCard — the proactive-tips feature is now reachable end-to-end (flag-gated, default off)

Part of plan: proactive-tips-v1.md (PR 6 of 7)