### PR TITLE
fix(tools): tool profiler RSS failures must not crash the agent loop

### DIFF
--- a/assistant/src/__tests__/tool-profiler.test.ts
+++ b/assistant/src/__tests__/tool-profiler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import {
   disposeToolProfiler,
@@ -99,6 +99,55 @@ describe("ToolProfiler", () => {
   });
 });
 
+/**
+ * A `process.memoryUsage` replacement that reproduces the Bun 1.3.11
+ * `SystemError: Failed to get memory usage, errno: 2` syscall failure. Cast to
+ * the real signature because an always-throwing arrow infers a `never` return.
+ */
+const throwingMemoryUsage = (() => {
+  throw new Error("Failed to get memory usage, errno: 2");
+}) as unknown as typeof process.memoryUsage;
+
+describe("ToolProfiler RSS sampling failures", () => {
+  let profiler: ToolProfiler;
+
+  beforeEach(() => {
+    profiler = new ToolProfiler();
+  });
+
+  afterEach(() => {
+    // Restore the real implementation between cases.
+    spyOn(process, "memoryUsage").mockRestore();
+  });
+
+  test("startRequest tolerates a throwing memoryUsage syscall", () => {
+    // Simulate the Bun 1.3.11 `SystemError: Failed to get memory usage` bug.
+    spyOn(process, "memoryUsage").mockImplementation(throwingMemoryUsage);
+
+    expect(() => profiler.startRequest()).not.toThrow();
+  });
+
+  test("recordToolCompletion still records stats when memoryUsage throws", () => {
+    profiler.startRequest();
+    spyOn(process, "memoryUsage").mockImplementation(throwingMemoryUsage);
+
+    // The RSS sample fails, but the tool's timing stats are still recorded and
+    // no exception escapes to the caller (the agent loop).
+    expect(() =>
+      profiler.recordToolCompletion("bash", 123, false),
+    ).not.toThrow();
+
+    const summary = profiler.getSummary();
+    expect(summary.toolCount).toBe(1);
+    expect(summary.tools["bash"]).toEqual({
+      count: 1,
+      totalMs: 123,
+      maxMs: 123,
+      errors: 0,
+    });
+  });
+});
+
 describe("conversation-keyed profiler registry", () => {
   test("recording before a request window is a silent no-op", () => {
     expect(() =>
@@ -123,6 +172,28 @@ describe("conversation-keyed profiler registry", () => {
     expect(() =>
       recordToolCompletion("conv-a", "bash", 1, false),
     ).not.toThrow();
+  });
+
+  test("recordToolCompletion swallows profiler failures instead of throwing", () => {
+    startToolProfilingRequest("conv-throwing");
+    const spy = spyOn(process, "memoryUsage").mockImplementation(
+      throwingMemoryUsage,
+    );
+
+    try {
+      // A throwing RSS syscall must never propagate to the executor/agent loop.
+      expect(() =>
+        recordToolCompletion("conv-throwing", "bash", 42, false),
+      ).not.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+
+    // The turn's timing stats survived even though the RSS sample failed.
+    expect(() =>
+      emitToolProfilingSummary("conv-throwing", "req-throwing"),
+    ).not.toThrow();
+    disposeToolProfiler("conv-throwing");
   });
 
   test("startToolProfilingRequest resets a conversation's prior window", () => {

--- a/assistant/src/tools/tool-profiler.ts
+++ b/assistant/src/tools/tool-profiler.ts
@@ -33,9 +33,29 @@ export class ToolProfiler {
   startRequest(): void {
     this.tools.clear();
     this.requestStartMs = Date.now();
-    const rss = process.memoryUsage().rss;
+    const rss = this.sampleRssBytes() ?? 0;
     this.rssStartBytes = rss;
     this.peakRssBytes = rss;
+  }
+
+  /**
+   * Sample the current RSS in bytes, returning `null` if the reading fails.
+   *
+   * Bun 1.3.11 can throw `SystemError: Failed to get memory usage, errno: 2`
+   * from the underlying syscall. Resource metrics are best-effort — a failed
+   * sample must never propagate, so it is logged and reported as `null` and the
+   * caller keeps its last known peak.
+   */
+  private sampleRssBytes(): number | null {
+    try {
+      return process.memoryUsage().rss;
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to sample RSS memory; skipping profiler sample",
+      );
+      return null;
+    }
   }
 
   recordToolCompletion(
@@ -57,8 +77,8 @@ export class ToolProfiler {
       stats.errors++;
     }
 
-    const currentRss = process.memoryUsage().rss;
-    if (currentRss > this.peakRssBytes) {
+    const currentRss = this.sampleRssBytes();
+    if (currentRss !== null && currentRss > this.peakRssBytes) {
       this.peakRssBytes = currentRss;
     }
   }
@@ -156,6 +176,10 @@ export function startToolProfilingRequest(conversationId: string): void {
 /**
  * Record a completed tool invocation into the conversation's profiler.
  * A no-op when no profiling window is active (e.g. standalone tool runs).
+ *
+ * The tool has already completed by the time this runs, so profiling is pure
+ * observation: any failure here is swallowed and logged rather than allowed to
+ * propagate into the executor and fail the agent loop.
  */
 export function recordToolCompletion(
   conversationId: string,
@@ -163,9 +187,16 @@ export function recordToolCompletion(
   durationMs: number,
   isError: boolean,
 ): void {
-  profilersByConversation
-    .get(conversationId)
-    ?.recordToolCompletion(toolName, durationMs, isError);
+  try {
+    profilersByConversation
+      .get(conversationId)
+      ?.recordToolCompletion(toolName, durationMs, isError);
+  } catch (err) {
+    log.warn(
+      { err, conversationId, toolName },
+      "Tool profiler failed to record completion; continuing",
+    );
+  }
 }
 
 /** Emit the end-of-turn profiling summary log for a conversation. */


### PR DESCRIPTION
## Prompt / plan

Fixes [ATL-1007](https://linear.app/vellum/issue/ATL-1007/tool-profiler-failures-in-recordtoolcompletion-must-not-crash-the).

**Context:** Bun 1.3.11 intermittently throws `SystemError: Failed to get memory usage, errno: 2` from `process.memoryUsage()`. When this fired inside `ToolProfiler.recordToolCompletion` (`tool-profiler.ts:60`), the exception propagated through `executor.ts` into the agent loop and failed the entire turn — even though the tool itself had already completed successfully. Tool profiling is pure observation and must never crash the agent loop.

**Approach:**
- Route both RSS reads (`startRequest` and `recordToolCompletion`) through a new `sampleRssBytes()` helper that catches the syscall failure, logs it, and returns `null`. The tool's timing stats are still recorded; only the best-effort memory sample is skipped, and the profiler keeps its last known peak.
- Wrap the registry-level `recordToolCompletion` — the exact function the executor calls — in a try/catch as a hard boundary, so no profiler failure of any kind (not just RSS) can ever reach the agent loop.

## Test plan

- Added unit tests in `tool-profiler.test.ts` that stub `process.memoryUsage` to throw and assert:
  - `startRequest()` does not throw.
  - the instance `recordToolCompletion` does not throw and still records the tool's timing stats when the RSS sample fails.
  - the registry-level `recordToolCompletion` swallows the failure instead of propagating it, and the turn's summary still emits cleanly.
- `bun test src/__tests__/tool-profiler.test.ts` → 14 pass, 0 fail.
- `tool-executor-lifecycle-events.test.ts` → 28 pass, 0 fail.
- `tsc --noEmit`, `eslint`, and `prettier` all clean (verified via pre-commit hooks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DTnVLHK89XNTAmmrEsargb)_