### PR TITLE
chore: round-2 review polish for consent-cleanup

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -6,7 +6,6 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 let shareAnalytics = true;
 
 mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
   getRawShareAnalytics: () => shareAnalytics,
 }));
 

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -10,7 +10,6 @@ import type { ConsentState } from "../platform/consent-cache.js";
 let shareAnalytics: ConsentState = true;
 
 mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics === true,
   getRawShareAnalytics: () => shareAnalytics,
 }));
 

--- a/assistant/src/__tests__/tool-audit.test.ts
+++ b/assistant/src/__tests__/tool-audit.test.ts
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let shareAnalytics: boolean | "unknown" = true;
 
 mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics === true,
   getRawShareAnalytics: () => shareAnalytics,
 }));
 
@@ -407,31 +406,6 @@ describe("tool audit terminals", () => {
       model: "model-a",
       inferenceProfile: "balanced",
       inferenceProfileSource: "active",
-    });
-  });
-
-  test("populates telemetry columns under confirmed opt-in", () => {
-    shareAnalytics = true;
-
-    recordToolExecuted({
-      conversationId: "conv-opt-in",
-      toolName: "file_read",
-      input: { path: "/tmp/a" },
-      resultContent: "ok",
-      resultBytes: 42,
-      decision: "allow",
-      riskLevel: "low",
-      durationMs: 5,
-      attribution: ATTRIBUTION,
-      wasPrompted: false,
-    });
-
-    expect(records).toHaveLength(1);
-    expect(records[0]).toMatchObject({
-      argBytes: Buffer.byteLength(JSON.stringify({ path: "/tmp/a" }), "utf8"),
-      resultBytes: 42,
-      provider: "anthropic",
-      model: "model-a",
     });
   });
 

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -81,7 +81,6 @@ mock.module("../telemetry/tool-audit.js", () => ({
 // Analytics consent is granted so any consent-gated telemetry path the audit
 // terminals consult sees the opted-in state.
 mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => true,
   getRawShareAnalytics: () => true,
 }));
 

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -34,7 +34,6 @@ import {
   __setCachedShareAnalyticsForTest,
   __setCachedShareDiagnosticsForTest,
   __setCachedShareDiagnosticsVersionForTest,
-  getCachedShareAnalytics,
   getCachedShareDiagnostics,
   getCachedShareDiagnosticsVersion,
   getRawShareAnalytics,
@@ -82,14 +81,12 @@ describe("consent-cache", () => {
 
   test("boot state is unknown; public accessor reads false", () => {
     expect(getRawShareAnalytics()).toBe("unknown");
-    expect(getCachedShareAnalytics()).toBe(false);
   });
 
   test("no platform client available → unknown; public accessor reads false", async () => {
     mockClient = null;
     await refreshConsentCache();
     expect(getRawShareAnalytics()).toBe("unknown");
-    expect(getCachedShareAnalytics()).toBe(false);
   });
 
   test("platform features disabled → confirmed false, not unknown", async () => {
@@ -111,19 +108,18 @@ describe("consent-cache", () => {
   test("becomes true after a successful fetch reporting shareAnalytics: true", async () => {
     mockClient = makeClient(makeConsent({ shareAnalytics: true }));
     await refreshConsentCache();
-    expect(getCachedShareAnalytics()).toBe(true);
     expect(getRawShareAnalytics()).toBe(true);
   });
 
   test("a null fetch keeps the last known value", async () => {
     mockClient = makeClient(makeConsent({ shareAnalytics: true }));
     await refreshConsentCache();
-    expect(getCachedShareAnalytics()).toBe(true);
+    expect(getRawShareAnalytics()).toBe(true);
 
     // Transient failure: consent endpoint returns null.
     mockClient = makeClient(null);
     await refreshConsentCache();
-    expect(getCachedShareAnalytics()).toBe(true);
+    expect(getRawShareAnalytics()).toBe(true);
   });
 
   test("a null fetch keeps a confirmed opt-out", async () => {
@@ -148,7 +144,6 @@ describe("consent-cache", () => {
     mockClient = null;
     await refreshConsentCache();
     expect(getRawShareAnalytics()).toBe("unknown");
-    expect(getCachedShareAnalytics()).toBe(false);
   });
 
   test("a client without a resolvable assistant identity demotes to unknown", async () => {
@@ -160,7 +155,6 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareAnalytics: true }), "");
     await refreshConsentCache();
     expect(getRawShareAnalytics()).toBe("unknown");
-    expect(getCachedShareAnalytics()).toBe(false);
   });
 
   test("legacy opt-out marker is honored at boot, before any refresh", () => {
@@ -170,7 +164,6 @@ describe("consent-cache", () => {
     // would otherwise leak events in that window).
     setConfig("legacyTelemetryOptOut", true);
     expect(getRawShareAnalytics()).toBe(false);
-    expect(getCachedShareAnalytics()).toBe(false);
   });
 
   test("legacy opt-out marker keeps analytics off despite platform opt-in", async () => {
@@ -179,7 +172,6 @@ describe("consent-cache", () => {
     await refreshConsentCache();
     // Platform reports opt-in, but the fail-closed marker forces off. The raw
     // accessor folds the marker into a confirmed false, not an unknown.
-    expect(getCachedShareAnalytics()).toBe(false);
     expect(getRawShareAnalytics()).toBe(false);
   });
 
@@ -187,7 +179,6 @@ describe("consent-cache", () => {
     __setCachedShareAnalyticsForTest(true);
     mockClient = makeClient(makeConsent({ shareDiagnostics: true }));
     await refreshConsentCache();
-    expect(getCachedShareAnalytics()).toBe(false);
     expect(getRawShareAnalytics()).toBe(false);
   });
 
@@ -199,7 +190,7 @@ describe("consent-cache", () => {
     // Let the fire-and-forget immediate refresh settle.
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(getCachedShareAnalytics()).toBe(true);
+    expect(getRawShareAnalytics()).toBe(true);
     // One immediate refresh from the first call; the second is a no-op.
     expect(createCallCount).toBe(1);
   });
@@ -211,7 +202,7 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareAnalytics: true }));
     startConsentRefresh();
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(getCachedShareAnalytics()).toBe(true);
+    expect(getRawShareAnalytics()).toBe(true);
   });
 
   // share_diagnostics tracks the same refresh as share_analytics; Sentry's
@@ -315,7 +306,7 @@ describe("consent-cache", () => {
     for (const state of [true, false, "unknown"] as const) {
       __setCachedShareAnalyticsForTest(state);
       __setCachedShareDiagnosticsForTest(state);
-      expect(getCachedShareAnalytics()).toBe(state === true);
+      expect(getRawShareAnalytics()).toBe(state);
       expect(getCachedShareDiagnostics()).toBe(state === true);
       expect(getRawShareAnalytics()).toBe(state);
     }

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -62,20 +62,11 @@ function isLegacyOptedOut(): boolean {
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 /**
- * Synchronous hot-path accessor for the effective `share_analytics` consent.
- * Never does I/O; returns `false` unless a successful refresh confirmed an
- * opt-in (`"unknown"` reads as `false`), and stays `false` while the legacy
- * fail-closed opt-out marker is set.
- */
-export function getCachedShareAnalytics(): boolean {
-  return cachedShareAnalytics === true && !isLegacyOptedOut();
-}
-
-/**
- * Raw tri-state `share_analytics` consent. The legacy fail-closed opt-out
+ * Raw tri-state `share_analytics` consent — the ONLY analytics accessor:
+ * every gate distinguishes a confirmed opt-out (`false`, the only state that
+ * drops or purges) from a not-yet-known one. The legacy fail-closed opt-out
  * marker folds into `false` — a workspace-level opt-out is a confirmed
- * opt-out, not an unknown. For callers that must distinguish a confirmed
- * opt-out from a not-yet-known state.
+ * opt-out, not an unknown. Never does I/O; hot-path safe.
  */
 export function getRawShareAnalytics(): ConsentState {
   return isLegacyOptedOut() ? false : cachedShareAnalytics;

--- a/assistant/src/telemetry/__tests__/outbox-test-harness.ts
+++ b/assistant/src/telemetry/__tests__/outbox-test-harness.ts
@@ -19,7 +19,6 @@ let shareDiagnosticsVersion = "2999-01-01";
 // imports are as safe as in the test files themselves (AGENTS.md "Test
 // machinery isolation" scopes its no-src/ rule to preload-time machinery).
 mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics === true,
   getRawShareAnalytics: () => shareAnalytics,
   getCachedShareDiagnostics: () => shareDiagnostics,
   getCachedShareDiagnosticsVersion: () => shareDiagnosticsVersion,

--- a/assistant/src/telemetry/tool-executed-events-store.test.ts
+++ b/assistant/src/telemetry/tool-executed-events-store.test.ts
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let shareAnalytics = true;
 
 mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics,
   getRawShareAnalytics: () => shareAnalytics,
 }));
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -107,7 +107,6 @@ const mockGetCachedShareDiagnosticsVersion = mock(() => "2999-01-01");
 
 mock.module("../platform/consent-cache.js", () => ({
   getRawShareAnalytics: mockGetRawShareAnalytics,
-  getCachedShareAnalytics: () => mockGetRawShareAnalytics() === true,
   getCachedShareDiagnostics: mockGetCachedShareDiagnostics,
   getCachedShareDiagnosticsVersion: mockGetCachedShareDiagnosticsVersion,
 }));

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -317,11 +317,8 @@ export class UsageTelemetryReporter {
       // checkpoint-unavailable skip above. Purging here would silently
       // destroy events recorded before the cache warmed up; instead the
       // backlog ships (or is purged) on a later cycle once the 5-minute
-      // refresh loop resolves the cache to a confirmed value. The deferral
-      // is bounded: the age prune above deletes outbox rows older than
-      // OUTBOX_MAX_ROW_AGE_MS, so a permanently-unknown state (never
-      // logged in, logged out, no resolvable owner) cannot accumulate
-      // rows without limit.
+      // refresh loop resolves the cache to a confirmed value. Bounded by
+      // the age prune above.
       if (shareAnalytics === "unknown") {
         log.debug(
           "Telemetry flush: share_analytics consent unknown — skipping, will retry next cycle",

--- a/assistant/src/telemetry/watchdog-direct-emit.test.ts
+++ b/assistant/src/telemetry/watchdog-direct-emit.test.ts
@@ -12,7 +12,6 @@ import type { ConsentState } from "../platform/consent-cache.js";
 
 let shareAnalytics: ConsentState = true;
 mock.module("../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics === true,
   getRawShareAnalytics: () => shareAnalytics,
 }));
 

--- a/assistant/src/watcher/__tests__/telemetry.test.ts
+++ b/assistant/src/watcher/__tests__/telemetry.test.ts
@@ -33,7 +33,6 @@ mock.module("../../persistence/lifecycle-events-store.js", () => ({
 }));
 
 mock.module("../../platform/consent-cache.js", () => ({
-  getCachedShareAnalytics: () => shareAnalytics === true,
   getRawShareAnalytics: () => shareAnalytics,
 }));
 

--- a/clients/web/src/lib/consent/consent-persistence.ts
+++ b/clients/web/src/lib/consent/consent-persistence.ts
@@ -70,7 +70,7 @@ const LEGACY_AI_PRIVACY_CONSENT_VERSION = "2026-06-08";
 // Required versions — server-supplied, constants as fallback
 // ---------------------------------------------------------------------------
 
-export interface RequiredConsentVersions {
+interface RequiredConsentVersions {
   tos: string;
   privacyPolicy: string;
   aiDataSharing: string;
@@ -478,11 +478,10 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
     // The platform computes effective consent in one place (null = enabled,
     // opt-out) and serves it as `share_*_effective`; an older backend omits
     // the fields, so fall back to the raw value's opt-out reading. These are
-    // the server-authoritative gate inputs that the fallback-deletion PR
-    // (plan PR 10) switches the data-capture gates to once platform deploys
-    // are confirmed; until then the store-based explicit-opt-out gates are
-    // behaviorally identical (effective differs from raw only when raw is
-    // null, which the gates read as enabled).
+    // the server-authoritative gate inputs; the store-based explicit-opt-out
+    // gates currently consume raw values, which are behaviorally identical
+    // (effective differs from raw only when raw is null, which the gates
+    // read as enabled).
     analyticsEffective:
       consent.share_analytics_effective ?? consent.share_analytics ?? true,
     diagnosticsEffective:

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -1,13 +1,5 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup } from "@testing-library/react";
-
 
 type MockSessionUser = {
   id?: string;
@@ -322,12 +314,10 @@ mock.module("@/assistant/api", () => ({
 }));
 
 const { useAuthStore } = await import("@/stores/auth-store");
-const { useAssistantLifecycleStore } = await import(
-  "@/assistant/lifecycle-store"
-);
-const { useResolvedAssistantsStore } = await import(
-  "@/stores/resolved-assistants-store"
-);
+const { useAssistantLifecycleStore } =
+  await import("@/assistant/lifecycle-store");
+const { useResolvedAssistantsStore } =
+  await import("@/stores/resolved-assistants-store");
 
 function resetAuthStore(): void {
   useAuthStore.setState({
@@ -825,7 +815,10 @@ describe("auth store onboarding flag reconciliation", () => {
         share_diagnostics_accepted_version: expect.any(String),
       }),
     );
-    const backfillBody = patchConsentMock.mock.calls[0][0] as Record<string, unknown>;
+    const backfillBody = patchConsentMock.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
     expect("share_analytics" in backfillBody).toBe(false);
     expect("share_analytics_accepted_version" in backfillBody).toBe(false);
     // A no-record response adopts nothing — its share values are API
@@ -859,11 +852,16 @@ describe("auth store onboarding flag reconciliation", () => {
     );
   });
 
-  test("backfill stamps the server-adopted required versions, not the frozen constants", async () => {
+  test("backfill stamps adopted required versions for acked axes; analytics stays at the build constant", async () => {
     // The server bumped required_versions past the build constants. The sync
-    // flow adopts them (via resolveServerConsent) before the backfill runs,
-    // so the backfill must stamp the adopted versions — frozen-constant
-    // stamps would write a stale server row and re-prompt every other device.
+    // flow adopts them (via resolveServerConsent) before the backfill runs.
+    // Device-ACKED axes (tos/privacy/diagnostics) stamp the adopted versions
+    // — their acks were validated against those requirements, and frozen
+    // stamps would write a stale server row that re-prompts other devices.
+    // Analytics has NO versioned device ack: a device value proves only a
+    // choice made under some build's disclosure, so it stamps the frozen
+    // build constant — stamping a bumped version would attest a disclosure
+    // the user never saw.
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockRequiredVersions = {
       tos: "2026-09-01",
@@ -886,7 +884,8 @@ describe("auth store onboarding flag reconciliation", () => {
         tos_accepted_version: "2026-09-01",
         privacy_policy_accepted_version: "2026-09-02",
         ai_data_sharing_accepted_version: "2026-09-03",
-        share_analytics_accepted_version: "2026-09-04",
+        share_analytics: false,
+        share_analytics_accepted_version: "2026-06-08",
         share_diagnostics_accepted_version: "2026-09-05",
       }),
     );

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -67,6 +67,7 @@ import {
   persistDiagnosticsAck,
   resolveServerConsent,
   getRequiredConsentVersions,
+  ANALYTICS_CONSENT_VERSION,
 } from "@/lib/consent/consent-persistence";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import {
@@ -308,7 +309,13 @@ function buildDeviceConsentBackfill(axes: {
     ...(axes.shareValues && axes.shareValues.analytics !== null
       ? {
           share_analytics: axes.shareValues.analytics,
-          share_analytics_accepted_version: required.shareAnalytics,
+          // The frozen build constant, NOT the adopted required version:
+          // analytics has no versioned device ack, so a device value proves
+          // only a choice made under some build's disclosure — stamping a
+          // server-bumped version would attest a disclosure the user never
+          // saw. The constant bounds the stamp to what this build could have
+          // shown; an under-stamp at worst re-reviews.
+          share_analytics_accepted_version: ANALYTICS_CONSENT_VERSION,
         }
       : {}),
     ...(axes.diagnostics
@@ -378,7 +385,8 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // off the raw version currency. Analytics has no device ack — its
       // version stamps are written server-side at choice time.
       let diagnosticsAck =
-        resolved.shareDiagnostics !== null && resolved.diagnosticsVersionCurrent;
+        resolved.shareDiagnostics !== null &&
+        resolved.diagnosticsVersionCurrent;
 
       // Fall back to device keys for a TRULY empty record: the device ack
       // keys are the only consent evidence, so they drive the legal axes and


### PR DESCRIPTION
## Summary
Fixes the round-2 review findings for consent-cleanup.md.

**Gaps:** two fresh Codex P2s on the fix PRs (analytics backfill stamped the adopted version — over-attests a bumped disclosure; temporal 'PR 10 / until then' comment) plus slop-audit trims (dead getCachedShareAnalytics accessor + 9 pointless mock stubs, redundant opt-in test, unconsumed interface export, duplicated prune rationale).
**Expected:** stamps bounded to what the build could have shown; present-tense comments; no dead exports.
**Found:** all present at the prior tip; all addressed here.