### PR TITLE
chore: bump all package versions to 0.10.9

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Vellum Assistant API
-  version: 0.10.8
+  version: 0.10.9
   description: Auto-generated OpenAPI specification for the Vellum Assistant runtime HTTP server.
 servers:
   - url: http://127.0.0.1:7821

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/assistant",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "assistant": {
       "name": "@vellumai/assistant",
-      "version": "0.10.8",
+      "version": "0.10.9",
       "bin": {
         "assistant": "./src/index.ts",
       },
@@ -92,7 +92,7 @@
     },
     "cli": {
       "name": "@vellumai/cli",
-      "version": "0.10.8",
+      "version": "0.10.9",
       "bin": {
         "vellum": "./src/index.ts",
       },
@@ -144,7 +144,7 @@
     },
     "clients/web": {
       "name": "@vellumai/web",
-      "version": "0.10.8",
+      "version": "0.10.9",
       "dependencies": {
         "@capacitor/app": "8.1.0",
         "@capacitor/browser": "8.0.3",
@@ -247,7 +247,7 @@
     },
     "credential-executor": {
       "name": "@vellumai/credential-executor",
-      "version": "0.10.8",
+      "version": "0.10.9",
       "bin": {
         "credential-executor": "./src/main.ts",
         "credential-executor-managed": "./src/managed-main.ts",
@@ -270,7 +270,7 @@
     },
     "gateway": {
       "name": "@vellumai/vellum-gateway",
-      "version": "0.10.8",
+      "version": "0.10.9",
       "dependencies": {
         "@slack/types": "2.21.1",
         "@vellumai/assistant-client": "workspace:*",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/cli",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "CLI tools for vellum-assistant",
   "type": "module",
   "exports": {

--- a/clients/chrome-extension/manifest.json
+++ b/clients/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vellum Assistant",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "minimum_chrome_version": "120",
   "description": "Bridges the Vellum assistant to your live browser session via Chrome DevTools Protocol (CDP) through chrome.debugger.",
   "homepage_url": "https://www.vellum.ai",

--- a/clients/chrome-extension/package.json
+++ b/clients/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/chrome-extension",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/web",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "type": "module",
   "description": "Pre-built web SPA for the Vellum Assistant",
   "license": "MIT",

--- a/credential-executor/package.json
+++ b/credential-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/credential-executor",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vellumai/vellum-gateway",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/meta/package.json
+++ b/meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vellum",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "license": "MIT",
   "description": "Install the full Vellum stack locally",
   "bin": {
@@ -16,11 +16,11 @@
     "npm-shrinkwrap.json"
   ],
   "dependencies": {
-    "@vellumai/assistant": "0.10.8",
-    "@vellumai/cli": "0.10.8",
-    "@vellumai/credential-executor": "0.10.8",
-    "@vellumai/vellum-gateway": "0.10.8",
-    "@vellumai/web": "0.10.8"
+    "@vellumai/assistant": "0.10.9",
+    "@vellumai/cli": "0.10.9",
+    "@vellumai/credential-executor": "0.10.9",
+    "@vellumai/vellum-gateway": "0.10.9",
+    "@vellumai/web": "0.10.9"
   },
   "overrides": {
     "drizzle-orm": "0.45.2",


### PR DESCRIPTION
## Prompt / plan

The 0.10.9 release shipped without bumping the version-bearing manifests: `main` is still on `0.10.8`, while the npm packages, Docker images, and clients were published as `0.10.9`. (The `0.10.9 round 1 cherry picks` back-merge overwrote the version bump that had already been applied.) This brings the source tree in line with what was actually released.

Bumps the full set the release version-bump script (`create-release-branch.yml`) touches:
- `assistant`, `cli`, `credential-executor`, `gateway`, `meta`, `clients/web`, and `clients/chrome-extension` — `package.json` `version`
- `clients/chrome-extension/manifest.json` `version`
- `meta/package.json` `@vellumai/*` dependency pins
- `bun.lock` workspace member versions
- `assistant/openapi.yaml` `info.version`

Applied with the same tools the release workflow uses (`jq` for the manifests); the diff is version lines only — no other content changed.

## Test plan

- Verified every version-bearing manifest now reads `0.10.9` and no `0.10.8` remains in the changed files.
- Confirmed the diff is purely version/dependency-pin bumps (10 files, version lines only) — no incidental reformatting.
- Cross-checked against the live registry: all six packages (`@vellumai/assistant`, `cli`, `credential-executor`, `vellum-gateway`, `web`, and `vellum`) are published at `0.10.9`, so this makes `main` match the shipped release.
- CI on this branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XhJH46kHm1mVhEbsViPXhA)_