### PR TITLE
docs(web): drop the reference to a nonexistent macOS ProvidersSheet

### DIFF
--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -135,10 +135,9 @@ export function ManageProvidersModal({
   };
 
   // Single Modal.Root for both views (list + editor). Body content swaps
-  // based on `editorOpen` — this is the master/detail pattern, matching the
-  // macOS `ProvidersSheet` flow. View-aware `onOpenChange`: a close
-  // intent (X / ESC / backdrop) returns to the list when in editor view,
-  // and closes the whole modal when in list view.
+  // based on `editorOpen` — the master/detail pattern. View-aware
+  // `onOpenChange`: a close intent (X / ESC / backdrop) returns to the list
+  // when in editor view, and closes the whole modal when in list view.
   return (
     <Modal.Root
       open={isOpen}


### PR DESCRIPTION
## Summary
- The providers-modal comment claimed its master/detail pattern matches "the macOS `ProvidersSheet` flow" — no such component exists anywhere in the repo. The macOS app's Electron config states its renderer IS the clients/web Vite project, so the desktop app renders this exact modal.
- One-line comment fix so the next reader (or planner) doesn't go hunting for a parallel macOS surface — the connection-removal plan budgeted a whole mirror PR because of this reference.

## Original prompt
PR 12 (Milestone A) of the connection-removal plan (papertrail on #38102) was scoped as a macOS ProvidersSheet mirror of the merged web changes (#38172). Discovery showed the macOS client has no renderer of its own — it hosts clients/web — so the milestone's UI changes already apply on macOS and PR 12 reduces to deleting the misleading comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->