### PR TITLE
feat(telemetry): record the self-reported subject on onboarding_research

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29133,6 +29133,14 @@ paths:
                   enum:
                     - done
                     - error
+                self_reported_occupation:
+                  type: string
+                self_reported_hobbies:
+                  type: array
+                  items:
+                    type: string
+                self_reported_timezone:
+                  type: string
                 claims:
                   type: array
                   items:

--- a/assistant/src/onboarding/onboarding-research-events-store.test.ts
+++ b/assistant/src/onboarding/onboarding-research-events-store.test.ts
@@ -92,6 +92,9 @@ describe("onboarding-research-events-store", () => {
     recordOnboardingResearchEvent({
       conversationId: "conv-xyz",
       status: "done",
+      selfReportedOccupation: "Chief Technology Officer",
+      selfReportedHobbies: ["gardening", "chess"],
+      selfReportedTimezone: "America/New_York",
       claims: SAMPLE_CLAIMS,
       suggestions: [
         { suggestion: "I'll find 3 papers", prompt: "Find me 3 papers" },
@@ -117,6 +120,11 @@ describe("onboarding-research-events-store", () => {
       recorded_at: row.createdAt,
       conversation_id: "conv-xyz",
       status: "done",
+      // The turn's INPUT, so a claim can be told apart from the form value it
+      // echoed back. No name field by design.
+      self_reported_occupation: "Chief Technology Officer",
+      self_reported_hobbies: ["gardening", "chess"],
+      self_reported_timezone: "America/New_York",
       claims: SAMPLE_CLAIMS,
       claim_count: 4,
       claims_confident: 2,
@@ -130,6 +138,27 @@ describe("onboarding-research-events-store", () => {
       installed_plugins: ["marketing-expert", "web-research"],
       assistant_version: APP_VERSION,
     });
+  });
+
+  test("an older client that omits the self-reported subject still records (the fields are absent, not null)", () => {
+    recordOnboardingResearchEvent({
+      conversationId: "conv-xyz",
+      status: "done",
+      claims: SAMPLE_CLAIMS,
+      suggestions: [],
+      plugins: [],
+      installedPlugins: [],
+    });
+
+    const row = pendingRows()[0]!;
+    const payload = row.payload as Record<string, unknown>;
+    expect(payload.status).toBe("done");
+    // Absent rather than an explicit null: the platform serializer treats the
+    // fields as optional, and a null would be a claim about the subject the
+    // client never made.
+    expect(payload.self_reported_occupation).toBeUndefined();
+    expect(payload.self_reported_hobbies).toBeUndefined();
+    expect(payload.self_reported_timezone).toBeUndefined();
   });
 
   test("empty claims/suggestions/plugins ship as empty arrays with zeroed counts; daemon_event_id falls back to the row id without a conversation", () => {

--- a/assistant/src/onboarding/onboarding-research-events-store.ts
+++ b/assistant/src/onboarding/onboarding-research-events-store.ts
@@ -15,6 +15,18 @@ export interface OnboardingResearchEvent {
 export interface RecordOnboardingResearchEventParams {
   conversationId: string | null;
   status: "done" | "error";
+  /**
+   * The onboarding-form values the research turn was run ON — its INPUT, as
+   * distinct from the claims/suggestions below (its OUTPUT). Without these a
+   * claim cannot be told apart from the form value it merely echoed back, and
+   * `installedPlugins` is unattributable (the deterministic floor is keyed on
+   * occupation). Excludes the user's name by design: directly identifying, and
+   * not needed to judge research quality. Optional throughout — an older web
+   * client omits them.
+   */
+  selfReportedOccupation?: string;
+  selfReportedHobbies?: string[];
+  selfReportedTimezone?: string;
   claims: OnboardingResearchClaim[];
   suggestions: OnboardingResearchSuggestion[];
   /** The model's raw top-level `plugins` picks, before the deterministic-floor merge. */
@@ -76,6 +88,9 @@ export function recordOnboardingResearchEvent(
       recorded_at: createdAt,
       conversation_id: params.conversationId,
       status: params.status,
+      self_reported_occupation: params.selfReportedOccupation,
+      self_reported_hobbies: params.selfReportedHobbies,
+      self_reported_timezone: params.selfReportedTimezone,
       claims: params.claims,
       claim_count: params.claims.length,
       claims_confident: countByConfidence(params.claims, "confident"),

--- a/assistant/src/runtime/routes/telemetry-routes.ts
+++ b/assistant/src/runtime/routes/telemetry-routes.ts
@@ -34,6 +34,14 @@ const onboardingResearchSuggestionSchema = z.object({
 const onboardingResearchRequestSchema = z.object({
   conversation_id: z.string().nullable(),
   status: z.enum(["done", "error"]),
+  // The onboarding-form values the turn was run ON. Optional: an older web
+  // client omits them, and the flow's own fields are optional. Kept permissive
+  // for the same reason the platform serializer is — a rejected request here
+  // would cost the whole research report, and the subject is the least
+  // important part of it.
+  self_reported_occupation: z.string().optional(),
+  self_reported_hobbies: z.array(z.string()).optional(),
+  self_reported_timezone: z.string().optional(),
   claims: z.array(onboardingResearchClaimSchema),
   suggestions: z.array(onboardingResearchSuggestionSchema),
   plugins: z.array(z.string()),
@@ -75,6 +83,9 @@ function handleRecordOnboardingResearchEvent({ body }: RouteHandlerArgs) {
   const event = recordOnboardingResearchEvent({
     conversationId: parsed.data.conversation_id,
     status: parsed.data.status,
+    selfReportedOccupation: parsed.data.self_reported_occupation,
+    selfReportedHobbies: parsed.data.self_reported_hobbies,
+    selfReportedTimezone: parsed.data.self_reported_timezone,
     claims: parsed.data.claims,
     suggestions: parsed.data.suggestions,
     plugins: parsed.data.plugins,

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -476,6 +476,14 @@ export interface OnboardingResearchTelemetryEvent extends TelemetryEventBase {
   type: "onboarding_research";
   conversation_id: string | null;
   status: "done" | "error";
+  /**
+   * The onboarding-form values the turn was run ON (its INPUT), as distinct
+   * from the inferred `claims` below (its OUTPUT). Excludes the user's name by
+   * design. Optional — an older web client omits them.
+   */
+  self_reported_occupation?: string;
+  self_reported_hobbies?: string[];
+  self_reported_timezone?: string;
   claims: OnboardingResearchClaim[];
   claim_count: number;
   claims_confident: number;

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -105,7 +105,7 @@ function researchSubjectFrom(values: ResearchOnboardingValues): ResearchSubject 
     firstName: values.firstName,
     lastName: values.lastName,
     occupation: values.role,
-    hobby: values.hobbies.join(", "),
+    hobbies: values.hobbies,
     timezone: getBrowserTimezone(),
   };
 }
@@ -507,7 +507,7 @@ export function ResearchOnboardingRoute() {
                 firstName,
                 lastName,
                 occupation: role,
-                hobby: hobbies.join(", "),
+                hobbies,
               }),
             // A hidden kickoff (the "Let's chat" handoff) drives the first reply
             // without rendering a user bubble, so the chat opens as a proactive

--- a/clients/web/src/domains/onboarding/research-prompt.test.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.test.ts
@@ -19,8 +19,35 @@ const SUBJECT = {
   firstName: "Ada",
   lastName: "Lovelace",
   occupation: "Technical founder",
-  hobby: "chess",
+  hobbies: ["chess"],
 };
+
+describe("buildResearchPrompt — hobbies rendering", () => {
+  test("joins multiple hobbies into the stated-details sentence", () => {
+    const prompt = buildResearchPrompt({
+      ...SUBJECT,
+      hobbies: ["chess", "gardening"],
+    });
+    expect(prompt).toContain("My hobby is chess, gardening.");
+  });
+
+  test("omits the hobby sentence when no hobbies were picked", () => {
+    expect(buildResearchPrompt({ ...SUBJECT, hobbies: [] })).not.toContain(
+      "My hobby is",
+    );
+    expect(
+      buildResearchPrompt({ ...SUBJECT, hobbies: undefined }),
+    ).not.toContain("My hobby is");
+  });
+
+  test("drops blank chips rather than rendering empty list items", () => {
+    const prompt = buildResearchPrompt({
+      ...SUBJECT,
+      hobbies: ["chess", "   ", ""],
+    });
+    expect(prompt).toContain("My hobby is chess.");
+  });
+});
 
 describe("buildResearchPrompt — capabilities", () => {
   test("omits the capabilities block when no catalog is passed", () => {

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -24,7 +24,14 @@ export interface ResearchSubject {
   firstName: string;
   lastName: string;
   occupation: string;
-  hobby?: string;
+  /**
+   * The form's multi-select chips, verbatim. Kept as the array the user
+   * actually picked rather than a pre-joined string: this is the shape the
+   * onboarding-research telemetry event records, and chips are free-typed, so
+   * a hobby containing a comma could not be split back out of a join. The
+   * prompt's `", "` rendering is applied below, at the point of use.
+   */
+  hobbies?: string[];
   /**
    * IANA timezone of the user's browser (e.g. "America/Denver"). A soft
    * location signal the prompt's identity gate checks candidate matches
@@ -92,7 +99,7 @@ export interface BuildResearchPromptOptions {
 }
 
 export function buildResearchPrompt(
-  { firstName, lastName, occupation, hobby, timezone }: ResearchSubject,
+  { firstName, lastName, occupation, hobbies, timezone }: ResearchSubject,
   availableCapabilities: AvailableCapability[] = [],
   { includeSuggestions = true }: BuildResearchPromptOptions = {},
 ): string {
@@ -100,7 +107,10 @@ export function buildResearchPrompt(
     .filter(Boolean)
     .join(" ");
   const role = occupation.trim();
-  const hobbyText = hobby?.trim() ?? "";
+  const hobbyText = (hobbies ?? [])
+    .map((h) => h.trim())
+    .filter(Boolean)
+    .join(", ");
   const timezoneText = timezone?.trim() ?? "";
   const capabilitiesBlock = renderCapabilitiesBlock(
     availableCapabilities,

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -196,6 +196,12 @@ async function installCapabilityBestEffort(
 }
 
 /**
+ * Cap on hobbies reported to telemetry. Matches the platform serializer's
+ * `self_reported_hobbies` bound so the two can't disagree.
+ */
+const MAX_REPORTED_HOBBIES = 32;
+
+/**
  * Report a research turn's outcome (claims/suggestions/plugin picks) for
  * analytics. Client-orchestrated: the daemon never detects this turn on its
  * own, so the client reports it once — either as the raw model output the
@@ -204,11 +210,18 @@ async function installCapabilityBestEffort(
  * plugins), or as whatever had been parsed so far if the poll ceiling fires
  * first (`status: "error"`). Fire-and-forget: a failure here must never
  * block or surface in the flow, mirroring `archiveResearchConversation`.
+ *
+ * Reports the `subject` the turn was run ON alongside its results, so a claim
+ * can be told apart from the form value it merely echoed back, and so
+ * `installed_plugins` is attributable (the deterministic floor is keyed on
+ * occupation). The name is deliberately NOT sent: directly identifying, and
+ * nothing downstream needs it to judge research quality.
  */
 async function sendOnboardingResearchTelemetry({
   assistantId,
   conversationId,
   status,
+  subject,
   claims,
   suggestions,
   plugins,
@@ -217,6 +230,7 @@ async function sendOnboardingResearchTelemetry({
   assistantId: string;
   conversationId: string;
   status: "done" | "error";
+  subject: ResearchSubject;
   claims: ResearchFact[];
   suggestions: ResearchSuggestion[];
   plugins: string[];
@@ -228,6 +242,17 @@ async function sendOnboardingResearchTelemetry({
       body: {
         conversation_id: conversationId,
         status,
+        self_reported_occupation: subject.occupation,
+        // Capped client-side: the chip field has no UI limit, and the
+        // platform serializer's own bound would drop the WHOLE event rather
+        // than the overflow (an invalid event is skipped while the batch
+        // still 2xxes). Truncating here keeps a pathological form from
+        // costing us the research report entirely.
+        self_reported_hobbies: (subject.hobbies ?? []).slice(
+          0,
+          MAX_REPORTED_HOBBIES,
+        ),
+        self_reported_timezone: subject.timezone,
         claims,
         suggestions,
         plugins,
@@ -642,6 +667,7 @@ export function useResearchRunner(): UseResearchRunner {
                   assistantId,
                   conversationId,
                   status: "done",
+                  subject,
                   claims,
                   suggestions,
                   plugins,
@@ -670,6 +696,7 @@ export function useResearchRunner(): UseResearchRunner {
               assistantId,
               conversationId,
               status: "error",
+              subject,
               claims: lastClaims,
               suggestions: lastSuggestions,
               plugins: lastPlugins,


### PR DESCRIPTION
Last step of the cross-repo sequence. Platform serializer (vellum-assistant-platform#9182) and Terraform columns (#9181) are **merged and applied**, and the regenerated wire module landed via the sync bot in #38255 — so this is unblocked.

## Why

`onboarding_research` reported the research turn's **output** (inferred `claims`, the resolved `installed_plugins`) but nothing about its **input** — the onboarding-form values the turn was run on. A real staging payload:

```json
{"status":"done",
 "claims":[{"claim":"Works as a Chief Technology Officer","confidence":"guessing","sources":[]},
           {"claim":"Gardening is a primary hobby","confidence":"guessing","sources":[]}],
 "plugins":["cofounder","plant-doctor"],
 "installed_plugins":["admin-copilot","git-workflow","cofounder","plant-doctor"]}
```

Both claims are almost certainly the model echoing back what the user typed two screens earlier — but with no record of the input, nobody can tell a genuine research hit from a parroted form value. `installed_plugins` had the same problem: `resolveOnboardingPluginInstalls` unions the model's picks onto `resolveDeterministicPlugins(role, validNames)`, so occupation determines part of that set (`admin-copilot` and `git-workflow` above came from the floor — unknowable from the event).

## What

Threads the `subject` **already in scope** at both emit sites through the daemon route → outbox store → wire payload as `self_reported_occupation` / `self_reported_hobbies` / `self_reported_timezone`.

The name is deliberately not sent: directly identifying, and not needed to judge research quality. What is sent is strictly less sensitive than the free-text `claims` already on this event, so the sensitivity class and `share_analytics` gating are unchanged.

## `ResearchSubject.hobby: string` → `hobbies: string[]`

The form's source of truth is a multi-select chip field (`hobbies: string[]`), but `researchSubjectFrom` collapsed it with `hobbies.join(", ")` **before the runner ever saw it** — so the array was already gone at the point telemetry needed it. The join now happens inside `buildResearchPrompt`, at the point of use.

- The prompt string is byte-identical (`", "` join, blank chips still dropped) — pinned by new tests.
- Storing the join would have been lossy: chips are free-typed, so `"reading, mostly sci-fi"` can't be split back out.
- An array is also what `unnest()` group-bys want. Mirrors `plugins` / `installed_plugins`.

Only two construction sites existed, both doing the same join.

## Optional end to end

Route schema, store params, and wire type all treat the three as optional, and they ship **absent rather than null** — a null would be a claim about the subject the client never made. Hobbies are capped client-side at 32 to match the platform serializer's bound: tripping that bound server-side would drop the **whole event** (invalid events are skipped while the batch still 2xxes), so truncating here keeps a pathological form from costing us the entire research report.

## On the ordering

Worth noting for future event changes: this order isn't just convention. The `_onboardingResearchKeysExist` assert in `types.ts` means the daemon type cannot name a field the wire contract lacks — I hit a hard `TS2344` until #38255 landed. The compiler enforces platform-first.

## Verification

- `assistant` typecheck ✅, `clients/web` typecheck ✅
- Daemon: 12 tests across the store + route suites ✅ (new: subject round-trips into the outbox payload; an older client omitting it still records, fields absent not null)
- Web: all 30 onboarding test files ✅ (new: hobbies join/omit/blank-chip rendering)
- `clients/web` lint: 0 errors (2908 pre-existing warnings, unchanged)
- Regenerated `assistant/openapi.yaml` — the +8 lines are the three new request fields

Web tests must be run per-file via `bun scripts/run-tests.ts <files>`; passing a directory runs them in one process and `mock.module` leaks across files (unrelated failures in `existing-assistant-step` / `connect-recovery-dialog`, which pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)