### PR TITLE
fix(compaction): bound image manifest to pre-boundary rows on summarize-up-to-here

### DIFF
--- a/assistant/src/__tests__/compactor-image-manifest-trust.test.ts
+++ b/assistant/src/__tests__/compactor-image-manifest-trust.test.ts
@@ -124,3 +124,53 @@ describe("collectImageManifest trust filtering", () => {
     expect(filenames).not.toContain("guardian-secret.png");
   });
 });
+
+describe("collectImageManifest fixed-boundary row bound", () => {
+  beforeEach(resetTables);
+
+  test("endRowIndex excludes images at and after the boundary row", async () => {
+    // GIVEN three image messages (rows 0, 1, 2)
+    const conv = createConversation();
+    await addImageMessage(conv.id, "guardian", "head-1.png");
+    await addImageMessage(conv.id, "guardian", "head-2.png");
+    await addImageMessage(conv.id, "guardian", "tail.png");
+
+    // WHEN the manifest is bounded to rows before index 2
+    const manifest = collectImageManifest(conv.id, "guardian", 2);
+
+    // THEN only head images are offered for retention
+    const filenames = manifest.map((e) => e.filename);
+    expect(filenames).toEqual(["head-1.png", "head-2.png"]);
+  });
+
+  test("omitted endRowIndex keeps the whole-conversation manifest", async () => {
+    // GIVEN two image messages
+    const conv = createConversation();
+    await addImageMessage(conv.id, "guardian", "first.png");
+    await addImageMessage(conv.id, "guardian", "second.png");
+
+    // WHEN the manifest is built without a boundary (auto-compaction path)
+    const manifest = collectImageManifest(conv.id, "guardian");
+
+    // THEN every image is listed
+    expect(manifest.map((e) => e.filename)).toEqual([
+      "first.png",
+      "second.png",
+    ]);
+  });
+
+  test("boundary slices the full row list before the trust filter", async () => {
+    // GIVEN guardian and unknown images interleaved across rows 0-2
+    const conv = createConversation();
+    await addImageMessage(conv.id, "guardian", "guardian-head.png");
+    await addImageMessage(conv.id, "unknown", "visitor-head.png");
+    await addImageMessage(conv.id, "unknown", "visitor-tail.png");
+
+    // WHEN an untrusted manifest is bounded to rows before index 2
+    const manifest = collectImageManifest(conv.id, "unknown", 2);
+
+    // THEN the boundary indexes the unfiltered row list (row 2 sliced away)
+    // and trust filtering still hides the guardian image from row 0
+    expect(manifest.map((e) => e.filename)).toEqual(["visitor-head.png"]);
+  });
+});

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -280,6 +280,14 @@ export interface CompactionRunArgs {
    * `[1, messages.length)` — otherwise the run returns `compacted: false`.
    */
   fixedTailStartIndex?: number;
+  /**
+   * Row-space twin of `fixedTailStartIndex`: index into the conversation's
+   * persisted rows of the first message kept verbatim. Bounds the image
+   * manifest to rows that are actually being summarized away — kept-tail
+   * images stay in context verbatim, so offering them for retention would
+   * only duplicate them. Only meaningful alongside `fixedTailStartIndex`.
+   */
+  fixedBoundaryRowIndex?: number;
 }
 
 export interface CompactionRunResult {
@@ -457,15 +465,23 @@ interface ManifestEntry {
  * `loadFromDb` applies when assembling history — so guardian-only images
  * never enter the manifest and therefore can never be retained back into
  * an untrusted actor's view.
+ *
+ * `endRowIndex` (exclusive, row-space) bounds the walk to rows before a
+ * caller-fixed compaction boundary — images in the kept tail survive
+ * verbatim and must not be offered for retention. The slice happens before
+ * the trust filter because the boundary indexes the full row list.
  */
 export function collectImageManifest(
   conversationId: string,
   actorTrustClass?: TrustClass,
+  endRowIndex?: number,
 ): ManifestEntry[] {
   const allRows = getMessages(conversationId);
+  const boundedRows =
+    endRowIndex != null ? allRows.slice(0, endRowIndex) : allRows;
   const rows = !resolveCapabilities(actorTrustClass).canAccessMemory
-    ? filterMessagesForUntrustedActor(allRows)
-    : allRows;
+    ? filterMessagesForUntrustedActor(boundedRows)
+    : boundedRows;
   const entries: ManifestEntry[] = [];
   for (const row of rows) {
     const atts = getAttachmentMetadataForMessage(row.id);
@@ -1096,10 +1112,12 @@ export async function runAssistantDrivenCompaction(
   // Build image manifest from the DB before invoking the model so the
   // instruction message carries a faithful picture of available images.
   // Filtered by actor trust so untrusted turns never see guardian-only
-  // attachments.
+  // attachments, and bounded to pre-boundary rows on fixed-boundary runs
+  // so kept-tail images are never offered for retention.
   const manifest = collectImageManifest(
     args.conversationId,
     args.actorTrustClass,
+    fixedTailStartIndex != null ? args.fixedBoundaryRowIndex : undefined,
   );
   const manifestText = renderImageManifest(manifest);
   const instruction = buildInstructionMessage(

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2011,6 +2011,7 @@ export class Conversation {
       }
       return await this.runCompaction(true, undefined, {
         fixedTailStartIndex: tailIndex,
+        fixedBoundaryRowIndex: boundaryRowIndex,
         // Slack projections gate on the persisted watermark, not on
         // `contextCompactedMessageCount` — without an advance, the summarized
         // rows would reappear verbatim in the projection alongside the new
@@ -2062,6 +2063,8 @@ export class Conversation {
    * `/compact`); without it the manager no-ops below the threshold.
    * `opts.fixedTailStartIndex` pins the kept tail to a caller-chosen history
    * index ("summarize up to here") instead of the token-budget cut;
+   * `opts.fixedBoundaryRowIndex` is the same boundary in row space, which
+   * bounds the compactor's image manifest to rows being summarized away;
    * `opts.fixedBoundarySlackWatermarkTs` is that path's row-space-derived
    * Slack watermark (the auto/forced Slack path derives its own from the
    * chronological projection).
@@ -2071,6 +2074,7 @@ export class Conversation {
     sizing?: CompactionSizing,
     opts?: {
       fixedTailStartIndex?: number;
+      fixedBoundaryRowIndex?: number;
       fixedBoundarySlackWatermarkTs?: string | null;
     },
   ): Promise<ContextWindowResult> {
@@ -2132,6 +2136,7 @@ export class Conversation {
       overrideProfile,
       actorTrustClass: this.trustContext?.trustClass,
       fixedTailStartIndex: opts?.fixedTailStartIndex,
+      fixedBoundaryRowIndex: opts?.fixedBoundaryRowIndex,
     });
     // Track circuit-breaker state for every compaction that ran a summary
     // call — user-initiated `/compact`, other forced paths, and the wake's

--- a/assistant/src/plugins/defaults/compaction/compact.ts
+++ b/assistant/src/plugins/defaults/compaction/compact.ts
@@ -58,6 +58,12 @@ export interface CompactionContext {
    */
   fixedTailStartIndex?: number;
   /**
+   * Row-space twin of `fixedTailStartIndex` — bounds the compactor's image
+   * manifest to rows before the user-chosen boundary so kept-tail images
+   * are never offered for retention.
+   */
+  fixedBoundaryRowIndex?: number;
+  /**
    * Set when this compaction is recovering from a provider context-overflow
    * rejection rather than the ordinary auto-threshold trip. Its presence
    * routes the request through the manager's reduction ladder (which escalates

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -169,6 +169,12 @@ export interface ContextWindowCompactOptions {
    * for range validation).
    */
   fixedTailStartIndex?: number;
+  /**
+   * Row-space twin of `fixedTailStartIndex` — bounds the compactor's image
+   * manifest to rows before the user-chosen boundary. See
+   * {@link CompactionRunArgs.fixedBoundaryRowIndex}.
+   */
+  fixedBoundaryRowIndex?: number;
 }
 
 export interface EmergencyCompactOptions {
@@ -766,6 +772,7 @@ export class ContextWindowManager {
         ...buildBaseArgs(),
         force: true,
         fixedTailStartIndex: options.fixedTailStartIndex,
+        fixedBoundaryRowIndex: options.fixedBoundaryRowIndex,
       });
       if (!result.compacted) return result;
       return {


### PR DESCRIPTION
## Summary
- `collectImageManifest` accepts an exclusive `endRowIndex` and slices the row walk before trust filtering, so a caller-fixed compaction boundary bounds the manifest to rows actually being summarized away
- Thread `fixedBoundaryRowIndex` (row-space twin of `fixedTailStartIndex`) from `summarizeUpToMessage` through `runCompaction` → `CompactionContext` → `ContextWindowCompactOptions` → `CompactionRunArgs`
- Auto-compaction is unchanged: without a fixed boundary the model picks the cut, so the whole-conversation manifest remains correct there

## Original prompt
User ran the new summarize-up-to-here action and the compaction prompt's IMAGE MANIFEST listed all 15 conversation images even though most were after the chosen boundary — the model dutifully listed them in `<retained_images>`, re-injecting 13 images that the kept tail already contains verbatim (duplicate image payloads in context every subsequent turn). Fix: only offer pre-boundary images for retention on fixed-boundary compactions.