### PR TITLE
feat(settings): speech cards become a single provider dropdown

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -1721,25 +1721,16 @@ describe("resolveTtsConfig", () => {
 // ---------------------------------------------------------------------------
 
 describe("TTS provider catalog integration", () => {
-  test("TTS_PROVIDER_IDS matches catalog provider IDs plus hidden providers", () => {
-    const catalogIds = listCatalogProviderIds();
-    // Every displayed provider is a canonical ID…
-    for (const id of catalogIds) {
-      expect(TTS_PROVIDER_IDS).toContain(id);
-    }
-    // …and the only canonical ID hidden from the display catalog is
-    // vellum: managed mode is selected via services.tts.mode, not the
-    // provider picker.
-    const hidden = TTS_PROVIDER_IDS.filter((id) => !catalogIds.includes(id));
-    expect(hidden).toEqual(["vellum"]);
+  test("TTS_PROVIDER_IDS matches the display catalog exactly", () => {
+    expect([...listCatalogProviderIds()].sort()).toEqual(
+      [...TTS_PROVIDER_IDS].sort(),
+    );
   });
 
   test("schema accepts all catalog provider IDs as services.tts.provider", () => {
     for (const providerId of listCatalogProviderIds()) {
-      // vellum is connection-based and only valid under managed mode.
-      const mode = providerId === "vellum" ? "managed" : "your-own";
       const result = AssistantConfigSchema.safeParse({
-        services: { tts: { mode, provider: providerId } },
+        services: { tts: { provider: providerId } },
       });
       expect(result.success).toBe(true);
       if (result.success) {

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -120,6 +120,37 @@ describe("voice_config_update — tts_provider", () => {
     expect(result.content).toContain("tts_provider must be one of");
   });
 
+  test("tts_provider resets a stale managed mode", async () => {
+    // A lingering `mode: "managed"` takes precedence over the BYOK provider,
+    // so a provider switch that left it in place would be silently ignored.
+    writeConfig({ services: { tts: { mode: "managed", provider: "vellum" } } });
+    invalidateConfigCache();
+
+    const result = await run(
+      { setting: "tts_provider", value: "elevenlabs" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const tts = (readConfig().services as any).tts;
+    expect(tts.provider).toBe("elevenlabs");
+    expect(tts.mode).toBe("your-own");
+  });
+
+  test("tts_provider vellum writes the managed pair", async () => {
+    mockManagedSpeechAvailable = true;
+
+    const result = await run(
+      { setting: "tts_provider", value: "vellum" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const tts = (readConfig().services as any).tts;
+    expect(tts.provider).toBe("vellum");
+    expect(tts.mode).toBe("managed");
+  });
+
   test("broadcasts ttsProvider to client", async () => {
     const messages: any[] = [];
     const ctx = makeContext({

--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -446,7 +446,22 @@ describe("voice_config_update — stt_mode / tts_mode", () => {
 // ---------------------------------------------------------------------------
 
 describe("voice_config_update — catalog-driven provider validation", () => {
+  test("rejects tts_provider vellum without a platform connection", async () => {
+    mockManagedSpeechAvailable = false;
+
+    const result = await run(
+      { setting: "tts_provider", value: "vellum" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("assistant platform connect");
+    expect((readConfig().services as any)?.tts?.provider).toBeUndefined();
+  });
+
   test("accepts every provider ID in the catalog", async () => {
+    // The catalog includes vellum, which is gated on a platform connection.
+    mockManagedSpeechAvailable = true;
     const catalogIds = listCatalogProviderIds();
     expect(catalogIds.length).toBeGreaterThanOrEqual(1);
 

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -217,6 +217,14 @@ export async function run(
 
   if (setting === "tts_provider") {
     setNestedValue(raw, "services.tts.provider", validation.coerced);
+    // Written as a pair, like the settings cards: a stale `mode: "managed"`
+    // takes precedence over a BYOK provider, so switching providers must
+    // also reset it — otherwise the requested switch is silently ignored.
+    setNestedValue(
+      raw,
+      "services.tts.mode",
+      validation.coerced === "vellum" ? "managed" : "your-own",
+    );
     saveRawConfig(raw);
     invalidateConfigCache();
   }

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -186,11 +186,11 @@ export async function run(
     return { content: `Error: ${validation.error}`, isError: true };
   }
 
-  if (
-    (setting === "stt_mode" || setting === "tts_mode") &&
-    validation.coerced === "managed" &&
-    !(await managedSpeechAvailable())
-  ) {
+  const wantsManagedSpeech =
+    ((setting === "stt_mode" || setting === "tts_mode") &&
+      validation.coerced === "managed") ||
+    (setting === "tts_provider" && validation.coerced === "vellum");
+  if (wantsManagedSpeech && !(await managedSpeechAvailable())) {
     return {
       content:
         "Error: managed speech requires a Vellum platform connection. Run 'assistant platform connect' first.",

--- a/assistant/src/tts/provider-catalog.ts
+++ b/assistant/src/tts/provider-catalog.ts
@@ -54,11 +54,9 @@ const DEFINITIONS = {
 /**
  * Definitions in display order (e.g. settings dropdowns).
  */
-// vellum is deliberately absent: managed mode is selected via
-// `services.tts.mode`, not the provider picker — the settings UI pairs the
-// picker with an API-key input, which vellum has no use for. The definition
-// stays in DEFINITIONS so managed-mode resolution works.
+// vellum leads: it is the managed option, selected like any other provider.
 const CATALOG: readonly TtsProviderDefinition[] = [
+  DEFINITIONS.vellum,
   DEFINITIONS.elevenlabs,
   DEFINITIONS["fish-audio"],
   DEFINITIONS.deepgram,

--- a/clients/web/src/domains/settings/ai/local-storage-keys.ts
+++ b/clients/web/src/domains/settings/ai/local-storage-keys.ts
@@ -14,10 +14,8 @@ export const LS_WEB_FETCH_PROVIDER = "vellum:ai:webFetchProvider";
 export const LS_EMAIL_MODE = "vellum:ai:emailMode";
 export const LS_EMAIL_BYO_PROVIDER = "vellum:ai:emailByoProvider";
 
-export const LS_TTS_MODE = "vellum:voice:ttsMode";
 export const LS_TTS_PROVIDER = "vellum:voice:ttsProvider";
 export const LS_TTS_API_KEY_PREFIX = "vellum:voice:ttsApiKey:";
 export const LS_TTS_VOICE_ID_PREFIX = "vellum:voice:ttsVoiceId:";
-export const LS_STT_MODE = "vellum:voice:sttMode";
 export const LS_STT_PROVIDER = "vellum:voice:sttProvider";
 export const LS_STT_API_KEY_PREFIX = "vellum:voice:sttApiKey:";

--- a/clients/web/src/domains/settings/ai/provider-catalogs.ts
+++ b/clients/web/src/domains/settings/ai/provider-catalogs.ts
@@ -31,6 +31,20 @@ export interface TTSProvider {
 
 export const TTS_PROVIDERS: readonly TTSProvider[] = [
   {
+    id: "vellum",
+    displayName: "Vellum Managed",
+    subtitle:
+      "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
+    supportsVoiceSelection: false,
+    apiKeyPlaceholder: "Connected via your Vellum account",
+    credentialsGuide: {
+      description:
+        "Connect this assistant to your Vellum account; managed speech uses that connection instead of a provider API key.",
+      url: "https://platform.vellum.ai/",
+      linkLabel: "Open Vellum Platform",
+    },
+  },
+  {
     id: "elevenlabs",
     displayName: "ElevenLabs",
     subtitle:
@@ -122,6 +136,12 @@ export interface STTProvider {
 export const MACOS_NATIVE_STT_PROVIDER_ID = "macos-native";
 
 export const STT_PROVIDERS: readonly STTProvider[] = [
+  {
+    id: "vellum",
+    displayName: "Vellum",
+    subtitle:
+      "Transcription through your Vellum account — billed to Vellum credits, no separate API key needed.",
+  },
   {
     id: "deepgram",
     displayName: "Deepgram",

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -288,14 +288,11 @@ describe("SpeechToTextCard — Vellum provider", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    // Written as a pair so the save stays valid on daemons whose schema
+    // still couples provider "vellum" to mode "managed".
     expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { stt: { provider: "vellum" } },
+      services: { stt: { provider: "vellum", mode: "managed" } },
     });
-    // The provider takes precedence over any mode on disk — nothing to reset.
-    expect(
-      (configPatchCalls[0]!.body as { services: { stt: object } }).services
-        .stt,
-    ).not.toHaveProperty("mode");
     expect(credentialsSetCalls).toHaveLength(0);
     expect(localStorage.getItem(LS_STT_PROVIDER)).toBe("vellum");
   });

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -21,7 +21,6 @@ import {
   render,
   screen,
   waitFor,
-  within,
 } from "@testing-library/react";
 
 let nativeDictationSupported = false;
@@ -119,11 +118,6 @@ function selectOption(label: string): void {
     );
   }
   fireEvent.click(option);
-}
-
-function setMode(label: "Managed" | "Your Own"): void {
-  const group = screen.getByRole("radiogroup", { name: "Service mode" });
-  fireEvent.click(within(group).getByRole("radio", { name: label }));
 }
 
 describe("SpeechToTextCard — macOS Native Dictation option", () => {
@@ -234,89 +228,103 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     expect(sttBody?.services?.stt ?? {}).not.toHaveProperty("provider");
   });
 
-  test("saving a key from the Your Own panel switches a managed-mode daemon back", async () => {
-    // Managed speech was auto-defaulted on connection; toggling to "Your Own"
-    // and saving a BYOK key is explicit intent to use it, so the mode flips —
-    // otherwise the key appears to save but the daemon stays on managed.
-    daemonConfigData = {
-      services: { stt: { provider: "deepgram", mode: "managed" } },
-    };
+  test("selecting a provider from a Vellum daemon writes that provider", async () => {
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
     renderCard();
 
-    // The card opens on the Managed panel; toggle to reach the BYOK inputs.
-    setMode("Your Own");
-    const keyInput = screen.getByPlaceholderText(/Enter your Deepgram API key/);
-    fireEvent.change(keyInput, { target: { value: "dg-secret" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    // Provider is unchanged (Deepgram), so it's preserved via deep-merge and
-    // omitted from the PATCH; the mode flips and the key is stored.
-    const sttBody = configPatchCalls[0]!.body as {
-      services: { stt: Record<string, unknown> };
-    };
-    expect(sttBody.services.stt.mode).toBe("your-own");
-    expect(sttBody.services.stt).not.toHaveProperty("provider");
-    expect(credentialsSetCalls).toHaveLength(1);
-    expect(credentialsSetCalls[0]!.body).toMatchObject({
-      service: "deepgram",
-      value: "dg-secret",
-    });
-  });
-
-  test("a provider change with no key from the Your Own panel leaves managed mode", async () => {
-    // Reaching the provider dropdown requires toggling off Managed, so saving —
-    // even without a new key — is explicit intent to use your own provider and
-    // must flip the daemon off managed.
-    daemonConfigData = {
-      services: { stt: { provider: "deepgram", mode: "managed" } },
-    };
-    renderCard();
-
-    setMode("Your Own");
     openProviderDropdown();
     selectOption("OpenAI");
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
     expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { stt: { provider: "openai-whisper", mode: "your-own" } },
+      services: { stt: { provider: "openai-whisper" } },
     });
     expect(credentialsSetCalls).toHaveLength(0);
   });
+});
 
-  test("renders the Managed panel (no BYOK inputs) when the daemon is managed", () => {
+describe("SpeechToTextCard — Vellum provider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    nativeDictationSupported = false;
+    credentialsSetCalls.length = 0;
+    configPatchCalls.length = 0;
+    daemonConfigData = { services: {} };
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  test("Vellum is offered in the provider dropdown", () => {
+    renderCard();
+
+    openProviderDropdown();
+    expect(visibleOptions()).toContain("Vellum");
+  });
+
+  test("a vellum daemon provider renders as the selected option with no API key field", () => {
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+    renderCard();
+
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="STT provider"]',
+    );
+    expect(trigger?.textContent).toContain("Vellum");
+    // Vellum authenticates via the platform connection — there is no key.
+    expect(screen.queryByText("API Key")).toBeNull();
+    expect(
+      screen.getByText(/Transcription runs through your Vellum account/),
+    ).toBeTruthy();
+  });
+
+  test("selecting Vellum saves provider vellum and stores no credential", async () => {
+    renderCard();
+
+    openProviderDropdown();
+    selectOption("Vellum");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { stt: { provider: "vellum" } },
+    });
+    // The provider takes precedence over any mode on disk — nothing to reset.
+    expect(
+      (configPatchCalls[0]!.body as { services: { stt: object } }).services
+        .stt,
+    ).not.toHaveProperty("mode");
+    expect(credentialsSetCalls).toHaveLength(0);
+    expect(localStorage.getItem(LS_STT_PROVIDER)).toBe("vellum");
+  });
+
+  // A config written by the legacy mode toggle marks managed via `mode` while
+  // `provider` holds the BYOK restore value.
+  test("a legacy managed-mode daemon renders as Vellum", () => {
     daemonConfigData = {
-      services: { stt: { provider: "deepgram", mode: "managed" } },
+      services: { stt: { mode: "managed", provider: "deepgram" } },
     };
     renderCard();
 
-    expect(
-      screen.getByText(/Managed transcription is included/),
-    ).toBeDefined();
-    // The provider dropdown belongs to the Your Own panel and must be absent.
-    expect(
-      document.querySelector('button[aria-label="STT provider"]'),
-    ).toBeNull();
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="STT provider"]',
+    );
+    expect(trigger?.textContent).toContain("Vellum");
+    expect(screen.queryByText("API Key")).toBeNull();
   });
 
-  // Provider "vellum" routes to managed regardless of mode, so a provider-only
-  // managed config (written via the CLI) must render and escape like one
-  // written by the toggle.
-  test("renders the Managed panel for a provider-only vellum daemon", () => {
-    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+  test("escaping a legacy managed-mode daemon resets mode alongside the provider", async () => {
+    // Without the mode reset, the stale `mode: "managed"` would win over the
+    // BYOK provider choice and the user would silently stay on Vellum.
+    daemonConfigData = {
+      services: { stt: { mode: "managed", provider: "deepgram" } },
+    };
     renderCard();
 
-    expect(
-      screen.getByText(/Managed transcription is included/),
-    ).toBeDefined();
-  });
-
-  test("escaping a provider-only vellum daemon replaces the provider", async () => {
-    daemonConfigData = { services: { stt: { provider: "vellum" } } };
-    renderCard();
-
-    setMode("Your Own");
+    openProviderDropdown();
+    selectOption("Deepgram");
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
@@ -325,121 +333,23 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     });
   });
 
-  test("Managed Save writes a daemon-mapped provider as the restore value", async () => {
-    // The stored provider is the your-own restore value for toggling back and
-    // must be a valid daemon id; effectiveSttProvider routes managed mode to
-    // Vellum at runtime.
-    daemonConfigData = { services: { stt: { provider: "deepgram" } } };
-    renderCard();
-
-    setMode("Managed");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { stt: { mode: "managed", provider: "deepgram" } },
-    });
-    expect(credentialsSetCalls).toHaveLength(0);
-  });
-
-  test("Managed Save preserves an unlisted daemon provider as the restore value", async () => {
-    // A valid daemon provider the dropdown can't represent (set via CLI) must
-    // survive a managed save so toggling back restores it.
-    daemonConfigData = { services: { stt: { provider: "google-gemini" } } };
-    renderCard();
-
-    setMode("Managed");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { stt: { mode: "managed", provider: "google-gemini" } },
-    });
-  });
-
-  test("Managed Save repoints a native-dictation choice off macos-native", async () => {
-    // prefersMacosNativeStt() keys off LS_STT_PROVIDER alone, so leaving it on
-    // "macos-native" would keep this client bypassing managed STT even after
-    // saving Managed.
+  test("leaving Vellum for native dictation writes a daemon-backed fallback", async () => {
+    // Native is client-only (no daemon mapping), so without an explicit write
+    // the daemon would stay on Vellum and a refetch would snap the dropdown
+    // back to it.
     nativeDictationSupported = true;
-    localStorage.setItem(LS_STT_PROVIDER, "macos-native");
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
     renderCard();
 
-    setMode("Managed");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    expect(localStorage.getItem(LS_STT_PROVIDER)).not.toBe("macos-native");
-    expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { stt: { mode: "managed", provider: "deepgram" } },
-    });
-  });
-
-  test("escaping managed to native dictation still flips the daemon mode", async () => {
-    // Native is client-only (no daemon mapping), but leaving managed must still
-    // PATCH services.stt.mode server-side — otherwise a refetch snaps the card
-    // back to Managed. The stored provider is preserved via deep-merge.
-    nativeDictationSupported = true;
-    daemonConfigData = {
-      services: { stt: { provider: "deepgram", mode: "managed" } },
-    };
-    renderCard();
-
-    setMode("Your Own");
     openProviderDropdown();
     selectOption("macOS Native Dictation");
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const sttBody = configPatchCalls[0]!.body as {
-      services: { stt: Record<string, unknown> };
-    };
-    expect(sttBody.services.stt.mode).toBe("your-own");
-    expect(sttBody.services.stt).not.toHaveProperty("provider");
-    expect(credentialsSetCalls).toHaveLength(0);
-  });
-
-  test("leaving managed without a provider change preserves an unlisted provider", async () => {
-    // Daemon provider is a valid one the dropdown can't show (set via CLI).
-    // Toggling to Your Own and saving mode-only must not overwrite it with the
-    // Deepgram fallback — the PATCH omits provider so deep-merge keeps it.
-    daemonConfigData = {
-      services: { stt: { provider: "google-gemini", mode: "managed" } },
-    };
-    renderCard();
-
-    setMode("Your Own");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const sttBody = configPatchCalls[0]!.body as {
-      services: { stt: Record<string, unknown> };
-    };
-    expect(sttBody.services.stt.mode).toBe("your-own");
-    expect(sttBody.services.stt).not.toHaveProperty("provider");
-    expect(credentialsSetCalls).toHaveLength(0);
-  });
-
-  test("toggling to Your Own is a saveable change on its own", async () => {
-    // A managed daemon with a stored provider has nothing else to edit —
-    // flipping the toggle must enable Save and persist mode: your-own. The
-    // stored provider is preserved via deep-merge (omitted from the PATCH).
-    daemonConfigData = {
-      services: { stt: { provider: "deepgram", mode: "managed" } },
-    };
-    renderCard();
-
-    setMode("Your Own");
-    const save = screen.getByRole("button", { name: "Save" });
-    expect(save.hasAttribute("disabled")).toBe(false);
-    fireEvent.click(save);
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const sttBody = configPatchCalls[0]!.body as {
-      services: { stt: Record<string, unknown> };
-    };
-    expect(sttBody.services.stt.mode).toBe("your-own");
-    expect(sttBody.services.stt).not.toHaveProperty("provider");
-    expect(credentialsSetCalls).toHaveLength(0);
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { stt: { provider: "deepgram" } },
+    });
+    // The client keeps routing dictation locally.
+    expect(localStorage.getItem(LS_STT_PROVIDER)).toBe("macos-native");
   });
 });

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -19,34 +19,33 @@ import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import {
+  ByoServiceCard,
   CredentialsGuide,
   ResetButton,
   SaveButton,
-  ServiceCard,
 } from "@/domains/settings/ai/shared-ui";
 import {
   LS_STT_API_KEY_PREFIX,
-  LS_STT_MODE,
   LS_STT_PROVIDER,
 } from "@/domains/settings/ai/local-storage-keys";
 import {
   MACOS_NATIVE_STT_PROVIDER_ID,
   STT_PROVIDERS,
 } from "@/domains/settings/ai/provider-catalogs";
-import { parseServiceMode } from "@/domains/settings/ai/utils";
-import type { ServiceMode } from "@/generated/daemon/types.gen";
 
 /**
  * How the daemon addresses each card provider: `provider` is the
  * `services.stt.provider` value (the card id and daemon id differ for
  * Whisper), and `credentialService` is the CES namespace for its key.
  * Client-only providers (macOS native dictation) are absent — they never
- * touch the daemon.
+ * touch the daemon. `vellum` authenticates via the platform connection, so
+ * it has no credential service of its own.
  */
 const STT_DAEMON_PROVIDER: Record<
   string,
-  { provider: string; credentialService: string }
+  { provider: string; credentialService?: string }
 > = {
+  vellum: { provider: "vellum" },
   deepgram: { provider: "deepgram", credentialService: "deepgram" },
   openai: { provider: "openai-whisper", credentialService: "openai" },
 };
@@ -58,9 +57,18 @@ const STT_DAEMON_PROVIDER: Record<
  * (e.g. google-gemini/xai) are intentionally absent so we never coerce them.
  */
 const CARD_ID_BY_DAEMON_PROVIDER: Record<string, string> = {
+  vellum: "vellum",
   deepgram: "deepgram",
   "openai-whisper": "openai",
 };
+
+/**
+ * Fallback provider, as both a card id and a daemon id. Mirrors the daemon's
+ * `services.stt.provider` schema default. Deliberately not `providers[0]` —
+ * the dropdown leads with Vellum, and an unconfigured client must not claim
+ * the managed provider on its own.
+ */
+const DEFAULT_PROVIDER_ID = "deepgram";
 
 export function SpeechToTextCard() {
   const assistantId = useActiveAssistantId();
@@ -74,7 +82,7 @@ export function SpeechToTextCard() {
       (p) => !p.requiresNativeDictation || isNativeDictationSupported(),
     ),
   );
-  const defaultProviderId = providers[0]?.id ?? "deepgram";
+  const defaultProviderId = DEFAULT_PROVIDER_ID;
 
   // Seed the provider from the daemon's live config so a Save doesn't clobber a
   // provider configured elsewhere (CLI/other client) when localStorage is stale
@@ -85,32 +93,14 @@ export function SpeechToTextCard() {
     staleTime: 30_000,
   });
   // `services.stt` falls under the ConfigGetResponse index signature
-  // (`unknown`), so narrow it explicitly to read the provider and mode.
+  // (`unknown`), so narrow it explicitly to read the provider.
   const daemonStt = daemonConfig?.services?.stt as
     { provider?: string; mode?: string } | undefined;
-  const daemonSttProvider = daemonStt?.provider;
-  // Provider "vellum" routes to managed regardless of mode, so the card must
-  // treat it as managed too — otherwise a provider-only managed config (e.g.
-  // written via the CLI) would render the Your Own panel, and a save from it
-  // could never escape: nothing would look changed, so no provider write.
-  const daemonManaged =
-    daemonStt?.mode === "managed" || daemonSttProvider === "vellum";
-
-  // Managed vs. your-own toggle. Derived from the daemon (source of truth),
-  // falling back to localStorage so the toggle doesn't flash "your-own" before
-  // the config query resolves. `useDraftOverride` lets the user flip it locally
-  // until a save + refetch converges the server value.
-  const serverMode = useMemo<ServiceMode>(
-    () =>
-      daemonManaged
-        ? "managed"
-        : parseServiceMode(
-            daemonStt?.mode ?? getLocalSetting(LS_STT_MODE, "your-own"),
-            "your-own",
-          ),
-    [daemonManaged, daemonStt?.mode],
-  );
-  const [mode, setDraftMode] = useDraftOverride(serverMode);
+  // A config written by the legacy mode toggle marks managed via `mode` while
+  // `provider` holds the BYOK restore value — the daemon routes it to Vellum,
+  // so the card must render it as Vellum too.
+  const daemonSttProvider =
+    daemonStt?.mode === "managed" ? "vellum" : daemonStt?.provider;
 
   const serverProvider = useMemo(() => {
     const mapped = daemonSttProvider
@@ -166,18 +156,13 @@ export function SpeechToTextCard() {
   const hasChanges = useMemo(() => {
     const providerChanged = draftProvider !== serverProvider;
     const hasNewKey = apiKeyText.trim().length > 0;
-    // Toggling off managed is itself a saveable change: a user with a BYOK
-    // provider+key already stored has nothing else to edit.
-    const modeChanged = mode !== serverMode;
-    return providerChanged || hasNewKey || modeChanged;
-  }, [draftProvider, serverProvider, apiKeyText, mode, serverMode]);
+    return providerChanged || hasNewKey;
+  }, [draftProvider, serverProvider, apiKeyText]);
 
   const handleSave = useCallback(async () => {
     const trimmedKey = apiKeyText.trim();
 
-    // Local settings back the client-side voice path; keep them in sync. This
-    // handler serves the "Your Own" panel, so the effective mode is your-own.
-    setLocalSetting(LS_STT_MODE, "your-own");
+    // Local settings back the client-side voice path; keep them in sync.
     setLocalSetting(LS_STT_PROVIDER, draftProvider);
     if (trimmedKey.length > 0) {
       setLocalSetting(LS_STT_API_KEY_PREFIX + draftProvider, trimmedKey);
@@ -190,7 +175,7 @@ export function SpeechToTextCard() {
 
     setSaving(true);
     try {
-      if (daemon) {
+      if (daemon?.credentialService) {
         // Push the effective key (freshly typed, else the one already stored
         // locally) so re-saving wires CES even when the masked field is left
         // untouched.
@@ -217,37 +202,33 @@ export function SpeechToTextCard() {
         }
       }
 
-      // The config PATCH runs even for the client-only native choice (which has
-      // no daemon mapping): leaving managed must still flip services.stt.mode
-      // server-side, or a refetch snaps the card back to Managed. Saving from
-      // the "Your Own" panel is explicit BYOK intent, so a managed daemon flips
-      // even without a new key — the user reached these inputs by toggling off
-      // Managed.
-      const escapeManaged = daemonManaged;
-      const providerChanged =
-        !!daemon && (draftProvider !== serverProvider || !daemonHasProvider);
-      // Write `provider` only when the user changed it, or when escaping managed
-      // leaves nothing valid to keep (no stored provider, or the "vellum"
-      // provider, which routes to managed regardless of mode). Otherwise
-      // write mode only and let the daemon's deep-merge preserve the stored
-      // provider — which may be one the dropdown can't represent (e.g.
-      // google-gemini via CLI) and would be silently overwritten by the fallback.
+      // Write `provider` only when the user changed it, or when the daemon has
+      // none stored. Otherwise let the deep-merge preserve what is there — it
+      // may be a provider the dropdown can't represent (e.g. google-gemini via
+      // CLI) that the fallback would silently overwrite.
+      //
+      // Leaving Vellum for the client-only native choice still has to write:
+      // that choice has no daemon mapping, so without it the daemon would stay
+      // on Vellum and a refetch would snap the dropdown back.
+      const leavingVellum =
+        daemonSttProvider === "vellum" && draftProvider !== "vellum";
       const writeProvider =
-        providerChanged ||
-        (escapeManaged &&
-          (!daemonSttProvider || daemonSttProvider === "vellum"));
-      if (writeProvider || escapeManaged) {
-        const providerValue =
-          daemon?.provider ??
-          STT_DAEMON_PROVIDER[draftProvider]?.provider ??
-          "deepgram";
+        (!!daemon && (draftProvider !== serverProvider || !daemonHasProvider)) ||
+        leavingVellum;
+      if (writeProvider) {
+        const providerValue = daemon?.provider ?? DEFAULT_PROVIDER_ID;
         const { response: cfgRes } = await configPatch({
           path: { assistant_id: assistantId },
           body: {
             services: {
               stt: {
-                ...(writeProvider ? { provider: providerValue } : {}),
-                ...(escapeManaged ? { mode: "your-own" } : {}),
+                provider: providerValue,
+                // A stale `mode: "managed"` from the legacy toggle would win
+                // over the BYOK choice, so escaping Vellum resets it. Vellum
+                // itself needs no mode — the provider takes precedence.
+                ...(providerValue !== "vellum"
+                  ? { mode: "your-own" }
+                  : {}),
               },
             },
           },
@@ -284,62 +265,7 @@ export function SpeechToTextCard() {
     selectedProvider,
     serverProvider,
     daemonHasProvider,
-    daemonManaged,
     daemonSttProvider,
-    queryClient,
-  ]);
-
-  const handleSaveManaged = useCallback(async () => {
-    setSaving(true);
-    try {
-      // Persist the BYOK provider as the restore value for toggling back. Keep
-      // the daemon's existing provider when it has one — it may be a valid
-      // provider the dropdown can't represent (e.g. google-gemini set via CLI),
-      // which the fallback would silently overwrite. Only synthesize one for a
-      // sparse config or the client-only native dictation choice ("deepgram" is
-      // the sane default there); the schema requires a provider, and "vellum"
-      // would defeat its purpose as a your-own restore value. The daemon routes
-      // managed mode to Vellum at runtime regardless of this value.
-      const restoreProvider =
-        daemonSttProvider && daemonSttProvider !== "vellum"
-          ? daemonSttProvider
-          : STT_DAEMON_PROVIDER[draftProvider]?.provider ?? "deepgram";
-      const { response: cfgRes } = await configPatch({
-        path: { assistant_id: assistantId },
-        body: { services: { stt: { mode: "managed", provider: restoreProvider } } },
-        throwOnError: false,
-      });
-      if (!cfgRes?.ok) {
-        throw new Error(
-          `Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`,
-        );
-      }
-      setLocalSetting(LS_STT_MODE, "managed");
-      // The client-only native-dictation choice makes `prefersMacosNativeStt()`
-      // keep routing transcription locally, bypassing managed STT on this
-      // client. Repoint the stored provider at a daemon-backed one so Managed
-      // actually takes effect.
-      if (draftProvider === MACOS_NATIVE_STT_PROVIDER_ID) {
-        setLocalSetting(LS_STT_PROVIDER, defaultProviderId);
-      }
-      void queryClient.invalidateQueries({
-        queryKey: configGetQueryKey({ path: { assistant_id: assistantId } }),
-      });
-      toast.success("Speech-to-text settings saved");
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : "Failed to save speech-to-text settings",
-      );
-    } finally {
-      setSaving(false);
-    }
-  }, [
-    assistantId,
-    daemonSttProvider,
-    draftProvider,
-    defaultProviderId,
     queryClient,
   ]);
 
@@ -354,68 +280,63 @@ export function SpeechToTextCard() {
     : selectedProvider.apiKeyPlaceholder;
 
   return (
-    <ServiceCard
+    <ByoServiceCard
       title="Speech-to-Text"
       subtitle="Configure how your assistant transcribes speech"
-      mode={mode}
-      onModeChange={(m) => setDraftMode(m)}
     >
-      {mode === "managed" ? (
-        <div className="space-y-3">
-          <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
-            Managed transcription is included with your Vellum connection.
-          </p>
-          <SaveButton onClick={handleSaveManaged} disabled={saving} />
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <label className="block text-body-small-default text-[var(--content-tertiary)]">
+            Provider
+          </label>
+          <Dropdown
+            value={draftProvider}
+            onChange={setDraftProvider}
+            options={providers.map((p) => ({
+              value: p.id,
+              label: p.displayName,
+            }))}
+            aria-label="STT provider"
+          />
         </div>
-      ) : (
-        <div className="space-y-4">
+
+        {requiresApiKey && (
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Provider
+              API Key
             </label>
-            <Dropdown
-              value={draftProvider}
-              onChange={setDraftProvider}
-              options={providers.map((p) => ({
-                value: p.id,
-                label: p.displayName,
-              }))}
-              aria-label="STT provider"
+            <Input
+              type="password"
+              value={apiKeyText}
+              onChange={(e) => setApiKeyText(e.target.value)}
+              placeholder={apiKeyPlaceholder}
+              fullWidth
             />
           </div>
+        )}
 
-          {requiresApiKey && (
-            <div className="space-y-1">
-              <label className="block text-body-small-default text-[var(--content-tertiary)]">
-                API Key
-              </label>
-              <Input
-                type="password"
-                value={apiKeyText}
-                onChange={(e) => setApiKeyText(e.target.value)}
-                placeholder={apiKeyPlaceholder}
-                fullWidth
-              />
-            </div>
-          )}
-
-          {selectedProvider.setupWarning && (
-            <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
-              <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-mid-strong)]" />
-              <span>{selectedProvider.setupWarning}</span>
-            </div>
-          )}
-
-          {selectedProvider.credentialsGuide && (
-            <CredentialsGuide guide={selectedProvider.credentialsGuide} />
-          )}
-
-          <div className="flex items-center justify-end gap-2">
-            <SaveButton onClick={handleSave} disabled={!hasChanges || saving} />
-            {providerHasKey && <ResetButton onClick={handleReset} />}
+        {selectedProvider.setupWarning && (
+          <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
+            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-mid-strong)]" />
+            <span>{selectedProvider.setupWarning}</span>
           </div>
+        )}
+
+        {selectedProvider.credentialsGuide && (
+          <CredentialsGuide guide={selectedProvider.credentialsGuide} />
+        )}
+
+        {draftProvider === "vellum" && (
+          <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+            Transcription runs through your Vellum account.
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-2">
+          <SaveButton onClick={handleSave} disabled={!hasChanges || saving} />
+          {providerHasKey && <ResetButton onClick={handleReset} />}
         </div>
-      )}
-    </ServiceCard>
+      </div>
+    </ByoServiceCard>
   );
 }

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -222,13 +222,13 @@ export function SpeechToTextCard() {
           body: {
             services: {
               stt: {
+                // The provider is always written as a pair with `mode`, which
+                // keeps the write valid on every daemon version: older schemas
+                // reject provider "vellum" without mode "managed", and a stale
+                // `mode: "managed"` from the legacy toggle would win over a
+                // BYOK choice unless reset.
                 provider: providerValue,
-                // A stale `mode: "managed"` from the legacy toggle would win
-                // over the BYOK choice, so escaping Vellum resets it. Vellum
-                // itself needs no mode — the provider takes precedence.
-                ...(providerValue !== "vellum"
-                  ? { mode: "your-own" }
-                  : {}),
+                mode: providerValue === "vellum" ? "managed" : "your-own",
               },
             },
           },

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -17,7 +17,6 @@ import {
   render,
   screen,
   waitFor,
-  within,
 } from "@testing-library/react";
 
 const ASSISTANT_ID = "asst-test";
@@ -99,11 +98,6 @@ function selectProvider(label: string): void {
   fireEvent.click(option);
 }
 
-function setMode(label: "Managed" | "Your Own"): void {
-  const group = screen.getByRole("radiogroup", { name: "Service mode" });
-  fireEvent.click(within(group).getByRole("radio", { name: label }));
-}
-
 describe("TextToSpeechCard — daemon provisioning on Save", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -168,17 +162,11 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     expect(ttsBody?.services?.tts ?? {}).not.toHaveProperty("provider");
   });
 
-  test("saving a key from the Your Own panel switches a managed-mode daemon back", async () => {
-    // Managed speech was auto-defaulted on connection; toggling to "Your Own"
-    // and saving a BYOK key is explicit intent to use it, so the mode flips —
-    // otherwise the key appears to save but the daemon stays on managed.
-    daemonConfigData = {
-      services: { tts: { provider: "fish-audio", mode: "managed" } },
-    };
+  test("selecting a BYOK provider from a Vellum daemon writes that provider", async () => {
+    daemonConfigData = { services: { tts: { provider: "vellum" } } };
     renderCard();
 
-    // The card opens on the Managed panel; toggle to reach the BYOK inputs.
-    setMode("Your Own");
+    selectProvider("Fish Audio");
     fireEvent.change(screen.getByPlaceholderText(/Fish Audio API key/), {
       target: { value: "fish-secret" },
     });
@@ -186,161 +174,90 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
     expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { tts: { provider: "fish-audio", mode: "your-own" } },
+      services: { tts: { provider: "fish-audio" } },
     });
-  });
-
-  test("a voice-ID-only save from the Your Own panel leaves managed mode", async () => {
-    // Reaching the voice-ID input requires toggling off Managed, so saving —
-    // even without a new key — is explicit intent to use your own provider and
-    // must flip the daemon off managed.
-    daemonConfigData = {
-      services: { tts: { provider: "fish-audio", mode: "managed" } },
-    };
-    renderCard();
-
-    setMode("Your Own");
-    fireEvent.change(screen.getByPlaceholderText("Enter a voice ID"), {
-      target: { value: "voice-456" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { tts: { provider: "fish-audio", mode: "your-own" } },
-    });
-    expect(credentialsSetCalls).toHaveLength(0);
-  });
-
-  test("a managed daemon reporting the reserved vellum provider gets a representable one", async () => {
-    // A managed daemon may report provider "vellum", which the dropdown cannot
-    // show and which is schema-invalid outside managed mode — the PATCH must
-    // carry the card's selected provider instead.
-    daemonConfigData = {
-      services: { tts: { provider: "vellum", mode: "managed" } },
-    };
-    renderCard();
-
-    setMode("Your Own");
-    // The dropdown falls back to the first representable provider
-    // (ElevenLabs, whose key placeholder is "sk_…").
-    fireEvent.change(screen.getByPlaceholderText("sk_…"), {
-      target: { value: "byok-secret" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const ttsBody = configPatchCalls[0]!.body as {
-      services: { tts: Record<string, unknown> };
-    };
-    expect(ttsBody.services.tts.mode).toBe("your-own");
-    expect(ttsBody.services.tts.provider).toBeDefined();
-    expect(ttsBody.services.tts.provider).not.toBe("vellum");
-    // The credential must land under the same provider the PATCH activates —
-    // storing it under the reserved id would leave the activated provider
-    // keyless while the save appears successful.
+    // The credential must land under the provider the PATCH activates.
     expect(credentialsSetCalls).toHaveLength(1);
     expect((credentialsSetCalls[0]!.body as { service: string }).service).toBe(
-      ttsBody.services.tts.provider as string,
+      "fish-audio",
     );
   });
+});
 
-  test("renders the Managed panel (no BYOK inputs) when the daemon is managed", async () => {
-    daemonConfigData = {
-      services: { tts: { provider: "fish-audio", mode: "managed" } },
-    };
-    renderCard();
-
-    expect(
-      screen.getByText(/Managed speech synthesis is included/),
-    ).toBeDefined();
-    // The provider dropdown belongs to the Your Own panel and must be absent.
-    expect(
-      document.querySelector('button[aria-label="TTS provider"]'),
-    ).toBeNull();
+describe("TextToSpeechCard — Vellum provider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    credentialsSetCalls.length = 0;
+    configPatchCalls.length = 0;
+    daemonConfigData = { services: {} };
   });
 
-  // Provider "vellum" routes to managed regardless of mode, so a provider-only
-  // managed config (written via the CLI) must render and escape like one
-  // written by the toggle.
-  test("renders the Managed panel for a provider-only vellum daemon", async () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  test("a vellum daemon provider hides the API key field and the Test button", () => {
     daemonConfigData = { services: { tts: { provider: "vellum" } } };
     renderCard();
 
-    expect(
-      screen.getByText(/Managed speech synthesis is included/),
-    ).toBeDefined();
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="TTS provider"]',
+    );
+    expect(trigger?.textContent).toContain("Vellum");
+    // Vellum authenticates via the platform connection, so there is no key to
+    // enter and nothing for the client-side Test path to use.
+    expect(screen.queryByText("API Key")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Test" })).toBeNull();
   });
 
-  test("escaping a provider-only vellum daemon replaces the provider", async () => {
-    daemonConfigData = { services: { tts: { provider: "vellum" } } };
+  test("selecting Vellum saves provider vellum and stores no credential", async () => {
     renderCard();
 
-    setMode("Your Own");
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const ttsBody = configPatchCalls[0]!.body as {
-      services: { tts: Record<string, unknown> };
-    };
-    expect(ttsBody.services.tts.mode).toBe("your-own");
-    expect(ttsBody.services.tts.provider).toBeDefined();
-    expect(ttsBody.services.tts.provider).not.toBe("vellum");
-  });
-
-  test("Managed Save writes the effective BYOK provider as the restore value", async () => {
-    // The stored provider is the your-own restore value for toggling back;
-    // effectiveTtsProvider routes managed mode to Vellum at runtime.
-    daemonConfigData = { services: { tts: { provider: "fish-audio" } } };
-    renderCard();
-
-    setMode("Managed");
+    selectProvider("Vellum Managed");
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
     expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { tts: { mode: "managed", provider: "fish-audio" } },
+      services: { tts: { provider: "vellum" } },
     });
+    // The provider takes precedence over any mode on disk — nothing to reset.
+    expect(
+      (configPatchCalls[0]!.body as { services: { tts: object } }).services
+        .tts,
+    ).not.toHaveProperty("mode");
     expect(credentialsSetCalls).toHaveLength(0);
   });
 
-  test("Managed Save always carries a representable provider (never vellum)", async () => {
-    // A managed daemon may report the reserved "vellum" provider; the write
-    // must fall back to a representable id so the restore value stays usable
-    // and the schema (which forbids "vellum" only outside managed) is happy.
+  // A config written by the legacy mode toggle marks managed via `mode` while
+  // `provider` holds the BYOK restore value.
+  test("a legacy managed-mode daemon renders as Vellum", () => {
     daemonConfigData = {
-      services: { tts: { provider: "vellum", mode: "managed" } },
+      services: { tts: { mode: "managed", provider: "fish-audio" } },
     };
     renderCard();
 
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(configPatchCalls.length).toBe(1));
-    const ttsBody = configPatchCalls[0]!.body as {
-      services: { tts: Record<string, unknown> };
-    };
-    expect(ttsBody.services.tts.mode).toBe("managed");
-    expect(ttsBody.services.tts.provider).toBeDefined();
-    expect(ttsBody.services.tts.provider).not.toBe("vellum");
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="TTS provider"]',
+    );
+    expect(trigger?.textContent).toContain("Vellum");
+    expect(screen.queryByText("API Key")).toBeNull();
   });
 
-  test("toggling to Your Own is a saveable change on its own", async () => {
-    // A managed daemon with a stored provider has nothing else to edit —
-    // flipping the toggle must enable Save and persist mode: your-own.
+  test("escaping a legacy managed-mode daemon resets mode alongside the provider", async () => {
+    // Without the mode reset, the stale `mode: "managed"` would win over the
+    // BYOK provider choice and the user would silently stay on Vellum.
     daemonConfigData = {
-      services: { tts: { provider: "fish-audio", mode: "managed" } },
+      services: { tts: { mode: "managed", provider: "fish-audio" } },
     };
     renderCard();
 
-    setMode("Your Own");
-    const save = screen.getByRole("button", { name: "Save" });
-    expect(save.hasAttribute("disabled")).toBe(false);
-    fireEvent.click(save);
+    selectProvider("Fish Audio");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
     expect(configPatchCalls[0]!.body).toMatchObject({
       services: { tts: { provider: "fish-audio", mode: "your-own" } },
     });
-    expect(credentialsSetCalls).toHaveLength(0);
   });
 });

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -29,18 +29,23 @@ mock.module("@vellumai/design-library/components/toast", () => ({
   Toaster: () => null,
   ToastContent: () => null,
 }));
+let orgReady = false;
 mock.module("@/hooks/use-is-org-ready", () => ({
-  useIsOrgReady: () => false,
+  useIsOrgReady: () => orgReady,
 }));
 // Controllable daemon config the config-get query resolves to. `initialData`
 // makes it available even though the query is `enabled: isOrgReady` (false),
 // mirroring how the real query would already be cached. Default `{ services: {} }`
 // leaves the daemon with no tts provider, so the happy-path tests still PATCH it.
 let daemonConfigData: { services: Record<string, unknown> } = { services: {} };
+// When set, the tts-providers query resolves to this catalog (as `initialData`,
+// so no async settling) — lets tests exercise a daemon-fetched provider list.
+let ttsCatalogData: { providers: unknown[] } | undefined;
 mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
   ttsProvidersGetOptions: () => ({
     queryKey: ["tts-providers-test"],
-    queryFn: () => Promise.resolve({ providers: [] }),
+    queryFn: () => Promise.resolve(ttsCatalogData ?? { providers: [] }),
+    ...(ttsCatalogData ? { initialData: ttsCatalogData } : {}),
   }),
   configGetOptions: () => ({
     queryKey: ["config-get-test"],
@@ -104,6 +109,8 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     credentialsSetCalls.length = 0;
     configPatchCalls.length = 0;
     daemonConfigData = { services: {} };
+    orgReady = false;
+    ttsCatalogData = undefined;
   });
 
   afterEach(() => {
@@ -190,6 +197,8 @@ describe("TextToSpeechCard — Vellum provider", () => {
     credentialsSetCalls.length = 0;
     configPatchCalls.length = 0;
     daemonConfigData = { services: {} };
+    orgReady = false;
+    ttsCatalogData = undefined;
   });
 
   afterEach(() => {
@@ -218,14 +227,11 @@ describe("TextToSpeechCard — Vellum provider", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    // Written as a pair so the save stays valid on daemons whose schema
+    // still couples provider "vellum" to mode "managed".
     expect(configPatchCalls[0]!.body).toMatchObject({
-      services: { tts: { provider: "vellum" } },
+      services: { tts: { provider: "vellum", mode: "managed" } },
     });
-    // The provider takes precedence over any mode on disk — nothing to reset.
-    expect(
-      (configPatchCalls[0]!.body as { services: { tts: object } }).services
-        .tts,
-    ).not.toHaveProperty("mode");
     expect(credentialsSetCalls).toHaveLength(0);
   });
 
@@ -259,5 +265,36 @@ describe("TextToSpeechCard — Vellum provider", () => {
     expect(configPatchCalls[0]!.body).toMatchObject({
       services: { tts: { provider: "fish-audio", mode: "your-own" } },
     });
+  });
+
+  test("grafts the Vellum option onto a fetched catalog that lacks it", () => {
+    // A daemon serving the pre-vellum catalog omits the managed option; the
+    // card must still offer it, or a legacy managed config has no selectable
+    // representation and managed TTS becomes unreachable from this UI.
+    orgReady = true;
+    ttsCatalogData = {
+      providers: [
+        {
+          id: "elevenlabs",
+          displayName: "ElevenLabs",
+          subtitle: "High-quality voice synthesis.",
+          supportsVoiceSelection: true,
+          apiKeyPlaceholder: "sk_…",
+          credentialsGuide: { description: "", url: "", linkLabel: "" },
+        },
+      ],
+    };
+    renderCard();
+
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="TTS provider"]',
+    );
+    expect(trigger).not.toBeNull();
+    fireEvent.click(trigger!);
+    const options = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(options).toContain("Vellum Managed");
+    expect(options).toContain("ElevenLabs");
   });
 });

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -57,7 +57,20 @@ export function TextToSpeechCard() {
     enabled: isOrgReady,
     staleTime: Infinity,
   });
-  const providers = catalogData?.providers ?? TTS_PROVIDERS;
+  const providers = useMemo(() => {
+    const fetched = catalogData?.providers;
+    if (!fetched) {
+      return TTS_PROVIDERS;
+    }
+    // Assistants running an older catalog omit vellum, but the managed option
+    // must still be offered (and a legacy managed config still renders as
+    // Vellum) — graft the static entry on.
+    if (fetched.some((p) => p.id === "vellum")) {
+      return fetched;
+    }
+    const vellum = TTS_PROVIDERS.find((p) => p.id === "vellum");
+    return vellum ? [vellum, ...fetched] : fetched;
+  }, [catalogData]);
 
   // Seed the provider from the daemon's live config so a Save doesn't clobber a
   // provider configured elsewhere (CLI/other client) when localStorage is stale.
@@ -173,12 +186,16 @@ export function TextToSpeechCard() {
       const shouldSetProvider =
         draftProvider !== serverProvider || !daemonHasProvider;
       const ttsBody = {
-        ...(shouldSetProvider ? { provider: activeProvider } : {}),
-        // A stale `mode: "managed"` from the legacy toggle would win over the
-        // BYOK choice, so escaping Vellum resets it. Vellum itself needs no
-        // mode — the provider takes precedence.
-        ...(shouldSetProvider && activeProvider !== "vellum"
-          ? { mode: "your-own" }
+        // The provider is always written as a pair with `mode`, which keeps
+        // the write valid on every daemon version: older schemas reject
+        // provider "vellum" without mode "managed", and a stale
+        // `mode: "managed"` from the legacy toggle would win over a BYOK
+        // choice unless reset.
+        ...(shouldSetProvider
+          ? {
+              provider: activeProvider,
+              mode: activeProvider === "vellum" ? "managed" : "your-own",
+            }
           : {}),
         ...(voiceField
           ? {

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -20,20 +20,17 @@ import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import {
+  ByoServiceCard,
   CredentialsGuide,
   ResetButton,
   SaveButton,
-  ServiceCard,
 } from "@/domains/settings/ai/shared-ui";
 import {
   LS_TTS_API_KEY_PREFIX,
-  LS_TTS_MODE,
   LS_TTS_PROVIDER,
   LS_TTS_VOICE_ID_PREFIX,
 } from "@/domains/settings/ai/local-storage-keys";
 import { TTS_PROVIDERS } from "@/domains/settings/ai/provider-catalogs";
-import { parseServiceMode } from "@/domains/settings/ai/utils";
-import type { ServiceMode } from "@/generated/daemon/types.gen";
 
 /**
  * The daemon config key that the "Voice ID" input maps to, per provider, under
@@ -70,34 +67,19 @@ export function TextToSpeechCard() {
     staleTime: 30_000,
   });
   // `services.tts` falls under the ConfigGetResponse index signature (`unknown`),
-  // so narrow it explicitly to read the provider and mode.
+  // so narrow it explicitly to read the provider.
   const daemonTts = daemonConfig?.services?.tts as
     { provider?: string; mode?: string } | undefined;
-  const daemonTtsProvider = daemonTts?.provider;
-  // Provider "vellum" routes to managed regardless of mode, so the card must
-  // treat it as managed too — otherwise a provider-only managed config (e.g.
-  // written via the CLI) would render the Your Own panel, and a save from it
-  // could never escape: nothing would look changed, so no provider write.
-  const daemonManaged =
-    daemonTts?.mode === "managed" || daemonTtsProvider === "vellum";
+  // A config written by the legacy mode toggle marks managed via `mode` while
+  // `provider` holds the BYOK restore value — the daemon routes it to Vellum,
+  // so the card must render it as Vellum too.
+  const daemonTtsProvider =
+    daemonTts?.mode === "managed" ? "vellum" : daemonTts?.provider;
 
-  // Managed vs. your-own toggle. Derived from the daemon (source of truth),
-  // falling back to localStorage so the toggle doesn't flash "your-own" before
-  // the config query resolves. `useDraftOverride` lets the user flip it locally
-  // until a save + refetch converges the server value.
-  const serverMode = useMemo<ServiceMode>(
-    () =>
-      daemonManaged
-        ? "managed"
-        : parseServiceMode(
-            daemonTts?.mode ?? getLocalSetting(LS_TTS_MODE, "your-own"),
-            "your-own",
-          ),
-    [daemonManaged, daemonTts?.mode],
-  );
-  const [mode, setDraftMode] = useDraftOverride(serverMode);
-
-  const defaultProviderId = providers[0]?.id ?? "elevenlabs";
+  // Mirrors the daemon's `services.tts.provider` schema default. Deliberately
+  // not `providers[0]` — the catalog leads with Vellum, and an unconfigured
+  // client must not claim the managed provider on its own.
+  const defaultProviderId = "elevenlabs";
   const serverProvider = useMemo(
     () =>
       daemonTtsProvider ?? getLocalSetting(LS_TTS_PROVIDER, defaultProviderId),
@@ -136,34 +118,20 @@ export function TextToSpeechCard() {
     const providerChanged = draftProvider !== serverProvider;
     const hasNewKey = apiKeyText.trim().length > 0;
     const voiceIdChanged = voiceIdText.trim() !== initialVoiceId;
-    // Toggling off managed is itself a saveable change: a user with a BYOK
-    // provider+key already stored has nothing else to edit.
-    const modeChanged = mode !== serverMode;
-    return providerChanged || hasNewKey || voiceIdChanged || modeChanged;
-  }, [
-    draftProvider,
-    serverProvider,
-    apiKeyText,
-    voiceIdText,
-    initialVoiceId,
-    mode,
-    serverMode,
-  ]);
+    return providerChanged || hasNewKey || voiceIdChanged;
+  }, [draftProvider, serverProvider, apiKeyText, voiceIdText, initialVoiceId]);
 
   const handleSave = useCallback(async () => {
     const trimmedKey = apiKeyText.trim();
     const trimmedVoiceId = voiceIdText.trim();
 
     // The provider everything is saved under. Matches draftProvider except
-    // when the daemon reports one the dropdown can't represent (e.g. the
-    // reserved managed-mode "vellum" id) — then it is the rendered fallback,
-    // so the credential, local state, and config PATCH all target the same
-    // provider the save activates.
+    // when the daemon reports one the dropdown can't represent — then it is
+    // the rendered fallback, so the credential, local state, and config PATCH
+    // all target the same provider the save activates.
     const activeProvider = selectedProvider.id;
 
-    // Local settings back the client-side voice path; keep them in sync. This
-    // handler serves the "Your Own" panel, so the effective mode is your-own.
-    setLocalSetting(LS_TTS_MODE, "your-own");
+    // Local settings back the client-side voice path; keep them in sync.
     setLocalSetting(LS_TTS_PROVIDER, activeProvider);
     if (trimmedKey.length > 0) {
       setLocalSetting(LS_TTS_API_KEY_PREFIX + activeProvider, trimmedKey);
@@ -201,18 +169,17 @@ export function TextToSpeechCard() {
       }
       // Only PATCH the provider when it truly diverges from the persisted
       // value (or the daemon has none yet); otherwise a re-save with just a new
-      // key/voice would silently switch a provider set elsewhere. Saving from
-      // the "Your Own" panel is explicit BYOK intent, so a managed-mode daemon
-      // is switched back to your-own even without a new key — the user reached
-      // these inputs by toggling off Managed.
-      const escapeManaged = daemonManaged;
+      // key/voice would silently switch a provider set elsewhere.
       const shouldSetProvider =
         draftProvider !== serverProvider || !daemonHasProvider;
       const ttsBody = {
-        ...(shouldSetProvider || escapeManaged
-          ? { provider: activeProvider }
+        ...(shouldSetProvider ? { provider: activeProvider } : {}),
+        // A stale `mode: "managed"` from the legacy toggle would win over the
+        // BYOK choice, so escaping Vellum resets it. Vellum itself needs no
+        // mode — the provider takes precedence.
+        ...(shouldSetProvider && activeProvider !== "vellum"
+          ? { mode: "your-own" }
           : {}),
-        ...(escapeManaged ? { mode: "your-own" } : {}),
         ...(voiceField
           ? {
               providers: { [activeProvider]: { [voiceField]: trimmedVoiceId } },
@@ -256,45 +223,8 @@ export function TextToSpeechCard() {
     selectedProvider,
     serverProvider,
     daemonHasProvider,
-    daemonManaged,
     queryClient,
   ]);
-
-  const handleSaveManaged = useCallback(async () => {
-    setSaving(true);
-    try {
-      // Persist the effective BYOK provider as the restore value for toggling
-      // back — `selectedProvider.id` is always representable (never the reserved
-      // "vellum" id, which would defeat its purpose as a restore value). The
-      // daemon's `effectiveTtsProvider` routes managed mode to Vellum at
-      // runtime regardless of this value.
-      const { response: cfgRes } = await configPatch({
-        path: { assistant_id: assistantId },
-        body: {
-          services: { tts: { mode: "managed", provider: selectedProvider.id } },
-        },
-        throwOnError: false,
-      });
-      if (!cfgRes?.ok) {
-        throw new Error(
-          `Failed to save configuration (HTTP ${cfgRes?.status ?? "?"})`,
-        );
-      }
-      setLocalSetting(LS_TTS_MODE, "managed");
-      void queryClient.invalidateQueries({
-        queryKey: configGetQueryKey({ path: { assistant_id: assistantId } }),
-      });
-      toast.success("Text-to-speech settings saved");
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : "Failed to save text-to-speech settings",
-      );
-    } finally {
-      setSaving(false);
-    }
-  }, [assistantId, selectedProvider, queryClient]);
 
   const handleReset = useCallback(() => {
     setLocalSetting(LS_TTS_API_KEY_PREFIX + draftProvider, "");
@@ -352,38 +282,32 @@ export function TextToSpeechCard() {
   const apiKeyPlaceholder = providerHasKey
     ? "••••••••  (Enter a new key to replace)"
     : selectedProvider.apiKeyPlaceholder;
+  // Vellum authenticates via the platform connection, so it has no key to enter
+  // and nothing for the client-side Test path (a direct provider call) to use.
+  const isManaged = draftProvider === "vellum";
 
   return (
-    <ServiceCard
+    <ByoServiceCard
       title="Text-to-Speech"
       subtitle="Configure how your assistant speaks"
-      mode={mode}
-      onModeChange={(m) => setDraftMode(m)}
     >
-      {mode === "managed" ? (
-        <div className="space-y-3">
-          <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
-            Managed speech synthesis is included with your Vellum connection.
-          </p>
-          <SaveButton onClick={handleSaveManaged} disabled={saving} />
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <label className="block text-body-small-default text-[var(--content-tertiary)]">
+            Provider
+          </label>
+          <Dropdown
+            value={draftProvider}
+            onChange={setDraftProvider}
+            options={providers.map((p) => ({
+              value: p.id,
+              label: p.displayName,
+            }))}
+            aria-label="TTS provider"
+          />
         </div>
-      ) : (
-        <div className="space-y-4">
-          <div className="space-y-1">
-            <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Provider
-            </label>
-            <Dropdown
-              value={draftProvider}
-              onChange={setDraftProvider}
-              options={providers.map((p) => ({
-                value: p.id,
-                label: p.displayName,
-              }))}
-              aria-label="TTS provider"
-            />
-          </div>
 
+        {!isManaged && (
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
               API Key
@@ -396,38 +320,39 @@ export function TextToSpeechCard() {
               fullWidth
             />
           </div>
+        )}
 
-          {selectedProvider.supportsVoiceSelection && (
-            <div className="space-y-1">
-              <label className="block text-body-small-default text-[var(--content-tertiary)]">
-                Voice ID
-              </label>
-              <Input
-                type="text"
-                value={voiceIdText}
-                onChange={(e) => setVoiceIdText(e.target.value)}
-                placeholder="Enter a voice ID"
-                fullWidth
-              />
-            </div>
-          )}
+        {selectedProvider.supportsVoiceSelection && (
+          <div className="space-y-1">
+            <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              Voice ID
+            </label>
+            <Input
+              type="text"
+              value={voiceIdText}
+              onChange={(e) => setVoiceIdText(e.target.value)}
+              placeholder="Enter a voice ID"
+              fullWidth
+            />
+          </div>
+        )}
 
-          <CredentialsGuide guide={selectedProvider.credentialsGuide} />
+        <CredentialsGuide guide={selectedProvider.credentialsGuide} />
 
-          <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2">
+          {!isManaged && (
             <Button variant="outlined" onClick={handleTest} disabled={testing}>
               {testing ? "Testing…" : "Test"}
             </Button>
-            <div className="ml-auto flex items-center gap-2">
-              <SaveButton
-                onClick={handleSave}
-                disabled={!hasChanges || saving}
-              />
-              {providerHasKey && <ResetButton onClick={handleReset} />}
-            </div>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <SaveButton onClick={handleSave} disabled={!hasChanges || saving} />
+            {providerHasKey && !isManaged && (
+              <ResetButton onClick={handleReset} />
+            )}
           </div>
         </div>
-      )}
-    </ServiceCard>
+      </div>
+    </ByoServiceCard>
   );
 }

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -1,6 +1,21 @@
 {
-  "version": 4,
+  "version": 5,
   "providers": [
+    {
+      "id": "vellum",
+      "displayName": "Vellum Managed",
+      "subtitle": "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
+      "setupMode": "cli",
+      "setupHint": "Connect your Vellum account to enable managed speech.",
+      "credentialMode": "credential",
+      "credentialNamespace": "vellum",
+      "supportsVoiceSelection": false,
+      "credentialsGuide": {
+        "description": "Connect this assistant to your Vellum account; managed speech uses that connection instead of a provider API key.",
+        "url": "https://platform.vellum.ai/",
+        "linkLabel": "Open Vellum Platform"
+      }
+    },
     {
       "id": "elevenlabs",
       "displayName": "ElevenLabs",


### PR DESCRIPTION
## What

The Managed/Your Own toggle is gone from both speech settings cards. Vellum is now the first option in the provider dropdown:

- enters the TTS display catalog (`tts/provider-catalog.ts`), `meta/tts-provider-catalog.json` (version 5 — parity guards pass), and both client static catalogs
- selecting it hides the API-key input, and Test for TTS — that path is a direct client-side provider call with a key Vellum doesn't have
- the mode localStorage keys (`LS_STT_MODE` / `LS_TTS_MODE`, read only by these cards) are deleted; with the dropdown as the state there is no toggle to preserve a BYOK choice across
- `voice_config_update` gates `tts_provider: "vellum"` on the platform connection — the catalog check no longer rejects it, so the guard moves to the provider value

## Two temporary bridges (removed by the end of the stack)

Configs written by the mode toggle still exist until `mode` is retired, so the cards bridge both directions:

- **read**: `mode: "managed"` renders as Vellum — the daemon routes it there, so the card must agree rather than showing the stale BYOK restore value
- **write**: escaping Vellum writes `mode: "your-own"` alongside the BYOK provider — a stale `mode: "managed"` would otherwise take precedence over the user's choice and silently keep them on Vellum

Both are covered by tests ("a legacy managed-mode daemon renders as Vellum", "escaping a legacy managed-mode daemon resets mode alongside the provider").

## One deliberate choice worth reviewing

The cards' fallback default is an explicit constant (`deepgram` / `elevenlabs`, mirroring the daemon schema defaults) — **not** `providers[0]`, which is now Vellum. An unconfigured client with no platform connection must not claim the managed provider on its own.

## Stack

2 of 4, **based on #38248** (the daemon must accept `provider: "vellum"` without `mode: "managed"` before this UI can write it — merge order matters):

1. #38248 — daemon accepts `provider: "vellum"` (inert)
2. **this** — single provider dropdown
3. drop `mode` + migration (`mode: "managed"` → `provider: "vellum"`)
4. platform-login gating on the Vellum option; the bridges above come out

## Testing

- 13 STT + 7 TTS card tests pass, including the bridge cases
- Daemon: config-schema, TTS catalog parity, catalog consistency, provider resolution, voice-config-update — 325 pass / 0 fail
- `tsc --noEmit` clean in both packages; eslint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)