### PR TITLE
feat(apps): hide read-only mutation actions on plugin apps in the Library

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -834,11 +834,14 @@ paths:
                     type: string
                   html:
                     type: string
+                  origin:
+                    type: string
                 required:
                   - appId
                   - dirName
                   - name
                   - html
+                  - origin
                 additionalProperties: false
   /v1/apps/{id}/preview:
     get:

--- a/assistant/src/__tests__/plugin-app-serve-routes.test.ts
+++ b/assistant/src/__tests__/plugin-app-serve-routes.test.ts
@@ -138,6 +138,38 @@ describe("plugin app serve routes", () => {
   });
 });
 
+describe("apps_open reports app origin", () => {
+  test("plugin app opens with a plugin:<name> origin", async () => {
+    installPluginApp("acme", "dash", {
+      "index.html": "<div id='root'>Plugin Home</div>",
+    });
+    const handler = findRoute(APP_MGMT_ROUTES, "apps_open").handler;
+    const result = (await handler({
+      pathParams: { id: "plugins~acme~dash" },
+    } as RouteHandlerArgs)) as { origin: string; html: string };
+
+    expect(result.origin).toBe("plugin:acme");
+    expect(result.html).toContain("Plugin Home");
+  });
+
+  test("workspace app opens with a workspace origin", async () => {
+    // Import lazily so the workspace-dir override from beforeEach is in effect.
+    const { createApp } = await import("../apps/app-store.js");
+    const app = createApp({
+      name: "My App",
+      schemaJson: "{}",
+      htmlDefinition: "<div id='root'>Workspace Home</div>",
+    });
+    const handler = findRoute(APP_MGMT_ROUTES, "apps_open").handler;
+    const result = (await handler({
+      pathParams: { id: app.id },
+    } as RouteHandlerArgs)) as { origin: string; html: string };
+
+    expect(result.origin).toBe("workspace");
+    expect(result.html).toContain("Workspace Home");
+  });
+});
+
 describe("plugin apps are read-only over the management surface", () => {
   test("apps_delete rejects a plugin app id", () => {
     installPluginApp("acme", "dash", { "index.html": "<div>x</div>" });

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -684,6 +684,13 @@ async function handleOpenApp({ pathParams }: RouteHandlerArgs) {
     dirName: source.dirName,
     name: source.name,
     html,
+    // Same "workspace" / "plugin:<name>" tagging as apps_list, so an opened
+    // app knows its provenance — clients hide the mutation actions (delete,
+    // share, deploy) that the daemon rejects for plugin-bundled apps.
+    origin:
+      source.origin.kind === "plugin"
+        ? `plugin:${source.origin.pluginName}`
+        : "workspace",
   };
 }
 
@@ -1015,6 +1022,7 @@ export const ROUTES: RouteDefinition[] = [
       dirName: z.string(),
       name: z.string(),
       html: z.string(),
+      origin: z.string(),
     }),
   },
   {

--- a/clients/web/src/domains/library/components/library-app-card.tsx
+++ b/clients/web/src/domains/library/components/library-app-card.tsx
@@ -1,17 +1,10 @@
-import {
-    ArrowUp,
-    Ellipsis,
-    Globe,
-    Pin,
-    PinOff,
-    Trash2,
-} from "lucide-react";
+import { ArrowUp, Ellipsis, Globe, Pin, PinOff, Trash2 } from "lucide-react";
 import { type MouseEvent, useCallback, useState } from "react";
 
 import { AppPreviewThumbnail } from "@/components/app-card";
 import { SwipeActionReveal } from "@/components/swipe-action-reveal";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import type { AppSummary } from "@/types/app-types";
+import { type AppSummary, isReadOnlyApp } from "@/types/app-types";
 import { getCachedAppHtml } from "@/utils/app-html-cache";
 import { formatFriendlyDate } from "@/utils/format-date";
 import { cn } from "@/utils/misc";
@@ -19,11 +12,11 @@ import { shareApp } from "@/utils/share-app";
 import { isPointerCoarse } from "@/utils/pointer";
 import type { SwipeAction } from "@/hooks/use-swipe-to-reveal";
 import {
-    BottomSheet,
-    Button,
-    Menu,
-    PanelItem,
-    toast,
+  BottomSheet,
+  Button,
+  Menu,
+  PanelItem,
+  toast,
 } from "@vellumai/design-library";
 
 interface LibraryAppCardProps {
@@ -50,6 +43,13 @@ export function LibraryAppCard({
   onAnimationEnd,
 }: LibraryAppCardProps) {
   const [isSharing, setIsSharing] = useState(false);
+  // Plugin-bundled apps are read-only: the daemon rejects delete/share/deploy
+  // against them, so drop those actions here rather than render buttons that
+  // error. Pin/Open stay — pinning is a client-only preference and opening is
+  // always allowed.
+  const readOnly = isReadOnlyApp(app.origin);
+  const deleteAction = readOnly ? undefined : onDelete;
+  const deployAction = readOnly ? undefined : onDeploy;
   const loadHtml = useCallback(
     () => getCachedAppHtml(assistantId, app.id),
     [assistantId, app.id],
@@ -87,14 +87,14 @@ export function LibraryAppCard({
           icon: isPinned ? PinOff : Pin,
           onSelect: () => onPin(app),
         },
-        ...(onDelete
+        ...(deleteAction
           ? [
               {
                 id: "delete",
                 label: "Delete",
                 icon: Trash2,
                 variant: "destructive" as const,
-                onSelect: () => onDelete(app),
+                onSelect: () => deleteAction(app),
               },
             ]
           : []),
@@ -102,10 +102,7 @@ export function LibraryAppCard({
     : [];
 
   return (
-    <SwipeActionReveal
-      trailingActions={trailingActions}
-      className="rounded-xl"
-    >
+    <SwipeActionReveal trailingActions={trailingActions} className="rounded-xl">
       <div
         className={cn(
           "group relative flex flex-col gap-2",
@@ -142,9 +139,9 @@ export function LibraryAppCard({
             open={menuOpen}
             onOpenChange={setMenuOpen}
             onPin={() => onPin(app)}
-            onDelete={onDelete ? () => onDelete(app) : undefined}
-            onShare={handleShare}
-            onDeploy={onDeploy}
+            onDelete={deleteAction ? () => deleteAction(app) : undefined}
+            onShare={readOnly ? undefined : handleShare}
+            onDeploy={deployAction}
             isMobile={isMobile}
           />
         </div>

--- a/clients/web/src/domains/library/library-detail-page.tsx
+++ b/clients/web/src/domains/library/library-detail-page.tsx
@@ -17,12 +17,15 @@ import { primeAppHtmlCache } from "@/utils/app-html-cache";
 import { navigateToNewConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 import { shareApp } from "@/utils/share-app";
+import { isReadOnlyApp } from "@/types/app-types";
 
 interface LoadedApp {
   appId: string;
   dirName?: string;
   name: string;
   html: string;
+  /** "workspace" or "plugin:<name>" — read-only apps hide edit/share/deploy. */
+  origin: string;
 }
 
 export function LibraryDetailPage() {
@@ -40,7 +43,9 @@ export function LibraryDetailPage() {
   const requestRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!appId) {return;}
+    if (!appId) {
+      return;
+    }
     requestRef.current = appId;
     setApp(null);
     setError(null);
@@ -50,17 +55,22 @@ export function LibraryDetailPage() {
       throwOnError: true,
     })
       .then(({ data: result }) => {
-        if (requestRef.current !== appId) {return;}
+        if (requestRef.current !== appId) {
+          return;
+        }
         primeAppHtmlCache(assistantId, result.appId, result.html);
         setApp({
           appId: result.appId,
           dirName: result.dirName,
           name: result.name,
           html: result.html,
+          origin: result.origin,
         });
       })
       .catch((err) => {
-        if (requestRef.current !== appId) {return;}
+        if (requestRef.current !== appId) {
+          return;
+        }
         setError(err instanceof Error ? err.message : "Failed to open app");
       });
 
@@ -82,11 +92,15 @@ export function LibraryDetailPage() {
 
   const editApp = useEditApp();
   const handleEdit = useCallback(() => {
-    if (app) {editApp(app);}
+    if (app) {
+      editApp(app);
+    }
   }, [app, editApp]);
 
   const handleShare = useCallback(async () => {
-    if (!app || isSharing) {return;}
+    if (!app || isSharing) {
+      return;
+    }
     setIsSharing(true);
     try {
       await shareApp(assistantId, app.appId, app.name);
@@ -101,7 +115,9 @@ export function LibraryDetailPage() {
   }, [assistantId, app, isSharing]);
 
   const handleDeploy = useCallback(() => {
-    if (!app) {return;}
+    if (!app) {
+      return;
+    }
     void useDeployStore
       .getState()
       .deployApp(assistantId, app.appId, app.name, app.html);
@@ -120,7 +136,9 @@ export function LibraryDetailPage() {
     [navigate],
   );
 
-  if (!appId) {return null;}
+  if (!appId) {
+    return null;
+  }
 
   if (error) {
     return (
@@ -160,18 +178,22 @@ export function LibraryDetailPage() {
           html={app.html}
           assistantId={assistantId}
           onClose={handleClose}
-          onEdit={handleEdit}
-          onShare={handleShare}
-          isSharing={isSharing}
-          onDeploy={handleDeploy}
-          isDeploying={isDeploying}
+          {...(isReadOnlyApp(app.origin)
+            ? {}
+            : {
+                onEdit: handleEdit,
+                onShare: handleShare,
+                isSharing,
+                onDeploy: handleDeploy,
+                isDeploying,
+              })}
           enableFullscreen
         />
       </div>
       <DeployDialogs
-          assistantId={assistantId}
-          onStartConversation={handleStartConversation}
-        />
+        assistantId={assistantId}
+        onStartConversation={handleStartConversation}
+      />
     </>
   );
 }

--- a/clients/web/src/types/app-types.test.ts
+++ b/clients/web/src/types/app-types.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Tests for `isReadOnlyApp` — the predicate the Library uses to hide mutation
+ * actions (delete / share / deploy) on plugin-bundled apps, which the daemon
+ * rejects server-side.
+ */
+
+import { expect, test } from "bun:test";
+
+import { isReadOnlyApp } from "@/types/app-types";
+
+test("workspace-origin apps are writable", () => {
+  expect(isReadOnlyApp("workspace")).toBe(false);
+});
+
+test("plugin-origin apps are read-only", () => {
+  expect(isReadOnlyApp("plugin:acme")).toBe(true);
+  expect(isReadOnlyApp("plugin:some-other-plugin")).toBe(true);
+});
+
+test("an absent origin is treated as writable (never lock down existing apps)", () => {
+  expect(isReadOnlyApp(undefined)).toBe(false);
+});

--- a/clients/web/src/types/app-types.ts
+++ b/clients/web/src/types/app-types.ts
@@ -6,3 +6,17 @@ import type {
 export type AppSummary = AppsGetResponse["apps"][number];
 
 export type AppOpenResponse = AppsByIdOpenPostResponse;
+
+/**
+ * Whether an app is read-only over the daemon's mutation surface. The daemon
+ * tags each app's provenance in `origin`: `"workspace"` for user-created apps,
+ * or `"plugin:<name>"` for apps bundled by an installed plugin. Plugin apps are
+ * owned by their plugin — the daemon rejects delete / share / deploy / preview
+ * mutations against them — so the Library hides those actions rather than
+ * offer buttons that error server-side. Anything not workspace-owned is
+ * read-only; an absent origin (older cached response) is treated as writable so
+ * existing workspace apps are never accidentally locked down.
+ */
+export function isReadOnlyApp(origin: string | undefined): boolean {
+  return origin != null && origin !== "workspace";
+}


### PR DESCRIPTION
## Prompt / plan

Follow-up to the plugin-apps arc. An end-to-end audit found that while a user can see and open a plugin-bundled app in the web Library, the Library still offers **Delete / Share / Deploy** (and **Edit** in the viewer) on plugin apps — actions the daemon rejects server-side via `assertNotPluginApp`. So acting on a plugin app produced an error toast instead of simply not offering the action. This PR closes that gap (audit gaps #1 + #2).

## What changed

- **Daemon** — `apps_open` now returns `origin` (`"workspace"` | `"plugin:<name>"`), matching what `apps_list` already reports, so an opened app knows whether it's writable. Regenerated `openapi.yaml`.
- **Web** — `isReadOnlyApp(origin)` centralizes the rule: anything not workspace-owned is read-only; an **absent** origin stays writable so existing/cached workspace apps are never accidentally locked down.
  - The library card drops Delete/Share/Deploy from both the actions menu and the swipe actions for read-only apps.
  - The app viewer (detail page) drops Edit/Share/Deploy for read-only apps.
  - **Pin** and **Open** stay — pinning is a client-only preference and opening is always allowed.

### On audit gap #1 (typing `origin` in the SDK)

No committed change was needed for the list surface: `origin` was already present on `apps_list` in `openapi.yaml`, and the web SDK types are generated from it at build time (the generated `types.gen.ts` and `daemon.json` are gitignored, rebuilt on `predev`/`prebuild`/`postinstall`). The audit was reading stale local build output. This PR does add `origin` to the `apps_open` response so the detail page can gate on the same semantic field as the card.

## Test plan

- New daemon tests in `plugin-app-serve-routes.test.ts`: `apps_open` returns `plugin:<name>` for a plugin app and `workspace` for a workspace app.
- New web unit test for `isReadOnlyApp` (workspace → writable, `plugin:*` → read-only, absent → writable).
- Existing app tests (`plugin-app-serve-routes`, `list-all-apps`, `app-routes-csp`) still green.
- Assistant + web typecheck and lint pass (pre-commit/pre-push).

## Follow-up

Gap #3 (auto-compile multi-file plugin apps on open, so a just-installed plugin app doesn't briefly render the "not compiled yet" fallback before the monitor's first pass) is intentionally left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG)_