### PR TITLE
Add Connect Claude Code settings UI (loopback one-click + cloud paste)

### DIFF
--- a/clients/web/src/domains/settings/acp/__tests__/connect-claude-section.test.tsx
+++ b/clients/web/src/domains/settings/acp/__tests__/connect-claude-section.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Tests for the Connect Claude Code settings section.
+ *
+ * Covers the three surfaces of the ACP OAuth flow: the loopback (desktop)
+ * one-click path that polls to "connected", the manual (cloud) one-paste path
+ * that exchanges a `code#state`, and the flag gate that hides the section.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+
+let flagEnabled = true;
+
+const openUrl = mock(async (_url: string) => {});
+mock.module("@/runtime/browser", () => ({
+  openUrl,
+  openUrlFinishedListener: () => () => {},
+}));
+
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => "assistant-123",
+}));
+
+mock.module("@/stores/assistant-feature-flag-store", () => {
+  const store = () => null;
+  store.use = {
+    acpClaudeOauthConnect: () => flagEnabled,
+  };
+  return { useAssistantFeatureFlagStore: store };
+});
+
+const startConnectClaude = mock(async (_assistantId: string) => ({
+  mode: "loopback" as "loopback" | "manual",
+  authorize_url: "https://claude.ai/oauth?x=1",
+  state: "state-abc",
+}));
+const pollConnectClaudeStatus = mock(
+  async (_assistantId: string, _state: string) => ({
+    status: "connected" as "pending" | "connected" | "error",
+  }),
+);
+const exchangeConnectClaude = mock(
+  async (_assistantId: string, _code: string, _state: string) => {},
+);
+mock.module("../connect-claude-api", () => ({
+  startConnectClaude,
+  pollConnectClaudeStatus,
+  exchangeConnectClaude,
+}));
+
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: ({
+    children,
+    size: _size,
+    variant: _variant,
+    ...props
+  }: {
+    children?: ReactNode;
+    size?: string;
+    variant?: string;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => <button {...props}>{children}</button>,
+}));
+
+mock.module("@vellumai/design-library/components/input", () => ({
+  Input: ({
+    fullWidth: _fullWidth,
+    ...props
+  }: {
+    fullWidth?: boolean;
+    value?: string;
+    placeholder?: string;
+    onChange?: (e: unknown) => void;
+  }) => <input {...props} />,
+}));
+
+mock.module("@vellumai/design-library/components/typography", () => ({
+  Typography: ({ children }: { children?: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+const { ConnectClaudeSection } = await import("../connect-claude-section");
+
+beforeEach(() => {
+  flagEnabled = true;
+  openUrl.mockClear();
+  startConnectClaude.mockClear();
+  startConnectClaude.mockImplementation(async () => ({
+    mode: "loopback",
+    authorize_url: "https://claude.ai/oauth?x=1",
+    state: "state-abc",
+  }));
+  pollConnectClaudeStatus.mockClear();
+  pollConnectClaudeStatus.mockImplementation(async () => ({
+    status: "connected",
+  }));
+  exchangeConnectClaude.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ConnectClaudeSection", () => {
+  test("does not render when the flag is off", () => {
+    flagEnabled = false;
+
+    render(<ConnectClaudeSection />);
+
+    expect(screen.queryByText("Connect Claude Code")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Connect Claude Code" }),
+    ).toBeNull();
+  });
+
+  test("loopback flow: start opens the browser, polls, then shows connected", async () => {
+    render(<ConnectClaudeSection />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Connect Claude Code" }),
+    );
+
+    await waitFor(() =>
+      expect(openUrl).toHaveBeenCalledWith("https://claude.ai/oauth?x=1"),
+    );
+    expect(startConnectClaude).toHaveBeenCalledWith("assistant-123");
+
+    await waitFor(
+      () => expect(screen.getByText("Claude Code connected.")).not.toBeNull(),
+      {
+        timeout: 4000,
+        interval: 50,
+      },
+    );
+    expect(pollConnectClaudeStatus).toHaveBeenCalledWith(
+      "assistant-123",
+      "state-abc",
+    );
+  }, 10000);
+
+  test("manual flow: shows the paste field and exchanges the pasted code", async () => {
+    startConnectClaude.mockImplementation(async () => ({
+      mode: "manual",
+      authorize_url: "https://claude.ai/oauth?x=2",
+      state: "state-xyz",
+    }));
+
+    render(<ConnectClaudeSection />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Connect Claude Code" }),
+    );
+
+    const input = await screen.findByPlaceholderText("Paste code here...");
+    fireEvent.change(input, { target: { value: "code-123#state-xyz" } });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Complete Connection" }),
+    );
+
+    await waitFor(() =>
+      expect(exchangeConnectClaude).toHaveBeenCalledWith(
+        "assistant-123",
+        "code-123#state-xyz",
+        "state-xyz",
+      ),
+    );
+    expect(await screen.findByText("Claude Code connected.")).not.toBeNull();
+    // The manual path never opens a loopback poll.
+    expect(pollConnectClaudeStatus).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/settings/acp/connect-claude-api.ts
+++ b/clients/web/src/domains/settings/acp/connect-claude-api.ts
@@ -1,0 +1,79 @@
+/**
+ * Thin API layer for the "Connect Claude" ACP OAuth flow.
+ *
+ * The daemon's `/v1/acp/*` routes are excluded from the generated web SDK
+ * (see `scripts/transform-daemon-spec.ts`), so these call the daemon client
+ * directly. The gateway proxies them via `/v1/assistants/{id}/acp/claude/auth/*`.
+ */
+
+import { client } from "@/generated/daemon/client.gen";
+
+// The generated client types `url` against known daemon paths; ACP routes are
+// excluded from codegen, so cast to a sibling path to satisfy the type.
+type KnownDaemonUrl = "/v1/assistants/{assistant_id}/config";
+
+export type ConnectClaudeMode = "loopback" | "manual";
+export type ConnectClaudeStatus = "pending" | "connected" | "error";
+
+export interface ConnectClaudeStartResponse {
+  /** `loopback` on a local host (daemon captures the redirect); `manual` in the
+   *  cloud (the user pastes the `code#state` the redirect page renders). */
+  mode: ConnectClaudeMode;
+  authorize_url: string;
+  state: string;
+}
+
+export interface ConnectClaudeStatusResponse {
+  status: ConnectClaudeStatus;
+  error?: string;
+}
+
+/** Begin the flow. Returns the authorize URL to open plus the flow `mode`. */
+export async function startConnectClaude(
+  assistantId: string,
+): Promise<ConnectClaudeStartResponse> {
+  const { data, response } = await client.post({
+    url: "/v1/assistants/{assistant_id}/acp/claude/auth/start" as KnownDaemonUrl,
+    path: { assistant_id: assistantId },
+    body: {} as Record<string, unknown>,
+  });
+  if (!response?.ok) {
+    throw new Error(`Failed to start Connect Claude flow: ${response?.status}`);
+  }
+  return data as unknown as ConnectClaudeStartResponse;
+}
+
+/** Poll a loopback flow until the daemon captures the token (or errors). */
+export async function pollConnectClaudeStatus(
+  assistantId: string,
+  state: string,
+): Promise<ConnectClaudeStatusResponse> {
+  const { data, response } = await client.get({
+    url: `/v1/assistants/{assistant_id}/acp/claude/auth/status/${encodeURIComponent(state)}` as KnownDaemonUrl,
+    path: { assistant_id: assistantId },
+  });
+  if (!response?.ok) {
+    throw new Error(
+      `Failed to poll Connect Claude status: ${response?.status}`,
+    );
+  }
+  return data as unknown as ConnectClaudeStatusResponse;
+}
+
+/** Complete a manual/cloud flow with the pasted `code#state` (or a raw code). */
+export async function exchangeConnectClaude(
+  assistantId: string,
+  code: string,
+  state: string,
+): Promise<void> {
+  const { response } = await client.post({
+    url: "/v1/assistants/{assistant_id}/acp/claude/auth/exchange" as KnownDaemonUrl,
+    path: { assistant_id: assistantId },
+    body: { code, state } as Record<string, unknown>,
+  });
+  if (!response?.ok) {
+    throw new Error(
+      `Failed to complete Connect Claude flow: ${response?.status}`,
+    );
+  }
+}

--- a/clients/web/src/domains/settings/acp/connect-claude-section.tsx
+++ b/clients/web/src/domains/settings/acp/connect-claude-section.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+import { Typography } from "@vellumai/design-library/components/typography";
+import { Loader2 } from "lucide-react";
+
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { useConnectClaude } from "./use-connect-claude";
+
+// ---------------------------------------------------------------------------
+// Connect Claude Code section
+// ---------------------------------------------------------------------------
+//
+// Settings surface for the ACP "Connect Claude" OAuth flow. Gated behind the
+// `acp-claude-oauth-connect` flag. Desktop is one-click (loopback poll); the
+// cloud is one-paste (manual exchange). See `useConnectClaude`.
+
+export function ConnectClaudeSection() {
+  const enabled = useAssistantFeatureFlagStore.use.acpClaudeOauthConnect();
+  if (!enabled) {
+    return null;
+  }
+  return <ConnectClaudeSectionInner />;
+}
+
+function ConnectClaudeSectionInner() {
+  const assistantId = useActiveAssistantId();
+  const { phase, error, connect, submitPastedCode, reset } =
+    useConnectClaude(assistantId);
+  const [pastedCode, setPastedCode] = useState("");
+
+  function handleReset() {
+    reset();
+    setPastedCode("");
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border border-[var(--border-base)] p-4">
+      <div className="space-y-1">
+        <Typography
+          variant="title-small"
+          as="p"
+          className="text-[var(--content-default)]"
+        >
+          Connect Claude Code
+        </Typography>
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--content-tertiary)]"
+        >
+          Sign in with your Claude account so your assistant can run Claude Code
+          agents without pasting an API key.
+        </Typography>
+      </div>
+
+      {phase === "idle" || phase === "error" ? (
+        <Button
+          variant="outlined"
+          size="compact"
+          onClick={() => void connect()}
+        >
+          Connect Claude Code
+        </Button>
+      ) : null}
+
+      {phase === "starting" ? <BusyRow label="Starting sign-in..." /> : null}
+      {phase === "awaiting_capture" ? (
+        <BusyRow label="Waiting for Claude sign-in to complete..." />
+      ) : null}
+      {phase === "exchanging" ? (
+        <BusyRow label="Completing sign-in..." />
+      ) : null}
+
+      {phase === "awaiting_paste" ? (
+        <div className="space-y-3">
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="text-[var(--content-secondary)]"
+          >
+            After signing in, copy the code Claude shows you and paste it below.
+          </Typography>
+          <Input
+            value={pastedCode}
+            onChange={(e) => setPastedCode(e.target.value)}
+            placeholder="Paste code here..."
+            fullWidth
+          />
+          <div className="flex justify-end">
+            <Button
+              variant="primary"
+              size="compact"
+              disabled={!pastedCode.trim()}
+              onClick={() => void submitPastedCode(pastedCode)}
+            >
+              Complete Connection
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {phase === "connected" ? (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--system-positive-strong)]"
+        >
+          Claude Code connected.
+        </Typography>
+      ) : null}
+
+      {error ? (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-(--system-negative-strong)"
+        >
+          {error}
+        </Typography>
+      ) : null}
+
+      {phase === "connected" ? (
+        <Button variant="ghost" size="compact" onClick={handleReset}>
+          Connect a different account
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function BusyRow({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <Loader2 className="h-4 w-4 animate-spin text-[var(--content-tertiary)]" />
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--content-tertiary)]"
+      >
+        {label}
+      </Typography>
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/acp/use-connect-claude.ts
+++ b/clients/web/src/domains/settings/acp/use-connect-claude.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { openUrl } from "@/runtime/browser";
+import {
+  exchangeConnectClaude,
+  pollConnectClaudeStatus,
+  startConnectClaude,
+  type ConnectClaudeMode,
+} from "./connect-claude-api";
+
+/**
+ * Drives the "Connect Claude Code" ACP OAuth flow. Two shapes:
+ *   loopback (local/desktop): open the authorize URL, then poll until the
+ *     daemon captures the token on its loopback callback.
+ *   manual   (cloud):         open the authorize URL, then let the user paste
+ *     the `code#state` the redirect page renders for the daemon to exchange.
+ *
+ * Exported standalone so PR 8 can render an inline Connect affordance when an
+ * ACP spawn fails for a missing token.
+ */
+export type ConnectClaudePhase =
+  | "idle"
+  | "starting"
+  // loopback: browser opened, waiting for the token to land on the callback.
+  | "awaiting_capture"
+  // manual/cloud: waiting for the user to paste the `code#state`.
+  | "awaiting_paste"
+  | "exchanging"
+  | "connected"
+  | "error";
+
+const POLL_INTERVAL_MS = 2000;
+// ~5 min of polling, comfortably inside the daemon's 10-min pending-flow TTL.
+const MAX_POLL_ATTEMPTS = 150;
+
+export interface UseConnectClaudeResult {
+  phase: ConnectClaudePhase;
+  mode: ConnectClaudeMode | null;
+  error: string | null;
+  /** A network/flow op is in flight (start, loopback poll, or exchange). */
+  isBusy: boolean;
+  /** Start the flow: open the browser, then poll (loopback) or await a paste. */
+  connect: () => Promise<void>;
+  /** Manual/cloud path: exchange a pasted `code#state` (or a raw code). */
+  submitPastedCode: (pasted: string) => Promise<void>;
+  /** Return to the initial state so the user can connect again. */
+  reset: () => void;
+}
+
+export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
+  const [phase, setPhase] = useState<ConnectClaudePhase>("idle");
+  const [mode, setMode] = useState<ConnectClaudeMode | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Bumped on every reset / new connect and on unmount, so a stale poll loop
+  // from an abandoned flow can't write state after the user restarts.
+  const flowIdRef = useRef(0);
+  const mountedRef = useRef(true);
+  const stateRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      flowIdRef.current++;
+    };
+  }, []);
+
+  const isStale = useCallback(
+    (flowId: number) => flowIdRef.current !== flowId || !mountedRef.current,
+    [],
+  );
+
+  const pollUntilSettled = useCallback(
+    async (flowId: number, state: string) => {
+      for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        if (isStale(flowId)) {
+          return;
+        }
+        let result;
+        try {
+          result = await pollConnectClaudeStatus(assistantId, state);
+        } catch {
+          continue; // Transient poll error — keep trying within the budget.
+        }
+        if (isStale(flowId)) {
+          return;
+        }
+        if (result.status === "connected") {
+          setPhase("connected");
+          return;
+        }
+        if (result.status === "error") {
+          setError(
+            result.error ?? "Connecting Claude failed. Please try again.",
+          );
+          setPhase("error");
+          return;
+        }
+      }
+      setError("Timed out waiting for Claude to connect. Please try again.");
+      setPhase("error");
+    },
+    [assistantId, isStale],
+  );
+
+  const connect = useCallback(async () => {
+    const flowId = ++flowIdRef.current;
+    setError(null);
+    setMode(null);
+    setPhase("starting");
+
+    let start;
+    try {
+      start = await startConnectClaude(assistantId);
+    } catch {
+      if (isStale(flowId)) {
+        return;
+      }
+      setError("Couldn't start Connect Claude. Please try again.");
+      setPhase("error");
+      return;
+    }
+    if (isStale(flowId)) {
+      return;
+    }
+
+    stateRef.current = start.state;
+    setMode(start.mode);
+    await openUrl(start.authorize_url);
+    if (isStale(flowId)) {
+      return;
+    }
+
+    if (start.mode === "loopback") {
+      setPhase("awaiting_capture");
+      void pollUntilSettled(flowId, start.state);
+    } else {
+      setPhase("awaiting_paste");
+    }
+  }, [assistantId, isStale, pollUntilSettled]);
+
+  const submitPastedCode = useCallback(
+    async (pasted: string) => {
+      const trimmed = pasted.trim();
+      if (!trimmed) {
+        setError("Paste the code shown on the Claude page.");
+        return;
+      }
+      const state = stateRef.current;
+      if (!state) {
+        setError("Start the Connect Claude flow first.");
+        return;
+      }
+      const flowId = flowIdRef.current;
+      setError(null);
+      setPhase("exchanging");
+      try {
+        // The daemon splits a pasted `code#state`; passing the tracked `state`
+        // too lets a raw code (no `#`) resolve as well.
+        await exchangeConnectClaude(assistantId, trimmed, state);
+      } catch {
+        if (isStale(flowId)) {
+          return;
+        }
+        setError(
+          "Couldn't complete Connect Claude. Check the pasted code and try again.",
+        );
+        setPhase("awaiting_paste");
+        return;
+      }
+      if (isStale(flowId)) {
+        return;
+      }
+      setPhase("connected");
+    },
+    [assistantId, isStale],
+  );
+
+  const reset = useCallback(() => {
+    flowIdRef.current++;
+    stateRef.current = null;
+    setMode(null);
+    setError(null);
+    setPhase("idle");
+  }, []);
+
+  const isBusy =
+    phase === "starting" ||
+    phase === "awaiting_capture" ||
+    phase === "exchanging";
+
+  return { phase, mode, error, isBusy, connect, submitPastedCode, reset };
+}

--- a/clients/web/src/domains/settings/ai/ai-page.tsx
+++ b/clients/web/src/domains/settings/ai/ai-page.tsx
@@ -8,6 +8,7 @@ import { EmailServiceCard } from "@/domains/settings/ai/email-service-card";
 import { ImageGenerationCard } from "@/domains/settings/ai/image-generation-card";
 import { TextToSpeechCard } from "@/domains/settings/ai/text-to-speech-card";
 import { SpeechToTextCard } from "@/domains/settings/ai/speech-to-text-card";
+import { ConnectClaudeSection } from "@/domains/settings/acp/connect-claude-section";
 
 // ---------------------------------------------------------------------------
 // AiPage — layout shell
@@ -50,6 +51,7 @@ export function AiPage() {
       <ImageGenerationCard />
       <TextToSpeechCard />
       <SpeechToTextCard />
+      <ConnectClaudeSection />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- New `domains/settings/acp` Connect Claude Code section + `use-connect-claude` hook: desktop one-click (loopback poll) and cloud one-paste (manual exchange), gated behind the `acp-claude-oauth-connect` flag.

Part of plan: acp-oauth-connect.md (PR 7 of 9)