### PR TITLE
fix: age-bound outbox buffering under unknown consent

### DIFF
--- a/assistant/src/telemetry/AGENTS.md
+++ b/assistant/src/telemetry/AGENTS.md
@@ -28,7 +28,7 @@ recordTelemetryEvent(
 );
 ```
 
-`recordTelemetryEvent` stamps the base fields (`type`, `daemon_event_id`, `recorded_at`, `assistant_version`) and gates on consent — dropping only on a confirmed `share_analytics` opt-out; an unknown consent state (cold cache) records, because consent is enforced again at flush time and a record-time drop would destroy the event permanently. The `fields` argument is typed as everything except the base fields.
+`recordTelemetryEvent` stamps the base fields (`type`, `daemon_event_id`, `recorded_at`, `assistant_version`) and gates on consent — dropping only on a confirmed `share_analytics` opt-out; an unknown consent state (cold cache) records, because consent is enforced again at flush time and a record-time drop would destroy the event permanently. Unknown-state buffering is bounded: the reporter prunes outbox rows older than `OUTBOX_MAX_ROW_AGE_MS` (30 days) at the start of every flush cycle, in every consent state, so a permanently-unknown state cannot grow the outbox forever. The `fields` argument is typed as everything except the base fields.
 
 Manual edits in this directory are needed **only** to override a default:
 

--- a/assistant/src/telemetry/telemetry-events-outbox.test.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./__tests__/outbox-test-harness.js";
 import {
   deleteTelemetryOutboxEvents,
+  deleteTelemetryOutboxEventsBefore,
   discardPendingTelemetryOutboxEvents,
   insertTelemetryOutboxEvent,
   insertTelemetryOutboxEvents,
@@ -326,6 +327,37 @@ describe("telemetry-events-outbox", () => {
       ).toBeNull();
     });
     expect(queryTelemetryOutboxBatch("watchdog", 10)).toEqual([]);
+  });
+
+  test("prune deletes rows strictly older than the cutoff across every name and returns the count", () => {
+    insert("evt-old-life", 1000, "lifecycle");
+    insert("evt-old-watch", 1500, "watchdog");
+    insert("evt-at-cutoff", 2000, "lifecycle");
+    insert("evt-fresh", 3000, "lifecycle");
+
+    expect(deleteTelemetryOutboxEventsBefore(2000)).toBe(2);
+
+    // Strictly-before semantics: the row AT the cutoff is retained.
+    expect(allIds()).toEqual(["evt-at-cutoff", "evt-fresh"]);
+    expect(queryTelemetryOutboxBatch("watchdog", 10)).toEqual([]);
+  });
+
+  test("prune with nothing expired deletes nothing and returns 0", () => {
+    insert("evt-1", 5000);
+
+    expect(deleteTelemetryOutboxEventsBefore(5000)).toBe(0);
+
+    expect(allIds()).toEqual(["evt-1"]);
+  });
+
+  test("prune returns 0 when the telemetry DB is unavailable", () => {
+    insert("evt-1", 1000);
+
+    withTelemetryDbUnavailable(() => {
+      expect(deleteTelemetryOutboxEventsBefore(2000)).toBe(0);
+    });
+
+    expect(allIds()).toEqual(["evt-1"]);
   });
 
   test("discards all pending rows for one name only", () => {

--- a/assistant/src/telemetry/telemetry-events-outbox.ts
+++ b/assistant/src/telemetry/telemetry-events-outbox.ts
@@ -9,7 +9,7 @@
 import { asc, eq, inArray } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getTelemetryDb } from "../persistence/db-connection.js";
+import { getSqliteFrom, getTelemetryDb } from "../persistence/db-connection.js";
 import { telemetryEvents } from "../persistence/schema/index.js";
 import { getRawShareAnalytics } from "../platform/consent-cache.js";
 import { APP_VERSION } from "../version.js";
@@ -22,6 +22,14 @@ import type {
 
 /** Ids per DELETE chunk — stays under SQLite's bound-variable limit. */
 const DELETE_CHUNK_SIZE = 500;
+
+/**
+ * Max age of a pending outbox row. The reporter prunes older rows at the
+ * start of every flush cycle, in every consent state — this is what bounds
+ * the unknown-consent buffering (a permanently-unknown state never resolves,
+ * and a row this stale is worthless telemetry anyway).
+ */
+export const OUTBOX_MAX_ROW_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
 /** One pending outbox row; `payload` is the wire `TelemetryEvent` JSON. */
 export interface TelemetryOutboxRow {
@@ -86,7 +94,9 @@ export function insertTelemetryOutboxEvent(
  * `share_analytics` opt-out — the record-time drop is a privacy courtesy for
  * known opt-outs. While consent is unknown (cold cache, no platform session)
  * the event is recorded: dropping on an unresolved state would permanently
- * destroy data, and consent is enforced again at flush time. Generates the
+ * destroy data, and consent is enforced again at flush time. Unknown-state
+ * buffering is bounded — the reporter prunes rows older than
+ * {@link OUTBOX_MAX_ROW_AGE_MS} each flush cycle. Generates the
  * outbox row identity, builds the wire payload via `buildEvent` (which owns
  * all stamping), and inserts. Returns the generated row identity, or null
  * when dropped for the opt-out or when the telemetry DB is unavailable
@@ -178,6 +188,25 @@ export function deleteTelemetryOutboxEvents(ids: string[]): void {
       .where(inArray(telemetryEvents.id, ids.slice(i, i + DELETE_CHUNK_SIZE)))
       .run();
   }
+}
+
+/**
+ * Delete rows recorded before `cutoffCreatedAt`, across every event name
+ * (age-bound prune). Returns the deleted row count; 0 when the telemetry DB
+ * is unavailable.
+ */
+export function deleteTelemetryOutboxEventsBefore(
+  cutoffCreatedAt: number,
+): number {
+  const db = getTelemetryDb();
+  if (!db) {
+    return 0;
+  }
+  // Raw statement: drizzle's bun-sqlite `.run()` is typed void, and the
+  // prune's only output is the changed-row count.
+  return getSqliteFrom(db)
+    .prepare("DELETE FROM telemetry_events WHERE created_at < ?")
+    .run(cutoffCreatedAt).changes;
 }
 
 /** Drop all pending rows for one event name (telemetry opt-out). */

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -221,6 +221,7 @@ import {
 } from "./telemetry-event-sources.js";
 import {
   insertTelemetryOutboxEvent,
+  OUTBOX_MAX_ROW_AGE_MS,
   queryTelemetryOutboxBatch,
 } from "./telemetry-events-outbox.js";
 import type { OutboxTelemetryEventName, TelemetryEvent } from "./types.js";
@@ -2006,7 +2007,8 @@ describe("UsageTelemetryReporter", () => {
     insertTelemetryOutboxEvent({
       id: "row-activation-old",
       name: "onboarding",
-      createdAt: 1700000100000,
+      // Row age drives the flush-cycle prune; only the payload is frozen-old.
+      createdAt: Date.now(),
       event: frozen,
     });
     mockFetch.mockImplementation(() =>
@@ -2996,6 +2998,10 @@ describe("UsageTelemetryReporter", () => {
   // shipped event type.
   const OUTBOX_NAME = "test_outbox" as OutboxTelemetryEventName;
 
+  // Recent base for row timestamps: the flush cycle prunes outbox rows older
+  // than OUTBOX_MAX_ROW_AGE_MS, so rows that must ship are seeded fresh.
+  const OUTBOX_BASE = Date.now() - 60_000;
+
   function seedOutboxRow(id: string, createdAt: number): void {
     insertTelemetryOutboxEvent({
       id,
@@ -3010,8 +3016,8 @@ describe("UsageTelemetryReporter", () => {
   }
 
   test("outboxSource ships pending rows and deletes them after a 2xx", async () => {
-    seedOutboxRow("ob-1", 1700000001000);
-    seedOutboxRow("ob-2", 1700000002000);
+    seedOutboxRow("ob-1", OUTBOX_BASE + 1000);
+    seedOutboxRow("ob-2", OUTBOX_BASE + 2000);
     const reporter = new UsageTelemetryReporter(
       [outboxSource(OUTBOX_NAME)],
       fakeFlushCheckpointStore,
@@ -3034,7 +3040,7 @@ describe("UsageTelemetryReporter", () => {
     mockFetch.mockImplementation(() =>
       Promise.resolve(new Response("error", { status: 500 })),
     );
-    seedOutboxRow("ob-1", 1700000001000);
+    seedOutboxRow("ob-1", OUTBOX_BASE + 1000);
     const reporter = new UsageTelemetryReporter(
       [outboxSource(OUTBOX_NAME)],
       fakeFlushCheckpointStore,
@@ -3047,8 +3053,8 @@ describe("UsageTelemetryReporter", () => {
 
   test("outboxSource opt-out discards all pending rows for the name", async () => {
     mockGetRawShareAnalytics.mockReturnValue(false);
-    seedOutboxRow("ob-1", 1700000001000);
-    seedOutboxRow("ob-2", 1700000002000);
+    seedOutboxRow("ob-1", OUTBOX_BASE + 1000);
+    seedOutboxRow("ob-2", OUTBOX_BASE + 2000);
     const reporter = new UsageTelemetryReporter(
       [outboxSource(OUTBOX_NAME)],
       fakeFlushCheckpointStore,
@@ -3062,8 +3068,8 @@ describe("UsageTelemetryReporter", () => {
 
   test("outboxSource unknown consent retains all pending rows", async () => {
     mockGetRawShareAnalytics.mockReturnValue("unknown");
-    seedOutboxRow("ob-1", 1700000001000);
-    seedOutboxRow("ob-2", 1700000002000);
+    seedOutboxRow("ob-1", OUTBOX_BASE + 1000);
+    seedOutboxRow("ob-2", OUTBOX_BASE + 2000);
     const reporter = new UsageTelemetryReporter(
       [outboxSource(OUTBOX_NAME)],
       fakeFlushCheckpointStore,
@@ -3075,6 +3081,76 @@ describe("UsageTelemetryReporter", () => {
     expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
   });
 
+  // -------------------------------------------------------------------------
+  // Flush-cycle age prune (bounds unknown-consent buffering)
+  // -------------------------------------------------------------------------
+
+  function seedExpiredAndFreshRows(): void {
+    seedOutboxRow("ob-expired", Date.now() - OUTBOX_MAX_ROW_AGE_MS - 60_000);
+    seedOutboxRow("ob-fresh", OUTBOX_BASE);
+  }
+
+  test("opted in: expired rows are pruned rather than shipped; fresh rows ship", async () => {
+    seedExpiredAndFreshRows();
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["wire-ob-fresh"]);
+    expect(pendingOutboxIds()).toEqual([]);
+  });
+
+  test("unknown consent: expired rows are pruned before the deferral; fresh rows are retained", async () => {
+    mockGetRawShareAnalytics.mockReturnValue("unknown");
+    seedExpiredAndFreshRows();
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    // The unknown-defer branch still sends and acks nothing, but the age
+    // prune has already bounded the backlog — a permanently-unknown state
+    // cannot accumulate rows forever.
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(pendingOutboxIds()).toEqual(["ob-fresh"]);
+    expect(mockSetFlushCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("expired rows are pruned even when the flush skips for platform-disabled", async () => {
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    seedExpiredAndFreshRows();
+    const reporter = new UsageTelemetryReporter(
+      [outboxSource(OUTBOX_NAME)],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(pendingOutboxIds()).toEqual(["ob-fresh"]);
+  });
+
+  test("a reporter without ack-mode sources never prunes the outbox", async () => {
+    // The daemon partition (watermark-only) does not own the outbox; the
+    // prune belongs to the reporter instance that flushes ack-mode sources.
+    seedExpiredAndFreshRows();
+    const reporter = new UsageTelemetryReporter(
+      [makeWatermarkSource("fake_wm")],
+      fakeFlushCheckpointStore,
+    );
+    await reporter.flush();
+
+    expect(pendingOutboxIds()).toEqual(["ob-expired", "ob-fresh"]);
+  });
+
   test("outboxSource purges corrupt-payload rows at collect while valid siblings ship", async () => {
     // Raw inserts: the store API only writes JSON.stringify-ed events, so
     // corrupt payloads (invalid JSON, non-object JSON) go in directly.
@@ -3084,20 +3160,20 @@ describe("UsageTelemetryReporter", () => {
         {
           id: "ob-corrupt-json",
           name: OUTBOX_NAME,
-          createdAt: 1700000001000,
+          createdAt: OUTBOX_BASE + 1000,
           conversationId: null,
           payload: "{not json",
         },
         {
           id: "ob-non-object",
           name: OUTBOX_NAME,
-          createdAt: 1700000002000,
+          createdAt: OUTBOX_BASE + 2000,
           conversationId: null,
           payload: "42",
         },
       ])
       .run();
-    seedOutboxRow("ob-valid", 1700000003000);
+    seedOutboxRow("ob-valid", OUTBOX_BASE + 3000);
     const reporter = new UsageTelemetryReporter(
       [outboxSource(OUTBOX_NAME)],
       fakeFlushCheckpointStore,
@@ -3119,7 +3195,7 @@ describe("UsageTelemetryReporter", () => {
     // 501 rows: the first collect fills BATCH_SIZE (500) and the fullBatch
     // recursion ships the remaining row.
     for (let i = 0; i < 501; i++) {
-      seedOutboxRow(`ob-${String(i).padStart(3, "0")}`, 1700000000000 + i);
+      seedOutboxRow(`ob-${String(i).padStart(3, "0")}`, OUTBOX_BASE + i);
     }
     const reporter = new UsageTelemetryReporter(
       [outboxSource(OUTBOX_NAME)],

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -45,6 +45,10 @@ import {
   TOOL_EXECUTED_SOURCE_ID,
   watermarkKeysForSource,
 } from "./telemetry-event-sources.js";
+import {
+  deleteTelemetryOutboxEventsBefore,
+  OUTBOX_MAX_ROW_AGE_MS,
+} from "./telemetry-events-outbox.js";
 import { useReadOnlyMainDbForTelemetry } from "./telemetry-main-db.js";
 import { validateWireEvents } from "./telemetry-wire-validation.js";
 
@@ -266,6 +270,23 @@ export class UsageTelemetryReporter {
         return;
       }
 
+      // Age-bound the ack-mode outbox before any skip gate (platform,
+      // checkpoint store, consent three-way), so the bound holds in every
+      // state — including the unknown-consent deferral below. Only the
+      // reporter partition that flushes the outbox (ack-mode sources)
+      // prunes it.
+      if (batchCount === 0 && this.sources.some((source) => source.ack)) {
+        const prunedCount = deleteTelemetryOutboxEventsBefore(
+          Date.now() - OUTBOX_MAX_ROW_AGE_MS,
+        );
+        if (prunedCount > 0) {
+          log.debug(
+            { prunedCount },
+            "Telemetry flush: pruned expired outbox rows",
+          );
+        }
+      }
+
       // Skip when platform features are disabled (VELLUM_DISABLE_PLATFORM in
       // local mode; the flag is ignored when IS_PLATFORM is set, matching
       // VellumPlatformClient.create()). Watermarks are NOT advanced here: this
@@ -296,7 +317,11 @@ export class UsageTelemetryReporter {
       // checkpoint-unavailable skip above. Purging here would silently
       // destroy events recorded before the cache warmed up; instead the
       // backlog ships (or is purged) on a later cycle once the 5-minute
-      // refresh loop resolves the cache to a confirmed value.
+      // refresh loop resolves the cache to a confirmed value. The deferral
+      // is bounded: the age prune above deletes outbox rows older than
+      // OUTBOX_MAX_ROW_AGE_MS, so a permanently-unknown state (never
+      // logged in, logged out, no resolvable owner) cannot accumulate
+      // rows without limit.
       if (shareAnalytics === "unknown") {
         log.debug(
           "Telemetry flush: share_analytics consent unknown — skipping, will retry next cycle",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for consent-cleanup.md.

**Gap:** permanently-unknown consent states (never logged in, logged out, no assistant id) accumulate outbox rows forever — record gates now insert, flush defers, nothing prunes.
**What was expected:** unknown-consent buffering is bounded.
**What was found:** telemetry_events has no TTL/cap; deletes only on flush-ack or confirmed-false purge.