### PR TITLE
feat(plugins): support upgrading untrusted GitHub-URL installs

### DIFF
--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -227,7 +227,7 @@ $ assistant plugins publish --json`,
       name: "upgrade",
       args: "<name>",
       description:
-        "Upgrade an installed plugin to the marketplace's current pin",
+        "Upgrade an installed plugin to its source's current revision (the marketplace pin, or — for a GitHub-URL install — whatever its recorded branch/tag/ref now resolves to)",
       options: [
         {
           flags: "--dry-run",
@@ -235,13 +235,24 @@ $ assistant plugins publish --json`,
         },
         {
           flags: "--strategy <strategy>",
-          description: `How to reconcile local edits with the pin: ${PLUGIN_UPGRADE_STRATEGIES.join(", ")} (default: ${DEFAULT_PLUGIN_UPGRADE_STRATEGY})`,
+          description: `How to reconcile local edits with the target: ${PLUGIN_UPGRADE_STRATEGIES.join(", ")} (default: ${DEFAULT_PLUGIN_UPGRADE_STRATEGY})`,
         },
         {
           flags: "--json",
           description: "Emit machine-readable JSON instead of a summary",
         },
       ],
+      helpText: `
+A marketplace plugin upgrades to the curated pin. A plugin installed directly
+from a GitHub URL (untrusted) upgrades against its recorded source: it re-fetches
+whatever its recorded ref resolves to now — a pinned commit SHA is immutable (a
+no-op), while a branch/tag/HEAD advances as upstream does — and re-materializes
+it verbatim, with no curated adapter overlay.
+
+Examples:
+  $ assistant plugins upgrade example
+  $ assistant plugins upgrade example --dry-run
+  $ assistant plugins upgrade example --strategy ours`,
     },
   ],
 };

--- a/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
@@ -24,6 +24,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { FetchLike } from "../fetch-like.js";
 import {
   type GitRunner,
+  PluginNotFoundError,
   PluginSourceUnavailableError,
 } from "../install-from-github.js";
 import { computeFingerprint } from "../plugin-fingerprint.js";
@@ -140,11 +141,50 @@ const unusedGitRunner: GitRunner = async (args) => {
   throw new Error(`git should not run for this upgrade: ${args.join(" ")}`);
 };
 
-/** Materialize an installed plugin copy with an optional provenance sidecar. */
+/**
+ * A fake git for a direct (GitHub-URL) upgrade. `ls-remote <url> <ref>` resolves
+ * `<ref>` to a commit via `refToCommit` (empty stdout when the ref is absent,
+ * modeling a deleted branch); a `fetch` clone materializes one file and reports
+ * `headCommit` at HEAD, mirroring the recorded-source re-install.
+ */
+function directGitRunner(
+  refToCommit: Record<string, string>,
+  headCommit: string,
+  opts: { calls?: string[][] } = {},
+): GitRunner {
+  return async (args, { cwd }) => {
+    opts.calls?.push([...args]);
+    switch (args[0]) {
+      case "ls-remote": {
+        const ref = args[args.length - 1]!;
+        const sha = refToCommit[ref];
+        return { stdout: sha ? `${sha}\trefs/heads/${ref}\n` : "" };
+      }
+      case "fetch": {
+        mkdirSync(join(cwd, ".git"), { recursive: true });
+        writeFileSync(join(cwd, ".git", "config"), "[core]\n");
+        writeFileSync(join(cwd, "package.json"), '{"name":"level-up"}');
+        return { stdout: "" };
+      }
+      case "rev-parse":
+        return { stdout: `${headCommit}\n` };
+      default:
+        return { stdout: "" };
+    }
+  };
+}
+
+/**
+ * Materialize an installed plugin copy with an optional provenance sidecar.
+ *
+ * `sidecar.ref` overrides the recorded source ref; it defaults to `commit`
+ * (a marketplace-style SHA pin). A branch/tag/`HEAD` ref models a direct
+ * (untrusted) GitHub-URL install, whose upgrade re-fetches that ref.
+ */
 function installCopy(
   pluginsDir: string,
   name: string,
-  sidecar: { commit: string; committedAt?: string } | null,
+  sidecar: { commit: string; committedAt?: string; ref?: string } | null,
 ): void {
   const dir = join(pluginsDir, name);
   mkdirSync(dir, { recursive: true });
@@ -162,7 +202,7 @@ function installCopy(
           kind: "github",
           owner: "example-org",
           repo: name,
-          ref: sidecar.commit,
+          ref: sidecar.ref ?? sidecar.commit,
         },
         commit: sidecar.commit,
         committedAt: sidecar.committedAt,
@@ -333,13 +373,14 @@ describe("upgradePlugin", () => {
     ).rejects.toBeInstanceOf(PluginNotInstalledError);
   });
 
-  test("throws PluginNotUpgradableError when not in the marketplace", async () => {
-    // GIVEN an installed copy but an empty marketplace catalog
-    installCopy(pluginsDir, "level-up", { commit: SHA_A });
+  test("throws PluginNotUpgradableError when not in the marketplace and no source is recorded", async () => {
+    // GIVEN an installed copy with no provenance sidecar (a manual copy) and an
+    // empty marketplace catalog
+    installCopy(pluginsDir, "level-up", null);
     const fetch = makeFetch({ manifest: undefined });
 
     // WHEN an upgrade is attempted
-    // THEN there is no pin to advance to
+    // THEN there is neither a marketplace pin nor a recorded source to advance
     await expect(
       upgradePlugin(
         { name: "level-up" },
@@ -388,6 +429,120 @@ describe("upgradePlugin", () => {
   });
 });
 
+describe("upgradePlugin — direct GitHub-URL installs", () => {
+  test("re-fetches the recorded branch when it has advanced", async () => {
+    // GIVEN a direct install tracking the `main` branch at SHA_A, absent from
+    // the marketplace
+    installCopy(pluginsDir, "level-up", { commit: SHA_A, ref: "main" });
+    const fetch = makeFetch({ manifest: undefined });
+    // AND the branch now points at SHA_B
+    const calls: string[][] = [];
+    const runGit = directGitRunner({ main: SHA_B }, SHA_B, { calls });
+
+    // WHEN the plugin is upgraded
+    const result = await upgradePlugin(
+      { name: "level-up" },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN it moves to the branch's current commit and records it
+    expect(result.outcome).toBe("upgraded");
+    expect(result.fromCommit).toBe(SHA_A);
+    expect(result.toCommit).toBe(SHA_B);
+    expect(result.fileCount).toBeGreaterThan(0);
+    expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_B);
+    // AND the recorded ref stays the branch, so later upgrades keep tracking it
+    const meta = JSON.parse(
+      readFileSync(join(pluginsDir, "level-up", "install-meta.json"), "utf-8"),
+    );
+    expect(meta.source.ref).toBe("main");
+    // AND the drift was resolved without cloning first (ls-remote, then fetch)
+    expect(calls[0]?.[0]).toBe("ls-remote");
+  });
+
+  test("is a no-op when the recorded branch still points at the installed commit", async () => {
+    // GIVEN a direct install tracking `main` at SHA_A
+    installCopy(pluginsDir, "level-up", { commit: SHA_A, ref: "main" });
+    const fetch = makeFetch({ manifest: undefined });
+    // AND the branch still resolves to SHA_A
+    const runGit = directGitRunner({ main: SHA_A }, SHA_A);
+
+    // WHEN the plugin is upgraded
+    const result = await upgradePlugin(
+      { name: "level-up" },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN it reports already-up-to-date and makes no changes
+    expect(result.outcome).toBe("already-up-to-date");
+    expect(result.fileCount).toBeNull();
+    expect(result.toCommit).toBe(SHA_A);
+  });
+
+  test("a SHA-pinned direct install is already up to date without any git", async () => {
+    // GIVEN a direct install pinned to an immutable full SHA
+    installCopy(pluginsDir, "level-up", { commit: SHA_A, ref: SHA_A });
+    const fetch = makeFetch({ manifest: undefined });
+
+    // WHEN the plugin is upgraded (git must never run — a SHA resolves to itself)
+    const result = await upgradePlugin(
+      { name: "level-up" },
+      { fetch, runGit: unusedGitRunner, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN there is nothing to advance to
+    expect(result.outcome).toBe("already-up-to-date");
+    expect(result.toCommit).toBe(SHA_A);
+  });
+
+  test("a dry run previews the move and resolves the target timestamp", async () => {
+    // GIVEN a direct install tracking `main` at SHA_A, whose HEAD dates
+    installCopy(pluginsDir, "level-up", {
+      commit: SHA_A,
+      committedAt: "2026-06-01T12:34:56.000Z",
+      ref: "main",
+    });
+    const fetch = makeFetch({ remoteCommitDate: "2026-06-05T08:12:24.000Z" });
+    // A dry run resolves the ref (ls-remote) but must never clone.
+    const runGit: GitRunner = async (args, ctx) => {
+      if (args[0] === "ls-remote") {
+        return directGitRunner({ main: SHA_B }, SHA_B)(args, ctx);
+      }
+      throw new Error(`git should not clone for a dry run: ${args.join(" ")}`);
+    };
+
+    // WHEN a dry-run upgrade is performed
+    const result = await upgradePlugin(
+      { name: "level-up", dryRun: true },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN it previews the move with the resolved timestamps, untouched on disk
+    expect(result.outcome).toBe("would-upgrade");
+    expect(result.dryRun).toBe(true);
+    expect(result.fromTimestamp).toBe("2026-06-01T12:34:56.000Z");
+    expect(result.toTimestamp).toBe("2026-06-05T08:12:24.000Z");
+    expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_A);
+  });
+
+  test("throws PluginNotFoundError when the recorded ref has vanished", async () => {
+    // GIVEN a direct install tracking a branch that no longer exists upstream
+    installCopy(pluginsDir, "level-up", { commit: SHA_A, ref: "gone" });
+    const fetch = makeFetch({ manifest: undefined });
+    // ls-remote resolves the branch to nothing (empty stdout)
+    const runGit = directGitRunner({}, SHA_B);
+
+    // WHEN an upgrade is attempted
+    // THEN there is no revision to advance to
+    await expect(
+      upgradePlugin(
+        { name: "level-up" },
+        { fetch, runGit, workspacePluginsDir: pluginsDir },
+      ),
+    ).rejects.toBeInstanceOf(PluginNotFoundError);
+  });
+});
+
 /** A file tree keyed by POSIX-relative path. */
 type Tree = Record<string, string>;
 
@@ -398,10 +553,18 @@ type Tree = Record<string, string>;
  * the last `git fetch` argument; `rev-parse HEAD` echoes it back so the
  * checked-out commit matches the requested ref.
  */
-function treeGitRunner(treesByRef: Record<string, Tree>): GitRunner {
+function treeGitRunner(
+  treesByRef: Record<string, Tree>,
+  lsRemote: Record<string, string> = {},
+): GitRunner {
   const refByCwd = new Map<string, string>();
   return async (args, { cwd }) => {
     switch (args[0]) {
+      case "ls-remote": {
+        const ref = args[args.length - 1]!;
+        const sha = lsRemote[ref];
+        return { stdout: sha ? `${sha}\trefs/heads/${ref}\n` : "" };
+      }
       case "fetch": {
         const ref = args[args.length - 1];
         refByCwd.set(cwd, ref);
@@ -436,6 +599,7 @@ function installMergeCopy(
   ours: Tree,
   commit: string,
   fingerprintTree: Tree | null,
+  ref: string = commit,
 ): void {
   const dir = join(pluginsDir, name);
   mkdirSync(dir, { recursive: true });
@@ -447,7 +611,7 @@ function installMergeCopy(
   const sidecar: Record<string, unknown> = {
     origin: "vellum",
     name,
-    source: { kind: "github", owner: "example-org", repo: name, ref: commit },
+    source: { kind: "github", owner: "example-org", repo: name, ref },
     commit,
     installedAt: "2026-06-10T12:00:00.000Z",
   };
@@ -673,5 +837,45 @@ describe("upgradePlugin --strategy", () => {
         { fetch, runGit, workspacePluginsDir: pluginsDir },
       ),
     ).rejects.toBeInstanceOf(PluginMergeBaselineError);
+  });
+
+  test("--strategy ours merges a direct GitHub-URL install's local edits forward", async () => {
+    // A direct install carries no curated adapter overlay, so the base/target
+    // re-materialize verbatim (stubRef null). Include a package.json in each
+    // tree so no minimal manifest is synthesized — matching what a real direct
+    // install recorded — and the base fingerprint reconstructs faithfully.
+    const PKG = '{"name":"level-up"}\n';
+    const directBase: Tree = { ...BASE, "package.json": PKG };
+    const directOurs: Tree = { ...OURS, "package.json": PKG };
+    const directTheirs: Tree = { ...THEIRS, "package.json": PKG };
+
+    // GIVEN a direct install tracking `main` at SHA_A with local edits, absent
+    // from the marketplace
+    installMergeCopy("level-up", directOurs, SHA_A, directBase, "main");
+    const fetch = makeFetch({ manifest: undefined });
+    // AND the branch has advanced to SHA_B; the base re-materializes at the
+    // recorded install commit (SHA_A), the target at the resolved branch tip
+    const runGit = treeGitRunner(
+      { [SHA_A]: directBase, [SHA_B]: directTheirs },
+      { main: SHA_B },
+    );
+
+    // WHEN the plugin is upgraded with the `ours` strategy
+    const result = await upgradePlugin(
+      { name: "level-up", strategy: "ours" },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN it moves to the branch tip, carrying both sides' edits forward and
+    // resolving conflicts toward the local edit — same as a marketplace merge
+    expect(result.outcome).toBe("upgraded");
+    expect(result.toCommit).toBe(SHA_B);
+    expect(result.strategy).toBe("ours");
+    expect(installedFile("level-up", "common.txt")).toBe("A\nb\nC\n");
+    expect(installedFile("level-up", "local-only.txt")).toBe("added locally\n");
+    expect(installedFile("level-up", "remote-only.txt")).toBe(
+      "added upstream\n",
+    );
+    expect(installedFile("level-up", "conflict.txt")).toBe("ours\n");
   });
 });

--- a/assistant/src/cli/lib/inspect-plugin.ts
+++ b/assistant/src/cli/lib/inspect-plugin.ts
@@ -224,8 +224,12 @@ function readRemote(
  * Best-effort: any failure (network, rate-limit, unexpected shape) yields
  * `null` so inspection still reports the remote pin's SHA without its date,
  * mirroring how the local side degrades to `unknown` when no date was recorded.
+ *
+ * Exported for reuse by `plugins upgrade`, which resolves the same
+ * human-readable "to" timestamp when previewing a directly-installed plugin's
+ * upgrade (its target commit has no marketplace entry to read the date from).
  */
-async function fetchCommitDate(
+export async function fetchCommitDate(
   repo: string,
   sha: string,
   fetch: FetchLike,

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -36,6 +36,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 
@@ -1024,10 +1025,7 @@ function normalizeInstalledManifest(
  * data is read — the install name is the only identity we trust for an
  * untrusted direct install.
  */
-function synthesizeMinimalPackageJson(
-  name: string,
-  stagingDir: string,
-): void {
+function synthesizeMinimalPackageJson(name: string, stagingDir: string): void {
   const manifestPath = join(stagingDir, "package.json");
 
   const manifest: PackageManifest = {
@@ -1278,6 +1276,72 @@ function pluginGitEnv(): NodeJS.ProcessEnv {
     env.PATH = [...current, ...missing].join(":");
   }
   return env;
+}
+
+/**
+ * Resolve the commit SHA a plugin source's recorded ref points at *now*, using
+ * a single `git ls-remote` — no clone. `plugins upgrade` uses this to detect
+ * drift for a directly-installed plugin (one sourced from a GitHub URL rather
+ * than the curated marketplace), whose "latest" is whatever its recorded
+ * branch / tag / `HEAD` currently resolves to.
+ *
+ * A full-SHA ref is immutable, so it resolves to itself with no network call
+ * (ls-remote lists refs, never arbitrary commits). For an annotated tag the
+ * peeled commit (`<ref>^{}`) is preferred — the commit a checkout lands on.
+ * Returns `null` when the ref no longer exists on the remote (a deleted branch /
+ * tag) or the repo is unreachable as a hard failure; throws
+ * {@link PluginSourceUnavailableError} on a transient git / network failure so
+ * the caller can surface a retryable 503.
+ */
+export async function resolveRefCommit(
+  source: PluginFetchSource,
+  runGit: GitRunner = defaultGitRunner,
+): Promise<string | null> {
+  if (isFullCommitSha(source.ref)) {
+    return source.ref;
+  }
+  const repoUrl = `https://github.com/${source.owner}/${source.repo}.git`;
+
+  let stdout: string;
+  try {
+    // ls-remote takes the URL explicitly and never reads a local working tree,
+    // so the OS temp dir is a safe, always-present cwd.
+    ({ stdout } = await runGit(["ls-remote", repoUrl, source.ref], {
+      cwd: tmpdir(),
+    }));
+  } catch (err) {
+    // A missing repo / ref (or a private one we can't reach) is a hard failure
+    // the caller maps to not-found; anything else — network loss, a transient
+    // GitHub outage — is retryable, so surface a 503.
+    if (isGitRefNotFound(err)) {
+      return null;
+    }
+    throw new PluginSourceUnavailableError(
+      `git ls-remote failed for ${source.owner}/${source.repo} @ ${source.ref}: ${subprocessErrorText(err)}`,
+      503,
+    );
+  }
+
+  // Each line is `<sha>\t<refname>`. Prefer the peeled commit of an annotated
+  // tag (`<ref>^{}`) — the commit a checkout resolves to — over the tag object.
+  let peeled: string | null = null;
+  let direct: string | null = null;
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") {
+      continue;
+    }
+    const [sha, refname] = trimmed.split(/\s+/);
+    if (sha === undefined || refname === undefined || !isFullCommitSha(sha)) {
+      continue;
+    }
+    if (refname.endsWith("^{}")) {
+      peeled = sha;
+    } else {
+      direct ??= sha;
+    }
+  }
+  return peeled ?? direct;
 }
 
 /** Inputs for {@link writeInstallMeta}, resolved during a fresh install. */

--- a/assistant/src/cli/lib/upgrade-plugin.ts
+++ b/assistant/src/cli/lib/upgrade-plugin.ts
@@ -1,11 +1,19 @@
 /**
- * Upgrade a single installed plugin to the marketplace's current pin.
+ * Upgrade a single installed plugin to its source's current revision.
  *
- * The marketplace pins every plugin to a full, immutable commit SHA (see
+ * A marketplace plugin pins to a full, immutable commit SHA (see
  * {@link ./plugin-marketplace}); an upgrade re-materializes the install at
  * whatever SHA the catalog currently advertises. Drift is detected with the
  * same exact commit-SHA comparison {@link ./inspect-plugin} uses, so an
  * upgrade is a no-op when the installed copy already matches the pin.
+ *
+ * A plugin installed directly from a GitHub URL (untrusted, not in the
+ * marketplace) is upgraded against its *recorded* source instead: its
+ * `install-meta.json` names the owner/repo/path/ref it was cloned from, and the
+ * upgrade target is whatever that ref resolves to now — a pinned SHA is
+ * immutable (a no-op), a branch / tag / `HEAD` advances as upstream does. Such
+ * an upgrade re-materializes verbatim, with no curated adapter overlay, exactly
+ * as the original untrusted install was (see {@link directUpgrade}).
  *
  * This is deliberately a distinct operation from install: `install` is
  * first-time materialization (and errors on an existing install unless
@@ -36,11 +44,11 @@ import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import type { FetchLike } from "./fetch-like.js";
 import {
+  fetchCommitDate,
   inspectPlugin,
   type PluginInspection,
   PluginInspectNotFoundError,
   type PluginLocalInfo,
-  type PluginRemoteInfo,
 } from "./inspect-plugin.js";
 import {
   finalizeStagedInstall,
@@ -52,6 +60,7 @@ import {
   PluginSourceUnavailableError,
   type PostinstallRunner,
   readInstallMeta,
+  resolveRefCommit,
   sanitizePluginName,
 } from "./install-from-github.js";
 import { type ConflictLabels, mergePluginTree } from "./merge-plugin-tree.js";
@@ -191,23 +200,27 @@ function pluginTarget(name: string, deps: UpgradePluginDeps): string {
 }
 
 /**
- * Move an installed plugin to the marketplace's current pin.
+ * Move an installed plugin to its source's current revision — the marketplace
+ * pin for a catalog plugin, or the recorded GitHub ref's current commit for a
+ * directly-installed one (delegated to {@link directUpgrade}).
  *
- * The `strategy` controls how local edits are reconciled with the pin:
- * `overwrite` (default) re-installs the pin wholesale; `ours`/`theirs`/
+ * The `strategy` controls how local edits are reconciled with the target:
+ * `overwrite` (default) re-installs it wholesale; `ours`/`theirs`/
  * `assistant` do a three-way merge that carries non-conflicting local edits
  * forward, resolving conflicting hunks toward the local edit (`ours`) or the
- * pin (`theirs`), or leaving git conflict markers in the file for the assistant
- * to resolve (`assistant`).
+ * target (`theirs`), or leaving git conflict markers in the file for the
+ * assistant to resolve (`assistant`).
  *
  * Throws {@link PluginNotInstalledError} when no copy is installed,
- * {@link PluginNotUpgradableError} when the install has no marketplace entry to
- * advance to, {@link PluginMergeBaselineError} when a merge strategy is
- * requested but the install-time baseline cannot be reconstructed,
- * {@link PluginSourceUnavailableError} when the marketplace catalog is
- * temporarily unreachable (a retryable outage, distinct from the permanent
- * no-entry case), and propagates {@link installPlugin}'s errors (e.g. source
- * unavailable, postinstall failure) when the re-install itself fails.
+ * {@link PluginNotUpgradableError} when the install is neither in the
+ * marketplace nor carries a recorded GitHub source to advance,
+ * {@link PluginMergeBaselineError} when a merge strategy is requested but the
+ * install-time baseline cannot be reconstructed,
+ * {@link PluginSourceUnavailableError} when the marketplace catalog or the
+ * plugin source is temporarily unreachable (a retryable outage, distinct from
+ * the permanent no-source case), and propagates {@link installPlugin}'s errors
+ * (e.g. source unavailable, postinstall failure) when the re-install itself
+ * fails.
  */
 export async function upgradePlugin(
   opts: UpgradePluginOptions,
@@ -233,11 +246,19 @@ export async function upgradePlugin(
   switch (inspection.status) {
     case "not-installed":
       throw new PluginNotInstalledError(name, pluginTarget(name, deps));
-    case "not-in-marketplace":
-      throw new PluginNotUpgradableError(
-        name,
-        "it has no marketplace entry to upgrade from",
-      );
+    case "not-in-marketplace": {
+      // The marketplace doesn't claim this name, but a plugin installed directly
+      // from a GitHub URL (untrusted) still has a recorded source to advance:
+      // upgrade it by re-fetching whatever its recorded ref now resolves to.
+      const local = inspection.local;
+      if (!local) {
+        throw new PluginNotUpgradableError(
+          name,
+          "it has no marketplace entry and no installed copy to upgrade",
+        );
+      }
+      return directUpgrade({ name, local, dryRun, strategy }, deps);
+    }
     case "remote-unavailable":
       // A transient catalog outage is not a permanent "cannot upgrade" state:
       // the same request can succeed once the marketplace source recovers, so
@@ -309,17 +330,28 @@ export async function upgradePlugin(
     strategy === "theirs" ||
     strategy === "assistant"
   ) {
+    const [remoteOwner, remoteRepo] = remote.repo.split("/");
     return mergeUpgrade(
       {
         name,
         strategy,
         local,
-        remote,
         fromCommit,
         fromTimestamp,
         toCommit,
         toTimestamp,
         provenanceWasUnknown,
+        theirsSource: {
+          owner: remoteOwner ?? "",
+          repo: remoteRepo ?? "",
+          rootPath: remote.path,
+          ref: remote.commit,
+        },
+        // The install baseline re-materializes with the curated adapter overlay
+        // (canonical ref); the target reads its overlay at the marketplace ref
+        // the pin was advertised from.
+        baseStubRef: DEFAULT_PLUGIN_REF,
+        theirsStubRef: remote.marketplaceRef,
       },
       deps,
     );
@@ -353,8 +385,175 @@ export async function upgradePlugin(
 }
 
 /**
+ * Upgrade a plugin the marketplace does not claim by re-fetching its recorded
+ * GitHub source — the untrusted-direct-install analogue of the marketplace
+ * upgrade above.
+ *
+ * A direct install (`plugins install <github-url>`) records the exact
+ * owner/repo/path/ref it was cloned from in its `install-meta.json`. Its
+ * "latest" is whatever that ref currently resolves to, so the upgrade target is
+ * {@link resolveRefCommit} of the recorded ref — a pinned full SHA is immutable
+ * (nothing to advance to), while a branch / tag / `HEAD` moves as upstream does.
+ * The move is then materialized verbatim, with no curated adapter overlay,
+ * exactly as the original untrusted install was.
+ *
+ * Throws {@link PluginNotUpgradableError} when no resolvable GitHub source was
+ * recorded (a manually-copied install), {@link PluginNotFoundError} when the
+ * recorded ref has vanished from the remote, {@link PluginMergeBaselineError}
+ * when a merge strategy's install-time baseline cannot be reconstructed, and
+ * {@link PluginSourceUnavailableError} on a transient source outage.
+ */
+async function directUpgrade(
+  ctx: {
+    readonly name: string;
+    readonly local: PluginLocalInfo;
+    readonly dryRun: boolean;
+    readonly strategy: PluginUpgradeStrategy;
+  },
+  deps: UpgradePluginDeps,
+): Promise<PluginUpgradeResult> {
+  const { name, local, dryRun, strategy } = ctx;
+  const source = local.source;
+  // Without resolvable GitHub coordinates in the provenance sidecar (a
+  // manually-copied install, or a sidecar naming a non-github source) there is
+  // nothing to re-fetch.
+  if (!source || source.kind !== "github" || !source.owner || !source.repo) {
+    throw new PluginNotUpgradableError(
+      name,
+      "it has no marketplace entry and no recorded GitHub source to re-fetch from",
+    );
+  }
+  const fetchSource: PluginFetchSource = {
+    owner: source.owner,
+    repo: source.repo,
+    rootPath: source.path ?? "",
+    ref: source.ref,
+  };
+
+  const fromCommit = local.commit;
+  const fromTimestamp = local.committedAt;
+  const provenanceWasUnknown = fromCommit === null;
+
+  // Resolve what the recorded ref points at now, without cloning. A pinned
+  // full-SHA ref is immutable, so it resolves to itself — nothing to advance to.
+  const toCommit = await resolveRefCommit(fetchSource, deps.runGit);
+  if (toCommit === null) {
+    // The recorded ref is gone from the remote (deleted branch / tag) or the
+    // repo is unreachable as a hard failure — there is no revision to move to.
+    throw new PluginNotFoundError(
+      name,
+      fetchSource.ref,
+      `${fetchSource.owner}/${fetchSource.repo}`,
+    );
+  }
+
+  if (
+    fromCommit !== null &&
+    toCommit.toLowerCase() === fromCommit.toLowerCase()
+  ) {
+    return {
+      name,
+      outcome: "already-up-to-date",
+      fromCommit,
+      fromTimestamp,
+      toCommit,
+      // The ref still points at the installed commit, so the "to" version is the
+      // "from" version — reuse its recorded timestamp rather than a fresh fetch.
+      toTimestamp: fromTimestamp,
+      target: local.target,
+      fileCount: null,
+      dryRun,
+      strategy,
+      conflicts: [],
+      binaryConflicts: [],
+      provenanceWasUnknown: false,
+    };
+  }
+
+  if (dryRun) {
+    // Preview: resolve the target commit's date the same way `plugins inspect`
+    // does, so the dry run shows the human-readable version it would move to.
+    const toTimestamp = await fetchCommitDate(
+      `${fetchSource.owner}/${fetchSource.repo}`,
+      toCommit,
+      deps.fetch,
+    );
+    return {
+      name,
+      outcome: "would-upgrade",
+      fromCommit,
+      fromTimestamp,
+      toCommit,
+      toTimestamp,
+      target: local.target,
+      fileCount: null,
+      dryRun: true,
+      strategy,
+      conflicts: [],
+      binaryConflicts: [],
+      provenanceWasUnknown,
+    };
+  }
+
+  if (
+    strategy === "ours" ||
+    strategy === "theirs" ||
+    strategy === "assistant"
+  ) {
+    // A direct install carries no curated adapter overlay, so both the install
+    // baseline and the incoming revision re-materialize verbatim (`stubRef`
+    // null), pinned to the recorded install commit and the resolved target.
+    return mergeUpgrade(
+      {
+        name,
+        strategy,
+        local,
+        fromCommit,
+        fromTimestamp,
+        toCommit,
+        toTimestamp: null,
+        provenanceWasUnknown,
+        theirsSource: { ...fetchSource, ref: toCommit },
+        baseStubRef: null,
+        theirsStubRef: null,
+      },
+      deps,
+    );
+  }
+
+  // overwrite (default): re-install the recorded direct source verbatim, moving
+  // to whatever its ref now resolves to. Untrusted — no curated adapter overlay,
+  // just as the original direct install was materialized.
+  const result = await installPlugin(
+    { name, force: true, directSource: fetchSource },
+    {
+      fetch: deps.fetch,
+      workspacePluginsDir: deps.workspacePluginsDir,
+      runGit: deps.runGit,
+      runPostinstall: deps.runPostinstall,
+    },
+  );
+
+  return {
+    name,
+    outcome: "upgraded",
+    fromCommit,
+    fromTimestamp,
+    toCommit: result.commit ?? toCommit,
+    toTimestamp: result.committedAt,
+    target: result.target,
+    fileCount: result.fileCount,
+    dryRun: false,
+    strategy,
+    conflicts: [],
+    binaryConflicts: [],
+    provenanceWasUnknown,
+  };
+}
+
+/**
  * Carry local edits forward by three-way merging the on-disk install (`ours`)
- * and the marketplace pin (`theirs`) against the re-materialized install commit
+ * and the incoming revision (`theirs`) against the re-materialized install commit
  * (`base`), then atomically swapping the merged tree into place pinned at the
  * new commit. Conflicting hunks resolve toward `ours` or `theirs` per the
  * strategy, or are left as git conflict markers under `assistant`;
@@ -365,16 +564,25 @@ async function mergeUpgrade(
     readonly name: string;
     readonly strategy: "ours" | "theirs" | "assistant";
     readonly local: PluginLocalInfo;
-    readonly remote: PluginRemoteInfo;
     readonly fromCommit: string | null;
     readonly fromTimestamp: string | null;
     readonly toCommit: string;
     readonly toTimestamp: string | null;
     readonly provenanceWasUnknown: boolean;
+    /** Coordinates of the revision being merged in (`theirs`), pinned to {@link ctx.toCommit}. */
+    readonly theirsSource: PluginFetchSource;
+    /**
+     * Curated-adapter-stub ref overlaid when re-materializing the install
+     * baseline, or `null` for a direct (untrusted) install that carries no
+     * curated overlay.
+     */
+    readonly baseStubRef: string | null;
+    /** Curated-adapter-stub ref overlaid on the incoming revision, or `null` for a direct install. */
+    readonly theirsStubRef: string | null;
   },
   deps: UpgradePluginDeps,
 ): Promise<PluginUpgradeResult> {
-  const { name, strategy, local, remote } = ctx;
+  const { name, strategy, local, theirsSource } = ctx;
 
   // Marker labels name each side by its commit so the assistant can tell the
   // local edit from the incoming pin when resolving.
@@ -401,13 +609,6 @@ async function mergeUpgrade(
     rootPath: meta.source.path ?? "",
     ref: meta.commit,
   };
-  const [remoteOwner, remoteRepo] = remote.repo.split("/");
-  const theirsSource: PluginFetchSource = {
-    owner: remoteOwner ?? "",
-    repo: remoteRepo ?? "",
-    rootPath: remote.path,
-    ref: remote.commit,
-  };
 
   const pluginsDir = deps.workspacePluginsDir ?? getWorkspacePluginsDir();
   const baseDir = mkdtempSync(join(tmpdir(), `plugin-upgrade-base-${name}-`));
@@ -429,7 +630,7 @@ async function mergeUpgrade(
       {
         source: baseSource,
         name,
-        stubRef: DEFAULT_PLUGIN_REF,
+        stubRef: ctx.baseStubRef,
         destDir: baseDir,
       },
       deps,
@@ -457,7 +658,7 @@ async function mergeUpgrade(
       {
         source: theirsSource,
         name,
-        stubRef: remote.marketplaceRef,
+        stubRef: ctx.theirsStubRef,
         destDir: theirsDir,
       },
       deps,
@@ -479,8 +680,8 @@ async function mergeUpgrade(
       conflictLabels,
     });
 
-    const toCommit = theirs.commit ?? remote.commit;
-    const toTimestamp = theirs.committedAt ?? remote.committedAt;
+    const toCommit = theirs.commit ?? ctx.toCommit;
+    const toTimestamp = theirs.committedAt ?? ctx.toTimestamp;
     finalizeStagedInstall(stagingDir, {
       name,
       source: theirsSource,

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1465,9 +1465,10 @@ async function handleUpgradePlugin({
     if (err instanceof PluginMergeBaselineError) {
       throw new ConflictError(err.message);
     }
-    // The install exists but has no marketplace entry to advance to — a
-    // permanent state the caller cannot resolve by retrying. 409 marks the
-    // request as well-formed but not actionable in the current state.
+    // The install has neither a marketplace entry nor a recorded GitHub source
+    // to advance to — a permanent state the caller cannot resolve by retrying.
+    // 409 marks the request as well-formed but not actionable in the current
+    // state.
     if (err instanceof PluginNotUpgradableError) {
       throw new ConflictError(err.message);
     }
@@ -1896,9 +1897,9 @@ export const ROUTES: RouteDefinition[] = [
       requiredScopes: ["settings.write"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
-    summary: "Upgrade a plugin to the marketplace pin",
+    summary: "Upgrade a plugin to its source's current revision",
     description:
-      'Move an installed plugin to the marketplace\'s current pinned commit, re-materializing it under `<workspaceDir>/plugins/<name>/`. Always resolves against the curated marketplace pin (no caller-supplied ref), mirroring `plugins install`\'s curation boundary. A no-op (`outcome: "already-up-to-date"`) when the installed commit already equals the pin; pass `dryRun` to preview the move (`outcome: "would-upgrade"`) without touching the install. Installs lacking provenance are re-pinned to the current SHA. The upgraded code is picked up live on the next read (no restart required). `strategy` controls how local edits are reconciled: `overwrite` (default) discards them and re-installs the pin wholesale; `ours`/`theirs`/`assistant` perform a three-way merge against the re-materialized install commit, carrying non-conflicting edits from both sides forward and resolving conflicting hunks toward the local edit (`ours`) or the pin (`theirs`), or writing git conflict markers into the file and reporting them in `conflicts`/`binaryConflicts` for the assistant to resolve (`assistant`). A merge strategy whose install-time baseline cannot be reconstructed returns 409. Mirrors the CLI\'s `assistant plugins upgrade <name> [--strategy <s>]`.',
+      'Move an installed plugin to its source\'s current revision, re-materializing it under `<workspaceDir>/plugins/<name>/`. A marketplace plugin advances to the curated pin; a plugin installed directly from a GitHub URL (untrusted, not in the marketplace) advances to whatever its recorded ref now resolves to — a pinned SHA is immutable (a no-op), a branch/tag/HEAD moves as upstream does — re-materialized verbatim with no curated adapter overlay, exactly as the original untrusted install was. The target ref is never taken from the request (no caller-supplied ref), mirroring `plugins install`\'s curation boundary. A no-op (`outcome: "already-up-to-date"`) when the installed commit already equals the target; pass `dryRun` to preview the move (`outcome: "would-upgrade"`) without touching the install. Installs lacking provenance are re-pinned to the current SHA. The upgraded code is picked up live on the next read (no restart required). `strategy` controls how local edits are reconciled: `overwrite` (default) discards them and re-installs the target wholesale; `ours`/`theirs`/`assistant` perform a three-way merge against the re-materialized install commit, carrying non-conflicting edits from both sides forward and resolving conflicting hunks toward the local edit (`ours`) or the target (`theirs`), or writing git conflict markers into the file and reporting them in `conflicts`/`binaryConflicts` for the assistant to resolve (`assistant`). A merge strategy whose install-time baseline cannot be reconstructed returns 409. Mirrors the CLI\'s `assistant plugins upgrade <name> [--strategy <s>]`.',
     tags: ["plugins"],
     pathParams: [
       {
@@ -1921,7 +1922,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "409": {
         description:
-          "The install exists but has no marketplace entry to advance to, or a merge strategy was requested whose install-time baseline cannot be reconstructed.",
+          "The install has neither a marketplace entry nor a recorded GitHub source to advance to, or a merge strategy was requested whose install-time baseline cannot be reconstructed.",
       },
       "503": {
         description:


### PR DESCRIPTION
## Prompt / plan

> Now let's support upgrades for untrusted github urls.

Follow-up to #38223 (which ran the plugin lifecycle in the daemon on upgrade).

### Why

`plugins upgrade` resolved its target through `inspectPlugin`, which knows only the curated marketplace, so a plugin installed directly from a GitHub URL (`assistant plugins install https://github.com/owner/repo`, classified `not-in-marketplace`) hit `PluginNotUpgradableError` — there was no way to pull newer code for it.

### What changed

A direct install now advances against its **own recorded source** — the exact `owner/repo/path/ref` its `install-meta.json` records at install time.

- **`resolveRefCommit()`** (`install-from-github.ts`) — resolves the recorded ref to a commit with a single `git ls-remote`, no clone. A full-SHA ref is immutable (resolves to itself with zero network calls); a branch/tag/HEAD moves as upstream does (annotated tags prefer the peeled commit). Transient git/network failure → retryable 503; a vanished ref/repo → `null` → 404.
- **`directUpgrade()`** (`upgrade-plugin.ts`) — takes over the `not-in-marketplace` case when a resolvable GitHub source is recorded: no-op when the ref still points at the installed commit, `--dry-run` preview (target date via the now-shared `fetchCommitDate`), and the same `overwrite`/`ours`/`theirs`/`assistant` strategies as marketplace upgrades. Re-materialized **verbatim — no curated adapter overlay**, exactly as the original untrusted install was.
- **`mergeUpgrade()`** generalized to take an explicit `theirsSource` plus base/theirs adapter-stub refs, so the marketplace path passes the curated refs and the direct path passes `null` (no overlay).
- The target ref is never caller-supplied, preserving the curation boundary. `PluginNotUpgradableError` now fires only when neither a marketplace entry nor a recorded GitHub source exists (a manually-copied install). Route/CLI docs and error mappings updated; a vanished ref maps to 404.

The daemon already runs the plugin's `init`/`shutdown` in-process after a successful upgrade (#38223), so a direct upgrade picks up live with no restart, same as a marketplace one.

## Test plan

- `bunx tsc --noEmit` (assistant) — clean.
- `bun test src/cli/lib/__tests__/upgrade-plugin.test.ts` — 24 pass (6 new direct cases: advances a tracked branch, no-ops when unchanged, SHA-pinned install up-to-date without any git, dry-run preview, 404 on vanished ref, `--strategy ours` merge).
- `bun test src/cli/lib/__tests__/install-from-github.test.ts` (38) / `inspect-plugin.test.ts` (15) — pass.
- `bun test src/runtime/routes/__tests__/plugins-routes.test.ts` (111) / `src/__tests__/mtime-cache.test.ts` — pass.
- `eslint` on changed files — 0 errors. (The full `src/cli/lib/__tests__/` dir has pre-existing, order-dependent `mock.module` cross-file leakage that fails the clone-based upgrade tests when run together; each file passes in isolation, and the same tests fail identically on `main`.)

## CLI verb checklist

No new route is added. `plugins_upgrade` already exists and has its `assistant plugins upgrade` verb; this PR only broadens what the route/verb can upgrade. No new env vars or DB/workspace migrations — the feature reads existing `install-meta.json` provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bebi83sSFqAMYbM7s7PU9

---
_Generated by [Claude Code](https://claude.ai/code/session_014bebi83sSFqAMYbM7s7PU9)_