### PR TITLE
fix: allowlist secure-keys importers + guard secrets route + regen openapi (self-review)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -238,6 +238,110 @@ paths:
                   - acpSessionId
                   - steered
                 additionalProperties: false
+  /v1/acp/claude/auth/exchange:
+    post:
+      operationId: acp_claude_auth_exchange_post
+      summary: Exchange a manual Connect Claude authorization code
+      description:
+        "Complete a containerized/manual Connect Claude flow: accept the pasted `code#state` (or a raw code plus
+        state), exchange it against Claude's manual redirect URI, and store the Claude OAuth token."
+      tags:
+        - acp
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                state:
+                  type: string
+              required:
+                - code
+                - state
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required:
+                  - ok
+                additionalProperties: false
+  /v1/acp/claude/auth/start:
+    post:
+      operationId: acp_claude_auth_start_post
+      summary: Start Connect Claude OAuth flow
+      description:
+        "Return a PKCE authorize URL plus a state token. On a local host (`mode: loopback`) the daemon binds a
+        loopback callback and captures the redirect itself; on a containerized host (`mode: manual`) it targets Claude's
+        manual redirect page and the web client posts the pasted `code#state` back to `.../auth/exchange`."
+      tags:
+        - acp
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  mode:
+                    type: string
+                    enum:
+                      - loopback
+                      - manual
+                  authorize_url:
+                    type: string
+                  state:
+                    type: string
+                required:
+                  - mode
+                  - authorize_url
+                  - state
+                additionalProperties: false
+  /v1/acp/claude/auth/status/{state}:
+    get:
+      operationId: acp_claude_auth_status_by_state_get
+      summary: Poll Connect Claude OAuth flow status
+      description:
+        Returns the current status of an in-flight Connect Claude OAuth flow (pending/connected/error) so the web
+        client can react once the token has landed.
+      tags:
+        - acp
+      parameters:
+        - name: state
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - pending
+                      - connected
+                      - error
+                  error:
+                    type: string
+                required:
+                  - status
+                additionalProperties: false
+        "404":
+          description: No active OAuth flow for the given state
   /v1/acp/sessions:
     delete:
       operationId: acp_sessions_delete
@@ -17878,6 +17982,8 @@ paths:
                                 type: string
                               isError:
                                 type: boolean
+                              errorCode:
+                                type: string
                               imageData:
                                 type: string
                               imageDataList:
@@ -18314,6 +18420,8 @@ paths:
                                         type: string
                                       isError:
                                         type: boolean
+                                      errorCode:
+                                        type: string
                                       imageData:
                                         type: string
                                       imageDataList:

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -185,6 +185,8 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "oauth/credential-token-resolver.ts", // centralized access-token key resolution for OAuth and manual-token providers
       "oauth/connection-resolver.ts", // resolve OAuthConnection from oauth-store (access_token lookup)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
+      "acp/acp-claude-oauth.ts", // Connect Claude OAuth token vault-store helper (stores sk-ant-oat token via setSecureKeyAsync)
+      "runtime/routes/acp-claude-auth-routes.ts", // Connect Claude Code daemon OAuth flow (stores OAuth token in vault)
       "runtime/routes/migration-routes.ts", // migration import credential restore
       "daemon/conversation-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)

--- a/assistant/src/__tests__/secret-routes-acp-guard.test.ts
+++ b/assistant/src/__tests__/secret-routes-acp-guard.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { ACP_OAUTH_TOKEN_FIELD, ACP_SERVICE } from "../acp/acp-credentials.js";
+import { credentialKey } from "../security/credential-key.js";
+
+let secureKeyStore: Record<string, string | undefined> = {};
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (key: string) => secureKeyStore[key],
+  getSecureKeyResultAsync: async (key: string) => ({
+    value: secureKeyStore[key],
+    unreachable: false,
+  }),
+  setSecureKeyAsync: async (key: string, value: string) => {
+    secureKeyStore[key] = value;
+    return true;
+  },
+  deleteSecureKeyAsync: async (key: string) => {
+    delete secureKeyStore[key];
+    return "deleted";
+  },
+  getActiveBackendName: () => "test",
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  assertMetadataWritable: () => {},
+  upsertCredentialMetadata: () => {},
+  deleteCredentialMetadata: () => {},
+}));
+
+mock.module("../oauth/manual-token-connection.js", () => ({
+  syncManualTokenConnection: async () => {},
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { BadRequestError } from "../runtime/routes/errors.js";
+import { ROUTES } from "../runtime/routes/secret-routes.js";
+
+const addRoute = ROUTES.find(
+  (r) => r.method === "POST" && r.endpoint === "secrets",
+)!;
+
+function addAcpOauthToken(value: string) {
+  return addRoute.handler({
+    body: {
+      type: "credential",
+      name: `${ACP_SERVICE}:${ACP_OAUTH_TOKEN_FIELD}`,
+      value,
+    },
+  });
+}
+
+describe("secret routes ACP OAuth-token format guard", () => {
+  beforeEach(() => {
+    secureKeyStore = {};
+  });
+
+  test("rejects an Anthropic API key with a 400 and does not persist it", async () => {
+    await expect(
+      addAcpOauthToken("sk-ant-api03-not-an-oauth-token"),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(
+      secureKeyStore[credentialKey(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD)],
+    ).toBeUndefined();
+  });
+
+  test("accepts a Claude OAuth token", async () => {
+    const result = await addAcpOauthToken("sk-ant-oat01-valid-oauth-token");
+    expect(result).toEqual(expect.objectContaining({ success: true }));
+    expect(
+      secureKeyStore[credentialKey(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD)],
+    ).toBe("sk-ant-oat01-valid-oauth-token");
+  });
+});

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -29,12 +29,12 @@ import {
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
+import { ACP_OAUTH_TOKEN_FIELD, ACP_SERVICE } from "./acp-credentials.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp:prepare-agent-env");
 
 const ACP_SPAWN_TOOL = "acp_spawn";
-const ACP_SERVICE = "acp";
 
 /**
  * Stable, machine-readable marker carried on the `FailedDependencyError.details`
@@ -175,7 +175,7 @@ export async function prepareAgentEnv(
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
       await injectCredential(
         env,
-        "claude_oauth_token",
+        ACP_OAUTH_TOKEN_FIELD,
         "CLAUDE_CODE_OAUTH_TOKEN",
         "Claude OAuth token for ACP agent authentication",
       );

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -10,6 +10,11 @@
 import { z } from "zod";
 
 import {
+  ACP_SERVICE,
+  AcpCredentialFormatError,
+  assertAcpCredentialFormat,
+} from "../../acp/acp-credentials.js";
+import {
   getPlatformAssistantId,
   setPlatformAssistantId,
   setPlatformBaseUrl,
@@ -242,6 +247,20 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
       assertMetadataWritable();
       const service = name.slice(0, colonIdx);
       const field = name.slice(colonIdx + 1);
+
+      // Reject an Anthropic API key pasted into the ACP OAuth-token field (a 401
+      // footgun) as a 400 rather than letting it persist and fail at runtime.
+      if (service === ACP_SERVICE) {
+        try {
+          assertAcpCredentialFormat(field, value);
+        } catch (err) {
+          if (err instanceof AcpCredentialFormatError) {
+            throw new BadRequestError(err.message);
+          }
+          throw err;
+        }
+      }
+
       const key = credentialKey(service, field);
 
       const TRIMMED_IDENTITY_FIELDS = new Set([


### PR DESCRIPTION
## Summary
Self-review remediation:
- Add `acp-claude-oauth.ts` + `acp-claude-auth-routes.ts` to the secure-keys `ALLOWED_IMPORTERS` invariant (was CI-red).
- Enforce `assertAcpCredentialFormat` on `secret-routes.ts handleAddSecret` (closes the guard bypass).
- Regenerate `openapi.yaml` for the new /v1/acp/claude/auth routes.
- Adopt canonical `ACP_SERVICE`/`ACP_OAUTH_TOKEN_FIELD` in prepare-agent-env.ts.

Part of plan: acp-oauth-connect.md (self-review fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
