### PR TITLE
feat(apps): compile multi-file plugin apps on open (ephemerally)

### DIFF
--- a/assistant/src/__tests__/plugin-app-serve-routes.test.ts
+++ b/assistant/src/__tests__/plugin-app-serve-routes.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -167,6 +167,36 @@ describe("apps_open reports app origin", () => {
 
     expect(result.origin).toBe("workspace");
     expect(result.html).toContain("Workspace Home");
+  });
+});
+
+describe("multi-file plugin apps compile on open", () => {
+  test("apps_open renders a plugin app with no dist without writing into the plugin tree", async () => {
+    installPluginApp("acme", "board", {
+      "src/index.html":
+        `<!DOCTYPE html><html><head></head><body>` +
+        `<div id="root"></div>` +
+        `<script type="module" src="/src/main.tsx"></script></body></html>`,
+      "src/main.tsx":
+        `import { render } from "preact";\n` +
+        `render(<div>Compiled Board</div>, document.getElementById("root")!);\n`,
+    });
+    const appDir = join(getWorkspacePluginsDir(), "acme", "apps", "board");
+    // Precondition: a multi-file app (src/, no root index.html) with no dist yet.
+    expect(existsSync(join(appDir, "dist"))).toBe(false);
+
+    const handler = findRoute(APP_MGMT_ROUTES, "apps_open").handler;
+    const result = (await handler({
+      pathParams: { id: "plugins~acme~board" },
+    } as RouteHandlerArgs)) as { html: string; origin: string };
+
+    // Rendered the compiled output, not the "not compiled yet" fallback.
+    expect(result.html).toContain("Compiled Board");
+    expect(result.html).not.toContain("not been compiled");
+    expect(result.origin).toBe("plugin:acme");
+    // The daemon must not write dist/ into the read-only plugin tree — that is
+    // the monitor's job. The on-open build happened in a throwaway temp dir.
+    expect(existsSync(join(appDir, "dist"))).toBe(false);
   });
 });
 

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -307,10 +307,11 @@ const compileSlots = new Map<string, CompileSlot>();
  * fresh compile.
  */
 export function compileApp(appDir: string): Promise<CompileResult> {
+  const distDir = join(appDir, "dist");
   const slot = compileSlots.get(appDir);
 
   if (!slot) {
-    const current = runCompile(appDir);
+    const current = runCompile(appDir, distDir);
     const onSettled = () => slotCompileSettled(appDir, current);
     current.then(onSettled, onSettled);
     compileSlots.set(appDir, { current });
@@ -328,13 +329,31 @@ export function compileApp(appDir: string): Promise<CompileResult> {
     } catch {
       // Ignore: we want to rerun regardless of the prior compile's outcome.
     }
-    return runCompile(appDir);
+    return runCompile(appDir, distDir);
   };
   const pending = rerun();
   const onSettled = () => slotCompileSettled(appDir, pending);
   pending.then(onSettled, onSettled);
   slot.pending = pending;
   return pending;
+}
+
+/**
+ * Compile a TSX app from `appDir/src/` into an arbitrary `outDir`, laid out
+ * exactly like a normal `dist/` (`outDir/main.js`, `outDir/index.html`, …).
+ *
+ * Unlike {@link compileApp}, this does not touch `appDir/dist` and is not
+ * routed through the per-`appDir` compile queue: each caller supplies its own
+ * private `outDir`, so builds never share a mutable target and cannot race.
+ * Used to render a plugin-bundled app on open without writing into the plugin
+ * tree (which the daemon treats as read-only) or racing the monitor process,
+ * which is the sole writer of a plugin app's real `dist/`.
+ */
+export function compileAppToDir(
+  appDir: string,
+  outDir: string,
+): Promise<CompileResult> {
+  return runCompile(appDir, outDir);
 }
 
 function slotCompileSettled(
@@ -358,10 +377,12 @@ function slotCompileSettled(
   }
 }
 
-async function runCompile(appDir: string): Promise<CompileResult> {
+async function runCompile(
+  appDir: string,
+  distDir: string,
+): Promise<CompileResult> {
   const start = performance.now();
   const srcDir = join(appDir, "src");
-  const distDir = join(appDir, "dist");
   const entryPoint = join(srcDir, "main.tsx");
 
   // Clear stale dist/ output so removed assets (e.g. CSS) don't persist

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -6,8 +6,10 @@ import { randomBytes } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readdirSync,
   readFileSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -19,6 +21,7 @@ import { z } from "zod";
 
 import {
   type AppDefinition,
+  type AppOrigin,
   createApp,
   createAppRecord,
   deleteApp,
@@ -38,7 +41,7 @@ import {
 } from "../../apps/app-store.js";
 import { createSharedAppLink } from "../../apps/shared-app-links-store.js";
 import { packageApp } from "../../bundler/app-bundler.js";
-import { compileApp } from "../../bundler/app-compiler.js";
+import { compileApp, compileAppToDir } from "../../bundler/app-compiler.js";
 import { scanBundle } from "../../bundler/bundle-scanner.js";
 import type { SignatureJson } from "../../bundler/bundle-signer.js";
 import { verifyBundleSignature } from "../../bundler/signature-verifier.js";
@@ -651,6 +654,51 @@ function handleMutateAppData({ pathParams, body }: RouteHandlerArgs) {
   return { success: true, result };
 }
 
+/**
+ * Wire-format provenance tag for an app, matching what `apps_list` reports:
+ * `"workspace"` for user-created apps, `"plugin:<name>"` for plugin-bundled
+ * ones. Clients read it to hide the mutation actions (delete, share, deploy)
+ * the daemon rejects for plugin apps.
+ */
+function appOriginWire(origin: AppOrigin): string {
+  return origin.kind === "plugin" ? `plugin:${origin.pluginName}` : "workspace";
+}
+
+/**
+ * Compile a multi-file plugin app on open, without touching its `dist/`.
+ *
+ * A plugin app's real `dist/` is owned by the monitor process
+ * (`plugin-source-watch`), which builds it on install and on every source
+ * change. But a just-installed app can be opened before the monitor's first
+ * pass lands, which would otherwise render the "not compiled yet" fallback.
+ * Building in place here would both write into the read-only plugin tree and
+ * race the monitor's `rm -rf dist` + write. Instead we compile into a private
+ * temp dir and return the self-contained HTML from there, leaving `dist/`
+ * ownership solely with the monitor. Returns `null` if the build fails, so the
+ * caller falls back to the standard fallback HTML.
+ */
+async function compilePluginAppHtmlEphemeral(
+  appId: string,
+  sourceDir: string,
+): Promise<string | null> {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "vellum-plugin-app-"));
+  try {
+    const result = await compileAppToDir(sourceDir, join(tmpRoot, "dist"));
+    if (!result.ok) {
+      log.warn(
+        { appId, errors: result.errors },
+        "Ephemeral compile failed on plugin app open",
+      );
+      return null;
+    }
+    // resolveEffectiveAppHtmlFromDir reads `<tmpRoot>/dist/index.html` and
+    // inlines its JS/CSS, yielding a self-contained page.
+    return resolveEffectiveAppHtmlFromDir(tmpRoot, 2);
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
 async function handleOpenApp({ pathParams }: RouteHandlerArgs) {
   const appId = pathParams?.id as string;
   const source = resolveAppSource(appId);
@@ -658,20 +706,38 @@ async function handleOpenApp({ pathParams }: RouteHandlerArgs) {
     throw new NotFoundError(`App not found: ${appId}`);
   }
 
-  // Multifile workspace apps auto-compile on open when their dist is missing.
-  // Plugin apps are not compiled here — a compile cache for plugin sources is a
-  // follow-up — so a multifile plugin app without a prebuilt dist/ renders its
-  // fallback message.
-  if (source.formatVersion === 2 && source.origin.kind === "workspace") {
-    const distIndex = join(source.sourceDir, "dist", "index.html");
-    if (!existsSync(distIndex)) {
-      const result = await compileApp(source.sourceDir);
-      if (!result.ok) {
+  const result = {
+    appId: source.id,
+    dirName: source.dirName,
+    name: source.name,
+    origin: appOriginWire(source.origin),
+  };
+
+  // Multi-file apps auto-compile on open when their dist/ is missing so a
+  // freshly installed app renders immediately instead of the "not compiled
+  // yet" fallback.
+  if (
+    source.formatVersion === 2 &&
+    !existsSync(join(source.sourceDir, "dist", "index.html"))
+  ) {
+    if (source.origin.kind === "workspace") {
+      // Workspace apps own their dist/ and are only compiled in this (daemon)
+      // process, so building in place is safe.
+      const compiled = await compileApp(source.sourceDir);
+      if (!compiled.ok) {
         log.warn(
-          { appId, errors: result.errors },
+          { appId, errors: compiled.errors },
           "Auto-compile failed on app open",
         );
       }
+    } else {
+      // Plugin apps: compile off to the side (see helper) rather than write
+      // into the plugin tree or race the monitor.
+      const html = await compilePluginAppHtmlEphemeral(appId, source.sourceDir);
+      if (html !== null) {
+        return { ...result, html };
+      }
+      // Build failed — fall through to the standard fallback HTML.
     }
   }
 
@@ -679,19 +745,7 @@ async function handleOpenApp({ pathParams }: RouteHandlerArgs) {
     source.sourceDir,
     source.formatVersion,
   );
-  return {
-    appId: source.id,
-    dirName: source.dirName,
-    name: source.name,
-    html,
-    // Same "workspace" / "plugin:<name>" tagging as apps_list, so an opened
-    // app knows its provenance — clients hide the mutation actions (delete,
-    // share, deploy) that the daemon rejects for plugin-bundled apps.
-    origin:
-      source.origin.kind === "plugin"
-        ? `plugin:${source.origin.pluginName}`
-        : "workspace",
-  };
+  return { ...result, html };
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

Final follow-up in the plugin-apps arc (audit gap #3). A multi-file (TSX) plugin app opened **before** the monitor's first compile pass rendered the "not compiled yet" fallback: `handleOpenApp` only auto-compiled *workspace* apps, deferring plugin compilation entirely to the monitor process (`plugin-source-watch`), which builds each plugin app's `dist/` on install and on change.

## The wrinkle, and the approach

The obvious fix — "just compile plugin apps in `handleOpenApp` too" — is unsafe: the monitor runs in a **separate OS process** and is the sole writer of a plugin app's real `dist/`. Building `dist/` in place from the daemon would (a) write into the plugin tree, which the daemon treats as read-only (see the read-only gating in #38144), and (b) race the monitor's `rm -rf dist` + write — exactly the shared-mutable-resource footgun `assistant/CLAUDE.md` calls out.

So the daemon compiles the app **into a private temp dir** and serves that self-contained HTML, leaving `dist/` ownership solely with the monitor. No shared-resource write, no cross-process lock, and the daemon never mutates the plugin tree. Once the monitor has populated `dist/`, open serves it directly and no on-the-fly build happens.

- **`app-compiler`** — factor the output directory out of `runCompile` and expose `compileAppToDir(appDir, outDir)`: an unserialised build into a caller-owned dir (each caller's `outDir` is private, so there's no shared target to race on). `compileApp` is unchanged in behavior (still builds `appDir/dist` through the per-`appDir` queue).
- **`app-management-routes`** — `handleOpenApp` compiles workspace apps in place (as before) and plugin apps into a throwaway temp dir via `compileAppToDir` + `resolveEffectiveAppHtmlFromDir`, returning `null`/falling back to the standard fallback HTML if the build fails. Factored the `"workspace"` / `"plugin:<name>"` origin tag into `appOriginWire`.

## Test plan

- New test in `plugin-app-serve-routes.test.ts`: `apps_open` on a dist-less multi-file plugin app returns the **compiled** output (not the fallback) **and** leaves no `dist/` in the plugin tree (proving the ephemeral, read-only guarantee).
- `app-compiler.test.ts` (25 real compiles) and `plugin-source-watch.test.ts` still green — confirms the `runCompile` refactor is behavior-preserving.
- Assistant typecheck + lint pass (pre-commit/pre-push).

## Notes

- No `openapi.yaml` change: the `apps_open` response shape is unchanged (`origin` was added in #38144); only how `html` is produced changed.
- Scoped to `apps_open` (the Library "open" path), per the audit. The share-link route (`pages_serve`) still serves from the monitor-built `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG)_