### PR TITLE
fix(voice): invalidate connections cache after voice OAuth connect (JARVIS-1286)

### DIFF
--- a/clients/web/.storybook/preview.tsx
+++ b/clients/web/.storybook/preview.tsx
@@ -12,6 +12,7 @@ import { create, themes } from "storybook/theming";
 import { addons } from "storybook/preview-api";
 import { GLOBALS_UPDATED } from "storybook/internal/core-events";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import type { PropsWithChildren } from "react";
 import type { ReactRenderer } from "@storybook/react-vite";
@@ -24,6 +25,13 @@ const themesAddon = themesAddonImport as unknown as () => ReturnType<
 >;
 
 import "./preview.css";
+
+// Some surfaces (e.g. OAuthConnectSurface) call `useQueryClient()`, which throws
+// without a provider. Give every story a shared client so Storybook/Chromatic
+// renders don't break; retries off keeps failed queries from looping in stories.
+const storybookQueryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
 
 const lightTheme = create({
   base: "light",
@@ -108,9 +116,11 @@ export default definePreview({
       attributeName: "data-theme",
     }),
     (Story) => (
-      <MemoryRouter>
-        <Story />
-      </MemoryRouter>
+      <QueryClientProvider client={storybookQueryClient}>
+        <MemoryRouter>
+          <Story />
+        </MemoryRouter>
+      </QueryClientProvider>
     ),
   ],
   parameters: {

--- a/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/choice-copy-surfaces.test.tsx
@@ -1,10 +1,19 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
 
 mock.module("@/domains/chat/components/chat-markdown-message", () => ({
   ChatMarkdownMessage: ({ content }: { content: string }) => (
     <div>{content}</div>
   ),
+}));
+
+// Keep the platform-id resolution deterministic: the surface resolves the
+// assistant's platform id before invalidating the connections query, and the
+// real resolver reaches into local-mode/gateway state.
+mock.module("@/lib/local-platform-identity", () => ({
+  resolveLocalAssistantPlatformIdentity: mock(async (id: string) => id),
 }));
 
 import { ChoiceSurface } from "@/domains/chat/components/surfaces/choice-surface";
@@ -15,6 +24,7 @@ import type {
   ManagedOAuthConnectClient,
   ManagedOAuthConnectResult,
 } from "@/domains/chat/api/managed-oauth";
+import { assistantsOauthConnectionsListQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import type { OAuthConnection } from "@/generated/api/types.gen";
 import type { Surface } from "@/domains/chat/types/types";
 
@@ -25,6 +35,21 @@ afterAll(() => {
 afterEach(() => {
   cleanup();
 });
+
+// The OAuth connect surface reads `useQueryClient()` to refresh the connections
+// list after a successful connect, so its renders need a provider. The returned
+// `invalidateQueries` spy lets tests assert the cache refresh (or its absence).
+function renderWithQueryClient(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const invalidateQueries = mock(() => Promise.resolve());
+  client.invalidateQueries = invalidateQueries as never;
+  return {
+    invalidateQueries,
+    ...render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>),
+  };
+}
 
 function makeSurface(overrides: Partial<Surface>): Surface {
   return {
@@ -198,7 +223,7 @@ describe("OAuthConnectSurface", () => {
       })),
     };
 
-    const { getByRole, queryByText } = render(
+    const { getByRole, queryByText, invalidateQueries } = renderWithQueryClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -241,6 +266,16 @@ describe("OAuthConnectSurface", () => {
         scopesGranted: ["gmail.readonly"],
       });
     });
+
+    // A successful connect refreshes the connections list so a just-connected
+    // account no longer reads as unconnected wherever the list is mounted.
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: assistantsOauthConnectionsListQueryKey({
+          path: { assistant_id: "assistant-1" },
+        }),
+      });
+    });
   });
 
   test("does not submit the surface action after the card unmounts mid-connect", async () => {
@@ -260,7 +295,7 @@ describe("OAuthConnectSurface", () => {
       ),
     };
 
-    const { getByRole, unmount } = render(
+    const { getByRole, unmount, invalidateQueries } = renderWithQueryClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -292,6 +327,8 @@ describe("OAuthConnectSurface", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(onAction).not.toHaveBeenCalled();
+    // The unmounted (losing) instance must not refresh the cache either.
+    expect(invalidateQueries).not.toHaveBeenCalled();
   });
 
   test("does not double the verb when displayName already includes 'Connect'", () => {
@@ -300,7 +337,7 @@ describe("OAuthConnectSurface", () => {
       connect: mock(async () => ({ status: "cancelled" as const })),
     };
 
-    const { getByText, queryByText } = render(
+    const { getByText, queryByText } = renderWithQueryClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -333,7 +370,7 @@ describe("OAuthConnectSurface", () => {
       connect: mock(async () => ({ status: "cancelled" as const })),
     };
 
-    const { getByRole } = render(
+    const { getByRole, invalidateQueries } = renderWithQueryClient(
       <OAuthConnectSurface
         surface={makeSurface({
           surfaceType: "oauth_connect",
@@ -356,6 +393,68 @@ describe("OAuthConnectSurface", () => {
       providerKey: "linear",
       providerLabel: "Linear",
     });
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  test("does not refresh the connections cache on a cancelled connect", async () => {
+    const onAction = mock(() => {});
+    const oauthClient: ManagedOAuthConnectClient = {
+      fetchProvider: mock(async () => null),
+      connect: mock(async () => ({ status: "cancelled" as const })),
+    };
+
+    const { getByRole, invalidateQueries } = renderWithQueryClient(
+      <OAuthConnectSurface
+        surface={makeSurface({
+          surfaceType: "oauth_connect",
+          data: { providerKey: "google", displayName: "Google" },
+        })}
+        assistantId="assistant-1"
+        oauthClient={oauthClient}
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Connect" }));
+    await waitFor(() =>
+      expect(onAction).toHaveBeenCalledWith("surface-1", "cancel", {
+        status: "cancelled",
+        providerKey: "google",
+        providerLabel: "Google",
+      }),
+    );
+
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  test("does not refresh the connections cache on a failed connect", async () => {
+    const onAction = mock(() => {});
+    const oauthClient: ManagedOAuthConnectClient = {
+      fetchProvider: mock(async () => null),
+      connect: mock(async () => ({
+        status: "error" as const,
+        message: "Authorization failed.",
+      })),
+    };
+
+    const { getByRole, findByText, invalidateQueries } = renderWithQueryClient(
+      <OAuthConnectSurface
+        surface={makeSurface({
+          surfaceType: "oauth_connect",
+          data: { providerKey: "google", displayName: "Google" },
+        })}
+        assistantId="assistant-1"
+        oauthClient={oauthClient}
+        onAction={onAction}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Connect" }));
+    // Error surfaces its message and never emits a surface action.
+    expect(await findByText("Authorization failed.")).toBeTruthy();
+
+    expect(onAction).not.toHaveBeenCalled();
+    expect(invalidateQueries).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@vellumai/design-library";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   CheckCircle2,
   ExternalLink,
@@ -16,6 +17,8 @@ import {
   type ManagedOAuthProviderSummary,
 } from "@/domains/chat/api/managed-oauth";
 import type { Surface } from "@/domains/chat/types/types";
+import { assistantsOauthConnectionsListQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import { resolveLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 
 interface OAuthConnectSurfaceData {
   providerKey?: string;
@@ -99,6 +102,7 @@ export function OAuthConnectSurface({
   assistantDisplayName,
   oauthClient = defaultManagedOAuthConnectClient,
 }: OAuthConnectSurfaceProps) {
+  const queryClient = useQueryClient();
   const data = surface.data as OAuthConnectSurfaceData;
   const providerKey = data.providerKey ?? "";
   const [provider, setProvider] = useState<ManagedOAuthProviderSummary | null>(
@@ -166,6 +170,18 @@ export function OAuthConnectSurface({
 
     if (result.status === "connected") {
       setState("connected");
+      // Refresh any mounted connections list (e.g. Settings integrations) so a
+      // just-connected account no longer reads as unconnected. Best-effort: the
+      // platform-id resolution can throw and must not block the surface action.
+      void resolveLocalAssistantPlatformIdentity(assistantId)
+        .then((platformAssistantId) =>
+          queryClient.invalidateQueries({
+            queryKey: assistantsOauthConnectionsListQueryKey({
+              path: { assistant_id: platformAssistantId },
+            }),
+          }),
+        )
+        .catch(() => {});
       onAction(surface.surfaceId, "connect", {
         status: "connected",
         providerKey,


### PR DESCRIPTION
## Summary
Follow-up to OAuth-in-voice (#38095/#38100): OAuthConnectSurface now invalidates the connections list query on a successful connect, so a just-connected account reflects as connected wherever the list is mounted (parity with the settings connect hook). Adds a Storybook QueryClientProvider if one was missing.

JARVIS-1286