### PR TITLE
Add acp-claude-oauth-connect feature flag (default off) + gate helper

### DIFF
--- a/assistant/src/acp/__tests__/acp-oauth-connect-flag.test.ts
+++ b/assistant/src/acp/__tests__/acp-oauth-connect-flag.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for `acp-oauth-connect-flag.ts` — the on/off predicate gating the
+ * in-app Connect Claude Code OAuth flow for ACP. The assistant flag resolver is
+ * mocked so the test asserts the composition: the predicate forwards
+ * `ACP_CLAUDE_OAUTH_CONNECT` and the config to `isAssistantFeatureFlagEnabled`
+ * and returns its boolean directly (default off).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../../config/schema.js";
+
+// The resolver is mocked BEFORE importing the module under test so the import
+// observes the spy at load time. The specifier is resolved relative to THIS
+// test file.
+const isAssistantFeatureFlagEnabled = mock(
+  (_flag: string, _config: AssistantConfig): boolean => false,
+);
+
+mock.module("../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled,
+}));
+
+const { isAcpClaudeOauthConnectEnabled, ACP_CLAUDE_OAUTH_CONNECT } =
+  await import("../acp-oauth-connect-flag.js");
+
+const cfg = {} as AssistantConfig;
+
+describe("acp-oauth-connect-flag", () => {
+  beforeEach(() => {
+    isAssistantFeatureFlagEnabled.mockReset();
+  });
+
+  test("constant is the kebab-case flag id", () => {
+    expect(ACP_CLAUDE_OAUTH_CONNECT).toBe("acp-claude-oauth-connect");
+  });
+
+  test("defaults false when the resolver returns false", () => {
+    isAssistantFeatureFlagEnabled.mockReturnValue(false);
+
+    expect(isAcpClaudeOauthConnectEnabled(cfg)).toBe(false);
+    expect(isAssistantFeatureFlagEnabled).toHaveBeenCalledTimes(1);
+    expect(isAssistantFeatureFlagEnabled).toHaveBeenCalledWith(
+      ACP_CLAUDE_OAUTH_CONNECT,
+      cfg,
+    );
+  });
+
+  test("true when the flag is enabled, resolver called with the flag id + config", () => {
+    isAssistantFeatureFlagEnabled.mockReturnValue(true);
+
+    expect(isAcpClaudeOauthConnectEnabled(cfg)).toBe(true);
+    expect(isAssistantFeatureFlagEnabled).toHaveBeenCalledWith(
+      ACP_CLAUDE_OAUTH_CONNECT,
+      cfg,
+    );
+  });
+});

--- a/assistant/src/acp/acp-oauth-connect-flag.ts
+++ b/assistant/src/acp/acp-oauth-connect-flag.ts
@@ -1,0 +1,13 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+/** Feature-flag id (kebab-case) gating the in-app Connect Claude Code OAuth
+ *  flow for ACP. Gates the connect UI; the cloud paste path is additionally
+ *  host-gated. Default off so the whole feature ships dark. */
+export const ACP_CLAUDE_OAUTH_CONNECT = "acp-claude-oauth-connect" as const;
+
+export function isAcpClaudeOauthConnectEnabled(
+  config: AssistantConfig,
+): boolean {
+  return isAssistantFeatureFlagEnabled(ACP_CLAUDE_OAUTH_CONNECT, config);
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -409,6 +409,14 @@
       "label": "Chat Credential Reveal",
       "description": "Persist chat secret redactions as sentinel markers instead of the legacy HTML marker, enriched with the vault identity when the value byte-matches a credential revealed this turn. Render support in clients is unconditional; this flag gates only the daemon persist format.",
       "defaultEnabled": false
+    },
+    {
+      "id": "acp-claude-oauth-connect",
+      "scope": "assistant",
+      "key": "acp-claude-oauth-connect",
+      "label": "ACP Claude OAuth Connect",
+      "description": "In-app Connect Claude Code OAuth flow for ACP (gates the connect UI; cloud paste path is additionally host-gated)",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -409,6 +409,14 @@
       "label": "Chat Credential Reveal",
       "description": "Persist chat secret redactions as sentinel markers instead of the legacy HTML marker, enriched with the vault identity when the value byte-matches a credential revealed this turn. Render support in clients is unconditional; this flag gates only the daemon persist format.",
       "defaultEnabled": false
+    },
+    {
+      "id": "acp-claude-oauth-connect",
+      "scope": "assistant",
+      "key": "acp-claude-oauth-connect",
+      "label": "ACP Claude OAuth Connect",
+      "description": "In-app Connect Claude Code OAuth flow for ACP (gates the connect UI; cloud paste path is additionally host-gated)",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- New assistant-scoped flag `acp-claude-oauth-connect` (default off) in the feature-flag registry + regenerated bundled copies.
- New gate helper `isAcpClaudeOauthConnectEnabled` in `assistant/src/acp/acp-oauth-connect-flag.ts`.

Follow-up (out of scope): create the flag via Terraform in vellum-assistant-platform for remote sync.

Part of plan: acp-oauth-connect.md (PR 3 of 9)