### PR TITLE
feat(chat): render canned status cards as standalone system notices

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -18799,6 +18799,8 @@ paths:
                             - output
                             - completedAt
                           additionalProperties: false
+                        systemCard:
+                          type: boolean
                         slackMessage:
                           type: object
                           properties:

--- a/assistant/src/__tests__/conversation-summarize-route.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-route.test.ts
@@ -3,8 +3,8 @@
  *
  * Validates that:
  * - The route 202s immediately and runs summarization async, persisting a
- *   result card via the canned-message path (assistant_text_delta +
- *   message_complete) exactly like the /compact branch.
+ *   system-card result row via the canned-message path (message_complete +
+ *   sync invalidation, no text delta) exactly like the /compact branch.
  * - Busy conversations are rejected with 409 without touching processing.
  * - Boundary UserErrors surface as a "Summarization skipped" card, not a
  *   conversation_error.
@@ -256,21 +256,24 @@ describe("POST /v1/conversations/summarize", () => {
     expect(convId).toBe("conv-summarize-test");
     expect(role).toBe("assistant");
     expect(content).toContain("Conversation summarized");
-    // Metadata mirrors the /compact card shape (channel keys + provenance);
+    // Metadata mirrors the /compact card shape (channel keys + provenance)
+    // plus the system-card marker that keeps the row a standalone notice;
     // interface keys are omitted because the route receives no interface id.
     expect(options?.metadata).toEqual({
       provenanceTrustClass: "unknown",
       userMessageChannel: "vellum",
       assistantMessageChannel: "vellum",
+      messageKind: "system_card",
     });
     expect(ctx.messages).toHaveLength(1);
 
-    // Turn-style SSE events: full text delta, then message_complete with the
-    // persisted assistant id (what the web client renders live).
+    // Cards are announced via message_complete + the messages-changed sync
+    // invalidation — never a text delta, which would stream the card into
+    // the tail assistant bubble as persona speech.
     const delta = broadcastEvents.find(
       (e) => e.type === "assistant_text_delta",
     );
-    expect(String(delta?.text)).toContain("Conversation summarized");
+    expect(delta).toBeUndefined();
     const complete = broadcastEvents.find((e) => e.type === "message_complete");
     expect(complete?.messageId).toBe("persisted-assistant-id");
     expect(publishConversationMessagesChangedMock).toHaveBeenCalledWith(

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -572,6 +572,11 @@ export const ConversationMessageSchema = z.object({
    *  (the in-memory completed ring does not survive restarts). `id` equals the
    *  spawning tool call's `{backgrounded,id}` id. */
   backgroundToolCompletion: BackgroundToolCompletionSchema.optional(),
+  /** Set on daemon-authored status cards (the /compact, /clean, and
+   *  summarize-up-to results). Clients render these rows as standalone
+   *  system notices — no avatar, no persona bubble — and never group them
+   *  with adjacent assistant turns. */
+  systemCard: z.boolean().optional(),
   slackMessage: ConversationSlackMessageSchema.optional(),
   /**
    * Queue state for a user message that is still waiting in the daemon's

--- a/assistant/src/conversations/__tests__/message-consolidation.test.ts
+++ b/assistant/src/conversations/__tests__/message-consolidation.test.ts
@@ -333,3 +333,51 @@ describe("mergeConsecutiveAssistantMessages", () => {
     expect(result).toHaveLength(3);
   });
 });
+
+describe("system-card boundaries", () => {
+  const cardMeta = JSON.stringify({ messageKind: "system_card" });
+
+  test("a card never merges into the preceding assistant run", () => {
+    const { messages } = mergeConsecutiveAssistantMessages([
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "reply" }])),
+      makeMsg(
+        "assistant",
+        JSON.stringify([{ type: "text", text: "**Conversation summarized**" }]),
+        { metadata: cardMeta },
+      ),
+    ]);
+    expect(messages).toHaveLength(2);
+  });
+
+  test("an assistant row never merges into a preceding card", () => {
+    const { messages } = mergeConsecutiveAssistantMessages([
+      makeMsg(
+        "assistant",
+        JSON.stringify([{ type: "text", text: "**Context Cleaned**" }]),
+        { metadata: cardMeta },
+      ),
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "reply" }])),
+    ]);
+    expect(messages).toHaveLength(2);
+  });
+
+  test("findDisplayTurnEndIndex treats a card as a single-row turn", () => {
+    const rows = [
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "card" }]), {
+        metadata: cardMeta,
+      }),
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "reply" }])),
+    ];
+    expect(findDisplayTurnEndIndex(rows, 0)).toBe(0);
+  });
+
+  test("findDisplayTurnEndIndex stops an assistant run before a card", () => {
+    const rows = [
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "reply" }])),
+      makeMsg("assistant", JSON.stringify([{ type: "text", text: "card" }]), {
+        metadata: cardMeta,
+      }),
+    ];
+    expect(findDisplayTurnEndIndex(rows, 0)).toBe(0);
+  });
+});

--- a/assistant/src/conversations/message-consolidation.ts
+++ b/assistant/src/conversations/message-consolidation.ts
@@ -32,10 +32,30 @@
  */
 
 import type { MessageRow } from "../persistence/conversation-crud.js";
+import { isSystemCardMetadata } from "../persistence/conversation-crud.js";
 import type { ContentBlock } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("message-consolidation");
+
+/**
+ * True when a row is a daemon-authored system card (`messageKind:
+ * "system_card"` metadata). Cards are standalone display turns: they never
+ * fold into an adjacent assistant run and adjacent assistant rows never
+ * fold into them.
+ */
+export function isSystemCardRow(msg: MessageRow): boolean {
+  if (msg.role !== "assistant" || !msg.metadata) {
+    return false;
+  }
+  try {
+    return isSystemCardMetadata(
+      JSON.parse(msg.metadata) as Record<string, unknown>,
+    );
+  } catch {
+    return false;
+  }
+}
 
 // ── Block predicates ────────────────────────────────────────────────
 
@@ -109,6 +129,10 @@ export function findDisplayTurnEndIndex(
   if (messages[startIdx]?.role !== "assistant") {
     return startIdx;
   }
+  // A system card is a single-row display turn — never spans neighbours.
+  if (isSystemCardRow(messages[startIdx]!)) {
+    return startIdx;
+  }
 
   let endIdx = startIdx;
   while (endIdx + 1 < messages.length) {
@@ -116,7 +140,7 @@ export function findDisplayTurnEndIndex(
     if (!next) {
       break;
     }
-    if (next.role === "assistant") {
+    if (next.role === "assistant" && !isSystemCardRow(next)) {
       endIdx += 1;
       continue;
     }
@@ -282,10 +306,15 @@ export function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
 
   for (const msg of messages) {
     const lastIdx = result.length - 1;
+    // System cards stay standalone in both directions: a card never folds
+    // into the preceding assistant run, and the following assistant row
+    // never folds into a card.
     const isConsecutiveAssistant =
       msg.role === "assistant" &&
+      !isSystemCardRow(msg) &&
       lastIdx >= 0 &&
-      result[lastIdx].role === "assistant";
+      result[lastIdx].role === "assistant" &&
+      !isSystemCardRow(result[lastIdx]);
 
     if (!isConsecutiveAssistant) {
       result.push(msg);

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -237,6 +237,14 @@ export const messageMetadataSchema = z
      */
     hidden: z.boolean().optional(),
     /**
+     * Discriminates daemon-authored rows from ordinary turns.
+     * `"system_card"` marks pre-composed status cards (the /compact, /clean,
+     * and summarize-up-to results); see {@link SYSTEM_CARD_MESSAGE_KIND}.
+     * Kept as a plain string so unknown future kinds never fail metadata
+     * validation.
+     */
+    messageKind: z.string().optional(),
+    /**
      * Structured terminal record stamped onto a `<background_event
      * source="background-tool">` wake so the web can rebuild the inline
      * bash/host_bash card from history after a daemon restart.
@@ -289,6 +297,27 @@ export function isHiddenMessageMetadata(
   metadata: Record<string, unknown> | null | undefined,
 ): boolean {
   return metadata?.hidden === true;
+}
+
+/**
+ * `messageKind` value marking a daemon-authored system card — a pre-composed
+ * status reply (the /compact, /clean, and summarize-up-to result cards) that
+ * bypasses the agent loop. Cards render as standalone system notices, never
+ * as the assistant persona speaking, and never merge into adjacent assistant
+ * display turns.
+ */
+export const SYSTEM_CARD_MESSAGE_KIND = "system_card";
+
+/**
+ * Shared predicate for the system-card marker on assistant-message metadata
+ * (see the `messageKind` field on {@link messageMetadataSchema}). One
+ * definition so display merging, transcript rendering, and turn grouping
+ * cannot drift.
+ */
+export function isSystemCardMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  return metadata?.messageKind === SYSTEM_CARD_MESSAGE_KIND;
 }
 
 /**

--- a/assistant/src/runtime/routes/canned-message-complete.ts
+++ b/assistant/src/runtime/routes/canned-message-complete.ts
@@ -3,6 +3,7 @@ import type { ServerMessage } from "../../daemon/message-protocol.js";
 import {
   addMessage,
   recordConversationPersistedSeq,
+  SYSTEM_CARD_MESSAGE_KIND,
 } from "../../persistence/conversation-crud.js";
 import type { Message } from "../../providers/types.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
@@ -40,16 +41,16 @@ export function emitCannedMessageComplete(
 
 /**
  * Persist a canned assistant "card" — a pre-composed reply that bypasses the
- * agent loop (the /compact, /clean, and summarize-up-to result cards) — and
- * emit the turn-style events clients expect for it: the full text as a single
- * `assistant_text_delta`, `message_complete` with the persisted assistant id,
- * the persisted-seq anchor advance (so a stale /messages reseed cannot erase
- * the card), and the messages-changed sync invalidation.
+ * agent loop (the /compact, /clean, and summarize-up-to result cards). The
+ * row is stamped `messageKind: "system_card"` so transcripts render it as a
+ * standalone system notice instead of assistant-persona speech, and display
+ * merging never folds it into an adjacent assistant turn.
  *
- * Callers that interleave other broadcasts between the persist and the
- * delta (the canned greeting and unknown-slash-command paths defer their
- * broadcasts behind the HTTP response with a `user_message_echo` in
- * between) cannot use this helper without reordering their events.
+ * Cards are announced with `message_complete` (persisted assistant id), the
+ * persisted-seq anchor advance (so a stale /messages reseed cannot erase the
+ * card), and the messages-changed sync invalidation that drives the client
+ * refetch. No `assistant_text_delta` is emitted — a delta would stream the
+ * card into the tail assistant bubble as if the persona were speaking.
  */
 export async function persistCannedAssistantCard(opts: {
   conversation: { getMessages(): Message[] };
@@ -64,14 +65,9 @@ export async function persistCannedAssistantCard(opts: {
     conversationId,
     "assistant",
     JSON.stringify(assistantMsg.content),
-    { metadata },
+    { metadata: { ...metadata, messageKind: SYSTEM_CARD_MESSAGE_KIND } },
   );
   conversation.getMessages().push(assistantMsg);
-  broadcastMessage({
-    type: "assistant_text_delta",
-    text,
-    conversationId,
-  });
   emitCannedMessageComplete(
     broadcastMessage,
     conversationId,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -114,6 +114,7 @@ import {
   hasMessages,
   isConversationProcessing,
   isHiddenMessageMetadata,
+  isSystemCardMetadata,
   type MessageRow,
   recordConversationPersistedSeq,
   setConversationInferenceProfile,
@@ -872,11 +873,17 @@ export function handleListMessages({
     let acpNotification: { acpSessionId: string; agent?: string } | undefined;
     let backgroundEventNotification: boolean | undefined;
     let backgroundToolCompletion: ConversationMessage["backgroundToolCompletion"];
+    let systemCard: boolean | undefined;
     if (msg.metadata) {
       try {
         const meta = JSON.parse(msg.metadata);
         if (typeof meta.sentAt === "number") {
           sentAt = meta.sentAt;
+        }
+        // Daemon-authored status cards (compact/clean/summarize results)
+        // render as standalone system notices, not persona speech.
+        if (isSystemCardMetadata(meta)) {
+          systemCard = true;
         }
         // Every wake persists a `<background_event source="...">` trigger row
         // (see `persistWakeTriggerMessage`) that the LLM reads. Flag any such
@@ -949,6 +956,7 @@ export function handleListMessages({
       acpNotification,
       backgroundEventNotification,
       backgroundToolCompletion,
+      systemCard,
       slackMessage,
       clientMessageId: msg.clientMessageId ?? undefined,
     };

--- a/clients/web/src/domains/chat/transcript/system-card-row.tsx
+++ b/clients/web/src/domains/chat/transcript/system-card-row.tsx
@@ -1,0 +1,26 @@
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+/**
+ * Standalone system notice for daemon-authored status cards (the /compact,
+ * /clean, and summarize-up-to results, flagged `isSystemCard`). Renders as a
+ * centered, subdued notice — never as assistant-persona speech: no avatar,
+ * no chat bubble, no hover actions.
+ */
+export function SystemCardRow({ message }: { message: DisplayMessage }) {
+  const blockText = (message.contentBlocks ?? [])
+    .flatMap((b) => (b.type === "text" ? [b.text] : []))
+    .join("\n")
+    .trim();
+  const text = blockText || (message.textSegments ?? []).join("\n").trim();
+  if (!text) {
+    return null;
+  }
+  return (
+    <div data-testid="system-card-row" className="flex justify-center">
+      <div className="max-w-full rounded-[var(--radius-lg)] bg-[var(--surface-overlay)] px-4 py-3 text-body-small-default text-[var(--content-secondary)]">
+        <ChatMarkdownMessage content={text} hardLineBreaks />
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -8,6 +8,7 @@ import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import { PendingConfirmationRow } from "@/domains/chat/transcript/pending-confirmation-row";
 import { PendingContactRequestRow } from "@/domains/chat/transcript/pending-contact-request-row";
 import { PendingSecretRow } from "@/domains/chat/transcript/pending-secret-row";
+import { SystemCardRow } from "@/domains/chat/transcript/system-card-row";
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
 import type { ConfirmationDecision } from "@/types/event-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -108,6 +109,11 @@ export const TranscriptRow = memo(function TranscriptRow({
 }: TranscriptRowProps) {
   switch (item.kind) {
     case "message": {
+      // Daemon-authored status cards render as standalone system notices,
+      // outside the persona bubble/avatar/hover-action machinery.
+      if (item.message.isSystemCard) {
+        return <SystemCardRow message={item.message} />;
+      }
       return (
         <TranscriptMessageBody
           message={item.message}

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -149,6 +149,10 @@ export interface DisplayMessage {
    *  defer/schedule/webhook/background-tool); suppressed from the transcript
    *  like {@link isSubagentNotification} — the wake card shows it instead. */
   isBackgroundEventNotification?: boolean;
+  /** True for daemon-authored status cards (the /compact, /clean, and
+   *  summarize-up-to results). Rendered as a standalone system notice —
+   *  no avatar, no persona bubble — never as assistant speech. */
+  isSystemCard?: boolean;
 }
 
 /**

--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -146,6 +146,18 @@ describe("mapRuntimeToDisplayMessage", () => {
     );
   });
 
+  test("flags a systemCard message as isSystemCard", () => {
+    const plain = makeMessage({ id: "m-plain", role: "assistant" });
+    expect(mapRuntimeToDisplayMessage(plain).isSystemCard).toBeUndefined();
+
+    const m = makeMessage({
+      id: "m-card",
+      role: "assistant",
+      systemCard: true,
+    });
+    expect(mapRuntimeToDisplayMessage(m).isSystemCard).toBe(true);
+  });
+
   test("carries server thinkingSegments and contentOrder onto the display message", () => {
     // GIVEN a persisted assistant message whose reasoning is reconstructed
     // from history as `thinkingSegments` + a `thinking` content-order entry

--- a/clients/web/src/domains/chat/utils/map-runtime-message.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.ts
@@ -161,6 +161,7 @@ export function mapRuntimeToDisplayMessage(
   if (m.subagentNotification) msg.isSubagentNotification = true;
   if (m.acpNotification) msg.isAcpNotification = true;
   if (m.backgroundEventNotification) msg.isBackgroundEventNotification = true;
+  if (m.systemCard) msg.isSystemCard = true;
   if (m.slackMessage) msg.slackMessage = m.slackMessage;
   if (toolCalls) msg.toolCalls = toolCalls;
   if (timestamp != null) msg.timestamp = timestamp;


### PR DESCRIPTION
## Summary
- `persistCannedAssistantCard` stamps `messageKind: "system_card"` metadata and no longer broadcasts a fake `assistant_text_delta` — cards announce via `message_complete` + the messages-changed sync invalidation (old clients degrade gracefully to showing the card on refetch)
- System cards are excluded from consecutive-assistant display merging and `findDisplayTurnEndIndex` treats them as single-row turns, so they never fold into the persona's turns (shared predicate `isSystemCardMetadata` in `conversation-crud.ts`)
- The messages endpoint serializes a `systemCard` flag; the web transcript renders flagged rows via a new `SystemCardRow` — centered subdued notice, no avatar, no persona bubble, no hover actions

## Original prompt
After running summarize-up-to-here, the result card ("Conversation summarized — 64 earlier messages…") streamed into the assistant persona's latest bubble mid-sentence and rendered as her speech, which looked broken. Requested fix: give daemon-authored status cards a distinct metadata kind and render them as standalone system notices instead of appending them to the latest assistant message.