### PR TITLE
feat(intelligence): color memory-graph concepts by cluster/theme

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
@@ -9,6 +9,9 @@ import type { ConceptNodeKind } from "./types";
 interface ConceptGraphLegendProps {
   /** Node kinds actually present in the graph, in display order. */
   nodeKinds: ConceptNodeKind[];
+  /** When true (concept-only graph), nodes are colored by cluster/theme, so a
+   * lone kind swatch would be meaningless — show a caption instead. */
+  coloredByTheme?: boolean;
   hasLinks: boolean;
   hasLearned: boolean;
 }
@@ -16,6 +19,7 @@ interface ConceptGraphLegendProps {
 /** Compact legend for node kinds and edge kinds present in the graph. */
 export function ConceptGraphLegend({
   nodeKinds,
+  coloredByTheme,
   hasLinks,
   hasLearned,
 }: ConceptGraphLegendProps) {
@@ -41,7 +45,12 @@ export function ConceptGraphLegend({
           </span>
         </div>
       ))}
-      {nodeKinds.length > 0 && (hasLinks || hasLearned) && (
+      {coloredByTheme && (
+        <span className="text-[11px]" style={{ color: "var(--content-tertiary)" }}>
+          Colored by theme
+        </span>
+      )}
+      {(nodeKinds.length > 0 || coloredByTheme) && (hasLinks || hasLearned) && (
         <div
           className="mt-0.5 border-t pt-1.5"
           style={{ borderColor: "var(--border-base)" }}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -18,7 +18,8 @@ import { buildForceLayout } from "./build-force-layout";
 import { ConceptDetailPanel, type ConceptDetailNode } from "./concept-detail-panel";
 import { ConceptGraphIntroBanner } from "./concept-graph-intro-banner";
 import { ConceptGraphLegend } from "./concept-graph-legend";
-import { EDGE_LEARNED_COLOR, NODE_KIND_COLORS } from "./constants";
+import { CLUSTER_PALETTE, EDGE_LEARNED_COLOR, NODE_KIND_COLORS } from "./constants";
+import { detectClusters } from "./detect-clusters";
 import type { ConceptNodeKind, GraphLayoutNode } from "./types";
 import { useGraphIntroDismissed } from "./use-graph-intro-dismissed";
 
@@ -128,6 +129,13 @@ export function ConceptGraphView({
     [graph],
   );
   const ready = query.data?.kind === "ready" && layout.nodes.length > 0;
+
+  // Group concepts into themes so the map reads as colored clusters instead of
+  // one flat color. Deterministic (see detect-clusters), so no render churn.
+  const clusters = useMemo(
+    () => detectClusters(layout.nodes, layout.edges),
+    [layout.nodes, layout.edges],
+  );
 
   // Neighbor adjacency for hover highlighting.
   const adjacency = useMemo(() => {
@@ -260,6 +268,7 @@ export function ConceptGraphView({
     // this loop) whenever the data changes, so these never go stale.
     const nodes = layout.nodes;
     const edges = layout.edges;
+    const nodeClusters = clusters;
     const adj = adjacency;
     const R = massRadius;
 
@@ -412,7 +421,12 @@ export function ConceptGraphView({
       for (const idx of order) {
         const p = proj[idx];
         const node = p.node;
-        const color = NODE_KIND_COLORS[node.kind];
+        // Concepts are colored by their detected theme/cluster; any non-concept
+        // node falls back to its per-kind color.
+        const color =
+          node.kind === "concept"
+            ? CLUSTER_PALETTE[(nodeClusters.get(node.id) ?? 0) % CLUSTER_PALETTE.length]
+            : NODE_KIND_COLORS[node.kind];
         const ghost = searchActive && !isMatch(node.id);
         const lit = !ghost && isLit(node.id);
         const isActive = node.id === activeId;
@@ -491,7 +505,7 @@ export function ConceptGraphView({
       cancelAnimationFrame(raf);
       ro.disconnect();
     };
-  }, [ready, layout, adjacency, massRadius]);
+  }, [ready, layout, adjacency, massRadius, clusters]);
 
   // Nearest node under a screen point; nearest-in-front wins. While a search is
   // active, ghosted (non-matching) nodes are skipped so hover/click land on a
@@ -717,6 +731,7 @@ export function ConceptGraphView({
 
         <ConceptGraphLegend
           nodeKinds={presentKinds.length > 1 ? presentKinds : []}
+          coloredByTheme={presentKinds.length <= 1}
           hasLinks={hasLinks}
           hasLearned={hasLearned}
         />

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -730,8 +730,8 @@ export function ConceptGraphView({
         ) : null}
 
         <ConceptGraphLegend
-          nodeKinds={presentKinds.length > 1 ? presentKinds : []}
-          coloredByTheme={presentKinds.length <= 1}
+          nodeKinds={presentKinds.filter((k) => k !== "concept")}
+          coloredByTheme={presentKinds.includes("concept")}
           hasLinks={hasLinks}
           hasLearned={hasLearned}
         />

--- a/clients/web/src/domains/intelligence/components/concept-graph/constants.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/constants.ts
@@ -10,6 +10,26 @@ export const NODE_KIND_COLORS: Record<ConceptNodeKind, string> = {
   other: "#8D99A5",
 };
 
+/** Categorical fills for concept clusters/themes, indexed by the compact
+ * cluster id from `detectClusters`. Ten distinct hues, ordered so adjacent
+ * cluster ids (0,1,2,…) contrast strongly, tuned bright enough to read on the
+ * dark graph surface. These are data-viz *series* colors — semantic by cluster,
+ * not by theme surface — so raw hex is correct here (see STYLE_GUIDE "Color →
+ * When raw hex is acceptable" and the `BAR_CHART_PALETTE` precedent). Callers
+ * index modulo the length; `NODE_KIND_COLORS` stays as the per-kind fallback. */
+export const CLUSTER_PALETTE: string[] = [
+  "#5B8DEF", // blue
+  "#FB923C", // orange
+  "#2DD4BF", // teal
+  "#F472B6", // pink
+  "#A3E635", // lime
+  "#C084FC", // violet
+  "#FACC15", // yellow
+  "#38BDF8", // sky
+  "#F87171", // red
+  "#4ADE80", // green
+];
+
 export const NODE_KIND_LABELS: Record<ConceptNodeKind, string> = {
   concept: "Concept",
   skill: "Skill",


### PR DESCRIPTION
## Summary
- Color concept nodes by detected cluster using a categorical palette, so a large graph reads as themes.
- Legend shows a 'Colored by theme' caption in concept-only mode.

Part of plan: memory-graph-enhancements.md (PR 2 of 8)