### PR TITLE
refactor(web): tri-state consent store; gates key on explicit opt-out only

### DIFF
--- a/clients/web/src/domains/onboarding/funnel-events.test.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.test.ts
@@ -48,7 +48,8 @@ function ingestPayload(callIndex: number): IngestPayload {
 beforeEach(() => {
   sessionStorage.clear();
   localStorage.clear();
-  useOnboardingStore.setState({ shareAnalytics: true });
+  // Never-asked baseline: analytics is opt-out, so null authorizes uploads.
+  useOnboardingStore.setState({ shareAnalytics: null });
   __resetOnboardingFunnelEventsForTests();
   ingestMock.mockClear();
 });
@@ -132,8 +133,6 @@ describe("onboarding funnel events", () => {
   });
 
   test("emits fire-and-forget telemetry payloads with the same session id", () => {
-    localStorage.setItem("device:share_analytics", "true");
-
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
@@ -161,8 +160,6 @@ describe("onboarding funnel events", () => {
   });
 
   test("stamps research-onboarding steps with the research funnel version", () => {
-    localStorage.setItem("device:share_analytics", "true");
-
     emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS.form, {
       userId: "user-123",
     });
@@ -198,8 +195,6 @@ describe("onboarding funnel events", () => {
   });
 
   test("emits the check-in calendar click on the research funnel", () => {
-    localStorage.setItem("device:share_analytics", "true");
-
     emitResearchOnboardingCheckinCalendarOpened({ userId: "user-123" });
 
     expect(ingestMock).toHaveBeenCalledTimes(1);
@@ -215,7 +210,7 @@ describe("onboarding funnel events", () => {
     });
   });
 
-  test("does not emit research telemetry until analytics sharing is opted in", () => {
+  test("does not emit research telemetry after an explicit analytics opt-out", () => {
     useOnboardingStore.setState({ shareAnalytics: false });
 
     emitResearchOnboardingStepCompleted(RESEARCH_ONBOARDING_FUNNEL_STEPS.form, {
@@ -226,24 +221,24 @@ describe("onboarding funnel events", () => {
   });
 
   test("emits by default (opt-out) but honors an explicit analytics opt-out", () => {
-    // Never-asked: no device preference on record — analytics is opt-out, so
-    // the event emits.
+    // Never-asked (null): analytics is opt-out, so the event emits.
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
       userId: "user-123",
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
     expect(ingestMock).toHaveBeenCalledTimes(1);
 
-    // An explicit device opt-out stops uploads.
-    localStorage.setItem("device:share_analytics", "false");
+    // An explicit opt-out through the store setter stops uploads.
+    useOnboardingStore.getState().setShareAnalytics(false);
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.gmailConnect, {
       userId: "user-123",
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
     expect(ingestMock).toHaveBeenCalledTimes(1);
 
-    // The in-memory store must agree: a failed opt-out write cannot leave an
-    // older stored opt-in authorizing a new event.
+    // The in-memory store is the single gate source: an explicit opt-out
+    // stops uploads even when a stale device key still says "true" (e.g. a
+    // failed opt-out write on another layer must not re-authorize events).
     localStorage.setItem("device:share_analytics", "true");
     useOnboardingStore.setState({ shareAnalytics: false });
     emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.nameVibe, {
@@ -251,5 +246,24 @@ describe("onboarding funnel events", () => {
       variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
     });
     expect(ingestMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("an explicit opt-in emits and a server-driven never-asked reset keeps emitting", () => {
+    useOnboardingStore.getState().setShareAnalytics(true);
+    emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
+      userId: "user-123",
+      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+    });
+    expect(ingestMock).toHaveBeenCalledTimes(1);
+
+    // A sync adopting server null (never asked) removes the device key and
+    // returns the store to null — still enabled under opt-out semantics.
+    useOnboardingStore.getState().setShareAnalytics(null);
+    expect(localStorage.getItem("device:share_analytics")).toBeNull();
+    emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.nameVibe, {
+      userId: "user-123",
+      variant: ONBOARDING_FUNNEL_VARIANTS.paredDown,
+    });
+    expect(ingestMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -1,4 +1,4 @@
-import { readShareAnalytics } from "@/domains/onboarding/prefs";
+import { isAnalyticsEnabled } from "@/domains/onboarding/prefs";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import { telemetryIngestCreate } from "@/generated/api/sdk.gen";
 import type { ResearchStep } from "@/domains/onboarding/research-onboarding-persistence";
@@ -232,7 +232,7 @@ export function emitOnboardingFunnelStepCompleted(
   options: OnboardingFunnelStepCompletedOptions = {},
 ): void {
   if (typeof window === "undefined") return;
-  if (!readShareAnalytics()) return;
+  if (!isAnalyticsEnabled()) return;
 
   const event = stripUndefined(buildOnboardingFunnelEvent(screen, options));
 

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -173,7 +173,7 @@ mock.module("@sentry/react", () => ({
 mock.module("@/domains/onboarding/prefs", () => ({
   readPrivacyConsent: () => true,
   readSelectedVersion: () => null,
-  readShareAnalytics: () => true,
+  isAnalyticsEnabled: () => true,
   readTosAccepted: () => true,
   writeSelectedVersion: writeSelectedVersionMock,
 }));

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -2,8 +2,10 @@
  * Zustand store for onboarding boolean preferences.
  *
  * **Device-persisted fields** (`shareAnalytics`, `shareDiagnostics`) are
- * written to `device:` localStorage keys on every setter call and synced
- * across tabs via `watchSetting`. They survive logout.
+ * tri-state: `null` means "never asked" (no device key), a boolean is an
+ * explicit user choice. Setters write the `device:` localStorage key for an
+ * explicit boolean and remove it for `null`, and the fields sync across tabs
+ * via `watchSetting`. They survive logout.
  *
  * **In-memory-only fields** (`tosAccepted`, `privacyConsent`,
  * `analyticsConsentCurrent`, `diagnosticsConsentCurrent`) start `false` and
@@ -22,7 +24,8 @@ import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
 import {
-  getLocalBool,
+  getLocalBoolOrNull,
+  removeLocalSetting,
   setLocalBool,
   watchSetting,
 } from "@/utils/local-settings";
@@ -35,13 +38,24 @@ import { deviceKey } from "@/utils/device-settings";
 const KEY_SHARE_ANALYTICS = deviceKey("shareAnalytics");
 const KEY_SHARE_DIAGNOSTICS = deviceKey("shareDiagnostics");
 
+/** Explicit boolean → persist; `null` (never asked) → remove the key. */
+function persistShareChoice(key: string, value: boolean | null): void {
+  if (value === null) {
+    removeLocalSetting(key);
+  } else {
+    setLocalBool(key, value);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // State + Actions
 // ---------------------------------------------------------------------------
 
 export interface OnboardingState {
-  shareAnalytics: boolean;
-  shareDiagnostics: boolean;
+  /** `null` = never asked; a boolean is an explicit user choice. */
+  shareAnalytics: boolean | null;
+  /** `null` = never asked; a boolean is an explicit user choice. */
+  shareDiagnostics: boolean | null;
   tosAccepted: boolean;
   privacyConsent: boolean;
   analyticsConsentCurrent: boolean;
@@ -54,8 +68,8 @@ export interface OnboardingState {
 }
 
 export interface OnboardingActions {
-  setShareAnalytics: (value: boolean) => void;
-  setShareDiagnostics: (value: boolean) => void;
+  setShareAnalytics: (value: boolean | null) => void;
+  setShareDiagnostics: (value: boolean | null) => void;
   setTosAccepted: (value: boolean) => void;
   setPrivacyConsent: (value: boolean) => void;
   setAnalyticsConsentCurrent: (value: boolean) => void;
@@ -70,8 +84,8 @@ export type OnboardingStore = OnboardingState & OnboardingActions;
 // ---------------------------------------------------------------------------
 
 const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
-  shareAnalytics: getLocalBool(KEY_SHARE_ANALYTICS, true),
-  shareDiagnostics: getLocalBool(KEY_SHARE_DIAGNOSTICS, true),
+  shareAnalytics: getLocalBoolOrNull(KEY_SHARE_ANALYTICS),
+  shareDiagnostics: getLocalBoolOrNull(KEY_SHARE_DIAGNOSTICS),
   tosAccepted: false,
   privacyConsent: false,
   analyticsConsentCurrent: false,
@@ -80,7 +94,7 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
 
   setShareAnalytics: (value) => {
     set({ shareAnalytics: value });
-    setLocalBool(KEY_SHARE_ANALYTICS, value);
+    persistShareChoice(KEY_SHARE_ANALYTICS, value);
   },
   setShareDiagnostics: (value) => {
     set({ shareDiagnostics: value });
@@ -88,7 +102,7 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
     // (`device:diagnostics_reporting`) — which actually drives the Sentry
     // clients via the `sentry-control.ts` watcher — is written separately by
     // the consent chokepoint (`setDiagnosticsReportingGate`).
-    setLocalBool(KEY_SHARE_DIAGNOSTICS, value);
+    persistShareChoice(KEY_SHARE_DIAGNOSTICS, value);
   },
   setTosAccepted: (value) => {
     set({ tosAccepted: value });
@@ -118,14 +132,10 @@ const SYNCED_KEYS: ReadonlyMap<string, keyof OnboardingState> = new Map([
   [KEY_SHARE_DIAGNOSTICS, "shareDiagnostics"],
 ]);
 
-const SYNCED_DEFAULTS: Record<string, boolean> = {
-  shareAnalytics: true,
-  shareDiagnostics: true,
-};
-
 for (const [key, field] of SYNCED_KEYS) {
   watchSetting(key, () => {
-    const next = getLocalBool(key, SYNCED_DEFAULTS[field] ?? false);
-    useOnboardingStoreBase.setState({ [field]: next } as Partial<OnboardingState>);
+    useOnboardingStoreBase.setState({
+      [field]: getLocalBoolOrNull(key),
+    } as Partial<OnboardingState>);
   });
 }

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -40,6 +40,10 @@ export function PrivacyScreen() {
   const preferredFunnelVariant =
     onboardingFunnelVariantFromExperiment(preChatExperimentArm);
   const [shareDiagnostics, setShareDiagnosticsReal] = useShareDiagnostics();
+  // Never-asked (null) displays as on — diagnostics is opt-out — and the
+  // toggle is on screen, so Start records the displayed value as an explicit
+  // choice.
+  const shareDiagnosticsChecked = shareDiagnostics ?? true;
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
   const [privacyConsent, setPrivacyConsentReal] = usePrivacyConsent();
   const hasPlatformSession = useHasPlatformSession();
@@ -68,7 +72,7 @@ export function PrivacyScreen() {
 
     // Analytics isn't asked here — the server keeps share_analytics null
     // until the user opts in via settings or review-terms.
-    saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics: null, shareDiagnostics, hasPlatformSession });
+    saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics: null, shareDiagnostics: shareDiagnosticsChecked, hasPlatformSession });
     if (!isNative) {
       const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
@@ -100,7 +104,7 @@ export function PrivacyScreen() {
     navigate,
     preferredFunnelVariant,
     searchParams,
-    shareDiagnostics,
+    shareDiagnosticsChecked,
     tosAccepted,
     userId,
   ]);
@@ -136,7 +140,7 @@ export function PrivacyScreen() {
           electron={electron}
           showAnalytics={false}
           shareAnalytics={false}
-          shareDiagnostics={shareDiagnostics}
+          shareDiagnostics={shareDiagnosticsChecked}
           onShareAnalyticsChange={noop}
           onShareDiagnosticsChange={setShareDiagnostics}
           className="mt-8 w-full"

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -45,6 +45,10 @@ export function ReviewTermsScreen() {
   const [shareDiagnostics, setShareDiagnostics] = useShareDiagnostics();
   const [analyticsConsentCurrent] = useAnalyticsConsentCurrent();
   const [diagnosticsConsentCurrent] = useDiagnosticsConsentCurrent();
+  // Never-asked (null) displays as on: both toggles are opt-out, so an
+  // unchosen toggle is effectively enabled.
+  const shareAnalyticsChecked = shareAnalytics ?? true;
+  const shareDiagnosticsChecked = shareDiagnostics ?? true;
 
   // Snapshot staleness at mount: these are the sections the user was routed
   // here to address. Gating render on live values would unmount a checkbox the
@@ -90,8 +94,8 @@ export function ReviewTermsScreen() {
       userId,
       tos: tosAccepted,
       privacy: privacyConsent,
-      shareAnalytics: showAnalytics ? shareAnalytics : null,
-      shareDiagnostics: showDiagnostics ? shareDiagnostics : null,
+      shareAnalytics: showAnalytics ? shareAnalyticsChecked : null,
+      shareDiagnostics: showDiagnostics ? shareDiagnosticsChecked : null,
       hasPlatformSession,
     });
 
@@ -102,8 +106,8 @@ export function ReviewTermsScreen() {
     hasPlatformSession,
     navigate,
     searchParams,
-    shareAnalytics,
-    shareDiagnostics,
+    shareAnalyticsChecked,
+    shareDiagnosticsChecked,
     showAnalytics,
     showDiagnostics,
     tosAccepted,
@@ -152,8 +156,8 @@ export function ReviewTermsScreen() {
             electron={electron}
             showAnalytics={showAnalytics}
             showDiagnostics={showDiagnostics}
-            shareAnalytics={shareAnalytics}
-            shareDiagnostics={shareDiagnostics}
+            shareAnalytics={shareAnalyticsChecked}
+            shareDiagnostics={shareDiagnosticsChecked}
             onShareAnalyticsChange={setShareAnalytics}
             onShareDiagnosticsChange={setShareDiagnostics}
             className="mt-9 w-full"

--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -1,10 +1,10 @@
 /**
  * Onboarding preference public API.
  *
- * Boolean preferences (`shareAnalytics`, `shareDiagnostics`, `tosAccepted`,
- * `privacyConsent`) are owned by `useOnboardingStore` — a
- * Zustand store with a custom per-key `persist` adapter that maps each
- * field to its existing localStorage key. This file exposes the hook +
+ * Consent preferences are owned by `useOnboardingStore` — the share toggles
+ * (`shareAnalytics`, `shareDiagnostics`) are tri-state (`null` = never
+ * asked), the legal flags (`tosAccepted`, `privacyConsent`) are booleans.
+ * The store persists each share toggle to its existing localStorage key. This file exposes the hook +
  * non-React shim around the store, plus the non-store helpers for the
  * onboarding-only keys that don't fit the boolean store shape
  * (`onboarding.selectedVersion`, `onboarding.lastUserId`).
@@ -20,7 +20,6 @@ import {
   removeLocalSetting,
   setLocalSetting,
 } from "@/utils/local-settings";
-import { getDeviceBool } from "@/utils/device-settings";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 
 // ---------------------------------------------------------------------------
@@ -40,11 +39,12 @@ const KEY_SELECTED_VERSION = "vellum:onboarding:selectedVersion";
 // ---------------------------------------------------------------------------
 
 /**
- * Share anonymous product analytics. Defaults to `true`.
- * Backed by the SAME localStorage key as `/settings/privacy` so onboarding
- * and settings are a single source of truth.
+ * Share anonymous product analytics. Tri-state: `null` = never asked
+ * (analytics is opt-out, so never-asked behaves as enabled), a boolean is an
+ * explicit choice. Backed by the SAME localStorage key as `/settings/privacy`
+ * so onboarding and settings are a single source of truth.
  */
-export function useShareAnalytics(): [boolean, (next: boolean) => void] {
+export function useShareAnalytics(): [boolean | null, (next: boolean) => void] {
   const value = useOnboardingStore.use.shareAnalytics();
   const setter = useCallback((next: boolean) => {
     useOnboardingStore.getState().setShareAnalytics(next);
@@ -53,10 +53,11 @@ export function useShareAnalytics(): [boolean, (next: boolean) => void] {
 }
 
 /**
- * Share crash reports and diagnostics. Defaults to `true`.
- * Backed by the SAME localStorage key as `/settings/privacy`.
+ * Share crash reports and diagnostics. Tri-state: `null` = never asked
+ * (diagnostics is opt-out), a boolean is an explicit choice. Backed by the
+ * SAME localStorage key as `/settings/privacy`.
  */
-export function useShareDiagnostics(): [boolean, (next: boolean) => void] {
+export function useShareDiagnostics(): [boolean | null, (next: boolean) => void] {
   const value = useOnboardingStore.use.shareDiagnostics();
   const setter = useCallback((next: boolean) => {
     useOnboardingStore.getState().setShareDiagnostics(next);
@@ -167,18 +168,15 @@ export function readConsentHydrated(): boolean {
 }
 
 /**
- * SSR-safe, non-hook read for telemetry emitters.
+ * SSR-safe, non-hook gate for telemetry emitters.
  *
- * Analytics is opt-out: an absent preference (never asked) authorizes uploads;
- * only an explicit opt-out stops them. The in-memory store must also agree so
- * a failed opt-out write cannot leave an older stored opt-in authorizing a new
- * event.
+ * Analytics is opt-out: never-asked (`null`) authorizes uploads; only an
+ * explicit opt-out stops them. The store is the single in-memory source —
+ * hydrated from the device key at init and from the server on sync — so an
+ * explicit opt-out stops uploads even if its server write failed.
  */
-export function readShareAnalytics(): boolean {
-  return (
-    useOnboardingStore.getState().shareAnalytics &&
-    getDeviceBool("shareAnalytics", true)
-  );
+export function isAnalyticsEnabled(): boolean {
+  return useOnboardingStore.getState().shareAnalytics !== false;
 }
 
 /**

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -701,6 +701,31 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
   });
 
+  test("a no-record response never adopts its default share values over a local opt-out", async () => {
+    // Older/default consent shapes materialize share_analytics: true on a
+    // record-less response; adopting it would clobber the device opt-out the
+    // backfill is about to seed the server with.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    localStorage.setItem("device:share_analytics", "false");
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: false,
+      privacy: false,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: false,
+      hasServerRecord: false,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(setShareAnalyticsMock).not.toHaveBeenCalled();
+  });
+
   test("no-record fallback without any device acks stays current and backfills neither toggle", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     restoreConsentForUserMock.mockReturnValueOnce({
@@ -797,9 +822,11 @@ describe("auth store onboarding flag reconciliation", () => {
     const backfillBody = patchConsentMock.mock.calls[0][0] as Record<string, unknown>;
     expect("share_analytics" in backfillBody).toBe(false);
     expect("share_analytics_accepted_version" in backfillBody).toBe(false);
-    // Never-asked propagates to the store (null adoption); the diagnostics
-    // preference is left untouched by the chokepoint on an unknown input.
-    expect(setShareAnalyticsMock).toHaveBeenCalledWith(null);
+    // A no-record response adopts nothing — its share values are API
+    // defaults, not a stored row, and adopting one would clobber the device
+    // state the backfill is seeding from. The diagnostics preference is
+    // likewise left untouched by the chokepoint on an unknown input.
+    expect(setShareAnalyticsMock).not.toHaveBeenCalled();
     expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -51,12 +51,10 @@ const restoreConsentForUserMock = mock(
   ): {
     tos: boolean;
     privacy: boolean;
-    analyticsCurrent: boolean;
     diagnosticsCurrent: boolean;
   } => ({
     tos: false,
     privacy: false,
-    analyticsCurrent: false,
     diagnosticsCurrent: false,
   }),
 );
@@ -64,10 +62,7 @@ const persistConsentForUserMock = mock(
   (_userId: string | null, _tos: boolean, _privacy: boolean) => {},
 );
 const persistToggleConsentMock = mock(
-  (
-    _userId: string | null,
-    _acks: { analyticsCurrent?: boolean; diagnosticsCurrent?: boolean },
-  ) => {},
+  (_userId: string | null, _acks: { diagnosticsCurrent?: boolean }) => {},
 );
 const resolveServerConsentMock = mock(
   (
@@ -77,6 +72,8 @@ const resolveServerConsentMock = mock(
     privacy: boolean;
     shareAnalytics: boolean | null;
     shareDiagnostics: boolean | null;
+    analyticsEffective: boolean;
+    diagnosticsEffective: boolean;
     analyticsCurrent: boolean;
     diagnosticsCurrent: boolean;
     analyticsVersionCurrent: boolean;
@@ -87,6 +84,8 @@ const resolveServerConsentMock = mock(
     privacy: false,
     shareAnalytics: null,
     shareDiagnostics: null,
+    analyticsEffective: true,
+    diagnosticsEffective: true,
     analyticsCurrent: false,
     diagnosticsCurrent: false,
     analyticsVersionCurrent: false,
@@ -236,13 +235,14 @@ const setTosAcceptedMock = mock((_value: boolean) => {});
 const setPrivacyConsentMock = mock((_value: boolean) => {});
 const setAnalyticsConsentCurrentMock = mock((_value: boolean) => {});
 const setDiagnosticsConsentCurrentMock = mock((_value: boolean) => {});
-const setShareAnalyticsMock = mock((_value: boolean) => {});
-const setShareDiagnosticsMock = mock((_value: boolean) => {});
+const setShareAnalyticsMock = mock((_value: boolean | null) => {});
+const setShareDiagnosticsMock = mock((_value: boolean | null) => {});
 const setConsentHydratedMock = mock((_value: boolean) => {});
-// Mirror the store's device-initialized share values; the backfill reads these
-// to send the device opt-out value alongside the accepted version.
-let mockStoreShareAnalytics = true;
-let mockStoreShareDiagnostics = true;
+// Mirror the store's device-initialized tri-state share values (null = never
+// asked); the backfill reads these to send an explicit device choice
+// alongside the accepted version.
+let mockStoreShareAnalytics: boolean | null = null;
+let mockStoreShareDiagnostics: boolean | null = null;
 
 mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: {
@@ -378,8 +378,8 @@ beforeEach(() => {
   setShareAnalyticsMock.mockClear();
   setShareDiagnosticsMock.mockClear();
   setConsentHydratedMock.mockClear();
-  mockStoreShareAnalytics = true;
-  mockStoreShareDiagnostics = true;
+  mockStoreShareAnalytics = null;
+  mockStoreShareDiagnostics = null;
   fetchConsentMock.mockClear();
   patchConsentMock.mockClear();
   mockFetchConsentResult = EMPTY_CONSENT;
@@ -567,6 +567,8 @@ describe("auth store onboarding flag reconciliation", () => {
       privacy: true,
       shareAnalytics: true,
       shareDiagnostics: true,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
       analyticsVersionCurrent: true,
@@ -579,11 +581,13 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(fetchConsentMock).toHaveBeenCalled();
     expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).not.toHaveBeenCalled();
+    // The explicit server choice is adopted unconditionally.
+    expect(setShareAnalyticsMock).toHaveBeenCalledWith(true);
     // Currency flags hydrate from the resolved server consent.
     expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
     expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    // Only diagnostics carries a device ack — analytics has none.
     expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
-      analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
@@ -596,6 +600,8 @@ describe("auth store onboarding flag reconciliation", () => {
       privacy: true,
       shareAnalytics: null,
       shareDiagnostics: true,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
       // The resolver reads a null share_analytics as "nothing to re-review".
       analyticsCurrent: true,
       diagnosticsCurrent: true,
@@ -613,8 +619,58 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
       diagnosticsCurrent: true,
     });
-    // A null server value never overwrites the device-local preference.
+    // Never-asked propagates: the store adopts null so tri-state chosen-ness
+    // mirrors the server.
+    expect(setShareAnalyticsMock).toHaveBeenCalledWith(null);
+  });
+
+  test("server null never overwrites a pending local explicit analytics opt-out", async () => {
+    // The user opted out on this device; the patchConsent write is still in
+    // flight (or failed), so the server still reports null. Adopting null
+    // would clear the opt-out and resume uploads the user declined.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockStoreShareAnalytics = false;
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: true,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: true,
+      hasServerRecord: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
     expect(setShareAnalyticsMock).not.toHaveBeenCalled();
+  });
+
+  test("an explicit server analytics value overrides a local opt-out", async () => {
+    // The server is authoritative for explicit choices — e.g. the user opted
+    // back in from another device.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockStoreShareAnalytics = false;
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      analyticsVersionCurrent: true,
+      diagnosticsVersionCurrent: true,
+      hasServerRecord: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(setShareAnalyticsMock).toHaveBeenCalledWith(true);
   });
 
   test("never-asked diagnostics (null on a real record) hydrates current but earns no device ack", async () => {
@@ -624,6 +680,8 @@ describe("auth store onboarding flag reconciliation", () => {
       privacy: true,
       shareAnalytics: true,
       shareDiagnostics: null,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
       analyticsCurrent: true,
       // The resolver reads a null share_diagnostics as "nothing to re-review".
       diagnosticsCurrent: true,
@@ -638,9 +696,7 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
     // ...but no versioned ack either: only an explicit choice may attest a
     // confirmation that could later backfill a server version stamp.
-    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
-      analyticsCurrent: true,
-    });
+    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {});
     // A null server value never overwrites the device-local preference.
     expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
   });
@@ -650,7 +706,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
       privacy: true,
-      analyticsCurrent: false,
       diagnosticsCurrent: false,
     });
 
@@ -674,7 +729,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
       privacy: true,
-      analyticsCurrent: false,
       diagnosticsCurrent: true,
     });
 
@@ -710,7 +764,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
       privacy: true,
-      analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
 
@@ -723,7 +776,6 @@ describe("auth store onboarding flag reconciliation", () => {
     // Acks are persisted from the device-restored values, not the empty
     // server values — otherwise the fallback would clobber its own input.
     expect(persistToggleConsentMock).toHaveBeenLastCalledWith("user-1", {
-      analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
     // Legal consent is persisted with the restored (true) values, after the
@@ -733,17 +785,21 @@ describe("auth store onboarding flag reconciliation", () => {
       true,
       true,
     );
-    // The backfill patch carries the current toggle versions so the next
-    // server fetch doesn't re-mark them stale and re-route to review-terms.
+    // The backfill patch carries the diagnostics version (device-attested) so
+    // the next server fetch doesn't re-mark it stale and re-route to
+    // review-terms. Analytics has never been chosen on this device (store is
+    // null), so no analytics fields are seeded — the server keeps null.
     expect(patchConsentMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        share_analytics_accepted_version: expect.any(String),
         share_diagnostics_accepted_version: expect.any(String),
       }),
     );
-    // The empty server record's default share booleans must NOT overwrite the
-    // device-local choices the store already holds.
-    expect(setShareAnalyticsMock).not.toHaveBeenCalled();
+    const backfillBody = patchConsentMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("share_analytics" in backfillBody).toBe(false);
+    expect("share_analytics_accepted_version" in backfillBody).toBe(false);
+    // Never-asked propagates to the store (null adoption); the diagnostics
+    // preference is left untouched by the chokepoint on an unknown input.
+    expect(setShareAnalyticsMock).toHaveBeenCalledWith(null);
     expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
   });
 
@@ -757,7 +813,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
       privacy: true,
-      analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
 
@@ -784,7 +839,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
       privacy: true,
-      analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
 
@@ -804,7 +858,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
       privacy: true,
-      analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
 
@@ -848,6 +901,8 @@ describe("auth store onboarding flag reconciliation", () => {
       privacy: false,
       shareAnalytics: false,
       shareDiagnostics: true,
+      analyticsEffective: false,
+      diagnosticsEffective: true,
       analyticsCurrent: false,
       diagnosticsCurrent: false,
       analyticsVersionCurrent: false,
@@ -871,6 +926,8 @@ describe("auth store onboarding flag reconciliation", () => {
       privacy: true,
       shareAnalytics: true,
       shareDiagnostics: true,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
       analyticsVersionCurrent: true,
@@ -888,13 +945,16 @@ describe("auth store onboarding flag reconciliation", () => {
     // acceptance of the CURRENT terms — the stale server record just means
     // the fire-and-forget backfill write never landed. The in-memory flags
     // must stay true (no bounce into onboarding/review-terms) and the
-    // backfill must be re-sent.
+    // backfill must be re-sent. Analytics has no device ack, so its stale
+    // explicit choice stays stale (re-review) and is never backfilled.
     sessionUser = { id: "user-1", email: "user@example.com" };
     resolveServerConsentMock.mockReturnValueOnce({
       tos: false,
       privacy: false,
       shareAnalytics: true,
       shareDiagnostics: true,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
       analyticsCurrent: false,
       diagnosticsCurrent: false,
       analyticsVersionCurrent: false,
@@ -904,7 +964,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
       privacy: true,
-      analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
 
@@ -912,7 +971,7 @@ describe("auth store onboarding flag reconciliation", () => {
 
     expect(setTosAcceptedMock).toHaveBeenCalledWith(true);
     expect(setPrivacyConsentMock).toHaveBeenCalledWith(true);
-    expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(false);
     expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
     expect(persistConsentForUserMock).toHaveBeenLastCalledWith(
       "user-1",
@@ -925,13 +984,14 @@ describe("auth store onboarding flag reconciliation", () => {
         tos_accepted_version: expect.any(String),
         privacy_policy_accepted_version: expect.any(String),
         ai_data_sharing_accepted_version: expect.any(String),
-        share_analytics_accepted_version: expect.any(String),
         share_diagnostics_accepted_version: expect.any(String),
       }),
     );
-    // …but never the share booleans: a real record's values are authoritative.
+    // …but never the share booleans (a real record's values are
+    // authoritative) nor an analytics stamp (nothing device-side attests it).
     const body = patchConsentMock.mock.calls[0]![0] as Record<string, unknown>;
     expect(body).not.toContainKey("share_analytics");
+    expect(body).not.toContainKey("share_analytics_accepted_version");
     expect(body).not.toContainKey("share_diagnostics");
   });
 
@@ -944,6 +1004,8 @@ describe("auth store onboarding flag reconciliation", () => {
       privacy: false,
       shareAnalytics: true,
       shareDiagnostics: true,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
       analyticsVersionCurrent: true,
@@ -953,7 +1015,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
       privacy: true,
-      analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
 
@@ -976,6 +1037,8 @@ describe("auth store onboarding flag reconciliation", () => {
       privacy: false,
       shareAnalytics: true,
       shareDiagnostics: true,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
       analyticsCurrent: false,
       diagnosticsCurrent: false,
       analyticsVersionCurrent: false,
@@ -985,7 +1048,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: false,
       privacy: false,
-      analyticsCurrent: false,
       diagnosticsCurrent: false,
     });
 
@@ -1034,7 +1096,6 @@ describe("auth store onboarding flag reconciliation", () => {
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
       privacy: true,
-      analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
 

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -279,20 +279,23 @@ function broadcastAuthChange(): void {
 
 /**
  * Payload for the fire-and-forget server backfill of device-attested consent.
- * Each axis contributes its current version stamp only when the device ack
- * attests it (device ack keys are version-stamped, so a true key proves
- * acceptance of the CURRENT version). Share boolean values ride along only
- * when `shareValues` is passed — appropriate for a truly empty server record,
- * where the API default would otherwise overwrite a device opt-out on the
- * next fetch. A real server record's share booleans are authoritative and
- * must not be patched from the device.
+ * The legal axes and diagnostics contribute their current version stamp only
+ * when the device ack attests it (device ack keys are version-stamped, so a
+ * true key proves acceptance of the CURRENT version). Share boolean values
+ * ride along only when `shareValues` is passed AND the value is an explicit
+ * choice (`null` = never asked = nothing to backfill) — appropriate for a
+ * truly empty server record, where the API default would otherwise overwrite
+ * a device opt-out on the next fetch. A real server record's share booleans
+ * are authoritative and must not be patched from the device. Analytics has no
+ * device ack; an explicit device value carries its version stamp directly (a
+ * device value only exists from an explicit choice, and a value without a
+ * stamp would read as stale and bounce the user to review-terms).
  */
 function buildDeviceConsentBackfill(axes: {
   tos: boolean;
   privacy: boolean;
-  analytics: boolean;
   diagnostics: boolean;
-  shareValues?: { analytics: boolean; diagnostics: boolean };
+  shareValues?: { analytics: boolean | null; diagnostics: boolean | null };
 }): ConsentPatch {
   return {
     ...(axes.tos ? { tos_accepted_version: TOS_CONSENT_VERSION } : {}),
@@ -302,18 +305,16 @@ function buildDeviceConsentBackfill(axes: {
           ai_data_sharing_accepted_version: PRIVACY_CONSENT_VERSION,
         }
       : {}),
-    ...(axes.analytics
+    ...(axes.shareValues && axes.shareValues.analytics !== null
       ? {
+          share_analytics: axes.shareValues.analytics,
           share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
-          ...(axes.shareValues
-            ? { share_analytics: axes.shareValues.analytics }
-            : {}),
         }
       : {}),
     ...(axes.diagnostics
       ? {
           share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
-          ...(axes.shareValues
+          ...(axes.shareValues && axes.shareValues.diagnostics !== null
             ? { share_diagnostics: axes.shareValues.diagnostics }
             : {}),
         }
@@ -327,13 +328,19 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       const consent = await fetchConsent();
       const resolved = resolveServerConsent(consent);
       const store = useOnboardingStore.getState();
-      // Only adopt the server's share-analytics boolean when the server has a
-      // real consent record. For an empty record it's just the API default and
-      // would clobber the device-local `device:share_analytics` choice that the
-      // fallback below relies on (the store already holds it from init). A real
-      // record's share value is authoritative even when its legal consent
-      // versions are stale (the nav layer routes to review-terms).
-      if (resolved.hasServerRecord && resolved.shareAnalytics !== null) {
+      // Local explicit share choices, captured before server adoption below —
+      // the truly-empty-record backfill must send what the user chose on this
+      // device, not the just-adopted server value.
+      const localShareAnalytics = store.shareAnalytics;
+      const localShareDiagnostics = store.shareDiagnostics;
+      // Adopt the server's tri-state share-analytics verbatim: an explicit
+      // choice is authoritative even when its legal consent versions are stale
+      // (the nav layer routes to review-terms), and null (never asked)
+      // propagates so the store reflects chosen-ness. One exception: null
+      // never overwrites a local explicit opt-out — its server write may still
+      // be in flight (or have failed), and clearing it would resume uploads
+      // the user declined.
+      if (resolved.shareAnalytics !== null || localShareAnalytics !== false) {
         store.setShareAnalytics(resolved.shareAnalytics);
       }
 
@@ -358,47 +365,45 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       let privacy = resolved.privacy;
       let analyticsCurrent = resolved.analyticsCurrent;
       let diagnosticsCurrent = resolved.diagnosticsCurrent;
-      // Genuine "confirmed under the current version" attestations, distinct
+      // Genuine "confirmed under the current version" attestation, distinct
       // from the `*Current` flags, which also read never-asked (a null server
-      // value, or an implicit pre-nullable-platform default) as "nothing to
-      // re-review". Only a genuine ack may be device-persisted or backfill a
-      // server version stamp, so acks key off the raw version currency.
-      let analyticsAck =
-        resolved.shareAnalytics !== null && resolved.analyticsVersionCurrent;
+      // value) as "nothing to re-review". Only a genuine ack may be
+      // device-persisted or backfill a server version stamp, so the ack keys
+      // off the raw version currency. Analytics has no device ack — its
+      // version stamps are written server-side at choice time.
       let diagnosticsAck =
         resolved.shareDiagnostics !== null && resolved.diagnosticsVersionCurrent;
 
       // Fall back to device keys for a TRULY empty record: the device ack
-      // keys are the only consent evidence, so they drive all four axes and
+      // keys are the only consent evidence, so they drive the legal axes and
       // seed the server via the backfill.
       if (!resolved.hasServerRecord) {
         const deviceConsent = restoreConsentForUser(nextUserId);
         // No server record means no explicit share-toggle consent exists —
         // never-asked, so nothing to re-review regardless of the device acks.
         analyticsCurrent = true;
-        analyticsAck = deviceConsent.analyticsCurrent;
         diagnosticsCurrent = true;
         diagnosticsAck = deviceConsent.diagnosticsCurrent;
         if (deviceConsent.tos && deviceConsent.privacy) {
           tos = true;
           privacy = true;
-          // Backfill the server from the device acks. Stamp any toggle version
-          // whose device ack is current AND send the device share value so the
-          // next fetch can't overwrite a device opt-out with the API default.
+          // Backfill the server from the device evidence: stamp the
+          // diagnostics version when its device ack is current, and send any
+          // explicit device share choice so the next fetch can't overwrite a
+          // device opt-out with the API default.
           void patchConsent(
             buildDeviceConsentBackfill({
               tos: true,
               privacy: true,
-              analytics: analyticsAck,
               diagnostics: diagnosticsAck,
               shareValues: {
-                analytics: store.shareAnalytics,
-                diagnostics: store.shareDiagnostics,
+                analytics: localShareAnalytics,
+                diagnostics: localShareDiagnostics,
               },
             }),
           ).catch(() => {});
         }
-      } else if (!tos || !privacy || !analyticsCurrent || !diagnosticsCurrent) {
+      } else if (!tos || !privacy || !diagnosticsCurrent) {
         // A real record with stale/false version-derived flags. The device ack
         // keys are version-stamped, so a true key attests acceptance of the
         // CURRENT version — a stale server version alongside a current device
@@ -407,12 +412,11 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         // backfill, so an established user isn't bounced into onboarding by a
         // record their own acceptance is still in flight to. Axes the server
         // records as current stay server-authoritative, as do the share
-        // boolean values (adopted above).
+        // boolean values (adopted above). Analytics has no device ack, so a
+        // stale explicit analytics choice always re-reviews.
         const deviceConsent = restoreConsentForUser(nextUserId);
         const tosFromDevice = !tos && deviceConsent.tos;
         const privacyFromDevice = !privacy && deviceConsent.privacy;
-        const analyticsFromDevice =
-          !analyticsCurrent && deviceConsent.analyticsCurrent;
         const diagnosticsFromDevice =
           !diagnosticsCurrent && deviceConsent.diagnosticsCurrent;
         if (tosFromDevice) {
@@ -421,25 +425,15 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         if (privacyFromDevice) {
           privacy = true;
         }
-        if (analyticsFromDevice) {
-          analyticsCurrent = true;
-          analyticsAck = true;
-        }
         if (diagnosticsFromDevice) {
           diagnosticsCurrent = true;
           diagnosticsAck = true;
         }
-        if (
-          tosFromDevice ||
-          privacyFromDevice ||
-          analyticsFromDevice ||
-          diagnosticsFromDevice
-        ) {
+        if (tosFromDevice || privacyFromDevice || diagnosticsFromDevice) {
           void patchConsent(
             buildDeviceConsentBackfill({
               tos: tosFromDevice,
               privacy: privacyFromDevice,
-              analytics: analyticsFromDevice,
               diagnostics: diagnosticsFromDevice,
             }),
           ).catch(() => {});
@@ -455,7 +449,6 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // reader, and writing false would erase a genuine device attestation
       // whose backfill patch simply hasn't landed on the server yet.
       persistToggleConsent(nextUserId, {
-        ...(analyticsAck ? { analyticsCurrent: true } : {}),
         ...(diagnosticsAck ? { diagnosticsCurrent: true } : {}),
       });
       syncOrganizationState(nextUserId);

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -336,11 +336,17 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // Adopt the server's tri-state share-analytics verbatim: an explicit
       // choice is authoritative even when its legal consent versions are stale
       // (the nav layer routes to review-terms), and null (never asked)
-      // propagates so the store reflects chosen-ness. One exception: null
-      // never overwrites a local explicit opt-out — its server write may still
-      // be in flight (or have failed), and clearing it would resume uploads
-      // the user declined.
-      if (resolved.shareAnalytics !== null || localShareAnalytics !== false) {
+      // propagates so the store reflects chosen-ness. Two exceptions:
+      // a no-record response adopts nothing — its values are API defaults
+      // (older shapes materialize `true` there), and adopting one would
+      // clobber the device opt-out the backfill below is about to seed the
+      // server with. And null never overwrites a local explicit opt-out —
+      // its server write may still be in flight (or have failed), and
+      // clearing it would resume uploads the user declined.
+      if (
+        resolved.hasServerRecord &&
+        (resolved.shareAnalytics !== null || localShareAnalytics !== false)
+      ) {
         store.setShareAnalytics(resolved.shareAnalytics);
       }
 

--- a/clients/web/src/utils/local-settings.ts
+++ b/clients/web/src/utils/local-settings.ts
@@ -54,6 +54,23 @@ export function setLocalBool(key: string, value: boolean): void {
   setLocalSetting(key, value ? "true" : "false");
 }
 
+/**
+ * Tri-state boolean read: `true`/`false` for an explicitly stored value,
+ * `null` when the key is absent or unreadable. Lets callers distinguish
+ * "never chosen" from an explicit choice.
+ */
+export function getLocalBoolOrNull(key: string): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export function getLocalNumber(key: string, fallback: number): number {
   if (typeof window === "undefined") return fallback;
   try {

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -486,31 +486,48 @@ describe("resolveServerConsent", () => {
 });
 
 describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
-  test("round-trips both ack keys", () => {
-    persistToggleConsent("user-1", { analyticsCurrent: true, diagnosticsCurrent: true });
+  test("round-trips the diagnostics ack key", () => {
+    persistToggleConsent("user-1", { diagnosticsCurrent: true });
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
     const r = restoreConsentForUser("user-1");
-    expect(r.analyticsCurrent).toBe(true);
     expect(r.diagnosticsCurrent).toBe(true);
   });
 
-  test("only writes the provided field", () => {
-    persistToggleConsent("user-1", { analyticsCurrent: true });
-    expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
+  test("writes nothing when no ack is provided", () => {
+    persistToggleConsent("user-1", {});
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
     const r = restoreConsentForUser("user-1");
-    expect(r.analyticsCurrent).toBe(true);
     expect(r.diagnosticsCurrent).toBe(false);
   });
 
   test("no-ops without a userId", () => {
-    persistToggleConsent(null, { analyticsCurrent: true });
-    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
+    persistToggleConsent(null, { diagnosticsCurrent: true });
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
   });
 
-  test("restore returns false for both with no userId", () => {
+  test("restore returns false with no userId", () => {
     const r = restoreConsentForUser(null);
-    expect(r.analyticsCurrent).toBe(false);
     expect(r.diagnosticsCurrent).toBe(false);
+  });
+
+  test("restore deletes stale analytics ack keys of any version without promoting them", () => {
+    // Analytics device acks are dead (analytics is opt-out; no versioned
+    // acknowledgment exists) — restore removes them for the current user,
+    // whatever version they were stamped under, and leaves other users' keys.
+    localStorage.setItem(analyticsKey("user-1"), "true");
+    localStorage.setItem(
+      "device:consent:share_analytics:v2026-01-01:user-1",
+      "true",
+    );
+    localStorage.setItem(analyticsKey("user-2"), "true");
+
+    restoreConsentForUser("user-1");
+
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
+    expect(
+      localStorage.getItem("device:consent:share_analytics:v2026-01-01:user-1"),
+    ).toBeNull();
+    expect(localStorage.getItem(analyticsKey("user-2"))).toBe("true");
   });
 
   test("cleans up the legacy 'ai' key without satisfying the current privacy version", () => {
@@ -595,7 +612,7 @@ describe("saveConsent", () => {
     expect(body.ai_data_sharing_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
   });
 
-  test("sets both currency flags and writes both ack keys", () => {
+  test("sets both currency flags and writes the diagnostics ack key only", () => {
     saveConsent({
       userId: "user-1",
       tos: true,
@@ -606,7 +623,8 @@ describe("saveConsent", () => {
     });
     expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
-    expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
+    // Analytics has no device ack — its version stamp is server-side only.
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
   });
 
@@ -698,11 +716,13 @@ describe("saveConsent", () => {
 });
 
 describe("savePreferenceToggle", () => {
-  test("stamps the analytics version and sets its flag only", () => {
+  test("stamps the analytics version server-side and sets its flag only (no device ack)", () => {
     savePreferenceToggle("share_analytics", true, { userId: "user-1", hasPlatformSession: true });
+    expect(storeState.setShareAnalytics).toHaveBeenCalledWith(true);
     expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(storeState.setDiagnosticsConsentCurrent).not.toHaveBeenCalled();
-    expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
+    // Analytics has no device ack key; the version stamp lives server-side.
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
     const body = patchConsentMock.mock.calls[0][0];
     expect(body.share_analytics).toBe(true);
@@ -720,9 +740,9 @@ describe("savePreferenceToggle", () => {
 
   test("offline persists the on/off value but skips the currency stamp, ack key, and server patch", () => {
     savePreferenceToggle("share_analytics", true, { userId: "user-1", hasPlatformSession: false });
-    // The chosen value is still recorded device-locally...
+    // The chosen value is still recorded (the store setter persists the
+    // device key)...
     expect(storeState.setShareAnalytics).toHaveBeenCalledWith(true);
-    expect(setDeviceBoolMock).toHaveBeenCalledWith("shareAnalytics", true);
     // ...but no version-currency is stamped without a session to record against.
     expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
     expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
@@ -731,7 +751,7 @@ describe("savePreferenceToggle", () => {
 
   test("an offline diagnostics opt-out still closes the reporting gate (opt-out follows the preference)", () => {
     savePreferenceToggle("share_diagnostics", false, { userId: "user-1", hasPlatformSession: false });
-    expect(setDeviceBoolMock).toHaveBeenCalledWith("shareDiagnostics", false);
+    expect(storeState.setShareDiagnostics).toHaveBeenCalledWith(false);
     expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", false);
     expect(storeState.setDiagnosticsConsentCurrent).not.toHaveBeenCalled();
     expect(patchConsentMock).not.toHaveBeenCalled();
@@ -744,8 +764,9 @@ describe("savePreferenceToggle", () => {
 });
 
 describe("clearConsentForUser", () => {
-  test("clears both toggle ack keys", () => {
-    persistToggleConsent("user-1", { analyticsCurrent: true, diagnosticsCurrent: true });
+  test("clears the diagnostics ack key and any stale analytics ack keys", () => {
+    persistToggleConsent("user-1", { diagnosticsCurrent: true });
+    localStorage.setItem(analyticsKey("user-1"), "true");
     clearConsentForUser("user-1");
     expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -1,18 +1,21 @@
 /**
  * Versioned, per-user consent persistence.
  *
- * Consent flags live in `device:consent:{tos,privacy,share_analytics,share_diagnostics}:v<VERSION>:<userId>`.
+ * Consent flags live in `device:consent:{tos,privacy,share_diagnostics}:v<VERSION>:<userId>`.
  * The `device:` prefix survives logout; the userId makes them per-user;
  * the version lets us force re-consent by bumping the relevant version
- * constant. The four consent axes version independently — ToS, the privacy
- * checkbox (privacy policy + AI data sharing), share-analytics, and
- * share-diagnostics — so any one can be re-reviewed without forcing the
- * others. Bumping the privacy policy, in particular, must not re-prompt the
- * two data-capture toggles, so those carry their own frozen versions.
+ * constant. The consent axes version independently — ToS, the privacy
+ * checkbox (privacy policy + AI data sharing), and share-diagnostics — so any
+ * one can be re-reviewed without forcing the others. Bumping the privacy
+ * policy, in particular, must not re-prompt diagnostics capture consent, so
+ * it carries its own frozen version.
  *
- * The `share_analytics`/`share_diagnostics` ack keys record the version under
- * which the toggle was last confirmed (its currency), independent of the
- * on/off value which lives in the unversioned `device:share_analytics` key.
+ * The `share_diagnostics` ack key records the version under which the toggle
+ * was last confirmed (its currency), independent of the on/off value which
+ * lives in the unversioned `device:share_diagnostics` key. Analytics has no
+ * device ack: it is opt-out and its toggle is never shown during onboarding,
+ * so there is no versioned acknowledgment to preserve — server-side version
+ * stamps are written directly at choice time.
  *
  * The onboarding Zustand store holds the in-memory state (`tosAccepted`,
  * `privacyConsent`). This module handles the durable device-key layer
@@ -21,13 +24,12 @@
  * - `resolveServerConsent` — compare server consent versions against the ToS/privacy versions
  * - `saveConsent`          — unified write: store + device keys + server sync
  * - `savePreferenceToggle` — single-field write for settings page toggles
- * - `restoreConsentForUser` — read device keys, return {tos, privacy, toggle acks}
+ * - `restoreConsentForUser` — read device keys, return {tos, privacy, diagnostics ack}
  * - `persistConsentForUser` — write tos/privacy device keys
- * - `persistToggleConsent`  — write versioned share-toggle ack keys
+ * - `persistToggleConsent`  — write the versioned diagnostics ack key
  * - `clearConsentForUser`   — delete device keys + legacy active keys
  */
 import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
-import { setDeviceBool } from "@/utils/device-settings";
 import { setDiagnosticsReportingGate } from "@/lib/consent/diagnostics-consent";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
@@ -53,12 +55,11 @@ export const DIAGNOSTICS_CONSENT_VERSION = "2026-06-18";
 const LEGACY_AI_PRIVACY_CONSENT_VERSION = "2026-06-08";
 
 // Version stamp embedded in each field's device-cache key. ToS, the privacy
-// checkbox (privacy policy + AI data sharing), and each share toggle track
-// their own version constant.
+// checkbox (privacy policy + AI data sharing), and the diagnostics toggle
+// track their own version constant. Analytics has no device ack key.
 const CONSENT_KEY_VERSION = {
   tos: TOS_CONSENT_VERSION,
   privacy: PRIVACY_CONSENT_VERSION,
-  share_analytics: ANALYTICS_CONSENT_VERSION,
   share_diagnostics: DIAGNOSTICS_CONSENT_VERSION,
 } as const;
 
@@ -72,14 +73,32 @@ function legacyPrivacyConsentKey(userId: string): string {
   return `device:consent:ai:v${LEGACY_AI_PRIVACY_CONSENT_VERSION}:${userId}`;
 }
 
+// Analytics device acks are no longer read or written (analytics is opt-out
+// and its toggle is never shown during onboarding — server version stamps are
+// written at choice time instead). Delete any stale keys, whatever version
+// they were stamped under, so they don't linger.
+function removeStaleAnalyticsAckKeys(userId: string): void {
+  const prefix = "device:consent:share_analytics:v";
+  const suffix = `:${userId}`;
+  const stale: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(prefix) && key.endsWith(suffix)) {
+      stale.push(key);
+    }
+  }
+  for (const key of stale) {
+    removeLocalSetting(key);
+  }
+}
+
 export function restoreConsentForUser(
   userId: string | null,
-): { tos: boolean; privacy: boolean; analyticsCurrent: boolean; diagnosticsCurrent: boolean } {
+): { tos: boolean; privacy: boolean; diagnosticsCurrent: boolean } {
   if (typeof window === "undefined" || !userId) {
-    return { tos: false, privacy: false, analyticsCurrent: false, diagnosticsCurrent: false };
+    return { tos: false, privacy: false, diagnosticsCurrent: false };
   }
   try {
-    const analyticsCurrent = getLocalBool(consentKey("share_analytics", userId), false);
     const diagnosticsCurrent = getLocalBool(consentKey("share_diagnostics", userId), false);
     const tos = getLocalBool(consentKey("tos", userId), false);
     const privacy = getLocalBool(consentKey("privacy", userId), false);
@@ -92,8 +111,11 @@ export function restoreConsentForUser(
     if (getLocalBool(legacyPrivacyConsentKey(userId), false)) {
       removeLocalSetting(legacyPrivacyConsentKey(userId));
     }
+    removeStaleAnalyticsAckKeys(userId);
 
-    if (tos || privacy) return { tos, privacy, analyticsCurrent, diagnosticsCurrent };
+    if (tos || privacy) {
+      return { tos, privacy, diagnosticsCurrent };
+    }
 
     // One-time migration: users who accepted before the per-user device
     // key change still have consent in the legacy vellum: active keys.
@@ -107,12 +129,12 @@ export function restoreConsentForUser(
     const legacyPrivacy = getLocalBool("vellum:onboarding:aiDataConsent", false);
     if (legacyTos || legacyPrivacy) {
       persistConsentForUser(userId, legacyTos, false);
-      return { tos: legacyTos, privacy: false, analyticsCurrent, diagnosticsCurrent };
+      return { tos: legacyTos, privacy: false, diagnosticsCurrent };
     }
 
-    return { tos: false, privacy: false, analyticsCurrent, diagnosticsCurrent };
+    return { tos: false, privacy: false, diagnosticsCurrent };
   } catch {
-    return { tos: false, privacy: false, analyticsCurrent: false, diagnosticsCurrent: false };
+    return { tos: false, privacy: false, diagnosticsCurrent: false };
   }
 }
 
@@ -132,13 +154,10 @@ export function persistConsentForUser(
 
 export function persistToggleConsent(
   userId: string | null,
-  acks: { analyticsCurrent?: boolean; diagnosticsCurrent?: boolean },
+  acks: { diagnosticsCurrent?: boolean },
 ): void {
   if (typeof window === "undefined" || !userId) return;
   try {
-    if (acks.analyticsCurrent !== undefined) {
-      setLocalBool(consentKey("share_analytics", userId), acks.analyticsCurrent);
-    }
     if (acks.diagnosticsCurrent !== undefined) {
       setLocalBool(consentKey("share_diagnostics", userId), acks.diagnosticsCurrent);
     }
@@ -156,7 +175,7 @@ export function clearConsentForUser(userId: string | null): void {
     removeLocalSetting(consentKey("tos", userId));
     removeLocalSetting(consentKey("privacy", userId));
     removeLocalSetting(legacyPrivacyConsentKey(userId));
-    removeLocalSetting(consentKey("share_analytics", userId));
+    removeStaleAnalyticsAckKeys(userId);
     removeLocalSetting(consentKey("share_diagnostics", userId));
   } catch {
     // Storage unavailable.
@@ -322,7 +341,6 @@ export function saveConsent(opts: {
 
   persistConsentForUser(opts.userId, opts.tos, opts.privacy);
   persistToggleConsent(opts.userId, {
-    ...(opts.shareAnalytics !== null ? { analyticsCurrent: true } : {}),
     ...(opts.shareDiagnostics !== null ? { diagnosticsCurrent: true } : {}),
   });
 
@@ -354,20 +372,18 @@ export function savePreferenceToggle(
 ): void {
   const store = useOnboardingStore.getState();
   const { userId, hasPlatformSession } = opts;
-  // The on/off value is always device-persisted, but the version-currency ack
-  // ("confirmed under the current terms version") is only earned with a live
-  // platform session to record it against — offline it would stamp a currency
-  // the user never reviewed terms for.
+  // The on/off value is always device-persisted (the store setter writes the
+  // device key), but the version-currency ack ("confirmed under the current
+  // terms version") is only earned with a live platform session to record it
+  // against — offline it would stamp a currency the user never reviewed terms
+  // for.
   if (field === "share_analytics") {
     store.setShareAnalytics(value);
-    setDeviceBool("shareAnalytics", value);
     if (hasPlatformSession) {
       store.setAnalyticsConsentCurrent(true);
-      persistToggleConsent(userId, { analyticsCurrent: true });
     }
   } else {
     store.setShareDiagnostics(value);
-    setDeviceBool("shareDiagnostics", value);
     // Opt-out: the effective gate equals the preference — an explicit "off"
     // closes it, anything else keeps it open. The version-currency ack below
     // is separate: it is only earned with a live session to record it against.
@@ -381,7 +397,10 @@ export function savePreferenceToggle(
   if (hasPlatformSession) {
     void patchConsent({
       [field]: value,
-      [`${field}_accepted_version`]: CONSENT_KEY_VERSION[field],
+      [`${field}_accepted_version`]:
+        field === "share_analytics"
+          ? ANALYTICS_CONSENT_VERSION
+          : DIAGNOSTICS_CONSENT_VERSION,
     }).catch(() => {});
   }
 }


### PR DESCRIPTION
## Summary
- `onboarding-store`: `shareAnalytics`/`shareDiagnostics` become `boolean | null` (null = never asked). Setters persist the device key for explicit booleans and REMOVE it for null; init + cross-tab sync read through a new tri-state helper `getLocalBoolOrNull` (in `utils/local-settings.ts`).
- `prefs.ts`: `readShareAnalytics()` (store-AND-deviceBool truthiness pair) is replaced by `isAnalyticsEnabled(): boolean` — `shareAnalytics !== false` — so the emit gate keys on explicit opt-out only and the store is the single in-memory source. `funnel-events.ts` and test mocks updated; an explicit opt-out still stops uploads even if its server write failed.
- `auth-store` sync: share-analytics adoption no longer gates on `hasServerRecord` — the server's tri-state value is adopted verbatim, including null, with one carve-out: **server null never overwrites a pending local explicit opt-out** (pinned by a new test; clearing it would resume uploads the user declined while their `patchConsent` write is in flight/failed). `hasServerRecord` remains only for the tos/privacy device-key fallback + backfill block. Diagnostics keeps flowing through `applyResolvedDiagnosticsConsent` with its contract unchanged (PR 7 reworks it); the store setter it calls is now tri-state-capable.
- Analytics device-ack machinery deleted: `restoreConsentForUser`/`persistToggleConsent`/`clearConsentForUser` lose the `share_analytics` ack key, and `analyticsAck` + its backfill stamping in `auth-store` follow. A one-time cleanup (`removeStaleAnalyticsAckKeys`) deletes stale `device:consent:share_analytics:v*:<userId>` keys, mirroring the legacy-key cleanup pattern.
- Truly-empty-record backfill now sends share values only when the device holds an explicit choice (null = never asked = nothing to seed); an explicit analytics value carries its version stamp directly so the seeded choice doesn't read as stale and bounce to review-terms.
- Onboarding/review-terms screens display never-asked as on (opt-out semantics) via `?? true` and record shown toggles as explicit choices on Continue/Start, unchanged behavior.

## Behavior notes for review
- The analytics device-ack *rescue* (stale server version excused by a device ack) is gone with the ack machinery — a stale explicit analytics choice now always re-reviews. The rescue only ever covered the narrow window where the ack landed but the same-moment `patchConsent` didn't.
- `resolved.analyticsEffective` (PR 5) is not consumed here: after verbatim adoption the store's tri-state value *is* the gate source (`!== false`), which matches the server's effective computation except in the deliberate pending-local-opt-out carve-out.

Completes the consumer half flagged in #38233's review.

Part of plan: consent-cleanup.md (PR 6 of 10)