### PR TITLE
fix: tips telemetry seams and shared helpers (plan review)

### DIFF
--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -77,6 +77,17 @@ describe("onboarding funnel events", () => {
     );
   });
 
+  test("stamps arbitrary variant arms beyond the pre-chat union", () => {
+    // Other funnels (e.g. tips) ride the same emitter with their own arms;
+    // the ingest stores ab_variant as an open string.
+    const event = buildOnboardingFunnelEvent(
+      ONBOARDING_FUNNEL_STEPS.privacyTos,
+      { variant: "on" },
+    );
+
+    expect(event.ab_variant).toBe("on");
+  });
+
   test("persists the assigned funnel variant for the session", () => {
     expect(
       resolveOnboardingFunnelVariant(ONBOARDING_FUNNEL_VARIANTS.paredDown),

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -117,9 +117,16 @@ export const RESEARCH_ONBOARDING_CHECKIN_STEP = {
  */
 export type OnboardingFunnelStepOutcome = "completed" | "skipped";
 
+/**
+ * A/B arm stamped on the event. The ingest stores `ab_variant` as an open
+ * CharField; the `OnboardingFunnelVariant` union documents the pre-chat arms
+ * while `(string & {})` admits other funnels' arms (e.g. tips flag variants).
+ */
+export type OnboardingFunnelAbVariant = OnboardingFunnelVariant | (string & {});
+
 export interface OnboardingFunnelStepCompletedOptions {
   userId?: string | null;
-  variant?: OnboardingFunnelVariant;
+  variant?: OnboardingFunnelAbVariant;
   /** Funnel this step belongs to; defaults to the pre-chat funnel version. */
   funnelVersion?: string;
   /** Completed vs skipped; omitted when the funnel doesn't distinguish. */
@@ -142,7 +149,7 @@ export interface OnboardingFunnelEvent {
   completed_at: string;
   user_id: string | null;
   funnel_version: string;
-  ab_variant: OnboardingFunnelVariant;
+  ab_variant: OnboardingFunnelAbVariant;
   /** Completed vs skipped; absent when the funnel doesn't distinguish. */
   outcome?: OnboardingFunnelStepOutcome;
 }

--- a/clients/web/src/domains/settings/components/show-tips-card.tsx
+++ b/clients/web/src/domains/settings/components/show-tips-card.tsx
@@ -1,14 +1,16 @@
 import { DetailCard } from "@/components/detail-card";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import {
+  isProactiveTipsOn,
+  useProactiveTipsVariant,
+} from "@/hooks/use-proactive-tips-flag";
 import { tipsEnabledStorage } from "@/utils/tips-storage";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 export function ShowTipsCard() {
-  const proactiveTips =
-    useClientFeatureFlagStore.use.stringFlags().proactiveTips;
+  const variant = useProactiveTipsVariant();
   const enabled = tipsEnabledStorage.useValue();
 
-  if (proactiveTips !== "on") {
+  if (!isProactiveTipsOn(variant)) {
     return null;
   }
 

--- a/clients/web/src/hooks/use-proactive-tips-flag.ts
+++ b/clients/web/src/hooks/use-proactive-tips-flag.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared seam for the `proactive-tips` string feature flag: the sidebar tip
+ * card (`useTipCard`) and the Settings "Show tips" toggle gate on the same
+ * arm, and the raw variant string is stamped on tip telemetry.
+ */
+
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+/** Current `proactive-tips` arm; "off" until flags hydrate. */
+export function useProactiveTipsVariant(): string {
+  return useClientFeatureFlagStore.use.stringFlags().proactiveTips ?? "off";
+}
+
+/** Whether the arm enables the tips surface. */
+export function isProactiveTipsOn(variant: string): boolean {
+  return variant === "on";
+}

--- a/clients/web/src/hooks/use-tip-card.test.ts
+++ b/clients/web/src/hooks/use-tip-card.test.ts
@@ -11,7 +11,9 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 const emitTipEvent = mock(() => {});
 mock.module("@/utils/tips-telemetry", () => ({ emitTipEvent }));
 
-const { useTipCard } = await import("@/hooks/use-tip-card");
+const { useTipCard, TIPS_MIN_ACCOUNT_AGE_MS } = await import(
+  "@/hooks/use-tip-card"
+);
 const { useAssistantFeatureFlagStore } = await import(
   "@/stores/assistant-feature-flag-store"
 );
@@ -22,9 +24,7 @@ const { useClientFeatureFlagStore } = await import(
   "@/stores/client-feature-flag-store"
 );
 const { TIPS_CATALOG } = await import("@/utils/tips-catalog");
-const { TIP_ROTATION_INTERVAL_MS, TIPS_MIN_ACCOUNT_AGE_MS } = await import(
-  "@/utils/tips-selection"
-);
+const { TIP_ROTATION_INTERVAL_MS } = await import("@/utils/tips-selection");
 const {
   recordTipDismissed,
   tipRecordsStorage,

--- a/clients/web/src/hooks/use-tip-card.ts
+++ b/clients/web/src/hooks/use-tip-card.ts
@@ -11,6 +11,10 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import {
+  isProactiveTipsOn,
+  useProactiveTipsVariant,
+} from "@/hooks/use-proactive-tips-flag";
 import { useSupportsPluginsSurface } from "@/lib/backwards-compat/plugins-surface";
 import { isElectron } from "@/runtime/is-electron";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -20,7 +24,6 @@ import { TIPS_CATALOG, type Tip } from "@/utils/tips-catalog";
 import {
   selectCurrentTip,
   TIP_ROTATION_INTERVAL_MS,
-  TIPS_MIN_ACCOUNT_AGE_MS,
 } from "@/utils/tips-selection";
 import {
   ensureTipsFirstSeenAt,
@@ -31,6 +34,9 @@ import {
   tipsFirstSeenAtStorage,
 } from "@/utils/tips-storage";
 import { emitTipEvent } from "@/utils/tips-telemetry";
+
+/** New-user grace: no tips until the account is at least this old. */
+export const TIPS_MIN_ACCOUNT_AGE_MS = 24 * 60 * 60 * 1000;
 
 interface TipGateContext {
   electron: boolean;
@@ -84,7 +90,7 @@ export function useTipCard(): UseTipCardResult {
   const records = tipRecordsStorage.useValue();
   const firstSeenAt = tipsFirstSeenAtStorage.useValue();
 
-  const variant = clientFlagState.stringFlags.proactiveTips ?? "off";
+  const variant = useProactiveTipsVariant();
 
   // Clock state for selection: reading Date.now() during render is impure
   // (react-hooks/purity), so renders see a snapshot that the rotation-boundary
@@ -144,7 +150,7 @@ export function useTipCard(): UseTipCardResult {
   }, [records, now]);
 
   const gatesOpen =
-    variant === "on" && tipsEnabled && !bannerVisible && ageEligible;
+    isProactiveTipsOn(variant) && tipsEnabled && !bannerVisible && ageEligible;
 
   const eligibleCatalog = TIPS_CATALOG.filter((tip) =>
     tipPassesGates(tip, {

--- a/clients/web/src/utils/composer-settings.ts
+++ b/clients/web/src/utils/composer-settings.ts
@@ -8,13 +8,7 @@
  * and survives logout, matching the native app's UserDefaults semantics.
  */
 
-import { createStorageAccessor } from "@/utils/typed-storage";
-
-function parseBool(raw: string): boolean | null {
-  if (raw === "true") return true;
-  if (raw === "false") return false;
-  return null;
-}
+import { createStorageAccessor, parseBool } from "@/utils/typed-storage";
 
 export const cmdEnterToSend = createStorageAccessor<boolean>({
   key: "device:cmd_enter_to_send",

--- a/clients/web/src/utils/tips-selection.ts
+++ b/clients/web/src/utils/tips-selection.ts
@@ -12,9 +12,6 @@
 import type { Tip } from "@/utils/tips-catalog";
 import type { TipRecord } from "@/utils/tips-storage";
 
-/** New-user grace: no tips until the account is at least this old. */
-export const TIPS_MIN_ACCOUNT_AGE_MS = 24 * 60 * 60 * 1000;
-
 /** A shown tip holds the slot this long; the next tip waits it out. */
 export const TIP_ROTATION_INTERVAL_MS = 24 * 60 * 60 * 1000;
 

--- a/clients/web/src/utils/tips-storage.ts
+++ b/clients/web/src/utils/tips-storage.ts
@@ -6,7 +6,7 @@
  * tips describe what this browser has already been told, not account state.
  */
 
-import { createStorageAccessor } from "@/utils/typed-storage";
+import { createStorageAccessor, parseBool } from "@/utils/typed-storage";
 
 export interface TipRecord {
   dismissedAt?: number;
@@ -45,16 +45,6 @@ function parseTipRecords(raw: string): Record<string, TipRecord> | null {
     }
   }
   return result;
-}
-
-function parseBool(raw: string): boolean | null {
-  if (raw === "true") {
-    return true;
-  }
-  if (raw === "false") {
-    return false;
-  }
-  return null;
 }
 
 function parseTimestamp(raw: string): number | null {

--- a/clients/web/src/utils/tips-telemetry.test.ts
+++ b/clients/web/src/utils/tips-telemetry.test.ts
@@ -72,8 +72,11 @@ describe("emitTipEvent", () => {
     emitTipEvent("voice-mode", "learn_more", "control");
     emitTipEvent("voice-mode", "dismiss", "control");
     emitTipEvent("voice-mode", "dont_show_again", "control");
+    // Reserved action-tip vocabulary, unused by v1 info tips.
+    emitTipEvent("voice-mode", "click", "control");
+    emitTipEvent("voice-mode", "completion", "control");
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
     expect(eventFromCall(fetchMock, 0)).toMatchObject({
       step_name: "impression",
       step_index: 0,
@@ -89,6 +92,14 @@ describe("emitTipEvent", () => {
     expect(eventFromCall(fetchMock, 3)).toMatchObject({
       step_name: "dont_show_again",
       step_index: 3,
+    });
+    expect(eventFromCall(fetchMock, 4)).toMatchObject({
+      step_name: "click",
+      step_index: 4,
+    });
+    expect(eventFromCall(fetchMock, 5)).toMatchObject({
+      step_name: "completion",
+      step_index: 5,
     });
   });
 

--- a/clients/web/src/utils/tips-telemetry.ts
+++ b/clients/web/src/utils/tips-telemetry.ts
@@ -6,10 +6,7 @@
  * `step_name` = the action taken.
  */
 
-import {
-  emitOnboardingFunnelStepCompleted,
-  type OnboardingFunnelVariant,
-} from "@/domains/onboarding/funnel-events";
+import { emitOnboardingFunnelStepCompleted } from "@/domains/onboarding/funnel-events";
 
 export const TIPS_FUNNEL_VERSION = "proactive-tips-v1";
 
@@ -17,13 +14,18 @@ export type TipTelemetryAction =
   | "impression"
   | "dismiss"
   | "learn_more"
-  | "dont_show_again";
+  | "dont_show_again"
+  // Reserved for action tips, so funnels stay comparable across phases.
+  | "click"
+  | "completion";
 
 const ACTION_STEP_INDICES: Record<TipTelemetryAction, number> = {
   impression: 0,
   learn_more: 1,
   dismiss: 2,
   dont_show_again: 3,
+  click: 4,
+  completion: 5,
 };
 
 export function emitTipEvent(
@@ -36,9 +38,7 @@ export function emitTipEvent(
     {
       funnelVersion: TIPS_FUNNEL_VERSION,
       screen: tipId,
-      // The ingest stores ab_variant as an open string; the union type on the
-      // base emitter documents the pre-chat A/B arms.
-      variant: variant as OnboardingFunnelVariant,
+      variant,
     },
   );
 }

--- a/clients/web/src/utils/typed-storage.test.ts
+++ b/clients/web/src/utils/typed-storage.test.ts
@@ -4,6 +4,7 @@ import {
   createKeyedStorageAccessor,
   createRecordStorageAccessor,
   createStorageAccessor,
+  parseBool,
 } from "./typed-storage";
 
 beforeEach(() => {
@@ -82,11 +83,7 @@ describe("createStorageAccessor", () => {
     const boolAccessor = createStorageAccessor<boolean>({
       key: "vellum:test-flag",
       scope: "user",
-      parse: (raw) => {
-        if (raw === "true") return true;
-        if (raw === "false") return false;
-        return null;
-      },
+      parse: parseBool,
       serialize: (v) => String(v),
       fallback: false,
     });

--- a/clients/web/src/utils/typed-storage.ts
+++ b/clients/web/src/utils/typed-storage.ts
@@ -106,6 +106,21 @@ function readRaw(key: string): string | null {
 }
 
 // ---------------------------------------------------------------------------
+// Shared parsers
+// ---------------------------------------------------------------------------
+
+/** Strict `parse` for boolean accessors: only "true"/"false" are valid. */
+export function parseBool(raw: string): boolean | null {
+  if (raw === "true") {
+    return true;
+  }
+  if (raw === "false") {
+    return false;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Static-key accessor
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review for proactive-tips-v1.md:
- Reserved click/completion telemetry actions + properly widened funnel variant typing (removes cast)
- Shared parseBool in typed-storage (used by tips-storage + composer-settings)
- TIPS_MIN_ACCOUNT_AGE_MS moved to its real owner (use-tip-card)
- Shared proactive-tips flag helper replaces duplicated "on" literals