### PR TITLE
feat(consent): server-effective verdicts drive the data-capture gates

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-store.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Contract tests for the onboarding store's server-effective verdict fields:
+ * in-memory only — boot null, never device-persisted, never cross-tab
+ * synced — unlike the device-backed share toggles beside them.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+
+beforeEach(() => {
+  localStorage.clear();
+  useOnboardingStore.setState({
+    shareAnalytics: null,
+    shareDiagnostics: null,
+    serverAnalyticsEffective: null,
+    serverDiagnosticsEffective: null,
+  });
+});
+
+describe("server-effective verdict fields", () => {
+  test("boot null (no sync yet)", () => {
+    expect(useOnboardingStore.getState().serverAnalyticsEffective).toBeNull();
+    expect(useOnboardingStore.getState().serverDiagnosticsEffective).toBeNull();
+  });
+
+  test("setters round-trip booleans and null", () => {
+    const store = useOnboardingStore.getState();
+    store.setServerAnalyticsEffective(false);
+    store.setServerDiagnosticsEffective(true);
+    expect(useOnboardingStore.getState().serverAnalyticsEffective).toBe(false);
+    expect(useOnboardingStore.getState().serverDiagnosticsEffective).toBe(true);
+    store.setServerAnalyticsEffective(null);
+    store.setServerDiagnosticsEffective(null);
+    expect(useOnboardingStore.getState().serverAnalyticsEffective).toBeNull();
+    expect(useOnboardingStore.getState().serverDiagnosticsEffective).toBeNull();
+  });
+
+  test("setters write no device keys (in-memory only)", () => {
+    useOnboardingStore.getState().setServerAnalyticsEffective(true);
+    useOnboardingStore.getState().setServerDiagnosticsEffective(false);
+    expect(localStorage.length).toBe(0);
+  });
+
+  test("cross-tab share-toggle sync leaves the verdicts untouched (not wired)", () => {
+    useOnboardingStore.getState().setServerAnalyticsEffective(false);
+    // Simulate another tab flipping the device-persisted analytics toggle:
+    // the watcher updates the tri-state, but the server verdict rides no
+    // device key, so nothing can sync it across tabs.
+    localStorage.setItem("device:share_analytics", "true");
+    window.dispatchEvent(
+      new CustomEvent("vellum:pref-changed", {
+        detail: { key: "device:share_analytics", value: "true" },
+      }),
+    );
+    expect(useOnboardingStore.getState().shareAnalytics).toBe(true);
+    expect(useOnboardingStore.getState().serverAnalyticsEffective).toBe(false);
+  });
+});

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -68,6 +68,12 @@ export interface OnboardingState {
    */
   serverAnalyticsEffective: boolean | null;
   /**
+   * PER-TAB by design (like `serverAnalyticsEffective` above): a verdict
+   * adopted in one tab reaches others on their own focus/backstop refresh.
+   * The bounded staleness is acceptable because the platform's ingest gate
+   * is the enforcement point — uploads from a stale tab under a server
+   * opt-out are dropped server-side; the client gate is an efficiency.
+   *
    * A local explicit analytics opt-in whose server write has not yet been
    * reflected by a sync. Lets the emit gate re-enable immediately on opt-in
    * without letting server-ADOPTED raw values bypass a divergent effective

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -17,6 +17,12 @@
  * flags, so route guards can distinguish "not yet loaded" from a genuine
  * `false`.
  *
+ * **Server-effective verdicts** (`serverAnalyticsEffective`,
+ * `serverDiagnosticsEffective`) are the platform-computed effective consent
+ * values adopted at sync; `null` means no successful sync with a server
+ * record yet. In-memory only — never device-persisted, never cross-tab
+ * synced — the data-capture gates read them alongside the local tri-state.
+ *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
 
@@ -56,6 +62,13 @@ export interface OnboardingState {
   shareAnalytics: boolean | null;
   /** `null` = never asked; a boolean is an explicit user choice. */
   shareDiagnostics: boolean | null;
+  /**
+   * Platform-computed effective analytics consent, adopted at sync; `null`
+   * before the first sync that saw a server record.
+   */
+  serverAnalyticsEffective: boolean | null;
+  /** See {@link serverAnalyticsEffective}; the diagnostics verdict. */
+  serverDiagnosticsEffective: boolean | null;
   tosAccepted: boolean;
   privacyConsent: boolean;
   analyticsConsentCurrent: boolean;
@@ -70,6 +83,8 @@ export interface OnboardingState {
 export interface OnboardingActions {
   setShareAnalytics: (value: boolean | null) => void;
   setShareDiagnostics: (value: boolean | null) => void;
+  setServerAnalyticsEffective: (value: boolean | null) => void;
+  setServerDiagnosticsEffective: (value: boolean | null) => void;
   setTosAccepted: (value: boolean) => void;
   setPrivacyConsent: (value: boolean) => void;
   setAnalyticsConsentCurrent: (value: boolean) => void;
@@ -86,6 +101,8 @@ export type OnboardingStore = OnboardingState & OnboardingActions;
 const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   shareAnalytics: getLocalBoolOrNull(KEY_SHARE_ANALYTICS),
   shareDiagnostics: getLocalBoolOrNull(KEY_SHARE_DIAGNOSTICS),
+  serverAnalyticsEffective: null,
+  serverDiagnosticsEffective: null,
   tosAccepted: false,
   privacyConsent: false,
   analyticsConsentCurrent: false,
@@ -103,6 +120,14 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
     // clients via the `sentry-control.ts` watcher — is written solely by the
     // consent chokepoints in `lib/consent/diagnostics-consent.ts`.
     persistShareChoice(KEY_SHARE_DIAGNOSTICS, value);
+  },
+  // In-memory only: the server verdicts are re-adopted on every sync, so
+  // persisting them would just serve a stale verdict across reloads.
+  setServerAnalyticsEffective: (value) => {
+    set({ serverAnalyticsEffective: value });
+  },
+  setServerDiagnosticsEffective: (value) => {
+    set({ serverDiagnosticsEffective: value });
   },
   setTosAccepted: (value) => {
     set({ tosAccepted: value });

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -67,6 +67,13 @@ export interface OnboardingState {
    * before the first sync that saw a server record.
    */
   serverAnalyticsEffective: boolean | null;
+  /**
+   * A local explicit analytics opt-in whose server write has not yet been
+   * reflected by a sync. Lets the emit gate re-enable immediately on opt-in
+   * without letting server-ADOPTED raw values bypass a divergent effective
+   * verdict. Cleared whenever a sync adopts server state. In-memory only.
+   */
+  pendingAnalyticsOptIn: boolean;
   /** See {@link serverAnalyticsEffective}; the diagnostics verdict. */
   serverDiagnosticsEffective: boolean | null;
   tosAccepted: boolean;
@@ -84,6 +91,7 @@ export interface OnboardingActions {
   setShareAnalytics: (value: boolean | null) => void;
   setShareDiagnostics: (value: boolean | null) => void;
   setServerAnalyticsEffective: (value: boolean | null) => void;
+  setPendingAnalyticsOptIn: (value: boolean) => void;
   setServerDiagnosticsEffective: (value: boolean | null) => void;
   setTosAccepted: (value: boolean) => void;
   setPrivacyConsent: (value: boolean) => void;
@@ -102,6 +110,7 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   shareAnalytics: getLocalBoolOrNull(KEY_SHARE_ANALYTICS),
   shareDiagnostics: getLocalBoolOrNull(KEY_SHARE_DIAGNOSTICS),
   serverAnalyticsEffective: null,
+  pendingAnalyticsOptIn: false,
   serverDiagnosticsEffective: null,
   tosAccepted: false,
   privacyConsent: false,
@@ -123,6 +132,9 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   },
   // In-memory only: the server verdicts are re-adopted on every sync, so
   // persisting them would just serve a stale verdict across reloads.
+  setPendingAnalyticsOptIn: (value) => {
+    set({ pendingAnalyticsOptIn: value });
+  },
   setServerAnalyticsEffective: (value) => {
     set({ serverAnalyticsEffective: value });
   },

--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -58,7 +58,10 @@ export function useShareAnalytics(): [boolean | null, (next: boolean) => void] {
  * (diagnostics is opt-out), a boolean is an explicit choice. Backed by the
  * SAME localStorage key as `/settings/privacy`.
  */
-export function useShareDiagnostics(): [boolean | null, (next: boolean) => void] {
+export function useShareDiagnostics(): [
+  boolean | null,
+  (next: boolean) => void,
+] {
   const value = useOnboardingStore.use.shareDiagnostics();
   const setter = useCallback((next: boolean) => {
     useOnboardingStore.getState().setShareDiagnostics(next);
@@ -94,7 +97,10 @@ export function usePrivacyConsent(): [boolean, (next: boolean) => void] {
  * version. Set on session sync by the auth store. A stale value means the user
  * must re-review the terms.
  */
-export function useAnalyticsConsentCurrent(): [boolean, (next: boolean) => void] {
+export function useAnalyticsConsentCurrent(): [
+  boolean,
+  (next: boolean) => void,
+] {
   const value = useOnboardingStore.use.analyticsConsentCurrent();
   const setter = useCallback((next: boolean) => {
     useOnboardingStore.getState().setAnalyticsConsentCurrent(next);
@@ -107,7 +113,10 @@ export function useAnalyticsConsentCurrent(): [boolean, (next: boolean) => void]
  * version. Set on session sync by the auth store. A stale value means the user
  * must re-review the terms.
  */
-export function useDiagnosticsConsentCurrent(): [boolean, (next: boolean) => void] {
+export function useDiagnosticsConsentCurrent(): [
+  boolean,
+  (next: boolean) => void,
+] {
   const value = useOnboardingStore.use.diagnosticsConsentCurrent();
   const setter = useCallback((next: boolean) => {
     useOnboardingStore.getState().setDiagnosticsConsentCurrent(next);
@@ -173,10 +182,9 @@ export function readConsentHydrated(): boolean {
  *
  * Thin wrapper over the shared `readAnalyticsConsent()` so the onboarding
  * funnel and the intelligence domain's Memory telemetry gate on the exact
- * same decision: analytics is opt-out — never-asked (`null`) authorizes
- * uploads; only an explicit opt-out stops them. The store is the single
- * in-memory source, so an explicit opt-out holds even if its server write
- * failed.
+ * same decision: a local explicit opt-out wins (its server write may be in
+ * flight); otherwise the server-computed effective verdict decides, with the
+ * opt-out default applying before the first sync.
  */
 export function isAnalyticsEnabled(): boolean {
   return readAnalyticsConsent();
@@ -213,5 +221,3 @@ export function writeSelectedVersion(version: string): void {
     // the right default.
   }
 }
-
-

--- a/clients/web/src/lib/consent/consent-persistence.test.ts
+++ b/clients/web/src/lib/consent/consent-persistence.test.ts
@@ -26,6 +26,7 @@ const storeState = {
   setTosAccepted: mock(() => {}),
   setPrivacyConsent: mock(() => {}),
   setShareAnalytics: mock(() => {}),
+  setPendingAnalyticsOptIn: mock(() => {}),
   setShareDiagnostics: mock(() => {}),
   setAnalyticsConsentCurrent: mock(() => {}),
   setDiagnosticsConsentCurrent: mock(() => {}),

--- a/clients/web/src/lib/consent/consent-persistence.test.ts
+++ b/clients/web/src/lib/consent/consent-persistence.test.ts
@@ -104,15 +104,6 @@ function makeConsent(overrides: Partial<UserConsent> = {}): UserConsent {
   };
 }
 
-/** A consent record from an older backend that predates `required_versions`. */
-function makeConsentWithoutRequiredVersions(
-  overrides: Partial<UserConsent> = {},
-): UserConsent {
-  const consent = makeConsent(overrides) as unknown as Record<string, unknown>;
-  delete consent.required_versions;
-  return consent as unknown as UserConsent;
-}
-
 // A server-side bump newer than every frozen build constant.
 const BUMPED_VERSION = "2026-08-01";
 const BUMPED_REQUIRED_VERSIONS = {
@@ -304,30 +295,6 @@ describe("resolveServerConsent", () => {
     expect(r.diagnosticsCurrent).toBe(false);
   });
 
-  test("absent effective fields (older backend) fall back to the raw values' opt-out reading", () => {
-    const legacy = (overrides: Partial<UserConsent>) => {
-      const consent = makeConsent(overrides) as unknown as Record<
-        string,
-        unknown
-      >;
-      delete consent.share_analytics_effective;
-      delete consent.share_diagnostics_effective;
-      return consent as unknown as UserConsent;
-    };
-    // Explicit values pass through...
-    const explicit = resolveServerConsent(
-      legacy({ share_analytics: false, share_diagnostics: true }),
-    );
-    expect(explicit.analyticsEffective).toBe(false);
-    expect(explicit.diagnosticsEffective).toBe(true);
-    // ...and never-asked defaults to enabled (opt-out semantics).
-    const neverAsked = resolveServerConsent(
-      legacy({ share_analytics: null, share_diagnostics: null }),
-    );
-    expect(neverAsked.analyticsEffective).toBe(true);
-    expect(neverAsked.diagnosticsEffective).toBe(true);
-  });
-
   test("an explicit grant with a version on record resolves the raw values", () => {
     const r = resolveServerConsent(makeConsent());
     expect(r.shareAnalytics).toBe(true);
@@ -467,9 +434,9 @@ describe("resolveServerConsent", () => {
     expect(r.hasServerRecord).toBe(false);
   });
 
-  test("hasServerRecord is false when share-version fields are omitted (older backend)", () => {
-    // Simulate a rollout-window response that predates the share-version
-    // fields: they are absent (undefined), not empty strings.
+  test("hasServerRecord is false when share-version fields are omitted", () => {
+    // Defensive pin: an absent version field (undefined, not "") must read
+    // as "no version on record", never as record evidence.
     const legacy = makeConsent({
       tos_accepted_version: "",
       privacy_policy_accepted_version: "",
@@ -1032,8 +999,8 @@ describe("server-supplied required versions", () => {
     expect(r.diagnosticsCurrent).toBe(true);
   });
 
-  test("absent required_versions (older backend) falls back to the frozen constants", () => {
-    const r = resolveServerConsent(makeConsentWithoutRequiredVersions());
+  test("an empty required_versions map falls back per-key to the constants (empty-value guard)", () => {
+    const r = resolveServerConsent(makeConsent({ required_versions: {} }));
     expect(r.tos).toBe(true);
     expect(r.privacy).toBe(true);
     expect(r.analyticsCurrent).toBe(true);
@@ -1173,11 +1140,11 @@ describe("server-supplied required versions", () => {
     });
   });
 
-  test("a later resolve without required_versions restores the constants for stamps", () => {
+  test("a later resolve with empty required_versions restores the constants for stamps", () => {
     resolveServerConsent(
       makeConsent({ required_versions: BUMPED_REQUIRED_VERSIONS }),
     );
-    resolveServerConsent(makeConsentWithoutRequiredVersions());
+    resolveServerConsent(makeConsent({ required_versions: {} }));
     savePreferenceToggle("share_diagnostics", true, {
       userId: "user-1",
       hasPlatformSession: true,

--- a/clients/web/src/lib/consent/consent-persistence.ts
+++ b/clients/web/src/lib/consent/consent-persistence.ts
@@ -454,7 +454,13 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
     !!consent.share_analytics_accepted_version ||
     !!consent.share_diagnostics_accepted_version ||
     consent.share_analytics === false ||
-    consent.share_diagnostics === false;
+    consent.share_diagnostics === false ||
+    // A synthesized no-row response can only carry effective true (null →
+    // enabled), so an effective false is by construction a stored-state or
+    // policy verdict — record evidence even without version stamps (e.g. a
+    // never-asked user denied by org/platform policy).
+    consent.share_analytics_effective === false ||
+    consent.share_diagnostics_effective === false;
   return {
     // The ToS checkbox covers only the Terms of Service. The privacy checkbox
     // covers both the Privacy Policy and the AI Data Sharing Policy, so it is

--- a/clients/web/src/lib/consent/consent-persistence.ts
+++ b/clients/web/src/lib/consent/consent-persistence.ts
@@ -540,6 +540,10 @@ function writeConsent(
   }
   if (shareAnalytics !== undefined) {
     store.setShareAnalytics(shareAnalytics);
+    // An explicit opt-in is pending until a sync reflects it, so the emit
+    // gate re-enables immediately; an explicit opt-out supersedes any
+    // pending opt-in (and wins in the gate on its own).
+    store.setPendingAnalyticsOptIn(shareAnalytics === true);
   }
   if (shareDiagnostics !== undefined) {
     // Opt-out: the effective reporting gate equals the preference — an

--- a/clients/web/src/lib/consent/consent-persistence.ts
+++ b/clients/web/src/lib/consent/consent-persistence.ts
@@ -96,17 +96,19 @@ const FALLBACK_REQUIRED_VERSIONS: RequiredConsentVersions = {
 let requiredVersions: RequiredConsentVersions = FALLBACK_REQUIRED_VERSIONS;
 
 function toRequiredVersions(
-  raw: Record<string, string>,
+  raw: Record<string, string> | undefined,
 ): RequiredConsentVersions {
-  // Per-key `||` is an empty-value guard only: a missing/empty entry in the
-  // server map means "not supplied", never "nothing required" — treating it
+  // `raw?.` and per-key `||` are absent/empty-value guards: the type says the
+  // map is always present, but a runtime response missing it must not throw
+  // the whole consent sync into the device-only fallback, and a missing or
+  // empty entry means "not supplied", never "nothing required" — treating it
   // as a requirement would mark every record current.
   return {
-    tos: raw.tos || TOS_CONSENT_VERSION,
-    privacyPolicy: raw.privacy_policy || PRIVACY_CONSENT_VERSION,
-    aiDataSharing: raw.ai_data_sharing || PRIVACY_CONSENT_VERSION,
-    shareAnalytics: raw.share_analytics || ANALYTICS_CONSENT_VERSION,
-    shareDiagnostics: raw.share_diagnostics || DIAGNOSTICS_CONSENT_VERSION,
+    tos: raw?.tos || TOS_CONSENT_VERSION,
+    privacyPolicy: raw?.privacy_policy || PRIVACY_CONSENT_VERSION,
+    aiDataSharing: raw?.ai_data_sharing || PRIVACY_CONSENT_VERSION,
+    shareAnalytics: raw?.share_analytics || ANALYTICS_CONSENT_VERSION,
+    shareDiagnostics: raw?.share_diagnostics || DIAGNOSTICS_CONSENT_VERSION,
   };
 }
 
@@ -475,8 +477,14 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
     // The platform computes effective consent in its single policy module
     // and serves it as `share_*_effective`. The data-capture gates consume
     // these verdicts verbatim; the raw values carry chosen-ness only.
-    analyticsEffective: consent.share_analytics_effective,
-    diagnosticsEffective: consent.share_diagnostics_effective,
+    // `??` is a runtime guard only — the contract guarantees the effective
+    // fields, but an absent one must never read as an opt-out: fall back to
+    // the raw value's opt-out reading (only explicit false disables).
+    analyticsEffective:
+      consent.share_analytics_effective ?? consent.share_analytics !== false,
+    diagnosticsEffective:
+      consent.share_diagnostics_effective ??
+      consent.share_diagnostics !== false,
     // Share-toggle re-review is owed only for an explicit, genuinely stale
     // choice on record. Onboarding doesn't show the analytics toggle, so
     // `share_analytics` stays null until the user chooses via settings or

--- a/clients/web/src/lib/consent/consent-persistence.ts
+++ b/clients/web/src/lib/consent/consent-persistence.ts
@@ -7,9 +7,9 @@
  * date). The `device:` prefix survives logout; the userId makes them
  * per-user. Currency is `storedVersion >= requiredVersion`, where the
  * required versions come from the server's `required_versions` (adopted by
- * `resolveServerConsent`) and fall back to the frozen build constants when
- * the backend predates the field — so a server-side version bump owes a
- * re-review without a client release. The consent axes version
+ * `resolveServerConsent`; the frozen build constants seed them before the
+ * first resolve) — so a server-side version bump owes a re-review without a
+ * client release. The consent axes version
  * independently — ToS, the privacy checkbox (privacy policy + AI data
  * sharing), and share-diagnostics — so any one can be re-reviewed without
  * forcing the others.
@@ -43,19 +43,20 @@ import { applyExplicitDiagnosticsChoice } from "@/lib/consent/diagnostics-consen
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
-// Offline/older-backend fallback required versions. The server's
-// `required_versions` is authoritative when present; these frozen constants
-// only back the paths where it isn't (a backend that predates the field, or
-// no successful resolve yet this session). Zero-padded ISO dates
-// (YYYY-MM-DD): currency is a monotonic comparison (`>=`), which requires a
+// Frozen build constants. The server's `required_versions` is authoritative;
+// these keep two roles only: seeding the module's required versions before
+// the first successful resolve (offline ack reads/stamps), and guarding
+// against an empty-string value inside the server map. Review-terms also
+// displays change notes keyed off them. Zero-padded ISO dates (YYYY-MM-DD):
+// currency is a monotonic comparison (`>=`), which requires a
 // lexicographically sortable, chronological format.
 export const TOS_CONSENT_VERSION = "2026-06-08";
 export const PRIVACY_CONSENT_VERSION = "2026-06-22";
 
 // The two data-capture toggles version independently from the privacy
 // policy, so bumping the privacy policy doesn't re-prompt capture consent.
-// Frozen at the prior privacy version as the fallback floor; genuine bumps
-// arrive via the server's `required_versions`.
+// Frozen at the prior privacy version as the pre-first-sync floor; genuine
+// bumps arrive via the server's `required_versions`.
 export const ANALYTICS_CONSENT_VERSION = "2026-06-18";
 export const DIAGNOSTICS_CONSENT_VERSION = "2026-06-18";
 
@@ -88,24 +89,24 @@ const FALLBACK_REQUIRED_VERSIONS: RequiredConsentVersions = {
 
 /**
  * The required versions from the most recent server consent record
- * `resolveServerConsent` saw, per-key falling back to the frozen constants.
- * `writeConsent` stamps PATCH bodies and the device-ack reads/writes consume
- * this, so the whole module agrees on one set of required versions: the
- * server's when it supplies them, the build's otherwise.
+ * `resolveServerConsent` saw; the frozen constants seed them until the first
+ * resolve. `writeConsent` stamps PATCH bodies and the device-ack reads/writes
+ * consume this, so the whole module agrees on one set of required versions.
  */
 let requiredVersions: RequiredConsentVersions = FALLBACK_REQUIRED_VERSIONS;
 
 function toRequiredVersions(
-  raw: Record<string, string> | undefined,
+  raw: Record<string, string>,
 ): RequiredConsentVersions {
-  // `||` (not `??`): an empty string means "not supplied", never "nothing
-  // required" — treating it as a requirement would mark every record current.
+  // Per-key `||` is an empty-value guard only: a missing/empty entry in the
+  // server map means "not supplied", never "nothing required" — treating it
+  // as a requirement would mark every record current.
   return {
-    tos: raw?.tos || TOS_CONSENT_VERSION,
-    privacyPolicy: raw?.privacy_policy || PRIVACY_CONSENT_VERSION,
-    aiDataSharing: raw?.ai_data_sharing || PRIVACY_CONSENT_VERSION,
-    shareAnalytics: raw?.share_analytics || ANALYTICS_CONSENT_VERSION,
-    shareDiagnostics: raw?.share_diagnostics || DIAGNOSTICS_CONSENT_VERSION,
+    tos: raw.tos || TOS_CONSENT_VERSION,
+    privacyPolicy: raw.privacy_policy || PRIVACY_CONSENT_VERSION,
+    aiDataSharing: raw.ai_data_sharing || PRIVACY_CONSENT_VERSION,
+    shareAnalytics: raw.share_analytics || ANALYTICS_CONSENT_VERSION,
+    shareDiagnostics: raw.share_diagnostics || DIAGNOSTICS_CONSENT_VERSION,
   };
 }
 
@@ -387,9 +388,9 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
   shareAnalytics: boolean | null;
   shareDiagnostics: boolean | null;
   /**
-   * Server-computed effective consent (opt-out semantics: null/never-asked =
-   * enabled). This is the value data-capture gates should honor; the raw
-   * `share*` fields above stay tri-state for chosen-ness.
+   * The platform's single-policy-module effective verdicts (opt-out
+   * semantics: null/never-asked = enabled). The data-capture gates consume
+   * these; the raw `share*` fields above carry chosen-ness only.
    */
   analyticsEffective: boolean;
   diagnosticsEffective: boolean;
@@ -414,8 +415,7 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
       privacy: false,
       shareAnalytics: null,
       shareDiagnostics: null,
-      // Opt-out semantics default to enabled, matching the fallback chain
-      // applied to an all-null record.
+      // No record means no verdict — opt-out semantics default to enabled.
       analyticsEffective: true,
       diagnosticsEffective: true,
       analyticsCurrent: false,
@@ -426,8 +426,7 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
     };
   }
   // The server is the source of truth for which versions are required: adopt
-  // its `required_versions` (per-key constants fallback for an older backend
-  // that omits the field) and remember them module-wide, so device-ack
+  // its `required_versions` and remember them module-wide, so device-ack
   // currency checks and PATCH version stamps agree with this resolution.
   const required = toRequiredVersions(consent.required_versions);
   requiredVersions = required;
@@ -444,10 +443,8 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
   // returns the API defaults (empty versions, null share booleans). Any
   // non-empty version or any `false` share boolean can only have come from a
   // real stored row, so it proves a record whose data is worth preserving.
-  // Truthiness (not `!== ""`) so a response that OMITS the newer
-  // share-version fields — e.g. an older backend during rollout — reads as
-  // absent rather than as record evidence. `undefined` and `""` both mean
-  // "no version on record".
+  // Truthiness (not `!== ""`) so an absent field never reads as record
+  // evidence: `undefined` and `""` both mean "no version on record".
   const hasServerRecord =
     !!consent.tos_accepted_version ||
     !!consent.privacy_policy_accepted_version ||
@@ -475,17 +472,11 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
     // consumed verbatim.
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
-    // The platform computes effective consent in one place (null = enabled,
-    // opt-out) and serves it as `share_*_effective`; an older backend omits
-    // the fields, so fall back to the raw value's opt-out reading. These are
-    // the server-authoritative gate inputs; the store-based explicit-opt-out
-    // gates currently consume raw values, which are behaviorally identical
-    // (effective differs from raw only when raw is null, which the gates
-    // read as enabled).
-    analyticsEffective:
-      consent.share_analytics_effective ?? consent.share_analytics ?? true,
-    diagnosticsEffective:
-      consent.share_diagnostics_effective ?? consent.share_diagnostics ?? true,
+    // The platform computes effective consent in its single policy module
+    // and serves it as `share_*_effective`. The data-capture gates consume
+    // these verdicts verbatim; the raw values carry chosen-ness only.
+    analyticsEffective: consent.share_analytics_effective,
+    diagnosticsEffective: consent.share_diagnostics_effective,
     // Share-toggle re-review is owed only for an explicit, genuinely stale
     // choice on record. Onboarding doesn't show the analytics toggle, so
     // `share_analytics` stays null until the user chooses via settings or
@@ -513,7 +504,7 @@ export function resolveServerConsent(consent: UserConsent | null | undefined): {
  *
  * Version stamps — device acks and PATCH bodies — use the module's required
  * versions: server-supplied when the last `resolveServerConsent` saw a
- * record, the frozen constants otherwise (offline, older backend).
+ * record, the frozen pre-first-sync seed otherwise (offline).
  *
  * `legal` is present only for a consent-screen save; that acceptance is an
  * explicit review of the current terms, so currency and hydration are

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -162,6 +162,31 @@ describe("refreshDiagnosticsConsent", () => {
     expect(setServerDiagnosticsEffective).toHaveBeenCalledWith(true);
   });
 
+  test("a refresh racing an in-flight opt-in PATCH keeps the pending flag on the stale record", async () => {
+    // The fetched record predates the opt-in (explicit false): pending must
+    // survive so the gate honors the user's fresh opt-in until the server
+    // reflects it.
+    consentResult = Promise.resolve(
+      consentRecord({
+        share_analytics: false,
+        share_analytics_accepted_version: "2026-06-18",
+      }),
+    );
+    await refreshDiagnosticsConsent();
+    expect(setPendingAnalyticsOptIn).not.toHaveBeenCalled();
+  });
+
+  test("a refresh clears the pending opt-in once the record reflects it", async () => {
+    consentResult = Promise.resolve(
+      consentRecord({
+        share_analytics: true,
+        share_analytics_accepted_version: "2026-06-18",
+      }),
+    );
+    await refreshDiagnosticsConsent();
+    expect(setPendingAnalyticsOptIn).toHaveBeenCalledWith(false);
+  });
+
   test("swallows a thrown fetch and leaves state unchanged", async () => {
     consentResult = Promise.reject(new Error("offline"));
     await refreshDiagnosticsConsent();

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -53,12 +53,14 @@ mock.module("@/stores/auth-store", () => ({
 
 const setShareDiagnostics = mock((_v: boolean) => {});
 const setServerAnalyticsEffective = mock((_v: boolean | null) => {});
+const setPendingAnalyticsOptIn = mock((_v: boolean) => {});
 const setServerDiagnosticsEffective = mock((_v: boolean | null) => {});
 mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: {
     getState: () => ({
       setShareDiagnostics,
       setServerAnalyticsEffective,
+      setPendingAnalyticsOptIn,
       setServerDiagnosticsEffective,
     }),
   },
@@ -111,6 +113,7 @@ beforeEach(() => {
   applyResolvedDiagnosticsConsent.mockClear();
   setShareDiagnostics.mockClear();
   setServerAnalyticsEffective.mockClear();
+  setPendingAnalyticsOptIn.mockClear();
   setServerDiagnosticsEffective.mockClear();
   currentUser = { id: "u1" };
   consentResult = Promise.resolve(consentRecord());

--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -34,6 +34,7 @@ const FLOOR_CLEAR_MS = 5 * 60_000;
 
 type Resolved = {
   shareDiagnostics: boolean | null;
+  diagnosticsEffective: boolean;
   hasServerRecord: boolean;
 };
 const applyResolvedDiagnosticsConsent = mock(
@@ -51,11 +52,20 @@ mock.module("@/stores/auth-store", () => ({
 }));
 
 const setShareDiagnostics = mock((_v: boolean) => {});
+const setServerAnalyticsEffective = mock((_v: boolean | null) => {});
+const setServerDiagnosticsEffective = mock((_v: boolean | null) => {});
 mock.module("@/domains/onboarding/onboarding-store", () => ({
-  useOnboardingStore: { getState: () => ({ setShareDiagnostics }) },
+  useOnboardingStore: {
+    getState: () => ({
+      setShareDiagnostics,
+      setServerAnalyticsEffective,
+      setServerDiagnosticsEffective,
+    }),
+  },
 }));
 
-const { DIAGNOSTICS_CONSENT_VERSION } = await import("@/lib/consent/consent-persistence");
+const { DIAGNOSTICS_CONSENT_VERSION } =
+  await import("@/lib/consent/consent-persistence");
 const { refreshDiagnosticsConsent, installConsentRefreshListeners } =
   await import("./consent-refresh");
 
@@ -100,6 +110,8 @@ beforeEach(() => {
   fetchConsent.mockClear();
   applyResolvedDiagnosticsConsent.mockClear();
   setShareDiagnostics.mockClear();
+  setServerAnalyticsEffective.mockClear();
+  setServerDiagnosticsEffective.mockClear();
   currentUser = { id: "u1" };
   consentResult = Promise.resolve(consentRecord());
   clock += FLOOR_CLEAR_MS;
@@ -128,14 +140,31 @@ describe("refreshDiagnosticsConsent", () => {
     const resolved = applyResolvedDiagnosticsConsent.mock.calls[0]![0];
     expect(resolved).toMatchObject({
       shareDiagnostics: false,
+      diagnosticsEffective: false,
       hasServerRecord: true,
     });
+  });
+
+  test("adopts both server-effective verdicts on a real record", async () => {
+    consentResult = Promise.resolve(
+      consentRecord({
+        share_analytics: false,
+        share_analytics_accepted_version: "2026-06-18",
+        share_diagnostics: true,
+        share_diagnostics_accepted_version: DIAGNOSTICS_CONSENT_VERSION,
+      }),
+    );
+    await refreshDiagnosticsConsent();
+    expect(setServerAnalyticsEffective).toHaveBeenCalledWith(false);
+    expect(setServerDiagnosticsEffective).toHaveBeenCalledWith(true);
   });
 
   test("swallows a thrown fetch and leaves state unchanged", async () => {
     consentResult = Promise.reject(new Error("offline"));
     await refreshDiagnosticsConsent();
     expect(applyResolvedDiagnosticsConsent).not.toHaveBeenCalled();
+    expect(setServerAnalyticsEffective).not.toHaveBeenCalled();
+    expect(setServerDiagnosticsEffective).not.toHaveBeenCalled();
   });
 
   test("leaves state unchanged for an empty server record", async () => {
@@ -147,6 +176,10 @@ describe("refreshDiagnosticsConsent", () => {
     await refreshDiagnosticsConsent();
     expect(fetchConsent).toHaveBeenCalledTimes(1);
     expect(applyResolvedDiagnosticsConsent).not.toHaveBeenCalled();
+    // The no-record verdicts are opt-out defaults, not adoptions — the
+    // auth resync owns the no-record posture.
+    expect(setServerAnalyticsEffective).not.toHaveBeenCalled();
+    expect(setServerDiagnosticsEffective).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/lib/consent/consent-refresh.ts
+++ b/clients/web/src/lib/consent/consent-refresh.ts
@@ -48,6 +48,7 @@ export async function refreshDiagnosticsConsent(): Promise<void> {
     const store = useOnboardingStore.getState();
     // Adopt both effective verdicts, mirroring the auth-store sync, so a
     // platform-side revoke closes the gates without a fresh login.
+    store.setPendingAnalyticsOptIn(false);
     store.setServerAnalyticsEffective(resolved.analyticsEffective);
     store.setServerDiagnosticsEffective(resolved.diagnosticsEffective);
     applyResolvedDiagnosticsConsent(

--- a/clients/web/src/lib/consent/consent-refresh.ts
+++ b/clients/web/src/lib/consent/consent-refresh.ts
@@ -1,12 +1,11 @@
 /**
- * Re-fetch platform diagnostics consent on visibility/focus + a long-interval
- * backstop, so a platform-side revoke is picked up without a fresh login.
- *
- * Everything routes through {@link applyResolvedDiagnosticsConsent} — the single
- * direction-asymmetric chokepoint that writes the saved preference, the
- * effective Sentry gate, and the Electron main-process mirror.
- * A failed/timed-out fetch is swallowed and leaves all diagnostics state
- * unchanged (never flips the gate on or off).
+ * Re-fetch platform consent on visibility/focus + a long-interval backstop,
+ * so a platform-side revoke is picked up without a fresh login. Adopts the
+ * server-effective verdicts for both data-capture gates; diagnostics
+ * additionally routes through {@link applyResolvedDiagnosticsConsent} — the
+ * single direction-asymmetric chokepoint that writes the saved preference and
+ * the effective Sentry gate. A failed/timed-out fetch is swallowed and leaves
+ * all consent state unchanged (never flips a gate on or off).
  */
 import { fetchConsent } from "@/domains/account/profile";
 import { applyResolvedDiagnosticsConsent } from "@/lib/consent/diagnostics-consent";
@@ -46,12 +45,18 @@ export async function refreshDiagnosticsConsent(): Promise<void> {
     // unchanged, matching the failed-fetch posture; the auth resync owns the
     // no-record path.
     if (!resolved.hasServerRecord) return;
+    const store = useOnboardingStore.getState();
+    // Adopt both effective verdicts, mirroring the auth-store sync, so a
+    // platform-side revoke closes the gates without a fresh login.
+    store.setServerAnalyticsEffective(resolved.analyticsEffective);
+    store.setServerDiagnosticsEffective(resolved.diagnosticsEffective);
     applyResolvedDiagnosticsConsent(
       {
         shareDiagnostics: resolved.shareDiagnostics,
+        diagnosticsEffective: resolved.diagnosticsEffective,
         hasServerRecord: resolved.hasServerRecord,
       },
-      useOnboardingStore.getState().setShareDiagnostics,
+      store.setShareDiagnostics,
     );
   } catch {
     // Fetch failed/timed out — leave diagnostics state untouched.

--- a/clients/web/src/lib/consent/consent-refresh.ts
+++ b/clients/web/src/lib/consent/consent-refresh.ts
@@ -47,8 +47,13 @@ export async function refreshDiagnosticsConsent(): Promise<void> {
     if (!resolved.hasServerRecord) return;
     const store = useOnboardingStore.getState();
     // Adopt both effective verdicts, mirroring the auth-store sync, so a
-    // platform-side revoke closes the gates without a fresh login.
-    store.setPendingAnalyticsOptIn(false);
+    // platform-side revoke closes the gates without a fresh login. The
+    // pending opt-in clears only once the fetched record REFLECTS it — a
+    // refresh racing the opt-in's in-flight PATCH must not flip uploads
+    // back off on the stale record.
+    if (resolved.shareAnalytics === true) {
+      store.setPendingAnalyticsOptIn(false);
+    }
     store.setServerAnalyticsEffective(resolved.analyticsEffective);
     store.setServerDiagnosticsEffective(resolved.diagnosticsEffective);
     applyResolvedDiagnosticsConsent(

--- a/clients/web/src/lib/consent/diagnostics-consent.test.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.test.ts
@@ -4,10 +4,11 @@
  * The module splits two values: the SAVED PREFERENCE
  * (`device:share_diagnostics`, applied via the `setShareDiagnostics` mock) and
  * the EFFECTIVE GATE (`device:diagnostics_reporting`), of which this module is
- * the sole writer. The preference tracks the server's share value
- * direction-asymmetrically; the gate is a derivation of the effective
- * preference — an explicit server value applies directly, an unknown one
- * follows the saved device preference (absent reads open — opt-out default).
+ * the sole writer. The preference tracks the server's RAW share value
+ * direction-asymmetrically; the gate closes on a local explicit opt-out,
+ * otherwise honors the server's effective verdict when a record exists, and
+ * follows the saved device preference when none does (absent reads open —
+ * opt-out default).
  *
  * `@/runtime/diagnostics` and `@/utils/device-settings` are mocked so the gate
  * writes are observable without a DOM/localStorage.
@@ -65,7 +66,11 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
   test("real record + true → preference true, gate true", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      { shareDiagnostics: true, hasServerRecord: true },
+      {
+        shareDiagnostics: true,
+        diagnosticsEffective: true,
+        hasServerRecord: true,
+      },
       setShareDiagnostics,
     );
     expect(result).toBe(true);
@@ -76,7 +81,11 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
   test("real record + false → preference false, gate false", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      { shareDiagnostics: false, hasServerRecord: true },
+      {
+        shareDiagnostics: false,
+        diagnosticsEffective: false,
+        hasServerRecord: true,
+      },
       setShareDiagnostics,
     );
     expect(result).toBe(false);
@@ -90,7 +99,11 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
   test("null + no record → preference unchanged, gate open (opt-out default)", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      { shareDiagnostics: null, hasServerRecord: false },
+      {
+        shareDiagnostics: null,
+        diagnosticsEffective: true,
+        hasServerRecord: false,
+      },
       setShareDiagnostics,
     );
     expect(result).toBeNull();
@@ -101,7 +114,11 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
   test("null grant with a server record → preference unchanged, gate open", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      { shareDiagnostics: null, hasServerRecord: true },
+      {
+        shareDiagnostics: null,
+        diagnosticsEffective: true,
+        hasServerRecord: true,
+      },
       setShareDiagnostics,
     );
     expect(result).toBeNull();
@@ -112,7 +129,11 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
   test("true grant but no server record → preference unchanged, gate open", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      { shareDiagnostics: true, hasServerRecord: false },
+      {
+        shareDiagnostics: true,
+        diagnosticsEffective: true,
+        hasServerRecord: false,
+      },
       setShareDiagnostics,
     );
     expect(result).toBeNull();
@@ -127,7 +148,11 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
     devicePreference = false;
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      { shareDiagnostics: true, hasServerRecord: false },
+      {
+        shareDiagnostics: true,
+        diagnosticsEffective: true,
+        hasServerRecord: false,
+      },
       setShareDiagnostics,
     );
     expect(result).toBeNull();
@@ -142,7 +167,11 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
     devicePreference = false;
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      { shareDiagnostics: null, hasServerRecord: true },
+      {
+        shareDiagnostics: null,
+        diagnosticsEffective: true,
+        hasServerRecord: true,
+      },
       setShareDiagnostics,
     );
     expect(result).toBeNull();
@@ -154,7 +183,11 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
     devicePreference = false;
     const setShareDiagnostics = mock((_: boolean) => {});
     applyResolvedDiagnosticsConsent(
-      { shareDiagnostics: true, hasServerRecord: true },
+      {
+        shareDiagnostics: true,
+        diagnosticsEffective: true,
+        hasServerRecord: true,
+      },
       setShareDiagnostics,
     );
     expect(setShareDiagnostics).toHaveBeenCalledWith(true);
@@ -164,11 +197,62 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
   test("explicit false with no prior record → preference false (eager revoke), gate false", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
-      { shareDiagnostics: false, hasServerRecord: false },
+      {
+        shareDiagnostics: false,
+        diagnosticsEffective: false,
+        hasServerRecord: false,
+      },
       setShareDiagnostics,
     );
     expect(result).toBe(false);
     expect(setShareDiagnostics).toHaveBeenCalledWith(false);
+    expectGate(false);
+  });
+
+  // KEY SERVER-AUTHORITY CASES: the platform's effective verdict closes the
+  // gate even where the raw value reads enabled — the raw tri-state carries
+  // chosen-ness only.
+  test("server-effective false with raw null → gate closed, preference untouched", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: null,
+        diagnosticsEffective: false,
+        hasServerRecord: true,
+      },
+      setShareDiagnostics,
+    );
+    expect(result).toBeNull();
+    expect(setShareDiagnostics).not.toHaveBeenCalled();
+    expectGate(false);
+  });
+
+  test("server-effective false with raw true → preference true (chosen-ness), gate closed", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: true,
+        diagnosticsEffective: false,
+        hasServerRecord: true,
+      },
+      setShareDiagnostics,
+    );
+    expect(result).toBe(true);
+    expect(setShareDiagnostics).toHaveBeenCalledWith(true);
+    expectGate(false);
+  });
+
+  test("server-effective true never reopens over a pending local opt-out", () => {
+    devicePreference = false;
+    const setShareDiagnostics = mock((_: boolean) => {});
+    applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: null,
+        diagnosticsEffective: true,
+        hasServerRecord: true,
+      },
+      setShareDiagnostics,
+    );
     expectGate(false);
   });
 
@@ -182,7 +266,11 @@ describe("applyResolvedDiagnosticsConsent — saved preference", () => {
         storedGate = stored;
         devicePreference = preference;
         applyResolvedDiagnosticsConsent(
-          { shareDiagnostics: null, hasServerRecord: true },
+          {
+            shareDiagnostics: null,
+            diagnosticsEffective: true,
+            hasServerRecord: true,
+          },
           mock((_: boolean) => {}),
         );
         expectGate(expected);

--- a/clients/web/src/lib/consent/diagnostics-consent.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.ts
@@ -7,18 +7,17 @@
  *   value (direction-asymmetric writes), so a stale-version record can't
  *   silently lose a prior explicit choice.
  * - **Effective reporting gate** (`device:diagnostics_reporting`) — what
- *   actually turns Sentry on. A pure derivation of the effective preference —
- *   explicit `false` → off, `true` or never-asked → on (diagnostics is
- *   opt-out) — kept as its own watchable key because the `sentry-control`
- *   cross-tab watcher and the Electron main mirror react to it, and because
- *   an absent key marks a device that has never resolved consent (see
- *   {@link failCloseDiagnosticsGateUntilFirstSync}). Following the preference
- *   — rather than forcing open on an unknown input — keeps an explicit local
- *   opt-out closed while its `patchConsent` write is still in flight (or
- *   failed), yet heals gates stuck closed by earlier strict-opt-in builds for
- *   users who never opted out. A stale-version grant keeps reporting on — the
- *   review-terms re-confirmation is driven by the consent-currency flags, not
- *   this gate.
+ *   actually turns Sentry on. A local explicit opt-out closes it — the
+ *   just-adopted revoke or a pending device opt-out whose `patchConsent`
+ *   write is still in flight (or failed). Otherwise, with a server record,
+ *   the platform-computed effective verdict (`diagnosticsEffective`) decides;
+ *   without one the gate derives from the device preference (absent reads
+ *   open — opt-out default). Kept as its own watchable key because the
+ *   `sentry-control` cross-tab watcher and the Electron main mirror react to
+ *   it, and because an absent key marks a device that has never resolved
+ *   consent (see {@link failCloseDiagnosticsGateUntilFirstSync}). A
+ *   stale-version grant keeps reporting on — the review-terms
+ *   re-confirmation is driven by the consent-currency flags, not this gate.
  *
  * This module is the ONLY writer of the gate key. Every path that learns a
  * diagnostics-consent value routes through one of the exported chokepoints:
@@ -38,6 +37,11 @@ import {
 export interface ResolvedDiagnosticsConsent {
   /** The server's `share_diagnostics` value; `null` when unknown/absent. */
   shareDiagnostics: boolean | null;
+  /**
+   * The platform-computed effective verdict (`share_diagnostics_effective`).
+   * Authoritative for the gate when `hasServerRecord` is set.
+   */
+  diagnosticsEffective: boolean;
   /** Whether the server returned a real consent record (not API defaults). */
   hasServerRecord: boolean;
 }
@@ -58,11 +62,13 @@ function setDiagnosticsReportingGate(enabled: boolean): void {
 /**
  * Apply a resolved server-consent input to both diagnostics values:
  *
- * 1. The saved preference, via `setShareDiagnostics` — written only for a
- *    confident grant or explicit revoke; an unknown input leaves it untouched.
- * 2. The effective reporting gate — re-derived from the effective preference:
- *    the just-applied authoritative value, or the existing device preference
- *    when the input is unknown (absent reads open — opt-out default).
+ * 1. The saved preference, via `setShareDiagnostics` — keyed on the RAW
+ *    tri-state: written only for a confident grant or explicit revoke; an
+ *    unknown input leaves it untouched.
+ * 2. The effective reporting gate — a local explicit opt-out closes it;
+ *    otherwise the server verdict (`diagnosticsEffective`) decides when a
+ *    record exists, and the device preference does when none does (absent
+ *    reads open — opt-out default).
  *
  * @returns the saved-preference decision: `true`/`false` when the preference was
  * written to that value, or `null` when the input is an unknown grant and the
@@ -77,11 +83,28 @@ export function applyResolvedDiagnosticsConsent(
     setShareDiagnostics(preference);
   }
 
-  setDiagnosticsReportingGate(
-    preference ?? getDeviceBool("shareDiagnostics", true),
-  );
+  setDiagnosticsReportingGate(deriveGate(preference, resolved));
 
   return preference;
+}
+
+/**
+ * Pure policy: resolve the EFFECTIVE REPORTING GATE value. A local explicit
+ * opt-out always wins — the just-adopted revoke, or a pending device opt-out
+ * whose server write may still be in flight (or failed). Otherwise the
+ * platform-computed effective verdict decides when a server record exists;
+ * without one the opt-out default applies (the preference already read open).
+ */
+function deriveGate(
+  preference: boolean | null,
+  resolved: ResolvedDiagnosticsConsent,
+): boolean {
+  const effectivePreference =
+    preference ?? getDeviceBool("shareDiagnostics", true);
+  if (!effectivePreference) {
+    return false;
+  }
+  return resolved.hasServerRecord ? resolved.diagnosticsEffective : true;
 }
 
 /**
@@ -94,7 +117,13 @@ export function applyExplicitDiagnosticsChoice(
   setShareDiagnostics: (value: boolean) => void,
 ): void {
   applyResolvedDiagnosticsConsent(
-    { shareDiagnostics: value, hasServerRecord: true },
+    // The choice is its own effective verdict until the next sync adopts
+    // the server's.
+    {
+      shareDiagnostics: value,
+      diagnosticsEffective: value,
+      hasServerRecord: true,
+    },
     setShareDiagnostics,
   );
 }

--- a/clients/web/src/lib/telemetry/consent.test.ts
+++ b/clients/web/src/lib/telemetry/consent.test.ts
@@ -65,15 +65,13 @@ describe("readAnalyticsConsent", () => {
       expected: false,
       why: "server-effective opt-out with never-asked local",
     },
-    // An explicit local choice wins in both directions: sync adopts the
-    // server's raw value into the store, so local true + effective false
-    // only exists while a local opt-in's server write is in flight — it
-    // must re-enable immediately, not on the next sync.
+    // A server-ADOPTED raw grant earns no override: with no pending local
+    // edit, a divergent effective opt-out wins.
     {
       local: true,
       server: false,
-      expected: true,
-      why: "mid-flight local opt-in wins over the cached server verdict",
+      expected: false,
+      why: "adopted raw grant never bypasses the effective opt-out",
     },
   ];
 
@@ -82,8 +80,27 @@ describe("readAnalyticsConsent", () => {
       useOnboardingStore.setState({
         shareAnalytics: local,
         serverAnalyticsEffective: server,
+        pendingAnalyticsOptIn: false,
       });
       expect(readAnalyticsConsent()).toBe(expected);
     });
   }
+
+  test("a PENDING local opt-in re-enables immediately over a stale server-effective opt-out", () => {
+    useOnboardingStore.setState({
+      shareAnalytics: true,
+      serverAnalyticsEffective: false,
+      pendingAnalyticsOptIn: true,
+    });
+    expect(readAnalyticsConsent()).toBe(true);
+  });
+
+  test("an explicit opt-out wins even while an older pending opt-in flag lingers", () => {
+    useOnboardingStore.setState({
+      shareAnalytics: false,
+      serverAnalyticsEffective: true,
+      pendingAnalyticsOptIn: true,
+    });
+    expect(readAnalyticsConsent()).toBe(false);
+  });
 });

--- a/clients/web/src/lib/telemetry/consent.test.ts
+++ b/clients/web/src/lib/telemetry/consent.test.ts
@@ -95,6 +95,28 @@ describe("readAnalyticsConsent", () => {
     expect(readAnalyticsConsent()).toBe(true);
   });
 
+  // -------------------------------------------------------------------------
+  // Pending-flag lifecycle matrix. The gate cases above cover READS; this
+  // table pins the WRITE/lifecycle contract implemented across
+  // consent-persistence (set on explicit local writes), auth-store /
+  // consent-refresh (cleared only on server reflection), and auth-store's
+  // account-change reset. Each row names the owning module so a transition
+  // regression points at its home.
+  //
+  // | transition                                   | pending after | owner              |
+  // | explicit local opt-in written                | true          | writeConsent       |
+  // | explicit local opt-out written               | false         | writeConsent       |
+  // | sync: record reflects opt-in (raw true)      | false         | auth-store/refresh |
+  // | sync: stale record (raw null/false)          | unchanged     | auth-store/refresh |
+  // | account switch (incl. to signed-out)         | false         | auth-store         |
+  // | same-user resync, unreflected                | unchanged     | auth-store         |
+  //
+  // The corresponding behavior pins live beside their owners:
+  // consent-persistence.test.ts (write path), consent-refresh.test.ts
+  // (reflection + stale-record race), auth-store.test.ts (reflection,
+  // account switch, same-user preservation, unconditional verdict adoption).
+  // -------------------------------------------------------------------------
+
   test("an explicit opt-out wins even while an older pending opt-in flag lingers", () => {
     useOnboardingStore.setState({
       shareAnalytics: false,

--- a/clients/web/src/lib/telemetry/consent.test.ts
+++ b/clients/web/src/lib/telemetry/consent.test.ts
@@ -57,19 +57,23 @@ describe("readAnalyticsConsent", () => {
       why: "server verdict enabled",
     },
     { local: true, server: true, expected: true, why: "both enabled" },
-    // The server-authority cases: an effective opt-out is honored even
-    // where the raw local value reads enabled.
+    // The server-authority case: an effective opt-out is honored when the
+    // local value is never-asked.
     {
       local: null,
       server: false,
       expected: false,
       why: "server-effective opt-out with never-asked local",
     },
+    // An explicit local choice wins in both directions: sync adopts the
+    // server's raw value into the store, so local true + effective false
+    // only exists while a local opt-in's server write is in flight — it
+    // must re-enable immediately, not on the next sync.
     {
       local: true,
       server: false,
-      expected: false,
-      why: "server-effective opt-out overrides a raw local grant",
+      expected: true,
+      why: "mid-flight local opt-in wins over the cached server verdict",
     },
   ];
 

--- a/clients/web/src/lib/telemetry/consent.test.ts
+++ b/clients/web/src/lib/telemetry/consent.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Truth table for the shared analytics emit gate: a local explicit opt-out
+ * always wins; otherwise the server-adopted effective verdict decides, with
+ * the opt-out default applying before the first sync. Runs against the real
+ * onboarding store (like the funnel-events tests) — the gate is a pure read
+ * over its state.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import { readAnalyticsConsent } from "@/lib/telemetry/consent";
+
+beforeEach(() => {
+  localStorage.clear();
+  useOnboardingStore.setState({
+    shareAnalytics: null,
+    serverAnalyticsEffective: null,
+  });
+});
+
+describe("readAnalyticsConsent", () => {
+  const cases: Array<{
+    local: boolean | null;
+    server: boolean | null;
+    expected: boolean;
+    why: string;
+  }> = [
+    {
+      local: false,
+      server: null,
+      expected: false,
+      why: "local opt-out, pre-sync",
+    },
+    {
+      local: false,
+      server: true,
+      expected: false,
+      why: "local opt-out beats a server grant (write may be in flight)",
+    },
+    {
+      local: false,
+      server: false,
+      expected: false,
+      why: "local and server both off",
+    },
+    {
+      local: null,
+      server: null,
+      expected: true,
+      why: "pre-sync opt-out default",
+    },
+    { local: true, server: null, expected: true, why: "local grant, pre-sync" },
+    {
+      local: null,
+      server: true,
+      expected: true,
+      why: "server verdict enabled",
+    },
+    { local: true, server: true, expected: true, why: "both enabled" },
+    // The server-authority cases: an effective opt-out is honored even
+    // where the raw local value reads enabled.
+    {
+      local: null,
+      server: false,
+      expected: false,
+      why: "server-effective opt-out with never-asked local",
+    },
+    {
+      local: true,
+      server: false,
+      expected: false,
+      why: "server-effective opt-out overrides a raw local grant",
+    },
+  ];
+
+  for (const { local, server, expected, why } of cases) {
+    test(`local ${String(local)} + serverEffective ${String(server)} → ${String(expected)} (${why})`, () => {
+      useOnboardingStore.setState({
+        shareAnalytics: local,
+        serverAnalyticsEffective: server,
+      });
+      expect(readAnalyticsConsent()).toBe(expected);
+    });
+  }
+});

--- a/clients/web/src/lib/telemetry/consent.ts
+++ b/clients/web/src/lib/telemetry/consent.ts
@@ -3,11 +3,11 @@ import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 /**
  * Shared analytics-consent read for telemetry emitters.
  *
- * Analytics is opt-out: never-asked (`null`) authorizes uploads; only an
- * explicit opt-out stops them. The onboarding store is the single in-memory
- * source — hydrated from the `device:share_analytics` key at init and from
- * the server on sync — so an explicit opt-out stops uploads even if its
- * server write failed.
+ * A local explicit opt-out always wins — its server write may still be in
+ * flight (or have failed). Otherwise the platform-computed effective verdict
+ * (`serverAnalyticsEffective`, adopted at sync) decides; before the first
+ * sync with a server record the opt-out default applies (analytics is
+ * opt-out, so never-asked authorizes uploads).
  *
  * This is the single consent decision every emitter gates on. It lives in
  * `lib/` (not a domain) so both the onboarding funnel and the intelligence
@@ -15,5 +15,8 @@ import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
  * cross-domain import (`local/no-cross-domain-imports`).
  */
 export function readAnalyticsConsent(): boolean {
-  return useOnboardingStore.getState().shareAnalytics !== false;
+  const { shareAnalytics, serverAnalyticsEffective } =
+    useOnboardingStore.getState();
+  if (shareAnalytics === false) return false;
+  return serverAnalyticsEffective ?? true;
 }

--- a/clients/web/src/lib/telemetry/consent.ts
+++ b/clients/web/src/lib/telemetry/consent.ts
@@ -3,11 +3,14 @@ import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 /**
  * Shared analytics-consent read for telemetry emitters.
  *
- * A local explicit opt-out always wins — its server write may still be in
- * flight (or have failed). Otherwise the platform-computed effective verdict
- * (`serverAnalyticsEffective`, adopted at sync) decides; before the first
- * sync with a server record the opt-out default applies (analytics is
- * opt-out, so never-asked authorizes uploads).
+ * An explicit local choice wins in BOTH directions — its server write may
+ * still be in flight (or have failed), and it is newer information than the
+ * verdict cached at the last sync (an opt-in after a server-effective
+ * opt-out must re-enable immediately, not on the next sync). The
+ * platform-computed effective verdict (`serverAnalyticsEffective`, adopted
+ * at sync) governs only the never-asked case; before the first sync with a
+ * server record the opt-out default applies (analytics is opt-out, so
+ * never-asked authorizes uploads).
  *
  * This is the single consent decision every emitter gates on. It lives in
  * `lib/` (not a domain) so both the onboarding funnel and the intelligence
@@ -17,6 +20,6 @@ import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 export function readAnalyticsConsent(): boolean {
   const { shareAnalytics, serverAnalyticsEffective } =
     useOnboardingStore.getState();
-  if (shareAnalytics === false) return false;
+  if (shareAnalytics !== null) return shareAnalytics;
   return serverAnalyticsEffective ?? true;
 }

--- a/clients/web/src/lib/telemetry/consent.ts
+++ b/clients/web/src/lib/telemetry/consent.ts
@@ -3,14 +3,18 @@ import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 /**
  * Shared analytics-consent read for telemetry emitters.
  *
- * An explicit local choice wins in BOTH directions — its server write may
- * still be in flight (or have failed), and it is newer information than the
- * verdict cached at the last sync (an opt-in after a server-effective
- * opt-out must re-enable immediately, not on the next sync). The
- * platform-computed effective verdict (`serverAnalyticsEffective`, adopted
- * at sync) governs only the never-asked case; before the first sync with a
- * server record the opt-out default applies (analytics is opt-out, so
- * never-asked authorizes uploads).
+ * Privacy-asymmetric precedence:
+ *   1. An explicit `false` anywhere locally always disables — an opt-out's
+ *      server write may still be in flight (or have failed).
+ *   2. A PENDING local opt-in (`pendingAnalyticsOptIn`, set by an explicit
+ *      user opt-in, cleared when a sync reflects it) enables immediately —
+ *      but a server-ADOPTED raw `true` earns no such override, so a
+ *      divergent server-effective opt-out is never bypassed by adopted
+ *      values.
+ *   3. Otherwise the platform-computed effective verdict
+ *      (`serverAnalyticsEffective`, adopted at sync) decides; before the
+ *      first sync with a server record the opt-out default applies
+ *      (analytics is opt-out, so never-asked authorizes uploads).
  *
  * This is the single consent decision every emitter gates on. It lives in
  * `lib/` (not a domain) so both the onboarding funnel and the intelligence
@@ -18,8 +22,9 @@ import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
  * cross-domain import (`local/no-cross-domain-imports`).
  */
 export function readAnalyticsConsent(): boolean {
-  const { shareAnalytics, serverAnalyticsEffective } =
+  const { shareAnalytics, serverAnalyticsEffective, pendingAnalyticsOptIn } =
     useOnboardingStore.getState();
-  if (shareAnalytics !== null) return shareAnalytics;
+  if (shareAnalytics === false) return false;
+  if (pendingAnalyticsOptIn) return true;
   return serverAnalyticsEffective ?? true;
 }

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -242,6 +242,7 @@ const setDiagnosticsConsentCurrentMock = mock((_value: boolean) => {});
 const setShareAnalyticsMock = mock((_value: boolean | null) => {});
 const setShareDiagnosticsMock = mock((_value: boolean | null) => {});
 const setServerAnalyticsEffectiveMock = mock((_value: boolean | null) => {});
+const setPendingAnalyticsOptInMock = mock((_value: boolean) => {});
 const setServerDiagnosticsEffectiveMock = mock((_value: boolean | null) => {});
 const setConsentHydratedMock = mock((_value: boolean) => {});
 // Mirror the store's device-initialized tri-state share values (null = never
@@ -258,6 +259,7 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
       setShareAnalytics: setShareAnalyticsMock,
       setShareDiagnostics: setShareDiagnosticsMock,
       setServerAnalyticsEffective: setServerAnalyticsEffectiveMock,
+      setPendingAnalyticsOptIn: setPendingAnalyticsOptInMock,
       setServerDiagnosticsEffective: setServerDiagnosticsEffectiveMock,
       setAnalyticsConsentCurrent: setAnalyticsConsentCurrentMock,
       setDiagnosticsConsentCurrent: setDiagnosticsConsentCurrentMock,
@@ -386,6 +388,7 @@ beforeEach(() => {
   setShareAnalyticsMock.mockClear();
   setShareDiagnosticsMock.mockClear();
   setServerAnalyticsEffectiveMock.mockClear();
+  setPendingAnalyticsOptInMock.mockClear();
   setServerDiagnosticsEffectiveMock.mockClear();
   setConsentHydratedMock.mockClear();
   mockStoreShareAnalytics = null;

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -241,6 +241,8 @@ const setAnalyticsConsentCurrentMock = mock((_value: boolean) => {});
 const setDiagnosticsConsentCurrentMock = mock((_value: boolean) => {});
 const setShareAnalyticsMock = mock((_value: boolean | null) => {});
 const setShareDiagnosticsMock = mock((_value: boolean | null) => {});
+const setServerAnalyticsEffectiveMock = mock((_value: boolean | null) => {});
+const setServerDiagnosticsEffectiveMock = mock((_value: boolean | null) => {});
 const setConsentHydratedMock = mock((_value: boolean) => {});
 // Mirror the store's device-initialized tri-state share values (null = never
 // asked); the backfill reads these to send an explicit device choice
@@ -255,6 +257,8 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
       setPrivacyConsent: setPrivacyConsentMock,
       setShareAnalytics: setShareAnalyticsMock,
       setShareDiagnostics: setShareDiagnosticsMock,
+      setServerAnalyticsEffective: setServerAnalyticsEffectiveMock,
+      setServerDiagnosticsEffective: setServerDiagnosticsEffectiveMock,
       setAnalyticsConsentCurrent: setAnalyticsConsentCurrentMock,
       setDiagnosticsConsentCurrent: setDiagnosticsConsentCurrentMock,
       setConsentHydrated: setConsentHydratedMock,
@@ -381,6 +385,8 @@ beforeEach(() => {
   setDiagnosticsConsentCurrentMock.mockClear();
   setShareAnalyticsMock.mockClear();
   setShareDiagnosticsMock.mockClear();
+  setServerAnalyticsEffectiveMock.mockClear();
+  setServerDiagnosticsEffectiveMock.mockClear();
   setConsentHydratedMock.mockClear();
   mockStoreShareAnalytics = null;
   mockStoreShareDiagnostics = null;
@@ -671,6 +677,83 @@ describe("auth store onboarding flag reconciliation", () => {
     await useAuthStore.getState().initSession();
 
     expect(setShareAnalyticsMock).toHaveBeenCalledWith(true);
+  });
+
+  test("a server record adopts both effective verdicts into the store", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: true,
+      // The platform's verdict can disagree with the raw values — it is
+      // adopted verbatim, not re-derived.
+      analyticsEffective: false,
+      diagnosticsEffective: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: true,
+      hasServerRecord: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(setServerAnalyticsEffectiveMock).toHaveBeenCalledWith(false);
+    expect(setServerDiagnosticsEffectiveMock).toHaveBeenCalledWith(true);
+  });
+
+  test("a no-record response keeps the effective verdicts null (pre-sync posture)", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+
+    await useAuthStore.getState().initSession();
+
+    expect(setServerAnalyticsEffectiveMock).toHaveBeenCalledWith(null);
+    expect(setServerDiagnosticsEffectiveMock).toHaveBeenCalledWith(null);
+  });
+
+  test("a failed consent fetch leaves the adopted effective verdicts untouched", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockFetchConsentError = new Error("offline");
+
+    await useAuthStore.getState().initSession();
+
+    expect(setServerAnalyticsEffectiveMock).not.toHaveBeenCalled();
+    expect(setServerDiagnosticsEffectiveMock).not.toHaveBeenCalled();
+  });
+
+  test("a settled signed-out sync clears the adopted effective verdicts", async () => {
+    sessionUser = null;
+
+    await useAuthStore.getState().initSession();
+
+    expect(setServerAnalyticsEffectiveMock).toHaveBeenCalledWith(null);
+    expect(setServerDiagnosticsEffectiveMock).toHaveBeenCalledWith(null);
+  });
+
+  test("a server-effective diagnostics opt-out closes the gate even when raw is null", async () => {
+    // The platform computes the verdict; a raw null (never asked) with an
+    // effective false must close the reporting gate through the chokepoint.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: null,
+      analyticsEffective: true,
+      diagnosticsEffective: false,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: false,
+      hasServerRecord: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(localStorage.getItem("device:diagnostics_reporting")).toBe("false");
+    // The raw tri-state (chosen-ness) is untouched by the verdict.
+    expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
   });
 
   test("never-asked diagnostics (null on a real record) hydrates current but earns no device ack", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -249,6 +249,7 @@ const setConsentHydratedMock = mock((_value: boolean) => {});
 // asked); the backfill reads these to send an explicit device choice
 // alongside the accepted version.
 let mockStoreShareAnalytics: boolean | null = null;
+let mockStorePendingAnalyticsOptIn = false;
 let mockStoreShareDiagnostics: boolean | null = null;
 
 mock.module("@/domains/onboarding/onboarding-store", () => ({
@@ -265,6 +266,7 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
       setDiagnosticsConsentCurrent: setDiagnosticsConsentCurrentMock,
       setConsentHydrated: setConsentHydratedMock,
       shareAnalytics: mockStoreShareAnalytics,
+      pendingAnalyticsOptIn: mockStorePendingAnalyticsOptIn,
       shareDiagnostics: mockStoreShareDiagnostics,
     }),
   },
@@ -394,6 +396,7 @@ beforeEach(() => {
   setServerDiagnosticsEffectiveMock.mockClear();
   setConsentHydratedMock.mockClear();
   mockStoreShareAnalytics = null;
+  mockStorePendingAnalyticsOptIn = false;
   mockStoreShareDiagnostics = null;
   fetchConsentMock.mockClear();
   patchConsentMock.mockClear();
@@ -793,6 +796,34 @@ describe("auth store onboarding flag reconciliation", () => {
 
     expect(setPendingAnalyticsOptInMock).toHaveBeenCalledWith(false);
     expect(setServerAnalyticsEffectiveMock).toHaveBeenCalledWith(null);
+  });
+
+  test("a stale server false is not adopted while an opt-in is pending", async () => {
+    // Same-user sync racing the opt-in PATCH: the stale record still says
+    // explicit false. Adopting it would trip the gate's explicit-false rule
+    // and silently flip the just-made opt-in back off.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    await useAuthStore.getState().initSession();
+    setShareAnalyticsMock.mockClear();
+
+    mockStorePendingAnalyticsOptIn = true;
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      shareAnalytics: false,
+      shareDiagnostics: null,
+      analyticsEffective: false,
+      diagnosticsEffective: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      analyticsVersionCurrent: true,
+      diagnosticsVersionCurrent: false,
+      hasServerRecord: true,
+    });
+    await useAuthStore.getState().refreshSession();
+
+    expect(setShareAnalyticsMock).not.toHaveBeenCalledWith(false);
+    expect(setPendingAnalyticsOptInMock).not.toHaveBeenCalledWith(false);
   });
 
   test("a same-user resync does not reset the pending opt-in at sync start", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -319,7 +319,8 @@ mock.module("@/assistant/api", () => ({
   listAssistants: listAssistantsMock,
 }));
 
-const { useAuthStore } = await import("@/stores/auth-store");
+const { useAuthStore, __resetConsentSyncUserForTesting } =
+  await import("@/stores/auth-store");
 const { useAssistantLifecycleStore } =
   await import("@/assistant/lifecycle-store");
 const { useResolvedAssistantsStore } =
@@ -350,6 +351,7 @@ function authenticatedLocalUserForTest() {
 }
 
 beforeEach(() => {
+  __resetConsentSyncUserForTesting();
   sessionUser = null;
   getSessionCallCount = 0;
   getSessionFailFirstCall = false;
@@ -785,6 +787,46 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(persistDiagnosticsAckMock).not.toHaveBeenCalled();
     // A null server value never overwrites the device-local preference.
     expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
+  });
+
+  test("an account switch resets the pending opt-in and adopted verdicts", async () => {
+    sessionUser = { id: "user-1", email: "one@example.com" };
+    await useAuthStore.getState().initSession();
+    setPendingAnalyticsOptInMock.mockClear();
+    setServerAnalyticsEffectiveMock.mockClear();
+
+    // Same-tab switch to a different account: the previous account's pending
+    // opt-in must never override the new account's server verdicts.
+    sessionUser = { id: "user-2", email: "two@example.com" };
+    await useAuthStore.getState().refreshSession();
+
+    expect(setPendingAnalyticsOptInMock).toHaveBeenCalledWith(false);
+    expect(setServerAnalyticsEffectiveMock).toHaveBeenCalledWith(null);
+  });
+
+  test("a same-user resync does not reset the pending opt-in at sync start", async () => {
+    sessionUser = { id: "user-1", email: "one@example.com" };
+    await useAuthStore.getState().initSession();
+    setPendingAnalyticsOptInMock.mockClear();
+
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      privacy: true,
+      shareAnalytics: null,
+      shareDiagnostics: null,
+      analyticsEffective: false,
+      diagnosticsEffective: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: false,
+      hasServerRecord: true,
+    });
+    await useAuthStore.getState().refreshSession();
+
+    // Raw is null (does not reflect an opt-in) and the user is unchanged:
+    // the pending flag must survive the sync (the in-flight-PATCH race).
+    expect(setPendingAnalyticsOptInMock).not.toHaveBeenCalledWith(false);
   });
 
   test("a no-record response never adopts its default share values over a local opt-out", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -708,15 +708,6 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(setServerDiagnosticsEffectiveMock).toHaveBeenCalledWith(true);
   });
 
-  test("a no-record response keeps the effective verdicts null (pre-sync posture)", async () => {
-    sessionUser = { id: "user-1", email: "user@example.com" };
-
-    await useAuthStore.getState().initSession();
-
-    expect(setServerAnalyticsEffectiveMock).toHaveBeenCalledWith(null);
-    expect(setServerDiagnosticsEffectiveMock).toHaveBeenCalledWith(null);
-  });
-
   test("a failed consent fetch leaves the adopted effective verdicts untouched", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockFetchConsentError = new Error("offline");
@@ -827,6 +818,53 @@ describe("auth store onboarding flag reconciliation", () => {
     // Raw is null (does not reflect an opt-in) and the user is unchanged:
     // the pending flag must survive the sync (the in-flight-PATCH race).
     expect(setPendingAnalyticsOptInMock).not.toHaveBeenCalledWith(false);
+  });
+
+  test("a policy denial without version evidence is adopted and counted as a record", async () => {
+    // Never-asked user denied by org/platform policy: raw null, effective
+    // false, no version stamps. The verdict must be adopted (unconditional
+    // adoption — no record heuristic on the verdict path) so the gate closes.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: false,
+      privacy: false,
+      shareAnalytics: null,
+      shareDiagnostics: null,
+      analyticsEffective: false,
+      diagnosticsEffective: false,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: false,
+      hasServerRecord: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(setServerAnalyticsEffectiveMock).toHaveBeenCalledWith(false);
+    expect(setServerDiagnosticsEffectiveMock).toHaveBeenCalledWith(false);
+  });
+
+  test("even a no-record response adopts the platform verdict (never-asked → enabled)", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: false,
+      privacy: false,
+      shareAnalytics: null,
+      shareDiagnostics: null,
+      analyticsEffective: true,
+      diagnosticsEffective: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+      analyticsVersionCurrent: false,
+      diagnosticsVersionCurrent: false,
+      hasServerRecord: false,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(setServerAnalyticsEffectiveMock).toHaveBeenCalledWith(true);
+    expect(setServerDiagnosticsEffectiveMock).toHaveBeenCalledWith(true);
   });
 
   test("a no-record response never adopts its default share values over a local opt-out", async () => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -366,22 +366,20 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       const localShareAnalytics = store.shareAnalytics;
       const localShareDiagnostics = store.shareDiagnostics;
       // Adopt the platform-computed effective verdicts for the data-capture
-      // gates. A no-record response carries no verdict (its values are API
-      // defaults), so the gates keep the pre-sync posture: opt-out default
-      // unless a local explicit opt-out. The pending opt-in clears only once
-      // the fetched record REFLECTS it — a sync racing the opt-in's
+      // gates UNCONDITIONALLY: the platform computes a verdict for every
+      // response, including no-row responses (never-asked → enabled), so
+      // there is no client-side judgment about record-ness on this path —
+      // that heuristic (hasServerRecord) guards only legal-consent fallback,
+      // backfill, and chosen-ness adoption. The pending opt-in clears only
+      // once the fetched record REFLECTS it — a sync racing the opt-in's
       // in-flight PATCH must not flip uploads back off on the stale record.
       // (An explicit server false is adopted into the store above, where the
       // gate's explicit-false rule closes uploads regardless of pending.)
       if (resolved.shareAnalytics === true) {
         store.setPendingAnalyticsOptIn(false);
       }
-      store.setServerAnalyticsEffective(
-        resolved.hasServerRecord ? resolved.analyticsEffective : null,
-      );
-      store.setServerDiagnosticsEffective(
-        resolved.hasServerRecord ? resolved.diagnosticsEffective : null,
-      );
+      store.setServerAnalyticsEffective(resolved.analyticsEffective);
+      store.setServerDiagnosticsEffective(resolved.diagnosticsEffective);
       // Adopt the server's tri-state share-analytics verbatim: an explicit
       // choice is authoritative even when its legal consent versions are stale
       // (the nav layer routes to review-terms), and null (never asked)

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -331,7 +331,30 @@ function buildDeviceConsentBackfill(axes: {
   };
 }
 
+// The account the consent flags were last synced for. `undefined` = no sync
+// yet this page load (the store boots clean, so there is nothing to reset).
+let lastConsentSyncUserId: string | null | undefined;
+
+/** Test-only: forget the last-synced account between tests. */
+export function __resetConsentSyncUserForTesting(): void {
+  lastConsentSyncUserId = undefined;
+}
+
 async function syncUserScopedState(nextUserId: string | null): Promise<void> {
+  if (
+    lastConsentSyncUserId !== undefined &&
+    lastConsentSyncUserId !== nextUserId
+  ) {
+    // The pending opt-in and adopted server verdicts belong to the previous
+    // account's session — a different account (or a signed-out state) must
+    // never inherit them: a stale pending opt-in could otherwise override
+    // the new account's server-effective opt-out.
+    const store = useOnboardingStore.getState();
+    store.setPendingAnalyticsOptIn(false);
+    store.setServerAnalyticsEffective(null);
+    store.setServerDiagnosticsEffective(null);
+  }
+  lastConsentSyncUserId = nextUserId;
   if (nextUserId) {
     try {
       const consent = await fetchConsent();

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -345,8 +345,14 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // Adopt the platform-computed effective verdicts for the data-capture
       // gates. A no-record response carries no verdict (its values are API
       // defaults), so the gates keep the pre-sync posture: opt-out default
-      // unless a local explicit opt-out.
-      store.setPendingAnalyticsOptIn(false);
+      // unless a local explicit opt-out. The pending opt-in clears only once
+      // the fetched record REFLECTS it — a sync racing the opt-in's
+      // in-flight PATCH must not flip uploads back off on the stale record.
+      // (An explicit server false is adopted into the store above, where the
+      // gate's explicit-false rule closes uploads regardless of pending.)
+      if (resolved.shareAnalytics === true) {
+        store.setPendingAnalyticsOptIn(false);
+      }
       store.setServerAnalyticsEffective(
         resolved.hasServerRecord ? resolved.analyticsEffective : null,
       );

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -342,6 +342,16 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // device, not the just-adopted server value.
       const localShareAnalytics = store.shareAnalytics;
       const localShareDiagnostics = store.shareDiagnostics;
+      // Adopt the platform-computed effective verdicts for the data-capture
+      // gates. A no-record response carries no verdict (its values are API
+      // defaults), so the gates keep the pre-sync posture: opt-out default
+      // unless a local explicit opt-out.
+      store.setServerAnalyticsEffective(
+        resolved.hasServerRecord ? resolved.analyticsEffective : null,
+      );
+      store.setServerDiagnosticsEffective(
+        resolved.hasServerRecord ? resolved.diagnosticsEffective : null,
+      );
       // Adopt the server's tri-state share-analytics verbatim: an explicit
       // choice is authoritative even when its legal consent versions are stale
       // (the nav layer routes to review-terms), and null (never asked)
@@ -365,6 +375,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       applyResolvedDiagnosticsConsent(
         {
           shareDiagnostics: resolved.shareDiagnostics,
+          diagnosticsEffective: resolved.diagnosticsEffective,
           hasServerRecord: resolved.hasServerRecord,
         },
         store.setShareDiagnostics,
@@ -479,9 +490,14 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   const store = useOnboardingStore.getState();
   // Consent fetch failed for a platform user: a device that has never
   // resolved a diagnostics gate fails closed until a successful sync can
-  // reveal a server-side explicit opt-out.
+  // reveal a server-side explicit opt-out. A failed fetch keeps the last
+  // adopted server verdicts; a signed-out sync clears them — they belong to
+  // the departed user's record.
   if (nextUserId) {
     failCloseDiagnosticsGateUntilFirstSync();
+  } else {
+    store.setServerAnalyticsEffective(null);
+    store.setServerDiagnosticsEffective(null);
   }
   store.setTosAccepted(consent.tos);
   store.setPrivacyConsent(consent.privacy);

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -346,6 +346,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // gates. A no-record response carries no verdict (its values are API
       // defaults), so the gates keep the pre-sync posture: opt-out default
       // unless a local explicit opt-out.
+      store.setPendingAnalyticsOptIn(false);
       store.setServerAnalyticsEffective(
         resolved.hasServerRecord ? resolved.analyticsEffective : null,
       );
@@ -496,6 +497,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   if (nextUserId) {
     failCloseDiagnosticsGateUntilFirstSync();
   } else {
+    store.setPendingAnalyticsOptIn(false);
     store.setServerAnalyticsEffective(null);
     store.setServerDiagnosticsEffective(null);
   }

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -387,12 +387,18 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // a no-record response adopts nothing — its values are API defaults
       // (older shapes materialize `true` there), and adopting one would
       // clobber the device opt-out the backfill below is about to seed the
-      // server with. And null never overwrites a local explicit opt-out —
-      // its server write may still be in flight (or have failed), and
-      // clearing it would resume uploads the user declined.
+      // server with. And a stale server value never overwrites a PENDING
+      // local edit in either direction: null must not clear an explicit
+      // local opt-out whose write may be in flight, and a stale false must
+      // not clobber a pending opt-in (the gate's explicit-false rule would
+      // silently flip the user's just-made choice back off).
       if (
         resolved.hasServerRecord &&
-        (resolved.shareAnalytics !== null || localShareAnalytics !== false)
+        (resolved.shareAnalytics !== null || localShareAnalytics !== false) &&
+        !(
+          resolved.shareAnalytics === false &&
+          useOnboardingStore.getState().pendingAnalyticsOptIn
+        )
       ) {
         store.setShareAnalytics(resolved.shareAnalytics);
       }


### PR DESCRIPTION
## Summary
- Web data-capture gates (analytics emit gate + diagnostics reporting gate) now consume the platform-computed `share_*_effective` verdicts adopted at sync, per the end-state `localExplicitOptOut ? false : serverEffective ?? true`; raw consent values remain only for chosen-ness/UI. Resolves the deferred architectural thread on #38250 (discussion_r3591658988) — a server-side effective opt-out is now honored even where raw values would read enabled.
- Deletes the `?? raw ?? true` effective-field fallback chain in `resolveServerConsent` — platform prod verifiably serves the fields; the deletion affects only future builds, so no installed-client gate applies.
- Demotes the frozen consent-version constants to their two remaining legitimate roles (pre-first-sync ack seeding; review-terms change-note display).

Completes 'PR 10' of the consent-cleanup plan (attached to #38209/#38250). BQ-row QA rides the release close-out, not this PR.

## Original prompt
Noa: with no clear timeline for old clients to upgrade, the installed-client gate on the plan's final PR is moot — make the code what we want it to be as long as the platform API stays backwards compatible. Platform prod is verified serving effective + required-version fields, so this ships the deferred end-state now: server as the single consent authority, fallbacks deleted, gates wired to effective verdicts.