### PR TITLE
feat(ui-surface): teach ui_show shapes at point of use via validation errors

### DIFF
--- a/assistant/src/__tests__/ui-shape-teaching.test.ts
+++ b/assistant/src/__tests__/ui-shape-teaching.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+import { uiShowTool } from "../tools/ui-surface/definitions.js";
+import {
+  SURFACE_SHAPE_DOCS,
+  SURFACE_TYPE_NAMES,
+  uiShowTeachingError,
+} from "../tools/ui-surface/surface-shape-docs.js";
+
+function makeContext(onProxy?: () => void): ToolContext {
+  return {
+    conversationId: "conversation-123",
+    workingDir: "/tmp",
+    trustClass: "guardian",
+    proxyToolResolver: async (): Promise<ToolExecutionResult> => {
+      onProxy?.();
+      return { content: "Surface displayed", isError: false };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Schema enum derivation
+// ---------------------------------------------------------------------------
+
+describe("surface_type enum derivation", () => {
+  test("input_schema enum is derived from SURFACE_SHAPE_DOCS", () => {
+    const surfaceTypeEnum = (
+      uiShowTool.input_schema as {
+        properties: { surface_type: { enum: string[] } };
+      }
+    ).properties.surface_type.enum;
+
+    expect(surfaceTypeEnum).toEqual(SURFACE_TYPE_NAMES);
+    expect(surfaceTypeEnum).toContain("card");
+    expect(surfaceTypeEnum).toContain("dynamic_page");
+    expect(surfaceTypeEnum.length).toBe(Object.keys(SURFACE_SHAPE_DOCS).length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown / missing surface_type
+// ---------------------------------------------------------------------------
+
+describe("ui_show unknown surface_type teaching", () => {
+  test("missing surface_type returns the type index without proxying", async () => {
+    let proxied = false;
+    const result = await uiShowTool.execute(
+      { data: { title: "Hi" } },
+      makeContext(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("`surface_type` is missing");
+    expect(result.content).toContain("card (");
+    expect(result.content).toContain("channel_setup");
+    expect(proxied).toBe(false);
+  });
+
+  test("prototype-chain keys are not surface types", async () => {
+    let proxied = false;
+    const result = await uiShowTool.execute(
+      { surface_type: "toString", data: {} },
+      makeContext(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"toString" is not a surface type');
+    expect(proxied).toBe(false);
+  });
+
+  test("unknown surface_type names the bad value and lists valid types", async () => {
+    let proxied = false;
+    const result = await uiShowTool.execute(
+      { surface_type: "banner", data: { title: "Hi" } },
+      makeContext(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"banner" is not a surface type');
+    expect(result.content).toContain("work_result");
+    expect(proxied).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing essential content per type
+// ---------------------------------------------------------------------------
+
+describe("ui_show missing-content teaching", () => {
+  const cases: Array<{
+    surfaceType: string;
+    data: Record<string, unknown>;
+    expectInError: string;
+  }> = [
+    {
+      surfaceType: "copy_block",
+      data: {},
+      expectInError: "{ text, label?, language? }",
+    },
+    {
+      surfaceType: "copy_block",
+      data: { text: "   " },
+      expectInError: "`data.text`",
+    },
+    {
+      surfaceType: "choice",
+      data: { options: [] },
+      expectInError: "recommended",
+    },
+    {
+      surfaceType: "table",
+      data: { rows: [] },
+      expectInError: "`data.columns`",
+    },
+    { surfaceType: "form", data: {}, expectInError: "`data.fields`" },
+    { surfaceType: "confirmation", data: {}, expectInError: "confirmLabel" },
+    { surfaceType: "list", data: { items: [] }, expectInError: "`data.items`" },
+    { surfaceType: "work_result", data: {}, expectInError: "summary" },
+    { surfaceType: "oauth_connect", data: {}, expectInError: "providerKey" },
+    {
+      surfaceType: "channel_setup",
+      data: { channel: "email" },
+      expectInError: '"slack", "telegram", "phone"',
+    },
+  ];
+
+  for (const { surfaceType, data, expectInError } of cases) {
+    test(`${surfaceType} without essential content returns its shape`, async () => {
+      let proxied = false;
+      const result = await uiShowTool.execute(
+        { surface_type: surfaceType, data },
+        makeContext(() => {
+          proxied = true;
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(
+        `ui_show ${surfaceType} was not displayed`,
+      );
+      expect(result.content).toContain(expectInError);
+      expect(result.content).toContain(SURFACE_SHAPE_DOCS[surfaceType]!.shape);
+      expect(proxied).toBe(false);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Displayable payloads pass through untouched
+// ---------------------------------------------------------------------------
+
+describe("ui_show displayable payloads proxy through", () => {
+  const cases: Array<{ surfaceType: string; input: Record<string, unknown> }> =
+    [
+      {
+        surfaceType: "choice",
+        input: {
+          surface_type: "choice",
+          data: { options: [{ id: "a", title: "Option A" }] },
+        },
+      },
+      {
+        surfaceType:
+          "card (lenient — top-level fields are normalized downstream)",
+        input: { surface_type: "card", title: "Status", data: {} },
+      },
+      {
+        surfaceType: "task_preferences",
+        input: { surface_type: "task_preferences", data: {} },
+      },
+      {
+        surfaceType: "file_upload",
+        input: { surface_type: "file_upload", data: {} },
+      },
+      {
+        surfaceType: "channel_setup",
+        input: { surface_type: "channel_setup", data: { channel: "telegram" } },
+      },
+    ];
+
+  for (const { surfaceType, input } of cases) {
+    test(`${surfaceType} proxies`, async () => {
+      let proxied = false;
+      const result = await uiShowTool.execute(
+        input,
+        makeContext(() => {
+          proxied = true;
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(proxied).toBe(true);
+    });
+  }
+
+  test("empty dynamic_page still gets the bespoke html envelope, not the generic one", async () => {
+    const result = await uiShowTool.execute(
+      { surface_type: "dynamic_page", data: {} },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("requires non-empty HTML in `data.html`");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// uiShowTeachingError unit behavior
+// ---------------------------------------------------------------------------
+
+describe("uiShowTeachingError", () => {
+  test("returns null for a known type with no guard", () => {
+    expect(uiShowTeachingError({ surface_type: "card", data: {} })).toBeNull();
+  });
+
+  test("treats a non-object data payload as empty", () => {
+    const error = uiShowTeachingError({
+      surface_type: "confirmation",
+      data: "delete it?",
+    });
+    expect(error).toContain("`data.message`");
+  });
+
+  test("every documented type has a purpose and shape", () => {
+    for (const name of SURFACE_TYPE_NAMES) {
+      expect(SURFACE_SHAPE_DOCS[name]!.purpose.length).toBeGreaterThan(0);
+      expect(SURFACE_SHAPE_DOCS[name]!.shape.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -15,6 +15,12 @@ import type {
   ToolDefinition,
   ToolExecutionResult,
 } from "../types.js";
+import {
+  asRecord,
+  hasContent,
+  SURFACE_TYPE_NAMES,
+  uiShowTeachingError,
+} from "./surface-shape-docs.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -36,6 +42,13 @@ function proxyExecute(toolName: string) {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> => {
+    if (toolName === "ui_show") {
+      const teachingError = uiShowTeachingError(input);
+      if (teachingError !== null) {
+        return { content: teachingError, isError: true };
+      }
+    }
+
     if (toolName === "ui_show" && isEmptyDynamicPage(input)) {
       return {
         content: isWeakOpenModel(context.attribution?.resolvedModel)
@@ -135,22 +148,6 @@ function isEmptyUpdate(input: Record<string, unknown>): boolean {
   return data === null || !hasContent(data);
 }
 
-function hasContent(value: unknown): boolean {
-  if (value === null || value === undefined) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return value.length > 0;
-  }
-  if (typeof value === "object") {
-    return Object.values(value).some(hasContent);
-  }
-  if (typeof value === "string") {
-    return value.trim().length > 0;
-  }
-  return true;
-}
-
 function isEmptyDynamicPage(input: Record<string, unknown>): boolean {
   if (input.surface_type !== "dynamic_page") {
     return false;
@@ -211,12 +208,6 @@ function collectRoutingText(input: Record<string, unknown>): string[] {
   return values;
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object"
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
 function addString(values: string[], value: unknown): void {
   if (typeof value === "string") {
     values.push(value);
@@ -255,21 +246,7 @@ export const uiShowTool = {
     properties: {
       surface_type: {
         type: "string",
-        enum: [
-          "card",
-          "channel_setup",
-          "choice",
-          "copy_block",
-          "oauth_connect",
-          "form",
-          "list",
-          "table",
-          "confirmation",
-          "dynamic_page",
-          "file_upload",
-          "task_preferences",
-          "work_result",
-        ],
+        enum: SURFACE_TYPE_NAMES,
         description: "The type of surface to display",
       },
       title: {

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -1,0 +1,207 @@
+/**
+ * Point-of-use shape documentation and essential-content guards for ui_show
+ * surfaces.
+ *
+ * Each entry documents one surface type: a one-phrase `purpose` (used in the
+ * unknown-type index error) and the full data `shape` spec (returned inside a
+ * teaching error when a payload is missing its load-bearing content). Keeping
+ * the specs here rather than in the always-present tool description lets the
+ * model recover the exact shape at the moment it gets one wrong.
+ *
+ * Guards are advisory and intentionally minimal: they check only the fields
+ * without which the surface renders blank or broken (mirroring the tolerant
+ * contract in `api/surfaces.ts` — a renderable payload must never be
+ * rejected). Normalization the daemon already performs (e.g. top-level
+ * `template`/`title` lifted into card data by `normalizeCardShowData`) must
+ * stay accepted, so card has no guard here.
+ */
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Whether a value carries any renderable content: a non-empty string, a
+ * non-empty array, a non-empty primitive, or an object with at least one
+ * content-bearing value (recursively).
+ */
+export function hasContent(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "object") {
+    return Object.values(value).some(hasContent);
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  return true;
+}
+
+function isNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isNonEmptyArray(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0;
+}
+
+interface SurfaceShapeDoc {
+  /** One-phrase purpose, shown in the unknown-surface_type index error. */
+  purpose: string;
+  /** Full `data` shape spec, shown in per-type teaching errors. */
+  shape: string;
+  /**
+   * Returns a description of the missing load-bearing content, or null when
+   * the payload has enough to render. Absent for types the daemon normalizes
+   * leniently (card), that render fine with defaults (file_upload,
+   * task_preferences), or that have bespoke handling (dynamic_page).
+   */
+  missingContent?: (data: Record<string, unknown>) => string | null;
+}
+
+export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
+  card: {
+    purpose: "structured info card, supports templates like task_progress",
+    shape:
+      '{ title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Templates: "task_progress" (live step tracker — update via ui_update on data.templateData; shape: { title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] }), "weather_forecast" (native weather widget)',
+  },
+  copy_block: {
+    purpose: "copyable text with a visible copy button",
+    shape: "{ text, label?, language? }",
+    missingContent: (data) =>
+      isNonEmptyString(data.text)
+        ? null
+        : "`data.text` must be a non-empty string",
+  },
+  choice: {
+    purpose: "clickable options for the user to pick from",
+    shape:
+      '{ description?, options: [{ id, title, description?, recommended?, data? }], selectionMode?: "single"|"multiple", commitOnSelect?, submitLabel? }. Single-select choices commit on option click by default; mark the strongest option with recommended: true',
+    missingContent: (data) =>
+      isNonEmptyArray(data.options)
+        ? null
+        : "`data.options` must be a non-empty array",
+  },
+  table: {
+    purpose: "tabular data, optionally with selectable rows",
+    shape:
+      '{ columns: [{ id, label }], rows: [{ id, cells: Record<columnId, string | { text, icon?, iconColor?: "success"|"warning"|"error"|"muted" }>, selectable?, selected? }], selectionMode?: "none"|"single"|"multiple", caption? }',
+    missingContent: (data) =>
+      isNonEmptyArray(data.columns)
+        ? null
+        : "`data.columns` must be a non-empty array",
+  },
+  work_result: {
+    purpose: "structured receipt after completed work",
+    shape:
+      '{ eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] }',
+    missingContent: (data) =>
+      hasContent(data)
+        ? null
+        : "`data` must carry at least a summary, metrics, or sections",
+  },
+  oauth_connect: {
+    purpose: "managed OAuth connection button for an integration account",
+    shape:
+      "{ providerKey, displayName?, description?, logoUrl? }. Do not include OAuth scopes; managed providers use the platform's configured scopes",
+    missingContent: (data) =>
+      isNonEmptyString(data.providerKey)
+        ? null
+        : "`data.providerKey` must name the provider to connect",
+  },
+  form: {
+    purpose: "input form, single or multi-page",
+    shape:
+      '{ description?, fields: [{ id, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label, placeholder?, required?, defaultValue?, options?: [{ label, value }] }], submitLabel? }. Multi-page: { pages: [{ id, title, description?, fields }], pageLabels?: { next?, back?, submit? }, submitLabel? }',
+    missingContent: (data) =>
+      isNonEmptyArray(data.fields) || isNonEmptyArray(data.pages)
+        ? null
+        : "`data.fields` (or `data.pages`) must be a non-empty array",
+  },
+  confirmation: {
+    purpose: "confirm/cancel prompt",
+    shape:
+      "{ message, detail?, confirmLabel?, confirmedLabel?, cancelLabel?, destructive? }",
+    missingContent: (data) =>
+      isNonEmptyString(data.message)
+        ? null
+        : "`data.message` must be a non-empty string",
+  },
+  list: {
+    purpose: "selectable item list",
+    shape:
+      '{ items: [{ id, title, subtitle?, icon?, selected? }], selectionMode: "single"|"multiple"|"none" }',
+    missingContent: (data) =>
+      isNonEmptyArray(data.items)
+        ? null
+        : "`data.items` must be a non-empty array",
+  },
+  file_upload: {
+    purpose: "prompt the user to upload files",
+    shape: "{ prompt, acceptedTypes?, maxFiles? }",
+  },
+  dynamic_page: {
+    purpose: "custom HTML page for transient UI only, never app-like builds",
+    shape:
+      "{ html, width?, height?, preview?: { title, subtitle?, description?, icon?, metrics?: [{ label, value }] } }",
+  },
+  channel_setup: {
+    purpose: "open the Slack/Telegram/Phone setup panel",
+    shape: '{ channel: "slack" | "telegram" | "phone" }',
+    missingContent: (data) =>
+      data.channel === "slack" ||
+      data.channel === "telegram" ||
+      data.channel === "phone"
+        ? null
+        : '`data.channel` must be one of "slack", "telegram", "phone"',
+  },
+  task_preferences: {
+    purpose: "task-preference picker",
+    shape: "{} (no data needed — categories are rendered client-side)",
+  },
+};
+
+/** Model-facing surface_type enum, derived so docs and schema cannot drift. */
+export const SURFACE_TYPE_NAMES = Object.keys(SURFACE_SHAPE_DOCS);
+
+const SURFACE_TYPE_INDEX = SURFACE_TYPE_NAMES.map(
+  (name) => `${name} (${SURFACE_SHAPE_DOCS[name]!.purpose})`,
+).join("; ");
+
+/**
+ * Teaching error for a ui_show payload that would render nothing, or null
+ * when the payload is displayable. Unknown/missing surface_type gets the
+ * full type index; a known type missing its load-bearing content gets that
+ * type's exact shape. dynamic_page emptiness is handled by the bespoke
+ * model-aware envelopes in `definitions.ts`, not here.
+ */
+export function uiShowTeachingError(
+  input: Record<string, unknown>,
+): string | null {
+  const surfaceType = input.surface_type;
+  if (
+    typeof surfaceType !== "string" ||
+    !Object.hasOwn(SURFACE_SHAPE_DOCS, surfaceType)
+  ) {
+    const got =
+      typeof surfaceType === "string" && surfaceType.trim().length > 0
+        ? `"${surfaceType}" is not a surface type`
+        : "`surface_type` is missing";
+    return `Error: ui_show was not displayed — ${got}. Valid types: ${SURFACE_TYPE_INDEX}. Resend ui_show with one of these surface_type values; if a type's data is missing required content, the error will include its exact shape.`;
+  }
+  const doc = SURFACE_SHAPE_DOCS[surfaceType]!;
+  if (!doc.missingContent) {
+    return null;
+  }
+  const missing = doc.missingContent(asRecord(input.data) ?? {});
+  if (missing === null) {
+    return null;
+  }
+  return `Error: ui_show ${surfaceType} was not displayed — ${missing}, so the user saw nothing. Data shape: ${doc.shape}. Resend ui_show with the missing content filled in.`;
+}


### PR DESCRIPTION
## Summary
- Adds `assistant/src/tools/ui-surface/surface-shape-docs.ts`: per-surface-type purpose lines, full data-shape specs, and minimal essential-content guards, plus `uiShowTeachingError()` which turns a would-render-blank `ui_show` into a teaching error carrying the exact shape.
- Wires the teaching check into `proxyExecute` ahead of the existing bespoke envelopes: missing/unknown `surface_type` returns the full type index (previously flowed to the client unchecked and vanished — ~25 such calls in 14d of fleet telemetry); a known type missing its load-bearing field (e.g. `choice` without `options`) returns that type's shape spec.
- Derives the `surface_type` schema enum from the docs map so docs and enum cannot drift; moves `asRecord`/`hasContent` into the new module. Card stays lenient (top-level `template`/`title` are normalized by `normalizeCardShowData`, so no guard), and empty `dynamic_page` keeps its model-aware envelopes.

Guards deliberately do NOT live as strict zod in `api/surfaces.ts` — that file's contract is tolerance at render time ("must never reject a real payload"); these are advisory pre-flight checks at the tool boundary that only fire when the surface would render blank.

This is PR 1 of 4 of the UI-surface-tools token reduction plan: it lands the point-of-use recovery path first, so a follow-up can slim the always-present `ui_show` description (~1,660 tokens today) without stranding the model on cold surface types.

## Original prompt
Fleet telemetry showed the three UI surface tools cost ~1,870 tokens on every request while ~78% of `ui_show` usage is three shapes, and the 13-type inline docs still produce malformed calls. The user approved a 4-PR reduction plan (teach-on-error backstop → slim docs → Slack-specific variant → rail-conditional `activation_moment`) and asked to execute all four in sequence via `/do`. This PR is step 1: add point-of-use shape docs and teaching errors to the `ui_show` execute path, keeping card lenient and existing dynamic_page envelopes intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)