### PR TITLE
feat(intelligence): instrument Memory-tab usage telemetry

### DIFF
--- a/clients/web/src/domains/intelligence/memory-page.tsx
+++ b/clients/web/src/domains/intelligence/memory-page.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useRef } from "react";
+
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { ConceptGraphView } from "@/domains/intelligence/components/concept-graph/concept-graph-view";
+import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
 
 interface MemoryPageProps {
   onOpenThread?: (message: string) => void;
@@ -15,6 +18,17 @@ interface MemoryPageProps {
  */
 export function MemoryPage({ onOpenThread }: MemoryPageProps) {
   const assistantId = useActiveAssistantId();
+
+  // Report the tab open exactly once per mount. The ref guard keeps React
+  // strict-mode's double-invoke (dev) from emitting a duplicate.
+  const openedEmitted = useRef(false);
+  useEffect(() => {
+    if (openedEmitted.current) {
+      return;
+    }
+    openedEmitted.current = true;
+    emitMemoryEvent("opened");
+  }, []);
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/clients/web/src/domains/intelligence/memory-telemetry.ts
+++ b/clients/web/src/domains/intelligence/memory-telemetry.ts
@@ -1,15 +1,13 @@
 import { getDeviceBool } from "@/utils/device-settings";
-import { getClientId } from "@/lib/telemetry/client-identity";
+import { postTelemetryEvents } from "@/lib/telemetry/ingest";
 
 /**
  * Memory-tab usage telemetry.
  *
- * Modeled on `domains/onboarding/funnel-events.ts`: POSTs directly to the
- * platform's `/v1/telemetry/ingest/` endpoint, consent-gated, device-scoped via
- * `getClientId()`. It reuses the existing `type: "onboarding"` event with a
- * distinct `funnel_version` (`memory_tab_v1`). `screen` / `step_name` /
- * `funnel_version` are open strings server-side, so these values ride the
- * existing wire shape and ingest path with no backend / terraform change.
+ * Reports through the shared `postTelemetryEvents` transport as a
+ * `type: "onboarding"` event with a distinct `funnel_version`
+ * (`memory_tab_v1`). `screen` / `step_name` / `funnel_version` are open strings
+ * server-side, so these values ride the existing ingest wire shape.
  *
  * Consent is read from the shared `device:share_analytics` bool
  * (`getDeviceBool("shareAnalytics", ...)`) rather than the onboarding domain's
@@ -42,12 +40,6 @@ interface MemoryEvent {
   user_id?: string;
 }
 
-function stripUndefined(value: object): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entry]) => entry !== undefined),
-  );
-}
-
 export function emitMemoryEvent(
   step: MemoryStep,
   options: { userId?: string } = {},
@@ -72,16 +64,5 @@ export function emitMemoryEvent(
     user_id: options.userId,
   };
 
-  const payload = JSON.stringify({
-    device_id: getClientId(),
-    assistant_version: import.meta.env.VITE_APP_VERSION ?? "web-dev",
-    events: [stripUndefined(event)],
-  });
-
-  void fetch("/v1/telemetry/ingest/", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: payload,
-    keepalive: true,
-  }).catch(() => {});
+  postTelemetryEvents([event]);
 }

--- a/clients/web/src/domains/intelligence/memory-telemetry.ts
+++ b/clients/web/src/domains/intelligence/memory-telemetry.ts
@@ -1,0 +1,87 @@
+import { getDeviceBool } from "@/utils/device-settings";
+import { getClientId } from "@/lib/telemetry/client-identity";
+
+/**
+ * Memory-tab usage telemetry.
+ *
+ * Modeled on `domains/onboarding/funnel-events.ts`: POSTs directly to the
+ * platform's `/v1/telemetry/ingest/` endpoint, consent-gated, device-scoped via
+ * `getClientId()`. It reuses the existing `type: "onboarding"` event with a
+ * distinct `funnel_version` (`memory_tab_v1`). `screen` / `step_name` /
+ * `funnel_version` are open strings server-side, so these values ride the
+ * existing wire shape and ingest path with no backend / terraform change.
+ *
+ * Consent is read from the shared `device:share_analytics` bool
+ * (`getDeviceBool("shareAnalytics", ...)`) rather than the onboarding domain's
+ * `readShareAnalytics()` — the intelligence domain can't import from onboarding
+ * (`local/no-cross-domain-imports`), and the device bool is the same persistent
+ * opt-out signal that reader gates on (and that `/settings/privacy` and the
+ * Sentry consent gate read directly).
+ */
+
+export const MEMORY_FUNNEL_VERSION = "memory_tab_v1";
+
+/** Which Memory-tab interaction is being reported. */
+export type MemoryStep = "opened" | "search" | "node_opened" | "chat_from_node";
+
+/**
+ * Per-page-load session id, generated once when this module first loads. Ties
+ * every Memory-tab event from a single load together, mirroring the onboarding
+ * funnel's `session_id`.
+ */
+const SESSION_ID = crypto.randomUUID();
+
+interface MemoryEvent {
+  type: "onboarding";
+  daemon_event_id: string;
+  recorded_at: number;
+  screen: string;
+  session_id: string;
+  step_name: string;
+  funnel_version: string;
+  user_id?: string;
+}
+
+function stripUndefined(value: object): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  );
+}
+
+export function emitMemoryEvent(
+  step: MemoryStep,
+  options: { userId?: string } = {},
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  // Analytics is opt-out; an absent preference authorizes uploads.
+  if (!getDeviceBool("shareAnalytics", true)) {
+    return;
+  }
+
+  const event: MemoryEvent = {
+    type: "onboarding",
+    daemon_event_id: crypto.randomUUID(),
+    recorded_at: Date.now(),
+    screen: "memory",
+    session_id: SESSION_ID,
+    step_name: step,
+    funnel_version: MEMORY_FUNNEL_VERSION,
+    // Omitted (→ stripped before send) when the caller has no user id.
+    user_id: options.userId,
+  };
+
+  const payload = JSON.stringify({
+    device_id: getClientId(),
+    assistant_version: import.meta.env.VITE_APP_VERSION ?? "web-dev",
+    events: [stripUndefined(event)],
+  });
+
+  void fetch("/v1/telemetry/ingest/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+    keepalive: true,
+  }).catch(() => {});
+}

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -1,5 +1,5 @@
 import { readShareAnalytics } from "@/domains/onboarding/prefs";
-import { getClientId } from "@/lib/telemetry/client-identity";
+import { postTelemetryEvents } from "@/lib/telemetry/ingest";
 import type { ResearchStep } from "@/domains/onboarding/research-onboarding-persistence";
 
 export const ONBOARDING_FUNNEL_VERSION = "onboarding_v3_2026_05";
@@ -142,12 +142,6 @@ export interface OnboardingFunnelEvent {
   outcome?: OnboardingFunnelStepOutcome;
 }
 
-function stripUndefined(value: object): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entry]) => entry !== undefined),
-  );
-}
-
 export function getOnboardingFunnelSessionId(): string {
   if (typeof window === "undefined") return crypto.randomUUID();
   let existing = "";
@@ -232,20 +226,7 @@ export function emitOnboardingFunnelStepCompleted(
   if (typeof window === "undefined") return;
   if (!readShareAnalytics()) return;
 
-  const event = stripUndefined(buildOnboardingFunnelEvent(screen, options));
-
-  const payload = JSON.stringify({
-    device_id: getClientId(),
-    assistant_version: import.meta.env.VITE_APP_VERSION ?? "web-dev",
-    events: [event],
-  });
-
-  void fetch("/v1/telemetry/ingest/", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: payload,
-    keepalive: true,
-  }).catch(() => {});
+  postTelemetryEvents([buildOnboardingFunnelEvent(screen, options)]);
 }
 
 /**

--- a/clients/web/src/lib/telemetry/ingest.ts
+++ b/clients/web/src/lib/telemetry/ingest.ts
@@ -1,0 +1,37 @@
+import { getClientId } from "./client-identity";
+
+/**
+ * Drops keys whose value is `undefined` so they are omitted from the wire
+ * payload rather than carried as explicit nulls. Callers stamp optional fields
+ * (e.g. `user_id`, `outcome`) as `undefined` when absent and rely on this to
+ * keep the ingested event shape stable.
+ */
+function stripUndefined(event: object): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(event).filter(([, value]) => value !== undefined),
+  );
+}
+
+/**
+ * Wraps events in the telemetry envelope and fire-and-forgets them to the
+ * platform's `/v1/telemetry/ingest/` endpoint. `keepalive` lets the request
+ * outlive a page unload, and failures are swallowed since telemetry is
+ * best-effort.
+ *
+ * Consent is NOT gated here — each caller applies its own opt-out check before
+ * calling, because the funnels read consent from different signals.
+ */
+export function postTelemetryEvents(events: readonly object[]): void {
+  const payload = JSON.stringify({
+    device_id: getClientId(),
+    assistant_version: import.meta.env.VITE_APP_VERSION ?? "web-dev",
+    events: events.map(stripUndefined),
+  });
+
+  void fetch("/v1/telemetry/ingest/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+    keepalive: true,
+  }).catch(() => {});
+}

--- a/clients/web/src/memory-page-route.tsx
+++ b/clients/web/src/memory-page-route.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { MemoryPage } from "@/domains/intelligence/memory-page";
+import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
 import { navigateToNewConversation } from "@/utils/conversation-navigation";
 
 export function MemoryPageRoute() {
@@ -12,6 +13,7 @@ export function MemoryPageRoute() {
     <MemoryPage
       key={assistantId}
       onOpenThread={(message) => {
+        emitMemoryEvent("chat_from_node");
         navigateToNewConversation(navigate, { prompt: message });
       }}
     />


### PR DESCRIPTION
## Summary
- Add memory-telemetry emitter (client-direct to /v1/telemetry/ingest, mirroring funnel-events.ts; onboarding event type, funnel_version memory_tab_v1 — no backend changes).
- Emit 'opened' on the Memory tab mount and 'chat_from_node' from the node chat action.

Part of plan: memory-graph-enhancements.md (PR 7 of 8)