### PR TITLE
fix(intelligence): concepts-only memory graph + sleeker intro card

### DIFF
--- a/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
@@ -251,28 +251,17 @@ export async function getMemoryGraph(
 
   const workspaceDir = getWorkspaceDir();
   const pageIndex = await getPageIndex(workspaceDir);
-  // Concepts plus functionality (skills / CLI-command capabilities). Feeding the
-  // full set to the edge builders is what lets a concept's `[[skills/foo]]` link
-  // and skill↔concept co-selections resolve to real edges — buildEdgeGraph and
-  // computeLearnedEdgeGraph both drop endpoints outside the set they're given.
-  // Functionality nodes that end up disconnected are pruned in assembleMemoryGraph.
-  const entries = pageIndex.entries;
-
-  // Synthetic rows (skills / CLI commands) carry `modifiedAt: 0` and have no
-  // on-disk page. Keyed by slug (not prefix) so a real user page that happens
-  // to live under a reserved prefix is NOT mistaken for a synthetic one.
-  const syntheticSlugs = new Set(
-    entries.filter((e) => e.modifiedAt <= 0).map((e) => e.slug),
-  );
+  // The Memory graph is the assistant's learned mind: concept pages and the
+  // links between them. Skills and plugins have their own dedicated pages, so
+  // synthetic capability rows (skills / CLI commands, which carry `modifiedAt: 0`)
+  // are excluded here — the map is about what the assistant knows, not what it
+  // can do.
+  const entries = pageIndex.entries.filter((e) => e.modifiedAt > 0);
 
   // Raw (frontmatter + body) page reader, matching the v3 lane build. A read
   // that rejects drops that article's authored/wikilink edges but keeps its
-  // numeric fallbacks. Synthetic capability rows have no page, so short-circuit
-  // their guaranteed-miss read; a real page is read so its links are captured.
+  // numeric fallbacks.
   const pageRaw = async (slug: Slug): Promise<string> => {
-    if (syntheticSlugs.has(slug)) {
-      return "";
-    }
     const page = await readPage(workspaceDir, slug);
     if (!page) {
       throw new Error(`page not found: ${slug}`);
@@ -309,7 +298,6 @@ export async function getMemoryGraph(
     entries,
     staticAdjacency: staticGraph.adjacency,
     learnedAdjacency: learnedGraph.adjacency,
-    pruneDisconnectedNonConcepts: true,
   });
 
   return { backend: BACKEND_MEMORY_V3, supported: true, ...assembled };

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
@@ -25,8 +25,7 @@ export function ConceptGraphIntroBanner({
       style={{
         backgroundColor: "var(--surface-lift)",
         border: "1px solid var(--border-base)",
-        boxShadow:
-          "0 8px 24px color-mix(in srgb, var(--content-default) 12%, transparent)",
+        boxShadow: "0 4px 12px rgba(0, 0, 0, 0.25)",
       }}
     >
       <span


### PR DESCRIPTION
Two refinements to the merged memory-graph work, based on seeing it populated on a dev build.

## 1. Concepts-only graph
The graph was dominated by skill (purple) and CLI-capability (teal) nodes, with the actual learned concepts (blue) a minority — the "assistant's mind" was drowned out by its tooling. Since **Skills and Plugins each have their own dedicated pages**, including them here both clutters the map and duplicates those surfaces.

`getMemoryGraph` now filters to real concept pages (`modifiedAt > 0`) and drops the synthetic skill / CLI-command rows. The graph becomes the assistant's learned concepts + the links between them; the legend auto-collapses to just Link/Learned (it only shows kind swatches when >1 kind is present).

This walks back the functionality-node inclusion from #38038. I deliberately **kept** the node-kind classification + `pruneDisconnectedNonConcepts` machinery in `assembleMemoryGraph` (still unit-tested) so functionality nodes can come back behind a legend filter later without a rebuild.

## 2. Sleeker intro card
The "This is your assistant's mind" card's shadow used a light color (`--content-default` at 12%), which renders as a white halo in dark mode. Swapped for a tight dark drop shadow (`0 4px 12px rgba(0,0,0,0.25)`) — subtle elevation instead of a glow.

## Tests
- `build-memory-graph.test.ts`: 9/9 pass (the pure `assembleMemoryGraph` + its option are unchanged).
- Assistant tsc clean; eslint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)