### PR TITLE
feat(intelligence): deterministic cluster detection for the memory graph

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.test.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import { detectClusters } from "./detect-clusters";
+
+function nodes(...ids: string[]): { id: string }[] {
+  return ids.map((id) => ({ id }));
+}
+
+function edge(fromId: string, toId: string): { fromId: string; toId: string } {
+  return { fromId, toId };
+}
+
+/** A closed triangle over three node ids. */
+function triangle(a: string, b: string, c: string) {
+  return [edge(a, b), edge(b, c), edge(c, a)];
+}
+
+describe("detectClusters", () => {
+  test("two disconnected triangles yield exactly 2 clusters", () => {
+    const clusters = detectClusters(nodes("a", "b", "c", "d", "e", "f"), [
+      ...triangle("a", "b", "c"),
+      ...triangle("d", "e", "f"),
+    ]);
+    // All six nodes are assigned, split into exactly two distinct clusters.
+    expect(clusters.size).toBe(6);
+    expect(new Set(clusters.values()).size).toBe(2);
+    // Each triangle shares one cluster; the two triangles differ.
+    expect(clusters.get("a")).toBe(clusters.get("b"));
+    expect(clusters.get("b")).toBe(clusters.get("c"));
+    expect(clusters.get("d")).toBe(clusters.get("e"));
+    expect(clusters.get("e")).toBe(clusters.get("f"));
+    expect(clusters.get("a")).not.toBe(clusters.get("d"));
+  });
+
+  test("one bridge edge merges the two triangles into 1 cluster", () => {
+    const clusters = detectClusters(nodes("a", "b", "c", "d", "e", "f"), [
+      ...triangle("a", "b", "c"),
+      ...triangle("d", "e", "f"),
+      edge("c", "d"), // bridge
+    ]);
+    expect(new Set(clusters.values()).size).toBe(1);
+  });
+
+  test("is deterministic — identical input yields an identical map", () => {
+    const ns = nodes("a", "b", "c", "d", "e", "f");
+    const es = [...triangle("a", "b", "c"), ...triangle("d", "e", "f")];
+    expect([...detectClusters(ns, es)]).toEqual([...detectClusters(ns, es)]);
+  });
+
+  test("two isolated nodes get two distinct cluster ids", () => {
+    const clusters = detectClusters(nodes("a", "b"), []);
+    expect(clusters.get("a")).not.toBe(clusters.get("b"));
+    expect(new Set(clusters.values()).size).toBe(2);
+  });
+
+  test("cluster ids are dense 0..k-1", () => {
+    const clusters = detectClusters(nodes("a", "b", "c", "d", "e"), [
+      ...triangle("a", "b", "c"),
+      edge("d", "e"),
+    ]);
+    const ids = [...new Set(clusters.values())].sort((x, y) => x - y);
+    expect(ids).toEqual(Array.from({ length: ids.length }, (_, i) => i));
+  });
+
+  test("returns an empty map for no nodes", () => {
+    expect(detectClusters([], [])).toEqual(new Map());
+  });
+});

--- a/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.ts
@@ -1,0 +1,85 @@
+/**
+ * Deterministic community detection for the memory concept graph.
+ *
+ * Pure and dependency-free: runs synchronous label propagation over an
+ * undirected view of the graph — NO RNG (Math.random is forbidden in layout
+ * code) and NO Date.now(), so identical input always yields an identical map.
+ * A later PR uses the returned cluster ids to color concept nodes by theme, so
+ * ids are renumbered into a compact 0..k-1 range a palette can index directly.
+ */
+
+const PASSES = 8;
+
+/**
+ * Partition graph nodes into clusters via deterministic label propagation.
+ *
+ * Each node starts in its own cluster and, over a fixed number of passes,
+ * adopts the most frequent label among its neighbors (ties broken by the lowest
+ * label id for determinism). Disconnected nodes (degree 0) keep their initial,
+ * unique label and therefore each land in their own cluster.
+ *
+ * @returns A map from every node id to a compact cluster id in `0..k-1`,
+ *   assigned in order of first appearance in `nodes`.
+ */
+export function detectClusters(
+  nodes: readonly { id: string }[],
+  edges: readonly { fromId: string; toId: string }[],
+): Map<string, number> {
+  const n = nodes.length;
+  if (n === 0) {return new Map();}
+
+  const indexById = new Map<string, number>();
+  nodes.forEach((node, i) => indexById.set(node.id, i));
+
+  // Undirected neighbor adjacency; drop self-loops and edges to unknown nodes.
+  const neighbors: number[][] = nodes.map(() => []);
+  for (const edge of edges) {
+    const a = indexById.get(edge.fromId);
+    const b = indexById.get(edge.toId);
+    if (a === undefined || b === undefined || a === b) {continue;}
+    neighbors[a].push(b);
+    neighbors[b].push(a);
+  }
+
+  // Each node begins in its own cluster (label = its stable array index).
+  const labels = nodes.map((_, i) => i);
+
+  for (let pass = 0; pass < PASSES; pass++) {
+    for (let i = 0; i < n; i++) {
+      const adjacent = neighbors[i];
+      if (adjacent.length === 0) {continue;}
+
+      // Tally neighbor labels, then take the most frequent — lowest label wins
+      // ties so the outcome never depends on iteration/insertion order.
+      const counts = new Map<number, number>();
+      for (const j of adjacent) {
+        counts.set(labels[j], (counts.get(labels[j]) ?? 0) + 1);
+      }
+      let bestLabel = labels[i];
+      let bestCount = -1;
+      for (const [label, count] of counts) {
+        if (count > bestCount || (count === bestCount && label < bestLabel)) {
+          bestLabel = label;
+          bestCount = count;
+        }
+      }
+      labels[i] = bestLabel;
+    }
+  }
+
+  // Renumber the surviving labels into a dense 0..k-1 range, in order of first
+  // appearance, so ids stay small and stable for a palette to index.
+  const compactByLabel = new Map<number, number>();
+  const clusterById = new Map<string, number>();
+  nodes.forEach((node, i) => {
+    const label = labels[i];
+    let compact = compactByLabel.get(label);
+    if (compact === undefined) {
+      compact = compactByLabel.size;
+      compactByLabel.set(label, compact);
+    }
+    clusterById.set(node.id, compact);
+  });
+
+  return clusterById;
+}

--- a/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.ts
@@ -4,8 +4,8 @@
  * Pure and dependency-free: runs synchronous label propagation over an
  * undirected view of the graph — NO RNG (Math.random is forbidden in layout
  * code) and NO Date.now(), so identical input always yields an identical map.
- * A later PR uses the returned cluster ids to color concept nodes by theme, so
- * ids are renumbered into a compact 0..k-1 range a palette can index directly.
+ * Cluster ids are renumbered into a compact 0..k-1 range so a caller can index
+ * a color palette by id directly.
  */
 
 const PASSES = 8;


### PR DESCRIPTION
## Summary
- Add pure, deterministic label-propagation cluster detection over the memory graph's nodes/edges.
- Returns a compact 0..k-1 cluster id per node for later theme-coloring.

Part of plan: memory-graph-enhancements.md (PR 1 of 8)