### PR TITLE
feat(memory): move memory_v3_ever_injected and memory_retrospective_state to the memory DB

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -21,7 +21,12 @@ import {
   getMessages,
 } from "../persistence/conversation-crud.js";
 import { getConversationDirPath } from "../persistence/conversation-disk-view.js";
-import { getDb, getLogsDb, getMemoryDb } from "../persistence/db-connection.js";
+import {
+  getDb,
+  getLogsDb,
+  getMemoryDb,
+  getMemorySqlite,
+} from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { getRequestLogsByMessageId } from "../persistence/llm-request-log-store.js";
 import { stringifyMessageContent } from "../persistence/message-content.js";
@@ -65,12 +70,14 @@ function resetTables(): void {
   db.delete(conversationAssistantAttentionState).run();
   getMemoryDb()!.delete(activationState).run();
   db.delete(conversationCompactionEvents).run();
+  // conversation_graph_memory_state, memory_retrospective_state, and
+  // memory_v3_ever_injected all live on the memory connection now.
   getMemoryDb()!.delete(conversationGraphMemoryState).run();
-  db.delete(memoryRetrospectiveState).run();
+  getMemoryDb()!.delete(memoryRetrospectiveState).run();
   getLogsDb()!.delete(llmRequestLogs).run();
   db.delete(toolInvocations).run();
   getMemoryDb()!.delete(memoryJobs).run();
-  db.run("DELETE FROM memory_v3_ever_injected");
+  getMemorySqlite()!.exec("DELETE FROM memory_v3_ever_injected");
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");
   db.run("DELETE FROM messages");

--- a/assistant/src/__tests__/conversation-fork-retrospective.test.ts
+++ b/assistant/src/__tests__/conversation-fork-retrospective.test.ts
@@ -22,6 +22,7 @@ import {
   getDb,
   getLogsDb,
   getMemoryDb,
+  getMemorySqlite,
   getSqlite,
 } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -59,13 +60,15 @@ function resetTables(): void {
   db.delete(channelInboundEvents).run();
   db.delete(externalConversationBindings).run();
   db.delete(conversationAssistantAttentionState).run();
+  // activation_state, conversation_graph_memory_state, and
+  // memory_retrospective_state all live on the memory connection now.
   getMemoryDb()!.delete(activationState).run();
   getMemoryDb()!.delete(conversationGraphMemoryState).run();
-  db.delete(memoryRetrospectiveState).run();
+  getMemoryDb()!.delete(memoryRetrospectiveState).run();
   getLogsDb()!.delete(llmRequestLogs).run();
   db.delete(toolInvocations).run();
   getMemoryDb()!.delete(memoryJobs).run();
-  db.run("DELETE FROM memory_v3_ever_injected");
+  getMemorySqlite()!.exec("DELETE FROM memory_v3_ever_injected");
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");
   db.run("DELETE FROM conversation_compaction_events");
@@ -383,7 +386,7 @@ describe("forkConversationForRetrospective — compacted source", () => {
         updatedAt: Date.now(),
       })
       .run();
-    getSqlite()
+    getMemorySqlite()!
       .query(
         `INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
          VALUES (?, 'card-a', ?, 12, NULL)`,
@@ -407,7 +410,7 @@ describe("forkConversationForRetrospective — compacted source", () => {
       .where(eq(activationState.conversationId, fork.id))
       .get();
     expect(forkActivation?.everInjectedJson).toBe(everInjected);
-    const v3Rows = getSqlite()
+    const v3Rows = getMemorySqlite()!
       .query(
         "SELECT slug FROM memory_v3_ever_injected WHERE conversation_id = ?",
       )

--- a/assistant/src/persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.ts
@@ -1,0 +1,62 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
+import {
+  type RelocationSpec,
+  runMemoryTableRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_v3_ever_injected` from `main` into the memory DB. Full
+ * copy — every (conversation, slug) row is the v3 injector's dedup and
+ * resident-footprint record and is worth preserving. The table never carried a
+ * foreign key (composite PK `(conversation_id, slug)`), so there is nothing to
+ * drop from the schema on the way over.
+ */
+export const MEMORY_V3_EVER_INJECTED_RELOCATION: RelocationSpec = {
+  table: "memory_v3_ever_injected",
+  targetDbPath: getMemoryDbPath,
+  columns: ["conversation_id", "slug", "injected_at", "bytes", "pruned_at"],
+};
+
+/**
+ * Create the `memory_v3_ever_injected` table and its index (mirroring migration
+ * 277) on the memory connection. Idempotent (`IF NOT EXISTS`) — the dedicated
+ * connection itself performs no DDL on open, so this migration owns the schema.
+ * Exported so tests can stand up the memory-side schema without running the
+ * full drain.
+ */
+export function ensureMemoryV3EverInjectedSchema(memoryRaw: Database): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_v3_ever_injected (
+      conversation_id TEXT NOT NULL,
+      slug TEXT NOT NULL,
+      injected_at INTEGER NOT NULL,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      pruned_at INTEGER,
+      PRIMARY KEY (conversation_id, slug)
+    )
+  `);
+  memoryRaw.exec(/*sql*/ `
+    CREATE INDEX IF NOT EXISTS idx_memory_v3_ever_injected_conv
+      ON memory_v3_ever_injected (conversation_id)
+  `);
+}
+
+/**
+ * Move `memory_v3_ever_injected` — memory-v3's per-conversation frozen-card
+ * carry record — into the dedicated memory database (`assistant-memory.db`),
+ * joining the plugin's other relocated per-conversation state so its store
+ * reads/writes ride the memory connection. The store never JOINs
+ * `conversations`, so the move is a straight full copy.
+ */
+export async function migrateMoveMemoryV3EverInjectedToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  await runMemoryTableRelocation(
+    database,
+    MEMORY_V3_EVER_INJECTED_RELOCATION,
+    ensureMemoryV3EverInjectedSchema,
+  );
+}

--- a/assistant/src/persistence/migrations/346-move-memory-retrospective-state-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/346-move-memory-retrospective-state-to-memory-db.ts
@@ -1,0 +1,67 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
+import {
+  type RelocationSpec,
+  runMemoryTableRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_retrospective_state` from `main` into the memory DB.
+ * Full copy — one row per source conversation tracks the retrospective job's
+ * pointers and cumulative remembered log, all worth preserving. A legacy
+ * source that predates migration 281 has no `remembered_log` column, so the
+ * drain NULL-fills it (see `drainStagedTable`).
+ */
+export const MEMORY_RETROSPECTIVE_STATE_RELOCATION: RelocationSpec = {
+  table: "memory_retrospective_state",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "conversation_id",
+    "last_processed_message_id",
+    "last_run_at",
+    "remembered_log",
+  ],
+};
+
+/**
+ * Create the `memory_retrospective_state` table on the memory connection with
+ * the schema from migration 245 plus the `remembered_log` column added by
+ * migration 281, but WITHOUT the `REFERENCES conversations(id) ON DELETE
+ * CASCADE` clause — SQLite foreign keys cannot span database files, and the
+ * memory DB has no `conversations` table. The lost cascade is replaced by the
+ * explicit delete in the `conversation-deleted` hook. Idempotent
+ * (`IF NOT EXISTS`); exported so tests can stand up the memory-side schema
+ * without running the full drain.
+ */
+export function ensureMemoryRetrospectiveStateSchema(
+  memoryRaw: Database,
+): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_retrospective_state (
+      conversation_id TEXT PRIMARY KEY,
+      last_processed_message_id TEXT NOT NULL,
+      last_run_at INTEGER NOT NULL,
+      remembered_log TEXT
+    )
+  `);
+}
+
+/**
+ * Move `memory_retrospective_state` — the per-conversation retrospective job
+ * pointers and remembered log — into the dedicated memory database
+ * (`assistant-memory.db`). The main-DB delete cascade that previously collected
+ * a state row with its source conversation stops firing once the table lives in
+ * a separate file, so the memory `conversation-deleted` hook now purges it
+ * explicitly.
+ */
+export async function migrateMoveMemoryRetrospectiveStateToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  await runMemoryTableRelocation(
+    database,
+    MEMORY_RETROSPECTIVE_STATE_RELOCATION,
+    ensureMemoryRetrospectiveStateSchema,
+  );
+}

--- a/assistant/src/persistence/schema/memory-core.ts
+++ b/assistant/src/persistence/schema/memory-core.ts
@@ -95,6 +95,9 @@ export const memoryCheckpoints = sqliteTable("memory_checkpoints", {
   updatedAt: integer("updated_at").notNull(),
 });
 
+// Per-conversation retrospective job pointers and cumulative remembered log.
+// Lives in the dedicated memory database (`assistant-memory.db`), not main —
+// access it via the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryRetrospectiveState = sqliteTable(
   "memory_retrospective_state",
   {

--- a/assistant/src/persistence/schema/memory-injection.ts
+++ b/assistant/src/persistence/schema/memory-injection.ts
@@ -27,7 +27,9 @@ export const memoryV2InjectionEvents = sqliteTable(
 );
 
 // Per-conversation record of every memory-v3 card ever injected, with a
-// pruned_at tombstone so re-injection can be suppressed after pruning.
+// pruned_at tombstone so re-injection can be suppressed after pruning. Lives in
+// the dedicated memory database (`assistant-memory.db`), not main — access it
+// via the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
 export const memoryV3EverInjected = sqliteTable(
   "memory_v3_ever_injected",
   {

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -452,6 +452,8 @@ import { migrateSweepCachelessGraphNodeVectors } from "./migrations/341-sweep-ca
 import { migrateAddConversationParentId } from "./migrations/342-add-conversation-parent-id.js";
 import { migrateMoveActivationStateToMemoryDb } from "./migrations/343-move-activation-state-to-memory-db.js";
 import { migrateMoveConversationGraphMemoryStateToMemoryDb } from "./migrations/344-move-conversation-graph-memory-state-to-memory-db.js";
+import { migrateMoveMemoryV3EverInjectedToMemoryDb } from "./migrations/345-move-memory-v3-ever-injected-to-memory-db.js";
+import { migrateMoveMemoryRetrospectiveStateToMemoryDb } from "./migrations/346-move-memory-retrospective-state-to-memory-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1422,6 +1424,19 @@ export const migrationSteps: MigrationStep[] = [
     dependsOn: [
       "migrateCreateConversationGraphMemoryState",
       "migrateDeletePrivateConversations",
+    ],
+  },
+  {
+    name: "migrateMoveMemoryV3EverInjectedToMemoryDb",
+    run: migrateMoveMemoryV3EverInjectedToMemoryDb,
+    dependsOn: ["migrateAddMemoryV3EverInjected"],
+  },
+  {
+    name: "migrateMoveMemoryRetrospectiveStateToMemoryDb",
+    run: migrateMoveMemoryRetrospectiveStateToMemoryDb,
+    dependsOn: [
+      "migrateMemoryRetrospectiveState",
+      "migrateMemoryRetrospectiveRememberedLog",
     ],
   },
 ];

--- a/assistant/src/plugins/defaults/memory/__tests__/conversation-memory-purge.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/conversation-memory-purge.test.ts
@@ -51,7 +51,9 @@ describe("conversation memory purge", () => {
         "activation_state",
         "conversation_graph_memory_state",
         "memory_recall_logs",
+        "memory_retrospective_state",
         "memory_v2_activation_logs",
+        "memory_v3_ever_injected",
         "memory_v3_selections",
       ].sort(),
     );

--- a/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
@@ -11,8 +11,9 @@
  *   3. The relocated memory tables (`memory_jobs`, `memory_v2_injection_events`,
  *      `memory_v2_activation_logs`, `memory_recall_logs`,
  *      `memory_v3_selections`, `activation_sessions`, `activation_state`,
- *      `conversation_graph_memory_state`) live in the dedicated memory
- *      connection, not in the main connection — proving the physical split.
+ *      `conversation_graph_memory_state`, `memory_v3_ever_injected`,
+ *      `memory_retrospective_state`) live in the dedicated memory connection,
+ *      not in the main connection — proving the physical split.
  *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
  *      CLI backend, leaving the main DB untouched.
  */
@@ -63,6 +64,8 @@ describe("memory database connection", () => {
     "activation_sessions",
     "activation_state",
     "conversation_graph_memory_state",
+    "memory_v3_ever_injected",
+    "memory_retrospective_state",
   ])("%s lives in the memory connection, not main", (table) => {
     const inMemory = getMemorySqlite()!
       .query<

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-log-stores-degraded.test.ts
@@ -8,18 +8,13 @@
  * resolves to null without mocking any module (module mocks would leak into
  * other test files in the same run).
  */
-import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-
-import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import type { DrizzleDb } from "../../../../persistence/db-connection.js";
 import {
   clearStoredDb,
   setStoredDb,
 } from "../../../../persistence/db-singleton.js";
-import { migrateAddMemoryV3EverInjected } from "../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
-import * as schema from "../../../../persistence/schema/index.js";
 import {
   backfillMemoryRecallLogMessageId,
   getMemoryRecallLogByMessageIds,
@@ -104,45 +99,30 @@ describe("memory log stores without a memory database", () => {
 });
 
 describe("memory-v3 prune valve without a memory database", () => {
-  // The valve's candidate accounting (`memory_v3_ever_injected`) lives in the
-  // MAIN database, which stays available — install a schema-bearing in-memory
-  // main DB into the `main` singleton slot so only the memory connection
-  // (degraded by the outer beforeEach) is down.
-  let mainSqlite: Database;
-
-  beforeEach(() => {
-    mainSqlite = new Database(":memory:");
-    const mainDb = drizzle(mainSqlite, { schema });
-    migrateAddMemoryV3EverInjected(mainDb);
-    setStoredDb("main", mainDb, () => mainSqlite.close());
-  });
-
-  afterEach(() => {
-    clearStoredDb("main");
-  });
-
-  test("planPrune falls back to injected_at recency without throwing", () => {
-    // With the memory DB unavailable the selection-recency read degrades to
-    // no rows, so every candidate ranks by its injected_at fallback.
+  // The valve's candidate accounting (`memory_v3_ever_injected`) now lives on
+  // the memory connection too, degraded by the outer beforeEach. With no
+  // resident candidates the valve cannot plan a prune, so it no-ops rather than
+  // throwing.
+  test("planPrune no-ops (returns null) when candidate accounting is unavailable", () => {
+    // The record write is a no-op (memory DB down), so the valve reads no
+    // resident entries.
     recordInjected(
       "conv-degraded-prune",
       [{ slug: "domain-a/page-old", bytes: 600 }],
       1_000,
     );
-    recordInjected(
-      "conv-degraded-prune",
-      [{ slug: "domain-a/page-new", bytes: 500 }],
-      2_000,
-    );
 
-    const plan = planPrune(
-      {
-        maxResidentBytes: 1_000,
-        targetResidentBytes: 500,
-        exemptSlugs: new Set(),
-      },
-      "conv-degraded-prune",
-    );
-    expect(plan).toEqual({ slugs: ["domain-a/page-old"], bytesFreed: 600 });
+    let plan: ReturnType<typeof planPrune> | undefined;
+    expect(() => {
+      plan = planPrune(
+        {
+          maxResidentBytes: 1_000,
+          targetResidentBytes: 500,
+          exemptSlugs: new Set(),
+        },
+        "conv-degraded-prune",
+      );
+    }).not.toThrow();
+    expect(plan).toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-state.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-state.test.ts
@@ -175,3 +175,25 @@ describe("memory-retrospective-state remembered log persistence", () => {
     ]);
   });
 });
+
+describe("fail-soft when the underlying statement fails", () => {
+  // The memory connection is present, but the relocated table is gone (a
+  // corrupt/dropped table, SQLITE_FULL, I/O error, or SQLITE_BUSY after
+  // timeout). The fork copy runs inside the main fork transaction, so it must
+  // degrade like the null-connection case — log a warning and no-op — rather
+  // than throwing out and aborting the user-visible fork. Dropped last so no
+  // later test in this file sees the missing table.
+  test("forkRetrospectiveState no-ops when the target table is missing", () => {
+    getMemorySqlite()!.exec("DROP TABLE memory_retrospective_state");
+
+    expect(() =>
+      forkRetrospectiveState({
+        database: getDb(),
+        sourceConversationId: "conv-parent",
+        forkedConversationId: "conv-child",
+        forkedMessageIds: new Map(),
+        lastCopiedSourceMessageId: null,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-state.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-state.test.ts
@@ -1,17 +1,16 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { eq } from "drizzle-orm";
-
 import { setConfig } from "../../../../__tests__/helpers/set-config.js";
 
 // Disable memory so persistence writes don't index into the real memory
 // pipeline (both flags default true under the real loader).
 setConfig("memory", { enabled: false, v2: { enabled: false } });
 
-import { createConversation } from "../../../../persistence/conversation-crud.js";
-import { getDb } from "../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
-import { memoryRetrospectiveState } from "../../../../persistence/schema/index.js";
 import {
   appendToRememberedLog,
   bumpRetrospectiveLastRunAt,
@@ -24,11 +23,11 @@ import {
 
 await initializeDb();
 
+// `memory_retrospective_state` now lives on the dedicated memory connection and
+// no longer carries a foreign key to `conversations`, so tests seed plain
+// conversation ids without a backing conversation row.
 function resetTables(): void {
-  const db = getDb();
-  db.delete(memoryRetrospectiveState).run();
-  db.run("DELETE FROM messages");
-  db.run("DELETE FROM conversations");
+  getMemorySqlite()!.exec("DELETE FROM memory_retrospective_state");
 }
 
 describe("appendToRememberedLog", () => {
@@ -77,107 +76,101 @@ describe("memory-retrospective-state remembered log persistence", () => {
   });
 
   test("upsert persists the log and getRetrospectiveState parses it back", () => {
-    const conv = createConversation("Log thread");
     upsertRetrospectiveState({
-      conversationId: conv.id,
+      conversationId: "conv-log",
       lastProcessedMessageId: "m1",
       lastRunAt: 1000,
       rememberedLog: ["save one", "save two"],
     });
 
-    const state = getRetrospectiveState(conv.id);
+    const state = getRetrospectiveState("conv-log");
     expect(state?.rememberedLog).toEqual(["save one", "save two"]);
     expect(state?.lastProcessedMessageId).toBe("m1");
   });
 
   test("upsert without rememberedLog preserves the stored log", () => {
-    const conv = createConversation("Preserve thread");
     upsertRetrospectiveState({
-      conversationId: conv.id,
+      conversationId: "conv-preserve",
       lastProcessedMessageId: "m1",
       lastRunAt: 1000,
       rememberedLog: ["keep me"],
     });
     upsertRetrospectiveState({
-      conversationId: conv.id,
+      conversationId: "conv-preserve",
       lastProcessedMessageId: "m2",
       lastRunAt: 2000,
     });
 
-    const state = getRetrospectiveState(conv.id);
+    const state = getRetrospectiveState("conv-preserve");
     expect(state?.lastProcessedMessageId).toBe("m2");
     expect(state?.rememberedLog).toEqual(["keep me"]);
   });
 
   test("missing/NULL column value parses as an empty log", () => {
-    const conv = createConversation("Null-log thread");
     upsertRetrospectiveState({
-      conversationId: conv.id,
+      conversationId: "conv-null-log",
       lastProcessedMessageId: "m1",
       lastRunAt: 1000,
     });
 
-    expect(getRetrospectiveState(conv.id)?.rememberedLog).toEqual([]);
+    expect(getRetrospectiveState("conv-null-log")?.rememberedLog).toEqual([]);
   });
 
   test("malformed stored JSON degrades to an empty log instead of throwing", () => {
-    const conv = createConversation("Corrupt thread");
     upsertRetrospectiveState({
-      conversationId: conv.id,
+      conversationId: "conv-corrupt",
       lastProcessedMessageId: "m1",
       lastRunAt: 1000,
       rememberedLog: ["x"],
     });
-    getDb()
-      .update(memoryRetrospectiveState)
-      .set({ rememberedLog: "not-json{{" })
-      .where(eq(memoryRetrospectiveState.conversationId, conv.id))
-      .run();
+    getMemorySqlite()!
+      .query(
+        "UPDATE memory_retrospective_state SET remembered_log = ? WHERE conversation_id = ?",
+      )
+      .run("not-json{{", "conv-corrupt");
 
-    expect(getRetrospectiveState(conv.id)?.rememberedLog).toEqual([]);
+    expect(getRetrospectiveState("conv-corrupt")?.rememberedLog).toEqual([]);
   });
 
   test("bumpRetrospectiveLastRunAt seeds the empty-string sentinel with an empty log and preserves an existing log", () => {
     // Failure-only row: "" sentinel, empty log.
-    const fresh = createConversation("Failure-only thread");
-    bumpRetrospectiveLastRunAt(fresh.id, 1000);
-    const freshState = getRetrospectiveState(fresh.id);
+    bumpRetrospectiveLastRunAt("conv-failure-only", 1000);
+    const freshState = getRetrospectiveState("conv-failure-only");
     expect(freshState?.lastProcessedMessageId).toBe("");
     expect(freshState?.rememberedLog).toEqual([]);
 
     // Existing row with a log: a failure bump must not clobber it.
-    const seasoned = createConversation("Seasoned thread");
     upsertRetrospectiveState({
-      conversationId: seasoned.id,
+      conversationId: "conv-seasoned",
       lastProcessedMessageId: "m1",
       lastRunAt: 1000,
       rememberedLog: ["survives failures"],
     });
-    bumpRetrospectiveLastRunAt(seasoned.id, 2000);
-    const seasonedState = getRetrospectiveState(seasoned.id);
+    bumpRetrospectiveLastRunAt("conv-seasoned", 2000);
+    const seasonedState = getRetrospectiveState("conv-seasoned");
     expect(seasonedState?.lastRunAt).toBe(2000);
     expect(seasonedState?.rememberedLog).toEqual(["survives failures"]);
   });
 
   test("forkRetrospectiveState copies the log verbatim to the forked child", () => {
-    const source = createConversation("Fork source");
-    const child = createConversation("Fork child");
     upsertRetrospectiveState({
-      conversationId: source.id,
+      conversationId: "conv-fork-source",
       lastProcessedMessageId: "",
       lastRunAt: 1000,
       rememberedLog: ["parent baseline"],
     });
 
     forkRetrospectiveState({
+      // The main-DB handle is unused now; the write lands on the memory
+      // connection.
       database: getDb(),
-      sourceConversationId: source.id,
-      forkedConversationId: child.id,
+      sourceConversationId: "conv-fork-source",
+      forkedConversationId: "conv-fork-child",
       forkedMessageIds: new Map(),
       lastCopiedSourceMessageId: null,
     });
 
-    expect(getRetrospectiveState(child.id)?.rememberedLog).toEqual([
+    expect(getRetrospectiveState("conv-fork-child")?.rememberedLog).toEqual([
       "parent baseline",
     ]);
   });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
@@ -14,7 +14,10 @@ mock.module("../memory-retrospective-enqueue.js", () => ({
 
 import type { AssistantConfig } from "../../../../config/types.js";
 import { createConversation } from "../../../../persistence/conversation-crud.js";
-import { getDb } from "../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
 import { messages } from "../../../../persistence/schema/index.js";
 import { SKILL_CARD_MESSAGE_KIND } from "../memory-retrospective-constants.js";
@@ -156,7 +159,8 @@ describe("shouldEnqueueRetrospective", () => {
 function resetTables(): void {
   const db = getDb();
   db.run(`DELETE FROM messages`);
-  db.run(`DELETE FROM memory_retrospective_state`);
+  // `memory_retrospective_state` lives on the memory connection now.
+  getMemorySqlite()!.exec(`DELETE FROM memory_retrospective_state`);
   db.run(`DELETE FROM conversations`);
 }
 

--- a/assistant/src/plugins/defaults/memory/__tests__/relocated-memory-test-rows.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/relocated-memory-test-rows.ts
@@ -68,6 +68,24 @@ export function seedRelocatedMemoryRow(
         )
         .run(conversationId, now, now);
       return;
+    case "memory_v3_ever_injected":
+      raw
+        .query(
+          `INSERT INTO memory_v3_ever_injected
+             (conversation_id, slug, injected_at, bytes, pruned_at)
+           VALUES (?, 'domain/page', ?, 0, NULL)`,
+        )
+        .run(conversationId, now);
+      return;
+    case "memory_retrospective_state":
+      raw
+        .query(
+          `INSERT INTO memory_retrospective_state
+             (conversation_id, last_processed_message_id, last_run_at, remembered_log)
+           VALUES (?, '', ?, NULL)`,
+        )
+        .run(conversationId, now);
+      return;
     default:
       throw new Error(`unhandled relocated memory table ${table}`);
   }

--- a/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
@@ -40,6 +40,10 @@ const { ACTIVATION_STATE_RELOCATION } =
   await import("../../../../persistence/migrations/343-move-activation-state-to-memory-db.js");
 const { CONVERSATION_GRAPH_MEMORY_STATE_RELOCATION } =
   await import("../../../../persistence/migrations/344-move-conversation-graph-memory-state-to-memory-db.js");
+const { MEMORY_V3_EVER_INJECTED_RELOCATION } =
+  await import("../../../../persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.js");
+const { MEMORY_RETROSPECTIVE_STATE_RELOCATION } =
+  await import("../../../../persistence/migrations/346-move-memory-retrospective-state-to-memory-db.js");
 
 await initializeDb();
 
@@ -580,5 +584,159 @@ describe("conversation_graph_memory_state drain", () => {
         updated_at: 2_000,
       },
     ]);
+  });
+});
+
+describe("memory_v3_ever_injected drain", () => {
+  test("copies every row of the composite-PK table, drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Clean slate: empty live table, fresh populated staging table.
+    memory.exec(`DELETE FROM memory_v3_ever_injected`);
+    sqlite.exec(
+      `DROP TABLE IF EXISTS main."memory_v3_ever_injected__relocating"`,
+    );
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_v3_ever_injected__relocating" (
+        conversation_id TEXT NOT NULL,
+        slug TEXT NOT NULL,
+        injected_at INTEGER NOT NULL,
+        bytes INTEGER NOT NULL DEFAULT 0,
+        pruned_at INTEGER,
+        PRIMARY KEY (conversation_id, slug)
+      )
+    `);
+
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_v3_ever_injected__relocating"
+         (conversation_id, slug, injected_at, bytes, pruned_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    insert.run("conv-1", "topics/page-a", 1_000, 100, null);
+    insert.run("conv-1", "topics/page-b", 2_000, 250, 3_000);
+
+    await drainStagedTable(sqlite, MEMORY_V3_EVER_INJECTED_RELOCATION);
+
+    // Staging dropped; the full-copy spec preserved every row, pruned state
+    // included.
+    expect(existsInMain("memory_v3_ever_injected__relocating")).toBe(false);
+    const kept = memory
+      .query(
+        `SELECT conversation_id, slug, injected_at, bytes, pruned_at
+           FROM memory_v3_ever_injected WHERE conversation_id = 'conv-1'
+           ORDER BY slug`,
+      )
+      .all();
+    expect(kept).toEqual([
+      {
+        conversation_id: "conv-1",
+        slug: "topics/page-a",
+        injected_at: 1_000,
+        bytes: 100,
+        pruned_at: null,
+      },
+      {
+        conversation_id: "conv-1",
+        slug: "topics/page-b",
+        injected_at: 2_000,
+        bytes: 250,
+        pruned_at: 3_000,
+      },
+    ]);
+  });
+});
+
+describe("memory_retrospective_state drain", () => {
+  test("copies every row (full copy) and drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    memory.exec(`DELETE FROM memory_retrospective_state`);
+    sqlite.exec(
+      `DROP TABLE IF EXISTS main."memory_retrospective_state__relocating"`,
+    );
+    // Staging shaped like a post-281 source, including remembered_log.
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_retrospective_state__relocating" (
+        conversation_id TEXT PRIMARY KEY,
+        last_processed_message_id TEXT NOT NULL,
+        last_run_at INTEGER NOT NULL,
+        remembered_log TEXT
+      )
+    `);
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_retrospective_state__relocating"
+         (conversation_id, last_processed_message_id, last_run_at, remembered_log)
+       VALUES (?, ?, ?, ?)`,
+    );
+    insert.run("conv-1", "m1", 1_000, '["saved one"]');
+    insert.run("conv-2", "", 2_000, null);
+
+    await drainStagedTable(sqlite, MEMORY_RETROSPECTIVE_STATE_RELOCATION);
+
+    expect(existsInMain("memory_retrospective_state__relocating")).toBe(false);
+    const kept = memory
+      .query(
+        `SELECT conversation_id, last_processed_message_id, last_run_at, remembered_log
+           FROM memory_retrospective_state
+           WHERE conversation_id IN ('conv-1', 'conv-2')
+           ORDER BY conversation_id`,
+      )
+      .all();
+    expect(kept).toEqual([
+      {
+        conversation_id: "conv-1",
+        last_processed_message_id: "m1",
+        last_run_at: 1_000,
+        remembered_log: '["saved one"]',
+      },
+      {
+        conversation_id: "conv-2",
+        last_processed_message_id: "",
+        last_run_at: 2_000,
+        remembered_log: null,
+      },
+    ]);
+  });
+
+  test("a pre-281 legacy source NULL-fills remembered_log", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    // Staging shaped like migration 245's original schema — no remembered_log.
+    memory.exec(`DELETE FROM memory_retrospective_state`);
+    sqlite.exec(
+      `DROP TABLE IF EXISTS main."memory_retrospective_state__relocating"`,
+    );
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_retrospective_state__relocating" (
+        conversation_id TEXT PRIMARY KEY,
+        last_processed_message_id TEXT NOT NULL,
+        last_run_at INTEGER NOT NULL
+      )
+    `);
+    sqlite
+      .prepare(
+        `INSERT INTO main."memory_retrospective_state__relocating"
+           (conversation_id, last_processed_message_id, last_run_at)
+         VALUES (?, ?, ?)`,
+      )
+      .run("conv-legacy", "m7", 5_000);
+
+    await drainStagedTable(sqlite, MEMORY_RETROSPECTIVE_STATE_RELOCATION);
+
+    expect(existsInMain("memory_retrospective_state__relocating")).toBe(false);
+    const row = memory
+      .query(
+        `SELECT last_processed_message_id, last_run_at, remembered_log
+           FROM memory_retrospective_state WHERE conversation_id = 'conv-legacy'`,
+      )
+      .get();
+    expect(row).toEqual({
+      last_processed_message_id: "m7",
+      last_run_at: 5_000,
+      remembered_log: null,
+    });
   });
 });

--- a/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
+++ b/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
@@ -18,6 +18,8 @@ export const CONVERSATION_KEYED_MEMORY_TABLES: readonly string[] = [
   "activation_sessions",
   "activation_state",
   "conversation_graph_memory_state",
+  "memory_v3_ever_injected",
+  "memory_retrospective_state",
 ];
 
 /**

--- a/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -181,8 +181,8 @@ const { getSqliteFrom } =
   await import("../../../../../persistence/db-connection.js");
 const { migrateActivationState } =
   await import("../../../../../persistence/migrations/232-activation-state.js");
-const { migrateAddMemoryV3EverInjected } =
-  await import("../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js");
+const { ensureMemoryV3EverInjectedSchema } =
+  await import("../../../../../persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.js");
 const { getActiveSlugs: getV3ActiveSlugs, recordInjected: recordV3Injected } =
   await import("../../v3/ever-injected-store.js");
 const schema = await import("../../../../../persistence/schema/index.js");
@@ -199,6 +199,9 @@ const { setStoredDb, clearStoredDb } =
 // others. A live mutable holder lets each `beforeEach` swap the handle
 // without re-registering the mock.
 let testDbHandle: DrizzleDb | null = null;
+// memory-v3's everInjected record lives on the dedicated memory connection now;
+// each test db carries a matching in-memory memory connection.
+let memorySqliteHandle: Database | null = null;
 const realDbModule =
   await import("../../../../../persistence/db-connection.js");
 mock.module("../../../../../persistence/db-connection.js", () => ({
@@ -207,6 +210,7 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
     if (!testDbHandle) throw new Error("test db not initialized");
     return testDbHandle;
   },
+  getMemorySqlite: () => memorySqliteHandle,
 }));
 
 // ---------------------------------------------------------------------------
@@ -226,8 +230,10 @@ function createTestDb(): DrizzleDb {
     )
   `);
   migrateActivationState(db);
-  // `onCompacted` also clears memory-v3's everInjected record.
-  migrateAddMemoryV3EverInjected(db);
+  // `onCompacted` also clears memory-v3's everInjected record, which lives on
+  // the memory connection.
+  memorySqliteHandle = new Database(":memory:");
+  ensureMemoryV3EverInjectedSchema(memorySqliteHandle);
   return db;
 }
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -20,14 +20,15 @@
 //     survives GC of superseded retrospective conversations and spans more
 //     than the last pass. Capped — see `appendToRememberedLog`.
 //
-// The schema enforces the foreign key with ON DELETE CASCADE, so deleting a
-// conversation collects its state row automatically.
+// The row lives on the dedicated memory connection (`assistant-memory.db`),
+// resolved via `memorySqliteOrNull`; every read/write degrades to a no-op when
+// that connection is unavailable. The memory database has no `conversations`
+// table, so there is no FK cascade — the `conversation-deleted` hook purges the
+// row explicitly instead.
 
-import { desc, eq } from "drizzle-orm";
-
-import { type DrizzleDb, getDb } from "../../../persistence/db-connection.js";
-import { memoryRetrospectiveState } from "../../../persistence/schema/index.js";
+import type { DrizzleDb } from "../../../persistence/db-connection.js";
 import { withSqliteRetry } from "./host-utils.js";
+import { memorySqliteOrNull } from "./memory-db.js";
 
 export interface MemoryRetrospectiveState {
   conversationId: string;
@@ -94,17 +95,28 @@ function serializeRememberedLog(log: string[]): string | null {
 export function listRetrospectiveStates(
   limit: number,
 ): MemoryRetrospectiveState[] {
-  const rows = getDb()
-    .select()
-    .from(memoryRetrospectiveState)
-    .orderBy(desc(memoryRetrospectiveState.lastRunAt))
-    .limit(limit)
-    .all();
+  const raw = memorySqliteOrNull("listRetrospectiveStates");
+  if (!raw) return [];
+  const rows = raw
+    .query(
+      /*sql*/ `
+      SELECT conversation_id, last_processed_message_id, last_run_at, remembered_log
+      FROM memory_retrospective_state
+      ORDER BY last_run_at DESC
+      LIMIT ?
+    `,
+    )
+    .all(limit) as Array<{
+    conversation_id: string;
+    last_processed_message_id: string;
+    last_run_at: number;
+    remembered_log: string | null;
+  }>;
   return rows.map((row) => ({
-    conversationId: row.conversationId,
-    lastProcessedMessageId: row.lastProcessedMessageId,
-    lastRunAt: row.lastRunAt,
-    rememberedLog: parseRememberedLog(row.rememberedLog),
+    conversationId: row.conversation_id,
+    lastProcessedMessageId: row.last_processed_message_id,
+    lastRunAt: row.last_run_at,
+    rememberedLog: parseRememberedLog(row.remembered_log),
   }));
 }
 
@@ -114,17 +126,27 @@ export function listRetrospectiveStates(
 export function getRetrospectiveState(
   conversationId: string,
 ): MemoryRetrospectiveState | null {
-  const row = getDb()
-    .select()
-    .from(memoryRetrospectiveState)
-    .where(eq(memoryRetrospectiveState.conversationId, conversationId))
-    .get();
+  const raw = memorySqliteOrNull("getRetrospectiveState");
+  if (!raw) return null;
+  const row = raw
+    .query(
+      /*sql*/ `
+      SELECT conversation_id, last_processed_message_id, last_run_at, remembered_log
+      FROM memory_retrospective_state WHERE conversation_id = ?
+    `,
+    )
+    .get(conversationId) as {
+    conversation_id: string;
+    last_processed_message_id: string;
+    last_run_at: number;
+    remembered_log: string | null;
+  } | null;
   if (!row) return null;
   return {
-    conversationId: row.conversationId,
-    lastProcessedMessageId: row.lastProcessedMessageId,
-    lastRunAt: row.lastRunAt,
-    rememberedLog: parseRememberedLog(row.rememberedLog),
+    conversationId: row.conversation_id,
+    lastProcessedMessageId: row.last_processed_message_id,
+    lastRunAt: row.last_run_at,
+    rememberedLog: parseRememberedLog(row.remembered_log),
   };
 }
 
@@ -141,32 +163,38 @@ export async function upsertRetrospectiveState(
     rememberedLog?: string[];
   },
 ): Promise<void> {
-  const db = getDb();
+  const raw = memorySqliteOrNull("upsertRetrospectiveState");
+  if (!raw) return;
   const serializedLog =
     args.rememberedLog === undefined
       ? undefined
       : serializeRememberedLog(args.rememberedLog);
+  // Only overwrite the stored log when the caller supplied one, so an
+  // omitted `rememberedLog` leaves the existing value untouched (seeded NULL
+  // on first insert).
+  const logUpdate =
+    serializedLog !== undefined
+      ? ", remembered_log = excluded.remembered_log"
+      : "";
   await withSqliteRetry(
     () =>
-      db
-        .insert(memoryRetrospectiveState)
-        .values({
-          conversationId: args.conversationId,
-          lastProcessedMessageId: args.lastProcessedMessageId,
-          lastRunAt: args.lastRunAt,
-          rememberedLog: serializedLog ?? null,
-        })
-        .onConflictDoUpdate({
-          target: memoryRetrospectiveState.conversationId,
-          set: {
-            lastProcessedMessageId: args.lastProcessedMessageId,
-            lastRunAt: args.lastRunAt,
-            ...(serializedLog !== undefined
-              ? { rememberedLog: serializedLog }
-              : {}),
-          },
-        })
-        .run(),
+      raw
+        .query(
+          /*sql*/ `
+          INSERT INTO memory_retrospective_state
+            (conversation_id, last_processed_message_id, last_run_at, remembered_log)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT (conversation_id) DO UPDATE SET
+            last_processed_message_id = excluded.last_processed_message_id,
+            last_run_at = excluded.last_run_at${logUpdate}
+        `,
+        )
+        .run(
+          args.conversationId,
+          args.lastProcessedMessageId,
+          args.lastRunAt,
+          serializedLog ?? null,
+        ),
     {
       op: "upsertRetrospectiveState",
       context: { conversationId: args.conversationId },
@@ -195,6 +223,10 @@ export async function upsertRetrospectiveState(
  * `lastRunAt` is copied verbatim — the cooldown gate inherits from source.
  * `rememberedLog` is copied verbatim — the parent's saves remain the child's
  * dedup baseline.
+ *
+ * The row lives on the memory connection, so this reads/writes there rather
+ * than on the main fork transaction's handle — the `database` arg is unused
+ * now, and an unavailable memory database is a best-effort no-op.
  */
 export function forkRetrospectiveState(args: {
   database: DrizzleDb;
@@ -204,23 +236,32 @@ export function forkRetrospectiveState(args: {
   lastCopiedSourceMessageId: string | null;
 }): void {
   const {
-    database,
     sourceConversationId,
     forkedConversationId,
     forkedMessageIds,
     lastCopiedSourceMessageId,
   } = args;
 
-  const sourceRow = database
-    .select()
-    .from(memoryRetrospectiveState)
-    .where(eq(memoryRetrospectiveState.conversationId, sourceConversationId))
-    .get();
+  const raw = memorySqliteOrNull("forkRetrospectiveState");
+  if (!raw) return;
+
+  const sourceRow = raw
+    .query(
+      /*sql*/ `
+      SELECT last_processed_message_id, last_run_at, remembered_log
+      FROM memory_retrospective_state WHERE conversation_id = ?
+    `,
+    )
+    .get(sourceConversationId) as {
+    last_processed_message_id: string;
+    last_run_at: number;
+    remembered_log: string | null;
+  } | null;
   if (!sourceRow) return;
 
   let forkedPointer = "";
-  if (sourceRow.lastProcessedMessageId !== "") {
-    const mapped = forkedMessageIds.get(sourceRow.lastProcessedMessageId);
+  if (sourceRow.last_processed_message_id !== "") {
+    const mapped = forkedMessageIds.get(sourceRow.last_processed_message_id);
     if (mapped !== undefined) {
       forkedPointer = mapped;
     } else if (lastCopiedSourceMessageId !== null) {
@@ -231,23 +272,24 @@ export function forkRetrospectiveState(args: {
     }
   }
 
-  database
-    .insert(memoryRetrospectiveState)
-    .values({
-      conversationId: forkedConversationId,
-      lastProcessedMessageId: forkedPointer,
-      lastRunAt: sourceRow.lastRunAt,
-      rememberedLog: sourceRow.rememberedLog,
-    })
-    .onConflictDoUpdate({
-      target: memoryRetrospectiveState.conversationId,
-      set: {
-        lastProcessedMessageId: forkedPointer,
-        lastRunAt: sourceRow.lastRunAt,
-        rememberedLog: sourceRow.rememberedLog,
-      },
-    })
-    .run();
+  raw
+    .query(
+      /*sql*/ `
+      INSERT INTO memory_retrospective_state
+        (conversation_id, last_processed_message_id, last_run_at, remembered_log)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT (conversation_id) DO UPDATE SET
+        last_processed_message_id = excluded.last_processed_message_id,
+        last_run_at = excluded.last_run_at,
+        remembered_log = excluded.remembered_log
+    `,
+    )
+    .run(
+      forkedConversationId,
+      forkedPointer,
+      sourceRow.last_run_at,
+      sourceRow.remembered_log,
+    );
 }
 
 /**
@@ -263,21 +305,21 @@ export async function bumpRetrospectiveLastRunAt(
   conversationId: string,
   lastRunAt: number,
 ): Promise<void> {
-  const db = getDb();
+  const raw = memorySqliteOrNull("bumpRetrospectiveLastRunAt");
+  if (!raw) return;
   await withSqliteRetry(
     () =>
-      db
-        .insert(memoryRetrospectiveState)
-        .values({
-          conversationId,
-          lastProcessedMessageId: "",
-          lastRunAt,
-        })
-        .onConflictDoUpdate({
-          target: memoryRetrospectiveState.conversationId,
-          set: { lastRunAt },
-        })
-        .run(),
+      raw
+        .query(
+          /*sql*/ `
+          INSERT INTO memory_retrospective_state
+            (conversation_id, last_processed_message_id, last_run_at)
+          VALUES (?, '', ?)
+          ON CONFLICT (conversation_id) DO UPDATE SET
+            last_run_at = excluded.last_run_at
+        `,
+        )
+        .run(conversationId, lastRunAt),
     { op: "bumpRetrospectiveLastRunAt", context: { conversationId } },
   );
 }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -28,7 +28,10 @@
 
 import type { DrizzleDb } from "../../../persistence/db-connection.js";
 import { withSqliteRetry } from "./host-utils.js";
+import { getLogger } from "./logging.js";
 import { memorySqliteOrNull } from "./memory-db.js";
+
+const log = getLogger("memory-retrospective-state");
 
 export interface MemoryRetrospectiveState {
   conversationId: string;
@@ -242,39 +245,40 @@ export function forkRetrospectiveState(args: {
     lastCopiedSourceMessageId,
   } = args;
 
-  const raw = memorySqliteOrNull("forkRetrospectiveState");
-  if (!raw) return;
+  try {
+    const raw = memorySqliteOrNull("forkRetrospectiveState");
+    if (!raw) return;
 
-  const sourceRow = raw
-    .query(
-      /*sql*/ `
+    const sourceRow = raw
+      .query(
+        /*sql*/ `
       SELECT last_processed_message_id, last_run_at, remembered_log
       FROM memory_retrospective_state WHERE conversation_id = ?
     `,
-    )
-    .get(sourceConversationId) as {
-    last_processed_message_id: string;
-    last_run_at: number;
-    remembered_log: string | null;
-  } | null;
-  if (!sourceRow) return;
+      )
+      .get(sourceConversationId) as {
+      last_processed_message_id: string;
+      last_run_at: number;
+      remembered_log: string | null;
+    } | null;
+    if (!sourceRow) return;
 
-  let forkedPointer = "";
-  if (sourceRow.last_processed_message_id !== "") {
-    const mapped = forkedMessageIds.get(sourceRow.last_processed_message_id);
-    if (mapped !== undefined) {
-      forkedPointer = mapped;
-    } else if (lastCopiedSourceMessageId !== null) {
-      // Source pointer is past the fork boundary — everything copied has
-      // already been processed by the source, so clamp to the last copied
-      // message so the fork waits for new post-fork messages.
-      forkedPointer = forkedMessageIds.get(lastCopiedSourceMessageId) ?? "";
+    let forkedPointer = "";
+    if (sourceRow.last_processed_message_id !== "") {
+      const mapped = forkedMessageIds.get(sourceRow.last_processed_message_id);
+      if (mapped !== undefined) {
+        forkedPointer = mapped;
+      } else if (lastCopiedSourceMessageId !== null) {
+        // Source pointer is past the fork boundary — everything copied has
+        // already been processed by the source, so clamp to the last copied
+        // message so the fork waits for new post-fork messages.
+        forkedPointer = forkedMessageIds.get(lastCopiedSourceMessageId) ?? "";
+      }
     }
-  }
 
-  raw
-    .query(
-      /*sql*/ `
+    raw
+      .query(
+        /*sql*/ `
       INSERT INTO memory_retrospective_state
         (conversation_id, last_processed_message_id, last_run_at, remembered_log)
       VALUES (?, ?, ?, ?)
@@ -283,13 +287,16 @@ export function forkRetrospectiveState(args: {
         last_run_at = excluded.last_run_at,
         remembered_log = excluded.remembered_log
     `,
-    )
-    .run(
-      forkedConversationId,
-      forkedPointer,
-      sourceRow.last_run_at,
-      sourceRow.remembered_log,
-    );
+      )
+      .run(
+        forkedConversationId,
+        forkedPointer,
+        sourceRow.last_run_at,
+        sourceRow.remembered_log,
+      );
+  } catch (err) {
+    log.warn({ err }, "failed to fork retrospective state; continuing");
+  }
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -58,8 +58,8 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
 import { stripSpotlightInjections } from "../../../../../context/strip-injections.js";
-import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
 import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
+import { ensureMemoryV3EverInjectedSchema } from "../../../../../persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import { unwrapMemoryBlock, wrapMemoryBlock } from "../../memory-marker.js";
 import { cardBytes, renderCard } from "../card.js";
@@ -128,17 +128,17 @@ mock.module("../dense.js", () => ({
 }));
 
 let testSqlite: Database;
-// Selection rows live on the dedicated memory connection, resolved via
-// `getMemorySqlite` — stubbed to a second in-memory DB carrying the relocated
-// table's schema. Messages and the everInjected store stay in main.
+// Selection and everInjected rows live on the dedicated memory connection,
+// resolved via `getMemorySqlite` — stubbed to a second in-memory DB carrying
+// the relocated tables' schema. Messages stay in main.
 let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3EverInjected(db);
   memorySqlite = new Database(":memory:");
   ensureMemoryV3SelectionsSchema(memorySqlite);
+  ensureMemoryV3EverInjectedSchema(memorySqlite);
   // Minimal `messages` shape — metadata persistence, the prune valve's
   // v3-ownership scan, and the restart rehydration read only these columns.
   testSqlite.run(/*sql*/ `

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -29,8 +29,8 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
-import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
 import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
+import { ensureMemoryV3EverInjectedSchema } from "../../../../../persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import type { InjectionBlock } from "../../../../types.js";
 import { unwrapMemoryBlock } from "../../memory-marker.js";
@@ -96,9 +96,9 @@ let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3EverInjected(db);
   memorySqlite = new Database(":memory:");
   ensureMemoryV3SelectionsSchema(memorySqlite);
+  ensureMemoryV3EverInjectedSchema(memorySqlite);
   // The prune valve plans only against slugs whose card sections are
   // locatable in persisted `memoryV3InjectedBlock` rows
   // (`collectPersistedV3Cards`) — minimal `messages` shape it reads.

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
@@ -31,7 +31,8 @@ import type {
 } from "@vellumai/plugin-api";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
+import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
+import { ensureMemoryV3EverInjectedSchema } from "../../../../../persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import { wrapMemoryBlock } from "../../memory-marker.js";
 import { cardBytes, renderCard } from "../card.js";
@@ -85,11 +86,17 @@ const realDbConnection = {
   ...(await import("../../../../../persistence/db-connection.js")),
 };
 let testSqlite: Database;
+// The everInjected carry and v3 selection rows live on the dedicated memory
+// connection, resolved via `getMemorySqlite` — stubbed to a second in-memory DB
+// carrying the relocated tables' schema.
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3EverInjected(db);
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3SelectionsSchema(memorySqlite);
+  ensureMemoryV3EverInjectedSchema(memorySqlite);
   return db;
 }
 mock.module("../../../../../persistence/db-connection.js", () => ({
@@ -101,6 +108,8 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
       : realDbConnection.getSqliteFrom(
           db as Parameters<typeof realDbConnection.getSqliteFrom>[0],
         ),
+  getMemorySqlite: () =>
+    denseMockActive ? memorySqlite : realDbConnection.getMemorySqlite(),
 }));
 
 const { orchestrate } = await import("../orchestrate.js");

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -28,8 +28,8 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
 import { MemoryV3GateSchema } from "../../../../../config/schemas/memory-v3.js";
-import { migrateAddMemoryV3EverInjected } from "../../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
 import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
+import { ensureMemoryV3EverInjectedSchema } from "../../../../../persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import type { HotSetEntry, HotSetOptions } from "../hot-set.js";
 import type { OrchestrateResult } from "../orchestrate.js";
@@ -169,9 +169,9 @@ let hotSetOpts: HotSetOptions | null = null;
 // page body.
 let capturedPageBody: ((slug: string) => Promise<string>) | null = null;
 
-// Shared in-memory DBs so writes are observable from the test. Selection rows
-// live on the dedicated memory connection (`memorySqlite`, resolved through
-// the stubbed `getMemorySqlite`); the everInjected store stays in main.
+// Shared in-memory DBs so writes are observable from the test. The selection
+// and everInjected rows live on the dedicated memory connection (`memorySqlite`,
+// resolved through the stubbed `getMemorySqlite`).
 let testSqlite: Database;
 let memorySqlite: Database;
 // When false, the stubbed `getMemorySqlite` resolves to null — the contract
@@ -182,10 +182,10 @@ function makeDb() {
   testSqlite = new Database(":memory:");
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
-  // The live injector's net-new dedup reads/writes the everInjected store.
-  migrateAddMemoryV3EverInjected(db);
   memorySqlite = new Database(":memory:");
   ensureMemoryV3SelectionsSchema(memorySqlite);
+  // The live injector's net-new dedup reads/writes the everInjected store.
+  ensureMemoryV3EverInjectedSchema(memorySqlite);
   return db;
 }
 

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
@@ -8,6 +8,12 @@
  *     seeding (`bytes = 0`, dedup-only);
  *   - migration idempotence (run twice).
  *
+ * The rows live on the dedicated memory connection, resolved via
+ * `getMemorySqlite` — stubbed to an in-memory DB carrying the relocated table's
+ * schema, with `memoryDbAvailable` toggled to `null` for the fail-soft case.
+ * The fork functions still accept a main-DB handle (unused now) so their call
+ * sites are unchanged.
+ *
  * `mock.module` is process-global and leaks into sibling files in a directory
  * run, so the db-connection stub DELEGATES to the real implementation unless
  * this test is actively running (`storeMockActive`, toggled in
@@ -19,7 +25,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { migrateAddMemoryV3EverInjected } from "../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
+import { ensureMemoryV3EverInjectedSchema } from "../../../../persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.js";
 import * as schema from "../../../../persistence/schema/index.js";
 
 const realDb = {
@@ -27,23 +33,28 @@ const realDb = {
 };
 
 let storeMockActive = false;
+let memoryDbAvailable = true;
 
+// The fork functions still take a (now unused) main-DB handle; keep a drizzle
+// stand-in to pass positionally so the call sites read the same as production.
 let testSqlite: Database;
+let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
-  const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3EverInjected(db);
-  return db;
+  memorySqlite = new Database(":memory:");
+  ensureMemoryV3EverInjectedSchema(memorySqlite);
+  return drizzle(testSqlite, { schema });
 }
 
 mock.module("../../../../persistence/db-connection.js", () => ({
   ...realDb,
-  getDb: () => (storeMockActive ? testDb : realDb.getDb()),
-  getSqliteFrom: (db: unknown) =>
+  getMemorySqlite: () =>
     storeMockActive
-      ? testSqlite
-      : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
+      ? memoryDbAvailable
+        ? memorySqlite
+        : null
+      : realDb.getMemorySqlite(),
 }));
 
 const {
@@ -61,6 +72,7 @@ const {
 
 beforeEach(() => {
   storeMockActive = true;
+  memoryDbAvailable = true;
   testDb = makeDb();
 });
 
@@ -114,7 +126,7 @@ describe("recordInjected / getInjected / getActiveSlugs", () => {
       prunedAt: null,
     });
     expect(getActiveSlugs("conv-1")).toEqual(new Set(["topics/page-a"]));
-    const row = testSqlite
+    const row = memorySqlite
       .query(
         "SELECT injected_at FROM memory_v3_ever_injected WHERE conversation_id = ? AND slug = ?",
       )
@@ -226,7 +238,7 @@ describe("seedEverInjectedFromSlugs", () => {
     // Inherited cards carry no byte accounting — resident accounting
     // restarts from the fork's own injections.
     expect(residentBytes("conv-child")).toBe(0);
-    const row = testSqlite
+    const row = memorySqlite
       .query(
         "SELECT injected_at FROM memory_v3_ever_injected WHERE conversation_id = ? AND slug = ?",
       )
@@ -296,12 +308,25 @@ describe("seedEverInjectedFromSlugs", () => {
   });
 });
 
-describe("migration", () => {
-  test("is idempotent — running twice leaves a usable table", () => {
-    // makeDb() already ran the migration once; run it again.
-    migrateAddMemoryV3EverInjected(testDb);
+describe("memory-side schema", () => {
+  test("ensure is idempotent — running twice leaves a usable table", () => {
+    // makeDb() already ensured the schema once; run it again.
+    ensureMemoryV3EverInjectedSchema(memorySqlite);
 
     recordInjected("conv-1", [{ slug: "topics/page-a", bytes: 100 }], 1_000);
     expect(getActiveSlugs("conv-1")).toEqual(new Set(["topics/page-a"]));
+  });
+});
+
+describe("fail-soft without a memory database", () => {
+  test("reads return empty and writes no-op when the memory DB is unavailable", () => {
+    memoryDbAvailable = false;
+    expect(() =>
+      recordInjected("conv-1", [{ slug: "topics/page-a", bytes: 100 }], 1_000),
+    ).not.toThrow();
+    expect(getActiveSlugs("conv-1").size).toBe(0);
+    expect(getInjected("conv-1").size).toBe(0);
+    expect(residentBytes("conv-1")).toBe(0);
+    expect(() => clearConversation("conv-1")).not.toThrow();
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
@@ -330,3 +330,31 @@ describe("fail-soft without a memory database", () => {
     expect(() => clearConversation("conv-1")).not.toThrow();
   });
 });
+
+describe("fail-soft when the underlying statement fails", () => {
+  // The memory connection is present, but the relocated table is gone (a
+  // corrupt/dropped table, SQLITE_FULL, I/O error, or SQLITE_BUSY after
+  // timeout). Every write must degrade like the null-connection case — log a
+  // warning and no-op — rather than throwing out of the turn.
+  test("write paths no-op when the target table is missing", () => {
+    memorySqlite.query("DROP TABLE memory_v3_ever_injected").run();
+
+    expect(() =>
+      recordInjected("conv-1", [{ slug: "topics/page-a", bytes: 100 }], 1_000),
+    ).not.toThrow();
+    expect(() => markPruned("conv-1", ["topics/page-a"], 2_000)).not.toThrow();
+    expect(() => clearConversation("conv-1")).not.toThrow();
+    expect(() =>
+      forkEverInjected(testDb, "conv-parent", "conv-child"),
+    ).not.toThrow();
+    expect(() =>
+      seedEverInjectedFromSlugs(
+        testDb,
+        "conv-parent",
+        "conv-child",
+        ["topics/page-a"],
+        5_000,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
@@ -28,7 +28,10 @@
  */
 
 import type { DrizzleDb } from "../../../../persistence/db-connection.js";
+import { getLogger } from "../logging.js";
 import { memorySqliteOrNull } from "../memory-db.js";
+
+const log = getLogger("memory-v3-ever-injected-store");
 
 /**
  * Message-metadata key the v3 injector persists each turn's card block under
@@ -146,18 +149,25 @@ export function recordInjected(
   at: number = Date.now(),
 ): void {
   if (entries.length === 0) return;
-  const raw = memorySqliteOrNull("recordInjected");
-  if (!raw) return;
-  const stmt = raw.query(/*sql*/ `
-    INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
-    VALUES (?, ?, ?, ?, NULL)
-    ON CONFLICT (conversation_id, slug) DO UPDATE SET
-      injected_at = excluded.injected_at,
-      bytes = excluded.bytes,
-      pruned_at = NULL
-  `);
-  for (const entry of entries) {
-    stmt.run(conversationId, entry.slug, at, entry.bytes);
+  // Best-effort — a derived injection-accounting write must never abort the
+  // agent turn, so a degraded memory connection or a failed statement only
+  // logs a warning.
+  try {
+    const raw = memorySqliteOrNull("recordInjected");
+    if (!raw) return;
+    const stmt = raw.query(/*sql*/ `
+      INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
+      VALUES (?, ?, ?, ?, NULL)
+      ON CONFLICT (conversation_id, slug) DO UPDATE SET
+        injected_at = excluded.injected_at,
+        bytes = excluded.bytes,
+        pruned_at = NULL
+    `);
+    for (const entry of entries) {
+      stmt.run(conversationId, entry.slug, at, entry.bytes);
+    }
+  } catch (err) {
+    log.warn({ err }, "failed to record ever-injected cards; continuing");
   }
 }
 
@@ -171,17 +181,21 @@ export function markPruned(
   at: number,
 ): void {
   if (slugs.length === 0) return;
-  const raw = memorySqliteOrNull("markPruned");
-  if (!raw) return;
-  const placeholders = slugs.map(() => "?").join(", ");
-  raw
-    .query(
-      /*sql*/ `
+  try {
+    const raw = memorySqliteOrNull("markPruned");
+    if (!raw) return;
+    const placeholders = slugs.map(() => "?").join(", ");
+    raw
+      .query(
+        /*sql*/ `
       UPDATE memory_v3_ever_injected SET pruned_at = ?
       WHERE conversation_id = ? AND slug IN (${placeholders})
     `,
-    )
-    .run(at, conversationId, ...slugs);
+      )
+      .run(at, conversationId, ...slugs);
+  } catch (err) {
+    log.warn({ err }, "failed to mark ever-injected cards pruned; continuing");
+  }
 }
 
 /**
@@ -189,15 +203,22 @@ export function markPruned(
  * blocks are gone from history, so every slug must become re-injectable.
  */
 export function clearConversation(conversationId: string): void {
-  const raw = memorySqliteOrNull("clearConversation");
-  if (!raw) return;
-  raw
-    .query(
-      /*sql*/ `
+  try {
+    const raw = memorySqliteOrNull("clearConversation");
+    if (!raw) return;
+    raw
+      .query(
+        /*sql*/ `
       DELETE FROM memory_v3_ever_injected WHERE conversation_id = ?
     `,
-    )
-    .run(conversationId);
+      )
+      .run(conversationId);
+  } catch (err) {
+    log.warn(
+      { err },
+      "failed to clear ever-injected record for conversation; continuing",
+    );
+  }
 }
 
 /** Total bytes of resident (non-pruned) cards — the prune-valve input. */
@@ -229,11 +250,12 @@ export function forkEverInjected(
   parentConversationId: string,
   newConversationId: string,
 ): void {
-  const raw = memorySqliteOrNull("forkEverInjected");
-  if (!raw) return;
-  raw
-    .query(
-      /*sql*/ `
+  try {
+    const raw = memorySqliteOrNull("forkEverInjected");
+    if (!raw) return;
+    raw
+      .query(
+        /*sql*/ `
       INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
       SELECT ?, slug, injected_at, bytes, pruned_at FROM memory_v3_ever_injected
       WHERE conversation_id = ?
@@ -242,8 +264,11 @@ export function forkEverInjected(
         bytes = excluded.bytes,
         pruned_at = excluded.pruned_at
     `,
-    )
-    .run(newConversationId, parentConversationId);
+      )
+      .run(newConversationId, parentConversationId);
+  } catch (err) {
+    log.warn({ err }, "failed to fork ever-injected record; continuing");
+  }
 }
 
 /**
@@ -280,23 +305,27 @@ export function seedEverInjectedFromSlugs(
   at: number,
 ): void {
   if (slugs.length === 0) return;
-  const raw = memorySqliteOrNull("seedEverInjectedFromSlugs");
-  if (!raw) return;
-  const prunedRows = raw
-    .query(
-      /*sql*/ `
+  try {
+    const raw = memorySqliteOrNull("seedEverInjectedFromSlugs");
+    if (!raw) return;
+    const prunedRows = raw
+      .query(
+        /*sql*/ `
       SELECT slug, pruned_at AS prunedAt FROM memory_v3_ever_injected
       WHERE conversation_id = ? AND pruned_at IS NOT NULL
     `,
-    )
-    .all(parentConversationId) as Array<{ slug: string; prunedAt: number }>;
-  const parentPrunedAt = new Map(prunedRows.map((r) => [r.slug, r.prunedAt]));
-  const stmt = raw.query(/*sql*/ `
+      )
+      .all(parentConversationId) as Array<{ slug: string; prunedAt: number }>;
+    const parentPrunedAt = new Map(prunedRows.map((r) => [r.slug, r.prunedAt]));
+    const stmt = raw.query(/*sql*/ `
     INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
     VALUES (?, ?, ?, 0, ?)
     ON CONFLICT (conversation_id, slug) DO NOTHING
   `);
-  for (const slug of slugs) {
-    stmt.run(newConversationId, slug, at, parentPrunedAt.get(slug) ?? null);
+    for (const slug of slugs) {
+      stmt.run(newConversationId, slug, at, parentPrunedAt.get(slug) ?? null);
+    }
+  } catch (err) {
+    log.warn({ err }, "failed to seed forked ever-injected record; continuing");
   }
 }

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
@@ -1,8 +1,11 @@
 /**
  * Per-conversation everInjected record for memory-v3's frozen-card carry.
  *
- * Backed by `memory_v3_ever_injected` (migration 277): one row per
- * (conversation, page-slug) the v3 injector ever attached as a card. The
+ * Backed by `memory_v3_ever_injected`, which lives on the dedicated memory
+ * connection (`assistant-memory.db`) — every read/write resolves it via
+ * `memorySqliteOrNull` and degrades to a no-op when that connection is
+ * unavailable. One row per (conversation, page-slug) the v3 injector ever
+ * attached as a card. The
  * active (non-pruned) slug set is the injection dedup record — a slug present
  * here rides the cached message prefix and must not be re-rendered — and
  * `bytes` sums into the resident footprint the prune valve bounds. Rows are
@@ -12,9 +15,10 @@
  * cached blocks those slugs lived on are gone, so future turns are free to
  * re-inject them.
  *
- * Fork semantics mirror v2's activation-store hooks (both run synchronously
- * inside the `forkConversation()` transaction — see
- * `assistant/src/memory/conversation-crud.ts`):
+ * Fork semantics mirror v2's activation-store hooks. The fork copy runs on the
+ * memory connection, so it is no longer atomic with the main-DB
+ * `forkConversation()` transaction that drives it — a best-effort copy that
+ * no-ops when the memory database is unavailable:
  *   - full-history forks copy the parent's rows wholesale
  *     (`forkEverInjected`), pruned state included;
  *   - truncated forks seed from the slugs scanned out of the inherited
@@ -23,11 +27,8 @@
  *     not contain, suppressing their re-injection forever.
  */
 
-import {
-  type DrizzleDb,
-  getDb,
-  getSqliteFrom,
-} from "../../../../persistence/db-connection.js";
+import type { DrizzleDb } from "../../../../persistence/db-connection.js";
+import { memorySqliteOrNull } from "../memory-db.js";
 
 /**
  * Message-metadata key the v3 injector persists each turn's card block under
@@ -52,7 +53,9 @@ export interface EverInjectedEntry {
 export function getInjected(
   conversationId: string,
 ): Map<string, EverInjectedEntry> {
-  const rows = getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("getInjected");
+  if (!raw) return new Map();
+  const rows = raw
     .query(
       /*sql*/ `
       SELECT slug, bytes, pruned_at AS prunedAt FROM memory_v3_ever_injected
@@ -72,7 +75,9 @@ export function getInjected(
 
 /** The injection dedup set: slugs whose cards are currently resident. */
 export function getActiveSlugs(conversationId: string): Set<string> {
-  const rows = getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("getActiveSlugs");
+  if (!raw) return new Set();
+  const rows = raw
     .query(
       /*sql*/ `
       SELECT slug FROM memory_v3_ever_injected
@@ -99,7 +104,9 @@ export interface ActiveInjectedEntry {
 export function getActiveEntries(
   conversationId: string,
 ): ActiveInjectedEntry[] {
-  return getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("getActiveEntries");
+  if (!raw) return [];
+  return raw
     .query(
       /*sql*/ `
       SELECT slug, bytes, injected_at AS injectedAt FROM memory_v3_ever_injected
@@ -115,7 +122,9 @@ export function getActiveEntries(
  * `prune.ts` / `daemon/conversation.ts`).
  */
 export function getPrunedSlugs(conversationId: string): Set<string> {
-  const rows = getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("getPrunedSlugs");
+  if (!raw) return new Set();
+  const rows = raw
     .query(
       /*sql*/ `
       SELECT slug FROM memory_v3_ever_injected
@@ -137,7 +146,9 @@ export function recordInjected(
   at: number = Date.now(),
 ): void {
   if (entries.length === 0) return;
-  const stmt = getSqliteFrom(getDb()).query(/*sql*/ `
+  const raw = memorySqliteOrNull("recordInjected");
+  if (!raw) return;
+  const stmt = raw.query(/*sql*/ `
     INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
     VALUES (?, ?, ?, ?, NULL)
     ON CONFLICT (conversation_id, slug) DO UPDATE SET
@@ -160,8 +171,10 @@ export function markPruned(
   at: number,
 ): void {
   if (slugs.length === 0) return;
+  const raw = memorySqliteOrNull("markPruned");
+  if (!raw) return;
   const placeholders = slugs.map(() => "?").join(", ");
-  getSqliteFrom(getDb())
+  raw
     .query(
       /*sql*/ `
       UPDATE memory_v3_ever_injected SET pruned_at = ?
@@ -176,7 +189,9 @@ export function markPruned(
  * blocks are gone from history, so every slug must become re-injectable.
  */
 export function clearConversation(conversationId: string): void {
-  getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("clearConversation");
+  if (!raw) return;
+  raw
     .query(
       /*sql*/ `
       DELETE FROM memory_v3_ever_injected WHERE conversation_id = ?
@@ -187,7 +202,9 @@ export function clearConversation(conversationId: string): void {
 
 /** Total bytes of resident (non-pruned) cards — the prune-valve input. */
 export function residentBytes(conversationId: string): number {
-  const row = getSqliteFrom(getDb())
+  const raw = memorySqliteOrNull("residentBytes");
+  if (!raw) return 0;
+  const row = raw
     .query(
       /*sql*/ `
       SELECT COALESCE(SUM(bytes), 0) AS total FROM memory_v3_ever_injected
@@ -200,18 +217,21 @@ export function residentBytes(conversationId: string): number {
 
 /**
  * Copy the parent conversation's rows to a new conversation id, pruned state
- * included. No-op if the parent has no rows. Mirrors `forkActivationState`:
- * synchronous so it can run inside the bun:sqlite transaction that wraps
- * `forkConversation()`, keeping the copy atomic with the message copies.
- * Full-history forks only — truncated forks must use
- * `seedEverInjectedFromSlugs` instead.
+ * included. No-op if the parent has no rows. Full-history forks only —
+ * truncated forks must use `seedEverInjectedFromSlugs` instead.
+ *
+ * The rows live on the memory connection, so this writes there rather than on
+ * the main fork transaction's handle — the `_db` main handle is unused. The
+ * copy is best-effort: an unavailable memory database is a no-op.
  */
 export function forkEverInjected(
-  db: DrizzleDb,
+  _db: DrizzleDb,
   parentConversationId: string,
   newConversationId: string,
 ): void {
-  getSqliteFrom(db)
+  const raw = memorySqliteOrNull("forkEverInjected");
+  if (!raw) return;
+  raw
     .query(
       /*sql*/ `
       INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
@@ -247,18 +267,22 @@ export function forkEverInjected(
  * live view at fork time; re-selection clears the tombstone and re-injects,
  * same as in the parent.
  *
- * No-op when the child inherited no card blocks. Synchronous so it can run
- * inside the `forkConversation()` transaction.
+ * No-op when the child inherited no card blocks. The rows live on the memory
+ * connection, so this writes there rather than on the main fork transaction's
+ * handle — the `_db` main handle is unused, and an unavailable memory database
+ * is a best-effort no-op.
  */
 export function seedEverInjectedFromSlugs(
-  db: DrizzleDb,
+  _db: DrizzleDb,
   parentConversationId: string,
   newConversationId: string,
   slugs: string[],
   at: number,
 ): void {
   if (slugs.length === 0) return;
-  const prunedRows = getSqliteFrom(db)
+  const raw = memorySqliteOrNull("seedEverInjectedFromSlugs");
+  if (!raw) return;
+  const prunedRows = raw
     .query(
       /*sql*/ `
       SELECT slug, pruned_at AS prunedAt FROM memory_v3_ever_injected
@@ -267,7 +291,7 @@ export function seedEverInjectedFromSlugs(
     )
     .all(parentConversationId) as Array<{ slug: string; prunedAt: number }>;
   const parentPrunedAt = new Map(prunedRows.map((r) => [r.slug, r.prunedAt]));
-  const stmt = getSqliteFrom(db).query(/*sql*/ `
+  const stmt = raw.query(/*sql*/ `
     INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
     VALUES (?, ?, ?, 0, ?)
     ON CONFLICT (conversation_id, slug) DO NOTHING

--- a/assistant/src/plugins/defaults/memory/v3/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.test.ts
@@ -31,8 +31,8 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Message } from "@vellumai/plugin-api";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { migrateAddMemoryV3EverInjected } from "../../../../persistence/migrations/277-add-memory-v3-ever-injected.js";
 import { ensureMemoryV3SelectionsSchema } from "../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
+import { ensureMemoryV3EverInjectedSchema } from "../../../../persistence/migrations/345-move-memory-v3-ever-injected-to-memory-db.js";
 import * as schema from "../../../../persistence/schema/index.js";
 import { wrapMemoryBlock } from "../memory-marker.js";
 
@@ -56,7 +56,6 @@ let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
-  migrateAddMemoryV3EverInjected(db);
   // Minimal `messages` shape — `collectPersistedV3Cards` reads only
   // `conversation_id` and `metadata`.
   testSqlite.run(/*sql*/ `
@@ -71,6 +70,7 @@ function makeDb() {
   `);
   memorySqlite = new Database(":memory:");
   ensureMemoryV3SelectionsSchema(memorySqlite);
+  ensureMemoryV3EverInjectedSchema(memorySqlite);
   return db;
 }
 


### PR DESCRIPTION
## Summary
- Relocate memory_v3_ever_injected and memory_retrospective_state into assistant-memory.db (migrations 342/343); retrospective_state created without its cross-file FK cascade.
- Add both tables to the conversation-deleted purge array (first real purge for ever_injected, closing a leak); repoint their stores to the memory connection, fail-soft.

Part of plan: memory-db-wave2.md (PR 3 of 3)