### PR TITLE
feat(intelligence): toggle link vs learned edges in the memory graph

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 import {
   EDGE_LEARNED_COLOR,
   EDGE_LINK_COLOR,
@@ -14,6 +16,13 @@ interface ConceptGraphLegendProps {
   coloredByTheme?: boolean;
   hasLinks: boolean;
   hasLearned: boolean;
+  /** When provided (both edge kinds present), the Link / Learned rows become
+   * toggles that show/hide that edge kind; the `*Active` flags dim the row
+   * while its kind is hidden. Omitted → static, non-interactive rows. */
+  onToggleLink?: () => void;
+  onToggleLearned?: () => void;
+  linkActive?: boolean;
+  learnedActive?: boolean;
 }
 
 /** Compact legend for node kinds and edge kinds present in the graph. */
@@ -22,6 +31,10 @@ export function ConceptGraphLegend({
   coloredByTheme,
   hasLinks,
   hasLearned,
+  onToggleLink,
+  onToggleLearned,
+  linkActive,
+  learnedActive,
 }: ConceptGraphLegendProps) {
   return (
     <div
@@ -57,33 +70,63 @@ export function ConceptGraphLegend({
         />
       )}
       {hasLinks && (
-        <div className="flex items-center gap-2">
-          <span
-            className="inline-block h-0 w-4"
-            style={{ borderTop: `2px solid ${EDGE_LINK_COLOR}` }}
-          />
-          <span
-            className="text-[11px]"
-            style={{ color: "var(--content-tertiary)" }}
-          >
-            Link
-          </span>
-        </div>
+        <EdgeLegendRow
+          swatchStyle={{ borderTop: `2px solid ${EDGE_LINK_COLOR}` }}
+          label="Link"
+          onToggle={onToggleLink}
+          active={linkActive}
+        />
       )}
       {hasLearned && (
-        <div className="flex items-center gap-2">
-          <span
-            className="inline-block h-0 w-4"
-            style={{ borderTop: `2px dashed ${EDGE_LEARNED_COLOR}` }}
-          />
-          <span
-            className="text-[11px]"
-            style={{ color: "var(--content-tertiary)" }}
-          >
-            Learned
-          </span>
-        </div>
+        <EdgeLegendRow
+          swatchStyle={{ borderTop: `2px dashed ${EDGE_LEARNED_COLOR}` }}
+          label="Learned"
+          onToggle={onToggleLearned}
+          active={learnedActive}
+        />
       )}
     </div>
+  );
+}
+
+/** One edge-kind legend row: a line swatch + label. With `onToggle` it renders
+ * as a button that shows/hides that edge kind (dimmed while its kind is hidden);
+ * without one it's a static, non-interactive row that keeps the legend's look. */
+function EdgeLegendRow({
+  swatchStyle,
+  label,
+  onToggle,
+  active,
+}: {
+  swatchStyle: CSSProperties;
+  label: string;
+  onToggle?: () => void;
+  active?: boolean;
+}) {
+  const swatch = <span className="inline-block h-0 w-4" style={swatchStyle} />;
+  const text = (
+    <span className="text-[11px]" style={{ color: "var(--content-tertiary)" }}>
+      {label}
+    </span>
+  );
+  if (!onToggle) {
+    return (
+      <div className="flex items-center gap-2">
+        {swatch}
+        {text}
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      className="pointer-events-auto flex cursor-pointer items-center gap-2 border-0 bg-transparent p-0 transition-opacity"
+      style={{ opacity: active === false ? 0.4 : 1 }}
+    >
+      {swatch}
+      {text}
+    </button>
   );
 }

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
@@ -38,6 +38,7 @@ export function ConceptGraphLegend({
 }: ConceptGraphLegendProps) {
   return (
     <div
+      data-graph-control
       className="pointer-events-none absolute bottom-4 left-4 flex flex-col gap-1.5 rounded-lg px-3 py-2"
       style={{
         backgroundColor: "color-mix(in srgb, var(--surface-base) 78%, transparent)",

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -276,6 +276,22 @@ export function ConceptGraphView({
     setRecency("all");
   }, [assistantId]);
 
+  // Edge-kind filter: toggle authored (link) vs behavioral (learned) edges to
+  // declutter. The active flags live in a ref the 60fps loop reads (so a toggle
+  // click doesn't re-run the render effect), and `dirty` is bumped whenever they
+  // change so reduced-motion redraws. Only surfaced when both kinds are present.
+  const [edgeFilter, setEdgeFilter] = useState({ link: true, learned: true });
+  const edgeFilterRef = useRef(edgeFilter);
+  useEffect(() => {
+    edgeFilterRef.current = edgeFilter;
+    view.current.dirty = true;
+  }, [edgeFilter]);
+  // Reset on assistant switch (mirrors the search/recency resets), so a hidden
+  // kind doesn't carry over and blank out edges on the new assistant's graph.
+  useEffect(() => {
+    setEdgeFilter({ link: true, learned: true });
+  }, [assistantId]);
+
   const labelFor = useCallback(
     (id: string | null): string | null => {
       if (!id) {return null;}
@@ -394,6 +410,9 @@ export function ConceptGraphView({
         recencyWindowMs != null &&
         (!n.updatedAtMs || nowMs - n.updatedAtMs > recencyWindowMs);
 
+      // Edge-kind toggle: a hidden kind is skipped entirely below.
+      const edgeKinds = edgeFilterRef.current;
+
       // Density fog: fade the resting learned-edge web as the corpus grows.
       const learnedFog =
         nodes.length <= FOG_FULL_BELOW
@@ -446,6 +465,11 @@ export function ConceptGraphView({
         const b = posById.get(e.toId);
         if (!a || !b) {continue;}
         const learned = e.kind === "learned";
+        // A hidden kind is neither drawn nor collected for edge-hover, so the
+        // hit-test stays consistent with what's on screen.
+        if (learned ? !edgeKinds.learned : !edgeKinds.link) {
+          continue;
+        }
         // An edge ghosts if either endpoint is ghosted by search or recency.
         const ghost =
           (searchActive && (!isMatch(e.fromId) || !isMatch(e.toId))) ||
@@ -871,6 +895,16 @@ export function ConceptGraphView({
           coloredByTheme={presentKinds.includes("concept")}
           hasLinks={hasLinks}
           hasLearned={hasLearned}
+          {...(hasLinks && hasLearned
+            ? {
+                onToggleLink: () =>
+                  setEdgeFilter((f) => ({ ...f, link: !f.link })),
+                onToggleLearned: () =>
+                  setEdgeFilter((f) => ({ ...f, learned: !f.learned })),
+                linkActive: edgeFilter.link,
+                learnedActive: edgeFilter.learned,
+              }
+            : {})}
         />
 
         {/* One pill for both hovers. Node hover and edge hover are mutually


### PR DESCRIPTION
## Summary
- Make the legend's Link/Learned rows interactive toggles that show/hide those edge kinds (only when both are present).
- Edge-hover respects the toggle; resets on assistant switch.

Part of plan: memory-graph-enhancements.md (PR 5 of 8)