### PR TITLE
Memory Concept Graph — Enhancements (Wave 2)

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
@@ -9,6 +9,9 @@ import type { ConceptNodeKind } from "./types";
 interface ConceptGraphLegendProps {
   /** Node kinds actually present in the graph, in display order. */
   nodeKinds: ConceptNodeKind[];
+  /** When true (concept-only graph), nodes are colored by cluster/theme, so a
+   * lone kind swatch would be meaningless — show a caption instead. */
+  coloredByTheme?: boolean;
   hasLinks: boolean;
   hasLearned: boolean;
 }
@@ -16,6 +19,7 @@ interface ConceptGraphLegendProps {
 /** Compact legend for node kinds and edge kinds present in the graph. */
 export function ConceptGraphLegend({
   nodeKinds,
+  coloredByTheme,
   hasLinks,
   hasLearned,
 }: ConceptGraphLegendProps) {
@@ -41,7 +45,12 @@ export function ConceptGraphLegend({
           </span>
         </div>
       ))}
-      {nodeKinds.length > 0 && (hasLinks || hasLearned) && (
+      {coloredByTheme && (
+        <span className="text-[11px]" style={{ color: "var(--content-tertiary)" }}>
+          Colored by theme
+        </span>
+      )}
+      {(nodeKinds.length > 0 || coloredByTheme) && (hasLinks || hasLearned) && (
         <div
           className="mt-0.5 border-t pt-1.5"
           style={{ borderColor: "var(--border-base)" }}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 import {
   EDGE_LEARNED_COLOR,
   EDGE_LINK_COLOR,
@@ -14,6 +16,13 @@ interface ConceptGraphLegendProps {
   coloredByTheme?: boolean;
   hasLinks: boolean;
   hasLearned: boolean;
+  /** When provided (both edge kinds present), the Link / Learned rows become
+   * toggles that show/hide that edge kind; the `*Active` flags dim the row
+   * while its kind is hidden. Omitted → static, non-interactive rows. */
+  onToggleLink?: () => void;
+  onToggleLearned?: () => void;
+  linkActive?: boolean;
+  learnedActive?: boolean;
 }
 
 /** Compact legend for node kinds and edge kinds present in the graph. */
@@ -22,9 +31,14 @@ export function ConceptGraphLegend({
   coloredByTheme,
   hasLinks,
   hasLearned,
+  onToggleLink,
+  onToggleLearned,
+  linkActive,
+  learnedActive,
 }: ConceptGraphLegendProps) {
   return (
     <div
+      data-graph-control
       className="pointer-events-none absolute bottom-4 left-4 flex flex-col gap-1.5 rounded-lg px-3 py-2"
       style={{
         backgroundColor: "color-mix(in srgb, var(--surface-base) 78%, transparent)",
@@ -57,33 +71,63 @@ export function ConceptGraphLegend({
         />
       )}
       {hasLinks && (
-        <div className="flex items-center gap-2">
-          <span
-            className="inline-block h-0 w-4"
-            style={{ borderTop: `2px solid ${EDGE_LINK_COLOR}` }}
-          />
-          <span
-            className="text-[11px]"
-            style={{ color: "var(--content-tertiary)" }}
-          >
-            Link
-          </span>
-        </div>
+        <EdgeLegendRow
+          swatchStyle={{ borderTop: `2px solid ${EDGE_LINK_COLOR}` }}
+          label="Link"
+          onToggle={onToggleLink}
+          active={linkActive}
+        />
       )}
       {hasLearned && (
-        <div className="flex items-center gap-2">
-          <span
-            className="inline-block h-0 w-4"
-            style={{ borderTop: `2px dashed ${EDGE_LEARNED_COLOR}` }}
-          />
-          <span
-            className="text-[11px]"
-            style={{ color: "var(--content-tertiary)" }}
-          >
-            Learned
-          </span>
-        </div>
+        <EdgeLegendRow
+          swatchStyle={{ borderTop: `2px dashed ${EDGE_LEARNED_COLOR}` }}
+          label="Learned"
+          onToggle={onToggleLearned}
+          active={learnedActive}
+        />
       )}
     </div>
+  );
+}
+
+/** One edge-kind legend row: a line swatch + label. With `onToggle` it renders
+ * as a button that shows/hides that edge kind (dimmed while its kind is hidden);
+ * without one it's a static, non-interactive row that keeps the legend's look. */
+function EdgeLegendRow({
+  swatchStyle,
+  label,
+  onToggle,
+  active,
+}: {
+  swatchStyle: CSSProperties;
+  label: string;
+  onToggle?: () => void;
+  active?: boolean;
+}) {
+  const swatch = <span className="inline-block h-0 w-4" style={swatchStyle} />;
+  const text = (
+    <span className="text-[11px]" style={{ color: "var(--content-tertiary)" }}>
+      {label}
+    </span>
+  );
+  if (!onToggle) {
+    return (
+      <div className="flex items-center gap-2">
+        {swatch}
+        {text}
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={active}
+      className="pointer-events-auto flex cursor-pointer items-center gap-2 border-0 bg-transparent p-0 transition-opacity"
+      style={{ opacity: active === false ? 0.4 : 1 }}
+    >
+      {swatch}
+      {text}
+    </button>
   );
 }

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -18,7 +18,8 @@ import { buildForceLayout } from "./build-force-layout";
 import { ConceptDetailPanel, type ConceptDetailNode } from "./concept-detail-panel";
 import { ConceptGraphIntroBanner } from "./concept-graph-intro-banner";
 import { ConceptGraphLegend } from "./concept-graph-legend";
-import { EDGE_LEARNED_COLOR, NODE_KIND_COLORS } from "./constants";
+import { CLUSTER_PALETTE, EDGE_LEARNED_COLOR, NODE_KIND_COLORS } from "./constants";
+import { detectClusters } from "./detect-clusters";
 import type { ConceptNodeKind, GraphLayoutNode } from "./types";
 import { useGraphIntroDismissed } from "./use-graph-intro-dismissed";
 
@@ -128,6 +129,13 @@ export function ConceptGraphView({
     [graph],
   );
   const ready = query.data?.kind === "ready" && layout.nodes.length > 0;
+
+  // Group concepts into themes so the map reads as colored clusters instead of
+  // one flat color. Deterministic (see detect-clusters), so no render churn.
+  const clusters = useMemo(
+    () => detectClusters(layout.nodes, layout.edges),
+    [layout.nodes, layout.edges],
+  );
 
   // Neighbor adjacency for hover highlighting.
   const adjacency = useMemo(() => {
@@ -260,6 +268,7 @@ export function ConceptGraphView({
     // this loop) whenever the data changes, so these never go stale.
     const nodes = layout.nodes;
     const edges = layout.edges;
+    const nodeClusters = clusters;
     const adj = adjacency;
     const R = massRadius;
 
@@ -412,7 +421,12 @@ export function ConceptGraphView({
       for (const idx of order) {
         const p = proj[idx];
         const node = p.node;
-        const color = NODE_KIND_COLORS[node.kind];
+        // Concepts are colored by their detected theme/cluster; any non-concept
+        // node falls back to its per-kind color.
+        const color =
+          node.kind === "concept"
+            ? CLUSTER_PALETTE[(nodeClusters.get(node.id) ?? 0) % CLUSTER_PALETTE.length]
+            : NODE_KIND_COLORS[node.kind];
         const ghost = searchActive && !isMatch(node.id);
         const lit = !ghost && isLit(node.id);
         const isActive = node.id === activeId;
@@ -491,7 +505,7 @@ export function ConceptGraphView({
       cancelAnimationFrame(raf);
       ro.disconnect();
     };
-  }, [ready, layout, adjacency, massRadius]);
+  }, [ready, layout, adjacency, massRadius, clusters]);
 
   // Nearest node under a screen point; nearest-in-front wins. While a search is
   // active, ghosted (non-matching) nodes are skipped so hover/click land on a
@@ -716,7 +730,8 @@ export function ConceptGraphView({
         ) : null}
 
         <ConceptGraphLegend
-          nodeKinds={presentKinds.length > 1 ? presentKinds : []}
+          nodeKinds={presentKinds.filter((k) => k !== "concept")}
+          coloredByTheme={presentKinds.includes("concept")}
           hasLinks={hasLinks}
           hasLearned={hasLearned}
         />

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -925,6 +925,18 @@ export function ConceptGraphView({
   }, [layout.nodes]);
   const hasLearned = useMemo(() => layout.edges.some((e) => e.kind === "learned"), [layout.edges]);
   const hasLinks = useMemo(() => layout.edges.some((e) => e.kind !== "learned"), [layout.edges]);
+  // The Link/Learned toggles only render when both kinds are present. If a
+  // refetch leaves only one kind, the controls disappear — so clear any active
+  // filter, otherwise a previously-hidden kind stays hidden with no way to
+  // restore it. Mirrors the recency-window reset.
+  useEffect(() => {
+    if (
+      !(hasLinks && hasLearned) &&
+      (!edgeFilter.link || !edgeFilter.learned)
+    ) {
+      setEdgeFilter({ link: true, learned: true });
+    }
+  }, [hasLinks, hasLearned, edgeFilter]);
 
   // The intro banner shows over a supported graph (empty or populated), never
   // over the loading / error / unsupported states.

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -20,6 +20,7 @@ import { ConceptGraphIntroBanner } from "./concept-graph-intro-banner";
 import { ConceptGraphLegend } from "./concept-graph-legend";
 import { CLUSTER_PALETTE, EDGE_LEARNED_COLOR, NODE_KIND_COLORS } from "./constants";
 import { detectClusters } from "./detect-clusters";
+import { RecencyLens, type RecencyWindow } from "./recency-lens";
 import type { ConceptNodeKind, GraphLayoutNode } from "./types";
 import { useGraphIntroDismissed } from "./use-graph-intro-dismissed";
 
@@ -65,6 +66,7 @@ interface Projected {
   sy: number;
   sr: number;
   depth: number; // 0 (far) .. 1 (near)
+  updatedAtMs?: number; // for recency hit-test skipping; undefined = stale/older
 }
 
 interface Colors {
@@ -229,6 +231,24 @@ export function ConceptGraphView({
     setSearch("");
   }, [assistantId]);
 
+  // Recency time-lens: "All · Month · Week" narrows the graph to concepts
+  // updated within the window — older ones ghost like non-search-matches, so
+  // "what did it learn recently?" pops. The window (in ms, or null for "all")
+  // lives in a ref the 60fps loop reads (so segment clicks don't re-run it), and
+  // `dirty` is bumped whenever it changes so reduced-motion redraws.
+  const [recency, setRecency] = useState<RecencyWindow>("all");
+  const recencyRef = useRef<{ windowMs: number | null }>({ windowMs: null });
+  useEffect(() => {
+    recencyRef.current.windowMs =
+      recency === "week" ? 7 * DAY_MS : recency === "month" ? 30 * DAY_MS : null;
+    view.current.dirty = true;
+  }, [recency]);
+  // Reset the window on assistant switch (mirrors the search reset above), so a
+  // stale window doesn't ghost the new assistant's freshly-loaded concepts.
+  useEffect(() => {
+    setRecency("all");
+  }, [assistantId]);
+
   const labelFor = useCallback(
     (id: string | null): string | null => {
       if (!id) {return null;}
@@ -340,6 +360,13 @@ export function ConceptGraphView({
       const isMatch = (id: string) =>
         !searchActive || (filter.matches?.has(id) ?? false);
 
+      // Recency lens: when a window is set, concepts not updated within it ghost
+      // (like non-search-matches). A missing timestamp counts as stale/older.
+      const recencyWindowMs = recencyRef.current.windowMs;
+      const isRecencyGhost = (n: GraphLayoutNode) =>
+        recencyWindowMs != null &&
+        (!n.updatedAtMs || nowMs - n.updatedAtMs > recencyWindowMs);
+
       // Density fog: fade the resting learned-edge web as the corpus grows.
       const learnedFog =
         nodes.length <= FOG_FULL_BELOW
@@ -390,7 +417,11 @@ export function ConceptGraphView({
         const b = posById.get(e.toId);
         if (!a || !b) {continue;}
         const learned = e.kind === "learned";
-        const ghost = searchActive && (!isMatch(e.fromId) || !isMatch(e.toId));
+        // An edge ghosts if either endpoint is ghosted by search or recency.
+        const ghost =
+          (searchActive && (!isMatch(e.fromId) || !isMatch(e.toId))) ||
+          isRecencyGhost(a.node) ||
+          isRecencyGhost(b.node);
         const incident = activeId != null && (e.fromId === activeId || e.toId === activeId);
         const depth = (a.depth + b.depth) / 2;
         // Learned edges fade with density in the resting web; authored links
@@ -427,7 +458,8 @@ export function ConceptGraphView({
           node.kind === "concept"
             ? CLUSTER_PALETTE[(nodeClusters.get(node.id) ?? 0) % CLUSTER_PALETTE.length]
             : NODE_KIND_COLORS[node.kind];
-        const ghost = searchActive && !isMatch(node.id);
+        const searchGhost = searchActive && !isMatch(node.id);
+        const ghost = searchGhost || isRecencyGhost(node);
         const lit = !ghost && isLit(node.id);
         const isActive = node.id === activeId;
         const depthA = DEPTH_ALPHA_MIN + (1 - DEPTH_ALPHA_MIN) * p.depth;
@@ -475,7 +507,8 @@ export function ConceptGraphView({
         // When nothing is focused, only label front-facing hubs (depth-gated) so
         // the dense middle of the mass doesn't turn into unreadable label soup.
         // While searching, label the matches instead (that's what you're after).
-        if (searchActive && !isMatch(node.id)) {continue;}
+        // Ghosted nodes (search or recency) never get labels.
+        if ((searchActive && !isMatch(node.id)) || isRecencyGhost(node)) {continue;}
         const showLabel = searchActive
           ? p.depth > 0.3
           : activeId != null
@@ -495,6 +528,7 @@ export function ConceptGraphView({
         sy: p.sy,
         sr: p.sr,
         depth: p.depth,
+        updatedAtMs: p.node.updatedAtMs,
       }));
 
       raf = requestAnimationFrame(render);
@@ -507,15 +541,24 @@ export function ConceptGraphView({
     };
   }, [ready, layout, adjacency, massRadius, clusters]);
 
-  // Nearest node under a screen point; nearest-in-front wins. While a search is
-  // active, ghosted (non-matching) nodes are skipped so hover/click land on a
-  // result, not a faded background node.
+  // Nearest node under a screen point; nearest-in-front wins. Ghosted nodes are
+  // skipped so hover/click land on a live node, not a faded background one: both
+  // search non-matches and, when a recency window is set, concepts older than it
+  // (a missing timestamp counts as stale). Mirrors the render-loop ghosting.
   const hitTest = useCallback((x: number, y: number): string | null => {
     const filter = filterRef.current;
+    const recencyWindowMs = recencyRef.current.windowMs;
+    const now = Date.now();
     let best: string | null = null;
     let bestDepth = -1;
     for (const p of projectedRef.current) {
       if (filter.active && !(filter.matches?.has(p.id) ?? false)) {continue;}
+      if (
+        recencyWindowMs != null &&
+        (!p.updatedAtMs || now - p.updatedAtMs > recencyWindowMs)
+      ) {
+        continue;
+      }
       const dx = x - p.sx;
       const dy = y - p.sy;
       if (dx * dx + dy * dy <= (p.sr + 5) * (p.sr + 5) && p.depth > bestDepth) {
@@ -726,6 +769,16 @@ export function ConceptGraphView({
                 </>
               ) : null}
             </div>
+          </div>
+        ) : null}
+
+        {/* Recency time-lens, tucked just under the search pill. Kept visible
+            while a non-"all" window is active even if the graph shrank below the
+            threshold (e.g. a refetch), so an active window is always resettable
+            — mirrors the search box's own guard. */}
+        {layout.nodes.length > SEARCH_MIN_NODES || recency !== "all" ? (
+          <div className={`absolute top-14 z-10 ${onToggleFullscreen ? "left-16" : "left-4"}`}>
+            <RecencyLens value={recency} onChange={setRecency} />
           </div>
         ) : null}
 

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -215,6 +215,9 @@ export function ConceptGraphView({
   // so a pointer can hit-test edges for the "why are these connected?" tooltip.
   const projectedEdgesRef = useRef<ProjectedEdge[]>([]);
   const colorsRef = useRef<Colors>({ content: "#e5e7eb", tertiary: "#8792a0" });
+  // Set by search jump-to. While non-null the render loop eases the camera each
+  // frame to center this concept, then clears it once the view has settled.
+  const focusTargetRef = useRef<string | null>(null);
 
   // Bumped only when the focused node changes, so the DOM tooltip re-renders.
   // The canvas itself never needs React state.
@@ -257,6 +260,17 @@ export function ConceptGraphView({
   useEffect(() => {
     setSearch("");
   }, [assistantId]);
+  // Top matches for the results list under the search box: most-connected first,
+  // capped so the dropdown stays scannable. The head is also the Enter target.
+  const searchResults = useMemo(() => {
+    if (!matchIds || matchIds.size === 0) {
+      return [];
+    }
+    return layout.nodes
+      .filter((n) => matchIds.has(n.id))
+      .sort((a, b) => b.degree - a.degree)
+      .slice(0, 8);
+  }, [matchIds, layout.nodes]);
 
   // Recency time-lens: "All · Month · Week" narrows the graph to concepts
   // updated within the window — older ones ghost like non-search-matches, so
@@ -319,6 +333,14 @@ export function ConceptGraphView({
     v.dirty = true;
   }, []);
 
+  // Fly the camera to center a concept (search jump-to). The render loop reads
+  // focusTargetRef each frame and eases yaw/pitch/zoom toward it.
+  const focusOn = useCallback((id: string) => {
+    focusTargetRef.current = id;
+    view.current.lastInteractAt = performance.now();
+    view.current.dirty = true;
+  }, []);
+
   useEffect(() => {
     if (!ready) {return;}
     const canvas = canvasRef.current;
@@ -366,9 +388,48 @@ export function ConceptGraphView({
       const colors = colorsRef.current;
       const nowMs = Date.now();
 
+      const focusId = focusTargetRef.current;
       const idle = !v.dragging && t - v.lastInteractAt > IDLE_RESUME_MS;
-      if (idle && !reduceMotion) {
+      // Suppress the idle drift while flying to a searched concept, or it fights
+      // the ease and the target never settles.
+      if (idle && !reduceMotion && !focusId) {
         v.yaw += AUTO_YAW_PER_SEC * dt;
+      }
+
+      // Search jump-to: ease the camera to bring the target node front-and-center
+      // (yaw/pitch face it, zoom pushes in), then clear the target once settled.
+      // Reduced motion snaps instantly (k=1). Runs before the reduced-motion
+      // static-frame skip so it keeps stepping the ease.
+      if (focusId) {
+        const target = nodes.find((n) => n.id === focusId);
+        if (!target) {
+          focusTargetRef.current = null;
+        } else {
+          const nx = target.x - VIRTUAL_CENTER.x;
+          const ny = target.y - VIRTUAL_CENTER.y;
+          const nz = target.z;
+          const targetYaw = -Math.atan2(nx, nz);
+          const r = Math.hypot(nx, nz);
+          const targetPitch = Math.max(
+            -PITCH_CLAMP,
+            Math.min(PITCH_CLAMP, Math.atan2(ny, r)),
+          );
+          const targetZoom = Math.min(MAX_ZOOM, 1.6);
+          const k = reduceMotion ? 1 : 0.15;
+          let dY = targetYaw - v.yaw;
+          dY = Math.atan2(Math.sin(dY), Math.cos(dY));
+          v.yaw += dY * k;
+          v.pitch += (targetPitch - v.pitch) * k;
+          v.zoom += (targetZoom - v.zoom) * k;
+          v.dirty = true;
+          if (
+            Math.abs(dY) < 0.01 &&
+            Math.abs(targetPitch - v.pitch) < 0.01 &&
+            Math.abs(targetZoom - v.zoom) < 0.02
+          ) {
+            focusTargetRef.current = null;
+          }
+        }
       }
 
       // With reduced motion there is no auto-rotation, so the scene is static
@@ -830,10 +891,12 @@ export function ConceptGraphView({
         {/* Keep the box visible whenever a search is active, even if the graph
             shrank below the threshold (e.g. a refetch) — otherwise an active
             filter would ghost nodes with no way to clear it short of remount. */}
+        {/* z-20 keeps the results dropdown above the recency lens (top-14,
+            z-10) so its top rows stay clickable while a search is active. */}
         {layout.nodes.length > SEARCH_MIN_NODES || search ? (
           <div
             data-graph-control
-            className={`absolute top-4 z-10 ${onToggleFullscreen ? "left-16" : "left-4"}`}
+            className={`absolute top-4 z-20 ${onToggleFullscreen ? "left-16" : "left-4"}`}
           >
             <div
               className="flex items-center gap-1.5 rounded-full px-2.5 py-1"
@@ -850,6 +913,9 @@ export function ConceptGraphView({
                 onKeyDown={(e) => {
                   if (e.key === "Escape") {
                     setSearch("");
+                  } else if (e.key === "Enter" && searchResults.length > 0) {
+                    e.preventDefault();
+                    focusOn(searchResults[0].id);
                   }
                 }}
                 placeholder="Search concepts…"
@@ -877,6 +943,39 @@ export function ConceptGraphView({
                 </>
               ) : null}
             </div>
+
+            {/* Results under the box: click (or Enter on the top row) flies the
+                camera to center that concept and opens its detail drawer. */}
+            {search && searchResults.length > 0 ? (
+              <ul
+                className="mt-1.5 flex max-h-56 w-52 list-none flex-col overflow-y-auto rounded-xl py-1"
+                style={{
+                  backgroundColor:
+                    "color-mix(in srgb, var(--surface-base) 92%, transparent)",
+                  border: "1px solid var(--border-base)",
+                }}
+              >
+                {searchResults.map((node) => (
+                  <li key={node.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        focusOn(node.id);
+                        setOpenNode({
+                          id: node.id,
+                          label: node.label,
+                          updatedAtMs: node.updatedAtMs,
+                        });
+                      }}
+                      className="block w-full truncate px-3 py-1 text-left text-[12px] hover:bg-[color-mix(in_srgb,var(--content-tertiary)_14%,transparent)]"
+                      style={{ color: "var(--content-default)" }}
+                    >
+                      {node.label}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
           </div>
         ) : null}
 

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -276,6 +276,22 @@ export function ConceptGraphView({
     setRecency("all");
   }, [assistantId]);
 
+  // Edge-kind filter: toggle authored (link) vs behavioral (learned) edges to
+  // declutter. The active flags live in a ref the 60fps loop reads (so a toggle
+  // click doesn't re-run the render effect), and `dirty` is bumped whenever they
+  // change so reduced-motion redraws. Only surfaced when both kinds are present.
+  const [edgeFilter, setEdgeFilter] = useState({ link: true, learned: true });
+  const edgeFilterRef = useRef(edgeFilter);
+  useEffect(() => {
+    edgeFilterRef.current = edgeFilter;
+    view.current.dirty = true;
+  }, [edgeFilter]);
+  // Reset on assistant switch (mirrors the search/recency resets), so a hidden
+  // kind doesn't carry over and blank out edges on the new assistant's graph.
+  useEffect(() => {
+    setEdgeFilter({ link: true, learned: true });
+  }, [assistantId]);
+
   const labelFor = useCallback(
     (id: string | null): string | null => {
       if (!id) {return null;}
@@ -394,6 +410,9 @@ export function ConceptGraphView({
         recencyWindowMs != null &&
         (!n.updatedAtMs || nowMs - n.updatedAtMs > recencyWindowMs);
 
+      // Edge-kind toggle: a hidden kind is skipped entirely below.
+      const edgeKinds = edgeFilterRef.current;
+
       // Density fog: fade the resting learned-edge web as the corpus grows.
       const learnedFog =
         nodes.length <= FOG_FULL_BELOW
@@ -446,6 +465,11 @@ export function ConceptGraphView({
         const b = posById.get(e.toId);
         if (!a || !b) {continue;}
         const learned = e.kind === "learned";
+        // A hidden kind is neither drawn nor collected for edge-hover, so the
+        // hit-test stays consistent with what's on screen.
+        if (learned ? !edgeKinds.learned : !edgeKinds.link) {
+          continue;
+        }
         // An edge ghosts if either endpoint is ghosted by search or recency.
         const ghost =
           (searchActive && (!isMatch(e.fromId) || !isMatch(e.toId))) ||
@@ -871,6 +895,16 @@ export function ConceptGraphView({
           coloredByTheme={presentKinds.includes("concept")}
           hasLinks={hasLinks}
           hasLearned={hasLearned}
+          {...(hasLinks && hasLearned
+            ? {
+                onToggleLink: () =>
+                  setEdgeFilter((f) => ({ ...f, link: !f.link })),
+                onToggleLearned: () =>
+                  setEdgeFilter((f) => ({ ...f, learned: !f.learned })),
+                linkActive: edgeFilter.link,
+                learnedActive: edgeFilter.learned,
+              }
+            : {})}
         />
 
         {/* One pill for both hovers. Node hover and edge hover are mutually

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { VIRTUAL_CENTER } from "@/domains/intelligence/components/constellation-view/constants";
 import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
+import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
 import { Button } from "@vellumai/design-library";
 
 import { buildForceLayout } from "./build-force-layout";
@@ -227,6 +228,13 @@ export function ConceptGraphView({
   const [edgeLabel, setEdgeLabel] = useState<string | null>(null);
   // The concept opened into the detail drawer (null = graph only).
   const [openNode, setOpenNode] = useState<ConceptDetailNode | null>(null);
+  // Opening a concept into the detail drawer (canvas click or search result)
+  // is a tracked memory interaction. Route every open through here so
+  // "node_opened" is emitted exactly once per open, from one place.
+  const openNodeDetail = useCallback((node: ConceptDetailNode) => {
+    emitMemoryEvent("node_opened");
+    setOpenNode(node);
+  }, []);
 
   // First-run explainer: shown over the graph (empty or populated) until the
   // user dismisses it; the dismissal sticks per-assistant.
@@ -237,6 +245,10 @@ export function ConceptGraphView({
   // a ref the 60fps render loop reads (so keystrokes don't re-run the effect),
   // and `dirty` is bumped whenever it changes so reduced-motion redraws.
   const [search, setSearch] = useState("");
+  // Latch so the "search" interaction is emitted once per search session — on
+  // the empty→non-empty transition — not per keystroke. Reset whenever the box
+  // empties (see the effect below), so a fresh search re-emits.
+  const searchEmittedRef = useRef(false);
   const searchLower = search.trim().toLowerCase();
   const matchIds = useMemo(() => {
     if (!searchLower) {return null;}
@@ -260,6 +272,14 @@ export function ConceptGraphView({
   useEffect(() => {
     setSearch("");
   }, [assistantId]);
+  // Reset the "search started" latch whenever the box empties — by keystroke,
+  // the clear button, Escape, or an assistant switch — so the next search
+  // re-emits its start event.
+  useEffect(() => {
+    if (!search.trim()) {
+      searchEmittedRef.current = false;
+    }
+  }, [search]);
   // Top matches for the results list under the search box: most-connected first,
   // capped so the dropdown stays scannable. The head is also the Enter target.
   const searchResults = useMemo(() => {
@@ -802,14 +822,18 @@ export function ConceptGraphView({
           // Click a node → open its concept page in the detail drawer.
           const n = layout.nodes.find((nn) => nn.id === hit);
           if (n) {
-            setOpenNode({ id: n.id, label: n.label, updatedAtMs: n.updatedAtMs });
+            openNodeDetail({
+              id: n.id,
+              label: n.label,
+              updatedAtMs: n.updatedAtMs,
+            });
           }
         } else {
           setFocusLabel(null);
         }
       }
     },
-    [hitTest, layout.nodes],
+    [hitTest, layout.nodes, openNodeDetail],
   );
 
   // Hover is only ever rewritten by moves inside the container, so without
@@ -909,7 +933,17 @@ export function ConceptGraphView({
               <input
                 type="text"
                 value={search}
-                onChange={(e) => setSearch(e.target.value)}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  // Emit once when a search session begins (empty → typed).
+                  // Key on the trimmed value so whitespace-only input, which the
+                  // graph treats as no search, doesn't latch/emit prematurely.
+                  if (value.trim() && !searchEmittedRef.current) {
+                    emitMemoryEvent("search");
+                    searchEmittedRef.current = true;
+                  }
+                  setSearch(value);
+                }}
                 onKeyDown={(e) => {
                   if (e.key === "Escape") {
                     setSearch("");
@@ -961,7 +995,7 @@ export function ConceptGraphView({
                       type="button"
                       onClick={() => {
                         focusOn(node.id);
-                        setOpenNode({
+                        openNodeDetail({
                           id: node.id,
                           label: node.label,
                           updatedAtMs: node.updatedAtMs,

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -69,6 +69,18 @@ interface Projected {
   updatedAtMs?: number; // for recency hit-test skipping; undefined = stale/older
 }
 
+// A drawn edge in screen space: the two endpoints (a → b), its kind, its
+// authored description (link edges only), and mid-segment depth for tie-breaks.
+interface ProjectedEdge {
+  ax: number;
+  ay: number;
+  bx: number;
+  by: number;
+  kind: string;
+  description?: string;
+  depth: number;
+}
+
 interface Colors {
   content: string;
   tertiary: string;
@@ -80,6 +92,15 @@ function resolveColors(el: HTMLElement): Colors {
     content: s.getPropertyValue("--content-default").trim() || "#e5e7eb",
     tertiary: s.getPropertyValue("--content-tertiary").trim() || "#8792a0",
   };
+}
+
+// Tooltip text for a hovered edge: a learned edge is a behavioral association;
+// a link edge carries an authored description (falling back to a generic label).
+function labelForEdge(edge: { kind: string; description?: string }): string {
+  if (edge.kind === "learned") {
+    return "Learned association";
+  }
+  return edge.description ?? "Linked concepts";
 }
 
 export interface ConceptGraphViewProps {
@@ -190,11 +211,17 @@ export function ConceptGraphView({
     dirty: true,
   });
   const projectedRef = useRef<Projected[]>([]);
+  // Screen-space segments of the edges drawn this frame (ghosted ones skipped),
+  // so a pointer can hit-test edges for the "why are these connected?" tooltip.
+  const projectedEdgesRef = useRef<ProjectedEdge[]>([]);
   const colorsRef = useRef<Colors>({ content: "#e5e7eb", tertiary: "#8792a0" });
 
   // Bumped only when the focused node changes, so the DOM tooltip re-renders.
   // The canvas itself never needs React state.
   const [focusLabel, setFocusLabel] = useState<string | null>(null);
+  // Set while the pointer is over an EDGE (and no node) — the tooltip then
+  // explains why two concepts connect. Node hover always wins (onPointerMove).
+  const [edgeLabel, setEdgeLabel] = useState<string | null>(null);
   // The concept opened into the detail drawer (null = graph only).
   const [openNode, setOpenNode] = useState<ConceptDetailNode | null>(null);
 
@@ -410,7 +437,9 @@ export function ConceptGraphView({
       const posById = new Map<string, (typeof proj)[number]>();
       for (const p of proj) {posById.set(p.node.id, p);}
 
-      // Edges (behind nodes).
+      // Edges (behind nodes). Each drawn, non-ghosted segment is also collected
+      // (screen-space endpoints) so the pointer can hit-test edges for hover.
+      const projEdges: ProjectedEdge[] = [];
       ctx.lineCap = "round";
       for (const e of edges) {
         const a = posById.get(e.fromId);
@@ -424,6 +453,18 @@ export function ConceptGraphView({
           isRecencyGhost(b.node);
         const incident = activeId != null && (e.fromId === activeId || e.toId === activeId);
         const depth = (a.depth + b.depth) / 2;
+        // Only offer hover on edges that read as present — skip faded ones.
+        if (!ghost) {
+          projEdges.push({
+            ax: a.sx,
+            ay: a.sy,
+            bx: b.sx,
+            by: b.sy,
+            kind: e.kind,
+            description: e.description,
+            depth,
+          });
+        }
         // Learned edges fade with density in the resting web; authored links
         // don't. A focused hover neighborhood reads at full contrast, though —
         // so lit edges use the unfogged base even in a dense graph.
@@ -530,6 +571,7 @@ export function ConceptGraphView({
         depth: p.depth,
         updatedAtMs: p.node.updatedAtMs,
       }));
+      projectedEdgesRef.current = projEdges;
 
       raf = requestAnimationFrame(render);
     };
@@ -568,6 +610,40 @@ export function ConceptGraphView({
     }
     return best;
   }, []);
+
+  // Nearest EDGE segment under a screen point, within ~5px (point-to-segment
+  // distance); on ties the one nearer the front (higher depth) wins. Only the
+  // non-ghosted edges the render loop collected are considered.
+  const edgeHitTest = useCallback(
+    (x: number, y: number): { kind: string; description?: string } | null => {
+      let best: { kind: string; description?: string } | null = null;
+      let bestDist = Infinity;
+      let bestDepth = -1;
+      for (const e of projectedEdgesRef.current) {
+        const vx = e.bx - e.ax;
+        const vy = e.by - e.ay;
+        const len2 = vx * vx + vy * vy;
+        let t = 0;
+        if (len2 > 0) {
+          t = ((x - e.ax) * vx + (y - e.ay) * vy) / len2;
+          t = Math.max(0, Math.min(1, t));
+        }
+        const dx = x - (e.ax + t * vx);
+        const dy = y - (e.ay + t * vy);
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist > 5) {
+          continue;
+        }
+        if (dist < bestDist || (dist === bestDist && e.depth > bestDepth)) {
+          best = { kind: e.kind, description: e.description };
+          bestDist = dist;
+          bestDepth = e.depth;
+        }
+      }
+      return best;
+    },
+    [],
+  );
 
   const localPoint = (e: React.PointerEvent) => {
     const rect = containerRef.current!.getBoundingClientRect();
@@ -610,8 +686,15 @@ export function ConceptGraphView({
         v.dirty = true;
         setFocusLabel(labelFor(hit));
       }
+      // Node hover wins: only probe edges when no node is under the cursor.
+      if (hit) {
+        setEdgeLabel(null);
+      } else {
+        const edge = edgeHitTest(x, y);
+        setEdgeLabel(edge ? labelForEdge(edge) : null);
+      }
     },
-    [hitTest, labelFor],
+    [hitTest, labelFor, edgeHitTest],
   );
 
   const onPointerUp = useCallback(
@@ -648,6 +731,7 @@ export function ConceptGraphView({
   // this the highlight + tooltip would stay pinned after the pointer leaves.
   const onPointerLeave = useCallback(() => {
     const v = view.current;
+    setEdgeLabel(null);
     if (v.dragging || v.hoveredId == null) {
       return;
     }
@@ -789,7 +873,10 @@ export function ConceptGraphView({
           hasLearned={hasLearned}
         />
 
-        {focusLabel && !showIntro ? (
+        {/* One pill for both hovers. Node hover and edge hover are mutually
+            exclusive (a node hit clears edgeLabel; an edge hit means no node,
+            so focusLabel is null), and focusLabel wins when both are present. */}
+        {(focusLabel ?? edgeLabel) && !showIntro ? (
           <div
             className="pointer-events-none absolute left-1/2 top-4 max-w-[80%] -translate-x-1/2 truncate rounded-full px-3 py-1 text-[12px]"
             style={{
@@ -798,7 +885,7 @@ export function ConceptGraphView({
               color: "var(--content-default)",
             }}
           >
-            {focusLabel}
+            {focusLabel ?? edgeLabel}
           </div>
         ) : null}
 

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -104,6 +104,20 @@ function labelForEdge(edge: { kind: string; description?: string }): string {
   return edge.description ?? "Linked concepts";
 }
 
+// Recency-lens staleness test: a node/point is stale when its last-update
+// timestamp falls outside the active window. With no window set (windowMs ==
+// null) nothing is stale; a missing timestamp counts as stale/older.
+function isStale(
+  updatedAtMs: number | undefined,
+  windowMs: number | null,
+  now: number,
+): boolean {
+  if (windowMs == null) {
+    return false;
+  }
+  return updatedAtMs == null || now - updatedAtMs > windowMs;
+}
+
 export interface ConceptGraphViewProps {
   assistantId: string;
   className?: string;
@@ -160,6 +174,35 @@ export function ConceptGraphView({
     () => detectClusters(layout.nodes, layout.edges),
     [layout.nodes, layout.edges],
   );
+
+  // One label per theme: the highest-degree node in each cluster is its hub, so
+  // even small clusters (every node below the hub-label degree threshold) get a
+  // name. Ties break to the lowest id for determinism. The render loop
+  // force-labels these ids so a theme always reads with at least one word.
+  // Disconnected nodes (degree 0) each form their own singleton cluster; they're
+  // not themes, so skipping them keeps orphans from turning into label soup.
+  const clusterHubs = useMemo(() => {
+    const bestByCluster = new Map<number, GraphLayoutNode>();
+    for (const node of layout.nodes) {
+      const cluster = clusters.get(node.id);
+      if (cluster == null || node.degree === 0) {
+        continue;
+      }
+      const current = bestByCluster.get(cluster);
+      if (
+        !current ||
+        node.degree > current.degree ||
+        (node.degree === current.degree && node.id < current.id)
+      ) {
+        bestByCluster.set(cluster, node);
+      }
+    }
+    const hubIds = new Set<string>();
+    for (const node of bestByCluster.values()) {
+      hubIds.add(node.id);
+    }
+    return hubIds;
+  }, [clusters, layout.nodes]);
 
   // Neighbor adjacency for hover highlighting.
   const adjacency = useMemo(() => {
@@ -266,12 +309,6 @@ export function ConceptGraphView({
     filterRef.current = { active: Boolean(matchIds), matches: matchIds };
     view.current.dirty = true;
   }, [matchIds]);
-  // Reset the search when the active assistant changes: this component is reused
-  // across assistants (IdentityTab doesn't key it), so a stale query would
-  // otherwise filter the new assistant's graph and ghost every node.
-  useEffect(() => {
-    setSearch("");
-  }, [assistantId]);
   // Reset the "search started" latch whenever the box empties — by keystroke,
   // the clear button, Escape, or an assistant switch — so the next search
   // re-emits its start event.
@@ -298,17 +335,19 @@ export function ConceptGraphView({
   // lives in a ref the 60fps loop reads (so segment clicks don't re-run it), and
   // `dirty` is bumped whenever it changes so reduced-motion redraws.
   const [recency, setRecency] = useState<RecencyWindow>("all");
-  const recencyRef = useRef<{ windowMs: number | null }>({ windowMs: null });
+  const recencyRef = useRef<number | null>(null);
   useEffect(() => {
-    recencyRef.current.windowMs =
+    recencyRef.current =
       recency === "week" ? 7 * DAY_MS : recency === "month" ? 30 * DAY_MS : null;
     view.current.dirty = true;
   }, [recency]);
-  // Reset the window on assistant switch (mirrors the search reset above), so a
-  // stale window doesn't ghost the new assistant's freshly-loaded concepts.
-  useEffect(() => {
-    setRecency("all");
-  }, [assistantId]);
+  // Whether any node carries a recency timestamp. Without one the lens has
+  // nothing to narrow by — showing it would let Week/Month ghost the entire
+  // graph — so the lens stays hidden.
+  const hasRecencyData = useMemo(
+    () => layout.nodes.some((n) => n.updatedAtMs != null),
+    [layout.nodes],
+  );
 
   // Edge-kind filter: toggle authored (link) vs behavioral (learned) edges to
   // declutter. The active flags live in a ref the 60fps loop reads (so a toggle
@@ -320,10 +359,15 @@ export function ConceptGraphView({
     edgeFilterRef.current = edgeFilter;
     view.current.dirty = true;
   }, [edgeFilter]);
-  // Reset on assistant switch (mirrors the search/recency resets), so a hidden
-  // kind doesn't carry over and blank out edges on the new assistant's graph.
+  // Reset every lens when the active assistant changes: this component is reused
+  // across assistants (IdentityTab doesn't key it), so a stale search, recency
+  // window, or hidden edge kind would otherwise ghost/blank the new assistant's
+  // freshly-loaded graph.
   useEffect(() => {
+    setSearch("");
+    setRecency("all");
     setEdgeFilter({ link: true, learned: true });
+    searchEmittedRef.current = false;
   }, [assistantId]);
 
   const labelFor = useCallback(
@@ -374,6 +418,7 @@ export function ConceptGraphView({
     const nodes = layout.nodes;
     const edges = layout.edges;
     const nodeClusters = clusters;
+    const hubIds = clusterHubs;
     const adj = adjacency;
     const R = massRadius;
 
@@ -486,10 +531,9 @@ export function ConceptGraphView({
 
       // Recency lens: when a window is set, concepts not updated within it ghost
       // (like non-search-matches). A missing timestamp counts as stale/older.
-      const recencyWindowMs = recencyRef.current.windowMs;
+      const recencyWindowMs = recencyRef.current;
       const isRecencyGhost = (n: GraphLayoutNode) =>
-        recencyWindowMs != null &&
-        (!n.updatedAtMs || nowMs - n.updatedAtMs > recencyWindowMs);
+        isStale(n.updatedAtMs, recencyWindowMs, nowMs);
 
       // Edge-kind toggle: a hidden kind is skipped entirely below.
       const edgeKinds = edgeFilterRef.current;
@@ -617,9 +661,9 @@ export function ConceptGraphView({
         const updatedAtMs = node.updatedAtMs;
         if (updatedAtMs) {
           const age = nowMs - updatedAtMs;
-          const recency = Math.max(0, 1 - age / RECENCY_GLOW_WINDOW_MS);
-          if (recency > 0) {
-            let boost = recency * RECENCY_GLOW_MAX;
+          const freshness = Math.max(0, 1 - age / RECENCY_GLOW_WINDOW_MS);
+          if (freshness > 0) {
+            let boost = freshness * RECENCY_GLOW_MAX;
             if (!reduceMotion && age < PULSE_WINDOW_MS) {
               boost *= 0.55 + 0.45 * Math.sin(t / 420 + idx * 1.7);
             }
@@ -651,7 +695,8 @@ export function ConceptGraphView({
         const p = proj[idx];
         const node = p.node;
         // When nothing is focused, only label front-facing hubs (depth-gated) so
-        // the dense middle of the mass doesn't turn into unreadable label soup.
+        // the dense middle of the mass doesn't turn into unreadable label soup —
+        // but always label each cluster's hub so every theme reads with a name.
         // While searching, label the matches instead (that's what you're after).
         // Ghosted nodes (search or recency) never get labels.
         if ((searchActive && !isMatch(node.id)) || isRecencyGhost(node)) {continue;}
@@ -659,7 +704,8 @@ export function ConceptGraphView({
           ? p.depth > 0.3
           : activeId != null
             ? isLit(node.id)
-            : node.degree >= HUB_LABEL_DEGREE && p.depth > 0.55;
+            : hubIds.has(node.id) ||
+              (node.degree >= HUB_LABEL_DEGREE && p.depth > 0.55);
         if (!showLabel) {continue;}
         ctx.globalAlpha = (node.id === activeId ? 1 : 0.85) * (0.4 + 0.6 * p.depth);
         ctx.fillStyle = colors.content;
@@ -686,7 +732,7 @@ export function ConceptGraphView({
       cancelAnimationFrame(raf);
       ro.disconnect();
     };
-  }, [ready, layout, adjacency, massRadius, clusters]);
+  }, [ready, layout, adjacency, massRadius, clusters, clusterHubs]);
 
   // Nearest node under a screen point; nearest-in-front wins. Ghosted nodes are
   // skipped so hover/click land on a live node, not a faded background one: both
@@ -694,16 +740,13 @@ export function ConceptGraphView({
   // (a missing timestamp counts as stale). Mirrors the render-loop ghosting.
   const hitTest = useCallback((x: number, y: number): string | null => {
     const filter = filterRef.current;
-    const recencyWindowMs = recencyRef.current.windowMs;
+    const recencyWindowMs = recencyRef.current;
     const now = Date.now();
     let best: string | null = null;
     let bestDepth = -1;
     for (const p of projectedRef.current) {
       if (filter.active && !(filter.matches?.has(p.id) ?? false)) {continue;}
-      if (
-        recencyWindowMs != null &&
-        (!p.updatedAtMs || now - p.updatedAtMs > recencyWindowMs)
-      ) {
+      if (isStale(p.updatedAtMs, recencyWindowMs, now)) {
         continue;
       }
       const dx = x - p.sx;
@@ -759,6 +802,9 @@ export function ConceptGraphView({
     if (e.button !== 0) {return;}
     if ((e.target as HTMLElement).closest("[data-graph-control]")) {return;}
     const v = view.current;
+    // A user grab takes control immediately: cancel any in-flight search
+    // jump-to ease so the drag isn't fighting the camera each frame.
+    focusTargetRef.current = null;
     v.dragging = true;
     v.moved = false;
     v.lastX = e.clientX;
@@ -1017,8 +1063,12 @@ export function ConceptGraphView({
             while a non-"all" window is active even if the graph shrank below the
             threshold (e.g. a refetch), so an active window is always resettable
             — mirrors the search box's own guard. */}
-        {layout.nodes.length > SEARCH_MIN_NODES || recency !== "all" ? (
-          <div className={`absolute top-14 z-10 ${onToggleFullscreen ? "left-16" : "left-4"}`}>
+        {(layout.nodes.length > SEARCH_MIN_NODES || recency !== "all") &&
+        hasRecencyData ? (
+          <div
+            data-graph-control
+            className={`absolute top-14 z-10 ${onToggleFullscreen ? "left-16" : "left-4"}`}
+          >
             <RecencyLens value={recency} onChange={setRecency} />
           </div>
         ) : null}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -348,6 +348,14 @@ export function ConceptGraphView({
     () => layout.nodes.some((n) => n.updatedAtMs != null),
     [layout.nodes],
   );
+  // If a refetch (or same-assistant data change) drops all timestamps while a
+  // Week/Month window is active, clear it. Otherwise the lens hides (no data)
+  // but the still-active window would ghost every node with no way to reset.
+  useEffect(() => {
+    if (!hasRecencyData && recency !== "all") {
+      setRecency("all");
+    }
+  }, [hasRecencyData, recency]);
 
   // Edge-kind filter: toggle authored (link) vs behavioral (learned) edges to
   // declutter. The active flags live in a ref the 60fps loop reads (so a toggle

--- a/clients/web/src/domains/intelligence/components/concept-graph/constants.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/constants.ts
@@ -10,6 +10,26 @@ export const NODE_KIND_COLORS: Record<ConceptNodeKind, string> = {
   other: "#8D99A5",
 };
 
+/** Categorical fills for concept clusters/themes, indexed by the compact
+ * cluster id from `detectClusters`. Ten distinct hues, ordered so adjacent
+ * cluster ids (0,1,2,…) contrast strongly, tuned bright enough to read on the
+ * dark graph surface. These are data-viz *series* colors — semantic by cluster,
+ * not by theme surface — so raw hex is correct here (see STYLE_GUIDE "Color →
+ * When raw hex is acceptable" and the `BAR_CHART_PALETTE` precedent). Callers
+ * index modulo the length; `NODE_KIND_COLORS` stays as the per-kind fallback. */
+export const CLUSTER_PALETTE: string[] = [
+  "#5B8DEF", // blue
+  "#FB923C", // orange
+  "#2DD4BF", // teal
+  "#F472B6", // pink
+  "#A3E635", // lime
+  "#C084FC", // violet
+  "#FACC15", // yellow
+  "#38BDF8", // sky
+  "#F87171", // red
+  "#4ADE80", // green
+];
+
 export const NODE_KIND_LABELS: Record<ConceptNodeKind, string> = {
   concept: "Concept",
   skill: "Skill",

--- a/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.test.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import { detectClusters } from "./detect-clusters";
+
+function nodes(...ids: string[]): { id: string }[] {
+  return ids.map((id) => ({ id }));
+}
+
+function edge(fromId: string, toId: string): { fromId: string; toId: string } {
+  return { fromId, toId };
+}
+
+/** A closed triangle over three node ids. */
+function triangle(a: string, b: string, c: string) {
+  return [edge(a, b), edge(b, c), edge(c, a)];
+}
+
+describe("detectClusters", () => {
+  test("two disconnected triangles yield exactly 2 clusters", () => {
+    const clusters = detectClusters(nodes("a", "b", "c", "d", "e", "f"), [
+      ...triangle("a", "b", "c"),
+      ...triangle("d", "e", "f"),
+    ]);
+    // All six nodes are assigned, split into exactly two distinct clusters.
+    expect(clusters.size).toBe(6);
+    expect(new Set(clusters.values()).size).toBe(2);
+    // Each triangle shares one cluster; the two triangles differ.
+    expect(clusters.get("a")).toBe(clusters.get("b"));
+    expect(clusters.get("b")).toBe(clusters.get("c"));
+    expect(clusters.get("d")).toBe(clusters.get("e"));
+    expect(clusters.get("e")).toBe(clusters.get("f"));
+    expect(clusters.get("a")).not.toBe(clusters.get("d"));
+  });
+
+  test("one bridge edge merges the two triangles into 1 cluster", () => {
+    const clusters = detectClusters(nodes("a", "b", "c", "d", "e", "f"), [
+      ...triangle("a", "b", "c"),
+      ...triangle("d", "e", "f"),
+      edge("c", "d"), // bridge
+    ]);
+    expect(new Set(clusters.values()).size).toBe(1);
+  });
+
+  test("is deterministic — identical input yields an identical map", () => {
+    const ns = nodes("a", "b", "c", "d", "e", "f");
+    const es = [...triangle("a", "b", "c"), ...triangle("d", "e", "f")];
+    expect([...detectClusters(ns, es)]).toEqual([...detectClusters(ns, es)]);
+  });
+
+  test("two isolated nodes get two distinct cluster ids", () => {
+    const clusters = detectClusters(nodes("a", "b"), []);
+    expect(clusters.get("a")).not.toBe(clusters.get("b"));
+    expect(new Set(clusters.values()).size).toBe(2);
+  });
+
+  test("cluster ids are dense 0..k-1", () => {
+    const clusters = detectClusters(nodes("a", "b", "c", "d", "e"), [
+      ...triangle("a", "b", "c"),
+      edge("d", "e"),
+    ]);
+    const ids = [...new Set(clusters.values())].sort((x, y) => x - y);
+    expect(ids).toEqual(Array.from({ length: ids.length }, (_, i) => i));
+  });
+
+  test("returns an empty map for no nodes", () => {
+    expect(detectClusters([], [])).toEqual(new Map());
+  });
+});

--- a/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/detect-clusters.ts
@@ -1,0 +1,85 @@
+/**
+ * Deterministic community detection for the memory concept graph.
+ *
+ * Pure and dependency-free: runs synchronous label propagation over an
+ * undirected view of the graph — NO RNG (Math.random is forbidden in layout
+ * code) and NO Date.now(), so identical input always yields an identical map.
+ * Cluster ids are renumbered into a compact 0..k-1 range so a caller can index
+ * a color palette by id directly.
+ */
+
+const PASSES = 8;
+
+/**
+ * Partition graph nodes into clusters via deterministic label propagation.
+ *
+ * Each node starts in its own cluster and, over a fixed number of passes,
+ * adopts the most frequent label among its neighbors (ties broken by the lowest
+ * label id for determinism). Disconnected nodes (degree 0) keep their initial,
+ * unique label and therefore each land in their own cluster.
+ *
+ * @returns A map from every node id to a compact cluster id in `0..k-1`,
+ *   assigned in order of first appearance in `nodes`.
+ */
+export function detectClusters(
+  nodes: readonly { id: string }[],
+  edges: readonly { fromId: string; toId: string }[],
+): Map<string, number> {
+  const n = nodes.length;
+  if (n === 0) {return new Map();}
+
+  const indexById = new Map<string, number>();
+  nodes.forEach((node, i) => indexById.set(node.id, i));
+
+  // Undirected neighbor adjacency; drop self-loops and edges to unknown nodes.
+  const neighbors: number[][] = nodes.map(() => []);
+  for (const edge of edges) {
+    const a = indexById.get(edge.fromId);
+    const b = indexById.get(edge.toId);
+    if (a === undefined || b === undefined || a === b) {continue;}
+    neighbors[a].push(b);
+    neighbors[b].push(a);
+  }
+
+  // Each node begins in its own cluster (label = its stable array index).
+  const labels = nodes.map((_, i) => i);
+
+  for (let pass = 0; pass < PASSES; pass++) {
+    for (let i = 0; i < n; i++) {
+      const adjacent = neighbors[i];
+      if (adjacent.length === 0) {continue;}
+
+      // Tally neighbor labels, then take the most frequent — lowest label wins
+      // ties so the outcome never depends on iteration/insertion order.
+      const counts = new Map<number, number>();
+      for (const j of adjacent) {
+        counts.set(labels[j], (counts.get(labels[j]) ?? 0) + 1);
+      }
+      let bestLabel = labels[i];
+      let bestCount = -1;
+      for (const [label, count] of counts) {
+        if (count > bestCount || (count === bestCount && label < bestLabel)) {
+          bestLabel = label;
+          bestCount = count;
+        }
+      }
+      labels[i] = bestLabel;
+    }
+  }
+
+  // Renumber the surviving labels into a dense 0..k-1 range, in order of first
+  // appearance, so ids stay small and stable for a palette to index.
+  const compactByLabel = new Map<number, number>();
+  const clusterById = new Map<string, number>();
+  nodes.forEach((node, i) => {
+    const label = labels[i];
+    let compact = compactByLabel.get(label);
+    if (compact === undefined) {
+      compact = compactByLabel.size;
+      compactByLabel.set(label, compact);
+    }
+    clusterById.set(node.id, compact);
+  });
+
+  return clusterById;
+}

--- a/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
@@ -1,0 +1,40 @@
+import {
+  SegmentControl,
+  type SegmentControlItem,
+} from "@vellumai/design-library";
+
+/** The recency window the graph highlights. "all" disables the lens. */
+export type RecencyWindow = "all" | "month" | "week";
+
+interface RecencyLensProps {
+  value: RecencyWindow;
+  onChange: (value: RecencyWindow) => void;
+}
+
+const ITEMS: SegmentControlItem<RecencyWindow>[] = [
+  { value: "all", label: "All" },
+  { value: "month", label: "Month" },
+  { value: "week", label: "Week" },
+];
+
+/**
+ * Segmented "All · Month · Week" control that picks the recency window the graph
+ * emphasizes: concepts updated outside the window ghost out (like non-matches of
+ * the search lens), so "what did it learn recently?" pops. Marked
+ * `data-graph-control` so clicks don't start an orbit drag.
+ */
+export function RecencyLens({ value, onChange }: RecencyLensProps) {
+  return (
+    <div data-graph-control>
+      <SegmentControl<RecencyWindow>
+        ariaLabel="Recency window"
+        items={ITEMS}
+        value={value}
+        onChange={onChange}
+        // Labeled mode defaults to full width with flex-1 segments; keep it
+        // compact (sized to its content) for the floating graph overlay.
+        className="!w-auto [&>*]:!flex-none"
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/recency-lens.tsx
@@ -20,21 +20,20 @@ const ITEMS: SegmentControlItem<RecencyWindow>[] = [
 /**
  * Segmented "All · Month · Week" control that picks the recency window the graph
  * emphasizes: concepts updated outside the window ghost out (like non-matches of
- * the search lens), so "what did it learn recently?" pops. Marked
- * `data-graph-control` so clicks don't start an orbit drag.
+ * the search lens), so "what did it learn recently?" pops. The caller's
+ * positioning wrapper carries `data-graph-control` so clicks don't start an
+ * orbit drag.
  */
 export function RecencyLens({ value, onChange }: RecencyLensProps) {
   return (
-    <div data-graph-control>
-      <SegmentControl<RecencyWindow>
-        ariaLabel="Recency window"
-        items={ITEMS}
-        value={value}
-        onChange={onChange}
-        // Labeled mode defaults to full width with flex-1 segments; keep it
-        // compact (sized to its content) for the floating graph overlay.
-        className="!w-auto [&>*]:!flex-none"
-      />
-    </div>
+    <SegmentControl<RecencyWindow>
+      ariaLabel="Recency window"
+      items={ITEMS}
+      value={value}
+      onChange={onChange}
+      // Labeled mode defaults to full width with flex-1 segments; keep it
+      // compact (sized to its content) for the floating graph overlay.
+      className="!w-auto [&>*]:!flex-none"
+    />
   );
 }

--- a/clients/web/src/domains/intelligence/memory-page.tsx
+++ b/clients/web/src/domains/intelligence/memory-page.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useRef } from "react";
+
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { ConceptGraphView } from "@/domains/intelligence/components/concept-graph/concept-graph-view";
+import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
 
 interface MemoryPageProps {
   onOpenThread?: (message: string) => void;
@@ -15,6 +18,17 @@ interface MemoryPageProps {
  */
 export function MemoryPage({ onOpenThread }: MemoryPageProps) {
   const assistantId = useActiveAssistantId();
+
+  // Report the tab open exactly once per mount. The ref guard keeps React
+  // strict-mode's double-invoke (dev) from emitting a duplicate.
+  const openedEmitted = useRef(false);
+  useEffect(() => {
+    if (openedEmitted.current) {
+      return;
+    }
+    openedEmitted.current = true;
+    emitMemoryEvent("opened");
+  }, []);
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/clients/web/src/domains/intelligence/memory-telemetry.ts
+++ b/clients/web/src/domains/intelligence/memory-telemetry.ts
@@ -1,0 +1,68 @@
+import { getDeviceBool } from "@/utils/device-settings";
+import { postTelemetryEvents } from "@/lib/telemetry/ingest";
+
+/**
+ * Memory-tab usage telemetry.
+ *
+ * Reports through the shared `postTelemetryEvents` transport as a
+ * `type: "onboarding"` event with a distinct `funnel_version`
+ * (`memory_tab_v1`). `screen` / `step_name` / `funnel_version` are open strings
+ * server-side, so these values ride the existing ingest wire shape.
+ *
+ * Consent is read from the shared `device:share_analytics` bool
+ * (`getDeviceBool("shareAnalytics", ...)`) rather than the onboarding domain's
+ * `readShareAnalytics()` — the intelligence domain can't import from onboarding
+ * (`local/no-cross-domain-imports`), and the device bool is the same persistent
+ * opt-out signal that reader gates on (and that `/settings/privacy` and the
+ * Sentry consent gate read directly).
+ */
+
+export const MEMORY_FUNNEL_VERSION = "memory_tab_v1";
+
+/** Which Memory-tab interaction is being reported. */
+export type MemoryStep = "opened" | "search" | "node_opened" | "chat_from_node";
+
+/**
+ * Per-page-load session id, generated once when this module first loads. Ties
+ * every Memory-tab event from a single load together, mirroring the onboarding
+ * funnel's `session_id`.
+ */
+const SESSION_ID = crypto.randomUUID();
+
+interface MemoryEvent {
+  type: "onboarding";
+  daemon_event_id: string;
+  recorded_at: number;
+  screen: string;
+  session_id: string;
+  step_name: string;
+  funnel_version: string;
+  user_id?: string;
+}
+
+export function emitMemoryEvent(
+  step: MemoryStep,
+  options: { userId?: string } = {},
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  // Analytics is opt-out; an absent preference authorizes uploads.
+  if (!getDeviceBool("shareAnalytics", true)) {
+    return;
+  }
+
+  const event: MemoryEvent = {
+    type: "onboarding",
+    daemon_event_id: crypto.randomUUID(),
+    recorded_at: Date.now(),
+    screen: "memory",
+    session_id: SESSION_ID,
+    step_name: step,
+    funnel_version: MEMORY_FUNNEL_VERSION,
+    // Omitted (→ stripped before send) when the caller has no user id.
+    user_id: options.userId,
+  };
+
+  postTelemetryEvents([event]);
+}

--- a/clients/web/src/domains/intelligence/memory-telemetry.ts
+++ b/clients/web/src/domains/intelligence/memory-telemetry.ts
@@ -1,4 +1,4 @@
-import { getDeviceBool } from "@/utils/device-settings";
+import { readAnalyticsConsent } from "@/lib/telemetry/consent";
 import { postTelemetryEvents } from "@/lib/telemetry/ingest";
 
 /**
@@ -9,18 +9,19 @@ import { postTelemetryEvents } from "@/lib/telemetry/ingest";
  * (`memory_tab_v1`). `screen` / `step_name` / `funnel_version` are open strings
  * server-side, so these values ride the existing ingest wire shape.
  *
- * Consent is read from the shared `device:share_analytics` bool
- * (`getDeviceBool("shareAnalytics", ...)`) rather than the onboarding domain's
- * `readShareAnalytics()` — the intelligence domain can't import from onboarding
- * (`local/no-cross-domain-imports`), and the device bool is the same persistent
- * opt-out signal that reader gates on (and that `/settings/privacy` and the
- * Sentry consent gate read directly).
+ * Consent is read through the shared `readAnalyticsConsent()` — the exact same
+ * decision the onboarding funnel gates on (the AND of the in-memory
+ * `shareAnalytics` store flag and the persisted `device:share_analytics` bool).
+ * Routing through the `lib/telemetry/` helper keeps the intelligence domain
+ * from importing onboarding directly (`local/no-cross-domain-imports`) while
+ * guaranteeing a failed opt-out write can't leave Memory telemetry uploading
+ * after onboarding telemetry has stopped.
  */
 
-export const MEMORY_FUNNEL_VERSION = "memory_tab_v1";
+const MEMORY_FUNNEL_VERSION = "memory_tab_v1";
 
 /** Which Memory-tab interaction is being reported. */
-export type MemoryStep = "opened" | "search" | "node_opened" | "chat_from_node";
+type MemoryStep = "opened" | "search" | "node_opened" | "chat_from_node";
 
 /**
  * Per-page-load session id, generated once when this module first loads. Ties
@@ -37,18 +38,13 @@ interface MemoryEvent {
   session_id: string;
   step_name: string;
   funnel_version: string;
-  user_id?: string;
 }
 
-export function emitMemoryEvent(
-  step: MemoryStep,
-  options: { userId?: string } = {},
-): void {
+export function emitMemoryEvent(step: MemoryStep): void {
   if (typeof window === "undefined") {
     return;
   }
-  // Analytics is opt-out; an absent preference authorizes uploads.
-  if (!getDeviceBool("shareAnalytics", true)) {
+  if (!readAnalyticsConsent()) {
     return;
   }
 
@@ -60,8 +56,6 @@ export function emitMemoryEvent(
     session_id: SESSION_ID,
     step_name: step,
     funnel_version: MEMORY_FUNNEL_VERSION,
-    // Omitted (→ stripped before send) when the caller has no user id.
-    user_id: options.userId,
   };
 
   postTelemetryEvents([event]);

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -1,5 +1,5 @@
 import { readShareAnalytics } from "@/domains/onboarding/prefs";
-import { getClientId } from "@/lib/telemetry/client-identity";
+import { postTelemetryEvents } from "@/lib/telemetry/ingest";
 import type { ResearchStep } from "@/domains/onboarding/research-onboarding-persistence";
 
 export const ONBOARDING_FUNNEL_VERSION = "onboarding_v3_2026_05";
@@ -142,12 +142,6 @@ export interface OnboardingFunnelEvent {
   outcome?: OnboardingFunnelStepOutcome;
 }
 
-function stripUndefined(value: object): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entry]) => entry !== undefined),
-  );
-}
-
 export function getOnboardingFunnelSessionId(): string {
   if (typeof window === "undefined") return crypto.randomUUID();
   let existing = "";
@@ -232,20 +226,7 @@ export function emitOnboardingFunnelStepCompleted(
   if (typeof window === "undefined") return;
   if (!readShareAnalytics()) return;
 
-  const event = stripUndefined(buildOnboardingFunnelEvent(screen, options));
-
-  const payload = JSON.stringify({
-    device_id: getClientId(),
-    assistant_version: import.meta.env.VITE_APP_VERSION ?? "web-dev",
-    events: [event],
-  });
-
-  void fetch("/v1/telemetry/ingest/", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: payload,
-    keepalive: true,
-  }).catch(() => {});
+  postTelemetryEvents([buildOnboardingFunnelEvent(screen, options)]);
 }
 
 /**

--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -20,7 +20,7 @@ import {
   removeLocalSetting,
   setLocalSetting,
 } from "@/utils/local-settings";
-import { getDeviceBool } from "@/utils/device-settings";
+import { readAnalyticsConsent } from "@/lib/telemetry/consent";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 
 // ---------------------------------------------------------------------------
@@ -169,16 +169,13 @@ export function readConsentHydrated(): boolean {
 /**
  * SSR-safe, non-hook read for telemetry emitters.
  *
- * Analytics is opt-out: an absent preference (never asked) authorizes uploads;
- * only an explicit opt-out stops them. The in-memory store must also agree so
- * a failed opt-out write cannot leave an older stored opt-in authorizing a new
- * event.
+ * Thin wrapper over the shared `readAnalyticsConsent()` so the onboarding
+ * funnel and the intelligence domain's Memory telemetry gate on the exact
+ * same decision (the AND of the in-memory `shareAnalytics` store flag and the
+ * persisted `device:share_analytics` bool).
  */
 export function readShareAnalytics(): boolean {
-  return (
-    useOnboardingStore.getState().shareAnalytics &&
-    getDeviceBool("shareAnalytics", true)
-  );
+  return readAnalyticsConsent();
 }
 
 /**

--- a/clients/web/src/lib/telemetry/consent.ts
+++ b/clients/web/src/lib/telemetry/consent.ts
@@ -1,0 +1,23 @@
+import { getDeviceBool } from "@/utils/device-settings";
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+
+/**
+ * Shared analytics-consent read for telemetry emitters.
+ *
+ * Analytics is opt-out: an absent preference (never asked) authorizes uploads;
+ * only an explicit opt-out stops them. The persisted device bool
+ * (`device:share_analytics`) and the in-memory `shareAnalytics` store flag must
+ * BOTH agree — the AND — so a failed opt-out write cannot leave an older stored
+ * opt-in authorizing a new event.
+ *
+ * This is the single consent decision every funnel gates on. It lives in
+ * `lib/` (not a domain) so both the onboarding funnel and the intelligence
+ * domain's Memory telemetry can route through the same check without a
+ * cross-domain import (`local/no-cross-domain-imports`).
+ */
+export function readAnalyticsConsent(): boolean {
+  return (
+    useOnboardingStore.getState().shareAnalytics &&
+    getDeviceBool("shareAnalytics", true)
+  );
+}

--- a/clients/web/src/lib/telemetry/ingest.ts
+++ b/clients/web/src/lib/telemetry/ingest.ts
@@ -1,0 +1,37 @@
+import { getClientId } from "./client-identity";
+
+/**
+ * Drops keys whose value is `undefined` so they are omitted from the wire
+ * payload rather than carried as explicit nulls. Callers stamp optional fields
+ * (e.g. `user_id`, `outcome`) as `undefined` when absent and rely on this to
+ * keep the ingested event shape stable.
+ */
+function stripUndefined(event: object): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(event).filter(([, value]) => value !== undefined),
+  );
+}
+
+/**
+ * Wraps events in the telemetry envelope and fire-and-forgets them to the
+ * platform's `/v1/telemetry/ingest/` endpoint. `keepalive` lets the request
+ * outlive a page unload, and failures are swallowed since telemetry is
+ * best-effort.
+ *
+ * Consent is NOT gated here — each caller applies its own opt-out check before
+ * calling, because the funnels read consent from different signals.
+ */
+export function postTelemetryEvents(events: readonly object[]): void {
+  const payload = JSON.stringify({
+    device_id: getClientId(),
+    assistant_version: import.meta.env.VITE_APP_VERSION ?? "web-dev",
+    events: events.map(stripUndefined),
+  });
+
+  void fetch("/v1/telemetry/ingest/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+    keepalive: true,
+  }).catch(() => {});
+}

--- a/clients/web/src/memory-page-route.tsx
+++ b/clients/web/src/memory-page-route.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { MemoryPage } from "@/domains/intelligence/memory-page";
+import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
 import { navigateToNewConversation } from "@/utils/conversation-navigation";
 
 export function MemoryPageRoute() {
@@ -12,6 +13,7 @@ export function MemoryPageRoute() {
     <MemoryPage
       key={assistantId}
       onOpenThread={(message) => {
+        emitMemoryEvent("chat_from_node");
         navigateToNewConversation(navigate, { prompt: message });
       }}
     />


### PR DESCRIPTION
## Summary
Wave 2 of the memory concept graph (Intelligence → Memory tab, behind the `memory-concept-graph` flag): usage telemetry, cluster/theme coloring, a recency time-lens, edge-hover insight, edge-kind filter chips, and search jump-to. All behind the existing flag, consistent with the concepts-only direction.

## Self-review result
GAPS FOUND → all addressed. 4 fresh-eyes passes (external feedback, plan-faithfulness, integration, slop) flagged a consent-gate weakness, a recency-lens blank-graph bug, a camera-vs-drag glitch, and several cross-PR cleanups. Fixed across 3 fix PRs. One architectural nit (hoisting analytics-consent state out of the onboarding store) deferred + documented as a follow-up, since it's consistent with existing precedent and a cross-cutting refactor beyond this scope.

## Feature PRs merged into the branch
- #38168 — deterministic cluster detection
- #38170 — Memory-tab usage telemetry (+ shared `lib/telemetry/ingest.ts`)
- #38173 — color concepts by cluster/theme
- #38175 — recency time-lens
- #38181 — edge-hover insight
- #38184 — link/learned edge filter toggles
- #38189 — search jump-to (camera fly)
- #38195 — search/node-open telemetry

### Fix PRs (self-review remediation)
- #38200 — honor in-memory analytics opt-out (shared consent read); drop dead scaffolding
- #38201 — recency-data gate, focus-vs-drag, cluster hub labels, graph-view cleanups
- #38204 — clear recency window when timestamps disappear

Part of plan: memory-graph-enhancements.md