### PR TITLE
fix(consent): treat platform-coerced false as never-asked so onboarding telemetry emits

### DIFF
--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -13,10 +13,23 @@ export interface UserConsent {
   privacy_policy_accepted_at: string | null;
   ai_data_sharing_accepted_version: string;
   ai_data_sharing_accepted_at: string | null;
-  /** Null until the user makes an explicit choice (settings or review-terms). */
+  /**
+   * The stored on/off value. The platform coerces a never-chosen value to a
+   * strict `false` on the wire (fail-closed), so `false` alone does NOT prove
+   * an explicit opt-out — read `share_analytics_chosen` to tell the two apart.
+   */
   share_analytics: boolean | null;
-  /** Null until the user makes an explicit choice (onboarding, settings, or review-terms). */
+  /** See {@link share_analytics}; read `share_diagnostics_chosen` to disambiguate. */
   share_diagnostics: boolean | null;
+  /**
+   * Whether the owner made an explicit analytics choice. `false` means the
+   * accompanying `share_analytics` is a platform-coerced default the user was
+   * never shown, not a real opt-out. Optional: older backends omit it, in
+   * which case a `false` value stays authoritative.
+   */
+  share_analytics_chosen?: boolean;
+  /** Whether the owner made an explicit diagnostics choice. See {@link share_analytics_chosen}. */
+  share_diagnostics_chosen?: boolean;
   share_analytics_accepted_version: string;
   share_analytics_accepted_at: string | null;
   share_diagnostics_accepted_version: string;

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -215,6 +215,62 @@ describe("resolveServerConsent", () => {
     expect(r.shareDiagnostics).toBe(true);
   });
 
+  test("coerced false (*_chosen: false, never shown) resolves to null — telemetry is opt-out", () => {
+    // The platform fail-closes a never-chosen value to a strict `false` on the
+    // wire (JARVIS-1292). Onboarding never asks about analytics, so every
+    // onboarding user lands here. It must NOT be adopted as an opt-out —
+    // resolve to null so the store keeps its default-on value and the emit
+    // gate stays open.
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics: false,
+        share_analytics_chosen: false,
+        share_analytics_accepted_version: "",
+        share_diagnostics: false,
+        share_diagnostics_chosen: false,
+        share_diagnostics_accepted_version: "",
+      }),
+    );
+    expect(r.shareAnalytics).toBeNull();
+    expect(r.shareDiagnostics).toBeNull();
+    // Never-asked, so nothing to re-review.
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("explicit false (*_chosen: true) stays an authoritative opt-out", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics: false,
+        share_analytics_chosen: true,
+        share_analytics_accepted_version: "",
+        share_diagnostics: false,
+        share_diagnostics_chosen: true,
+        share_diagnostics_accepted_version: "",
+      }),
+    );
+    expect(r.shareAnalytics).toBe(false);
+    expect(r.shareDiagnostics).toBe(false);
+    // An explicit opt-out with an empty version still owes a re-review.
+    expect(r.analyticsCurrent).toBe(false);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+
+  test("false with no *_chosen field (older backend) stays authoritative", () => {
+    // Pre-rollout backends omit `*_chosen`; a bare `false` cannot be proven a
+    // coerced default, so it is honored as-is rather than silently re-enabled.
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics: false,
+        share_analytics_accepted_version: "",
+        share_diagnostics: false,
+        share_diagnostics_accepted_version: "",
+      }),
+    );
+    expect(r.shareAnalytics).toBe(false);
+    expect(r.shareDiagnostics).toBe(false);
+  });
+
   test("reports stale toggles for explicit opt-outs with empty versions", () => {
     // An explicit false is never excused by an empty version — it still
     // owes a re-review.

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -220,13 +220,15 @@ export function resolveServerConsent(
     DIAGNOSTICS_CONSENT_VERSION,
   );
   // The endpoint always returns an object; for a user with no stored row it
-  // returns the API defaults (empty versions, share booleans true). Any
-  // non-empty version or any `false` share boolean can only have come from a
-  // real stored row, so it proves a record whose data is worth preserving.
-  // Truthiness (not `!== ""`) so a response that OMITS the newer
-  // share-version fields — e.g. an older backend during rollout — reads as
-  // absent rather than as record evidence. `undefined` and `""` both mean
-  // "no version on record".
+  // returns the API defaults (empty versions, share booleans coerced to a
+  // strict value). A non-empty version or a `false` share boolean indicates a
+  // stored row worth preserving. A coerced `false` (`*_chosen: false`) can also
+  // land here, but that only widens `hasServerRecord` — the values it guards
+  // resolve to null via the never-asked check below, so every consumer that
+  // gates on `!== null` / `=== true` skips it. Truthiness (not `!== ""`) so a
+  // response that OMITS the newer share-version fields — e.g. an older backend
+  // during rollout — reads as absent rather than as record evidence.
+  // `undefined` and `""` both mean "no version on record".
   const hasServerRecord =
     !!consent.tos_accepted_version ||
     !!consent.privacy_policy_accepted_version ||
@@ -235,18 +237,33 @@ export function resolveServerConsent(
     !!consent.share_diagnostics_accepted_version ||
     consent.share_analytics === false ||
     consent.share_diagnostics === false;
-  // An implicit grant — true with NO version on record — is never-asked in
-  // disguise, not an explicit choice: a pre-nullable platform materializes
-  // its DB default `true` on rows created without the toggle shown (e.g. a
-  // ToS-only row), while every explicit write stamps a version. Resolve it
-  // to null so no consumer can mistake it for a user grant — the diagnostics
-  // gate chokepoint and the analytics store adoption would otherwise
-  // overwrite an explicit local opt-out whose patch hasn't landed. An
-  // explicit opt-out (false) is never excused this way.
-  const analyticsImplicitDefault =
-    consent.share_analytics === true && !consent.share_analytics_accepted_version;
-  const diagnosticsImplicitDefault =
-    consent.share_diagnostics === true && !consent.share_diagnostics_accepted_version;
+  // A never-asked value is not a user choice and must not be adopted as one —
+  // the diagnostics gate chokepoint and the analytics store adoption would
+  // otherwise overwrite the local default-on (telemetry is opt-out) or an
+  // explicit local opt-out whose patch hasn't landed. Two shapes are
+  // never-asked:
+  //   1. An implicit grant — `true` with NO version on record: a pre-nullable
+  //      platform materializes its DB default `true` on rows created without
+  //      the toggle shown (e.g. a ToS-only row); every explicit write stamps a
+  //      version.
+  //   2. A platform-coerced `false` flagged `*_chosen: false` — the fail-closed
+  //      default the platform serves for an owner who was never shown the
+  //      toggle (JARVIS-1292). Onboarding never asks about analytics, so every
+  //      onboarding user lands here; adopting it as a hard `false` silently
+  //      disabled all browser onboarding telemetry.
+  // A real opt-out carries `*_chosen: true` and is never excused. A bare
+  // `false` with no `*_chosen` field (older backend, pre-rollout) also stays
+  // authoritative.
+  const analyticsNeverAsked =
+    (consent.share_analytics === true &&
+      !consent.share_analytics_accepted_version) ||
+    (consent.share_analytics === false &&
+      consent.share_analytics_chosen === false);
+  const diagnosticsNeverAsked =
+    (consent.share_diagnostics === true &&
+      !consent.share_diagnostics_accepted_version) ||
+    (consent.share_diagnostics === false &&
+      consent.share_diagnostics_chosen === false);
   return {
     // The ToS checkbox covers only the Terms of Service. The privacy checkbox
     // covers both the Privacy Policy and the AI Data Sharing Policy, so it is
@@ -255,8 +272,8 @@ export function resolveServerConsent(
     privacy:
       versionIsCurrent(consent.privacy_policy_accepted_version, PRIVACY_CONSENT_VERSION) &&
       versionIsCurrent(consent.ai_data_sharing_accepted_version, PRIVACY_CONSENT_VERSION),
-    shareAnalytics: analyticsImplicitDefault ? null : consent.share_analytics,
-    shareDiagnostics: diagnosticsImplicitDefault ? null : consent.share_diagnostics,
+    shareAnalytics: analyticsNeverAsked ? null : consent.share_analytics,
+    shareDiagnostics: diagnosticsNeverAsked ? null : consent.share_diagnostics,
     // Share-toggle re-review is owed only for an explicit, genuinely stale
     // choice on record. Onboarding doesn't show the analytics toggle, so
     // `share_analytics` stays null until the user chooses via settings or
@@ -265,11 +282,11 @@ export function resolveServerConsent(
     // false with a stale/empty version still re-reviews.
     analyticsCurrent:
       consent.share_analytics === null ||
-      analyticsImplicitDefault ||
+      analyticsNeverAsked ||
       analyticsVersionCurrent,
     diagnosticsCurrent:
       consent.share_diagnostics === null ||
-      diagnosticsImplicitDefault ||
+      diagnosticsNeverAsked ||
       diagnosticsVersionCurrent,
     analyticsVersionCurrent,
     diagnosticsVersionCurrent,


### PR DESCRIPTION
## Problem

All **browser-originated** onboarding telemetry — the entire research funnel and the Day-2 `research_checkin` CTA — has landed **zero** rows in BigQuery (`telemetry.onboarding_raw`) since the Jun 19 pre-chat→research onboarding cutover. Daemon-side completion events are unaffected, which masked the outage (~4 weeks, unrecoverable). 0.10.9 (#37998) did **not** fix it.

## Root cause

The emit gate is `readShareAnalytics()` = `store.shareAnalytics && getDeviceBool("shareAnalytics", true)`. #37998 fixed the `getDeviceBool` default, but the **web** resolver `resolveServerConsent` still adopted a platform-coerced `false` as an explicit opt-out. Its never-asked rescue only covered `share_analytics === true && no version`; a `false` passed straight through. Session-sync then wrote `setShareAnalytics(false)` into the store, closing the gate.

Onboarding **never asks about analytics** (the privacy screen collects only ToS + Privacy), so every onboarding user gets the platform's fail-closed default `share_analytics: false` + `share_analytics_chosen: false` — a never-shown default, not an opt-out. The daemon already handles this via `*_chosen`; the web didn't.

Verified live: prod bundle has the `getDeviceBool(..., true)` fix and `POST /v1/telemetry/ingest/` returns `200 {"accepted":1}` for a real research event — so endpoint + payload are fine; the block was purely this client-side resolution.

## Fix

Mirror the daemon (#37998): treat a `false` flagged `*_chosen: false` as never-asked → resolve to `null`, so the store keeps its default-on value and the opt-out gate holds. Telemetry is opt-out (never-asked → enabled).

- `UserConsent`: add optional `share_analytics_chosen` / `share_diagnostics_chosen` (older backends omit them).
- `resolveServerConsent`: `analyticsNeverAsked` / `diagnosticsNeverAsked` now also match coerced-`false` (`*_chosen === false`); used for both the resolved value and the `*Current` re-review flags.

Preserved exactly:
- **Real opt-out** (`false` + `*_chosen: true`) → stays `false`, still owes re-review.
- **Older backend** (`false`, no `*_chosen`) → stays authoritative `false`.

## Testing

- `bun test src/utils/onboarding-cleanup.test.ts` — 49 pass (3 new: coerced-false→null, explicit-false honored, older-backend-absent authoritative; existing explicit-`false`-empty-version case still passes).
- `bun run typecheck` — clean.

## Follow-ups (not in this PR)
- Harden the gate to emit unless there's an *explicit* opt-out (don't require `store.shareAnalytics` truthy).
- BQ volume alert on browser onboarding events — 2nd silent regression on this path in a month; nothing paged either time.

Closes JARVIS-1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)