### PR TITLE
chore(web): retire the pre-chat-onboarding-experiment-2026-06-06 flag (collapse to control)

### DIFF
--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -6,7 +6,6 @@ import {
   emitOnboardingFunnelStepCompleted,
   emitResearchOnboardingStepCompleted,
   emitResearchOnboardingCheckinCalendarOpened,
-  onboardingFunnelVariantFromExperiment,
   ONBOARDING_FUNNEL_STEPS,
   ONBOARDING_FUNNEL_VERSION,
   ONBOARDING_FUNNEL_VARIANTS,
@@ -31,11 +30,6 @@ afterEach(() => {
 });
 
 describe("onboarding funnel events", () => {
-  test("maps experiment arms to funnel variants", () => {
-    expect(onboardingFunnelVariantFromExperiment("control")).toBe("control");
-    expect(onboardingFunnelVariantFromExperiment("variant-a")).toBe("pared_down");
-  });
-
   test("builds the expected event shape with a stable session id", () => {
     const privacy = buildOnboardingFunnelEvent(
       ONBOARDING_FUNNEL_STEPS.privacyTos,

--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -9,8 +9,6 @@ import {
   ONBOARDING_FUNNEL_STEPS,
   ONBOARDING_FUNNEL_VERSION,
   ONBOARDING_FUNNEL_VARIANTS,
-  readOnboardingFunnelVariant,
-  resolveOnboardingFunnelVariant,
   RESEARCH_ONBOARDING_FUNNEL_STEPS,
   RESEARCH_ONBOARDING_FUNNEL_VERSION,
 } from "@/domains/onboarding/funnel-events";
@@ -35,14 +33,14 @@ describe("onboarding funnel events", () => {
       ONBOARDING_FUNNEL_STEPS.privacyTos,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
     const nameVibe = buildOnboardingFunnelEvent(
       ONBOARDING_FUNNEL_STEPS.nameVibe,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
 
@@ -56,7 +54,7 @@ describe("onboarding funnel events", () => {
       step_index: 0,
       user_id: "user-123",
       funnel_version: ONBOARDING_FUNNEL_VERSION,
-      ab_variant: "pared_down",
+      ab_variant: "control",
     });
     expect(nameVibe).toMatchObject({
       screen: "name_vibe",
@@ -64,21 +62,18 @@ describe("onboarding funnel events", () => {
       step_index: 1,
       user_id: "user-123",
       funnel_version: ONBOARDING_FUNNEL_VERSION,
-      ab_variant: "pared_down",
+      ab_variant: "control",
     });
     expect(privacy.completed_at).toMatch(
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
     );
   });
 
-  test("persists the assigned funnel variant for the session", () => {
-    expect(
-      resolveOnboardingFunnelVariant(ONBOARDING_FUNNEL_VARIANTS.paredDown),
-    ).toBe("pared_down");
-    expect(
-      resolveOnboardingFunnelVariant(ONBOARDING_FUNNEL_VARIANTS.control),
-    ).toBe("pared_down");
-    expect(readOnboardingFunnelVariant()).toBe("pared_down");
+  test("defaults ab_variant to control when no variant is passed", () => {
+    const event = buildOnboardingFunnelEvent(ONBOARDING_FUNNEL_STEPS.nameVibe, {
+      userId: "user-123",
+    });
+    expect(event.ab_variant).toBe("control");
   });
 
   test("uses control step indices for the existing funnel", () => {
@@ -110,11 +105,11 @@ describe("onboarding funnel events", () => {
 
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -139,7 +134,7 @@ describe("onboarding funnel events", () => {
       step_index: 2,
       user_id: "user-123",
       funnel_version: ONBOARDING_FUNNEL_VERSION,
-      ab_variant: "pared_down",
+      ab_variant: "control",
     });
   });
 
@@ -254,7 +249,7 @@ describe("onboarding funnel events", () => {
     // the event emits.
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -262,7 +257,7 @@ describe("onboarding funnel events", () => {
     localStorage.setItem("device:share_analytics", "false");
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -272,7 +267,7 @@ describe("onboarding funnel events", () => {
     useOnboardingStore.setState({ shareAnalytics: false });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.nameVibe, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -14,14 +14,6 @@ export const ONBOARDING_FUNNEL_VARIANTS = {
 export type OnboardingFunnelVariant =
   (typeof ONBOARDING_FUNNEL_VARIANTS)[keyof typeof ONBOARDING_FUNNEL_VARIANTS];
 
-export function onboardingFunnelVariantFromExperiment(
-  experimentArm: string,
-): OnboardingFunnelVariant {
-  return experimentArm === "variant-a"
-    ? ONBOARDING_FUNNEL_VARIANTS.paredDown
-    : ONBOARDING_FUNNEL_VARIANTS.control;
-}
-
 export const ONBOARDING_FUNNEL_STEPS = {
   privacyTos: { stepName: "privacy_tos", stepIndex: 0 },
   nameVibe: { stepName: "name_vibe", stepIndex: 1 },

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -4,11 +4,9 @@ import type { ResearchStep } from "@/domains/onboarding/research-onboarding-pers
 
 export const ONBOARDING_FUNNEL_VERSION = "onboarding_v3_2026_05";
 const SESSION_STORAGE_KEY = "onboarding.funnelSessionId";
-const VARIANT_STORAGE_KEY = "onboarding.funnelVariant";
 
 export const ONBOARDING_FUNNEL_VARIANTS = {
   control: "control",
-  paredDown: "pared_down",
 } as const;
 
 export type OnboardingFunnelVariant =
@@ -158,48 +156,12 @@ export function getOnboardingFunnelSessionId(): string {
   return next;
 }
 
-function isOnboardingFunnelVariant(
-  value: string | null,
-): value is OnboardingFunnelVariant {
-  return (
-    value === ONBOARDING_FUNNEL_VARIANTS.control ||
-    value === ONBOARDING_FUNNEL_VARIANTS.paredDown
-  );
-}
-
-export function readOnboardingFunnelVariant(): OnboardingFunnelVariant | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const stored = sessionStorage.getItem(VARIANT_STORAGE_KEY);
-    return isOnboardingFunnelVariant(stored) ? stored : null;
-  } catch {
-    return null;
-  }
-}
-
-export function resolveOnboardingFunnelVariant(
-  preferred: OnboardingFunnelVariant,
-): OnboardingFunnelVariant {
-  const existing = readOnboardingFunnelVariant();
-  if (existing) return existing;
-  if (typeof window === "undefined") return preferred;
-  try {
-    sessionStorage.setItem(VARIANT_STORAGE_KEY, preferred);
-  } catch {
-    // Storage may be unavailable; the current event still carries the variant.
-  }
-  return preferred;
-}
-
 export function buildOnboardingFunnelEvent(
   screen: OnboardingFunnelStepDescriptor,
   options: OnboardingFunnelStepCompletedOptions = {},
 ): OnboardingFunnelEvent {
   const now = Date.now();
-  const variant =
-    options.variant ??
-    readOnboardingFunnelVariant() ??
-    ONBOARDING_FUNNEL_VARIANTS.control;
+  const variant = options.variant ?? ONBOARDING_FUNNEL_VARIANTS.control;
   return {
     type: "onboarding",
     daemon_event_id: crypto.randomUUID(),
@@ -246,8 +208,7 @@ export function emitOnboardingFunnelStepCompleted(
  * emits the same step-completed event on both its Continue and Skip handlers.
  *
  * The research flow has no A/B arm, so events are stamped with the `control`
- * variant (passed explicitly so this never reads the pre-chat funnel's stored
- * variant) and the research funnel version.
+ * variant and the research funnel version.
  *
  * `outcome` records whether the step was completed (Continue) or skipped;
  * defaults to `completed` for the Continue-only steps.
@@ -286,7 +247,6 @@ export function __resetOnboardingFunnelEventsForTests(): void {
   if (typeof window === "undefined") return;
   try {
     sessionStorage.removeItem(SESSION_STORAGE_KEY);
-    sessionStorage.removeItem(VARIANT_STORAGE_KEY);
   } catch {
     // ignore
   }

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -71,7 +71,6 @@ type TestOnboardingRecipe = {
   skipPrechat: boolean;
 };
 
-let preChatOnboardingExperiment = "variant-a";
 let activationFlowExperiment = "control";
 let selfIntroGreeting = true;
 let isIOSWeb = false;
@@ -278,7 +277,6 @@ mock.module("@/stores/client-feature-flag-store", () => ({
   useClientFeatureFlagStore: {
     use: {
       stringFlags: () => ({
-        preChatOnboardingExperiment20260606: preChatOnboardingExperiment,
         experimentActivationFlow20260603: activationFlowExperiment,
       }),
       selfIntroGreeting: () => selfIntroGreeting,
@@ -440,7 +438,6 @@ beforeEach(() => {
   checkAssistantImpl = async () => {};
   fetchTraitsImpl = async () => null;
   getAssistantImpl = async () => assistantResult("active");
-  preChatOnboardingExperiment = "variant-a";
   activationFlowExperiment = "control";
   selfIntroGreeting = true;
   isIOSWeb = false;
@@ -534,10 +531,9 @@ describe("onboarding lifecycle sync", () => {
     render(<PreChatFlow />);
 
     fireEvent.click(await screen.findByTestId("name-continue"));
-    expect(await screen.findByText("Gmail")).toBeTruthy();
-    expect(screen.getByText("Google Calendar")).toBeTruthy();
-    expect(screen.getByText("Google Drive")).toBeTruthy();
-    fireEvent.click(screen.getByText("Skip for now"));
+    fireEvent.click(await screen.findByTestId("task-continue"));
+    fireEvent.click(await screen.findByTestId("tools-continue"));
+    fireEvent.click(await screen.findByTestId("prior-continue"));
 
     expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
       tools: [],
@@ -567,7 +563,9 @@ describe("onboarding lifecycle sync", () => {
     render(<PreChatFlow />);
 
     fireEvent.click(await screen.findByTestId("name-continue"));
-    fireEvent.click(await screen.findByText("Skip for now"));
+    fireEvent.click(await screen.findByTestId("task-continue"));
+    fireEvent.click(await screen.findByTestId("tools-continue"));
+    fireEvent.click(await screen.findByTestId("prior-continue"));
 
     await waitFor(() => expect(checkAssistantMock).toHaveBeenCalled());
     expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
@@ -586,7 +584,9 @@ describe("onboarding lifecycle sync", () => {
     render(<PreChatFlow />);
 
     fireEvent.click(await screen.findByTestId("name-continue"));
-    fireEvent.click(await screen.findByText("Skip for now"));
+    fireEvent.click(await screen.findByTestId("task-continue"));
+    fireEvent.click(await screen.findByTestId("tools-continue"));
+    fireEvent.click(await screen.findByTestId("prior-continue"));
 
     await waitFor(() => expect(checkAssistantMock).toHaveBeenCalled());
     expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
@@ -601,9 +601,7 @@ describe("onboarding lifecycle sync", () => {
     });
   });
 
-  test("pre-chat keeps the existing full funnel when the v3 flag is off", async () => {
-    preChatOnboardingExperiment = "control";
-
+  test("pre-chat shows the full control funnel", async () => {
     render(<PreChatFlow />);
 
     fireEvent.click(await screen.findByTestId("name-continue"));
@@ -613,7 +611,6 @@ describe("onboarding lifecycle sync", () => {
   });
 
   test("pre-chat control flow skips the macOS app step on macOS web", async () => {
-    preChatOnboardingExperiment = "control";
     isMacOSWeb = true;
     macOsAppDownloaded = false;
 
@@ -651,51 +648,6 @@ describe("onboarding lifecycle sync", () => {
     expect(await screen.findByTestId("name-continue")).toBeTruthy();
   });
 
-  test("recipe skip does not bypass the pared-down pre-chat screens", async () => {
-    const recipe: TestOnboardingRecipe = {
-      cohort: "content-automation",
-      tasks: ["writing", "research"],
-      tone: "grounded",
-      bootstrapTemplate: "BOOTSTRAP-CONTENT-AUTOMATION.md",
-      initialMessage: "I want to write articles that rank better in GEO",
-      skills: ["content-automation"],
-      skipPrechat: true,
-    };
-    fetchOnboardingRecipeImpl = async () => recipe;
-    selfIntroGreeting = false;
-
-    render(<PreChatFlow />);
-
-    expect(await screen.findByTestId("name-continue")).toBeTruthy();
-    expect(checkAssistantMock).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByTestId("name-continue"));
-    expect(await screen.findByText("Gmail")).toBeTruthy();
-    expect(screen.getByText("Google Calendar")).toBeTruthy();
-    expect(screen.getByText("Google Drive")).toBeTruthy();
-    fireEvent.click(screen.getByText("Skip for now"));
-
-    await waitFor(() => expect(checkAssistantMock).toHaveBeenCalled());
-    await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith(
-        `${routes.assistant}?onboarding=1`,
-        { replace: true },
-      ),
-    );
-
-    expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
-      tools: [],
-      tasks: recipe.tasks,
-      tone: recipe.tone,
-      userName: "Alice",
-      googleConnected: false,
-      cohort: recipe.cohort,
-      initialMessage: recipe.initialMessage,
-      bootstrapTemplate: recipe.bootstrapTemplate,
-      skills: recipe.skills,
-    });
-  });
-
   test("local mode never fetches the platform-only onboarding recipe", async () => {
     isLocalModeValue = true;
 
@@ -706,7 +658,6 @@ describe("onboarding lifecycle sync", () => {
   });
 
   test("local mode without a platform session gates the prior-assistants step", async () => {
-    preChatOnboardingExperiment = "control";
     isLocalModeValue = true;
     platformSessionValue = "absent";
 
@@ -727,7 +678,6 @@ describe("onboarding lifecycle sync", () => {
   });
 
   test("local mode with a platform session shows the prior-assistants step", async () => {
-    preChatOnboardingExperiment = "control";
     isLocalModeValue = true;
     platformSessionValue = "present";
 

--- a/clients/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/clients/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -7,7 +7,6 @@ import { readIOSAppDownloaded } from "@/hooks/use-ios-app-nudge";
 import { fetchOnboardingRecipe } from "@/domains/onboarding/recipe-client.js";
 import {
   emitOnboardingFunnelStepCompleted,
-  onboardingFunnelVariantFromExperiment,
   ONBOARDING_FUNNEL_STEPS,
   ONBOARDING_FUNNEL_VARIANTS,
   readOnboardingFunnelVariant,
@@ -85,17 +84,13 @@ export function PreChatFlow() {
   const localMode = isLocalMode();
   const isIOSWeb = useIsIOSWeb();
   const showIOSAppStep = isIOSWeb && !readIOSAppDownloaded();
-  const preChatExperimentArm =
-    useClientFeatureFlagStore.use.stringFlags()
-      .preChatOnboardingExperiment20260606 ?? "control";
   const activationFlowArm =
     useClientFeatureFlagStore.use.stringFlags()
       .experimentActivationFlow20260603 ?? "control";
   const activationFlowEnabled = activationFlowArm === "variant-a";
   const selfIntroGreetingEnabled =
     useClientFeatureFlagStore.use.selfIntroGreeting();
-  const preferredFunnelVariant =
-    onboardingFunnelVariantFromExperiment(preChatExperimentArm);
+  const preferredFunnelVariant = ONBOARDING_FUNNEL_VARIANTS.control;
   const webFunnelVariant =
     readOnboardingFunnelVariant() ?? preferredFunnelVariant;
   const paredDownPrechat =

--- a/clients/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/clients/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -8,9 +8,6 @@ import { fetchOnboardingRecipe } from "@/domains/onboarding/recipe-client.js";
 import {
   emitOnboardingFunnelStepCompleted,
   ONBOARDING_FUNNEL_STEPS,
-  ONBOARDING_FUNNEL_VARIANTS,
-  readOnboardingFunnelVariant,
-  resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
 import { GetIOSAppScreen } from "@/domains/onboarding/screens/get-ios-app-screen.js";
 import { GoogleConnectScreen } from "@/domains/onboarding/screens/google-connect-screen.js";
@@ -90,11 +87,6 @@ export function PreChatFlow() {
   const activationFlowEnabled = activationFlowArm === "variant-a";
   const selfIntroGreetingEnabled =
     useClientFeatureFlagStore.use.selfIntroGreeting();
-  const preferredFunnelVariant = ONBOARDING_FUNNEL_VARIANTS.control;
-  const webFunnelVariant =
-    readOnboardingFunnelVariant() ?? preferredFunnelVariant;
-  const paredDownPrechat =
-    webFunnelVariant === ONBOARDING_FUNNEL_VARIANTS.paredDown;
   const localPlatformAssistantId = localMode
     ? readLocalPlatformAssistantId()
     : null;
@@ -156,15 +148,11 @@ export function PreChatFlow() {
 
   function emitWebFunnelStep(
     step: (typeof ONBOARDING_FUNNEL_STEPS)[keyof typeof ONBOARDING_FUNNEL_STEPS],
-    variant = webFunnelVariant,
   ): void {
     if (isPreview) {
       return;
     }
-    emitOnboardingFunnelStepCompleted(step, {
-      userId,
-      variant: resolveOnboardingFunnelVariant(variant),
-    });
+    emitOnboardingFunnelStepCompleted(step, { userId });
   }
 
   const hasGoogleTool = [...selectedTools].some((id) =>
@@ -174,7 +162,6 @@ export function PreChatFlow() {
   const steps: PreChatStep[] = isNative
     ? resolveNativeSteps()
     : resolveWebSteps({
-        paredDown: paredDownPrechat,
         canOfferPriorAssistants,
         canOfferGoogleStep: isPreview ? false : canOfferGoogleStep,
         hasGoogleTool,
@@ -191,7 +178,7 @@ export function PreChatFlow() {
     }
 
     const context = buildPreChatContext({
-      mode: isNative ? "native" : paredDownPrechat ? "paredDown" : "control",
+      mode: isNative ? "native" : "control",
       recipe: isNative ? null : recipe,
       selectedTools,
       selectedTasks,

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -35,8 +35,7 @@ mock.module("@/domains/onboarding/funnel-events", () => ({
   emitOnboardingFunnelStepCompleted: emitFunnelStepCompletedMock,
   getOnboardingFunnelSessionId: () => "session-1",
   ONBOARDING_FUNNEL_STEPS: { privacyTos: "privacy_tos" },
-  ONBOARDING_FUNNEL_VARIANTS: { control: "control", paredDown: "pared_down" },
-  resolveOnboardingFunnelVariant: () => "control",
+  ONBOARDING_FUNNEL_VARIANTS: { control: "control" },
 }));
 
 mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -35,14 +35,13 @@ mock.module("@/domains/onboarding/funnel-events", () => ({
   emitOnboardingFunnelStepCompleted: emitFunnelStepCompletedMock,
   getOnboardingFunnelSessionId: () => "session-1",
   ONBOARDING_FUNNEL_STEPS: { privacyTos: "privacy_tos" },
-  onboardingFunnelVariantFromExperiment: () => "control",
+  ONBOARDING_FUNNEL_VARIANTS: { control: "control", paredDown: "pared_down" },
   resolveOnboardingFunnelVariant: () => "control",
 }));
 
 mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
 // Mutable platform/flag state so individual tests can flip them.
 let nativePlatform = false;
-let researchFlag = false;
 let localMode = false;
 mock.module("@/lib/local-mode", () => ({ isLocalMode: () => localMode }));
 mock.module("@/runtime/native-auth", () => ({
@@ -54,7 +53,7 @@ mock.module("@/stores/auth-store", () => ({
 }));
 mock.module("@/stores/client-feature-flag-store", () => ({
   useClientFeatureFlagStore: {
-    use: { stringFlags: () => ({}), researchOnboarding: () => researchFlag },
+    use: { stringFlags: () => ({}) },
   },
 }));
 
@@ -104,13 +103,11 @@ describe("PrivacyScreen — Start navigation", () => {
     navigateMock.mockClear();
     saveConsentMock.mockClear();
     emitFunnelStepCompletedMock.mockClear();
-    researchFlag = false;
     nativePlatform = false;
     localMode = false;
   });
   afterEach(() => {
     cleanup();
-    researchFlag = false;
     nativePlatform = false;
     localMode = false;
   });

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -11,7 +11,7 @@ import {
     emitOnboardingFunnelStepCompleted,
     getOnboardingFunnelSessionId,
     ONBOARDING_FUNNEL_STEPS,
-    onboardingFunnelVariantFromExperiment,
+    ONBOARDING_FUNNEL_VARIANTS,
     resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
@@ -24,7 +24,6 @@ import {
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { saveConsent } from "@/utils/onboarding-cleanup";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -35,10 +34,7 @@ export function PrivacyScreen() {
   const userId = useAuthStore.use.user()?.id ?? null;
   const electron = isElectron();
   const isNative = useIsNativePlatform();
-  const preChatExperimentArm =
-    useClientFeatureFlagStore.use.stringFlags().preChatOnboardingExperiment20260606 ?? "control";
-  const preferredFunnelVariant =
-    onboardingFunnelVariantFromExperiment(preChatExperimentArm);
+  const preferredFunnelVariant = ONBOARDING_FUNNEL_VARIANTS.control;
   const [shareDiagnostics, setShareDiagnosticsReal] = useShareDiagnostics();
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
   const [privacyConsent, setPrivacyConsentReal] = usePrivacyConsent();

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -12,7 +12,6 @@ import {
     getOnboardingFunnelSessionId,
     ONBOARDING_FUNNEL_STEPS,
     ONBOARDING_FUNNEL_VARIANTS,
-    resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { isLocalMode } from "@/lib/local-mode";
@@ -34,7 +33,6 @@ export function PrivacyScreen() {
   const userId = useAuthStore.use.user()?.id ?? null;
   const electron = isElectron();
   const isNative = useIsNativePlatform();
-  const preferredFunnelVariant = ONBOARDING_FUNNEL_VARIANTS.control;
   const [shareDiagnostics, setShareDiagnosticsReal] = useShareDiagnostics();
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
   const [privacyConsent, setPrivacyConsentReal] = usePrivacyConsent();
@@ -66,10 +64,9 @@ export function PrivacyScreen() {
     // until the user opts in via settings or review-terms.
     saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics: null, shareDiagnostics, hasPlatformSession });
     if (!isNative) {
-      const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
         userId,
-        variant,
+        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       });
     }
 
@@ -94,7 +91,6 @@ export function PrivacyScreen() {
     isNative,
     isPreview,
     navigate,
-    preferredFunnelVariant,
     searchParams,
     shareDiagnostics,
     tosAccepted,

--- a/clients/web/src/domains/onboarding/prechat-context.test.ts
+++ b/clients/web/src/domains/onboarding/prechat-context.test.ts
@@ -5,7 +5,6 @@ import {
   ACTIVATION_FLOW_COHORT,
   ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
   buildPreChatContext,
-  PARED_DOWN_GOOGLE_TOOL_IDS,
   type BuildPreChatContextInput,
 } from "@/domains/onboarding/prechat-context";
 
@@ -112,22 +111,6 @@ describe("buildPreChatContext — control", () => {
     );
     expect(context.googleConnected).toBe(true);
     expect(context.googleScopes).toEqual(["gmail.send"]);
-  });
-});
-
-describe("buildPreChatContext — pared-down", () => {
-  test("implies the Google tool bundle only when connected this action", () => {
-    const connected = buildPreChatContext(
-      baseInput({ mode: "paredDown", connectedScopes: ["gmail.readonly"] }),
-    );
-    expect(connected.tools).toEqual([...PARED_DOWN_GOOGLE_TOOL_IDS]);
-    expect(connected.googleConnected).toBe(true);
-    expect(connected.googleScopes).toEqual(["gmail.readonly"]);
-
-    const skipped = buildPreChatContext(baseInput({ mode: "paredDown" }));
-    expect(skipped.tools).toEqual([]);
-    expect(skipped.googleConnected).toBe(false);
-    expect(skipped.googleScopes).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/onboarding/prechat-context.ts
+++ b/clients/web/src/domains/onboarding/prechat-context.ts
@@ -3,8 +3,8 @@
  * during the flow. Pure input→output: no React, no storage, no navigation —
  * the component owns those side effects and calls this to produce the payload.
  *
- * Three modes share one builder so the context shape can't drift between the
- * web control funnel, the pared-down funnel variant, and the native iOS flow.
+ * Both modes share one builder so the context shape can't drift between the
+ * web control funnel and the native iOS flow.
  */
 import type { OnboardingRecipe } from "@/domains/onboarding/recipe-client.js";
 import {
@@ -14,21 +14,11 @@ import {
 } from "@/domains/onboarding/prechat";
 import { stripOtherPrefix } from "@/domains/onboarding/prechat-tools";
 
-/**
- * Tools implied by connecting Google in the pared-down funnel, which has no
- * tool-selection screen. Kept in sync with the daemon's onboarding contract.
- */
-export const PARED_DOWN_GOOGLE_TOOL_IDS = [
-  "gmail",
-  "google-calendar",
-  "google-drive",
-];
-
 export const ACTIVATION_FLOW_COHORT = "experiment-activation-flow-2026-06-03";
 export const ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE =
   "BOOTSTRAP-ACTIVATION-RAIL.md";
 
-export type PreChatMode = "control" | "paredDown" | "native";
+export type PreChatMode = "control" | "native";
 
 export interface BuildPreChatContextInput {
   mode: PreChatMode;
@@ -81,13 +71,6 @@ export function buildPreChatContext(
   let context: PreChatOnboardingContext;
   if (mode === "native") {
     context = { tools: [], tasks: [], tone: input.tone, googleConnected: false };
-  } else if (mode === "paredDown") {
-    context = {
-      tools: connectedWithCurrentAction ? [...PARED_DOWN_GOOGLE_TOOL_IDS] : [],
-      tasks: recipe?.tasks ?? [],
-      tone: input.tone,
-      googleConnected: connectedWithCurrentAction,
-    };
   } else {
     context = {
       tools: stripOtherPrefix([...input.selectedTools]),
@@ -114,11 +97,7 @@ export function buildPreChatContext(
   const trimmedAssistant = input.assistantName.trim();
   if (trimmedAssistant) context.assistantName = trimmedAssistant;
 
-  if (mode === "paredDown") {
-    if (connectedWithCurrentAction) {
-      context.googleScopes = input.connectedScopes;
-    }
-  } else if (mode === "control") {
+  if (mode === "control") {
     if (connectedWithCurrentAction) {
       context.googleConnected = true;
       context.googleScopes = input.connectedScopes;

--- a/clients/web/src/domains/onboarding/prechat-steps.test.ts
+++ b/clients/web/src/domains/onboarding/prechat-steps.test.ts
@@ -13,7 +13,6 @@ import {
 } from "@/domains/onboarding/prechat-steps";
 
 const CONTROL: WebStepCapabilities = {
-  paredDown: false,
   canOfferPriorAssistants: true,
   canOfferGoogleStep: true,
   hasGoogleTool: true,
@@ -90,57 +89,11 @@ describe("resolveWebSteps", () => {
     expect(ids({ ...CONTROL, showIOSAppStep: false })).not.toContain("iosApp");
   });
 
-  test("pared-down funnel: name then google only", () => {
-    const steps = resolveWebSteps({
-      paredDown: true,
-      canOfferPriorAssistants: true,
-      canOfferGoogleStep: true,
-      hasGoogleTool: false,
-      showIOSAppStep: true,
-    });
-    expect(steps.map((s) => s.id)).toEqual(["name", "google"]);
-    // Back from google skips every gated control step and lands on name.
-    expect(prevStep(steps, "google")).toBe("name");
-  });
-
-  test("pared-down funnel offers google without a tool selection", () => {
-    // No tool-selection screen in this variant, so hasGoogleTool is irrelevant.
-    expect(
-      ids({
-        paredDown: true,
-        canOfferPriorAssistants: true,
-        canOfferGoogleStep: true,
-        hasGoogleTool: false,
-        showIOSAppStep: false,
-      }),
-    ).toEqual(["name", "google"]);
-  });
-
-  test("pared-down funnel collapses to name when google is unavailable", () => {
-    expect(
-      ids({
-        paredDown: true,
-        canOfferPriorAssistants: true,
-        canOfferGoogleStep: false,
-        hasGoogleTool: true,
-        showIOSAppStep: true,
-      }),
-    ).toEqual(["name"]);
-  });
-
-  test("emits the variant-specific google funnel event", () => {
+  test("google step emits the control gmail-connect funnel event", () => {
     const control = resolveWebSteps(CONTROL).find((s) => s.id === "google");
     expect(control?.funnelStep).toBe(
       ONBOARDING_FUNNEL_STEPS.controlGmailConnect,
     );
-    const pared = resolveWebSteps({
-      paredDown: true,
-      canOfferPriorAssistants: true,
-      canOfferGoogleStep: true,
-      hasGoogleTool: false,
-      showIOSAppStep: false,
-    }).find((s) => s.id === "google");
-    expect(pared?.funnelStep).toBe(ONBOARDING_FUNNEL_STEPS.gmailConnect);
   });
 });
 

--- a/clients/web/src/domains/onboarding/prechat-steps.ts
+++ b/clients/web/src/domains/onboarding/prechat-steps.ts
@@ -3,9 +3,9 @@
  *
  * The flow is expressed as an ordered list of steps, each with the funnel
  * event it emits when the user advances past it. Which steps appear is a pure
- * function of the runtime's capabilities — local mode, feature-flag variant,
- * connected tools, and platform all "fall out" of the predicates here rather
- * than being special-cased across navigation handlers.
+ * function of the runtime's capabilities — local mode, connected tools, and
+ * platform all "fall out" of the predicates here rather than being
+ * special-cased across navigation handlers.
  *
  * Navigation operates on step **ids**, never numeric indices: `nextStep` and
  * `prevStep` resolve to the adjacent *enabled* step. Because back always lands
@@ -39,12 +39,11 @@ export interface PreChatStep {
 
 /**
  * Capabilities that decide which web steps are reachable. Each maps to an
- * existing self-gate in the flow: feature-flag variant, the platform-backed
- * prior-assistants import, the Google OAuth step, whether a Google tool was
- * picked, and the iOS app nudge.
+ * existing self-gate in the flow: the platform-backed prior-assistants import,
+ * the Google OAuth step, whether a Google tool was picked, and the iOS app
+ * nudge.
  */
 export interface WebStepCapabilities {
-  paredDown: boolean;
   canOfferPriorAssistants: boolean;
   canOfferGoogleStep: boolean;
   hasGoogleTool: boolean;
@@ -80,11 +79,10 @@ export function isPlatformFunnelAvailable(args: {
 }
 
 /**
- * Resolve the ordered, enabled web steps. The pared-down funnel variant is the
- * same flow with most steps gated off, not a separate code path.
+ * Resolve the ordered, enabled web steps. A single control funnel: which steps
+ * appear falls out of the runtime capabilities rather than a separate code path.
  */
 export function resolveWebSteps(caps: WebStepCapabilities): PreChatStep[] {
-  const { paredDown } = caps;
   const candidates: Array<PreChatStep & { enabled: boolean }> = [
     {
       id: "name",
@@ -94,32 +92,29 @@ export function resolveWebSteps(caps: WebStepCapabilities): PreChatStep[] {
     {
       id: "taskTone",
       funnelStep: ONBOARDING_FUNNEL_STEPS.controlWorkType,
-      enabled: !paredDown,
+      enabled: true,
     },
     {
       id: "tools",
       funnelStep: ONBOARDING_FUNNEL_STEPS.controlTools,
-      enabled: !paredDown,
+      enabled: true,
     },
     {
       id: "priorAssistants",
       funnelStep: ONBOARDING_FUNNEL_STEPS.controlPriorAssistants,
-      enabled: !paredDown && caps.canOfferPriorAssistants,
+      enabled: caps.canOfferPriorAssistants,
     },
     {
       id: "google",
-      funnelStep: paredDown
-        ? ONBOARDING_FUNNEL_STEPS.gmailConnect
-        : ONBOARDING_FUNNEL_STEPS.controlGmailConnect,
-      // The pared-down funnel has no tool-selection screen, so it offers
-      // Google whenever the step is available; the control funnel only offers
-      // it when the user actually picked a Google tool.
-      enabled: caps.canOfferGoogleStep && (paredDown || caps.hasGoogleTool),
+      funnelStep: ONBOARDING_FUNNEL_STEPS.controlGmailConnect,
+      // The control funnel offers Google only when the user actually picked a
+      // Google tool.
+      enabled: caps.canOfferGoogleStep && caps.hasGoogleTool,
     },
     {
       id: "iosApp",
       funnelStep: ONBOARDING_FUNNEL_STEPS.controlGetApp,
-      enabled: !paredDown && caps.showIOSAppStep,
+      enabled: caps.showIOSAppStep,
     },
   ];
   return candidates


### PR DESCRIPTION
## Summary
- Remove the `pre-chat-onboarding-experiment-2026-06-06` flag reads in the pre-chat flow and privacy screen; funnel variant is now unconditionally `control`.
- Delete the now-unused `onboardingFunnelVariantFromExperiment` helper and its test.

Part of plan: onboarding-ff-cleanup.md (PR 2 of 3)