### PR TITLE
fix(web): share Connect Claude UI + keep manual OAuth from unloading the page (self-review)

### DIFF
--- a/clients/web/src/components/connect-claude-panel.tsx
+++ b/clients/web/src/components/connect-claude-panel.tsx
@@ -1,0 +1,114 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+import { Typography } from "@vellumai/design-library/components/typography";
+import { Loader2 } from "lucide-react";
+
+import type { UseConnectClaudeResult } from "@/hooks/use-connect-claude";
+
+// Shared "Connect Claude Code" phase-switch, driven by a `useConnectClaude`
+// result. Rendered by both the settings section and the inline chat affordance;
+// each supplies its own outer chrome and per-surface copy. Lives under
+// `src/components/` so neither domain owns it (cross-domain imports are banned).
+//
+// Returns a fragment (no wrapper element) so its children stay direct children
+// of the caller's `space-y-*` container and inherit the same vertical rhythm.
+
+export interface ConnectClaudePanelProps {
+  connection: UseConnectClaudeResult;
+  pastedCode: string;
+  onPastedCodeChange: (value: string) => void;
+  /** Copy shown above the paste input on the manual/cloud path. */
+  pasteInstructions: string;
+  /** Copy shown once the flow reaches `connected`. */
+  connectedMessage: string;
+}
+
+export function ConnectClaudePanel({
+  connection: { phase, error, connect, submitPastedCode },
+  pastedCode,
+  onPastedCodeChange,
+  pasteInstructions,
+  connectedMessage,
+}: ConnectClaudePanelProps) {
+  return (
+    <>
+      {phase === "idle" || phase === "error" ? (
+        <Button
+          variant="outlined"
+          size="compact"
+          onClick={() => void connect()}
+        >
+          Connect Claude Code
+        </Button>
+      ) : null}
+
+      {phase === "starting" ? <BusyRow label="Starting sign-in..." /> : null}
+      {phase === "awaiting_capture" ? (
+        <BusyRow label="Waiting for Claude sign-in to complete..." />
+      ) : null}
+      {phase === "exchanging" ? <BusyRow label="Completing sign-in..." /> : null}
+
+      {phase === "awaiting_paste" ? (
+        <div className="space-y-2">
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="text-[var(--content-secondary)]"
+          >
+            {pasteInstructions}
+          </Typography>
+          <Input
+            value={pastedCode}
+            onChange={(e) => onPastedCodeChange(e.target.value)}
+            placeholder="Paste code here..."
+            fullWidth
+          />
+          <div className="flex justify-end">
+            <Button
+              variant="primary"
+              size="compact"
+              disabled={!pastedCode.trim()}
+              onClick={() => void submitPastedCode(pastedCode)}
+            >
+              Complete Connection
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {phase === "connected" ? (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--system-positive-strong)]"
+        >
+          {connectedMessage}
+        </Typography>
+      ) : null}
+
+      {error ? (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--system-negative-strong)]"
+        >
+          {error}
+        </Typography>
+      ) : null}
+    </>
+  );
+}
+
+function BusyRow({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <Loader2 className="h-4 w-4 animate-spin text-[var(--content-tertiary)]" />
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--content-tertiary)]"
+      >
+        {label}
+      </Typography>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
@@ -17,6 +17,7 @@ let flagEnabled = true;
 
 mock.module("@/runtime/browser", () => ({
   openUrl: async (_url: string) => {},
+  openUrlInNewTab: async (_url: string) => {},
   openUrlFinishedListener: () => () => {},
 }));
 

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -1,11 +1,9 @@
 import { useState } from "react";
 
-import { Button } from "@vellumai/design-library/components/button";
-import { Input } from "@vellumai/design-library/components/input";
 import { Typography } from "@vellumai/design-library/components/typography";
-import { Loader2 } from "lucide-react";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { ConnectClaudePanel } from "@/components/connect-claude-panel";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import { useConnectClaude } from "@/hooks/use-connect-claude";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -46,8 +44,7 @@ export function AcpConnectAffordance() {
 
 function AcpConnectAffordanceInner() {
   const assistantId = useActiveAssistantId();
-  const { phase, error, connect, submitPastedCode } =
-    useConnectClaude(assistantId);
+  const connection = useConnectClaude(assistantId);
   const [pastedCode, setPastedCode] = useState("");
 
   return (
@@ -64,79 +61,13 @@ function AcpConnectAffordanceInner() {
         so no API key is needed.
       </Typography>
 
-      {phase === "idle" || phase === "error" ? (
-        <Button variant="outlined" size="compact" onClick={() => void connect()}>
-          Connect Claude Code
-        </Button>
-      ) : null}
-
-      {phase === "starting" ? <BusyRow label="Starting sign-in..." /> : null}
-      {phase === "awaiting_capture" ? (
-        <BusyRow label="Waiting for Claude sign-in to complete..." />
-      ) : null}
-      {phase === "exchanging" ? <BusyRow label="Completing sign-in..." /> : null}
-
-      {phase === "awaiting_paste" ? (
-        <div className="space-y-2">
-          <Typography
-            variant="body-small-default"
-            as="p"
-            className="text-[var(--content-tertiary)]"
-          >
-            After signing in, paste the code Claude shows you.
-          </Typography>
-          <Input
-            value={pastedCode}
-            onChange={(e) => setPastedCode(e.target.value)}
-            placeholder="Paste code here..."
-            fullWidth
-          />
-          <div className="flex justify-end">
-            <Button
-              variant="primary"
-              size="compact"
-              disabled={!pastedCode.trim()}
-              onClick={() => void submitPastedCode(pastedCode)}
-            >
-              Complete Connection
-            </Button>
-          </div>
-        </div>
-      ) : null}
-
-      {phase === "connected" ? (
-        <Typography
-          variant="body-small-default"
-          as="p"
-          className="text-[var(--system-positive-strong)]"
-        >
-          Claude Code connected. Ask again to run the agent.
-        </Typography>
-      ) : null}
-
-      {error ? (
-        <Typography
-          variant="body-small-default"
-          as="p"
-          className="text-[var(--system-negative-strong)]"
-        >
-          {error}
-        </Typography>
-      ) : null}
-    </div>
-  );
-}
-
-function BusyRow({ label }: { label: string }) {
-  return (
-    <div className="flex items-center gap-2">
-      <Loader2 className="h-4 w-4 animate-spin text-[var(--content-tertiary)]" />
-      <Typography
-        variant="body-small-default"
-        className="text-[var(--content-tertiary)]"
-      >
-        {label}
-      </Typography>
+      <ConnectClaudePanel
+        connection={connection}
+        pastedCode={pastedCode}
+        onPastedCodeChange={setPastedCode}
+        pasteInstructions="After signing in, paste the code Claude shows you."
+        connectedMessage="Claude Code connected. Ask again to run the agent."
+      />
     </div>
   );
 }

--- a/clients/web/src/domains/settings/acp/__tests__/connect-claude-section.test.tsx
+++ b/clients/web/src/domains/settings/acp/__tests__/connect-claude-section.test.tsx
@@ -19,8 +19,10 @@ import type { ReactNode } from "react";
 let flagEnabled = true;
 
 const openUrl = mock(async (_url: string) => {});
+const openUrlInNewTab = mock(async (_url: string) => {});
 mock.module("@/runtime/browser", () => ({
   openUrl,
+  openUrlInNewTab,
   openUrlFinishedListener: () => () => {},
 }));
 
@@ -93,6 +95,7 @@ const { ConnectClaudeSection } = await import("../connect-claude-section");
 beforeEach(() => {
   flagEnabled = true;
   openUrl.mockClear();
+  openUrlInNewTab.mockClear();
   startConnectClaude.mockClear();
   startConnectClaude.mockImplementation(async () => ({
     mode: "loopback",
@@ -133,6 +136,8 @@ describe("ConnectClaudeSection", () => {
       expect(openUrl).toHaveBeenCalledWith("https://claude.ai/oauth?x=1"),
     );
     expect(startConnectClaude).toHaveBeenCalledWith("assistant-123");
+    // Loopback stays in the same tab (the daemon captures the callback).
+    expect(openUrlInNewTab).not.toHaveBeenCalled();
 
     await waitFor(
       () => expect(screen.getByText("Claude Code connected.")).not.toBeNull(),
@@ -160,7 +165,13 @@ describe("ConnectClaudeSection", () => {
       screen.getByRole("button", { name: "Connect Claude Code" }),
     );
 
+    // Manual mode opens a NEW tab, never same-tab navigation — same-tab would
+    // unload this page and destroy the pending state + paste field below.
     const input = await screen.findByPlaceholderText("Paste code here...");
+    expect(openUrlInNewTab).toHaveBeenCalledWith("https://claude.ai/oauth?x=2");
+    expect(openUrl).not.toHaveBeenCalled();
+
+    // The paste field survives the open and stays usable.
     fireEvent.change(input, { target: { value: "code-123#state-xyz" } });
 
     fireEvent.click(

--- a/clients/web/src/domains/settings/acp/connect-claude-section.tsx
+++ b/clients/web/src/domains/settings/acp/connect-claude-section.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
-import { Input } from "@vellumai/design-library/components/input";
 import { Typography } from "@vellumai/design-library/components/typography";
-import { Loader2 } from "lucide-react";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { ConnectClaudePanel } from "@/components/connect-claude-panel";
 import { useConnectClaude } from "@/hooks/use-connect-claude";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
@@ -27,8 +26,8 @@ export function ConnectClaudeSection() {
 
 function ConnectClaudeSectionInner() {
   const assistantId = useActiveAssistantId();
-  const { phase, error, connect, submitPastedCode, reset } =
-    useConnectClaude(assistantId);
+  const connection = useConnectClaude(assistantId);
+  const { phase, reset } = connection;
   const [pastedCode, setPastedCode] = useState("");
 
   function handleReset() {
@@ -56,91 +55,19 @@ function ConnectClaudeSectionInner() {
         </Typography>
       </div>
 
-      {phase === "idle" || phase === "error" ? (
-        <Button
-          variant="outlined"
-          size="compact"
-          onClick={() => void connect()}
-        >
-          Connect Claude Code
-        </Button>
-      ) : null}
-
-      {phase === "starting" ? <BusyRow label="Starting sign-in..." /> : null}
-      {phase === "awaiting_capture" ? (
-        <BusyRow label="Waiting for Claude sign-in to complete..." />
-      ) : null}
-      {phase === "exchanging" ? (
-        <BusyRow label="Completing sign-in..." />
-      ) : null}
-
-      {phase === "awaiting_paste" ? (
-        <div className="space-y-3">
-          <Typography
-            variant="body-small-default"
-            as="p"
-            className="text-[var(--content-secondary)]"
-          >
-            After signing in, copy the code Claude shows you and paste it below.
-          </Typography>
-          <Input
-            value={pastedCode}
-            onChange={(e) => setPastedCode(e.target.value)}
-            placeholder="Paste code here..."
-            fullWidth
-          />
-          <div className="flex justify-end">
-            <Button
-              variant="primary"
-              size="compact"
-              disabled={!pastedCode.trim()}
-              onClick={() => void submitPastedCode(pastedCode)}
-            >
-              Complete Connection
-            </Button>
-          </div>
-        </div>
-      ) : null}
-
-      {phase === "connected" ? (
-        <Typography
-          variant="body-small-default"
-          as="p"
-          className="text-[var(--system-positive-strong)]"
-        >
-          Claude Code connected.
-        </Typography>
-      ) : null}
-
-      {error ? (
-        <Typography
-          variant="body-small-default"
-          as="p"
-          className="text-(--system-negative-strong)"
-        >
-          {error}
-        </Typography>
-      ) : null}
+      <ConnectClaudePanel
+        connection={connection}
+        pastedCode={pastedCode}
+        onPastedCodeChange={setPastedCode}
+        pasteInstructions="After signing in, copy the code Claude shows you and paste it below."
+        connectedMessage="Claude Code connected."
+      />
 
       {phase === "connected" ? (
         <Button variant="ghost" size="compact" onClick={handleReset}>
           Connect a different account
         </Button>
       ) : null}
-    </div>
-  );
-}
-
-function BusyRow({ label }: { label: string }) {
-  return (
-    <div className="flex items-center gap-2">
-      <Loader2 className="h-4 w-4 animate-spin text-[var(--content-tertiary)]" />
-      <Typography
-        variant="body-small-default"
-        className="text-[var(--content-tertiary)]"
-      >
-        {label}
-      </Typography>
     </div>
   );
 }

--- a/clients/web/src/hooks/use-connect-claude.ts
+++ b/clients/web/src/hooks/use-connect-claude.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { openUrl } from "@/runtime/browser";
+import { openUrl, openUrlInNewTab } from "@/runtime/browser";
 import {
   exchangeConnectClaude,
   pollConnectClaudeStatus,
@@ -128,15 +128,23 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
 
     stateRef.current = start.state;
     setMode(start.mode);
-    await openUrl(start.authorize_url);
-    if (isStale(flowId)) {
-      return;
-    }
 
     if (start.mode === "loopback") {
+      // Loopback/desktop: the daemon captures the token on its own callback, so
+      // a same-tab open is fine.
+      await openUrl(start.authorize_url);
+      if (isStale(flowId)) {
+        return;
+      }
       setPhase("awaiting_capture");
       void pollUntilSettled(flowId, start.state);
     } else {
+      // Manual/cloud: open a new tab so this page — and the pending `state` plus
+      // paste field — survives; same-tab navigation would unload it.
+      await openUrlInNewTab(start.authorize_url);
+      if (isStale(flowId)) {
+        return;
+      }
       setPhase("awaiting_paste");
     }
   }, [assistantId, isStale, pollUntilSettled]);

--- a/clients/web/src/runtime/browser.ts
+++ b/clients/web/src/runtime/browser.ts
@@ -4,19 +4,17 @@ import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
 import { isElectron } from "@/runtime/is-electron";
 
 /**
- * Opens a URL in the most appropriate context:
- * - Electron: system browser via the main-process `setWindowOpenHandler`
- *   (which routes `target=_blank` opens to `shell.openExternal`).
- * - Native (Capacitor): `SFSafariViewController` via `@capacitor/browser`,
- *   which keeps the user inside the app and properly handles OAuth / Stripe
- *   redirect flows that would otherwise break out to Safari.
- * - Web: falls back to `window.location.href` (same-tab navigation), matching
- *   the previous behaviour.
+ * Shared cross-shell open routing. Electron (external system browser) and
+ * native Capacitor (`SFSafariViewController`) never unload the current page;
+ * only the plain-web path varies, so callers supply the web fallback.
  *
  * The plugin is lazy-imported so it is never loaded in SSR or plain-browser
  * contexts where the Capacitor runtime is absent.
  */
-export const openUrl = async (url: string): Promise<void> => {
+const openUrlAcrossShells = async (
+  url: string,
+  webFallback: (url: string) => void,
+): Promise<void> => {
   if (isElectron()) {
     window.open(url, "_blank");
     return;
@@ -27,13 +25,41 @@ export const openUrl = async (url: string): Promise<void> => {
       await Browser.open({ url, presentationStyle: "popover" });
     } catch {
       // Plugin not available (e.g. older app binary without @capacitor/browser
-      // registered). Fall back to same-tab navigation so checkout still works.
-      window.location.href = url;
+      // registered). Fall back to the web behaviour so checkout still works.
+      webFallback(url);
     }
   } else {
-    window.location.href = url;
+    webFallback(url);
   }
 };
+
+/**
+ * Opens a URL in the most appropriate context:
+ * - Electron: system browser via the main-process `setWindowOpenHandler`
+ *   (which routes `target=_blank` opens to `shell.openExternal`).
+ * - Native (Capacitor): `SFSafariViewController` via `@capacitor/browser`,
+ *   which keeps the user inside the app and properly handles OAuth / Stripe
+ *   redirect flows that would otherwise break out to Safari.
+ * - Web: falls back to `window.location.href` (same-tab navigation), matching
+ *   the previous behaviour.
+ */
+export const openUrl = (url: string): Promise<void> =>
+  openUrlAcrossShells(url, (u) => {
+    window.location.href = u;
+  });
+
+/**
+ * Like {@link openUrl}, but the plain-web fallback opens a new tab
+ * (`window.open`) instead of same-tab navigation, so the current page — and any
+ * pending state on it — survives. Use for flows that must not unload the page,
+ * e.g. the manual/cloud Connect Claude path where the user pastes a code back
+ * into the still-mounted settings surface. Electron and native behave as in
+ * `openUrl` (both already open without unloading).
+ */
+export const openUrlInNewTab = (url: string): Promise<void> =>
+  openUrlAcrossShells(url, (u) => {
+    window.open(u, "_blank", "noopener");
+  });
 
 /**
  * Subscribe to the Capacitor Browser `browserFinished` event, which fires


### PR DESCRIPTION
## Summary
Self-review remediation for the web Connect Claude UI:
- Extract a shared `ConnectClaudePanel` (+ BusyRow) consumed by both the settings section and the inline chat affordance (removes the duplicated phase-switch).
- Manual (cloud) mode now opens the authorize URL in a new tab so the paste field/pending state survive (was same-tab unload).

Part of plan: acp-oauth-connect.md (self-review fixes)