### PR TITLE
feat(live-voice): barge in during "thinking" to interrupt pre-TTS turns (JARVIS-1266)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -417,8 +417,8 @@ describe("LiveVoiceSession server VAD", () => {
     await waitFor(() => releaseDeltaSend !== undefined);
     await waitFor(() => streamTtsAudio.mock.calls.length === 1);
 
-    // User speaks while the tts_audio frame is queued but unsent: no audio
-    // has reached the client, so the turn must not be treated as audible.
+    // A short blip while the tts_audio frame is queued but unsent: the
+    // sustained-speech guard is not met, so nothing cancels yet.
     await session.handleBinaryAudio(LOUD_CHUNK);
     await flushAsyncCallbacks();
     expect(countType(frames, "turn_cancelled")).toBe(0);
@@ -445,7 +445,7 @@ describe("LiveVoiceSession server VAD", () => {
     await waitFor(() => abort.mock.calls.length === 1);
   });
 
-  test("speech while the turn is still thinking emits speech_started but does not cancel", async () => {
+  test("sustained speech while the turn is still thinking aborts the pre-TTS turn", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
@@ -466,11 +466,72 @@ describe("LiveVoiceSession server VAD", () => {
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() => frames.some((frame) => frame.type === "thinking"));
 
-    // No TTS audio has been forwarded yet — the turn is still "thinking".
+    // No assistant_text_delta yet — the turn is still pre-TTS "thinking".
+    // Sustained speech over the unspoken reply meets the barge-in guard and
+    // cancels the in-flight turn before it ever starts talking (JARVIS-1266).
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+
+    const types = frameTypes(frames);
+    const bargeInSpeechStartedIndex = types.lastIndexOf("speech_started");
+    const turnCancelledIndex = types.indexOf("turn_cancelled");
+    expect(bargeInSpeechStartedIndex).toBeGreaterThan(-1);
+    expect(bargeInSpeechStartedIndex).toBeLessThan(turnCancelledIndex);
+    expect(countType(frames, "turn_cancelled")).toBe(1);
+    expect(frames[turnCancelledIndex]).toMatchObject({
+      type: "turn_cancelled",
+      turnId: "live-turn-1",
+    });
+    await waitFor(() => abort.mock.calls.length === 1);
+
+    // The aborted thinking turn never produced audio and never completes:
+    // no orphaned/late assistant response lands after the interrupt.
+    expect(countType(frames, "tts_audio")).toBe(0);
+    expect(
+      frames.some(
+        (frame) => frame.type === "tts_done" && frame.turnId === "live-turn-1",
+      ),
+    ).toBe(false);
+
+    // The barge-in speech was captured from onset into the next utterance,
+    // which starts its own turn. Exactly one startVoiceTurn per real utterance
+    // (the bridge emits one user_message_echo per call) — no double echo.
+    await waitFor(() => startVoiceTurn.mock.calls.length === 2);
+    expect(startVoiceTurn.mock.calls[1]?.[0]).toMatchObject({
+      content: "second question",
+    });
+    expect(countType(frames, "utterance_end")).toBe(2);
+  });
+
+  test("a brief blip while thinking arms the guard but does not cancel", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks ??= options.callbacks;
+      return { turnId: "bridge-turn", abort };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // A short blip (well under bargeInMinSpeechMs) while the turn is still
+    // "thinking": the sustained-speech guard arms but does not trip, so a
+    // cough or noise cannot kill the in-flight agent loop.
     await session.handleBinaryAudio(LOUD_CHUNK);
     await flushAsyncCallbacks();
 
-    expect(countType(frames, "speech_started")).toBe(2);
     expect(countType(frames, "turn_cancelled")).toBe(0);
     expect(abort).not.toHaveBeenCalled();
 
@@ -483,6 +544,7 @@ describe("LiveVoiceSession server VAD", () => {
       ),
     );
     expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(abort).not.toHaveBeenCalled();
   });
 
   test("runs two VAD turns back-to-back on one session", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -505,6 +505,101 @@ describe("LiveVoiceSession server VAD", () => {
     expect(countType(frames, "utterance_end")).toBe(2);
   });
 
+  test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks ??= options.callbacks;
+      return { turnId: "bridge-turn", abort };
+    });
+    let releaseTurnCancelled: (() => void) | undefined;
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      startVoiceTurn,
+      // Suspend the async barge-in teardown at the turn_cancelled send so the
+      // aborted turn stays non-finalized — the exact window a late model delta
+      // could race into before cancelAssistantTurn finishes.
+      holdSendFrame: (payload) => {
+        if (payload.type !== "turn_cancelled" || releaseTurnCancelled) {
+          return null;
+        }
+        return new Promise<void>((resolve) => {
+          releaseTurnCancelled = resolve;
+        });
+      },
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => callbacks !== undefined);
+
+    // Barge in while thinking; teardown blocks on the held turn_cancelled, so
+    // the turn is aborted but not yet finalized.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => releaseTurnCancelled !== undefined);
+
+    // A first assistant_text_delta lands in that window — fenced on the abort
+    // signal, it must not be forwarded to the client.
+    callbacks?.assistant_text_delta?.(makeTextDelta("stale thinking reply"));
+    await flushAsyncCallbacks();
+    expect(countType(frames, "assistant_text_delta")).toBe(0);
+
+    releaseTurnCancelled?.();
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    expect(countType(frames, "assistant_text_delta")).toBe(0);
+  });
+
+  test("a thinking barge-in that rejects the pending turn start emits no error frame", async () => {
+    // startVoiceTurn hangs like a real turn waiting for the conversation lock
+    // and rejects when the turn's signal aborts (the waitForIdle behavior), so
+    // the turn is still "thinking" with no handle when barge-in hits.
+    const startVoiceTurn: LiveVoiceTurnStarter = async (options) => {
+      await new Promise<void>((_resolve, reject) => {
+        const fail = () =>
+          reject(new Error("turn aborted while waiting for the lock"));
+        if (options.signal?.aborted) {
+          fail();
+          return;
+        }
+        options.signal?.addEventListener("abort", fail, { once: true });
+      });
+      return { turnId: "bridge-turn", abort: mock() };
+    };
+    let releaseTurnCancelled: (() => void) | undefined;
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      startVoiceTurn,
+      holdSendFrame: (payload) => {
+        if (payload.type !== "turn_cancelled" || releaseTurnCancelled) {
+          return null;
+        }
+        return new Promise<void>((resolve) => {
+          releaseTurnCancelled = resolve;
+        });
+      },
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge in while the turn's start is still pending on the lock: the abort
+    // rejects startVoiceTurn, whose catch must treat the aborted turn as dead
+    // rather than surface a stray error frame while teardown is in flight.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => releaseTurnCancelled !== undefined);
+    await flushAsyncCallbacks();
+    expect(countType(frames, "error")).toBe(0);
+
+    releaseTurnCancelled?.();
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    expect(countType(frames, "error")).toBe(0);
+  });
+
   test("a brief blip while thinking arms the guard but does not cancel", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -551,6 +551,65 @@ describe("LiveVoiceSession server VAD", () => {
     expect(countType(frames, "assistant_text_delta")).toBe(0);
   });
 
+  test("a queued assistant_text_delta is dropped at send time once a thinking barge-in aborts", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks ??= options.callbacks;
+      return { turnId: "bridge-turn", abort };
+    });
+    let releaseFirstDelta: (() => void) | undefined;
+    // No TTS streamer: the turn emits text but never leaves the pre-TTS phase.
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      startVoiceTurn,
+      streamTtsAudio: null,
+      // Hold the first assistant_text_delta's transport write so the second
+      // one sits queued behind it (a backed-up outbound queue).
+      holdSendFrame: (payload) => {
+        if (
+          payload.type !== "assistant_text_delta" ||
+          releaseFirstDelta !== undefined
+        ) {
+          return null;
+        }
+        return new Promise<void>((resolve) => {
+          releaseFirstDelta = resolve;
+        });
+      },
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => callbacks !== undefined);
+
+    // First delta passes shouldSend, then blocks in the transport; the second
+    // is enqueued behind it and has not yet been send-time checked.
+    callbacks?.assistant_text_delta?.(makeTextDelta("early reply"));
+    await waitFor(() => releaseFirstDelta !== undefined);
+    callbacks?.assistant_text_delta?.(makeTextDelta("leaked tail"));
+
+    // Barge in while both deltas are queued: the turn aborts before the second
+    // delta drains.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await flushAsyncCallbacks();
+
+    // Release the queue: the first (already-committed) delta writes, but the
+    // second must be dropped by the send-time guard — no cancelled-reply text
+    // leaks after the abort.
+    releaseFirstDelta?.();
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    expect(countType(frames, "assistant_text_delta")).toBe(1);
+    expect(
+      frames.some(
+        (frame) =>
+          frame.type === "assistant_text_delta" && frame.text === "leaked tail",
+      ),
+    ).toBe(false);
+  });
+
   test("a thinking barge-in that rejects the pending turn start emits no error frame", async () => {
     // startVoiceTurn hangs like a real turn waiting for the conversation lock
     // and rejects when the turn's signal aborts (the waitForIdle behavior), so

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1734,7 +1734,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       this.markFirstAssistantDelta(utterance, turnId);
-      void this.sendFrame({ type: "assistant_text_delta", text: chunk });
+      // Same send-time abort gate as the default-leg delta path: a front-door
+      // delta queued behind a backed-up outbound frame must not be written
+      // once barge-in aborts the turn. Escalation aborts the front-door handle,
+      // not this turn's controller, so legitimate front-door text still sends.
+      void this.sendFrame(
+        { type: "assistant_text_delta", text: chunk },
+        () => !activeTurn.abortController.signal.aborted && !this.isClosed,
+      );
       this.bufferAssistantTextForTts(token, chunk);
     };
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -943,8 +943,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     const turn = this.activeAssistantTurn;
     // Any in-flight, non-finalized turn is interruptible, whether it is still
-    // "thinking" (pre-TTS) or audibly speaking. Dropping the ttsAudioStarted
-    // requirement is what lets a user interrupt during the thinking phase.
+    // "thinking" (pre-TTS) or audibly speaking, so a user can cut in before the
+    // assistant starts talking.
     const bargeableTurn = turn && !turn.finalized ? turn : null;
     // The client can still be draining audible playback after tts_done
     // (the turn is already cleared server-side) — that tail deserves the

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1808,10 +1808,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               return;
             }
             this.markFirstAssistantDelta(utterance, turnId);
-            void this.sendFrame({
-              type: "assistant_text_delta",
-              text: msg.text,
-            });
+            void this.sendFrame(
+              {
+                type: "assistant_text_delta",
+                text: msg.text,
+              },
+              // Re-check at send time (mirrors the tts_audio path): a delta
+              // already queued behind a backed-up outbound frame must not be
+              // written once barge-in has aborted the turn, or the cancelled
+              // reply's text leaks ahead of turn_cancelled. Key off this turn's
+              // own abort signal — a normal message_complete finalizes and
+              // clears activeAssistantTurn while trailing deltas may still be
+              // draining, so an activeAssistantTurn-based guard would drop them.
+              () =>
+                !activeTurn.abortController.signal.aborted && !this.isClosed,
+            );
             this.bufferAssistantTextForTts(token, msg.text);
           },
           message_complete: (msg) => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -269,8 +269,8 @@ interface ActiveAssistantTurn {
   handle: VoiceTurnHandle | null;
   assistantCompleted: boolean;
   ttsDone: boolean;
-  // A tts_audio frame actually went out to the client — the barge-in gate:
-  // speech only cancels a turn that has audibly started speaking.
+  // A tts_audio frame actually went out to the client — latches on the first
+  // forwarded chunk so the firstTtsAudio metric is marked exactly once per turn.
   ttsAudioStarted: boolean;
   finalized: boolean;
   // Triage-and-escalate (Voice Mode): the front-door leg emitted [ESCALATE]
@@ -926,12 +926,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   // VAD speech onset. Contract: speech_started tells the client to flush
-  // tail playback immediately; barge-in then cancels the active turn only
-  // once its first tts_audio chunk was forwarded — speech during a pre-TTS
-  // "thinking" turn never kills the unspoken reply. While a turn is audibly
-  // speaking, both are deferred behind the sustained-speech guard so a
-  // cough or noise blip cannot kill the reply; onset while listening keeps
-  // the instant speech_started (turn-taking latency is untouched).
+  // tail playback immediately; barge-in then cancels any in-flight,
+  // non-finalized turn — including a pre-TTS "thinking" turn whose reply is
+  // still being generated, so a user can cut in before the assistant starts
+  // talking (JARVIS-1266). Speaking over a thinking or audibly speaking turn
+  // is deferred behind the same sustained-speech guard, so a cough or noise
+  // blip cannot kill an unspoken reply or clip a spoken one; sustained speech
+  // aborts the turn. Onset while listening keeps the instant speech_started
+  // (turn-taking latency is untouched).
   private handleVadSpeechStart(): void {
     if (this.isClosed || this.state === "failed") {
       return;
@@ -940,25 +942,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.vadSpeechStartPending = true;
 
     const turn = this.activeAssistantTurn;
-    const speakingTurn =
-      turn && !turn.finalized && turn.ttsAudioStarted ? turn : null;
+    // Any in-flight, non-finalized turn is interruptible, whether it is still
+    // "thinking" (pre-TTS) or audibly speaking. Dropping the ttsAudioStarted
+    // requirement is what lets a user interrupt during the thinking phase.
+    const bargeableTurn = turn && !turn.finalized ? turn : null;
     // The client can still be draining audible playback after tts_done
     // (the turn is already cleared server-side) — that tail deserves the
     // same guard, or a noise blip clips the reply's last words.
     const drainingPlayback = Date.now() < this.assistantPlaybackTailUntilMs;
 
-    if ((speakingTurn || drainingPlayback) && this.bargeInMinSpeechMs > 0) {
+    if ((bargeableTurn || drainingPlayback) && this.bargeInMinSpeechMs > 0) {
       // Onset audio keeps flowing into the cycle/pre-roll while the guard
       // accumulates (trackBargeInGuard), so no speech is lost either way.
-      this.pendingBargeIn = { turn: speakingTurn, speechMs: 0 };
+      this.pendingBargeIn = { turn: bargeableTurn, speechMs: 0 };
       return;
     }
 
     this.pendingBargeIn = null;
     this.assistantPlaybackTailUntilMs = 0;
     void this.sendFrame({ type: "speech_started" });
-    if (speakingTurn) {
-      this.bargeIn(speakingTurn);
+    if (bargeableTurn) {
+      this.bargeIn(bargeableTurn);
     }
   }
 
@@ -2281,10 +2285,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         },
         () => this.isForwardingTts(token),
       );
-      // Arm the barge-in gate only once a tts_audio frame was actually
-      // written — a backed-up outbound queue must not let speech cancel a
-      // still-unspoken reply. Token match keeps a stale turn's late send
-      // from arming a newer turn.
+      // Skip a frame that wasn't actually written — a backed-up outbound
+      // queue hasn't reached the client, so it must not extend the
+      // playback-tail estimate or latch first-audio state. Token match keeps
+      // a stale turn's late send from latching a newer turn.
       if (!sent) {
         return;
       }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1984,7 +1984,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private isActiveAssistantTurn(token: symbol): boolean {
     const activeTurn = this.activeAssistantTurn;
     return (
-      activeTurn?.token === token && !activeTurn.finalized && !this.isClosed
+      activeTurn?.token === token &&
+      !activeTurn.finalized &&
+      // Barge-in aborts synchronously but finalizes through an async
+      // cancelAssistantTurn chain; the abort makes the turn dead at once so a
+      // rejected startVoiceTurn or a trailing onError in that window does not
+      // treat it as live (and emit a stray error frame or double-finalize).
+      !activeTurn.abortController.signal.aborted &&
+      !this.isClosed
     );
   }
 
@@ -1994,6 +2001,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       activeTurn?.token === token &&
       !activeTurn.assistantCompleted &&
       !activeTurn.finalized &&
+      // Fence a late first assistant_text_delta once barge-in aborts a pre-TTS
+      // turn, before its async teardown finalizes — mirrors isForwardingTts so
+      // no cancelled-turn text leaks after turn_cancelled.
+      !activeTurn.abortController.signal.aborted &&
       !this.isClosed
     );
   }


### PR DESCRIPTION
## Summary
- Relax the `ttsAudioStarted` barge-in gate in `handleVadSpeechStart` so a user utterance during the pre-TTS "thinking" phase aborts the in-flight turn and starts a fresh one, reusing the existing barge-in teardown path (JARVIS-1266). Synchronous abort + TTS fenced on the abort signal means no orphaned/late assistant response; each real utterance drives exactly one `startVoiceTurn`, so no double `user_message_echo`.
- Thinking-phase interrupts go through the same sustained-speech guard (`bargeInMinSpeechMs`): a brief blip arms but doesn't trip; sustained speech cancels. No new feature flag — naturally scoped to `server_vad`/hands-free. Barge-in during active speech is unchanged.
- No web change: the client's `turn_cancelled`/`speech_started` handlers already reflect a pre-TTS interrupt. Metrics handle a pre-TTS barge-in cleanly (no TTS-latency mark). Rewrote the VAD test that encoded the old "thinking never cancels" behavior into two cases (sustained aborts; blip doesn't) and refreshed now-stale comments on `ttsAudioStarted`.

## Original prompt
Implement JARVIS-1266 ("Barge-in during thinking: interrupt pre-TTS turns"), the first concrete step of the true-duplex frontier. Today barge-in only fires once TTS audio has started; while the assistant is thinking, speaking doesn't interrupt and the user must wait for speech to begin before cutting in. The goal is to let a user utterance during the thinking/transcribing phase abort the in-flight agent loop and start a new turn — tearing down cleanly (no orphaned/late assistant response, no double user_message_echo) and reusing the existing barge-in teardown/signaling. Decisions confirmed during planning: ship as a direct behavior change (no new flag) and reuse the existing sustained-speech guard during thinking.