### PR TITLE
Add Claude Code OAuth config, PKCE authorize-URL builder, and vault-store helper

### DIFF
--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the Claude OAuth config + capture/store helpers.
+ *
+ * The store helper reaches into secure-keys and the ACP credential policy, so
+ * we mock both (wired BEFORE importing the module under test via dynamic
+ * import) and assert the vault write targets `credential/acp/claude_oauth_token`
+ * and throws when the backend rejects the write.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — wired BEFORE importing the module via dynamic import.
+// ---------------------------------------------------------------------------
+
+let storeReturn = true;
+const setSecureKeyAsync = mock(
+  async (_account: string, _value: string) => storeReturn,
+);
+const ensureAcpCredentialPolicy = mock(
+  (_field: string, _usageDescription: string) => {},
+);
+
+mock.module("../../security/secure-keys.js", () => ({ setSecureKeyAsync }));
+mock.module("../prepare-agent-env.js", () => ({ ensureAcpCredentialPolicy }));
+
+const {
+  CLAUDE_OAUTH_CONFIG,
+  CLAUDE_LOOPBACK_CALLBACK_PORT,
+  CLAUDE_MANUAL_REDIRECT_URI,
+  buildClaudeAuthorizeUrl,
+  parseManualClaudeCode,
+  storeAcpClaudeToken,
+} = await import("../acp-claude-oauth.js");
+
+beforeEach(() => {
+  storeReturn = true;
+  setSecureKeyAsync.mockClear();
+  ensureAcpCredentialPolicy.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+describe("CLAUDE_OAUTH_CONFIG", () => {
+  test("matches the verified endpoints, client id, and scope", () => {
+    expect(CLAUDE_OAUTH_CONFIG.authorizeUrl).toBe(
+      "https://claude.ai/oauth/authorize",
+    );
+    expect(CLAUDE_OAUTH_CONFIG.tokenExchangeUrl).toBe(
+      "https://platform.claude.com/v1/oauth/token",
+    );
+    expect(CLAUDE_OAUTH_CONFIG.clientId).toBe(
+      "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+    );
+    expect(CLAUDE_OAUTH_CONFIG.scopes).toEqual(["user:inference"]);
+    expect(CLAUDE_OAUTH_CONFIG.scopeSeparator).toBe(" ");
+  });
+
+  test("exposes the manual redirect URI and a fixed loopback port", () => {
+    expect(CLAUDE_MANUAL_REDIRECT_URI).toBe(
+      "https://platform.claude.com/oauth/code/callback",
+    );
+    expect(typeof CLAUDE_LOOPBACK_CALLBACK_PORT).toBe("number");
+    expect(Number.isInteger(CLAUDE_LOOPBACK_CALLBACK_PORT)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildClaudeAuthorizeUrl
+// ---------------------------------------------------------------------------
+
+describe("buildClaudeAuthorizeUrl", () => {
+  test("produces a URL that parses back to the expected query params", () => {
+    const redirectUri = `http://localhost:${CLAUDE_LOOPBACK_CALLBACK_PORT}/callback`;
+    const url = buildClaudeAuthorizeUrl(redirectUri, {
+      codeChallenge: "challenge-123",
+      state: "state-abc",
+    });
+
+    const parsed = new URL(url);
+    expect(`${parsed.origin}${parsed.pathname}`).toBe(
+      "https://claude.ai/oauth/authorize",
+    );
+
+    const params = parsed.searchParams;
+    expect(params.get("response_type")).toBe("code");
+    expect(params.get("client_id")).toBe(
+      "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+    );
+    expect(params.get("redirect_uri")).toBe(redirectUri);
+    expect(params.get("scope")).toBe("user:inference");
+    expect(params.get("state")).toBe("state-abc");
+    expect(params.get("code_challenge")).toBe("challenge-123");
+    expect(params.get("code_challenge_method")).toBe("S256");
+  });
+
+  test("works with the manual redirect URI too", () => {
+    const url = buildClaudeAuthorizeUrl(CLAUDE_MANUAL_REDIRECT_URI, {
+      codeChallenge: "c",
+      state: "s",
+    });
+    expect(new URL(url).searchParams.get("redirect_uri")).toBe(
+      CLAUDE_MANUAL_REDIRECT_URI,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseManualClaudeCode
+// ---------------------------------------------------------------------------
+
+describe("parseManualClaudeCode", () => {
+  test("round-trips `code#state`", () => {
+    expect(parseManualClaudeCode("abc#xyz")).toEqual({
+      code: "abc",
+      state: "xyz",
+    });
+  });
+
+  test("throws on input missing the `#` separator", () => {
+    expect(() => parseManualClaudeCode("nohash")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// storeAcpClaudeToken
+// ---------------------------------------------------------------------------
+
+describe("storeAcpClaudeToken", () => {
+  test("writes the token to credential/acp/claude_oauth_token and provisions the policy", async () => {
+    await storeAcpClaudeToken("sk-ant-oat-token");
+
+    expect(setSecureKeyAsync).toHaveBeenCalledTimes(1);
+    expect(setSecureKeyAsync).toHaveBeenCalledWith(
+      "credential/acp/claude_oauth_token",
+      "sk-ant-oat-token",
+    );
+    expect(ensureAcpCredentialPolicy).toHaveBeenCalledTimes(1);
+    expect(ensureAcpCredentialPolicy.mock.calls[0][0]).toBe(
+      "claude_oauth_token",
+    );
+  });
+
+  test("throws when the secure store rejects the write", async () => {
+    storeReturn = false;
+
+    await expect(storeAcpClaudeToken("sk-ant-oat-token")).rejects.toThrow(
+      /Failed to store/,
+    );
+    expect(ensureAcpCredentialPolicy).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -1,0 +1,102 @@
+/**
+ * Claude Code OAuth config + capture/store helpers for the "Connect Claude"
+ * ACP flow.
+ *
+ * This module owns the verified Claude OAuth endpoints/client and the pure
+ * helpers the daemon connect routes call: the loopback path (PR 5) builds an
+ * authorize URL against a localhost redirect, while the cloud paste path
+ * (PR 6) builds one against the manual redirect page and parses the
+ * `code#state` string the user copies back. Both converge on
+ * `storeAcpClaudeToken`, which writes the `acp/claude_oauth_token` vault field
+ * the ACP broker reads at spawn time and provisions the `acp_spawn` read
+ * policy.
+ */
+
+import { credentialKey } from "../security/credential-key.js";
+import type { OAuth2Config } from "../security/oauth2.js";
+import { setSecureKeyAsync } from "../security/secure-keys.js";
+import { ACP_OAUTH_TOKEN_FIELD, ACP_SERVICE } from "./acp-credentials.js";
+import { ensureAcpCredentialPolicy } from "./prepare-agent-env.js";
+
+/**
+ * Verified Claude Code public OAuth client. PKCE-only (no client secret);
+ * the single `user:inference` scope is what the ACP adapter's
+ * `CLAUDE_CODE_OAUTH_TOKEN` requires.
+ */
+export const CLAUDE_OAUTH_CONFIG: OAuth2Config = {
+  authorizeUrl: "https://claude.ai/oauth/authorize",
+  tokenExchangeUrl: "https://platform.claude.com/v1/oauth/token",
+  clientId: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+  scopes: ["user:inference"],
+  scopeSeparator: " ",
+};
+
+/**
+ * Fixed loopback port for the local connect path (PR 5). The redirect URI is
+ * `http://localhost:<port>/callback`; a fixed port keeps it stable for the
+ * pre-registered client.
+ */
+export const CLAUDE_LOOPBACK_CALLBACK_PORT = 54545;
+
+/**
+ * Manual redirect target for the cloud paste path (PR 6): Claude renders the
+ * `code#state` string on this page for the user to copy back.
+ */
+export const CLAUDE_MANUAL_REDIRECT_URI =
+  "https://platform.claude.com/oauth/code/callback";
+
+/** Build the Claude authorize URL for a PKCE flow. */
+export function buildClaudeAuthorizeUrl(
+  redirectUri: string,
+  pkce: { codeChallenge: string; state: string },
+): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: CLAUDE_OAUTH_CONFIG.clientId,
+    redirect_uri: redirectUri,
+    scope: CLAUDE_OAUTH_CONFIG.scopes.join(CLAUDE_OAUTH_CONFIG.scopeSeparator),
+    state: pkce.state,
+    code_challenge: pkce.codeChallenge,
+    code_challenge_method: "S256",
+  });
+  return `${CLAUDE_OAUTH_CONFIG.authorizeUrl}?${params.toString()}`;
+}
+
+/**
+ * Parse the `code#state` string the manual redirect page shows the user.
+ * Throws on malformed input (missing the `#` separator).
+ */
+export function parseManualClaudeCode(input: string): {
+  code: string;
+  state: string;
+} {
+  const hashIndex = input.indexOf("#");
+  if (hashIndex === -1) {
+    throw new Error(
+      "Malformed Claude authorization code: expected `code#state`.",
+    );
+  }
+  return {
+    code: input.slice(0, hashIndex),
+    state: input.slice(hashIndex + 1),
+  };
+}
+
+/**
+ * Store a captured Claude OAuth token in the `acp/claude_oauth_token` vault
+ * field and provision the `acp_spawn` read policy so the broker can inject it
+ * at spawn time. Throws when the backing store rejects the write.
+ */
+export async function storeAcpClaudeToken(token: string): Promise<void> {
+  const stored = await setSecureKeyAsync(
+    credentialKey(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD),
+    token,
+  );
+  if (!stored) {
+    throw new Error("Failed to store Claude OAuth token in secure storage.");
+  }
+  ensureAcpCredentialPolicy(
+    ACP_OAUTH_TOKEN_FIELD,
+    "Claude OAuth token for ACP agent authentication",
+  );
+}

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -47,7 +47,7 @@ const ACP_SERVICE = "acp";
  *   by the user/admin. Respect it even if `acp_spawn` is absent; the
  *   broker will deny the read and the caller decides whether that's fatal.
  */
-function ensureAcpCredentialPolicy(
+export function ensureAcpCredentialPolicy(
   field: string,
   usageDescription: string,
 ): void {


### PR DESCRIPTION
## Summary
- New `assistant/src/acp/acp-claude-oauth.ts`: `CLAUDE_OAUTH_CONFIG`, `buildClaudeAuthorizeUrl`, `parseManualClaudeCode`, `storeAcpClaudeToken` (writes the `acp/claude_oauth_token` vault field + provisions the acp_spawn policy).

Part of plan: acp-oauth-connect.md (PR 2 of 9)