### PR TITLE
fix(plugins): use install directory name as the plugin identity (surfaces plugin skills)

### DIFF
--- a/assistant/src/__tests__/external-plugin-loader.test.ts
+++ b/assistant/src/__tests__/external-plugin-loader.test.ts
@@ -59,20 +59,24 @@ afterAll(() => {
 });
 
 describe("loadExternalPlugin — manifest", () => {
-  test("uses package.json name and version", async () => {
+  test("identity is the directory name; version comes from package.json", async () => {
+    // The install directory name is the plugin's identity — not the authored
+    // `package.json` `name`, which routinely differs from the install slug.
     const dir = freshPluginDir("minimal");
     writePackageJson(dir, { name: "minimal-plugin", version: "1.2.3" });
 
     await loadExternalPlugin(dir);
 
     const registered = getRegisteredPlugins().find(
-      (p) => p.manifest.name === "minimal-plugin",
+      (p) => p.manifest.name === "minimal",
     );
     expect(registered).toBeDefined();
     expect(registered?.manifest.version).toBe("1.2.3");
+    // The authored package.json name is not used as the identity.
+    expect(registeredNames()).not.toContain("minimal-plugin");
   });
 
-  test("strips npm scope from name", async () => {
+  test("identity is the directory name even when package.json name is scoped", async () => {
     const dir = freshPluginDir("scoped");
     writePackageJson(dir, {
       name: "@vellumai/simple-memory",
@@ -81,7 +85,8 @@ describe("loadExternalPlugin — manifest", () => {
 
     await loadExternalPlugin(dir);
 
-    expect(registeredNames()).toContain("simple-memory");
+    expect(registeredNames()).toContain("scoped");
+    expect(registeredNames()).not.toContain("simple-memory");
   });
 
   test("defaults version to 0.0.0 when package.json omits it", async () => {
@@ -91,8 +96,9 @@ describe("loadExternalPlugin — manifest", () => {
     await loadExternalPlugin(dir);
 
     const registered = getRegisteredPlugins().find(
-      (p) => p.manifest.name === "no-version-plugin",
+      (p) => p.manifest.name === "no-version",
     );
+    expect(registered).toBeDefined();
     expect(registered?.manifest.version).toBe("0.0.0");
   });
 });

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -340,15 +340,20 @@ describe("plugin-resident skills", () => {
     expect(skill).toBeUndefined();
   });
 
-  test("ignores plugin dirs whose package.json name mismatches the directory", () => {
-    // Mirrors the loader's recognition gate: an un-adapted clone whose
-    // package.json declares `caveman-installer` in a `caveman` dir is skipped.
+  test("surfaces plugin skills when package.json name differs from the directory", () => {
+    // A plugin is installed under its slug (marketplace name or GitHub path
+    // leaf), which routinely differs from its authored `package.json` name —
+    // e.g. cognee installs to `cognee`/`vellum-assistant` while its package is
+    // named `cognee-memory`. The skill must still surface, attributed to the
+    // install directory (the identity every other surface uses).
     writePluginSkill("caveman", "caveman", "Caveman", "Terse mode", "body", {
       packageName: "caveman-installer",
     });
 
     const skill = loadSkillCatalog().find((s) => s.id === "caveman");
-    expect(skill).toBeUndefined();
+    expect(skill).toBeDefined();
+    expect(skill!.source).toBe("plugin");
+    expect(skill!.owner).toEqual({ kind: "plugin", id: "caveman" });
   });
 
   test("warns when a plugin directory is missing package.json", () => {

--- a/assistant/src/__tests__/user-plugin-loader.test.ts
+++ b/assistant/src/__tests__/user-plugin-loader.test.ts
@@ -131,14 +131,14 @@ describe("user plugin loader", () => {
     expect(getCachedUserTools()).toHaveLength(0);
   });
 
-  test("strips npm scope from package.json name", async () => {
+  test("loads a plugin whose package.json name differs from its directory", async () => {
     writePlugin("scoped", { name: "@vellumai/cool-plugin", version: "0.1.0" });
 
     await loadUserPlugins();
 
-    // The plugin should be cached under the scope-stripped name.
-    // We verify by checking that a hook from "cool-plugin" is found.
-    // Since no hooks were written, we just verify no crash.
+    // The plugin's identity is its directory name (`scoped`), not the authored
+    // package.json name. No hooks were written, so we just verify it loads
+    // without crashing.
     expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(0);
   });
 });

--- a/assistant/src/config/__tests__/plugin-resident-skill-discovery.test.ts
+++ b/assistant/src/config/__tests__/plugin-resident-skill-discovery.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for plugin-resident skill discovery in `loadSkillCatalog`.
+ *
+ * The catalog surfaces skills a plugin ships at `plugins/<dir>/skills/<id>/`.
+ * The gate is a loadable manifest (parseable `package.json` with a non-empty
+ * `name`) — the manifest `name` need NOT equal the install directory name.
+ * That match must not be required: a plugin is installed under its marketplace
+ * slug or GitHub path leaf, which routinely differs from its `package.json`
+ * `name` (e.g. cognee installs to `cognee`/`vellum-assistant` while its package
+ * is named `cognee-memory`). Requiring the match silently drops the plugin's
+ * skills even though the runtime loads its hooks and tools fine.
+ */
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getWorkspacePluginsDir } from "../../util/platform.js";
+import { loadSkillCatalog } from "../skills.js";
+
+function writePlugin(
+  dirName: string,
+  packageName: string,
+  skills: Array<{ id: string; description: string }>,
+  opts: { disabled?: boolean; packageJson?: string | null } = {},
+): void {
+  const pluginDir = join(getWorkspacePluginsDir(), dirName);
+  mkdirSync(pluginDir, { recursive: true });
+
+  if (opts.packageJson === null) {
+    // Intentionally omit package.json.
+  } else {
+    writeFileSync(
+      join(pluginDir, "package.json"),
+      opts.packageJson ??
+        JSON.stringify({
+          name: packageName,
+          version: "1.0.0",
+          peerDependencies: { "@vellumai/plugin-api": "*" },
+        }),
+    );
+  }
+
+  if (opts.disabled) writeFileSync(join(pluginDir, ".disabled"), "");
+
+  for (const skill of skills) {
+    const skillDir = join(pluginDir, "skills", skill.id);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---\nname: ${skill.id}\ndescription: ${skill.description}\n---\n\nBody for ${skill.id}.\n`,
+    );
+  }
+}
+
+function skillById(id: string) {
+  return loadSkillCatalog().find((s) => s.id === id);
+}
+
+describe("discoverPluginResidentSkills (via loadSkillCatalog)", () => {
+  beforeEach(() => {
+    const pluginsDir = getWorkspacePluginsDir();
+    if (existsSync(pluginsDir))
+      rmSync(pluginsDir, { recursive: true, force: true });
+  });
+
+  test("surfaces a plugin skill when the install dir name differs from package.json name", () => {
+    // dir `vellum-assistant` (GitHub path leaf) vs package `cognee-memory`:
+    // the exact cognee shape that was silently dropped before.
+    writePlugin("vellum-assistant", "cognee-memory", [
+      {
+        id: "qa-cognee-sync",
+        description: "Sync session memory into the graph.",
+      },
+    ]);
+
+    const skill = skillById("qa-cognee-sync");
+    expect(skill).toBeDefined();
+    expect(skill!.source).toBe("plugin");
+    // Attribution is the install slug (directory name), which is the identity
+    // used by `plugins list` and per-conversation plugin scoping.
+    expect(skill!.owner).toEqual({ kind: "plugin", id: "vellum-assistant" });
+  });
+
+  test("surfaces a plugin skill when dir name equals package.json name", () => {
+    writePlugin("demo-matched", "demo-matched", [
+      { id: "qa-matched-skill", description: "A matched-name plugin skill." },
+    ]);
+
+    const skill = skillById("qa-matched-skill");
+    expect(skill).toBeDefined();
+    expect(skill!.owner).toEqual({ kind: "plugin", id: "demo-matched" });
+  });
+
+  test("skips a plugin directory that has no package.json", () => {
+    writePlugin(
+      "no-manifest",
+      "unused",
+      [{ id: "qa-no-manifest-skill", description: "Should not surface." }],
+      { packageJson: null },
+    );
+
+    expect(skillById("qa-no-manifest-skill")).toBeUndefined();
+  });
+
+  test("skips a plugin directory whose package.json is unparseable", () => {
+    writePlugin(
+      "bad-manifest",
+      "unused",
+      [{ id: "qa-bad-manifest-skill", description: "Should not surface." }],
+      { packageJson: "{ not valid json" },
+    );
+
+    expect(skillById("qa-bad-manifest-skill")).toBeUndefined();
+  });
+
+  test("skips a plugin directory whose package.json has no name", () => {
+    writePlugin(
+      "nameless",
+      "unused",
+      [{ id: "qa-nameless-skill", description: "Should not surface." }],
+      { packageJson: JSON.stringify({ version: "1.0.0" }) },
+    );
+
+    expect(skillById("qa-nameless-skill")).toBeUndefined();
+  });
+
+  test("hides resident skills of a disabled plugin", () => {
+    writePlugin(
+      "disabled-plugin",
+      "disabled-pkg",
+      [{ id: "qa-disabled-skill", description: "Hidden while disabled." }],
+      { disabled: true },
+    );
+
+    expect(skillById("qa-disabled-skill")).toBeUndefined();
+  });
+});

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -684,25 +684,26 @@ function discoverSkillDirectories(skillsDir: string): string[] {
 }
 
 /**
- * Whether `pluginDir` is a recognized installed plugin: it must carry a
- * parseable `package.json` whose `name` equals the directory name. This
- * mirrors the external plugin loader's recognition gate, which skips any
- * directory whose `manifest.name` does not match its directory name.
+ * Whether `pluginDir` carries a plugin manifest the runtime can load: a
+ * parseable `package.json` with a non-empty string `name`. This mirrors the
+ * external plugin loader (`buildPluginFromDir`), which builds a plugin from
+ * any such directory and derives the plugin's identity from `package.json`
+ * `name` — it imposes no match between that `name` and the directory name.
+ *
+ * The directory name is the install slug (a marketplace slug or a GitHub path
+ * leaf), which routinely differs from the plugin's own `package.json` `name`;
+ * requiring the two to match would silently drop the resident skills of every
+ * such plugin even though the runtime loads its hooks and tools fine.
  *
  * The caller is responsible for the missing-`package.json` case (it emits a
  * diagnostic warning); this function only judges a manifest that is present.
  */
-function isRecognizedPluginDir(pluginDir: string, dirName: string): boolean {
+function hasLoadablePluginManifest(pluginDir: string): boolean {
   const manifestPath = join(pluginDir, "package.json");
   if (!existsSync(manifestPath)) return false;
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf-8"));
-    return (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "name" in parsed &&
-      (parsed as { name: unknown }).name === dirName
-    );
+    parsed = JSON.parse(readFileSync(manifestPath, "utf-8"));
   } catch (err) {
     log.warn(
       { err, manifestPath },
@@ -710,12 +711,19 @@ function isRecognizedPluginDir(pluginDir: string, dirName: string): boolean {
     );
     return false;
   }
+  return (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "name" in parsed &&
+    typeof (parsed as { name: unknown }).name === "string" &&
+    (parsed as { name: string }).name.length > 0
+  );
 }
 
 /**
  * Discover skills shipped on disk inside installed plugins. Each installed
  * plugin — a directory under `<workspaceDir>/plugins/` recognized by
- * {@link isRecognizedPluginDir} — may ship skills at `skills/<id>/SKILL.md`.
+ * {@link hasLoadablePluginManifest} — may ship skills at `skills/<id>/SKILL.md`.
  * Returned summaries are attributed to the owning plugin via their `owner`
  * descriptor (`{ kind: "plugin", id: <plugin dir name> }`).
  */
@@ -747,7 +755,7 @@ function discoverPluginResidentSkills(): SkillSummary[] {
     if (!existsSync(join(pluginDir, "package.json"))) {
       log.warn(
         { pluginDir },
-        "Plugin directory is missing package.json — skipping; its skills will not be available. Add a package.json whose `name` matches the directory.",
+        "Plugin directory is missing package.json — skipping; its skills will not be available. Add a package.json with a `name`.",
       );
       continue;
     }
@@ -757,13 +765,15 @@ function discoverPluginResidentSkills(): SkillSummary[] {
     // tools, so its resident skills must not be loadable either.
     if (existsSync(join(pluginDir, ".disabled"))) continue;
 
-    // Mirror the plugin loader's recognition gate: a directory is a real
-    // installed plugin only if its `package.json` `name` matches the directory.
-    // This rejects staging dirs and malformed/mismatched clones (e.g. an
-    // un-adapted `caveman-installer`) that the loader itself would skip, so the
-    // catalog never surfaces skills from a directory the runtime would refuse
-    // to load.
-    if (!isRecognizedPluginDir(pluginDir, entry.name)) continue;
+    // Mirror the plugin loader: a directory contributes its resident skills
+    // when it carries a loadable manifest (parseable `package.json` with a
+    // non-empty `name`). The manifest `name` need not equal the directory name
+    // — the loader imposes no such match — so a plugin installed under a
+    // marketplace slug or GitHub path leaf that differs from its `package.json`
+    // `name` still surfaces its skills, matching the hooks and tools the
+    // runtime already loads from it. A parseable manifest still rejects staging
+    // dirs and malformed clones the loader would itself refuse.
+    if (!hasLoadablePluginManifest(pluginDir)) continue;
 
     const skillsDir = join(pluginDir, "skills");
     if (!existsSync(skillsDir)) continue;

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -42,7 +42,7 @@
 
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import semver from "semver";
@@ -98,15 +98,6 @@ export interface LoadExternalPluginOptions {
    * {@link DEFAULT_IMPORT_TIMEOUT_MS}.
    */
   readonly importTimeoutMs?: number;
-}
-
-/**
- * Strip the npm scope from a package name. `@vellumai/simple-memory` →
- * `simple-memory`; an unscoped name passes through unchanged.
- */
-export function stripScope(name: string): string {
-  const match = /^@[^/]+\/(.+)$/.exec(name);
-  return match ? match[1]! : name;
 }
 
 export function toToolNameSegment(value: string): string {
@@ -229,7 +220,15 @@ async function buildPluginFromDir(pluginDir: string): Promise<Plugin> {
     );
   }
   const pkg: PluginPackageJson = parsed.data;
-  const name = stripScope(pkg.name);
+  // A plugin's identity is its install directory name — the slug the plugin
+  // was installed under (a marketplace slug or a GitHub path leaf). This is
+  // the identity every other surface uses: `plugins list`, enable/disable,
+  // per-conversation plugin scoping, and resident-skill `owner.id`. The
+  // `package.json` `name` is authored by the plugin and routinely differs
+  // from the slug, so keying runtime registration off it would desync the
+  // registry from the identity the user toggles and the scope filters match.
+  // The manifest is still required (schema-validated above) as the load gate.
+  const name = basename(pluginDir);
   const version = pkg.version && pkg.version.length > 0 ? pkg.version : "0.0.0";
 
   // Host-compat negotiation: plugins declare their plugin-api version
@@ -381,11 +380,12 @@ export async function loadExternalPlugin(
 
 /**
  * Parse a plugin's `package.json` manifest from disk. Returns the plugin
- * name (scope-stripped) and version, or `undefined` when the file is
- * missing, unparseable, or fails schema validation.
+ * identity (its install directory name) and version, or `undefined` when the
+ * `package.json` is missing, unparseable, or fails schema validation.
  *
  * Exported so the mtime cache can discover plugin identity without going
- * through the full `buildExternalPlugin` path.
+ * through the full `buildExternalPlugin` path. The identity mirrors
+ * {@link buildPluginFromDir}: the directory name, not `package.json` `name`.
  */
 export async function parsePluginManifest(
   pluginDir: string,
@@ -411,7 +411,7 @@ export async function parsePluginManifest(
     return undefined;
   }
   const pkg: PluginPackageJson = parsed.data;
-  const name = stripScope(pkg.name);
+  const name = basename(pluginDir);
   const version = pkg.version && pkg.version.length > 0 ? pkg.version : "0.0.0";
   return { name, version };
 }


### PR DESCRIPTION
## Prompt / plan

Partner QA of a cognee plugin install found that the `cognee-sync` skill never auto-fired — the assistant had to be told to invoke it manually. Investigation traced this to how plugin identity is resolved, not the plugin itself.

I reproduced it end-to-end on a local instance: installing the real cognee plugin (`topoteretes/cognee-integrations/integrations/vellum-assistant` @ `d79bd9a`) puts its three skills (`cognee-sync`, `cognee-search`, `cognee-remember`) on disk, the runtime loads its hooks + `cognee_recall` tool, and `plugins inspect` even lists the skills — yet **`skills list` (the catalog the model actually sees) returned none of them.**

**Root cause — two identities for one plugin.** A plugin is installed under its *slug* (marketplace name or GitHub path leaf), which becomes its **directory name**. That directory name is the identity used by `plugins list`, enable/disable, per-conversation plugin scoping, and resident-skill `owner.id`. But two places instead used the authored `package.json` `name`, which routinely differs:

| install path | directory (slug) | `package.json` name |
|---|---|---|
| marketplace | `cognee` | `cognee-memory` |
| GitHub direct | `vellum-assistant` | `cognee-memory` |

This PR fixes both:

**1. Skill discovery** (`config/skills.ts`) required `package.json.name === directory`, so mismatched plugins had all their skills silently dropped from the catalog even though the runtime loaded everything else. Relaxed to mirror the loader: recognize any directory with a parseable `package.json` (non-empty `name`), attributing skills to the install slug.

**2. Plugin identity in the loader** (`plugins/external-plugin-loader.ts`) — flagged as an inconsistency in review. `buildPluginFromDir` / `parsePluginManifest` derived the runtime `manifest.name` from `stripScope(pkg.name)`, while everything else keys on the directory name. This was a latent scoping bug, not just cosmetic: plugin **tools** are cached and attributed under `manifest.name`, and the tool scope filter checks `effectiveSet.has(owner.id)` / `isPluginDisabled(id)` against the directory-name identity — so for a mismatched plugin, enabling/disabling it didn't actually gate its tools. Now the identity is the install directory basename everywhere, so registration, activation, tool namespacing, skills, and scoping all agree. `package.json` stays schema-validated as the load gate; only its role as the identity source is dropped. Removed the now-unused `stripScope`.

## Test plan

- **New FS-level regression test** (`config/__tests__/plugin-resident-skill-discovery.test.ts`, 6 cases): mismatched dir≠name surfaces the skill (the cognee shape); matched dir==name surfaces it; skips missing / unparseable / nameless manifests and `.disabled` plugins.
- **Updated loader tests** (`external-plugin-loader.test.ts`, `user-plugin-loader.test.ts`, `skills.test.ts`) to assert directory-name identity, including the previously-failing case that asserted the old dir==name requirement.
- Full affected suites green: skills (54), external-plugin-loader (24), user-plugin-loader (5), plugin-bootstrap (12), mtime-cache (35), plugin-source-watch (10), conversation-tool-setup (8) + exclude (12), skill-load-plugin-scope (6), conversation-routes-enabled-plugins (5), plugin-resident-skill-discovery (6).
- `bunx tsc --noEmit` clean; eslint 0 errors; Prettier clean.
- **End-to-end on a live local instance:** restarted the daemon on the patched source, dropped a mismatched-name plugin, and confirmed `assistant skills list` now surfaces its skill (`source=plugin:<slug>`, `owner={kind:plugin,id:<slug>}`) where before the fix it did not.
