### PR TITLE
refactor(config): drop mode from the speech schemas

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -2053,8 +2053,7 @@ A parallel **client artifact** (`meta/tts-provider-catalog.json`) captures the s
 
 | Field                         | Type   | Default        | Description                                               |
 | ----------------------------- | ------ | -------------- | --------------------------------------------------------- |
-| `services.tts.mode`           | enum   | `"your-own"`   | Service mode (only `"your-own"` is supported)             |
-| `services.tts.provider`       | enum   | `"elevenlabs"` | Active TTS provider (must be a catalog-known provider ID) |
+| `services.tts.provider`       | enum   | `"elevenlabs"` | Active TTS provider (must be a catalog-known provider ID); `"vellum"` = platform-managed |
 | `services.tts.providers.<id>` | object | _(defaults)_   | Provider-specific settings, one block per catalog entry   |
 
 Provider-specific config is nested under `services.tts.providers.<id>`. All legacy top-level keys (`elevenlabs.*`, `fishAudio.*`) were removed by workspace migration 032 — only canonical `services.tts` paths are supported at runtime.

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1201,7 +1201,6 @@ describe("AssistantConfigSchema", () => {
 
   test("applies services.tts defaults when not specified", () => {
     const result = AssistantConfigSchema.parse({});
-    expect(result.services.tts.mode).toBe("your-own");
     expect(result.services.tts.provider).toBe("elevenlabs");
     expect(result.services.tts.providers.elevenlabs.voiceId).toBe(
       DEFAULT_ELEVENLABS_VOICE_ID,
@@ -1227,7 +1226,6 @@ describe("AssistantConfigSchema", () => {
       services: { tts: { provider: "fish-audio" } },
     });
     expect(result.services.tts.provider).toBe("fish-audio");
-    expect(result.services.tts.mode).toBe("your-own");
   });
 
   test("accepts deepgram as services.tts.provider", () => {
@@ -1235,7 +1233,6 @@ describe("AssistantConfigSchema", () => {
       services: { tts: { provider: "deepgram" } },
     });
     expect(result.services.tts.provider).toBe("deepgram");
-    expect(result.services.tts.mode).toBe("your-own");
   });
 
   test("accepts valid services.tts.providers.elevenlabs overrides", () => {
@@ -1288,16 +1285,20 @@ describe("AssistantConfigSchema", () => {
     expect(result.services.tts.providers.deepgram.format).toBe("opus");
   });
 
-  test("accepts services.tts.mode = managed", () => {
-    const result = AssistantConfigSchema.safeParse({
+  // Legacy config objects on disk may carry a `mode` key. Parsing must strip
+  // it rather than reject the config — and must not treat it as a managed
+  // selection, which is what migration 130 rewrites to `provider: "vellum"`.
+  test("ignores a legacy tts mode key", () => {
+    const result = AssistantConfigSchema.parse({
       services: { tts: { mode: "managed" } },
     });
-    expect(result.success).toBe(true);
+    expect(result.services.tts).not.toHaveProperty("mode");
+    expect(result.services.tts.provider).toBe("elevenlabs");
   });
 
-  test("accepts tts provider vellum regardless of mode", () => {
+  test("accepts tts provider vellum as an ordinary choice", () => {
     const result = AssistantConfigSchema.safeParse({
-      services: { tts: { mode: "your-own", provider: "vellum" } },
+      services: { tts: { provider: "vellum" } },
     });
     expect(result.success).toBe(true);
   });
@@ -1360,18 +1361,19 @@ describe("AssistantConfigSchema", () => {
     }
   });
 
-  test("services.tts.mode accepts your-own and managed", () => {
-    // Explicit your-own should work
-    const valid = TtsServiceSchema.safeParse({ mode: "your-own" });
-    expect(valid.success).toBe(true);
+  test("services.tts.provider defaults to elevenlabs and rejects unknown ids", () => {
+    const defaulted = TtsServiceSchema.safeParse({});
+    expect(defaulted.success).toBe(true);
+    if (defaulted.success) {
+      expect(defaulted.data.provider).toBe("elevenlabs");
+    }
 
-    // managed is supported; the BYOK provider choice is preserved
-    const managed = TtsServiceSchema.safeParse({ mode: "managed" });
-    expect(managed.success).toBe(true);
-
-    // Any other string should be rejected
-    const invalid2 = TtsServiceSchema.safeParse({ mode: "self-hosted" });
-    expect(invalid2.success).toBe(false);
+    expect(TtsServiceSchema.safeParse({ provider: "vellum" }).success).toBe(
+      true,
+    );
+    expect(TtsServiceSchema.safeParse({ provider: "self-hosted" }).success).toBe(
+      false,
+    );
   });
 
   // ── services.stt config ──────────────────────────────────────────────
@@ -1392,7 +1394,6 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({
       services: { stt: { provider: "openai-whisper" } },
     });
-    expect(result.services.stt.mode).toBe("your-own");
     expect(result.services.stt.provider).toBe("openai-whisper");
     // providers defaults to empty sparse map
     expect(result.services.stt.providers).toEqual({});
@@ -1403,7 +1404,6 @@ describe("AssistantConfigSchema", () => {
       services: { stt: { provider: "openai-whisper" } },
     });
     expect(result.services.stt.provider).toBe("openai-whisper");
-    expect(result.services.stt.mode).toBe("your-own");
   });
 
   test("accepts valid services.stt.providers.openai-whisper overrides", () => {
@@ -1447,16 +1447,20 @@ describe("AssistantConfigSchema", () => {
     });
   });
 
-  test("accepts services.stt.mode = managed with a provider", () => {
-    const result = AssistantConfigSchema.safeParse({
+  // Legacy config objects on disk may carry a `mode` key. Parsing must strip
+  // it rather than reject the config — and must not treat it as a managed
+  // selection, which is what migration 130 rewrites to `provider: "vellum"`.
+  test("ignores a legacy stt mode key", () => {
+    const result = AssistantConfigSchema.parse({
       services: { stt: { mode: "managed", provider: "deepgram" } },
     });
-    expect(result.success).toBe(true);
+    expect(result.services.stt).not.toHaveProperty("mode");
+    expect(result.services.stt.provider).toBe("deepgram");
   });
 
-  test("accepts stt provider vellum regardless of mode", () => {
+  test("accepts stt provider vellum as an ordinary choice", () => {
     const result = AssistantConfigSchema.safeParse({
-      services: { stt: { mode: "your-own", provider: "vellum" } },
+      services: { stt: { provider: "vellum" } },
     });
     expect(result.success).toBe(true);
   });
@@ -1477,7 +1481,6 @@ describe("AssistantConfigSchema", () => {
       services: { stt: { provider: "deepgram" } },
     });
     expect(result.services.stt.provider).toBe("deepgram");
-    expect(result.services.stt.mode).toBe("your-own");
   });
 
   test("accepts google-gemini as services.stt.provider", () => {
@@ -1485,14 +1488,12 @@ describe("AssistantConfigSchema", () => {
       services: { stt: { provider: "google-gemini" } },
     });
     expect(result.services.stt.provider).toBe("google-gemini");
-    expect(result.services.stt.mode).toBe("your-own");
   });
 
   test("applies services.stt structural defaults when google-gemini provider is explicit", () => {
     const result = AssistantConfigSchema.parse({
       services: { stt: { provider: "google-gemini" } },
     });
-    expect(result.services.stt.mode).toBe("your-own");
     expect(result.services.stt.provider).toBe("google-gemini");
     expect(result.services.stt.providers).toEqual({});
   });
@@ -1536,27 +1537,16 @@ describe("AssistantConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  test("services.stt.mode accepts your-own and managed", () => {
-    // Explicit your-own should work
-    const valid = SttServiceSchema.safeParse({
-      mode: "your-own",
-      provider: "openai-whisper",
-    });
-    expect(valid.success).toBe(true);
-
-    // managed is supported; the BYOK provider choice is preserved
-    const managed = SttServiceSchema.safeParse({
-      mode: "managed",
-      provider: "openai-whisper",
-    });
-    expect(managed.success).toBe(true);
-
-    // Any other string should be rejected
-    const invalid2 = SttServiceSchema.safeParse({
-      mode: "self-hosted",
-      provider: "openai-whisper",
-    });
-    expect(invalid2.success).toBe(false);
+  test("services.stt.provider accepts known ids and rejects unknown ones", () => {
+    expect(
+      SttServiceSchema.safeParse({ provider: "openai-whisper" }).success,
+    ).toBe(true);
+    expect(SttServiceSchema.safeParse({ provider: "vellum" }).success).toBe(
+      true,
+    );
+    expect(
+      SttServiceSchema.safeParse({ provider: "self-hosted" }).success,
+    ).toBe(false);
   });
 
   test("rejects hostBrowser.cdpInspect.desktopAuto.cooldownMs above 300000", () => {

--- a/assistant/src/__tests__/managed-speech-defaults.test.ts
+++ b/assistant/src/__tests__/managed-speech-defaults.test.ts
@@ -62,18 +62,15 @@ describe("maybeDefaultSpeechToManaged", () => {
     expect(config.services).toBeUndefined();
   });
 
-  test("defaults both services to managed when no BYOK credentials resolve", async () => {
+  test("defaults both services to vellum when no BYOK credentials resolve", async () => {
     mockManagedSpeechAvailable = true;
 
     await maybeDefaultSpeechToManaged();
 
     const config = readConfig();
-    expect((config.services as any)?.stt?.mode).toBe("managed");
-    expect((config.services as any)?.tts?.mode).toBe("managed");
-    // Sparse configs must stay schema-valid: SttServiceSchema requires
-    // `provider` whenever the stt object exists.
-    expect((config.services as any)?.stt?.provider).toBeDefined();
-    expect(getConfig().services.stt.mode).toBe("managed");
+    expect((config.services as any)?.stt?.provider).toBe("vellum");
+    expect((config.services as any)?.tts?.provider).toBe("vellum");
+    expect(getConfig().services.stt.provider).toBe("vellum");
   });
 
   test("leaves a service alone when its BYOK credential resolves", async () => {
@@ -83,8 +80,8 @@ describe("maybeDefaultSpeechToManaged", () => {
     await maybeDefaultSpeechToManaged();
 
     const config = readConfig();
-    expect((config.services as any)?.stt?.mode).toBeUndefined();
-    expect((config.services as any)?.tts?.mode).toBe("managed");
+    expect((config.services as any)?.stt?.provider).toBeUndefined();
+    expect((config.services as any)?.tts?.provider).toBe("vellum");
   });
 
   test("no-ops when both BYOK credentials resolve", async () => {
@@ -98,12 +95,12 @@ describe("maybeDefaultSpeechToManaged", () => {
     expect(config.services).toBeUndefined();
   });
 
-  test("no-ops when services are already managed", async () => {
+  test("no-ops when services are already on vellum", async () => {
     mockManagedSpeechAvailable = true;
     writeConfig({
       services: {
-        stt: { mode: "managed", provider: "deepgram" },
-        tts: { mode: "managed" },
+        stt: { provider: "vellum" },
+        tts: { provider: "vellum" },
       },
     });
 
@@ -112,27 +109,27 @@ describe("maybeDefaultSpeechToManaged", () => {
     const config = readConfig();
     expect(config).toEqual({
       services: {
-        stt: { mode: "managed", provider: "deepgram" },
-        tts: { mode: "managed" },
+        stt: { provider: "vellum" },
+        tts: { provider: "vellum" },
       },
     });
   });
 
-  test("never downgrades an explicit your-own mode with resolving credentials", async () => {
+  test("never repoints an explicit BYOK provider with resolving credentials", async () => {
     mockManagedSpeechAvailable = true;
     mockSttKeyResolves = true;
     mockTtsSecretResolves = true;
     writeConfig({
       services: {
-        stt: { mode: "your-own", provider: "deepgram" },
-        tts: { mode: "your-own", provider: "elevenlabs" },
+        stt: { provider: "deepgram" },
+        tts: { provider: "elevenlabs" },
       },
     });
 
     await maybeDefaultSpeechToManaged();
 
     const config = readConfig();
-    expect((config.services as any).stt.mode).toBe("your-own");
-    expect((config.services as any).tts.mode).toBe("your-own");
+    expect((config.services as any).stt.provider).toBe("deepgram");
+    expect((config.services as any).tts.provider).toBe("elevenlabs");
   });
 });

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -120,9 +120,9 @@ describe("voice_config_update — tts_provider", () => {
     expect(result.content).toContain("tts_provider must be one of");
   });
 
-  test("tts_provider resets a stale managed mode", async () => {
-    // A lingering `mode: "managed"` takes precedence over the BYOK provider,
-    // so a provider switch that left it in place would be silently ignored.
+  test("a provider switch away from vellum takes effect over a legacy mode key", async () => {
+    // A raw config may still carry a legacy `mode` key; the schema strips it,
+    // so the provider write alone decides the routing.
     writeConfig({ services: { tts: { mode: "managed", provider: "vellum" } } });
     invalidateConfigCache();
 
@@ -132,12 +132,10 @@ describe("voice_config_update — tts_provider", () => {
     );
 
     expect(result.isError).toBe(false);
-    const tts = (readConfig().services as any).tts;
-    expect(tts.provider).toBe("elevenlabs");
-    expect(tts.mode).toBe("your-own");
+    expect((readConfig().services as any).tts.provider).toBe("elevenlabs");
   });
 
-  test("tts_provider vellum writes the managed pair", async () => {
+  test("tts_provider vellum persists when a platform connection is available", async () => {
     mockManagedSpeechAvailable = true;
 
     const result = await run(
@@ -146,9 +144,7 @@ describe("voice_config_update — tts_provider", () => {
     );
 
     expect(result.isError).toBe(false);
-    const tts = (readConfig().services as any).tts;
-    expect(tts.provider).toBe("vellum");
-    expect(tts.mode).toBe("managed");
+    expect((readConfig().services as any).tts.provider).toBe("vellum");
   });
 
   test("broadcasts ttsProvider to client", async () => {
@@ -372,103 +368,80 @@ describe("voice_config_update — deepgram", () => {
 // Tests: stt_mode / tts_mode
 // ---------------------------------------------------------------------------
 
-describe("voice_config_update — stt_mode / tts_mode", () => {
-  test("persists stt_mode your-own to services.stt.mode with a provider", async () => {
+describe("voice_config_update — stt_provider", () => {
+  test("persists a BYOK provider to services.stt.provider", async () => {
     const result = await run(
-      { setting: "stt_mode", value: "your-own" },
+      { setting: "stt_provider", value: "openai-whisper" },
       makeContext(),
     );
 
     expect(result.isError).toBe(false);
-    const config = readConfig();
-    expect((config.services as any)?.stt?.mode).toBe("your-own");
-    // SttServiceSchema requires `provider` whenever the stt object exists —
-    // a mode-only write would invalidate a sparse config.
-    expect((config.services as any)?.stt?.provider).toBeDefined();
-  });
-
-  test("switching tts_mode to your-own replaces a vellum provider", async () => {
-    writeConfig({
-      services: { tts: { mode: "managed", provider: "vellum" } },
-    });
-    invalidateConfigCache();
-
-    const result = await run(
-      { setting: "tts_mode", value: "your-own" },
-      makeContext(),
+    expect((readConfig().services as any)?.stt?.provider).toBe(
+      "openai-whisper",
     );
-
-    expect(result.isError).toBe(false);
-    const config = readConfig();
-    expect((config.services as any)?.tts?.mode).toBe("your-own");
-    expect((config.services as any)?.tts?.provider).toBe("elevenlabs");
   });
 
-  test("switching stt_mode to your-own replaces a vellum provider", async () => {
-    writeConfig({
-      services: { stt: { mode: "managed", provider: "vellum" } },
-    });
-    invalidateConfigCache();
-
-    const result = await run(
-      { setting: "stt_mode", value: "your-own" },
-      makeContext(),
-    );
-
-    expect(result.isError).toBe(false);
-    const config = readConfig();
-    expect((config.services as any)?.stt?.mode).toBe("your-own");
-    expect((config.services as any)?.stt?.provider).toBe("deepgram");
-  });
-
-  test("persists tts_mode managed when platform connection is available", async () => {
+  test("persists the vellum provider when a platform connection is available", async () => {
     mockManagedSpeechAvailable = true;
 
     const result = await run(
-      { setting: "tts_mode", value: "managed" },
+      { setting: "stt_provider", value: "vellum" },
       makeContext(),
     );
 
     expect(result.isError).toBe(false);
-    const config = readConfig();
-    expect((config.services as any)?.tts?.mode).toBe("managed");
+    expect((readConfig().services as any)?.stt?.provider).toBe("vellum");
   });
 
-  test("rejects managed mode without a platform connection", async () => {
+  test("rejects the vellum provider without a platform connection", async () => {
     mockManagedSpeechAvailable = false;
 
     const result = await run(
-      { setting: "stt_mode", value: "managed" },
+      { setting: "stt_provider", value: "vellum" },
       makeContext(),
     );
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("assistant platform connect");
-    const config = readConfig();
-    expect((config.services as any)?.stt?.mode).toBeUndefined();
+    expect((readConfig().services as any)?.stt?.provider).toBeUndefined();
   });
 
-  test("rejects invalid mode value", async () => {
+  test("switching away from vellum takes effect", async () => {
+    writeConfig({ services: { stt: { provider: "vellum" } } });
+    invalidateConfigCache();
+
     const result = await run(
-      { setting: "tts_mode", value: "bogus" },
+      { setting: "stt_provider", value: "deepgram" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect((readConfig().services as any)?.stt?.provider).toBe("deepgram");
+  });
+
+  test("rejects an unknown provider", async () => {
+    const result = await run(
+      { setting: "stt_provider", value: "bogus" },
       makeContext(),
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("tts_mode must be one of");
+    expect(result.content).toContain("stt_provider must be one of");
   });
 
-  test("does not broadcast mode changes to the desktop client", async () => {
+  test("does not broadcast stt_provider changes to the desktop client", async () => {
     const messages: any[] = [];
     const ctx = makeContext({
       sendToClient: (msg: any) => messages.push(msg),
     });
 
-    const result = await run({ setting: "stt_mode", value: "your-own" }, ctx);
+    const result = await run(
+      { setting: "stt_provider", value: "deepgram" },
+      ctx,
+    );
 
     expect(result.isError).toBe(false);
     expect(messages).toHaveLength(0);
-    expect(result.content).not.toContain("broadcast");
   });
 });
 

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -124,9 +124,10 @@ describe("voice_config_update — tts_provider", () => {
     expect(result.content).toContain("tts_provider must be one of");
   });
 
-  test("a provider switch away from vellum takes effect over a legacy mode key", async () => {
-    // A raw config may still carry a legacy `mode` key; the schema strips it,
-    // so the provider write alone decides the routing.
+  test("a provider switch scrubs a legacy mode key from the raw config", async () => {
+    // The daemon ignores a legacy `mode` key, but the settings cards read
+    // `mode: "managed"` as the Vellum marker — left behind, they would render
+    // Vellum while the daemon routes the newly chosen provider.
     writeConfig({ services: { tts: { mode: "managed", provider: "vellum" } } });
     invalidateConfigCache();
 
@@ -136,7 +137,9 @@ describe("voice_config_update — tts_provider", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect((readConfig().services as any).tts.provider).toBe("elevenlabs");
+    const tts = (readConfig().services as any).tts;
+    expect(tts.provider).toBe("elevenlabs");
+    expect(tts).not.toHaveProperty("mode");
   });
 
   test("tts_provider vellum persists when a platform connection is available", async () => {
@@ -436,6 +439,21 @@ describe("voice_config_update — stt_provider", () => {
 
     expect(result.isError).toBe(false);
     expect((readConfig().services as any)?.stt?.provider).toBe("deepgram");
+  });
+
+  test("a provider switch scrubs a legacy mode key from the raw config", async () => {
+    writeConfig({ services: { stt: { mode: "managed", provider: "vellum" } } });
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "stt_provider", value: "deepgram" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const stt = (readConfig().services as any).stt;
+    expect(stt.provider).toBe("deepgram");
+    expect(stt).not.toHaveProperty("mode");
   });
 
   test("rejects an unknown provider", async () => {

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -31,7 +31,11 @@ function ensureTestDir(): void {
   }
 }
 
-import { run } from "../config/bundled-skills/settings/tools/voice-config-update.js";
+import settingsSkillTools from "../config/bundled-skills/settings/TOOLS.json" with { type: "json" };
+import {
+  run,
+  VALID_SETTINGS,
+} from "../config/bundled-skills/settings/tools/voice-config-update.js";
 import { invalidateConfigCache } from "../config/loader.js";
 import type { ToolContext } from "../tools/types.js";
 import { listCatalogProviderIds } from "../tts/provider-catalog.js";
@@ -305,6 +309,21 @@ describe("voice_config_update — conversation_timeout", () => {
 // ---------------------------------------------------------------------------
 // Tests: validation edge cases
 // ---------------------------------------------------------------------------
+
+describe("voice_config_update — manifest parity", () => {
+  // The skill's TOOLS.json schema gates calls before the executor runs: a
+  // setting missing from the enum is rejected by JSON-schema validation, and
+  // an enum entry the executor doesn't know dies with "Unknown setting". The
+  // two lists must stay identical.
+  test("the TOOLS.json setting enum matches the executor's settings", () => {
+    const manifest = settingsSkillTools.tools.find(
+      (t) => t.name === "voice_config_update",
+    );
+    const enumValues = manifest?.input_schema.properties.setting
+      ?.enum as readonly string[];
+    expect([...enumValues].sort()).toEqual([...VALID_SETTINGS].sort());
+  });
+});
 
 describe("voice_config_update — validation", () => {
   test("missing setting returns error", async () => {

--- a/assistant/src/__tests__/workspace-migration-130-speech-mode-to-provider.test.ts
+++ b/assistant/src/__tests__/workspace-migration-130-speech-mode-to-provider.test.ts
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { AssistantConfigSchema } from "../config/schema.js";
 import { speechModeToProviderMigration } from "../workspace/migrations/130-speech-mode-to-provider.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { getLastWorkspaceMigrationId } from "../workspace/migrations/runner.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -60,6 +62,21 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("130-speech-mode-to-provider", () => {
+  // This migration's id (130) is below the already-shipped 131, so it must
+  // not sit last in the registry: getLastWorkspaceMigrationId() reports the
+  // final entry as the registry ceiling to the identity and rollback routes.
+  test("the registry ceiling stays at the highest-numbered migration", () => {
+    const numericId = (id: string) => Number.parseInt(id, 10);
+    const highest = Math.max(
+      ...WORKSPACE_MIGRATIONS.map((m) => numericId(m.id)).filter(
+        Number.isFinite,
+      ),
+    );
+    const last = getLastWorkspaceMigrationId(WORKSPACE_MIGRATIONS);
+    expect(last).not.toBeNull();
+    expect(numericId(last!)).toBe(highest);
+  });
+
   test("rewrites a managed service to provider vellum", () => {
     writeConfig({
       services: {

--- a/assistant/src/__tests__/workspace-migration-130-speech-mode-to-provider.test.ts
+++ b/assistant/src/__tests__/workspace-migration-130-speech-mode-to-provider.test.ts
@@ -1,0 +1,176 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { AssistantConfigSchema } from "../config/schema.js";
+import { speechModeToProviderMigration } from "../workspace/migrations/130-speech-mode-to-provider.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-130-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function services(config: Record<string, unknown>): Record<string, any> {
+  return config.services as Record<string, any>;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("130-speech-mode-to-provider", () => {
+  test("rewrites a managed service to provider vellum", () => {
+    writeConfig({
+      services: {
+        stt: { mode: "managed", provider: "deepgram", providers: {} },
+        tts: { mode: "managed", provider: "elevenlabs" },
+      },
+    });
+
+    speechModeToProviderMigration.run(workspaceDir);
+
+    const svc = services(readConfig());
+    expect(svc.stt).toEqual({ provider: "vellum", providers: {} });
+    expect(svc.tts).toEqual({ provider: "vellum" });
+  });
+
+  test("keeps the BYOK provider and drops mode for your-own", () => {
+    writeConfig({
+      services: {
+        stt: { mode: "your-own", provider: "openai-whisper" },
+        tts: { mode: "your-own", provider: "fish-audio" },
+      },
+    });
+
+    speechModeToProviderMigration.run(workspaceDir);
+
+    const svc = services(readConfig());
+    expect(svc.stt).toEqual({ provider: "openai-whisper" });
+    expect(svc.tts).toEqual({ provider: "fish-audio" });
+  });
+
+  // The pre-migration schema allowed provider "vellum" alongside mode
+  // "managed"; that pair must survive rather than double-rewrite.
+  test("preserves an already-vellum managed service", () => {
+    writeConfig({ services: { stt: { mode: "managed", provider: "vellum" } } });
+
+    speechModeToProviderMigration.run(workspaceDir);
+
+    expect(services(readConfig()).stt).toEqual({ provider: "vellum" });
+  });
+
+  test("is idempotent", () => {
+    writeConfig({ services: { stt: { mode: "managed", provider: "deepgram" } } });
+
+    speechModeToProviderMigration.run(workspaceDir);
+    const once = readConfig();
+    speechModeToProviderMigration.run(workspaceDir);
+
+    expect(readConfig()).toEqual(once);
+  });
+
+  test("leaves untouched configs and unrelated keys alone", () => {
+    writeConfig({ services: { "web-search": { provider: "brave" } } });
+
+    speechModeToProviderMigration.run(workspaceDir);
+
+    expect(readConfig()).toEqual({
+      services: { "web-search": { provider: "brave" } },
+    });
+  });
+
+  test("survives a missing config and malformed JSON", () => {
+    expect(() => speechModeToProviderMigration.run(workspaceDir)).not.toThrow();
+
+    writeFileSync(join(workspaceDir, "config.json"), "{ not json");
+    expect(() => speechModeToProviderMigration.run(workspaceDir)).not.toThrow();
+  });
+
+  // The migrated shape is what the daemon actually parses, so a managed user
+  // must land on vellum rather than falling back to a keyless BYOK provider.
+  test("migrated output parses to the vellum provider", () => {
+    writeConfig({
+      services: {
+        stt: { mode: "managed", provider: "deepgram", providers: {} },
+        tts: { mode: "managed", provider: "elevenlabs" },
+      },
+    });
+
+    speechModeToProviderMigration.run(workspaceDir);
+    const parsed = AssistantConfigSchema.parse(readConfig());
+
+    expect(parsed.services.stt.provider).toBe("vellum");
+    expect(parsed.services.tts.provider).toBe("vellum");
+  });
+
+  describe("down", () => {
+    test("restores mode from the provider", () => {
+      writeConfig({
+        services: {
+          stt: { provider: "vellum" },
+          tts: { provider: "elevenlabs" },
+        },
+      });
+
+      speechModeToProviderMigration.down(workspaceDir);
+
+      const svc = services(readConfig());
+      expect(svc.stt).toEqual({ mode: "managed", provider: "vellum" });
+      expect(svc.tts).toEqual({ mode: "your-own", provider: "elevenlabs" });
+    });
+
+    test("does not re-add mode when it is already present", () => {
+      writeConfig({
+        services: { stt: { mode: "your-own", provider: "deepgram" } },
+      });
+
+      speechModeToProviderMigration.down(workspaceDir);
+
+      expect(services(readConfig()).stt).toEqual({
+        mode: "your-own",
+        provider: "deepgram",
+      });
+    });
+  });
+});

--- a/assistant/src/calls/telephony-credential-preflight.ts
+++ b/assistant/src/calls/telephony-credential-preflight.ts
@@ -15,7 +15,6 @@
  */
 
 import { getConfig } from "../config/loader.js";
-import { effectiveSttProvider } from "../config/schemas/stt.js";
 import type { TelephonySttCapability } from "../providers/speech-to-text/resolve.js";
 import { resolveTelephonySttCapability } from "../providers/speech-to-text/resolve.js";
 import { findPlayableTelephonyTtsFallback } from "./resolve-call-tts-provider.js";
@@ -75,7 +74,7 @@ export async function resolveTelephonyCredentialReadiness(): Promise<TelephonyCr
     const providerId =
       "providerId" in stt
         ? stt.providerId
-        : effectiveSttProvider(getConfig().services.stt);
+        : getConfig().services.stt.provider;
     missing.push({ kind: "stt", providerId, reason: stt.reason });
     clauses.push(sttGapClause(stt, providerId));
   }

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "voice_config_update",
-      "description": "Update a voice configuration setting. Use tts_provider to switch the global TTS provider (valid providers: elevenlabs, fish-audio, deepgram, xai — defined by the provider catalog). Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Deepgram uses the same API key as speech-to-text and requires no additional voice config. Use stt_mode / tts_mode to switch between \"your-own\" (bring your own provider API key) and \"managed\" (Vellum-managed speech, billed to your organization; requires a Vellum platform connection via 'assistant platform connect'). Changes persist to services.stt / services.tts config and take effect immediately.",
+      "description": "Update a voice configuration setting. Use tts_provider / stt_provider to switch the active TTS / STT provider. Provider \"vellum\" is Vellum-managed speech (billed to your organization; requires a Vellum platform connection via 'assistant platform connect'); any other provider uses the user's own API key. Valid TTS providers come from the provider catalog (vellum, elevenlabs, fish-audio, deepgram, xai); valid STT providers: vellum, deepgram, google-gemini, openai-whisper, xai. Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Deepgram uses the same API key for TTS and STT and requires no additional voice config. Changes persist to services.stt / services.tts config and take effect immediately.",
       "category": "system",
       "risk": "low",
       "input_schema": {
@@ -15,15 +15,14 @@
               "activation_key",
               "conversation_timeout",
               "fish_audio_reference_id",
-              "stt_mode",
-              "tts_mode",
+              "stt_provider",
               "tts_provider",
               "tts_voice_id"
             ],
-            "description": "The voice setting to change. tts_provider selects the global TTS provider from the provider catalog (valid providers: elevenlabs, fish-audio, deepgram, xai). tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference. Deepgram uses its default model and shares the STT API key. stt_mode / tts_mode select \"your-own\" or \"managed\" speech for each service."
+            "description": "The voice setting to change. tts_provider / stt_provider select the active provider for each service (\"vellum\" = Vellum-managed speech; anything else = the user's own API key). tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference. Deepgram uses its default model and shares one API key across TTS and STT."
           },
           "value": {
-            "description": "The new value for the setting. For tts_provider: one of elevenlabs, fish-audio, deepgram, xai. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string. For stt_mode / tts_mode: \"your-own\" or \"managed\"."
+            "description": "The new value for the setting. For tts_provider: one of vellum, elevenlabs, fish-audio, deepgram, xai. For stt_provider: one of vellum, deepgram, google-gemini, openai-whisper, xai. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
           }
         }
       },

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -6,13 +6,13 @@ import type {
 } from "../../../../tools/types.js";
 import { listCatalogProviderIds } from "../../../../tts/provider-catalog.js";
 import {
-  getConfig,
   invalidateConfigCache,
   loadRawConfig,
   saveRawConfig,
   setNestedValue,
 } from "../../../loader.js";
 import { VALID_CONVERSATION_TIMEOUTS } from "../../../schemas/elevenlabs.js";
+import { VALID_STT_PROVIDERS } from "../../../schemas/stt.js";
 
 /**
  * Valid voice config settings and their UserDefaults key mappings.
@@ -38,8 +38,7 @@ const VOICE_SETTINGS = {
     userDefaultsKey: "fishAudioReferenceId",
     type: "string",
   },
-  stt_mode: { type: "string" },
-  tts_mode: { type: "string" },
+  stt_provider: { type: "string" },
 } satisfies Record<string, VoiceSettingMeta>;
 
 type VoiceSettingName = keyof typeof VOICE_SETTINGS;
@@ -54,11 +53,8 @@ const FRIENDLY_NAMES: Record<VoiceSettingName, string> = {
   tts_provider: "TTS provider",
   tts_voice_id: "ElevenLabs voice",
   fish_audio_reference_id: "Fish Audio voice",
-  stt_mode: "Speech-to-text mode",
-  tts_mode: "Text-to-speech mode",
+  stt_provider: "Speech-to-text provider",
 };
-
-const VALID_SPEECH_MODES = ["your-own", "managed"] as const;
 
 function validateSetting(
   setting: string,
@@ -129,17 +125,12 @@ function validateSetting(
       }
       return { ok: true, coerced: value.trim() };
     }
-    case "stt_mode":
-    case "tts_mode": {
-      if (
-        typeof value !== "string" ||
-        !VALID_SPEECH_MODES.includes(
-          value.trim() as (typeof VALID_SPEECH_MODES)[number],
-        )
-      ) {
+    case "stt_provider": {
+      const sttIds: readonly string[] = VALID_STT_PROVIDERS;
+      if (typeof value !== "string" || !sttIds.includes(value.trim())) {
         return {
           ok: false,
-          error: `${setting} must be one of: ${VALID_SPEECH_MODES.join(", ")}`,
+          error: `stt_provider must be one of: ${sttIds.join(", ")}`,
         };
       }
       return { ok: true, coerced: value.trim() };
@@ -187,9 +178,8 @@ export async function run(
   }
 
   const wantsManagedSpeech =
-    ((setting === "stt_mode" || setting === "tts_mode") &&
-      validation.coerced === "managed") ||
-    (setting === "tts_provider" && validation.coerced === "vellum");
+    (setting === "stt_provider" || setting === "tts_provider") &&
+    validation.coerced === "vellum";
   if (wantsManagedSpeech && !(await managedSpeechAvailable())) {
     return {
       content:
@@ -217,14 +207,6 @@ export async function run(
 
   if (setting === "tts_provider") {
     setNestedValue(raw, "services.tts.provider", validation.coerced);
-    // Written as a pair, like the settings cards: a stale `mode: "managed"`
-    // takes precedence over a BYOK provider, so switching providers must
-    // also reset it — otherwise the requested switch is silently ignored.
-    setNestedValue(
-      raw,
-      "services.tts.mode",
-      validation.coerced === "vellum" ? "managed" : "your-own",
-    );
     saveRawConfig(raw);
     invalidateConfigCache();
   }
@@ -259,34 +241,8 @@ export async function run(
     invalidateConfigCache();
   }
 
-  if (setting === "stt_mode") {
-    setNestedValue(raw, "services.stt.mode", validation.coerced);
-    // SttServiceSchema requires `provider` whenever the stt object exists, so
-    // writing `mode` alone would invalidate a sparse config. And a provider of
-    // "vellum" routes to managed regardless of mode, so switching to your-own
-    // must also replace it with a BYOK provider.
-    const currentProvider = getConfig().services.stt.provider;
-    setNestedValue(
-      raw,
-      "services.stt.provider",
-      currentProvider === "vellum" && validation.coerced === "your-own"
-        ? "deepgram"
-        : currentProvider,
-    );
-    saveRawConfig(raw);
-    invalidateConfigCache();
-  }
-
-  if (setting === "tts_mode") {
-    setNestedValue(raw, "services.tts.mode", validation.coerced);
-    // A provider of "vellum" routes to managed regardless of mode, so
-    // switching to your-own must also replace a vellum provider.
-    if (
-      validation.coerced === "your-own" &&
-      getConfig().services.tts.provider === "vellum"
-    ) {
-      setNestedValue(raw, "services.tts.provider", "elevenlabs");
-    }
+  if (setting === "stt_provider") {
+    setNestedValue(raw, "services.stt.provider", validation.coerced);
     saveRawConfig(raw);
     invalidateConfigCache();
   }

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -43,7 +43,10 @@ const VOICE_SETTINGS = {
 
 type VoiceSettingName = keyof typeof VOICE_SETTINGS;
 
-const VALID_SETTINGS = Object.keys(VOICE_SETTINGS) as VoiceSettingName[];
+/** Exported so tests can assert parity with the TOOLS.json `setting` enum. */
+export const VALID_SETTINGS = Object.keys(
+  VOICE_SETTINGS,
+) as VoiceSettingName[];
 
 const VALID_TIMEOUTS: readonly number[] = VALID_CONVERSATION_TIMEOUTS;
 

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -152,6 +152,28 @@ function validateSetting(
   }
 }
 
+/**
+ * Remove a legacy `mode` key from a raw `services.<svc>` block. The schema
+ * no longer has the field, but the settings cards still write it (for
+ * compatibility with older daemons) and read `mode: "managed"` as the
+ * Vellum marker — left stale after a provider switch here, the cards would
+ * render Vellum while the daemon routes the newly chosen provider.
+ */
+function deleteLegacySpeechMode(
+  raw: Record<string, unknown>,
+  svc: "stt" | "tts",
+): void {
+  const services = raw.services;
+  if (!services || typeof services !== "object" || Array.isArray(services)) {
+    return;
+  }
+  const entry = (services as Record<string, unknown>)[svc];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return;
+  }
+  delete (entry as Record<string, unknown>).mode;
+}
+
 export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
@@ -210,6 +232,7 @@ export async function run(
 
   if (setting === "tts_provider") {
     setNestedValue(raw, "services.tts.provider", validation.coerced);
+    deleteLegacySpeechMode(raw, "tts");
     saveRawConfig(raw);
     invalidateConfigCache();
   }
@@ -246,6 +269,7 @@ export async function run(
 
   if (setting === "stt_provider") {
     setNestedValue(raw, "services.stt.provider", validation.coerced);
+    deleteLegacySpeechMode(raw, "stt");
     saveRawConfig(raw);
     invalidateConfigCache();
   }

--- a/assistant/src/config/managed-speech-defaults.ts
+++ b/assistant/src/config/managed-speech-defaults.ts
@@ -2,11 +2,11 @@
  * Managed-speech defaulting on Vellum connection.
  *
  * When the platform connection completes and a speech service has no working
- * BYOK credential, default that service to `mode: "managed"` so a fresh
+ * BYOK credential, default that service to `provider: "vellum"` so a fresh
  * Vellum connection gets voice features with zero configuration. A service
  * whose BYOK credential is already configured is never modified — connecting
  * Vellum must not silently reroute an existing voice setup — and a service
- * already in managed mode is left alone.
+ * already on Vellum is left alone.
  */
 
 import { ttsSecretResolves } from "../calls/telephony-tts-capability.js";
@@ -23,7 +23,6 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "./loader.js";
-import { effectiveTtsProvider } from "./schemas/tts.js";
 
 const log = getLogger("managed-speech-defaults");
 
@@ -53,12 +52,12 @@ async function ttsByokCredentialsResolve(provider: string): Promise<boolean> {
 }
 
 /**
- * Default unconfigured speech services to managed mode.
+ * Default unconfigured speech services to the Vellum provider.
  *
  * Safe to call repeatedly (idempotent) and safe to fire-and-forget: it
  * no-ops unless the platform connection is fully usable, and it only ever
- * flips `mode` from `"your-own"` to `"managed"` for services with no
- * working BYOK credential.
+ * repoints `provider` at `"vellum"` for services with no working BYOK
+ * credential.
  */
 export async function maybeDefaultSpeechToManaged(): Promise<void> {
   try {
@@ -70,20 +69,17 @@ export async function maybeDefaultSpeechToManaged(): Promise<void> {
     const updates: string[] = [];
 
     if (
-      services.stt.mode !== "managed" &&
+      services.stt.provider !== "vellum" &&
       !(await sttByokCredentialResolves(services.stt.provider))
     ) {
-      updates.push("services.stt.mode");
+      updates.push("services.stt.provider");
     }
 
-    if (services.tts.mode !== "managed") {
-      const byokProvider = effectiveTtsProvider({
-        mode: "your-own",
-        provider: services.tts.provider,
-      });
-      if (!(await ttsByokCredentialsResolve(byokProvider))) {
-        updates.push("services.tts.mode");
-      }
+    if (
+      services.tts.provider !== "vellum" &&
+      !(await ttsByokCredentialsResolve(services.tts.provider))
+    ) {
+      updates.push("services.tts.provider");
     }
 
     if (updates.length === 0) {
@@ -92,18 +88,13 @@ export async function maybeDefaultSpeechToManaged(): Promise<void> {
 
     const raw = loadRawConfig();
     for (const path of updates) {
-      setNestedValue(raw, path, "managed");
-    }
-    // SttServiceSchema requires `provider` whenever the stt object exists, so
-    // a sparse config would become invalid if we wrote `mode` alone.
-    if (updates.includes("services.stt.mode")) {
-      setNestedValue(raw, "services.stt.provider", services.stt.provider);
+      setNestedValue(raw, path, "vellum");
     }
     saveRawConfig(raw);
     invalidateConfigCache();
     log.info(
       { defaulted: updates },
-      "Defaulted unconfigured speech services to managed mode after Vellum connection",
+      "Defaulted unconfigured speech services to the Vellum provider after connection",
     );
   } catch (err) {
     // Convenience defaulting must never break credential storage.

--- a/assistant/src/config/schemas/__tests__/stt.test.ts
+++ b/assistant/src/config/schemas/__tests__/stt.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  effectiveSttProvider,
   SttProvidersSchema,
   SttServiceSchema,
   VALID_STT_PROVIDERS,
@@ -68,41 +67,19 @@ describe("SttServiceSchema", () => {
   });
 });
 
-describe("managed mode", () => {
-  test("accepts mode: managed with a BYOK provider preserved", () => {
-    const parsed = SttServiceSchema.parse({
-      mode: "managed",
-      provider: "deepgram",
-    });
-    expect(parsed.mode).toBe("managed");
-    expect(parsed.provider).toBe("deepgram");
-  });
-
-  test("accepts provider vellum under managed mode", () => {
-    const parsed = SttServiceSchema.parse({
-      mode: "managed",
-      provider: "vellum",
-    });
+describe("managed provider", () => {
+  test("accepts vellum as an ordinary provider choice", () => {
+    const parsed = SttServiceSchema.parse({ provider: "vellum" });
     expect(parsed.provider).toBe("vellum");
   });
 
-  test("accepts provider vellum regardless of mode", () => {
-    const result = SttServiceSchema.safeParse({
-      mode: "your-own",
+  // Migration 130 folds mode into provider; a stale key must not resurrect
+  // the second axis or fail the parse.
+  test("ignores a legacy mode key", () => {
+    const parsed = SttServiceSchema.parse({
+      mode: "managed",
       provider: "vellum",
     });
-    expect(result.success).toBe(true);
-  });
-
-  test("effectiveSttProvider routes provider vellum and managed mode to vellum, preserves BYOK otherwise", () => {
-    expect(effectiveSttProvider({ mode: "your-own", provider: "vellum" })).toBe(
-      "vellum",
-    );
-    expect(
-      effectiveSttProvider({ mode: "managed", provider: "deepgram" }),
-    ).toBe("vellum");
-    expect(
-      effectiveSttProvider({ mode: "your-own", provider: "deepgram" }),
-    ).toBe("deepgram");
+    expect(parsed).toEqual({ provider: "vellum", providers: {} });
   });
 });

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -128,7 +128,6 @@ export const ServicesSchema = z.object({
   ),
   "web-fetch": WebFetchServiceSchema.default(WebFetchServiceSchema.parse({})),
   stt: SttServiceSchema.default({
-    mode: "your-own" as const,
     provider: "deepgram" as const,
     providers: {},
   }),

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -46,23 +46,11 @@ export type SttProviders = z.infer<typeof SttProvidersSchema>;
 /**
  * Canonical STT service configuration.
  *
- * Managed transcription (through the user's Vellum account, billed to Vellum
- * credits) is selectable two ways: `provider: "vellum"` directly, or
- * `mode: "managed"` alongside a BYOK `provider` — the form the mode toggle
- * writes, which leaves the BYOK choice untouched so switching back to
- * `"your-own"` restores it. Use {@link effectiveSttProvider} to resolve
- * which provider is actually active.
+ * `provider` is the only axis: `"vellum"` transcribes through the platform,
+ * billed to Vellum credits; any other provider uses the user's own API key.
  */
 export const SttServiceSchema = z
   .object({
-    mode: z
-      .enum(["your-own", "managed"], {
-        error: 'services.stt.mode must be "your-own" or "managed"',
-      })
-      .default("your-own" as const)
-      .describe(
-        'STT service mode -- "your-own" uses the configured provider with your API key; "managed" transcribes through your Vellum account',
-      ),
     provider: z
       .preprocess(
         (v) => {
@@ -84,21 +72,3 @@ export const SttServiceSchema = z
   );
 
 export type SttService = z.infer<typeof SttServiceSchema>;
-
-/**
- * Resolve the provider that is actually active for the service config.
- *
- * `provider: "vellum"` selects managed transcription directly. Otherwise
- * `mode: "managed"` routes to `vellum` while leaving the user's BYOK
- * `provider` choice untouched, so toggling back to `"your-own"` restores
- * their previous setup.
- */
-export function effectiveSttProvider(service: {
-  mode: SttService["mode"];
-  provider: string;
-}): string {
-  if (service.provider === "vellum") {
-    return "vellum";
-  }
-  return service.mode === "managed" ? "vellum" : service.provider;
-}

--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -273,23 +273,11 @@ for (const id of schemaKeys) {
 /**
  * Canonical TTS service configuration.
  *
- * Managed synthesis (through the user's Vellum account, billed to Vellum
- * credits) is selectable two ways: `provider: "vellum"` directly, or
- * `mode: "managed"` alongside a BYOK `provider` — the form the mode toggle
- * writes, which leaves the BYOK choice untouched so switching back to
- * `"your-own"` restores it. Use {@link effectiveTtsProvider} to resolve
- * which provider is actually active.
+ * `provider` is the only axis: `"vellum"` synthesizes through the platform,
+ * billed to Vellum credits; any other provider uses the user's own API key.
  */
 export const TtsServiceSchema = z
   .object({
-    mode: z
-      .enum(["your-own", "managed"], {
-        error: 'services.tts.mode must be "your-own" or "managed"',
-      })
-      .default("your-own" as const)
-      .describe(
-        'TTS service mode — "your-own" uses the configured provider with your API key; "managed" synthesizes through your Vellum account',
-      ),
     provider: z
       .enum(TTS_PROVIDER_IDS, {
         error: `services.tts.provider must be one of: ${TTS_PROVIDER_IDS.join(", ")}`,
@@ -303,24 +291,3 @@ export const TtsServiceSchema = z
   );
 
 export type TtsService = z.infer<typeof TtsServiceSchema>;
-
-/**
- * Resolve the provider that is actually active for the service config.
- *
- * `provider: "vellum"` selects managed synthesis directly. Otherwise
- * `mode: "managed"` routes to `vellum` while leaving the user's BYOK
- * `provider` choice untouched, so toggling back to `"your-own"` restores
- * their previous setup.
- */
-export function effectiveTtsProvider(service: {
-  mode: TtsService["mode"];
-  provider?: string;
-}): string {
-  if (service.provider === "vellum") {
-    return "vellum";
-  }
-  if (service.mode === "managed") {
-    return "vellum";
-  }
-  return service.provider ?? "elevenlabs";
-}

--- a/assistant/src/live-voice/live-voice-credential-preflight.ts
+++ b/assistant/src/live-voice/live-voice-credential-preflight.ts
@@ -16,7 +16,6 @@ import {
   ttsSecretResolves,
 } from "../calls/telephony-tts-capability.js";
 import { getConfig } from "../config/loader.js";
-import { effectiveSttProvider } from "../config/schemas/stt.js";
 import { managedSpeechAvailable } from "../platform/managed-speech.js";
 import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import {
@@ -108,7 +107,7 @@ async function resolveSttGap(): Promise<GapWithClause | null> {
     return null;
   }
 
-  const providerId = effectiveSttProvider(getConfig().services.stt);
+  const providerId = getConfig().services.stt.provider;
   const entry = getProviderEntry(providerId as SttProviderId);
   if (!entry) {
     return {

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -159,9 +159,8 @@ const {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function applyConfig(overrides: { provider?: string; mode?: string }): void {
+function applyConfig(overrides: { provider?: string }): void {
   const provider = overrides.provider ?? "openai-whisper";
-  const mode = overrides.mode ?? "your-own";
   // Seed a schema-valid base so the loader caches a fresh config object, then
   // set the provider under test on that live cached object. `services.stt.
   // provider` is a strict enum, so the "unconfigured" cases (empty string /
@@ -170,7 +169,6 @@ function applyConfig(overrides: { provider?: string; mode?: string }): void {
   // path the raw mock did.
   setConfig("services", {
     stt: {
-      mode,
       provider: "openai-whisper",
       providers: {
         "openai-whisper": {},
@@ -969,25 +967,25 @@ describe("vellum managed resolution", () => {
     vellumStreamCtorCalls.length = 0;
   });
 
-  test("managed mode resolves the vellum batch transcriber when the platform connection exists", async () => {
+  test("the vellum provider resolves the batch transcriber when the platform connection exists", async () => {
     mockVellumAvailable = true;
-    applyConfig({ provider: "deepgram", mode: "managed" });
+    applyConfig({ provider: "vellum" });
 
     const transcriber = await resolveBatchTranscriber();
     expect(transcriber?.providerId).toBe("vellum");
   });
 
-  test("managed mode resolves null without a platform connection", async () => {
+  test("the vellum provider resolves null without a platform connection", async () => {
     mockVellumAvailable = false;
-    applyConfig({ provider: "deepgram", mode: "managed" });
+    applyConfig({ provider: "vellum" });
 
     expect(await resolveBatchTranscriber()).toBeNull();
   });
 
-  test("managed mode preserves the BYOK provider choice (effective provider is vellum)", async () => {
+  test("the vellum provider wins over a stored BYOK key", async () => {
     mockVellumAvailable = true;
     mockProviderKeys = { deepgram: "dg-key" };
-    applyConfig({ provider: "deepgram", mode: "managed" });
+    applyConfig({ provider: "vellum" });
 
     const capability = await resolveConversationStreamingSttCapability();
     expect(capability.status).toBe("supported");
@@ -1004,7 +1002,7 @@ describe("vellum managed resolution", () => {
       httpBaseUrl: "http://gateway.test",
       mintServiceToken: () => "vk-test",
     };
-    applyConfig({ provider: "openai-whisper", mode: "managed" });
+    applyConfig({ provider: "vellum" });
 
     const transcriber = await resolveStreamingTranscriber({
       sampleRate: 24000,
@@ -1025,7 +1023,7 @@ describe("vellum managed resolution", () => {
       httpBaseUrl: "http://gateway.test",
       mintServiceToken: () => "vk-test",
     };
-    applyConfig({ provider: "deepgram", mode: "managed" });
+    applyConfig({ provider: "vellum" });
 
     expect(await resolveStreamingTranscriber({ sampleRate: 16000 })).toBeNull();
     expect(vellumStreamCtorCalls).toHaveLength(0);
@@ -1034,7 +1032,7 @@ describe("vellum managed resolution", () => {
   test("streaming resolver returns null when the velay connection is missing", async () => {
     mockVellumAvailable = true;
     mockVelayConnection = null;
-    applyConfig({ provider: "deepgram", mode: "managed" });
+    applyConfig({ provider: "vellum" });
 
     expect(await resolveStreamingTranscriber({ sampleRate: 16000 })).toBeNull();
     expect(vellumStreamCtorCalls).toHaveLength(0);
@@ -1042,7 +1040,7 @@ describe("vellum managed resolution", () => {
 
   test("conversation streaming capability reports missing credentials without a connection", async () => {
     mockVellumAvailable = false;
-    applyConfig({ provider: "deepgram", mode: "managed" });
+    applyConfig({ provider: "vellum" });
 
     const capability = await resolveConversationStreamingSttCapability();
     expect(capability.status).toBe("missing-credentials");

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -1,5 +1,4 @@
 import { getConfig } from "../../config/loader.js";
-import { effectiveSttProvider } from "../../config/schemas/stt.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { createDaemonBatchTranscriber } from "../../stt/daemon-batch-transcriber.js";
 import type {
@@ -36,7 +35,7 @@ const log = getLogger("stt-resolver");
  */
 export async function resolveBatchTranscriber(): Promise<BatchTranscriber | null> {
   const config = getConfig();
-  const provider = effectiveSttProvider(config.services.stt);
+  const provider = config.services.stt.provider;
 
   // Look up credential provider via the catalog.
   const credentialProviderName = getCredentialProvider(
@@ -112,7 +111,7 @@ export type TelephonySttCapability =
  */
 export async function resolveTelephonySttCapability(): Promise<TelephonySttCapability> {
   const config = getConfig();
-  const provider = effectiveSttProvider(config.services.stt);
+  const provider = config.services.stt.provider;
 
   const entry = getProviderEntry(provider as SttProviderId);
   if (!entry) {
@@ -201,7 +200,7 @@ export type ConversationStreamingSttCapability =
  */
 export async function resolveConversationStreamingSttCapability(): Promise<ConversationStreamingSttCapability> {
   const config = getConfig();
-  const provider = effectiveSttProvider(config.services.stt);
+  const provider = config.services.stt.provider;
 
   const entry = getProviderEntry(provider as SttProviderId);
   if (!entry) {
@@ -306,7 +305,7 @@ export async function resolveStreamingTranscriber(
   options: ResolveStreamingTranscriberOptions = {},
 ): Promise<StreamingTranscriber | null> {
   const config = getConfig();
-  const provider = effectiveSttProvider(config.services.stt);
+  const provider = config.services.stt.provider;
   const diarizePreference: DiarizePreference = options.diarize ?? "off";
 
   // Look up credential provider via the catalog.

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -22,7 +22,6 @@ import {
 } from "../config/env.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
-import { effectiveSttProvider } from "../config/schemas/stt.js";
 import {
   getDbMigrationReadiness,
   isDbMigrationGateBypassed,
@@ -236,9 +235,7 @@ export class RuntimeHttpServer {
             // reads config inside SttStreamSession.start()'s own guarded path.
             let configuredProvider: string | undefined;
             try {
-              configuredProvider = effectiveSttProvider(
-                getConfig().services.stt,
-              );
+              configuredProvider = getConfig().services.stt.provider;
 
               // Mismatch telemetry: when the optional requested provider
               // disagrees with the configured provider, log a warning so

--- a/assistant/src/tts/__tests__/provider-resolution.test.ts
+++ b/assistant/src/tts/__tests__/provider-resolution.test.ts
@@ -83,27 +83,19 @@ describe("TTS provider resolution", () => {
   });
 });
 
-describe("managed TTS mode resolution", () => {
+describe("managed TTS provider resolution", () => {
   const configWith = (tts: Record<string, unknown>) =>
     ({ services: { tts } }) as unknown as Parameters<
       typeof resolveTtsConfig
     >[0];
 
-  test("managed mode resolves provider vellum regardless of the BYOK choice", () => {
-    const config = configWith({
-      mode: "managed",
-      provider: "elevenlabs",
-      providers: {},
-    });
+  test("resolves the vellum provider", () => {
+    const config = configWith({ provider: "vellum", providers: {} });
     expect(resolveTtsConfig(config).provider).toBe("vellum");
   });
 
-  test("your-own mode still resolves the configured provider", () => {
-    const config = configWith({
-      mode: "your-own",
-      provider: "deepgram",
-      providers: {},
-    });
+  test("resolves a BYOK provider", () => {
+    const config = configWith({ provider: "deepgram", providers: {} });
     expect(resolveTtsConfig(config).provider).toBe("deepgram");
   });
 });

--- a/assistant/src/tts/tts-config-resolver.ts
+++ b/assistant/src/tts/tts-config-resolver.ts
@@ -7,7 +7,6 @@
  * have canonical fields materialised.
  */
 
-import { effectiveTtsProvider } from "../config/schemas/tts.js";
 import type { AssistantConfig } from "../config/types.js";
 import type { TtsProviderId } from "./types.js";
 
@@ -38,7 +37,7 @@ export interface ResolvedTtsConfig {
 export function resolveTtsConfig(config: AssistantConfig): ResolvedTtsConfig {
   const ttsService = config.services.tts;
 
-  const provider = effectiveTtsProvider(ttsService) as TtsProviderId;
+  const provider = ttsService.provider as TtsProviderId;
 
   // Resolve provider-specific config from the canonical providers map.
   const providerConfig = resolveProviderConfig(config, provider);

--- a/assistant/src/workspace/migrations/130-speech-mode-to-provider.ts
+++ b/assistant/src/workspace/migrations/130-speech-mode-to-provider.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Fold `services.stt.mode` / `services.tts.mode` into the provider field.
+ *
+ * Managed speech used to be a second axis: `mode: "managed"` routed to Vellum
+ * while `provider` held the untouched BYOK choice. Provider is now the only
+ * axis, with `"vellum"` meaning managed, so a managed service must be rewritten
+ * to `provider: "vellum"` before the new schema reads it — otherwise the
+ * lingering BYOK provider would be taken at face value and a managed user would
+ * silently fall back to a provider they have no key for.
+ *
+ * Idempotent: a config with no `mode` key is left untouched.
+ */
+export const speechModeToProviderMigration: WorkspaceMigration = {
+  id: "130-speech-mode-to-provider",
+  description:
+    "Fold services.stt/tts mode into provider (managed -> provider: vellum)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed JSON — skip
+    }
+
+    const services = readObj(config, "services");
+    if (!services) return;
+
+    let changed = false;
+    for (const key of ["stt", "tts"]) {
+      const service = readObj(services, key);
+      if (!service || !("mode" in service)) continue;
+
+      if (service.mode === "managed") {
+        service.provider = "vellum";
+      }
+      delete service.mode;
+      changed = true;
+    }
+
+    if (changed) {
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    }
+  },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const services = readObj(config, "services");
+    if (!services) return;
+
+    let changed = false;
+    for (const key of ["stt", "tts"]) {
+      const service = readObj(services, key);
+      if (!service || "mode" in service) continue;
+
+      // The pre-migration schema accepts provider "vellum" alongside mode
+      // "managed", so the managed pair round-trips exactly. What a managed
+      // service had chosen for BYOK before is not recoverable — it was
+      // overwritten on the way up.
+      service.mode = service.provider === "vellum" ? "managed" : "your-own";
+      changed = true;
+    }
+
+    if (changed) {
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers (self-contained per migration AGENTS.md)
+// ---------------------------------------------------------------------------
+
+function readObj(
+  parent: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = parent[key];
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -267,6 +267,10 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   backfillDefaultProviderMigration,
   repairStaleOpenrouterGrokModelIdsMigration,
   removeAnalyzeConversationConfigMigration,
-  dropWebFetchModeMigration,
+  // 130 sits before 131 despite landing later: getLastWorkspaceMigrationId()
+  // reports the final array entry as the registry ceiling (identity/rollback
+  // routes), so the highest id must stay last. The two touch disjoint config
+  // keys, so relative execution order is irrelevant.
   speechModeToProviderMigration,
+  dropWebFetchModeMigration,
 ];

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -127,6 +127,7 @@ import { stripManagedProfileBodiesMigration } from "./126-strip-managed-profile-
 import { backfillDefaultProviderMigration } from "./127-backfill-default-provider.js";
 import { repairStaleOpenrouterGrokModelIdsMigration } from "./128-repair-stale-openrouter-grok-model-ids.js";
 import { removeAnalyzeConversationConfigMigration } from "./129-remove-analyze-conversation-config.js";
+import { speechModeToProviderMigration } from "./130-speech-mode-to-provider.js";
 import { dropWebFetchModeMigration } from "./131-drop-web-fetch-mode.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
@@ -267,4 +268,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairStaleOpenrouterGrokModelIdsMigration,
   removeAnalyzeConversationConfigMigration,
   dropWebFetchModeMigration,
+  speechModeToProviderMigration,
 ];


### PR DESCRIPTION
## What

The final structural step of the speech provider-dropdown stack (after #38248, #38252, #38305): `mode` is removed from `services.stt` / `services.tts`. Provider is the only axis — `"vellum"` is managed, anything else is BYOK — and `effectiveSttProvider` / `effectiveTtsProvider` are deleted; every read site asks `config.services.{stt,tts}.provider` directly.

## Migration 130 is the load-bearing piece

An existing managed user has `{ mode: "managed", provider: "deepgram" }` on disk. Drop `mode` without rewriting and the schema reads that provider at face value — every managed voice user silently downgrades to a provider they have no key for. `130-speech-mode-to-provider` rewrites `mode: "managed"` → `provider: "vellum"` and deletes the key either way, before the new schema ever parses the file.

Two deliberate choices in it:
- The managed user's coexisting BYOK provider is **overwritten**. That value only existed to serve the removed toggle ("switch back restores it"); with a dropdown, re-picking is the restore path.
- `down()` restores the managed pair exactly, but the pre-managed BYOK choice is unrecoverable — stated in the migration rather than hidden.

Covered by a round-trip test that runs the migration and parses the result through the real `AssistantConfigSchema`, asserting managed users land on `vellum`.

## Writers follow

- `maybeDefaultSpeechToManaged()` (connect + startup, after #38305) repoints `provider` at `"vellum"` instead of flipping `mode`
- `voice_config_update` swaps `stt_mode`/`tts_mode` for `stt_provider`; both provider settings gate `"vellum"` on the platform connection; the `tts_provider` handler drops its `mode` pairing (daemon-internal, always version-matched)

## What deliberately still writes `mode`

The web cards (merged in #38252 + follow-ups) keep sending legacy `mode` keys alongside provider writes — required for compatibility with **older daemons**, whose schemas couple `provider: "vellum"` to `mode: "managed"`. On this daemon those keys are stripped at parse and are inert; the raw config file can re-accumulate a dead `mode` key from card saves until the card bridges are retired (stack PR 4), which is cosmetic. Tested: "ignores a legacy tts/stt mode key" asserts stripping never resurrects a managed selection.

## Numbering note

Migration ids are 130 here and 131 (web-fetch, already on main). 130 sits BEFORE 131 in the registry: `getLastWorkspaceMigrationId()` reports the final array entry as the ceiling to the identity and rollback routes, so the highest id must stay last (Codex catch — an earlier revision appended 130 at the end and demoted the reported ceiling). Relative execution order is irrelevant: disjoint keys, both idempotent. A test pins the ceiling to the highest-numbered id.

## Testing

- 569 tests across config-schema, voice-config-update, managed-speech-defaults, migration 130, schema suites, tts suites, catalog parity — 0 fail
- `resolve.test.ts` 63/63 in isolation (its known cross-file mock-contamination flake in big batches is pre-existing on main)
- `tsc --noEmit` clean; regenerated `openapi.yaml` — zero diff (stt/tts ride the wire passthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
