### PR TITLE
fix(voice): order confirmation broadcasts before auto-resolution; clarify deny copy and interceptor structure

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -36,7 +36,10 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import {
+  assistantEventHub,
+  broadcastMessage,
+} from "../runtime/assistant-event-hub.js";
 
 await initializeDb();
 
@@ -482,8 +485,10 @@ describe("voice-session-bridge", () => {
       assistantMessageChannel: "vellum",
       userMessageInterface: "macos",
       assistantMessageInterface: "macos",
-      voiceControlPrompt:
-        "You are speaking in a local live voice session. Keep replies brief and conversational.",
+      // Synthetic fixture — this test only asserts pass-through of a
+      // caller-supplied prompt, not the production live-voice prompt (that
+      // string is pinned in live-voice-events.test.ts).
+      voiceControlPrompt: "test control prompt",
       content: "Hello from local live voice",
       isInbound: true,
       callbacks: {
@@ -502,9 +507,7 @@ describe("voice-session-bridge", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(capturedVoiceSessionId).toBe("live-voice-session-1");
-    expect(capturedPrompts[0]).toBe(
-      "You are speaking in a local live voice session. Keep replies brief and conversational.",
-    );
+    expect(capturedPrompts[0]).toBe("test control prompt");
     expect(textDeltaEvents).toEqual([events[0]]);
     expect(completeEvents).toEqual([events[1]]);
     expect(persistedAssistantMessageId).toBe("assistant-msg-1");
@@ -761,6 +764,95 @@ describe("voice-session-bridge", () => {
     expect(handleConfirmationCalls[0].decision).toBe("deny");
     expect(handleConfirmationCalls[0].decisionContext).toContain("voice call");
     expect(handleConfirmationCalls[0].decisionContext).toContain("host_bash");
+    // Phone callers get the guardian-access framing, not the local-session
+    // could-not-verify copy.
+    expect(handleConfirmationCalls[0].decisionContext).toContain(
+      "requires guardian-level access",
+    );
+  });
+
+  test("auto-denies with could-not-verify copy for local live-voice (vellum) turns", async () => {
+    const conversation = createConversation(
+      "voice bridge auto-deny vellum copy test",
+    );
+
+    let clientHandler: (msg: ServerMessage) => void = () => {};
+    const handleConfirmationCalls: Array<{
+      requestId: string;
+      decision: string;
+      decisionContext?: string;
+    }> = [];
+
+    const session = {
+      isProcessing: () => false,
+      persistUserMessage: async () => ({
+        id: "test-msg-id",
+        deduplicated: false,
+      }),
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setTrustContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      setVoiceCallControlPrompt: () => {},
+      updateClient: (handler: (msg: ServerMessage) => void) => {
+        clientHandler = handler;
+      },
+      ensureActorScopedHistory: async () => {},
+      runAgentLoop: async () => {
+        clientHandler({
+          type: "confirmation_request",
+          requestId: "req-voice-vellum",
+          toolName: "host_bash",
+          input: { command: "touch /tmp/x" },
+          riskLevel: "medium",
+          allowlistOptions: [],
+          scopeOptions: [],
+        } as ServerMessage);
+      },
+      handleConfirmationResponse: (
+        requestId: string,
+        decision: string,
+        options?: { decisionContext?: string },
+      ) => {
+        handleConfirmationCalls.push({
+          requestId,
+          decision,
+          decisionContext: options?.decisionContext,
+        });
+      },
+      abort: () => {},
+    } as unknown as Conversation;
+
+    injectDeps(() => session);
+
+    // No trustContext: the local session's guardian trust could not be
+    // resolved (fresh install, gateway unreachable). The turn is still the
+    // device owner's own client, so the deny copy must say verification
+    // failed rather than implying they lack guardian access.
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      userMessageChannel: "vellum",
+      userMessageInterface: "macos",
+      content: "run a command",
+      isInbound: true,
+      onTextDelta: () => {},
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(handleConfirmationCalls.length).toBe(1);
+    expect(handleConfirmationCalls[0].decision).toBe("deny");
+    expect(handleConfirmationCalls[0].decisionContext).toContain(
+      "could not be verified for this voice session",
+    );
+    expect(handleConfirmationCalls[0].decisionContext).toContain("text chat");
+    expect(handleConfirmationCalls[0].decisionContext).not.toContain(
+      "requires guardian-level access",
+    );
   });
 
   test("auto-denies confirmation requests for unverified_channel voice turns", async () => {
@@ -962,6 +1054,150 @@ describe("voice-session-bridge", () => {
     expect(handleConfirmationCalls.length).toBe(1);
     expect(handleConfirmationCalls[0].requestId).toBe("req-voice-3");
     expect(handleConfirmationCalls[0].decision).toBe("allow");
+  });
+
+  // Resolving a confirmation synchronously broadcasts `interaction_resolved`
+  // (handleConfirmationResponse → prompter → pending-interactions), and
+  // clients clear their approval card only on that event. The bridge must
+  // therefore broadcast the `confirmation_request` BEFORE resolving it —
+  // the reverse wire order leaves an orphaned, un-clearable card in any
+  // attached UI (e.g. the web app behind a live-voice room). The fake's
+  // handleConfirmationResponse mirrors the production broadcast so the wire
+  // order is observable through the event hub, which serializes publishes
+  // in call order.
+  function makeConfirmationOrderingSession(
+    conversationId: string,
+    requestId: string,
+  ): Conversation {
+    let clientHandler: (msg: ServerMessage) => void = () => {};
+    return {
+      isProcessing: () => false,
+      persistUserMessage: async () => ({
+        id: "test-msg-id",
+        deduplicated: false,
+      }),
+      setChannelCapabilities: () => {},
+      setAssistantId: () => {},
+      setTrustContext: () => {},
+      setCommandIntent: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      setVoiceCallControlPrompt: () => {},
+      updateClient: (handler: (msg: ServerMessage) => void) => {
+        clientHandler = handler;
+      },
+      ensureActorScopedHistory: async () => {},
+      runAgentLoop: async () => {
+        clientHandler({
+          type: "confirmation_request",
+          requestId,
+          toolName: "host_bash",
+          input: { command: "ls" },
+          riskLevel: "low",
+          allowlistOptions: [],
+          scopeOptions: [],
+          conversationId,
+        } as ServerMessage);
+      },
+      handleConfirmationResponse: (resolvedRequestId: string) => {
+        broadcastMessage({
+          type: "interaction_resolved",
+          requestId: resolvedRequestId,
+          conversationId,
+          kind: "confirmation",
+          state: "approved",
+        } as ServerMessage);
+      },
+      abort: () => {},
+    } as unknown as Conversation;
+  }
+
+  async function collectConfirmationWireOrder(
+    conversationId: string,
+    turn: () => Promise<unknown>,
+  ): Promise<{ requestIndex: number; resolvedIndex: number }> {
+    const published: ServerMessage[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      filter: { conversationId },
+      callback: (event) => {
+        published.push(event.message);
+      },
+    });
+    try {
+      await turn();
+      await new Promise((r) => setTimeout(r, 50));
+    } finally {
+      subscription.dispose();
+    }
+    return {
+      requestIndex: published.findIndex(
+        (m) => m.type === "confirmation_request",
+      ),
+      resolvedIndex: published.findIndex(
+        (m) => m.type === "interaction_resolved",
+      ),
+    };
+  }
+
+  test("broadcasts the confirmation_request before auto-allowing it (guardian)", async () => {
+    const conversation = createConversation(
+      "voice bridge confirmation order allow test",
+    );
+    injectDeps(() =>
+      makeConfirmationOrderingSession(conversation.id, "req-order-allow"),
+    );
+
+    const { requestIndex, resolvedIndex } = await collectConfirmationWireOrder(
+      conversation.id,
+      () =>
+        startVoiceTurn({
+          conversationId: conversation.id,
+          content: "List files",
+          isInbound: true,
+          trustContext: {
+            sourceChannel: "phone",
+            trustClass: "guardian",
+            guardianExternalUserId: "+15555550100",
+            guardianChatId: "+15555550100",
+          },
+          onTextDelta: () => {},
+          onComplete: () => {},
+          onError: () => {},
+        }),
+    );
+
+    expect(requestIndex).toBeGreaterThanOrEqual(0);
+    expect(resolvedIndex).toBeGreaterThan(requestIndex);
+  });
+
+  test("broadcasts the confirmation_request before auto-denying it (non-guardian)", async () => {
+    const conversation = createConversation(
+      "voice bridge confirmation order deny test",
+    );
+    injectDeps(() =>
+      makeConfirmationOrderingSession(conversation.id, "req-order-deny"),
+    );
+
+    const { requestIndex, resolvedIndex } = await collectConfirmationWireOrder(
+      conversation.id,
+      () =>
+        startVoiceTurn({
+          conversationId: conversation.id,
+          content: "List files",
+          isInbound: true,
+          trustContext: {
+            sourceChannel: "phone",
+            trustClass: "trusted_contact",
+          },
+          onTextDelta: () => {},
+          onComplete: () => {},
+          onError: () => {},
+        }),
+    );
+
+    expect(requestIndex).toBeGreaterThanOrEqual(0);
+    expect(resolvedIndex).toBeGreaterThan(requestIndex);
   });
 
   test("auto-resolves secret requests for voice turns (no secret-entry UI)", async () => {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -826,12 +826,18 @@ export async function startVoiceTurn(
 
   // Hook into conversation to intercept confirmation_request and secret_request events.
   // Voice auto-denies/auto-allows/auto-resolves these since there's no interactive UI.
-  const autoDeny = !isGuardian;
-  const autoAllow = isGuardian;
   let lastError: string | null = null;
   conversation.updateClient(async (msg: ServerMessage) => {
     if (msg.type === "confirmation_request") {
-      if (autoDeny) {
+      // Broadcast the request BEFORE resolving it: resolution synchronously
+      // broadcasts `interaction_resolved` (handleConfirmationResponse →
+      // prompter → pending-interactions), and attached clients (e.g. the
+      // web app behind a live-voice room) clear their approval card only on
+      // that event — resolving first would put `interaction_resolved`
+      // before `confirmation_request` on the wire, leaving an orphaned card
+      // whose Allow/Deny buttons 404.
+      broadcastMessage(msg);
+      if (!isGuardian) {
         // Non-guardian voice callers have no interactive approval UI.
         // The pre-exec gate (tool-approval-handler.ts) handles grant
         // consumption with retry for tool execution confirmations, but
@@ -872,7 +878,6 @@ export async function startVoiceTurn(
             conversation.handleConfirmationResponse(msg.requestId, "allow", {
               decisionContext: `Permission approved for "${msg.toolName}": guardian pre-approved via scoped grant.`,
             });
-            broadcastMessage(msg);
             return;
           }
         } catch (err) {
@@ -886,25 +891,34 @@ export async function startVoiceTurn(
           { turnId, toolName: msg.toolName },
           "Auto-denying confirmation request for non-guardian voice turn (no matching scoped grant)",
         );
+        // A local live-voice session (vellum channel) belongs to the device
+        // owner's own authenticated client, so a non-guardian turn there
+        // means guardian trust could not be resolved (fresh install,
+        // gateway unreachable) — tell the model verification failed rather
+        // than implying the owner lacks guardian access.
         conversation.handleConfirmationResponse(msg.requestId, "deny", {
-          decisionContext: `Permission denied for "${msg.toolName}": this voice call does not have interactive approval capabilities. Side-effect tools are not available for non-guardian voice callers. In your next assistant reply, explain briefly that this action requires guardian-level access and cannot be performed during this call.`,
+          decisionContext:
+            turnChannelContext.userMessageChannel === "vellum"
+              ? `Permission denied for "${msg.toolName}": the caller's permissions could not be verified for this voice session, so side-effect tools are unavailable. In your next assistant reply, briefly say you could not verify permissions for this action right now and suggest retrying or completing it in text chat.`
+              : `Permission denied for "${msg.toolName}": this voice call does not have interactive approval capabilities. Side-effect tools are not available for non-guardian voice callers. In your next assistant reply, explain briefly that this action requires guardian-level access and cannot be performed during this call.`,
         });
-        broadcastMessage(msg);
         return;
       }
-      if (autoAllow) {
-        log.info(
-          { turnId, toolName: msg.toolName },
-          "Auto-approving confirmation request for guardian voice turn",
-        );
-        conversation.handleConfirmationResponse(msg.requestId, "allow", {
-          decisionContext: `Permission approved for "${msg.toolName}": this is a verified guardian voice call.`,
-        });
-        broadcastMessage(msg);
-        return;
-      }
-    } else if (msg.type === "secret_request") {
-      // Voice calls have no secret-entry UI, so resolve immediately.
+      log.info(
+        { turnId, toolName: msg.toolName },
+        "Auto-approving confirmation request for guardian voice turn",
+      );
+      conversation.handleConfirmationResponse(msg.requestId, "allow", {
+        decisionContext: `Permission approved for "${msg.toolName}": this is a verified guardian voice call.`,
+      });
+      return;
+    }
+    if (msg.type === "secret_request") {
+      // Defense-in-depth: SecretPrompter.prompt fails fast with
+      // `unsupported_channel` on voice turns (supportsDynamicUi is forced
+      // off above), so a secret_request should never reach this handler.
+      // Resolve immediately anyway in case an emitter bypasses the
+      // prompter's channel check or races a capability install.
       log.info(
         { turnId, service: msg.service, field: msg.field },
         "Auto-resolving secret request for voice turn (no secret-entry UI)",

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -250,6 +250,10 @@ describe("LiveVoiceSession archive and metrics events", () => {
       assistantMessageChannel: "vellum",
       userMessageInterface: "macos",
       assistantMessageInterface: "macos",
+      // Pins the full production control prompt, including the no-UI rule
+      // (voice turns are non-interactive — everything is conveyed in speech).
+      voiceControlPrompt:
+        "You are speaking in a local live voice session. Keep replies brief and conversational. You cannot display cards, forms, or any on-screen UI during the call — convey everything in speech.",
     });
     callbacks?.assistant_text_delta?.(makeTextDelta("Hello there."));
     callbacks?.message_complete?.(makeMessageComplete());


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-noninteractive.md.

- Broadcast `confirmation_request` before auto-resolving so the web client's approval card clears via `interaction_resolved` (was orphaned + un-clearable during live-voice)
- Distinct auto-deny copy when a local voice session's guardian trust can't be verified (was misleading 'requires guardian-level access' for the device owner)
- Collapse the complementary autoDeny/autoAllow flags; mark the secret_request auto-resolve branch as defense-in-depth
- Pin the extended voice control prompt in tests; replace a stale prompt literal with a synthetic fixture