### PR TITLE
fix(voice): gate ui-surface tools off voice turns — calls are non-interactive

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -347,6 +347,53 @@ describe("startVoiceTurn triage-and-escalate control prompt", () => {
   });
 });
 
+describe("startVoiceTurn channel capabilities", () => {
+  // Voice calls are non-interactive: the bridge forces supportsDynamicUi off
+  // for every voice turn so ui-surface tools never reach the model mid-call,
+  // while leaving the rest of the channel's resolved capabilities intact.
+
+  // The turn installs its capabilities, then cleanup resets them to null — so
+  // capture every applied value and read the installed (non-null) one.
+  function captureInstalledCapabilities(): () =>
+    | Record<string, unknown>
+    | undefined {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+    const applied: unknown[] = [];
+    fake.conversation.setChannelCapabilities = (caps) => {
+      applied.push(caps);
+    };
+    return () =>
+      applied.find(
+        (caps): caps is Record<string, unknown> =>
+          caps != null && typeof caps === "object",
+      );
+  }
+
+  test("a vellum/macos (live-voice) turn forces supportsDynamicUi off, other fields untouched", async () => {
+    const installed = captureInstalledCapabilities();
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      userMessageChannel: "vellum",
+      userMessageInterface: "macos",
+    });
+    const caps = installed();
+    expect(caps?.supportsDynamicUi).toBe(false);
+    // The override is surgical: live-voice keeps identifying as vellum/macos.
+    expect(caps?.dashboardCapable).toBe(true);
+    expect(caps?.supportsVoiceInput).toBe(true);
+    expect(caps?.clientOS).toBe("macos");
+  });
+
+  test("phone defaults (no channel overrides) also yield supportsDynamicUi false", async () => {
+    const installed = captureInstalledCapabilities();
+    await startVoiceTurn(makeTurnOptions());
+    const caps = installed();
+    expect(caps?.channel).toBe("phone");
+    expect(caps?.supportsDynamicUi).toBe(false);
+  });
+});
+
 describe("startVoiceTurn conversation-lock wait", () => {
   test("an idle conversation starts the turn without consulting waitForIdle", async () => {
     const fake = makeFakeConversation({ processing: false });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -630,10 +630,21 @@ export async function startVoiceTurn(
     trustContext: opts.trustContext ?? null,
     turnChannelContext,
     turnInterfaceContext,
-    channelCapabilities: resolveChannelCapabilities(
-      turnChannelContext.userMessageChannel,
-      turnInterfaceContext.userMessageInterface,
-    ),
+    channelCapabilities: {
+      ...resolveChannelCapabilities(
+        turnChannelContext.userMessageChannel,
+        turnInterfaceContext.userMessageInterface,
+      ),
+      // Voice calls are non-interactive: no surface can be shown, read, or
+      // clicked mid-call, so `ui_show`/`ui_update`/`ui_dismiss` (and thus
+      // `oauth_connect`, a ui_show surface_type) must never reach the model.
+      // Phone already resolves to false via its channel; live-voice resolves
+      // vellum/macos → true, so force it off here for every voice turn. This
+      // also flips the runtime-context `supports_dynamic_ui` line the prompt
+      // advertises, the secret-prompter's dynamic-UI branch, and the
+      // task-progress-nudge hook — all correctly non-UI during a call.
+      supportsDynamicUi: false,
+    },
     voiceCallControlPrompt,
   };
   const installVoiceTurnState = () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1776,7 +1776,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         userMessageInterface: "macos",
         assistantMessageInterface: "macos",
         voiceControlPrompt:
-          "You are speaking in a local live voice session. Keep replies brief and conversational.",
+          "You are speaking in a local live voice session. Keep replies brief and conversational. You cannot display cards, forms, or any on-screen UI during the call — convey everything in speech.",
         approvalMode: "local-live-voice",
         content: leg.content,
         isInbound: true,


### PR DESCRIPTION
## Summary
- Force `supportsDynamicUi: false` for every voice turn in `startVoiceTurn` — `ui_show`/`ui_update`/`ui_dismiss` (and thus `oauth_connect`) never reach the model during a call, matching the phone channel's structural gate
- Live-voice keeps identifying as vellum/macos (dashboardCapable/supportsVoiceInput untouched) so persistence and echo behavior are unchanged
- Extend the live-voice control prompt so the model doesn't offer on-screen UI in speech

Part of plan: voice-noninteractive.md (PR 1 of 4)