### PR TITLE
docs: finish the boolean-accessor removal

### DIFF
--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -53,8 +53,9 @@ Flow, end to end:
    - emission is best-effort (wrapped in try/catch) and never blocks or alters
      the surface-action flow;
    - `recordActivationEvent` respects the platform `share_analytics` consent gate
-     via `getCachedShareAnalytics()` (returns `null` / no row when the platform
-     user has not consented; default-off when there is no platform session).
+     via `getRawShareAnalytics()`: only a confirmed opt-out (`false`) drops the
+     event; an `"unknown"` state (cold cache, no platform session) records and
+     lets the flush/ingest gates enforce consent before anything ships.
 2. **Reporter flushes** every ~5 min: `usage-telemetry-reporter.ts`
    (`REPORT_INTERVAL_MS = 5 * 60 * 1000`, with a one-time
    `INITIAL_FLUSH_DELAY_MS = 30_000` after startup) POSTs queued onboarding
@@ -180,10 +181,11 @@ the conversation in `activation_sessions` on first build of the system prompt.
 Two distinct concerns: whether record-time rows reach SQLite (consent gate), and
 whether those rows reach BigQuery (flush gate, dev-disabled).
 
-1. `recordActivationEvent` no-ops when the platform `share_analytics` consent is
-   off (it reads `getCachedShareAnalytics()`), and the consent is **default-off
-   when there is no platform session**. So the dev session must be signed in to
-   the platform with `share_analytics` consent enabled, or no rows are written to
+1. `recordActivationEvent` no-ops only on a confirmed `share_analytics` opt-out
+   (it reads `getRawShareAnalytics()`); an `"unknown"` state records, but the
+   flush defers until consent resolves. So for rows to actually SHIP, the dev
+   session must be signed in to
+   the platform with `share_analytics` consent enabled, or no rows reach
    SQLite. The consent cache is refreshed by `startConsentRefresh()` in
    `assistant/src/daemon/lifecycle.ts`, which runs **regardless of dev mode** — so
    a dev session signed in with `share_analytics` consent enabled writes

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -79,11 +79,11 @@ describe("consent-cache", () => {
     await stopConsentRefresh();
   });
 
-  test("boot state is unknown; public accessor reads false", () => {
+  test("boot state is unknown", () => {
     expect(getRawShareAnalytics()).toBe("unknown");
   });
 
-  test("no platform client available → unknown; public accessor reads false", async () => {
+  test("no platform client available → unknown", async () => {
     mockClient = null;
     await refreshConsentCache();
     expect(getRawShareAnalytics()).toBe("unknown");
@@ -139,7 +139,7 @@ describe("consent-cache", () => {
     expect(getCachedShareDiagnostics()).toBe(false);
   });
 
-  test("a missing client demotes a prior opt-in to unknown (public accessor reads false)", async () => {
+  test("a missing client demotes a prior opt-in to unknown", async () => {
     __setCachedShareAnalyticsForTest(true);
     mockClient = null;
     await refreshConsentCache();
@@ -237,7 +237,7 @@ describe("consent-cache", () => {
     expect(getCachedShareDiagnostics()).toBe(true);
   });
 
-  test("a missing client demotes a prior diagnostics opt-in (public accessor reads false)", async () => {
+  test("a missing client demotes a prior diagnostics opt-in", async () => {
     __setCachedShareDiagnosticsForTest(true);
     mockClient = null;
     await refreshConsentCache();
@@ -297,7 +297,7 @@ describe("consent-cache", () => {
     expect(getCachedShareDiagnosticsVersion()).toBe("2026-06-18");
   });
 
-  test("public accessors collapse unknown to false; the raw analytics accessor exposes the tri-state", async () => {
+  test("diagnostics accessor collapses unknown to false; raw analytics exposes the tri-state", async () => {
     // Refresh once so the module's legacy opt-out marker reflects the
     // beforeEach config (the marker is only re-read during a refresh).
     mockClient = null;
@@ -308,7 +308,6 @@ describe("consent-cache", () => {
       __setCachedShareDiagnosticsForTest(state);
       expect(getRawShareAnalytics()).toBe(state);
       expect(getCachedShareDiagnostics()).toBe(state === true);
-      expect(getRawShareAnalytics()).toBe(state);
     }
   });
 

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -20,11 +20,11 @@
  * confirmed states from a successful platform fetch; `"unknown"` means no
  * confirmed state exists — boot before the first refresh, no platform session,
  * or no resolvable owner identity. A transient fetch failure keeps the
- * previous value so a known opt-in is not flipped mid-session. The boolean
- * accessors collapse `"unknown"` to `false` (fail-closed); the raw analytics
- * accessor exposes the tri-state for callers that must distinguish a confirmed
- * opt-out from a not-yet-known state. Diagnostics gates are deliberately
- * fail-closed, so no raw diagnostics accessor exists.
+ * previous value so a known opt-in is not flipped mid-session. Analytics
+ * exposes only the raw tri-state accessor (gates drop solely on a confirmed
+ * opt-out); the diagnostics boolean accessors collapse `"unknown"` to `false`
+ * — diagnostics gates are deliberately fail-closed, so no raw diagnostics
+ * accessor exists.
  */
 
 import { getConfigReadOnly } from "../config/loader.js";

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -294,9 +294,11 @@ function buildDeviceConsentBackfill(axes: {
   diagnostics: boolean;
   shareValues?: { analytics: boolean | null; diagnostics: boolean | null };
 }): ConsentPatch {
-  // Stamps come from the adopted required versions (server-supplied when the
-  // preceding resolveServerConsent saw them, frozen constants otherwise) so a
-  // server-side version bump is never backfilled with a stale stamp.
+  // Legal and diagnostics stamps come from the adopted required versions
+  // (server-supplied when the preceding resolveServerConsent saw them, frozen
+  // constants otherwise) — their device acks were validated against those
+  // requirements, so a server-side version bump is never backfilled with a
+  // stale stamp. Analytics is the deliberate exception below.
   const required = getRequiredConsentVersions();
   return {
     ...(axes.tos ? { tos_accepted_version: required.tos } : {}),


### PR DESCRIPTION
## Summary
Fixes the round-3 review findings for consent-cleanup.md (all documentation/naming; zero behavior).

**Gaps:** activation-funnel docs still described the deleted getCachedShareAnalytics(); four consent-cache test titles promised deleted assertions (plus one duplicated assertion); the backfill blanket comment contradicted the deliberate analytics-constant exception; the consent-cache module header framed the raw accessor as an alternative to a boolean accessor that no longer exists.