### PR TITLE
docs(plugin-builder): document Apps as a plugin surface

### DIFF
--- a/skills/plugin-builder/SKILL.md
+++ b/skills/plugin-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-builder
-description: "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles hooks, tools, skills, and routes into one installable package."
+description: "Use when the user wants to build, scaffold, ship, or edit a Vellum plugin that bundles hooks, tools, skills, routes, and apps into one installable package."
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🧩"
@@ -22,7 +22,7 @@ metadata:
 
 # Plugin Builder
 
-Build on top of Vellum with plugins. A plugin bundles hooks, tools, skills, and routes into a single installable package that extends what an assistant can do.
+Build on top of Vellum with plugins. A plugin bundles hooks, tools, skills, routes, and apps into a single installable package that extends what an assistant can do.
 
 Plugins are in beta. The peer-dep range you declare is what gets you load. Treat everything you write as something that can break between Vellum releases until 1.0 ships, and pin a real range.
 
@@ -46,6 +46,7 @@ A single plugin can contribute several different kinds of behavior. Each surface
 | [Skills](references/skills.md)             | `skills/<name>/`   | Directories of instructions and associated assets, scripts, and resources that the Assistant loads dynamically when relevant.    |
 | [Model-visible tools](references/tools.md) | `tools/<name>.ts`  | Add new tools the model can call. Plugin tools land in the same catalog as built-in tools.                                       |
 | [HTTP routes](references/routes.md)        | `routes/<path>.ts` | Serve HTTP endpoints (webhooks, integrations, callbacks) in the plugin's own `/x/plugins/<name>/` namespace.                     |
+| [Apps](references/apps.md)                 | `apps/<app>/`      | Ship persistent, interactive apps (dashboards, tools, games) served in the workspace panel, as single-file HTML or compiled multi-file React. |
 
 The two extensibility patterns serve different goals. **Plugins are for distribution**: you intend to share the capability, publish to the marketplace, or install it across multiple assistants. The plugin manifest (`package.json`), the `@vellumai/plugin-api` peer dependency, and the install flow exist to make a capability portable, versioned, and discoverable by others.
 
@@ -62,7 +63,7 @@ Vellum's plugin model was designed to line up with the agent harnesses you may a
 Ask before building. Six questions, in this order. Stop if the user is unclear on any of them.
 
 1. **What job does the plugin do?** One sentence, plain language. If you cannot write this, the plugin should not be built yet.
-2. **Which surfaces does it ship?** Tools (model calls), hooks (lifecycle transforms), skills (on-demand instructions), and routes (HTTP endpoints). Most plugins ship one or two, not all of them. See `references/plugins.md` for the directory layout and manifest, and the surface-specific references for each surface's contract.
+2. **Which surfaces does it ship?** Tools (model calls), hooks (lifecycle transforms), skills (on-demand instructions), routes (HTTP endpoints), and apps (interactive UI in the workspace panel). Most plugins ship one or two, not all of them. See `references/plugins.md` for the directory layout and manifest, and the surface-specific references for each surface's contract.
 3. **Does it need credentials?** An API key, OAuth token, or webhook secret is not a value that belongs in a `.ts` file. For LLM inference credentials, use `getConfiguredProvider()` from `@vellumai/plugin-api` to route through the workspace's stored credentials without handling plaintext. For other credential types (OAuth tokens, webhook secrets), store them via the credential vault and resolve at runtime through the assistant's credential system.
 4. **Does it keep state?** A plugin is fully self-contained: durable state lives in its `data/` directory (`InitContext.pluginStorageDir`), with schema created idempotently by the `init` hook, handles closed in `shutdown`, and per-conversation rows purged in `conversation-deleted`. A plugin never persists state in the assistant's database or elsewhere in the workspace. See "State is plugin-owned" in `references/plugins.md`.
 5. **Where will the source live?** A GitHub repo, ideally under the user's own namespace. The marketplace entry pins to a full commit SHA.
@@ -123,4 +124,5 @@ Once merged, users install by name: `assistant plugins install my-plugin`. The n
 - `references/tools.md`: Tool definition fields, the execute context, result shape, resolution order, and a tool anatomy example.
 - `references/skills.md`: Frontmatter reference, resolution order, and a skill anatomy example.
 - `references/routes.md`: The `/x/plugins/<name>/` namespace, path mapping, handler signature, and a route anatomy example.
+- `references/apps.md`: Single-file vs multi-file apps, the `plugins~<name>~<app>` id and `plugin:<name>` origin, serving and isolation, and an app anatomy example.
 - `references/distribution.md`: Marketplace catalog, CLI commands, drift and upgrades, the manifest schema, commit pinning, and adapters.

--- a/skills/plugin-builder/references/apps.md
+++ b/skills/plugin-builder/references/apps.md
@@ -1,0 +1,65 @@
+# Apps
+
+Ship a persistent, interactive app from a plugin — a dashboard, a game, a small tool — that renders in the workspace panel. Unlike a tool (which the model calls) or a route (which an external caller hits), an app is a piece of UI the user opens and interacts with directly, and it persists between opens.
+
+An app is a directory under `apps/<app>/`. Each immediate subdirectory of `apps/` is one app: its directory name is the app name and its contents are the source. Like every other surface, a missing `apps/` directory is simply skipped, so a plugin ships an app only if it wants to.
+
+## Two shapes
+
+The app's shape is chosen by what its directory contains.
+
+### Single-file apps
+
+The simplest app is a single `index.html` at the app root. No build step runs: the host serves that HTML directly, and its **inline** scripts are allowed to execute (the page is served with a Content-Security-Policy of `script-src 'self' 'unsafe-inline'`). Sibling files in the app directory (images, stylesheets) are served as assets next to it. Reach for this when the whole app fits in one hand-written HTML file.
+
+### Multi-file apps
+
+Anything without a root `index.html` is treated as a multi-file app: TSX/React source under `src/` that compiles to a sibling `dist/`. The bundler (esbuild) maps `react` / `react-dom` onto `preact/compat`, so you write ordinary React components. Compiled apps load external scripts from `dist/`, so they are served under a stricter CSP (`script-src 'self'` — no inline scripts).
+
+The compile happens off the daemon's hot path: the plugin source watcher builds each app's `src/` into its sibling `dist/` when it detects a change, and that generated `apps/<app>/dist` is excluded from source fingerprinting and drift detection (it is build output, not tracked source). If an app is opened before its `dist/` exists, it is compiled on demand in a throwaway temporary directory — the read-only plugin tree is never written to at open time.
+
+## How apps are addressed
+
+A plugin-bundled app has a deterministic id derived from its location, rather than the opaque UUID a user-created workspace app gets:
+
+```
+plugins~<plugin-name>~<app-dir>
+```
+
+which maps to `<workspaceDir>/plugins/<plugin-name>/apps/<app-dir>/` (the `apps/` segment is implied). The delimiter is `~`, a URL-unreserved character, so the whole id is a single URL path segment that survives route params and proxies without percent-encoding. When an app is opened, the host reports its origin as `plugin:<plugin-name>`, distinguishing it from a `workspace` app.
+
+## Serving and isolation
+
+An app is served only for an **installed, enabled** plugin: the plugin directory must exist, carry a `package.json` manifest, and not be disabled (no `.disabled` sentinel) — the same gates the plugin's other surfaces pass. Asset requests are confined to the app directory: a path that tries to traverse out of it (`../../package.json`) is rejected, and an id whose segments contain separators or `..` never resolves to a path.
+
+Because a compiled app loads external scripts under the stricter CSP while a single-file app may run inline scripts, keep untrusted or heavier logic in a multi-file app rather than inlining it.
+
+## Read-only apps
+
+A plugin app is part of the plugin's source tree, so it is read-only over the app-management surface: it can be opened and its assets served, but it cannot be deleted or have its data mutated through the management API the way a user-created workspace app can. Its lifecycle is the plugin's: it arrives on install, updates on upgrade, and is removed on uninstall. Any durable state the app needs follows the same rule as the rest of the plugin — it lives in the plugin's `data/` directory, owned by the plugin's lifecycle hooks, not written back into the app source.
+
+## Anatomy of an app
+
+A single-file app is one `index.html`; a multi-file app is a `src/` tree that compiles to `dist/`. A plugin can ship several apps side by side:
+
+```
+my-plugin/
+└── apps/
+    ├── dashboard/            # single-file app
+    │   ├── index.html        → served directly (inline scripts allowed)
+    │   └── logo.svg          → served as a sibling asset
+    └── board/                # multi-file app
+        ├── src/
+        │   ├── index.html
+        │   └── main.tsx       # React (preact/compat under the hood)
+        └── dist/              # generated build output (not tracked source)
+            ├── index.html
+            └── main.js
+```
+
+```tsx
+// apps/board/src/main.tsx
+import { render } from "preact";
+
+render(<div>Compiled Board</div>, document.getElementById("root")!);
+```

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -19,6 +19,10 @@ my-plugin/
 │   └── example.ts
 ├── routes/                    # HTTP routes, served under /x/plugins/<name>/
 │   └── status.ts
+├── apps/                      # Interactive apps served in the workspace panel
+│   └── dashboard/
+│       └── src/
+│           └── main.tsx
 ├── skills/                    # On-demand instruction bundles
 │   └── my-skill/
 │       └── SKILL.md
@@ -58,7 +62,7 @@ The assistant's own database is internal — `@vellumai/plugin-api` exposes no h
 
 Each surface can also be dropped straight into the workspace at `/workspace/<surface>/<name>/` without wrapping it in a plugin. A plugin is what lets you ship several surfaces together as one installable unit.
 
-The per-surface contracts live in their own references: [hooks.md](hooks.md), [tools.md](tools.md), [skills.md](skills.md), and [routes.md](routes.md).
+The per-surface contracts live in their own references: [hooks.md](hooks.md), [tools.md](tools.md), [skills.md](skills.md), [routes.md](routes.md), and [apps.md](apps.md).
 
 ## The manifest
 
@@ -120,7 +124,6 @@ The assistant supports these surfaces today, but they are not yet contributed th
 | Surface        | What it does                                                                                                  |
 | -------------- | ------------------------------------------------------------------------------------------------------------- |
 | Schedules      | Cron-style triggers that fire on a recurring schedule.                                                        |
-| Apps           | Persistent interactive apps (dashboards, games, tools) served in the workspace panel.                         |
 | Artifacts      | Versioned outputs the assistant produces and tracks (documents, diagrams, generated files).                   |
 | Webhooks       | Inbound HTTP endpoints that deliver external events into the assistant.                                       |
 | Prompts        | Reusable system prompt fragments and templates.                                                               |


### PR DESCRIPTION
## Why

The runtime already serves plugin-bundled **apps** — see `assistant/src/apps/app-store.ts` (the `plugins~<name>~<app>` id + `plugin:<name>` origin), `runtime/routes/app-routes.ts` / `app-management-routes.ts`, `monitoring/plugin-source-watch.ts` (the `apps/<app>/src` → `dist/` compile), and `plugin-app-serve-routes.test.ts`. But the plugin-builder skill still listed **Apps** under *"surfaces not yet available in plugins"* and omitted it from the surface table. Routes was already documented as a surface; apps was missed.

This brings the skill in line with the code, and keeps it in sync with the platform extensibility docs ([vellum-assistant-platform#9117](https://github.com/vellum-ai/vellum-assistant-platform/pull/9117), which documents the same surface for the public docs site).

## What changed

- **New `references/apps.md`** — single-file (root `index.html`, inline scripts, `unsafe-inline` CSP) vs multi-file (`src/` → compiled `dist/` via esbuild with `react`/`react-dom` aliased to `preact/compat`, stricter `script-src 'self'` CSP); the deterministic `plugins~<name>~<app>` id and `plugin:<name>` origin; install/enabled gates and asset-traversal isolation; read-only-over-management lifecycle; and an anatomy example.
- **`SKILL.md`** — added Apps to the surface table, the intro line + `description` frontmatter, the "which surfaces does it ship?" alignment question, and the reference-file list.
- **`references/plugins.md`** — added `apps/` (multi-file form) to the directory-layout tree, linked `apps.md` from the per-surface contracts line, and removed Apps from the "surfaces not yet available in plugins" table.

Docs-only; no code or behavior changes. Content verified against the runtime modules above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UefVtVSUGUXTh4EqmdsnoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UefVtVSUGUXTh4EqmdsnoQ)_