### PR TITLE
docs(web): correct stale comments about the removed onboarding flags

### DIFF
--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
@@ -1,6 +1,6 @@
 /**
  * Hidden kickoff sent on the user's behalf when they hit "Let's chat" at the
- * end of the personality-onboarding flow. It drives the assistant's first
+ * end of the research-onboarding flow. It drives the assistant's first
  * reply but renders no user bubble, so the chat opens with the assistant
  * proactively greeting the user in the persona they just configured.
  *

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -550,7 +550,7 @@ export function ResearchOnboardingRoute() {
       });
   }
 
-  // Final personality-onboarding handoff: wait out any background capability
+  // Final research-onboarding handoff: wait out any background capability
   // installs (so the primed chat can discover their skills), any removal
   // correction (so rejected claims can't leak in), and the personality rewrite
   // (so the greeting lands in the configured persona), then drop into a fresh

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -83,7 +83,7 @@ export interface BuildResearchPromptOptions {
   /**
    * Whether to ask the model for clickable follow-up `suggestions`. The
    * suggestions-based final step is being retired in favor of the "Let's chat"
-   * handoff (gated behind the personality-onboarding flag), which installs the
+   * handoff (now always on), which installs the
    * picked plugins and drops the user straight into a primed chat. When false,
    * the prompt asks for ONLY `plugins` + `claims` and omits all suggestion
    * guidance. Defaults to true so the legacy suggestions flow is unchanged.
@@ -129,7 +129,7 @@ export function buildResearchPrompt(
     : "I'd like you to get to know me before we start working together.";
 
   // The clickable-suggestions block is optional: the "Let's chat" final step
-  // (personality-onboarding flag) installs the picked plugins and drops the
+  // (now always on) installs the picked plugins and drops the
   // user into a primed chat instead, so it asks for only `plugins` + `claims`.
   const suggestionsArrayExample = includeSuggestions
     ? ` "suggestions": [ { "suggestion": "I'll find the 3 newest arXiv eval papers worth your time", "prompt": "Find me the 3 newest arXiv eval papers worth reading." }, { "suggestion": "I'll draft a crisp summary of the latest model-serving trade-offs", "prompt": "Draft me a short summary of the latest model-serving trade-offs." }, { "suggestion": "Connect GitHub and I'll triage your stalest issues", "prompt": "Connect to GitHub and triage my oldest open issues." }, { "suggestion": "I'll plan a weekend climbing trip near Boulder", "prompt": "Plan me a weekend climbing trip near Boulder." } ]`

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -287,7 +287,7 @@ export interface StartResearchOptions {
   onConversationCreated?: (conversationId: string) => void;
   /**
    * Whether to ask the model for clickable `suggestions`. Off for the "Let's
-   * chat" final step (personality-onboarding flag), which installs the picked
+   * chat" final step (now always on), which installs the picked
    * plugins and primes a chat instead of surfacing suggestion cards. Defaults to
    * true so the legacy suggestions flow is unchanged.
    */

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -876,8 +876,9 @@ export function SuggestionsStep({
 // ---------------------------------------------------------------------------
 
 /**
- * Terminal step for the personality-onboarding flow (replaces SuggestionsStep
- * when that flag is on). The suggestions idea is retired: instead this confirms
+ * Terminal step for the research-onboarding flow (replaces SuggestionsStep,
+ * now that the "Create my personality" step is always on). The suggestions idea
+ * is retired: instead this confirms
  * the capabilities already set up for the assistant — chosen from the user's
  * role, hobby, and what the web research surfaced — and offers a single "Let's
  * chat" button. Clicking primes a fresh chat with a hidden kickoff message so

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -111,8 +111,8 @@ export const routes = {
     privacy: r("/assistant/onboarding/privacy"),
     prechat: r("/assistant/onboarding/prechat"),
     hatching: r("/assistant/onboarding/hatching"),
-    // SPIKE — research-onboarding front door. Reachable on demand behind the
-    // default-off research-onboarding flag (see routes.tsx).
+    // SPIKE — research-onboarding front door. Reachable on demand behind auth
+    // alone (no flag; see routes.tsx).
     research: r("/assistant/onboarding/research"),
   },
 


### PR DESCRIPTION
## Summary
The `research-onboarding` and `personality-onboarding` flags were removed; several comments still described behavior as gated behind them. Update those comments to reflect reality (personality step always on; research route reachable behind auth; mock harness dev-gated). Comments only — no logic change.

Fixes a gap found during plan review for onboarding-ff-cleanup.md.