### PR TITLE
fix(gateway): checkpoint m0006/m0008 when the assistant ACL columns are gone

### DIFF
--- a/assistant/src/persistence/migrations/305-drop-contact-acl-columns.ts
+++ b/assistant/src/persistence/migrations/305-drop-contact-acl-columns.ts
@@ -9,8 +9,9 @@ const log = getLogger("migration-305");
  * Drops the redundant contact ACL columns now owned by the gateway DB.
  *
  * Combo 11 Phase B: the gateway DB is the source of truth for contact ACL,
- * making these assistant-DB columns redundant mirrors. Phase A already drained
- * every production read off them.
+ * making these assistant-DB columns redundant mirrors. Phase A drained the
+ * runtime reads; gateway data migrations m0006/m0008 still read them to seed a
+ * pre-cutover gateway, and checkpoint once they are gone.
  *
  * No DROP INDEX needed: the only contact_channels index
  * (idx_contact_channels_type_ext_chat on (type, external_chat_id)) covers none

--- a/gateway/src/__tests__/data-migration-m0008-upsert-acl-columns-from-assistant.test.ts
+++ b/gateway/src/__tests__/data-migration-m0008-upsert-acl-columns-from-assistant.test.ts
@@ -58,12 +58,14 @@ const fakeAssistantDb = {
   hasContactsTable: true,
   hasChannelsTable: true,
   hasInviteIdColumn: true,
+  hasAclColumns: true,
   reset(): void {
     this.contacts.clear();
     this.channels.clear();
     this.hasContactsTable = true;
     this.hasChannelsTable = true;
     this.hasInviteIdColumn = true;
+    this.hasAclColumns = true;
   },
 };
 
@@ -72,6 +74,11 @@ mock.module("../db/assistant-db-proxy.js", () => ({
     const lower = sql.toLowerCase();
     if (lower.includes("pragma_table_info('contact_channels')")) {
       return fakeAssistantDb.hasInviteIdColumn ? [{ "1": 1 }] : [];
+    }
+    if (lower.includes("pragma_table_info('contacts')")) {
+      return fakeAssistantDb.hasAclColumns
+        ? [{ name: "role" }, { name: "principal_id" }]
+        : [];
     }
     if (lower.includes("sqlite_master")) {
       if (lower.includes("'contacts'")) {
@@ -86,7 +93,10 @@ mock.module("../db/assistant-db-proxy.js", () => ({
       // Mirror SQLite: referencing the dropped column errors; the NULL alias
       // is not a column reference.
       const columnRefs = lower.replaceAll("null as invite_id", "");
-      if (!fakeAssistantDb.hasInviteIdColumn && columnRefs.includes("invite_id")) {
+      if (
+        !fakeAssistantDb.hasInviteIdColumn &&
+        columnRefs.includes("invite_id")
+      ) {
         throw new Error("no such column: invite_id");
       }
       const rows = Array.from(fakeAssistantDb.channels.values());
@@ -95,6 +105,9 @@ mock.module("../db/assistant-db-proxy.js", () => ({
         : rows.map((ch) => ({ ...ch, invite_id: null }));
     }
     if (lower.includes("from contacts")) {
+      if (!fakeAssistantDb.hasAclColumns && lower.includes("role")) {
+        throw new Error("no such column: role");
+      }
       return Array.from(fakeAssistantDb.contacts.values());
     }
     return [];
@@ -145,21 +158,23 @@ function seedGatewayContact(opts: { id: string } & Partial<FakeContact>): void {
     .run();
 }
 
-function seedGatewayChannel(opts: {
-  id: string;
-  contactId: string;
-  type: string;
-  address: string;
-} & Partial<{
-  isPrimary: boolean;
-  status: string;
-  policy: string;
-  verifiedAt: number | null;
-  verifiedVia: string | null;
-  lastSeenAt: number | null;
-  interactionCount: number;
-  lastInteraction: number | null;
-}>): void {
+function seedGatewayChannel(
+  opts: {
+    id: string;
+    contactId: string;
+    type: string;
+    address: string;
+  } & Partial<{
+    isPrimary: boolean;
+    status: string;
+    policy: string;
+    verifiedAt: number | null;
+    verifiedVia: string | null;
+    lastSeenAt: number | null;
+    interactionCount: number;
+    lastInteraction: number | null;
+  }>,
+): void {
   getGatewayDb()
     .insert(contactChannels)
     .values({
@@ -195,7 +210,12 @@ function seedAssistantContact(
 }
 
 function seedAssistantChannel(
-  opts: { id: string; contact_id: string; type: string; address: string } & Partial<FakeChannel>,
+  opts: {
+    id: string;
+    contact_id: string;
+    type: string;
+    address: string;
+  } & Partial<FakeChannel>,
 ): void {
   fakeAssistantDb.channels.set(opts.id, {
     is_primary: 0,
@@ -214,8 +234,8 @@ function seedAssistantChannel(
 }
 
 function gwContact(id: string): Record<string, unknown> | undefined {
-  return getGatewayDb().$client
-    .prepare("SELECT * FROM contacts WHERE id = ?")
+  return getGatewayDb()
+    .$client.prepare("SELECT * FROM contacts WHERE id = ?")
     .get(id) as Record<string, unknown> | undefined;
 }
 
@@ -223,15 +243,17 @@ function gwChannelByAddress(
   type: string,
   address: string,
 ): Record<string, unknown> | undefined {
-  return getGatewayDb().$client
-    .prepare("SELECT * FROM contact_channels WHERE type = ? AND address = ?")
+  return getGatewayDb()
+    .$client.prepare(
+      "SELECT * FROM contact_channels WHERE type = ? AND address = ?",
+    )
     .get(type, address) as Record<string, unknown> | undefined;
 }
 
 function gwChannelCount(): number {
   return (
-    getGatewayDb().$client
-      .prepare("SELECT count(*) AS n FROM contact_channels")
+    getGatewayDb()
+      .$client.prepare("SELECT count(*) AS n FROM contact_channels")
       .get() as { n: number }
   ).n;
 }
@@ -300,7 +322,12 @@ describe("m0008-upsert-acl-columns-from-assistant", () => {
 
   test("coerces an assistant escalate policy to deny on both upsert paths", async () => {
     // Update path: existing gateway row.
-    seedGatewayContact({ id: "c-esc", display_name: "gw", role: "contact", principal_id: null });
+    seedGatewayContact({
+      id: "c-esc",
+      display_name: "gw",
+      role: "contact",
+      principal_id: null,
+    });
     seedGatewayChannel({
       id: "ch-esc-upd",
       contactId: "c-esc",
@@ -553,6 +580,18 @@ describe("m0008-upsert-acl-columns-from-assistant", () => {
     const result = await m0008Up();
     expect(result).toBe("skip");
     expect(gwContact("ignored") ?? undefined).toBeUndefined();
+    expect(gwChannelCount()).toBe(0);
+  });
+
+  test("checkpoints instead of throwing when the assistant ACL columns are gone", async () => {
+    // Unlike the absent table above, which is transient on a fresh install,
+    // assistant persistence migration 305 dropping the columns is terminal.
+    fakeAssistantDb.hasAclColumns = false;
+    seedAssistantContact({ id: "unreachable" });
+
+    const result = await m0008Up();
+    expect(result).toBe("done");
+    expect(gwContact("unreachable") ?? undefined).toBeUndefined();
     expect(gwChannelCount()).toBe(0);
   });
 

--- a/gateway/src/__tests__/m0006-reconcile-contacts.test.ts
+++ b/gateway/src/__tests__/m0006-reconcile-contacts.test.ts
@@ -56,12 +56,14 @@ const fakeAssistantDb = {
   hasContactsTable: true,
   hasChannelsTable: true,
   hasInviteIdColumn: true,
+  hasAclColumns: true,
   reset(): void {
     this.contacts.clear();
     this.channels.clear();
     this.hasContactsTable = true;
     this.hasChannelsTable = true;
     this.hasInviteIdColumn = true;
+    this.hasAclColumns = true;
   },
 };
 
@@ -71,20 +73,37 @@ mock.module("../db/assistant-db-proxy.js", () => ({
     if (lower.includes("pragma_table_info('contact_channels')")) {
       return fakeAssistantDb.hasInviteIdColumn ? [{ "1": 1 }] : [];
     }
+    if (lower.includes("pragma_table_info('contacts')")) {
+      return fakeAssistantDb.hasAclColumns
+        ? [{ name: "role" }, { name: "principal_id" }]
+        : [];
+    }
     if (lower.includes("sqlite_master") && lower.includes("'contacts'")) {
       return fakeAssistantDb.hasContactsTable ? [{ "1": 1 }] : [];
     }
-    if (lower.includes("sqlite_master") && lower.includes("'contact_channels'")) {
+    if (
+      lower.includes("sqlite_master") &&
+      lower.includes("'contact_channels'")
+    ) {
       return fakeAssistantDb.hasChannelsTable ? [{ "1": 1 }] : [];
     }
-    if (lower.includes("from contacts") && !lower.includes("contact_channels")) {
+    if (
+      lower.includes("from contacts") &&
+      !lower.includes("contact_channels")
+    ) {
+      if (!fakeAssistantDb.hasAclColumns && lower.includes("role")) {
+        throw new Error("no such column: role");
+      }
       return Array.from(fakeAssistantDb.contacts.values());
     }
     if (lower.includes("from contact_channels")) {
       // Mirror SQLite: referencing the dropped column errors; the NULL alias
       // is not a column reference.
       const columnRefs = lower.replaceAll("null as invite_id", "");
-      if (!fakeAssistantDb.hasInviteIdColumn && columnRefs.includes("invite_id")) {
+      if (
+        !fakeAssistantDb.hasInviteIdColumn &&
+        columnRefs.includes("invite_id")
+      ) {
         throw new Error("no such column: invite_id");
       }
       const rows = Array.from(fakeAssistantDb.channels.values());
@@ -104,7 +123,10 @@ import {
   resetGatewayDb,
 } from "../db/connection.js";
 import { contacts, contactChannels } from "../db/schema.js";
-import { up as m0006Up, down as m0006Down } from "../db/data-migrations/m0006-reconcile-contacts-from-assistant.js";
+import {
+  up as m0006Up,
+  down as m0006Down,
+} from "../db/data-migrations/m0006-reconcile-contacts-from-assistant.js";
 
 beforeAll(async () => {
   await initGatewayDb();
@@ -186,15 +208,15 @@ function seedAssistantChannel(opts: {
 }
 
 function gatewayContactIds(): string[] {
-  const rows = getGatewayDb().$client
-    .prepare("SELECT id FROM contacts")
+  const rows = getGatewayDb()
+    .$client.prepare("SELECT id FROM contacts")
     .all() as { id: string }[];
   return rows.map((r) => r.id).sort();
 }
 
 function gatewayChannelIds(): string[] {
-  const rows = getGatewayDb().$client
-    .prepare("SELECT id FROM contact_channels")
+  const rows = getGatewayDb()
+    .$client.prepare("SELECT id FROM contact_channels")
     .all() as { id: string }[];
   return rows.map((r) => r.id).sort();
 }
@@ -202,10 +224,26 @@ function gatewayChannelIds(): string[] {
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 describe("m0006-reconcile-contacts-from-assistant", () => {
+  test("checkpoints instead of throwing when the assistant ACL columns are gone", async () => {
+    // Assistant persistence migration 305 dropped contacts.role/principal_id.
+    // A gateway first running m0006 afterwards has no source to read.
+    fakeAssistantDb.hasAclColumns = false;
+    seedAssistantContact({ id: "unreachable", role: "guardian" });
+
+    const result = await m0006Up();
+
+    expect(result).toBe("done");
+    expect(gatewayContactIds()).toEqual([]);
+  });
+
   test("seeds contacts missing from gateway", async () => {
     seedGatewayContact({ id: "existing-gw" });
     seedAssistantContact({ id: "existing-gw" });
-    seedAssistantContact({ id: "missing-1", role: "guardian", principalId: "prin-1" });
+    seedAssistantContact({
+      id: "missing-1",
+      role: "guardian",
+      principalId: "prin-1",
+    });
     seedAssistantContact({ id: "missing-2" });
 
     const result = await m0006Up();
@@ -216,8 +254,8 @@ describe("m0006-reconcile-contacts-from-assistant", () => {
     );
 
     // Verify the reconciled contact has the right ACL fields.
-    const row = getGatewayDb().$client
-    .prepare("SELECT role, principal_id FROM contacts WHERE id = ?")
+    const row = getGatewayDb()
+      .$client.prepare("SELECT role, principal_id FROM contacts WHERE id = ?")
       .get("missing-1") as { role: string; principal_id: string };
     expect(row.role).toBe("guardian");
     expect(row.principal_id).toBe("prin-1");
@@ -234,8 +272,10 @@ describe("m0006-reconcile-contacts-from-assistant", () => {
     expect(gatewayChannelIds()).toEqual(["ch1", "ch2"].sort());
 
     // Verify channel has correct fields.
-    const ch = getGatewayDb().$client
-    .prepare("SELECT type, address, status FROM contact_channels WHERE id = ?")
+    const ch = getGatewayDb()
+      .$client.prepare(
+        "SELECT type, address, status FROM contact_channels WHERE id = ?",
+      )
       .get("ch1") as { type: string; address: string; status: string };
     expect(ch.type).toBe("telegram");
     expect(ch.address).toBe("addr-ch1");
@@ -244,13 +284,17 @@ describe("m0006-reconcile-contacts-from-assistant", () => {
 
   test("coerces an assistant escalate policy to deny on import", async () => {
     seedAssistantContact({ id: "c-esc" });
-    seedAssistantChannel({ id: "ch-esc", contactId: "c-esc", policy: "escalate" });
+    seedAssistantChannel({
+      id: "ch-esc",
+      contactId: "c-esc",
+      policy: "escalate",
+    });
 
     const result = await m0006Up();
 
     expect(result).toBe("done");
-    const ch = getGatewayDb().$client
-      .prepare("SELECT policy FROM contact_channels WHERE id = ?")
+    const ch = getGatewayDb()
+      .$client.prepare("SELECT policy FROM contact_channels WHERE id = ?")
       .get("ch-esc") as { policy: string };
     expect(ch.policy).toBe("deny");
   });
@@ -273,8 +317,8 @@ describe("m0006-reconcile-contacts-from-assistant", () => {
 
     await m0006Up();
 
-    const row = getGatewayDb().$client
-    .prepare("SELECT display_name FROM contacts WHERE id = ?")
+    const row = getGatewayDb()
+      .$client.prepare("SELECT display_name FROM contacts WHERE id = ?")
       .get("c1") as { display_name: string };
     // Gateway's version is preserved, not overwritten.
     expect(row.display_name).toBe("gateway-name");
@@ -322,8 +366,8 @@ describe("m0006-reconcile-contacts-from-assistant", () => {
     expect(result).toBe("done");
     expect(gatewayContactIds()).toEqual(["c1"]);
     expect(gatewayChannelIds()).toEqual(["ch1"]);
-    const ch = getGatewayDb().$client
-      .prepare("SELECT invite_id FROM contact_channels WHERE id = ?")
+    const ch = getGatewayDb()
+      .$client.prepare("SELECT invite_id FROM contact_channels WHERE id = ?")
       .get("ch1") as { invite_id: string | null };
     expect(ch.invite_id).toBeNull();
   });
@@ -345,8 +389,8 @@ describe("m0006-reconcile-contacts-from-assistant", () => {
   test("skips channels that conflict by (type, address) COLLATE NOCASE", async () => {
     // Gateway has contact c1 + a channel with address "Addr-1" (mixed case).
     seedGatewayContact({ id: "c1" });
-    getGatewayDb().$client
-      .prepare(
+    getGatewayDb()
+      .$client.prepare(
         `INSERT INTO contact_channels
            (id, contact_id, type, address, is_primary, external_chat_id,
             status, policy, verified_at, verified_via, invite_id,

--- a/gateway/src/__tests__/m0006-reconcile-contacts.test.ts
+++ b/gateway/src/__tests__/m0006-reconcile-contacts.test.ts
@@ -236,6 +236,18 @@ describe("m0006-reconcile-contacts-from-assistant", () => {
     expect(gatewayContactIds()).toEqual([]);
   });
 
+  test("checkpointing an already-seeded gateway leaves its contacts intact", async () => {
+    // The benign half of the branch above: the ACL landed before 305 ran, so
+    // the missing columns cost nothing.
+    fakeAssistantDb.hasAclColumns = false;
+    seedGatewayContact({ id: "already-seeded", role: "guardian" });
+
+    const result = await m0006Up();
+
+    expect(result).toBe("done");
+    expect(gatewayContactIds()).toEqual(["already-seeded"]);
+  });
+
   test("seeds contacts missing from gateway", async () => {
     seedGatewayContact({ id: "existing-gw" });
     seedAssistantContact({ id: "existing-gw" });

--- a/gateway/src/db/data-migrations/assistant-contact-acl-columns.ts
+++ b/gateway/src/db/data-migrations/assistant-contact-acl-columns.ts
@@ -1,0 +1,17 @@
+/**
+ * `contacts.role` and `contacts.principal_id` exist only on assistant DBs that
+ * predate their drop (assistant persistence migration 305). Migrations that
+ * copy the ACL source into the gateway probe with this helper first: once the
+ * columns are gone they are never coming back, so there is nothing to reconcile
+ * and nothing to wait for.
+ */
+
+import { assistantDbQuery } from "../assistant-db-proxy.js";
+
+export async function assistantHasContactAclColumns(): Promise<boolean> {
+  const rows = await assistantDbQuery(
+    `SELECT name FROM pragma_table_info('contacts')
+      WHERE name IN ('role', 'principal_id')`,
+  );
+  return rows.length === 2;
+}

--- a/gateway/src/db/data-migrations/m0006-reconcile-contacts-from-assistant.ts
+++ b/gateway/src/db/data-migrations/m0006-reconcile-contacts-from-assistant.ts
@@ -76,9 +76,24 @@ export async function up(): Promise<MigrationResult> {
     return "done";
   }
 
-  // Terminal, not transient: checkpoint rather than retry on every boot.
+  // Terminal, not transient: post-assistant-ready runs data migrations only
+  // after the assistant's own migrations, so once 305 ships the columns are
+  // always already gone here and no retry can ever see them. Checkpointing an
+  // empty gateway is real ACL loss, so say so rather than checkpointing quietly.
   if (!(await assistantHasContactAclColumns())) {
-    log.info("Assistant DB has no contact ACL columns — nothing to reconcile");
+    const gwContacts = (
+      gwDb.prepare("SELECT count(*) AS n FROM contacts").get() as { n: number }
+    ).n;
+    if (gwContacts === 0) {
+      log.warn(
+        "Assistant DB has no contact ACL columns and the gateway has no contacts — " +
+          "ACL was never reconciled and the source is gone; re-pair to recover",
+      );
+    } else {
+      log.info(
+        "Assistant DB has no contact ACL columns — nothing to reconcile",
+      );
+    }
     return "done";
   }
 

--- a/gateway/src/db/data-migrations/m0006-reconcile-contacts-from-assistant.ts
+++ b/gateway/src/db/data-migrations/m0006-reconcile-contacts-from-assistant.ts
@@ -17,6 +17,7 @@ import { Database } from "bun:sqlite";
 import { getGatewayDb } from "../connection.js";
 import { getLogger } from "../../logger.js";
 import { assistantDbQuery } from "../assistant-db-proxy.js";
+import { assistantHasContactAclColumns } from "./assistant-contact-acl-columns.js";
 import { assistantInviteIdSelect } from "./assistant-invite-id-column.js";
 
 import type { MigrationResult } from "./index.js";
@@ -72,6 +73,12 @@ export async function up(): Promise<MigrationResult> {
   );
   if (hasContactsTable.length === 0) {
     log.info("Assistant DB has no contacts table — nothing to reconcile");
+    return "done";
+  }
+
+  // Terminal, not transient: checkpoint rather than retry on every boot.
+  if (!(await assistantHasContactAclColumns())) {
+    log.info("Assistant DB has no contact ACL columns — nothing to reconcile");
     return "done";
   }
 

--- a/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
+++ b/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
@@ -23,6 +23,7 @@ import { Database } from "bun:sqlite";
 import { getGatewayDb } from "../connection.js";
 import { getLogger } from "../../logger.js";
 import { assistantDbQuery } from "../assistant-db-proxy.js";
+import { assistantHasContactAclColumns } from "./assistant-contact-acl-columns.js";
 import { assistantInviteIdSelect } from "./assistant-invite-id-column.js";
 
 import type { MigrationResult } from "./index.js";
@@ -85,6 +86,12 @@ export async function up(): Promise<MigrationResult> {
         "Assistant DB missing contacts/contact_channels — retrying next boot",
       );
       return "skip";
+    }
+
+    // Terminal, unlike the absent table above: checkpoint, don't retry.
+    if (!(await assistantHasContactAclColumns())) {
+      log.info("Assistant DB has no contact ACL columns — nothing to backfill");
+      return "done";
     }
 
     // ── 2. Read the assistant ACL source rows ──────────────────────────────

--- a/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
+++ b/gateway/src/db/data-migrations/m0008-upsert-acl-columns-from-assistant.ts
@@ -88,9 +88,26 @@ export async function up(): Promise<MigrationResult> {
       return "skip";
     }
 
-    // Terminal, unlike the absent table above: checkpoint, don't retry.
+    // Terminal, unlike the absent table above: data migrations run only after
+    // the assistant's own, so once 305 ships the columns are always already
+    // gone here and no retry can ever see them. Checkpointing an empty gateway
+    // is real ACL loss, so say so rather than checkpointing quietly.
     if (!(await assistantHasContactAclColumns())) {
-      log.info("Assistant DB has no contact ACL columns — nothing to backfill");
+      const gwContacts = (
+        gwDb.prepare("SELECT count(*) AS n FROM contacts").get() as {
+          n: number;
+        }
+      ).n;
+      if (gwContacts === 0) {
+        log.warn(
+          "Assistant DB has no contact ACL columns and the gateway has no contacts — " +
+            "ACL was never backfilled and the source is gone; re-pair to recover",
+        );
+      } else {
+        log.info(
+          "Assistant DB has no contact ACL columns — nothing to backfill",
+        );
+      }
       return "done";
     }
 


### PR DESCRIPTION
## Summary

- `m0006-reconcile-contacts-from-assistant` and `m0008-upsert-acl-columns-from-assistant` both `SELECT id, display_name, role, principal_id ... FROM contacts` against the assistant DB. `assistant/src/persistence/migrations/305-drop-contact-acl-columns.ts` drops `contacts.role` and `contacts.principal_id`, so a gateway that first runs these migrations *after* 305 has run throws `SQLiteError: no such column: role`.
- The runner (`gateway/src/db/data-migrations/index.ts`) only checkpoints on `"done"`; a throw is caught and logged as "will retry on next startup". So both migrations fail on **every boot, forever**, and never checkpoint.
- Both now probe for the ACL columns via a new `assistantHasContactAclColumns()` helper and return `"done"` when they are absent. The source is gone for good — there is nothing to reconcile and nothing to wait for. When the columns *are* present (an instance that has not yet run 305), behavior is unchanged.

Confirmed on a live gateway. Every boot logs:

```json
{"level":50,"err":{"name":"IpcTransportError","message":"SQLiteError: no such column: role"},
 "key":"m0006-reconcile-contacts-from-assistant","msg":"Data migration failed — will retry on next startup"}
```

and its `one_time_migrations` ledger has rows for m0005, m0007, m0009–m0014 but **no m0006 and no m0008** — the two gaps are exactly the two migrations that read the dropped columns.

## Why `"done"` and not `"skip"`

`"skip"` re-runs next boot, which is right for a *transient* condition. A dropped column is terminal — `"skip"` would preserve the infinite retry. m0008's existing `"skip"` for an absent `contacts`/`contact_channels` **table** is left as-is: no migration drops those tables, so an absent one means a fresh install that hasn't created the DB yet, which genuinely does resolve on a later boot.

## Real-world impact

This is not just log noise. An instance offline from 2026-06-24 to 2026-07-13 never booted during the window between m0006 shipping (2026-06-20, #35536) and 305 dropping its source (2026-07-02, #37030). m0006's first-ever run came 11 days after its source columns were deleted, so the gateway's `contacts` table was never populated (`contacts_total=0`, `guardian_rows=0`, `channels_total=0`, with 9 actor tokens intact).

With zero contacts, `gateway/src/risk/trust-verdict-resolver.ts` cannot classify anyone as guardian — both the address-match and guardian-by-principal paths start from a `contacts` row. `resolveOrCreateVellumGuardian` then correctly refuses to mint a replacement over evidence of prior onboarding (`VellumGuardianMintRefusedError`), producing a self-sustaining `missing_guardian` state: the seed path can't run, and bootstrap won't mint. **This is the mechanical reason that state never self-heals.** Every channel-ingress sender on such an instance resolves as a stranger.

## Prior art in this directory

`assistant-invite-id-column.ts` exists for exactly this problem — assistant migration 316 dropped `contact_channels.invite_id`, and readers tolerate it via a `pragma_table_info` probe. The new helper follows that idiom. The same shim was never added for `role`/`principal_id`.

## Testing

- New case in each of `m0006-reconcile-contacts.test.ts` and `data-migration-m0008-upsert-acl-columns-from-assistant.test.ts`: assistant `contacts` exists but lacks the ACL columns → `up()` returns `"done"` and writes nothing.
- Both fake-assistant mocks now model the dropped column the way they already model dropped `invite_id` (referencing it throws), so the tests reproduce the production error.
- **Verified these tests fail without the fix** (`no such column: role`, 2 fail) and pass with it (27 pass).
- The two test files also pick up Prettier line-wrapping on pre-existing lines — they were committed non-conforming and the format gate reformats the whole file once touched. Cosmetic only.
- Pre-existing on `origin/main`, unrelated to this change: `m0015-guardian-requests-backfill` and `m0017-coerce-escalate-policy` each fail one case when the data-migration suite runs as a batch (they pass in isolation — looks like `mock.module` leaking across files). Reproduced on a clean checkout with these changes stashed.

## Out of scope

- **The cross-service ordering hazard.** `gateway/AGENTS.md:177` documents the correct pattern — "m0016 (checkpoint-gated on m0015) dropped the assistant-side tables" — but 305 is assistant-side and cannot read the gateway's `one_time_migrations` ledger, which lives behind the `GATEWAY_SECURITY_DIR` security boundary. So this drop could not be checkpoint-gated the way m0016 was. Worth a design follow-up; this PR only makes the readers survive it.
- **Data recovery.** Any instance that ran 305 before m0006 ever succeeded has permanently lost its contact ACL data. This fix stops the failure loop; it cannot restore data.

## Original prompt

While diagnosing a live platform-hosted instance whose gateway reported `missing_guardian` with zero contacts, we traced the cause to m0006 throwing `no such column: role` on every boot since 2026-07-02. The user asked for a PR with the code fixes that investigation surfaced. The durable finding was that the only path which repopulates gateway contacts can never complete, which is why an empty `contacts` never recovers on its own.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->