### PR TITLE
refactor(web): inline the control ab_variant on onboarding funnel events

### DIFF
--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -8,7 +8,6 @@ import {
   emitResearchOnboardingCheckinCalendarOpened,
   ONBOARDING_FUNNEL_STEPS,
   ONBOARDING_FUNNEL_VERSION,
-  ONBOARDING_FUNNEL_VARIANTS,
   RESEARCH_ONBOARDING_FUNNEL_STEPS,
   RESEARCH_ONBOARDING_FUNNEL_VERSION,
 } from "@/domains/onboarding/funnel-events";
@@ -33,14 +32,12 @@ describe("onboarding funnel events", () => {
       ONBOARDING_FUNNEL_STEPS.privacyTos,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
     const nameVibe = buildOnboardingFunnelEvent(
       ONBOARDING_FUNNEL_STEPS.nameVibe,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
 
@@ -81,7 +78,6 @@ describe("onboarding funnel events", () => {
       ONBOARDING_FUNNEL_STEPS.controlTools,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
 
@@ -105,11 +101,9 @@ describe("onboarding funnel events", () => {
 
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -249,7 +243,6 @@ describe("onboarding funnel events", () => {
     // the event emits.
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -257,7 +250,6 @@ describe("onboarding funnel events", () => {
     localStorage.setItem("device:share_analytics", "false");
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -267,7 +259,6 @@ describe("onboarding funnel events", () => {
     useOnboardingStore.setState({ shareAnalytics: false });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.nameVibe, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -109,7 +109,6 @@ export type OnboardingFunnelStepOutcome = "completed" | "skipped";
 
 export interface OnboardingFunnelStepCompletedOptions {
   userId?: string | null;
-  variant?: OnboardingFunnelVariant;
   /** Funnel this step belongs to; defaults to the pre-chat funnel version. */
   funnelVersion?: string;
   /** Completed vs skipped; omitted when the funnel doesn't distinguish. */
@@ -161,7 +160,6 @@ export function buildOnboardingFunnelEvent(
   options: OnboardingFunnelStepCompletedOptions = {},
 ): OnboardingFunnelEvent {
   const now = Date.now();
-  const variant = options.variant ?? ONBOARDING_FUNNEL_VARIANTS.control;
   return {
     type: "onboarding",
     daemon_event_id: crypto.randomUUID(),
@@ -173,7 +171,7 @@ export function buildOnboardingFunnelEvent(
     completed_at: new Date(now).toISOString(),
     user_id: options.userId ?? null,
     funnel_version: options.funnelVersion ?? ONBOARDING_FUNNEL_VERSION,
-    ab_variant: variant,
+    ab_variant: ONBOARDING_FUNNEL_VARIANTS.control,
     // Omitted (→ stripped before send) unless the caller distinguishes the two.
     outcome: options.outcome,
   };
@@ -219,7 +217,6 @@ export function emitResearchOnboardingStepCompleted(
 ): void {
   emitOnboardingFunnelStepCompleted(step, {
     userId: options.userId,
-    variant: ONBOARDING_FUNNEL_VARIANTS.control,
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
     outcome: options.outcome ?? "completed",
   });
@@ -237,7 +234,6 @@ export function emitResearchOnboardingCheckinCalendarOpened(
 ): void {
   emitOnboardingFunnelStepCompleted(RESEARCH_ONBOARDING_CHECKIN_STEP, {
     userId: options.userId,
-    variant: ONBOARDING_FUNNEL_VARIANTS.control,
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
     outcome: "completed",
   });

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -35,7 +35,6 @@ mock.module("@/domains/onboarding/funnel-events", () => ({
   emitOnboardingFunnelStepCompleted: emitFunnelStepCompletedMock,
   getOnboardingFunnelSessionId: () => "session-1",
   ONBOARDING_FUNNEL_STEPS: { privacyTos: "privacy_tos" },
-  ONBOARDING_FUNNEL_VARIANTS: { control: "control" },
 }));
 
 mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -11,7 +11,6 @@ import {
     emitOnboardingFunnelStepCompleted,
     getOnboardingFunnelSessionId,
     ONBOARDING_FUNNEL_STEPS,
-    ONBOARDING_FUNNEL_VARIANTS,
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { isLocalMode } from "@/lib/local-mode";
@@ -66,7 +65,6 @@ export function PrivacyScreen() {
     if (!isNative) {
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
         userId,
-        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       });
     }
 


### PR DESCRIPTION
## Summary
With the pared-down funnel retired, the onboarding funnel has a single variant. Remove the now-dead `variant` option pass-through (interface field, the `?? control` default, and the explicit `variant: control` passes) and stamp `ab_variant: control` directly. Telemetry wire behavior is unchanged.

Fixes a gap found during plan review for onboarding-ff-cleanup.md.