### PR TITLE
refactor(web): diagnostics gate becomes a single-writer derivation of the pref

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -100,8 +100,8 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
     set({ shareDiagnostics: value });
     // Writes only the saved preference. The effective reporting gate
     // (`device:diagnostics_reporting`) — which actually drives the Sentry
-    // clients via the `sentry-control.ts` watcher — is written separately by
-    // the consent chokepoint (`setDiagnosticsReportingGate`).
+    // clients via the `sentry-control.ts` watcher — is written solely by the
+    // consent chokepoints in `lib/consent/diagnostics-consent.ts`.
     persistShareChoice(KEY_SHARE_DIAGNOSTICS, value);
   },
   setTosAccepted: (value) => {

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -41,7 +41,8 @@ const applyResolvedDiagnosticsConsent = mock(
 );
 mock.module("@/lib/consent/diagnostics-consent", () => ({
   applyResolvedDiagnosticsConsent,
-  setDiagnosticsReportingGate: mock(() => {}),
+  applyExplicitDiagnosticsChoice: mock(() => {}),
+  failCloseDiagnosticsGateUntilFirstSync: mock(() => {}),
 }));
 
 let currentUser: { id: string } | null = { id: "u1" };

--- a/clients/web/src/lib/consent/diagnostics-consent.test.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.test.ts
@@ -1,13 +1,13 @@
 /**
- * Matrix tests for the diagnostics-consent chokepoint.
+ * Matrix tests for the diagnostics-consent chokepoints.
  *
- * The chokepoint splits two values: the SAVED PREFERENCE
+ * The module splits two values: the SAVED PREFERENCE
  * (`device:share_diagnostics`, applied via the `setShareDiagnostics` mock) and
- * the EFFECTIVE GATE (`device:diagnostics_reporting` + the main-process sync,
- * written by `setDiagnosticsReportingGate`). The preference tracks the server's
- * share value direction-asymmetrically; the gate applies an explicit server
- * value directly and follows the saved device preference on an unknown one
- * (absent reads open — opt-out default).
+ * the EFFECTIVE GATE (`device:diagnostics_reporting`), of which this module is
+ * the sole writer. The preference tracks the server's share value
+ * direction-asymmetrically; the gate is a derivation of the effective
+ * preference — an explicit server value applies directly, an unknown one
+ * follows the saved device preference (absent reads open — opt-out default).
  *
  * `@/runtime/diagnostics` and `@/utils/device-settings` are mocked so the gate
  * writes are observable without a DOM/localStorage.
@@ -23,22 +23,31 @@ const syncDiagnosticsToMain = mock((_enabled: boolean) => {});
 // The saved device preference (`device:share_diagnostics`); null models
 // "never written", which resolves to the opt-out default via the fallback.
 let devicePreference: boolean | null = null;
+// The stored effective gate (`device:diagnostics_reporting`); "" models a
+// device that has never resolved a gate (unhydrated).
+let storedGate = "";
 
 mock.module("@/utils/device-settings", () => ({
   setDeviceBool,
   getDeviceBool: (_name: string, fallback: boolean) =>
     devicePreference ?? fallback,
+  getDeviceSetting: (_name: string, fallback: string) =>
+    storedGate === "" ? fallback : storedGate,
   watchDeviceSetting: () => () => {},
 }));
 mock.module("@/runtime/diagnostics", () => ({ syncDiagnosticsToMain }));
 
-const { applyResolvedDiagnosticsConsent, setDiagnosticsReportingGate } =
-  await import("./diagnostics-consent");
+const {
+  applyResolvedDiagnosticsConsent,
+  applyExplicitDiagnosticsChoice,
+  failCloseDiagnosticsGateUntilFirstSync,
+} = await import("./diagnostics-consent");
 
 beforeEach(() => {
   setDeviceBool.mockClear();
   syncDiagnosticsToMain.mockClear();
   devicePreference = null;
+  storedGate = "";
 });
 
 /**
@@ -162,17 +171,87 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
     expect(setShareDiagnostics).toHaveBeenCalledWith(false);
     expectGate(false);
   });
+
+  // The derivation ignores prior hydration: whatever the stored gate says, an
+  // unknown input re-derives the gate from the saved preference — explicit
+  // false closes, true or never-asked opens.
+  for (const stored of ["", "true", "false"]) {
+    for (const preference of [null, true, false]) {
+      const expected = preference !== false;
+      test(`unknown input re-derives: stored gate ${JSON.stringify(stored)} + preference ${String(preference)} → gate ${String(expected)}`, () => {
+        storedGate = stored;
+        devicePreference = preference;
+        applyResolvedDiagnosticsConsent(
+          { shareDiagnostics: null, hasServerRecord: true },
+          mock((_: boolean) => {}),
+        );
+        expectGate(expected);
+      });
+    }
+  }
 });
 
-describe("setDiagnosticsReportingGate", () => {
-  test("writes the device bool AND the main-process sync with the effective value", () => {
-    setDiagnosticsReportingGate(true);
+describe("applyExplicitDiagnosticsChoice", () => {
+  test("true → preference true, gate true", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    applyExplicitDiagnosticsChoice(true, setShareDiagnostics);
+    expect(setShareDiagnostics).toHaveBeenCalledWith(true);
     expectGate(true);
+  });
 
-    setDeviceBool.mockClear();
-    syncDiagnosticsToMain.mockClear();
-
-    setDiagnosticsReportingGate(false);
+  test("false → preference false, gate false — even over a prior open gate", () => {
+    storedGate = "true";
+    const setShareDiagnostics = mock((_: boolean) => {});
+    applyExplicitDiagnosticsChoice(false, setShareDiagnostics);
+    expect(setShareDiagnostics).toHaveBeenCalledWith(false);
     expectGate(false);
+  });
+});
+
+describe("failCloseDiagnosticsGateUntilFirstSync", () => {
+  // An unhydrated device (gate never written) fails closed whatever the
+  // saved preference says — the server may hold an opt-out it hasn't seen.
+  for (const preference of [null, true, false]) {
+    test(`never-resolved gate closes (preference ${String(preference)})`, () => {
+      devicePreference = preference;
+      failCloseDiagnosticsGateUntilFirstSync();
+      expectGate(false);
+    });
+  }
+
+  // A hydrated device keeps its resolved gate — the failed sync says nothing
+  // new, and closing an open gate here would flap Sentry on every outage.
+  for (const stored of ["true", "false"]) {
+    test(`already-resolved gate ${stored} is left untouched`, () => {
+      storedGate = stored;
+      failCloseDiagnosticsGateUntilFirstSync();
+      expect(setDeviceBool).not.toHaveBeenCalled();
+    });
+  }
+});
+
+describe("single-writer invariant", () => {
+  test("only diagnostics-consent.ts writes the diagnostics_reporting gate key", async () => {
+    // Structural guard for the module contract: every gate write routes
+    // through this module's chokepoints. Reads (`getDeviceSetting`/
+    // `getDeviceBool`/`watchDeviceSetting`) and the device-settings registry
+    // entry are fine anywhere.
+    const srcRoot = new URL("../..", import.meta.url).pathname;
+    const writePatterns = [
+      /\bset(?:DeviceBool|DeviceSetting)\(\s*["']diagnosticsReporting["']/,
+      /\bset(?:LocalBool|LocalSetting)\(\s*["']device:diagnostics_reporting["']/,
+      /localStorage\.setItem\(\s*["']device:diagnostics_reporting["']/,
+    ];
+    const writers: string[] = [];
+    for await (const file of new Bun.Glob("**/*.{ts,tsx}").scan(srcRoot)) {
+      if (/\.test\.tsx?$/.test(file)) {
+        continue;
+      }
+      const text = await Bun.file(`${srcRoot}${file}`).text();
+      if (writePatterns.some((pattern) => pattern.test(text))) {
+        writers.push(file);
+      }
+    }
+    expect(writers).toEqual(["lib/consent/diagnostics-consent.ts"]);
   });
 });

--- a/clients/web/src/lib/consent/diagnostics-consent.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.ts
@@ -1,38 +1,39 @@
 /**
- * The single, direction-asymmetric decision point for the two
- * diagnostics-consent values:
+ * The single decision point for the two diagnostics-consent values:
  *
- * - **Saved preference** (`device:share_diagnostics`) — the user's opt-in/out,
- *   shown and re-submitted by the re-consent screen. It always tracks the
- *   server's `share_diagnostics` value (direction-asymmetric writes), so a
- *   stale-version record can't silently lose a prior explicit choice.
+ * - **Saved preference** (`device:share_diagnostics`) — the user's tri-state
+ *   opt-in/out (`null` = never asked), shown and re-submitted by the
+ *   re-consent screen. It always tracks the server's `share_diagnostics`
+ *   value (direction-asymmetric writes), so a stale-version record can't
+ *   silently lose a prior explicit choice.
  * - **Effective reporting gate** (`device:diagnostics_reporting`) — what
- *   actually turns Sentry on. Diagnostics is opt-out, and the gate always
- *   equals the effective saved preference: an authoritative server signal
- *   (the same rules the preference uses — a grant needs a real record, a
- *   revoke is always honored) applies directly, while an unknown input
- *   (null, or a non-false value on a no-row API default) leaves the device
- *   preference in charge, absent reading open. Following the preference —
- *   rather than forcing open — keeps an explicit local opt-out closed while
- *   its `patchConsent` write is still in flight (or failed), yet heals gates
- *   stuck closed by earlier strict-opt-in builds for users who never opted
- *   out. A stale-version grant keeps reporting on — the review-terms
- *   re-confirmation is driven by the consent-currency flags, not this gate.
+ *   actually turns Sentry on. A pure derivation of the effective preference —
+ *   explicit `false` → off, `true` or never-asked → on (diagnostics is
+ *   opt-out) — kept as its own watchable key because the `sentry-control`
+ *   cross-tab watcher and the Electron main mirror react to it, and because
+ *   an absent key marks a device that has never resolved consent (see
+ *   {@link failCloseDiagnosticsGateUntilFirstSync}). Following the preference
+ *   — rather than forcing open on an unknown input — keeps an explicit local
+ *   opt-out closed while its `patchConsent` write is still in flight (or
+ *   failed), yet heals gates stuck closed by earlier strict-opt-in builds for
+ *   users who never opted out. A stale-version grant keeps reporting on — the
+ *   review-terms re-confirmation is driven by the consent-currency flags, not
+ *   this gate.
  *
- * Every non-onboarding path that learns a diagnostics-consent value from the
- * server routes through {@link applyResolvedDiagnosticsConsent} so this policy
- * lives in exactly one place.
- *
- * - **Preference (direction-asymmetric)** — a confident grant
- *   (`hasServerRecord && shareDiagnostics === true`) writes `true` even on a
- *   stale version; an explicit revoke (`shareDiagnostics === false`) writes
- *   `false`; an unknown input (`null` / no record) leaves the preference
- *   untouched.
- * - **Gate** — always the effective preference: the authoritative value just
- *   applied, or the saved device preference when unknown (absent reads open).
+ * This module is the ONLY writer of the gate key. Every path that learns a
+ * diagnostics-consent value routes through one of the exported chokepoints:
+ * {@link applyResolvedDiagnosticsConsent} for server-resolved inputs,
+ * {@link applyExplicitDiagnosticsChoice} for a user's explicit toggle/screen
+ * choice, and {@link failCloseDiagnosticsGateUntilFirstSync} for the
+ * failed-sync posture. A structural test in `diagnostics-consent.test.ts`
+ * enforces the single-writer invariant.
  */
 
-import { getDeviceBool, setDeviceBool } from "@/utils/device-settings";
+import {
+  getDeviceBool,
+  getDeviceSetting,
+  setDeviceBool,
+} from "@/utils/device-settings";
 
 export interface ResolvedDiagnosticsConsent {
   /** The server's `share_diagnostics` value; `null` when unknown/absent. */
@@ -42,14 +43,15 @@ export interface ResolvedDiagnosticsConsent {
 }
 
 /**
- * Write the effective Sentry reporting gate (`diagnosticsReporting` device
- * bool). The Electron main mirror is NOT synced here: the `sentry-control`
- * watcher reacts to this device-setting change and pushes the
+ * SOLE writer of the effective reporting gate (`diagnosticsReporting` device
+ * bool), module-private so every write flows through the exported chokepoints.
+ * The Electron main mirror is NOT synced here: the `sentry-control` watcher
+ * reacts to this device-setting change and pushes the
  * platform-session-composed value (`diagnosticsConsentGranted()`) to main, so a
  * device gate that is `true` without a confirmed live session never enables the
  * main client. Syncing the raw gate here would race that composed write.
  */
-export function setDiagnosticsReportingGate(enabled: boolean): void {
+function setDiagnosticsReportingGate(enabled: boolean): void {
   setDeviceBool("diagnosticsReporting", enabled);
 }
 
@@ -58,10 +60,9 @@ export function setDiagnosticsReportingGate(enabled: boolean): void {
  *
  * 1. The saved preference, via `setShareDiagnostics` — written only for a
  *    confident grant or explicit revoke; an unknown input leaves it untouched.
- * 2. The effective reporting gate, via {@link setDiagnosticsReportingGate} —
- *    always the effective preference: the just-applied authoritative value,
- *    or the existing device preference when the input is unknown (absent
- *    reads open — opt-out default).
+ * 2. The effective reporting gate — re-derived from the effective preference:
+ *    the just-applied authoritative value, or the existing device preference
+ *    when the input is unknown (absent reads open — opt-out default).
  *
  * @returns the saved-preference decision: `true`/`false` when the preference was
  * written to that value, or `null` when the input is an unknown grant and the
@@ -72,13 +73,43 @@ export function applyResolvedDiagnosticsConsent(
   setShareDiagnostics: (value: boolean) => void,
 ): boolean | null {
   const preference = resolvePreference(resolved);
-  if (preference !== null) setShareDiagnostics(preference);
+  if (preference !== null) {
+    setShareDiagnostics(preference);
+  }
 
   setDiagnosticsReportingGate(
     preference ?? getDeviceBool("shareDiagnostics", true),
   );
 
   return preference;
+}
+
+/**
+ * Apply an explicit user choice (settings toggle / consent screen): the same
+ * policy as a confident server record — the preference is written and the
+ * gate re-derived, so an explicit "off" closes it and "on" opens it.
+ */
+export function applyExplicitDiagnosticsChoice(
+  value: boolean,
+  setShareDiagnostics: (value: boolean) => void,
+): void {
+  applyResolvedDiagnosticsConsent(
+    { shareDiagnostics: value, hasServerRecord: true },
+    setShareDiagnostics,
+  );
+}
+
+/**
+ * Failed-sync posture: on a device that has never resolved a gate, close it
+ * until the first successful consent sync can reveal a server-side explicit
+ * opt-out — hydration alone must not let the opt-out default open the gate. A
+ * previously resolved gate keeps its value. Every successful sync path writes
+ * the gate, so the conservative value never outlives the outage.
+ */
+export function failCloseDiagnosticsGateUntilFirstSync(): void {
+  if (getDeviceSetting("diagnosticsReporting", "") === "") {
+    setDiagnosticsReportingGate(false);
+  }
 }
 
 /**
@@ -93,10 +124,14 @@ function resolvePreference(
   const { shareDiagnostics, hasServerRecord } = resolved;
 
   // Explicit revoke — eagerly write the opt-out (even on an unknown record).
-  if (shareDiagnostics === false) return false;
+  if (shareDiagnostics === false) {
+    return false;
+  }
 
   // Confident grant — adopt the server's opt-in, regardless of version.
-  if (hasServerRecord && shareDiagnostics === true) return true;
+  if (hasServerRecord && shareDiagnostics === true) {
+    return true;
+  }
 
   // Unknown grant (`null`, or no server record) — leave the preference untouched.
   return null;

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -4,8 +4,8 @@
  * platform session.
  *
  * The reporting gate tracks the saved Share Diagnostics preference with
- * opt-out semantics: it closes only for an explicit opt-out. It is written by
- * the consent-resolution paths (`setDiagnosticsReportingGate`).
+ * opt-out semantics: it closes only for an explicit opt-out. It is written
+ * solely by the consent chokepoints in `lib/consent/diagnostics-consent.ts`.
  *
  * Diagnostics are recorded against a platform account, so an offline /
  * self-hosted client — including a believed offline restore (LUM-2412) that no

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -74,9 +74,8 @@ import {
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import {
   applyResolvedDiagnosticsConsent,
-  setDiagnosticsReportingGate,
+  failCloseDiagnosticsGateUntilFirstSync,
 } from "@/lib/consent/diagnostics-consent";
-import { getDeviceSetting } from "@/utils/device-settings";
 import {
   clearOrganization,
   useOrganizationStore,
@@ -467,13 +466,11 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
 
   const consent = restoreConsentForUser(nextUserId);
   const store = useOnboardingStore.getState();
-  // Consent fetch failed for a platform user and this device has never
-  // resolved a diagnostics gate: fail closed until a successful sync can
-  // reveal a server-side explicit opt-out — hydration alone must not let the
-  // opt-out default open the gate. Every successful sync path writes the
-  // gate, so this conservative value never outlives the outage.
-  if (nextUserId && getDeviceSetting("diagnosticsReporting", "") === "") {
-    setDiagnosticsReportingGate(false);
+  // Consent fetch failed for a platform user: a device that has never
+  // resolved a diagnostics gate fails closed until a successful sync can
+  // reveal a server-side explicit opt-out.
+  if (nextUserId) {
+    failCloseDiagnosticsGateUntilFirstSync();
   }
   store.setTosAccepted(consent.tos);
   store.setPrivacyConsent(consent.privacy);

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -46,6 +46,11 @@ mock.module("@/generated/api/client.gen", () => ({ client: {} }));
 const setDeviceBoolMock = mock((_name: string, _value: boolean) => {});
 mock.module("@/utils/device-settings", () => ({
   setDeviceBool: setDeviceBoolMock,
+  // The real diagnostics-consent chokepoint runs against this mock; provide
+  // its read surface (only reached on unknown inputs, never for the explicit
+  // choices these tests exercise).
+  getDeviceBool: (_name: string, fallback: boolean) => fallback,
+  getDeviceSetting: (_name: string, fallback: string) => fallback,
 }));
 
 import {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -30,7 +30,7 @@
  * - `clearConsentForUser`   — delete device keys + legacy active keys
  */
 import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
-import { setDiagnosticsReportingGate } from "@/lib/consent/diagnostics-consent";
+import { applyExplicitDiagnosticsChoice } from "@/lib/consent/diagnostics-consent";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
@@ -302,6 +302,101 @@ export function resolveServerConsent(
 // Unified write API
 // ---------------------------------------------------------------------------
 
+/**
+ * The single internal write path for user-initiated consent: store updates,
+ * per-user device keys, the diagnostics gate chokepoint, and the server
+ * PATCH. `saveConsent` and `savePreferenceToggle` are thin argument-shapers
+ * over it.
+ *
+ * `legal` is present only for a consent-screen save; that acceptance is an
+ * explicit review of the current terms, so currency and hydration are
+ * authoritative without a live session. A lone toggle write earns version
+ * currency only with a live platform session to record it against — offline
+ * it would stamp a currency the user never reviewed terms for. A share field
+ * is written only when its toggle was actually shown (`undefined` = absent =
+ * nothing persisted anywhere for that axis).
+ */
+function writeConsent(
+  fields: {
+    legal?: { tos: boolean; privacy: boolean };
+    shareAnalytics?: boolean;
+    shareDiagnostics?: boolean;
+  },
+  opts: { userId: string | null; hasPlatformSession: boolean },
+): void {
+  const { legal, shareAnalytics, shareDiagnostics } = fields;
+  const store = useOnboardingStore.getState();
+
+  if (legal) {
+    store.setTosAccepted(legal.tos);
+    store.setPrivacyConsent(legal.privacy);
+    persistConsentForUser(opts.userId, legal.tos, legal.privacy);
+  }
+  if (shareAnalytics !== undefined) {
+    store.setShareAnalytics(shareAnalytics);
+  }
+  if (shareDiagnostics !== undefined) {
+    // Opt-out: the effective reporting gate equals the preference — an
+    // explicit "off" closes it, "on" opens it. Routed through the diagnostics
+    // chokepoint, the gate key's single writer. An absent choice leaves the
+    // gate (and any explicit device opt-out) untouched.
+    applyExplicitDiagnosticsChoice(shareDiagnostics, store.setShareDiagnostics);
+  }
+
+  // A consent screen settles both share axes as current — never-asked has
+  // nothing to re-review, so it must not bounce the user to review-terms —
+  // and is authoritative hydration: route guards may trust the flags without
+  // waiting for a session sync. A settings toggle marks only its own axis,
+  // and only with a live session.
+  if (legal) {
+    store.setAnalyticsConsentCurrent(true);
+    store.setDiagnosticsConsentCurrent(true);
+    store.setConsentHydrated(true);
+  } else if (opts.hasPlatformSession) {
+    if (shareAnalytics !== undefined) {
+      store.setAnalyticsConsentCurrent(true);
+    }
+    if (shareDiagnostics !== undefined) {
+      store.setDiagnosticsConsentCurrent(true);
+    }
+  }
+
+  // The versioned diagnostics ack ("confirmed under the current version") is
+  // earned by a consent-screen review, or by a toggle change made with a live
+  // session to record it against. Analytics has no device ack.
+  if (shareDiagnostics !== undefined && (legal || opts.hasPlatformSession)) {
+    persistToggleConsent(opts.userId, { diagnosticsCurrent: true });
+  }
+
+  if (opts.hasPlatformSession) {
+    void patchConsent({
+      ...(legal
+        ? {
+            tos_accepted_version: legal.tos ? TOS_CONSENT_VERSION : "",
+            privacy_policy_accepted_version: legal.privacy
+              ? PRIVACY_CONSENT_VERSION
+              : "",
+            ai_data_sharing_accepted_version: legal.privacy
+              ? PRIVACY_CONSENT_VERSION
+              : "",
+          }
+        : {}),
+      ...(shareAnalytics !== undefined
+        ? {
+            share_analytics: shareAnalytics,
+            share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
+          }
+        : {}),
+      ...(shareDiagnostics !== undefined
+        ? {
+            share_diagnostics: shareDiagnostics,
+            share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
+          }
+        : {}),
+    }).catch(() => {});
+  }
+}
+
 export function saveConsent(opts: {
   userId: string | null;
   tos: boolean;
@@ -321,48 +416,18 @@ export function saveConsent(opts: {
   shareDiagnostics: boolean | null;
   hasPlatformSession: boolean;
 }): void {
-  const store = useOnboardingStore.getState();
-  store.setTosAccepted(opts.tos);
-  store.setPrivacyConsent(opts.privacy);
-  if (opts.shareAnalytics !== null) {
-    store.setShareAnalytics(opts.shareAnalytics);
-  }
-  if (opts.shareDiagnostics !== null) {
-    store.setShareDiagnostics(opts.shareDiagnostics);
-    // Only an explicit choice writes the gate; null leaves the existing
-    // gate (and any explicit device opt-out) untouched.
-    setDiagnosticsReportingGate(opts.shareDiagnostics);
-  }
-  store.setAnalyticsConsentCurrent(true);
-  store.setDiagnosticsConsentCurrent(true);
-  // An explicit user acceptance is authoritative hydration — route guards may
-  // trust the flags without waiting for a session sync.
-  store.setConsentHydrated(true);
-
-  persistConsentForUser(opts.userId, opts.tos, opts.privacy);
-  persistToggleConsent(opts.userId, {
-    ...(opts.shareDiagnostics !== null ? { diagnosticsCurrent: true } : {}),
-  });
-
-  if (opts.hasPlatformSession) {
-    void patchConsent({
-      tos_accepted_version: opts.tos ? TOS_CONSENT_VERSION : "",
-      privacy_policy_accepted_version: opts.privacy ? PRIVACY_CONSENT_VERSION : "",
-      ai_data_sharing_accepted_version: opts.privacy ? PRIVACY_CONSENT_VERSION : "",
+  writeConsent(
+    {
+      legal: { tos: opts.tos, privacy: opts.privacy },
       ...(opts.shareAnalytics !== null
-        ? {
-            share_analytics: opts.shareAnalytics,
-            share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
-          }
+        ? { shareAnalytics: opts.shareAnalytics }
         : {}),
       ...(opts.shareDiagnostics !== null
-        ? {
-            share_diagnostics: opts.shareDiagnostics,
-            share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
-          }
+        ? { shareDiagnostics: opts.shareDiagnostics }
         : {}),
-    }).catch(() => {});
-  }
+    },
+    { userId: opts.userId, hasPlatformSession: opts.hasPlatformSession },
+  );
 }
 
 export function savePreferenceToggle(
@@ -370,37 +435,10 @@ export function savePreferenceToggle(
   value: boolean,
   opts: { userId: string | null; hasPlatformSession: boolean },
 ): void {
-  const store = useOnboardingStore.getState();
-  const { userId, hasPlatformSession } = opts;
-  // The on/off value is always device-persisted (the store setter writes the
-  // device key), but the version-currency ack ("confirmed under the current
-  // terms version") is only earned with a live platform session to record it
-  // against — offline it would stamp a currency the user never reviewed terms
-  // for.
-  if (field === "share_analytics") {
-    store.setShareAnalytics(value);
-    if (hasPlatformSession) {
-      store.setAnalyticsConsentCurrent(true);
-    }
-  } else {
-    store.setShareDiagnostics(value);
-    // Opt-out: the effective gate equals the preference — an explicit "off"
-    // closes it, anything else keeps it open. The version-currency ack below
-    // is separate: it is only earned with a live session to record it against.
-    setDiagnosticsReportingGate(value);
-    if (hasPlatformSession) {
-      store.setDiagnosticsConsentCurrent(true);
-      persistToggleConsent(userId, { diagnosticsCurrent: true });
-    }
-  }
-
-  if (hasPlatformSession) {
-    void patchConsent({
-      [field]: value,
-      [`${field}_accepted_version`]:
-        field === "share_analytics"
-          ? ANALYTICS_CONSENT_VERSION
-          : DIAGNOSTICS_CONSENT_VERSION,
-    }).catch(() => {});
-  }
+  writeConsent(
+    field === "share_analytics"
+      ? { shareAnalytics: value }
+      : { shareDiagnostics: value },
+    opts,
+  );
 }


### PR DESCRIPTION
## Summary
- `device:diagnostics_reporting` now has exactly one writer: the module-private `setDiagnosticsReportingGate` in `lib/consent/diagnostics-consent.ts`. Every other call site routes through the exported chokepoints: `applyResolvedDiagnosticsConsent` (server-resolved inputs), new `applyExplicitDiagnosticsChoice` (settings toggle / consent screens), and new `failCloseDiagnosticsGateUntilFirstSync` (auth-store offline fail-closed path, which previously wrote the gate directly).
- Unified `saveConsent` and `savePreferenceToggle` over one internal `writeConsent(fields, opts)` path (store updates + device keys + gate chokepoint + server PATCH); both public signatures and all persistence rules are unchanged (toggle-on-screen ⇒ value+version; absent ⇒ nothing).
- Tests: gate-derivation matrix for pref null/true/false × stored-gate absent/true/false, fail-close hydration matrix, explicit-choice transitions, and a structural test asserting no file outside `diagnostics-consent.ts` writes the gate key. Existing sentry-control behavior matrix passes unmodified.

Part of plan: consent-cleanup.md (PR 7 of 10)