### PR TITLE
fix: tool-audit columns survive unknown consent

### DIFF
--- a/assistant/src/__tests__/tool-audit.test.ts
+++ b/assistant/src/__tests__/tool-audit.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Toggle for the share_analytics opt-out gate consulted when populating the
-// telemetry columns.
-let shareAnalytics = true;
+// Tri-state share_analytics consent consulted when populating the telemetry
+// columns: only a confirmed `false` NULLs them.
+let shareAnalytics: boolean | "unknown" = true;
 
 mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
+  getCachedShareAnalytics: () => shareAnalytics === true,
+  getRawShareAnalytics: () => shareAnalytics,
 }));
 
 // Capture the audit rows the terminals would insert, and the lifecycle-event
@@ -376,6 +377,61 @@ describe("tool audit terminals", () => {
       result: "error: boom",
       decision: "error",
       durationMs: 9,
+    });
+  });
+
+  test("populates telemetry columns under unknown consent (cold cache)", () => {
+    // NULL columns are permanently excluded by the projection's
+    // arg_bytes IS NOT NULL filter, so only a CONFIRMED opt-out may NULL
+    // them — unknown records, and flush-time consent gating decides later.
+    shareAnalytics = "unknown";
+
+    recordToolExecuted({
+      conversationId: "conv-unknown",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      resultContent: "ok",
+      resultBytes: 99,
+      decision: "allow",
+      riskLevel: "low",
+      durationMs: 12,
+      attribution: ATTRIBUTION,
+      wasPrompted: false,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      argBytes: Buffer.byteLength(JSON.stringify({ path: "/tmp/a" }), "utf8"),
+      resultBytes: 99,
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+  });
+
+  test("populates telemetry columns under confirmed opt-in", () => {
+    shareAnalytics = true;
+
+    recordToolExecuted({
+      conversationId: "conv-opt-in",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      resultContent: "ok",
+      resultBytes: 42,
+      decision: "allow",
+      riskLevel: "low",
+      durationMs: 5,
+      attribution: ATTRIBUTION,
+      wasPrompted: false,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      argBytes: Buffer.byteLength(JSON.stringify({ path: "/tmp/a" }), "utf8"),
+      resultBytes: 42,
+      provider: "anthropic",
+      model: "model-a",
     });
   });
 

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -38,7 +38,6 @@ import {
   getCachedShareDiagnostics,
   getCachedShareDiagnosticsVersion,
   getRawShareAnalytics,
-  getRawShareDiagnostics,
   refreshConsentCache,
   startConsentRefresh,
   stopConsentRefresh,
@@ -105,7 +104,7 @@ describe("consent-cache", () => {
       delete process.env.VELLUM_DISABLE_PLATFORM;
     }
     expect(getRawShareAnalytics()).toBe(false);
-    expect(getRawShareDiagnostics()).toBe(false);
+    expect(getCachedShareDiagnostics()).toBe(false);
     expect(getCachedShareDiagnosticsVersion()).toBe("");
   });
 
@@ -141,7 +140,7 @@ describe("consent-cache", () => {
     mockClient = makeClient(null);
     await refreshConsentCache();
     expect(getRawShareAnalytics()).toBe("unknown");
-    expect(getRawShareDiagnostics()).toBe("unknown");
+    expect(getCachedShareDiagnostics()).toBe(false);
   });
 
   test("a missing client demotes a prior opt-in to unknown (public accessor reads false)", async () => {
@@ -217,8 +216,7 @@ describe("consent-cache", () => {
 
   // share_diagnostics tracks the same refresh as share_analytics; Sentry's
   // beforeSend re-reads it per event so a revocation is honored within a cycle.
-  test("diagnostics boots unknown; public accessor reads false", () => {
-    expect(getRawShareDiagnostics()).toBe("unknown");
+  test("diagnostics reads false at boot (unknown collapses to false)", () => {
     expect(getCachedShareDiagnostics()).toBe(false);
   });
 
@@ -226,7 +224,6 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareDiagnostics: true }));
     await refreshConsentCache();
     expect(getCachedShareDiagnostics()).toBe(true);
-    expect(getRawShareDiagnostics()).toBe(true);
   });
 
   test("a later fetch reporting shareDiagnostics: false honors the revocation", async () => {
@@ -237,7 +234,6 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareDiagnostics: false }));
     await refreshConsentCache();
     expect(getCachedShareDiagnostics()).toBe(false);
-    expect(getRawShareDiagnostics()).toBe(false);
   });
 
   test("a null diagnostics fetch keeps the last known value", async () => {
@@ -250,19 +246,17 @@ describe("consent-cache", () => {
     expect(getCachedShareDiagnostics()).toBe(true);
   });
 
-  test("a missing client demotes a prior diagnostics opt-in to unknown (public accessor reads false)", async () => {
+  test("a missing client demotes a prior diagnostics opt-in (public accessor reads false)", async () => {
     __setCachedShareDiagnosticsForTest(true);
     mockClient = null;
     await refreshConsentCache();
-    expect(getRawShareDiagnostics()).toBe("unknown");
     expect(getCachedShareDiagnostics()).toBe(false);
   });
 
-  test("a client without a resolvable assistant identity demotes diagnostics to unknown", async () => {
+  test("a client without a resolvable assistant identity demotes diagnostics", async () => {
     __setCachedShareDiagnosticsForTest(true);
     mockClient = makeClient(makeConsent({ shareDiagnostics: true }), "");
     await refreshConsentCache();
-    expect(getRawShareDiagnostics()).toBe("unknown");
     expect(getCachedShareDiagnostics()).toBe(false);
   });
 
@@ -312,7 +306,7 @@ describe("consent-cache", () => {
     expect(getCachedShareDiagnosticsVersion()).toBe("2026-06-18");
   });
 
-  test("public accessors collapse unknown to false; raw accessors expose the tri-state", async () => {
+  test("public accessors collapse unknown to false; the raw analytics accessor exposes the tri-state", async () => {
     // Refresh once so the module's legacy opt-out marker reflects the
     // beforeEach config (the marker is only re-read during a refresh).
     mockClient = null;
@@ -324,15 +318,13 @@ describe("consent-cache", () => {
       expect(getCachedShareAnalytics()).toBe(state === true);
       expect(getCachedShareDiagnostics()).toBe(state === true);
       expect(getRawShareAnalytics()).toBe(state);
-      expect(getRawShareDiagnostics()).toBe(state);
     }
   });
 
-  test("legacy opt-out marker folds the raw analytics state to false (diagnostics unaffected)", async () => {
+  test("legacy opt-out marker folds the raw analytics state to false", async () => {
     setConfig("legacyTelemetryOptOut", true);
     mockClient = null;
     await refreshConsentCache();
     expect(getRawShareAnalytics()).toBe(false);
-    expect(getRawShareDiagnostics()).toBe("unknown");
   });
 });

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -21,9 +21,10 @@
  * confirmed state exists — boot before the first refresh, no platform session,
  * or no resolvable owner identity. A transient fetch failure keeps the
  * previous value so a known opt-in is not flipped mid-session. The boolean
- * accessors collapse `"unknown"` to `false` (fail-closed); the raw accessors
- * expose the tri-state for callers that must distinguish a confirmed opt-out
- * from a not-yet-known state.
+ * accessors collapse `"unknown"` to `false` (fail-closed); the raw analytics
+ * accessor exposes the tri-state for callers that must distinguish a confirmed
+ * opt-out from a not-yet-known state. Diagnostics gates are deliberately
+ * fail-closed, so no raw diagnostics accessor exists.
  */
 
 import { getConfigReadOnly } from "../config/loader.js";
@@ -89,14 +90,6 @@ export function getRawShareAnalytics(): ConsentState {
  */
 export function getCachedShareDiagnostics(): boolean {
   return cachedShareDiagnostics === true;
-}
-
-/**
- * Raw tri-state `share_diagnostics` consent, for callers that must
- * distinguish a confirmed opt-out from a not-yet-known state.
- */
-export function getRawShareDiagnostics(): ConsentState {
-  return cachedShareDiagnostics;
 }
 
 /**

--- a/assistant/src/telemetry/tool-audit.ts
+++ b/assistant/src/telemetry/tool-audit.ts
@@ -14,16 +14,19 @@
  *   - `logToolFailure` emits the operator-facing failure log.
  *
  * The telemetry-only columns (payload sizes + model attribution) are the
- * single write-time privacy gate for `tool_executed` telemetry: when usage
- * data collection is disabled they persist as NULL, which the projection's
- * `arg_bytes IS NOT NULL` filter excludes permanently. The audit fields
+ * single write-time privacy gate for `tool_executed` telemetry: on a confirmed
+ * `share_analytics` opt-out they persist as NULL, which the projection's
+ * `arg_bytes IS NOT NULL` filter excludes permanently. An unknown consent
+ * state (cold cache) populates the columns — NULLing them would destroy the
+ * data irreversibly, and consent is enforced again at flush time and platform
+ * ingest, so opted-out rows never leave the device. The audit fields
  * themselves (tool name, decision, redacted input/result previews, duration)
  * are unaffected — `tool_invocations` is a local always-on audit log.
  */
 
 import { isAllowDecision, type UserDecision } from "../permissions/types.js";
 import { recordLifecycleEvent } from "../persistence/lifecycle-events-store.js";
-import { getCachedShareAnalytics } from "../platform/consent-cache.js";
+import { getRawShareAnalytics } from "../platform/consent-cache.js";
 import { redactJsonStringLeaves } from "../security/redact-json.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import { redactSecrets } from "../security/secret-scanner.js";
@@ -257,17 +260,20 @@ const NULL_TELEMETRY_COLUMNS: TelemetryColumns = {
 };
 
 /**
- * Telemetry-only columns (payload sizes + model attribution). When usage data
- * collection is disabled the columns persist as NULL, which the projection's
- * `arg_bytes IS NOT NULL` filter excludes permanently — the same mechanism
- * that excludes legacy pre-migration rows (see tool-executed-events-store.ts).
+ * Telemetry-only columns (payload sizes + model attribution). NULLed only on a
+ * confirmed `share_analytics` opt-out — the projection's `arg_bytes IS NOT
+ * NULL` filter excludes NULL rows permanently (the same mechanism that
+ * excludes legacy pre-migration rows, see tool-executed-events-store.ts), so
+ * an unknown consent state (cold cache) must populate the columns rather than
+ * destroy them. Consent is enforced again at flush time and platform ingest,
+ * so opted-out rows never ship.
  */
 function telemetryColumns(
   attribution: UsageAttributionSnapshot | null,
   rawInput: string,
   resultBytes: number,
 ): TelemetryColumns {
-  if (!getCachedShareAnalytics()) {
+  if (getRawShareAnalytics() === false) {
     return NULL_TELEMETRY_COLUMNS;
   }
   return {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for consent-cleanup.md.

**Gap:** tool-audit write-time gate destroyed telemetry columns under unknown consent (cold-cache class); getRawShareDiagnostics had no consumers.
**What was expected:** record-time gates drop only on known explicit opt-out; no dead exports.
**What was found:** telemetryColumns() used the fail-closed accessor; NULL columns are permanently unreportable.