### PR TITLE
feat(web): Providers modal — provider-first cards, derived auth, no connection/auth-type copy

### DIFF
--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -864,7 +864,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   // subscription-auth pseudo-provider. Cards and pickers render both as
   // providers, so they need display names.
   vellum: "Vellum",
-  chatgpt: "ChatGPT",
+  chatgpt: "ChatGPT Subscription",
   anthropic: "Anthropic",
   openai: "OpenAI",
   gemini: "Google Gemini",

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -835,8 +835,7 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
   ],
-  "openai-compatible": [
-  ],
+  "openai-compatible": [],
 } as const satisfies Record<string, readonly LlmCatalogModel[]>;
 
 export type LlmProviderId = keyof typeof MODELS_BY_PROVIDER;
@@ -861,6 +860,11 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
  *   PROVIDER_DISPLAY_NAMES[id] ?? id
  */
 export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  // Not catalog providers: the platform-managed routing sentinel and the
+  // subscription-auth pseudo-provider. Cards and pickers render both as
+  // providers, so they need display names.
+  vellum: "Vellum",
+  chatgpt: "ChatGPT",
   anthropic: "Anthropic",
   openai: "OpenAI",
   gemini: "Google Gemini",

--- a/clients/web/src/domains/settings/ai/language-model-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.test.tsx
@@ -181,7 +181,9 @@ describe("default-provider availability notice", () => {
     ].find((b) => b.textContent === "Providers");
     fireEvent.click(providersButton as HTMLButtonElement);
     await waitFor(() => {
-      expect(result.baseElement.textContent).toContain("Provider Connections");
+      expect(result.baseElement.textContent).toContain(
+        "Manage the model providers your assistant can use.",
+      );
     });
 
     setAvailability("ok");

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -8,7 +8,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement } from "react";
 
 import type {
@@ -132,24 +132,22 @@ function renderModal() {
   );
 }
 
-function rowFor(result: ReturnType<typeof render>, connectionName: string) {
-  const deleteButton = result.baseElement.querySelector(
-    `button[aria-label="Delete ${connectionName}"]`,
-  );
-  if (!deleteButton) {
-    throw new Error(`Row "${connectionName}" not found`);
+function rowFor(result: ReturnType<typeof render>, providerTitle: string) {
+  const title = Array.from(
+    result.baseElement.querySelectorAll<HTMLElement>("span"),
+  ).find((element) => element.textContent?.trim() === providerTitle);
+  if (!title) {
+    throw new Error(`Provider "${providerTitle}" not found`);
   }
-  return (
-    deleteButton.closest("div.flex.items-center.gap-3")?.parentElement ?? null
-  );
+  return title.closest("div.flex.items-center.gap-3")?.parentElement ?? null;
 }
 
 async function waitForRow(
   result: ReturnType<typeof render>,
-  connectionName: string,
+  providerTitle: string,
 ) {
   await waitFor(() => {
-    expect(rowFor(result, connectionName)).not.toBeNull();
+    expect(rowFor(result, providerTitle)).not.toBeNull();
   });
 }
 
@@ -200,13 +198,13 @@ describe("default marker", () => {
       expect(result.baseElement.textContent).toContain("Default");
     });
 
-    const defaultRow = rowFor(result, "anthropic-personal");
+    const defaultRow = rowFor(result, "Anthropic");
     expect(defaultRow?.textContent).toContain("Default");
-    const otherRow = rowFor(result, "openai-personal");
+    const otherRow = rowFor(result, "OpenAI");
     expect(otherRow?.textContent).not.toContain("Default");
 
     const deleteButton = defaultRow?.querySelector<HTMLButtonElement>(
-      'button[aria-label="Delete anthropic-personal"]',
+      'button[aria-label="Delete Anthropic"]',
     );
     expect(deleteButton?.disabled).toBe(true);
     expect(deleteButton?.title).toContain("default provider");
@@ -224,9 +222,9 @@ describe("default marker", () => {
     };
 
     const result = renderModal();
-    await waitForRow(result, "work-openai");
+    await waitForRow(result, "OpenAI");
 
-    const otherRow = rowFor(result, "work-openai");
+    const otherRow = rowFor(result, "OpenAI");
     const setDefaultButton = [
       ...(otherRow?.querySelectorAll("button") ?? []),
     ].find((b) => b.textContent === "Set as default");
@@ -242,7 +240,7 @@ describe("default marker", () => {
     // Invalidation refetches the GET (now pointing at work-openai) and the
     // tag moves to the new row.
     await waitFor(() => {
-      const refreshedRow = rowFor(result, "work-openai");
+      const refreshedRow = rowFor(result, "OpenAI");
       expect(refreshedRow?.textContent).toContain("Default");
     });
   });
@@ -253,9 +251,9 @@ describe("default marker", () => {
     ];
 
     const result = renderModal();
-    await waitForRow(result, "local-ollama");
+    await waitForRow(result, "Ollama");
 
-    const row = rowFor(result, "local-ollama");
+    const row = rowFor(result, "Ollama");
     const setDefaultButton = [...(row?.querySelectorAll("button") ?? [])].find(
       (b) => b.textContent === "Set as default",
     );
@@ -273,7 +271,7 @@ describe("default marker", () => {
     ];
 
     const result = renderModal();
-    await waitForRow(result, "openai-personal");
+    await waitForRow(result, "OpenAI");
 
     expect(result.baseElement.textContent).not.toContain("Set as default");
     expect(result.baseElement.textContent).not.toContain("Default");
@@ -287,9 +285,9 @@ describe("default marker", () => {
     putShouldFail = true;
 
     const result = renderModal();
-    await waitForRow(result, "openai-personal");
+    await waitForRow(result, "OpenAI");
 
-    const row = rowFor(result, "openai-personal");
+    const row = rowFor(result, "OpenAI");
     const setDefaultButton = [...(row?.querySelectorAll("button") ?? [])].find(
       (b) => b.textContent === "Set as default",
     );
@@ -325,13 +323,23 @@ describe("card titles", () => {
     });
 
     // THEN each provider has a distinct title without internal-key subtitles
-    const apiKeyRow = rowFor(result, "openai-personal");
+    const apiKeyRow = rowFor(result, "OpenAI");
     expect(apiKeyRow?.textContent).toContain("OpenAI");
     expect(apiKeyRow?.textContent).not.toContain("ChatGPT");
     expect(result.baseElement.textContent).not.toContain(
       "chatgpt-subscription",
     );
     expect(result.baseElement.textContent).not.toContain("openai-personal");
+    expect(
+      result.baseElement.querySelector(
+        'button[aria-label="Delete ChatGPT Subscription"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      result.baseElement.querySelector(
+        'button[aria-label="Delete openai-personal"]',
+      ),
+    ).toBeNull();
   });
 });
 
@@ -339,15 +347,17 @@ describe("delete-guard errors", () => {
   async function clickDelete(name: string) {
     connectionsState = [makeConnection({ name, provider: "openai" })];
     const result = renderModal();
-    await waitForRow(result, name);
+    await waitForRow(result, "OpenAI");
     const deleteButton = result.baseElement.querySelector<HTMLButtonElement>(
-      `button[aria-label="Delete ${name}"]`,
+      'button[aria-label="Delete OpenAI"]',
     );
-    fireEvent.click(deleteButton as HTMLButtonElement);
+    await act(async () => {
+      fireEvent.click(deleteButton as HTMLButtonElement);
+    });
     return result;
   }
 
-  test("409 renders the daemon's guard message verbatim", async () => {
+  test("409 renders a user-facing guard without internal provider names", async () => {
     deleteResult = {
       status: 409,
       body: {
@@ -363,20 +373,11 @@ describe("delete-guard errors", () => {
     const result = await clickDelete("work-openai");
     await waitFor(() => {
       expect(result.baseElement.textContent).toContain(
-        "is referenced by llm.defaultProvider",
+        "This provider is in use by a profile or as the default provider",
       );
     });
-  });
-
-  test("409 without a parseable envelope falls back to the generic string", async () => {
-    deleteResult = { status: 409, body: "not-an-envelope" };
-
-    const result = await clickDelete("work-openai");
-    await waitFor(() => {
-      expect(result.baseElement.textContent).toContain(
-        "This provider is in use by one or more profiles",
-      );
-    });
+    expect(result.baseElement.textContent).not.toContain("work-openai");
+    expect(result.baseElement.textContent).not.toContain("llm.defaultProvider");
   });
 
   test("non-guarded connections still delete cleanly", async () => {
@@ -396,7 +397,7 @@ describe("delete-guard errors", () => {
     ];
 
     const result = renderModal();
-    await waitForRow(result, "openai-personal");
+    await waitForRow(result, "OpenAI");
     const setDefaultButton = [
       ...result.baseElement.querySelectorAll("button"),
     ].find((b) => b.textContent === "Set as default");
@@ -411,9 +412,9 @@ describe("delete-guard errors", () => {
 describe("editability", () => {
   function editButtonFor(
     result: ReturnType<typeof render>,
-    connectionName: string,
+    providerTitle: string,
   ): HTMLButtonElement | undefined {
-    const row = rowFor(result, connectionName);
+    const row = rowFor(result, providerTitle);
     return [...(row?.querySelectorAll("button") ?? [])].find(
       (b) => b.textContent === "Edit",
     ) as HTMLButtonElement | undefined;
@@ -428,10 +429,29 @@ describe("editability", () => {
 
     // WHEN the modal renders
     const result = renderModal();
-    await waitForRow(result, "anthropic-personal");
+    await waitForRow(result, "Anthropic");
 
     // THEN the managed row has no Edit button, but the user-owned one does
-    expect(editButtonFor(result, "vellum")).toBeUndefined();
-    expect(editButtonFor(result, "anthropic-personal")).toBeDefined();
+    expect(editButtonFor(result, "Vellum")).toBeUndefined();
+    expect(editButtonFor(result, "Anthropic")).toBeDefined();
+  });
+
+  test("the editor identifies providers without exposing their internal names", async () => {
+    connectionsState = [
+      makeConnection({
+        name: "ollama-personal",
+        provider: "ollama",
+        auth: { type: "none" },
+      }),
+    ];
+
+    const result = renderModal();
+    await waitForRow(result, "Ollama");
+    fireEvent.click(editButtonFor(result, "Ollama") as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("Editing Ollama.");
+    });
+    expect(result.baseElement.textContent).not.toContain("ollama-personal");
   });
 });

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -299,6 +299,31 @@ describe("default marker", () => {
   });
 });
 
+describe("card titles", () => {
+  test("titles a ChatGPT subscription row distinctly from OpenAI API-key rows", async () => {
+    connectionsState = [
+      makeConnection({
+        name: "chatgpt-subscription",
+        provider: "openai",
+        auth: {
+          type: "oauth_subscription",
+          credential: "credential/chatgpt/access_token",
+        },
+      }),
+      makeConnection({ name: "openai-personal", provider: "openai" }),
+    ];
+
+    const result = renderModal();
+    await waitFor(() => {
+      expect(result.baseElement.textContent).toContain("ChatGPT Subscription");
+    });
+    // The API-key row still titles by the provider display name.
+    const apiKeyRow = rowFor(result, "openai-personal");
+    expect(apiKeyRow?.textContent).toContain("OpenAI");
+    expect(apiKeyRow?.textContent).not.toContain("ChatGPT");
+  });
+});
+
 describe("delete-guard errors", () => {
   async function clickDelete(name: string) {
     connectionsState = [makeConnection({ name, provider: "openai" })];

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -132,13 +132,25 @@ function renderModal() {
   );
 }
 
-function rowFor(result: ReturnType<typeof render>, label: string) {
-  const spans = [...result.baseElement.querySelectorAll("span, p")];
-  const labelEl = spans.find((el) => el.textContent === label);
-  if (!labelEl) {
-    throw new Error(`Row "${label}" not found`);
+function rowFor(result: ReturnType<typeof render>, connectionName: string) {
+  const deleteButton = result.baseElement.querySelector(
+    `button[aria-label="Delete ${connectionName}"]`,
+  );
+  if (!deleteButton) {
+    throw new Error(`Row "${connectionName}" not found`);
   }
-  return labelEl.closest("div.flex.items-center.gap-3")?.parentElement ?? null;
+  return (
+    deleteButton.closest("div.flex.items-center.gap-3")?.parentElement ?? null
+  );
+}
+
+async function waitForRow(
+  result: ReturnType<typeof render>,
+  connectionName: string,
+) {
+  await waitFor(() => {
+    expect(rowFor(result, connectionName)).not.toBeNull();
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -212,9 +224,7 @@ describe("default marker", () => {
     };
 
     const result = renderModal();
-    await waitFor(() => {
-      expect(result.baseElement.textContent).toContain("work-openai");
-    });
+    await waitForRow(result, "work-openai");
 
     const otherRow = rowFor(result, "work-openai");
     const setDefaultButton = [
@@ -243,9 +253,7 @@ describe("default marker", () => {
     ];
 
     const result = renderModal();
-    await waitFor(() => {
-      expect(result.baseElement.textContent).toContain("local-ollama");
-    });
+    await waitForRow(result, "local-ollama");
 
     const row = rowFor(result, "local-ollama");
     const setDefaultButton = [...(row?.querySelectorAll("button") ?? [])].find(
@@ -265,9 +273,7 @@ describe("default marker", () => {
     ];
 
     const result = renderModal();
-    await waitFor(() => {
-      expect(result.baseElement.textContent).toContain("openai-personal");
-    });
+    await waitForRow(result, "openai-personal");
 
     expect(result.baseElement.textContent).not.toContain("Set as default");
     expect(result.baseElement.textContent).not.toContain("Default");
@@ -281,9 +287,7 @@ describe("default marker", () => {
     putShouldFail = true;
 
     const result = renderModal();
-    await waitFor(() => {
-      expect(result.baseElement.textContent).toContain("openai-personal");
-    });
+    await waitForRow(result, "openai-personal");
 
     const row = rowFor(result, "openai-personal");
     const setDefaultButton = [...(row?.querySelectorAll("button") ?? [])].find(
@@ -301,6 +305,7 @@ describe("default marker", () => {
 
 describe("card titles", () => {
   test("titles a ChatGPT subscription row distinctly from OpenAI API-key rows", async () => {
+    // GIVEN unlabeled ChatGPT subscription and OpenAI API-key providers
     connectionsState = [
       makeConnection({
         name: "chatgpt-subscription",
@@ -313,14 +318,20 @@ describe("card titles", () => {
       makeConnection({ name: "openai-personal", provider: "openai" }),
     ];
 
+    // WHEN the provider list renders
     const result = renderModal();
     await waitFor(() => {
       expect(result.baseElement.textContent).toContain("ChatGPT Subscription");
     });
-    // The API-key row still titles by the provider display name.
+
+    // THEN each provider has a distinct title without internal-key subtitles
     const apiKeyRow = rowFor(result, "openai-personal");
     expect(apiKeyRow?.textContent).toContain("OpenAI");
     expect(apiKeyRow?.textContent).not.toContain("ChatGPT");
+    expect(result.baseElement.textContent).not.toContain(
+      "chatgpt-subscription",
+    );
+    expect(result.baseElement.textContent).not.toContain("openai-personal");
   });
 });
 
@@ -328,9 +339,7 @@ describe("delete-guard errors", () => {
   async function clickDelete(name: string) {
     connectionsState = [makeConnection({ name, provider: "openai" })];
     const result = renderModal();
-    await waitFor(() => {
-      expect(result.baseElement.textContent).toContain(name);
-    });
+    await waitForRow(result, name);
     const deleteButton = result.baseElement.querySelector<HTMLButtonElement>(
       `button[aria-label="Delete ${name}"]`,
     );
@@ -387,9 +396,7 @@ describe("delete-guard errors", () => {
     ];
 
     const result = renderModal();
-    await waitFor(() => {
-      expect(result.baseElement.textContent).toContain("openai-personal");
-    });
+    await waitForRow(result, "openai-personal");
     const setDefaultButton = [
       ...result.baseElement.querySelectorAll("button"),
     ].find((b) => b.textContent === "Set as default");
@@ -421,9 +428,7 @@ describe("editability", () => {
 
     // WHEN the modal renders
     const result = renderModal();
-    await waitFor(() => {
-      expect(result.baseElement.textContent).toContain("anthropic-personal");
-    });
+    await waitForRow(result, "anthropic-personal");
 
     // THEN the managed row has no Edit button, but the user-owned one does
     expect(editButtonFor(result, "vellum")).toBeUndefined();

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -302,6 +302,29 @@ describe("default marker", () => {
 });
 
 describe("card titles", () => {
+  test("renders Vellum first regardless of API order", async () => {
+    connectionsState = [
+      makeConnection({ name: "anthropic-personal", provider: "anthropic" }),
+      makeConnection({
+        name: "vellum",
+        provider: "vellum",
+        label: "Vellum",
+        auth: { type: "platform" },
+        isManaged: true,
+      }),
+      makeConnection({ name: "openai-personal", provider: "openai" }),
+    ];
+
+    const result = renderModal();
+    await waitForRow(result, "Vellum");
+
+    const providerList = rowFor(result, "Vellum")?.parentElement;
+    const titles = Array.from(providerList?.children ?? []).map(
+      (row) => row.querySelector("span")?.textContent,
+    );
+    expect(titles).toEqual(["Vellum", "Anthropic", "OpenAI"]);
+  });
+
   test("titles a ChatGPT subscription row distinctly from OpenAI API-key rows", async () => {
     // GIVEN unlabeled ChatGPT subscription and OpenAI API-key providers
     connectionsState = [

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.test.tsx
@@ -340,7 +340,7 @@ describe("delete-guard errors", () => {
     const result = await clickDelete("work-openai");
     await waitFor(() => {
       expect(result.baseElement.textContent).toContain(
-        "Connection is in use by one or more profiles",
+        "This provider is in use by one or more profiles",
       );
     });
   });

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -64,19 +64,22 @@ function errorEnvelopeMessage(error: unknown): string | undefined {
     : undefined;
 }
 
-function formatAuthSummary(auth: ProviderConnection["auth"]): string {
-  switch (auth.type) {
-    case "api_key":
-      return `API key · ${auth.credential}`;
-    case "oauth_subscription":
-      return "ChatGPT Subscription";
-    case "platform":
-      return "Managed proxy";
-    case "none":
-      return "None (local)";
-    default:
-      return auth.type;
-  }
+/** Card title: user label, else the provider's display name. */
+function providerCardTitle(conn: ProviderConnection): string {
+  return conn.label ?? PROVIDER_DISPLAY_NAMES[conn.provider] ?? conn.provider;
+}
+
+/**
+ * Card subtitle: the internal key and provider name, omitting parts that
+ * would just repeat the title.
+ */
+function providerCardSubtitle(conn: ProviderConnection): string {
+  const title = providerCardTitle(conn);
+  const parts = [
+    conn.name,
+    PROVIDER_DISPLAY_NAMES[conn.provider] ?? conn.provider,
+  ];
+  return [...new Set(parts)].filter((p) => p !== title).join(" · ");
 }
 
 // ---------------------------------------------------------------------------
@@ -316,18 +319,18 @@ function ManageProvidersModalInner({
           ...prev,
           [name]:
             errorEnvelopeMessage(error) ??
-            "Connection is in use by one or more profiles. Remove those references first.",
+            "This provider is in use by one or more profiles. Remove those references first.",
         }));
       } else {
         setRowErrors((prev) => ({
           ...prev,
-          [name]: "Failed to delete connection. Please try again.",
+          [name]: "Failed to delete provider. Please try again.",
         }));
       }
     } catch {
       setRowErrors((prev) => ({
         ...prev,
-        [name]: "Failed to delete connection. Please try again.",
+        [name]: "Failed to delete provider. Please try again.",
       }));
     } finally {
       setDeleting((prev) => {
@@ -341,10 +344,9 @@ function ManageProvidersModalInner({
   return (
     <Modal.Content size="md">
       <Modal.Header>
-        <Modal.Title>Provider Connections</Modal.Title>
+        <Modal.Title>Providers</Modal.Title>
         <Modal.Description>
-          Manage inference provider connections. Each connection binds a name to
-          a provider and auth configuration.
+          Manage the model providers your assistant can use.
         </Modal.Description>
       </Modal.Header>
 
@@ -364,7 +366,7 @@ function ManageProvidersModalInner({
             as="p"
             className="py-4 text-center text-(--system-negative-strong)"
           >
-            Failed to load connections. Please try again.
+            Failed to load providers. Please try again.
           </Typography>
         ) : connections.length === 0 ? (
           <Typography
@@ -372,13 +374,14 @@ function ManageProvidersModalInner({
             as="p"
             className="py-4 text-center text-(--content-tertiary)"
           >
-            No connections yet. Create one to get started.
+            No providers yet. Add one to get started.
           </Typography>
         ) : (
           <div className="space-y-1">
             {connections.map((conn) => {
               const isDeleting = deleting[conn.name] ?? false;
               const rowError = rowErrors[conn.name];
+              const subtitle = providerCardSubtitle(conn);
               const isManaged = conn.isManaged ?? false;
               const isDefault = conn.name === defaultConnectionName;
               const eligibleForDefault = isDefaultProviderId(conn.provider);
@@ -389,7 +392,7 @@ function ManageProvidersModalInner({
               return (
                 <div key={conn.name}>
                   <div className="flex items-center gap-3 rounded-lg px-2 py-2">
-                    {/* Connection info */}
+                    {/* Provider info */}
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <Typography
@@ -397,12 +400,12 @@ function ManageProvidersModalInner({
                           as="span"
                           className="text-(--content-default)"
                         >
-                          {conn.label ?? conn.name}
+                          {providerCardTitle(conn)}
                         </Typography>
                         {isManaged && (
                           <Tag
                             tone="positive"
-                            title="Managed by Platform — auth is locked, but you can rename this connection."
+                            title="Managed by Platform — you can rename this provider, but not edit it."
                           >
                             Platform
                           </Tag>
@@ -410,22 +413,21 @@ function ManageProvidersModalInner({
                         {isDefault && (
                           <Tag
                             tone="info"
-                            title="Built-in profiles (Balanced, Quality, Speed) run through this connection."
+                            title="Built-in profiles (Balanced, Quality, Speed) use this provider."
                           >
                             Default
                           </Tag>
                         )}
                       </div>
-                      <Typography
-                        variant="body-medium-lighter"
-                        as="p"
-                        className="mt-0.5 text-(--content-tertiary)"
-                      >
-                        {conn.label ? `${conn.name} · ` : ""}
-                        {PROVIDER_DISPLAY_NAMES[conn.provider] ?? conn.provider}
-                        {" · "}
-                        {formatAuthSummary(conn.auth)}
-                      </Typography>
+                      {subtitle ? (
+                        <Typography
+                          variant="body-medium-lighter"
+                          as="p"
+                          className="mt-0.5 text-(--content-tertiary)"
+                        >
+                          {subtitle}
+                        </Typography>
+                      ) : null}
                     </div>
 
                     {/* Actions */}
@@ -437,7 +439,7 @@ function ManageProvidersModalInner({
                           disabled={!eligibleForDefault || isSettingDefault}
                           title={
                             eligibleForDefault
-                              ? "Run the built-in profiles through this connection."
+                              ? "Use this provider for the built-in profiles."
                               : "Built-in profiles can't run on this provider."
                           }
                           onClick={() => handleSetDefault(conn)}
@@ -465,9 +467,9 @@ function ManageProvidersModalInner({
                         disabled={isManaged || isDefault || isDeleting}
                         title={
                           isManaged
-                            ? "Managed connections cannot be deleted"
+                            ? "The Vellum provider cannot be removed"
                             : isDefault
-                              ? "This connection serves your default provider. Set another connection as default first."
+                              ? "This is your default provider. Set another provider as default first."
                               : undefined
                         }
                         onClick={() => void handleDelete(conn.name)}
@@ -494,7 +496,7 @@ function ManageProvidersModalInner({
 
       <Modal.Footer className="justify-between">
         <Button variant="outlined" size="compact" onClick={onNewClick}>
-          + New Connection
+          + Add Provider
         </Button>
         <Button variant="outlined" size="compact" onClick={onClose}>
           Done

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -21,6 +21,7 @@ import type {
   DefaultProviderStatus,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
+import { VELLUM_CONNECTION_PROVIDER } from "@/domains/settings/ai/constants";
 import { providerConnectionDisplayName } from "@/domains/settings/ai/provider-editor-constants";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
@@ -88,7 +89,17 @@ export function ManageProvidersModal({
     enabled: isOpen && supportsDefaultProvider,
   });
 
-  const connections = useMemo(() => data?.connections ?? [], [data]);
+  const connections = useMemo(() => {
+    const fetchedConnections = data?.connections ?? [];
+    return [
+      ...fetchedConnections.filter(
+        (connection) => connection.provider === VELLUM_CONNECTION_PROVIDER,
+      ),
+      ...fetchedConnections.filter(
+        (connection) => connection.provider !== VELLUM_CONNECTION_PROVIDER,
+      ),
+    ];
+  }, [data]);
 
   function handleDefaultChanged() {
     void queryClient.invalidateQueries({

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -21,7 +21,7 @@ import type {
   DefaultProviderStatus,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
-import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import { providerConnectionDisplayName } from "@/domains/settings/ai/provider-editor-constants";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
 import { ProviderEditorContent } from "@/domains/settings/ai/provider-editor-modal";
@@ -44,40 +44,6 @@ const DEFAULT_PROVIDER_ELIGIBLE: Record<DefaultProviderId, true> = {
 
 function isDefaultProviderId(provider: string): provider is DefaultProviderId {
   return provider in DEFAULT_PROVIDER_ELIGIBLE;
-}
-
-/**
- * Extracts the daemon's error-envelope message (`{ error: { message } }`,
- * per the runtime's http-errors adapter) from a generated-SDK `error` field.
- */
-function errorEnvelopeMessage(error: unknown): string | undefined {
-  if (typeof error !== "object" || error === null) {
-    return undefined;
-  }
-  const inner = (error as { error?: unknown }).error;
-  if (typeof inner !== "object" || inner === null) {
-    return undefined;
-  }
-  const message = (inner as { message?: unknown }).message;
-  return typeof message === "string" && message.length > 0
-    ? message
-    : undefined;
-}
-
-/**
- * Card title: user label, else the provider's display name. Subscription
- * auth gets its own identity — without it, an unlabeled ChatGPT row (stored
- * as provider "openai") would be indistinguishable from an OpenAI API-key
- * card now that the auth subtitle is gone.
- */
-function providerCardTitle(conn: ProviderConnection): string {
-  if (conn.label) {
-    return conn.label;
-  }
-  if (conn.auth.type === "oauth_subscription") {
-    return PROVIDER_DISPLAY_NAMES.chatgpt;
-  }
-  return PROVIDER_DISPLAY_NAMES[conn.provider] ?? conn.provider;
 }
 
 // ---------------------------------------------------------------------------
@@ -303,21 +269,17 @@ function ManageProvidersModalInner({
       return next;
     });
     try {
-      const { error, response } =
-        await inferenceProviderconnectionsByNameDelete({
-          path: { assistant_id: assistantId, name },
-        });
+      const { response } = await inferenceProviderconnectionsByNameDelete({
+        path: { assistant_id: assistantId, name },
+      });
       if (response?.ok || response?.status === 404) {
         // 404 means already gone — still remove from local list.
         onConnectionDeleted(name);
       } else if (response?.status === 409) {
-        // The daemon's guard names what blocks the delete (default provider,
-        // referencing profiles) and the fix — render it verbatim.
         setRowErrors((prev) => ({
           ...prev,
           [name]:
-            errorEnvelopeMessage(error) ??
-            "This provider is in use by one or more profiles. Remove those references first.",
+            "This provider is in use by a profile or as the default provider. Update those settings before deleting it.",
         }));
       } else {
         setRowErrors((prev) => ({
@@ -397,7 +359,7 @@ function ManageProvidersModalInner({
                           as="span"
                           className="text-(--content-default)"
                         >
-                          {providerCardTitle(conn)}
+                          {providerConnectionDisplayName(conn)}
                         </Typography>
                         {isManaged && (
                           <Tag
@@ -451,7 +413,7 @@ function ManageProvidersModalInner({
                         variant="ghost"
                         size="compact"
                         iconOnly={<Trash2 />}
-                        aria-label={`Delete ${conn.name}`}
+                        aria-label={`Delete ${providerConnectionDisplayName(conn)}`}
                         disabled={isManaged || isDefault || isDeleting}
                         title={
                           isManaged

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -64,9 +64,20 @@ function errorEnvelopeMessage(error: unknown): string | undefined {
     : undefined;
 }
 
-/** Card title: user label, else the provider's display name. */
+/**
+ * Card title: user label, else the provider's display name. Subscription
+ * auth gets its own identity — without it, an unlabeled ChatGPT row (stored
+ * as provider "openai") would be indistinguishable from an OpenAI API-key
+ * card now that the auth subtitle is gone.
+ */
 function providerCardTitle(conn: ProviderConnection): string {
-  return conn.label ?? PROVIDER_DISPLAY_NAMES[conn.provider] ?? conn.provider;
+  if (conn.label) {
+    return conn.label;
+  }
+  if (conn.auth.type === "oauth_subscription") {
+    return PROVIDER_DISPLAY_NAMES.chatgpt;
+  }
+  return PROVIDER_DISPLAY_NAMES[conn.provider] ?? conn.provider;
 }
 
 /**

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -80,19 +80,6 @@ function providerCardTitle(conn: ProviderConnection): string {
   return PROVIDER_DISPLAY_NAMES[conn.provider] ?? conn.provider;
 }
 
-/**
- * Card subtitle: the internal key and provider name, omitting parts that
- * would just repeat the title.
- */
-function providerCardSubtitle(conn: ProviderConnection): string {
-  const title = providerCardTitle(conn);
-  const parts = [
-    conn.name,
-    PROVIDER_DISPLAY_NAMES[conn.provider] ?? conn.provider,
-  ];
-  return [...new Set(parts)].filter((p) => p !== title).join(" · ");
-}
-
 // ---------------------------------------------------------------------------
 // ManageProvidersModal
 // ---------------------------------------------------------------------------
@@ -392,7 +379,6 @@ function ManageProvidersModalInner({
             {connections.map((conn) => {
               const isDeleting = deleting[conn.name] ?? false;
               const rowError = rowErrors[conn.name];
-              const subtitle = providerCardSubtitle(conn);
               const isManaged = conn.isManaged ?? false;
               const isDefault = conn.name === defaultConnectionName;
               const eligibleForDefault = isDefaultProviderId(conn.provider);
@@ -430,15 +416,6 @@ function ManageProvidersModalInner({
                           </Tag>
                         )}
                       </div>
-                      {subtitle ? (
-                        <Typography
-                          variant="body-medium-lighter"
-                          as="p"
-                          className="mt-0.5 text-(--content-tertiary)"
-                        >
-                          {subtitle}
-                        </Typography>
-                      ) : null}
                     </div>
 
                     {/* Actions */}

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -139,22 +139,6 @@ function getSaveBtn(): HTMLButtonElement {
   return btn;
 }
 
-/**
- * The inline ProviderCreateForm keeps its Display Name + Key fields under a
- * collapsed "Advanced" disclosure. Open it so those inputs mount.
- */
-function openInlineProviderAdvanced(): void {
-  const button = Array.from(
-    document.querySelectorAll<HTMLButtonElement>("button"),
-  ).find((b) => b.textContent?.trim() === "Advanced");
-  if (!button) {
-    throw new Error("expected the inline provider Advanced disclosure");
-  }
-  if (button.getAttribute("aria-expanded") !== "true") {
-    fireEvent.click(button);
-  }
-}
-
 /** All Dropdown triggers (custom comboboxes) in document order. */
 function dropdownTriggers(): HTMLButtonElement[] {
   return Array.from(
@@ -527,15 +511,12 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     selectProvider("+ Create new provider");
 
-    // Inline ProviderCreateForm is mounted; its Key field lives under Advanced.
-    openInlineProviderAdvanced();
-    const inlineKey = getInputByPlaceholder("e.g. anthropic-personal");
-    expect(inlineKey).toBeDefined();
-
-    // Fill the inline form and create (anthropic defaults to platform auth,
-    // so no API key entry is required).
-    fireEvent.change(inlineKey, { target: { value: "anthropic-personal" } });
-    fireEvent.click(getButton("Create"));
+    // Inline ProviderCreateForm is mounted; auth derives from the provider
+    // (anthropic → api_key), so entering a key is the whole flow.
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+    fireEvent.click(getButton("Add"));
 
     // After create, the sub-form collapses and the provider is selected.
     await waitFor(() => {
@@ -572,11 +553,10 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     renderCreate([], onSave);
 
     selectProvider("+ Create new provider");
-    openInlineProviderAdvanced();
-    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
-      target: { value: "anthropic-personal" },
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
     });
-    fireEvent.click(getButton("Create"));
+    fireEvent.click(getButton("Add"));
 
     await waitFor(() => {
       expect(document.body.textContent).toContain(

--- a/clients/web/src/domains/settings/ai/profile-prefill.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-prefill.test.ts
@@ -65,21 +65,23 @@ describe("deriveProviderDefaults", () => {
   test("uses the display name and a deduped slug key", () => {
     expect(deriveProviderDefaults("anthropic", [])).toEqual({
       name: "Anthropic",
-      key: "anthropic",
+      key: "anthropic-personal",
     });
   });
 
   test("dedupes the key against existing connection names", () => {
-    expect(deriveProviderDefaults("anthropic", ["anthropic"])).toEqual({
+    expect(
+      deriveProviderDefaults("anthropic", ["anthropic-personal"]),
+    ).toEqual({
       name: "Anthropic",
-      key: "anthropic-2",
+      key: "anthropic-personal-2",
     });
   });
 
   test("falls back to the provider type when no display name exists", () => {
     expect(deriveProviderDefaults("custom-provider", [])).toEqual({
       name: "custom-provider",
-      key: "custom-provider",
+      key: "custom-provider-personal",
     });
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-prefill.ts
+++ b/clients/web/src/domains/settings/ai/profile-prefill.ts
@@ -32,7 +32,11 @@ function dedupeKey(base: string, existing: string[]): string {
 /**
  * Derive default display name and key for a new provider connection of the
  * given provider type, ensuring the key does not collide with existing
- * connection names.
+ * connection names. The key follows the daemon's `${provider}-personal`
+ * convention (see `resolveDefaultConnectionName`) so that recreating a
+ * provider satisfies dangling default-provider/profile bindings that
+ * reference the conventional row — the key editor is hidden for catalog
+ * providers, so the seed must match the convention on its own.
  */
 export function deriveProviderDefaults(
   providerType: string,
@@ -40,7 +44,10 @@ export function deriveProviderDefaults(
 ): { name: string; key: string } {
   return {
     name: PROVIDER_DISPLAY_NAMES[providerType] ?? providerType,
-    key: dedupeKey(slugify(providerType), existingConnectionNames),
+    key: dedupeKey(
+      `${slugify(providerType)}-personal`,
+      existingConnectionNames,
+    ),
   };
 }
 

--- a/clients/web/src/domains/settings/ai/profile-prefill.ts
+++ b/clients/web/src/domains/settings/ai/profile-prefill.ts
@@ -35,8 +35,8 @@ function dedupeKey(base: string, existing: string[]): string {
  * connection names. The key follows the daemon's `${provider}-personal`
  * convention (see `resolveDefaultConnectionName`) so that recreating a
  * provider satisfies dangling default-provider/profile bindings that
- * reference the conventional row — the key editor is hidden for catalog
- * providers, so the seed must match the convention on its own.
+ * reference the conventional row. Provider keys are not user-editable, so the
+ * seed must match the convention and remain unique on its own.
  */
 export function deriveProviderDefaults(
   providerType: string,

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -167,9 +167,9 @@ function getButton(label: string): HTMLButtonElement {
 }
 
 /**
- * Display Name (and, for openai-compatible, the Key) live under a collapsed
- * "Advanced" disclosure. Open it so those inputs mount before a test reads
- * or edits them. Idempotent — a no-op when the section is already expanded.
+ * Display Name lives under a collapsed "Advanced" disclosure. Open it so the
+ * input mounts before a test reads or edits it. Idempotent — a no-op when the
+ * section is already expanded.
  */
 function openAdvancedFields(): void {
   const button = Array.from(
@@ -285,12 +285,12 @@ describe("ProviderCreateForm submit sequence", () => {
     expect(created?.name).toBe("anthropic-personal");
   });
 
-  test("blocks a duplicate openai-compatible key with the validation message", () => {
+  test("dedupes openai-compatible names without exposing the internal key", async () => {
     render(
       <ModalWrapper>
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
-          existingNames={["my-endpoint"]}
+          existingNames={["openai-compatible-personal"]}
           defaultProviderType="openai-compatible"
           onCreated={() => {}}
           onCancel={() => {}}
@@ -299,14 +299,24 @@ describe("ProviderCreateForm submit sequence", () => {
     );
 
     openAdvancedFields();
-    fireEvent.change(getInputByPlaceholder("e.g. my-endpoint"), {
-      target: { value: "my-endpoint" },
-    });
-
-    expect(document.body.textContent).toContain(
-      'A provider named "my-endpoint" already exists.',
+    expect(document.body.textContent).not.toContain(
+      "openai-compatible-personal",
     );
-    expect(getButton("Add").disabled).toBe(true);
+    expect(
+      Array.from(document.querySelectorAll<HTMLInputElement>("input")).some(
+        (input) => input.placeholder === "e.g. my-endpoint",
+      ),
+    ).toBe(false);
+
+    fireEvent.click(getButton("Add"));
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    expect(createConnectionCalls[0].body).toMatchObject({
+      name: "openai-compatible-personal-2",
+      provider: "openai-compatible",
+    });
   });
 
   test("variant=inline renders the form without Modal chrome and still creates", async () => {
@@ -616,7 +626,7 @@ describe("ProviderCreateForm submit sequence", () => {
     });
   });
 
-  test("a provider switch re-seeds the hidden key even after a Display Name edit", async () => {
+  test("switching to openai-compatible re-seeds the hidden name after a Display Name edit", async () => {
     render(
       <ModalWrapper>
         <ProviderCreateForm
@@ -633,11 +643,8 @@ describe("ProviderCreateForm submit sequence", () => {
     fireEvent.change(getInputByPlaceholder("e.g. My Anthropic Key"), {
       target: { value: "My Custom Name" },
     });
-    selectDropdownOption("Provider", "OpenAI");
+    selectDropdownOption("Provider", "OpenAI-compatible");
 
-    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
-      target: { value: "sk-test-123" },
-    });
     fireEvent.click(getButton("Add"));
 
     await waitFor(() => {
@@ -645,8 +652,8 @@ describe("ProviderCreateForm submit sequence", () => {
     });
     // Label edit preserved; key follows the provider's convention seed.
     expect(createConnectionCalls[0].body).toMatchObject({
-      name: "openai-personal",
-      provider: "openai",
+      name: "openai-compatible-personal",
+      provider: "openai-compatible",
       label: "My Custom Name",
     });
   });
@@ -683,7 +690,7 @@ describe("ProviderCreateForm submit sequence", () => {
     });
   });
 
-  test("the key input only exists for openai-compatible", () => {
+  test("internal provider keys never render as editable inputs", () => {
     render(
       <ModalWrapper>
         <ProviderCreateForm
@@ -696,17 +703,20 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
-    const keyInputMounted = () =>
+    const internalKeyInputMounted = () =>
       Array.from(document.querySelectorAll<HTMLInputElement>("input")).some(
         (el) => el.placeholder === "e.g. my-endpoint",
       );
 
     openAdvancedFields();
-    expect(keyInputMounted()).toBe(false);
+    expect(internalKeyInputMounted()).toBe(false);
 
     selectDropdownOption("Provider", "OpenAI-compatible");
     openAdvancedFields();
-    expect(keyInputMounted()).toBe(true);
+    expect(internalKeyInputMounted()).toBe(false);
+    expect(document.body.textContent).not.toContain(
+      "openai-compatible-personal",
+    );
   });
 
   test("clicking Cancel invokes onCancel", () => {

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -435,7 +435,7 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
-    selectDropdownOption("Provider", "ChatGPT");
+    selectDropdownOption("Provider", "ChatGPT Subscription");
 
     // Subscription auth is owned by the OAuth flow: no API key field, no
     // Add button, sign-in affordance present.

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -651,6 +651,38 @@ describe("ProviderCreateForm submit sequence", () => {
     });
   });
 
+  test("openai-compatible with no API key creates a keyless provider", async () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="openai-compatible"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("https://api.example.com/v1"), {
+      target: { value: "http://localhost:1234/v1" },
+    });
+    fireEvent.change(getInputByPlaceholder("model-1, model-2"), {
+      target: { value: "my-model" },
+    });
+    fireEvent.click(getButton("Add"));
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    expect(secretsPostCalls).toEqual([]);
+    expect(createConnectionCalls[0].body).toMatchObject({
+      provider: "openai-compatible",
+      auth: { type: "none" },
+      base_url: "http://localhost:1234/v1",
+    });
+  });
+
   test("the key input only exists for openai-compatible", () => {
     render(
       <ModalWrapper>

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -9,6 +9,10 @@
  *      assembled `CreateConnectionInput`, then hand the returned connection
  *      back to the consumer via `onCreated`.
  *
+ * Auth is derived from the chosen provider (keyless → none, everything else
+ * → api_key; ChatGPT is a subscription pseudo-provider whose connection is
+ * created by the OAuth flow) — there is no auth-type control.
+ *
  * We mock the generated daemon SDK (sdk.gen) at module scope via
  * module-level holders so each test can inspect the exact request bodies,
  * mirroring the mocking style in
@@ -78,8 +82,11 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
 // Stub the credential hooks so render doesn't issue real daemon queries.
 // `hasStoredCredential: false` matches the empty create-mode state.
 mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
-  credentialPresenceQueryKey: (assistantId: string, kind: string, name: string) =>
-    ["credentialPresence", assistantId, kind, name] as const,
+  credentialPresenceQueryKey: (
+    assistantId: string,
+    kind: string,
+    name: string,
+  ) => ["credentialPresence", assistantId, kind, name] as const,
   useStoredCredentialPresence: () => ({
     hasStoredCredential: false,
     isLoading: false,
@@ -93,9 +100,8 @@ mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
   }),
 }));
 
-const { ProviderCreateForm } = await import(
-  "@/domains/settings/ai/provider-create-form"
-);
+const { ProviderCreateForm } =
+  await import("@/domains/settings/ai/provider-create-form");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -161,9 +167,9 @@ function getButton(label: string): HTMLButtonElement {
 }
 
 /**
- * Display Name + Key live under a collapsed "Advanced" disclosure. Open it
- * so those inputs mount before a test reads or edits them. Idempotent — a
- * no-op when the section is already expanded.
+ * Display Name (and, for openai-compatible, the Key) live under a collapsed
+ * "Advanced" disclosure. Open it so those inputs mount before a test reads
+ * or edits them. Idempotent — a no-op when the section is already expanded.
  */
 function openAdvancedFields(): void {
   const button = Array.from(
@@ -208,7 +214,7 @@ function selectDropdownOption(ariaLabel: string, optionLabel: string): void {
 beforeEach(() => {
   secretsPostCalls = [];
   createConnectionCalls = [];
-  createdConnection = makeConnection("anthropic-personal");
+  createdConnection = makeConnection("anthropic");
   createResponseOk = true;
   createResponseStatus = 200;
   toastSuccessCalls = [];
@@ -224,13 +230,14 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("ProviderCreateForm submit sequence", () => {
-  test("submitting an API key fires secretsPost then inferenceProviderconnectionsPost and calls onCreated", async () => {
+  test("a keyed provider derives api_key auth: secretsPost then inferenceProviderconnectionsPost", async () => {
     let created: ProviderConnection | undefined;
     render(
       <ModalWrapper>
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
           existingNames={[]}
+          defaultProviderType="anthropic"
           onCreated={(c) => {
             created = c;
           }}
@@ -239,21 +246,13 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
-    // Default provider is anthropic with platform auth — switch to API Key.
-    // Type a Key (name) and an API key value.
-    openAdvancedFields();
-    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
-      target: { value: "anthropic-personal" },
-    });
-
-    // Select API Key auth so the API Key field renders.
-    selectDropdownOption("Auth type", "API Key");
-
+    // No auth-type control: a keyed provider goes straight to the API key
+    // field, and the connection name is seeded from the provider.
     fireEvent.change(getInputByPlaceholder("Enter your API key"), {
       target: { value: "sk-test-123" },
     });
 
-    fireEvent.click(getButton("Create"));
+    fireEvent.click(getButton("Add"));
 
     await waitFor(() => {
       expect(createConnectionCalls.length).toBe(1);
@@ -269,10 +268,12 @@ describe("ProviderCreateForm submit sequence", () => {
       value: "sk-test-123",
     });
 
-    // Then inferenceProviderconnectionsPost with the CreateConnectionInput.
+    // Then inferenceProviderconnectionsPost with the full derived auth
+    // object (NOT the bare `credential` field — older daemons only accept
+    // explicit auth, and this form must work against them without a gate).
     expect(createConnectionCalls[0].path.assistant_id).toBe(ASSISTANT_ID);
     expect(createConnectionCalls[0].body).toMatchObject({
-      name: "anthropic-personal",
+      name: "anthropic",
       provider: "anthropic",
       auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
@@ -281,15 +282,16 @@ describe("ProviderCreateForm submit sequence", () => {
     await waitFor(() => {
       expect(created).toBeDefined();
     });
-    expect(created?.name).toBe("anthropic-personal");
+    expect(created?.name).toBe("anthropic");
   });
 
-  test("blocks duplicate names with the existing validation message", () => {
+  test("blocks a duplicate openai-compatible key with the validation message", () => {
     render(
       <ModalWrapper>
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
-          existingNames={["anthropic-personal"]}
+          existingNames={["my-endpoint"]}
+          defaultProviderType="openai-compatible"
           onCreated={() => {}}
           onCancel={() => {}}
         />
@@ -297,14 +299,14 @@ describe("ProviderCreateForm submit sequence", () => {
     );
 
     openAdvancedFields();
-    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
-      target: { value: "anthropic-personal" },
+    fireEvent.change(getInputByPlaceholder("e.g. my-endpoint"), {
+      target: { value: "my-endpoint" },
     });
 
     expect(document.body.textContent).toContain(
-      'A connection named "anthropic-personal" already exists.',
+      'A provider named "my-endpoint" already exists.',
     );
-    expect(getButton("Create").disabled).toBe(true);
+    expect(getButton("Add").disabled).toBe(true);
   });
 
   test("variant=inline renders the form without Modal chrome and still creates", async () => {
@@ -315,6 +317,7 @@ describe("ProviderCreateForm submit sequence", () => {
           variant="inline"
           assistantId={ASSISTANT_ID}
           existingNames={[]}
+          defaultProviderType="anthropic"
           onCreated={(c) => {
             created = c;
           }}
@@ -324,44 +327,40 @@ describe("ProviderCreateForm submit sequence", () => {
     );
 
     // Inline variant drops the modal title.
-    expect(document.body.textContent).not.toContain("New Provider Connection");
+    expect(document.body.textContent).not.toContain("Add Provider");
 
-    openAdvancedFields();
-    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
-      target: { value: "anthropic-personal" },
-    });
-
-    selectDropdownOption("Auth type", "API Key");
     fireEvent.change(getInputByPlaceholder("Enter your API key"), {
       target: { value: "sk-test-123" },
     });
 
-    fireEvent.click(getButton("Create"));
+    fireEvent.click(getButton("Add"));
 
     await waitFor(() => {
       expect(createConnectionCalls.length).toBe(1);
     });
     await waitFor(() => {
-      expect(created?.name).toBe("anthropic-personal");
+      expect(created?.name).toBe("anthropic");
     });
   });
 
-  test("a provider without platform auth (e.g. openrouter) seeds api_key, not platform", () => {
-    // openrouter has no managed proxy, so defaulting to `platform` would let the
-    // user create an unusable connection. The initial auth seed must fall back
-    // to api_key — the API Key field's presence confirms it.
+  test("there is no auth-type control — auth derives from the provider", () => {
     render(
       <ModalWrapper>
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
           existingNames={[]}
-          defaultProviderType="openrouter"
+          defaultProviderType="anthropic"
           onCreated={() => {}}
           onCancel={() => {}}
         />
       </ModalWrapper>,
     );
 
+    expect(
+      document.querySelector('button[role="combobox"][aria-label="Auth type"]'),
+    ).toBeNull();
+    expect(document.body.textContent).not.toContain("Auth Type");
+    // Keyed provider → API key field present.
     expect(getInputByPlaceholder("Enter your API key")).toBeDefined();
   });
 
@@ -387,7 +386,7 @@ describe("ProviderCreateForm submit sequence", () => {
       ),
     ).toBe(false);
 
-    fireEvent.click(getButton("Create"));
+    fireEvent.click(getButton("Add"));
 
     await waitFor(() => {
       expect(createConnectionCalls.length).toBe(1);
@@ -400,7 +399,7 @@ describe("ProviderCreateForm submit sequence", () => {
     });
   });
 
-  test("platform-hosted assistants ignore an Ollama default provider seed", async () => {
+  test("platform-hosted assistants ignore an Ollama default provider seed", () => {
     useAssistantLifecycleStore.setState({
       assistantState: { kind: "active", isLocal: false },
     });
@@ -416,16 +415,41 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
-    fireEvent.click(getButton("Create"));
+    // Ollama isn't selectable on platform-hosted assistants, so the picker
+    // falls back to the first selectable provider — a keyed one, so the API
+    // key field renders (adding a provider always means your own key now;
+    // platform-managed routing is the Vellum row, not a per-provider choice).
+    expect(getInputByPlaceholder("Enter your API key")).toBeDefined();
+  });
 
-    await waitFor(() => {
-      expect(createConnectionCalls.length).toBe(1);
-    });
-    expect(createConnectionCalls[0].body).toMatchObject({
-      name: "anthropic",
-      provider: "anthropic",
-      auth: { type: "platform" },
-    });
+  test("selecting ChatGPT shows the sign-in flow instead of Save", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    selectDropdownOption("Provider", "ChatGPT");
+
+    // Subscription auth is owned by the OAuth flow: no API key field, no
+    // Add button, sign-in affordance present.
+    expect(
+      Array.from(document.querySelectorAll<HTMLInputElement>("input")).some(
+        (el) => el.placeholder === "Enter your API key",
+      ),
+    ).toBe(false);
+    expect(
+      Array.from(document.querySelectorAll<HTMLButtonElement>("button")).some(
+        (b) => b.textContent?.trim() === "Add",
+      ),
+    ).toBe(false);
+    expect(document.body.textContent).toContain("ChatGPT");
   });
 
   test("fires a 'Provider connected' success toast on a successful create", async () => {
@@ -434,22 +458,18 @@ describe("ProviderCreateForm submit sequence", () => {
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
           existingNames={[]}
+          defaultProviderType="anthropic"
           onCreated={() => {}}
           onCancel={() => {}}
         />
       </ModalWrapper>,
     );
 
-    openAdvancedFields();
-    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
-      target: { value: "anthropic-personal" },
-    });
-    selectDropdownOption("Auth type", "API Key");
     fireEvent.change(getInputByPlaceholder("Enter your API key"), {
       target: { value: "sk-test-123" },
     });
 
-    fireEvent.click(getButton("Create"));
+    fireEvent.click(getButton("Add"));
 
     await waitFor(() => {
       expect(toastSuccessCalls).toEqual(["Provider connected"]);
@@ -465,38 +485,6 @@ describe("ProviderCreateForm submit sequence", () => {
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
           existingNames={[]}
-          onCreated={() => {}}
-          onCancel={() => {}}
-        />
-      </ModalWrapper>,
-    );
-
-    openAdvancedFields();
-    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
-      target: { value: "anthropic-personal" },
-    });
-    selectDropdownOption("Auth type", "API Key");
-    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
-      target: { value: "sk-test-123" },
-    });
-
-    fireEvent.click(getButton("Create"));
-
-    // The connection-failure message surfaces inline...
-    await waitFor(() => {
-      expect(createConnectionCalls.length).toBe(1);
-    });
-    expect(toastSuccessCalls).toEqual([]);
-    // ...and the form stays mounted (the Create button is still present).
-    expect(getButton("Create")).toBeDefined();
-  });
-
-  test("seeds Name + Key from the initial provider type", () => {
-    render(
-      <ModalWrapper>
-        <ProviderCreateForm
-          assistantId={ASSISTANT_ID}
-          existingNames={[]}
           defaultProviderType="anthropic"
           onCreated={() => {}}
           onCancel={() => {}}
@@ -504,16 +492,22 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
-    openAdvancedFields();
-    expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe(
-      "Anthropic",
-    );
-    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
-      "anthropic",
-    );
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+
+    fireEvent.click(getButton("Add"));
+
+    // The connection-failure message surfaces inline...
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    expect(toastSuccessCalls).toEqual([]);
+    // ...and the form stays mounted (the Add button is still present).
+    expect(getButton("Add")).toBeDefined();
   });
 
-  test("dedupes the seeded Key against existingNames", () => {
+  test("seeds Display Name from the provider and dedupes the key against existingNames", async () => {
     render(
       <ModalWrapper>
         <ProviderCreateForm
@@ -530,12 +524,24 @@ describe("ProviderCreateForm submit sequence", () => {
     expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe(
       "Anthropic",
     );
-    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
-      "anthropic-2",
-    );
+
+    // The key is auto-derived (no input for keyed providers) — its deduped
+    // value is observable in the POST body.
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+    fireEvent.click(getButton("Add"));
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    expect(createConnectionCalls[0].body).toMatchObject({
+      name: "anthropic-2",
+      provider: "anthropic",
+    });
   });
 
-  test("changing the provider type re-seeds Name + Key", () => {
+  test("changing the provider type re-seeds the Display Name", () => {
     render(
       <ModalWrapper>
         <ProviderCreateForm
@@ -552,12 +558,9 @@ describe("ProviderCreateForm submit sequence", () => {
     selectDropdownOption("Provider", "OpenAI");
 
     expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe("OpenAI");
-    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
-      "openai",
-    );
   });
 
-  test("a manual Name edit is NOT overwritten by a later provider-type change", () => {
+  test("a manual Display Name edit is NOT overwritten by a later provider-type change", () => {
     render(
       <ModalWrapper>
         <ProviderCreateForm
@@ -570,7 +573,6 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
-    // User overrides the Name; the Key auto-follows the label edit.
     openAdvancedFields();
     fireEvent.change(getInputByPlaceholder("e.g. My Anthropic Key"), {
       target: { value: "My Custom Name" },
@@ -581,12 +583,9 @@ describe("ProviderCreateForm submit sequence", () => {
     expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe(
       "My Custom Name",
     );
-    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
-      "my-custom-name",
-    );
   });
 
-  test("a manual Key edit is NOT overwritten by a later provider-type change", () => {
+  test("the key input only exists for openai-compatible", () => {
     render(
       <ModalWrapper>
         <ProviderCreateForm
@@ -599,82 +598,17 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
-    openAdvancedFields();
-    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
-      target: { value: "my-custom-key" },
-    });
-
-    selectDropdownOption("Provider", "OpenAI");
-
-    expect(getInputByPlaceholder("e.g. anthropic-personal").value).toBe(
-      "my-custom-key",
-    );
-  });
-
-  test("Display Name + Key are collapsed by default and reveal on Advanced", () => {
-    render(
-      <ModalWrapper>
-        <ProviderCreateForm
-          assistantId={ASSISTANT_ID}
-          existingNames={[]}
-          defaultProviderType="anthropic"
-          onCreated={() => {}}
-          onCancel={() => {}}
-        />
-      </ModalWrapper>,
-    );
-
-    // Collapsed: neither the Display Name nor Key input is mounted yet.
-    const isMounted = (placeholder: string) =>
+    const keyInputMounted = () =>
       Array.from(document.querySelectorAll<HTMLInputElement>("input")).some(
-        (el) => el.placeholder === placeholder,
+        (el) => el.placeholder === "e.g. my-endpoint",
       );
-    expect(isMounted("e.g. My Anthropic Key")).toBe(false);
-    expect(isMounted("e.g. anthropic-personal")).toBe(false);
 
-    // Opening the disclosure mounts both.
     openAdvancedFields();
-    expect(isMounted("e.g. My Anthropic Key")).toBe(true);
-    expect(isMounted("e.g. anthropic-personal")).toBe(true);
-  });
+    expect(keyInputMounted()).toBe(false);
 
-  test("a duplicate Key keeps Advanced open even when the user collapses it", () => {
-    render(
-      <ModalWrapper>
-        <ProviderCreateForm
-          assistantId={ASSISTANT_ID}
-          existingNames={["anthropic"]}
-          defaultProviderType="anthropic"
-          onCreated={() => {}}
-          onCancel={() => {}}
-        />
-      </ModalWrapper>,
-    );
-
-    // The seeded Key dedupes to "anthropic-2", so type the colliding name.
+    selectDropdownOption("Provider", "OpenAI-compatible");
     openAdvancedFields();
-    fireEvent.change(getInputByPlaceholder("e.g. anthropic-personal"), {
-      target: { value: "anthropic" },
-    });
-
-    // Try to collapse the disclosure — the pending error must force it open,
-    // keeping the Key field and its validation message visible.
-    const disclosure = Array.from(
-      document.querySelectorAll<HTMLButtonElement>("button"),
-    ).find((b) => b.textContent?.trim() === "Advanced");
-    if (!disclosure) {
-      throw new Error("expected the Advanced disclosure button");
-    }
-    fireEvent.click(disclosure);
-
-    expect(document.body.textContent).toContain(
-      'A connection named "anthropic" already exists.',
-    );
-    expect(
-      Array.from(document.querySelectorAll<HTMLInputElement>("input")).some(
-        (el) => el.placeholder === "e.g. anthropic-personal",
-      ),
-    ).toBe(true);
+    expect(keyInputMounted()).toBe(true);
   });
 
   test("clicking Cancel invokes onCancel", () => {

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -585,6 +585,72 @@ describe("ProviderCreateForm submit sequence", () => {
     );
   });
 
+  test("a Display Name edit does not drag the hidden key off the -personal convention", async () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    openAdvancedFields();
+    fireEvent.change(getInputByPlaceholder("e.g. My Anthropic Key"), {
+      target: { value: "Work Anthropic" },
+    });
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+    fireEvent.click(getButton("Add"));
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    expect(createConnectionCalls[0].body).toMatchObject({
+      name: "anthropic-personal",
+      label: "Work Anthropic",
+    });
+  });
+
+  test("a provider switch re-seeds the hidden key even after a Display Name edit", async () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    openAdvancedFields();
+    fireEvent.change(getInputByPlaceholder("e.g. My Anthropic Key"), {
+      target: { value: "My Custom Name" },
+    });
+    selectDropdownOption("Provider", "OpenAI");
+
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+    fireEvent.click(getButton("Add"));
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    // Label edit preserved; key follows the provider's convention seed.
+    expect(createConnectionCalls[0].body).toMatchObject({
+      name: "openai-personal",
+      provider: "openai",
+      label: "My Custom Name",
+    });
+  });
+
   test("the key input only exists for openai-compatible", () => {
     render(
       <ModalWrapper>

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -214,7 +214,7 @@ function selectDropdownOption(ariaLabel: string, optionLabel: string): void {
 beforeEach(() => {
   secretsPostCalls = [];
   createConnectionCalls = [];
-  createdConnection = makeConnection("anthropic");
+  createdConnection = makeConnection("anthropic-personal");
   createResponseOk = true;
   createResponseStatus = 200;
   toastSuccessCalls = [];
@@ -273,7 +273,7 @@ describe("ProviderCreateForm submit sequence", () => {
     // explicit auth, and this form must work against them without a gate).
     expect(createConnectionCalls[0].path.assistant_id).toBe(ASSISTANT_ID);
     expect(createConnectionCalls[0].body).toMatchObject({
-      name: "anthropic",
+      name: "anthropic-personal",
       provider: "anthropic",
       auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
@@ -282,7 +282,7 @@ describe("ProviderCreateForm submit sequence", () => {
     await waitFor(() => {
       expect(created).toBeDefined();
     });
-    expect(created?.name).toBe("anthropic");
+    expect(created?.name).toBe("anthropic-personal");
   });
 
   test("blocks a duplicate openai-compatible key with the validation message", () => {
@@ -339,7 +339,7 @@ describe("ProviderCreateForm submit sequence", () => {
       expect(createConnectionCalls.length).toBe(1);
     });
     await waitFor(() => {
-      expect(created?.name).toBe("anthropic");
+      expect(created?.name).toBe("anthropic-personal");
     });
   });
 
@@ -393,7 +393,7 @@ describe("ProviderCreateForm submit sequence", () => {
     });
     expect(secretsPostCalls).toEqual([]);
     expect(createConnectionCalls[0].body).toMatchObject({
-      name: "ollama",
+      name: "ollama-personal",
       provider: "ollama",
       auth: { type: "none" },
     });
@@ -512,7 +512,7 @@ describe("ProviderCreateForm submit sequence", () => {
       <ModalWrapper>
         <ProviderCreateForm
           assistantId={ASSISTANT_ID}
-          existingNames={["anthropic"]}
+          existingNames={["anthropic-personal"]}
           defaultProviderType="anthropic"
           onCreated={() => {}}
           onCancel={() => {}}
@@ -536,7 +536,7 @@ describe("ProviderCreateForm submit sequence", () => {
       expect(createConnectionCalls.length).toBe(1);
     });
     expect(createConnectionCalls[0].body).toMatchObject({
-      name: "anthropic-2",
+      name: "anthropic-personal-2",
       provider: "anthropic",
     });
   });

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -235,12 +235,17 @@ export function ProviderCreateForm({
           } finally {
             setIsSavingKey(false);
           }
-        } else if (!hasStoredCredential) {
+          auth = { type: "api_key", credential: effectiveCredential };
+        } else if (hasStoredCredential) {
+          auth = { type: "api_key", credential: effectiveCredential };
+        } else if (isOpenAICompatible) {
+          // Custom endpoints have no fixed auth story: local servers are
+          // usually keyless. No key entered → keyless auth.
+          auth = { type: "none" };
+        } else {
           setError("Enter an API key or select an existing credential.");
           return;
         }
-
-        auth = { type: "api_key", credential: effectiveCredential };
       } else if (authType === "oauth_subscription") {
         // OAuth subscription connections are created by the OAuth flow
         // (ChatgptOAuthSection), not through Save.

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useRef, useState, type ReactNode } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
@@ -35,7 +35,6 @@ import {
 } from "@/domains/settings/ai/provider-editor-constants";
 import { useSelectableConnectionProviders } from "@/domains/settings/ai/provider-availability";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
-import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
 
 // ---------------------------------------------------------------------------
@@ -78,11 +77,8 @@ export function ProviderCreateForm({
       ? defaultProviderType
       : (selectableConnectionProviders[0] ?? "anthropic");
 
-  // Seed Display Name (label) + Key (name) from the initial provider type so
-  // the form opens pre-filled (e.g. Anthropic → "Anthropic" / "anthropic"),
-  // deduped against existing connection names. The user can override both, and
-  // a provider-type change re-seeds only while they haven't edited the fields
-  // (see the dirty guard in the Provider dropdown's onChange below).
+  // Seed the user-facing label and internal name from the provider type,
+  // deduped against existing provider names.
   const initialDefaults = deriveProviderDefaults(
     initialProvider,
     existingNames,
@@ -130,19 +126,12 @@ export function ProviderCreateForm({
     return base;
   }, [isChatgpt, provider, selectableConnectionProviders]);
 
-  // Key-follows-label sync only while the key field is visible
-  // (openai-compatible). For catalog providers the key has no editor and must
-  // stay on the `${provider}-personal` convention seed, so label edits pass
-  // through in the hook's non-syncing mode (still marking the form dirty).
-  const {
-    handleLabelChange,
-    handleKeyChange: handleNameChange,
-    getDirty,
-  } = useLabelKeySync(
-    isOpenAICompatible ? "create" : "edit",
-    setLabel,
-    setName,
-  );
+  const isLabelDirty = useRef(false);
+
+  function handleLabelChange(newLabel: string) {
+    isLabelDirty.current = true;
+    setLabel(newLabel);
+  }
 
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
@@ -171,17 +160,7 @@ export function ProviderCreateForm({
     enabled: true,
   });
 
-  const nameError = (() => {
-    if (!name.trim()) {
-      return null;
-    }
-    if (existingNames.includes(name.trim())) {
-      return `A provider named "${name.trim()}" already exists.`;
-    }
-    return null;
-  })();
-
-  const canSave = name.trim().length > 0 && !nameError;
+  const canSave = name.trim().length > 0;
 
   async function handleSave() {
     if (!canSave) {
@@ -280,19 +259,7 @@ export function ProviderCreateForm({
           body: input,
         });
       if (!createRes?.ok) {
-        let serverMessage: string | undefined;
-        try {
-          const body = await createRes?.json();
-          if (typeof body?.error?.message === "string") {
-            serverMessage = body.error.message;
-          }
-        } catch {
-          // Response body not JSON-parseable; fall through to generic message.
-        }
-        setError(
-          serverMessage ||
-            connectionSaveErrorMessage(createRes?.status, name.trim()),
-        );
+        setError(connectionSaveErrorMessage(createRes?.status));
         return;
       }
       if (!created) {
@@ -326,10 +293,8 @@ export function ProviderCreateForm({
     hasStoredCredential,
   );
 
-  // Display Name + Key are auto-derived from the selected provider and rarely
-  // need editing, so they live under an "Advanced" disclosure. Force it open
-  // when the Key collides with an existing connection so the error is visible.
-  const detailsOpen = isDetailsExpanded || Boolean(nameError);
+  // Display Name is optional and rarely needs editing.
+  const detailsOpen = isDetailsExpanded;
 
   const advancedDetailsSection = (
     <div>
@@ -361,34 +326,6 @@ export function ProviderCreateForm({
             />
           </div>
 
-          {/* Key — auto-derived from the provider; editable only for
-              openai-compatible, where several endpoints can coexist and the
-              key is what tells them apart. */}
-          {isOpenAICompatible && (
-            <div className="space-y-1">
-              <label className="block text-body-small-default text-[var(--content-tertiary)]">
-                Key
-              </label>
-              <Input
-                value={name}
-                onChange={(e) => {
-                  handleNameChange(e.target.value);
-                  setError(null);
-                }}
-                placeholder="e.g. my-endpoint"
-                fullWidth
-              />
-            </div>
-          )}
-          {nameError && (
-            <Typography
-              variant="body-small-default"
-              as="p"
-              className="text-(--system-negative-strong)"
-            >
-              {nameError}
-            </Typography>
-          )}
         </div>
       )}
     </div>
@@ -410,23 +347,16 @@ export function ProviderCreateForm({
             if (newSelected === "chatgpt") {
               return;
             }
-            // Re-seed Name + Key from the newly selected provider type.
-            // A user-edited Display Name is preserved (dirty tracking lives
-            // in useLabelKeySync), but the key ALWAYS follows the provider
-            // for catalog providers — it has no editor there, so a stale
-            // seed from a previous selection would silently violate the
-            // `${provider}-personal` convention. Seeding writes state
-            // directly so it doesn't itself flip the dirty flag.
+            // Internal names always follow the selected provider. Preserve a
+            // user-edited Display Name across provider changes.
             const { name: seedName, key: seedKey } = deriveProviderDefaults(
               newSelected,
               existingNames,
             );
-            if (!getDirty()) {
+            if (!isLabelDirty.current) {
               setLabel(seedName);
-              setName(seedKey);
-            } else if (newSelected !== "openai-compatible") {
-              setName(seedKey);
             }
+            setName(seedKey);
             setCredential(
               newSelected === "ollama"
                 ? ""

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -130,11 +130,19 @@ export function ProviderCreateForm({
     return base;
   }, [isChatgpt, provider, selectableConnectionProviders]);
 
+  // Key-follows-label sync only while the key field is visible
+  // (openai-compatible). For catalog providers the key has no editor and must
+  // stay on the `${provider}-personal` convention seed, so label edits pass
+  // through in the hook's non-syncing mode (still marking the form dirty).
   const {
     handleLabelChange,
     handleKeyChange: handleNameChange,
     getDirty,
-  } = useLabelKeySync("create", setLabel, setName);
+  } = useLabelKeySync(
+    isOpenAICompatible ? "create" : "edit",
+    setLabel,
+    setName,
+  );
 
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
@@ -397,16 +405,21 @@ export function ProviderCreateForm({
             if (newSelected === "chatgpt") {
               return;
             }
-            // Re-seed Name + Key from the newly selected provider type, but
-            // only while the user hasn't manually edited either field (dirty
-            // tracking lives in useLabelKeySync). Seeding writes state
+            // Re-seed Name + Key from the newly selected provider type.
+            // A user-edited Display Name is preserved (dirty tracking lives
+            // in useLabelKeySync), but the key ALWAYS follows the provider
+            // for catalog providers — it has no editor there, so a stale
+            // seed from a previous selection would silently violate the
+            // `${provider}-personal` convention. Seeding writes state
             // directly so it doesn't itself flip the dirty flag.
+            const { name: seedName, key: seedKey } = deriveProviderDefaults(
+              newSelected,
+              existingNames,
+            );
             if (!getDirty()) {
-              const { name: seedName, key: seedKey } = deriveProviderDefaults(
-                newSelected,
-                existingNames,
-              );
               setLabel(seedName);
+              setName(seedKey);
+            } else if (newSelected !== "openai-compatible") {
               setName(seedKey);
             }
             setCredential(

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -9,23 +9,29 @@ import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { ChevronRight } from "lucide-react";
 
-import { credentialPresenceQueryKey, useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
+import {
+  credentialPresenceQueryKey,
+  useStoredCredentialPresence,
+} from "@/domains/settings/ai/use-stored-credential-presence";
 import { secretsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-    inferenceProviderconnectionsPost,
-    secretsPost,
+  inferenceProviderconnectionsPost,
+  secretsPost,
 } from "@/generated/daemon/sdk.gen";
 
-import { providerSupportsPlatformAuth, PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
 import { deriveProviderDefaults } from "@/domains/settings/ai/profile-prefill";
-import type { Auth, ConnectionProvider, InferenceProviderconnectionsPostData, ProviderConnection } from "@/generated/daemon/types.gen";
+import type {
+  Auth,
+  ConnectionProvider,
+  InferenceProviderconnectionsPostData,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
 import {
-    AUTH_TYPE_DISPLAY_NAMES,
-    connectionSaveErrorMessage,
-    parseCredentialRef,
-    type AuthType,
+  connectionSaveErrorMessage,
+  parseCredentialRef,
 } from "@/domains/settings/ai/provider-editor-constants";
 import { useSelectableConnectionProviders } from "@/domains/settings/ai/provider-availability";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
@@ -77,18 +83,28 @@ export function ProviderCreateForm({
   // deduped against existing connection names. The user can override both, and
   // a provider-type change re-seeds only while they haven't edited the fields
   // (see the dirty guard in the Provider dropdown's onChange below).
-  const initialDefaults = deriveProviderDefaults(initialProvider, existingNames);
+  const initialDefaults = deriveProviderDefaults(
+    initialProvider,
+    existingNames,
+  );
 
   const [label, setLabel] = useState(initialDefaults.name);
   const [name, setName] = useState(initialDefaults.key);
-  const [provider, setProvider] = useState<ConnectionProvider>(initialProvider);
-  const [authType, setAuthType] = useState<AuthType>(() =>
-    initialProvider === "ollama"
-      ? "none"
-      : providerSupportsPlatformAuth(initialProvider)
-        ? "platform"
-        : "api_key",
+  // The picker offers real connection providers plus "chatgpt", a
+  // subscription-auth pseudo-provider: its connection is created by the OAuth
+  // sign-in flow rather than this form's Save.
+  const [selected, setSelected] = useState<ConnectionProvider | "chatgpt">(
+    initialProvider,
   );
+  const isChatgpt = selected === "chatgpt";
+  const provider: ConnectionProvider = isChatgpt ? "openai" : selected;
+  // Auth is derived from the provider, never user-chosen: ollama is keyless,
+  // ChatGPT is subscription (OAuth), everything else authenticates by API key.
+  const authType: Auth["type"] = isChatgpt
+    ? "oauth_subscription"
+    : provider === "ollama"
+      ? "none"
+      : "api_key";
   const [credential, setCredential] = useState(() =>
     initialProvider === "ollama" ? "" : `credential/${initialProvider}/api_key`,
   );
@@ -99,38 +115,50 @@ export function ProviderCreateForm({
   const [isDetailsExpanded, setIsDetailsExpanded] = useState(false);
 
   const isOpenAICompatible = provider === "openai-compatible";
-  const connectionProviderOptions = useMemo(() => {
-    if (provider && !selectableConnectionProviders.includes(provider)) {
-      return [...selectableConnectionProviders, provider];
+  const connectionProviderOptions = useMemo<
+    Array<ConnectionProvider | "chatgpt">
+  >(() => {
+    const base: Array<ConnectionProvider | "chatgpt"> =
+      !isChatgpt && !selectableConnectionProviders.includes(provider)
+        ? [...selectableConnectionProviders, provider]
+        : [...selectableConnectionProviders];
+    // Subscription-auth entry, right after its API-key sibling.
+    const openaiIndex = base.indexOf("openai");
+    if (openaiIndex >= 0) {
+      base.splice(openaiIndex + 1, 0, "chatgpt");
     }
-    return selectableConnectionProviders;
-  }, [provider, selectableConnectionProviders]);
+    return base;
+  }, [isChatgpt, provider, selectableConnectionProviders]);
 
-  const { handleLabelChange, handleKeyChange: handleNameChange, getDirty } =
-    useLabelKeySync("create", setLabel, setName);
+  const {
+    handleLabelChange,
+    handleKeyChange: handleNameChange,
+    getDirty,
+  } = useLabelKeySync("create", setLabel, setName);
 
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
   const queryClient = useQueryClient();
 
   // --- Credential presence (shared hook) ---
-  const parsedCredRef = useMemo(() => parseCredentialRef(credential), [credential]);
+  const parsedCredRef = useMemo(
+    () => parseCredentialRef(credential),
+    [credential],
+  );
   const needsCredentialCheck = authType === "api_key" && parsedCredRef !== null;
 
-  const {
-    hasStoredCredential,
-    isLoading: isLoadingCredential,
-  } = useStoredCredentialPresence({
-    assistantId,
-    credentialKind: "credential",
-    credentialName: parsedCredRef ? `${parsedCredRef.service}:${parsedCredRef.field}` : "",
-    enabled: needsCredentialCheck,
-  });
+  const { hasStoredCredential, isLoading: isLoadingCredential } =
+    useStoredCredentialPresence({
+      assistantId,
+      credentialKind: "credential",
+      credentialName: parsedCredRef
+        ? `${parsedCredRef.service}:${parsedCredRef.field}`
+        : "",
+      enabled: needsCredentialCheck,
+    });
 
   // --- Available credentials list ---
-  const {
-    credentials: availableCredentials,
-  } = useProviderCredentialsList({
+  const { credentials: availableCredentials } = useProviderCredentialsList({
     assistantId,
     enabled: true,
   });
@@ -140,7 +168,7 @@ export function ProviderCreateForm({
       return null;
     }
     if (existingNames.includes(name.trim())) {
-      return `A connection named "${name.trim()}" already exists.`;
+      return `A provider named "${name.trim()}" already exists.`;
     }
     return null;
   })();
@@ -189,7 +217,9 @@ export function ProviderCreateForm({
             );
             queryClient.setQueryData(presenceKey, true);
             void queryClient.invalidateQueries({
-              queryKey: secretsGetQueryKey({ path: { assistant_id: assistantId } }),
+              queryKey: secretsGetQueryKey({
+                path: { assistant_id: assistantId },
+              }),
             });
           } catch {
             setError("Failed to save API key. Please try again.");
@@ -206,15 +236,12 @@ export function ProviderCreateForm({
       } else if (authType === "oauth_subscription") {
         // OAuth subscription connections are created by the OAuth flow
         // (ChatgptOAuthSection), not through Save.
-        setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
-        return;
-      } else if (authType === "none") {
-        auth = { type: "none" };
-      } else if (authType === "service_account") {
-        setError("Service account connections cannot be created through this form.");
+        setError(
+          'Use the "Sign in with ChatGPT" button to connect your subscription.',
+        );
         return;
       } else {
-        auth = { type: "platform" };
+        auth = { type: "none" };
       }
 
       const labelValue = label.trim() || null;
@@ -234,10 +261,11 @@ export function ProviderCreateForm({
             : null,
         }),
       };
-      const { data: created, response: createRes } = await inferenceProviderconnectionsPost({
-        path: { assistant_id: assistantId },
-        body: input,
-      });
+      const { data: created, response: createRes } =
+        await inferenceProviderconnectionsPost({
+          path: { assistant_id: assistantId },
+          body: input,
+        });
       if (!createRes?.ok) {
         let serverMessage: string | undefined;
         try {
@@ -248,7 +276,10 @@ export function ProviderCreateForm({
         } catch {
           // Response body not JSON-parseable; fall through to generic message.
         }
-        setError(serverMessage || connectionSaveErrorMessage(createRes?.status, name.trim()));
+        setError(
+          serverMessage ||
+            connectionSaveErrorMessage(createRes?.status, name.trim()),
+        );
         return;
       }
       if (!created) {
@@ -260,7 +291,7 @@ export function ProviderCreateForm({
       toast.success("Provider connected");
       onCreated(created);
     } catch {
-      setError("Failed to save connection. Please try again.");
+      setError("Failed to save provider. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -317,30 +348,34 @@ export function ProviderCreateForm({
             />
           </div>
 
-          {/* Key — editable on create, auto-derived from label */}
-          <div className="space-y-1">
-            <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Key
-            </label>
-            <Input
-              value={name}
-              onChange={(e) => {
-                handleNameChange(e.target.value);
-                setError(null);
-              }}
-              placeholder="e.g. anthropic-personal"
-              fullWidth
-            />
-            {nameError && (
-              <Typography
-                variant="body-small-default"
-                as="p"
-                className="text-(--system-negative-strong)"
-              >
-                {nameError}
-              </Typography>
-            )}
-          </div>
+          {/* Key — auto-derived from the provider; editable only for
+              openai-compatible, where several endpoints can coexist and the
+              key is what tells them apart. */}
+          {isOpenAICompatible && (
+            <div className="space-y-1">
+              <label className="block text-body-small-default text-[var(--content-tertiary)]">
+                Key
+              </label>
+              <Input
+                value={name}
+                onChange={(e) => {
+                  handleNameChange(e.target.value);
+                  setError(null);
+                }}
+                placeholder="e.g. my-endpoint"
+                fullWidth
+              />
+            </div>
+          )}
+          {nameError && (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-(--system-negative-strong)"
+            >
+              {nameError}
+            </Typography>
+          )}
         </div>
       )}
     </div>
@@ -355,45 +390,30 @@ export function ProviderCreateForm({
         </label>
         <Dropdown
           aria-label="Provider"
-          value={provider}
-          onChange={(newProvider) => {
-            setProvider(newProvider);
+          value={selected}
+          onChange={(newSelected) => {
+            setSelected(newSelected);
+            setError(null);
+            if (newSelected === "chatgpt") {
+              return;
+            }
             // Re-seed Name + Key from the newly selected provider type, but
             // only while the user hasn't manually edited either field (dirty
             // tracking lives in useLabelKeySync). Seeding writes state
             // directly so it doesn't itself flip the dirty flag.
             if (!getDirty()) {
               const { name: seedName, key: seedKey } = deriveProviderDefaults(
-                newProvider,
+                newSelected,
                 existingNames,
               );
               setLabel(seedName);
               setName(seedKey);
             }
-            if (newProvider === "ollama") {
-              setAuthType("none");
-              setCredential("");
-            } else {
-              setAuthType((prev) => {
-                if (prev === "none") {
-                  return "api_key";
-                }
-                if (
-                  prev === "oauth_subscription" &&
-                  newProvider !== "openai"
-                ) {
-                  return "api_key";
-                }
-                if (
-                  prev === "platform" &&
-                  !providerSupportsPlatformAuth(newProvider)
-                ) {
-                  return "api_key";
-                }
-                return prev;
-              });
-              setCredential(`credential/${newProvider}/api_key`);
-            }
+            setCredential(
+              newSelected === "ollama"
+                ? ""
+                : `credential/${newSelected}/api_key`,
+            );
             // Credential ref changes above trigger a new TQ query key,
             // so the presence check auto-refetches for the new provider.
           }}
@@ -439,44 +459,7 @@ export function ProviderCreateForm({
         </>
       )}
 
-      {/* Auth type */}
-      <div className="space-y-1">
-        <label className="block text-body-small-default text-[var(--content-tertiary)]">
-          Auth Type
-        </label>
-        <Dropdown
-          aria-label="Auth type"
-          value={authType}
-          onChange={(v) => {
-            setAuthType(v);
-            setError(null);
-          }}
-          disabled={provider === "ollama"}
-          options={(() => {
-            let types: AuthType[];
-            if (provider === "ollama") {
-              types = ["none"];
-            } else if (providerSupportsPlatformAuth(provider)) {
-              types = ["api_key", "platform"];
-            } else {
-              types = ["api_key"];
-            }
-            // Add oauth_subscription when ChatGPT flag is enabled for OpenAI.
-            if (provider === "openai") {
-              types.push("oauth_subscription");
-            }
-            if (authType && !types.includes(authType)) {
-              types.push(authType);
-            }
-            return types.map((t) => ({
-              value: t,
-              label: AUTH_TYPE_DISPLAY_NAMES[t],
-            }));
-          })()}
-        />
-      </div>
-
-      {/* API Key + Advanced disclosure — only shown for api_key auth */}
+      {/* API Key + Advanced disclosure — only shown for key-based providers */}
       {authType === "api_key" && (
         <ProviderEditorApiKeySection
           apiKeyValue={apiKeyValue}
@@ -500,7 +483,7 @@ export function ProviderCreateForm({
         />
       )}
 
-      {advancedDetailsSection}
+      {!isChatgpt && advancedDetailsSection}
 
       {error && (
         <Typography
@@ -519,14 +502,16 @@ export function ProviderCreateForm({
       <Button variant="ghost" size="compact" onClick={onCancel}>
         Cancel
       </Button>
-      <Button
-        variant="primary"
-        size="compact"
-        disabled={!canSave || saving || isSavingKey}
-        onClick={() => void handleSave()}
-      >
-        {saving ? "Saving…" : "Create"}
-      </Button>
+      {!isChatgpt && (
+        <Button
+          variant="primary"
+          size="compact"
+          disabled={!canSave || saving || isSavingKey}
+          onClick={() => void handleSave()}
+        >
+          {saving ? "Saving…" : "Add"}
+        </Button>
+      )}
     </>
   );
 
@@ -542,9 +527,9 @@ export function ProviderCreateForm({
   return (
     <Modal.Content size="md">
       <Modal.Header>
-        <Modal.Title>New Provider Connection</Modal.Title>
+        <Modal.Title>Add Provider</Modal.Title>
         <Modal.Description>
-          Define a provider and auth configuration for inference routing.
+          Choose a provider and paste its API key.
         </Modal.Description>
       </Modal.Header>
 

--- a/clients/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/clients/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -31,19 +31,13 @@ export const CONNECTION_PROVIDERS: ConnectionProvider[] = [
   "openai-compatible",
 ];
 
-export const AUTH_TYPE_DISPLAY_NAMES: Record<AuthType, string> = {
-  api_key: "API Key",
-  platform: "Platform (managed proxy)",
-  none: "None (local / no auth)",
-  oauth_subscription: "ChatGPT Subscription",
-  service_account: "Service Account",
-};
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-export function parseCredentialRef(credRef: string): { service: string; field: string } | null {
+export function parseCredentialRef(
+  credRef: string,
+): { service: string; field: string } | null {
   const parts = credRef.split("/");
   if (parts.length < 3 || parts[0] !== "credential") return null;
   return { service: parts[1], field: parts.slice(2).join("/") };
@@ -55,12 +49,12 @@ export function connectionSaveErrorMessage(
 ): string {
   switch (status) {
     case 409:
-      return `A connection named "${connectionName}" already exists.`;
+      return `A provider named "${connectionName}" already exists.`;
     case 404:
-      return "Connection not found. It may have been deleted.";
+      return "Provider not found. It may have been removed.";
     case 400:
-      return "Invalid configuration. Check the provider and auth settings.";
+      return "Invalid configuration. Check the provider settings.";
     default:
-      return "Failed to save connection. Please try again.";
+      return "Failed to save provider. Please try again.";
   }
 }

--- a/clients/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/clients/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -1,4 +1,9 @@
-import type { Auth, ConnectionProvider } from "@/generated/daemon/types.gen";
+import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import type {
+  Auth,
+  ConnectionProvider,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,17 +44,18 @@ export function parseCredentialRef(
   credRef: string,
 ): { service: string; field: string } | null {
   const parts = credRef.split("/");
-  if (parts.length < 3 || parts[0] !== "credential") return null;
+  if (parts.length < 3 || parts[0] !== "credential") {
+    return null;
+  }
   return { service: parts[1], field: parts.slice(2).join("/") };
 }
 
 export function connectionSaveErrorMessage(
   status: number | undefined,
-  connectionName: string,
 ): string {
   switch (status) {
     case 409:
-      return `A provider named "${connectionName}" already exists.`;
+      return "A provider with these settings already exists.";
     case 404:
       return "Provider not found. It may have been removed.";
     case 400:
@@ -57,4 +63,16 @@ export function connectionSaveErrorMessage(
     default:
       return "Failed to save provider. Please try again.";
   }
+}
+
+export function providerConnectionDisplayName(
+  connection: ProviderConnection,
+): string {
+  if (connection.label) {
+    return connection.label;
+  }
+  if (connection.auth.type === "oauth_subscription") {
+    return PROVIDER_DISPLAY_NAMES.chatgpt;
+  }
+  return PROVIDER_DISPLAY_NAMES[connection.provider] ?? connection.provider;
 }

--- a/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -2,42 +2,37 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
-import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Typography } from "@vellumai/design-library/components/typography";
 
-import { credentialPresenceQueryKey, useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
+import {
+  credentialPresenceQueryKey,
+  useStoredCredentialPresence,
+} from "@/domains/settings/ai/use-stored-credential-presence";
 import { secretsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-    inferenceProviderconnectionsByNamePatch,
-    secretsPost,
+  inferenceProviderconnectionsByNamePatch,
+  secretsPost,
 } from "@/generated/daemon/sdk.gen";
 
-import { providerSupportsPlatformAuth, PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
-import type { Auth, ConnectionProvider, InferenceProviderconnectionsByNamePatchData, ProviderConnection } from "@/generated/daemon/types.gen";
+import type {
+  Auth,
+  ConnectionProvider,
+  InferenceProviderconnectionsByNamePatchData,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
 import {
-    AUTH_TYPE_DISPLAY_NAMES,
-    type AuthType,
-    connectionSaveErrorMessage,
-    parseCredentialRef,
+  connectionSaveErrorMessage,
+  parseCredentialRef,
 } from "@/domains/settings/ai/provider-editor-constants";
-import { useSelectableConnectionProviders } from "@/domains/settings/ai/provider-availability";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
-
-// NOTE: The `platform` auth gate is `providerSupportsPlatformAuth()`. The
-// daemon derives `supportsPlatformAuth` from `PLATFORM_PROVIDER_META`
-// (assistant/src/providers/platform-proxy/constants.ts) into
-// meta/llm-provider-catalog.json via `cd assistant && bun run
-// sync:llm-catalog`; the web mirrors it in the hand-maintained
-// `PROVIDER_SUPPORTS_PLATFORM_AUTH` map in
-// clients/web/src/assistant/llm-model-catalog.ts, with parity tests guarding
-// drift against the meta catalog.
 
 // ---------------------------------------------------------------------------
 // ProviderEditorContent
@@ -70,10 +65,9 @@ export function ProviderEditorContent({
   const [provider, setProvider] = useState<ConnectionProvider>(
     connection?.provider ?? "anthropic",
   );
-  const [authType, setAuthType] = useState<AuthType>(() => {
-    if (!connection) return "platform";
-    return connection.auth.type;
-  });
+  // Auth is fixed to the stored type — the editor rotates keys but never
+  // switches auth modality (that's a different provider entry).
+  const authType: Auth["type"] = connection?.auth.type ?? "api_key";
   const [credential, setCredential] = useState(() => {
     if (connection?.auth.type === "api_key") return connection.auth.credential;
     if (!connection) return `credential/anthropic/api_key`;
@@ -90,43 +84,40 @@ export function ProviderEditorContent({
   const [error, setError] = useState<string | null>(null);
 
   const isOpenAICompatible = provider === "openai-compatible";
-  const selectableConnectionProviders = useSelectableConnectionProviders();
-  const connectionProviderOptions = useMemo(() => {
-    if (provider && !selectableConnectionProviders.includes(provider)) {
-      return [...selectableConnectionProviders, provider];
-    }
-    return selectableConnectionProviders;
-  }, [provider, selectableConnectionProviders]);
 
-  const { handleLabelChange, resetDirty } =
-    useLabelKeySync(mode, setLabel, setName);
+  const { handleLabelChange, resetDirty } = useLabelKeySync(
+    mode,
+    setLabel,
+    setName,
+  );
 
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
   const queryClient = useQueryClient();
 
   // --- Credential presence (shared hook) ---
-  const parsedCredRef = useMemo(() => parseCredentialRef(credential), [credential]);
+  const parsedCredRef = useMemo(
+    () => parseCredentialRef(credential),
+    [credential],
+  );
   const needsCredentialCheck = authType === "api_key" && parsedCredRef !== null;
 
-  const {
-    hasStoredCredential,
-    isLoading: isLoadingCredential,
-  } = useStoredCredentialPresence({
-    assistantId,
-    credentialKind: "credential",
-    credentialName: parsedCredRef ? `${parsedCredRef.service}:${parsedCredRef.field}` : "",
-    enabled: needsCredentialCheck,
-  });
+  const { hasStoredCredential, isLoading: isLoadingCredential } =
+    useStoredCredentialPresence({
+      assistantId,
+      credentialKind: "credential",
+      credentialName: parsedCredRef
+        ? `${parsedCredRef.service}:${parsedCredRef.field}`
+        : "",
+      enabled: needsCredentialCheck,
+    });
 
   // --- Available credentials list ---
   // Create mode is fully owned by ProviderCreateForm (early return below), so
   // the only reachable path here is edit — gate purely on auth.
   const needsCredentialsList = authType === "api_key";
 
-  const {
-    credentials: availableCredentials,
-  } = useProviderCredentialsList({
+  const { credentials: availableCredentials } = useProviderCredentialsList({
     assistantId,
     enabled: needsCredentialsList,
   });
@@ -138,7 +129,6 @@ export function ProviderEditorContent({
     setLabel(connection?.label ?? "");
     setName(connection?.name ?? "");
     setProvider(effectiveProvider);
-    setAuthType(connection ? connection.auth.type : "platform");
     if (connection?.auth.type === "api_key") {
       setCredential(connection.auth.credential);
     } else if (!connection) {
@@ -210,7 +200,9 @@ export function ProviderEditorContent({
             );
             queryClient.setQueryData(presenceKey, true);
             void queryClient.invalidateQueries({
-              queryKey: secretsGetQueryKey({ path: { assistant_id: assistantId } }),
+              queryKey: secretsGetQueryKey({
+                path: { assistant_id: assistantId },
+              }),
             });
           } catch {
             setError("Failed to save API key. Please try again.");
@@ -221,28 +213,13 @@ export function ProviderEditorContent({
         }
 
         auth = { type: "api_key", credential: effectiveCredential };
-      } else if (authType === "oauth_subscription") {
-        if (connection?.auth.type === "oauth_subscription") {
-          // Editing an existing oauth_subscription connection — preserve
-          // the stored auth so users can update display name / status.
-          auth = connection.auth;
-        } else {
-          // OAuth subscription connections are created by the OAuth flow
-          // (handleChatgptUrlSubmit), not through Save.
-          setError("Use the \"Sign in with ChatGPT\" button to connect your subscription.");
-          return;
-        }
-      } else if (authType === "service_account") {
-        if (connection?.auth.type === "service_account") {
-          auth = connection.auth;
-        } else {
-          setError("Service account connections cannot be created through this form.");
-          return;
-        }
-      } else if (authType === "none") {
-        auth = { type: "none" };
+      } else if (connection) {
+        // Non-key auth (oauth_subscription, none, platform, service_account)
+        // is preserved verbatim — the editor only changes display fields.
+        auth = connection.auth;
       } else {
-        auth = { type: "platform" };
+        setError("Nothing to edit. Close and try again.");
+        return;
       }
 
       const labelValue = label.trim() || null;
@@ -263,10 +240,14 @@ export function ProviderEditorContent({
             : null,
         }),
       };
-      const { data: updated, response: updateRes } = await inferenceProviderconnectionsByNamePatch({
-        path: { assistant_id: assistantId, name: connection?.name ?? name.trim() },
-        body: input,
-      });
+      const { data: updated, response: updateRes } =
+        await inferenceProviderconnectionsByNamePatch({
+          path: {
+            assistant_id: assistantId,
+            name: connection?.name ?? name.trim(),
+          },
+          body: input,
+        });
       if (!updateRes?.ok) {
         let serverMessage: string | undefined;
         try {
@@ -277,7 +258,10 @@ export function ProviderEditorContent({
         } catch {
           // Response body not JSON-parseable; fall through to generic message.
         }
-        setError(serverMessage || connectionSaveErrorMessage(updateRes?.status, name.trim()));
+        setError(
+          serverMessage ||
+            connectionSaveErrorMessage(updateRes?.status, name.trim()),
+        );
         return;
       }
       if (!updated) {
@@ -286,7 +270,7 @@ export function ProviderEditorContent({
       }
       onSave(updated);
     } catch {
-      setError("Failed to save connection. Please try again.");
+      setError("Failed to save provider. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -308,8 +292,7 @@ export function ProviderEditorContent({
   const isEditingApiKeyConnection =
     mode !== "create" && connection?.auth.type === "api_key";
   const shouldShowAdvancedSection =
-    providerCredentials.length > 0 ||
-    isEditingApiKeyConnection;
+    providerCredentials.length > 0 || isEditingApiKeyConnection;
   const apiKeyPlaceholder = secretPlaceholder(
     "Enter your API key",
     hasStoredCredential,
@@ -335,9 +318,9 @@ export function ProviderEditorContent({
   return (
     <Modal.Content size="md">
       <Modal.Header>
-        <Modal.Title>Edit Connection</Modal.Title>
+        <Modal.Title>Edit Provider</Modal.Title>
         <Modal.Description>
-          {`Editing "${connection?.name}".`}
+          {`Editing ${PROVIDER_DISPLAY_NAMES[provider] ?? provider} (${connection?.name}).`}
         </Modal.Description>
       </Modal.Header>
 
@@ -353,37 +336,6 @@ export function ProviderEditorContent({
             onChange={(e) => handleLabelChange(e.target.value)}
             placeholder="e.g. My Anthropic Key"
             fullWidth
-          />
-        </div>
-
-        {/* Key — fixed once a connection exists; edit only. */}
-        <div className="space-y-1">
-          <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Key
-          </label>
-          <Input
-            value={name}
-            placeholder="e.g. anthropic-personal"
-            disabled
-            fullWidth
-          />
-        </div>
-
-        {/* Provider — read-only in edit (provider is fixed once a connection
-            exists; create mode lives in ProviderCreateForm). */}
-        <div className="space-y-1">
-          <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Provider
-          </label>
-          <Dropdown
-            aria-label="Provider"
-            value={provider}
-            onChange={setProvider}
-            disabled
-            options={connectionProviderOptions.map((p) => ({
-              value: p,
-              label: PROVIDER_DISPLAY_NAMES[p],
-            }))}
           />
         </div>
 
@@ -422,42 +374,6 @@ export function ProviderEditorContent({
           </>
         )}
 
-        {/* Auth type */}
-        <div className="space-y-1">
-          <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Auth Type
-          </label>
-          <Dropdown
-            aria-label="Auth type"
-            value={authType}
-            onChange={(v) => {
-              setAuthType(v);
-              setError(null);
-            }}
-            disabled={provider === "ollama"}
-            options={(() => {
-              let types: AuthType[];
-              if (provider === "ollama") {
-                types = ["none"];
-              } else if (providerSupportsPlatformAuth(provider)) {
-                types = ["api_key", "platform"];
-              } else {
-                types = ["api_key"];
-              }
-              // Preserve the current auth type in edit mode so existing
-              // connections display their saved value even if the type is
-              // no longer offered for new connections.
-              if (authType && !types.includes(authType)) {
-                types.push(authType);
-              }
-              return types.map((t) => ({
-                value: t,
-                label: AUTH_TYPE_DISPLAY_NAMES[t],
-              }));
-            })()}
-          />
-        </div>
-
         {/* API Key + Advanced disclosure — only shown for api_key auth */}
         {authType === "api_key" && (
           <ProviderEditorApiKeySection
@@ -476,10 +392,7 @@ export function ProviderEditorContent({
 
         {/* ChatGPT Subscription OAuth — shown when auth type is oauth_subscription */}
         {authType === "oauth_subscription" && (
-          <ChatgptOAuthSection
-            assistantId={assistantId}
-            onConnected={onSave}
-          />
+          <ChatgptOAuthSection assistantId={assistantId} onConnected={onSave} />
         )}
 
         {error && (

--- a/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -16,7 +16,6 @@ import {
   secretsPost,
 } from "@/generated/daemon/sdk.gen";
 
-import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
 import type {
   Auth,
@@ -29,9 +28,9 @@ import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-edit
 import {
   connectionSaveErrorMessage,
   parseCredentialRef,
+  providerConnectionDisplayName,
 } from "@/domains/settings/ai/provider-editor-constants";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
-import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
 
 // ---------------------------------------------------------------------------
@@ -61,16 +60,18 @@ export function ProviderEditorContent({
   onCancel,
 }: ProviderEditorContentProps) {
   const [label, setLabel] = useState(connection?.label ?? "");
-  const [name, setName] = useState(connection?.name ?? "");
-  const [provider, setProvider] = useState<ConnectionProvider>(
-    connection?.provider ?? "anthropic",
-  );
+  const name = connection?.name ?? "";
+  const provider: ConnectionProvider = connection?.provider ?? "anthropic";
   // Auth is fixed to the stored type — the editor rotates keys but never
   // switches auth modality (that's a different provider entry).
   const authType: Auth["type"] = connection?.auth.type ?? "api_key";
   const [credential, setCredential] = useState(() => {
-    if (connection?.auth.type === "api_key") return connection.auth.credential;
-    if (!connection) return `credential/anthropic/api_key`;
+    if (connection?.auth.type === "api_key") {
+      return connection.auth.credential;
+    }
+    if (!connection) {
+      return `credential/anthropic/api_key`;
+    }
     return "";
   });
   const [baseUrl, setBaseUrl] = useState(connection?.baseUrl ?? "");
@@ -84,12 +85,6 @@ export function ProviderEditorContent({
   const [error, setError] = useState<string | null>(null);
 
   const isOpenAICompatible = provider === "openai-compatible";
-
-  const { handleLabelChange, resetDirty } = useLabelKeySync(
-    mode,
-    setLabel,
-    setName,
-  );
 
   const [apiKeyValue, setApiKeyValue] = useState("");
   const [isSavingKey, setIsSavingKey] = useState(false);
@@ -127,8 +122,6 @@ export function ProviderEditorContent({
   useEffect(() => {
     const effectiveProvider = connection?.provider ?? "anthropic";
     setLabel(connection?.label ?? "");
-    setName(connection?.name ?? "");
-    setProvider(effectiveProvider);
     if (connection?.auth.type === "api_key") {
       setCredential(connection.auth.credential);
     } else if (!connection) {
@@ -136,8 +129,6 @@ export function ProviderEditorContent({
     } else {
       setCredential("");
     }
-    resetDirty();
-
     setError(null);
 
     // Reset openai-compatible fields
@@ -152,16 +143,16 @@ export function ProviderEditorContent({
     // newCredentialName) resets automatically on unmount/remount.
     setApiKeyValue("");
     setIsSavingKey(false);
-  }, [connection, resetDirty]);
+  }, [connection]);
 
-  // Only edit reaches this component's own Save (create is owned by
-  // ProviderCreateForm via the early return below), and the Key field is
-  // fixed/disabled there, so a non-empty name is the only save gate. Duplicate
-  // -name validation lives in ProviderCreateForm.
+  // Only edit reaches this component's own Save. The internal provider name
+  // remains fixed, so a non-empty value is the only save gate.
   const canSave = name.trim().length > 0;
 
   async function handleSave() {
-    if (!canSave) return;
+    if (!canSave) {
+      return;
+    }
     setSaving(true);
     setError(null);
     try {
@@ -249,19 +240,7 @@ export function ProviderEditorContent({
           body: input,
         });
       if (!updateRes?.ok) {
-        let serverMessage: string | undefined;
-        try {
-          const body = await updateRes?.json();
-          if (typeof body?.error?.message === "string") {
-            serverMessage = body.error.message;
-          }
-        } catch {
-          // Response body not JSON-parseable; fall through to generic message.
-        }
-        setError(
-          serverMessage ||
-            connectionSaveErrorMessage(updateRes?.status, name.trim()),
-        );
+        setError(connectionSaveErrorMessage(updateRes?.status));
         return;
       }
       if (!updated) {
@@ -320,7 +299,9 @@ export function ProviderEditorContent({
       <Modal.Header>
         <Modal.Title>Edit Provider</Modal.Title>
         <Modal.Description>
-          {`Editing ${PROVIDER_DISPLAY_NAMES[provider] ?? provider} (${connection?.name}).`}
+          {connection
+            ? `Editing ${providerConnectionDisplayName(connection)}.`
+            : "Edit provider settings."}
         </Modal.Description>
       </Modal.Header>
 
@@ -333,7 +314,7 @@ export function ProviderEditorContent({
           </label>
           <Input
             value={label}
-            onChange={(e) => handleLabelChange(e.target.value)}
+            onChange={(e) => setLabel(e.target.value)}
             placeholder="e.g. My Anthropic Key"
             fullWidth
           />


### PR DESCRIPTION
## Prompt / plan

Make provider settings provider-first: remove connection/auth-type plumbing and internal provider keys from visible and accessible UI, derive authentication from the selected provider, preserve automatic unique internal names, support keyless OpenAI-compatible endpoints, and keep the managed Vellum provider first in the list.

## Test plan

- `bun test src/domains/settings/ai/provider-create-form.test.tsx`
- `bun test src/domains/settings/ai/manage-providers-modal.test.tsx`
- `bun run lint`
- `bunx tsc --noEmit`
- Local Providers modal walkthrough covering Vellum ordering, provider cards, create/edit states, ChatGPT Subscription, Ollama, catalog providers, and keyless OpenAI-compatible creation

Link to Devin session: https://app.devin.ai/sessions/205f2bd68c564e019a0e090fa88bed0b
Requested by: @emmiekehoe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->