### PR TITLE
fix(voice): voice calls use phone approval policy — drop the local-live-voice mode

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -37,7 +37,6 @@ import {
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
-import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 await initializeDb();
 
@@ -161,7 +160,6 @@ describe("voice-session-bridge", () => {
     const db = getDb();
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
-    pendingInteractions.clear();
   });
 
   test("throws when deps not injected", async () => {
@@ -479,7 +477,7 @@ describe("voice-session-bridge", () => {
 
     await startVoiceTurn({
       conversationId: conversation.id,
-      voiceSessionId: "local-live-voice-session-1",
+      voiceSessionId: "live-voice-session-1",
       userMessageChannel: "vellum",
       assistantMessageChannel: "vellum",
       userMessageInterface: "macos",
@@ -503,7 +501,7 @@ describe("voice-session-bridge", () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    expect(capturedVoiceSessionId).toBe("local-live-voice-session-1");
+    expect(capturedVoiceSessionId).toBe("live-voice-session-1");
     expect(capturedPrompts[0]).toBe(
       "You are speaking in a local live voice session. Keep replies brief and conversational.",
     );
@@ -893,105 +891,6 @@ describe("voice-session-bridge", () => {
     expect(handleConfirmationCalls.length).toBe(1);
     expect(handleConfirmationCalls[0].requestId).toBe("req-voice-unknown");
     expect(handleConfirmationCalls[0].decision).toBe("deny");
-  });
-
-  test("publishes local live voice confirmation requests without auto-resolving them", async () => {
-    const conversation = createConversation(
-      "voice bridge local live voice approval test",
-    );
-
-    let clientHandler: (msg: ServerMessage) => void = () => {};
-    const handleConfirmationCalls: Array<{
-      requestId: string;
-      decision: string;
-    }> = [];
-    const publishedMessages: ServerMessage[] = [];
-    const subscription = assistantEventHub.subscribe({
-      type: "process",
-      filter: {
-        conversationId: conversation.id,
-      },
-      callback: (event) => {
-        publishedMessages.push(event.message);
-      },
-    });
-
-    const session = {
-      isProcessing: () => false,
-      persistUserMessage: async () => ({
-        id: "test-msg-id",
-        deduplicated: false,
-      }),
-      setChannelCapabilities: () => {},
-      setAssistantId: () => {},
-      setTrustContext: () => {},
-      setCommandIntent: () => {},
-      setTurnChannelContext: () => {},
-      setTurnInterfaceContext: () => {},
-      setVoiceCallControlPrompt: () => {},
-      updateClient: (handler: (msg: ServerMessage) => void) => {
-        clientHandler = handler;
-      },
-      ensureActorScopedHistory: async () => {},
-      runAgentLoop: async () => {
-        clientHandler({
-          type: "confirmation_request",
-          requestId: "req-local-live-voice",
-          toolName: "host_bash",
-          input: { command: "ls" },
-          riskLevel: "low",
-          allowlistOptions: [],
-          scopeOptions: [],
-          conversationId: conversation.id,
-        } as ServerMessage);
-      },
-      handleConfirmationResponse: (requestId: string, decision: string) => {
-        handleConfirmationCalls.push({ requestId, decision });
-      },
-      abort: () => {},
-    } as unknown as Conversation;
-
-    try {
-      injectDeps(() => session);
-
-      await startVoiceTurn({
-        conversationId: conversation.id,
-        approvalMode: "local-live-voice",
-        content: "List files",
-        isInbound: true,
-        trustContext: {
-          sourceChannel: "phone",
-          trustClass: "guardian",
-          guardianExternalUserId: "+12125550142",
-          guardianChatId: "+12125550142",
-        },
-        onTextDelta: () => {},
-        onComplete: () => {},
-        onError: () => {},
-      });
-
-      await new Promise((r) => setTimeout(r, 50));
-
-      expect(handleConfirmationCalls).toHaveLength(0);
-      expect(
-        publishedMessages.some(
-          (message) =>
-            message.type === "confirmation_request" &&
-            message.requestId === "req-local-live-voice",
-        ),
-      ).toBe(true);
-      expect(pendingInteractions.get("req-local-live-voice")).toMatchObject({
-        conversationId: conversation.id,
-        kind: "confirmation",
-        confirmationDetails: {
-          toolName: "host_bash",
-          riskLevel: "low",
-        },
-      });
-    } finally {
-      pendingInteractions.resolve("req-local-live-voice");
-      subscription.dispose();
-    }
   });
 
   test("auto-allows confirmation requests for guardian voice turns", async () => {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -26,7 +26,6 @@ import { recordConversationPersistedSeq } from "../persistence/conversation-crud
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
-import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { createAbortReason } from "../util/abort-reasons.js";
@@ -188,8 +187,6 @@ export interface VoiceTurnOptions {
   assistantId?: string;
   /** Guardian trust context for the caller. */
   trustContext?: TrustContext;
-  /** Permission handling mode. Defaults to phone-call auto policy. */
-  approvalMode?: "phone-call" | "local-live-voice";
   /** Whether this is an inbound call (no outbound task). */
   isInbound: boolean;
   /** The outbound call task, if any. */
@@ -405,15 +402,12 @@ export async function startVoiceTurn(
     },
   };
 
-  // Phone voice has no interactive permission/secret UI, so apply explicit
-  // per-role policies by default. Local live voice opts into the normal
-  // client approval path instead. Side-effect double-defense
+  // Voice calls have no interactive permission/secret UI, so explicit
+  // per-role policies apply. Side-effect double-defense
   // (forcePromptSideEffects) is wired inside the agent-loop IIFE so it
   // is always paired with cleanup() in the IIFE's finally.
   const trustClass = opts.trustContext?.trustClass;
   const isGuardian = trustClass === "guardian";
-  const approvalMode = opts.approvalMode ?? "phone-call";
-  const usesLocalInteractiveApprovals = approvalMode === "local-live-voice";
   const voiceSessionId = opts.voiceSessionId ?? opts.callSessionId;
   const turnChannelContext: TurnChannelContext = {
     userMessageChannel: opts.userMessageChannel ?? "phone",
@@ -845,25 +839,6 @@ export async function startVoiceTurn(
   let lastError: string | null = null;
   conversation.updateClient(async (msg: ServerMessage) => {
     if (msg.type === "confirmation_request") {
-      if (usesLocalInteractiveApprovals) {
-        pendingInteractions.register(msg.requestId, {
-          conversationId: opts.conversationId,
-          kind: "confirmation",
-          confirmationDetails: {
-            toolName: msg.toolName,
-            input: msg.input,
-            riskLevel: msg.riskLevel,
-            executionTarget: msg.executionTarget,
-            allowlistOptions: msg.allowlistOptions,
-            scopeOptions: msg.scopeOptions,
-            persistentDecisionsAllowed: msg.persistentDecisionsAllowed,
-            acpToolKind: msg.acpToolKind,
-            acpOptions: msg.acpOptions,
-          },
-        });
-        broadcastMessage(msg);
-        return;
-      }
       if (autoDeny) {
         // Non-guardian voice callers have no interactive approval UI.
         // The pre-exec gate (tool-approval-handler.ts) handles grant
@@ -937,14 +912,7 @@ export async function startVoiceTurn(
         return;
       }
     } else if (msg.type === "secret_request") {
-      if (usesLocalInteractiveApprovals) {
-        // Local live voice runs alongside the desktop client, which has a
-        // secret-entry UI. Forward the broadcast and let the prompter's
-        // existing registration handle the response.
-        broadcastMessage(msg);
-        return;
-      }
-      // Phone voice has no secret-entry UI, so resolve immediately.
+      // Voice calls have no secret-entry UI, so resolve immediately.
       log.info(
         { turnId, service: msg.service, field: msg.field },
         "Auto-resolving secret request for voice turn (no secret-entry UI)",
@@ -974,15 +942,14 @@ export async function startVoiceTurn(
   // Fire-and-forget the agent loop
   void (async () => {
     try {
-      // Non-guardian phone voice forces side-effect tools to prompt so the
+      // Non-guardian voice callers force side-effect tools to prompt so the
       // auto-deny handler above reliably sees a confirmation_request. Without
       // this, a broad allow trust rule (e.g. wildcard bash) would let
       // side-effect tools execute without ever emitting an event for the
       // auto-deny / scoped-grant handler to intercept. Set inside the
       // try/finally so a failed setup before this point cannot leak the
       // flag into subsequent non-voice turns on the same conversation.
-      conversation.forcePromptSideEffects =
-        !isGuardian && !usesLocalInteractiveApprovals;
+      conversation.forcePromptSideEffects = !isGuardian;
       // Surface-resume turns install the resumed surface as the active surface
       // so `buildActiveSurfaceContext` re-injects its dynamic_page/app context,
       // and clear `currentPage` so the resumed surface isn't paired with a prior

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -246,7 +246,10 @@ describe("LiveVoiceSession archive and metrics events", () => {
 
     await startReleasedTurn(session);
     expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
-      approvalMode: "local-live-voice",
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
     });
     callbacks?.assistant_text_delta?.(makeTextDelta("Hello there."));
     callbacks?.message_complete?.(makeMessageComplete());

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1777,7 +1777,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         assistantMessageInterface: "macos",
         voiceControlPrompt:
           "You are speaking in a local live voice session. Keep replies brief and conversational. You cannot display cards, forms, or any on-screen UI during the call — convey everything in speech.",
-        approvalMode: "local-live-voice",
         content: leg.content,
         isInbound: true,
         signal: activeTurn.abortController.signal,


### PR DESCRIPTION
## Summary
- Remove the `local-live-voice` approval mode: all voice turns now use phone's policy — guardian confirmations auto-allow, non-guardian auto-deny (with spoken explanation / scoped-grant lookup), secret requests auto-resolve
- `forcePromptSideEffects` now applies to every non-guardian voice turn
- Live-voice was the mode's only caller; the interactive approval/secret-entry forwarding paths are gone

Part of plan: voice-noninteractive.md (PR 2 of 4)