### PR TITLE
fix: test hygiene from plan re-review

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -136,19 +136,6 @@ describe("getEnvFlagOverridesForScope", () => {
     }
   });
 
-  test("still boolean-coerces booleanish Vite env values for boolean flags", () => {
-    (globalThis as Record<string, unknown>).window = undefined;
-    process.env.VITE_VELLUM_FLAG_HOME_TAB = "on";
-    try {
-      resetEnvOverridesCache();
-      const result = getEnvFlagOverridesForScope("client");
-      expect(result.bool.homeTab).toBe(true);
-      expect(result.str).not.toHaveProperty("homeTab");
-    } finally {
-      delete process.env.VITE_VELLUM_FLAG_HOME_TAB;
-    }
-  });
-
   test("matches string-flag env arms case-insensitively and stores the canonical arm", () => {
     (globalThis as Record<string, unknown>).window = undefined;
     process.env.VITE_VELLUM_FLAG_PROACTIVE_TIPS = "ON";
@@ -183,14 +170,16 @@ describe("getEnvFlagOverridesForScope", () => {
 
   test("boolean flags keep case-insensitive env coercion", () => {
     (globalThis as Record<string, unknown>).window = undefined;
-    process.env.VITE_VELLUM_FLAG_HOME_TAB = "ON";
-    try {
-      resetEnvOverridesCache();
-      const result = getEnvFlagOverridesForScope("client");
-      expect(result.bool.homeTab).toBe(true);
-      expect(result.str).not.toHaveProperty("homeTab");
-    } finally {
-      delete process.env.VITE_VELLUM_FLAG_HOME_TAB;
+    for (const raw of ["on", "ON"]) {
+      process.env.VITE_VELLUM_FLAG_HOME_TAB = raw;
+      try {
+        resetEnvOverridesCache();
+        const result = getEnvFlagOverridesForScope("client");
+        expect(result.bool.homeTab).toBe(true);
+        expect(result.str).not.toHaveProperty("homeTab");
+      } finally {
+        delete process.env.VITE_VELLUM_FLAG_HOME_TAB;
+      }
     }
   });
 

--- a/clients/web/src/utils/tips-telemetry.test.ts
+++ b/clients/web/src/utils/tips-telemetry.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
-import { emitTipEvent, TIPS_FUNNEL_VERSION } from "@/utils/tips-telemetry";
+import { emitTipEvent } from "@/utils/tips-telemetry";
 
 const originalFetch = globalThis.fetch;
 
@@ -60,7 +60,7 @@ describe("emitTipEvent", () => {
       screen: "what-are-skills",
       step_name: "impression",
       step_index: 0,
-      funnel_version: TIPS_FUNNEL_VERSION,
+      funnel_version: "proactive-tips-v1",
       ab_variant: "control",
     });
   });

--- a/clients/web/src/utils/tips-telemetry.ts
+++ b/clients/web/src/utils/tips-telemetry.ts
@@ -8,7 +8,7 @@
 
 import { emitOnboardingFunnelStepCompleted } from "@/domains/onboarding/funnel-events";
 
-export const TIPS_FUNNEL_VERSION = "proactive-tips-v1";
+const TIPS_FUNNEL_VERSION = "proactive-tips-v1";
 
 export type TipTelemetryAction =
   | "impression"


### PR DESCRIPTION
## Summary
Final self-review round for proactive-tips-v1.md:
- tips-telemetry test asserts the literal funnel version (self-referential constant un-exported)
- merged near-duplicate boolean env-coercion tests