### PR TITLE
test(image-fallback): fix caption-cache eviction test timeout on CI

### DIFF
--- a/assistant/src/plugins/defaults/image-fallback/__tests__/caption-cache-persistence.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/caption-cache-persistence.test.ts
@@ -149,9 +149,13 @@ describe("caption cache durable layer", () => {
   });
 
   test("write eviction keeps the most recently used rows within the cap", () => {
-    for (let i = 0; i < 2_000; i++) {
-      insertRow(`hash-${i}`, "conv-1", `caption ${i}`, i + 1);
-    }
+    // Seed in one transaction — 2,000 autocommit inserts fsync individually
+    // and time the test out on slow CI disks.
+    inspector.transaction(() => {
+      for (let i = 0; i < 2_000; i++) {
+        insertRow(`hash-${i}`, "conv-1", `caption ${i}`, i + 1);
+      }
+    })();
     const newestHash = imageHash("one-over-the-cap");
     setCachedCaption(newestHash, "conv-1", "The newest caption.");
     expect(rowCount()).toBe(2_000);


### PR DESCRIPTION
## Summary
- The `write eviction keeps the most recently used rows within the cap` test in `caption-cache-persistence.test.ts` seeded 2,000 rows as individual autocommit inserts, each with its own fsync — on CI's slow shared disks this exceeded bun's 5s per-test timeout (failed at ~6s on both the initial pass and the retry of the `CI Main Assistant Checks` run on `main`).
- Wraps the seed loop in a single `inspector.transaction(...)()` so the seeding commits once; the file now runs in ~58ms locally (was ~6s), with identical assertion semantics — the eviction-triggering write still goes through `setCachedCaption`.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29467930323/job/87524928870 — the `Test` job of `CI Main Assistant Checks` failing on `main` with a single test timeout in the image-fallback plugin's caption-cache persistence suite.