### PR TITLE
fix: sidebar tip overlay polish (plan review)

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -725,7 +725,14 @@ export function ChatLayout() {
           triggerVariant={args.variant === "overlay" ? "pill" : "item"}
         />
       }
-      tipCard={<SidebarTipCard />}
+      // The overlay subtree mounts mid edge-swipe while still off-screen;
+      // mounting the tip card there stamps an impression for a tip never
+      // seen, so the overlay only gets it once the drawer settles open.
+      tipCard={
+        args.variant === "overlay" && !drawerOpen ? undefined : (
+          <SidebarTipCard />
+        )
+      }
       onClose={args.onClose}
     />
   );

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -347,15 +347,6 @@ describe("AssistantSideMenu · overlay bottom scroll reserve", () => {
     return html.slice(open, close + 1);
   };
 
-  test("overlay static markup keeps the pb-24 fallback (layout effects don't run in static rendering)", () => {
-    const tag = sliceBodyOpeningTag(
-      renderMenu({ conversations, variant: "overlay", includeTipCard: true }),
-    );
-
-    expect(tag).toContain("pb-24");
-    expect(tag).not.toContain("padding-bottom");
-  });
-
   test("rail body reserves no bottom padding", () => {
     const tag = sliceBodyOpeningTag(renderMenu({ conversations }));
 

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -229,9 +229,7 @@ export function AssistantSideMenu({
     const observer = new ResizeObserver(updateHeight);
     observer.observe(el);
     return () => observer.disconnect();
-    // `tipCard` re-runs the initial measure on card mount/unmount as a
-    // fallback for environments without ResizeObserver.
-  }, [variant, tipCard]);
+  }, [variant]);
 
   // --- Drag-reorder (Pinned + custom groups; sections sorted by displayOrder) ---
 
@@ -414,9 +412,8 @@ export function AssistantSideMenu({
         <SideMenu.Body
           className={
             variant === "overlay"
-              /* pb-24 approximates the floating-column reserve until the
-                 measured inline padding below takes over (layout effects
-                 don't run in static/server markup). */
+              /* pb-24 is a coarse floating-column reserve until the measured
+                 inline padding below is applied. */
               ? "gap-4 pt-3 pb-24 max-md:pt-4"
               : "gap-4 pt-3 max-md:pt-4"
           }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review for proactive-tips-v1.md:
- Overlay reserve effect no longer keys on unstable tipCard element (ResizeObserver churn) and its comment is corrected
- Mobile overlay passes tipCard only when the drawer is settled open — abandoned edge-swipes no longer stamp impressions
- Removed the self-referential pb-24 fallback test