### PR TITLE
fix(assistant): persist conversation row in runConversationTurn

### DIFF
--- a/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
+++ b/assistant/src/__tests__/run-conversation-turn-persistence.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  createConversation,
+  getConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+// Capture the list-invalidation calls `runConversationTurn` fires when it
+// creates a brand-new conversation row, without pulling in the real sync
+// publisher (which reaches for live SSE subscribers).
+const listChangedCalls: Array<{ kind: string; conversationId: string }> = [];
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationListAndMetadataChanged: (
+    kind: string,
+    conversationId: string,
+  ) => {
+    listChangedCalls.push({ kind, conversationId });
+  },
+}));
+
+// Stub the heavy machinery: the in-memory conversation build (provider wiring,
+// system prompt, history hydration) and the SSE event fan-out. The agent turn
+// itself is a no-op — this test only asserts that the `conversations` row is
+// persisted before the turn runs, which is what `ensureConversationExists`
+// guarantees. The persistence module is intentionally NOT mocked so the real
+// `ensureConversationExists` runs against the real DB.
+let lastProcessMessageConversationId: string | undefined;
+mock.module("../daemon/conversation-store.js", () => ({
+  getOrCreateConversation: async (conversationId: string) => ({
+    abortController: undefined,
+    isProcessing: () => false,
+    async processMessage() {
+      // The row must already exist by the time the turn persists its user
+      // message — record the id so the FK precondition can be asserted.
+      lastProcessMessageConversationId = conversationId;
+      return "user-message-id";
+    },
+    enqueueMessage: () => ({ rejected: false }),
+  }),
+}));
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: () => {},
+}));
+
+mock.module("../providers/media-resolve.js", () => ({
+  resolveMediaSourceData: () => null,
+}));
+
+// Import under test AFTER the mocks are registered so its dynamic imports
+// resolve to the stubs above.
+const { runConversationTurn } =
+  await import("../plugin-api/conversation-turn.js");
+
+describe("runConversationTurn persistence", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+    listChangedCalls.length = 0;
+    lastProcessMessageConversationId = undefined;
+  });
+
+  test("persists a conversations row for a freshly-minted conversation", async () => {
+    const result = await runConversationTurn({
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    // The row exists on disk — not just as an in-memory Conversation object —
+    // so the user-message persist inside the turn has its FK target.
+    const row = getConversation(result.conversationId);
+    expect(row?.id).toBe(result.conversationId);
+    expect(lastProcessMessageConversationId).toBe(result.conversationId);
+
+    // Siblings/sidebars are told about the new conversation, mirroring the
+    // send-message route.
+    expect(listChangedCalls).toEqual([
+      { kind: "created", conversationId: result.conversationId },
+    ]);
+  });
+
+  test("adopts a caller-supplied conversation id verbatim when no row exists", async () => {
+    const conversationId = "0f9c1e2a-3b4d-5e6f-7a8b-9c0d1e2f3a4b";
+
+    const result = await runConversationTurn({
+      conversationId,
+      content: [{ type: "text", text: "hello" }],
+    });
+
+    expect(result.conversationId).toBe(conversationId);
+    expect(getConversation(conversationId)?.id).toBe(conversationId);
+    expect(listChangedCalls).toEqual([{ kind: "created", conversationId }]);
+  });
+
+  test("is a no-op for an already-persisted conversation row", async () => {
+    const existing = createConversation({ title: "already here" });
+    listChangedCalls.length = 0;
+
+    const result = await runConversationTurn({
+      conversationId: existing.id,
+      content: [{ type: "text", text: "follow up" }],
+    });
+
+    expect(result.conversationId).toBe(existing.id);
+    // Row is untouched and no duplicate "created" invalidation fires.
+    expect(getConversation(existing.id)?.title).toBe("already here");
+    expect(listChangedCalls).toEqual([]);
+  });
+});

--- a/assistant/src/plugin-api/conversation-turn.ts
+++ b/assistant/src/plugin-api/conversation-turn.ts
@@ -71,7 +71,9 @@ export interface RunConversationTurnResult {
  */
 function extractContentAndAttachments(
   blocks: ContentBlock[],
-  resolveMedia: (source: MediaSource) => { data: string; media_type: string } | null,
+  resolveMedia: (
+    source: MediaSource,
+  ) => { data: string; media_type: string } | null,
 ): { text: string; attachments: UserMessageAttachment[] } {
   const textParts: string[] = [];
   const attachments: UserMessageAttachment[] = [];
@@ -126,21 +128,35 @@ export async function runConversationTurn(
   options: RunConversationTurnOptions,
 ): Promise<RunConversationTurnResult> {
   const { v7: uuidv7 } = await import("uuid");
-  const { getOrCreateConversation } = await import(
-    "../daemon/conversation-store.js"
-  );
-  const { broadcastMessage } = await import(
-    "../runtime/assistant-event-hub.js"
-  );
-  const { resolveMediaSourceData } = await import(
-    "../providers/media-resolve.js"
-  );
-  const { getMessageById, getMessages } = await import(
-    "../persistence/conversation-crud.js"
-  );
+  const { getOrCreateConversation } =
+    await import("../daemon/conversation-store.js");
+  const { broadcastMessage } =
+    await import("../runtime/assistant-event-hub.js");
+  const { resolveMediaSourceData } =
+    await import("../providers/media-resolve.js");
+  const { ensureConversationExists, getMessageById, getMessages } =
+    await import("../persistence/conversation-crud.js");
+  const { publishConversationListAndMetadataChanged } =
+    await import("../runtime/sync/resource-sync-events.js");
 
   const conversationId = options.conversationId ?? uuidv7();
   const conversation = await getOrCreateConversation(conversationId);
+
+  // `getOrCreateConversation` only builds the in-memory conversation (provider,
+  // system prompt, history hydration) — it never writes a `conversations` row.
+  // On the first turn of a brand-new chat (a minted id, or a caller-supplied id
+  // with no persisted row), the user-message persist inside `processMessage`
+  // would insert into `messages` against a nonexistent FK target. Ensure the
+  // row exists (idempotent) before persisting, mirroring the live-voice ingress
+  // which faces the same adopted-id-without-row gap.
+  const createdConversation = ensureConversationExists(conversationId);
+  if (createdConversation) {
+    // The row was created outside the normal send-message route, which is where
+    // sibling clients/sidebars learn about a new conversation. Emit the same
+    // "created" list invalidation that route does so they see it without
+    // waiting for a reload.
+    publishConversationListAndMetadataChanged("created", conversationId);
+  }
 
   // Wire the external abort signal to the conversation's internal abort
   // controller so aborting the signal terminates the in-flight agent loop.


### PR DESCRIPTION
## Prompt / plan

`runConversationTurn` (the plugin-facing agent-turn facade) never created a DB `conversations` row.

The chain:
- `runConversationTurn` calls `getOrCreateConversation(conversationId)`, which builds an **in-memory** `Conversation` (provider wiring, system prompt, history hydration via `loadFromDb`) but never writes a `conversations` row.
- The turn then runs `processMessage` → `persistUserMessage` → `addMessage` → `insertMessageCore`, which inserts into `messages` and bumps the parent conversation's `updatedAt` / `lastMessageAt`.
- On the first turn of a brand-new chat (a minted id, or a caller-supplied id with no persisted row), the `messages` row targets a nonexistent FK (`messages.conversation_id → conversations.id`), and the `UPDATE conversations` bump silently touches 0 rows — the conversation row simply never exists.

The fix mirrors the live-voice ingress, which already faces the identical "adopted id without a row yet" gap: call the idempotent `ensureConversationExists(conversationId)` before running the turn, and emit the same `publishConversationListAndMetadataChanged("created", …)` list invalidation the send-message route emits so sibling clients/sidebars learn about the new conversation without a reload.

## Test plan

- New regression test `assistant/src/__tests__/run-conversation-turn-persistence.test.ts` (mocks the in-memory conversation build / SSE fan-out but exercises the **real** persistence layer against a real DB):
  - persists a `conversations` row for a freshly-minted conversation, and fires exactly one `"created"` invalidation;
  - adopts a caller-supplied id verbatim when no row exists;
  - is a no-op (no row change, no duplicate invalidation) for an already-persisted conversation.
- `bun test` for the new file and the sibling `ensure-conversation-exists.test.ts`: pass.
- Pre-commit + pre-push hooks (prettier, eslint, tsc) pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KngxHTBnRLQUZDzPrXnony)_