### PR TITLE
fix(chat): show progress indicator for summarize-up-to-here

### DIFF
--- a/assistant/src/__tests__/conversation-summarize-route.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-route.test.ts
@@ -249,6 +249,12 @@ describe("POST /v1/conversations/summarize", () => {
       "context_compacting",
       { statusText: "Summarizing conversation" },
     );
+    // The thinking activity gets a paired terminal so a client that started
+    // an indicator from it always clears.
+    expect(ctx.emitActivityState).toHaveBeenLastCalledWith(
+      "idle",
+      "message_complete",
+    );
 
     // Card persisted as an assistant message and pushed onto in-memory history.
     expect(addMessageMock).toHaveBeenCalledTimes(1);
@@ -413,6 +419,12 @@ describe("POST /v1/conversations/summarize", () => {
     expect(error?.code).toBe("UNKNOWN");
     expect(error?.retryable).toBe(true);
     expect(String(error?.userMessage)).toContain("summary call exploded");
+    // No card means no message_complete — the idle activity emit is the only
+    // terminal signal clearing a client-side indicator on this path.
+    expect(ctx.emitActivityState).toHaveBeenLastCalledWith(
+      "idle",
+      "error_terminal",
+    );
     expect(ctx.conversation.isProcessing()).toBe(false);
     expect(ctx.drainQueue).toHaveBeenCalledTimes(1);
   });

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -260,6 +260,13 @@ async function handleSummarizeConversation({
   // all emitted inside the shared compaction write path — only the result
   // card is the route's responsibility.
   (async () => {
+    // The paired terminal for the thinking activity emitted below. Clients
+    // that started an indicator from the thinking event need a definitive
+    // idle — the result card's `message_complete` covers the happy path,
+    // but the hard-error path persists no card, so the idle emit in
+    // `finally` is what guarantees the indicator always clears.
+    let terminalReason: "message_complete" | "error_terminal" =
+      "message_complete";
     try {
       conversation.emitActivityState("thinking", "context_compacting", {
         statusText: "Summarizing conversation",
@@ -277,6 +284,7 @@ async function handleSummarizeConversation({
           err = cardErr;
         }
       }
+      terminalReason = "error_terminal";
       log.error({ err, conversationId }, "Summarize command failed");
       broadcastMessage({
         type: "conversation_error",
@@ -286,6 +294,7 @@ async function handleSummarizeConversation({
         retryable: true,
       });
     } finally {
+      conversation.emitActivityState("idle", terminalReason);
       conversation.setProcessing(false);
       silentlyWithLog(
         conversation.drainQueue(),

--- a/clients/web/src/domains/chat/turn-store.test.ts
+++ b/clients/web/src/domains/chat/turn-store.test.ts
@@ -429,6 +429,28 @@ describe("ACTIVITY_STATE_THINKING", () => {
     expect(state).toBe(INITIAL_TURN_STATE);
   });
 
+  test("starts server-driven activity from idle when canStartFromIdle", () => {
+    const state = turnReducer(INITIAL_TURN_STATE, {
+      type: "ACTIVITY_STATE_THINKING",
+      statusText: "Summarizing conversation",
+      canStartFromIdle: true,
+    });
+    expect(state.phase).toBe("thinking");
+    expect(state.statusText).toBe("Summarizing conversation");
+    expect(state.activeTurnId).toBeNull();
+  });
+
+  test("server-driven activity still tears down on turn completion", () => {
+    const thinking = turnReducer(INITIAL_TURN_STATE, {
+      type: "ACTIVITY_STATE_THINKING",
+      statusText: "Summarizing conversation",
+      canStartFromIdle: true,
+    });
+    const state = turnReducer(thinking, { type: "MESSAGE_COMPLETE" });
+    expect(state.phase).toBe("idle");
+    expect(state.statusText).toBeNull();
+  });
+
   test("is discarded when errored with null activeTurnId", () => {
     const errored: TurnState = {
       ...INITIAL_TURN_STATE,

--- a/clients/web/src/domains/chat/turn-store.ts
+++ b/clients/web/src/domains/chat/turn-store.ts
@@ -126,6 +126,8 @@ export interface ToolActivityMetadataEvent {
 export interface ActivityStateThinking {
   type: "ACTIVITY_STATE_THINKING";
   statusText?: string;
+  /** Mirrors `onActivityThinking`'s `canStartFromIdle` option. */
+  canStartFromIdle?: boolean;
 }
 
 export interface UISurfaceShow {
@@ -253,7 +255,16 @@ export interface TurnActions {
     toolUseId: string,
     metadata: ToolActivityMetadata,
   ) => void;
-  onActivityThinking: (statusText?: string) => void;
+  onActivityThinking: (
+    statusText?: string,
+    opts?: {
+      /** Allow the thinking signal to START activity from an idle turn
+       *  store. Set by the stream handler only when the event belongs to
+       *  the ACTIVE conversation — daemon-initiated work (e.g. summarize
+       *  up to here) reports thinking without a client-initiated turn. */
+      canStartFromIdle?: boolean;
+    },
+  ) => void;
   showSurface: (interactive?: boolean) => void;
   updateSurface: () => void;
   dismissSurface: () => void;
@@ -372,13 +383,27 @@ const useTurnStoreBase = create<TurnStore>()((set, get) => ({
 
   // ----- Daemon activity state -----
 
-  onActivityThinking: (statusText) => {
+  onActivityThinking: (statusText, opts) => {
     const s = get();
     // Server-driven thinking signal — the daemon reports that the agent
     // is processing (e.g. after a tool_result, during context compaction,
     // or after confirmation resolution). Transition back to "thinking"
     // so the thinking indicator re-appears in the post-tool-call gap.
-    if (isStale(s)) return;
+    if (isStale(s)) {
+      // No client-initiated turn is active. Daemon-initiated work (e.g.
+      // summarize-up-to-here) still reports thinking — accept it only when
+      // the handler scoped the event to the active conversation, so a
+      // background conversation's activity can't light this tab's
+      // indicator. Terminal teardown arrives via the paired idle activity
+      // event or the result card's message_complete (both call endTurn).
+      if (!opts?.canStartFromIdle) return;
+      set({
+        phase: "thinking",
+        statusText: statusText ?? null,
+        lastTerminalReason: null,
+      });
+      return;
+    }
     if (s.phase === "awaiting_user_input") return;
     set({ phase: "thinking", statusText: statusText ?? null });
   },
@@ -658,7 +683,17 @@ export function turnReducer(state: TurnState, event: DomainEvent): TurnState {
       };
 
     case "ACTIVITY_STATE_THINKING":
-      if (isStale(state)) return state;
+      if (isStale(state)) {
+        // Daemon-initiated activity (e.g. summarize-up-to-here) may start
+        // without a client-initiated turn — mirrors `onActivityThinking`.
+        if (!event.canStartFromIdle) return state;
+        return {
+          ...state,
+          phase: "thinking",
+          statusText: event.statusText ?? null,
+          lastTerminalReason: null,
+        };
+      }
       if (state.phase === "awaiting_user_input") return state;
       return {
         ...state,

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
@@ -14,6 +14,7 @@ import {
   handleGenerationCancelled,
 } from "@/domains/chat/utils/stream-handlers/message-handlers";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useConversationStore } from "@/stores/conversation-store";
 import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
 import { findConversation } from "@/utils/conversation-cache";
 import type { Conversation } from "@/types/conversation-types";
@@ -173,7 +174,10 @@ describe("handleAssistantActivityState", () => {
       ctx,
     );
     expect(ctx.lastActivityVersionRef.current.get("conv-1")).toBe(2);
-    expect(ctx.turnActions.onActivityThinking).toHaveBeenCalledWith(undefined);
+    expect(ctx.turnActions.onActivityThinking).toHaveBeenCalledWith(
+      undefined,
+      { canStartFromIdle: false },
+    );
     expect(ctx.startReconciliationLoop).not.toHaveBeenCalled();
   });
 
@@ -193,7 +197,49 @@ describe("handleAssistantActivityState", () => {
     );
     expect(ctx.turnActions.onActivityThinking).toHaveBeenCalledWith(
       "Processing bash results",
+      { canStartFromIdle: false },
     );
+  });
+
+  it("marks thinking as idle-startable only for the active conversation", () => {
+    useConversationStore.getState().setActiveConversationId("conv-1");
+    try {
+      const ctx = makeCtx();
+      handleAssistantActivityState(
+        {
+          type: "assistant_activity_state",
+          activityVersion: 4,
+          phase: "thinking",
+          anchor: "assistant_turn",
+          reason: "context_compacting",
+          statusText: "Summarizing conversation",
+          conversationId: "conv-1",
+        },
+        ctx,
+      );
+      expect(ctx.turnActions.onActivityThinking).toHaveBeenCalledWith(
+        "Summarizing conversation",
+        { canStartFromIdle: true },
+      );
+
+      handleAssistantActivityState(
+        {
+          type: "assistant_activity_state",
+          activityVersion: 1,
+          phase: "thinking",
+          anchor: "assistant_turn",
+          reason: "context_compacting",
+          conversationId: "conv-other",
+        },
+        ctx,
+      );
+      expect(ctx.turnActions.onActivityThinking).toHaveBeenLastCalledWith(
+        undefined,
+        { canStartFromIdle: false },
+      );
+    } finally {
+      useConversationStore.getState().setActiveConversationId(null);
+    }
   });
 
   it("returns early for non-idle, non-thinking phase", () => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
@@ -168,7 +168,16 @@ export function handleAssistantActivityState(
   }
 
   if (event.phase === "thinking") {
-    ctx.turnActions.onActivityThinking(event.statusText);
+    // Daemon-initiated work (e.g. summarize-up-to-here) reports thinking
+    // without a client-initiated turn. Allow the signal to start activity
+    // from an idle turn store only when the event belongs to the active
+    // conversation — a background conversation's activity must not light
+    // this tab's indicator.
+    const activeConversationId =
+      useConversationStore.getState().activeConversationId;
+    ctx.turnActions.onActivityThinking(event.statusText, {
+      canStartFromIdle: convId != null && convId === activeConversationId,
+    });
     recordDiagnostic("sse_activity_state_thinking_handled", {
       convId,
       reason: event.reason,


### PR DESCRIPTION
## Summary
- Web turn store: `onActivityThinking` (and its reducer mirror) accepts `canStartFromIdle` — the stream handler sets it only when the event belongs to the active conversation, so daemon-initiated work (summarize-up-to-here) lights the thinking shimmer with its `statusText` ("Summarizing conversation") while a background conversation's activity cannot
- Daemon: the summarize route emits `assistant_activity_state(idle)` in its `finally` — reason `message_complete` on card-persisting outcomes, `error_terminal` on hard failures — pairing every thinking emit with a definitive terminal
- Teardown reuses the existing terminal machinery (`endTurn` → `completeTurn`), which already resets from any phase

## Original prompt
Clicking "Summarize up to here" gave no feedback for the ~54 seconds the summary LLM call ran — the user clicked, saw nothing, and assumed the feature was broken. Root cause: the turn store's staleness guard drops daemon thinking signals when the user hasn't sent a message. Requested fix: show the standard thinking indicator for the duration of a summarize, scoped to the active conversation, with a guaranteed terminal.