### PR TITLE
refactor(apps): fold compileAppToDir into runCompile; harden plugin compile-on-open

### DIFF
--- a/assistant/src/__tests__/plugin-app-serve-routes.test.ts
+++ b/assistant/src/__tests__/plugin-app-serve-routes.test.ts
@@ -198,6 +198,19 @@ describe("multi-file plugin apps compile on open", () => {
     // the monitor's job. The on-open build happened in a throwaway temp dir.
     expect(existsSync(join(appDir, "dist"))).toBe(false);
   });
+
+  test("apps_open on a malformed plugin app (no src/, no dist/) serves the fallback, not a 500", async () => {
+    // An app dir with neither a root index.html nor src/ nor dist/ is
+    // classified as multi-file; the on-open compile must not throw.
+    installPluginApp("acme", "broken", {});
+    const handler = findRoute(APP_MGMT_ROUTES, "apps_open").handler;
+    const result = (await handler({
+      pathParams: { id: "plugins~acme~broken" },
+    } as RouteHandlerArgs)) as { html: string; origin: string };
+
+    expect(result.origin).toBe("plugin:acme");
+    expect(result.html).toContain("App compilation failed");
+  });
 });
 
 describe("plugin apps are read-only over the management surface", () => {

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -338,24 +338,6 @@ export function compileApp(appDir: string): Promise<CompileResult> {
   return pending;
 }
 
-/**
- * Compile a TSX app from `appDir/src/` into an arbitrary `outDir`, laid out
- * exactly like a normal `dist/` (`outDir/main.js`, `outDir/index.html`, …).
- *
- * Unlike {@link compileApp}, this does not touch `appDir/dist` and is not
- * routed through the per-`appDir` compile queue: each caller supplies its own
- * private `outDir`, so builds never share a mutable target and cannot race.
- * Used to render a plugin-bundled app on open without writing into the plugin
- * tree (which the daemon treats as read-only) or racing the monitor process,
- * which is the sole writer of a plugin app's real `dist/`.
- */
-export function compileAppToDir(
-  appDir: string,
-  outDir: string,
-): Promise<CompileResult> {
-  return runCompile(appDir, outDir);
-}
-
 function slotCompileSettled(
   appDir: string,
   finished: Promise<CompileResult>,
@@ -377,7 +359,19 @@ function slotCompileSettled(
   }
 }
 
-async function runCompile(
+/**
+ * Compile a TSX app from `appDir/src/` into `distDir`, laid out exactly like a
+ * normal `dist/` (`distDir/main.js`, `distDir/index.html`, …).
+ *
+ * {@link compileApp} wraps this to build `appDir/dist` through the per-`appDir`
+ * serialisation queue. Call it directly to build into a caller-owned directory
+ * instead: because each caller supplies its own private `distDir`, such builds
+ * never share a mutable target and need no serialisation. This is how a
+ * plugin-bundled app is rendered on open without writing into the plugin tree
+ * (which the daemon treats as read-only) or racing the monitor process, which
+ * is the sole writer of a plugin app's real `dist/`.
+ */
+export async function runCompile(
   appDir: string,
   distDir: string,
 ): Promise<CompileResult> {

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -41,7 +41,7 @@ import {
 } from "../../apps/app-store.js";
 import { createSharedAppLink } from "../../apps/shared-app-links-store.js";
 import { packageApp } from "../../bundler/app-bundler.js";
-import { compileApp, compileAppToDir } from "../../bundler/app-compiler.js";
+import { compileApp, runCompile } from "../../bundler/app-compiler.js";
 import { scanBundle } from "../../bundler/bundle-scanner.js";
 import type { SignatureJson } from "../../bundler/bundle-signer.js";
 import { verifyBundleSignature } from "../../bundler/signature-verifier.js";
@@ -681,9 +681,17 @@ async function compilePluginAppHtmlEphemeral(
   appId: string,
   sourceDir: string,
 ): Promise<string | null> {
+  // `resolveAppSource` classifies any app without a root index.html as
+  // multi-file, even a malformed one with no src/ (or one whose source was
+  // removed before the monitor built dist/). Building that would make the
+  // compiler throw, so skip it and let the caller serve the standard fallback
+  // rather than surfacing a 500 from a plain open.
+  if (!existsSync(join(sourceDir, "src"))) {
+    return null;
+  }
   const tmpRoot = mkdtempSync(join(tmpdir(), "vellum-plugin-app-"));
   try {
-    const result = await compileAppToDir(sourceDir, join(tmpRoot, "dist"));
+    const result = await runCompile(sourceDir, join(tmpRoot, "dist"));
     if (!result.ok) {
       log.warn(
         { appId, errors: result.errors },
@@ -694,6 +702,12 @@ async function compilePluginAppHtmlEphemeral(
     // resolveEffectiveAppHtmlFromDir reads `<tmpRoot>/dist/index.html` and
     // inlines its JS/CSS, yielding a self-contained page.
     return resolveEffectiveAppHtmlFromDir(tmpRoot, 2);
+  } catch (err) {
+    // The compiler reports build failures via `ok: false`; a thrown error is
+    // unexpected (e.g. a filesystem fault mid-build) and must still degrade to
+    // the fallback instead of a 500.
+    log.warn({ appId, err }, "Ephemeral compile threw on plugin app open");
+    return null;
   } finally {
     rmSync(tmpRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Prompt / plan

Review follow-up to #38145, addressing both review threads on that PR.

## What changed

- **Cleanup (`app-compiler`)** — `compileAppToDir` was a one-line pass-through to `runCompile`. Dropped it and exported `runCompile` directly (it already takes an explicit output directory). `compileApp` still wraps `runCompile` for the serialised `appDir/dist` build; the on-open ephemeral path calls `runCompile` with its own temp dir. No behavior change — one fewer redundant method.
- **Robustness (`app-management-routes`)** — the on-open ephemeral compile now handles a multi-file plugin app that has **no `src/`** (a malformed plugin, or source removed before the monitor built `dist/`). `resolveAppSource` still classifies such an app as multi-file, and compiling it would throw — turning a plain `apps_open` into a 500 instead of the previous "not compiled yet" fallback. The compile is now skipped when `src/` is absent, and any unexpected build-time throw is caught, so `apps_open` degrades to the standard fallback HTML.

## Test plan

- New test: `apps_open` on a malformed plugin app (no `src/`, no `dist/`) serves the fallback HTML rather than throwing.
- Existing `plugin-app-serve-routes.test.ts` (compile-on-open + read-only) and `app-compiler.test.ts` (25 real compiles) still green — confirms exporting `runCompile` is behavior-preserving.
- Assistant typecheck + lint pass.

## Review threads addressed

- dvargasfuertes — "`compileAppToDir` is a redundant method, delete" → deleted; `runCompile` is exported instead.
- codex P2 — "Handle missing plugin sources without throwing" → `src/` guard + catch around the ephemeral build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015swe8U8yqzmBJvy3UTczhG)_