### PR TITLE
feat(config): accept provider "vellum" for stt/tts independent of mode

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1283,15 +1283,11 @@ describe("AssistantConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  test("rejects tts provider vellum outside managed mode", () => {
+  test("accepts tts provider vellum regardless of mode", () => {
     const result = AssistantConfigSchema.safeParse({
       services: { tts: { mode: "your-own", provider: "vellum" } },
     });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const msgs = result.error.issues.map((i) => i.message);
-      expect(msgs.some((m) => m.includes("managed"))).toBe(true);
-    }
+    expect(result.success).toBe(true);
   });
 
   // ── hostBrowser.cdpInspect.desktopAuto config ───────────────────────
@@ -1446,15 +1442,11 @@ describe("AssistantConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  test("rejects provider vellum outside managed mode", () => {
+  test("accepts stt provider vellum regardless of mode", () => {
     const result = AssistantConfigSchema.safeParse({
       services: { stt: { mode: "your-own", provider: "vellum" } },
     });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const msgs = result.error.issues.map((i) => i.message);
-      expect(msgs.some((m) => m.includes("managed"))).toBe(true);
-    }
+    expect(result.success).toBe(true);
   });
 
   test("rejects invalid services.stt.provider", () => {

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -253,10 +253,10 @@ export async function run(
 
   if (setting === "stt_mode") {
     setNestedValue(raw, "services.stt.mode", validation.coerced);
-    // SttServiceSchema requires `provider` whenever the stt object exists and
-    // forbids provider "vellum" outside managed mode, so writing `mode` alone
-    // (or keeping "vellum" when switching to your-own) would make the saved
-    // config invalid.
+    // SttServiceSchema requires `provider` whenever the stt object exists, so
+    // writing `mode` alone would invalidate a sparse config. And a provider of
+    // "vellum" routes to managed regardless of mode, so switching to your-own
+    // must also replace it with a BYOK provider.
     const currentProvider = getConfig().services.stt.provider;
     setNestedValue(
       raw,
@@ -271,7 +271,7 @@ export async function run(
 
   if (setting === "tts_mode") {
     setNestedValue(raw, "services.tts.mode", validation.coerced);
-    // TtsServiceSchema forbids provider "vellum" outside managed mode, so
+    // A provider of "vellum" routes to managed regardless of mode, so
     // switching to your-own must also replace a vellum provider.
     if (
       validation.coerced === "your-own" &&

--- a/assistant/src/config/schemas/__tests__/stt.test.ts
+++ b/assistant/src/config/schemas/__tests__/stt.test.ts
@@ -61,15 +61,18 @@ describe("managed mode", () => {
     expect(parsed.provider).toBe("vellum");
   });
 
-  test("rejects provider vellum under your-own mode", () => {
+  test("accepts provider vellum regardless of mode", () => {
     const result = SttServiceSchema.safeParse({
       mode: "your-own",
       provider: "vellum",
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
-  test("effectiveSttProvider routes managed mode to vellum and preserves BYOK otherwise", () => {
+  test("effectiveSttProvider routes provider vellum and managed mode to vellum, preserves BYOK otherwise", () => {
+    expect(
+      effectiveSttProvider({ mode: "your-own", provider: "vellum" }),
+    ).toBe("vellum");
     expect(
       effectiveSttProvider({ mode: "managed", provider: "deepgram" }),
     ).toBe("vellum");

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -33,11 +33,12 @@ export type SttProviders = z.infer<typeof SttProvidersSchema>;
 /**
  * Canonical STT service configuration.
  *
- * `mode` selects between the user's own provider key (`"your-own"`) and
- * Vellum-managed transcription billed to Vellum credits (`"managed"`).
- * The `provider` field always holds the user's BYOK choice so switching
- * back from managed mode restores it; use {@link effectiveSttProvider}
- * to resolve which provider is actually active.
+ * Managed transcription (through the user's Vellum account, billed to Vellum
+ * credits) is selectable two ways: `provider: "vellum"` directly, or
+ * `mode: "managed"` alongside a BYOK `provider` — the form the mode toggle
+ * writes, which leaves the BYOK choice untouched so switching back to
+ * `"your-own"` restores it. Use {@link effectiveSttProvider} to resolve
+ * which provider is actually active.
  */
 export const SttServiceSchema = z
   .object({
@@ -56,16 +57,6 @@ export const SttServiceSchema = z
       .describe("Active STT provider used for speech-to-text transcription"),
     providers: SttProvidersSchema.default({}),
   })
-  .superRefine((service, ctx) => {
-    if (service.provider === "vellum" && service.mode !== "managed") {
-      ctx.addIssue({
-        code: "custom",
-        path: ["provider"],
-        message:
-          'services.stt.provider "vellum" requires services.stt.mode "managed"',
-      });
-    }
-  })
   .describe(
     "Speech-to-text service configuration -- provider selection and per-provider settings",
   );
@@ -75,13 +66,17 @@ export type SttService = z.infer<typeof SttServiceSchema>;
 /**
  * Resolve the provider that is actually active for the service config.
  *
- * Managed mode always routes to the `vellum` provider while leaving the
- * user's BYOK `provider` choice untouched, so toggling back to
- * `"your-own"` restores their previous setup.
+ * `provider: "vellum"` selects managed transcription directly. Otherwise
+ * `mode: "managed"` routes to `vellum` while leaving the user's BYOK
+ * `provider` choice untouched, so toggling back to `"your-own"` restores
+ * their previous setup.
  */
 export function effectiveSttProvider(service: {
   mode: SttService["mode"];
   provider: string;
 }): string {
+  if (service.provider === "vellum") {
+    return "vellum";
+  }
   return service.mode === "managed" ? "vellum" : service.provider;
 }

--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -273,11 +273,12 @@ for (const id of schemaKeys) {
 /**
  * Canonical TTS service configuration.
  *
- * `mode` selects between the user's own provider key (`"your-own"`) and
- * Vellum-managed synthesis billed to Vellum credits (`"managed"`). The
- * `provider` field always holds the user's BYOK choice so switching back
- * from managed mode restores it; use {@link effectiveTtsProvider} to
- * resolve which provider is actually active.
+ * Managed synthesis (through the user's Vellum account, billed to Vellum
+ * credits) is selectable two ways: `provider: "vellum"` directly, or
+ * `mode: "managed"` alongside a BYOK `provider` — the form the mode toggle
+ * writes, which leaves the BYOK choice untouched so switching back to
+ * `"your-own"` restores it. Use {@link effectiveTtsProvider} to resolve
+ * which provider is actually active.
  */
 export const TtsServiceSchema = z
   .object({
@@ -297,16 +298,6 @@ export const TtsServiceSchema = z
       .describe("Active TTS provider used for speech synthesis"),
     providers: TtsProvidersSchema.default(TtsProvidersSchema.parse({})),
   })
-  .superRefine((service, ctx) => {
-    if (service.provider === "vellum" && service.mode !== "managed") {
-      ctx.addIssue({
-        code: "custom",
-        path: ["provider"],
-        message:
-          'services.tts.provider "vellum" requires services.tts.mode "managed"',
-      });
-    }
-  })
   .describe(
     "Text-to-speech service configuration — provider selection and per-provider settings",
   );
@@ -316,14 +307,18 @@ export type TtsService = z.infer<typeof TtsServiceSchema>;
 /**
  * Resolve the provider that is actually active for the service config.
  *
- * Managed mode always routes to the `vellum` provider while leaving the
- * user's BYOK `provider` choice untouched, so toggling back to
- * `"your-own"` restores their previous setup.
+ * `provider: "vellum"` selects managed synthesis directly. Otherwise
+ * `mode: "managed"` routes to `vellum` while leaving the user's BYOK
+ * `provider` choice untouched, so toggling back to `"your-own"` restores
+ * their previous setup.
  */
 export function effectiveTtsProvider(service: {
   mode: TtsService["mode"];
   provider?: string;
 }): string {
+  if (service.provider === "vellum") {
+    return "vellum";
+  }
   if (service.mode === "managed") {
     return "vellum";
   }

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -55,9 +55,9 @@ const DEFINITIONS = {
  * Definitions in display order (e.g. settings dropdowns).
  */
 // vellum is deliberately absent: managed mode is selected via
-// `services.tts.mode`, not the provider picker — today's settings UI writes
-// only `provider` + an API key, which the schema rejects for vellum. The
-// definition stays in DEFINITIONS so managed-mode resolution works.
+// `services.tts.mode`, not the provider picker — the settings UI pairs the
+// picker with an API-key input, which vellum has no use for. The definition
+// stays in DEFINITIONS so managed-mode resolution works.
 const CATALOG: readonly TtsProviderDefinition[] = [
   DEFINITIONS.elevenlabs,
   DEFINITIONS["fish-audio"],

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -300,6 +300,31 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     ).toBeNull();
   });
 
+  // Provider "vellum" routes to managed regardless of mode, so a provider-only
+  // managed config (written via the CLI) must render and escape like one
+  // written by the toggle.
+  test("renders the Managed panel for a provider-only vellum daemon", () => {
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+    renderCard();
+
+    expect(
+      screen.getByText(/Managed transcription is included/),
+    ).toBeDefined();
+  });
+
+  test("escaping a provider-only vellum daemon replaces the provider", async () => {
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+    renderCard();
+
+    setMode("Your Own");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { stt: { provider: "deepgram", mode: "your-own" } },
+    });
+  });
+
   test("Managed Save writes a daemon-mapped provider as the restore value", async () => {
     // The stored provider is the your-own restore value for toggling back and
     // must be a valid daemon id; effectiveSttProvider routes managed mode to

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -89,7 +89,12 @@ export function SpeechToTextCard() {
   const daemonStt = daemonConfig?.services?.stt as
     { provider?: string; mode?: string } | undefined;
   const daemonSttProvider = daemonStt?.provider;
-  const daemonManaged = daemonStt?.mode === "managed";
+  // Provider "vellum" routes to managed regardless of mode, so the card must
+  // treat it as managed too — otherwise a provider-only managed config (e.g.
+  // written via the CLI) would render the Your Own panel, and a save from it
+  // could never escape: nothing would look changed, so no provider write.
+  const daemonManaged =
+    daemonStt?.mode === "managed" || daemonSttProvider === "vellum";
 
   // Managed vs. your-own toggle. Derived from the daemon (source of truth),
   // falling back to localStorage so the toggle doesn't flash "your-own" before
@@ -97,11 +102,13 @@ export function SpeechToTextCard() {
   // until a save + refetch converges the server value.
   const serverMode = useMemo<ServiceMode>(
     () =>
-      parseServiceMode(
-        daemonStt?.mode ?? getLocalSetting(LS_STT_MODE, "your-own"),
-        "your-own",
-      ),
-    [daemonStt?.mode],
+      daemonManaged
+        ? "managed"
+        : parseServiceMode(
+            daemonStt?.mode ?? getLocalSetting(LS_STT_MODE, "your-own"),
+            "your-own",
+          ),
+    [daemonManaged, daemonStt?.mode],
   );
   const [mode, setDraftMode] = useDraftOverride(serverMode);
 

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -220,8 +220,8 @@ export function SpeechToTextCard() {
       const providerChanged =
         !!daemon && (draftProvider !== serverProvider || !daemonHasProvider);
       // Write `provider` only when the user changed it, or when escaping managed
-      // leaves nothing valid to keep (no stored provider, or the managed-only
-      // "vellum" sentinel the schema rejects outside managed mode). Otherwise
+      // leaves nothing valid to keep (no stored provider, or the "vellum"
+      // provider, which routes to managed regardless of mode). Otherwise
       // write mode only and let the daemon's deep-merge preserve the stored
       // provider — which may be one the dropdown can't represent (e.g.
       // google-gemini via CLI) and would be silently overwritten by the fallback.
@@ -290,9 +290,9 @@ export function SpeechToTextCard() {
       // provider the dropdown can't represent (e.g. google-gemini set via CLI),
       // which the fallback would silently overwrite. Only synthesize one for a
       // sparse config or the client-only native dictation choice ("deepgram" is
-      // the sane default there); the schema requires a provider and rejects
-      // "vellum" outside managed. `effectiveSttProvider` routes managed mode to
-      // Vellum at runtime regardless of this value.
+      // the sane default there); the schema requires a provider, and "vellum"
+      // would defeat its purpose as a your-own restore value. The daemon routes
+      // managed mode to Vellum at runtime regardless of this value.
       const restoreProvider =
         daemonSttProvider && daemonSttProvider !== "vellum"
           ? daemonSttProvider

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -260,6 +260,34 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     ).toBeNull();
   });
 
+  // Provider "vellum" routes to managed regardless of mode, so a provider-only
+  // managed config (written via the CLI) must render and escape like one
+  // written by the toggle.
+  test("renders the Managed panel for a provider-only vellum daemon", async () => {
+    daemonConfigData = { services: { tts: { provider: "vellum" } } };
+    renderCard();
+
+    expect(
+      screen.getByText(/Managed speech synthesis is included/),
+    ).toBeDefined();
+  });
+
+  test("escaping a provider-only vellum daemon replaces the provider", async () => {
+    daemonConfigData = { services: { tts: { provider: "vellum" } } };
+    renderCard();
+
+    setMode("Your Own");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const ttsBody = configPatchCalls[0]!.body as {
+      services: { tts: Record<string, unknown> };
+    };
+    expect(ttsBody.services.tts.mode).toBe("your-own");
+    expect(ttsBody.services.tts.provider).toBeDefined();
+    expect(ttsBody.services.tts.provider).not.toBe("vellum");
+  });
+
   test("Managed Save writes the effective BYOK provider as the restore value", async () => {
     // The stored provider is the your-own restore value for toggling back;
     // effectiveTtsProvider routes managed mode to Vellum at runtime.

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -258,9 +258,9 @@ export function TextToSpeechCard() {
     try {
       // Persist the effective BYOK provider as the restore value for toggling
       // back — `selectedProvider.id` is always representable (never the reserved
-      // "vellum" id). The daemon's `effectiveTtsProvider` routes managed mode to
-      // Vellum at runtime regardless; the schema only forbids "vellum" outside
-      // managed mode, which this write is not.
+      // "vellum" id, which would defeat its purpose as a restore value). The
+      // daemon's `effectiveTtsProvider` routes managed mode to Vellum at
+      // runtime regardless of this value.
       const { response: cfgRes } = await configPatch({
         path: { assistant_id: assistantId },
         body: {

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -74,7 +74,12 @@ export function TextToSpeechCard() {
   const daemonTts = daemonConfig?.services?.tts as
     { provider?: string; mode?: string } | undefined;
   const daemonTtsProvider = daemonTts?.provider;
-  const daemonManaged = daemonTts?.mode === "managed";
+  // Provider "vellum" routes to managed regardless of mode, so the card must
+  // treat it as managed too — otherwise a provider-only managed config (e.g.
+  // written via the CLI) would render the Your Own panel, and a save from it
+  // could never escape: nothing would look changed, so no provider write.
+  const daemonManaged =
+    daemonTts?.mode === "managed" || daemonTtsProvider === "vellum";
 
   // Managed vs. your-own toggle. Derived from the daemon (source of truth),
   // falling back to localStorage so the toggle doesn't flash "your-own" before
@@ -82,11 +87,13 @@ export function TextToSpeechCard() {
   // until a save + refetch converges the server value.
   const serverMode = useMemo<ServiceMode>(
     () =>
-      parseServiceMode(
-        daemonTts?.mode ?? getLocalSetting(LS_TTS_MODE, "your-own"),
-        "your-own",
-      ),
-    [daemonTts?.mode],
+      daemonManaged
+        ? "managed"
+        : parseServiceMode(
+            daemonTts?.mode ?? getLocalSetting(LS_TTS_MODE, "your-own"),
+            "your-own",
+          ),
+    [daemonManaged, daemonTts?.mode],
   );
   const [mode, setDraftMode] = useDraftOverride(serverMode);
 


### PR DESCRIPTION
## What

Managed speech becomes selectable through the provider field itself: `services.stt.provider` / `services.tts.provider` may now be `"vellum"` without `mode: "managed"`. The `superRefine` guards coupling the two fields are gone, and `effectiveSttProvider` / `effectiveTtsProvider` give `provider: "vellum"` precedence — otherwise `mode: "managed"` routes to vellum exactly as before.

**Inert on its own.** No picker offers vellum yet (the TTS display catalog still excludes it; the STT card's dropdown doesn't list it), and the wire spec is unchanged (the refinement was never expressible in OpenAPI). Both representations coexist:

| config | effective provider |
|---|---|
| `{ provider: "vellum" }` (any mode) | vellum |
| `{ mode: "managed", provider: "deepgram" }` | vellum |
| `{ mode: "your-own", provider: "deepgram" }` | deepgram |

Every existing writer already replaces a `vellum` provider when switching to your-own (`voice_config_update`, both web cards) — that behavior is unchanged but its *reason* changed: the pair is no longer schema-invalid; instead a lingering `vellum` provider would win over the mode. Comments citing the dropped guard are retargeted so none of them lie.

## Why this exists as its own PR

This is 1 of a 4-PR stack replacing the Managed/Your Own toggle with a single provider dropdown (vellum = managed), replacing #38236 which bundled it all:

1. **this** — daemon accepts `provider: "vellum"` (inert)
2. web cards → single provider dropdown; vellum enters the TTS catalog + client catalogs
3. drop `mode` from the schemas + migration rewriting `mode: "managed"` → `provider: "vellum"`
4. platform-login gating on the vellum option (`PlatformLoginNotice` when logged out)

Ordering is the point: UI-first is rejected by today's schema; schema-removal-first silently no-ops the existing Managed toggle. Accept-first keeps every commit on main shippable.

## Testing

- Flipped the three rejection tests to acceptance; `effectiveSttProvider` precedence covered
- Schema/config/voice suites pass; the 11 failures in the big batch are the known pre-existing `resolve.test.ts` cross-file mock contamination (63/63 in isolation, identical set on clean main)
- `tsc --noEmit` clean; regenerated `openapi.yaml` — zero diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)