### PR TITLE
feat(app-builder): autoload frontend-design via skill includes

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   vellum:
     display-name: "App Builder"
     category: "development"
+    includes: ["frontend-design"]
     activation-hints:
       - "User asks to build a dashboard, tracker, calculator, data visualization, chart, simple landing page, or slide deck for their own use"
       - "User asks to visualize something, make a chart, or build an artifact — build a real persistent app here, never a ui_show dynamic_page"
@@ -16,9 +17,9 @@ metadata:
 
 You build small, personal visual tools — dashboards, trackers, calculators, data visualizations, simple landing pages, and slide decks. These are quick, single-user tools the user wants **for themselves**, not products they ship to other people.
 
-Load `frontend-design` first (`skill_load("frontend-design")`), then move fast: think, plan in one pass, pick a striking visual direction following that skill, and build it immediately. Don't ask permission to be creative — pick the colors, the layout, the atmosphere, the micro-interactions. Every tool gets its own identity: a plant tracker feels earthy and green, a finance dashboard precise and navy. They should feel designed, not generated.
+Move fast: think, plan in one pass, pick a striking visual direction following the `frontend-design` skill (included with this load — see *Included Skill: Frontend Design* below), and build it immediately. Don't ask permission to be creative — pick the colors, the layout, the atmosphere, the micro-interactions. Every tool gets its own identity: a plant tracker feels earthy and green, a finance dashboard precise and navy. They should feel designed, not generated.
 
-**Design quality is delegated to the `frontend-design` skill. You MUST call `skill_load("frontend-design")` before building anything, every time, and follow it completely.** That skill owns the aesthetics (typography, color, motion); this skill owns the technical infrastructure (sandbox, data, widgets, lifecycle). Skipping the load gives generic, templated UI, which is a failed build.
+**Design quality is delegated to the `frontend-design` skill, and you MUST follow it completely.** That skill owns the aesthetics (typography, color, motion); this skill owns the technical infrastructure (sandbox, data, widgets, lifecycle). Its instructions load automatically with this skill — if they are missing (listed under *Suggested Included Skills (not loaded)*), call `skill_load("frontend-design")` before building anything. Building without them gives generic, templated UI, which is a failed build.
 
 ---
 

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -7,7 +7,7 @@
     },
     "app-builder": {
       "docsSlug": "app-builder",
-      "sha256": "d6b28136ac023c7bc53d62d377eb58f6f5b28bec429f690f8431da8ea1568173"
+      "sha256": "2d49b345ef770f660bb9ef6b45927e807e27d8cce245de72c7f75dc2419288a3"
     },
     "computer-use": {
       "docsSlug": "computer-use",


### PR DESCRIPTION
## Summary
- Declare `frontend-design` in app-builder's `metadata.vellum.includes`, so `skill_load("app-builder")` returns the design skill's instructions in the same tool result (auto-installing it from the catalog when missing) instead of relying on the model to issue a second manual `skill_load` call
- Rewrite the SKILL.md load mandate to match: design quality is still delegated to `frontend-design` and must be followed completely; the manual `skill_load("frontend-design")` call is demoted to a fallback for the advisory "Suggested Included Skills (not loaded)" case
- Re-record the app-builder fingerprint in `scripts/skill-docs-sync.manifest.json` (the public docs page does not describe the load mechanics, so no docs-page change is needed)

## Original prompt
While reviewing the app-builder ↔ frontend-design relationship, we established that app-builder already treats frontend-design as an unconditional dependency — its SKILL.md mandates loading it before every build and calls a build without it a failed build — but enforcement was prompt-only. The `includes` mechanism in `skill_load` mechanizes exactly this relationship (established precedent: `phone-calls`, `inbox-cleanup`, `voice-setup`), removes a tool round trip per build, and degrades gracefully to an advisory line when the child cannot be installed. The user asked to ship that change: add the `includes` declaration, demote the manual load to a fallback, and re-record the skill-docs-sync fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)