### PR TITLE
fix: harden ACP Connect routes (dead port const, refresh persistence, manual exchange errors)

### DIFF
--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -26,7 +26,6 @@ mock.module("../prepare-agent-env.js", () => ({ ensureAcpCredentialPolicy }));
 
 const {
   CLAUDE_OAUTH_CONFIG,
-  CLAUDE_LOOPBACK_CALLBACK_PORT,
   CLAUDE_MANUAL_REDIRECT_URI,
   buildClaudeAuthorizeUrl,
   parseManualClaudeCode,
@@ -58,12 +57,10 @@ describe("CLAUDE_OAUTH_CONFIG", () => {
     expect(CLAUDE_OAUTH_CONFIG.scopeSeparator).toBe(" ");
   });
 
-  test("exposes the manual redirect URI and a fixed loopback port", () => {
+  test("exposes the manual redirect URI", () => {
     expect(CLAUDE_MANUAL_REDIRECT_URI).toBe(
       "https://platform.claude.com/oauth/code/callback",
     );
-    expect(typeof CLAUDE_LOOPBACK_CALLBACK_PORT).toBe("number");
-    expect(Number.isInteger(CLAUDE_LOOPBACK_CALLBACK_PORT)).toBe(true);
   });
 });
 
@@ -73,7 +70,7 @@ describe("CLAUDE_OAUTH_CONFIG", () => {
 
 describe("buildClaudeAuthorizeUrl", () => {
   test("produces a URL that parses back to the expected query params", () => {
-    const redirectUri = `http://localhost:${CLAUDE_LOOPBACK_CALLBACK_PORT}/callback`;
+    const redirectUri = "http://localhost:54545/callback";
     const url = buildClaudeAuthorizeUrl(redirectUri, {
       codeChallenge: "challenge-123",
       state: "state-abc",

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -32,13 +32,6 @@ export const CLAUDE_OAUTH_CONFIG: OAuth2Config = {
 };
 
 /**
- * Fixed loopback port for the local connect path (PR 5). The redirect URI is
- * `http://localhost:<port>/callback`; a fixed port keeps it stable for the
- * pre-registered client.
- */
-export const CLAUDE_LOOPBACK_CALLBACK_PORT = 54545;
-
-/**
  * Manual redirect target for the cloud paste path (PR 6): Claude renders the
  * `code#state` string on this page for the user to copy back.
  */

--- a/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-claude-auth-routes.test.ts
@@ -19,9 +19,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { OAuth2FlowResult } from "../../../security/oauth2.js";
 
-const CLAUDE_MANUAL_REDIRECT_URI =
-  "https://platform.claude.com/oauth/code/callback";
-
 // ---------------------------------------------------------------------------
 // Mocks — wired BEFORE importing the module under test.
 // ---------------------------------------------------------------------------
@@ -50,19 +47,11 @@ mock.module("../../../security/oauth2.js", () => ({
 }));
 
 const actualClaudeOauth = await import("../../../acp/acp-claude-oauth.js");
+const { CLAUDE_MANUAL_REDIRECT_URI } = actualClaudeOauth;
 const storeAcpClaudeTokenMock = mock(async (_token: string) => {});
 mock.module("../../../acp/acp-claude-oauth.js", () => ({
   ...actualClaudeOauth,
   storeAcpClaudeToken: storeAcpClaudeTokenMock,
-}));
-
-const actualSecureKeys = await import("../../../security/secure-keys.js");
-const setSecureKeyAsyncMock = mock(
-  async (_key: string, _value: string) => true,
-);
-mock.module("../../../security/secure-keys.js", () => ({
-  ...actualSecureKeys,
-  setSecureKeyAsync: setSecureKeyAsyncMock,
 }));
 
 // Host detection: default false (local/loopback) so the PR-5 tests are
@@ -156,7 +145,6 @@ beforeEach(() => {
   prepareOAuth2FlowMock.mockClear();
   exchangeCodeForTokensMock.mockClear();
   storeAcpClaudeTokenMock.mockClear();
-  setSecureKeyAsyncMock.mockClear();
   // Reset host + flag to their defaults (local host, flag on).
   getIsContainerizedMock.mockReturnValue(false);
   isConnectEnabledMock.mockReturnValue(true);
@@ -219,16 +207,6 @@ describe("loopback capture", () => {
     // Access token persisted via storeAcpClaudeToken.
     expect(storeAcpClaudeTokenMock).toHaveBeenCalledTimes(1);
     expect(storeAcpClaudeTokenMock).toHaveBeenCalledWith("sk-ant-oat-access");
-
-    // Refresh token + expiry persisted under the ACP service keys.
-    expect(setSecureKeyAsyncMock).toHaveBeenCalledWith(
-      "credential/acp/claude_oauth_refresh_token",
-      "refresh-xyz",
-    );
-    const expiresCall = setSecureKeyAsyncMock.mock.calls.find(
-      (c) => c[0] === "credential/acp/claude_oauth_expires_at",
-    );
-    expect(expiresCall).toBeDefined();
   });
 
   test("flips status to error when the exchange fails", async () => {
@@ -395,5 +373,25 @@ describe("acp_claude_auth_exchange", () => {
       Date.now = realNow;
     }
     expect(exchangeCodeForTokensMock).not.toHaveBeenCalled();
+  });
+
+  test("exchange failure yields a 400 (not 500) and the flow is not left pending", async () => {
+    const state = await startManual();
+    exchangeCodeForTokensMock.mockImplementationOnce(async () => {
+      throw new Error("token endpoint rejected the code");
+    });
+
+    let thrown: { statusCode?: number } | undefined;
+    try {
+      await exchangeHandler({ body: { code: `bad#${state}`, state: "" } });
+    } catch (err) {
+      thrown = err as { statusCode?: number };
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown!.statusCode).toBe(400);
+
+    // The flow is marked errored (not left pending) and the token is not stored.
+    expect(getStatus(state).status).toBe("error");
+    expect(storeAcpClaudeTokenMock).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/runtime/routes/acp-claude-auth-routes.ts
+++ b/assistant/src/runtime/routes/acp-claude-auth-routes.ts
@@ -32,12 +32,9 @@ import {
   parseManualClaudeCode,
   storeAcpClaudeToken,
 } from "../../acp/acp-claude-oauth.js";
-import { ACP_SERVICE } from "../../acp/acp-credentials.js";
 import { isAcpClaudeOauthConnectEnabled } from "../../acp/acp-oauth-connect-flag.js";
 import { getIsContainerized } from "../../config/env-registry.js";
 import { loadConfig } from "../../config/loader.js";
-import { credentialKey } from "../../security/credential-key.js";
-import type { OAuth2FlowResult } from "../../security/oauth2.js";
 import {
   exchangeCodeForTokens,
   generateCodeChallenge,
@@ -45,7 +42,6 @@ import {
   generateState,
   prepareOAuth2Flow,
 } from "../../security/oauth2.js";
-import { setSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, ForbiddenError, NotFoundError } from "./errors.js";
@@ -56,11 +52,6 @@ const log = getLogger("acp-claude-auth");
 // Claude's OAuth client requires the loopback redirect path to be exactly
 // `/callback`, not oauth2.ts's default `/oauth/callback`.
 const CLAUDE_LOOPBACK_CALLBACK_PATH = "/callback";
-
-// ACP vault fields for the captured OAuth token's companion metadata. The
-// access token itself is written by `storeAcpClaudeToken`.
-const CLAUDE_REFRESH_TOKEN_FIELD = "claude_oauth_refresh_token";
-const CLAUDE_EXPIRES_AT_FIELD = "claude_oauth_expires_at";
 
 // ---------------------------------------------------------------------------
 // Pending-flow tracking (shared by the loopback + manual/cloud branches)
@@ -114,29 +105,6 @@ function markFlow(state: string, status: FlowStatus, error?: string): void {
   }
 }
 
-/**
- * Persist a captured Claude OAuth token (+ refresh token / expiry when
- * present) into the ACP vault so the broker can inject it at agent spawn.
- */
-async function persistClaudeTokens(result: OAuth2FlowResult): Promise<void> {
-  await storeAcpClaudeToken(result.tokens.accessToken);
-
-  if (result.tokens.refreshToken) {
-    await setSecureKeyAsync(
-      credentialKey(ACP_SERVICE, CLAUDE_REFRESH_TOKEN_FIELD),
-      result.tokens.refreshToken,
-    );
-  }
-
-  if (result.tokens.expiresIn) {
-    const expiresAt = Math.floor(Date.now() / 1000 + result.tokens.expiresIn);
-    await setSecureKeyAsync(
-      credentialKey(ACP_SERVICE, CLAUDE_EXPIRES_AT_FIELD),
-      String(expiresAt),
-    );
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -185,7 +153,7 @@ async function handleStartLocalAuth(): Promise<StartResponse> {
   // can react. Runs in the background — the web client opens `authorize_url`.
   void flow.completion
     .then(async (result) => {
-      await persistClaudeTokens(result);
+      await storeAcpClaudeToken(result.tokens.accessToken);
       markFlow(flow.state, "connected");
       log.info("ACP Claude local OAuth flow connected");
     })
@@ -267,15 +235,26 @@ async function handleExchange(args: RouteHandlerArgs): Promise<{ ok: true }> {
     );
   }
 
-  const result = await exchangeCodeForTokens(
-    CLAUDE_OAUTH_CONFIG,
-    code,
-    pending.redirectUri ?? CLAUDE_MANUAL_REDIRECT_URI,
-    pending.codeVerifier,
-  );
-  await persistClaudeTokens(result);
-  pendingFlows.delete(state);
+  // Surface a bad code / token-endpoint failure as a client-actionable 400 and
+  // mark the flow errored (mirroring the loopback path) so it isn't left pending.
+  try {
+    const result = await exchangeCodeForTokens(
+      CLAUDE_OAUTH_CONFIG,
+      code,
+      pending.redirectUri ?? CLAUDE_MANUAL_REDIRECT_URI,
+      pending.codeVerifier,
+    );
+    await storeAcpClaudeToken(result.tokens.accessToken);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    markFlow(state, "error", message);
+    log.error({ err: message }, "ACP Claude manual OAuth flow failed");
+    throw new BadRequestError(
+      `Failed to exchange Claude authorization code: ${message}`,
+    );
+  }
 
+  pendingFlows.delete(state);
   log.info("ACP Claude manual OAuth flow connected");
   return { ok: true };
 }


### PR DESCRIPTION
## Summary
Self-review remediation for the Connect Claude routes:
- Remove dead `CLAUDE_LOOPBACK_CALLBACK_PORT` (loopback uses a dynamic port).
- Wrap the manual `exchange` so failures return 400 + mark the flow errored (no 500 / stuck pending).
- Drop write-only refresh-token/expiry persistence (no reader/policy yet).
- Import `CLAUDE_MANUAL_REDIRECT_URI` in the test instead of re-hardcoding.

Part of plan: acp-oauth-connect.md (self-review fixes)