### PR TITLE
refactor(settings): name the consolidated tab Debug

### DIFF
--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -401,7 +401,7 @@ describe("StatusBanner", () => {
       expect(html).toContain("bg-[var(--system-negative-weak)]");
       expect(html).toContain("lucide-triangle-alert");
       expect(html).toContain("Go to Doctor");
-      expect(html).toContain("/assistant/settings/advanced?tab=doctor");
+      expect(html).toContain("/assistant/settings/debug?tab=doctor");
     }
   });
 

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -443,7 +443,7 @@ function localHealthBannerConfig(
 function doctorAction(): ReactNode {
   return (
     <Button asChild variant="outlined" size="compact">
-      <Link to={`${routes.settings.advanced}?tab=doctor`}>Go to Doctor</Link>
+      <Link to={`${routes.settings.debug}?tab=doctor`}>Go to Doctor</Link>
     </Button>
   );
 }

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -455,7 +455,7 @@ describe("ChatBody — generic chat error Notice (dismiss UX)", () => {
           genericChatError: {
             message: "Model doesn't support image input.",
             actions: (
-              <a href="/assistant/settings/advanced?tab=doctor">Go to Doctor</a>
+              <a href="/assistant/settings/debug?tab=doctor">Go to Doctor</a>
             ),
           },
           onDismissChatError: () => {},

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -564,7 +564,7 @@ export function ChatMainPanel({
     assistantState.kind === "active" && !assistantState.isLocal;
   const doctorAction = showDoctorAction ? (
     <Button asChild variant="outlined" size="compact">
-      <Link to={`${routes.settings.advanced}?tab=doctor`}>
+      <Link to={`${routes.settings.debug}?tab=doctor`}>
         Go to Doctor
       </Link>
     </Button>

--- a/clients/web/src/domains/chat/components/maintenance-recovery-card.tsx
+++ b/clients/web/src/domains/chat/components/maintenance-recovery-card.tsx
@@ -26,10 +26,10 @@ export function MaintenanceRecoveryCard() {
         Chat is unavailable while maintenance is active.
       </p>
       <Link
-        to={`${routes.settings.advanced}?tab=terminal`}
+        to={`${routes.settings.debug}?tab=terminal`}
         className="mt-4 inline-flex items-center gap-1.5 rounded-md border border-[var(--system-mid-strong)] bg-[var(--surface-lift)] px-3 py-1.5 text-body-small-default text-[var(--system-mid-strong)] transition-colors hover:bg-[var(--system-mid-weak)]"
       >
-        Go to Advanced Settings
+        Go to Debug Settings
       </Link>
     </div>
   );

--- a/clients/web/src/domains/settings/pages/archive-redirect-page.tsx
+++ b/clients/web/src/domains/settings/pages/archive-redirect-page.tsx
@@ -11,7 +11,7 @@ export function ArchiveRedirectPage() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    navigate(`${routes.settings.advanced}?tab=archive`, { replace: true });
+    navigate(`${routes.settings.debug}?tab=archive`, { replace: true });
   }, [navigate]);
 
   return null;

--- a/clients/web/src/domains/settings/pages/debug-page.tsx
+++ b/clients/web/src/domains/settings/pages/debug-page.tsx
@@ -16,11 +16,11 @@ const ALL_TABS = [
   { id: "archive", label: "Archive" },
 ] as const;
 
-type AdvancedTabId = (typeof ALL_TABS)[number]["id"];
+type DebugTabId = (typeof ALL_TABS)[number]["id"];
 
-const DEFAULT_TAB: AdvancedTabId = "general";
+const DEFAULT_TAB: DebugTabId = "general";
 
-export function AdvancedPage() {
+export function DebugPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   // Terminal and Doctor are platform-routed and must be hidden when the active
   // assistant is self-hosted — `platformHostedOnly: true` is the correct
@@ -46,7 +46,7 @@ export function AdvancedPage() {
   // A gated deep-link (e.g. ?tab=doctor on a self-hosted assistant) has no
   // matching visible tab, so fall back to General rather than rendering a
   // panel with no trigger.
-  const activeTab: AdvancedTabId = useMemo(() => {
+  const activeTab: DebugTabId = useMemo(() => {
     const tabParam = searchParams.get("tab");
     const match = tabs.find((tab) => tab.id === tabParam);
     return match?.id ?? DEFAULT_TAB;

--- a/clients/web/src/routes.test.ts
+++ b/clients/web/src/routes.test.ts
@@ -187,4 +187,21 @@ describe("settings route compatibility", () => {
       "McpSettingsRedirect",
     );
   });
+
+  test("legacy Advanced settings URL redirects to Debug", () => {
+    expect(leafRouteComponentName("/assistant/settings/advanced")).toBe(
+      "AdvancedSettingsRedirect",
+    );
+  });
+
+  test("the Debug settings URL renders the page rather than redirecting", () => {
+    const matches = matchRoutes(routeTree as never, "/assistant/settings/debug");
+    const leaf = matches?.at(-1)?.route as
+      | { lazy?: unknown; Component?: { name?: string } }
+      | undefined;
+    // `lazy` is the page itself; a redirect route would carry a named
+    // `Component` instead.
+    expect(leaf?.lazy).toBeDefined();
+    expect(leaf?.Component).toBeUndefined();
+  });
 });

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -39,18 +39,16 @@ function McpSettingsRedirect() {
 }
 
 /**
- * Forwards `/assistant/settings/debug` deep links to Settings → Advanced, which
- * hosts the General, Terminal, and Doctor tabs. The query string is preserved
- * so `?tab=terminal` and `?tab=doctor` land on the matching in-page tab.
+ * Forwards legacy `/assistant/settings/advanced` deep links to Settings → Debug,
+ * which hosts the General, Terminal, Doctor, and Archive tabs. The query string
+ * is preserved so `?tab=terminal` and `?tab=doctor` land on the matching in-page
+ * tab.
  */
-function DebugSettingsRedirect() {
+function AdvancedSettingsRedirect() {
   const [searchParams] = useSearchParams();
   const qs = searchParams.toString();
   return (
-    <Navigate
-      to={`${routes.settings.advanced}${qs ? `?${qs}` : ""}`}
-      replace
-    />
+    <Navigate to={`${routes.settings.debug}${qs ? `?${qs}` : ""}`} replace />
   );
 }
 
@@ -296,9 +294,9 @@ export const routeTree = [
                 { path: "billing/upgrade/success", lazy: { Component: () => import("@/domains/settings/billing/upgrade-success-page").then((m) => m.UpgradeSuccessPage) } },
                 { path: "community", lazy: { Component: () => import("@/domains/settings/pages/community-page").then((m) => m.CommunityPage) } },
                 { path: "mcp", Component: McpSettingsRedirect },
-                { path: "debug", Component: DebugSettingsRedirect },
+                { path: "debug", lazy: { Component: () => import("@/domains/settings/pages/debug-page").then((m) => m.DebugPage) } },
                 { path: "developer", lazy: { Component: () => import("@/domains/settings/pages/developer-page").then((m) => m.DeveloperPage) } },
-                { path: "advanced", lazy: { Component: () => import("@/domains/settings/pages/advanced-page").then((m) => m.AdvancedPage) } },
+                { path: "advanced", Component: AdvancedSettingsRedirect },
                 { path: "danger-zone", lazy: { Component: () => import("@/domains/settings/pages/danger-zone-redirect-page").then((m) => m.DangerZoneRedirectPage) } },
                 { path: "system-events", lazy: { Component: () => import("@/domains/settings/pages/system-events-redirect-page").then((m) => m.SystemEventsRedirectPage) } },
               ],

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -193,7 +193,7 @@ export const routes = {
     community: r("/assistant/settings/community"),
     developer: r("/assistant/settings/developer"),
     mcp: r("/assistant/settings/mcp"),
-    advanced: r("/assistant/settings/advanced"),
+    debug: r("/assistant/settings/debug"),
     dangerZone: r("/assistant/settings/danger-zone"),
     systemEvents: r("/assistant/settings/system-events"),
     upgradeCancel: r("/assistant/settings/billing/upgrade/cancel"),

--- a/clients/web/src/utils/settings-navigation.test.ts
+++ b/clients/web/src/utils/settings-navigation.test.ts
@@ -1,32 +1,48 @@
 import { describe, expect, test } from "bun:test";
 
-import { getSettingsRouteForClientTab } from "@/utils/settings-navigation";
+import {
+  SETTINGS_SIDEBAR,
+  getSettingsRouteForClientTab,
+} from "@/utils/settings-navigation";
 
-describe("getSettingsRouteForClientTab — Advanced merge", () => {
-  test("resolves the debug and developer client tabs to the Advanced page", () => {
+describe("getSettingsRouteForClientTab — Debug page", () => {
+  test("resolves the debug and developer client tabs to the Debug page", () => {
     expect(getSettingsRouteForClientTab("debug")).toBe(
-      "/assistant/settings/advanced",
+      "/assistant/settings/debug",
     );
     expect(getSettingsRouteForClientTab("developer")).toBe(
-      "/assistant/settings/advanced",
+      "/assistant/settings/debug",
     );
   });
 
-  test("routes the archive alias to the Advanced Archive tab", () => {
-    // The bare Advanced route opens General, so archive must carry ?tab=archive
-    // to land on the Archive tab.
+  test("routes the archive alias to the Debug Archive tab", () => {
+    // The bare Debug route opens General, so archive must carry ?tab=archive to
+    // land on the Archive tab.
     expect(getSettingsRouteForClientTab("archive")).toBe(
-      "/assistant/settings/advanced?tab=archive",
+      "/assistant/settings/debug?tab=archive",
     );
     expect(getSettingsRouteForClientTab("Archive")).toBe(
-      "/assistant/settings/advanced?tab=archive",
+      "/assistant/settings/debug?tab=archive",
     );
   });
 
-  test("resolves the Advanced sidebar label to the Advanced page without ambiguity", () => {
-    expect(getSettingsRouteForClientTab("Advanced")).toBe(
-      "/assistant/settings/advanced",
+  test("resolves the Debug sidebar label to the Debug page without ambiguity", () => {
+    expect(getSettingsRouteForClientTab("Debug")).toBe(
+      "/assistant/settings/debug",
     );
+  });
+
+  test("keeps resolving the legacy Advanced tab name to the Debug page", () => {
+    expect(getSettingsRouteForClientTab("Advanced")).toBe(
+      "/assistant/settings/debug",
+    );
+  });
+
+  test("no two sidebar items share a label", () => {
+    // The label is a lookup key in the fallback tier, so a duplicate would make
+    // resolution order-dependent.
+    const labels = SETTINGS_SIDEBAR.map((item) => item.label.toLowerCase());
+    expect(new Set(labels).size).toBe(labels.length);
   });
 
   test("returns null for an unknown tab name", () => {

--- a/clients/web/src/utils/settings-navigation.ts
+++ b/clients/web/src/utils/settings-navigation.ts
@@ -11,12 +11,12 @@ import type { LucideIcon } from "lucide-react";
 import {
   Bell,
   Bookmark,
+  Bug,
   Code,
   Cpu,
   CreditCard,
   KeyRound,
   Mic,
-  Settings,
   Users,
   Puzzle,
   ShieldCheck,
@@ -41,7 +41,7 @@ export const PANEL_IDS = [
   "billing",
   "community",
   "assistant-status",
-  "advanced",
+  "debug",
   "developer",
 ] as const;
 
@@ -78,15 +78,15 @@ export const SETTINGS_SIDEBAR: SidebarItem[] = [
   { id: "bookmarks", label: "Bookmarks", href: routes.settings.bookmarks, icon: Bookmark },
   { id: "billing", label: "Billing & Usage", href: routes.settings.billing, icon: CreditCard },
   { id: "community", label: "Community", href: routes.settings.community, icon: Users },
-  { id: "advanced", label: "Advanced", href: routes.settings.advanced, icon: Settings },
+  { id: "debug", label: "Debug", href: routes.settings.debug, icon: Bug },
   { id: "developer", label: "Developer", href: routes.settings.developer, icon: Code },
 ];
 
 const SETTINGS_TAB_ID_ALIASES: Record<string, PanelId> = {
-  // General, Terminal, and Doctor are in-page tabs on the Advanced page, so the
-  // "developer" and "debug" client tab names resolve there.
-  developer: "advanced",
-  debug: "advanced",
+  // General, Terminal, and Doctor are in-page tabs on the Debug page, so the
+  // "developer" and legacy "advanced" client tab names resolve there.
+  developer: "debug",
+  advanced: "debug",
   model: "model",
   privacy: "privacy",
   // Two-factor auth moved from the retired Security tab onto General.
@@ -107,9 +107,9 @@ const SETTINGS_TAB_ROUTE_ALIASES: Record<string, string> = {
   "keyboard shortcuts": `${routes.settings.general}?preferences=open`,
   // Sounds is an in-page tab on the Voice & Sounds page.
   sounds: `${routes.settings.voice}?tab=sounds`,
-  // Archive is an in-page tab on the Advanced page; the bare Advanced route
-  // opens General, so the archive alias carries the ?tab= param.
-  archive: `${routes.settings.advanced}?tab=archive`,
+  // Archive is an in-page tab on the Debug page; the bare Debug route opens
+  // General, so the archive alias carries the ?tab= param.
+  archive: `${routes.settings.debug}?tab=archive`,
 };
 
 function normalizeSettingsTabName(tab: string): string {


### PR DESCRIPTION
## Summary

Names the consolidated Settings tab **Debug** instead of **Advanced**, at `/assistant/settings/debug` with the `Bug` icon.

#38214 folded the old Debug tab into Advanced and kept the *Advanced* name. The intended end state is the opposite: the surviving tab — which hosts General, Terminal, Doctor, and Archive — should be called **Debug**. This is the rename, on top of #38214 (now merged).

## What changed

- **Label + icon** — `Advanced` → `Debug`, `Settings` icon → `Bug`.
- **Canonical URL** — `routes.settings.advanced` → `routes.settings.debug` (`/assistant/settings/debug`).
- **Redirect reversed** — `DebugSettingsRedirect` becomes `AdvancedSettingsRedirect`, forwarding `/assistant/settings/advanced` → `/assistant/settings/debug`. The query string is preserved, so `?tab=terminal`, `?tab=doctor`, and `?tab=archive` still land on the right in-page tab.
- **Symbols follow the file** — `advanced-page.tsx` → `debug-page.tsx`, `AdvancedPage` → `DebugPage`, `AdvancedTabId` → `DebugTabId`, per `docs/STYLE_GUIDE.md` ("Component filenames match the export"). `git mv` preserves blame.
- **`PanelId`** — `advanced` → `debug`, keeping id/label/href/route coherent. The symbol is confined to `settings-navigation.ts` with no external consumers and no persistence, so the rename has no blast radius.
- **Deep links updated** — the Doctor links in `status-banner.tsx` and `chat-route-content.tsx`, the Terminal link in `maintenance-recovery-card.tsx` (whose copy now reads "Go to Debug Settings"), and `archive-redirect-page.tsx`.

## Compatibility

`/assistant/settings/advanced` has shipped and has real bookmark history, so it keeps working via the redirect stub — the same pattern already used for `mcp`, `archive`, `security`, `devices`, and friends. `clients/web/AGENTS.md`: *"URL paths are part of the contract… Don't rename URL patterns without a deprecation period."*

Native clients that still send the `Advanced` tab name resolve through an explicit `advanced: "debug"` alias. The `developer: "debug"` alias is retained deliberately — it shadows the `developer` sidebar item via alias precedence, and the daemon's `navigate_settings_tab` enum does emit `"Developer"`.

## Testing

- Full web suite green: **623 passed** via `bun run test:ci` (per-file isolation, as CI runs it). One unrelated file, `src/lib/streaming/event-parser.test.ts`, fails identically on plain `main` in the same environment — pre-existing, not from this change.
- `typecheck` and `lint` clean (lint exits 0).
- New tests: the reverse redirect and the Debug route resolution in `routes.test.ts` — both verified to **fail** when the route swap is reverted, so they aren't vacuous. Plus a guard that no two sidebar items share a label, which is the invariant that constrained #38214's design.
- Updated `settings-navigation.test.ts`, including a case pinning the legacy `Advanced` tab name to the Debug page.

## Manual QA

- [ ] Sidebar shows a single **Debug** entry with the bug icon; header title reads "Debug".
- [ ] `/assistant/settings/advanced` → `/assistant/settings/debug` (history `replace`, no back-button trap).
- [ ] `?tab=terminal` / `?tab=doctor` / `?tab=archive` survive the redirect.
- [ ] `/assistant/settings/archive` → `/assistant/settings/debug?tab=archive`.
- [ ] Self-hosted: Terminal + Doctor stay hidden; `?tab=doctor` falls back to General.
- [ ] `navigate_settings_tab({tab: "Archive"})` and `{tab: "Developer"}` both land on Debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)