### PR TITLE
feat(intelligence): recency time-lens for the memory graph

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -20,6 +20,7 @@ import { ConceptGraphIntroBanner } from "./concept-graph-intro-banner";
 import { ConceptGraphLegend } from "./concept-graph-legend";
 import { CLUSTER_PALETTE, EDGE_LEARNED_COLOR, NODE_KIND_COLORS } from "./constants";
 import { detectClusters } from "./detect-clusters";
+import { RecencyLens, type RecencyWindow } from "./recency-lens";
 import type { ConceptNodeKind, GraphLayoutNode } from "./types";
 import { useGraphIntroDismissed } from "./use-graph-intro-dismissed";
 
@@ -229,6 +230,24 @@ export function ConceptGraphView({
     setSearch("");
   }, [assistantId]);
 
+  // Recency time-lens: "All · Month · Week" narrows the graph to concepts
+  // updated within the window — older ones ghost like non-search-matches, so
+  // "what did it learn recently?" pops. The window (in ms, or null for "all")
+  // lives in a ref the 60fps loop reads (so segment clicks don't re-run it), and
+  // `dirty` is bumped whenever it changes so reduced-motion redraws.
+  const [recency, setRecency] = useState<RecencyWindow>("all");
+  const recencyRef = useRef<{ windowMs: number | null }>({ windowMs: null });
+  useEffect(() => {
+    recencyRef.current.windowMs =
+      recency === "week" ? 7 * DAY_MS : recency === "month" ? 30 * DAY_MS : null;
+    view.current.dirty = true;
+  }, [recency]);
+  // Reset the window on assistant switch (mirrors the search reset above), so a
+  // stale window doesn't ghost the new assistant's freshly-loaded concepts.
+  useEffect(() => {
+    setRecency("all");
+  }, [assistantId]);
+
   const labelFor = useCallback(
     (id: string | null): string | null => {
       if (!id) {return null;}
@@ -340,6 +359,13 @@ export function ConceptGraphView({
       const isMatch = (id: string) =>
         !searchActive || (filter.matches?.has(id) ?? false);
 
+      // Recency lens: when a window is set, concepts not updated within it ghost
+      // (like non-search-matches). A missing timestamp counts as stale/older.
+      const recencyWindowMs = recencyRef.current.windowMs;
+      const isRecencyGhost = (n: GraphLayoutNode) =>
+        recencyWindowMs != null &&
+        (!n.updatedAtMs || nowMs - n.updatedAtMs > recencyWindowMs);
+
       // Density fog: fade the resting learned-edge web as the corpus grows.
       const learnedFog =
         nodes.length <= FOG_FULL_BELOW
@@ -390,7 +416,11 @@ export function ConceptGraphView({
         const b = posById.get(e.toId);
         if (!a || !b) {continue;}
         const learned = e.kind === "learned";
-        const ghost = searchActive && (!isMatch(e.fromId) || !isMatch(e.toId));
+        // An edge ghosts if either endpoint is ghosted by search or recency.
+        const ghost =
+          (searchActive && (!isMatch(e.fromId) || !isMatch(e.toId))) ||
+          isRecencyGhost(a.node) ||
+          isRecencyGhost(b.node);
         const incident = activeId != null && (e.fromId === activeId || e.toId === activeId);
         const depth = (a.depth + b.depth) / 2;
         // Learned edges fade with density in the resting web; authored links
@@ -427,7 +457,8 @@ export function ConceptGraphView({
           node.kind === "concept"
             ? CLUSTER_PALETTE[(nodeClusters.get(node.id) ?? 0) % CLUSTER_PALETTE.length]
             : NODE_KIND_COLORS[node.kind];
-        const ghost = searchActive && !isMatch(node.id);
+        const searchGhost = searchActive && !isMatch(node.id);
+        const ghost = searchGhost || isRecencyGhost(node);
         const lit = !ghost && isLit(node.id);
         const isActive = node.id === activeId;
         const depthA = DEPTH_ALPHA_MIN + (1 - DEPTH_ALPHA_MIN) * p.depth;
@@ -475,7 +506,8 @@ export function ConceptGraphView({
         // When nothing is focused, only label front-facing hubs (depth-gated) so
         // the dense middle of the mass doesn't turn into unreadable label soup.
         // While searching, label the matches instead (that's what you're after).
-        if (searchActive && !isMatch(node.id)) {continue;}
+        // Ghosted nodes (search or recency) never get labels.
+        if ((searchActive && !isMatch(node.id)) || isRecencyGhost(node)) {continue;}
         const showLabel = searchActive
           ? p.depth > 0.3
           : activeId != null
@@ -726,6 +758,16 @@ export function ConceptGraphView({
                 </>
               ) : null}
             </div>
+          </div>
+        ) : null}
+
+        {/* Recency time-lens, tucked just under the search pill. Kept visible
+            while a non-"all" window is active even if the graph shrank below the
+            threshold (e.g. a refetch), so an active window is always resettable
+            — mirrors the search box's own guard. */}
+        {layout.nodes.length > SEARCH_MIN_NODES || recency !== "all" ? (
+          <div className={`absolute top-14 z-10 ${onToggleFullscreen ? "left-16" : "left-4"}`}>
+            <RecencyLens value={recency} onChange={setRecency} />
           </div>
         ) : null}
 

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -66,6 +66,7 @@ interface Projected {
   sy: number;
   sr: number;
   depth: number; // 0 (far) .. 1 (near)
+  updatedAtMs?: number; // for recency hit-test skipping; undefined = stale/older
 }
 
 interface Colors {
@@ -527,6 +528,7 @@ export function ConceptGraphView({
         sy: p.sy,
         sr: p.sr,
         depth: p.depth,
+        updatedAtMs: p.node.updatedAtMs,
       }));
 
       raf = requestAnimationFrame(render);
@@ -539,15 +541,24 @@ export function ConceptGraphView({
     };
   }, [ready, layout, adjacency, massRadius, clusters]);
 
-  // Nearest node under a screen point; nearest-in-front wins. While a search is
-  // active, ghosted (non-matching) nodes are skipped so hover/click land on a
-  // result, not a faded background node.
+  // Nearest node under a screen point; nearest-in-front wins. Ghosted nodes are
+  // skipped so hover/click land on a live node, not a faded background one: both
+  // search non-matches and, when a recency window is set, concepts older than it
+  // (a missing timestamp counts as stale). Mirrors the render-loop ghosting.
   const hitTest = useCallback((x: number, y: number): string | null => {
     const filter = filterRef.current;
+    const recencyWindowMs = recencyRef.current.windowMs;
+    const now = Date.now();
     let best: string | null = null;
     let bestDepth = -1;
     for (const p of projectedRef.current) {
       if (filter.active && !(filter.matches?.has(p.id) ?? false)) {continue;}
+      if (
+        recencyWindowMs != null &&
+        (!p.updatedAtMs || now - p.updatedAtMs > recencyWindowMs)
+      ) {
+        continue;
+      }
       const dx = x - p.sx;
       const dy = y - p.sy;
       if (dx * dx + dy * dy <= (p.sr + 5) * (p.sr + 5) && p.depth > bestDepth) {

--- a/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
@@ -1,0 +1,58 @@
+/** The recency window the graph highlights. "all" disables the lens. */
+export type RecencyWindow = "all" | "month" | "week";
+
+interface RecencyLensProps {
+  value: RecencyWindow;
+  onChange: (value: RecencyWindow) => void;
+}
+
+const SEGMENTS: { value: RecencyWindow; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "month", label: "Month" },
+  { value: "week", label: "Week" },
+];
+
+/**
+ * Segmented "All · Month · Week" control that picks the recency window the graph
+ * emphasizes: concepts updated outside the window ghost out (like non-matches of
+ * the search lens), so "what did it learn recently?" pops. Styled to match the
+ * search pill; marked `data-graph-control` so clicks don't start an orbit drag.
+ */
+export function RecencyLens({ value, onChange }: RecencyLensProps) {
+  return (
+    <div
+      data-graph-control
+      role="group"
+      aria-label="Recency window"
+      className="flex items-center gap-0.5 rounded-full p-0.5 text-[12px]"
+      style={{
+        backgroundColor: "color-mix(in srgb, var(--surface-base) 82%, transparent)",
+        border: "1px solid var(--border-base)",
+      }}
+    >
+      {SEGMENTS.map((seg) => {
+        const active = seg.value === value;
+        return (
+          <button
+            key={seg.value}
+            type="button"
+            onClick={() => onChange(seg.value)}
+            aria-pressed={active}
+            className="rounded-full px-2 py-0.5 transition-colors"
+            style={
+              active
+                ? {
+                    color: "var(--content-default)",
+                    backgroundColor:
+                      "color-mix(in srgb, var(--content-default) 10%, transparent)",
+                  }
+                : { color: "var(--content-tertiary)" }
+            }
+          >
+            {seg.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
@@ -1,3 +1,8 @@
+import {
+  SegmentControl,
+  type SegmentControlItem,
+} from "@vellumai/design-library";
+
 /** The recency window the graph highlights. "all" disables the lens. */
 export type RecencyWindow = "all" | "month" | "week";
 
@@ -6,7 +11,7 @@ interface RecencyLensProps {
   onChange: (value: RecencyWindow) => void;
 }
 
-const SEGMENTS: { value: RecencyWindow; label: string }[] = [
+const ITEMS: SegmentControlItem<RecencyWindow>[] = [
   { value: "all", label: "All" },
   { value: "month", label: "Month" },
   { value: "week", label: "Week" },
@@ -15,44 +20,21 @@ const SEGMENTS: { value: RecencyWindow; label: string }[] = [
 /**
  * Segmented "All · Month · Week" control that picks the recency window the graph
  * emphasizes: concepts updated outside the window ghost out (like non-matches of
- * the search lens), so "what did it learn recently?" pops. Styled to match the
- * search pill; marked `data-graph-control` so clicks don't start an orbit drag.
+ * the search lens), so "what did it learn recently?" pops. Marked
+ * `data-graph-control` so clicks don't start an orbit drag.
  */
 export function RecencyLens({ value, onChange }: RecencyLensProps) {
   return (
-    <div
-      data-graph-control
-      role="group"
-      aria-label="Recency window"
-      className="flex items-center gap-0.5 rounded-full p-0.5 text-[12px]"
-      style={{
-        backgroundColor: "color-mix(in srgb, var(--surface-base) 82%, transparent)",
-        border: "1px solid var(--border-base)",
-      }}
-    >
-      {SEGMENTS.map((seg) => {
-        const active = seg.value === value;
-        return (
-          <button
-            key={seg.value}
-            type="button"
-            onClick={() => onChange(seg.value)}
-            aria-pressed={active}
-            className="rounded-full px-2 py-0.5 transition-colors"
-            style={
-              active
-                ? {
-                    color: "var(--content-default)",
-                    backgroundColor:
-                      "color-mix(in srgb, var(--content-default) 10%, transparent)",
-                  }
-                : { color: "var(--content-tertiary)" }
-            }
-          >
-            {seg.label}
-          </button>
-        );
-      })}
+    <div data-graph-control>
+      <SegmentControl<RecencyWindow>
+        ariaLabel="Recency window"
+        items={ITEMS}
+        value={value}
+        onChange={onChange}
+        // Labeled mode defaults to full width with flex-1 segments; keep it
+        // compact (sized to its content) for the floating graph overlay.
+        className="!w-auto [&>*]:!flex-none"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add an All/Month/Week recency lens that ghosts concepts older than the window, so recent learning stands out.
- Combines with the existing search lens; resets on assistant switch.

Part of plan: memory-graph-enhancements.md (PR 3 of 8)