### PR TITLE
Add ACP Anthropic token classifier + format-guard helper

### DIFF
--- a/assistant/src/acp/__tests__/acp-credentials.test.ts
+++ b/assistant/src/acp/__tests__/acp-credentials.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the Anthropic token classifier and ACP OAuth-field guard.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ACP_OAUTH_TOKEN_FIELD,
+  ACP_SERVICE,
+  AcpCredentialFormatError,
+  assertAcpCredentialFormat,
+  classifyAnthropicToken,
+} from "../acp-credentials.js";
+
+describe("classifyAnthropicToken", () => {
+  test("classifies an OAuth token", () => {
+    expect(classifyAnthropicToken("sk-ant-oat01-x")).toBe("oauth");
+  });
+
+  test("classifies an API key", () => {
+    expect(classifyAnthropicToken("sk-ant-api03-x")).toBe("api_key");
+  });
+
+  test("classifies an arbitrary string as unknown", () => {
+    expect(classifyAnthropicToken("hello world")).toBe("unknown");
+    expect(classifyAnthropicToken("")).toBe("unknown");
+    expect(classifyAnthropicToken("sk-ant-something")).toBe("unknown");
+  });
+
+  test("tolerates surrounding whitespace", () => {
+    expect(classifyAnthropicToken("  sk-ant-oat01-x  ")).toBe("oauth");
+    expect(classifyAnthropicToken("\tsk-ant-api03-x\n")).toBe("api_key");
+  });
+});
+
+describe("assertAcpCredentialFormat", () => {
+  test("throws when an API key is written into the OAuth field", () => {
+    expect(() =>
+      assertAcpCredentialFormat(ACP_OAUTH_TOKEN_FIELD, "sk-ant-api03-x"),
+    ).toThrow(AcpCredentialFormatError);
+  });
+
+  test("throws even when the API key has surrounding whitespace", () => {
+    expect(() =>
+      assertAcpCredentialFormat(ACP_OAUTH_TOKEN_FIELD, "  sk-ant-api03-x  "),
+    ).toThrow(AcpCredentialFormatError);
+  });
+
+  test("does not throw for an OAuth token in the OAuth field", () => {
+    expect(() =>
+      assertAcpCredentialFormat(ACP_OAUTH_TOKEN_FIELD, "sk-ant-oat01-x"),
+    ).not.toThrow();
+  });
+
+  test("does not throw for an unknown value in the OAuth field", () => {
+    expect(() =>
+      assertAcpCredentialFormat(ACP_OAUTH_TOKEN_FIELD, "whatever"),
+    ).not.toThrow();
+  });
+
+  test("does not throw for an API key in a non-OAuth field", () => {
+    expect(() =>
+      assertAcpCredentialFormat("some_other_field", "sk-ant-api03-x"),
+    ).not.toThrow();
+  });
+});
+
+describe("constants", () => {
+  test("expose the ACP service and OAuth field names", () => {
+    expect(ACP_SERVICE).toBe("acp");
+    expect(ACP_OAUTH_TOKEN_FIELD).toBe("claude_oauth_token");
+  });
+});

--- a/assistant/src/acp/acp-credentials.ts
+++ b/assistant/src/acp/acp-credentials.ts
@@ -1,0 +1,54 @@
+/**
+ * ACP credential identifiers and Anthropic token format guard.
+ *
+ * The "Connect Claude" flow stores a Claude OAuth token (`sk-ant-oat…`) in the
+ * ACP vault field `acp/claude_oauth_token`. Users have historically pasted an
+ * Anthropic API key (`sk-ant-api…`) into that field, which then 401s at runtime.
+ * This module classifies a token by prefix and rejects that specific mismatch
+ * at the write path.
+ *
+ * Pure and dependency-free so it is safe to import from both route handlers and
+ * the CLI.
+ */
+
+export const ACP_SERVICE = "acp";
+export const ACP_OAUTH_TOKEN_FIELD = "claude_oauth_token";
+
+export type AnthropicTokenKind = "oauth" | "api_key" | "unknown";
+
+/**
+ * Classifies an Anthropic token by prefix. Version digits (e.g. `oat01`,
+ * `api03`) are part of the tolerated prefix, so matching is prefix-based rather
+ * than exact.
+ */
+export function classifyAnthropicToken(value: string): AnthropicTokenKind {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("sk-ant-oat")) return "oauth";
+  if (trimmed.startsWith("sk-ant-api")) return "api_key";
+  return "unknown";
+}
+
+export class AcpCredentialFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AcpCredentialFormatError";
+  }
+}
+
+/**
+ * Guards a credential write. Throws only when an Anthropic API key is written
+ * into the OAuth-token field; the oauth and unknown kinds, and any other field,
+ * pass through untouched.
+ */
+export function assertAcpCredentialFormat(field: string, value: string): void {
+  if (
+    field === ACP_OAUTH_TOKEN_FIELD &&
+    classifyAnthropicToken(value) === "api_key"
+  ) {
+    throw new AcpCredentialFormatError(
+      "That looks like an Anthropic **API key** (`sk-ant-api…`), but this " +
+        "field needs a **Claude OAuth token** (`sk-ant-oat…`) from the " +
+        "Connect Claude flow / `claude setup-token`.",
+    );
+  }
+}

--- a/assistant/src/acp/acp-credentials.ts
+++ b/assistant/src/acp/acp-credentials.ts
@@ -23,8 +23,12 @@ export type AnthropicTokenKind = "oauth" | "api_key" | "unknown";
  */
 export function classifyAnthropicToken(value: string): AnthropicTokenKind {
   const trimmed = value.trim();
-  if (trimmed.startsWith("sk-ant-oat")) return "oauth";
-  if (trimmed.startsWith("sk-ant-api")) return "api_key";
+  if (trimmed.startsWith("sk-ant-oat")) {
+    return "oauth";
+  }
+  if (trimmed.startsWith("sk-ant-api")) {
+    return "api_key";
+  }
   return "unknown";
 }
 


### PR DESCRIPTION
## Summary
- New pure module `assistant/src/acp/acp-credentials.ts`: `classifyAnthropicToken`, `assertAcpCredentialFormat`, `ACP_SERVICE`/`ACP_OAUTH_TOKEN_FIELD`, `AcpCredentialFormatError`.
- Rejects an Anthropic API key written into the ACP OAuth-token field (the original 401 footgun).

Part of plan: acp-oauth-connect.md (PR 1 of 9)