### PR TITLE
Repin agent-wrapped to 7e5e797 (data-only skill flow)

### DIFF
--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -23,9 +23,9 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "be38bd9cd57aaac6bf06b22d82885c09219320bf"
+        "ref": "7e5e7971a38a90120cee9b1e393b733622e24d17"
       },
-      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
+      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Presents the stats as data in chat and publishes a shareable page at agent-wrapped.com.",
       "category": "creative",
       "license": "MIT",
       "submittedBy": "marina",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -23,9 +23,9 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/agent-wrapped",
-        "ref": "be38bd9cd57aaac6bf06b22d82885c09219320bf"
+        "ref": "7e5e7971a38a90120cee9b1e393b733622e24d17"
       },
-      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Ships a stats collector tool, a CLI, a Claude Code plugin, and a skill for the shareable cards experience.",
+      "description": "Your agent's year in review: conversations, days together, memories formed, swear count, top topics, and the receipt (total tokens + LLM calls). Works with Vellum agents and Claude Code. Presents the stats as data in chat and publishes a shareable page at agent-wrapped.com.",
       "category": "creative",
       "license": "MIT",
       "submittedBy": "marina",


### PR DESCRIPTION
Repins the agent-wrapped plugin from `be38bd9` to `7e5e797` and updates the marketplace description in both manifests.

**What changed in the plugin:**

The skill was still instructing agents to build a cards UI (standalone HTML page deployed to Vercel), so installed agents kept building apps when asked for their wrapped. The new flow is strict and three steps:

1. Gather stats via `wrapped_stats`
2. Present them as plain data in chat, no apps, no pages, no card UIs
3. Ask the user if they want to publish, and on yes publish the share page at agent-wrapped.com

The published page is the only visual surface. Tool description, activation hints, and the marketplace description were updated to match, and the old "Building the cards experience" section was removed entirely.