### PR TITLE
fix(web): respect open_conversation events instead of dropping them as unknown

### DIFF
--- a/assistant/src/api/events/open-conversation.test.ts
+++ b/assistant/src/api/events/open-conversation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { OpenConversationEventSchema } from "./open-conversation.js";
+
+describe("OpenConversationEventSchema", () => {
+  test("parses an event with all fields", () => {
+    const event = {
+      type: "open_conversation" as const,
+      conversationId: "conv-abc",
+      title: "New conversation",
+      anchorMessageId: "msg-42",
+      focus: true,
+    };
+
+    const result = OpenConversationEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual(event);
+  });
+
+  test("parses an event with only the required conversationId", () => {
+    const event = {
+      type: "open_conversation" as const,
+      conversationId: "conv-abc",
+    };
+
+    const result = OpenConversationEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual(event);
+  });
+
+  test("parses a non-focusing fan-out open", () => {
+    const event = {
+      type: "open_conversation" as const,
+      conversationId: "conv-abc",
+      focus: false,
+    };
+
+    const result = OpenConversationEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.focus).toBe(false);
+  });
+
+  test("rejects an event missing conversationId", () => {
+    const result = OpenConversationEventSchema.safeParse({
+      type: "open_conversation",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("strips an unrecognized field for forward compatibility", () => {
+    const result = OpenConversationEventSchema.safeParse({
+      type: "open_conversation",
+      conversationId: "conv-abc",
+      seq: 7,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.success && "seq" in result.data).toBe(false);
+  });
+});

--- a/assistant/src/api/events/open-conversation.ts
+++ b/assistant/src/api/events/open-conversation.ts
@@ -1,0 +1,33 @@
+/**
+ * `open_conversation` SSE event.
+ *
+ * Server push instructing the client to open (and, by default, focus) a
+ * conversation. Emitted by the conversation launcher when a persistent
+ * `ui_show` card fires a `launch_conversation` action, so the freshly
+ * created conversation surfaces on the user's screen.
+ *
+ * Unlike most conversation-scoped events, `conversationId` here is the
+ * **target** conversation to open — not the stream the event travelled on.
+ * Clients must route it globally rather than gating it against the active
+ * conversation.
+ *
+ * `focus` defaults to omitted (client-side default of `true`) so single-
+ * target "jump to the new conversation" callers keep their existing
+ * behavior. Fan-out launchers set `focus: false` to register the
+ * conversation in the sidebar without stealing focus from the origin.
+ *
+ * Canonical wire-contract source. Daemon code imports the type directly
+ * from this file; external consumers import via `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const OpenConversationEventSchema = z.object({
+  type: z.literal("open_conversation"),
+  conversationId: z.string(),
+  title: z.string().optional(),
+  anchorMessageId: z.string().optional(),
+  focus: z.boolean().optional(),
+});
+
+export type OpenConversationEvent = z.infer<typeof OpenConversationEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -40,6 +40,7 @@ import { MessageQueuedDeletedEventSchema } from "./events/message-queued-deleted
 import { MessageRequestCompleteEventSchema } from "./events/message-request-complete.js";
 import { NavigateSettingsEventSchema } from "./events/navigate-settings.js";
 import { NotificationIntentEventSchema } from "./events/notification-intent.js";
+import { OpenConversationEventSchema } from "./events/open-conversation.js";
 import { OpenPanelEventSchema } from "./events/open-panel.js";
 import { OpenUrlEventSchema } from "./events/open-url.js";
 import { QuestionRequestEventSchema } from "./events/question-request.js";
@@ -275,6 +276,10 @@ export {
   type NotificationIntentEvent,
   NotificationIntentEventSchema,
 } from "./events/notification-intent.js";
+export {
+  type OpenConversationEvent,
+  OpenConversationEventSchema,
+} from "./events/open-conversation.js";
 export {
   type OpenPanelEvent,
   OpenPanelEventSchema,
@@ -591,6 +596,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   MessageRequestCompleteEventSchema,
   NavigateSettingsEventSchema,
   NotificationIntentEventSchema,
+  OpenConversationEventSchema,
   OpenPanelEventSchema,
   OpenUrlEventSchema,
   QuestionRequestEventSchema,

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -8,6 +8,7 @@ import type { ConversationNoticeEvent } from "../../api/events/conversation-noti
 import type { ConversationTitleUpdatedEvent } from "../../api/events/conversation-title-updated.js";
 import type { GenerationCancelledEvent } from "../../api/events/generation-cancelled.js";
 import type { GenerationHandoffEvent } from "../../api/events/generation-handoff.js";
+import type { OpenConversationEvent } from "../../api/events/open-conversation.js";
 import type { UsageProgressEvent } from "../../api/events/usage-progress.js";
 import type { UsageUpdateEvent } from "../../api/events/usage-update.js";
 import type {
@@ -505,22 +506,10 @@ export interface ScheduleConversationCreated {
   title: string;
 }
 
-/**
- * Server push — instructs the client to open and focus a conversation. If
- * the conversation isn't already present in the client's sidebar list (e.g.
- * it was just created via `POST /v1/conversations`), the client should stub
- * a sidebar entry using the provided `title` before navigating.
- */
-export interface OpenConversation {
-  type: "open_conversation";
-  conversationId: string;
-  /** Optional conversation title; supplied when the client may not yet have the conversation in its list. */
-  title?: string;
-  /** Optional message ID to scroll to after focus. */
-  anchorMessageId?: string;
-  /** When `false`, the client should register the conversation in its sidebar (so it's visible and navigable) but must NOT switch focus to it. Omitting the field defaults to `true` for backward compatibility with existing single-target 'jump to conversation' callers. */
-  focus?: boolean;
-}
+// `open_conversation` is a migrated event: its canonical wire contract lives
+// in `../../api/events/open-conversation.ts` (imported as
+// `OpenConversationEvent`). Instructs the client to open and, by default,
+// focus a conversation — see that file for the full field docs.
 
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
@@ -565,4 +554,4 @@ export type _ConversationsServerMessages =
   | MessageContentResponse
   | ConversationListInvalidatedEvent
   | ScheduleConversationCreated
-  | OpenConversation;
+  | OpenConversationEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -15,6 +15,7 @@ import {
   handleOpenUrl,
   handleNavigateSettings,
   handleOpenPanel,
+  handleOpenConversation,
 } from "@/domains/chat/utils/stream-handlers/navigation-handlers";
 import {
   handleAssistantTextDelta,
@@ -268,6 +269,9 @@ export function useStreamEventHandler(
           break;
         case "open_panel":
           handleOpenPanel(event, ctx);
+          break;
+        case "open_conversation":
+          handleOpenConversation(event, ctx);
           break;
         case "assistant_turn_start":
           handleAssistantTurnStart(event, ctx);

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -1,4 +1,7 @@
-import { type DisplayMessage, isSurfaceInteractive } from "@/domains/chat/types/types";
+import {
+  type DisplayMessage,
+  isSurfaceInteractive,
+} from "@/domains/chat/types/types";
 import type { IdentityGetResponse } from "@/generated/daemon/types.gen";
 import type { Conversation } from "@/types/conversation-types";
 import type { AssistantEvent } from "@/types/event-types";
@@ -29,6 +32,12 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   // (daemon emits `{ type, tab }`), so the conversation-id gate would
   // otherwise drop it before it reached `handleNavigateSettings`.
   "navigate_settings",
+  // Client directive to open/focus a conversation. Its `conversationId` is
+  // the TARGET conversation to open, not the stream the event arrived on, so
+  // the conversation-id gate (which compares against the active stream's
+  // conversation) would otherwise drop it as a mismatch before it reached
+  // `handleOpenConversation`.
+  "open_conversation",
   "identity_changed",
   "avatar_updated",
   "sync_changed",

--- a/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.test.ts
@@ -52,9 +52,10 @@ mock.module("@/runtime/browser", () => ({
   openUrl: (url: string) => nativeOpenUrlMock(url),
 }));
 
-const { handleOpenPanel, handleOpenUrl } =
+const { handleOpenPanel, handleOpenUrl, handleOpenConversation } =
   await import("@/domains/chat/utils/stream-handlers/navigation-handlers");
 const { useViewerStore } = await import("@/stores/viewer-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
 
 function makeCtx(
   overrides: Partial<StreamHandlerContext> = {},
@@ -84,7 +85,9 @@ function setMockWindow({
   open,
 }: {
   origin?: string;
-  open?: ((url?: string, target?: string, features?: string) => Window | null) | null;
+  open?:
+    | ((url?: string, target?: string, features?: string) => Window | null)
+    | null;
 } = {}): void {
   Object.defineProperty(globalThis, "window", {
     configurable: true,
@@ -201,7 +204,10 @@ describe("handleOpenUrl", () => {
     setMockWindow({ open: null });
     const { ctx, push } = makeOpenUrlCtx();
 
-    handleOpenUrl(makeOpenUrlEvent("https://app.vellum.ai/settings?tab=x"), ctx);
+    handleOpenUrl(
+      makeOpenUrlEvent("https://app.vellum.ai/settings?tab=x"),
+      ctx,
+    );
 
     expect(push).toHaveBeenCalledWith("/settings?tab=x");
   });
@@ -214,7 +220,11 @@ describe("handleOpenUrl", () => {
 
     handleOpenUrl(makeOpenUrlEvent(oauthUrl), ctx);
 
-    expect(open).toHaveBeenCalledWith(oauthUrl, "_blank", "width=500,height=600");
+    expect(open).toHaveBeenCalledWith(
+      oauthUrl,
+      "_blank",
+      "width=500,height=600",
+    );
     expect(setError).not.toHaveBeenCalled();
     expect(setNotice).not.toHaveBeenCalled();
   });
@@ -253,5 +263,45 @@ describe("handleOpenUrl", () => {
 
     expect(setError).toHaveBeenCalledTimes(1);
     expect(setNotice).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleOpenConversation", () => {
+  it("switches to and focuses the target conversation by default", () => {
+    useConversationStore.getState().setActiveConversationId("conv-origin");
+    const push = mock((_url: string) => {});
+    const ctx = { router: { push } } as unknown as StreamHandlerContext;
+
+    handleOpenConversation(
+      { type: "open_conversation", conversationId: "conv-target" },
+      ctx,
+    );
+
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      "conv-target",
+    );
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(push.mock.calls[0]?.[0]).toContain("conv-target");
+  });
+
+  it("does not switch focus when focus is false", () => {
+    useConversationStore.getState().setActiveConversationId("conv-origin");
+    const push = mock((_url: string) => {});
+    const ctx = { router: { push } } as unknown as StreamHandlerContext;
+
+    handleOpenConversation(
+      {
+        type: "open_conversation",
+        conversationId: "conv-target",
+        focus: false,
+      },
+      ctx,
+    );
+
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      "conv-origin",
+    );
+    expect(push).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.ts
@@ -2,13 +2,18 @@ import { dispatchOpenUrl } from "@/domains/chat/utils/oauth-popup-links";
 import { getSettingsRouteForClientTab } from "@/utils/settings-navigation";
 import { isSetupChannelId } from "@/types/channel-types";
 import { recordDiagnostic } from "@/lib/diagnostics";
+import { routes } from "@/utils/routes";
 import { submitSurfaceAction } from "@/domains/chat/api/surfaces";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 import type {
   NavigateSettingsEvent,
+  OpenConversationEvent,
   OpenPanelEvent,
   OpenUrlEvent,
 } from "@vellumai/assistant-api";
@@ -37,6 +42,34 @@ export function handleOpenUrl(
       actionUrl: outcome.url,
     });
   }
+}
+
+/**
+ * Server-directed "open this conversation" command. The event's
+ * `conversationId` is the TARGET conversation (typically just created by the
+ * conversation launcher), not the stream this event travelled on — the
+ * conversation-id gate is bypassed by listing `open_conversation` as a global
+ * stream event.
+ *
+ * `focus === false` means the daemon wants the conversation registered in the
+ * sidebar without stealing focus from the origin. On web the sidebar list is
+ * driven by the conversation-list query (refreshed via `sync_changed` when a
+ * new conversation is created), so a non-focusing open needs no navigation —
+ * we simply do not switch. Any other value (including the omitted default)
+ * switches to and focuses the target, mirroring `navigateToConversation`.
+ */
+export function handleOpenConversation(
+  event: OpenConversationEvent,
+  ctx: StreamHandlerContext,
+): void {
+  if (event.focus === false) {
+    return;
+  }
+  useViewerStore.getState().setMainView("chat");
+  useSubagentStore.getState().reset();
+  useWorkflowStore.getState().reset();
+  useConversationStore.getState().setActiveConversationId(event.conversationId);
+  ctx.router.push(routes.conversation(event.conversationId));
 }
 
 export function handleNavigateSettings(

--- a/clients/web/src/lib/streaming/event-parser.test.ts
+++ b/clients/web/src/lib/streaming/event-parser.test.ts
@@ -1428,6 +1428,44 @@ describe("parseAssistantEvent", () => {
     });
   });
 
+  test("parses open_conversation with all fields (not unknown)", () => {
+    const event = parseEvent({
+      type: "open_conversation",
+      conversationId: "conv-1",
+      title: "New conversation",
+      anchorMessageId: "msg-42",
+      focus: true,
+    });
+    expect(event).toEqual({
+      type: "open_conversation",
+      conversationId: "conv-1",
+      title: "New conversation",
+      anchorMessageId: "msg-42",
+      focus: true,
+    });
+  });
+
+  test("parses open_conversation with only the required conversationId", () => {
+    const event = parseEvent({
+      type: "open_conversation",
+      conversationId: "conv-1",
+    });
+    expect(event).toEqual({
+      type: "open_conversation",
+      conversationId: "conv-1",
+    });
+  });
+
+  test("returns unknown open_conversation event when conversationId is missing", () => {
+    const data = { type: "open_conversation", focus: true };
+    const event = parseEvent(data);
+    expect(event).toEqual({
+      type: "unknown",
+      rawType: "open_conversation",
+      data,
+    });
+  });
+
   describe("disk_pressure_status_changed", () => {
     const criticalStatus: DiskPressureStatus = {
       enabled: true,


### PR DESCRIPTION
## Prompt / plan

Bug report: "our open conversation events are not respected by the client." A client-side debug object showed the event arriving parsed as `{ type: "unknown", rawType: "open_conversation", data: { type: "open_conversation", conversationId: "…", focus: true } }` — i.e. recognized on the wire but ignored.

**Root cause:** `open_conversation` is emitted by the daemon (the conversation launcher, `launchConversation`) but was never a member of the canonical `AssistantEventSchema` discriminated union in `@vellumai/assistant-api`. The web parser (`event-parser.ts`) validates every SSE payload against that schema and drops anything it doesn't recognize into an `UnknownEvent` fallback, so the client never opened or focused the launched conversation. On top of that, the web client had no handler for the event at all.

The fix follows the API package's documented migration recipe (`assistant/src/api/README.md`):

- Add `OpenConversationEventSchema` under `assistant/src/api/events/` and register it in the `AssistantEventSchema` union so the parser recognizes the event.
- Adopt the canonical `OpenConversationEvent` type in the daemon message-types, removing the duplicate local interface so the wire shapes can't drift.
- Mark `open_conversation` as a **global** stream event on the client: its `conversationId` is the *target* conversation to open, not the stream it arrived on, so the conversation-id gate would otherwise reject it as a mismatch.
- Add `handleOpenConversation`, which switches to and focuses the target conversation (mirroring `navigateToConversation`) and no-ops for `focus: false` fan-out launches, and wire it into the stream-event dispatch switch.

## Test plan

- New schema tests: `assistant/src/api/events/open-conversation.test.ts` (all fields, required-only, non-focusing, missing `conversationId` → reject, forward-compat strip).
- New parser tests in `event-parser.test.ts` confirming `open_conversation` now parses into a typed event (not `unknown`), plus the missing-`conversationId` → `unknown` case.
- New handler tests in `navigation-handlers.test.ts` covering focus (switch + push) and `focus: false` (no switch).
- `bunx tsc --noEmit` passes for both `assistant/` and `clients/web/` — the exhaustive dispatch switch compiling confirms the new union member is handled.
- Existing daemon tests that assert on `open_conversation` emission (`conversation-surfaces-launch.test.ts`, `user-route-dispatcher.test.ts`) still pass.
- eslint clean (0 errors) and prettier-formatted; pre-commit and pre-push hooks passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HGF5prLmnpqfcKsY9j1kBw)_