### PR TITLE
Retire the research/pre-chat onboarding feature flags + pared-down funnel

### DIFF
--- a/clients/web/src/domains/chat/onboarding-research/research-mock-page.tsx
+++ b/clients/web/src/domains/chat/onboarding-research/research-mock-page.tsx
@@ -18,7 +18,6 @@ import { Navigate, useNavigate } from "react-router";
 import { Button } from "@vellumai/design-library/components/button";
 
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { routes } from "@/utils/routes";
 import { ResearchResultsView } from "@/domains/chat/onboarding-research/research-results-view";
@@ -88,7 +87,6 @@ type Mode = "loading" | "results" | "empty";
 
 export function ResearchMockPage() {
   const navigate = useNavigate();
-  const enabled = useClientFeatureFlagStore.use.researchOnboarding();
   const [mode, setMode] = useState<Mode>("results");
   const [removals, setRemovals] = useState<Map<number, RemovalReason | null>>(
     () => new Map(),
@@ -104,7 +102,8 @@ export function ResearchMockPage() {
     );
   };
 
-  if (!enabled) {
+  // Throwaway dev harness — keep it out of production builds without a flag.
+  if (!import.meta.env.DEV) {
     return <Navigate to={routes.assistant} replace />;
   }
 

--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -6,12 +6,9 @@ import {
   emitOnboardingFunnelStepCompleted,
   emitResearchOnboardingStepCompleted,
   emitResearchOnboardingCheckinCalendarOpened,
-  onboardingFunnelVariantFromExperiment,
   ONBOARDING_FUNNEL_STEPS,
   ONBOARDING_FUNNEL_VERSION,
   ONBOARDING_FUNNEL_VARIANTS,
-  readOnboardingFunnelVariant,
-  resolveOnboardingFunnelVariant,
   RESEARCH_ONBOARDING_FUNNEL_STEPS,
   RESEARCH_ONBOARDING_FUNNEL_VERSION,
 } from "@/domains/onboarding/funnel-events";
@@ -31,24 +28,19 @@ afterEach(() => {
 });
 
 describe("onboarding funnel events", () => {
-  test("maps experiment arms to funnel variants", () => {
-    expect(onboardingFunnelVariantFromExperiment("control")).toBe("control");
-    expect(onboardingFunnelVariantFromExperiment("variant-a")).toBe("pared_down");
-  });
-
   test("builds the expected event shape with a stable session id", () => {
     const privacy = buildOnboardingFunnelEvent(
       ONBOARDING_FUNNEL_STEPS.privacyTos,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
     const nameVibe = buildOnboardingFunnelEvent(
       ONBOARDING_FUNNEL_STEPS.nameVibe,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
 
@@ -62,7 +54,7 @@ describe("onboarding funnel events", () => {
       step_index: 0,
       user_id: "user-123",
       funnel_version: ONBOARDING_FUNNEL_VERSION,
-      ab_variant: "pared_down",
+      ab_variant: "control",
     });
     expect(nameVibe).toMatchObject({
       screen: "name_vibe",
@@ -70,21 +62,18 @@ describe("onboarding funnel events", () => {
       step_index: 1,
       user_id: "user-123",
       funnel_version: ONBOARDING_FUNNEL_VERSION,
-      ab_variant: "pared_down",
+      ab_variant: "control",
     });
     expect(privacy.completed_at).toMatch(
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
     );
   });
 
-  test("persists the assigned funnel variant for the session", () => {
-    expect(
-      resolveOnboardingFunnelVariant(ONBOARDING_FUNNEL_VARIANTS.paredDown),
-    ).toBe("pared_down");
-    expect(
-      resolveOnboardingFunnelVariant(ONBOARDING_FUNNEL_VARIANTS.control),
-    ).toBe("pared_down");
-    expect(readOnboardingFunnelVariant()).toBe("pared_down");
+  test("defaults ab_variant to control when no variant is passed", () => {
+    const event = buildOnboardingFunnelEvent(ONBOARDING_FUNNEL_STEPS.nameVibe, {
+      userId: "user-123",
+    });
+    expect(event.ab_variant).toBe("control");
   });
 
   test("uses control step indices for the existing funnel", () => {
@@ -116,11 +105,11 @@ describe("onboarding funnel events", () => {
 
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -145,7 +134,7 @@ describe("onboarding funnel events", () => {
       step_index: 2,
       user_id: "user-123",
       funnel_version: ONBOARDING_FUNNEL_VERSION,
-      ab_variant: "pared_down",
+      ab_variant: "control",
     });
   });
 
@@ -260,7 +249,7 @@ describe("onboarding funnel events", () => {
     // the event emits.
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -268,7 +257,7 @@ describe("onboarding funnel events", () => {
     localStorage.setItem("device:share_analytics", "false");
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -278,7 +267,7 @@ describe("onboarding funnel events", () => {
     useOnboardingStore.setState({ shareAnalytics: false });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.nameVibe, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -8,7 +8,6 @@ import {
   emitResearchOnboardingCheckinCalendarOpened,
   ONBOARDING_FUNNEL_STEPS,
   ONBOARDING_FUNNEL_VERSION,
-  ONBOARDING_FUNNEL_VARIANTS,
   RESEARCH_ONBOARDING_FUNNEL_STEPS,
   RESEARCH_ONBOARDING_FUNNEL_VERSION,
 } from "@/domains/onboarding/funnel-events";
@@ -33,14 +32,12 @@ describe("onboarding funnel events", () => {
       ONBOARDING_FUNNEL_STEPS.privacyTos,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
     const nameVibe = buildOnboardingFunnelEvent(
       ONBOARDING_FUNNEL_STEPS.nameVibe,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
 
@@ -81,7 +78,6 @@ describe("onboarding funnel events", () => {
       ONBOARDING_FUNNEL_STEPS.controlTools,
       {
         userId: "user-123",
-        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       },
     );
 
@@ -105,11 +101,9 @@ describe("onboarding funnel events", () => {
 
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -249,7 +243,6 @@ describe("onboarding funnel events", () => {
     // the event emits.
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -257,7 +250,6 @@ describe("onboarding funnel events", () => {
     localStorage.setItem("device:share_analytics", "false");
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -267,7 +259,6 @@ describe("onboarding funnel events", () => {
     useOnboardingStore.setState({ shareAnalytics: false });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.nameVibe, {
       userId: "user-123",
-      variant: ONBOARDING_FUNNEL_VARIANTS.control,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -4,23 +4,13 @@ import type { ResearchStep } from "@/domains/onboarding/research-onboarding-pers
 
 export const ONBOARDING_FUNNEL_VERSION = "onboarding_v3_2026_05";
 const SESSION_STORAGE_KEY = "onboarding.funnelSessionId";
-const VARIANT_STORAGE_KEY = "onboarding.funnelVariant";
 
 export const ONBOARDING_FUNNEL_VARIANTS = {
   control: "control",
-  paredDown: "pared_down",
 } as const;
 
 export type OnboardingFunnelVariant =
   (typeof ONBOARDING_FUNNEL_VARIANTS)[keyof typeof ONBOARDING_FUNNEL_VARIANTS];
-
-export function onboardingFunnelVariantFromExperiment(
-  experimentArm: string,
-): OnboardingFunnelVariant {
-  return experimentArm === "variant-a"
-    ? ONBOARDING_FUNNEL_VARIANTS.paredDown
-    : ONBOARDING_FUNNEL_VARIANTS.control;
-}
 
 export const ONBOARDING_FUNNEL_STEPS = {
   privacyTos: { stepName: "privacy_tos", stepIndex: 0 },
@@ -166,48 +156,12 @@ export function getOnboardingFunnelSessionId(): string {
   return next;
 }
 
-function isOnboardingFunnelVariant(
-  value: string | null,
-): value is OnboardingFunnelVariant {
-  return (
-    value === ONBOARDING_FUNNEL_VARIANTS.control ||
-    value === ONBOARDING_FUNNEL_VARIANTS.paredDown
-  );
-}
-
-export function readOnboardingFunnelVariant(): OnboardingFunnelVariant | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const stored = sessionStorage.getItem(VARIANT_STORAGE_KEY);
-    return isOnboardingFunnelVariant(stored) ? stored : null;
-  } catch {
-    return null;
-  }
-}
-
-export function resolveOnboardingFunnelVariant(
-  preferred: OnboardingFunnelVariant,
-): OnboardingFunnelVariant {
-  const existing = readOnboardingFunnelVariant();
-  if (existing) return existing;
-  if (typeof window === "undefined") return preferred;
-  try {
-    sessionStorage.setItem(VARIANT_STORAGE_KEY, preferred);
-  } catch {
-    // Storage may be unavailable; the current event still carries the variant.
-  }
-  return preferred;
-}
-
 export function buildOnboardingFunnelEvent(
   screen: OnboardingFunnelStepDescriptor,
   options: OnboardingFunnelStepCompletedOptions = {},
 ): OnboardingFunnelEvent {
   const now = Date.now();
-  const variant =
-    options.variant ??
-    readOnboardingFunnelVariant() ??
-    ONBOARDING_FUNNEL_VARIANTS.control;
+  const variant = options.variant ?? ONBOARDING_FUNNEL_VARIANTS.control;
   return {
     type: "onboarding",
     daemon_event_id: crypto.randomUUID(),
@@ -254,8 +208,7 @@ export function emitOnboardingFunnelStepCompleted(
  * emits the same step-completed event on both its Continue and Skip handlers.
  *
  * The research flow has no A/B arm, so events are stamped with the `control`
- * variant (passed explicitly so this never reads the pre-chat funnel's stored
- * variant) and the research funnel version.
+ * variant and the research funnel version.
  *
  * `outcome` records whether the step was completed (Continue) or skipped;
  * defaults to `completed` for the Continue-only steps.
@@ -294,7 +247,6 @@ export function __resetOnboardingFunnelEventsForTests(): void {
   if (typeof window === "undefined") return;
   try {
     sessionStorage.removeItem(SESSION_STORAGE_KEY);
-    sessionStorage.removeItem(VARIANT_STORAGE_KEY);
   } catch {
     // ignore
   }

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -109,7 +109,6 @@ export type OnboardingFunnelStepOutcome = "completed" | "skipped";
 
 export interface OnboardingFunnelStepCompletedOptions {
   userId?: string | null;
-  variant?: OnboardingFunnelVariant;
   /** Funnel this step belongs to; defaults to the pre-chat funnel version. */
   funnelVersion?: string;
   /** Completed vs skipped; omitted when the funnel doesn't distinguish. */
@@ -161,7 +160,6 @@ export function buildOnboardingFunnelEvent(
   options: OnboardingFunnelStepCompletedOptions = {},
 ): OnboardingFunnelEvent {
   const now = Date.now();
-  const variant = options.variant ?? ONBOARDING_FUNNEL_VARIANTS.control;
   return {
     type: "onboarding",
     daemon_event_id: crypto.randomUUID(),
@@ -173,7 +171,7 @@ export function buildOnboardingFunnelEvent(
     completed_at: new Date(now).toISOString(),
     user_id: options.userId ?? null,
     funnel_version: options.funnelVersion ?? ONBOARDING_FUNNEL_VERSION,
-    ab_variant: variant,
+    ab_variant: ONBOARDING_FUNNEL_VARIANTS.control,
     // Omitted (→ stripped before send) unless the caller distinguishes the two.
     outcome: options.outcome,
   };
@@ -219,7 +217,6 @@ export function emitResearchOnboardingStepCompleted(
 ): void {
   emitOnboardingFunnelStepCompleted(step, {
     userId: options.userId,
-    variant: ONBOARDING_FUNNEL_VARIANTS.control,
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
     outcome: options.outcome ?? "completed",
   });
@@ -237,7 +234,6 @@ export function emitResearchOnboardingCheckinCalendarOpened(
 ): void {
   emitOnboardingFunnelStepCompleted(RESEARCH_ONBOARDING_CHECKIN_STEP, {
     userId: options.userId,
-    variant: ONBOARDING_FUNNEL_VARIANTS.control,
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
     outcome: "completed",
   });

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
@@ -1,6 +1,6 @@
 /**
  * Hidden kickoff sent on the user's behalf when they hit "Let's chat" at the
- * end of the personality-onboarding flow. It drives the assistant's first
+ * end of the research-onboarding flow. It drives the assistant's first
  * reply but renders no user bubble, so the chat opens with the assistant
  * proactively greeting the user in the persona they just configured.
  *

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -71,7 +71,6 @@ type TestOnboardingRecipe = {
   skipPrechat: boolean;
 };
 
-let preChatOnboardingExperiment = "variant-a";
 let activationFlowExperiment = "control";
 let selfIntroGreeting = true;
 let isIOSWeb = false;
@@ -278,7 +277,6 @@ mock.module("@/stores/client-feature-flag-store", () => ({
   useClientFeatureFlagStore: {
     use: {
       stringFlags: () => ({
-        preChatOnboardingExperiment20260606: preChatOnboardingExperiment,
         experimentActivationFlow20260603: activationFlowExperiment,
       }),
       selfIntroGreeting: () => selfIntroGreeting,
@@ -440,7 +438,6 @@ beforeEach(() => {
   checkAssistantImpl = async () => {};
   fetchTraitsImpl = async () => null;
   getAssistantImpl = async () => assistantResult("active");
-  preChatOnboardingExperiment = "variant-a";
   activationFlowExperiment = "control";
   selfIntroGreeting = true;
   isIOSWeb = false;
@@ -534,10 +531,9 @@ describe("onboarding lifecycle sync", () => {
     render(<PreChatFlow />);
 
     fireEvent.click(await screen.findByTestId("name-continue"));
-    expect(await screen.findByText("Gmail")).toBeTruthy();
-    expect(screen.getByText("Google Calendar")).toBeTruthy();
-    expect(screen.getByText("Google Drive")).toBeTruthy();
-    fireEvent.click(screen.getByText("Skip for now"));
+    fireEvent.click(await screen.findByTestId("task-continue"));
+    fireEvent.click(await screen.findByTestId("tools-continue"));
+    fireEvent.click(await screen.findByTestId("prior-continue"));
 
     expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
       tools: [],
@@ -567,7 +563,9 @@ describe("onboarding lifecycle sync", () => {
     render(<PreChatFlow />);
 
     fireEvent.click(await screen.findByTestId("name-continue"));
-    fireEvent.click(await screen.findByText("Skip for now"));
+    fireEvent.click(await screen.findByTestId("task-continue"));
+    fireEvent.click(await screen.findByTestId("tools-continue"));
+    fireEvent.click(await screen.findByTestId("prior-continue"));
 
     await waitFor(() => expect(checkAssistantMock).toHaveBeenCalled());
     expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
@@ -586,7 +584,9 @@ describe("onboarding lifecycle sync", () => {
     render(<PreChatFlow />);
 
     fireEvent.click(await screen.findByTestId("name-continue"));
-    fireEvent.click(await screen.findByText("Skip for now"));
+    fireEvent.click(await screen.findByTestId("task-continue"));
+    fireEvent.click(await screen.findByTestId("tools-continue"));
+    fireEvent.click(await screen.findByTestId("prior-continue"));
 
     await waitFor(() => expect(checkAssistantMock).toHaveBeenCalled());
     expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
@@ -601,9 +601,7 @@ describe("onboarding lifecycle sync", () => {
     });
   });
 
-  test("pre-chat keeps the existing full funnel when the v3 flag is off", async () => {
-    preChatOnboardingExperiment = "control";
-
+  test("pre-chat shows the full control funnel", async () => {
     render(<PreChatFlow />);
 
     fireEvent.click(await screen.findByTestId("name-continue"));
@@ -613,7 +611,6 @@ describe("onboarding lifecycle sync", () => {
   });
 
   test("pre-chat control flow skips the macOS app step on macOS web", async () => {
-    preChatOnboardingExperiment = "control";
     isMacOSWeb = true;
     macOsAppDownloaded = false;
 
@@ -651,51 +648,6 @@ describe("onboarding lifecycle sync", () => {
     expect(await screen.findByTestId("name-continue")).toBeTruthy();
   });
 
-  test("recipe skip does not bypass the pared-down pre-chat screens", async () => {
-    const recipe: TestOnboardingRecipe = {
-      cohort: "content-automation",
-      tasks: ["writing", "research"],
-      tone: "grounded",
-      bootstrapTemplate: "BOOTSTRAP-CONTENT-AUTOMATION.md",
-      initialMessage: "I want to write articles that rank better in GEO",
-      skills: ["content-automation"],
-      skipPrechat: true,
-    };
-    fetchOnboardingRecipeImpl = async () => recipe;
-    selfIntroGreeting = false;
-
-    render(<PreChatFlow />);
-
-    expect(await screen.findByTestId("name-continue")).toBeTruthy();
-    expect(checkAssistantMock).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByTestId("name-continue"));
-    expect(await screen.findByText("Gmail")).toBeTruthy();
-    expect(screen.getByText("Google Calendar")).toBeTruthy();
-    expect(screen.getByText("Google Drive")).toBeTruthy();
-    fireEvent.click(screen.getByText("Skip for now"));
-
-    await waitFor(() => expect(checkAssistantMock).toHaveBeenCalled());
-    await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith(
-        `${routes.assistant}?onboarding=1`,
-        { replace: true },
-      ),
-    );
-
-    expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "null")).toEqual({
-      tools: [],
-      tasks: recipe.tasks,
-      tone: recipe.tone,
-      userName: "Alice",
-      googleConnected: false,
-      cohort: recipe.cohort,
-      initialMessage: recipe.initialMessage,
-      bootstrapTemplate: recipe.bootstrapTemplate,
-      skills: recipe.skills,
-    });
-  });
-
   test("local mode never fetches the platform-only onboarding recipe", async () => {
     isLocalModeValue = true;
 
@@ -706,7 +658,6 @@ describe("onboarding lifecycle sync", () => {
   });
 
   test("local mode without a platform session gates the prior-assistants step", async () => {
-    preChatOnboardingExperiment = "control";
     isLocalModeValue = true;
     platformSessionValue = "absent";
 
@@ -727,7 +678,6 @@ describe("onboarding lifecycle sync", () => {
   });
 
   test("local mode with a platform session shows the prior-assistants step", async () => {
-    preChatOnboardingExperiment = "control";
     isLocalModeValue = true;
     platformSessionValue = "present";
 

--- a/clients/web/src/domains/onboarding/pages/pre-chat-flow.tsx
+++ b/clients/web/src/domains/onboarding/pages/pre-chat-flow.tsx
@@ -7,11 +7,7 @@ import { readIOSAppDownloaded } from "@/hooks/use-ios-app-nudge";
 import { fetchOnboardingRecipe } from "@/domains/onboarding/recipe-client.js";
 import {
   emitOnboardingFunnelStepCompleted,
-  onboardingFunnelVariantFromExperiment,
   ONBOARDING_FUNNEL_STEPS,
-  ONBOARDING_FUNNEL_VARIANTS,
-  readOnboardingFunnelVariant,
-  resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
 import { GetIOSAppScreen } from "@/domains/onboarding/screens/get-ios-app-screen.js";
 import { GoogleConnectScreen } from "@/domains/onboarding/screens/google-connect-screen.js";
@@ -85,21 +81,12 @@ export function PreChatFlow() {
   const localMode = isLocalMode();
   const isIOSWeb = useIsIOSWeb();
   const showIOSAppStep = isIOSWeb && !readIOSAppDownloaded();
-  const preChatExperimentArm =
-    useClientFeatureFlagStore.use.stringFlags()
-      .preChatOnboardingExperiment20260606 ?? "control";
   const activationFlowArm =
     useClientFeatureFlagStore.use.stringFlags()
       .experimentActivationFlow20260603 ?? "control";
   const activationFlowEnabled = activationFlowArm === "variant-a";
   const selfIntroGreetingEnabled =
     useClientFeatureFlagStore.use.selfIntroGreeting();
-  const preferredFunnelVariant =
-    onboardingFunnelVariantFromExperiment(preChatExperimentArm);
-  const webFunnelVariant =
-    readOnboardingFunnelVariant() ?? preferredFunnelVariant;
-  const paredDownPrechat =
-    webFunnelVariant === ONBOARDING_FUNNEL_VARIANTS.paredDown;
   const localPlatformAssistantId = localMode
     ? readLocalPlatformAssistantId()
     : null;
@@ -161,15 +148,11 @@ export function PreChatFlow() {
 
   function emitWebFunnelStep(
     step: (typeof ONBOARDING_FUNNEL_STEPS)[keyof typeof ONBOARDING_FUNNEL_STEPS],
-    variant = webFunnelVariant,
   ): void {
     if (isPreview) {
       return;
     }
-    emitOnboardingFunnelStepCompleted(step, {
-      userId,
-      variant: resolveOnboardingFunnelVariant(variant),
-    });
+    emitOnboardingFunnelStepCompleted(step, { userId });
   }
 
   const hasGoogleTool = [...selectedTools].some((id) =>
@@ -179,7 +162,6 @@ export function PreChatFlow() {
   const steps: PreChatStep[] = isNative
     ? resolveNativeSteps()
     : resolveWebSteps({
-        paredDown: paredDownPrechat,
         canOfferPriorAssistants,
         canOfferGoogleStep: isPreview ? false : canOfferGoogleStep,
         hasGoogleTool,
@@ -196,7 +178,7 @@ export function PreChatFlow() {
     }
 
     const context = buildPreChatContext({
-      mode: isNative ? "native" : paredDownPrechat ? "paredDown" : "control",
+      mode: isNative ? "native" : "control",
       recipe: isNative ? null : recipe,
       selectedTools,
       selectedTasks,

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -35,14 +35,12 @@ mock.module("@/domains/onboarding/funnel-events", () => ({
   emitOnboardingFunnelStepCompleted: emitFunnelStepCompletedMock,
   getOnboardingFunnelSessionId: () => "session-1",
   ONBOARDING_FUNNEL_STEPS: { privacyTos: "privacy_tos" },
-  onboardingFunnelVariantFromExperiment: () => "control",
-  resolveOnboardingFunnelVariant: () => "control",
+  ONBOARDING_FUNNEL_VARIANTS: { control: "control" },
 }));
 
 mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
 // Mutable platform/flag state so individual tests can flip them.
 let nativePlatform = false;
-let researchFlag = false;
 let localMode = false;
 mock.module("@/lib/local-mode", () => ({ isLocalMode: () => localMode }));
 mock.module("@/runtime/native-auth", () => ({
@@ -54,7 +52,7 @@ mock.module("@/stores/auth-store", () => ({
 }));
 mock.module("@/stores/client-feature-flag-store", () => ({
   useClientFeatureFlagStore: {
-    use: { stringFlags: () => ({}), researchOnboarding: () => researchFlag },
+    use: { stringFlags: () => ({}) },
   },
 }));
 
@@ -104,13 +102,11 @@ describe("PrivacyScreen — Start navigation", () => {
     navigateMock.mockClear();
     saveConsentMock.mockClear();
     emitFunnelStepCompletedMock.mockClear();
-    researchFlag = false;
     nativePlatform = false;
     localMode = false;
   });
   afterEach(() => {
     cleanup();
-    researchFlag = false;
     nativePlatform = false;
     localMode = false;
   });

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -35,7 +35,6 @@ mock.module("@/domains/onboarding/funnel-events", () => ({
   emitOnboardingFunnelStepCompleted: emitFunnelStepCompletedMock,
   getOnboardingFunnelSessionId: () => "session-1",
   ONBOARDING_FUNNEL_STEPS: { privacyTos: "privacy_tos" },
-  ONBOARDING_FUNNEL_VARIANTS: { control: "control" },
 }));
 
 mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -11,7 +11,6 @@ import {
     emitOnboardingFunnelStepCompleted,
     getOnboardingFunnelSessionId,
     ONBOARDING_FUNNEL_STEPS,
-    ONBOARDING_FUNNEL_VARIANTS,
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { isLocalMode } from "@/lib/local-mode";
@@ -66,7 +65,6 @@ export function PrivacyScreen() {
     if (!isNative) {
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
         userId,
-        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       });
     }
 

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -11,8 +11,7 @@ import {
     emitOnboardingFunnelStepCompleted,
     getOnboardingFunnelSessionId,
     ONBOARDING_FUNNEL_STEPS,
-    onboardingFunnelVariantFromExperiment,
-    resolveOnboardingFunnelVariant,
+    ONBOARDING_FUNNEL_VARIANTS,
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { isLocalMode } from "@/lib/local-mode";
@@ -24,7 +23,6 @@ import {
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { saveConsent } from "@/utils/onboarding-cleanup";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -35,10 +33,6 @@ export function PrivacyScreen() {
   const userId = useAuthStore.use.user()?.id ?? null;
   const electron = isElectron();
   const isNative = useIsNativePlatform();
-  const preChatExperimentArm =
-    useClientFeatureFlagStore.use.stringFlags().preChatOnboardingExperiment20260606 ?? "control";
-  const preferredFunnelVariant =
-    onboardingFunnelVariantFromExperiment(preChatExperimentArm);
   const [shareDiagnostics, setShareDiagnosticsReal] = useShareDiagnostics();
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
   const [privacyConsent, setPrivacyConsentReal] = usePrivacyConsent();
@@ -70,10 +64,9 @@ export function PrivacyScreen() {
     // until the user opts in via settings or review-terms.
     saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics: null, shareDiagnostics, hasPlatformSession });
     if (!isNative) {
-      const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
         userId,
-        variant,
+        variant: ONBOARDING_FUNNEL_VARIANTS.control,
       });
     }
 
@@ -98,7 +91,6 @@ export function PrivacyScreen() {
     isNative,
     isPreview,
     navigate,
-    preferredFunnelVariant,
     searchParams,
     shareDiagnostics,
     tosAccepted,

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -550,7 +550,7 @@ export function ResearchOnboardingRoute() {
       });
   }
 
-  // Final personality-onboarding handoff: wait out any background capability
+  // Final research-onboarding handoff: wait out any background capability
   // installs (so the primed chat can discover their skills), any removal
   // correction (so rejected claims can't leak in), and the personality rewrite
   // (so the greeting lands in the configured persona), then drop into a fresh

--- a/clients/web/src/domains/onboarding/prechat-context.test.ts
+++ b/clients/web/src/domains/onboarding/prechat-context.test.ts
@@ -5,7 +5,6 @@ import {
   ACTIVATION_FLOW_COHORT,
   ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
   buildPreChatContext,
-  PARED_DOWN_GOOGLE_TOOL_IDS,
   type BuildPreChatContextInput,
 } from "@/domains/onboarding/prechat-context";
 
@@ -112,22 +111,6 @@ describe("buildPreChatContext — control", () => {
     );
     expect(context.googleConnected).toBe(true);
     expect(context.googleScopes).toEqual(["gmail.send"]);
-  });
-});
-
-describe("buildPreChatContext — pared-down", () => {
-  test("implies the Google tool bundle only when connected this action", () => {
-    const connected = buildPreChatContext(
-      baseInput({ mode: "paredDown", connectedScopes: ["gmail.readonly"] }),
-    );
-    expect(connected.tools).toEqual([...PARED_DOWN_GOOGLE_TOOL_IDS]);
-    expect(connected.googleConnected).toBe(true);
-    expect(connected.googleScopes).toEqual(["gmail.readonly"]);
-
-    const skipped = buildPreChatContext(baseInput({ mode: "paredDown" }));
-    expect(skipped.tools).toEqual([]);
-    expect(skipped.googleConnected).toBe(false);
-    expect(skipped.googleScopes).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/onboarding/prechat-context.ts
+++ b/clients/web/src/domains/onboarding/prechat-context.ts
@@ -3,8 +3,8 @@
  * during the flow. Pure input→output: no React, no storage, no navigation —
  * the component owns those side effects and calls this to produce the payload.
  *
- * Three modes share one builder so the context shape can't drift between the
- * web control funnel, the pared-down funnel variant, and the native iOS flow.
+ * Both modes share one builder so the context shape can't drift between the
+ * web control funnel and the native iOS flow.
  */
 import type { OnboardingRecipe } from "@/domains/onboarding/recipe-client.js";
 import {
@@ -14,21 +14,11 @@ import {
 } from "@/domains/onboarding/prechat";
 import { stripOtherPrefix } from "@/domains/onboarding/prechat-tools";
 
-/**
- * Tools implied by connecting Google in the pared-down funnel, which has no
- * tool-selection screen. Kept in sync with the daemon's onboarding contract.
- */
-export const PARED_DOWN_GOOGLE_TOOL_IDS = [
-  "gmail",
-  "google-calendar",
-  "google-drive",
-];
-
 export const ACTIVATION_FLOW_COHORT = "experiment-activation-flow-2026-06-03";
 export const ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE =
   "BOOTSTRAP-ACTIVATION-RAIL.md";
 
-export type PreChatMode = "control" | "paredDown" | "native";
+export type PreChatMode = "control" | "native";
 
 export interface BuildPreChatContextInput {
   mode: PreChatMode;
@@ -81,13 +71,6 @@ export function buildPreChatContext(
   let context: PreChatOnboardingContext;
   if (mode === "native") {
     context = { tools: [], tasks: [], tone: input.tone, googleConnected: false };
-  } else if (mode === "paredDown") {
-    context = {
-      tools: connectedWithCurrentAction ? [...PARED_DOWN_GOOGLE_TOOL_IDS] : [],
-      tasks: recipe?.tasks ?? [],
-      tone: input.tone,
-      googleConnected: connectedWithCurrentAction,
-    };
   } else {
     context = {
       tools: stripOtherPrefix([...input.selectedTools]),
@@ -114,11 +97,7 @@ export function buildPreChatContext(
   const trimmedAssistant = input.assistantName.trim();
   if (trimmedAssistant) context.assistantName = trimmedAssistant;
 
-  if (mode === "paredDown") {
-    if (connectedWithCurrentAction) {
-      context.googleScopes = input.connectedScopes;
-    }
-  } else if (mode === "control") {
+  if (mode === "control") {
     if (connectedWithCurrentAction) {
       context.googleConnected = true;
       context.googleScopes = input.connectedScopes;

--- a/clients/web/src/domains/onboarding/prechat-steps.test.ts
+++ b/clients/web/src/domains/onboarding/prechat-steps.test.ts
@@ -13,7 +13,6 @@ import {
 } from "@/domains/onboarding/prechat-steps";
 
 const CONTROL: WebStepCapabilities = {
-  paredDown: false,
   canOfferPriorAssistants: true,
   canOfferGoogleStep: true,
   hasGoogleTool: true,
@@ -90,57 +89,11 @@ describe("resolveWebSteps", () => {
     expect(ids({ ...CONTROL, showIOSAppStep: false })).not.toContain("iosApp");
   });
 
-  test("pared-down funnel: name then google only", () => {
-    const steps = resolveWebSteps({
-      paredDown: true,
-      canOfferPriorAssistants: true,
-      canOfferGoogleStep: true,
-      hasGoogleTool: false,
-      showIOSAppStep: true,
-    });
-    expect(steps.map((s) => s.id)).toEqual(["name", "google"]);
-    // Back from google skips every gated control step and lands on name.
-    expect(prevStep(steps, "google")).toBe("name");
-  });
-
-  test("pared-down funnel offers google without a tool selection", () => {
-    // No tool-selection screen in this variant, so hasGoogleTool is irrelevant.
-    expect(
-      ids({
-        paredDown: true,
-        canOfferPriorAssistants: true,
-        canOfferGoogleStep: true,
-        hasGoogleTool: false,
-        showIOSAppStep: false,
-      }),
-    ).toEqual(["name", "google"]);
-  });
-
-  test("pared-down funnel collapses to name when google is unavailable", () => {
-    expect(
-      ids({
-        paredDown: true,
-        canOfferPriorAssistants: true,
-        canOfferGoogleStep: false,
-        hasGoogleTool: true,
-        showIOSAppStep: true,
-      }),
-    ).toEqual(["name"]);
-  });
-
-  test("emits the variant-specific google funnel event", () => {
+  test("google step emits the control gmail-connect funnel event", () => {
     const control = resolveWebSteps(CONTROL).find((s) => s.id === "google");
     expect(control?.funnelStep).toBe(
       ONBOARDING_FUNNEL_STEPS.controlGmailConnect,
     );
-    const pared = resolveWebSteps({
-      paredDown: true,
-      canOfferPriorAssistants: true,
-      canOfferGoogleStep: true,
-      hasGoogleTool: false,
-      showIOSAppStep: false,
-    }).find((s) => s.id === "google");
-    expect(pared?.funnelStep).toBe(ONBOARDING_FUNNEL_STEPS.gmailConnect);
   });
 });
 

--- a/clients/web/src/domains/onboarding/prechat-steps.ts
+++ b/clients/web/src/domains/onboarding/prechat-steps.ts
@@ -3,9 +3,9 @@
  *
  * The flow is expressed as an ordered list of steps, each with the funnel
  * event it emits when the user advances past it. Which steps appear is a pure
- * function of the runtime's capabilities — local mode, feature-flag variant,
- * connected tools, and platform all "fall out" of the predicates here rather
- * than being special-cased across navigation handlers.
+ * function of the runtime's capabilities — local mode, connected tools, and
+ * platform all "fall out" of the predicates here rather than being
+ * special-cased across navigation handlers.
  *
  * Navigation operates on step **ids**, never numeric indices: `nextStep` and
  * `prevStep` resolve to the adjacent *enabled* step. Because back always lands
@@ -39,12 +39,11 @@ export interface PreChatStep {
 
 /**
  * Capabilities that decide which web steps are reachable. Each maps to an
- * existing self-gate in the flow: feature-flag variant, the platform-backed
- * prior-assistants import, the Google OAuth step, whether a Google tool was
- * picked, and the iOS app nudge.
+ * existing self-gate in the flow: the platform-backed prior-assistants import,
+ * the Google OAuth step, whether a Google tool was picked, and the iOS app
+ * nudge.
  */
 export interface WebStepCapabilities {
-  paredDown: boolean;
   canOfferPriorAssistants: boolean;
   canOfferGoogleStep: boolean;
   hasGoogleTool: boolean;
@@ -80,11 +79,10 @@ export function isPlatformFunnelAvailable(args: {
 }
 
 /**
- * Resolve the ordered, enabled web steps. The pared-down funnel variant is the
- * same flow with most steps gated off, not a separate code path.
+ * Resolve the ordered, enabled web steps. A single control funnel: which steps
+ * appear falls out of the runtime capabilities rather than a separate code path.
  */
 export function resolveWebSteps(caps: WebStepCapabilities): PreChatStep[] {
-  const { paredDown } = caps;
   const candidates: Array<PreChatStep & { enabled: boolean }> = [
     {
       id: "name",
@@ -94,32 +92,29 @@ export function resolveWebSteps(caps: WebStepCapabilities): PreChatStep[] {
     {
       id: "taskTone",
       funnelStep: ONBOARDING_FUNNEL_STEPS.controlWorkType,
-      enabled: !paredDown,
+      enabled: true,
     },
     {
       id: "tools",
       funnelStep: ONBOARDING_FUNNEL_STEPS.controlTools,
-      enabled: !paredDown,
+      enabled: true,
     },
     {
       id: "priorAssistants",
       funnelStep: ONBOARDING_FUNNEL_STEPS.controlPriorAssistants,
-      enabled: !paredDown && caps.canOfferPriorAssistants,
+      enabled: caps.canOfferPriorAssistants,
     },
     {
       id: "google",
-      funnelStep: paredDown
-        ? ONBOARDING_FUNNEL_STEPS.gmailConnect
-        : ONBOARDING_FUNNEL_STEPS.controlGmailConnect,
-      // The pared-down funnel has no tool-selection screen, so it offers
-      // Google whenever the step is available; the control funnel only offers
-      // it when the user actually picked a Google tool.
-      enabled: caps.canOfferGoogleStep && (paredDown || caps.hasGoogleTool),
+      funnelStep: ONBOARDING_FUNNEL_STEPS.controlGmailConnect,
+      // The control funnel offers Google only when the user actually picked a
+      // Google tool.
+      enabled: caps.canOfferGoogleStep && caps.hasGoogleTool,
     },
     {
       id: "iosApp",
       funnelStep: ONBOARDING_FUNNEL_STEPS.controlGetApp,
-      enabled: !paredDown && caps.showIOSAppStep,
+      enabled: caps.showIOSAppStep,
     },
   ];
   return candidates

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -83,7 +83,7 @@ export interface BuildResearchPromptOptions {
   /**
    * Whether to ask the model for clickable follow-up `suggestions`. The
    * suggestions-based final step is being retired in favor of the "Let's chat"
-   * handoff (gated behind the personality-onboarding flag), which installs the
+   * handoff (now always on), which installs the
    * picked plugins and drops the user straight into a primed chat. When false,
    * the prompt asks for ONLY `plugins` + `claims` and omits all suggestion
    * guidance. Defaults to true so the legacy suggestions flow is unchanged.
@@ -129,7 +129,7 @@ export function buildResearchPrompt(
     : "I'd like you to get to know me before we start working together.";
 
   // The clickable-suggestions block is optional: the "Let's chat" final step
-  // (personality-onboarding flag) installs the picked plugins and drops the
+  // (now always on) installs the picked plugins and drops the
   // user into a primed chat instead, so it asks for only `plugins` + `claims`.
   const suggestionsArrayExample = includeSuggestions
     ? ` "suggestions": [ { "suggestion": "I'll find the 3 newest arXiv eval papers worth your time", "prompt": "Find me the 3 newest arXiv eval papers worth reading." }, { "suggestion": "I'll draft a crisp summary of the latest model-serving trade-offs", "prompt": "Draft me a short summary of the latest model-serving trade-offs." }, { "suggestion": "Connect GitHub and I'll triage your stalest issues", "prompt": "Connect to GitHub and triage my oldest open issues." }, { "suggestion": "I'll plan a weekend climbing trip near Boulder", "prompt": "Plan me a weekend climbing trip near Boulder." } ]`

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -287,7 +287,7 @@ export interface StartResearchOptions {
   onConversationCreated?: (conversationId: string) => void;
   /**
    * Whether to ask the model for clickable `suggestions`. Off for the "Let's
-   * chat" final step (personality-onboarding flag), which installs the picked
+   * chat" final step (now always on), which installs the picked
    * plugins and primes a chat instead of surfacing suggestion cards. Defaults to
    * true so the legacy suggestions flow is unchanged.
    */

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -876,8 +876,9 @@ export function SuggestionsStep({
 // ---------------------------------------------------------------------------
 
 /**
- * Terminal step for the personality-onboarding flow (replaces SuggestionsStep
- * when that flag is on). The suggestions idea is retired: instead this confirms
+ * Terminal step for the research-onboarding flow (replaces SuggestionsStep,
+ * now that the "Create my personality" step is always on). The suggestions idea
+ * is retired: instead this confirms
  * the capabilities already set up for the assistant — chosen from the user's
  * role, hobby, and what the web research surfaced — and offers a single "Let's
  * chat" button. Clicking primes a fresh chat with a hidden kickoff message so

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -97,8 +97,8 @@ describe("getEnvFlagOverridesForScope", () => {
         "home-tab": true,
         // assistant-only flag (boolean) — should be excluded from client scope
         "settings-developer-nav": true,
-        // client-only flag (string)
-        "pre-chat-onboarding-experiment-2026-06-06": "variant-a",
+        // client-visible flag (string)
+        "experiment-activation-flow-2026-06-03": "variant-a",
       },
     };
     resetEnvOverridesCache();
@@ -106,7 +106,7 @@ describe("getEnvFlagOverridesForScope", () => {
     const result = getEnvFlagOverridesForScope("client");
     expect(result.bool).toEqual({ homeTab: true });
     expect(result.str).toEqual({
-      preChatOnboardingExperiment20260606: "variant-a",
+      experimentActivationFlow20260603: "variant-a",
     });
     expect(result.bool).not.toHaveProperty("settingsDeveloperNav");
   });

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -10,18 +10,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "pre-chat-onboarding-experiment-2026-06-06",
-      "scope": "client",
-      "key": "pre-chat-onboarding-experiment-2026-06-06",
-      "label": "Pre-chat Onboarding Experiment 2026-06-06",
-      "description": "Pre-chat onboarding experiment with control and variant-a arms. Control shows the full funnel; variant-a shows the condensed pared-down flow.",
-      "defaultEnabled": "control",
-      "values": [
-        "control",
-        "variant-a"
-      ]
-    },
-    {
       "id": "experiment-activation-flow-2026-06-03",
       "scope": "both",
       "key": "experiment-activation-flow-2026-06-03",
@@ -312,22 +300,6 @@
       "key": "self-intro-greeting",
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
-      "defaultEnabled": false
-    },
-    {
-      "id": "research-onboarding",
-      "scope": "client",
-      "key": "research-onboarding",
-      "label": "Research onboarding (spike)",
-      "description": "Spike: replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "personality-onboarding",
-      "scope": "client",
-      "key": "personality-onboarding",
-      "label": "Personality onboarding step (spike)",
-      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
       "defaultEnabled": false
     },
     {

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -111,8 +111,8 @@ export const routes = {
     privacy: r("/assistant/onboarding/privacy"),
     prechat: r("/assistant/onboarding/prechat"),
     hatching: r("/assistant/onboarding/hatching"),
-    // SPIKE — research-onboarding front door. Reachable on demand behind the
-    // default-off research-onboarding flag (see routes.tsx).
+    // SPIKE — research-onboarding front door. Reachable on demand behind auth
+    // alone (no flag; see routes.tsx).
     research: r("/assistant/onboarding/research"),
   },
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -10,18 +10,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "pre-chat-onboarding-experiment-2026-06-06",
-      "scope": "client",
-      "key": "pre-chat-onboarding-experiment-2026-06-06",
-      "label": "Pre-chat Onboarding Experiment 2026-06-06",
-      "description": "Pre-chat onboarding experiment with control and variant-a arms. Control shows the full funnel; variant-a shows the condensed pared-down flow.",
-      "defaultEnabled": "control",
-      "values": [
-        "control",
-        "variant-a"
-      ]
-    },
-    {
       "id": "experiment-activation-flow-2026-06-03",
       "scope": "both",
       "key": "experiment-activation-flow-2026-06-03",
@@ -312,22 +300,6 @@
       "key": "self-intro-greeting",
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
-      "defaultEnabled": false
-    },
-    {
-      "id": "research-onboarding",
-      "scope": "client",
-      "key": "research-onboarding",
-      "label": "Research onboarding (spike)",
-      "description": "Spike: replace pre-chat onboarding with a web-research \"here's what I know about you\" flow, including a Google Calendar \"Let's chat tomorrow\" step shown over the streaming research. Gates the /assistant/onboarding/research route and the research mock harness. Off by default; enable locally via the feature-flags panel.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "personality-onboarding",
-      "scope": "client",
-      "key": "personality-onboarding",
-      "label": "Personality onboarding step (spike)",
-      "description": "Spike: show the \"Create my personality\" trait-slider step in the research-onboarding flow (between the pitch and the integration step). On continue it applies the sliders to the assistant's persona on a throwaway side conversation. When off, the step is skipped entirely. Off by default; enable locally via the feature-flags panel.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
"Research onboarding" is the only onboarding experience we offer now, so this retires the dead feature-flag code around it. Removes three client flags — `research-onboarding`, `pre-chat-onboarding-experiment-2026-06-06`, `personality-onboarding` — from the code that read them and from the flag registry, and (because the pre-chat experiment flag was the only selector of the pared-down pre-chat funnel) fully retires the pared-down funnel variant, collapsing the pre-chat funnel to a single `control` flow. `user-hosted-enabled` is intentionally left in place (out of scope).

Telemetry is unchanged: onboarding funnel events still emit `ab_variant: "control"`. The assistant-daemon research-onboarding telemetry (`onboarding_research` event, Day-2 check-in) is flag-independent and untouched.

## Self-review result
PASS — 2 gaps found and fixed across 2 fix PRs (dead single-variant plumbing inlined; stale flag comments corrected). Re-review clean.

## PRs merged into feature branch
- #38193: gate the research-onboarding mock page on `import.meta.env.DEV` instead of the flag
- #38196: retire the `pre-chat-onboarding-experiment-2026-06-06` flag + fully retire the pared-down pre-chat funnel variant
- #38208: remove the three retired flags from the flag registry (+ re-sync web copy)

### Fix PRs
- #38218: correct comments referencing the removed flags (comments-only)
- #38219: drop the dead single-variant A/B plumbing (inline `ab_variant: control`)

## Cross-repo follow-up
The LaunchDarkly definitions for `research-onboarding` and `pre-chat-onboarding-experiment-2026-06-06` live in `vellum-assistant-platform` terraform and should be archived (not deleted) separately — plan drafted at `.private/plans/onboarding-ff-cleanup.md` in that repo.

Part of plan: onboarding-ff-cleanup.md