### PR TITLE
fix(telemetry): send browser funnel events through the authenticated generated client

### DIFF
--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -3717,6 +3717,36 @@ paths:
           description: ''
       x-vellum-api-clients:
       - platform
+  /v1/assistants/telemetry/ingest/:
+    post:
+      operationId: assistants_telemetry_ingest_create
+      tags:
+      - assistants
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TelemetryIngestRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TelemetryIngestRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TelemetryIngestRequestRequest'
+        required: true
+      security:
+      - SDKCompatibleAssistantKey: []
+      - XSessionTokenAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TelemetryIngestResponse'
+          description: ''
+      x-vellum-api-clients:
+      - platform
   /v1/assistants/upgrade/:
     post:
       operationId: assistants_upgrade_create
@@ -5338,6 +5368,80 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ReleaseListItem'
+          description: ''
+      x-vellum-api-clients:
+      - platform
+  /v1/telemetry/ingest/:
+    post:
+      operationId: telemetry_ingest_create
+      tags:
+      - telemetry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TelemetryIngestRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TelemetryIngestRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TelemetryIngestRequestRequest'
+        required: true
+      security:
+      - SDKCompatibleAssistantKey: []
+      - XSessionTokenAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TelemetryIngestResponse'
+          description: ''
+      x-vellum-api-clients:
+      - platform
+  /v1/user/consent/:
+    get:
+      operationId: user_consent_retrieve
+      tags:
+      - user
+      security:
+      - cookieAuth: []
+      - XSessionTokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserConsent'
+          description: ''
+      x-vellum-api-clients:
+      - platform
+    put:
+      operationId: user_consent_update
+      tags:
+      - user
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserConsentRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UserConsentRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UserConsentRequest'
+      security:
+      - cookieAuth: []
+      - XSessionTokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserConsent'
           description: ''
       x-vellum-api-clients:
       - platform
@@ -8673,6 +8777,44 @@ components:
         * `wake` - Wake
         * `profiler` - Profiler
         * `other` - Other
+    TelemetryIngestRequestRequest:
+      type: object
+      properties:
+        device_id:
+          type: string
+          minLength: 1
+          maxLength: 255
+        installation_id:
+          type: string
+          minLength: 1
+          maxLength: 255
+        assistant_version:
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 64
+        events:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+      required:
+      - events
+    TelemetryIngestResponse:
+      type: object
+      properties:
+        accepted:
+          type: integer
+        persisted:
+          type: integer
+        dropped:
+          type: object
+          additionalProperties:
+            type: integer
+      required:
+      - accepted
+      - dropped
+      - persisted
     TierChangeStatusEnum:
       enum:
       - ok
@@ -8892,6 +9034,85 @@ components:
       required:
       - event_count
       - total_usd
+    UserConsent:
+      type: object
+      properties:
+        tos_accepted_version:
+          type: string
+          maxLength: 32
+        tos_accepted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        privacy_policy_accepted_version:
+          type: string
+          maxLength: 32
+        privacy_policy_accepted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        ai_data_sharing_accepted_version:
+          type: string
+          maxLength: 32
+        ai_data_sharing_accepted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        share_analytics:
+          type: boolean
+          nullable: true
+        share_diagnostics:
+          type: boolean
+          nullable: true
+        share_analytics_accepted_version:
+          type: string
+          maxLength: 32
+        share_analytics_accepted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        share_diagnostics_accepted_version:
+          type: string
+          maxLength: 32
+        share_diagnostics_accepted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+      required:
+      - ai_data_sharing_accepted_at
+      - privacy_policy_accepted_at
+      - share_analytics_accepted_at
+      - share_diagnostics_accepted_at
+      - tos_accepted_at
+    UserConsentRequest:
+      type: object
+      properties:
+        tos_accepted_version:
+          type: string
+          maxLength: 32
+        privacy_policy_accepted_version:
+          type: string
+          maxLength: 32
+        ai_data_sharing_accepted_version:
+          type: string
+          maxLength: 32
+        share_analytics:
+          type: boolean
+          nullable: true
+        share_diagnostics:
+          type: boolean
+          nullable: true
+        share_analytics_accepted_version:
+          type: string
+          maxLength: 32
+        share_diagnostics_accepted_version:
+          type: string
+          maxLength: 32
     UserOutcomeEnum:
       enum:
       - resolved

--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -1,27 +1,26 @@
 import { client } from "@/generated/api/client.gen";
 import {
+  userConsentRetrieve,
+  userConsentUpdate,
+} from "@/generated/api/sdk.gen";
+import type { UserConsent as GeneratedUserConsent } from "@/generated/api/types.gen";
+import {
   ApiError,
   assertHasResponse,
   extractErrorMessage,
 } from "@/utils/api-errors";
 import { parseDrfFieldError } from "@/domains/account/parse-drf-field-error";
 
-export interface UserConsent {
-  tos_accepted_version: string;
-  tos_accepted_at: string | null;
-  privacy_policy_accepted_version: string;
-  privacy_policy_accepted_at: string | null;
-  ai_data_sharing_accepted_version: string;
-  ai_data_sharing_accepted_at: string | null;
-  /** Null until the user makes an explicit choice (settings or review-terms). */
-  share_analytics: boolean | null;
-  /** Null until the user makes an explicit choice (onboarding, settings, or review-terms). */
-  share_diagnostics: boolean | null;
-  share_analytics_accepted_version: string;
-  share_analytics_accepted_at: string | null;
-  share_diagnostics_accepted_version: string;
-  share_diagnostics_accepted_at: string | null;
-}
+/**
+ * The generated wire type, tightened for reads: DRF serializes every field on
+ * a GET (the generated optionality is write-side schema conservatism). Tying
+ * this to the generated contract means a field that doesn't exist on the
+ * server fails the build instead of silently reading `undefined` — a
+ * hand-written copy of this interface once declared fields the endpoint never
+ * returned (see PR #38160). The share booleans are null until the user makes
+ * an explicit choice.
+ */
+export type UserConsent = Required<GeneratedUserConsent>;
 
 export type ConsentPatch = Partial<
   Omit<
@@ -146,8 +145,7 @@ export async function updateMe(patch: UpdateMePatch): Promise<UpdateMeResult> {
 }
 
 export async function fetchConsent(): Promise<UserConsent> {
-  const { data, error, response } = await client.get<UserConsent, unknown>({
-    url: "/v1/user/consent/",
+  const { data, error, response } = await userConsentRetrieve({
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to load consent.");
@@ -157,13 +155,13 @@ export async function fetchConsent(): Promise<UserConsent> {
       extractErrorMessage(error, response, "Failed to load consent."),
     );
   }
-  return data;
+  // Safe: DRF serializes every field on a read; see the UserConsent alias.
+  return data as UserConsent;
 }
 
 // PUTs /v1/user/consent/ — partial bodies are accepted, no writable field is required.
 export async function patchConsent(consent: ConsentPatch): Promise<void> {
-  await client.put({
-    url: "/v1/user/consent/",
+  await userConsentUpdate({
     body: consent,
     throwOnError: true,
   });

--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -15,10 +15,8 @@ import { parseDrfFieldError } from "@/domains/account/parse-drf-field-error";
  * The generated wire type, tightened for reads: DRF serializes every field on
  * a GET (the generated optionality is write-side schema conservatism). Tying
  * this to the generated contract means a field that doesn't exist on the
- * server fails the build instead of silently reading `undefined` — a
- * hand-written copy of this interface once declared fields the endpoint never
- * returned (see PR #38160). The share booleans are null until the user makes
- * an explicit choice.
+ * server fails the build instead of silently reading `undefined`. The share
+ * booleans are null until the user makes an explicit choice.
  */
 export type UserConsent = Required<GeneratedUserConsent>;
 

--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -1,6 +1,22 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+
+// The emitter posts through the generated client (so the session credentials
+// the ingest endpoint authenticates are attached); mock the sdk function and
+// assert on the typed request body.
+const ingestMock = mock(
+  async (_options: { body: unknown; keepalive?: boolean }) => ({
+    data: { accepted: 1, persisted: 1, dropped: {} },
+    error: undefined,
+    response: { ok: true, status: 200 } as Response,
+  }),
+);
+mock.module("@/generated/api/sdk.gen", () => ({
+  telemetryIngestCreate: ingestMock,
+}));
+
+const {
   __resetOnboardingFunnelEventsForTests,
   buildOnboardingFunnelEvent,
   emitOnboardingFunnelStepCompleted,
@@ -14,26 +30,35 @@ import {
   resolveOnboardingFunnelVariant,
   RESEARCH_ONBOARDING_FUNNEL_STEPS,
   RESEARCH_ONBOARDING_FUNNEL_VERSION,
-} from "@/domains/onboarding/funnel-events";
-import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+} = await import("@/domains/onboarding/funnel-events");
 
-const originalFetch = globalThis.fetch;
+interface IngestPayload {
+  device_id: string;
+  assistant_version: string;
+  events: Array<Record<string, unknown>>;
+}
+
+function ingestPayload(callIndex: number): IngestPayload {
+  const options = ingestMock.mock.calls[callIndex]?.[0] as
+    { body: IngestPayload } | undefined;
+  if (!options) throw new Error(`No ingest call at index ${callIndex}`);
+  return options.body;
+}
 
 beforeEach(() => {
   sessionStorage.clear();
   localStorage.clear();
   useOnboardingStore.setState({ shareAnalytics: true });
   __resetOnboardingFunnelEventsForTests();
-});
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
+  ingestMock.mockClear();
 });
 
 describe("onboarding funnel events", () => {
   test("maps experiment arms to funnel variants", () => {
     expect(onboardingFunnelVariantFromExperiment("control")).toBe("control");
-    expect(onboardingFunnelVariantFromExperiment("variant-a")).toBe("pared_down");
+    expect(onboardingFunnelVariantFromExperiment("variant-a")).toBe(
+      "pared_down",
+    );
   });
 
   test("builds the expected event shape with a stable session id", () => {
@@ -108,11 +133,6 @@ describe("onboarding funnel events", () => {
 
   test("emits fire-and-forget telemetry payloads with the same session id", () => {
     localStorage.setItem("device:share_analytics", "true");
-    const fetchMock = mock(
-      async (_input: RequestInfo | URL, _init?: RequestInit) =>
-        new Response("{}", { status: 200 }),
-    );
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
@@ -123,20 +143,11 @@ describe("onboarding funnel events", () => {
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const calls = fetchMock.mock.calls as Array<
-      [RequestInfo | URL, RequestInit | undefined]
-    >;
-    const firstPayload = JSON.parse(
-      calls[0]?.[1]?.body as string,
-    ) as { events: Array<Record<string, unknown>> };
-    const secondPayload = JSON.parse(
-      calls[1]?.[1]?.body as string,
-    ) as { events: Array<Record<string, unknown>> };
-    const firstEvent = firstPayload.events[0];
-    const secondEvent = secondPayload.events[0];
+    expect(ingestMock).toHaveBeenCalledTimes(2);
+    const firstEvent = ingestPayload(0).events[0];
+    const secondEvent = ingestPayload(1).events[0];
 
-    expect(calls[0]?.[0]).toBe("/v1/telemetry/ingest/");
+    expect(ingestPayload(0).device_id).toBeTruthy();
     expect(firstEvent?.session_id).toBeTruthy();
     expect(secondEvent?.session_id).toBe(firstEvent?.session_id);
     expect(secondEvent).toMatchObject({
@@ -151,11 +162,6 @@ describe("onboarding funnel events", () => {
 
   test("stamps research-onboarding steps with the research funnel version", () => {
     localStorage.setItem("device:share_analytics", "true");
-    const fetchMock = mock(
-      async (_input: RequestInfo | URL, _init?: RequestInit) =>
-        new Response("{}", { status: 200 }),
-    );
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS.form, {
       userId: "user-123",
@@ -166,22 +172,10 @@ describe("onboarding funnel events", () => {
       { userId: "user-123", outcome: "skipped" },
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const calls = fetchMock.mock.calls as Array<
-      [RequestInfo | URL, RequestInit | undefined]
-    >;
-    const firstEvent = (
-      JSON.parse(calls[0]?.[1]?.body as string) as {
-        events: Array<Record<string, unknown>>;
-      }
-    ).events[0];
-    const secondEvent = (
-      JSON.parse(calls[1]?.[1]?.body as string) as {
-        events: Array<Record<string, unknown>>;
-      }
-    ).events[0];
+    expect(ingestMock).toHaveBeenCalledTimes(2);
+    const firstEvent = ingestPayload(0).events[0];
+    const secondEvent = ingestPayload(1).events[0];
 
-    expect(calls[0]?.[0]).toBe("/v1/telemetry/ingest/");
     expect(firstEvent).toMatchObject({
       type: "onboarding",
       screen: "research_form",
@@ -205,24 +199,11 @@ describe("onboarding funnel events", () => {
 
   test("emits the check-in calendar click on the research funnel", () => {
     localStorage.setItem("device:share_analytics", "true");
-    const fetchMock = mock(
-      async (_input: RequestInfo | URL, _init?: RequestInit) =>
-        new Response("{}", { status: 200 }),
-    );
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     emitResearchOnboardingCheckinCalendarOpened({ userId: "user-123" });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const calls = fetchMock.mock.calls as Array<
-      [RequestInfo | URL, RequestInit | undefined]
-    >;
-    expect(calls[0]?.[0]).toBe("/v1/telemetry/ingest/");
-    const event = (
-      JSON.parse(calls[0]?.[1]?.body as string) as {
-        events: Array<Record<string, unknown>>;
-      }
-    ).events[0];
+    expect(ingestMock).toHaveBeenCalledTimes(1);
+    const event = ingestPayload(0).events[0];
     expect(event).toMatchObject({
       type: "onboarding",
       step_name: "research_checkin_open",
@@ -236,33 +217,22 @@ describe("onboarding funnel events", () => {
 
   test("does not emit research telemetry until analytics sharing is opted in", () => {
     useOnboardingStore.setState({ shareAnalytics: false });
-    const fetchMock = mock(
-      async (_input: RequestInfo | URL, _init?: RequestInit) =>
-        new Response("{}", { status: 200 }),
-    );
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS.form, {
       userId: "user-123",
     });
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ingestMock).not.toHaveBeenCalled();
   });
 
   test("emits by default (opt-out) but honors an explicit analytics opt-out", () => {
-    const fetchMock = mock(
-      async (_input: RequestInfo | URL, _init?: RequestInit) =>
-        new Response("{}", { status: 200 }),
-    );
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
-
     // Never-asked: no device preference on record — analytics is opt-out, so
     // the event emits.
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(ingestMock).toHaveBeenCalledTimes(1);
 
     // An explicit device opt-out stops uploads.
     localStorage.setItem("device:share_analytics", "false");
@@ -270,7 +240,7 @@ describe("onboarding funnel events", () => {
       userId: "user-123",
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(ingestMock).toHaveBeenCalledTimes(1);
 
     // The in-memory store must agree: a failed opt-out write cannot leave an
     // older stored opt-in authorizing a new event.
@@ -280,6 +250,6 @@ describe("onboarding funnel events", () => {
       userId: "user-123",
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(ingestMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -239,8 +239,7 @@ export function emitOnboardingFunnelStepCompleted(
   // The generated client (not a raw fetch): its interceptors attach the
   // session credentials the ingest endpoint authenticates — an
   // unauthenticated POST is acknowledged with 200 but silently dropped
-  // server-side (JARVIS-1292: a bare fetch here lost every browser funnel
-  // event for four weeks).
+  // server-side.
   void telemetryIngestCreate({
     body: {
       device_id: getClientId(),

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -1,5 +1,6 @@
 import { readShareAnalytics } from "@/domains/onboarding/prefs";
 import { getClientId } from "@/lib/telemetry/client-identity";
+import { telemetryIngestCreate } from "@/generated/api/sdk.gen";
 import type { ResearchStep } from "@/domains/onboarding/research-onboarding-persistence";
 
 export const ONBOARDING_FUNNEL_VERSION = "onboarding_v3_2026_05";
@@ -54,7 +55,8 @@ export interface OnboardingFunnelStepDescriptor {
  * and ingest path. The backend stores step_name/funnel_version as open strings, so
  * these new values need no backend/terraform change.
  */
-export const RESEARCH_ONBOARDING_FUNNEL_VERSION = "research_onboarding_v1_2026_06";
+export const RESEARCH_ONBOARDING_FUNNEL_VERSION =
+  "research_onboarding_v1_2026_06";
 
 export const RESEARCH_ONBOARDING_FUNNEL_STEPS = {
   form: { stepName: "research_form", stepIndex: 0 },
@@ -234,18 +236,28 @@ export function emitOnboardingFunnelStepCompleted(
 
   const event = stripUndefined(buildOnboardingFunnelEvent(screen, options));
 
-  const payload = JSON.stringify({
-    device_id: getClientId(),
-    assistant_version: import.meta.env.VITE_APP_VERSION ?? "web-dev",
-    events: [event],
-  });
-
-  void fetch("/v1/telemetry/ingest/", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: payload,
+  // The generated client (not a raw fetch): its interceptors attach the
+  // session credentials the ingest endpoint authenticates — an
+  // unauthenticated POST is acknowledged with 200 but silently dropped
+  // server-side (JARVIS-1292: a bare fetch here lost every browser funnel
+  // event for four weeks).
+  void telemetryIngestCreate({
+    body: {
+      device_id: getClientId(),
+      assistant_version: import.meta.env.VITE_APP_VERSION ?? "web-dev",
+      events: [event],
+    },
     keepalive: true,
-  }).catch(() => {});
+  })
+    .then(({ data, response }) => {
+      if (!import.meta.env.DEV) return;
+      if (!response?.ok) {
+        console.warn("onboarding funnel event rejected", response?.status);
+      } else if (data && data.persisted < data.accepted) {
+        console.warn("onboarding funnel event dropped by server", data.dropped);
+      }
+    })
+    .catch(() => {});
 }
 
 /**
@@ -262,7 +274,10 @@ export function emitOnboardingFunnelStepCompleted(
  */
 export function emitResearchOnboardingStepCompleted(
   step: ResearchOnboardingFunnelStep,
-  options: { userId?: string | null; outcome?: OnboardingFunnelStepOutcome } = {},
+  options: {
+    userId?: string | null;
+    outcome?: OnboardingFunnelStepOutcome;
+  } = {},
 ): void {
   emitOnboardingFunnelStepCompleted(step, {
     userId: options.userId,


### PR DESCRIPTION
## Summary
- Routes the onboarding funnel emitter through the generated `telemetryIngestCreate` instead of a raw relative `fetch` — the generated client's interceptors attach the session credentials that platform ingest authenticates (companion to platform PR vellum-ai/vellum-assistant-platform#9131, which makes ingest accept session auth; gate 1 there has silently dropped every browser-originated event since Jun 19 while returning `200 accepted:N` — JARVIS-1292).
- Syncs `platform.yaml` (now exposing `/v1/telemetry/ingest/` + `/v1/user/consent/`) and replaces the hand-written `UserConsent` interface with the generated wire type — the hand-written copy is how PR #38160 invented a field (`share_analytics_chosen`) the endpoint never returns without the compiler objecting. `fetchConsent`/`patchConsent` now use the generated SDK functions.
- Adds a dev-console warning when ingest reports a rejected or server-dropped event (using #9131's new `persisted`/`dropped` response fields) instead of `.catch(() => {})` swallowing everything.
- Deploy-safe standalone: against the pre-#9131 platform, events keep being dropped exactly as today. Merge order with #9131 doesn't matter; browser telemetry starts flowing when both are live.

Part of JARVIS-1292 — closes only after browser funnel rows are verified in BigQuery post-deploy.

## Original prompt
Noa flagged the run of consent/telemetry band-aids and asked for a root-cause cleanup across both repos. Diagnosis (BQ + git archaeology) showed the browser funnel outage was a transport/auth bug, not consent logic: the old pre-chat funnel landed ~500 rows/day until exactly Jun 19 — the day platform privacy gate 1 (#8540) started silently swallowing unauthenticated ingest — and the research funnel (same raw-fetch emitter) never landed a single row. This PR is Phase 0c of the approved plan: typed, authenticated transport for browser telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)