### PR TITLE
fix(telemetry): record events unless consent is a known explicit opt-out

### DIFF
--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -69,11 +69,18 @@ describe("auth-fallback-events-store", () => {
     });
   });
 
-  test("honors the share_analytics opt-out (records nothing)", () => {
+  test("honors a confirmed share_analytics opt-out (records nothing)", () => {
     setShareAnalytics(false);
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(0);
     expect(pendingOutboxRows("auth_fallback").length).toBe(0);
+  });
+
+  test("records while consent is unknown (a cold cache never drops data)", () => {
+    setShareAnalytics("unknown");
+    const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
+    expect(recorded).toBe(2);
+    expect(pendingOutboxRows("auth_fallback").length).toBe(2);
   });
 
   test("empty counts batch is a no-op", () => {

--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -7,6 +7,7 @@ let shareAnalytics = true;
 
 mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
+  getRawShareAnalytics: () => shareAnalytics,
 }));
 
 let broadcastedMessages: ServerMessage[] = [];

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -1,14 +1,17 @@
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
-// Toggle for the share_analytics opt-out the real store consults. The store
+import type { ConsentState } from "../platform/consent-cache.js";
+
+// Toggle for the share_analytics consent the real store consults. The store
 // module is intentionally NOT mocked here — it has its own DB-backed tests, and
 // Bun's `mock.module` is process-global, so mocking it would leak into those
 // tests when files share an invocation. Exercising the real store keeps every
 // auth-fallback test order-independent.
-let shareAnalytics = true;
+let shareAnalytics: ConsentState = true;
 
 mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
+  getCachedShareAnalytics: () => shareAnalytics === true,
+  getRawShareAnalytics: () => shareAnalytics,
 }));
 
 // The watchdog relay must go through the direct (unbuffered) emit; capture the
@@ -104,10 +107,16 @@ describe("internal-telemetry-routes: auth-fallback", () => {
     });
   });
 
-  test("returns skipped and persists nothing under the opt-out", () => {
+  test("returns skipped and persists nothing under a confirmed opt-out", () => {
     shareAnalytics = false;
     expect(call(VALID_BODY)).toEqual({ skipped: true });
     expect(pendingAuthFallbackPayloads().length).toBe(0);
+  });
+
+  test("records the batch while consent is unknown (a cold cache never drops data)", () => {
+    shareAnalytics = "unknown";
+    expect(call(VALID_BODY)).toEqual({ recorded: 1 });
+    expect(pendingAuthFallbackPayloads().length).toBe(1);
   });
 
   test("throws 503 when consent is on but the telemetry DB is unavailable, so the gateway re-queues", () => {
@@ -121,6 +130,17 @@ describe("internal-telemetry-routes: auth-fallback", () => {
 
     // Once the DB is back the same batch records normally.
     expect(call(VALID_BODY)).toEqual({ recorded: 1 });
+  });
+
+  test("throws 503 (not skipped) when consent is unknown and the telemetry DB is unavailable", () => {
+    shareAnalytics = "unknown";
+    const spy = spyOn(dbConnection, "getTelemetryDb").mockReturnValue(null);
+    try {
+      expect(() => call(VALID_BODY)).toThrow(ServiceUnavailableError);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(pendingAuthFallbackPayloads().length).toBe(0);
   });
 
   test("rejects a malformed body without persisting", () => {

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -82,6 +82,7 @@ mock.module("../telemetry/tool-audit.js", () => ({
 // terminals consult sees the opted-in state.
 mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => true,
+  getRawShareAnalytics: () => true,
 }));
 
 mock.module("../permissions/checker.js", () => ({

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -553,7 +553,7 @@ export async function runDaemon(): Promise<void> {
   }
 
   // Refresh the consent cache regardless of dev mode so record-time telemetry
-  // writes (gated on getCachedShareAnalytics()) work in dev too. The usage
+  // writes (which drop on a confirmed opt-out) work in dev too. The usage
   // telemetry reporter re-checks share_analytics on every flush, so dev still
   // never sends telemetry to the platform. Fire-and-forget: startConsentRefresh()
   // runs an immediate non-blocking refresh, so the startup hot path is never

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -164,6 +164,16 @@ describe("consent-cache", () => {
     expect(getCachedShareAnalytics()).toBe(false);
   });
 
+  test("legacy opt-out marker is honored at boot, before any refresh", () => {
+    // The marker is read live from config: a workspace carrying
+    // legacyTelemetryOptOut=true must gate recording in the window between
+    // daemon start and the first consent refresh (unknown-consent recording
+    // would otherwise leak events in that window).
+    setConfig("legacyTelemetryOptOut", true);
+    expect(getRawShareAnalytics()).toBe(false);
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
   test("legacy opt-out marker keeps analytics off despite platform opt-in", async () => {
     setConfig("legacyTelemetryOptOut", true);
     mockClient = makeClient(makeConsent({ shareAnalytics: true }));

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -93,6 +93,22 @@ describe("consent-cache", () => {
     expect(getCachedShareAnalytics()).toBe(false);
   });
 
+  test("platform features disabled → confirmed false, not unknown", async () => {
+    // A config-level platform opt-out is permanent, not a cold cache: no
+    // flush will ever drain the outbox, so record-time gates must stay
+    // closed (confirmed false) instead of accumulating rows forever.
+    __setCachedShareAnalyticsForTest(true);
+    process.env.VELLUM_DISABLE_PLATFORM = "1";
+    try {
+      await refreshConsentCache();
+    } finally {
+      delete process.env.VELLUM_DISABLE_PLATFORM;
+    }
+    expect(getRawShareAnalytics()).toBe(false);
+    expect(getRawShareDiagnostics()).toBe(false);
+    expect(getCachedShareDiagnosticsVersion()).toBe("");
+  });
+
   test("becomes true after a successful fetch reporting shareAnalytics: true", async () => {
     mockClient = makeClient(makeConsent({ shareAnalytics: true }));
     await refreshConsentCache();

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -45,8 +45,19 @@ let cachedShareDiagnosticsVersion = ""; // "" fails the trace disclosure gate
 // before telemetry moved to platform `share_analytics` consent (migration 106).
 // While set, telemetry stays off regardless of platform consent. Cleared by a
 // future cross-repo reconciliation once the platform exposes an explicit
-// re-consent signal; not auto-cleared here.
-let legacyOptOut = false;
+// re-consent signal; not auto-cleared here. Read live from config (an
+// in-memory cached read, safe on the hot path): a boot-time default would
+// leave the record-time gates open between daemon start and the first
+// consent refresh, exactly the window unknown-consent recording now keeps
+// events flowing in.
+function isLegacyOptedOut(): boolean {
+  try {
+    return getConfigReadOnly().legacyTelemetryOptOut === true;
+  } catch {
+    // Config not yet loaded — no marker to honor yet.
+    return false;
+  }
+}
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 /**
@@ -56,7 +67,7 @@ let refreshTimer: ReturnType<typeof setInterval> | null = null;
  * fail-closed opt-out marker is set.
  */
 export function getCachedShareAnalytics(): boolean {
-  return cachedShareAnalytics === true && !legacyOptOut;
+  return cachedShareAnalytics === true && !isLegacyOptedOut();
 }
 
 /**
@@ -66,7 +77,7 @@ export function getCachedShareAnalytics(): boolean {
  * opt-out from a not-yet-known state.
  */
 export function getRawShareAnalytics(): ConsentState {
-  return legacyOptOut ? false : cachedShareAnalytics;
+  return isLegacyOptedOut() ? false : cachedShareAnalytics;
 }
 
 /**
@@ -109,8 +120,6 @@ export function getCachedShareDiagnosticsVersion(): string {
  * flipped off mid-session.
  */
 export async function refreshConsentCache(): Promise<void> {
-  legacyOptOut = getConfigReadOnly().legacyTelemetryOptOut === true;
-
   // Platform features disabled is a PERMANENT condition (config-level), not a
   // cold-cache transient: telemetry can never ship, so confirmed-off keeps the
   // record-time gates closed and the outbox from accumulating rows that no

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -29,6 +29,7 @@
 import { getConfigReadOnly } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { VellumPlatformClient } from "./client.js";
+import { arePlatformFeaturesEnabled } from "./feature-gate.js";
 
 const log = getLogger("consent-cache");
 
@@ -109,6 +110,17 @@ export function getCachedShareDiagnosticsVersion(): string {
  */
 export async function refreshConsentCache(): Promise<void> {
   legacyOptOut = getConfigReadOnly().legacyTelemetryOptOut === true;
+
+  // Platform features disabled is a PERMANENT condition (config-level), not a
+  // cold-cache transient: telemetry can never ship, so confirmed-off keeps the
+  // record-time gates closed and the outbox from accumulating rows that no
+  // flush will ever drain.
+  if (!arePlatformFeaturesEnabled()) {
+    setCachedShareAnalytics(false);
+    setCachedShareDiagnostics(false);
+    setCachedShareDiagnosticsVersion("");
+    return;
+  }
 
   const client = await VellumPlatformClient.create();
   if (!client) {

--- a/assistant/src/runtime/routes/internal-telemetry-routes.ts
+++ b/assistant/src/runtime/routes/internal-telemetry-routes.ts
@@ -16,7 +16,7 @@
 
 import { z } from "zod";
 
-import { getCachedShareAnalytics } from "../../platform/consent-cache.js";
+import { getRawShareAnalytics } from "../../platform/consent-cache.js";
 import {
   type AuthFallbackCount,
   recordAuthFallbackCounts,
@@ -61,15 +61,16 @@ function handleRecordAuthFallback({ body }: RouteHandlerArgs) {
 
   const recorded = recordAuthFallbackCounts(window_start, window_end, mapped);
   if (recorded === 0) {
-    if (getCachedShareAnalytics()) {
-      // Consent is on but nothing was recorded (the body guarantees counts),
-      // so the telemetry DB is unavailable. Fail so the gateway's reporter
-      // merges the batch back and retries next flush instead of losing it.
+    if (getRawShareAnalytics() !== false) {
+      // Consent is not a confirmed opt-out but nothing was recorded (the
+      // body guarantees counts), so the telemetry DB is unavailable. Fail so
+      // the gateway's reporter merges the batch back and retries next flush
+      // instead of losing it.
       throw new ServiceUnavailableError(
         "Telemetry database unavailable; retry the auth-fallback batch",
       );
     }
-    // share_analytics consent is off: drop the counts to honor the opt-out.
+    // Confirmed share_analytics opt-out: drop the counts to honor it.
     return { skipped: true };
   }
   log.debug({ recorded }, "Recorded auth-fallback counts");

--- a/assistant/src/security/auth-fallback-events-store.ts
+++ b/assistant/src/security/auth-fallback-events-store.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from "uuid";
 
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { getRawShareAnalytics } from "../platform/consent-cache.js";
 import { insertTelemetryOutboxEvents } from "../telemetry/telemetry-events-outbox.js";
 import type { AuthFallbackTelemetryEvent } from "../telemetry/types.js";
 import { APP_VERSION } from "../version.js";
@@ -19,17 +19,18 @@ export interface AuthFallbackCount {
  * flush window, each carrying its full wire event built at record time. The
  * whole batch inserts atomically, so a failure never leaves a partial batch
  * committed (the gateway retries the full batch on `recorded === 0`). Returns
- * the number of rows recorded, or 0 when usage data collection is disabled
- * (the counts are dropped to honor the opt-out, matching the rest of
- * telemetry) or the telemetry database is unavailable (degraded mode). Callers
- * that must tell those apart check `getCachedShareAnalytics()` themselves.
+ * the number of rows recorded, or 0 when `share_analytics` is a confirmed
+ * opt-out (the counts are dropped to honor it, matching the rest of
+ * telemetry — an unknown consent state records) or the telemetry database is
+ * unavailable (degraded mode). Callers that must tell those apart check
+ * `getRawShareAnalytics()` themselves.
  */
 export function recordAuthFallbackCounts(
   windowStart: number,
   windowEnd: number,
   counts: AuthFallbackCount[],
 ): number {
-  if (!getCachedShareAnalytics()) {
+  if (getRawShareAnalytics() === false) {
     return 0;
   }
   if (counts.length === 0) {

--- a/assistant/src/telemetry/AGENTS.md
+++ b/assistant/src/telemetry/AGENTS.md
@@ -28,7 +28,7 @@ recordTelemetryEvent(
 );
 ```
 
-`recordTelemetryEvent` stamps the base fields (`type`, `daemon_event_id`, `recorded_at`, `assistant_version`) and gates on consent; the `fields` argument is typed as everything except those.
+`recordTelemetryEvent` stamps the base fields (`type`, `daemon_event_id`, `recorded_at`, `assistant_version`) and gates on consent — dropping only on a confirmed `share_analytics` opt-out; an unknown consent state (cold cache) records, because consent is enforced again at flush time and a record-time drop would destroy the event permanently. The `fields` argument is typed as everything except the base fields.
 
 Manual edits in this directory are needed **only** to override a default:
 

--- a/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
@@ -60,10 +60,18 @@ describe("config-setting-snapshot", () => {
     expect(recordedPairs()).toEqual([["memory.v2.enabled", "false"]]);
   });
 
-  test("unknown consent records the snapshot (a cold cache never drops data)", () => {
+  test("unknown consent skips entirely — no rows, no memo", () => {
     setShareAnalytics("unknown");
     recordConfigSettingSnapshot(makeConfig(true, false));
 
+    // A snapshot is re-derivable state (unlike outbox events), so nothing is
+    // recorded while consent is unresolved...
+    expect(recordedPairs()).toHaveLength(0);
+
+    // ...and nothing was memoized: once consent resolves, the next snapshot
+    // records the complete current set.
+    setShareAnalytics(true);
+    recordConfigSettingSnapshot(makeConfig(true, false));
     expect(recordedPairs().sort()).toEqual([
       ["memory.enabled", "true"],
       ["memory.v2.enabled", "false"],

--- a/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
@@ -60,6 +60,16 @@ describe("config-setting-snapshot", () => {
     expect(recordedPairs()).toEqual([["memory.v2.enabled", "false"]]);
   });
 
+  test("unknown consent records the snapshot (a cold cache never drops data)", () => {
+    setShareAnalytics("unknown");
+    recordConfigSettingSnapshot(makeConfig(true, false));
+
+    expect(recordedPairs().sort()).toEqual([
+      ["memory.enabled", "true"],
+      ["memory.v2.enabled", "false"],
+    ]);
+  });
+
   test("consent off drops the snapshot without poisoning the memo", () => {
     setShareAnalytics(false);
     recordConfigSettingSnapshot(makeConfig(true, true));

--- a/assistant/src/telemetry/__tests__/outbox-test-harness.ts
+++ b/assistant/src/telemetry/__tests__/outbox-test-harness.ts
@@ -1,6 +1,8 @@
 import { mock, spyOn } from "bun:test";
 
-let shareAnalytics = true;
+import type { ConsentState } from "../../platform/consent-cache.js";
+
+let shareAnalytics: ConsentState = true;
 // Owner's `share_diagnostics` consent + accepted version — a second,
 // independent gate some outbox event types layer on top of
 // `share_analytics` (their payload carries content richer than metadata).
@@ -17,7 +19,8 @@ let shareDiagnosticsVersion = "2999-01-01";
 // imports are as safe as in the test files themselves (AGENTS.md "Test
 // machinery isolation" scopes its no-src/ rule to preload-time machinery).
 mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
+  getCachedShareAnalytics: () => shareAnalytics === true,
+  getRawShareAnalytics: () => shareAnalytics,
   getCachedShareDiagnostics: () => shareDiagnostics,
   getCachedShareDiagnosticsVersion: () => shareDiagnosticsVersion,
 }));
@@ -31,7 +34,7 @@ import { queryTelemetryOutboxBatch } from "../telemetry-events-outbox.js";
 await initializeDb();
 
 /** Flip the mocked share_analytics consent; call with true in beforeEach. */
-export function setShareAnalytics(value: boolean): void {
+export function setShareAnalytics(value: ConsentState): void {
   shareAnalytics = value;
 }
 

--- a/assistant/src/telemetry/config-setting-snapshot.ts
+++ b/assistant/src/telemetry/config-setting-snapshot.ts
@@ -1,6 +1,6 @@
 import { getConfigReadOnly } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { getRawShareAnalytics } from "../platform/consent-cache.js";
 import { getLogger } from "../util/logger.js";
 import { recordConfigSettingEvent } from "./config-setting-events-store.js";
 
@@ -51,13 +51,15 @@ const lastRecorded = new Map<string, string>();
  * Record a `config_setting` event for every tracked setting whose effective
  * value differs from what this process last recorded.
  *
- * Consent-gated with a memo reset on opt-out. While `share_analytics` is off,
- * nothing is recorded and the memo is cleared: the reporter's opt-out flush
- * discards any config_setting rows still pending upload, so a memo entry from
- * before the opt-out no longer corresponds to a delivered row. Clearing it
- * means a later re-opt-in (in the same process, unchanged config) re-records
- * the full current snapshot rather than skipping memoized keys — consumers
- * that expect a complete snapshot after re-opt-in stay correct.
+ * Consent-gated with a memo reset on opt-out. While `share_analytics` is a
+ * confirmed opt-out, nothing is recorded and the memo is cleared: the
+ * reporter's opt-out flush discards any config_setting rows still pending
+ * upload, so a memo entry from before the opt-out no longer corresponds to a
+ * delivered row. Clearing it means a later re-opt-in (in the same process,
+ * unchanged config) re-records the full current snapshot rather than skipping
+ * memoized keys — consumers that expect a complete snapshot after re-opt-in
+ * stay correct. An unknown consent state records normally — the record-time
+ * drop is a courtesy for known opt-outs only, never a reason to lose data.
  *
  * Retry-friendly when opted in: `recordConfigSettingEvent` returns false when
  * the telemetry DB is momentarily unavailable, and the memo is only advanced
@@ -67,7 +69,7 @@ const lastRecorded = new Map<string, string>();
  * retries on the next invocation.
  */
 export function recordConfigSettingSnapshot(config: AssistantConfig): void {
-  if (!getCachedShareAnalytics()) {
+  if (getRawShareAnalytics() === false) {
     lastRecorded.clear();
     return;
   }

--- a/assistant/src/telemetry/config-setting-snapshot.ts
+++ b/assistant/src/telemetry/config-setting-snapshot.ts
@@ -58,8 +58,11 @@ const lastRecorded = new Map<string, string>();
  * delivered row. Clearing it means a later re-opt-in (in the same process,
  * unchanged config) re-records the full current snapshot rather than skipping
  * memoized keys — consumers that expect a complete snapshot after re-opt-in
- * stay correct. An unknown consent state records normally — the record-time
- * drop is a courtesy for known opt-outs only, never a reason to lose data.
+ * stay correct. An UNKNOWN consent state skips entirely (no record, no memo,
+ * no clear): unlike outbox events, a snapshot is re-derivable state, so
+ * deferring it loses nothing — while recording it would either memoize a row
+ * a later opt-out purge invalidates, or (without the memo) double-record on
+ * every boot.
  *
  * Retry-friendly when opted in: `recordConfigSettingEvent` returns false when
  * the telemetry DB is momentarily unavailable, and the memo is only advanced
@@ -69,7 +72,11 @@ const lastRecorded = new Map<string, string>();
  * retries on the next invocation.
  */
 export function recordConfigSettingSnapshot(config: AssistantConfig): void {
-  if (getRawShareAnalytics() === false) {
+  const consent = getRawShareAnalytics();
+  if (consent === "unknown") {
+    return;
+  }
+  if (consent === false) {
     lastRecorded.clear();
     return;
   }
@@ -91,6 +98,14 @@ export function recordConfigSettingSnapshot(config: AssistantConfig): void {
 }
 
 let snapshotTimer: ReturnType<typeof setInterval> | null = null;
+let bootRetryTimer: ReturnType<typeof setTimeout> | null = null;
+
+// The boot-time snapshot races the first consent refresh (fire-and-forget in
+// the monitor's startup), so consent is usually still "unknown" on the first
+// call and the snapshot is skipped. Retry on a short timer until consent
+// resolves rather than waiting a full hourly interval for the per-boot
+// assertion.
+const BOOT_RETRY_INTERVAL_MS = 60_000;
 
 function recordSnapshotFromConfig(): void {
   try {
@@ -100,6 +115,19 @@ function recordSnapshotFromConfig(): void {
   } catch (err) {
     log.warn({ err }, "Config-setting snapshot failed (non-fatal)");
   }
+}
+
+function recordBootSnapshotOnceConsentKnown(): void {
+  if (getRawShareAnalytics() === "unknown") {
+    bootRetryTimer = setTimeout(
+      recordBootSnapshotOnceConsentKnown,
+      BOOT_RETRY_INTERVAL_MS,
+    );
+    bootRetryTimer.unref?.();
+    return;
+  }
+  bootRetryTimer = null;
+  recordSnapshotFromConfig();
 }
 
 /**
@@ -116,7 +144,7 @@ export function startConfigSnapshotReporter(): void {
   if (snapshotTimer) {
     return;
   }
-  recordSnapshotFromConfig();
+  recordBootSnapshotOnceConsentKnown();
   snapshotTimer = setInterval(
     recordSnapshotFromConfig,
     CONFIG_SNAPSHOT_INTERVAL_MS,
@@ -128,6 +156,10 @@ export function stopConfigSnapshotReporter(): void {
   if (snapshotTimer) {
     clearInterval(snapshotTimer);
     snapshotTimer = null;
+  }
+  if (bootRetryTimer) {
+    clearTimeout(bootRetryTimer);
+    bootRetryTimer = null;
   }
 }
 

--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -290,7 +290,7 @@ describe("telemetry-events-outbox", () => {
     );
   });
 
-  test("recordTelemetryEvent honors the share_analytics opt-out", () => {
+  test("recordTelemetryEvent honors a confirmed share_analytics opt-out", () => {
     setShareAnalytics(false);
     expect(
       recordTelemetryEvent("watchdog", {
@@ -300,6 +300,19 @@ describe("telemetry-events-outbox", () => {
       }),
     ).toBeNull();
     expect(queryTelemetryOutboxBatch("watchdog", 10)).toEqual([]);
+  });
+
+  test("recordTelemetryEvent records while consent is unknown (cold cache)", () => {
+    setShareAnalytics("unknown");
+    const recorded = recordTelemetryEvent("watchdog", {
+      check_name: "c",
+      value: null,
+      detail: null,
+    });
+    expect(recorded).not.toBeNull();
+    expect(queryTelemetryOutboxBatch("watchdog", 10).map((r) => r.id)).toEqual([
+      recorded!.id,
+    ]);
   });
 
   test("recordTelemetryEvent returns null when the telemetry DB is unavailable", () => {

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -11,7 +11,7 @@ import { v4 as uuid } from "uuid";
 
 import { getTelemetryDb } from "../persistence/db-connection.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { getRawShareAnalytics } from "../platform/consent-cache.js";
 import { APP_VERSION } from "../version.js";
 import type {
   OutboxTelemetryEventName,
@@ -82,19 +82,23 @@ export function insertTelemetryOutboxEvent(
 /**
  * Lower-level record escape hatch: for payloads that need the record-time
  * `(id, createdAt)` inside type-specific fields (onboarding's activation
- * `daemon_event_id` override and `completed_at`). Gates on usage-data
- * consent, generates the outbox row identity, builds the wire payload via
- * `buildEvent` (which owns all stamping), and inserts. Returns the generated
- * row identity, or null when usage data collection is disabled (the event is
- * dropped to honor the opt-out) or the telemetry DB is unavailable (degraded
- * mode). Prefer `recordTelemetryEvent` when the payload doesn't need them.
+ * `daemon_event_id` override and `completed_at`). Drops only on a confirmed
+ * `share_analytics` opt-out — the record-time drop is a privacy courtesy for
+ * known opt-outs. While consent is unknown (cold cache, no platform session)
+ * the event is recorded: dropping on an unresolved state would permanently
+ * destroy data, and consent is enforced again at flush time. Generates the
+ * outbox row identity, builds the wire payload via `buildEvent` (which owns
+ * all stamping), and inserts. Returns the generated row identity, or null
+ * when dropped for the opt-out or when the telemetry DB is unavailable
+ * (degraded mode). Prefer `recordTelemetryEvent` when the payload doesn't
+ * need them.
  */
 export function recordTelemetryOutboxEvent(
   name: string,
   buildEvent: (id: string, createdAt: number) => TelemetryEvent,
   opts?: { conversationId?: string | null },
 ): { id: string; createdAt: number } | null {
-  if (!getCachedShareAnalytics()) {
+  if (getRawShareAnalytics() === false) {
     return null;
   }
   const id = uuid();

--- a/assistant/src/telemetry/tool-executed-events-store.test.ts
+++ b/assistant/src/telemetry/tool-executed-events-store.test.ts
@@ -6,6 +6,7 @@ let shareAnalytics = true;
 
 mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: () => shareAnalytics,
+  getRawShareAnalytics: () => shareAnalytics,
 }));
 
 import {

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -102,6 +102,9 @@ const mockGetCachedShareDiagnosticsVersion = mock(() => "2999-01-01");
 
 mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: mockGetCachedShareAnalytics,
+  // Raw tri-state accessor the record-time gates consult; these tests only
+  // exercise confirmed true/false states, so it mirrors the boolean mock.
+  getRawShareAnalytics: () => mockGetCachedShareAnalytics(),
   getCachedShareDiagnostics: mockGetCachedShareDiagnostics,
   getCachedShareDiagnosticsVersion: mockGetCachedShareDiagnosticsVersion,
 }));

--- a/assistant/src/telemetry/watchdog-direct-emit.test.ts
+++ b/assistant/src/telemetry/watchdog-direct-emit.test.ts
@@ -8,9 +8,12 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-let shareAnalytics = true;
+import type { ConsentState } from "../platform/consent-cache.js";
+
+let shareAnalytics: ConsentState = true;
 mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
+  getCachedShareAnalytics: () => shareAnalytics === true,
+  getRawShareAnalytics: () => shareAnalytics,
 }));
 
 let platformEnabled = true;
@@ -84,10 +87,16 @@ describe("emitWatchdogEventDirect", () => {
     });
   });
 
-  test("sends nothing when share_analytics is opted out", async () => {
+  test("sends nothing when share_analytics is a confirmed opt-out", async () => {
     shareAnalytics = false;
     await emitWatchdogEventDirect("sqlite_corrupted", { database: "main" });
     expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("emits while consent is unknown (no buffer to defer into)", async () => {
+    shareAnalytics = "unknown";
+    await emitWatchdogEventDirect("sqlite_corrupted", { database: "main" });
+    expect(fetchCalls).toHaveLength(1);
   });
 
   test("sends nothing when platform features are disabled", async () => {

--- a/assistant/src/telemetry/watchdog-direct-emit.ts
+++ b/assistant/src/telemetry/watchdog-direct-emit.ts
@@ -20,7 +20,7 @@ import { v4 as uuid } from "uuid";
 
 import { getPlatformOrganizationId, getPlatformUserId } from "../config/env.js";
 import { VellumPlatformClient } from "../platform/client.js";
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { getRawShareAnalytics } from "../platform/consent-cache.js";
 import { arePlatformFeaturesEnabled } from "../platform/feature-gate.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
@@ -35,9 +35,11 @@ const TELEMETRY_INGEST_PATH = "/v1/telemetry/ingest/";
 
 /**
  * POST one `watchdog` event directly to the platform, bypassing the SQLite
- * buffer. Honors the `share_analytics` opt-out and the platform-features gate,
- * matching the batched reporter. Never throws — the caller is on a query hot
- * path.
+ * buffer. Honors a confirmed `share_analytics` opt-out and the
+ * platform-features gate. An unknown consent state emits: this path reports
+ * SQLite corruption and has no outbox to defer into, and platform ingest
+ * re-gates on consent authoritatively server-side. Never throws — the caller
+ * is on a query hot path.
  */
 export async function emitWatchdogEventDirect(
   checkName: string,
@@ -45,8 +47,9 @@ export async function emitWatchdogEventDirect(
   value: number | null = null,
 ): Promise<void> {
   try {
-    // Opt-out and deployment gates, mirroring the batched reporter's flush.
-    if (!getCachedShareAnalytics()) return;
+    // Drop only on a confirmed opt-out; unknown emits (no buffer to defer
+    // into, and platform ingest re-gates on consent server-side).
+    if (getRawShareAnalytics() === false) return;
     if (!arePlatformFeaturesEnabled()) return;
 
     // Authenticated-only. Null before the CES handshake resolves credentials;

--- a/assistant/src/telemetry/watchdog-direct-emit.ts
+++ b/assistant/src/telemetry/watchdog-direct-emit.ts
@@ -49,7 +49,9 @@ export async function emitWatchdogEventDirect(
   try {
     // Drop only on a confirmed opt-out; unknown emits (no buffer to defer
     // into, and platform ingest re-gates on consent server-side).
-    if (getRawShareAnalytics() === false) return;
+    if (getRawShareAnalytics() === false) {
+      return;
+    }
     if (!arePlatformFeaturesEnabled()) return;
 
     // Authenticated-only. Null before the CES handshake resolves credentials;

--- a/assistant/src/watcher/__tests__/telemetry.test.ts
+++ b/assistant/src/watcher/__tests__/telemetry.test.ts
@@ -9,11 +9,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { LifecycleEvent } from "../../persistence/lifecycle-events-store.js";
+import type { ConsentState } from "../../platform/consent-cache.js";
 
 const checkpoints = new Map<string, string>();
 const recordedEvents: string[] = [];
 let fakeEnabledWatchers: Array<{ providerId: string }> = [];
-let shareAnalytics = true;
+let shareAnalytics: ConsentState = true;
 const recordAndReturnEvent = (name: string): LifecycleEvent => {
   recordedEvents.push(name);
   return { id: "evt-1", eventName: name, createdAt: 0 };
@@ -32,7 +33,8 @@ mock.module("../../persistence/lifecycle-events-store.js", () => ({
 }));
 
 mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
+  getCachedShareAnalytics: () => shareAnalytics === true,
+  getRawShareAnalytics: () => shareAnalytics,
 }));
 
 mock.module("../watcher-store.js", () => ({
@@ -135,16 +137,28 @@ describe("recordWatcherInventoryIfDue", () => {
     expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE + 3));
   });
 
-  test("advances the checkpoint when consent is off", () => {
+  test("advances the checkpoint when consent is a confirmed opt-out", () => {
     fakeEnabledWatchers = [{ providerId: "gmail" }];
     shareAnalytics = false;
-    // Consent-off skip: the store records nothing and returns null.
+    // Confirmed-opt-out skip: the store records nothing and returns null.
     recordImpl = () => null;
 
     recordWatcherInventoryIfDue(BASE + 4);
 
     expect(recordedEvents).toEqual([]);
     expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE + 4));
+  });
+
+  test("leaves the checkpoint for retry when the store returns null while consent is unknown", () => {
+    fakeEnabledWatchers = [{ providerId: "gmail" }];
+    shareAnalytics = "unknown";
+    // Unknown consent never drops at record time, so a null here means the
+    // telemetry DB is unavailable — retry, don't skip a day.
+    recordImpl = () => null;
+
+    recordWatcherInventoryIfDue(BASE + 4);
+
+    expect(checkpoints.get(INVENTORY_KEY)).toBeUndefined();
   });
 });
 

--- a/assistant/src/watcher/telemetry.ts
+++ b/assistant/src/watcher/telemetry.ts
@@ -24,7 +24,7 @@ import {
   setMemoryCheckpoint,
 } from "../persistence/checkpoints.js";
 import { recordLifecycleEvent } from "../persistence/lifecycle-events-store.js";
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { getRawShareAnalytics } from "../platform/consent-cache.js";
 import { getLogger } from "../util/logger.js";
 import { listWatchers } from "./watcher-store.js";
 
@@ -39,9 +39,9 @@ let warnedInventoryDbUnavailable = false;
  * Record one `watcher_enabled:<providerId>` lifecycle event per enabled
  * watcher, at most once per 24h. Called from every watcher tick; the
  * checkpoint advances only after the events are recorded, so a transient
- * storage failure (a throw, or a degraded-mode `null` while analytics
- * consent is granted) retries on the next tick instead of skipping a day.
- * A consent-off `null` is a deliberate skip and still advances. Retries
+ * storage failure (a throw, or a degraded-mode `null` while consent is not
+ * a confirmed opt-out) retries on the next tick instead of skipping a day.
+ * A confirmed-opt-out `null` is a deliberate skip and still advances. Retries
  * can duplicate events for watchers recorded before the failure point —
  * an acceptable overcount for best-effort telemetry, where losing a full
  * day's inventory would not be.
@@ -54,7 +54,7 @@ export function recordWatcherInventoryIfDue(now: number): void {
       const recorded = recordLifecycleEvent(
         `watcher_enabled:${watcher.providerId}`,
       );
-      if (recorded === null && getCachedShareAnalytics()) {
+      if (recorded === null && getRawShareAnalytics() !== false) {
         if (!warnedInventoryDbUnavailable) {
           warnedInventoryDbUnavailable = true;
           log.warn(


### PR DESCRIPTION
## Summary
- Move every daemon record-time telemetry gate from the boolean consent accessor to the tri-state `getRawShareAnalytics()`: events are dropped only on a **confirmed** `share_analytics` opt-out; an unknown state (cold cache at boot, no platform session) records, so an unresolved consent state never permanently destroys data (the #38088 cold-cache loss class).
- Gates updated: `recordTelemetryOutboxEvent` (generic outbox), `recordConfigSettingSnapshot`, `recordAuthFallbackCounts`, and the watcher-inventory null disambiguation (`watcher/telemetry.ts`), which now keys consent-off-null vs DB-unavailable-null on known-false.
- `emitWatchdogEventDirect` emits unless known-false: it reports SQLite corruption, has no outbox to defer into, and platform ingest re-gates on consent authoritatively server-side.
- The internal auth-fallback route's 503-vs-skip disambiguation also keys on known-false now — otherwise unknown consent + telemetry DB down would be mislabeled as an opt-out skip and the gateway would drop the batch instead of retrying (the same data-destruction class this PR removes). New route tests cover unknown→recorded and unknown+DB-down→503.
- Per-store tests: unknown → recorded/emitted, confirmed false → dropped exactly as before, true → recorded. The outbox test harness and per-file consent-cache mocks now expose the tri-state `getRawShareAnalytics`.
- Updated `src/telemetry/AGENTS.md` record-gate description and the stale `daemon/lifecycle.ts` comment.

Flush-time defer-on-unknown is PR 4 (parallel, `usage-telemetry-reporter.ts` untouched here).

Part of plan: consent-cleanup.md (PR 3 of 10)