### PR TITLE
fix(voice): harden the connect-card backwards-compat gate

### DIFF
--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -152,7 +152,7 @@ Each module owns one feature's old/new split. Current registry:
 | `default-provider-settings.ts`      | `0.10.8`                          | No default-provider marker UI in the Providers modal; status query never fires                           | "Default" tag + "Set as default" via `GET/PUT /v1/config/llm/default-provider`             |
 | `complete-profile-snapshots.ts`     | `0.10.8`                          | Blank profile fields live-inherit (deep merge); no snapshot copy in the editor                            | Blanks are baked at save time; editor shows the snapshot helper line                        |
 | `use-supports-redacted-credential-chips.ts` | `0.11.0`                  | Sentinel-shaped transcript text renders as plain text (daemon neither mints nor neutralizes sentinels)   | Assistant-message sentinels upgrade to redacted-credential reveal chips                     |
-| `use-supports-noninteractive-voice-turns.ts` | `0.10.10`                | Voice turns can raise `oauth_connect` surfaces mid-call; the voice room renders its own reachable connect card | Voice turns force `supportsDynamicUi: false` (no mid-call surfaces); the room card stays hidden |
+| `use-supports-noninteractive-voice-turns.ts` | `0.11.0`                 | Voice turns can raise `oauth_connect` surfaces mid-call; the voice room renders its own reachable connect card | Voice turns force `supportsDynamicUi: false` (no mid-call surfaces); the room card stays hidden |
 
 When you delete a row here, also delete its module, its test, and the now-dead
 legacy branch at the call site.

--- a/clients/web/src/domains/chat/voice/voice-room/use-active-connect-surface.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-active-connect-surface.ts
@@ -2,6 +2,11 @@
  * Selects the active (not completed, not dismissed) `oauth_connect` surface
  * from the live transcript, for rendering inside the voice room.
  *
+ * Backwards-compat fallback: only assistants that can still raise
+ * `oauth_connect` mid-call need the room's copy of the card — see
+ * `lib/backwards-compat/use-supports-noninteractive-voice-turns.ts` (the
+ * canonical writeup); delete this module together with that gate.
+ *
  * The voice room is a `fixed inset-0 z-50` modal over a blurred, pointer-events
  * disabled transcript, so an `oauth_connect` card attached to a transcript
  * message is invisible and unclickable during a live session — the user can
@@ -45,12 +50,20 @@ function findActiveConnectSurface(
 /**
  * The active pending `oauth_connect` surface to render in the voice room, or
  * `null` when the assistant hasn't asked to connect anything.
+ *
+ * `enabled: false` short-circuits the selector to `null` without scanning the
+ * transcript — the chat session store updates on every streaming token during
+ * a call, so a gated room must not pay the reverse messages×surfaces scan per
+ * update just to discard the result. The flag keeps the hook unconditionally
+ * callable (rules of hooks) while making the disabled path free.
  */
-export function useActiveConnectSurface(): Surface | null {
+export function useActiveConnectSurface(enabled: boolean): Surface | null {
   return useChatSessionStore((state) =>
-    findActiveConnectSurface(
-      state.snapshot?.messages ?? [],
-      state.dismissedSurfaceIds,
-    ),
+    enabled
+      ? findActiveConnectSurface(
+          state.snapshot?.messages ?? [],
+          state.dismissedSurfaceIds,
+        )
+      : null,
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -237,11 +237,11 @@ afterEach(() => {
 
 const connectCard = () => screen.queryByTestId("room-connect-card");
 
-// The card is a backwards-compat fallback: only assistants below the
-// non-interactive-voice gate's MIN_VERSION can still raise `oauth_connect`
-// surfaces mid-call. The suite runs with the version unknown (cleared in
-// `beforeEach`), which the gate conservatively reads as "legacy" — the card
-// stays reachable exactly as it would against an old assistant.
+// Backwards-compat fallback card — see
+// use-supports-noninteractive-voice-turns.ts for the canonical writeup. The
+// suite runs with the identity cleared in `beforeEach`, which the gate
+// conservatively reads as "legacy" — the card stays reachable exactly as it
+// would against an old assistant.
 describe("VoiceRoom — OAuth connect card (backwards-compat fallback)", () => {
   test("renders a reachable connect card when a pending oauth_connect surface exists (version unknown)", () => {
     startOwnedSession("listening");
@@ -256,7 +256,9 @@ describe("VoiceRoom — OAuth connect card (backwards-compat fallback)", () => {
   });
 
   test("renders the card for a legacy assistant below the non-interactive gate", () => {
-    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.8");
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("test-asst", "0.10.8", ASSISTANT_ID);
     startOwnedSession("listening");
     seedTranscriptSurface(connectSurface("surface-oauth-1", "google"));
     render(<VoiceRoom />);
@@ -269,11 +271,24 @@ describe("VoiceRoom — OAuth connect card (backwards-compat fallback)", () => {
     // stays hidden even if a stale pending surface lingers in the snapshot.
     useAssistantIdentityStore
       .getState()
-      .setIdentity("test-asst", NONINTERACTIVE_VOICE_MIN_VERSION);
+      .setIdentity("test-asst", NONINTERACTIVE_VOICE_MIN_VERSION, ASSISTANT_ID);
     startOwnedSession("listening");
     seedTranscriptSurface(connectSurface("surface-oauth-1", "google"));
     render(<VoiceRoom />);
     expect(connectCard()).toBeNull();
+  });
+
+  test("keeps the card when the hydrated version belongs to a different assistant", () => {
+    // Identity switch/re-hydration mid-call: another assistant's version
+    // must not vouch for this session's assistant — the gate scopes to the
+    // session owner and conservatively keeps the fallback reachable.
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("test-asst", NONINTERACTIVE_VOICE_MIN_VERSION, "asst-other");
+    startOwnedSession("listening");
+    seedTranscriptSurface(connectSurface("surface-oauth-1", "google"));
+    render(<VoiceRoom />);
+    expect(connectCard()).not.toBeNull();
   });
 
   test("routes the card action to handleSurfaceAction", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -167,19 +167,12 @@ function VoiceRoomOverlay() {
   const showAssistantTranscript =
     useVoicePrefsStore.use.showAssistantTranscript();
 
-  // Backwards-compat fallback (delete with the gate): assistants below the
-  // gate's MIN_VERSION can still raise `oauth_connect` surfaces mid-call,
-  // and the transcript's copy is buried behind this modal — so the room
-  // renders its own reachable instance; completing it resumes the turn as a
-  // spoken reply (JARVIS-1287). Assistants at or above MIN_VERSION force
-  // `supportsDynamicUi: false` on voice turns and can never raise one, so
-  // the card stays hidden. Unknown version reads as "not supported", which
-  // conservatively keeps the fallback card available.
-  const voiceTurnsAreNoninteractive = useSupportsNoninteractiveVoiceTurns();
-  const activeConnectSurface = useActiveConnectSurface();
-  const connectSurface = voiceTurnsAreNoninteractive
-    ? null
-    : activeConnectSurface;
+  // Backwards-compat fallback for assistants that can still raise
+  // `oauth_connect` mid-call — see use-supports-noninteractive-voice-turns.ts
+  // (the canonical writeup); delete with the gate.
+  const voiceTurnsAreNoninteractive =
+    useSupportsNoninteractiveVoiceTurns(assistantId);
+  const connectSurface = useActiveConnectSurface(!voiceTurnsAreNoninteractive);
 
   // Resolve the assistant's look: color-with-eyes for character avatars, the
   // ambient void otherwise. The accent var is still published for the
@@ -299,15 +292,9 @@ function VoiceRoomOverlay() {
           avatar and stays absent by default. */}
       <VoiceAmbientTranscript />
 
-      {/* Backwards-compat fallback: a reachable OAuth connect card, rendered
-          only against assistants old enough to still raise `oauth_connect`
-          mid-call (`connectSurface` is pre-nulled by the version gate above).
-          The room takes over the whole app, so the transcript's copy of this
-          surface is invisible/unclickable underneath — render our own,
-          anchored in the lower center above the session controls, with pointer
-          events re-enabled just for the card. Completing it submits the same
-          surface action the transcript would, which the daemon resumes as a
-          spoken turn (JARVIS-1287). Delete this slot with the gate. */}
+      {/* Backwards-compat fallback card for assistants that can still raise
+          `oauth_connect` mid-call — see use-supports-noninteractive-voice-turns.ts;
+          delete this slot with the gate. */}
       <AnimatePresence>
         {connectSurface ? (
           <motion.div

--- a/clients/web/src/lib/backwards-compat/use-supports-noninteractive-voice-turns.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-noninteractive-voice-turns.test.ts
@@ -4,11 +4,20 @@ import { cleanup, renderHook } from "@testing-library/react";
 import { useSupportsNoninteractiveVoiceTurns } from "@/lib/backwards-compat/use-supports-noninteractive-voice-turns";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
+const SESSION_ASSISTANT_ID = "asst-session";
+
 /** Read the gate synchronously through the exported hook. */
-function readGate(version: string | null): boolean {
-  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
-  return renderHook(() => useSupportsNoninteractiveVoiceTurns()).result
-    .current;
+function readGate(
+  version: string | null,
+  sessionAssistantId: string | null | undefined = SESSION_ASSISTANT_ID,
+  identityAssistantId: string | null = SESSION_ASSISTANT_ID,
+): boolean {
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("test-asst", version, identityAssistantId);
+  return renderHook(() =>
+    useSupportsNoninteractiveVoiceTurns(sessionAssistantId),
+  ).result.current;
 }
 
 beforeEach(() => {
@@ -21,33 +30,57 @@ afterEach(() => {
 });
 
 // Exhaustive semver truth-table lives in `utils.test.ts`. Here we verify the
-// boundary on each side of MIN_VERSION (0.10.10 — the first release that can
-// force `supportsDynamicUi: false` on voice turns; v0.10.9 shipped without it)
-// plus the conservative-on-unknown policy, exercised through the public hook.
-// `false` means the voice room keeps its fallback OAuth connect card reachable.
+// boundary on each side of MIN_VERSION (0.11.0 — the first release guaranteed
+// to force `supportsDynamicUi: false` on voice turns), the conservative-on-
+// unknown policy, and the session-assistant scoping, exercised through the
+// public hook. `false` means the voice room keeps its fallback OAuth connect
+// card reachable.
 describe("useSupportsNoninteractiveVoiceTurns", () => {
   test("reads false when the version is unknown (fallback card stays available)", () => {
     expect(readGate(null)).toBe(false);
   });
 
-  test("reads false below 0.10.10 — those assistants can still raise oauth_connect mid-call", () => {
+  test("reads false below 0.11.0 — those assistants may still raise oauth_connect mid-call", () => {
+    expect(readGate("0.10.10")).toBe(false);
     expect(readGate("0.10.9")).toBe(false);
-    expect(readGate("0.10.8")).toBe(false);
     expect(readGate("0.9.0")).toBe(false);
   });
 
-  test("reads true for assistants on 0.10.10+", () => {
-    expect(readGate("0.10.10")).toBe(true);
+  test("reads true for assistants on 0.11.0+", () => {
     expect(readGate("0.11.0")).toBe(true);
+    expect(readGate("0.11.1")).toBe(true);
     expect(readGate("1.0.0")).toBe(true);
   });
 
-  test("reads true for dev builds on the 0.10.10 base", () => {
-    expect(readGate("0.10.10-dev.202607150000.abc1234")).toBe(true);
+  test("reads true for dev builds on the 0.11.0 base", () => {
+    expect(readGate("0.11.0-dev.202607150000.abc1234")).toBe(true);
   });
 
   test("reads false for unparseable versions", () => {
     expect(readGate("garbage")).toBe(false);
     expect(readGate("0.11")).toBe(false);
+  });
+
+  test("reads false when the identity version belongs to a different assistant", () => {
+    // An identity switch/re-hydration mid-call: the hydrated version no
+    // longer describes the assistant that owns the voice session, so it
+    // must not hide that session's fallback card.
+    expect(readGate("0.11.0", SESSION_ASSISTANT_ID, "asst-other")).toBe(false);
+  });
+
+  test("reads false when the session has no assistant resolved", () => {
+    expect(readGate("0.11.0", null)).toBe(false);
+    // Passed explicitly (a default parameter would swallow `undefined`).
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("test-asst", "0.11.0", SESSION_ASSISTANT_ID);
+    const { result } = renderHook(() =>
+      useSupportsNoninteractiveVoiceTurns(undefined),
+    );
+    expect(result.current).toBe(false);
+  });
+
+  test("reads false when the identity store has no owner recorded", () => {
+    expect(readGate("0.11.0", SESSION_ASSISTANT_ID, null)).toBe(false);
   });
 });

--- a/clients/web/src/lib/backwards-compat/use-supports-noninteractive-voice-turns.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-noninteractive-voice-turns.ts
@@ -1,6 +1,10 @@
 /**
  * Backwards-compat gate: non-interactive voice turns.
  *
+ * This is the canonical writeup for the voice room's fallback OAuth
+ * connect card — the hook site and card slot in `voice-room.tsx` and the
+ * suite in `voice-room.test.tsx` point back here.
+ *
  * Voice calls are non-interactive: the daemon forces
  * `supportsDynamicUi: false` on voice turns, so the assistant can no
  * longer raise interactive UI surfaces (e.g. `oauth_connect`) mid-call —
@@ -21,37 +25,68 @@
  * - New behavior (>= MIN_VERSION): voice turns can never raise UI
  *   surfaces; the room card is dead weight and stays hidden.
  *
- * MIN_VERSION is 0.10.10 — the first release that can ship the
- * daemon-side `supportsDynamicUi: false` enforcement on voice turns
- * (v0.10.9 was cut 2026-07-14, before that change merged, so 0.10.9
- * assistants still raise surfaces mid-call). If the next cut is a minor
- * (0.11.0) instead of a patch, the semver comparison still passes.
- * Erring HIGH is safe here: the fallback card self-hides when no
- * pending surface exists, so showing the fallback slot against a newer
- * assistant that never raises one costs nothing; erring LOW would hide
- * the card from assistants that can still raise it mid-call.
+ * MIN_VERSION is 0.11.0. v0.10.9 was released 2026-07-14 without the
+ * daemon-side `supportsDynamicUi: false` enforcement, and a later 0.10.x
+ * patch could be cut without it too; 0.11.0 is the first release
+ * GUARANTEED to contain it (the other in-flight gates in this directory
+ * pin the same 0.11.0). The asymmetry makes erring HIGH free: if the
+ * enforcement happens to ship in an earlier patch, the only cost is the
+ * fallback card remaining available for that patch's assistants — it
+ * self-hides whenever no pending surface exists, and such an assistant
+ * never raises one mid-call. Gating LOWER would risk hiding the card
+ * from assistants that can still raise surfaces mid-call — the exact
+ * stall the card exists to prevent.
+ *
+ * The gate is scoped to the assistant that owns the live voice session:
+ * the identity store records which assistant its version was fetched for
+ * (written atomically with the version in the same store update), and
+ * the gate reads `true` only when that owner is the session's assistant.
+ * A mismatch — e.g. the identity store re-hydrating for a different
+ * assistant mid-call — conservatively reads as "not supported", keeping
+ * the fallback card available.
+ *
+ * Accepted edge: an assistant at or above MIN_VERSION can still raise an
+ * `oauth_connect` surface in a TEXT turn just before the call starts,
+ * and the gate hides the room's copy of that card too. Intended: with
+ * the surface voice-resume machinery gone, completing it mid-call would
+ * produce an unspoken text-path reply, and the transcript's own card is
+ * reachable again the moment the call ends.
  *
  * Delete this gate — along with the voice-room connect card
  * (`use-active-connect-surface.ts` and the card slot in
  * `voice-room.tsx`) — once the minimum supported assistant is
  * >= MIN_VERSION.
  */
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
 import { useAssistantSupports } from "./utils";
 
-export const MIN_VERSION = "0.10.10";
+export const MIN_VERSION = "0.11.0";
 
 /**
- * Returns `true` when the active assistant enforces non-interactive
- * voice turns (it can no longer raise `oauth_connect` or other UI
- * surfaces mid-call), so the voice room's fallback connect card can stay
- * hidden.
+ * Returns `true` when the assistant that owns the live voice session
+ * (`sessionAssistantId`) enforces non-interactive voice turns (it can no
+ * longer raise `oauth_connect` or other UI surfaces mid-call), so the
+ * voice room's fallback connect card can stay hidden. Both the version
+ * and its owner are read from the identity store — a single atomic
+ * snapshot — so the version can never be checked against a different
+ * assistant's session, even transiently during an assistant switch.
  *
- * Returns `false` while the identity store has no version yet, when the
- * version is unparseable, or when it falls below `MIN_VERSION` — on the
- * `false` branch the room keeps rendering the reachable connect card,
- * which any assistant understands (it self-hides with no pending
- * surface).
+ * Returns `false` when the session's assistant is null/undefined, when
+ * the identity store's version was fetched for a different assistant,
+ * while no version has hydrated yet, when the version is unparseable, or
+ * when it falls below `MIN_VERSION` — on the `false` branch the room
+ * keeps rendering the reachable connect card, which any assistant
+ * understands (it self-hides with no pending surface).
  */
-export function useSupportsNoninteractiveVoiceTurns(): boolean {
-  return useAssistantSupports(MIN_VERSION);
+export function useSupportsNoninteractiveVoiceTurns(
+  sessionAssistantId: string | null | undefined,
+): boolean {
+  const identityAssistantId = useAssistantIdentityStore.use.assistantId();
+  const versionSupported = useAssistantSupports(MIN_VERSION);
+  return (
+    versionSupported &&
+    sessionAssistantId != null &&
+    sessionAssistantId === identityAssistantId
+  );
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-noninteractive.md.

- MIN_VERSION 0.11.0 — first release guaranteed to contain the daemon-side voice gate; erring high is free (card self-hides), erring low reintroduces the mid-call OAuth stall
- Gate scoped to the voice session's assistant (mismatch/unknown → conservative fallback), addressing the outstanding Codex P2 on #38161
- `useActiveConnectSurface(enabled)` short-circuits so gated sessions stop scanning the transcript per store update
- Single canonical compat writeup in the gate module; pointers elsewhere; pre-call text-raised-surface case documented