### PR TITLE
fix: flag-catalog and banner-store hygiene (plan review)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -18,10 +18,7 @@ import { type ButtonHTMLAttributes, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { ChatBodyProps } from "@/domains/chat/components/chat-body";
-import {
-  isBannerVisible,
-  useBannerVisibilityStore,
-} from "@/stores/banner-visibility-store";
+import { useBannerVisibilityStore } from "@/stores/banner-visibility-store";
 
 // Stub child components that require browser APIs or complex hooks.
 // NOTE: Do NOT mock chat-scroll-area itself — that leaks across test
@@ -309,7 +306,7 @@ describe("ChatBody — banner-visibility store mirroring", () => {
   // clobbering each other.
   const bannerSlot = <div data-testid="banner">BANNER_CONTENT</div>;
   const visible = () =>
-    isBannerVisible(useBannerVisibilityStore.getState().visibleBannerCount);
+    useBannerVisibilityStore.getState().visibleBannerCount > 0;
 
   beforeEach(() => {
     useBannerVisibilityStore.setState({ visibleBannerCount: 0 });

--- a/clients/web/src/domains/chat/hooks/use-chat-banner-slots.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-banner-slots.test.tsx
@@ -1,8 +1,6 @@
 /**
  * Tests that `useChatBannerSlots` builds the main banner slot from the nudge
- * flags. Banner *visibility* is mirrored into the shared store by `ChatBody`
- * (which owns the actual mount conditions), not by this hook — see
- * `chat-body.test.tsx`.
+ * state: any active nudge flag yields a slot node, none yields null.
  *
  * The banner components and queued drawer are stubbed via `mock.module` so
  * the test stays focused on the slot construction logic.

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -149,6 +149,51 @@ describe("getEnvFlagOverridesForScope", () => {
     }
   });
 
+  test("matches string-flag env arms case-insensitively and stores the canonical arm", () => {
+    (globalThis as Record<string, unknown>).window = undefined;
+    process.env.VITE_VELLUM_FLAG_PROACTIVE_TIPS = "ON";
+    try {
+      resetEnvOverridesCache();
+      expect(getEnvFlagOverridesForScope("client").str.proactiveTips).toBe(
+        "on",
+      );
+
+      process.env.VITE_VELLUM_FLAG_PROACTIVE_TIPS = "On";
+      resetEnvOverridesCache();
+      expect(getEnvFlagOverridesForScope("client").str.proactiveTips).toBe(
+        "on",
+      );
+    } finally {
+      delete process.env.VITE_VELLUM_FLAG_PROACTIVE_TIPS;
+    }
+  });
+
+  test("drops string-flag env values that match no declared arm", () => {
+    (globalThis as Record<string, unknown>).window = undefined;
+    process.env.VITE_VELLUM_FLAG_PROACTIVE_TIPS = "bogus";
+    try {
+      resetEnvOverridesCache();
+      const result = getEnvFlagOverridesForScope("client");
+      expect(result.str).not.toHaveProperty("proactiveTips");
+      expect(result.bool).not.toHaveProperty("proactiveTips");
+    } finally {
+      delete process.env.VITE_VELLUM_FLAG_PROACTIVE_TIPS;
+    }
+  });
+
+  test("boolean flags keep case-insensitive env coercion", () => {
+    (globalThis as Record<string, unknown>).window = undefined;
+    process.env.VITE_VELLUM_FLAG_HOME_TAB = "ON";
+    try {
+      resetEnvOverridesCache();
+      const result = getEnvFlagOverridesForScope("client");
+      expect(result.bool.homeTab).toBe(true);
+      expect(result.str).not.toHaveProperty("homeTab");
+    } finally {
+      delete process.env.VITE_VELLUM_FLAG_HOME_TAB;
+    }
+  });
+
   test("maps boolean-coerced window overrides back onto on/off string flags", () => {
     (globalThis as Record<string, unknown>).window = {
       __VELLUM_FLAG_OVERRIDES__: { "proactive-tips": true },

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.ts
@@ -111,13 +111,20 @@ function isStringFlag(def: FlagDefinition | undefined): boolean {
   return typeof def?.defaultEnabled === "string";
 }
 
-function parseEnvValue(flagKey: string, raw: string): boolean | string {
-  // String-valued flags take the env value verbatim — arms like "on"/"off"
-  // are variant names, not booleans.
-  if (isStringFlag(FLAG_KEY_TO_DEF.get(flagKey))) {
-    return raw;
-  }
+function parseEnvValue(
+  flagKey: string,
+  raw: string,
+): boolean | string | undefined {
+  const def = FLAG_KEY_TO_DEF.get(flagKey);
   const lower = raw.toLowerCase();
+  // Arms like "on"/"off" are variant names, not booleans — match declared
+  // arms case-insensitively; a value matching no arm is dropped as invalid.
+  if (isStringFlag(def)) {
+    if (!def?.values) {
+      return raw;
+    }
+    return def.values.find((arm) => arm.toLowerCase() === lower);
+  }
   if (TRUTHY.has(lower)) {
     return true;
   }
@@ -142,7 +149,10 @@ function computeEnvFlagOverrides(): Record<string, boolean | string> {
       const flagKey = upperSnakeToKebab(key.slice(VITE_FLAG_PREFIX.length));
       const raw = env[key as keyof ImportMetaEnv];
       if (raw != null) {
-        overrides[flagKey] = parseEnvValue(flagKey, raw);
+        const value = parseEnvValue(flagKey, raw);
+        if (value !== undefined) {
+          overrides[flagKey] = value;
+        }
       }
     }
   }

--- a/clients/web/src/stores/banner-visibility-store.test.ts
+++ b/clients/web/src/stores/banner-visibility-store.test.ts
@@ -2,13 +2,12 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { act, renderHook } from "@testing-library/react";
 
 import {
-  isBannerVisible,
   useBannerVisibilityStore,
   useBannerVisible,
 } from "@/stores/banner-visibility-store";
 
 const visible = () =>
-  isBannerVisible(useBannerVisibilityStore.getState().visibleBannerCount);
+  useBannerVisibilityStore.getState().visibleBannerCount > 0;
 
 beforeEach(() => {
   useBannerVisibilityStore.setState({ visibleBannerCount: 0 });

--- a/clients/web/src/stores/banner-visibility-store.ts
+++ b/clients/web/src/stores/banner-visibility-store.ts
@@ -1,3 +1,7 @@
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
 /**
  * Zustand store tracking whether a composer nudge banner is currently
  * rendered. Contract for mutual exclusivity: a sidebar tip must never render
@@ -13,33 +17,19 @@
  *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
-
-import { create } from "zustand";
-
-import { createSelectors } from "@/utils/create-selectors";
-
-// ---------------------------------------------------------------------------
-// State & Actions
-// ---------------------------------------------------------------------------
-
-export interface BannerVisibilityState {
+interface BannerVisibilityState {
   /** Number of currently mounted nudge banner overlays. */
   visibleBannerCount: number;
 }
 
-export interface BannerVisibilityActions {
+interface BannerVisibilityActions {
   registerVisibleBanner: () => void;
   unregisterVisibleBanner: () => void;
 }
 
-export type BannerVisibilityStore = BannerVisibilityState &
-  BannerVisibilityActions;
-
-// ---------------------------------------------------------------------------
-// Store
-// ---------------------------------------------------------------------------
-
-const useBannerVisibilityStoreBase = create<BannerVisibilityStore>()((set) => ({
+const useBannerVisibilityStoreBase = create<
+  BannerVisibilityState & BannerVisibilityActions
+>()((set) => ({
   visibleBannerCount: 0,
 
   registerVisibleBanner: () =>
@@ -54,14 +44,6 @@ export const useBannerVisibilityStore = createSelectors(
   useBannerVisibilityStoreBase,
 );
 
-// ---------------------------------------------------------------------------
-// Derivation
-// ---------------------------------------------------------------------------
-
-/** Pure predicate — true while any nudge banner is mounted. */
-export const isBannerVisible = (visibleBannerCount: number) =>
-  visibleBannerCount > 0;
-
-/** Reactive read for components (e.g. tip surfaces). */
+/** Reactive read for tip surfaces — true while any nudge banner is mounted. */
 export const useBannerVisible = () =>
-  isBannerVisible(useBannerVisibilityStore.use.visibleBannerCount());
+  useBannerVisibilityStore.use.visibleBannerCount() > 0;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review for proactive-tips-v1.md:
- String-flag env overrides now match declared arms case-insensitively
- banner-visibility-store: private interfaces, no test-only export surface, sibling-store style
- use-chat-banner-slots test header describes what it tests