### PR TITLE
feat(memory): purge relocated memory tables on conversation delete

### DIFF
--- a/assistant/src/plugins/defaults/memory/__tests__/conversation-memory-purge.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/conversation-memory-purge.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Purge coverage for the memory `conversation-deleted` hook: deleting a
+ * conversation removes its rows — and only its rows — from the relocated
+ * per-conversation memory tables on the memory connection, and degrades to a
+ * no-op when that connection is unavailable.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type {
+  ConversationDeletedContext,
+  HookFunction,
+} from "@vellumai/plugin-api";
+
+import type { DrizzleDb } from "../../../../persistence/db-connection.js";
+import { getMemorySqlite } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import {
+  clearStoredDb,
+  setStoredDb,
+} from "../../../../persistence/db-singleton.js";
+import {
+  CONVERSATION_KEYED_MEMORY_TABLES,
+  purgeConversationMemoryTables,
+} from "../conversation-memory-purge.js";
+import conversationDeleted from "../hooks/conversation-deleted.js";
+
+await initializeDb();
+
+async function runHook(conversationId: string): Promise<void> {
+  const hook = conversationDeleted as HookFunction<ConversationDeletedContext>;
+  await hook({ conversationId } as ConversationDeletedContext);
+}
+
+function seedRow(table: string, conversationId: string): void {
+  const raw = getMemorySqlite()!;
+  const now = Date.now();
+  switch (table) {
+    case "memory_v2_activation_logs":
+      raw
+        .query(
+          `INSERT INTO memory_v2_activation_logs
+             (id, conversation_id, turn, mode, concepts_json, skills_json, config_json, created_at)
+           VALUES (?, ?, 1, 'per-turn', '[]', '[]', '{}', ?)`,
+        )
+        .run(`${conversationId}-al`, conversationId, now);
+      return;
+    case "memory_recall_logs":
+      raw
+        .query(
+          `INSERT INTO memory_recall_logs
+             (id, conversation_id, enabled, degraded, semantic_hits, merged_count,
+              selected_count, tier1_count, tier2_count, hybrid_search_latency_ms,
+              sparse_vector_used, injected_tokens, latency_ms, top_candidates_json, created_at)
+           VALUES (?, ?, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '[]', ?)`,
+        )
+        .run(`${conversationId}-rl`, conversationId, now);
+      return;
+    case "memory_v3_selections":
+      raw
+        .query(
+          `INSERT INTO memory_v3_selections
+             (conversation_id, turn, slug, source, created_at)
+           VALUES (?, 1, 'domain/page', 'auto', ?)`,
+        )
+        .run(conversationId, now);
+      return;
+    case "activation_sessions":
+      raw
+        .query(
+          `INSERT INTO activation_sessions (conversation_id, created_at) VALUES (?, ?)`,
+        )
+        .run(conversationId, now);
+      return;
+    default:
+      throw new Error(`unhandled table ${table}`);
+  }
+}
+
+function rowCount(table: string, conversationId: string): number {
+  const { n } = getMemorySqlite()!
+    .query(`SELECT COUNT(*) AS n FROM ${table} WHERE conversation_id = ?`)
+    .get(conversationId) as { n: number };
+  return n;
+}
+
+describe("conversation memory purge", () => {
+  beforeEach(() => {
+    for (const table of CONVERSATION_KEYED_MEMORY_TABLES) {
+      getMemorySqlite()!.exec(`DELETE FROM ${table}`);
+    }
+  });
+
+  test("the shared table list covers the four relocated Wave 1 tables", () => {
+    expect([...CONVERSATION_KEYED_MEMORY_TABLES].sort()).toEqual(
+      [
+        "activation_sessions",
+        "memory_recall_logs",
+        "memory_v2_activation_logs",
+        "memory_v3_selections",
+      ].sort(),
+    );
+  });
+
+  test("the hook deletes the deleted conversation's rows from every table", async () => {
+    for (const table of CONVERSATION_KEYED_MEMORY_TABLES) {
+      seedRow(table, "doomed");
+    }
+
+    await runHook("doomed");
+
+    for (const table of CONVERSATION_KEYED_MEMORY_TABLES) {
+      expect(rowCount(table, "doomed")).toBe(0);
+    }
+  });
+
+  test("the purge leaves other conversations' rows untouched", () => {
+    for (const table of CONVERSATION_KEYED_MEMORY_TABLES) {
+      seedRow(table, "doomed");
+      seedRow(table, "survivor");
+    }
+
+    purgeConversationMemoryTables("doomed");
+
+    for (const table of CONVERSATION_KEYED_MEMORY_TABLES) {
+      expect(rowCount(table, "doomed")).toBe(0);
+      expect(rowCount(table, "survivor")).toBe(1);
+    }
+  });
+});
+
+describe("conversation memory purge without a memory database", () => {
+  // Install a connection with no underlying sqlite client so
+  // getMemorySqlite() resolves to null without mocking any module.
+  beforeEach(() => {
+    setStoredDb("memory", { $client: null } as unknown as DrizzleDb, () => {});
+  });
+
+  afterEach(() => {
+    clearStoredDb("memory");
+  });
+
+  test("the purge no-ops without throwing when the memory DB is unavailable", () => {
+    expect(() => purgeConversationMemoryTables("doomed")).not.toThrow();
+  });
+});

--- a/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
+++ b/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
@@ -8,8 +8,8 @@ const log = getLogger("conversation-memory-purge");
  * conversation delete must purge. SQLite foreign keys cannot span database
  * files, so the main-DB conversation-delete cascade never reaches these rows;
  * the `conversation-deleted` hook deletes them explicitly instead. Each table
- * keys on `conversation_id`. Wave 2's move PRs extend this list one line each
- * as their tables relocate.
+ * keys on `conversation_id`; a table joins this list when it moves to the
+ * memory connection.
  */
 export const CONVERSATION_KEYED_MEMORY_TABLES: readonly string[] = [
   "memory_v2_activation_logs",

--- a/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
+++ b/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
@@ -1,0 +1,47 @@
+import { getLogger } from "./logging.js";
+import { memorySqliteOrNull } from "./memory-db.js";
+
+const log = getLogger("conversation-memory-purge");
+
+/**
+ * Per-conversation memory tables on the dedicated memory connection that a
+ * conversation delete must purge. SQLite foreign keys cannot span database
+ * files, so the main-DB conversation-delete cascade never reaches these rows;
+ * the `conversation-deleted` hook deletes them explicitly instead. Each table
+ * keys on `conversation_id`. Wave 2's move PRs extend this list one line each
+ * as their tables relocate.
+ */
+export const CONVERSATION_KEYED_MEMORY_TABLES: readonly string[] = [
+  "memory_v2_activation_logs",
+  "memory_recall_logs",
+  "memory_v3_selections",
+  "activation_sessions",
+];
+
+/**
+ * Delete the given conversation's rows from every table in
+ * {@link CONVERSATION_KEYED_MEMORY_TABLES} on the memory connection.
+ *
+ * Best-effort: an unavailable memory database no-ops, and one table's failing
+ * delete is logged and swallowed so the remaining tables are still purged. A
+ * lost purge must never break conversation deletion — for these derived tables
+ * a stray orphan row is harmless garbage.
+ */
+export function purgeConversationMemoryTables(conversationId: string): void {
+  const raw = memorySqliteOrNull("purgeConversationMemoryTables");
+  if (!raw) {
+    return;
+  }
+  for (const table of CONVERSATION_KEYED_MEMORY_TABLES) {
+    try {
+      raw
+        .query(`DELETE FROM ${table} WHERE conversation_id = ?`)
+        .run(conversationId);
+    } catch (err) {
+      log.warn(
+        { err, conversationId, table },
+        "Failed to purge memory table for deleted conversation; continuing",
+      );
+    }
+  }
+}

--- a/assistant/src/plugins/defaults/memory/hooks/conversation-deleted.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/conversation-deleted.ts
@@ -1,16 +1,23 @@
 /**
  * Default `memory` conversation-deleted hook.
  *
- * Fails the plugin's own still-pending background jobs referencing the
- * deleted conversation (graph extraction, embeddings, sweeps, …) so the
- * worker does not burn cycles — and error noise — on jobs whose conversation
- * no longer exists.
+ * Does two independent things for the deleted conversation:
  *
- * The sweep is scoped to the plugin's own job types (derived from its handler
- * table). The dispatch is fire-and-forget, so the sweep runs concurrently
- * with the host cleanup jobs the delete primitive enqueues (e.g. the lexical
- * purge) — scoping by type is what keeps those host jobs out of its blast
- * radius without needing any ordering between them.
+ * 1. Fails the plugin's own still-pending background jobs referencing it
+ *    (graph extraction, embeddings, sweeps, …) so the worker does not burn
+ *    cycles — and error noise — on jobs whose conversation no longer exists.
+ *    The sweep is scoped to the plugin's own job types (derived from its
+ *    handler table). The dispatch is fire-and-forget, so the sweep runs
+ *    concurrently with the host cleanup jobs the delete primitive enqueues
+ *    (e.g. the lexical purge) — scoping by type is what keeps those host jobs
+ *    out of its blast radius without needing any ordering between them.
+ *
+ * 2. Purges the conversation's rows from the per-conversation memory tables on
+ *    the dedicated memory connection. SQLite foreign keys cannot span database
+ *    files, so the main-DB delete cascade never reaches those relocated tables;
+ *    this hook replaces the lost cascade with an explicit best-effort delete.
+ *    It touches a disjoint set of tables from the job sweep, so the two do not
+ *    interfere.
  */
 
 import type {
@@ -18,6 +25,7 @@ import type {
   HookFunction,
 } from "@vellumai/plugin-api";
 
+import { purgeConversationMemoryTables } from "../conversation-memory-purge.js";
 import { memoryJobHandlers } from "../job-handlers.js";
 import { cancelPendingJobsForConversation } from "../task-memory-cleanup.js";
 
@@ -29,6 +37,7 @@ const conversationDeleted: HookFunction<ConversationDeletedContext> = async (
   ctx,
 ) => {
   cancelPendingJobsForConversation(ctx.conversationId, MEMORY_JOB_TYPES);
+  purgeConversationMemoryTables(ctx.conversationId);
 };
 
 export default conversationDeleted;


### PR DESCRIPTION
## Summary
- Extends the memory conversation-deleted hook to delete a deleted conversation's rows from the relocated Wave 1 memory tables on the memory connection — a manual cascade replacing the cross-file FK cascade that Wave 2 will drop.
- Closes a Wave 1 gap: those tables (incl. memory_recall_logs, which holds injected content) were never purged on delete.

Part of plan: memory-db-wave2.md (PR 1 of 3)