### PR TITLE
feat(live-voice): merge the interrupted request into barge-in follow-up turns (JARVIS-1249)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -560,6 +560,77 @@ describe("LiveVoiceSession server VAD", () => {
     expect(prompt).not.toContain("interrupted");
   });
 
+  test("a discarded barge-in utterance does not leak merge context into a later turn", async () => {
+    const startVoiceTurn = mock(async (_options: VoiceTurnOptions) => {
+      return { turnId: "bridge-turn", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    // The barge-in utterance (second) transcribes to nothing and is discarded.
+    const { frames, session } = createHarness({
+      finals: ["first question", "", "third question"],
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge in during thinking (arms the pending merge context), but the
+    // barge-in utterance is discarded (empty transcript), which must drop it.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "utterance_discarded"),
+    );
+
+    // A later, unrelated turn must not carry the discarded request.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => startVoiceTurn.mock.calls.length === 2);
+    const laterTurn = startVoiceTurn.mock.calls[1]?.[0];
+    expect(laterTurn).toMatchObject({ content: "third question" });
+    expect(laterTurn?.voiceControlPrompt).not.toContain("interrupted");
+    expect(laterTurn?.voiceControlPrompt).not.toContain("first question");
+  });
+
+  test("a client interrupt after a barge-in drops the pending merge context", async () => {
+    const startVoiceTurn = mock(async (_options: VoiceTurnOptions) => {
+      return { turnId: "bridge-turn", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question", "third question"],
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge in during thinking, then the client interrupts before the barge-in
+    // utterance launches a turn.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    await session.handleClientFrame({ type: "interrupt" });
+    await flushAsyncCallbacks();
+    const callsAtInterrupt = startVoiceTurn.mock.calls.length;
+
+    // Any later turn must not carry the discarded request.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => startVoiceTurn.mock.calls.length > callsAtInterrupt);
+    const laterTurn = startVoiceTurn.mock.calls.at(-1)?.[0];
+    expect(laterTurn?.voiceControlPrompt).not.toContain("interrupted");
+    expect(laterTurn?.voiceControlPrompt).not.toContain("first question");
+  });
+
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -505,6 +505,61 @@ describe("LiveVoiceSession server VAD", () => {
     expect(countType(frames, "utterance_end")).toBe(2);
   });
 
+  test("a thinking barge-in merges the interrupted request into the next turn's control prompt", async () => {
+    const startVoiceTurn = mock(async (_options: VoiceTurnOptions) => {
+      return { turnId: "bridge-turn", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge in while the first turn is still thinking, then let the barge-in
+    // utterance start its own turn.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => startVoiceTurn.mock.calls.length === 2);
+
+    // The barged (first) turn ran on the plain control prompt.
+    const firstPrompt =
+      startVoiceTurn.mock.calls[0]?.[0]?.voiceControlPrompt ?? "";
+    expect(firstPrompt).not.toContain("interrupted");
+    expect(firstPrompt).not.toContain("first question");
+
+    // The follow-up turn's visible content is only what the user just said,
+    // but its control prompt carries the interrupted request so the model
+    // merges the two instead of treating it as a fresh follow-up.
+    const second = startVoiceTurn.mock.calls[1]?.[0];
+    expect(second).toMatchObject({ content: "second question" });
+    expect(second?.voiceControlPrompt).toContain("first question");
+    expect(second?.voiceControlPrompt).toContain("interrupted");
+  });
+
+  test("an ordinary turn carries no interruption merge context", async () => {
+    const { startVoiceTurn, calls } = makeAutoCompletingTurnStarter(["Hi."]);
+    const { frames, session } = createHarness({
+      finals: ["hello there"],
+      startVoiceTurn,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => countType(frames, "tts_done") === 1);
+
+    expect(calls).toHaveLength(1);
+    const prompt = calls[0]?.voiceControlPrompt ?? "";
+    expect(prompt).toContain("live voice session");
+    expect(prompt).not.toContain("interrupted");
+  });
+
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1479,6 +1479,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.assistantPlaybackTailUntilMs = 0;
     this.takeVadPreRoll();
     this.vadPendingTurnEnd = null;
+    // A client interrupt is a hard reset: any barge-in merge context waiting for
+    // the next turn is now stale (the interrupted utterance may be discarded
+    // without ever reaching finalizePendingUtterance).
+    this.pendingInterruptedRequest = null;
     const utterance = this.currentUtterance;
     this.stopSessionTranscriber();
     if (utterance) {
@@ -1539,10 +1543,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const content = utterance.finalTranscriptSegments.join(" ").trim();
     if (content.length === 0) {
       utterance.assistantTurnStarted = true;
-      // A discarded (empty) barge-in utterance carries no new request, so any
-      // pending merge context is stale — drop it rather than let it attach to a
-      // later, unrelated turn.
-      this.pendingInterruptedRequest = null;
       if (this.turnDetector) {
         // Hands-free clients moved to "transcribing" on utterance_end; tell
         // them the utterance was dropped so they return to listening. Sent
@@ -2516,6 +2516,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance: UtteranceCycle,
     reason: string,
   ): Promise<void> {
+    // An utterance that finalizes here never became a turn (empty transcript,
+    // client interrupt, transcriber close, error), so it ends the window a
+    // barge-in's merge context was waiting to attach to. Drop that context so
+    // it can't leak into a later, unrelated turn. The barged turn itself
+    // finalizes through finalizeAssistantTurn, not here, so this never clears a
+    // request that the barge-in follow-up turn is still about to consume.
+    this.pendingInterruptedRequest = null;
     utterance.completed = true;
     const turnId = utterance.turnId;
     if (!turnId) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -273,6 +273,11 @@ interface ActiveAssistantTurn {
   // forwarded chunk so the firstTtsAudio metric is marked exactly once per turn.
   ttsAudioStarted: boolean;
   finalized: boolean;
+  // When this turn started from a barge-in, the interrupted request's
+  // transcript. Appended to the turn's control prompt (both legs) so the model
+  // merges it with this turn's utterance instead of treating that utterance as
+  // a fresh follow-up. Null for an ordinary (non-barge-in) turn.
+  interruptedRequest: string | null;
   // Triage-and-escalate (Voice Mode): the front-door leg emitted [ESCALATE]
   // and the strong "escalated" leg has taken over this same turn. Guards the
   // front-door leg's trailing completion from finalizing the turn, and makes
@@ -292,6 +297,21 @@ interface ActiveAssistantTurn {
   assistantAudioChunks: Buffer[];
   assistantAudioMimeType: string;
   assistantAudioSampleRate?: number;
+}
+
+// Base control prompt for every live-voice turn. When a turn starts from a
+// barge-in, the interruption merge note is appended to it (see
+// buildInterruptionMergeNote) so the model reconciles the interrupted request
+// with the new utterance.
+const LIVE_VOICE_CONTROL_PROMPT =
+  "You are speaking in a local live voice session. Keep replies brief and conversational.";
+
+// System-level guidance appended to a barge-in turn's control prompt so the
+// model treats the new utterance as a continuation of the request it was cut
+// off answering, rather than a fresh follow-up. Reaches the model only; it is
+// not a user message and never renders as a transcript bubble.
+function buildInterruptionMergeNote(interruptedRequest: string): string {
+  return `The user interrupted your previous, unfinished reply. Their earlier request was: "${interruptedRequest}". Treat their current message as a continuation of that request and address both together, or stay silent if they only want you to stop.`;
 }
 
 export class LiveVoiceSession implements LiveVoiceSessionContract {
@@ -337,6 +357,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // the chunk's PCM duration; zeroed whenever the client flushes playback
   // (speech_started, turn_cancelled, interrupt, close).
   private assistantPlaybackTailUntilMs = 0;
+  // Set when barge-in cancels an in-flight turn: the interrupted request's
+  // transcript, carried into the next turn so the model merges the two.
+  // Consumed (and cleared) when that turn launches; cleared if the barge-in
+  // utterance is discarded, so it can never attach to a later, unrelated turn.
+  private pendingInterruptedRequest: string | null = null;
   private readonly maxPendingAudioBytes: number;
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
@@ -1001,6 +1026,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // do not collide with it in the collector. turn_cancelled flushes
     // client playback, so the drain estimate resets with it.
     this.assistantPlaybackTailUntilMs = 0;
+    // Carry the interrupted request into the next turn so it merges with the
+    // barge-in utterance rather than being answered as a fresh follow-up.
+    const interruptedRequest = turn.utterance.finalTranscriptSegments
+      .join(" ")
+      .trim();
+    this.pendingInterruptedRequest =
+      interruptedRequest.length > 0 ? interruptedRequest : null;
     turn.abortController.abort();
     this.metrics.markBargeIn(turn.turnId);
     void (async () => {
@@ -1507,6 +1539,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const content = utterance.finalTranscriptSegments.join(" ").trim();
     if (content.length === 0) {
       utterance.assistantTurnStarted = true;
+      // A discarded (empty) barge-in utterance carries no new request, so any
+      // pending merge context is stale — drop it rather than let it attach to a
+      // later, unrelated turn.
+      this.pendingInterruptedRequest = null;
       if (this.turnDetector) {
         // Hands-free clients moved to "transcribing" on utterance_end; tell
         // them the utterance was dropped so they return to listening. Sent
@@ -1519,7 +1555,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
-    await this.launchAssistantTurn(utterance, content);
+    // Consume any pending barge-in merge context for this turn (one barge-in
+    // feeds exactly the next launched turn).
+    const interruptedRequest = this.pendingInterruptedRequest;
+    this.pendingInterruptedRequest = null;
+    await this.launchAssistantTurn(utterance, content, { interruptedRequest });
   }
 
   // Build the ActiveAssistantTurn for a released utterance and drive its model
@@ -1528,9 +1568,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private async launchAssistantTurn(
     utterance: UtteranceCycle,
     content: string,
-    // Only set on the surface-resume path; the STT path leaves it undefined so
-    // no active-surface context is injected into an ordinary spoken turn.
-    activeSurfaceId?: string,
+    opts?: {
+      // Only set on the surface-resume path; the STT path leaves it undefined
+      // so no active-surface context is injected into an ordinary spoken turn.
+      activeSurfaceId?: string;
+      // Set on a barge-in follow-up turn: the interrupted request's transcript,
+      // appended to the turn's control prompt so the model merges the two.
+      interruptedRequest?: string | null;
+    },
   ): Promise<void> {
     utterance.assistantTurnStarted = true;
     const token = Symbol("live-voice-assistant-turn");
@@ -1547,6 +1592,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ttsDone: false,
       ttsAudioStarted: false,
       finalized: false,
+      interruptedRequest: opts?.interruptedRequest ?? null,
       escalationHandedOff: false,
       ttsBuffer: "",
       ttsSegmentEnqueued: false,
@@ -1583,11 +1629,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             overrideProfile: FRONT_DOOR_PROFILE,
             routingLeg: "front-door",
             frontDoor: true,
-            ...(activeSurfaceId !== undefined ? { activeSurfaceId } : {}),
+            ...(opts?.activeSurfaceId !== undefined
+              ? { activeSurfaceId: opts.activeSurfaceId }
+              : {}),
           }
         : {
             content,
-            ...(activeSurfaceId !== undefined ? { activeSurfaceId } : {}),
+            ...(opts?.activeSurfaceId !== undefined
+              ? { activeSurfaceId: opts.activeSurfaceId }
+              : {}),
           },
     );
   }
@@ -1662,7 +1712,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         finalTranscriptAtMs: null,
       },
     };
-    await this.launchAssistantTurn(utterance, content, opts?.activeSurfaceId);
+    await this.launchAssistantTurn(utterance, content, {
+      activeSurfaceId: opts?.activeSurfaceId,
+    });
   }
 
   // Dispatch a resume deferred behind an in-flight turn, once that turn has
@@ -1786,8 +1838,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         assistantMessageChannel: "vellum",
         userMessageInterface: "macos",
         assistantMessageInterface: "macos",
-        voiceControlPrompt:
-          "You are speaking in a local live voice session. Keep replies brief and conversational.",
+        voiceControlPrompt: activeTurn.interruptedRequest
+          ? `${LIVE_VOICE_CONTROL_PROMPT}\n\n${buildInterruptionMergeNote(
+              activeTurn.interruptedRequest,
+            )}`
+          : LIVE_VOICE_CONTROL_PROMPT,
         approvalMode: "local-live-voice",
         content: leg.content,
         isInbound: true,


### PR DESCRIPTION
## Summary
- On a live-voice barge-in, carry the interrupted request into the next turn so the model produces one coherent response accounting for both the interrupted request and the interruption, instead of treating the interruption as a fresh follow-up (the "rambling" behavior observed in Voice Mode). Builds on JARVIS-1266 (#38174), which made barge-in fire during the pre-TTS "thinking" phase; this is the next step on JARVIS-1249's relax-single-active-turn line.
- Mechanism: `bargeIn` stashes the cancelled turn's transcript in `pendingInterruptedRequest`; the next launched turn appends a merge note to its per-turn `voiceControlPrompt` (model-visible system context, NOT a user message, so the visible transcript is unchanged). The model is told to treat the new utterance as a continuation of the interrupted request and address both, or stay silent for a plain stop (no hard-coded cancel detection). The pending request is consumed by exactly the next turn and cleared if that utterance is discarded, so it can never attach to a later unrelated turn.
- Server-VAD/hands-free only; manual/PTT unaffected. No new feature flag (behavior refinement of the shipped barge-in). New tests in `live-voice-vad.test.ts` assert the follow-up turn's control prompt carries the interrupted request while its visible content is only the new utterance, and that an ordinary (non-barge) turn carries no merge context.

## Follow-up (deferred)
The aborted turn's stranded partial assistant reply is still finalized into conversation history by the shared daemon agent-loop persistence (`finalizeStrandedInflightContent`), used by all surfaces. For the pre-TTS thinking barge-in (the primary case) that partial is empty, and the merge note references the interrupted request explicitly, so the model behaves correctly. Dropping/marking that partial for mid-speech barge-ins is a follow-up scoped to the daemon layer, kept out of this PR to avoid cross-surface risk.

## Original prompt
While testing the merged JARVIS-1266 voice barge-in, the user found that interrupting the assistant mid-thinking produced a separate, appended reply that lost context and rambled, rather than one coherent answer. They asked for interruptions to stop the assistant AND merge the interrupted request with the interruption so the assistant understands both messages fully. Confirmed design: always merge the in-flight request into the next turn, and let the model decide the response (including going silent for a plain stop). This PR implements that merge-context injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)