### PR TITLE
refactor(web): consent resolver consumes server effective fields

### DIFF
--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -9067,6 +9067,12 @@ components:
         share_diagnostics:
           type: boolean
           nullable: true
+        share_analytics_effective:
+          type: boolean
+          readOnly: true
+        share_diagnostics_effective:
+          type: boolean
+          readOnly: true
         share_analytics_accepted_version:
           type: string
           maxLength: 32
@@ -9087,7 +9093,9 @@ components:
       - ai_data_sharing_accepted_at
       - privacy_policy_accepted_at
       - share_analytics_accepted_at
+      - share_analytics_effective
       - share_diagnostics_accepted_at
+      - share_diagnostics_effective
       - tos_accepted_at
     UserConsentRequest:
       type: object

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -59,7 +59,7 @@ const { refreshDiagnosticsConsent, installConsentRefreshListeners } =
   await import("./consent-refresh");
 
 function consentRecord(overrides: Partial<UserConsent> = {}): UserConsent {
-  return {
+  const base: UserConsent = {
     tos_accepted_version: "",
     tos_accepted_at: null,
     privacy_policy_accepted_version: "",
@@ -68,11 +68,21 @@ function consentRecord(overrides: Partial<UserConsent> = {}): UserConsent {
     ai_data_sharing_accepted_at: null,
     share_analytics: true,
     share_diagnostics: true,
+    share_analytics_effective: true,
+    share_diagnostics_effective: true,
     share_analytics_accepted_version: "",
     share_analytics_accepted_at: null,
     share_diagnostics_accepted_version: "",
     share_diagnostics_accepted_at: null,
     ...overrides,
+  };
+  // Mirror the wire contract: the platform serves effective = value ?? true.
+  return {
+    ...base,
+    share_analytics_effective:
+      overrides.share_analytics_effective ?? base.share_analytics ?? true,
+    share_diagnostics_effective:
+      overrides.share_diagnostics_effective ?? base.share_diagnostics ?? true,
   };
 }
 

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -63,7 +63,7 @@ import {
 import type { UserConsent } from "@/domains/account/profile";
 
 function makeConsent(overrides: Partial<UserConsent> = {}): UserConsent {
-  return {
+  const base: UserConsent = {
     tos_accepted_version: TOS_CONSENT_VERSION,
     tos_accepted_at: null,
     privacy_policy_accepted_version: PRIVACY_CONSENT_VERSION,
@@ -72,11 +72,22 @@ function makeConsent(overrides: Partial<UserConsent> = {}): UserConsent {
     ai_data_sharing_accepted_at: null,
     share_analytics: true,
     share_diagnostics: true,
+    share_analytics_effective: true,
+    share_diagnostics_effective: true,
     share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
     share_analytics_accepted_at: null,
     share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
     share_diagnostics_accepted_at: null,
     ...overrides,
+  };
+  // Mirror the wire contract unless a test overrides the effective fields
+  // directly: the platform computes effective = value ?? true (opt-out).
+  return {
+    ...base,
+    share_analytics_effective:
+      overrides.share_analytics_effective ?? base.share_analytics ?? true,
+    share_diagnostics_effective:
+      overrides.share_diagnostics_effective ?? base.share_diagnostics ?? true,
   };
 }
 
@@ -185,28 +196,84 @@ describe("resolveServerConsent", () => {
     expect(resolved.diagnosticsCurrent).toBe(false);
   });
 
-  test("implicit defaults (true + empty version) read as never-asked, not stale", () => {
-    // A pre-nullable platform materializes its DB default `true` with no
-    // version on rows created without the toggle shown — never-asked in
-    // disguise. Must not bounce to review-terms, but earns no version ack.
+  // The implicit-default cases (`true` + empty version resolving to null)
+  // are gone: they guarded a pre-nullable platform that materialized its DB
+  // default `true` on rows created without the toggle shown. Platform
+  // migration 0169 nulled every such implicit ledger row on the single
+  // deployment, so that shape no longer exists on the wire — never-asked is
+  // exactly `share_analytics === null` now, and any explicit value with an
+  // empty version owes a re-review like any other stale explicit choice.
+
+  test("server effective fields are consumed verbatim when present", () => {
+    // Never-asked row: raw null stays null (chosen-ness), while the
+    // server-computed effective (null = enabled) is surfaced directly.
     const r = resolveServerConsent(
       makeConsent({
-        share_analytics: true,
+        share_analytics: null,
         share_analytics_accepted_version: "",
-        share_diagnostics: true,
+        share_diagnostics: null,
         share_diagnostics_accepted_version: "",
       }),
     );
-    expect(r.analyticsCurrent).toBe(true);
-    expect(r.diagnosticsCurrent).toBe(true);
-    expect(r.analyticsVersionCurrent).toBe(false);
-    expect(r.diagnosticsVersionCurrent).toBe(false);
-    // The values resolve to null so no consumer treats the materialized
-    // default as an explicit grant — the diagnostics gate chokepoint and
-    // the analytics store adoption must not overwrite an explicit local
-    // opt-out whose patch hasn't landed on such a row.
     expect(r.shareAnalytics).toBeNull();
     expect(r.shareDiagnostics).toBeNull();
+    expect(r.analyticsEffective).toBe(true);
+    expect(r.diagnosticsEffective).toBe(true);
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("effective fields win over the raw values when they disagree", () => {
+    // The platform owns the effective computation; the resolver must not
+    // re-derive it from the raw value when the server sent one.
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics: true,
+        share_analytics_effective: false,
+        share_diagnostics: null,
+        share_diagnostics_effective: false,
+      }),
+    );
+    expect(r.analyticsEffective).toBe(false);
+    expect(r.diagnosticsEffective).toBe(false);
+  });
+
+  test("an explicit opt-out resolves effective false and still owes re-review when stale", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics: false,
+        share_analytics_accepted_version: "",
+        share_diagnostics: false,
+        share_diagnostics_accepted_version: "2020-01-01",
+      }),
+    );
+    expect(r.shareAnalytics).toBe(false);
+    expect(r.shareDiagnostics).toBe(false);
+    expect(r.analyticsEffective).toBe(false);
+    expect(r.diagnosticsEffective).toBe(false);
+    expect(r.analyticsCurrent).toBe(false);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+
+  test("absent effective fields (older backend) fall back to the raw values' opt-out reading", () => {
+    const legacy = (overrides: Partial<UserConsent>) => {
+      const consent = makeConsent(overrides) as unknown as Record<string, unknown>;
+      delete consent.share_analytics_effective;
+      delete consent.share_diagnostics_effective;
+      return consent as unknown as UserConsent;
+    };
+    // Explicit values pass through...
+    const explicit = resolveServerConsent(
+      legacy({ share_analytics: false, share_diagnostics: true }),
+    );
+    expect(explicit.analyticsEffective).toBe(false);
+    expect(explicit.diagnosticsEffective).toBe(true);
+    // ...and never-asked defaults to enabled (opt-out semantics).
+    const neverAsked = resolveServerConsent(
+      legacy({ share_analytics: null, share_diagnostics: null }),
+    );
+    expect(neverAsked.analyticsEffective).toBe(true);
+    expect(neverAsked.diagnosticsEffective).toBe(true);
   });
 
   test("an explicit grant with a version on record resolves the raw values", () => {
@@ -235,6 +302,9 @@ describe("resolveServerConsent", () => {
     expect(resolveServerConsent(null).diagnosticsCurrent).toBe(false);
     expect(resolveServerConsent(undefined).analyticsCurrent).toBe(false);
     expect(resolveServerConsent(undefined).diagnosticsCurrent).toBe(false);
+    // No record at all still resolves effective to enabled (opt-out).
+    expect(resolveServerConsent(null).analyticsEffective).toBe(true);
+    expect(resolveServerConsent(null).diagnosticsEffective).toBe(true);
   });
 
   // A server version newer than this build's constant counts as current on

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -185,6 +185,13 @@ export function resolveServerConsent(
   privacy: boolean;
   shareAnalytics: boolean | null;
   shareDiagnostics: boolean | null;
+  /**
+   * Server-computed effective consent (opt-out semantics: null/never-asked =
+   * enabled). This is the value data-capture gates should honor; the raw
+   * `share*` fields above stay tri-state for chosen-ness.
+   */
+  analyticsEffective: boolean;
+  diagnosticsEffective: boolean;
   analyticsCurrent: boolean;
   diagnosticsCurrent: boolean;
   /**
@@ -204,6 +211,10 @@ export function resolveServerConsent(
       privacy: false,
       shareAnalytics: null,
       shareDiagnostics: null,
+      // No server record to resolve; opt-out semantics default to enabled,
+      // matching the fallback chain applied to an all-null record.
+      analyticsEffective: true,
+      diagnosticsEffective: true,
       analyticsCurrent: false,
       diagnosticsCurrent: false,
       analyticsVersionCurrent: false,
@@ -220,7 +231,7 @@ export function resolveServerConsent(
     DIAGNOSTICS_CONSENT_VERSION,
   );
   // The endpoint always returns an object; for a user with no stored row it
-  // returns the API defaults (empty versions, share booleans true). Any
+  // returns the API defaults (empty versions, null share booleans). Any
   // non-empty version or any `false` share boolean can only have come from a
   // real stored row, so it proves a record whose data is worth preserving.
   // Truthiness (not `!== ""`) so a response that OMITS the newer
@@ -235,18 +246,6 @@ export function resolveServerConsent(
     !!consent.share_diagnostics_accepted_version ||
     consent.share_analytics === false ||
     consent.share_diagnostics === false;
-  // An implicit grant — true with NO version on record — is never-asked in
-  // disguise, not an explicit choice: a pre-nullable platform materializes
-  // its DB default `true` on rows created without the toggle shown (e.g. a
-  // ToS-only row), while every explicit write stamps a version. Resolve it
-  // to null so no consumer can mistake it for a user grant — the diagnostics
-  // gate chokepoint and the analytics store adoption would otherwise
-  // overwrite an explicit local opt-out whose patch hasn't landed. An
-  // explicit opt-out (false) is never excused this way.
-  const analyticsImplicitDefault =
-    consent.share_analytics === true && !consent.share_analytics_accepted_version;
-  const diagnosticsImplicitDefault =
-    consent.share_diagnostics === true && !consent.share_diagnostics_accepted_version;
   return {
     // The ToS checkbox covers only the Terms of Service. The privacy checkbox
     // covers both the Privacy Policy and the AI Data Sharing Policy, so it is
@@ -255,22 +254,25 @@ export function resolveServerConsent(
     privacy:
       versionIsCurrent(consent.privacy_policy_accepted_version, PRIVACY_CONSENT_VERSION) &&
       versionIsCurrent(consent.ai_data_sharing_accepted_version, PRIVACY_CONSENT_VERSION),
-    shareAnalytics: analyticsImplicitDefault ? null : consent.share_analytics,
-    shareDiagnostics: diagnosticsImplicitDefault ? null : consent.share_diagnostics,
+    // Raw tri-state chosen-ness: null = never asked, boolean = explicit
+    // choice. The platform stores explicit choices only, so the value can be
+    // consumed verbatim.
+    shareAnalytics: consent.share_analytics,
+    shareDiagnostics: consent.share_diagnostics,
+    // The platform computes effective consent in one place (null = enabled,
+    // opt-out) and serves it as `share_*_effective`. The fields are required
+    // in the current schema, but an older backend omits them — fall back to
+    // the raw value's opt-out reading so behavior is unchanged there.
+    analyticsEffective: consent.share_analytics_effective ?? consent.share_analytics ?? true,
+    diagnosticsEffective:
+      consent.share_diagnostics_effective ?? consent.share_diagnostics ?? true,
     // Share-toggle re-review is owed only for an explicit, genuinely stale
     // choice on record. Onboarding doesn't show the analytics toggle, so
     // `share_analytics` stays null until the user chooses via settings or
-    // review-terms — null (including an implicit default resolved to null
-    // above) reads as "nothing to re-review", not stale consent. An explicit
-    // false with a stale/empty version still re-reviews.
-    analyticsCurrent:
-      consent.share_analytics === null ||
-      analyticsImplicitDefault ||
-      analyticsVersionCurrent,
-    diagnosticsCurrent:
-      consent.share_diagnostics === null ||
-      diagnosticsImplicitDefault ||
-      diagnosticsVersionCurrent,
+    // review-terms — null reads as "nothing to re-review", not stale consent.
+    // An explicit choice with a stale/empty version still re-reviews.
+    analyticsCurrent: consent.share_analytics === null || analyticsVersionCurrent,
+    diagnosticsCurrent: consent.share_diagnostics === null || diagnosticsVersionCurrent,
     analyticsVersionCurrent,
     diagnosticsVersionCurrent,
     hasServerRecord,


### PR DESCRIPTION
## Summary
- Sync `platform.yaml` with the platform's new server-computed `share_analytics_effective`/`share_diagnostics_effective` fields on `UserConsent` (required, readOnly booleans)
- `resolveServerConsent` now returns `analyticsEffective`/`diagnosticsEffective`, read verbatim from the server with a deploy-safe fallback chain (`share_*_effective ?? share_* ?? true`) so behavior against a not-yet-deployed platform is unchanged
- Delete the implicit-default heuristic (`true` + empty version → treat-as-null): platform migration 0169 nulled every implicit ledger row, so that wire shape no longer exists — never-asked is exactly `share_* === null`, and `*Current` collapses to `null || versionCurrent`
- Chosen-ness stays tri-state on the RAW nullable fields; review-terms/ack semantics unchanged (explicit choice with stale/empty version still owes re-review)
- Tests: drop the implicit-default cases (documented in place), add effective-field cases (present → verbatim, absent → fallback), mirror the wire contract in the `makeConsent`/`consentRecord` fixtures (the latter needed the new required fields to keep typechecking)

Part of plan: consent-cleanup.md (PR 5 of 10)