### PR TITLE
feat(plugins): run init/shutdown in the daemon on upgrade, and support upgrading untrusted GitHub-URL installs

### DIFF
--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -679,14 +679,42 @@ export function registerPluginsCommand(program: Command): void {
             return;
           }
           try {
-            const result = await libs.upgrade.upgradePlugin(
+            // Prefer the daemon: when the upgrade re-materializes files it runs
+            // the plugin's `shutdown` + `init` hooks in the main process —
+            // symmetric to how install/uninstall run their lifecycle there.
+            // Fall back to a local upgrade only when the daemon is unreachable
+            // (a transport error carries no `statusCode`); an operator can still
+            // upgrade while it's stopped, and the new code is picked up on the
+            // daemon's next start. A daemon-side decision (not installed, not
+            // upgradable, …) is surfaced rather than silently retried locally.
+            const daemon = await cliIpcCall<PluginUpgradeResult>(
+              "plugins_upgrade",
               {
-                name,
-                dryRun: opts.dryRun,
-                strategy: strategy as PluginUpgradeStrategy | undefined,
+                pathParams: { name },
+                body: { dryRun: opts.dryRun, strategy },
               },
-              { fetch: globalThis.fetch.bind(globalThis) },
             );
+            let result: PluginUpgradeResult;
+            if (daemon.ok && daemon.result) {
+              result = daemon.result;
+            } else if (daemon.statusCode === undefined) {
+              log.debug(
+                { name, error: daemon.error },
+                "upgrade could not reach the daemon; upgrading locally",
+              );
+              result = await libs.upgrade.upgradePlugin(
+                {
+                  name,
+                  dryRun: opts.dryRun,
+                  strategy: strategy as PluginUpgradeStrategy | undefined,
+                },
+                { fetch: globalThis.fetch.bind(globalThis) },
+              );
+            } else {
+              console.error(daemon.error ?? "Plugin upgrade failed.");
+              process.exitCode = 1;
+              return;
+            }
 
             if (opts.json) {
               process.stdout.write(JSON.stringify(result, null, 2) + "\n");
@@ -1174,7 +1202,7 @@ function formatUpgrade(result: PluginUpgradeResult): string[] {
         `Upgraded "${name}" ${move}`,
         "",
         `${count}→ ${result.target}`,
-        "Restart the assistant to pick up the upgrade.",
+        "The upgrade is picked up live (no restart required).",
       ];
       if (mergeNote) {
         lines.push(mergeNote);

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1418,6 +1418,21 @@ async function handleUpgradePlugin({
       { name: rawName, dryRun, strategy },
       { fetch: globalThis.fetch.bind(globalThis) },
     );
+    // An upgrade that actually moved files (outcome `upgraded`) rewrites the
+    // plugin's on-disk source; bring the change up in-process right now — run
+    // the old version's `shutdown` and the new version's `init` via the
+    // reconcile — instead of waiting for the resource monitor to republish the
+    // sentinel and a later turn to apply it. This is what makes the lifecycle
+    // fire as part of the upgrade rather than at the next daemon boot,
+    // symmetric to the install and uninstall routes. A no-op or dry run leaves
+    // the tree unchanged, so there is nothing to reconcile. Ensure the
+    // workspace `@vellumai/plugin-api` shim first (as uninstall does) so a hook
+    // that imports the package resolves even inside the daemon boot window.
+    // Never throws; a failure is contained and logged.
+    if (result.outcome === "upgraded") {
+      await ensurePluginApiShim().catch(() => {});
+      await reconcilePluginSourcesNow();
+    }
     publishPluginsChanged(getOriginClientId(headers));
     return {
       name: result.name,


### PR DESCRIPTION
## Prompt / plan

Two related follow-ups to the plugin lifecycle work in #38039:

1. > We recently IPC'd plugin install and plugin uninstall from the CLI to the daemon. We need to do the same for upgrade so that the daemon runs init / shutdown.
2. > Now let's support upgrades for untrusted github urls.

### Part 1 — run the plugin lifecycle in the daemon on upgrade

Install and uninstall already IPC their lifecycle to the daemon so it runs `init`/`shutdown` in the long-lived process. Upgrade did not — the CLI ran `upgradePlugin` locally, and the daemon route re-materialized the tree without bringing the change up in-process.

- **Daemon route** (`POST /v1/plugins/:name/upgrade`): after a successful `upgraded` outcome, ensure the `@vellumai/plugin-api` shim and call `reconcilePluginSourcesNow()` so the old version's `shutdown` and the new version's `init` run in the daemon. No-op/dry-run skips it.
- **CLI `plugins upgrade`**: prefers the daemon over IPC (lifecycle runs in the main process), falling back to a local upgrade only when the daemon is unreachable — mirroring `plugins uninstall`.
- CLI success message reflects live pickup ("no restart required").

### Part 2 — upgrade untrusted GitHub-URL installs

`plugins upgrade` resolved its target through `inspectPlugin`, which knows only the curated marketplace, so a plugin installed directly from a GitHub URL (`not-in-marketplace`) hit `PluginNotUpgradableError`. It now advances a direct install against its **own recorded source** — the owner/repo/path/ref in its `install-meta.json`.

- `resolveRefCommit()` resolves the recorded ref to a commit with a single `git ls-remote` — no clone. A full-SHA ref is immutable (resolves to itself, no network); a branch/tag/HEAD moves as upstream does.
- `directUpgrade()` handles the `not-in-marketplace` case when a resolvable GitHub source exists: no-op when unchanged, `--dry-run` preview, and the same `overwrite`/`ours`/`theirs`/`assistant` strategies as marketplace upgrades. Re-materialized verbatim — no curated adapter overlay, exactly as the original untrusted install was.
- `mergeUpgrade()` generalized to take an explicit `theirsSource` + base/theirs stub refs (marketplace passes curated refs; direct passes `null`).
- The target ref is never caller-supplied, preserving the curation boundary. `PluginNotUpgradableError` now fires only when neither a marketplace entry nor a recorded source exists; a vanished ref maps to 404.

## Test plan

- `bunx tsc --noEmit` (assistant) — clean.
- `bun test src/cli/lib/__tests__/upgrade-plugin.test.ts` — 24 pass (6 new direct-upgrade cases: advances a tracked branch, no-ops when unchanged, SHA-pinned install up-to-date without any git, dry-run preview, 404 on vanished ref, `--strategy ours` merge).
- `bun test src/cli/lib/__tests__/install-from-github.test.ts` (38) / `inspect-plugin.test.ts` (15) — pass.
- `bun test src/runtime/routes/__tests__/plugins-routes.test.ts` (111) / `src/__tests__/mtime-cache.test.ts` — pass.
- `eslint` on changed files — 0 errors. (The repo's full `src/cli/lib/__tests__/` dir has pre-existing, order-dependent `mock.module` cross-file leakage that fails the clone-based upgrade tests when run together; each file passes in isolation, and the same tests fail identically on `main`.)

## CLI verb checklist

No new route is added. `plugins_upgrade` already exists and has its `assistant plugins upgrade` verb; this PR changes that verb (daemon delegation) and broadens what the route can upgrade. No new env vars or DB/workspace migrations — the feature reads existing `install-meta.json` provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bebi83sSFqAMYbM7s7PU9