### PR TITLE
chore(web): lint rule banning raw fetch of /v1 API paths

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -915,6 +915,20 @@ cannot support the use case (e.g. SSE/streaming endpoints that need
 custom `EventSource` handling). If bypassing, add a comment explaining
 why.
 
+### API transport: no raw `fetch` of `/v1` paths
+
+A raw `fetch("/v1/...")` (including template literals and
+`window.fetch`/`globalThis.fetch`) bypasses the generated client's
+auth interceptors — the request ships without the session token /
+CSRF headers and fails silently against authenticated deployments.
+An ESLint rule (`no-restricted-syntax` in `eslint.config.mjs`,
+`rawApiFetchRules`) blocks these call forms everywhere in `src/`.
+
+Always call the generated SDK function for the endpoint instead. If
+the endpoint has no generated function or type, it is missing from
+`platform.yaml` — tag it with `PLATFORM_API_CLIENT_EXTENSION` in the
+platform repo and regenerate, rather than hand-rolling the request.
+
 ### Generated types are the source of truth
 
 Never hand-write a type for a value the codegen produces — a request

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -94,6 +94,42 @@ const universalAuthRules = [
 ];
 
 /**
+ * Raw `/v1` fetch ban — the generated HeyAPI client is the only
+ * transport for API paths. A raw `fetch("/v1/...")` skips the auth
+ * interceptors on the generated singleton, so the request silently
+ * ships without the session token / CSRF headers.
+ */
+const rawApiFetchMessage =
+  "Raw fetch to /v1 bypasses the generated client's auth interceptors (session token/CSRF) — use the generated SDK function; if the endpoint has no generated type, it's missing from platform.yaml (tag it with PLATFORM_API_CLIENT_EXTENSION in the platform repo).";
+
+const rawApiFetchRules = [
+  // fetch("/v1/...") — string-literal first argument.
+  {
+    selector:
+      "CallExpression[callee.name='fetch'][arguments.0.value=/^\\/v1\\//]",
+    message: rawApiFetchMessage,
+  },
+  // fetch(`/v1/...`) — template literal starting with /v1/.
+  {
+    selector:
+      "CallExpression[callee.name='fetch'][arguments.0.quasis.0.value.raw=/^\\/v1\\//]",
+    message: rawApiFetchMessage,
+  },
+  // window.fetch("/v1/...") / globalThis.fetch("/v1/...").
+  {
+    selector:
+      "CallExpression[callee.object.name=/^(window|globalThis)$/][callee.property.name='fetch'][arguments.0.value=/^\\/v1\\//]",
+    message: rawApiFetchMessage,
+  },
+  // window.fetch(`/v1/...`) / globalThis.fetch(`/v1/...`).
+  {
+    selector:
+      "CallExpression[callee.object.name=/^(window|globalThis)$/][callee.property.name='fetch'][arguments.0.quasis.0.value.raw=/^\\/v1\\//]",
+    message: rawApiFetchMessage,
+  },
+];
+
+/**
  * Header-literal rules — apply OUTSIDE the auth boundary only.
  *
  * The `lib/auth/` directory and `lib/api-interceptors.ts` are the only
@@ -166,6 +202,7 @@ const eslintConfig = defineConfig([
         "error",
         ...darkPairedColorScaleRules,
         ...universalAuthRules,
+        ...rawApiFetchRules,
         ...headerLiteralRules,
       ],
 
@@ -209,6 +246,7 @@ const eslintConfig = defineConfig([
         "error",
         ...darkPairedColorScaleRules,
         ...universalAuthRules,
+        ...rawApiFetchRules,
       ],
     },
   },


### PR DESCRIPTION
## Summary
- Adds a `rawApiFetchRules` group to the web ESLint config banning raw `fetch` of `/v1` paths (string literal, template literal, and `window.fetch`/`globalThis.fetch` forms) — a raw fetch bypasses the generated client's auth interceptors (session token/CSRF), which is how browser telemetry was silently lost for 4 weeks.
- Spreads the group into both `no-restricted-syntax` arrays (base + auth-boundary override), since flat config replaces the array on override.
- Documents the rule in `clients/web/docs/CONVENTIONS.md` under "API transport", pointing offenders at the generated SDK and `PLATFORM_API_CLIENT_EXTENSION` for missing endpoints.

Part of plan: consent-cleanup.md (PR 1 of 10)