### PR TITLE
fix: privacy page uses the consent store; API trims

### DIFF
--- a/clients/web/.cross-domain-allowlist.json
+++ b/clients/web/.cross-domain-allowlist.json
@@ -28,5 +28,8 @@
   ],
   "src/domains/home/hooks/use-home-schedules-data.ts": [
     "settings"
+  ],
+  "src/domains/settings/pages/privacy-page.tsx": [
+    "onboarding"
   ]
 }

--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -9,9 +9,9 @@
  * onboarding-only keys that don't fit the boolean store shape
  * (`onboarding.selectedVersion`, `onboarding.lastUserId`).
  *
- * Storage keys are documented in `onboarding-store.ts`. The privacy
- * settings page and the Sentry consent gate read `device:share_*`
- * directly — that contract is preserved by the per-key adapter.
+ * Storage keys are documented in `onboarding-store.ts`. The Sentry consent
+ * gate reads `device:share_*` directly — that contract is preserved by the
+ * per-key adapter.
  */
 import { useCallback } from "react";
 

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -3,6 +3,10 @@ import { useState } from "react";
 import { DetailCard } from "@/components/detail-card";
 import { SettingRow } from "@/components/setting-row";
 import { SystemPermissionsCard } from "@/components/system-permissions-card";
+import {
+    useShareAnalytics,
+    useShareDiagnostics,
+} from "@/domains/onboarding/prefs";
 import { AccessConsentSetting } from "@/domains/settings/components/access-consent-setting";
 import { BiometricSettingsCard } from "@/domains/settings/components/biometric-settings-card";
 import { MediaEmbedsCard } from "@/domains/settings/components/media-embeds-card";
@@ -14,7 +18,6 @@ import {
   useHasConfirmedPlatformSession,
 } from "@/stores/auth-store";
 import {
-    getDeviceBool,
     getDeviceSetting,
     setDeviceSetting,
 } from "@/utils/device-settings";
@@ -52,26 +55,29 @@ export function PrivacyPage() {
   const hasPlatformSession = useHasConfirmedPlatformSession();
   const showShareConsent = hasPlatformSession;
   const userId = useAuthStore.use.user()?.id ?? null;
-  const [shareAnalytics, setShareAnalytics] = useState(
-    () => getDeviceBool("shareAnalytics", true),
-  );
-  const [shareDiagnostics, setShareDiagnostics] = useState(
-    () => getDeviceBool("shareDiagnostics", true),
-  );
+  // Never-asked (null) displays as on: both toggles are opt-out. The store
+  // setters inside `savePreferenceToggle` keep these reactive, so server
+  // syncs and cross-tab writes update the rows in place.
+  const [shareAnalytics] = useShareAnalytics();
+  const [shareDiagnostics] = useShareDiagnostics();
+  const shareAnalyticsChecked = shareAnalytics ?? true;
+  const shareDiagnosticsChecked = shareDiagnostics ?? true;
   const [retentionId, setRetentionId] = useState(() =>
     getDeviceSetting("llmLogRetention", DEFAULT_RETENTION_ID),
   );
 
   const handleAnalyticsToggle = () => {
-    const next = !shareAnalytics;
-    setShareAnalytics(next);
-    savePreferenceToggle("share_analytics", next, { userId, hasPlatformSession });
+    savePreferenceToggle("share_analytics", !shareAnalyticsChecked, {
+      userId,
+      hasPlatformSession,
+    });
   };
 
   const handleDiagnosticsToggle = () => {
-    const next = !shareDiagnostics;
-    setShareDiagnostics(next);
-    savePreferenceToggle("share_diagnostics", next, { userId, hasPlatformSession });
+    savePreferenceToggle("share_diagnostics", !shareDiagnosticsChecked, {
+      userId,
+      hasPlatformSession,
+    });
   };
 
   const handleRetentionChange = (value: string) => {
@@ -111,7 +117,7 @@ export function PrivacyPage() {
               <SettingRow
                 label="Share Analytics"
                 helperText="Send aggregated product usage data"
-                checked={shareAnalytics}
+                checked={shareAnalyticsChecked}
                 onChange={handleAnalyticsToggle}
                 variant="toggle-trailing"
               />
@@ -119,7 +125,7 @@ export function PrivacyPage() {
               <SettingRow
                 label="Share Diagnostics"
                 helperText="Send crash reports, conversation traces, and session replay data"
-                checked={shareDiagnostics}
+                checked={shareDiagnosticsChecked}
                 onChange={handleDiagnosticsToggle}
                 variant="toggle-trailing"
               />

--- a/clients/web/src/lib/consent/consent-persistence.test.ts
+++ b/clients/web/src/lib/consent/consent-persistence.test.ts
@@ -60,7 +60,7 @@ import {
   DIAGNOSTICS_CONSENT_VERSION,
   __resetRequiredConsentVersionsForTesting,
   clearConsentForUser,
-  persistToggleConsent,
+  persistDiagnosticsAck,
   resolveServerConsent,
   restoreConsentForUser,
   saveConsent,
@@ -540,9 +540,9 @@ describe("resolveServerConsent", () => {
   });
 });
 
-describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
+describe("persistDiagnosticsAck + restoreConsentForUser round-trip", () => {
   test("round-trips the diagnostics ack key (value = acknowledged version)", () => {
-    persistToggleConsent("user-1", { diagnosticsCurrent: true });
+    persistDiagnosticsAck("user-1");
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe(
       DIAGNOSTICS_CONSENT_VERSION,
     );
@@ -550,15 +550,14 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     expect(r.diagnosticsCurrent).toBe(true);
   });
 
-  test("writes nothing when no ack is provided", () => {
-    persistToggleConsent("user-1", {});
+  test("restore reads false while no ack has been stamped", () => {
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
     const r = restoreConsentForUser("user-1");
     expect(r.diagnosticsCurrent).toBe(false);
   });
 
   test("no-ops without a userId", () => {
-    persistToggleConsent(null, { diagnosticsCurrent: true });
+    persistDiagnosticsAck(null);
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
   });
 
@@ -973,7 +972,7 @@ describe("savePreferenceToggle", () => {
 
 describe("clearConsentForUser", () => {
   test("clears the ack keys, legacy versioned keys, and stale analytics ack keys", () => {
-    persistToggleConsent("user-1", { diagnosticsCurrent: true });
+    persistDiagnosticsAck("user-1");
     localStorage.setItem(tosAckKey("user-1"), TOS_CONSENT_VERSION);
     localStorage.setItem(
       privacyPolicyAckKey("user-1"),

--- a/clients/web/src/lib/consent/consent-persistence.ts
+++ b/clients/web/src/lib/consent/consent-persistence.ts
@@ -30,7 +30,7 @@
  * - `savePreferenceToggle` — single-field write for settings page toggles
  * - `restoreConsentForUser` — read device keys, return {tos, privacy, diagnostics ack}
  * - `persistConsentForUser` — write tos/privacy device keys
- * - `persistToggleConsent`  — write the diagnostics ack key
+ * - `persistDiagnosticsAck` — stamp the diagnostics ack key
  * - `clearConsentForUser`   — delete device keys + legacy active keys
  */
 import {
@@ -317,22 +317,19 @@ export function persistConsentForUser(
   }
 }
 
-export function persistToggleConsent(
-  userId: string | null,
-  acks: { diagnosticsCurrent?: boolean },
-): void {
+/**
+ * Stamp the diagnostics ack key at the required version. Removal is owned by
+ * `clearConsentForUser`.
+ */
+export function persistDiagnosticsAck(userId: string | null): void {
   if (typeof window === "undefined" || !userId) {
     return;
   }
   try {
-    if (acks.diagnosticsCurrent === true) {
-      setLocalSetting(
-        consentAckKey("share_diagnostics", userId),
-        requiredAckVersion("share_diagnostics"),
-      );
-    } else if (acks.diagnosticsCurrent === false) {
-      removeLocalSetting(consentAckKey("share_diagnostics", userId));
-    }
+    setLocalSetting(
+      consentAckKey("share_diagnostics", userId),
+      requiredAckVersion("share_diagnostics"),
+    );
   } catch {
     // Storage unavailable.
   }
@@ -470,9 +467,13 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
     // The platform computes effective consent in one place (null = enabled,
-    // opt-out) and serves it as `share_*_effective`. The fields are required
-    // in the current schema, but an older backend omits them — fall back to
-    // the raw value's opt-out reading so behavior is unchanged there.
+    // opt-out) and serves it as `share_*_effective`; an older backend omits
+    // the fields, so fall back to the raw value's opt-out reading. These are
+    // the server-authoritative gate inputs that the fallback-deletion PR
+    // (plan PR 10) switches the data-capture gates to once platform deploys
+    // are confirmed; until then the store-based explicit-opt-out gates are
+    // behaviorally identical (effective differs from raw only when raw is
+    // null, which the gates read as enabled).
     analyticsEffective:
       consent.share_analytics_effective ?? consent.share_analytics ?? true,
     diagnosticsEffective:
@@ -563,7 +564,7 @@ function writeConsent(
   // earned by a consent-screen review, or by a toggle change made with a live
   // session to record it against. Analytics has no device ack.
   if (shareDiagnostics !== undefined && (legal || opts.hasPlatformSession)) {
-    persistToggleConsent(opts.userId, { diagnosticsCurrent: true });
+    persistDiagnosticsAck(opts.userId);
   }
 
   if (opts.hasPlatformSession) {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -61,9 +61,7 @@ const restoreConsentForUserMock = mock(
 const persistConsentForUserMock = mock(
   (_userId: string | null, _tos: boolean, _privacy: boolean) => {},
 );
-const persistToggleConsentMock = mock(
-  (_userId: string | null, _acks: { diagnosticsCurrent?: boolean }) => {},
-);
+const persistDiagnosticsAckMock = mock((_userId: string | null) => {});
 const resolveServerConsentMock = mock(
   (
     _consent: unknown,
@@ -223,7 +221,7 @@ mock.module("@/domains/account/profile", () => ({
 mock.module("@/lib/consent/consent-persistence", () => ({
   restoreConsentForUser: restoreConsentForUserMock,
   persistConsentForUser: persistConsentForUserMock,
-  persistToggleConsent: persistToggleConsentMock,
+  persistDiagnosticsAck: persistDiagnosticsAckMock,
   resolveServerConsent: resolveServerConsentMock,
   TOS_CONSENT_VERSION: "2026-06-08",
   PRIVACY_CONSENT_VERSION: "2026-06-08",
@@ -369,7 +367,7 @@ beforeEach(() => {
   refreshRemoteGatewaySessionMock.mockClear();
   restoreConsentForUserMock.mockClear();
   persistConsentForUserMock.mockClear();
-  persistToggleConsentMock.mockClear();
+  persistDiagnosticsAckMock.mockClear();
   resolveServerConsentMock.mockClear();
   setTosAcceptedMock.mockClear();
   setPrivacyConsentMock.mockClear();
@@ -587,9 +585,7 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
     expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
     // Only diagnostics carries a device ack — analytics has none.
-    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
-      diagnosticsCurrent: true,
-    });
+    expect(persistDiagnosticsAckMock).toHaveBeenCalledWith("user-1");
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
@@ -616,9 +612,7 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
     // ...but no versioned ack either: only an explicit choice may attest a
     // confirmation that could later backfill a server version stamp.
-    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
-      diagnosticsCurrent: true,
-    });
+    expect(persistDiagnosticsAckMock).toHaveBeenCalledWith("user-1");
     // Never-asked propagates: the store adopts null so tri-state chosen-ness
     // mirrors the server.
     expect(setShareAnalyticsMock).toHaveBeenCalledWith(null);
@@ -696,7 +690,7 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
     // ...but no versioned ack either: only an explicit choice may attest a
     // confirmation that could later backfill a server version stamp.
-    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {});
+    expect(persistDiagnosticsAckMock).not.toHaveBeenCalled();
     // A null server value never overwrites the device-local preference.
     expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
   });
@@ -746,7 +740,7 @@ describe("auth store onboarding flag reconciliation", () => {
     expect("share_analytics_accepted_version" in body).toBe(false);
     expect("share_diagnostics_accepted_version" in body).toBe(false);
     // No ack keys are written for never-asked toggles.
-    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {});
+    expect(persistDiagnosticsAckMock).not.toHaveBeenCalled();
   });
 
   test("no-record fallback without an analytics device ack stays current and backfills without analytics", async () => {
@@ -768,9 +762,7 @@ describe("auth store onboarding flag reconciliation", () => {
     expect("share_analytics" in body).toBe(false);
     expect("share_analytics_accepted_version" in body).toBe(false);
     expect(body.share_diagnostics_accepted_version).toEqual(expect.any(String));
-    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
-      diagnosticsCurrent: true,
-    });
+    expect(persistDiagnosticsAckMock).toHaveBeenCalledWith("user-1");
   });
 
   test("initSession falls through to device keys when server versions are empty", async () => {
@@ -800,9 +792,7 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
     // Acks are persisted from the device-restored values, not the empty
     // server values — otherwise the fallback would clobber its own input.
-    expect(persistToggleConsentMock).toHaveBeenLastCalledWith("user-1", {
-      diagnosticsCurrent: true,
-    });
+    expect(persistDiagnosticsAckMock).toHaveBeenLastCalledWith("user-1");
     // Legal consent is persisted with the restored (true) values, after the
     // fallback — never the empty server values that would erase device acks.
     expect(persistConsentForUserMock).toHaveBeenLastCalledWith(

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -64,7 +64,7 @@ import {
 import {
   restoreConsentForUser,
   persistConsentForUser,
-  persistToggleConsent,
+  persistDiagnosticsAck,
   resolveServerConsent,
   TOS_CONSENT_VERSION,
   PRIVACY_CONSENT_VERSION,
@@ -453,9 +453,9 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // A false toggle ack is never written: absent ≡ false for every
       // reader, and writing false would erase a genuine device attestation
       // whose backfill patch simply hasn't landed on the server yet.
-      persistToggleConsent(nextUserId, {
-        ...(diagnosticsAck ? { diagnosticsCurrent: true } : {}),
-      });
+      if (diagnosticsAck) {
+        persistDiagnosticsAck(nextUserId);
+      }
       syncOrganizationState(nextUserId);
       store.setConsentHydrated(true);
       return;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for consent-cleanup.md.

**Gap:** settings privacy page was the last direct device-key reader (missed cross-tab/server updates); persistToggleConsent kept a dead one-field options shape; the effective-fields PR-10 seam was undocumented.
**What was expected:** store is the single in-memory source; no vestigial API shapes.
**What was found:** one-shot getDeviceBool useState seeds; unreachable removal branch.

Note: privacy-page now imports the share hooks from `@/domains/onboarding/prefs` (settings→onboarding); the cross-domain allowlist was regenerated via `bun run audit:cross-domain` (not hand-edited). Lifting the consent hooks to a shared dir is a candidate follow-up for the arc.