### PR TITLE
refactor(web): shared assistant-scoped compat-gate primitive

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -1056,15 +1056,12 @@ describe("voice-session-bridge", () => {
     expect(handleConfirmationCalls[0].decision).toBe("allow");
   });
 
-  // Resolving a confirmation synchronously broadcasts `interaction_resolved`
-  // (handleConfirmationResponse → prompter → pending-interactions), and
-  // clients clear their approval card only on that event. The bridge must
-  // therefore broadcast the `confirmation_request` BEFORE resolving it —
-  // the reverse wire order leaves an orphaned, un-clearable card in any
-  // attached UI (e.g. the web app behind a live-voice room). The fake's
-  // handleConfirmationResponse mirrors the production broadcast so the wire
-  // order is observable through the event hub, which serializes publishes
-  // in call order.
+  // Wire-order invariant under test: the bridge must broadcast the
+  // `confirmation_request` BEFORE resolving it — canonical rationale on the
+  // broadcast in voice-session-bridge.ts's confirmation_request branch. The
+  // fake's handleConfirmationResponse mirrors production's synchronous
+  // `interaction_resolved` broadcast so the wire order is observable through
+  // the event hub, which serializes publishes in call order.
   function makeConfirmationOrderingSession(
     conversationId: string,
     requestId: string,

--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -34,7 +34,7 @@ informing us of live clients in use so we can delete old cold paths incrementall
 | Module                                                 | Role                                                                                                                                                                                |
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/lib/backwards-compat/`                            | The centralized registry. One file per gated feature, each declaring its own `MIN_VERSION`. `grep` this path to find everything that can eventually be deleted.                     |
-| `src/lib/backwards-compat/utils.ts`                    | The shared gate primitives: `useAssistantSupports`, `assistantSupports`, `whenAssistantVersionKnown`. Every gate uses these so semver parsing and pre-release handling are uniform. |
+| `src/lib/backwards-compat/utils.ts`                    | The shared gate primitives: `useAssistantSupports`, `useAssistantScopedSupports`, `assistantSupports`, `whenAssistantVersionKnown`. Every gate uses these so semver parsing and pre-release handling are uniform. |
 | `src/utils/semver.ts`                                  | Low-level `parseSemver` / `compareParsed` / `comparePreRelease`. No app knowledge — just version-string math.                                                                       |
 | `src/stores/assistant-identity-store.ts`               | Zustand store holding the active assistant's `{ name, version }`. The source of truth every gate reads.                                                                             |
 | `src/assistant/identity.ts`                            | Fetches identity from the assistant's `/identity` endpoint and refreshes it on the SSE `identity_changed` event.                                                                    |
@@ -52,6 +52,14 @@ version off the identity store. Pick by call site:
 - **`assistantSupports(minVersion): boolean`** — the snapshot. Reads
   `getState().version` once. Safe outside React: event handlers, async
   ops, request builders.
+- **`useAssistantScopedSupports(minVersion, ownerAssistantId): boolean`** —
+  the assistant-scoped hook. Like `useAssistantSupports`, but additionally
+  requires the identity store's version to have been fetched for
+  `ownerAssistantId` (the assistant owning the gated surface — a
+  transcript, a live voice session), read as a single atomic snapshot.
+  Conservative `false` on any mismatch or unknown. Use when the gated
+  feature belongs to a specific assistant rather than "whichever assistant
+  is active."
 - **`whenAssistantVersionKnown(timeoutMs?): Promise<void>`** — resolves
   once the version is non-null (or after a 5 s timeout). Used by write
   paths before reading a snapshot gate; see [Read vs. write

--- a/clients/web/src/lib/backwards-compat/use-supports-noninteractive-voice-turns.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-noninteractive-voice-turns.test.ts
@@ -9,14 +9,13 @@ const SESSION_ASSISTANT_ID = "asst-session";
 /** Read the gate synchronously through the exported hook. */
 function readGate(
   version: string | null,
-  sessionAssistantId: string | null | undefined = SESSION_ASSISTANT_ID,
   identityAssistantId: string | null = SESSION_ASSISTANT_ID,
 ): boolean {
   useAssistantIdentityStore
     .getState()
     .setIdentity("test-asst", version, identityAssistantId);
   return renderHook(() =>
-    useSupportsNoninteractiveVoiceTurns(sessionAssistantId),
+    useSupportsNoninteractiveVoiceTurns(SESSION_ASSISTANT_ID),
   ).result.current;
 }
 
@@ -29,58 +28,25 @@ afterEach(() => {
   useAssistantIdentityStore.getState().clearIdentity();
 });
 
-// Exhaustive semver truth-table lives in `utils.test.ts`. Here we verify the
-// boundary on each side of MIN_VERSION (0.11.0 — the first release guaranteed
-// to force `supportsDynamicUi: false` on voice turns), the conservative-on-
-// unknown policy, and the session-assistant scoping, exercised through the
-// public hook. `false` means the voice room keeps its fallback OAuth connect
-// card reachable.
+// Semver semantics and the session-assistant scoping truth-table live in
+// `utils.test.ts` (`useAssistantSupports` / `useAssistantScopedSupports`).
+// Here we verify the boundary on each side of MIN_VERSION (0.11.0 — the
+// first release guaranteed to force `supportsDynamicUi: false` on voice
+// turns) plus one scoping smoke case, exercised through the public hook.
+// `false` means the voice room keeps its fallback OAuth connect card
+// reachable.
 describe("useSupportsNoninteractiveVoiceTurns", () => {
-  test("reads false when the version is unknown (fallback card stays available)", () => {
-    expect(readGate(null)).toBe(false);
-  });
-
   test("reads false below 0.11.0 — those assistants may still raise oauth_connect mid-call", () => {
     expect(readGate("0.10.10")).toBe(false);
     expect(readGate("0.10.9")).toBe(false);
-    expect(readGate("0.9.0")).toBe(false);
   });
 
   test("reads true for assistants on 0.11.0+", () => {
     expect(readGate("0.11.0")).toBe(true);
     expect(readGate("0.11.1")).toBe(true);
-    expect(readGate("1.0.0")).toBe(true);
-  });
-
-  test("reads true for dev builds on the 0.11.0 base", () => {
-    expect(readGate("0.11.0-dev.202607150000.abc1234")).toBe(true);
-  });
-
-  test("reads false for unparseable versions", () => {
-    expect(readGate("garbage")).toBe(false);
-    expect(readGate("0.11")).toBe(false);
   });
 
   test("reads false when the identity version belongs to a different assistant", () => {
-    // An identity switch/re-hydration mid-call: the hydrated version no
-    // longer describes the assistant that owns the voice session, so it
-    // must not hide that session's fallback card.
-    expect(readGate("0.11.0", SESSION_ASSISTANT_ID, "asst-other")).toBe(false);
-  });
-
-  test("reads false when the session has no assistant resolved", () => {
-    expect(readGate("0.11.0", null)).toBe(false);
-    // Passed explicitly (a default parameter would swallow `undefined`).
-    useAssistantIdentityStore
-      .getState()
-      .setIdentity("test-asst", "0.11.0", SESSION_ASSISTANT_ID);
-    const { result } = renderHook(() =>
-      useSupportsNoninteractiveVoiceTurns(undefined),
-    );
-    expect(result.current).toBe(false);
-  });
-
-  test("reads false when the identity store has no owner recorded", () => {
-    expect(readGate("0.11.0", SESSION_ASSISTANT_ID, null)).toBe(false);
+    expect(readGate("0.11.0", "asst-other")).toBe(false);
   });
 });

--- a/clients/web/src/lib/backwards-compat/use-supports-noninteractive-voice-turns.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-noninteractive-voice-turns.ts
@@ -37,13 +37,10 @@
  * from assistants that can still raise surfaces mid-call — the exact
  * stall the card exists to prevent.
  *
- * The gate is scoped to the assistant that owns the live voice session:
- * the identity store records which assistant its version was fetched for
- * (written atomically with the version in the same store update), and
- * the gate reads `true` only when that owner is the session's assistant.
- * A mismatch — e.g. the identity store re-hydrating for a different
- * assistant mid-call — conservatively reads as "not supported", keeping
- * the fallback card available.
+ * The gate is scoped to the assistant that owns the live voice session
+ * via `useAssistantScopedSupports` — see its JSDoc in `./utils.ts` for
+ * the atomic version+owner snapshot and conservative-on-mismatch
+ * semantics.
  *
  * Accepted edge: an assistant at or above MIN_VERSION can still raise an
  * `oauth_connect` surface in a TEXT turn just before the call starts,
@@ -57,9 +54,7 @@
  * `voice-room.tsx`) — once the minimum supported assistant is
  * >= MIN_VERSION.
  */
-import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-
-import { useAssistantSupports } from "./utils";
+import { useAssistantScopedSupports } from "./utils";
 
 export const MIN_VERSION = "0.11.0";
 
@@ -67,26 +62,15 @@ export const MIN_VERSION = "0.11.0";
  * Returns `true` when the assistant that owns the live voice session
  * (`sessionAssistantId`) enforces non-interactive voice turns (it can no
  * longer raise `oauth_connect` or other UI surfaces mid-call), so the
- * voice room's fallback connect card can stay hidden. Both the version
- * and its owner are read from the identity store — a single atomic
- * snapshot — so the version can never be checked against a different
- * assistant's session, even transiently during an assistant switch.
+ * voice room's fallback connect card can stay hidden.
  *
- * Returns `false` when the session's assistant is null/undefined, when
- * the identity store's version was fetched for a different assistant,
- * while no version has hydrated yet, when the version is unparseable, or
- * when it falls below `MIN_VERSION` — on the `false` branch the room
- * keeps rendering the reachable connect card, which any assistant
- * understands (it self-hides with no pending surface).
+ * On the `false` branch — below `MIN_VERSION`, or any of
+ * `useAssistantScopedSupports`'s conservative unknown/mismatch cases —
+ * the room keeps rendering the reachable connect card, which any
+ * assistant understands (it self-hides with no pending surface).
  */
 export function useSupportsNoninteractiveVoiceTurns(
   sessionAssistantId: string | null | undefined,
 ): boolean {
-  const identityAssistantId = useAssistantIdentityStore.use.assistantId();
-  const versionSupported = useAssistantSupports(MIN_VERSION);
-  return (
-    versionSupported &&
-    sessionAssistantId != null &&
-    sessionAssistantId === identityAssistantId
-  );
+  return useAssistantScopedSupports(MIN_VERSION, sessionAssistantId);
 }

--- a/clients/web/src/lib/backwards-compat/use-supports-redacted-credential-chips.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-redacted-credential-chips.test.ts
@@ -6,20 +6,15 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 const OWNER_ID = "asst-owner";
 
-function setIdentity(version: string | null, assistantId: string | null) {
-  useAssistantIdentityStore
-    .getState()
-    .setIdentity("test-asst", version, assistantId);
-}
-
 function check(
   version: string | null,
-  transcriptAssistantId: string | null | undefined = OWNER_ID,
   identityAssistantId: string | null = OWNER_ID,
 ): boolean {
-  setIdentity(version, identityAssistantId);
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("test-asst", version, identityAssistantId);
   const { result } = renderHook(() =>
-    useSupportsRedactedCredentialChips(transcriptAssistantId),
+    useSupportsRedactedCredentialChips(OWNER_ID),
   );
   return result.current;
 }
@@ -33,71 +28,24 @@ afterEach(() => {
   useAssistantIdentityStore.getState().clearIdentity();
 });
 
+// Semver semantics and the transcript-owner scoping truth-table live in
+// `utils.test.ts` (`useAssistantSupports` / `useAssistantScopedSupports`).
+// Here we verify the boundary on each side of MIN_VERSION (0.11.0 — the
+// release that ships daemon-side sentinel minting and neutralization) plus
+// one scoping smoke case, exercised through the public hook. `false` means
+// sentinel-shaped text renders as plain text.
 describe("useSupportsRedactedCredentialChips", () => {
-  test("returns false when the version is unknown", () => {
-    expect(check(null)).toBe(false);
-    expect(check("")).toBe(false);
-  });
-
-  test("returns true at exactly MIN_VERSION (0.11.0) for the identity owner's transcript", () => {
-    expect(check("0.11.0")).toBe(true);
-  });
-
-  test("returns true for dev builds ahead of MIN_VERSION", () => {
-    expect(check("0.11.0-dev.202607131200.abc1234")).toBe(true);
-  });
-
-  test("returns true for versions above MIN_VERSION", () => {
-    expect(check("0.11.1")).toBe(true);
-    expect(check("0.12.0")).toBe(true);
-    expect(check("1.0.0")).toBe(true);
-  });
-
   test("returns false for versions below MIN_VERSION", () => {
     expect(check("0.10.8")).toBe(false);
     expect(check("0.10.9")).toBe(false);
-    expect(check("0.9.0")).toBe(false);
   });
 
-  test("returns false for dev builds based below MIN_VERSION", () => {
-    expect(check("0.10.8-dev.202607131200.abc1234")).toBe(false);
-  });
-
-  test("returns false for unparseable versions", () => {
-    expect(check("not-a-version")).toBe(false);
-    expect(check("0.11")).toBe(false);
+  test("returns true at MIN_VERSION (0.11.0) and above for the identity owner's transcript", () => {
+    expect(check("0.11.0")).toBe(true);
+    expect(check("0.11.1")).toBe(true);
   });
 
   test("returns false when the identity version belongs to a different assistant", () => {
-    // The assistant-switch race: the previous assistant's supported
-    // version is still hydrated while the transcript now belongs to a
-    // new assistant whose identity hasn't loaded. The version must not
-    // validate the new owner's transcript.
-    expect(check("0.11.0", "asst-new-owner", "asst-previous")).toBe(false);
-  });
-
-  test("returns false when the transcript owner is null or undefined", () => {
-    expect(check("0.11.0", null)).toBe(false);
-    // Passed explicitly (a default parameter would swallow `undefined`).
-    setIdentity("0.11.0", OWNER_ID);
-    const { result } = renderHook(() =>
-      useSupportsRedactedCredentialChips(undefined),
-    );
-    expect(result.current).toBe(false);
-  });
-
-  test("returns false when the identity store has no owner recorded", () => {
-    expect(check("0.11.0", OWNER_ID, null)).toBe(false);
-  });
-
-  test("flips off the moment the identity is cleared for an assistant switch", () => {
-    setIdentity("0.11.0", OWNER_ID);
-    const { result, rerender } = renderHook(() =>
-      useSupportsRedactedCredentialChips(OWNER_ID),
-    );
-    expect(result.current).toBe(true);
-    useAssistantIdentityStore.getState().clearIdentity();
-    rerender();
-    expect(result.current).toBe(false);
+    expect(check("0.11.0", "asst-previous")).toBe(false);
   });
 });

--- a/clients/web/src/lib/backwards-compat/use-supports-redacted-credential-chips.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-redacted-credential-chips.ts
@@ -15,48 +15,29 @@
  * so there is nothing legitimate to render — keep chips off entirely until
  * the assistant that owns the transcript is known to neutralize.
  *
- * The gate is bound to the **transcript owner**: the identity store records
- * which assistant its version was fetched for (written atomically with the
- * version in the same store update), and chips enable only when that owner
- * is the transcript's owner. Comparing against the identity store's own
- * `assistantId` — rather than `activeAssistantId` from the
- * resolved-assistants store — keeps the check race-free on assistant
- * switch: the two stores update at different times, so a cross-store
- * pairing could briefly validate an old-daemon transcript against the
- * previous assistant's version. Conservative on unknown.
+ * The gate is bound to the **transcript owner** via
+ * `useAssistantScopedSupports` — see its JSDoc in `./utils.ts` for the
+ * atomic version+owner snapshot and conservative-on-mismatch semantics.
  *
  * MIN_VERSION targets 0.11.0 — the release that ships daemon-side sentinel
  * minting and neutralization. On the `false` branch callers leave sentinel
  * text as plain literal text.
  */
-import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-
-import { useAssistantSupports } from "./utils";
+import { useAssistantScopedSupports } from "./utils";
 
 export const MIN_VERSION = "0.11.0";
 
 /**
  * Returns `true` when the transcript owned by `transcriptAssistantId` may
  * upgrade sentinel text into reveal chips: the identity store's hydrated
- * version must belong to that same assistant and meet `MIN_VERSION`. Both
- * facts are read from the identity store — a single atomic snapshot — so
- * the version can never be checked against a different assistant's
- * transcript, even transiently during an assistant switch.
+ * version must belong to that same assistant and meet `MIN_VERSION`.
  *
- * Returns `false` when the owner is null/undefined, when the identity
- * store's version was fetched for a different assistant, while no version
- * has hydrated yet, when the version is unparseable, or when it falls
- * below `MIN_VERSION` — callers render sentinel-shaped text as plain text
- * on the `false` branch.
+ * On the `false` branch — below `MIN_VERSION`, or any of
+ * `useAssistantScopedSupports`'s conservative unknown/mismatch cases —
+ * callers render sentinel-shaped text as plain text.
  */
 export function useSupportsRedactedCredentialChips(
   transcriptAssistantId: string | null | undefined,
 ): boolean {
-  const identityAssistantId = useAssistantIdentityStore.use.assistantId();
-  const versionSupported = useAssistantSupports(MIN_VERSION);
-  return (
-    versionSupported &&
-    transcriptAssistantId != null &&
-    transcriptAssistantId === identityAssistantId
-  );
+  return useAssistantScopedSupports(MIN_VERSION, transcriptAssistantId);
 }

--- a/clients/web/src/lib/backwards-compat/utils.test.ts
+++ b/clients/web/src/lib/backwards-compat/utils.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
 import {
+  useAssistantScopedSupports,
   useAssistantSupports,
   whenAssistantVersionKnown,
 } from "@/lib/backwards-compat/utils";
@@ -90,6 +91,74 @@ describe("useAssistantSupports", () => {
     expect(check("0.10.0", "0.10.0-dev.202606211252.5cf8576")).toBe(false);
     // But 0.10.1 stable (next release) is ahead.
     expect(check("0.10.1", "0.10.0-dev.202606211252.5cf8576")).toBe(true);
+  });
+});
+
+describe("useAssistantScopedSupports", () => {
+  const OWNER_ID = "asst-owner";
+  const MIN = "0.11.0";
+
+  function setIdentity(version: string | null, assistantId: string | null) {
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("test-asst", version, assistantId);
+  }
+
+  function checkScoped(
+    version: string | null,
+    ownerAssistantId: string | null | undefined = OWNER_ID,
+    identityAssistantId: string | null = OWNER_ID,
+  ): boolean {
+    setIdentity(version, identityAssistantId);
+    const { result } = renderHook(() =>
+      useAssistantScopedSupports(MIN, ownerAssistantId),
+    );
+    return result.current;
+  }
+
+  test("returns true when the version meets minVersion and the owner matches", () => {
+    expect(checkScoped("0.11.0")).toBe(true);
+    expect(checkScoped("1.0.0")).toBe(true);
+  });
+
+  test("returns false when the version is unknown or below minVersion", () => {
+    expect(checkScoped(null)).toBe(false);
+    expect(checkScoped("0.10.9")).toBe(false);
+  });
+
+  test("returns false when the identity version belongs to a different assistant", () => {
+    // The assistant-switch race: the previous assistant's supported
+    // version is still hydrated while the gated surface now belongs to a
+    // different assistant whose identity hasn't loaded. The version must
+    // not validate the new owner's surface.
+    expect(checkScoped("0.11.0", "asst-new-owner", "asst-previous")).toBe(
+      false,
+    );
+  });
+
+  test("returns false when the owner is null or undefined", () => {
+    expect(checkScoped("0.11.0", null)).toBe(false);
+    // Passed explicitly (a default parameter would swallow `undefined`).
+    setIdentity("0.11.0", OWNER_ID);
+    const { result } = renderHook(() =>
+      useAssistantScopedSupports(MIN, undefined),
+    );
+    expect(result.current).toBe(false);
+  });
+
+  test("returns false when the identity store has no owner recorded", () => {
+    expect(checkScoped("0.11.0", OWNER_ID, null)).toBe(false);
+  });
+
+  test("flips off the moment the identity is cleared for an assistant switch", () => {
+    setIdentity("0.11.0", OWNER_ID);
+    const { result, rerender } = renderHook(() =>
+      useAssistantScopedSupports(MIN, OWNER_ID),
+    );
+    expect(result.current).toBe(true);
+    useAssistantIdentityStore.getState().clearIdentity();
+    rerender();
+    expect(result.current).toBe(false);
   });
 });
 

--- a/clients/web/src/lib/backwards-compat/utils.ts
+++ b/clients/web/src/lib/backwards-compat/utils.ts
@@ -53,6 +53,41 @@ export function useAssistantSupports(minVersion: string): boolean {
 }
 
 /**
+ * Assistant-scoped variant of `useAssistantSupports`: returns `true` only
+ * when the active assistant's version meets `minVersion` AND the identity
+ * store's version was fetched for `ownerAssistantId` — the assistant that
+ * owns whatever the caller is gating (a transcript, a live voice session).
+ *
+ * Both the version and its owner are read from the identity store — a
+ * single atomic snapshot (`setIdentity` writes them in the same store
+ * update) — so the version can never be checked against a different
+ * assistant's feature surface, even transiently during an assistant
+ * switch. Comparing against the identity store's own `assistantId` —
+ * rather than `activeAssistantId` from the resolved-assistants store —
+ * keeps the check race-free: the two stores update at different times, so
+ * a cross-store pairing could briefly validate against the previous
+ * assistant's version.
+ *
+ * Conservative on mismatch or unknown: returns `false` when
+ * `ownerAssistantId` is null/undefined, when the identity store's version
+ * was fetched for a different assistant (or has no owner recorded), while
+ * no version has hydrated yet, when the version is unparseable, or when
+ * it falls below `minVersion`.
+ */
+export function useAssistantScopedSupports(
+  minVersion: string,
+  ownerAssistantId: string | null | undefined,
+): boolean {
+  const identityAssistantId = useAssistantIdentityStore.use.assistantId();
+  const versionSupported = useAssistantSupports(minVersion);
+  return (
+    versionSupported &&
+    ownerAssistantId != null &&
+    ownerAssistantId === identityAssistantId
+  );
+}
+
+/**
  * Non-hook variant of `useAssistantSupports`: reads the version
  * snapshot via `useAssistantIdentityStore.getState()` so it's safe to
  * call from non-hook contexts (event handlers, async ops, request


### PR DESCRIPTION
## Summary
Fixes review gaps for voice-noninteractive.md (round 2).

- Extract `useAssistantScopedSupports` into backwards-compat utils; both assistant-scoped gates (noninteractive-voice-turns, redacted-credential-chips) delegate to it; scoping semantics tested once in utils.test.ts
- Trim the duplicated broadcast-before-resolve rationale in the bridge ordering test to a pointer at the canonical production comment