### PR TITLE
fix(voice): active-surface context + single echo on voice surface resumes (JARVIS-1287)

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -21,7 +21,10 @@ import type {
   UiSurfaceShow,
 } from "../daemon/message-protocol.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
-import type { VoiceResumeHandler } from "../live-voice/live-voice-resume-registry.js";
+import type {
+  VoiceResumeHandler,
+  VoiceResumeOptions,
+} from "../live-voice/live-voice-resume-registry.js";
 
 interface ProcessMessageCall {
   content: string;
@@ -523,7 +526,7 @@ describe("surface action delivery to assistant", () => {
 
     const resumeCalls: Array<{
       content: string;
-      opts?: { displayContent?: string; sourceActorPrincipalId?: string };
+      opts?: VoiceResumeOptions;
     }> = [];
     const handler: VoiceResumeHandler = {
       resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
@@ -551,6 +554,9 @@ describe("surface action delivery to assistant", () => {
 
       // Routed to the spoken resume, not the silent text pipeline.
       expect(resumeCalls).toHaveLength(1);
+      // The accepted surface is threaded so the resumed turn re-injects its
+      // active-surface context (parity with the text path's activeSurfaceId).
+      expect(resumeCalls[0].opts?.activeSurfaceId).toBe(surfaceId);
       expect(ctx.processMessageCalls).toHaveLength(0);
       // The one-shot surface still completes and the pending guard is cleared.
       expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(false);
@@ -560,6 +566,53 @@ describe("surface action delivery to assistant", () => {
             msg.type === "ui_surface_complete" && msg.surfaceId === surfaceId,
         ),
       ).toBe(true);
+    } finally {
+      unregisterVoiceResumeHandler(ctx.conversationId, handler);
+    }
+  });
+
+  test("relayed-prompt voice resume emits no pre-echo (single user bubble comes from the resume turn)", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const resumeCalls: Array<{
+      content: string;
+      opts?: VoiceResumeOptions;
+    }> = [];
+    const handler: VoiceResumeHandler = {
+      resumeWithText: (content, opts) => resumeCalls.push({ content, opts }),
+    };
+    registerVoiceResumeHandler(ctx.conversationId, handler);
+
+    try {
+      const surfaceId = "card-relay-1";
+      ctx.pendingSurfaceActions.set(surfaceId, { surfaceType: "card" });
+      ctx.surfaceState.set(surfaceId, {
+        surfaceType: "card",
+        data: { title: "Ready?" } as SurfaceData,
+        actions: [
+          {
+            id: "relay_prompt",
+            label: "Do it",
+            data: { prompt: "Do the thing" },
+          },
+        ],
+      });
+
+      await handleSurfaceAction(ctx, surfaceId, "relay_prompt");
+
+      // Routed to the spoken resume with the relayed prompt as content.
+      expect(resumeCalls).toHaveLength(1);
+      expect(resumeCalls[0].content).toBe("Do the thing");
+      expect(resumeCalls[0].opts?.activeSurfaceId).toBe(surfaceId);
+      expect(ctx.processMessageCalls).toHaveLength(0);
+
+      // The resume turn's own startVoiceTurn broadcasts the single
+      // user_message_echo, so handleSurfaceAction must not pre-echo here —
+      // otherwise the click renders two user bubbles.
+      expect(
+        broadcastedMessages.filter((msg) => msg.type === "user_message_echo"),
+      ).toHaveLength(0);
     } finally {
       unregisterVoiceResumeHandler(ctx.conversationId, handler);
     }

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -70,6 +70,8 @@ interface FakeConversation {
   updateClient: (cb: unknown, reset?: boolean) => void;
   runAgentLoop: (...args: unknown[]) => Promise<void>;
   abort: (reason?: unknown) => void;
+  currentActiveSurfaceId?: string;
+  currentPage?: string;
 }
 
 function makeFakeConversation(opts: {
@@ -969,5 +971,54 @@ describe("startVoiceTurn race-loss state restore", () => {
     expect(waited.channelCapabilities).toBe(winnerState.channelCapabilities);
     expect(waited.callSessionId).toBe(winnerState.callSessionId);
     expect(waited.assistantId).toBe(winnerState.assistantId);
+  });
+});
+
+describe("startVoiceTurn active-surface context (voice surface resume)", () => {
+  // Captured via an object property (not a bare `let`) so the closure write is
+  // visible to the assertion without control-flow narrowing to `null`.
+  const captureSurfaceStateAtLoop = () => {
+    const captured: {
+      value: { activeSurfaceId?: string; currentPage?: string } | null;
+    } = { value: null };
+    const fake = makeFakeConversation({
+      processing: false,
+      runAgentLoop: async () => {
+        captured.value = {
+          activeSurfaceId: fake.conversation.currentActiveSurfaceId,
+          currentPage: fake.conversation.currentPage,
+        };
+      },
+    });
+    return { fake, captured };
+  };
+
+  test("installs activeSurfaceId and clears currentPage before the agent loop runs", async () => {
+    const { fake, captured } = captureSurfaceStateAtLoop();
+    fakeConversation = fake.conversation;
+    // A prior turn's stale page must not survive into the resumed surface turn.
+    fake.conversation.currentPage = "stale-page";
+
+    await startVoiceTurn({ ...makeTurnOptions(), activeSurfaceId: "surf-1" });
+    await flushMicrotasks();
+
+    expect(captured.value).toEqual({
+      activeSurfaceId: "surf-1",
+      currentPage: undefined,
+    });
+  });
+
+  test("leaves currentPage untouched on an ordinary STT turn (no activeSurfaceId)", async () => {
+    const { fake, captured } = captureSurfaceStateAtLoop();
+    fakeConversation = fake.conversation;
+    fake.conversation.currentPage = "keep-me";
+
+    await startVoiceTurn(makeTurnOptions()); // no activeSurfaceId
+    await flushMicrotasks();
+
+    expect(captured.value).toEqual({
+      activeSurfaceId: undefined,
+      currentPage: "keep-me",
+    });
   });
 });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -221,6 +221,14 @@ export interface VoiceTurnOptions {
    * supplies its own `voiceControlPrompt`.
    */
   routingLeg?: VoiceRoutingLeg;
+  /**
+   * The interactive surface being resumed as a spoken turn. When set, the turn
+   * runs with this surface as the active surface (and no active page) so
+   * `buildActiveSurfaceContext` re-injects its `dynamic_page`/app HTML+schema,
+   * matching the text path's `activeSurfaceId`. Undefined on ordinary STT
+   * turns, which carry no active surface.
+   */
+  activeSurfaceId?: string;
 }
 
 export interface VoiceTurnHandle {
@@ -964,6 +972,16 @@ export async function startVoiceTurn(
       // flag into subsequent non-voice turns on the same conversation.
       conversation.forcePromptSideEffects =
         !isGuardian && !usesLocalInteractiveApprovals;
+      // Surface-resume turns install the resumed surface as the active surface
+      // so `buildActiveSurfaceContext` re-injects its dynamic_page/app context,
+      // and clear `currentPage` so the resumed surface isn't paired with a prior
+      // turn's stale page (parity with the text path, which passes no page for
+      // surface actions). `runAgentLoop` clears `currentActiveSurfaceId` at turn
+      // end, so this stays turn-scoped. Left untouched on ordinary STT turns.
+      if (opts.activeSurfaceId !== undefined) {
+        conversation.currentActiveSurfaceId = opts.activeSurfaceId;
+        conversation.currentPage = undefined;
+      }
       await conversation.runAgentLoop(persistedContent, messageId, {
         onEvent: (msg: ServerMessage) => {
           if (msg.type === "error") {

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2410,13 +2410,9 @@ export async function handleSurfaceAction(
     if (accumulatedState && Object.keys(accumulatedState).length > 0) {
       ctx.accumulatedSurfaceState.delete(surfaceId);
     }
-    if (shouldRelayPrompt && prompt) {
-      broadcastMessage({
-        type: "user_message_echo",
-        text: prompt,
-        conversationId: ctx.conversationId,
-      });
-    }
+    // The resumed turn's own turn-start (startVoiceTurn) broadcasts the
+    // user_message_echo for the resume content, so this path does not pre-echo
+    // — otherwise a relayed-prompt click would render two user bubbles.
     if (!retainPending) {
       ctx.pendingSurfaceActions.delete(surfaceId);
     }
@@ -2428,6 +2424,7 @@ export async function handleSurfaceAction(
       "Surface action follow-up: resuming as spoken live-voice turn",
     );
     voiceResumeHandler.resumeWithText(content, {
+      activeSurfaceId: surfaceId,
       ...(displayContent ? { displayContent } : {}),
       ...(sourceActorPrincipalId ? { sourceActorPrincipalId } : {}),
     });

--- a/assistant/src/live-voice/__tests__/live-voice-resume-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-resume-turn.test.ts
@@ -175,6 +175,29 @@ describe("LiveVoiceSession surface resume", () => {
     await session.close("client_end");
   });
 
+  test("resumeWithText threads activeSurfaceId into the voice turn", async () => {
+    const { frames, session, startVoiceTurn } = createSessionHarness();
+    await session.start();
+
+    const handler = getVoiceResumeHandler(CONVERSATION_ID);
+    handler?.resumeWithText("Thanks for connecting Google.", {
+      activeSurfaceId: "surf-oauth-1",
+    });
+
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    // The resumed surface reaches the bridge so its active-surface context is
+    // re-injected into the spoken turn.
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      conversationId: CONVERSATION_ID,
+      content: "Thanks for connecting Google.",
+      activeSurfaceId: "surf-oauth-1",
+    });
+
+    await session.close("client_end");
+  });
+
   test("unregisters the resume handler on close", async () => {
     const { session } = createSessionHarness();
     await session.start();

--- a/assistant/src/live-voice/live-voice-resume-registry.ts
+++ b/assistant/src/live-voice/live-voice-resume-registry.ts
@@ -9,11 +9,19 @@
  * both reference this module, and neither imports the other — avoiding a require
  * cycle between the live-voice session and the daemon surface handler.
  */
+export interface VoiceResumeOptions {
+  displayContent?: string;
+  sourceActorPrincipalId?: string;
+  /**
+   * The interactive surface being resumed. Threaded into the resumed turn so
+   * `buildActiveSurfaceContext` re-injects the active `dynamic_page`/app
+   * HTML+schema, matching the text path's `activeSurfaceId` (JARVIS-1287).
+   */
+  activeSurfaceId?: string;
+}
+
 export interface VoiceResumeHandler {
-  resumeWithText(
-    content: string,
-    opts?: { displayContent?: string; sourceActorPrincipalId?: string },
-  ): void;
+  resumeWithText(content: string, opts?: VoiceResumeOptions): void;
 }
 
 const handlers = new Map<string, VoiceResumeHandler>();

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -58,6 +58,7 @@ import {
   registerVoiceResumeHandler,
   unregisterVoiceResumeHandler,
   type VoiceResumeHandler,
+  type VoiceResumeOptions,
 } from "./live-voice-resume-registry.js";
 import {
   type LiveVoiceSession as LiveVoiceSessionContract,
@@ -379,7 +380,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // once the active turn settles (see flushPendingResume).
   private pendingResume: {
     content: string;
-    opts?: { displayContent?: string; sourceActorPrincipalId?: string };
+    opts?: VoiceResumeOptions;
   } | null = null;
 
   constructor(
@@ -1523,6 +1524,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private async launchAssistantTurn(
     utterance: UtteranceCycle,
     content: string,
+    // Only set on the surface-resume path; the STT path leaves it undefined so
+    // no active-surface context is injected into an ordinary spoken turn.
+    activeSurfaceId?: string,
   ): Promise<void> {
     utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
@@ -1575,8 +1579,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             overrideProfile: FRONT_DOOR_PROFILE,
             routingLeg: "front-door",
             frontDoor: true,
+            ...(activeSurfaceId !== undefined ? { activeSurfaceId } : {}),
           }
-        : { content },
+        : {
+            content,
+            ...(activeSurfaceId !== undefined ? { activeSurfaceId } : {}),
+          },
     );
   }
 
@@ -1590,10 +1598,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * If a turn is still in flight the resume is deferred (pendingResume) and
    * dispatched once that turn settles — never rejected with CONVERSATION_BUSY.
    */
-  resumeWithText(
-    content: string,
-    opts?: { displayContent?: string; sourceActorPrincipalId?: string },
-  ): void {
+  resumeWithText(content: string, opts?: VoiceResumeOptions): void {
     const trimmed = content.trim();
     if (
       this.isClosed ||
@@ -1617,13 +1622,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async startResumeTurn(
     content: string,
-    _opts?: { displayContent?: string; sourceActorPrincipalId?: string },
+    opts?: VoiceResumeOptions,
   ): Promise<void> {
     if (this.isClosed || this.state === "failed" || !this.startVoiceTurn) {
       return;
     }
     if (this.activeAssistantTurn) {
-      this.pendingResume = { content, opts: _opts };
+      this.pendingResume = { content, opts };
       return;
     }
     // A synthetic utterance carrying only the resume text: it is not
@@ -1653,7 +1658,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         finalTranscriptAtMs: null,
       },
     };
-    await this.launchAssistantTurn(utterance, content);
+    await this.launchAssistantTurn(utterance, content, opts?.activeSurfaceId);
   }
 
   // Dispatch a resume deferred behind an in-flight turn, once that turn has
@@ -1703,6 +1708,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       overrideProfile?: string;
       routingLeg?: VoiceRoutingLeg;
       frontDoor?: boolean;
+      // Present only on the primary surface-resume leg — never on the escalated
+      // continuation leg, so the active-surface context stays turn-scoped.
+      activeSurfaceId?: string;
     },
   ): Promise<void> {
     if (!this.startVoiceTurn) {
@@ -1777,6 +1785,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           ? { overrideProfile: leg.overrideProfile }
           : {}),
         ...(leg.routingLeg != null ? { routingLeg: leg.routingLeg } : {}),
+        ...(leg.activeSurfaceId != null
+          ? { activeSurfaceId: leg.activeSurfaceId }
+          : {}),
         callbacks: {
           assistant_text_delta: (msg) => {
             if (!this.isForwardingAssistantText(token)) {


### PR DESCRIPTION
## Summary
Follow-up fixes to the OAuth-in-voice spoken-resume path (#38100):
- Thread activeSurfaceId + clear currentPage so a dynamic_page/app surface action resumed via voice keeps its active-surface context (parity with the text path; buildActiveSurfaceContext was returning null / a stale page).
- Skip the relay-prompt pre-echo on the voice path so a relayed-prompt surface click renders a single user bubble instead of two.

JARVIS-1287