### PR TITLE
Add local loopback Connect Claude OAuth routes (start/status)

### DIFF
--- a/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for the local (loopback) Connect Claude OAuth routes.
+ *
+ * `start` binds a real loopback via the oauth2 layer (default, un-mocked) so we
+ * assert it produces a genuine Claude authorize URL with a localhost `/callback`
+ * redirect and registers pending state. The capture/exchange/store path is
+ * driven by overriding `prepareOAuth2Flow` with a controllable completion so we
+ * can flip it to resolved (connected) or rejected (error) without real network.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OAuth2FlowResult } from "../../../security/oauth2.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — wired BEFORE importing the module under test.
+// ---------------------------------------------------------------------------
+
+const actualOauth2 = await import("../../../security/oauth2.js");
+// Default implementation delegates to the real loopback flow; individual tests
+// override it with `mockImplementationOnce` to inject a controllable completion.
+const prepareOAuth2FlowMock = mock(actualOauth2.prepareOAuth2Flow);
+mock.module("../../../security/oauth2.js", () => ({
+  ...actualOauth2,
+  prepareOAuth2Flow: prepareOAuth2FlowMock,
+}));
+
+const actualClaudeOauth = await import("../../../acp/acp-claude-oauth.js");
+const storeAcpClaudeTokenMock = mock(async (_token: string) => {});
+mock.module("../../../acp/acp-claude-oauth.js", () => ({
+  ...actualClaudeOauth,
+  storeAcpClaudeToken: storeAcpClaudeTokenMock,
+}));
+
+const actualSecureKeys = await import("../../../security/secure-keys.js");
+const setSecureKeyAsyncMock = mock(
+  async (_key: string, _value: string) => true,
+);
+mock.module("../../../security/secure-keys.js", () => ({
+  ...actualSecureKeys,
+  setSecureKeyAsync: setSecureKeyAsyncMock,
+}));
+
+const { ROUTES } = await import("../acp-claude-auth-routes.js");
+
+const startHandler = ROUTES.find(
+  (r) => r.operationId === "acp_claude_auth_start",
+)!.handler;
+const statusHandler = ROUTES.find(
+  (r) => r.operationId === "acp_claude_auth_status",
+)!.handler;
+
+const CLAUDE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
+interface StartResult {
+  authorize_url: string;
+  state: string;
+}
+interface StatusResult {
+  status: "pending" | "connected" | "error";
+  error?: string;
+}
+
+function getStatus(state: string): StatusResult {
+  return statusHandler({ pathParams: { state } }) as StatusResult;
+}
+
+/** Poll the status handler until it reaches `target` (or give up). */
+async function waitForStatus(
+  state: string,
+  target: StatusResult["status"],
+): Promise<StatusResult> {
+  for (let i = 0; i < 40; i++) {
+    const status = getStatus(state);
+    if (status.status === target) return status;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(`status for ${state} never reached ${target}`);
+}
+
+/** Build a controllable `prepareOAuth2Flow` result for one start call. */
+function deferredFlow(state: string): {
+  resolve: (r: OAuth2FlowResult) => void;
+  reject: (e: Error) => void;
+} {
+  let resolve!: (r: OAuth2FlowResult) => void;
+  let reject!: (e: Error) => void;
+  const completion = new Promise<OAuth2FlowResult>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  prepareOAuth2FlowMock.mockImplementationOnce(async () => ({
+    authorizeUrl: `https://claude.ai/oauth/authorize?state=${state}`,
+    state,
+    completion,
+  }));
+  return { resolve, reject };
+}
+
+beforeEach(() => {
+  prepareOAuth2FlowMock.mockClear();
+  storeAcpClaudeTokenMock.mockClear();
+  setSecureKeyAsyncMock.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// start
+// ---------------------------------------------------------------------------
+
+describe("acp_claude_auth_start", () => {
+  test("returns a well-formed Claude authorize URL with a localhost /callback redirect and registers pending state", async () => {
+    // Uses the real prepareOAuth2Flow (binds an ephemeral loopback port).
+    const result = (await startHandler({})) as StartResult;
+
+    const url = new URL(result.authorize_url);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://claude.ai/oauth/authorize",
+    );
+    expect(url.searchParams.get("client_id")).toBe(CLAUDE_CLIENT_ID);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+
+    const redirectUri = url.searchParams.get("redirect_uri") ?? "";
+    expect(redirectUri).toMatch(/^http:\/\/localhost:\d+\/callback$/);
+
+    expect(result.state).toBeTruthy();
+    expect(url.searchParams.get("state")).toBe(result.state);
+
+    // The flow is now tracked as pending.
+    expect(getStatus(result.state)).toEqual({ status: "pending" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// capture -> connected
+// ---------------------------------------------------------------------------
+
+describe("loopback capture", () => {
+  test("stores the token and flips status pending -> connected", async () => {
+    const state = "connect-state-1";
+    const flow = deferredFlow(state);
+
+    const result = (await startHandler({})) as StartResult;
+    expect(result.state).toBe(state);
+    // Before the redirect is captured, the flow is pending.
+    expect(getStatus(state).status).toBe("pending");
+
+    flow.resolve({
+      tokens: {
+        accessToken: "sk-ant-oat-access",
+        refreshToken: "refresh-xyz",
+        expiresIn: 3600,
+      },
+      grantedScopes: ["user:inference"],
+      rawTokenResponse: {},
+    });
+
+    const status = await waitForStatus(state, "connected");
+    expect(status).toEqual({ status: "connected" });
+
+    // Access token persisted via storeAcpClaudeToken.
+    expect(storeAcpClaudeTokenMock).toHaveBeenCalledTimes(1);
+    expect(storeAcpClaudeTokenMock).toHaveBeenCalledWith("sk-ant-oat-access");
+
+    // Refresh token + expiry persisted under the ACP service keys.
+    expect(setSecureKeyAsyncMock).toHaveBeenCalledWith(
+      "credential/acp/claude_oauth_refresh_token",
+      "refresh-xyz",
+    );
+    const expiresCall = setSecureKeyAsyncMock.mock.calls.find(
+      (c) => c[0] === "credential/acp/claude_oauth_expires_at",
+    );
+    expect(expiresCall).toBeDefined();
+  });
+
+  test("flips status to error when the exchange fails", async () => {
+    const state = "connect-state-2";
+    const flow = deferredFlow(state);
+
+    await startHandler({});
+    flow.reject(new Error("token exchange failed"));
+
+    const status = await waitForStatus(state, "error");
+    expect(status.status).toBe("error");
+    expect(status.error).toContain("token exchange failed");
+    expect(storeAcpClaudeTokenMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+describe("acp_claude_auth_status", () => {
+  test("unknown state yields a 404 error, not a 500", () => {
+    let thrown: { statusCode?: number } | undefined;
+    try {
+      getStatus("no-such-state");
+    } catch (err) {
+      thrown = err as { statusCode?: number };
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown!.statusCode).toBe(404);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
@@ -72,7 +72,9 @@ async function waitForStatus(
 ): Promise<StatusResult> {
   for (let i = 0; i < 40; i++) {
     const status = getStatus(state);
-    if (status.status === target) return status;
+    if (status.status === target) {
+      return status;
+    }
     await new Promise((r) => setTimeout(r, 5));
   }
   throw new Error(`status for ${state} never reached ${target}`);

--- a/assistant/src/runtime/routes/acp-claude-auth-routes.ts
+++ b/assistant/src/runtime/routes/acp-claude-auth-routes.ts
@@ -72,7 +72,9 @@ function cleanupExpiredFlows(): void {
 /** Update a tracked flow's status in place, if it still exists. */
 function markFlow(state: string, status: FlowStatus, error?: string): void {
   const flow = pendingFlows.get(state);
-  if (!flow) return;
+  if (!flow) {
+    return;
+  }
   flow.status = status;
   if (error !== undefined) {
     flow.error = error;

--- a/assistant/src/runtime/routes/acp-claude-auth-routes.ts
+++ b/assistant/src/runtime/routes/acp-claude-auth-routes.ts
@@ -1,0 +1,210 @@
+/**
+ * Route definitions for the "Connect Claude" ACP OAuth flow.
+ *
+ * This module owns the LOCAL/desktop true-one-click path: the daemon binds a
+ * loopback callback server, hands the web client an authorize URL to open, and
+ * captures + exchanges the redirect itself — no browser is opened daemon-side.
+ *
+ * POST /v1/acp/claude/auth/start — bind a loopback callback, return
+ *   `{ authorize_url, state }` for the web client to open, and begin capturing
+ *   the redirect in the background.
+ * GET  /v1/acp/claude/auth/status/:state — poll the flow's status
+ *   (`pending` | `connected` | `error`) so the web client knows when the token
+ *   has landed.
+ *
+ * PR 6 adds the CLOUD manual-paste branch to this same module; the pending-flow
+ * map + `markFlow` helper are shared so that addition slots in cleanly.
+ */
+
+import { z } from "zod";
+
+import {
+  CLAUDE_OAUTH_CONFIG,
+  storeAcpClaudeToken,
+} from "../../acp/acp-claude-oauth.js";
+import { ACP_SERVICE } from "../../acp/acp-credentials.js";
+import { credentialKey } from "../../security/credential-key.js";
+import type { OAuth2FlowResult } from "../../security/oauth2.js";
+import { prepareOAuth2Flow } from "../../security/oauth2.js";
+import { setSecureKeyAsync } from "../../security/secure-keys.js";
+import { getLogger } from "../../util/logger.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { NotFoundError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("acp-claude-auth");
+
+// Claude's OAuth client requires the loopback redirect path to be exactly
+// `/callback`, not oauth2.ts's default `/oauth/callback`.
+const CLAUDE_LOOPBACK_CALLBACK_PATH = "/callback";
+
+// ACP vault fields for the captured OAuth token's companion metadata. The
+// access token itself is written by `storeAcpClaudeToken`.
+const CLAUDE_REFRESH_TOKEN_FIELD = "claude_oauth_refresh_token";
+const CLAUDE_EXPIRES_AT_FIELD = "claude_oauth_expires_at";
+
+// ---------------------------------------------------------------------------
+// Pending-flow tracking (shared with the PR 6 cloud/manual branch)
+// ---------------------------------------------------------------------------
+
+type FlowStatus = "pending" | "connected" | "error";
+
+interface PendingFlow {
+  status: FlowStatus;
+  error?: string;
+  createdAt: number;
+}
+
+const pendingFlows = new Map<string, PendingFlow>();
+
+const PENDING_FLOW_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+/** Remove entries older than the TTL so the map can't grow unbounded. */
+function cleanupExpiredFlows(): void {
+  const cutoff = Date.now() - PENDING_FLOW_TTL_MS;
+  for (const [state, flow] of pendingFlows) {
+    if (flow.createdAt < cutoff) {
+      pendingFlows.delete(state);
+    }
+  }
+}
+
+/** Update a tracked flow's status in place, if it still exists. */
+function markFlow(state: string, status: FlowStatus, error?: string): void {
+  const flow = pendingFlows.get(state);
+  if (!flow) return;
+  flow.status = status;
+  if (error !== undefined) {
+    flow.error = error;
+  }
+}
+
+/**
+ * Persist a captured Claude OAuth token (+ refresh token / expiry when
+ * present) into the ACP vault so the broker can inject it at agent spawn.
+ */
+async function persistClaudeTokens(result: OAuth2FlowResult): Promise<void> {
+  await storeAcpClaudeToken(result.tokens.accessToken);
+
+  if (result.tokens.refreshToken) {
+    await setSecureKeyAsync(
+      credentialKey(ACP_SERVICE, CLAUDE_REFRESH_TOKEN_FIELD),
+      result.tokens.refreshToken,
+    );
+  }
+
+  if (result.tokens.expiresIn) {
+    const expiresAt = Math.floor(Date.now() / 1000 + result.tokens.expiresIn);
+    await setSecureKeyAsync(
+      credentialKey(ACP_SERVICE, CLAUDE_EXPIRES_AT_FIELD),
+      String(expiresAt),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async function handleStartLocalAuth(
+  _args: RouteHandlerArgs,
+): Promise<{ authorize_url: string; state: string }> {
+  cleanupExpiredFlows();
+
+  // Bind a fresh loopback port and let the oauth2 layer capture + exchange the
+  // redirect. The port is OS-assigned (dynamic): Claude matches localhost
+  // redirects port-agnostically per RFC 8252, so a random port sidesteps
+  // "port in use" collisions while still producing a valid redirect_uri.
+  const flow = await prepareOAuth2Flow(CLAUDE_OAUTH_CONFIG, {
+    callbackTransport: "loopback",
+    loopbackCallbackPath: CLAUDE_LOOPBACK_CALLBACK_PATH,
+  });
+
+  pendingFlows.set(flow.state, { status: "pending", createdAt: Date.now() });
+
+  // The capture + token exchange happen inside `completion`; persist the token
+  // when it resolves and flip the flow status so the web client's status poll
+  // can react. Runs in the background — the web client opens `authorize_url`.
+  void flow.completion
+    .then(async (result) => {
+      await persistClaudeTokens(result);
+      markFlow(flow.state, "connected");
+      log.info("ACP Claude local OAuth flow connected");
+    })
+    .catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      markFlow(flow.state, "error", message);
+      log.error({ err: message }, "ACP Claude local OAuth flow failed");
+    });
+
+  return { authorize_url: flow.authorizeUrl, state: flow.state };
+}
+
+function handleAuthStatus({ pathParams }: RouteHandlerArgs): {
+  status: FlowStatus;
+  error?: string;
+} {
+  const { state } = pathParams as { state: string };
+  const flow = pendingFlows.get(state);
+
+  if (!flow) {
+    throw new NotFoundError(
+      "No active Claude auth flow for the given state. Restart the connect flow.",
+    );
+  }
+
+  return flow.error
+    ? { status: flow.status, error: flow.error }
+    : { status: flow.status };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "acp_claude_auth_start",
+    endpoint: "acp/claude/auth/start",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Start local Connect Claude OAuth flow",
+    description:
+      "Bind a daemon loopback callback and return a PKCE authorize URL plus a " +
+      "state token. The web client opens the URL; the daemon captures the " +
+      "redirect, exchanges the code, and stores the Claude OAuth token.",
+    tags: ["acp"],
+    responseBody: z.object({
+      authorize_url: z.string(),
+      state: z.string(),
+    }),
+    handler: handleStartLocalAuth,
+  },
+  {
+    operationId: "acp_claude_auth_status",
+    endpoint: "acp/claude/auth/status/:state",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Poll Connect Claude OAuth flow status",
+    description:
+      "Returns the current status of an in-flight Connect Claude OAuth flow " +
+      "(pending/connected/error) so the web client can react once the token " +
+      "has landed.",
+    tags: ["acp"],
+    pathParams: [{ name: "state" }],
+    additionalResponses: {
+      "404": { description: "No active OAuth flow for the given state" },
+    },
+    responseBody: z.object({
+      status: z.enum(["pending", "connected", "error"]),
+      error: z.string().optional(),
+    }),
+    handler: handleAuthStatus,
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -14,6 +14,7 @@ import { ROUTES as MEMORY_ITEM_ROUTES } from "../../plugins/defaults/memory/rout
 import { ROUTES as MEMORY_V2_ROUTES } from "../../plugins/defaults/memory/routes/memory-v2-routes.js";
 import { ROUTES as MEMORY_V3_ROUTES } from "../../plugins/defaults/memory/routes/memory-v3-routes.js";
 import { ROUTES as MEMORY_WORKER_ROUTES } from "../../plugins/defaults/memory/routes/memory-worker-routes.js";
+import { ROUTES as ACP_CLAUDE_AUTH_ROUTES } from "./acp-claude-auth-routes.js";
 import { ROUTES as ACP_ROUTES } from "./acp-routes.js";
 import { ROUTES as APP_MANAGEMENT_ROUTES } from "./app-management-routes.js";
 import { ROUTES as APP_ROUTES } from "./app-routes.js";
@@ -159,6 +160,7 @@ import { ROUTES as WORKSPACE_ROUTES } from "./workspace-routes.js";
 export const ROUTES: RouteDefinition[] = [
   ...ATTACHMENT_ROUTES,
   ...ACP_ROUTES,
+  ...ACP_CLAUDE_AUTH_ROUTES,
   ...APP_MANAGEMENT_ROUTES,
   ...APP_ROUTES,
   ...APPROVAL_ROUTES,


### PR DESCRIPTION
## Summary
- New `assistant/src/runtime/routes/acp-claude-auth-routes.ts`: `POST /v1/acp/claude/auth/start` (daemon-loopback PKCE capture) + `GET /v1/acp/claude/auth/status/:state`, storing the captured OAuth token via `storeAcpClaudeToken`. Registered in routes/index.ts.

Part of plan: acp-oauth-connect.md (PR 5 of 9)