### PR TITLE
feat(macos): add right-click Copy Image context menu

### DIFF
--- a/clients/macos/src/main/image-context-menu.test.ts
+++ b/clients/macos/src/main/image-context-menu.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { WebContents } from "electron";
+
+// Capture the template each Menu.buildFromTemplate call receives and the
+// popup options, so tests can assert the menu shape and anchoring without a
+// real Electron runtime.
+type TemplateItem = {
+  label: string;
+  enabled?: boolean;
+  click?: () => void;
+};
+
+const fakeWindow = { __kind: "window" };
+const popupMock = mock((_opts: unknown) => undefined);
+const buildFromTemplateMock = mock((_template: TemplateItem[]) => ({
+  popup: popupMock,
+}));
+const fromWebContentsMock = mock((_contents: unknown): unknown => fakeWindow);
+mock.module("electron", () => ({
+  Menu: { buildFromTemplate: buildFromTemplateMock },
+  BrowserWindow: { fromWebContents: fromWebContentsMock },
+}));
+
+const { installImageContextMenu } = await import("./image-context-menu");
+
+type ContextMenuListener = (
+  event: unknown,
+  params: Record<string, unknown>,
+) => void;
+
+// Minimal WebContents stand-in: records `context-menu` listeners and exposes
+// a trigger so tests can simulate a right-click with arbitrary params.
+const makeContents = () => {
+  const listeners: ContextMenuListener[] = [];
+  const copyImageAtMock = mock((_x: number, _y: number) => undefined);
+  const contents = {
+    on: (event: string, listener: ContextMenuListener) => {
+      if (event === "context-menu") {
+        listeners.push(listener);
+      }
+      return contents;
+    },
+    copyImageAt: copyImageAtMock,
+  };
+  return {
+    contents: contents as unknown as WebContents,
+    copyImageAtMock,
+    rightClick: (params: Record<string, unknown>) => {
+      for (const listener of listeners) {
+        listener({}, params);
+      }
+    },
+  };
+};
+
+const imageParams = (
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  mediaType: "image",
+  hasImageContents: true,
+  x: 120,
+  y: 45,
+  ...overrides,
+});
+
+const lastTemplate = (): TemplateItem[] =>
+  buildFromTemplateMock.mock.calls.at(-1)![0];
+
+beforeEach(() => {
+  popupMock.mockClear();
+  buildFromTemplateMock.mockClear();
+  fromWebContentsMock.mockClear();
+  fromWebContentsMock.mockReturnValue(fakeWindow);
+});
+
+describe("installImageContextMenu", () => {
+  test("right-clicking an image pops a single-item Copy Image menu", () => {
+    const { contents, rightClick } = makeContents();
+    installImageContextMenu(contents);
+
+    rightClick(imageParams());
+
+    expect(buildFromTemplateMock).toHaveBeenCalledTimes(1);
+    const template = lastTemplate();
+    expect(template).toHaveLength(1);
+    expect(template[0]!.label).toBe("Copy Image");
+    expect(template[0]!.enabled).toBe(true);
+    expect(popupMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("clicking Copy Image copies the bitmap at the click position", () => {
+    const { contents, copyImageAtMock, rightClick } = makeContents();
+    installImageContextMenu(contents);
+
+    rightClick(imageParams({ x: 300, y: 88 }));
+    lastTemplate()[0]!.click!();
+
+    expect(copyImageAtMock).toHaveBeenCalledTimes(1);
+    expect(copyImageAtMock).toHaveBeenCalledWith(300, 88);
+  });
+
+  test("non-image right-clicks show no menu", () => {
+    const { contents, rightClick } = makeContents();
+    installImageContextMenu(contents);
+
+    rightClick(imageParams({ mediaType: "none" }));
+    rightClick(imageParams({ mediaType: "video" }));
+
+    expect(buildFromTemplateMock).not.toHaveBeenCalled();
+    expect(popupMock).not.toHaveBeenCalled();
+  });
+
+  test("Copy Image is disabled for an image with no decodable contents", () => {
+    const { contents, rightClick } = makeContents();
+    installImageContextMenu(contents);
+
+    rightClick(imageParams({ hasImageContents: false }));
+
+    expect(lastTemplate()[0]!.enabled).toBe(false);
+  });
+
+  test("the menu anchors to the owning window", () => {
+    const { contents, rightClick } = makeContents();
+    installImageContextMenu(contents);
+
+    rightClick(imageParams());
+
+    expect(fromWebContentsMock).toHaveBeenCalledWith(contents);
+    expect(popupMock).toHaveBeenCalledWith({ window: fakeWindow });
+  });
+
+  test("windowless contents fall back to the focused window", () => {
+    fromWebContentsMock.mockReturnValue(null);
+    const { contents, rightClick } = makeContents();
+    installImageContextMenu(contents);
+
+    rightClick(imageParams());
+
+    expect(popupMock).toHaveBeenCalledWith({ window: undefined });
+  });
+});

--- a/clients/macos/src/main/image-context-menu.ts
+++ b/clients/macos/src/main/image-context-menu.ts
@@ -1,0 +1,37 @@
+import { BrowserWindow, Menu, type WebContents } from "electron";
+
+/**
+ * Native right-click menu for images. The web app renders images as plain
+ * `<img>` elements (chat bubbles, attachment previews, artifacts) with no
+ * copy affordance of their own, and Electron shows no context menu unless
+ * the app builds one — so this listener is the clipboard path for images.
+ *
+ * `copyImageAt` copies the decoded bitmap at the click position out of the
+ * renderer, so it works uniformly for `blob:` object URLs and app-protocol
+ * resources — no refetch, no CORS. The item is disabled when the image has
+ * no decodable contents (e.g. a broken image glyph), matching Chromium's
+ * own menu behavior.
+ *
+ * Pages that handle `contextmenu` themselves (`preventDefault()`) never
+ * reach the WebContents `context-menu` event, so in-page custom menus are
+ * unaffected by construction.
+ */
+export const installImageContextMenu = (contents: WebContents): void => {
+  contents.on("context-menu", (_event, params) => {
+    if (params.mediaType !== "image") {
+      return;
+    }
+    const menu = Menu.buildFromTemplate([
+      {
+        label: "Copy Image",
+        enabled: params.hasImageContents,
+        click: () => contents.copyImageAt(params.x, params.y),
+      },
+    ]);
+    // Anchor to the owning window rather than the focused one — a right-click
+    // in an unfocused auxiliary window (popout, command palette) must pop its
+    // menu there. `fromWebContents` is null for windowless contents; the
+    // undefined fallback lets Electron use the focused window.
+    menu.popup({ window: BrowserWindow.fromWebContents(contents) ?? undefined });
+  });
+};

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -48,6 +48,7 @@ import { installFeedbackIpc } from "./feedback";
 import { installGlobalShortcuts } from "./global-shortcuts";
 import { installHotkeyHelper } from "./hotkey-helper";
 import { installHotkeysIpc } from "./hotkeys";
+import { installImageContextMenu } from "./image-context-menu";
 import { installPopoutWindows } from "./popout-window";
 import { installQuickInput } from "./quick-input-window";
 import { installLocalMode, resolveCliInvocation } from "./local-mode";
@@ -486,6 +487,10 @@ app.on("web-contents-created", (_event, contents) => {
   // exceed the default 10-listener cap per WebContents, triggering a spurious
   // MaxListenersExceededWarning. Bump the limit to silence it.
   contents.setMaxListeners(20);
+
+  // Right-click on an image → native "Copy Image" menu. Wired here so every
+  // surface (main window, popouts, command palette, child popups) gets it.
+  installImageContextMenu(contents);
 
   // Mirror renderer console output (info and up) into the main log file.
   // The packaged app has no devtools, so without this the renderer's


### PR DESCRIPTION
## Summary
- Add `installImageContextMenu` in the Electron main process: a `context-menu` WebContents listener that pops a native **Copy Image** menu (via `webContents.copyImageAt(x, y)`) when right-clicking an image, disabled when the image has no decodable contents — matching Chromium's own menu behavior.
- Wire it in the global `web-contents-created` handler in `index.ts` so every surface (main window, popouts, command palette, child popups) gets it.
- Unit tests cover menu shape, click→`copyImageAt` coordinates, non-image suppression, the disabled state, and owning-window anchoring.

## Original prompt
In the Vellum desktop (Electron) app there was no way to copy an image from chat to the clipboard: the attachment preview modal only offers Download, and the shell registered no `context-menu` handler, so right-clicking an image showed nothing. Of the two shapes discussed (native right-click menu in the Electron main process vs. a copy button in the web preview modal), the user asked to ship the first — a native right-click → Copy Image menu, which covers every image surface in the desktop app.