### PR TITLE
refactor(daemon): tri-state consent cache; drop dead pre-#9043 _chosen handling

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29113,8 +29113,8 @@ paths:
       description:
         'Record the settled result of an onboarding "research me" web-search turn (claims, suggestions, and
         plugin picks). Client-orchestrated: the web client reports this once it has observed the turn complete. Gated on
-        share_diagnostics consent (in addition to share_analytics) since the payload carries the model''s raw inferred
-        claims about the user.'
+        share_analytics consent like every other outbox-backed event; the platform re-checks the owner''s consent
+        server-side at ingest.'
       tags:
         - telemetry
       requestBody:
@@ -29201,7 +29201,7 @@ paths:
                       skipped:
                         type: boolean
                         const: true
-                        description: "Event skipped: usage data collection or diagnostics consent is disabled/ineligible"
+                        description: "Event skipped: usage data collection is disabled or the telemetry database is unavailable"
                     required:
                       - skipped
                     additionalProperties: false

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -287,34 +287,13 @@ describe("VellumPlatformClient", () => {
       });
     });
 
-    test("coerced false with share_analytics_chosen=false (never chose) maps to true", async () => {
+    test("explicit false is an opt-out", async () => {
       globalThis.fetch = mock(
         async () =>
           new Response(
             JSON.stringify({
               share_analytics: false,
-              share_analytics_chosen: false,
-              share_diagnostics: true,
-              share_diagnostics_accepted_version: "2026-06-18",
-            }),
-            { status: 200 },
-          ),
-      ) as unknown as typeof globalThis.fetch;
-
-      const client = await VellumPlatformClient.create();
-      const consent = await client!.getOwnerConsent();
-      expect(consent!.shareAnalytics).toBe(true);
-    });
-
-    test("explicit false with share_analytics_chosen=true stays an opt-out", async () => {
-      globalThis.fetch = mock(
-        async () =>
-          new Response(
-            JSON.stringify({
-              share_analytics: false,
-              share_analytics_chosen: true,
               share_diagnostics: false,
-              share_diagnostics_chosen: true,
               share_diagnostics_accepted_version: "2026-06-18",
             }),
             { status: 200 },
@@ -327,28 +306,6 @@ describe("VellumPlatformClient", () => {
         shareAnalytics: false,
         shareDiagnostics: false,
         shareDiagnosticsAcceptedVersion: "2026-06-18",
-      });
-    });
-
-    test("false without a *_chosen field (older platform) stays authoritative", async () => {
-      globalThis.fetch = mock(
-        async () =>
-          new Response(
-            JSON.stringify({
-              share_analytics: false,
-              share_diagnostics: false,
-              share_diagnostics_accepted_version: "",
-            }),
-            { status: 200 },
-          ),
-      ) as unknown as typeof globalThis.fetch;
-
-      const client = await VellumPlatformClient.create();
-      const consent = await client!.getOwnerConsent();
-      expect(consent).toEqual({
-        shareAnalytics: false,
-        shareDiagnostics: false,
-        shareDiagnosticsAcceptedVersion: "",
       });
     });
 

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -18,11 +18,9 @@ let _missingPrereqsWarned = false;
 
 export interface OwnerConsent {
   /**
-   * Telemetry is opt-out: a null wire value (the owner was never shown the
-   * choice) maps to `true` here — only an explicit opt-out disables sharing.
-   * A `false` accompanied by `share_analytics_chosen: false` is the platform
-   * coercing a never-chose null to a strict boolean, not a real opt-out, so
-   * it also maps to `true`.
+   * Telemetry is opt-out: the owner-consent endpoint returns effective
+   * values (a never-chose null is served as consented), so an explicit
+   * `false` is the only thing that disables sharing.
    */
   shareAnalytics: boolean;
   /** Same opt-out semantics as {@link shareAnalytics}. */
@@ -132,10 +130,11 @@ export class VellumPlatformClient {
   /**
    * Fetch the platform owner's telemetry consent for this assistant.
    *
+   * The endpoint returns effective consent values (a never-chose null is
+   * served as consented); an explicit `false` is the only disable.
+   *
    * Returns `null` whenever the consent is unknown — missing assistant id,
-   * any non-2xx response (e.g. 404 before the endpoint is deployed), a
-   * malformed body, or a network error. Callers treat `null` as default-off.
-   * Never throws.
+   * any non-2xx response, a malformed body, or a network error. Never throws.
    */
   async getOwnerConsent(): Promise<OwnerConsent | null> {
     if (!this.assistantId) {
@@ -156,9 +155,7 @@ export class VellumPlatformClient {
 
       const body = (await res.json()) as {
         share_analytics?: unknown;
-        share_analytics_chosen?: unknown;
         share_diagnostics?: unknown;
-        share_diagnostics_chosen?: unknown;
         share_diagnostics_accepted_version?: unknown;
       };
       if (
@@ -172,16 +169,9 @@ export class VellumPlatformClient {
       }
 
       return {
-        // Opt-out: anything but an explicit false enables sharing. A false
-        // with `*_chosen: false` is a platform-coerced never-chose default
-        // (not a real opt-out), so it enables too. An absent `*_chosen`
-        // (older platform) leaves false authoritative.
-        shareAnalytics:
-          body.share_analytics !== false ||
-          body.share_analytics_chosen === false,
-        shareDiagnostics:
-          body.share_diagnostics !== false ||
-          body.share_diagnostics_chosen === false,
+        // Opt-out: anything but an explicit false enables sharing.
+        shareAnalytics: body.share_analytics !== false,
+        shareDiagnostics: body.share_diagnostics !== false,
         // Back-compat: an older platform that doesn't return this field yields
         // "" → fails the trace-collection version gate → fail-closed (no trace).
         shareDiagnosticsAcceptedVersion:

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -37,6 +37,8 @@ import {
   getCachedShareAnalytics,
   getCachedShareDiagnostics,
   getCachedShareDiagnosticsVersion,
+  getRawShareAnalytics,
+  getRawShareDiagnostics,
   refreshConsentCache,
   startConsentRefresh,
   stopConsentRefresh,
@@ -69,8 +71,9 @@ describe("consent-cache", () => {
     // Legacy fail-closed opt-out marker read via getConfigReadOnly(). Default
     // off so existing behavior is unchanged.
     setConfig("legacyTelemetryOptOut", false);
-    __setCachedShareAnalyticsForTest(false);
-    __setCachedShareDiagnosticsForTest(false);
+    // Boot state: no confirmed consent yet.
+    __setCachedShareAnalyticsForTest("unknown");
+    __setCachedShareDiagnosticsForTest("unknown");
     __setCachedShareDiagnosticsVersionForTest("");
   });
 
@@ -78,13 +81,15 @@ describe("consent-cache", () => {
     await stopConsentRefresh();
   });
 
-  test("defaults to false before any refresh", () => {
+  test("boot state is unknown; public accessor reads false", () => {
+    expect(getRawShareAnalytics()).toBe("unknown");
     expect(getCachedShareAnalytics()).toBe(false);
   });
 
-  test("stays false when no platform client is available", async () => {
+  test("no platform client available → unknown; public accessor reads false", async () => {
     mockClient = null;
     await refreshConsentCache();
+    expect(getRawShareAnalytics()).toBe("unknown");
     expect(getCachedShareAnalytics()).toBe(false);
   });
 
@@ -92,6 +97,7 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareAnalytics: true }));
     await refreshConsentCache();
     expect(getCachedShareAnalytics()).toBe(true);
+    expect(getRawShareAnalytics()).toBe(true);
   });
 
   test("a null fetch keeps the last known value", async () => {
@@ -105,20 +111,40 @@ describe("consent-cache", () => {
     expect(getCachedShareAnalytics()).toBe(true);
   });
 
-  test("a missing client flips a prior opt-in back to false", async () => {
+  test("a null fetch keeps a confirmed opt-out", async () => {
+    mockClient = makeClient(makeConsent({ shareAnalytics: false }));
+    await refreshConsentCache();
+    expect(getRawShareAnalytics()).toBe(false);
+
+    mockClient = makeClient(null);
+    await refreshConsentCache();
+    expect(getRawShareAnalytics()).toBe(false);
+  });
+
+  test("a null fetch keeps the boot unknown state", async () => {
+    mockClient = makeClient(null);
+    await refreshConsentCache();
+    expect(getRawShareAnalytics()).toBe("unknown");
+    expect(getRawShareDiagnostics()).toBe("unknown");
+  });
+
+  test("a missing client demotes a prior opt-in to unknown (public accessor reads false)", async () => {
     __setCachedShareAnalyticsForTest(true);
     mockClient = null;
     await refreshConsentCache();
+    expect(getRawShareAnalytics()).toBe("unknown");
     expect(getCachedShareAnalytics()).toBe(false);
   });
 
-  test("a client without a resolvable assistant identity fails closed", async () => {
+  test("a client without a resolvable assistant identity demotes to unknown", async () => {
     __setCachedShareAnalyticsForTest(true);
     // Identity cleared mid-session (e.g. assistantId emptied while base URL +
     // API key persist). getOwnerConsent must not be relied upon to preserve the
-    // prior opt-in here — fail closed instead.
+    // prior opt-in here — losing the owner mapping is not an opt-out, but the
+    // stale opt-in must not keep riding either.
     mockClient = makeClient(makeConsent({ shareAnalytics: true }), "");
     await refreshConsentCache();
+    expect(getRawShareAnalytics()).toBe("unknown");
     expect(getCachedShareAnalytics()).toBe(false);
   });
 
@@ -126,8 +152,10 @@ describe("consent-cache", () => {
     setConfig("legacyTelemetryOptOut", true);
     mockClient = makeClient(makeConsent({ shareAnalytics: true }));
     await refreshConsentCache();
-    // Platform reports opt-in, but the fail-closed marker forces off.
+    // Platform reports opt-in, but the fail-closed marker forces off. The raw
+    // accessor folds the marker into a confirmed false, not an unknown.
     expect(getCachedShareAnalytics()).toBe(false);
+    expect(getRawShareAnalytics()).toBe(false);
   });
 
   test("a fetch reporting shareAnalytics: false turns the cache off", async () => {
@@ -135,6 +163,7 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareDiagnostics: true }));
     await refreshConsentCache();
     expect(getCachedShareAnalytics()).toBe(false);
+    expect(getRawShareAnalytics()).toBe(false);
   });
 
   test("startConsentRefresh is idempotent and runs an immediate refresh", async () => {
@@ -162,7 +191,8 @@ describe("consent-cache", () => {
 
   // share_diagnostics tracks the same refresh as share_analytics; Sentry's
   // beforeSend re-reads it per event so a revocation is honored within a cycle.
-  test("diagnostics defaults to false before any refresh", () => {
+  test("diagnostics boots unknown; public accessor reads false", () => {
+    expect(getRawShareDiagnostics()).toBe("unknown");
     expect(getCachedShareDiagnostics()).toBe(false);
   });
 
@@ -170,6 +200,7 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareDiagnostics: true }));
     await refreshConsentCache();
     expect(getCachedShareDiagnostics()).toBe(true);
+    expect(getRawShareDiagnostics()).toBe(true);
   });
 
   test("a later fetch reporting shareDiagnostics: false honors the revocation", async () => {
@@ -180,6 +211,7 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareDiagnostics: false }));
     await refreshConsentCache();
     expect(getCachedShareDiagnostics()).toBe(false);
+    expect(getRawShareDiagnostics()).toBe(false);
   });
 
   test("a null diagnostics fetch keeps the last known value", async () => {
@@ -192,17 +224,19 @@ describe("consent-cache", () => {
     expect(getCachedShareDiagnostics()).toBe(true);
   });
 
-  test("a missing client flips a prior diagnostics opt-in back to false", async () => {
+  test("a missing client demotes a prior diagnostics opt-in to unknown (public accessor reads false)", async () => {
     __setCachedShareDiagnosticsForTest(true);
     mockClient = null;
     await refreshConsentCache();
+    expect(getRawShareDiagnostics()).toBe("unknown");
     expect(getCachedShareDiagnostics()).toBe(false);
   });
 
-  test("a client without a resolvable assistant identity fails diagnostics closed", async () => {
+  test("a client without a resolvable assistant identity demotes diagnostics to unknown", async () => {
     __setCachedShareDiagnosticsForTest(true);
     mockClient = makeClient(makeConsent({ shareDiagnostics: true }), "");
     await refreshConsentCache();
+    expect(getRawShareDiagnostics()).toBe("unknown");
     expect(getCachedShareDiagnostics()).toBe(false);
   });
 
@@ -250,5 +284,29 @@ describe("consent-cache", () => {
     mockClient = makeClient(null);
     await refreshConsentCache();
     expect(getCachedShareDiagnosticsVersion()).toBe("2026-06-18");
+  });
+
+  test("public accessors collapse unknown to false; raw accessors expose the tri-state", async () => {
+    // Refresh once so the module's legacy opt-out marker reflects the
+    // beforeEach config (the marker is only re-read during a refresh).
+    mockClient = null;
+    await refreshConsentCache();
+
+    for (const state of [true, false, "unknown"] as const) {
+      __setCachedShareAnalyticsForTest(state);
+      __setCachedShareDiagnosticsForTest(state);
+      expect(getCachedShareAnalytics()).toBe(state === true);
+      expect(getCachedShareDiagnostics()).toBe(state === true);
+      expect(getRawShareAnalytics()).toBe(state);
+      expect(getRawShareDiagnostics()).toBe(state);
+    }
+  });
+
+  test("legacy opt-out marker folds the raw analytics state to false (diagnostics unaffected)", async () => {
+    setConfig("legacyTelemetryOptOut", true);
+    mockClient = null;
+    await refreshConsentCache();
+    expect(getRawShareAnalytics()).toBe(false);
+    expect(getRawShareDiagnostics()).toBe("unknown");
   });
 });

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -14,10 +14,16 @@
  * synchronous, I/O-free read, so this module owns the values and refreshes them
  * periodically in the background. Consent is opt-out — an owner who never made
  * an explicit choice reports as consented (the client maps a never-chose wire
- * value to `true`) — but UNKNOWN consent stays off: an absent session, a
- * disabled platform, or a transient fetch failure all leave the values
- * untouched (initial `false`), so we never report analytics or send crash
- * diagnostics without a confirmed consent state.
+ * value to `true`).
+ *
+ * The consent values are tri-state (`ConsentState`): `true`/`false` are
+ * confirmed states from a successful platform fetch; `"unknown"` means no
+ * confirmed state exists — boot before the first refresh, no platform session,
+ * or no resolvable owner identity. A transient fetch failure keeps the
+ * previous value so a known opt-in is not flipped mid-session. The boolean
+ * accessors collapse `"unknown"` to `false` (fail-closed); the raw accessors
+ * expose the tri-state for callers that must distinguish a confirmed opt-out
+ * from a not-yet-known state.
  */
 
 import { getConfigReadOnly } from "../config/loader.js";
@@ -28,8 +34,11 @@ const log = getLogger("consent-cache");
 
 const REFRESH_INTERVAL_MS = 5 * 60_000; // refresh consent every 5 min
 
-let cachedShareAnalytics = false; // default-off until first success
-let cachedShareDiagnostics = false; // default-off until first success
+/** Cached consent value: a confirmed boolean, or `"unknown"` when no confirmed state exists. */
+export type ConsentState = boolean | "unknown";
+
+let cachedShareAnalytics: ConsentState = "unknown"; // no confirmed state until first success
+let cachedShareDiagnostics: ConsentState = "unknown"; // no confirmed state until first success
 let cachedShareDiagnosticsVersion = ""; // "" fails the trace disclosure gate
 // Fail-closed marker for a workspace that locally opted out of usage data
 // before telemetry moved to platform `share_analytics` consent (migration 106).
@@ -41,20 +50,40 @@ let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 /**
  * Synchronous hot-path accessor for the effective `share_analytics` consent.
- * Never does I/O; returns `false` until a successful refresh proves otherwise,
- * and stays `false` while the legacy fail-closed opt-out marker is set.
+ * Never does I/O; returns `false` unless a successful refresh confirmed an
+ * opt-in (`"unknown"` reads as `false`), and stays `false` while the legacy
+ * fail-closed opt-out marker is set.
  */
 export function getCachedShareAnalytics(): boolean {
-  return cachedShareAnalytics && !legacyOptOut;
+  return cachedShareAnalytics === true && !legacyOptOut;
+}
+
+/**
+ * Raw tri-state `share_analytics` consent. The legacy fail-closed opt-out
+ * marker folds into `false` — a workspace-level opt-out is a confirmed
+ * opt-out, not an unknown. For callers that must distinguish a confirmed
+ * opt-out from a not-yet-known state.
+ */
+export function getRawShareAnalytics(): ConsentState {
+  return legacyOptOut ? false : cachedShareAnalytics;
 }
 
 /**
  * Synchronous hot-path accessor for the `share_diagnostics` consent (read by
- * Sentry `beforeSend`). Never does I/O; returns `false` until a successful
- * refresh proves otherwise. Because every Sentry event re-reads this, a
- * mid-session opt-out is honored within one refresh cycle.
+ * Sentry `beforeSend`). Never does I/O; returns `false` unless a successful
+ * refresh confirmed an opt-in (`"unknown"` reads as `false`). Because every
+ * Sentry event re-reads this, a mid-session opt-out is honored within one
+ * refresh cycle.
  */
 export function getCachedShareDiagnostics(): boolean {
+  return cachedShareDiagnostics === true;
+}
+
+/**
+ * Raw tri-state `share_diagnostics` consent, for callers that must
+ * distinguish a confirmed opt-out from a not-yet-known state.
+ */
+export function getRawShareDiagnostics(): ConsentState {
   return cachedShareDiagnostics;
 }
 
@@ -70,28 +99,26 @@ export function getCachedShareDiagnosticsVersion(): string {
 /**
  * Refresh the cached consent from the platform.
  *
- * No platform session / features disabled (`create()` is null) → default-off.
+ * No platform session / features disabled (`create()` is null) → `"unknown"`.
  * No resolvable assistant identity (no owner whose consent we can attest to) →
- * fail closed. A successful fetch adopts the reported values. A `null` fetch
- * (transient failure / undeployed endpoint) leaves the previous values
- * unchanged so a known opt-in is not flipped off mid-session.
+ * `"unknown"` — losing the owner mapping is not an opt-out, but it also isn't
+ * a confirmed opt-in, so we stop riding a stale one. A successful fetch adopts
+ * the reported values. A `null` fetch (transient failure / undeployed
+ * endpoint) leaves the previous values unchanged so a known opt-in is not
+ * flipped off mid-session.
  */
 export async function refreshConsentCache(): Promise<void> {
   legacyOptOut = getConfigReadOnly().legacyTelemetryOptOut === true;
 
   const client = await VellumPlatformClient.create();
   if (!client) {
-    setCachedShareAnalytics(false);
-    setCachedShareDiagnostics(false);
-    setCachedShareDiagnosticsVersion("");
+    resetConsentToUnknown();
     return;
   }
 
-  // No resolvable owner identity → fail closed (don't ride a stale opt-in).
+  // No resolvable owner identity → unknown (don't ride a stale opt-in).
   if (!client.platformAssistantId) {
-    setCachedShareAnalytics(false);
-    setCachedShareDiagnostics(false);
-    setCachedShareDiagnosticsVersion("");
+    resetConsentToUnknown();
     return;
   }
 
@@ -103,7 +130,13 @@ export async function refreshConsentCache(): Promise<void> {
   }
 }
 
-function setCachedShareAnalytics(value: boolean): void {
+function resetConsentToUnknown(): void {
+  setCachedShareAnalytics("unknown");
+  setCachedShareDiagnostics("unknown");
+  setCachedShareDiagnosticsVersion("");
+}
+
+function setCachedShareAnalytics(value: ConsentState): void {
   if (value !== cachedShareAnalytics) {
     log.debug(
       { from: cachedShareAnalytics, to: value },
@@ -113,7 +146,7 @@ function setCachedShareAnalytics(value: boolean): void {
   }
 }
 
-function setCachedShareDiagnostics(value: boolean): void {
+function setCachedShareDiagnostics(value: ConsentState): void {
   if (value !== cachedShareDiagnostics) {
     log.debug(
       { from: cachedShareDiagnostics, to: value },
@@ -161,12 +194,12 @@ export async function stopConsentRefresh(): Promise<void> {
 }
 
 /** Test-only: override the cached analytics value without going through a refresh. */
-export function __setCachedShareAnalyticsForTest(value: boolean): void {
+export function __setCachedShareAnalyticsForTest(value: ConsentState): void {
   cachedShareAnalytics = value;
 }
 
 /** Test-only: override the cached diagnostics value without going through a refresh. */
-export function __setCachedShareDiagnosticsForTest(value: boolean): void {
+export function __setCachedShareDiagnosticsForTest(value: ConsentState): void {
   cachedShareDiagnostics = value;
 }
 

--- a/assistant/src/runtime/routes/telemetry-routes.ts
+++ b/assistant/src/runtime/routes/telemetry-routes.ts
@@ -152,7 +152,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Record onboarding-research event",
     description:
-      'Record the settled result of an onboarding "research me" web-search turn (claims, suggestions, and plugin picks). Client-orchestrated: the web client reports this once it has observed the turn complete. Gated on share_diagnostics consent (in addition to share_analytics) since the payload carries the model\'s raw inferred claims about the user.',
+      'Record the settled result of an onboarding "research me" web-search turn (claims, suggestions, and plugin picks). Client-orchestrated: the web client reports this once it has observed the turn complete. Gated on share_analytics consent like every other outbox-backed event; the platform re-checks the owner\'s consent server-side at ingest.',
     tags: ["telemetry"],
     requestBody: onboardingResearchRequestSchema,
     responseBody: z.union([
@@ -161,7 +161,7 @@ export const ROUTES: RouteDefinition[] = [
         skipped: z
           .literal(true)
           .describe(
-            "Event skipped: usage data collection or diagnostics consent is disabled/ineligible",
+            "Event skipped: usage data collection is disabled or the telemetry database is unavailable",
           ),
       }),
     ]),


### PR DESCRIPTION
## Summary
- Consent cache values become tri-state (`boolean | "unknown"`): boot and the two hard-fail refresh branches (no platform client / no resolvable owner identity) now cache `"unknown"` instead of `false` — losing the owner mapping is not an opt-out. Public accessors keep their exact fail-closed semantics (`unknown` reads as `false`), so this PR is zero behavior change; new raw accessors `getRawShareAnalytics()` / `getRawShareDiagnostics()` expose the tri-state for the record-gate (PR 3) and flush-defer (PR 4) follow-ups.
- Deletes the dead pre-#9043 `share_*_chosen` rescue in `getOwnerConsent()`: the platform (single deployment) has served effective owner-consent values (null coerced to true) since 2026-07-13, so only an explicit `false` disables sharing.
- Fixes the stale onboarding-research route description (the share_diagnostics gate was removed by #38088; the event is share_analytics-gated like every other outbox event) and regenerates `openapi.yaml`.

Part of plan: consent-cleanup.md (PR 2 of 10)