### PR TITLE
feat(web): consent currency from server required_versions

### DIFF
--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -9089,9 +9089,15 @@ components:
           format: date-time
           readOnly: true
           nullable: true
+        required_versions:
+          type: object
+          additionalProperties:
+            type: string
+          readOnly: true
       required:
       - ai_data_sharing_accepted_at
       - privacy_policy_accepted_at
+      - required_versions
       - share_analytics_accepted_at
       - share_analytics_effective
       - share_diagnostics_accepted_at

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -75,6 +75,7 @@ function consentRecord(overrides: Partial<UserConsent> = {}): UserConsent {
     share_analytics_accepted_at: null,
     share_diagnostics_accepted_version: "",
     share_diagnostics_accepted_at: null,
+    required_versions: {},
     ...overrides,
   };
   // Mirror the wire contract: the platform serves effective = value ?? true.

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -125,7 +125,10 @@ const BUMPED_REQUIRED_VERSIONS = {
 
 // Unversioned per-user ack keys; the VALUE is the acknowledged version.
 const tosAckKey = (userId: string) => `device:consent:tos:${userId}`;
-const privacyAckKey = (userId: string) => `device:consent:privacy:${userId}`;
+const privacyPolicyAckKey = (userId: string) =>
+  `device:consent:privacy_policy:${userId}`;
+const aiDataSharingAckKey = (userId: string) =>
+  `device:consent:ai_data_sharing:${userId}`;
 const diagnosticsKey = (userId: string) =>
   `device:consent:share_diagnostics:${userId}`;
 // Legacy layout: the version was embedded in the KEY over a boolean value.
@@ -204,28 +207,40 @@ describe("resolveServerConsent", () => {
 
   test("null share_analytics (never asked) resolves analytics current — nothing to re-review", () => {
     const resolved = resolveServerConsent(
-      makeConsent({ share_analytics: null, share_analytics_accepted_version: "" }),
+      makeConsent({
+        share_analytics: null,
+        share_analytics_accepted_version: "",
+      }),
     );
     expect(resolved.analyticsCurrent).toBe(true);
   });
 
   test("an explicit analytics choice under a stale version still requires re-review", () => {
     const resolved = resolveServerConsent(
-      makeConsent({ share_analytics: false, share_analytics_accepted_version: "2026-01-01" }),
+      makeConsent({
+        share_analytics: false,
+        share_analytics_accepted_version: "2026-01-01",
+      }),
     );
     expect(resolved.analyticsCurrent).toBe(false);
   });
 
   test("null share_diagnostics (never asked) resolves diagnostics current — nothing to re-review", () => {
     const resolved = resolveServerConsent(
-      makeConsent({ share_diagnostics: null, share_diagnostics_accepted_version: "" }),
+      makeConsent({
+        share_diagnostics: null,
+        share_diagnostics_accepted_version: "",
+      }),
     );
     expect(resolved.diagnosticsCurrent).toBe(true);
   });
 
   test("an explicit diagnostics choice under a stale version still requires re-review", () => {
     const resolved = resolveServerConsent(
-      makeConsent({ share_diagnostics: false, share_diagnostics_accepted_version: "2026-01-01" }),
+      makeConsent({
+        share_diagnostics: false,
+        share_diagnostics_accepted_version: "2026-01-01",
+      }),
     );
     expect(resolved.diagnosticsCurrent).toBe(false);
   });
@@ -291,7 +306,10 @@ describe("resolveServerConsent", () => {
 
   test("absent effective fields (older backend) fall back to the raw values' opt-out reading", () => {
     const legacy = (overrides: Partial<UserConsent>) => {
-      const consent = makeConsent(overrides) as unknown as Record<string, unknown>;
+      const consent = makeConsent(overrides) as unknown as Record<
+        string,
+        unknown
+      >;
       delete consent.share_analytics_effective;
       delete consent.share_diagnostics_effective;
       return consent as unknown as UserConsent;
@@ -483,7 +501,10 @@ describe("resolveServerConsent", () => {
     };
     expect(
       resolveServerConsent(
-        makeConsent({ ...allDefaults, tos_accepted_version: TOS_CONSENT_VERSION }),
+        makeConsent({
+          ...allDefaults,
+          tos_accepted_version: TOS_CONSENT_VERSION,
+        }),
       ).hasServerRecord,
     ).toBe(true);
     expect(
@@ -578,7 +599,8 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     expect(r.privacy).toBe(false);
     // The stale key is removed and privacy is not stamped current.
     expect(localStorage.getItem(legacyAiKey)).toBeNull();
-    expect(localStorage.getItem(privacyAckKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(privacyPolicyAckKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(aiDataSharingAckKey("user-1"))).toBeNull();
   });
 
   test("migrates legacy unversioned ToS but forces privacy re-review", () => {
@@ -596,7 +618,8 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     expect(r.privacy).toBe(false);
     // ToS is promoted; privacy is not stamped current.
     expect(localStorage.getItem(tosAckKey("user-1"))).toBe(TOS_CONSENT_VERSION);
-    expect(localStorage.getItem(privacyAckKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(privacyPolicyAckKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(aiDataSharingAckKey("user-1"))).toBeNull();
   });
 
   test("promotes legacy versioned ack keys to unversioned keys (version becomes the value)", () => {
@@ -612,7 +635,11 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
       "true",
     );
     localStorage.setItem(
-      legacyVersionedKey("share_diagnostics", DIAGNOSTICS_CONSENT_VERSION, "user-1"),
+      legacyVersionedKey(
+        "share_diagnostics",
+        DIAGNOSTICS_CONSENT_VERSION,
+        "user-1",
+      ),
       "true",
     );
 
@@ -622,7 +649,10 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     expect(r.privacy).toBe(true);
     expect(r.diagnosticsCurrent).toBe(true);
     expect(localStorage.getItem(tosAckKey("user-1"))).toBe(TOS_CONSENT_VERSION);
-    expect(localStorage.getItem(privacyAckKey("user-1"))).toBe(
+    expect(localStorage.getItem(privacyPolicyAckKey("user-1"))).toBe(
+      PRIVACY_CONSENT_VERSION,
+    );
+    expect(localStorage.getItem(aiDataSharingAckKey("user-1"))).toBe(
       PRIVACY_CONSENT_VERSION,
     );
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
@@ -664,7 +694,11 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
   test("migration never promotes a false legacy ack, and an existing unversioned key wins", () => {
     // A false legacy key is swept without promotion.
     localStorage.setItem(
-      legacyVersionedKey("share_diagnostics", DIAGNOSTICS_CONSENT_VERSION, "user-1"),
+      legacyVersionedKey(
+        "share_diagnostics",
+        DIAGNOSTICS_CONSENT_VERSION,
+        "user-1",
+      ),
       "false",
     );
     restoreConsentForUser("user-1");
@@ -673,7 +707,11 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     // Once an unversioned ack exists, a lingering legacy key can't overwrite it.
     localStorage.setItem(diagnosticsKey("user-1"), "2099-01-01");
     localStorage.setItem(
-      legacyVersionedKey("share_diagnostics", DIAGNOSTICS_CONSENT_VERSION, "user-1"),
+      legacyVersionedKey(
+        "share_diagnostics",
+        DIAGNOSTICS_CONSENT_VERSION,
+        "user-1",
+      ),
       "true",
     );
     restoreConsentForUser("user-1");
@@ -702,8 +740,12 @@ describe("saveConsent", () => {
     });
     expect(patchConsentMock).toHaveBeenCalledTimes(1);
     const body = patchConsentMock.mock.calls[0][0];
-    expect(body.share_analytics_accepted_version).toBe(ANALYTICS_CONSENT_VERSION);
-    expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
+    expect(body.share_analytics_accepted_version).toBe(
+      ANALYTICS_CONSENT_VERSION,
+    );
+    expect(body.share_diagnostics_accepted_version).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
   });
 
   test("ToS stamps the ToS version; the privacy checkbox stamps privacy policy + AI data sharing", () => {
@@ -768,7 +810,9 @@ describe("saveConsent", () => {
     expect("share_analytics" in body).toBe(false);
     expect("share_analytics_accepted_version" in body).toBe(false);
     expect(body.share_diagnostics).toBe(true);
-    expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
     expect(storeState.setShareAnalytics).not.toHaveBeenCalled();
     expect(localStorage.getItem(analyticsKey("user-1"))).toBe(null);
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
@@ -812,7 +856,10 @@ describe("saveConsent", () => {
       shareDiagnostics: true,
       hasPlatformSession: false,
     });
-    expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", true);
+    expect(setDeviceBoolMock).toHaveBeenCalledWith(
+      "diagnosticsReporting",
+      true,
+    );
   });
 
   test("explicit shareDiagnostics=false persists the opt-out and closes the reporting gate", () => {
@@ -824,10 +871,15 @@ describe("saveConsent", () => {
       shareDiagnostics: false,
       hasPlatformSession: true,
     });
-    expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", false);
+    expect(setDeviceBoolMock).toHaveBeenCalledWith(
+      "diagnosticsReporting",
+      false,
+    );
     const body = patchConsentMock.mock.calls[0][0];
     expect(body.share_diagnostics).toBe(false);
-    expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
       DIAGNOSTICS_CONSENT_VERSION,
     );
@@ -848,7 +900,10 @@ describe("saveConsent", () => {
 
 describe("savePreferenceToggle", () => {
   test("stamps the analytics version server-side and sets its flag only (no device ack)", () => {
-    savePreferenceToggle("share_analytics", true, { userId: "user-1", hasPlatformSession: true });
+    savePreferenceToggle("share_analytics", true, {
+      userId: "user-1",
+      hasPlatformSession: true,
+    });
     expect(storeState.setShareAnalytics).toHaveBeenCalledWith(true);
     expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(storeState.setDiagnosticsConsentCurrent).not.toHaveBeenCalled();
@@ -857,20 +912,30 @@ describe("savePreferenceToggle", () => {
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
     const body = patchConsentMock.mock.calls[0][0];
     expect(body.share_analytics).toBe(true);
-    expect(body.share_analytics_accepted_version).toBe(ANALYTICS_CONSENT_VERSION);
+    expect(body.share_analytics_accepted_version).toBe(
+      ANALYTICS_CONSENT_VERSION,
+    );
   });
 
   test("stamps the diagnostics version and sets its flag only", () => {
-    savePreferenceToggle("share_diagnostics", false, { userId: "user-1", hasPlatformSession: true });
+    savePreferenceToggle("share_diagnostics", false, {
+      userId: "user-1",
+      hasPlatformSession: true,
+    });
     expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
     const body = patchConsentMock.mock.calls[0][0];
     expect(body.share_diagnostics).toBe(false);
-    expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
   });
 
   test("offline persists the on/off value but skips the currency stamp, ack key, and server patch", () => {
-    savePreferenceToggle("share_analytics", true, { userId: "user-1", hasPlatformSession: false });
+    savePreferenceToggle("share_analytics", true, {
+      userId: "user-1",
+      hasPlatformSession: false,
+    });
     // The chosen value is still recorded (the store setter persists the
     // device key)...
     expect(storeState.setShareAnalytics).toHaveBeenCalledWith(true);
@@ -881,16 +946,28 @@ describe("savePreferenceToggle", () => {
   });
 
   test("an offline diagnostics opt-out still closes the reporting gate (opt-out follows the preference)", () => {
-    savePreferenceToggle("share_diagnostics", false, { userId: "user-1", hasPlatformSession: false });
+    savePreferenceToggle("share_diagnostics", false, {
+      userId: "user-1",
+      hasPlatformSession: false,
+    });
     expect(storeState.setShareDiagnostics).toHaveBeenCalledWith(false);
-    expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", false);
+    expect(setDeviceBoolMock).toHaveBeenCalledWith(
+      "diagnosticsReporting",
+      false,
+    );
     expect(storeState.setDiagnosticsConsentCurrent).not.toHaveBeenCalled();
     expect(patchConsentMock).not.toHaveBeenCalled();
   });
 
   test("an offline diagnostics opt-in opens the reporting gate", () => {
-    savePreferenceToggle("share_diagnostics", true, { userId: "user-1", hasPlatformSession: false });
-    expect(setDeviceBoolMock).toHaveBeenCalledWith("diagnosticsReporting", true);
+    savePreferenceToggle("share_diagnostics", true, {
+      userId: "user-1",
+      hasPlatformSession: false,
+    });
+    expect(setDeviceBoolMock).toHaveBeenCalledWith(
+      "diagnosticsReporting",
+      true,
+    );
   });
 });
 
@@ -898,7 +975,14 @@ describe("clearConsentForUser", () => {
   test("clears the ack keys, legacy versioned keys, and stale analytics ack keys", () => {
     persistToggleConsent("user-1", { diagnosticsCurrent: true });
     localStorage.setItem(tosAckKey("user-1"), TOS_CONSENT_VERSION);
-    localStorage.setItem(privacyAckKey("user-1"), PRIVACY_CONSENT_VERSION);
+    localStorage.setItem(
+      privacyPolicyAckKey("user-1"),
+      PRIVACY_CONSENT_VERSION,
+    );
+    localStorage.setItem(
+      aiDataSharingAckKey("user-1"),
+      PRIVACY_CONSENT_VERSION,
+    );
     localStorage.setItem(analyticsKey("user-1"), "true");
     localStorage.setItem(
       legacyVersionedKey("tos", TOS_CONSENT_VERSION, "user-1"),
@@ -908,7 +992,8 @@ describe("clearConsentForUser", () => {
     expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
     expect(localStorage.getItem(tosAckKey("user-1"))).toBeNull();
-    expect(localStorage.getItem(privacyAckKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(privacyPolicyAckKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(aiDataSharingAckKey("user-1"))).toBeNull();
     expect(
       localStorage.getItem(
         legacyVersionedKey("tos", TOS_CONSENT_VERSION, "user-1"),
@@ -1006,8 +1091,60 @@ describe("server-supplied required versions", () => {
     expect(body.share_analytics_accepted_version).toBe(BUMPED_VERSION);
     expect(body.share_diagnostics_accepted_version).toBe(BUMPED_VERSION);
     expect(localStorage.getItem(tosAckKey("user-1"))).toBe(BUMPED_VERSION);
-    expect(localStorage.getItem(privacyAckKey("user-1"))).toBe(BUMPED_VERSION);
+    expect(localStorage.getItem(privacyPolicyAckKey("user-1"))).toBe(
+      BUMPED_VERSION,
+    );
+    expect(localStorage.getItem(aiDataSharingAckKey("user-1"))).toBe(
+      BUMPED_VERSION,
+    );
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(BUMPED_VERSION);
+  });
+
+  test("privacy artifacts version independently — an ai_data_sharing bump is not masked by a newer privacy_policy ack", () => {
+    // Accept while privacy_policy requires a NEWER version than
+    // ai_data_sharing. Each artifact ack stores its own version — a single
+    // collapsed max would attest ai_data_sharing versions the user never saw.
+    resolveServerConsent(
+      makeConsent({
+        required_versions: {
+          tos: "2026-06-08",
+          privacy_policy: "2026-08-01",
+          ai_data_sharing: "2026-06-22",
+          share_analytics: "2026-06-18",
+          share_diagnostics: "2026-06-18",
+        },
+      }),
+    );
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: null,
+      hasPlatformSession: false,
+    });
+    expect(localStorage.getItem(privacyPolicyAckKey("user-1"))).toBe(
+      "2026-08-01",
+    );
+    expect(localStorage.getItem(aiDataSharingAckKey("user-1"))).toBe(
+      "2026-06-22",
+    );
+    expect(restoreConsentForUser("user-1").privacy).toBe(true);
+
+    // ai_data_sharing bumps to a version still BELOW the stored
+    // privacy_policy ack — the checkbox must go stale anyway.
+    resolveServerConsent(
+      makeConsent({
+        required_versions: {
+          tos: "2026-06-08",
+          privacy_policy: "2026-08-01",
+          ai_data_sharing: "2026-07-01",
+          share_analytics: "2026-06-18",
+          share_diagnostics: "2026-06-18",
+        },
+      }),
+    );
+    expect(restoreConsentForUser("user-1").privacy).toBe(false);
   });
 
   test("device acks stamped under the constants read stale once the server bumps", () => {

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -58,6 +58,7 @@ import {
   PRIVACY_CONSENT_VERSION,
   ANALYTICS_CONSENT_VERSION,
   DIAGNOSTICS_CONSENT_VERSION,
+  __resetRequiredConsentVersionsForTesting,
   clearConsentForUser,
   persistToggleConsent,
   resolveServerConsent,
@@ -83,6 +84,13 @@ function makeConsent(overrides: Partial<UserConsent> = {}): UserConsent {
     share_analytics_accepted_at: null,
     share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
     share_diagnostics_accepted_at: null,
+    required_versions: {
+      tos: TOS_CONSENT_VERSION,
+      privacy_policy: PRIVACY_CONSENT_VERSION,
+      ai_data_sharing: PRIVACY_CONSENT_VERSION,
+      share_analytics: ANALYTICS_CONSENT_VERSION,
+      share_diagnostics: DIAGNOSTICS_CONSENT_VERSION,
+    },
     ...overrides,
   };
   // Mirror the wire contract unless a test overrides the effective fields
@@ -96,12 +104,38 @@ function makeConsent(overrides: Partial<UserConsent> = {}): UserConsent {
   };
 }
 
-const analyticsKey = (userId: string) =>
-  `device:consent:share_analytics:v${ANALYTICS_CONSENT_VERSION}:${userId}`;
+/** A consent record from an older backend that predates `required_versions`. */
+function makeConsentWithoutRequiredVersions(
+  overrides: Partial<UserConsent> = {},
+): UserConsent {
+  const consent = makeConsent(overrides) as unknown as Record<string, unknown>;
+  delete consent.required_versions;
+  return consent as unknown as UserConsent;
+}
+
+// A server-side bump newer than every frozen build constant.
+const BUMPED_VERSION = "2026-08-01";
+const BUMPED_REQUIRED_VERSIONS = {
+  tos: BUMPED_VERSION,
+  privacy_policy: BUMPED_VERSION,
+  ai_data_sharing: BUMPED_VERSION,
+  share_analytics: BUMPED_VERSION,
+  share_diagnostics: BUMPED_VERSION,
+};
+
+// Unversioned per-user ack keys; the VALUE is the acknowledged version.
+const tosAckKey = (userId: string) => `device:consent:tos:${userId}`;
+const privacyAckKey = (userId: string) => `device:consent:privacy:${userId}`;
 const diagnosticsKey = (userId: string) =>
-  `device:consent:share_diagnostics:v${DIAGNOSTICS_CONSENT_VERSION}:${userId}`;
+  `device:consent:share_diagnostics:${userId}`;
+// Legacy layout: the version was embedded in the KEY over a boolean value.
+const legacyVersionedKey = (field: string, version: string, userId: string) =>
+  `device:consent:${field}:v${version}:${userId}`;
+const analyticsKey = (userId: string) =>
+  legacyVersionedKey("share_analytics", ANALYTICS_CONSENT_VERSION, userId);
 
 beforeEach(() => {
+  __resetRequiredConsentVersionsForTesting();
   storeState.setTosAccepted.mockReset();
   storeState.setPrivacyConsent.mockReset();
   storeState.setShareAnalytics.mockReset();
@@ -148,18 +182,13 @@ describe("resolveServerConsent", () => {
     expect(r.diagnosticsCurrent).toBe(true);
   });
 
-  test("the data-capture toggles freeze at the prior privacy version (no re-prompt)", () => {
-    // Guards the no-re-prompt guarantee: the toggle versions must stay pinned to
-    // the value existing acks/device keys were stamped under. A careless future
-    // edit that re-points them at the bumped privacy version fails here.
+  test("the data-capture toggle fallbacks freeze at the prior privacy version (no re-prompt)", () => {
+    // Guards the no-re-prompt guarantee on the fallback path: the frozen
+    // constants must stay pinned to the value existing acks were stamped
+    // under. A careless future edit that re-points them at the bumped privacy
+    // version fails here — genuine bumps arrive via server `required_versions`.
     expect(ANALYTICS_CONSENT_VERSION).toBe("2026-06-18");
     expect(DIAGNOSTICS_CONSENT_VERSION).toBe("2026-06-18");
-    expect(analyticsKey("user-1")).toBe(
-      "device:consent:share_analytics:v2026-06-18:user-1",
-    );
-    expect(diagnosticsKey("user-1")).toBe(
-      "device:consent:share_diagnostics:v2026-06-18:user-1",
-    );
   });
 
   test("reports stale toggles for mismatched versions", () => {
@@ -491,9 +520,11 @@ describe("resolveServerConsent", () => {
 });
 
 describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
-  test("round-trips the diagnostics ack key", () => {
+  test("round-trips the diagnostics ack key (value = acknowledged version)", () => {
     persistToggleConsent("user-1", { diagnosticsCurrent: true });
-    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
     const r = restoreConsentForUser("user-1");
     expect(r.diagnosticsCurrent).toBe(true);
   });
@@ -540,7 +571,6 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     // The privacy version has since been bumped, so that stale consent must not
     // be promoted as current — the key is cleaned up and privacy stays un-set.
     const legacyAiKey = `device:consent:ai:v2026-06-08:user-1`;
-    const privacyKey = `device:consent:privacy:v${PRIVACY_CONSENT_VERSION}:user-1`;
     localStorage.setItem(legacyAiKey, "true");
 
     const r = restoreConsentForUser("user-1");
@@ -548,25 +578,115 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     expect(r.privacy).toBe(false);
     // The stale key is removed and privacy is not stamped current.
     expect(localStorage.getItem(legacyAiKey)).toBeNull();
-    expect(localStorage.getItem(privacyKey)).toBeNull();
+    expect(localStorage.getItem(privacyAckKey("user-1"))).toBeNull();
   });
 
   test("migrates legacy unversioned ToS but forces privacy re-review", () => {
-    // A pre-versioning user with only the legacy active keys. ToS is unchanged
-    // so it migrates as current; the unversioned privacy consent predates the
-    // current privacy version, so it must NOT be promoted as current.
+    // A pre-versioning user with only the legacy active keys. ToS is stamped
+    // at the frozen constant — the version the legacy acceptance actually
+    // attests — so it migrates as current; the unversioned privacy consent
+    // predates the current privacy version, so it must NOT be promoted as
+    // current.
     localStorage.setItem("vellum:onboarding:tosAccepted", "true");
     localStorage.setItem("vellum:onboarding:aiDataConsent", "true");
-    const privacyKey = `device:consent:privacy:v${PRIVACY_CONSENT_VERSION}:user-1`;
-    const tosKey = `device:consent:tos:v${TOS_CONSENT_VERSION}:user-1`;
 
     const r = restoreConsentForUser("user-1");
 
     expect(r.tos).toBe(true);
     expect(r.privacy).toBe(false);
     // ToS is promoted; privacy is not stamped current.
-    expect(localStorage.getItem(tosKey)).toBe("true");
-    expect(localStorage.getItem(privacyKey)).toBe("false");
+    expect(localStorage.getItem(tosAckKey("user-1"))).toBe(TOS_CONSENT_VERSION);
+    expect(localStorage.getItem(privacyAckKey("user-1"))).toBeNull();
+  });
+
+  test("promotes legacy versioned ack keys to unversioned keys (version becomes the value)", () => {
+    // The legacy layout embedded the version in the key over a boolean value.
+    // Migration carries the exact attested version into the new key's value
+    // and removes every legacy key for the field.
+    localStorage.setItem(
+      legacyVersionedKey("tos", TOS_CONSENT_VERSION, "user-1"),
+      "true",
+    );
+    localStorage.setItem(
+      legacyVersionedKey("privacy", PRIVACY_CONSENT_VERSION, "user-1"),
+      "true",
+    );
+    localStorage.setItem(
+      legacyVersionedKey("share_diagnostics", DIAGNOSTICS_CONSENT_VERSION, "user-1"),
+      "true",
+    );
+
+    const r = restoreConsentForUser("user-1");
+
+    expect(r.tos).toBe(true);
+    expect(r.privacy).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+    expect(localStorage.getItem(tosAckKey("user-1"))).toBe(TOS_CONSENT_VERSION);
+    expect(localStorage.getItem(privacyAckKey("user-1"))).toBe(
+      PRIVACY_CONSENT_VERSION,
+    );
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
+    expect(
+      localStorage.getItem(
+        legacyVersionedKey("tos", TOS_CONSENT_VERSION, "user-1"),
+      ),
+    ).toBeNull();
+    expect(
+      localStorage.getItem(
+        legacyVersionedKey("privacy", PRIVACY_CONSENT_VERSION, "user-1"),
+      ),
+    ).toBeNull();
+    expect(
+      localStorage.getItem(
+        legacyVersionedKey(
+          "share_diagnostics",
+          DIAGNOSTICS_CONSENT_VERSION,
+          "user-1",
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  test("migration promotes the attested version verbatim — an old version reads stale, not current", () => {
+    localStorage.setItem(
+      legacyVersionedKey("share_diagnostics", "2020-01-01", "user-1"),
+      "true",
+    );
+
+    const r = restoreConsentForUser("user-1");
+
+    expect(r.diagnosticsCurrent).toBe(false);
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("2020-01-01");
+  });
+
+  test("migration never promotes a false legacy ack, and an existing unversioned key wins", () => {
+    // A false legacy key is swept without promotion.
+    localStorage.setItem(
+      legacyVersionedKey("share_diagnostics", DIAGNOSTICS_CONSENT_VERSION, "user-1"),
+      "false",
+    );
+    restoreConsentForUser("user-1");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
+
+    // Once an unversioned ack exists, a lingering legacy key can't overwrite it.
+    localStorage.setItem(diagnosticsKey("user-1"), "2099-01-01");
+    localStorage.setItem(
+      legacyVersionedKey("share_diagnostics", DIAGNOSTICS_CONSENT_VERSION, "user-1"),
+      "true",
+    );
+    restoreConsentForUser("user-1");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("2099-01-01");
+    expect(
+      localStorage.getItem(
+        legacyVersionedKey(
+          "share_diagnostics",
+          DIAGNOSTICS_CONSENT_VERSION,
+          "user-1",
+        ),
+      ),
+    ).toBeNull();
   });
 });
 
@@ -630,7 +750,9 @@ describe("saveConsent", () => {
     expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
     // Analytics has no device ack — its version stamp is server-side only.
     expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
-    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
   });
 
   test("null shareAnalytics (toggle not shown) omits analytics from the patch and skips its ack", () => {
@@ -649,7 +771,9 @@ describe("saveConsent", () => {
     expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
     expect(storeState.setShareAnalytics).not.toHaveBeenCalled();
     expect(localStorage.getItem(analyticsKey("user-1"))).toBe(null);
-    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
     // Never-asked has nothing to re-review — must not bounce to review-terms.
     expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
   });
@@ -704,7 +828,9 @@ describe("saveConsent", () => {
     const body = patchConsentMock.mock.calls[0][0];
     expect(body.share_diagnostics).toBe(false);
     expect(body.share_diagnostics_accepted_version).toBe(DIAGNOSTICS_CONSENT_VERSION);
-    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
   });
 
   test("marks consent hydrated — an explicit acceptance is authoritative", () => {
@@ -769,11 +895,163 @@ describe("savePreferenceToggle", () => {
 });
 
 describe("clearConsentForUser", () => {
-  test("clears the diagnostics ack key and any stale analytics ack keys", () => {
+  test("clears the ack keys, legacy versioned keys, and stale analytics ack keys", () => {
     persistToggleConsent("user-1", { diagnosticsCurrent: true });
+    localStorage.setItem(tosAckKey("user-1"), TOS_CONSENT_VERSION);
+    localStorage.setItem(privacyAckKey("user-1"), PRIVACY_CONSENT_VERSION);
     localStorage.setItem(analyticsKey("user-1"), "true");
+    localStorage.setItem(
+      legacyVersionedKey("tos", TOS_CONSENT_VERSION, "user-1"),
+      "true",
+    );
     clearConsentForUser("user-1");
     expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(tosAckKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(privacyAckKey("user-1"))).toBeNull();
+    expect(
+      localStorage.getItem(
+        legacyVersionedKey("tos", TOS_CONSENT_VERSION, "user-1"),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("server-supplied required versions", () => {
+  test("required_versions newer than the accepted versions owes re-review on every axis", () => {
+    const r = resolveServerConsent(
+      makeConsent({ required_versions: BUMPED_REQUIRED_VERSIONS }),
+    );
+    expect(r.tos).toBe(false);
+    expect(r.privacy).toBe(false);
+    // Explicit choices on record are stale against the bumped requirement.
+    expect(r.analyticsCurrent).toBe(false);
+    expect(r.diagnosticsCurrent).toBe(false);
+    expect(r.analyticsVersionCurrent).toBe(false);
+    expect(r.diagnosticsVersionCurrent).toBe(false);
+  });
+
+  test("accepted versions at the bumped requirement resolve current", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        required_versions: BUMPED_REQUIRED_VERSIONS,
+        tos_accepted_version: BUMPED_VERSION,
+        privacy_policy_accepted_version: BUMPED_VERSION,
+        ai_data_sharing_accepted_version: BUMPED_VERSION,
+        share_analytics_accepted_version: BUMPED_VERSION,
+        share_diagnostics_accepted_version: BUMPED_VERSION,
+      }),
+    );
+    expect(r.tos).toBe(true);
+    expect(r.privacy).toBe(true);
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("absent required_versions (older backend) falls back to the frozen constants", () => {
+    const r = resolveServerConsent(makeConsentWithoutRequiredVersions());
+    expect(r.tos).toBe(true);
+    expect(r.privacy).toBe(true);
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("each privacy artifact compares against its own required version", () => {
+    // Only the AI data sharing requirement is bumped: the privacy checkbox
+    // (covering both artifacts) goes stale while every other axis stays
+    // current.
+    const r = resolveServerConsent(
+      makeConsent({
+        required_versions: {
+          tos: TOS_CONSENT_VERSION,
+          privacy_policy: PRIVACY_CONSENT_VERSION,
+          ai_data_sharing: BUMPED_VERSION,
+          share_analytics: ANALYTICS_CONSENT_VERSION,
+          share_diagnostics: DIAGNOSTICS_CONSENT_VERSION,
+        },
+      }),
+    );
+    expect(r.privacy).toBe(false);
+    expect(r.tos).toBe(true);
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("missing keys inside required_versions fall back per-key to the constants", () => {
+    const r = resolveServerConsent(
+      makeConsent({ required_versions: { tos: BUMPED_VERSION } }),
+    );
+    expect(r.tos).toBe(false);
+    expect(r.privacy).toBe(true);
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("PATCH bodies and device acks stamp the server-supplied required versions", () => {
+    resolveServerConsent(
+      makeConsent({ required_versions: BUMPED_REQUIRED_VERSIONS }),
+    );
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      privacy: true,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      hasPlatformSession: true,
+    });
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.tos_accepted_version).toBe(BUMPED_VERSION);
+    expect(body.privacy_policy_accepted_version).toBe(BUMPED_VERSION);
+    expect(body.ai_data_sharing_accepted_version).toBe(BUMPED_VERSION);
+    expect(body.share_analytics_accepted_version).toBe(BUMPED_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(BUMPED_VERSION);
+    expect(localStorage.getItem(tosAckKey("user-1"))).toBe(BUMPED_VERSION);
+    expect(localStorage.getItem(privacyAckKey("user-1"))).toBe(BUMPED_VERSION);
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(BUMPED_VERSION);
+  });
+
+  test("device acks stamped under the constants read stale once the server bumps", () => {
+    // Acks earned while the module still ran on the constants fallback...
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: true,
+      hasPlatformSession: false,
+    });
+    expect(restoreConsentForUser("user-1")).toEqual({
+      tos: true,
+      privacy: true,
+      diagnosticsCurrent: true,
+    });
+
+    // ...owe a re-review after a resolve adopts bumped requirements.
+    resolveServerConsent(
+      makeConsent({ required_versions: BUMPED_REQUIRED_VERSIONS }),
+    );
+    expect(restoreConsentForUser("user-1")).toEqual({
+      tos: false,
+      privacy: false,
+      diagnosticsCurrent: false,
+    });
+  });
+
+  test("a later resolve without required_versions restores the constants for stamps", () => {
+    resolveServerConsent(
+      makeConsent({ required_versions: BUMPED_REQUIRED_VERSIONS }),
+    );
+    resolveServerConsent(makeConsentWithoutRequiredVersions());
+    savePreferenceToggle("share_diagnostics", true, {
+      userId: "user-1",
+      hasPlatformSession: true,
+    });
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.share_diagnostics_accepted_version).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
+      DIAGNOSTICS_CONSENT_VERSION,
+    );
   });
 });

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -118,10 +118,13 @@ export function __resetRequiredConsentVersionsForTesting(): void {
 // Device ack keys
 // ---------------------------------------------------------------------------
 
-// The three device-acknowledged axes: ToS, the privacy checkbox (privacy
-// policy + AI data sharing), and the diagnostics toggle. Analytics has no
+// The device-acknowledged axes. The privacy CHECKBOX covers two artifacts
+// (privacy policy + AI data sharing) whose required versions bump
+// independently, so each artifact keeps its own ack — a single collapsed
+// version would attest an artifact bump the user never saw. Analytics has no
 // device ack key.
-type DeviceAckField = "tos" | "privacy" | "share_diagnostics";
+type DeviceAckField =
+  "tos" | "privacy_policy" | "ai_data_sharing" | "share_diagnostics";
 
 function consentAckKey(field: DeviceAckField, userId: string): string {
   return `device:consent:${field}:${userId}`;
@@ -132,12 +135,10 @@ function requiredAckVersion(field: DeviceAckField): string {
   switch (field) {
     case "tos":
       return requiredVersions.tos;
-    case "privacy":
-      // One checkbox covers both privacy artifacts, so its ack must satisfy
-      // whichever required version is newer.
-      return requiredVersions.privacyPolicy >= requiredVersions.aiDataSharing
-        ? requiredVersions.privacyPolicy
-        : requiredVersions.aiDataSharing;
+    case "privacy_policy":
+      return requiredVersions.privacyPolicy;
+    case "ai_data_sharing":
+      return requiredVersions.aiDataSharing;
     case "share_diagnostics":
       return requiredVersions.shareDiagnostics;
   }
@@ -152,7 +153,10 @@ function readAckVersion(field: DeviceAckField, userId: string): string {
 }
 
 function isAckCurrent(field: DeviceAckField, userId: string): boolean {
-  return versionIsCurrent(readAckVersion(field, userId), requiredAckVersion(field));
+  return versionIsCurrent(
+    readAckVersion(field, userId),
+    requiredAckVersion(field),
+  );
 }
 
 // The previous release stored privacy consent under a field named "ai" (now
@@ -173,11 +177,11 @@ function legacyPrivacyConsentKey(userId: string): string {
  * so stale keys are deleted without promotion.
  */
 function migrateLegacyVersionedAcks(
-  field: DeviceAckField | "share_analytics",
+  legacyField: "tos" | "privacy" | "share_diagnostics" | "share_analytics",
   userId: string,
-  promote: boolean,
+  promoteTo: DeviceAckField[],
 ): void {
-  const prefix = `device:consent:${field}:v`;
+  const prefix = `device:consent:${legacyField}:v`;
   const suffix = `:${userId}`;
   const legacyKeys: string[] = [];
   let newestAcked = "";
@@ -197,32 +201,39 @@ function migrateLegacyVersionedAcks(
       newestAcked = version;
     }
   }
-  if (
-    promote &&
-    newestAcked &&
-    field !== "share_analytics" &&
-    !readAckVersion(field, userId)
-  ) {
-    setLocalSetting(consentAckKey(field, userId), newestAcked);
+  if (newestAcked) {
+    for (const target of promoteTo) {
+      if (!readAckVersion(target, userId)) {
+        setLocalSetting(consentAckKey(target, userId), newestAcked);
+      }
+    }
   }
   for (const key of legacyKeys) {
     removeLocalSetting(key);
   }
 }
 
-export function restoreConsentForUser(
-  userId: string | null,
-): { tos: boolean; privacy: boolean; diagnosticsCurrent: boolean } {
+export function restoreConsentForUser(userId: string | null): {
+  tos: boolean;
+  privacy: boolean;
+  diagnosticsCurrent: boolean;
+} {
   if (typeof window === "undefined" || !userId) {
     return { tos: false, privacy: false, diagnosticsCurrent: false };
   }
   try {
-    migrateLegacyVersionedAcks("tos", userId, true);
-    migrateLegacyVersionedAcks("privacy", userId, true);
-    migrateLegacyVersionedAcks("share_diagnostics", userId, true);
+    migrateLegacyVersionedAcks("tos", userId, ["tos"]);
+    // A legacy privacy ack attested BOTH artifacts at its stamped version.
+    migrateLegacyVersionedAcks("privacy", userId, [
+      "privacy_policy",
+      "ai_data_sharing",
+    ]);
+    migrateLegacyVersionedAcks("share_diagnostics", userId, [
+      "share_diagnostics",
+    ]);
     // Analytics device acks are never read (analytics is opt-out with
     // server-side version stamps only) — sweep stale keys, no promotion.
-    migrateLegacyVersionedAcks("share_analytics", userId, false);
+    migrateLegacyVersionedAcks("share_analytics", userId, []);
 
     // The legacy "ai"-named key was written under the previous privacy version,
     // so it cannot attest to the current one. Never promote it — that would
@@ -234,7 +245,9 @@ export function restoreConsentForUser(
     }
 
     const tos = isAckCurrent("tos", userId);
-    const privacy = isAckCurrent("privacy", userId);
+    const privacy =
+      isAckCurrent("privacy_policy", userId) &&
+      isAckCurrent("ai_data_sharing", userId);
     const diagnosticsCurrent = isAckCurrent("share_diagnostics", userId);
 
     if (tos || privacy) {
@@ -251,7 +264,10 @@ export function restoreConsentForUser(
     // backfill it) without showing the updated privacy checkbox. Force
     // privacy through re-review instead.
     const legacyTos = getLocalBool("vellum:onboarding:tosAccepted", false);
-    const legacyPrivacy = getLocalBool("vellum:onboarding:aiDataConsent", false);
+    const legacyPrivacy = getLocalBool(
+      "vellum:onboarding:aiDataConsent",
+      false,
+    );
     if (legacyTos || legacyPrivacy) {
       if (legacyTos) {
         setLocalSetting(consentAckKey("tos", userId), TOS_CONSENT_VERSION);
@@ -285,11 +301,16 @@ export function persistConsentForUser(
     }
     if (privacy) {
       setLocalSetting(
-        consentAckKey("privacy", userId),
-        requiredAckVersion("privacy"),
+        consentAckKey("privacy_policy", userId),
+        requiredAckVersion("privacy_policy"),
+      );
+      setLocalSetting(
+        consentAckKey("ai_data_sharing", userId),
+        requiredAckVersion("ai_data_sharing"),
       );
     } else {
-      removeLocalSetting(consentAckKey("privacy", userId));
+      removeLocalSetting(consentAckKey("privacy_policy", userId));
+      removeLocalSetting(consentAckKey("ai_data_sharing", userId));
     }
   } catch {
     // Storage unavailable.
@@ -326,13 +347,14 @@ export function clearConsentForUser(userId: string | null): void {
   }
   try {
     removeLocalSetting(consentAckKey("tos", userId));
-    removeLocalSetting(consentAckKey("privacy", userId));
+    removeLocalSetting(consentAckKey("privacy_policy", userId));
+    removeLocalSetting(consentAckKey("ai_data_sharing", userId));
     removeLocalSetting(consentAckKey("share_diagnostics", userId));
     removeLocalSetting(legacyPrivacyConsentKey(userId));
-    migrateLegacyVersionedAcks("tos", userId, false);
-    migrateLegacyVersionedAcks("privacy", userId, false);
-    migrateLegacyVersionedAcks("share_diagnostics", userId, false);
-    migrateLegacyVersionedAcks("share_analytics", userId, false);
+    migrateLegacyVersionedAcks("tos", userId, []);
+    migrateLegacyVersionedAcks("privacy", userId, []);
+    migrateLegacyVersionedAcks("share_diagnostics", userId, []);
+    migrateLegacyVersionedAcks("share_analytics", userId, []);
   } catch {
     // Storage unavailable.
   }
@@ -353,9 +375,7 @@ function versionIsCurrent(accepted: string, required: string): boolean {
   return accepted >= required;
 }
 
-export function resolveServerConsent(
-  consent: UserConsent | null | undefined,
-): {
+export function resolveServerConsent(consent: UserConsent | null | undefined): {
   tos: boolean;
   privacy: boolean;
   shareAnalytics: boolean | null;
@@ -453,7 +473,8 @@ export function resolveServerConsent(
     // opt-out) and serves it as `share_*_effective`. The fields are required
     // in the current schema, but an older backend omits them — fall back to
     // the raw value's opt-out reading so behavior is unchanged there.
-    analyticsEffective: consent.share_analytics_effective ?? consent.share_analytics ?? true,
+    analyticsEffective:
+      consent.share_analytics_effective ?? consent.share_analytics ?? true,
     diagnosticsEffective:
       consent.share_diagnostics_effective ?? consent.share_diagnostics ?? true,
     // Share-toggle re-review is owed only for an explicit, genuinely stale
@@ -461,8 +482,10 @@ export function resolveServerConsent(
     // `share_analytics` stays null until the user chooses via settings or
     // review-terms — null reads as "nothing to re-review", not stale consent.
     // An explicit choice with a stale/empty version still re-reviews.
-    analyticsCurrent: consent.share_analytics === null || analyticsVersionCurrent,
-    diagnosticsCurrent: consent.share_diagnostics === null || diagnosticsVersionCurrent,
+    analyticsCurrent:
+      consent.share_analytics === null || analyticsVersionCurrent,
+    diagnosticsCurrent:
+      consent.share_diagnostics === null || diagnosticsVersionCurrent,
     analyticsVersionCurrent,
     diagnosticsVersionCurrent,
     hasServerRecord,

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -1,14 +1,18 @@
 /**
  * Versioned, per-user consent persistence.
  *
- * Consent flags live in `device:consent:{tos,privacy,share_diagnostics}:v<VERSION>:<userId>`.
- * The `device:` prefix survives logout; the userId makes them per-user;
- * the version lets us force re-consent by bumping the relevant version
- * constant. The consent axes version independently — ToS, the privacy
- * checkbox (privacy policy + AI data sharing), and share-diagnostics — so any
- * one can be re-reviewed without forcing the others. Bumping the privacy
- * policy, in particular, must not re-prompt diagnostics capture consent, so
- * it carries its own frozen version.
+ * Consent acknowledgments live in per-user device keys
+ * (`device:consent:{tos,privacy,share_diagnostics}:<userId>`) whose VALUE is
+ * the required version the user last confirmed under (a zero-padded ISO
+ * date). The `device:` prefix survives logout; the userId makes them
+ * per-user. Currency is `storedVersion >= requiredVersion`, where the
+ * required versions come from the server's `required_versions` (adopted by
+ * `resolveServerConsent`) and fall back to the frozen build constants when
+ * the backend predates the field — so a server-side version bump owes a
+ * re-review without a client release. The consent axes version
+ * independently — ToS, the privacy checkbox (privacy policy + AI data
+ * sharing), and share-diagnostics — so any one can be re-reviewed without
+ * forcing the others.
  *
  * The `share_diagnostics` ack key records the version under which the toggle
  * was last confirmed (its currency), independent of the on/off value which
@@ -21,29 +25,37 @@
  * `privacyConsent`). This module handles the durable device-key layer
  * and the unified read/write API for all consent state:
  *
- * - `resolveServerConsent` — compare server consent versions against the ToS/privacy versions
+ * - `resolveServerConsent` — compare server consent versions against the required versions
  * - `saveConsent`          — unified write: store + device keys + server sync
  * - `savePreferenceToggle` — single-field write for settings page toggles
  * - `restoreConsentForUser` — read device keys, return {tos, privacy, diagnostics ack}
  * - `persistConsentForUser` — write tos/privacy device keys
- * - `persistToggleConsent`  — write the versioned diagnostics ack key
+ * - `persistToggleConsent`  — write the diagnostics ack key
  * - `clearConsentForUser`   — delete device keys + legacy active keys
  */
-import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
+import {
+  getLocalSetting,
+  setLocalSetting,
+  removeLocalSetting,
+  getLocalBool,
+} from "@/utils/local-settings";
 import { applyExplicitDiagnosticsChoice } from "@/lib/consent/diagnostics-consent";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
-// Consent versions must be zero-padded ISO dates (YYYY-MM-DD): currency is a
-// monotonic comparison (`resolveServerConsent` uses `>=`), which requires a
+// Offline/older-backend fallback required versions. The server's
+// `required_versions` is authoritative when present; these frozen constants
+// only back the paths where it isn't (a backend that predates the field, or
+// no successful resolve yet this session). Zero-padded ISO dates
+// (YYYY-MM-DD): currency is a monotonic comparison (`>=`), which requires a
 // lexicographically sortable, chronological format.
 export const TOS_CONSENT_VERSION = "2026-06-08";
 export const PRIVACY_CONSENT_VERSION = "2026-06-22";
 
-// The two data-capture toggles version independently from the privacy policy.
-// Frozen at the prior privacy version (the value existing toggle acks/device
-// keys are stamped under) so bumping the privacy policy doesn't re-prompt
-// capture consent. Bump each independently when its own disclosure changes.
+// The two data-capture toggles version independently from the privacy
+// policy, so bumping the privacy policy doesn't re-prompt capture consent.
+// Frozen at the prior privacy version as the fallback floor; genuine bumps
+// arrive via the server's `required_versions`.
 export const ANALYTICS_CONSENT_VERSION = "2026-06-18";
 export const DIAGNOSTICS_CONSENT_VERSION = "2026-06-18";
 
@@ -54,17 +66,93 @@ export const DIAGNOSTICS_CONSENT_VERSION = "2026-06-18";
 // key rather than treating it as current consent.
 const LEGACY_AI_PRIVACY_CONSENT_VERSION = "2026-06-08";
 
-// Version stamp embedded in each field's device-cache key. ToS, the privacy
-// checkbox (privacy policy + AI data sharing), and the diagnostics toggle
-// track their own version constant. Analytics has no device ack key.
-const CONSENT_KEY_VERSION = {
-  tos: TOS_CONSENT_VERSION,
-  privacy: PRIVACY_CONSENT_VERSION,
-  share_diagnostics: DIAGNOSTICS_CONSENT_VERSION,
-} as const;
+// ---------------------------------------------------------------------------
+// Required versions — server-supplied, constants as fallback
+// ---------------------------------------------------------------------------
 
-function consentKey(field: keyof typeof CONSENT_KEY_VERSION, userId: string): string {
-  return `device:consent:${field}:v${CONSENT_KEY_VERSION[field]}:${userId}`;
+interface RequiredConsentVersions {
+  tos: string;
+  privacyPolicy: string;
+  aiDataSharing: string;
+  shareAnalytics: string;
+  shareDiagnostics: string;
+}
+
+const FALLBACK_REQUIRED_VERSIONS: RequiredConsentVersions = {
+  tos: TOS_CONSENT_VERSION,
+  privacyPolicy: PRIVACY_CONSENT_VERSION,
+  aiDataSharing: PRIVACY_CONSENT_VERSION,
+  shareAnalytics: ANALYTICS_CONSENT_VERSION,
+  shareDiagnostics: DIAGNOSTICS_CONSENT_VERSION,
+};
+
+/**
+ * The required versions from the most recent server consent record
+ * `resolveServerConsent` saw, per-key falling back to the frozen constants.
+ * `writeConsent` stamps PATCH bodies and the device-ack reads/writes consume
+ * this, so the whole module agrees on one set of required versions: the
+ * server's when it supplies them, the build's otherwise.
+ */
+let requiredVersions: RequiredConsentVersions = FALLBACK_REQUIRED_VERSIONS;
+
+function toRequiredVersions(
+  raw: Record<string, string> | undefined,
+): RequiredConsentVersions {
+  // `||` (not `??`): an empty string means "not supplied", never "nothing
+  // required" — treating it as a requirement would mark every record current.
+  return {
+    tos: raw?.tos || TOS_CONSENT_VERSION,
+    privacyPolicy: raw?.privacy_policy || PRIVACY_CONSENT_VERSION,
+    aiDataSharing: raw?.ai_data_sharing || PRIVACY_CONSENT_VERSION,
+    shareAnalytics: raw?.share_analytics || ANALYTICS_CONSENT_VERSION,
+    shareDiagnostics: raw?.share_diagnostics || DIAGNOSTICS_CONSENT_VERSION,
+  };
+}
+
+/** Test-only: restore the constants-fallback required versions. */
+export function __resetRequiredConsentVersionsForTesting(): void {
+  requiredVersions = FALLBACK_REQUIRED_VERSIONS;
+}
+
+// ---------------------------------------------------------------------------
+// Device ack keys
+// ---------------------------------------------------------------------------
+
+// The three device-acknowledged axes: ToS, the privacy checkbox (privacy
+// policy + AI data sharing), and the diagnostics toggle. Analytics has no
+// device ack key.
+type DeviceAckField = "tos" | "privacy" | "share_diagnostics";
+
+function consentAckKey(field: DeviceAckField, userId: string): string {
+  return `device:consent:${field}:${userId}`;
+}
+
+/** The required version a device ack for `field` must meet to be current. */
+function requiredAckVersion(field: DeviceAckField): string {
+  switch (field) {
+    case "tos":
+      return requiredVersions.tos;
+    case "privacy":
+      // One checkbox covers both privacy artifacts, so its ack must satisfy
+      // whichever required version is newer.
+      return requiredVersions.privacyPolicy >= requiredVersions.aiDataSharing
+        ? requiredVersions.privacyPolicy
+        : requiredVersions.aiDataSharing;
+    case "share_diagnostics":
+      return requiredVersions.shareDiagnostics;
+  }
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** The acknowledged version stored for `field`, or `""` when absent/garbled. */
+function readAckVersion(field: DeviceAckField, userId: string): string {
+  const value = getLocalSetting(consentAckKey(field, userId), "");
+  return ISO_DATE_RE.test(value) ? value : "";
+}
+
+function isAckCurrent(field: DeviceAckField, userId: string): boolean {
+  return versionIsCurrent(readAckVersion(field, userId), requiredAckVersion(field));
 }
 
 // The previous release stored privacy consent under a field named "ai" (now
@@ -73,21 +161,51 @@ function legacyPrivacyConsentKey(userId: string): string {
   return `device:consent:ai:v${LEGACY_AI_PRIVACY_CONSENT_VERSION}:${userId}`;
 }
 
-// Analytics device acks are no longer read or written (analytics is opt-out
-// and its toggle is never shown during onboarding — server version stamps are
-// written at choice time instead). Delete any stale keys, whatever version
-// they were stamped under, so they don't linger.
-function removeStaleAnalyticsAckKeys(userId: string): void {
-  const prefix = "device:consent:share_analytics:v";
+/**
+ * One-time migration of the legacy ack layout, which embedded the version in
+ * the KEY (`device:consent:<field>:v<VERSION>:<userId>`, boolean value).
+ * When `promote` is set and no unversioned ack exists yet, the newest
+ * affirmative legacy key's version becomes the unversioned key's value — the
+ * legacy key attests exactly the version it was stamped under, so currency
+ * against a later required version is decided by the comparison, never
+ * assumed. Every legacy key for the field is then removed. Analytics runs
+ * with `promote: false`: its device acks are dead (server-side stamps only),
+ * so stale keys are deleted without promotion.
+ */
+function migrateLegacyVersionedAcks(
+  field: DeviceAckField | "share_analytics",
+  userId: string,
+  promote: boolean,
+): void {
+  const prefix = `device:consent:${field}:v`;
   const suffix = `:${userId}`;
-  const stale: string[] = [];
+  const legacyKeys: string[] = [];
+  let newestAcked = "";
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
-    if (key && key.startsWith(prefix) && key.endsWith(suffix)) {
-      stale.push(key);
+    if (!key || !key.startsWith(prefix) || !key.endsWith(suffix)) {
+      continue;
+    }
+    const version = key.slice(prefix.length, key.length - suffix.length);
+    // The version segment is always an ISO date; anything else is not a
+    // legacy ack key (e.g. an unversioned key whose userId starts with "v").
+    if (!ISO_DATE_RE.test(version)) {
+      continue;
+    }
+    legacyKeys.push(key);
+    if (getLocalBool(key, false) && version > newestAcked) {
+      newestAcked = version;
     }
   }
-  for (const key of stale) {
+  if (
+    promote &&
+    newestAcked &&
+    field !== "share_analytics" &&
+    !readAckVersion(field, userId)
+  ) {
+    setLocalSetting(consentAckKey(field, userId), newestAcked);
+  }
+  for (const key of legacyKeys) {
     removeLocalSetting(key);
   }
 }
@@ -99,9 +217,12 @@ export function restoreConsentForUser(
     return { tos: false, privacy: false, diagnosticsCurrent: false };
   }
   try {
-    const diagnosticsCurrent = getLocalBool(consentKey("share_diagnostics", userId), false);
-    const tos = getLocalBool(consentKey("tos", userId), false);
-    const privacy = getLocalBool(consentKey("privacy", userId), false);
+    migrateLegacyVersionedAcks("tos", userId, true);
+    migrateLegacyVersionedAcks("privacy", userId, true);
+    migrateLegacyVersionedAcks("share_diagnostics", userId, true);
+    // Analytics device acks are never read (analytics is opt-out with
+    // server-side version stamps only) — sweep stale keys, no promotion.
+    migrateLegacyVersionedAcks("share_analytics", userId, false);
 
     // The legacy "ai"-named key was written under the previous privacy version,
     // so it cannot attest to the current one. Never promote it — that would
@@ -111,7 +232,10 @@ export function restoreConsentForUser(
     if (getLocalBool(legacyPrivacyConsentKey(userId), false)) {
       removeLocalSetting(legacyPrivacyConsentKey(userId));
     }
-    removeStaleAnalyticsAckKeys(userId);
+
+    const tos = isAckCurrent("tos", userId);
+    const privacy = isAckCurrent("privacy", userId);
+    const diagnosticsCurrent = isAckCurrent("share_diagnostics", userId);
 
     if (tos || privacy) {
       return { tos, privacy, diagnosticsCurrent };
@@ -119,17 +243,24 @@ export function restoreConsentForUser(
 
     // One-time migration: users who accepted before the per-user device
     // key change still have consent in the legacy vellum: active keys.
-    // Promote ToS so they aren't re-prompted — its version is unchanged, so the
-    // legacy acceptance is still current. The legacy privacy key is unversioned
-    // and predates the current privacy version, so promoting it would stamp
-    // stale consent as current (and let the empty-server fallback backfill it)
-    // without showing the updated privacy checkbox. Force privacy through
-    // re-review instead.
+    // Promote ToS at the frozen constant — the version the legacy acceptance
+    // actually attests — so a later required-version bump correctly reads it
+    // stale instead of assuming currency. The legacy privacy key is
+    // unversioned and predates the current privacy version, so promoting it
+    // would stamp stale consent as current (and let the empty-server fallback
+    // backfill it) without showing the updated privacy checkbox. Force
+    // privacy through re-review instead.
     const legacyTos = getLocalBool("vellum:onboarding:tosAccepted", false);
     const legacyPrivacy = getLocalBool("vellum:onboarding:aiDataConsent", false);
     if (legacyTos || legacyPrivacy) {
-      persistConsentForUser(userId, legacyTos, false);
-      return { tos: legacyTos, privacy: false, diagnosticsCurrent };
+      if (legacyTos) {
+        setLocalSetting(consentAckKey("tos", userId), TOS_CONSENT_VERSION);
+      }
+      return {
+        tos: legacyTos && isAckCurrent("tos", userId),
+        privacy: false,
+        diagnosticsCurrent,
+      };
     }
 
     return { tos: false, privacy: false, diagnosticsCurrent };
@@ -143,10 +274,23 @@ export function persistConsentForUser(
   tos: boolean,
   privacy: boolean,
 ): void {
-  if (typeof window === "undefined" || !userId) return;
+  if (typeof window === "undefined" || !userId) {
+    return;
+  }
   try {
-    setLocalBool(consentKey("tos", userId), tos);
-    setLocalBool(consentKey("privacy", userId), privacy);
+    if (tos) {
+      setLocalSetting(consentAckKey("tos", userId), requiredAckVersion("tos"));
+    } else {
+      removeLocalSetting(consentAckKey("tos", userId));
+    }
+    if (privacy) {
+      setLocalSetting(
+        consentAckKey("privacy", userId),
+        requiredAckVersion("privacy"),
+      );
+    } else {
+      removeLocalSetting(consentAckKey("privacy", userId));
+    }
   } catch {
     // Storage unavailable.
   }
@@ -156,10 +300,17 @@ export function persistToggleConsent(
   userId: string | null,
   acks: { diagnosticsCurrent?: boolean },
 ): void {
-  if (typeof window === "undefined" || !userId) return;
+  if (typeof window === "undefined" || !userId) {
+    return;
+  }
   try {
-    if (acks.diagnosticsCurrent !== undefined) {
-      setLocalBool(consentKey("share_diagnostics", userId), acks.diagnosticsCurrent);
+    if (acks.diagnosticsCurrent === true) {
+      setLocalSetting(
+        consentAckKey("share_diagnostics", userId),
+        requiredAckVersion("share_diagnostics"),
+      );
+    } else if (acks.diagnosticsCurrent === false) {
+      removeLocalSetting(consentAckKey("share_diagnostics", userId));
     }
   } catch {
     // Storage unavailable.
@@ -170,13 +321,18 @@ export function clearConsentForUser(userId: string | null): void {
   removeLocalSetting("vellum:onboarding:tosAccepted");
   removeLocalSetting("vellum:onboarding:aiDataConsent");
   removeLocalSetting("vellum:onboarding:selectedVersion");
-  if (typeof window === "undefined" || !userId) return;
+  if (typeof window === "undefined" || !userId) {
+    return;
+  }
   try {
-    removeLocalSetting(consentKey("tos", userId));
-    removeLocalSetting(consentKey("privacy", userId));
+    removeLocalSetting(consentAckKey("tos", userId));
+    removeLocalSetting(consentAckKey("privacy", userId));
+    removeLocalSetting(consentAckKey("share_diagnostics", userId));
     removeLocalSetting(legacyPrivacyConsentKey(userId));
-    removeStaleAnalyticsAckKeys(userId);
-    removeLocalSetting(consentKey("share_diagnostics", userId));
+    migrateLegacyVersionedAcks("tos", userId, false);
+    migrateLegacyVersionedAcks("privacy", userId, false);
+    migrateLegacyVersionedAcks("share_diagnostics", userId, false);
+    migrateLegacyVersionedAcks("share_analytics", userId, false);
   } catch {
     // Storage unavailable.
   }
@@ -187,10 +343,10 @@ export function clearConsentForUser(userId: string | null): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Whether a server-recorded `accepted` version satisfies the `required` build
- * version. Monotonic (`>=`): a version at or newer than the build's constant is
- * current, so a build never treats a newer client's acceptance as stale. `""`
- * (never accepted) sorts below any real version and stays stale. Relies on the
+ * Whether a recorded `accepted` version satisfies the `required` version.
+ * Monotonic (`>=`): a version at or newer than the requirement is current, so
+ * a lagging requirement never treats a newer acceptance as stale. `""` (never
+ * accepted) sorts below any real version and stays stale. Relies on the
  * ISO-date version format (see the version constants above).
  */
 function versionIsCurrent(accepted: string, required: string): boolean {
@@ -215,7 +371,7 @@ export function resolveServerConsent(
   diagnosticsCurrent: boolean;
   /**
    * Raw version currency for each toggle — true only when the recorded
-   * accepted version is at/past the build's constant. Unlike the `*Current`
+   * accepted version is at/past the required version. Unlike the `*Current`
    * flags (which also read never-asked as "nothing to re-review"), these back
    * the genuine "confirmed under the current version" attestation that may be
    * device-persisted or backfilled to the server.
@@ -225,13 +381,15 @@ export function resolveServerConsent(
   hasServerRecord: boolean;
 } {
   if (!consent) {
+    // No server record to resolve — and no required-version information, so
+    // the module keeps whatever required versions it last adopted.
     return {
       tos: false,
       privacy: false,
       shareAnalytics: null,
       shareDiagnostics: null,
-      // No server record to resolve; opt-out semantics default to enabled,
-      // matching the fallback chain applied to an all-null record.
+      // Opt-out semantics default to enabled, matching the fallback chain
+      // applied to an all-null record.
       analyticsEffective: true,
       diagnosticsEffective: true,
       analyticsCurrent: false,
@@ -241,13 +399,20 @@ export function resolveServerConsent(
       hasServerRecord: false,
     };
   }
+  // The server is the source of truth for which versions are required: adopt
+  // its `required_versions` (per-key constants fallback for an older backend
+  // that omits the field) and remember them module-wide, so device-ack
+  // currency checks and PATCH version stamps agree with this resolution.
+  const required = toRequiredVersions(consent.required_versions);
+  requiredVersions = required;
+
   const analyticsVersionCurrent = versionIsCurrent(
     consent.share_analytics_accepted_version,
-    ANALYTICS_CONSENT_VERSION,
+    required.shareAnalytics,
   );
   const diagnosticsVersionCurrent = versionIsCurrent(
     consent.share_diagnostics_accepted_version,
-    DIAGNOSTICS_CONSENT_VERSION,
+    required.shareDiagnostics,
   );
   // The endpoint always returns an object; for a user with no stored row it
   // returns the API defaults (empty versions, null share booleans). Any
@@ -268,11 +433,17 @@ export function resolveServerConsent(
   return {
     // The ToS checkbox covers only the Terms of Service. The privacy checkbox
     // covers both the Privacy Policy and the AI Data Sharing Policy, so it is
-    // current only when BOTH versions are at or past the current version.
-    tos: versionIsCurrent(consent.tos_accepted_version, TOS_CONSENT_VERSION),
+    // current only when BOTH artifacts meet their own required versions.
+    tos: versionIsCurrent(consent.tos_accepted_version, required.tos),
     privacy:
-      versionIsCurrent(consent.privacy_policy_accepted_version, PRIVACY_CONSENT_VERSION) &&
-      versionIsCurrent(consent.ai_data_sharing_accepted_version, PRIVACY_CONSENT_VERSION),
+      versionIsCurrent(
+        consent.privacy_policy_accepted_version,
+        required.privacyPolicy,
+      ) &&
+      versionIsCurrent(
+        consent.ai_data_sharing_accepted_version,
+        required.aiDataSharing,
+      ),
     // Raw tri-state chosen-ness: null = never asked, boolean = explicit
     // choice. The platform stores explicit choices only, so the value can be
     // consumed verbatim.
@@ -307,6 +478,10 @@ export function resolveServerConsent(
  * per-user device keys, the diagnostics gate chokepoint, and the server
  * PATCH. `saveConsent` and `savePreferenceToggle` are thin argument-shapers
  * over it.
+ *
+ * Version stamps — device acks and PATCH bodies — use the module's required
+ * versions: server-supplied when the last `resolveServerConsent` saw a
+ * record, the frozen constants otherwise (offline, older backend).
  *
  * `legal` is present only for a consent-screen save; that acceptance is an
  * explicit review of the current terms, so currency and hydration are
@@ -372,25 +547,26 @@ function writeConsent(
     void patchConsent({
       ...(legal
         ? {
-            tos_accepted_version: legal.tos ? TOS_CONSENT_VERSION : "",
+            tos_accepted_version: legal.tos ? requiredVersions.tos : "",
             privacy_policy_accepted_version: legal.privacy
-              ? PRIVACY_CONSENT_VERSION
+              ? requiredVersions.privacyPolicy
               : "",
             ai_data_sharing_accepted_version: legal.privacy
-              ? PRIVACY_CONSENT_VERSION
+              ? requiredVersions.aiDataSharing
               : "",
           }
         : {}),
       ...(shareAnalytics !== undefined
         ? {
             share_analytics: shareAnalytics,
-            share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
+            share_analytics_accepted_version: requiredVersions.shareAnalytics,
           }
         : {}),
       ...(shareDiagnostics !== undefined
         ? {
             share_diagnostics: shareDiagnostics,
-            share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
+            share_diagnostics_accepted_version:
+              requiredVersions.shareDiagnostics,
           }
         : {}),
     }).catch(() => {});


### PR DESCRIPTION
## Summary
- `resolveServerConsent` adopts the server's read-only `required_versions` object for every currency comparison, falling back per-key to the frozen build constants when an older backend omits the field. The privacy checkbox keeps its dual check, now comparing `privacy_policy` and `ai_data_sharing` each against its own required version.
- Device consent acks (tos, privacy, share_diagnostics) move from version-in-the-KEY boolean keys (`device:consent:<field>:v<VERSION>:<userId>`) to unversioned per-user keys whose VALUE is the acknowledged version; currency becomes `storedAckVersion >= requiredVersion`. A one-time migration in `restoreConsentForUser` promotes the newest affirmative legacy key's version verbatim into the new key (an existing new-style key wins), then sweeps all legacy keys — stale analytics acks sweep through the same helper.
- `writeConsent` PATCH version stamps and device-ack stamps use the module's last-known required versions (server-supplied when the last resolve saw a record, constants otherwise). Public shapes of `saveConsent` / `savePreferenceToggle` / `persistToggleConsent` / `persistConsentForUser` are unchanged.
- Tests: server bump (required > stored ack) owes re-review, equal does not; per-artifact privacy requirement; per-key fallback inside a partial `required_versions`; PATCH + ack stamping of bumped versions; ack-key migration (promote, stale-version promoted verbatim, false never promoted, new key wins); the absent-field fallback path keeps all pre-existing currency tests passing unmodified.

This dissolves the frozen-constant skew class — a consent-version bump becomes a platform deploy, not a client release (the platform's write-side non-downgrade clamp stays as defense). Known residue, out of this PR's file scope: `auth-store`'s `buildDeviceConsentBackfill` still stamps the build constants; its device-attestation inputs now correctly read stale after a server bump, so it can only under-stamp, never over-attest — worth threading the resolved required versions through when the lib/consent move (PR 8) lands.

Part of plan: consent-cleanup.md (PR 9 of 10)