### PR TITLE
fix: backfill stamps adopted required versions

### DIFF
--- a/clients/web/src/lib/consent/consent-persistence.ts
+++ b/clients/web/src/lib/consent/consent-persistence.ts
@@ -70,7 +70,7 @@ const LEGACY_AI_PRIVACY_CONSENT_VERSION = "2026-06-08";
 // Required versions — server-supplied, constants as fallback
 // ---------------------------------------------------------------------------
 
-interface RequiredConsentVersions {
+export interface RequiredConsentVersions {
   tos: string;
   privacyPolicy: string;
   aiDataSharing: string;
@@ -107,6 +107,15 @@ function toRequiredVersions(
     shareAnalytics: raw?.share_analytics || ANALYTICS_CONSENT_VERSION,
     shareDiagnostics: raw?.share_diagnostics || DIAGNOSTICS_CONSENT_VERSION,
   };
+}
+
+/**
+ * The module's current required versions (server-adopted, constants
+ * fallback), for callers stamping server-bound consent versions outside this
+ * module — e.g. the device-consent backfill.
+ */
+export function getRequiredConsentVersions(): RequiredConsentVersions {
+  return { ...requiredVersions };
 }
 
 /** Test-only: restore the constants-fallback required versions. */

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -94,6 +94,19 @@ const resolveServerConsentMock = mock(
   }),
 );
 
+// Adopted-or-fallback required versions served by the mocked accessor; the
+// backfill stamps from these. Defaults mirror the frozen constants; tests
+// override to simulate a server-side required_versions bump.
+const DEFAULT_REQUIRED_VERSIONS = {
+  tos: "2026-06-08",
+  privacyPolicy: "2026-06-08",
+  aiDataSharing: "2026-06-08",
+  shareAnalytics: "2026-06-08",
+  shareDiagnostics: "2026-06-08",
+};
+let mockRequiredVersions = { ...DEFAULT_REQUIRED_VERSIONS };
+const getRequiredConsentVersionsMock = mock(() => mockRequiredVersions);
+
 const EMPTY_CONSENT = {
   tos_accepted_version: "",
   tos_accepted_at: null,
@@ -225,6 +238,7 @@ mock.module("@/lib/consent/consent-persistence", () => ({
   persistConsentForUser: persistConsentForUserMock,
   persistToggleConsent: persistToggleConsentMock,
   resolveServerConsent: resolveServerConsentMock,
+  getRequiredConsentVersions: getRequiredConsentVersionsMock,
   TOS_CONSENT_VERSION: "2026-06-08",
   PRIVACY_CONSENT_VERSION: "2026-06-08",
   ANALYTICS_CONSENT_VERSION: "2026-06-08",
@@ -371,6 +385,8 @@ beforeEach(() => {
   persistConsentForUserMock.mockClear();
   persistToggleConsentMock.mockClear();
   resolveServerConsentMock.mockClear();
+  mockRequiredVersions = { ...DEFAULT_REQUIRED_VERSIONS };
+  getRequiredConsentVersionsMock.mockClear();
   setTosAcceptedMock.mockClear();
   setPrivacyConsentMock.mockClear();
   setAnalyticsConsentCurrentMock.mockClear();
@@ -849,6 +865,39 @@ describe("auth store onboarding flag reconciliation", () => {
       expect.objectContaining({
         share_analytics_accepted_version: "2026-06-08",
         share_analytics: false,
+      }),
+    );
+  });
+
+  test("backfill stamps the server-adopted required versions, not the frozen constants", async () => {
+    // The server bumped required_versions past the build constants. The sync
+    // flow adopts them (via resolveServerConsent) before the backfill runs,
+    // so the backfill must stamp the adopted versions — frozen-constant
+    // stamps would write a stale server row and re-prompt every other device.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockRequiredVersions = {
+      tos: "2026-09-01",
+      privacyPolicy: "2026-09-02",
+      aiDataSharing: "2026-09-03",
+      shareAnalytics: "2026-09-04",
+      shareDiagnostics: "2026-09-05",
+    };
+    mockStoreShareAnalytics = false;
+    restoreConsentForUserMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      diagnosticsCurrent: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(patchConsentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tos_accepted_version: "2026-09-01",
+        privacy_policy_accepted_version: "2026-09-02",
+        ai_data_sharing_accepted_version: "2026-09-03",
+        share_analytics_accepted_version: "2026-09-04",
+        share_diagnostics_accepted_version: "2026-09-05",
       }),
     );
   });

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -66,10 +66,7 @@ import {
   persistConsentForUser,
   persistToggleConsent,
   resolveServerConsent,
-  TOS_CONSENT_VERSION,
-  PRIVACY_CONSENT_VERSION,
-  ANALYTICS_CONSENT_VERSION,
-  DIAGNOSTICS_CONSENT_VERSION,
+  getRequiredConsentVersions,
 } from "@/lib/consent/consent-persistence";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import {
@@ -296,23 +293,27 @@ function buildDeviceConsentBackfill(axes: {
   diagnostics: boolean;
   shareValues?: { analytics: boolean | null; diagnostics: boolean | null };
 }): ConsentPatch {
+  // Stamps come from the adopted required versions (server-supplied when the
+  // preceding resolveServerConsent saw them, frozen constants otherwise) so a
+  // server-side version bump is never backfilled with a stale stamp.
+  const required = getRequiredConsentVersions();
   return {
-    ...(axes.tos ? { tos_accepted_version: TOS_CONSENT_VERSION } : {}),
+    ...(axes.tos ? { tos_accepted_version: required.tos } : {}),
     ...(axes.privacy
       ? {
-          privacy_policy_accepted_version: PRIVACY_CONSENT_VERSION,
-          ai_data_sharing_accepted_version: PRIVACY_CONSENT_VERSION,
+          privacy_policy_accepted_version: required.privacyPolicy,
+          ai_data_sharing_accepted_version: required.aiDataSharing,
         }
       : {}),
     ...(axes.shareValues && axes.shareValues.analytics !== null
       ? {
           share_analytics: axes.shareValues.analytics,
-          share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
+          share_analytics_accepted_version: required.shareAnalytics,
         }
       : {}),
     ...(axes.diagnostics
       ? {
-          share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
+          share_diagnostics_accepted_version: required.shareDiagnostics,
           ...(axes.shareValues && axes.shareValues.diagnostics !== null
             ? { share_diagnostics: axes.shareValues.diagnostics }
             : {}),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for consent-cleanup.md (Codex P2 on #38240 left unaddressed).

**Gap:** buildDeviceConsentBackfill stamps frozen version constants while acks validate against server-adopted required_versions.
**What was expected:** all server-bound version stamps derive from adopted required_versions with constants as fallback.
**What was found:** a server bump + device backfill re-sends old frozen versions — cross-device re-prompt loop.