### PR TITLE
fix(web): surface field-specific 400 validation messages in provider forms

### DIFF
--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -265,12 +265,12 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
     }
     if (result.error.code === "base_url_required") {
       throw new BadRequestError(
-        "base_url is required for openai-compatible connections.",
+        "base_url is required for openai-compatible providers.",
       );
     }
     if (result.error.code === "models_required") {
       throw new BadRequestError(
-        "At least one model is required for openai-compatible connections.",
+        "At least one model is required for openai-compatible providers.",
       );
     }
     throw new BadRequestError("Invalid auth configuration.");
@@ -353,12 +353,12 @@ async function handleUpdateConnection({
     }
     if (result.error.code === "base_url_required") {
       throw new BadRequestError(
-        "base_url is required for openai-compatible connections.",
+        "base_url is required for openai-compatible providers.",
       );
     }
     if (result.error.code === "models_required") {
       throw new BadRequestError(
-        "At least one model is required for openai-compatible connections.",
+        "At least one model is required for openai-compatible providers.",
       );
     }
     throw new BadRequestError("Invalid auth configuration.");

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -50,6 +50,7 @@ let createConnectionCalls: CreateConnectionCall[] = [];
 let createdConnection: ProviderConnection;
 let createResponseOk = true;
 let createResponseStatus = 200;
+let createResponseJson: unknown = null;
 let toastSuccessCalls: string[] = [];
 const initialLifecycleState = useAssistantLifecycleStore.getState();
 
@@ -74,7 +75,11 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     createConnectionCalls.push(opts);
     return Promise.resolve({
       data: createResponseOk ? createdConnection : undefined,
-      response: { ok: createResponseOk, status: createResponseStatus },
+      response: {
+        ok: createResponseOk,
+        status: createResponseStatus,
+        json: () => Promise.resolve(createResponseJson),
+      },
     });
   },
 }));
@@ -217,6 +222,7 @@ beforeEach(() => {
   createdConnection = makeConnection("anthropic-personal");
   createResponseOk = true;
   createResponseStatus = 200;
+  createResponseJson = null;
   toastSuccessCalls = [];
   useAssistantLifecycleStore.setState(initialLifecycleState, true);
 });
@@ -483,6 +489,37 @@ describe("ProviderCreateForm submit sequence", () => {
 
     await waitFor(() => {
       expect(toastSuccessCalls).toEqual(["Provider connected"]);
+    });
+  });
+
+  test("a 400 validation failure renders the daemon's field-specific message", async () => {
+    createResponseOk = false;
+    createResponseStatus = 400;
+    createResponseJson = {
+      error: { message: "Invalid base_url: must be a valid http(s) URL" },
+    };
+
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="anthropic"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-123" },
+    });
+    fireEvent.click(getButton("Add"));
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain(
+        "Invalid base_url: must be a valid http(s) URL",
+      );
     });
   });
 

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -75,11 +75,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     createConnectionCalls.push(opts);
     return Promise.resolve({
       data: createResponseOk ? createdConnection : undefined,
-      response: {
-        ok: createResponseOk,
-        status: createResponseStatus,
-        json: () => Promise.resolve(createResponseJson),
-      },
+      // Mirrors the generated client: the error body arrives pre-parsed on
+      // `error`; the Response body is consumed and cannot be re-read.
+      error: createResponseOk ? undefined : createResponseJson,
+      response: { ok: createResponseOk, status: createResponseStatus },
     });
   },
 }));

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -254,14 +254,17 @@ export function ProviderCreateForm({
             : null,
         }),
       };
-      const { data: created, response: createRes } =
-        await inferenceProviderconnectionsPost({
-          path: { assistant_id: assistantId },
-          body: input,
-        });
+      const {
+        data: created,
+        error: createErr,
+        response: createRes,
+      } = await inferenceProviderconnectionsPost({
+        path: { assistant_id: assistantId },
+        body: input,
+      });
       if (!createRes?.ok) {
         setError(
-          (await validationErrorMessage(createRes)) ??
+          validationErrorMessage(createRes?.status, createErr) ??
             connectionSaveErrorMessage(createRes?.status),
         );
         return;

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -32,6 +32,7 @@ import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-edit
 import {
   connectionSaveErrorMessage,
   parseCredentialRef,
+  validationErrorMessage,
 } from "@/domains/settings/ai/provider-editor-constants";
 import { useSelectableConnectionProviders } from "@/domains/settings/ai/provider-availability";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
@@ -259,7 +260,10 @@ export function ProviderCreateForm({
           body: input,
         });
       if (!createRes?.ok) {
-        setError(connectionSaveErrorMessage(createRes?.status));
+        setError(
+          (await validationErrorMessage(createRes)) ??
+            connectionSaveErrorMessage(createRes?.status),
+        );
         return;
       }
       if (!created) {
@@ -325,7 +329,6 @@ export function ProviderCreateForm({
               fullWidth
             />
           </div>
-
         </div>
       )}
     </div>

--- a/clients/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/clients/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -65,27 +65,24 @@ export function connectionSaveErrorMessage(status: number | undefined): string {
 
 /**
  * Extract the daemon's error-envelope message for 400 validation responses,
- * which are field-specific and actionable ("Invalid base_url: …"). Other
- * statuses intentionally fall back to the generic status-mapped copy so
- * internal identifiers never leak into the provider-first UI.
+ * which are field-specific and actionable ("Invalid base_url: …"). Reads the
+ * generated SDK's already-parsed `error` field — the client consumes the
+ * response body, so re-reading `response.json()` would throw. Other statuses
+ * intentionally fall back to the generic status-mapped copy so internal
+ * identifiers never leak into the provider-first UI.
  */
-export async function validationErrorMessage(
-  response: { status?: number; json: () => Promise<unknown> } | undefined,
-): Promise<string | undefined> {
-  if (!response || response.status !== 400) {
+export function validationErrorMessage(
+  status: number | undefined,
+  sdkError: unknown,
+): string | undefined {
+  if (status !== 400) {
     return undefined;
   }
-  try {
-    const body = (await response.json()) as {
-      error?: { message?: unknown };
-    } | null;
-    const message = body?.error?.message;
-    return typeof message === "string" && message.length > 0
-      ? message
-      : undefined;
-  } catch {
-    return undefined;
-  }
+  const inner = (sdkError as { error?: { message?: unknown } } | null)?.error;
+  const message = inner?.message;
+  return typeof message === "string" && message.length > 0
+    ? message
+    : undefined;
 }
 
 export function providerConnectionDisplayName(

--- a/clients/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/clients/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -50,9 +50,7 @@ export function parseCredentialRef(
   return { service: parts[1], field: parts.slice(2).join("/") };
 }
 
-export function connectionSaveErrorMessage(
-  status: number | undefined,
-): string {
+export function connectionSaveErrorMessage(status: number | undefined): string {
   switch (status) {
     case 409:
       return "A provider with these settings already exists.";
@@ -62,6 +60,31 @@ export function connectionSaveErrorMessage(
       return "Invalid configuration. Check the provider settings.";
     default:
       return "Failed to save provider. Please try again.";
+  }
+}
+
+/**
+ * Extract the daemon's error-envelope message for 400 validation responses,
+ * which are field-specific and actionable ("Invalid base_url: …"). Other
+ * statuses intentionally fall back to the generic status-mapped copy so
+ * internal identifiers never leak into the provider-first UI.
+ */
+export async function validationErrorMessage(
+  response: { status?: number; json: () => Promise<unknown> } | undefined,
+): Promise<string | undefined> {
+  if (!response || response.status !== 400) {
+    return undefined;
+  }
+  try {
+    const body = (await response.json()) as {
+      error?: { message?: unknown };
+    } | null;
+    const message = body?.error?.message;
+    return typeof message === "string" && message.length > 0
+      ? message
+      : undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -232,17 +232,20 @@ export function ProviderEditorContent({
             : null,
         }),
       };
-      const { data: updated, response: updateRes } =
-        await inferenceProviderconnectionsByNamePatch({
-          path: {
-            assistant_id: assistantId,
-            name: connection?.name ?? name.trim(),
-          },
-          body: input,
-        });
+      const {
+        data: updated,
+        error: updateErr,
+        response: updateRes,
+      } = await inferenceProviderconnectionsByNamePatch({
+        path: {
+          assistant_id: assistantId,
+          name: connection?.name ?? name.trim(),
+        },
+        body: input,
+      });
       if (!updateRes?.ok) {
         setError(
-          (await validationErrorMessage(updateRes)) ??
+          validationErrorMessage(updateRes?.status, updateErr) ??
             connectionSaveErrorMessage(updateRes?.status),
         );
         return;

--- a/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -27,6 +27,7 @@ import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
 import {
   connectionSaveErrorMessage,
+  validationErrorMessage,
   parseCredentialRef,
   providerConnectionDisplayName,
 } from "@/domains/settings/ai/provider-editor-constants";
@@ -240,7 +241,10 @@ export function ProviderEditorContent({
           body: input,
         });
       if (!updateRes?.ok) {
-        setError(connectionSaveErrorMessage(updateRes?.status));
+        setError(
+          (await validationErrorMessage(updateRes)) ??
+            connectionSaveErrorMessage(updateRes?.status),
+        );
         return;
       }
       if (!updated) {


### PR DESCRIPTION
## Summary
- The #38172 error-copy simplification flattened ALL provider save errors to generic status text. That was deliberate (and stays) for 409s/delete guards, whose daemon wording leaks internal identifiers (`llm.defaultProvider`, connection names) — but 400 validation messages are field-specific and actionable ("Invalid base_url: must be a valid http(s) URL", the SSRF rejections), and losing them means users can't tell which field is wrong.
- Restores envelope-message extraction **for 400s only** via a shared `validationErrorMessage` helper used by the create form and editor; everything else keeps the generic copy.
- Rewords the two daemon 400s that still said "openai-compatible connections" to "providers", so verbatim rendering can't reintroduce the removed vocabulary.

## Original prompt
Post-merge review of #38172 flagged that Devin's error-copy simplification also dropped the M7 "explainable errors" behavior for validation failures; Emmie wasn't sure that part was deliberate. The delete-guard genericization is provably intentional (a test asserts internal names are hidden), so this restores only the field-level 400 messages. Part of Milestone A of the connection-removal plan (papertrail on #38102).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->