### PR TITLE
feat(plugin-api): expose resolveCredential with plugin-scoped access

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -231,6 +231,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "tools/network/web-fetch.ts", // Firecrawl /scrape BYOK fetch provider API key lookup (firecrawl provider key)
       "workspace/default-provider-ensure.ts", // legacy anthropic echo disambiguation (vault key presence check)
       "providers/inference/connection-availability.ts", // shared (provider, connection) availability status (credential presence check only; value never leaves the helper)
+      "plugin-api/resolve-credential.ts", // plugin-facing resolveCredential — reveal-equivalent plaintext read, scoped to the in-context plugin's own field
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/plugin-api-resolve-credential.test.ts
+++ b/assistant/src/__tests__/plugin-api-resolve-credential.test.ts
@@ -1,65 +1,77 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
 
-// ---------------------------------------------------------------------------
-// Mutable mock state
-// ---------------------------------------------------------------------------
+import { credentialKey } from "@vellumai/credential-storage";
+
+import {
+  CredentialResolutionError,
+  resolveCredential,
+} from "../plugin-api/resolve-credential.js";
+import { runInPluginContext } from "../plugins/plugin-execution-context.js";
+import * as secureKeys from "../security/secure-keys.js";
+import {
+  _setMetadataPath,
+  upsertCredentialMetadata,
+} from "../tools/credentials/metadata-store.js";
+
+// Real metadata store backed by a temp file (no module mocking — a mock.module
+// on metadata-store / secure-keys would replace the whole module namespace and
+// leak into other test files in the same process). Only the secure backend read
+// is intercepted, via a restorable spy.
+
+const TEST_DIR = join(
+  tmpdir(),
+  `vellum-plugin-resolvecred-${randomBytes(4).toString("hex")}`,
+);
+const META_PATH = join(TEST_DIR, "metadata.json");
 
 let secureStore: Map<string, string>;
 let unreachable: boolean;
+let getSpy: ReturnType<typeof spyOn>;
 
-mock.module("../security/credential-key.js", () => ({
-  credentialKey: (service: string, field: string) => `${service}:${field}`,
-}));
-
-mock.module("@vellumai/credential-storage", () => ({
-  credentialKey: (service: string, field: string) => `${service}:${field}`,
-}));
-
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyResultAsync: mock(async (key: string) => ({
-    value: secureStore.get(key),
-    unreachable: unreachable && !secureStore.has(key),
-  })),
-}));
-
-interface FakeMeta {
-  credentialId: string;
-  service: string;
-  field: string;
-  injectionTemplates?: unknown[];
-}
-
-let metadataStore: Map<string, FakeMeta>;
-const metaKey = (service: string, field: string) => `${service}:${field}`;
-
-mock.module("../tools/credentials/metadata-store.js", () => ({
-  getCredentialMetadata: (service: string, field: string) =>
-    metadataStore.get(metaKey(service, field)),
-  getCredentialMetadataById: (id: string) =>
-    Array.from(metadataStore.values()).find((m) => m.credentialId === id),
-  listCredentialMetadata: () => Array.from(metadataStore.values()),
-}));
-
-// Imported AFTER mocks are registered.
-const { resolveCredential, CredentialResolutionError } =
-  await import("../plugin-api/resolve-credential.js");
-const { runInPluginContext } =
-  await import("../plugins/plugin-execution-context.js");
-
-function seedCredential(service: string, field: string, value: string): void {
-  metadataStore.set(metaKey(service, field), {
-    credentialId: `id-${service}-${field}`,
-    service,
-    field,
-    injectionTemplates: [],
-  });
-  secureStore.set(`${service}:${field}`, value);
+function seedCredential(service: string, field: string, value: string): string {
+  const meta = upsertCredentialMetadata(service, field, {});
+  secureStore.set(credentialKey(service, field), value);
+  return meta.credentialId;
 }
 
 beforeEach(() => {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
+  mkdirSync(TEST_DIR, { recursive: true });
+  _setMetadataPath(META_PATH);
+
   secureStore = new Map();
-  metadataStore = new Map();
   unreachable = false;
+  getSpy = spyOn(secureKeys, "getSecureKeyResultAsync").mockImplementation(
+    async (key: string) => ({
+      value: secureStore.get(key),
+      unreachable: unreachable && !secureStore.has(key),
+    }),
+  );
+});
+
+afterEach(() => {
+  getSpy.mockRestore();
+});
+
+afterAll(() => {
+  _setMetadataPath(null);
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true });
+  }
 });
 
 describe("resolveCredential", () => {
@@ -71,10 +83,8 @@ describe("resolveCredential", () => {
   });
 
   test("resolves plaintext by credential UUID", async () => {
-    seedCredential("stripe", "acme", "stripe-secret");
-    await expect(resolveCredential("id-stripe-acme")).resolves.toBe(
-      "stripe-secret",
-    );
+    const id = seedCredential("stripe", "acme", "stripe-secret");
+    await expect(resolveCredential(id)).resolves.toBe("stripe-secret");
   });
 
   test("throws not found for an unknown ref", async () => {
@@ -84,12 +94,7 @@ describe("resolveCredential", () => {
   });
 
   test("throws when the store is unreachable", async () => {
-    metadataStore.set(metaKey("openai", "api_key"), {
-      credentialId: "id-openai-api_key",
-      service: "openai",
-      field: "api_key",
-      injectionTemplates: [],
-    });
+    upsertCredentialMetadata("openai", "api_key", {});
     unreachable = true;
     await expect(resolveCredential("openai/api_key")).rejects.toThrow(
       /unreachable/,
@@ -114,13 +119,11 @@ describe("resolveCredential", () => {
 
     test("does not read the secure backend when out of scope", async () => {
       seedCredential("openai", "api_key", "sk-secret");
-      const secureKeys = await import("../security/secure-keys.js");
-      const spy = secureKeys.getSecureKeyResultAsync as ReturnType<typeof mock>;
-      spy.mockClear();
+      getSpy.mockClear();
       await expect(
         runInPluginContext("acme", () => resolveCredential("openai/api_key")),
       ).rejects.toThrow(CredentialResolutionError);
-      expect(spy).not.toHaveBeenCalled();
+      expect(getSpy).not.toHaveBeenCalled();
     });
 
     test("scoping applies by field only, across any service", async () => {

--- a/assistant/src/__tests__/plugin-api-resolve-credential.test.ts
+++ b/assistant/src/__tests__/plugin-api-resolve-credential.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mutable mock state
+// ---------------------------------------------------------------------------
+
+let secureStore: Map<string, string>;
+let unreachable: boolean;
+
+mock.module("../security/credential-key.js", () => ({
+  credentialKey: (service: string, field: string) => `${service}:${field}`,
+}));
+
+mock.module("@vellumai/credential-storage", () => ({
+  credentialKey: (service: string, field: string) => `${service}:${field}`,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyResultAsync: mock(async (key: string) => ({
+    value: secureStore.get(key),
+    unreachable: unreachable && !secureStore.has(key),
+  })),
+}));
+
+interface FakeMeta {
+  credentialId: string;
+  service: string;
+  field: string;
+  injectionTemplates?: unknown[];
+}
+
+let metadataStore: Map<string, FakeMeta>;
+const metaKey = (service: string, field: string) => `${service}:${field}`;
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: (service: string, field: string) =>
+    metadataStore.get(metaKey(service, field)),
+  getCredentialMetadataById: (id: string) =>
+    Array.from(metadataStore.values()).find((m) => m.credentialId === id),
+  listCredentialMetadata: () => Array.from(metadataStore.values()),
+}));
+
+// Imported AFTER mocks are registered.
+const { resolveCredential, CredentialResolutionError } =
+  await import("../plugin-api/resolve-credential.js");
+const { runInPluginContext } =
+  await import("../plugins/plugin-execution-context.js");
+
+function seedCredential(service: string, field: string, value: string): void {
+  metadataStore.set(metaKey(service, field), {
+    credentialId: `id-${service}-${field}`,
+    service,
+    field,
+    injectionTemplates: [],
+  });
+  secureStore.set(`${service}:${field}`, value);
+}
+
+beforeEach(() => {
+  secureStore = new Map();
+  metadataStore = new Map();
+  unreachable = false;
+});
+
+describe("resolveCredential", () => {
+  test("resolves plaintext by service/field ref when no plugin is in context", async () => {
+    seedCredential("openai", "api_key", "sk-secret");
+    await expect(resolveCredential("openai/api_key")).resolves.toBe(
+      "sk-secret",
+    );
+  });
+
+  test("resolves plaintext by credential UUID", async () => {
+    seedCredential("stripe", "acme", "stripe-secret");
+    await expect(resolveCredential("id-stripe-acme")).resolves.toBe(
+      "stripe-secret",
+    );
+  });
+
+  test("throws not found for an unknown ref", async () => {
+    await expect(resolveCredential("nope/missing")).rejects.toBeInstanceOf(
+      CredentialResolutionError,
+    );
+  });
+
+  test("throws when the store is unreachable", async () => {
+    metadataStore.set(metaKey("openai", "api_key"), {
+      credentialId: "id-openai-api_key",
+      service: "openai",
+      field: "api_key",
+      injectionTemplates: [],
+    });
+    unreachable = true;
+    await expect(resolveCredential("openai/api_key")).rejects.toThrow(
+      /unreachable/,
+    );
+  });
+
+  describe("plugin scoping", () => {
+    test("allows a plugin to resolve a credential whose field matches its name", async () => {
+      seedCredential("openai", "acme", "scoped-secret");
+      const value = await runInPluginContext("acme", () =>
+        resolveCredential("openai/acme"),
+      );
+      expect(value).toBe("scoped-secret");
+    });
+
+    test("blocks a plugin from resolving a credential whose field differs from its name", async () => {
+      seedCredential("openai", "api_key", "sk-secret");
+      await expect(
+        runInPluginContext("acme", () => resolveCredential("openai/api_key")),
+      ).rejects.toThrow(/out of scope/);
+    });
+
+    test("does not read the secure backend when out of scope", async () => {
+      seedCredential("openai", "api_key", "sk-secret");
+      const secureKeys = await import("../security/secure-keys.js");
+      const spy = secureKeys.getSecureKeyResultAsync as ReturnType<typeof mock>;
+      spy.mockClear();
+      await expect(
+        runInPluginContext("acme", () => resolveCredential("openai/api_key")),
+      ).rejects.toThrow(CredentialResolutionError);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test("scoping applies by field only, across any service", async () => {
+      seedCredential("stripe", "acme", "stripe-secret");
+      seedCredential("openai", "acme", "openai-secret");
+      await expect(
+        runInPluginContext("acme", () => resolveCredential("stripe/acme")),
+      ).resolves.toBe("stripe-secret");
+      await expect(
+        runInPluginContext("acme", () => resolveCredential("openai/acme")),
+      ).resolves.toBe("openai-secret");
+    });
+  });
+});

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -150,6 +150,16 @@ export { getModelProfiles } from "./model-profiles.js";
 // looks up the model catalog's `supportsVision` flag (mix profiles are
 // vision-capable if any arm is). Returns false when nothing resolves.
 export { doesSupportVision } from "./vision-support.js";
+// Resolve a stored credential to its plaintext value — the same value
+// `assistant credentials reveal` prints — from a UUID or a "service/field"
+// reference. When a plugin is in context, resolution is scoped to credentials
+// whose `field` matches the plugin's manifest name; outside any plugin it is
+// unscoped. Throws CredentialResolutionError when the ref does not resolve, the
+// store is unreachable, or the credential is out of the plugin's scope.
+export {
+  CredentialResolutionError,
+  resolveCredential,
+} from "./resolve-credential.js";
 // Resolve a provider for a call site (optionally overriding the profile) so a
 // plugin can run inference through the workspace's configured profiles and
 // credentials — managed-proxy or BYOK — without supplying its own API key.

--- a/assistant/src/plugin-api/resolve-credential.ts
+++ b/assistant/src/plugin-api/resolve-credential.ts
@@ -1,0 +1,75 @@
+/**
+ * Plugin-facing credential resolution.
+ *
+ * {@link resolveCredential} returns a stored credential's plaintext value — the
+ * same value `assistant credentials reveal` prints — resolving a reference that
+ * is either a credential UUID or a `"service/field"` string, exactly as the
+ * reveal path does (see {@link ../tools/credentials/resolve.resolveCredentialRef}
+ * and the `credentials/reveal` route).
+ *
+ * ## Plugin scoping
+ *
+ * When a plugin is in context — its hook or tool is executing, tracked by
+ * {@link ../plugins/plugin-execution-context.getCurrentPluginName} — resolution
+ * is restricted: the plugin may only resolve credentials whose `field` equals
+ * the plugin's own manifest name. A plugin named `acme` can therefore read
+ * `openai/acme` or `stripe/acme` but not `openai/api_key`. Outside any plugin
+ * context (host-internal callers, CLI, tests) the resolver is unscoped and
+ * behaves like a direct reveal.
+ */
+
+import { getCurrentPluginName } from "../plugins/plugin-execution-context.js";
+import { getSecureKeyResultAsync } from "../security/secure-keys.js";
+import { resolveCredentialRef } from "../tools/credentials/resolve.js";
+
+/**
+ * Raised when a credential cannot be resolved: the reference does not match a
+ * stored credential, the store is unreachable, or the calling plugin is not
+ * permitted to resolve the requested credential.
+ */
+export class CredentialResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CredentialResolutionError";
+  }
+}
+
+/**
+ * Resolve a credential reference to its plaintext value.
+ *
+ * @param ref A credential UUID or a `"service/field"` string.
+ * @returns The plaintext credential value.
+ * @throws {CredentialResolutionError} when the reference does not resolve, the
+ *   store is unreachable, or a plugin in context is not scoped to the credential.
+ */
+export async function resolveCredential(ref: string): Promise<string> {
+  const resolved = resolveCredentialRef(ref);
+  if (!resolved) {
+    throw new CredentialResolutionError(`Credential not found: ${ref}`);
+  }
+
+  // Scope the resolution to the plugin in context, if any. The field-name gate
+  // is enforced before the plaintext is read so an out-of-scope plugin never
+  // touches the secure backend.
+  const pluginName = getCurrentPluginName();
+  if (pluginName !== undefined && resolved.field !== pluginName) {
+    throw new CredentialResolutionError(
+      `Plugin "${pluginName}" may only resolve credentials whose field matches its name; ` +
+        `"${resolved.service}/${resolved.field}" is out of scope.`,
+    );
+  }
+
+  const { value, unreachable } = await getSecureKeyResultAsync(
+    resolved.storageKey,
+  );
+  if (value == null || value.length === 0) {
+    if (unreachable) {
+      throw new CredentialResolutionError(
+        "Credential store is unreachable — ensure the assistant is running",
+      );
+    }
+    throw new CredentialResolutionError(`Credential not found: ${ref}`);
+  }
+
+  return value;
+}

--- a/assistant/src/plugins/AGENTS.md
+++ b/assistant/src/plugins/AGENTS.md
@@ -18,28 +18,6 @@ Canonical example: `defaults/image-fallback` — `hooks/init.ts` opens `caption-
 
 Calling the assistant's service APIs from a default plugin (e.g. `persistence/conversation-crud.ts` reads) is fine — the boundary is about _owning state_: plugin tables, plugin migrations, and plugin files belong to the plugin.
 
-## Plugin Execution Context & Credential Scoping
-
-Host APIs that must know _which_ plugin is calling them read the plugin
-currently in context from the `AsyncLocalStorage` in
-`plugin-execution-context.ts`. The context is established around a plugin's hook
-invocation (`pipeline.ts` `runHook`, when `owner.kind === "plugin"`) and around
-a plugin tool's `execute()` (`tools/executor.ts`, when the tool's registry owner
-is a plugin). Standalone workspace hooks and non-plugin tools establish no
-context.
-
-`@vellumai/plugin-api`'s `resolveCredential(ref)` uses this to scope credential
-access: when a plugin is in context, it may only resolve credentials whose
-`field` equals the plugin's manifest name (`resolve-credential.ts`). Outside any
-plugin context the resolver is unscoped (behaves like `assistant credentials
-reveal`).
-
-**When adding a new seam that runs plugin-authored code** (a new hook type, a new
-plugin surface), wrap the invocation in `runInPluginContext(pluginName, …)` so
-scoped host APIs keep enforcing. The context must be set around the call that
-_creates_ the plugin's promise, not around the `await`, so the binding
-propagates across the plugin's internal awaits.
-
 ## Plugin HTTP Routes
 
 A plugin's HTTP routes live on disk under `<pluginDir>/routes/` and are served in the plugin's own namespace at `/x/plugins/<plugin-name>/<path>`. They are **not** a `Plugin` contribution slot and are not wired through the loader or bootstrap — the `/x/*` route dispatcher (`runtime/routes/user-route-dispatcher.ts`) resolves each request against the filesystem at request time, exactly like the workspace `/x/*` user routes it shares code with.

--- a/assistant/src/plugins/AGENTS.md
+++ b/assistant/src/plugins/AGENTS.md
@@ -18,6 +18,28 @@ Canonical example: `defaults/image-fallback` — `hooks/init.ts` opens `caption-
 
 Calling the assistant's service APIs from a default plugin (e.g. `persistence/conversation-crud.ts` reads) is fine — the boundary is about _owning state_: plugin tables, plugin migrations, and plugin files belong to the plugin.
 
+## Plugin Execution Context & Credential Scoping
+
+Host APIs that must know _which_ plugin is calling them read the plugin
+currently in context from the `AsyncLocalStorage` in
+`plugin-execution-context.ts`. The context is established around a plugin's hook
+invocation (`pipeline.ts` `runHook`, when `owner.kind === "plugin"`) and around
+a plugin tool's `execute()` (`tools/executor.ts`, when the tool's registry owner
+is a plugin). Standalone workspace hooks and non-plugin tools establish no
+context.
+
+`@vellumai/plugin-api`'s `resolveCredential(ref)` uses this to scope credential
+access: when a plugin is in context, it may only resolve credentials whose
+`field` equals the plugin's manifest name (`resolve-credential.ts`). Outside any
+plugin context the resolver is unscoped (behaves like `assistant credentials
+reveal`).
+
+**When adding a new seam that runs plugin-authored code** (a new hook type, a new
+plugin surface), wrap the invocation in `runInPluginContext(pluginName, …)` so
+scoped host APIs keep enforcing. The context must be set around the call that
+_creates_ the plugin's promise, not around the `await`, so the binding
+propagates across the plugin's internal awaits.
+
 ## Plugin HTTP Routes
 
 A plugin's HTTP routes live on disk under `<pluginDir>/routes/` and are served in the plugin's own namespace at `/x/plugins/<plugin-name>/<path>`. They are **not** a `Plugin` contribution slot and are not wired through the loader or bootstrap — the `/x/*` route dispatcher (`runtime/routes/user-route-dispatcher.ts`) resolves each request against the filesystem at request time, exactly like the workspace `/x/*` user routes it shares code with.

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -25,6 +25,7 @@ import { getHookEntriesFor } from "../hooks/registry.js";
 import type { BaseHookContext } from "../hooks/types.js";
 import { type HookName, HOOKS } from "../plugin-api/constants.js";
 import { getLogger } from "../util/logger.js";
+import { runInPluginContext } from "./plugin-execution-context.js";
 import type { HookEntry } from "./types.js";
 
 // ─── Hook runner ────────────────────────────────────────────────────────────
@@ -352,8 +353,15 @@ export async function runHook<TInput extends object>(
       broadcast: makeHookBroadcast({ conversationId, hookName: name, owner }),
     };
     try {
+      // Mark the contributing plugin as in context so host APIs the hook
+      // reaches (e.g. resolveCredential) can scope to it. Standalone workspace
+      // hooks are not plugins and establish no context.
+      const invokeHook =
+        owner.kind === "plugin"
+          ? () => runInPluginContext(owner.id, () => fn(draft))
+          : () => fn(draft);
       const result = await callWithTimeout(
-        () => fn(draft),
+        invokeHook,
         HOOK_TIMEOUT_MS,
         `plugin hook '${name}' (${owner.id}) timed out after ${HOOK_TIMEOUT_MS}ms`,
       );

--- a/assistant/src/plugins/plugin-execution-context.ts
+++ b/assistant/src/plugins/plugin-execution-context.ts
@@ -1,0 +1,44 @@
+/**
+ * Plugin execution context — tracks which plugin's code is currently running.
+ *
+ * Host APIs exposed to plugins through `@vellumai/plugin-api` sometimes need to
+ * know *which* plugin is calling them so they can scope their behavior to that
+ * plugin (e.g. {@link ../plugin-api/resolve-credential.resolveCredential} limits
+ * a plugin to its own credentials). A plugin's manifest name is not threaded
+ * through every host call, so the pipeline that invokes a plugin's hook — and
+ * the tool executor that runs a plugin's tool — mark the plugin as "in context"
+ * for the duration of that invocation via an {@link AsyncLocalStorage}. Host
+ * APIs read {@link getCurrentPluginName} to recover it.
+ *
+ * The store propagates across `await` boundaries, so a plugin that awaits a
+ * host API deep inside its hook/tool body is still seen as in context. When no
+ * plugin is in context (host-internal callers, the CLI, tests), the store is
+ * empty and scoped APIs fall back to their unscoped behavior.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface PluginExecutionContext {
+  /** Manifest name of the plugin whose hook or tool is currently executing. */
+  pluginName: string;
+}
+
+const storage = new AsyncLocalStorage<PluginExecutionContext>();
+
+/**
+ * Run `fn` with `pluginName` marked as the plugin currently in context. The
+ * returned value (including a promise) carries the context across its async
+ * continuations, so callers pass the promise straight to a timeout wrapper
+ * without losing the binding.
+ */
+export function runInPluginContext<T>(pluginName: string, fn: () => T): T {
+  return storage.run({ pluginName }, fn);
+}
+
+/**
+ * Name of the plugin whose hook or tool is currently executing, or `undefined`
+ * when no plugin is in context.
+ */
+export function getCurrentPluginName(): string | undefined {
+  return storage.getStore()?.pluginName;
+}

--- a/assistant/src/runtime/routes/__tests__/migration-vellum-metadata-reconcile.test.ts
+++ b/assistant/src/runtime/routes/__tests__/migration-vellum-metadata-reconcile.test.ts
@@ -28,6 +28,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { credentialKey } from "../../../security/credential-key.js";
+import * as actualMetadataStore from "../../../tools/credentials/metadata-store.js";
 
 type MetadataRecord = {
   credentialId: string;
@@ -80,7 +81,13 @@ mock.module("../../../security/secure-keys.js", () => ({
   _resetBackend: () => {},
 }));
 
+// Spread the real module so every export the reconcile handler's transitive
+// graph links (e.g. getCredentialMetadataById, listCredentialMetadata pulled in
+// via the plugin-api hub) stays present; only the two functions under test are
+// overridden. A partial mock replaces the whole namespace and fails to link the
+// unlisted exports.
 mock.module("../../../tools/credentials/metadata-store.js", () => ({
+  ...actualMetadataStore,
   getCredentialMetadata: (service: string, field: string) =>
     metadataStore.get(`${service}:${field}`),
   upsertCredentialMetadata: (

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { getConfig } from "../config/loader.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { RiskLevel } from "../permissions/types.js";
+import { runInPluginContext } from "../plugins/plugin-execution-context.js";
 import { TokenExpiredError } from "../security/token-manager.js";
 import {
   recordToolError,
@@ -19,6 +20,7 @@ import {
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
 import { executeWithTimeout, safeTimeoutMs } from "./execution-timeout.js";
 import { PermissionChecker } from "./permission-checker.js";
+import { getToolOwner } from "./registry.js";
 import { extractAndSanitize } from "./sensitive-output-placeholders.js";
 import { applyEdit } from "./shared/filesystem/edit-engine.js";
 import { sandboxPolicy } from "./shared/filesystem/path-policy.js";
@@ -223,8 +225,19 @@ export class ToolExecutor {
       const toolTimeoutMs = computePerToolTimeoutMs(name, input);
       const execContext = context;
 
+      // Mark the owning plugin as in context (via AsyncLocalStorage) so host
+      // APIs the tool reaches — e.g. resolveCredential — can scope to it. The
+      // context must be established around the `execute()` call itself so the
+      // returned promise carries the binding across its awaits. Non-plugin
+      // tools (default/skill/mcp/workspace) establish no context.
+      const owner = getToolOwner(name);
+      const execPromise =
+        owner?.kind === "plugin"
+          ? runInPluginContext(owner.id, () => tool.execute(input, execContext))
+          : tool.execute(input, execContext);
+
       let execResult: ToolExecutionResult = await executeWithTimeout(
-        tool.execute(input, execContext),
+        execPromise,
         toolTimeoutMs,
         name,
       );


### PR DESCRIPTION
## Prompt / plan

> expose a `resolveCredential(...)` in the plugin-api. this will resolve a credential in the same way that `assistant credentials reveal` does, but we should figure out a way to hack on plugin scoping somehow such that if the loaded plugin is in context, we only allow credentials to be resolved from `field == plugin name`

### What this adds

`@vellumai/plugin-api` now exports `resolveCredential(ref)` (plus a `CredentialResolutionError`). Given a reference that is either a credential UUID or a `"service/field"` string, it returns the credential's plaintext value — the same value `assistant credentials reveal` prints — by reusing the existing resolution primitives (`resolveCredentialRef` + `getSecureKeyResultAsync`), not by duplicating the reveal logic.

### The plugin-scoping "hack"

There was no existing notion of a "plugin currently in context" at a host API call site — hook/tool code just calls into `@vellumai/plugin-api` functions with no ambient identity. This PR introduces one:

- **`plugins/plugin-execution-context.ts`** — an `AsyncLocalStorage` that records the manifest name of the plugin whose code is running. It propagates across `await` boundaries.
- The **hook pipeline** (`pipeline.ts` `runHook`) and the **tool executor** (`tools/executor.ts`) establish this context around a plugin's invocation — but only when the owner is a plugin (`owner.kind === "plugin"` for hooks; the tool registry's owner kind for tools). Standalone workspace hooks and default/skill/mcp/workspace tools establish no context. The context is set around the call that *creates* the plugin's promise so the binding survives the plugin's internal awaits.

`resolveCredential` reads that context: when a plugin is in context, it may only resolve credentials whose **`field` equals the plugin's name** (e.g. plugin `acme` can read `openai/acme` or `stripe/acme`, but not `openai/api_key`). The field-name gate runs *before* the secure backend is touched, so an out-of-scope plugin never reaches the credential store. Outside any plugin context (host-internal callers, CLI, tests) the resolver is unscoped and behaves like a direct reveal.

## Test plan

- New unit suite `src/__tests__/plugin-api-resolve-credential.test.ts` (8 tests): resolution by service/field and by UUID; not-found and store-unreachable errors; in-scope allow; out-of-scope block; verification that the secure backend is *not* read when out of scope; and that scoping keys on `field` across any service.
- Existing `plugin-api-shim`, tool-executor lifecycle, and hook-pipeline suites still pass (the 5 pre-existing `plugin-pipeline` failures on `main` are unrelated to this change).
- `bunx tsc --noEmit`, `eslint`, and prettier all clean via the pre-commit hook.

<!-- No new routes added; CLI verb checklist not applicable. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015p41vB8KPZq7k1gpuQHXHY

---
_Generated by [Claude Code](https://claude.ai/code/session_015p41vB8KPZq7k1gpuQHXHY)_