### PR TITLE
fix(security): confine memory prompt-path overrides to the workspace root

### DIFF
--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -63,7 +63,7 @@ export const MemoryRetrospectiveConfigSchema = z
       .nullable()
       .default(null)
       .describe(
-        "Optional path to a file whose contents replace the bundled retrospective fork-instruction prompt. Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The loaded contents may include `{{AVAILABLE_TOOLS_LINE}}`, `{{WINDOW_ANCHOR}}`, `{{ALREADY_REMEMBERED}}`, and `{{SKILL_AUTHORING_SECTION}}`, which are substituted at runtime. If the file is missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
+        "Optional path to a file whose contents replace the bundled retrospective fork-instruction prompt. Relative paths resolve under the workspace root; absolute paths and a leading `~/` (expanded to the home directory) are honored only when they still resolve inside the workspace root — a path that lands outside the workspace (including via symlinks) is rejected. The loaded contents may include `{{AVAILABLE_TOOLS_LINE}}`, `{{WINDOW_ANCHOR}}`, `{{ALREADY_REMEMBERED}}`, and `{{SKILL_AUTHORING_SECTION}}`, which are substituted at runtime. If the file is rejected, missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
       ),
   })
   .describe(

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -235,7 +235,7 @@ export const MemoryV2ConfigSchema = z
       .nullable()
       .default(null)
       .describe(
-        "Optional path to a file whose contents replace the bundled consolidation prompt. Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The loaded contents may include `{{CUTOFF}}`, which is substituted with the run's ISO-8601 cutoff timestamp. If the file is missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
+        "Optional path to a file whose contents replace the bundled consolidation prompt. Relative paths resolve under the workspace root; absolute paths and a leading `~/` (expanded to the home directory) are honored only when they still resolve inside the workspace root — a path that lands outside the workspace (including via symlinks) is rejected. The loaded contents may include `{{CUTOFF}}`, which is substituted with the run's ISO-8601 cutoff timestamp. If the file is rejected, missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
       ),
     rerank: z
       .object({
@@ -306,7 +306,7 @@ export const MemoryV2ConfigSchema = z
           .nullable()
           .default(null)
           .describe(
-            "Optional path to a file whose contents replace the bundled router prompt. Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The loaded contents may include `{{ASSISTANT_NAME}}`, `{{USER_NAME}}`, and `{{PAGE_INDEX}}`, which are substituted at runtime. If the file is missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
+            "Optional path to a file whose contents replace the bundled router prompt. Relative paths resolve under the workspace root; absolute paths and a leading `~/` (expanded to the home directory) are honored only when they still resolve inside the workspace root — a path that lands outside the workspace (including via symlinks) is rejected. The loaded contents may include `{{ASSISTANT_NAME}}`, `{{USER_NAME}}`, and `{{PAGE_INDEX}}`, which are substituted at runtime. If the file is rejected, missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
           ),
         batch_size: z
           .number()

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -394,7 +394,7 @@ export const MemoryV3ConfigSchema = z
       .nullable()
       .default(null)
       .describe(
-        "Optional path to a file whose contents replace the bundled per-turn selector system prompt (the instructions that tell the selector which candidate pages to keep). Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The selector prompt takes no placeholders — the candidate pool is supplied separately as the user message — so the file is used verbatim. If the file is missing, unreadable, empty, or over 1 MiB, the bundled prompt is used and a warning is logged.",
+        "Optional path to a file whose contents replace the bundled per-turn selector system prompt (the instructions that tell the selector which candidate pages to keep). Relative paths resolve under the workspace root; absolute paths and a leading `~/` (expanded to the home directory) are honored only when they still resolve inside the workspace root — a path that lands outside the workspace (including via symlinks) is rejected. The selector prompt takes no placeholders — the candidate pool is supplied separately as the user message — so the file is used verbatim. If the file is rejected, missing, unreadable, empty, or over 1 MiB, the bundled prompt is used and a warning is logged.",
       ),
     edge: MemoryV3EdgeSchema.default(MemoryV3EdgeSchema.parse({})),
     entity: MemoryV3EntitySchema.default(MemoryV3EntitySchema.parse({})),

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { getWorkspaceDir } from "../paths.js";
 
 // ---------------------------------------------------------------------------
 // Mock state. Reset between tests.
@@ -810,7 +811,12 @@ describe("memoryRetrospectiveJob", () => {
   });
 
   test("honors memory.retrospective.promptPath override when set", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "retro-job-prompt-override-"));
+    // Overrides outside the workspace root are rejected, so the fixture must
+    // live under the process workspace.
+    mkdirSync(getWorkspaceDir(), { recursive: true });
+    const dir = mkdtempSync(
+      join(getWorkspaceDir(), "retro-job-prompt-override-"),
+    );
     const overridePath = join(dir, "custom-instruction.md");
     writeFileSync(
       overridePath,

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -8,6 +8,7 @@ import {
   type ForkInstructionArgs,
   RETROSPECTIVE_INSTRUCTION_TEMPLATE,
 } from "../memory-retrospective-prompt.js";
+import { getWorkspaceDir } from "../paths.js";
 
 function makeArgs(
   overrides: Partial<ForkInstructionArgs> = {},
@@ -136,7 +137,10 @@ For everything else in your review window, use the \`remember\` tool on facts, p
 });
 
 describe("promptOverridePath", () => {
-  const dir = mkdtempSync(join(tmpdir(), "retro-prompt-override-"));
+  // buildForkInstruction resolves overrides against the process workspace and
+  // rejects anything outside it, so fixtures must live under the workspace.
+  mkdirSync(getWorkspaceDir(), { recursive: true });
+  const dir = mkdtempSync(join(getWorkspaceDir(), "retro-prompt-override-"));
 
   test("override file replaces the bundled body and gets the same substitutions", () => {
     const overridePath = join(dir, "custom-instruction.md");
@@ -176,5 +180,20 @@ describe("promptOverridePath", () => {
       makeArgs({ promptOverridePath: join(dir, "does-not-exist.md") }),
     );
     expect(out).toBe(buildForkInstruction(makeArgs()));
+  });
+
+  test("an override outside the workspace root is rejected and falls back to the bundled rendering", () => {
+    // The persisted fork instruction is readable through the messages API, so
+    // an out-of-workspace override would disclose arbitrary local files.
+    const outside = mkdtempSync(join(tmpdir(), "retro-prompt-outside-"));
+    const overridePath = join(outside, "smuggled.md");
+    writeFileSync(overridePath, "SENSITIVE FILE CONTENTS\n");
+
+    const out = buildForkInstruction(
+      makeArgs({ promptOverridePath: overridePath }),
+    );
+
+    expect(out).toBe(buildForkInstruction(makeArgs()));
+    expect(out).not.toContain("SENSITIVE FILE CONTENTS");
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/prompt-override.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/prompt-override.test.ts
@@ -3,13 +3,13 @@
  * (`assistant/src/memory/prompt-override.ts`) and the memory-v3
  * `resolveSelectorPrompt` built on it. Mirrors the v2 router/consolidation
  * prompt-path suites: a configured file replaces the bundled prompt, and any
- * missing / empty / oversized / non-regular / unreadable file degrades to the
- * bundled prompt with a diagnostic warning.
+ * out-of-workspace / missing / empty / oversized / non-regular / unreadable
+ * file degrades to the bundled prompt with a diagnostic warning.
  */
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
@@ -50,6 +50,7 @@ const load = (
   });
 
 describe("resolveOverridePath", () => {
+  // Pure resolution — workspace containment is enforced by loadPromptOverride.
   test("expands a leading ~/ to the home directory", () => {
     expect(resolveOverridePath("~/sub/x.md", tmpDir)).toBe(
       join(homedir(), "sub/x.md"),
@@ -91,15 +92,78 @@ describe("loadPromptOverride — usable override", () => {
     expect(warnCalls).toHaveLength(0);
   });
 
-  test("expands a leading ~/ to the home directory", () => {
+  test("honors a ~/ path that resolves inside the workspace", () => {
+    let wsUnderHome: string;
+    try {
+      wsUnderHome = mkdtempSync(join(homedir(), ".vellum-prompt-override-ws-"));
+    } catch {
+      // Home directory not writable on this platform — skip without failing.
+      return;
+    }
+    try {
+      writeFileSync(join(wsUnderHome, "x.md"), "home workspace body\n");
+      const out = loadPromptOverride({
+        overridePath: `~/${basename(wsUnderHome)}/x.md`,
+        workspaceDir: wsUnderHome,
+        log: recordingLogger,
+        label: "test prompt",
+      });
+      expect(out).toBe("home workspace body\n");
+      expect(warnCalls).toHaveLength(0);
+    } finally {
+      rmSync(wsUnderHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadPromptOverride — workspace containment", () => {
+  test("an absolute path outside the workspace is rejected", () => {
+    const outside = mkdtempSync(join(tmpdir(), "prompt-override-outside-"));
+    try {
+      const p = join(outside, "secret.md");
+      writeFileSync(p, "SENSITIVE CONTENTS\n");
+      expect(load(p)).toBeNull();
+      expect(warnCalls).toHaveLength(1);
+      expect(warnCalls[0].data.reason).toBe("outside_workspace");
+      expect(warnCalls[0].data.fallback).toBe("bundled");
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("a relative path escaping the workspace via .. is rejected", () => {
+    const name = `prompt-override-escape-${process.pid}.md`;
+    const target = join(tmpDir, "..", name);
+    writeFileSync(target, "escaped\n");
+    try {
+      expect(load(join("..", name))).toBeNull();
+      expect(warnCalls[0].data.reason).toBe("outside_workspace");
+    } finally {
+      rmSync(target, { force: true });
+    }
+  });
+
+  test("a ~/ path outside the workspace is rejected", () => {
     const filename = `.vellum-prompt-override-test-${process.pid}.md`;
     const p = join(homedir(), filename);
     writeFileSync(p, "home body\n");
     try {
-      expect(load(`~/${filename}`)).toBe("home body\n");
-      expect(warnCalls).toHaveLength(0);
+      expect(load(`~/${filename}`)).toBeNull();
+      expect(warnCalls[0].data.reason).toBe("outside_workspace");
     } finally {
       rmSync(p, { force: true });
+    }
+  });
+
+  test("a symlinked directory pointing outside the workspace is rejected", () => {
+    const outside = mkdtempSync(join(tmpdir(), "prompt-override-outside-"));
+    try {
+      writeFileSync(join(outside, "secret.md"), "SENSITIVE CONTENTS\n");
+      symlinkSync(outside, join(tmpDir, "linked-dir"));
+      expect(load(join("linked-dir", "secret.md"))).toBeNull();
+      expect(warnCalls[0].data.reason).toBe("outside_workspace");
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
     }
   });
 });

--- a/assistant/src/plugins/defaults/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/memory-v2.ts
@@ -24,10 +24,11 @@
 // still surface lexical hits, and vice versa.
 
 import { readdir, readFile, realpath, stat } from "node:fs/promises";
-import { extname, isAbsolute, join, relative } from "node:path";
+import { extname, join } from "node:path";
 
 import { embedWithRetry } from "../../../../../persistence/embeddings/embed.js";
 import { getLogger } from "../../logging.js";
+import { isPathInsideRoot } from "../../path-containment.js";
 import { spreadActivation } from "../../v2/activation.js";
 import { getEdgeIndex } from "../../v2/edge-index.js";
 import {
@@ -578,14 +579,6 @@ function termOverlap(
 
 function normalizeExcerpt(excerpt: string): string {
   return excerpt.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-function isPathInsideRoot(pathToCheck: string, rootRealPath: string): boolean {
-  const pathRelativeToRoot = relative(rootRealPath, pathToCheck);
-  return (
-    pathRelativeToRoot === "" ||
-    (!pathRelativeToRoot.startsWith("..") && !isAbsolute(pathRelativeToRoot))
-  );
 }
 
 function truncateExcerpt(text: string, maxChars: number): string {

--- a/assistant/src/plugins/defaults/memory/context-search/sources/workspace.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/workspace.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import { extname, isAbsolute, join, relative, sep } from "node:path";
 
+import { isPathInsideRoot } from "../../path-containment.js";
 import type {
   RecallEvidence,
   RecallSearchContext,
@@ -1206,14 +1207,6 @@ export function normalizeWorkspacePathLiteral(
     return null;
   }
   return withoutLineSuffix.split(sep).join("/");
-}
-
-function isPathInsideRoot(pathToCheck: string, rootRealPath: string): boolean {
-  const pathRelativeToRoot = relative(rootRealPath, pathToCheck);
-  return (
-    pathRelativeToRoot === "" ||
-    (!pathRelativeToRoot.startsWith("..") && !isAbsolute(pathRelativeToRoot))
-  );
 }
 
 function toWorkspaceRelativePath(

--- a/assistant/src/plugins/defaults/memory/path-containment.ts
+++ b/assistant/src/plugins/defaults/memory/path-containment.ts
@@ -1,0 +1,21 @@
+/**
+ * Path-containment predicate shared by the plugin modules that gate filesystem
+ * access to a workspace-owned root (the prompt-override loader and the
+ * context-search sources).
+ *
+ * Callers must pass paths with symlinks already resolved (realpaths) on both
+ * sides — otherwise a symlinked directory component can alias out of the root.
+ */
+import { isAbsolute, relative, sep } from "node:path";
+
+/** True when `pathToCheck` is `rootRealPath` itself or a descendant of it. */
+export function isPathInsideRoot(
+  pathToCheck: string,
+  rootRealPath: string,
+): boolean {
+  const rel = relative(rootRealPath, pathToCheck);
+  return (
+    rel === "" ||
+    (rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+  );
+}

--- a/assistant/src/plugins/defaults/memory/prompt-override.ts
+++ b/assistant/src/plugins/defaults/memory/prompt-override.ts
@@ -1,20 +1,31 @@
 /**
  * Shared loader for file-based prompt overrides.
  *
- * The memory router, consolidation, and v3 selector prompts each ship a bundled
- * default that operators may replace by pointing a config field at a file. The
- * load-with-fallback semantics are identical across all three, so they live
- * here: path resolution, the size guard, and the permissive fallback that keeps
- * retrieval/consolidation working when an override is missing or malformed.
+ * The memory router, consolidation, v3 selector, and retrospective prompts each
+ * ship a bundled default that operators may replace by pointing a config field
+ * at a file. The load-with-fallback semantics are identical across all of them,
+ * so they live here: path resolution, workspace containment, the size guard,
+ * and the permissive fallback that keeps retrieval/consolidation working when
+ * an override is missing or malformed.
+ *
+ * Containment is a security boundary, not a convenience. The override fields
+ * are writable by any `settings.write` principal, and the loaded contents reach
+ * the LLM provider — and, for the retrospective prompt, are persisted onto a
+ * fork conversation readable with `chat.read`. Confining overrides to the
+ * workspace root (which by policy holds no secrets) keeps the loader from
+ * doubling as an arbitrary-file-read primitive for daemon-readable files such
+ * as SSH keys or token stores.
  *
  * The caller owns the bundled default and any placeholder substitution — this
  * module only decides whether a usable override file exists and returns its raw
  * contents, or `null` to mean "fall back to the bundled prompt."
  */
 
-import { lstatSync, readFileSync } from "node:fs";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
+
+import { isPathInsideRoot } from "./path-containment.js";
 
 /**
  * Minimal logger surface the loader needs. Structurally compatible with
@@ -36,7 +47,9 @@ export const MAX_PROMPT_OVERRIDE_BYTES = 1 * 1024 * 1024;
 /**
  * Resolve a configured override path to an absolute path: a leading `~/` expands
  * to the home directory, an absolute path is used as-is, and a relative path
- * resolves under `workspaceDir`.
+ * resolves under `workspaceDir`. Resolution alone grants no read access —
+ * {@link loadPromptOverride} additionally requires the resolved real path to
+ * stay inside `workspaceDir`.
  */
 export function resolveOverridePath(
   overridePath: string,
@@ -55,11 +68,18 @@ export function resolveOverridePath(
  * the caller should fall back to its bundled prompt. A nullish `overridePath`
  * (`null` or `undefined`) returns `null` without touching the filesystem.
  *
- * Fallback is intentionally total — an absent override, a missing, non-regular,
- * oversized, unreadable, or empty/whitespace-only file all degrade to `null`.
- * Memory retrieval and consolidation must never break because of a bad
- * override, so `undefined` (an unset config field) is treated as "no override"
- * rather than crashing on path resolution.
+ * The override must live inside `workspaceDir`: the configured path is
+ * resolved, then its real path (symlinks followed) is required to stay under
+ * the workspace root's real path. Anything else — an absolute path elsewhere on
+ * disk, a `~/` path outside the workspace, a `..` escape, or a symlinked
+ * directory pointing out — is rejected with an `outside_workspace` warning, so
+ * a settings-writable field can never read files the workspace doesn't own.
+ *
+ * Fallback is intentionally total — an absent override, a missing,
+ * out-of-workspace, non-regular, oversized, unreadable, or empty/whitespace-only
+ * file all degrade to `null`. Memory retrieval and consolidation must never
+ * break because of a bad override, so `undefined` (an unset config field) is
+ * treated as "no override" rather than crashing on path resolution.
  *
  * `label` names the prompt in the warning messages (e.g. `"router prompt"`).
  */
@@ -75,6 +95,24 @@ export function loadPromptOverride(opts: {
   const resolvedPath = resolveOverridePath(overridePath, workspaceDir);
   let contents: string;
   try {
+    const realWorkspaceDir = realpathSync(workspaceDir);
+    const realResolvedPath = realpathSync(resolvedPath);
+    if (!isPathInsideRoot(realResolvedPath, realWorkspaceDir)) {
+      log.warn(
+        {
+          configuredPath: overridePath,
+          resolvedPath,
+          realPath: realResolvedPath,
+          workspaceDir: realWorkspaceDir,
+          reason: "outside_workspace",
+          fallback: "bundled",
+        },
+        `${label} override resolves outside the workspace root; using bundled prompt`,
+      );
+      return null;
+    }
+    // lstat the unresolved path so a symlink final component stays rejected
+    // even when its target is a regular file inside the workspace.
     const stat = lstatSync(resolvedPath);
     if (!stat.isFile()) {
       log.warn(
@@ -102,7 +140,7 @@ export function loadPromptOverride(opts: {
       );
       return null;
     }
-    contents = readFileSync(resolvedPath, "utf-8");
+    contents = readFileSync(realResolvedPath, "utf-8");
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     log.warn(

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/prompts-consolidation.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/prompts-consolidation.test.ts
@@ -210,7 +210,7 @@ describe("resolveConsolidationPrompt — with override", () => {
     expect(warnCalls).toHaveLength(0);
   });
 
-  test("expands a leading ~/ to the home directory", () => {
+  test("rejects a ~/ path that resolves outside the workspace", () => {
     const filename = `.vellum-prompt-test-${process.pid}.md`;
     const path = join(homedir(), filename);
     writeFileSync(path, "Home dir {{CUTOFF}}\n");
@@ -220,8 +220,10 @@ describe("resolveConsolidationPrompt — with override", () => {
         CUTOFF,
         NO_CORE,
       );
-      expect(result).toBe(`Home dir ${CUTOFF}\n`);
-      expect(warnCalls).toHaveLength(0);
+      expect(result).toBe(bundledPrompt());
+      expect(warnCalls).toHaveLength(1);
+      const data = warnCalls[0].data as Record<string, unknown>;
+      expect(data.reason).toBe("outside_workspace");
     } finally {
       rmSync(path, { force: true });
     }


### PR DESCRIPTION
## Summary
- `loadPromptOverride` now requires the configured path's realpath (symlinks resolved) to stay inside the workspace root. Absolute paths elsewhere on disk, `~/` paths outside the workspace, `..` escapes, and symlinked-directory escapes are all rejected with an `outside_workspace` warning and fall back to the bundled prompt. This closes a local-file-disclosure hole (Codex finding `edf989f598f88191a4c97d8472472375`, high severity): a caller holding a normal actor token (`settings.write` + `chat.read`) could PATCH `memory.retrospective.promptPath` to a sensitive daemon-readable file (e.g. an SSH key), wait for a retrospective run, and read the file contents back through the fork conversation's messages API — or leak them to the configured LLM provider. The fix covers all four override call sites that share the loader: retrospective, v2 router, v2 consolidation, and v3 selector prompts.
- Consolidated the plugin's three copies of the path-containment predicate (the loader's new check plus two pre-existing `isPathInsideRoot` locals in the context-search sources) into a single shared `path-containment.ts`.
- Updated the four config schema descriptions to document containment, moved test fixtures that previously lived outside the workspace into it, and added escape-vector tests (absolute, `~/`, `..`, symlinked directory) plus a retrospective-level regression test.

**Behavior change:** overrides pointing outside the workspace root — previously honored — now fall back to the bundled prompt with a warning. Workspace-relative paths (the documented convention) are unaffected.

## Original prompt
Fix the Codex security finding "[Security] Retrospective promptPath can disclose local files" (high, vellum-ai/vellum-assistant commit `35c5318c4f`): the new `memory.retrospective.promptPath` config is passed to the shared prompt-override loader, which reads any regular file under 1 MiB at any absolute path; the contents replace the retrospective instruction and are persisted as the fork's hidden user message, which the messages API exposes to normal actor tokens — allowing arbitrary local file disclosure. The size cap and regular-file check did not prevent it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)