### PR TITLE
fix(api): derive none auth for openai-compatible when no credential is given

### DIFF
--- a/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
+++ b/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
@@ -46,7 +46,7 @@ describe("openai-compatible adapter factory", () => {
     expect(adapter).not.toBeNull();
   });
 
-  test("createAdapterFromConnection rejects 'none' auth for openai-compatible", () => {
+  test("createAdapterFromConnection supports keyless openai-compatible with baseUrl", () => {
     const connection: ProviderConnection = {
       name: "my-vllm",
       provider: "openai-compatible",
@@ -59,14 +59,39 @@ describe("openai-compatible adapter factory", () => {
       isManaged: false,
     };
 
-    const resolvedAuth: ResolvedAuth = { kind: "none" };
+    // Keyless local endpoints (LM Studio, vLLM) dispatch with none auth;
+    // the baseUrl travels on the resolved auth (#33108).
+    const resolvedAuth: ResolvedAuth = {
+      kind: "none",
+      baseUrl: "http://localhost:8080/v1",
+    };
 
     const adapter = createAdapterFromConnection(connection, resolvedAuth, {
       model: "my-model",
     });
 
-    // openai-compatible is setupMode: "api-key", not keyless, so none auth
-    // should be rejected.
+    expect(adapter).not.toBeNull();
+  });
+
+  test("createAdapterFromConnection still rejects 'none' auth for keyed catalog providers", () => {
+    const connection: ProviderConnection = {
+      name: "my-anthropic",
+      provider: "anthropic",
+      auth: { type: "none" },
+      label: null,
+      baseUrl: null,
+      models: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isManaged: false,
+    };
+
+    const adapter = createAdapterFromConnection(
+      connection,
+      { kind: "none" },
+      { model: "claude-opus-4-8" },
+    );
+
     expect(adapter).toBeNull();
   });
 });

--- a/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
+++ b/assistant/src/providers/inference/__tests__/adapter-factory-openai-compatible.test.ts
@@ -60,7 +60,7 @@ describe("openai-compatible adapter factory", () => {
     };
 
     // Keyless local endpoints (LM Studio, vLLM) dispatch with none auth;
-    // the baseUrl travels on the resolved auth (#33108).
+    // the baseUrl travels on the resolved auth.
     const resolvedAuth: ResolvedAuth = {
       kind: "none",
       baseUrl: "http://localhost:8080/v1",

--- a/assistant/src/providers/inference/__tests__/connection-availability-keyless.test.ts
+++ b/assistant/src/providers/inference/__tests__/connection-availability-keyless.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Availability for keyless connections: none-auth is `ok` exactly where
+ * dispatch succeeds — keyless catalog providers (ollama) and dual-mode
+ * openai-compatible endpoints — and `unsupported_auth` for keyed catalog
+ * providers, mirroring `createAdapterFromConnection`.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import { providerConnections } from "../../../persistence/schema/inference.js";
+import { computeConnectionAvailability } from "../connection-availability.js";
+
+await initializeDb();
+
+function seedConnection(opts: {
+  name: string;
+  provider: string;
+  auth: object;
+}): void {
+  const now = Date.now();
+  getDb()
+    .insert(providerConnections)
+    .values({
+      name: opts.name,
+      provider: opts.provider,
+      auth: JSON.stringify(opts.auth),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+beforeEach(() => {
+  getDb().delete(providerConnections).run();
+});
+
+describe("computeConnectionAvailability — none auth", () => {
+  test("keyless openai-compatible endpoints are ok", async () => {
+    seedConnection({
+      name: "local-llm",
+      provider: "openai-compatible",
+      auth: { type: "none" },
+    });
+    const availability = await computeConnectionAvailability(
+      "openai-compatible",
+      "local-llm",
+    );
+    expect(availability.status).toBe("ok");
+  });
+
+  test("keyless catalog providers (ollama) are ok", async () => {
+    seedConnection({
+      name: "ollama-personal",
+      provider: "ollama",
+      auth: { type: "none" },
+    });
+    const availability = await computeConnectionAvailability(
+      "ollama",
+      "ollama-personal",
+    );
+    expect(availability.status).toBe("ok");
+  });
+
+  test("keyed catalog providers stay unsupported_auth", async () => {
+    seedConnection({
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: { type: "none" },
+    });
+    const availability = await computeConnectionAvailability(
+      "anthropic",
+      "anthropic-personal",
+    );
+    expect(availability.status).toBe("unsupported_auth");
+  });
+});

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -210,8 +210,7 @@ export function createAdapterFromConnection(
   if (!entry) return null;
   const isKeyless = entry.setupMode === "keyless";
   // openai-compatible is dual-mode: local endpoints (LM Studio, vLLM) are
-  // keyless, hosted ones keyed — none auth is valid for it (see #33108;
-  // the exemption was lost when this file moved under inference/).
+  // keyless, hosted ones keyed — none auth is valid for it.
   const isOpenAICompatible = provider === "openai-compatible";
 
   // Keyed providers can't operate without a credential.

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -120,8 +120,10 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
       streamTimeoutMs,
       ...(baseURL ? { baseURL } : {}),
     }),
+  // Keyless openai-compatible endpoints (e.g. LM Studio) ignore the key; the
+  // placeholder satisfies the OpenAI SDK, which requires a non-empty key.
   "openai-compatible": ({ apiKey, model, streamTimeoutMs, baseURL }) =>
-    new OpenAIChatCompletionsProvider(apiKey, model, {
+    new OpenAIChatCompletionsProvider(apiKey || "not-needed", model, {
       providerName: "openai-compatible",
       providerLabel: "OpenAI-compatible",
       streamTimeoutMs,
@@ -207,16 +209,24 @@ export function createAdapterFromConnection(
   const entry = PROVIDER_CATALOG.find((e) => e.id === provider);
   if (!entry) return null;
   const isKeyless = entry.setupMode === "keyless";
+  // openai-compatible is dual-mode: local endpoints (LM Studio, vLLM) are
+  // keyless, hosted ones keyed — none auth is valid for it (see #33108;
+  // the exemption was lost when this file moved under inference/).
+  const isOpenAICompatible = provider === "openai-compatible";
 
   // Keyed providers can't operate without a credential.
-  if (!isKeyless && resolvedAuth.kind === "none") return null;
+  if (!isKeyless && !isOpenAICompatible && resolvedAuth.kind === "none") {
+    return null;
+  }
 
   const apiKey =
     resolvedAuth.kind === "header"
       ? (resolvedAuth.headers["Authorization"] ?? "").replace(/^Bearer /, "")
       : "";
   const baseURL =
-    resolvedAuth.kind === "header" ? resolvedAuth.baseUrl : undefined;
+    resolvedAuth.kind === "header" || resolvedAuth.kind === "none"
+      ? resolvedAuth.baseUrl
+      : undefined;
 
   const codexSubscription =
     connection.auth.type === "oauth_subscription" && provider === "openai";

--- a/assistant/src/providers/inference/auth.ts
+++ b/assistant/src/providers/inference/auth.ts
@@ -64,6 +64,11 @@ export function deriveAuthForProvider(
   if (entry?.setupMode === "keyless") {
     return { type: "none" };
   }
+  if (provider === "openai-compatible") {
+    // Custom endpoints have no fixed auth story: local servers are usually
+    // keyless, hosted ones keyed. Credential presence decides.
+    return credential ? { type: "api_key", credential } : { type: "none" };
+  }
   return credential ? { type: "api_key", credential } : null;
 }
 

--- a/assistant/src/providers/inference/auth.ts
+++ b/assistant/src/providers/inference/auth.ts
@@ -84,7 +84,7 @@ export function deriveAuthForProvider(
 export type ResolvedAuth =
   | { kind: "header"; headers: Record<string, string>; baseUrl?: string }
   | { kind: "runtime_proxy"; route: string }
-  | { kind: "none" };
+  | { kind: "none"; baseUrl?: string };
 
 // ---------------------------------------------------------------------------
 // Valid provider identifiers — derived from PROVIDER_CATALOG

--- a/assistant/src/providers/inference/connection-availability.ts
+++ b/assistant/src/providers/inference/connection-availability.ts
@@ -174,14 +174,15 @@ export async function computeConnectionAvailability(
         message: `Connection "${resolvedConnectionName}" uses Vellum platform auth, which cannot serve provider "${provider}". Add an API-key connection for "${provider}" ${SETTINGS_HINT}.`,
       };
     case "none": {
-      // Keyless providers (catalog setupMode "keyless", e.g. ollama)
+      // Keyless providers (catalog setupMode "keyless", e.g. ollama) and
+      // openai-compatible endpoints (dual-mode: local servers are keyless)
       // legitimately dispatch with none-auth — mirror
       // `createAdapterFromConnection`, which only rejects none-auth for
       // keyed catalog entries.
       const isKeyless =
         PROVIDER_CATALOG.find((entry) => entry.id === provider)?.setupMode ===
         "keyless";
-      if (isKeyless) {
+      if (isKeyless || provider === "openai-compatible") {
         return { status: "ok" };
       }
       return {

--- a/assistant/src/providers/inference/resolve-auth.ts
+++ b/assistant/src/providers/inference/resolve-auth.ts
@@ -84,7 +84,15 @@ export async function resolveAuth(
     }
 
     case "none":
-      return { ok: true, resolved: { kind: "none" } };
+      // Keyless endpoints still need their custom baseUrl threaded through
+      // (LM Studio / vLLM openai-compatible servers).
+      return {
+        ok: true,
+        resolved: {
+          kind: "none",
+          ...(safeBaseUrl ? { baseUrl: safeBaseUrl } : {}),
+        },
+      };
 
     case "oauth_subscription": {
       // Extract the credential prefix from the credential key.

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -262,6 +262,40 @@ describe("POST inference/provider-connections (create)", () => {
     expect(result.auth).toEqual({ type: "platform" });
   });
 
+  test("derives none auth for openai-compatible without a credential", async () => {
+    const result = (await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "derived-local-llm",
+          provider: "openai-compatible",
+          base_url: "http://localhost:1234/v1",
+          models: [{ id: "my-model" }],
+        },
+      },
+    )) as { auth: object };
+    expect(result.auth).toEqual({ type: "none" });
+  });
+
+  test("derives api_key auth for openai-compatible with a credential", async () => {
+    const result = (await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "derived-hosted-llm",
+          provider: "openai-compatible",
+          credential: "credential/hosted/key",
+          base_url: "https://api.example.com/v1",
+          models: [{ id: "my-model" }],
+        },
+      },
+    )) as { auth: object };
+    expect(result.auth).toEqual({
+      type: "api_key",
+      credential: "credential/hosted/key",
+    });
+  });
+
   test("throws 400 when auth is omitted and a keyed provider has no credential", async () => {
     await expect(
       call(findHandler("inference_provider_connections_create"), {


### PR DESCRIPTION
## Summary
- `deriveAuthForProvider` (shipped in #38104) treated `openai-compatible` like any keyed catalog provider, so an auth-less create without `credential` returned 400 — but keyless local endpoints (LM Studio, vLLM) are the primary openai-compatible use case. Credential presence now decides: `credential` → `api_key`, none → `none`.
- **Restores the lost #33108 keyless-dispatch support**: the adapter-factory exemption (+ placeholder key for the OpenAI SDK) from #33108 was silently dropped when `adapter-factory.ts` was recreated under `inference/` during the M3-era refactor — the old rejection test came back with it, and `resolve-auth` never threaded `baseUrl` through `none` auth. Without this, none-auth openai-compatible rows could be created but never dispatch (caught by Codex on #38179).
- Same derivation rule now on all three surfaces: daemon (this PR), CLI (#38179), web (#38172).

## Original prompt
Follow-up to Milestone A of the connection-removal plan (papertrail on #38102): Codex review of the CLI PR caught that the derived-auth mapping breaks keyless openai-compatible endpoints, and verifying the claim uncovered the regressed #33108 dispatch support underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)