### PR TITLE
docs(plugin-builder): document apps as a plugin surface

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -694,7 +694,7 @@
     {
       "id": "plugin-builder",
       "name": "plugin-builder",
-      "description": "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles hooks, tools, skills, and routes into one installable package.",
+      "description": "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles multiple surfaces (hooks, tools, skills, and more) into one installable package.",
       "metadata": {
         "emoji": "🧩",
         "vellum": {
@@ -716,7 +716,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-14T12:09:21.000Z"
+      "updatedAt": "2026-07-15T15:44:53.000Z"
     },
     {
       "id": "public-ingress",
@@ -1266,7 +1266,7 @@
           "emoji": "📺"
         }
       },
-      "updatedAt": "2026-07-15T00:08:07.000Z"
+      "updatedAt": "2026-07-15T00:42:43.000Z"
     },
     {
       "id": "watcher",

--- a/skills/plugin-builder/SKILL.md
+++ b/skills/plugin-builder/SKILL.md
@@ -46,6 +46,7 @@ A single plugin can contribute several different kinds of behavior. Each surface
 | [Skills](references/skills.md)             | `skills/<name>/`   | Directories of instructions and associated assets, scripts, and resources that the Assistant loads dynamically when relevant.    |
 | [Model-visible tools](references/tools.md) | `tools/<name>.ts`  | Add new tools the model can call. Plugin tools land in the same catalog as built-in tools.                                       |
 | [HTTP routes](references/routes.md)        | `routes/<path>.ts` | Serve HTTP endpoints (webhooks, integrations, callbacks) in the plugin's own `/x/plugins/<name>/` namespace.                     |
+| [Apps](references/apps.md)                 | `apps/<name>/`     | Ship persistent interactive apps (dashboards, trackers, visualizations) rendered in the workspace panel from bundled HTML or a compiled TSX bundle. |
 
 The two extensibility patterns serve different goals. **Plugins are for distribution**: you intend to share the capability, publish to the marketplace, or install it across multiple assistants. The plugin manifest (`package.json`), the `@vellumai/plugin-api` peer dependency, and the install flow exist to make a capability portable, versioned, and discoverable by others.
 
@@ -62,7 +63,7 @@ Vellum's plugin model was designed to line up with the agent harnesses you may a
 Ask before building. Six questions, in this order. Stop if the user is unclear on any of them.
 
 1. **What job does the plugin do?** One sentence, plain language. If you cannot write this, the plugin should not be built yet.
-2. **Which surfaces does it ship?** Tools (model calls), hooks (lifecycle transforms), skills (on-demand instructions), and routes (HTTP endpoints). Most plugins ship one or two, not all of them. See `references/plugins.md` for the directory layout and manifest, and the surface-specific references for each surface's contract.
+2. **Which surfaces does it ship?** Tools (model calls), hooks (lifecycle transforms), skills (on-demand instructions), routes (HTTP endpoints), and apps (interactive workspace-panel UIs). Most plugins ship one or two, not all of them. See `references/plugins.md` for the directory layout and manifest, and the surface-specific references for each surface's contract.
 3. **Does it need credentials?** An API key, OAuth token, or webhook secret is not a value that belongs in a `.ts` file. For LLM inference credentials, use `getConfiguredProvider()` from `@vellumai/plugin-api` to route through the workspace's stored credentials without handling plaintext. For other credential types (OAuth tokens, webhook secrets), store them via the credential vault and resolve at runtime through the assistant's credential system.
 4. **Does it keep state?** A plugin is fully self-contained: durable state lives in its `data/` directory (`InitContext.pluginStorageDir`), with schema created idempotently by the `init` hook, handles closed in `shutdown`, and per-conversation rows purged in `conversation-deleted`. A plugin never persists state in the assistant's database or elsewhere in the workspace. See "State is plugin-owned" in `references/plugins.md`.
 5. **Where will the source live?** A GitHub repo, ideally under the user's own namespace. The marketplace entry pins to a full commit SHA.
@@ -96,7 +97,7 @@ A URL install bypasses the marketplace entirely: the tree is cloned verbatim (no
 
 1. Plugin directory copied into `plugins/<name>/`, `assistant plugins list` shows status `ok` (not `error`, not `skipped`).
 2. `assistant plugins inspect <name>` reports `up-to-date` and `drift: none`.
-3. Each surface exercised on a real code path: a tool called by the model, a hook fires on the right event, a skill loads when hints match.
+3. Each surface exercised on a real code path: a tool called by the model, a hook fires on the right event, a skill loads when hints match, an app opens and renders in the workspace panel.
 4. Compiled files win: if you ship both `.js` and `.ts` for the same basename, the `.js` is loaded.
 
 If a surface fails to load or fire, see `references/plugins.md` for loader rules and `references/distribution.md` for the CLI diagnostic commands.
@@ -110,7 +111,7 @@ Once merged, users install by name: `assistant plugins install my-plugin`. The n
 ## SKILL COMPLETE WHEN
 
 - Job and surfaces locked in the alignment pass (questions 1 and 2 answered).
-- Directory matches the loader convention (`hooks/`, `tools/`, `skills/`, optional `src/`).
+- Directory matches the loader convention (`hooks/`, `tools/`, `skills/`, `routes/`, `apps/`, optional `src/`).
 - `package.json` declares `name`, `version`, and a real `peerDependencies["@vellumai/plugin-api"]` range.
 - Any durable state lives in `data/`, created by `init` and cleaned up by `shutdown` / `conversation-deleted`.
 - Each surface has been exercised locally with a working example.
@@ -123,4 +124,5 @@ Once merged, users install by name: `assistant plugins install my-plugin`. The n
 - `references/tools.md`: Tool definition fields, the execute context, result shape, resolution order, and a tool anatomy example.
 - `references/skills.md`: Frontmatter reference, resolution order, and a skill anatomy example.
 - `references/routes.md`: The `/x/plugins/<name>/` namespace, path mapping, handler signature, and a route anatomy example.
+- `references/apps.md`: The single-file vs multi-file app formats, `src/`→`dist/` compilation, the `plugins~<name>~<app>` id scheme, serving in the workspace panel, and an app anatomy example.
 - `references/distribution.md`: Marketplace catalog, CLI commands, drift and upgrades, the manifest schema, commit pinning, and adapters.

--- a/skills/plugin-builder/SKILL.md
+++ b/skills/plugin-builder/SKILL.md
@@ -46,7 +46,7 @@ A single plugin can contribute several different kinds of behavior. Each surface
 | [Skills](references/skills.md)             | `skills/<name>/`   | Directories of instructions and associated assets, scripts, and resources that the Assistant loads dynamically when relevant.    |
 | [Model-visible tools](references/tools.md) | `tools/<name>.ts`  | Add new tools the model can call. Plugin tools land in the same catalog as built-in tools.                                       |
 | [HTTP routes](references/routes.md)        | `routes/<path>.ts` | Serve HTTP endpoints (webhooks, integrations, callbacks) in the plugin's own `/x/plugins/<name>/` namespace.                     |
-| [Apps](references/apps.md)                 | `apps/<name>/`     | Ship persistent interactive apps (dashboards, trackers, visualizations) rendered in the workspace panel from bundled HTML or a compiled TSX bundle. |
+| [Apps](references/apps.md)                 | `apps/<name>/`     | Ship persistent interactive apps (dashboards, trackers, visualizations) compiled from a Preact + TSX bundle and rendered in the workspace panel. |
 
 The two extensibility patterns serve different goals. **Plugins are for distribution**: you intend to share the capability, publish to the marketplace, or install it across multiple assistants. The plugin manifest (`package.json`), the `@vellumai/plugin-api` peer dependency, and the install flow exist to make a capability portable, versioned, and discoverable by others.
 
@@ -63,7 +63,7 @@ Vellum's plugin model was designed to line up with the agent harnesses you may a
 Ask before building. Six questions, in this order. Stop if the user is unclear on any of them.
 
 1. **What job does the plugin do?** One sentence, plain language. If you cannot write this, the plugin should not be built yet.
-2. **Which surfaces does it ship?** Tools (model calls), hooks (lifecycle transforms), skills (on-demand instructions), routes (HTTP endpoints), and apps (interactive workspace-panel UIs). Most plugins ship one or two, not all of them. See `references/plugins.md` for the directory layout and manifest, and the surface-specific references for each surface's contract.
+2. **Which surfaces does it ship?** Pick from the surfaces table above. Most plugins ship one or two, not all of them. See `references/plugins.md` for the directory layout and manifest, and the surface-specific references for each surface's contract.
 3. **Does it need credentials?** An API key, OAuth token, or webhook secret is not a value that belongs in a `.ts` file. For LLM inference credentials, use `getConfiguredProvider()` from `@vellumai/plugin-api` to route through the workspace's stored credentials without handling plaintext. For other credential types (OAuth tokens, webhook secrets), store them via the credential vault and resolve at runtime through the assistant's credential system.
 4. **Does it keep state?** A plugin is fully self-contained: durable state lives in its `data/` directory (`InitContext.pluginStorageDir`), with schema created idempotently by the `init` hook, handles closed in `shutdown`, and per-conversation rows purged in `conversation-deleted`. A plugin never persists state in the assistant's database or elsewhere in the workspace. See "State is plugin-owned" in `references/plugins.md`.
 5. **Where will the source live?** A GitHub repo, ideally under the user's own namespace. The marketplace entry pins to a full commit SHA.
@@ -97,7 +97,7 @@ A URL install bypasses the marketplace entirely: the tree is cloned verbatim (no
 
 1. Plugin directory copied into `plugins/<name>/`, `assistant plugins list` shows status `ok` (not `error`, not `skipped`).
 2. `assistant plugins inspect <name>` reports `up-to-date` and `drift: none`.
-3. Each surface exercised on a real code path: a tool called by the model, a hook fires on the right event, a skill loads when hints match, an app opens and renders in the workspace panel.
+3. Each surface the plugin ships exercised on a real code path — invoked, fired, loaded, or opened the way a user would reach it.
 4. Compiled files win: if you ship both `.js` and `.ts` for the same basename, the `.js` is loaded.
 
 If a surface fails to load or fire, see `references/plugins.md` for loader rules and `references/distribution.md` for the CLI diagnostic commands.
@@ -111,7 +111,7 @@ Once merged, users install by name: `assistant plugins install my-plugin`. The n
 ## SKILL COMPLETE WHEN
 
 - Job and surfaces locked in the alignment pass (questions 1 and 2 answered).
-- Directory matches the loader convention (`hooks/`, `tools/`, `skills/`, `routes/`, `apps/`, optional `src/`).
+- Directory matches the loader convention: one subdirectory per surface it ships (see the surfaces table), plus an optional `src/` for internal modules.
 - `package.json` declares `name`, `version`, and a real `peerDependencies["@vellumai/plugin-api"]` range.
 - Any durable state lives in `data/`, created by `init` and cleaned up by `shutdown` / `conversation-deleted`.
 - Each surface has been exercised locally with a working example.
@@ -124,5 +124,5 @@ Once merged, users install by name: `assistant plugins install my-plugin`. The n
 - `references/tools.md`: Tool definition fields, the execute context, result shape, resolution order, and a tool anatomy example.
 - `references/skills.md`: Frontmatter reference, resolution order, and a skill anatomy example.
 - `references/routes.md`: The `/x/plugins/<name>/` namespace, path mapping, handler signature, and a route anatomy example.
-- `references/apps.md`: The single-file vs multi-file app formats, `src/`→`dist/` compilation, the `plugins~<name>~<app>` id scheme, serving in the workspace panel, and an app anatomy example.
+- `references/apps.md`: The Preact + TSX app structure, `src/`→`dist/` compilation, the `plugins~<name>~<app>` id scheme, serving in the workspace panel, and an app anatomy example.
 - `references/distribution.md`: Marketplace catalog, CLI commands, drift and upgrades, the manifest schema, commit pinning, and adapters.

--- a/skills/plugin-builder/SKILL.md
+++ b/skills/plugin-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-builder
-description: "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles hooks, tools, skills, and routes into one installable package."
+description: "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles multiple surfaces (hooks, tools, skills, and more) into one installable package."
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🧩"
@@ -22,7 +22,7 @@ metadata:
 
 # Plugin Builder
 
-Build on top of Vellum with plugins. A plugin bundles hooks, tools, skills, and routes into a single installable package that extends what an assistant can do.
+Build on top of Vellum with plugins. A plugin bundles multiple surfaces into a single installable package that extends what an assistant can do.
 
 Plugins are in beta. The peer-dep range you declare is what gets you load. Treat everything you write as something that can break between Vellum releases until 1.0 ships, and pin a real range.
 
@@ -40,12 +40,12 @@ Plugins can also be discovered and managed from the Plugins tab in the app, or s
 
 A single plugin can contribute several different kinds of behavior. Each surface is discovered by convention from a named subdirectory. Missing directories are simply skipped, so a plugin contributes only what it ships.
 
-| Surface                                    | Lives in           | What it does                                                                                                                     |
-| ------------------------------------------ | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| [Lifecycle hooks](references/hooks.md)     | `hooks/<name>.ts`  | Run code at fixed points in the Assistant's lifecycle to read or transform what flows through, and broadcast progress to the UI. |
-| [Skills](references/skills.md)             | `skills/<name>/`   | Directories of instructions and associated assets, scripts, and resources that the Assistant loads dynamically when relevant.    |
-| [Model-visible tools](references/tools.md) | `tools/<name>.ts`  | Add new tools the model can call. Plugin tools land in the same catalog as built-in tools.                                       |
-| [HTTP routes](references/routes.md)        | `routes/<path>.ts` | Serve HTTP endpoints (webhooks, integrations, callbacks) in the plugin's own `/x/plugins/<name>/` namespace.                     |
+| Surface                                    | Lives in           | What it does                                                                                                                                     |
+| ------------------------------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Lifecycle hooks](references/hooks.md)     | `hooks/<name>.ts`  | Run code at fixed points in the Assistant's lifecycle to read or transform what flows through, and broadcast progress to the UI.                 |
+| [Skills](references/skills.md)             | `skills/<name>/`   | Directories of instructions and associated assets, scripts, and resources that the Assistant loads dynamically when relevant.                    |
+| [Model-visible tools](references/tools.md) | `tools/<name>.ts`  | Add new tools the model can call. Plugin tools land in the same catalog as built-in tools.                                                       |
+| [HTTP routes](references/routes.md)        | `routes/<path>.ts` | Serve HTTP endpoints (webhooks, integrations, callbacks) in the plugin's own `/x/plugins/<name>/` namespace.                                     |
 | [Apps](references/apps.md)                 | `apps/<name>/`     | Ship persistent interactive apps (dashboards, trackers, visualizations) compiled from a Preact + TSX bundle and rendered in the workspace panel. |
 
 The two extensibility patterns serve different goals. **Plugins are for distribution**: you intend to share the capability, publish to the marketplace, or install it across multiple assistants. The plugin manifest (`package.json`), the `@vellumai/plugin-api` peer dependency, and the install flow exist to make a capability portable, versioned, and discoverable by others.

--- a/skills/plugin-builder/references/apps.md
+++ b/skills/plugin-builder/references/apps.md
@@ -1,0 +1,85 @@
+# Apps
+
+Ship a persistent, interactive app from a plugin — a dashboard, tracker, calculator, data visualization, or slide deck the assistant renders in the workspace panel. An app is a self-contained UI the user opens and interacts with, packaged alongside the plugin's other surfaces.
+
+An app is a directory under `apps/<name>/`. There is no registration step and no manifest entry: the assistant discovers each app by walking the plugin's `apps/` directory on disk, exactly as it does for a plugin's routes. Each immediate subdirectory of `apps/` is one app, and the directory name is the app's name.
+
+## Two app formats
+
+An app is served in one of two formats, chosen by what the directory ships:
+
+- **Single-file.** An `index.html` at the app root. The assistant serves it as-is — inline `<script>` and `<style>` are allowed (the served page's CSP permits `'unsafe-inline'`). Good for a small self-contained page with no build step.
+- **Multi-file.** A Preact + TSX project under `src/`, with no root `index.html`. The assistant compiles `src/` into a sibling `dist/` with esbuild and serves the bundled `dist/index.html`. The served page's CSP is stricter (`script-src 'self'`, no inline), matching workspace apps built through the app-builder skill.
+
+The presence of a root `index.html` is what distinguishes the two: `index.html` at the app root ⇒ single-file; otherwise ⇒ multi-file compiled from `src/`.
+
+```
+apps/
+├── dashboard/            # single-file app
+│   └── index.html
+└── tracker/              # multi-file app
+    ├── src/
+    │   ├── index.html    # shell that loads the bundle
+    │   ├── main.tsx      # renders <App /> into #app
+    │   ├── components/
+    │   │   └── App.tsx
+    │   └── styles.css
+    └── dist/             # compiled output — generated, never hand-written
+```
+
+## Compilation and live reload
+
+Multi-file apps are compiled off the assistant's hot path by the plugin source watcher, which already fingerprints plugin source for live reload. When a plugin's source changes, the watcher builds each `apps/<app>/src` into its sibling `apps/<app>/dist` and the new bundle is picked up on the next open — no restart.
+
+- **`dist/` is generated, not source.** You never hand-write or commit `dist/`. It is excluded from the plugin source fingerprint and from install-time drift detection (the `apps/<app>/dist` path is a recognized generated-build directory), so the watcher's own compile never reads as a source change and generated output never shows as drift against the pinned commit. Ship only `src/` (or a root `index.html`) in your repo.
+- **The plugin tree is read-only to the assistant.** The daemon never writes into the plugin directory. If a multi-file app is opened before the watcher has produced its `dist/`, the daemon compiles it in a throwaway temp directory to render that open — the persistent `dist/` is still the watcher's job.
+
+## Addressing and serving
+
+A plugin app's id encodes its location rather than being an opaque handle:
+
+```
+plugins~<plugin-name>~<app-dir>
+```
+
+which maps to `<workspaceDir>/plugins/<plugin-name>/apps/<app-dir>`. The delimiter is `~` (not `/`) so the id stays a single URL path segment. Workspace apps — the ones a user builds with the app-builder skill — instead use an opaque UUID and live under `<workspaceDir>/data/apps/`; a plugin app is resolved by building its path directly from the id.
+
+Once resolved, a plugin app is opened and served exactly like a workspace app: opening it reports an origin of `plugin:<plugin-name>`, its HTML is rendered into the workspace panel, and a multi-file app's compiled JS/CSS is inlined so the page is self-contained. Files bundled next to the app (images, fonts, media) are served from the app's own directory with path traversal rejected, and are addressed at runtime through the same `window.vellum.asset(...)` bridge workspace apps use.
+
+## Discovery and lifecycle
+
+App discovery mirrors the plugin loader's own scan, so an app is visible on exactly the same terms as the plugin's tools, hooks, and routes:
+
+- **Installed plugins only.** A directory contributes apps only if it carries a `package.json` manifest. Stray directories without a manifest are ignored.
+- **Disabled plugins contribute nothing.** A plugin with a `.disabled` sentinel serves no apps, matching how its other surfaces are gated.
+- **Missing `apps/` is skipped.** A plugin with no `apps/` directory simply bundles no apps, like any absent surface.
+
+## The frontend contract
+
+This reference covers how an app is packaged, compiled, and served as a plugin surface. The *authoring* contract for the app itself — the design system and `--v-*` tokens, the widget library, responsive rules, the `window.vellum` bridge (`fetch`, `asset`, `subscribe`, `sendAction`), and how an app reaches backend data through routes — is owned by the **app-builder** skill, with design quality delegated to **frontend-design**. Build the app's UI by those skills, then drop the resulting directory (single-file `index.html`, or a multi-file `src/`) under your plugin's `apps/`. A plugin that also ships `routes/` can back its app's data with its own namespaced HTTP routes (see [routes.md](routes.md)).
+
+## Anatomy of an app
+
+```
+my-plugin/
+└── apps/
+    └── expenses/
+        ├── src/
+        │   ├── index.html
+        │   ├── main.tsx
+        │   ├── components/
+        │   │   └── App.tsx
+        │   └── styles.css
+        └── dist/          # produced by the watcher — do not commit
+```
+
+```tsx
+// apps/expenses/src/main.tsx
+import { render } from "preact";
+import { App } from "./components/App";
+import "./styles.css";
+
+render(<App />, document.getElementById("app")!);
+```
+
+The app above is addressed as `plugins~my-plugin~expenses` and opens in the workspace panel with a `plugin:my-plugin` origin.

--- a/skills/plugin-builder/references/apps.md
+++ b/skills/plugin-builder/references/apps.md
@@ -41,7 +41,7 @@ Once resolved, a plugin app is opened and served exactly like a workspace app: o
 
 ## Discovery and lifecycle
 
-App discovery mirrors the plugin loader's own scan, so an app is visible on exactly the same terms as the plugin's tools, hooks, and routes:
+App discovery mirrors the plugin loader's own scan, so an app is visible on exactly the same terms as the plugin's other surfaces:
 
 - **Installed plugins only.** A directory contributes apps only if it carries a `package.json` manifest. Stray directories without a manifest are ignored.
 - **Disabled plugins contribute nothing.** A plugin with a `.disabled` sentinel serves no apps, matching how its other surfaces are gated.
@@ -49,7 +49,7 @@ App discovery mirrors the plugin loader's own scan, so an app is visible on exac
 
 ## The frontend contract
 
-This reference covers how an app is packaged, compiled, and served as a plugin surface. The *authoring* contract for the app itself — the design system and `--v-*` tokens, the widget library, responsive rules, the `window.vellum` bridge (`fetch`, `asset`, `subscribe`, `sendAction`), and how an app reaches backend data through routes — is owned by the **app-builder** skill, with design quality delegated to **frontend-design**. Build the app's UI by those skills, then drop the resulting `src/` under your plugin's `apps/`. A plugin that also ships `routes/` can back its app's data with its own namespaced HTTP routes (see [routes.md](routes.md)).
+This reference covers how an app is packaged, compiled, and served as a plugin surface. The _authoring_ contract for the app itself — the design system and `--v-*` tokens, the widget library, responsive rules, the `window.vellum` bridge (`fetch`, `asset`, `subscribe`, `sendAction`), and how an app reaches backend data through routes — is owned by the **app-builder** skill, with design quality delegated to **frontend-design**. Build the app's UI by those skills, then drop the resulting `src/` under your plugin's `apps/`. A plugin that also ships `routes/` can back its app's data with its own namespaced HTTP routes (see [routes.md](routes.md)).
 
 ## Anatomy of an app
 

--- a/skills/plugin-builder/references/apps.md
+++ b/skills/plugin-builder/references/apps.md
@@ -4,20 +4,13 @@ Ship a persistent, interactive app from a plugin — a dashboard, tracker, calcu
 
 An app is a directory under `apps/<name>/`. There is no registration step and no manifest entry: the assistant discovers each app by walking the plugin's `apps/` directory on disk, exactly as it does for a plugin's routes. Each immediate subdirectory of `apps/` is one app, and the directory name is the app's name.
 
-## Two app formats
+## App structure
 
-An app is served in one of two formats, chosen by what the directory ships:
-
-- **Single-file.** An `index.html` at the app root. The assistant serves it as-is — inline `<script>` and `<style>` are allowed (the served page's CSP permits `'unsafe-inline'`). Good for a small self-contained page with no build step.
-- **Multi-file.** A Preact + TSX project under `src/`, with no root `index.html`. The assistant compiles `src/` into a sibling `dist/` with esbuild and serves the bundled `dist/index.html`. The served page's CSP is stricter (`script-src 'self'`, no inline), matching workspace apps built through the app-builder skill.
-
-The presence of a root `index.html` is what distinguishes the two: `index.html` at the app root ⇒ single-file; otherwise ⇒ multi-file compiled from `src/`.
+An app is a Preact + TSX project under `src/`, which the assistant compiles into a sibling `dist/` with esbuild and serves. The compiled page runs under a strict content-security policy (`script-src 'self'`, no inline scripts), which is why the app ships as a bundle rather than an inline-script HTML file.
 
 ```
 apps/
-├── dashboard/            # single-file app
-│   └── index.html
-└── tracker/              # multi-file app
+└── tracker/
     ├── src/
     │   ├── index.html    # shell that loads the bundle
     │   ├── main.tsx      # renders <App /> into #app
@@ -29,10 +22,10 @@ apps/
 
 ## Compilation and live reload
 
-Multi-file apps are compiled off the assistant's hot path by the plugin source watcher, which already fingerprints plugin source for live reload. When a plugin's source changes, the watcher builds each `apps/<app>/src` into its sibling `apps/<app>/dist` and the new bundle is picked up on the next open — no restart.
+Apps are compiled off the assistant's hot path by the plugin source watcher, which already fingerprints plugin source for live reload. When a plugin's source changes, the watcher builds each `apps/<app>/src` into its sibling `apps/<app>/dist` and the new bundle is picked up on the next open — no restart.
 
-- **`dist/` is generated, not source.** You never hand-write or commit `dist/`. It is excluded from the plugin source fingerprint and from install-time drift detection (the `apps/<app>/dist` path is a recognized generated-build directory), so the watcher's own compile never reads as a source change and generated output never shows as drift against the pinned commit. Ship only `src/` (or a root `index.html`) in your repo.
-- **The plugin tree is read-only to the assistant.** The daemon never writes into the plugin directory. If a multi-file app is opened before the watcher has produced its `dist/`, the daemon compiles it in a throwaway temp directory to render that open — the persistent `dist/` is still the watcher's job.
+- **`dist/` is generated, not source.** You never hand-write or commit `dist/`. It is excluded from the plugin source fingerprint and from install-time drift detection (the `apps/<app>/dist` path is a recognized generated-build directory), so the watcher's own compile never reads as a source change and generated output never shows as drift against the pinned commit. Ship only `src/` in your repo.
+- **The watcher owns the persistent build.** The source watcher is what writes `apps/<app>/dist` into the plugin directory. On the open path, if an app is opened before the watcher has produced its `dist/`, the assistant compiles it in a throwaway temporary directory to render that one open, rather than writing into the plugin tree — the persistent `dist/` is still the watcher's job.
 
 ## Addressing and serving
 
@@ -44,7 +37,7 @@ plugins~<plugin-name>~<app-dir>
 
 which maps to `<workspaceDir>/plugins/<plugin-name>/apps/<app-dir>`. The delimiter is `~` (not `/`) so the id stays a single URL path segment. Workspace apps — the ones a user builds with the app-builder skill — instead use an opaque UUID and live under `<workspaceDir>/data/apps/`; a plugin app is resolved by building its path directly from the id.
 
-Once resolved, a plugin app is opened and served exactly like a workspace app: opening it reports an origin of `plugin:<plugin-name>`, its HTML is rendered into the workspace panel, and a multi-file app's compiled JS/CSS is inlined so the page is self-contained. Files bundled next to the app (images, fonts, media) are served from the app's own directory with path traversal rejected, and are addressed at runtime through the same `window.vellum.asset(...)` bridge workspace apps use.
+Once resolved, a plugin app is opened and served exactly like a workspace app: opening it reports an origin of `plugin:<plugin-name>`, its HTML is rendered into the workspace panel, and its compiled JS/CSS is inlined so the page is self-contained. Files bundled next to the app (images, fonts, media) are served from the app's own directory with path traversal rejected, and are addressed at runtime through the same `window.vellum.asset(...)` bridge workspace apps use.
 
 ## Discovery and lifecycle
 
@@ -56,7 +49,7 @@ App discovery mirrors the plugin loader's own scan, so an app is visible on exac
 
 ## The frontend contract
 
-This reference covers how an app is packaged, compiled, and served as a plugin surface. The *authoring* contract for the app itself — the design system and `--v-*` tokens, the widget library, responsive rules, the `window.vellum` bridge (`fetch`, `asset`, `subscribe`, `sendAction`), and how an app reaches backend data through routes — is owned by the **app-builder** skill, with design quality delegated to **frontend-design**. Build the app's UI by those skills, then drop the resulting directory (single-file `index.html`, or a multi-file `src/`) under your plugin's `apps/`. A plugin that also ships `routes/` can back its app's data with its own namespaced HTTP routes (see [routes.md](routes.md)).
+This reference covers how an app is packaged, compiled, and served as a plugin surface. The *authoring* contract for the app itself — the design system and `--v-*` tokens, the widget library, responsive rules, the `window.vellum` bridge (`fetch`, `asset`, `subscribe`, `sendAction`), and how an app reaches backend data through routes — is owned by the **app-builder** skill, with design quality delegated to **frontend-design**. Build the app's UI by those skills, then drop the resulting `src/` under your plugin's `apps/`. A plugin that also ships `routes/` can back its app's data with its own namespaced HTTP routes (see [routes.md](routes.md)).
 
 ## Anatomy of an app
 

--- a/skills/plugin-builder/references/distribution.md
+++ b/skills/plugin-builder/references/distribution.md
@@ -52,7 +52,7 @@ The Vellum team reviews each entry before it lands in the catalog. The review ch
 - The pinned commit matches a public, reachable revision of the repo.
 - The plugin has a valid `package.json` with a `@vellumai/plugin-api` peer dependency.
 - The plugin loads cleanly (hooks register, tools validate, no import errors at boot).
-- The surfaces the plugin claims (hooks, tools, skills) contribute something on boot rather than silently failing.
+- The surfaces the plugin claims (hooks, tools, skills, routes, apps) contribute something on boot rather than silently failing.
 
 Once the review approves and the PR merges, the plugin appears in `assistant plugins search` and is installable by name.
 

--- a/skills/plugin-builder/references/distribution.md
+++ b/skills/plugin-builder/references/distribution.md
@@ -52,7 +52,7 @@ The Vellum team reviews each entry before it lands in the catalog. The review ch
 - The pinned commit matches a public, reachable revision of the repo.
 - The plugin has a valid `package.json` with a `@vellumai/plugin-api` peer dependency.
 - The plugin loads cleanly (hooks register, tools validate, no import errors at boot).
-- The surfaces the plugin claims (hooks, tools, skills, routes, apps) contribute something on boot rather than silently failing.
+- The surfaces the plugin claims contribute something on boot rather than silently failing.
 
 Once the review approves and the PR merges, the plugin appears in `assistant plugins search` and is installable by name.
 

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -22,6 +22,9 @@ my-plugin/
 ├── skills/                    # On-demand instruction bundles
 │   └── my-skill/
 │       └── SKILL.md
+├── apps/                      # Interactive apps served in the workspace panel
+│   └── my-app/
+│       └── src/               # (dist/ is generated — never committed)
 └── src/                       # Internal modules (NOT walked by the loader)
     └── state.ts
 ```
@@ -46,6 +49,8 @@ Three entries at the plugin root are runtime-owned state, not part of the plugin
 
 Uninstalling a plugin (`assistant plugins uninstall`) removes the entire plugin directory, so `config.json`, `data/`, and `.disabled` go with it. No orphaned state is left behind.
 
+One more path is runtime-generated rather than source: `apps/<app>/dist`, the compiled output the source watcher builds from a multi-file app's `src/`. Like the preserved entries, it is excluded from fingerprinting and drift detection, so the watcher's own compile is not seen as a source change and generated bundles never show as drift against the pinned commit. Ship only the app's `src/` (or a root `index.html`); never commit `dist/`. See [apps.md](apps.md).
+
 ### State is plugin-owned
 
 A plugin must be fully self-contained: every byte of durable state it keeps lives in `data/`, and its lifecycle hooks own that state end-to-end.
@@ -58,7 +63,7 @@ The assistant's own database is internal — `@vellumai/plugin-api` exposes no h
 
 Each surface can also be dropped straight into the workspace at `/workspace/<surface>/<name>/` without wrapping it in a plugin. A plugin is what lets you ship several surfaces together as one installable unit.
 
-The per-surface contracts live in their own references: [hooks.md](hooks.md), [tools.md](tools.md), [skills.md](skills.md), and [routes.md](routes.md).
+The per-surface contracts live in their own references: [hooks.md](hooks.md), [tools.md](tools.md), [skills.md](skills.md), [routes.md](routes.md), and [apps.md](apps.md).
 
 ## The manifest
 
@@ -120,7 +125,6 @@ The assistant supports these surfaces today, but they are not yet contributed th
 | Surface        | What it does                                                                                                  |
 | -------------- | ------------------------------------------------------------------------------------------------------------- |
 | Schedules      | Cron-style triggers that fire on a recurring schedule.                                                        |
-| Apps           | Persistent interactive apps (dashboards, games, tools) served in the workspace panel.                         |
 | Artifacts      | Versioned outputs the assistant produces and tracks (documents, diagrams, generated files).                   |
 | Webhooks       | Inbound HTTP endpoints that deliver external events into the assistant.                                       |
 | Prompts        | Reusable system prompt fragments and templates.                                                               |

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -63,7 +63,7 @@ The assistant's own database is internal — `@vellumai/plugin-api` exposes no h
 
 Each surface can also be dropped straight into the workspace at `/workspace/<surface>/<name>/` without wrapping it in a plugin. A plugin is what lets you ship several surfaces together as one installable unit.
 
-The per-surface contracts live in their own references: [hooks.md](hooks.md), [tools.md](tools.md), [skills.md](skills.md), [routes.md](routes.md), and [apps.md](apps.md).
+Each surface's contract lives in its own reference file next to this one, linked from the surfaces table in `SKILL.md`.
 
 ## The manifest
 

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -49,7 +49,7 @@ Three entries at the plugin root are runtime-owned state, not part of the plugin
 
 Uninstalling a plugin (`assistant plugins uninstall`) removes the entire plugin directory, so `config.json`, `data/`, and `.disabled` go with it. No orphaned state is left behind.
 
-One more path is runtime-generated rather than source: `apps/<app>/dist`, the compiled output the source watcher builds from a multi-file app's `src/`. Like the preserved entries, it is excluded from fingerprinting and drift detection, so the watcher's own compile is not seen as a source change and generated bundles never show as drift against the pinned commit. Ship only the app's `src/` (or a root `index.html`); never commit `dist/`. See [apps.md](apps.md).
+One more path is runtime-generated rather than source: `apps/<app>/dist`, the compiled output the source watcher builds from an app's `src/`. Like the preserved entries, it is excluded from fingerprinting and drift detection, so the watcher's own compile is not seen as a source change and generated bundles never show as drift against the pinned commit. Ship only the app's `src/`; never commit `dist/`. See [apps.md](apps.md).
 
 ### State is plugin-owned
 


### PR DESCRIPTION
## Prompt / plan

> we need to update the plugin builder skill to now document our support for `apps` as a plugin surface. follow the pattern as our other surfaces

Apps are already wired as a plugin surface in code (the plugin source watcher compiles each `apps/<app>/src` into a sibling `dist/`, the generated build dir is excluded from source fingerprinting via `GENERATED_APP_BUILD_DIR`, and plugin apps are enumerated/served under the `plugins~<name>~<app>` id scheme in `apps/app-store.ts` + the app serve routes). This PR brings the `plugin-builder` skill docs in line with that support, mirroring the existing per-surface reference pattern (hooks / tools / skills / routes).

Changes:
- **New `references/apps.md`** — the authoring contract for the apps surface: single-file (`index.html`) vs multi-file (`src/` → compiled `dist/`) formats and their CSP difference, `src/`→`dist/` compilation by the plugin source watcher (with `dist/` treated as generated, not source), the `plugins~<plugin>~<app>` id scheme, how apps are opened/served in the workspace panel, discovery/lifecycle gating (installed + enabled plugins only), and a pointer to the `app-builder`/`frontend-design` skills for the frontend contract.
- **`SKILL.md`** — added Apps to the surfaces table, the "which surfaces does it ship?" alignment question, the verify + `SKILL COMPLETE WHEN` checklists, and the reference-files list.
- **`references/plugins.md`** — added `apps/` to the directory layout, documented that the generated `apps/<app>/dist` output is excluded from fingerprinting/drift, moved Apps out of the "Surfaces not yet available in plugins" table, and cross-linked `apps.md`.
- **`references/distribution.md`** — included apps in the marketplace review-check surface list.

## Test plan

Docs-only change to a bundled skill (no code, no frontmatter changes). Verified by:
- Reading the actual apps-as-plugin-surface implementation (`monitoring/plugin-source-watch.ts` `compilePluginApps`, `plugins/plugin-tree-walk.ts` `GENERATED_APP_BUILD_DIR`, `apps/app-store.ts` enumeration/resolution, `__tests__/plugin-app-serve-routes.test.ts`) so the documented contract matches behavior.
- Confirming every cross-reference resolves (all `references/*.md` links point at existing files) and that the surface tables, directory layout, and checklists stay internally consistent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AoJ8uVT2pDFcaYGodYRTAz)_