### PR TITLE
feat(providers): add Baseten provider serving Thinking Machines Inkling (BYOK)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14091,7 +14091,7 @@ paths:
             type: string
           description:
             "Filter by provider id. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
-            vercel-ai-gateway, openai-compatible, minimax, atlascloud"
+            vercel-ai-gateway, openai-compatible, minimax, atlascloud, baseten"
       responses:
         "200":
           description: Successful response
@@ -14322,7 +14322,7 @@ paths:
             type: string
           description:
             "Filter by provider. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
-            vercel-ai-gateway, openai-compatible, minimax, atlascloud, vellum"
+            vercel-ai-gateway, openai-compatible, minimax, atlascloud, baseten, vellum"
       responses:
         "200":
           description: Successful response
@@ -31628,6 +31628,7 @@ components:
         - minimax
         - atlascloud
         - together
+        - baseten
     ProfilePatchEntry:
       type: object
       properties:
@@ -32004,6 +32005,7 @@ components:
         - openai-compatible
         - minimax
         - atlascloud
+        - baseten
         - vellum
     Auth:
       oneOf:

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -31,6 +31,7 @@ export const LLMProvider = z
     "minimax",
     "atlascloud",
     "together",
+    "baseten",
   ])
   .meta({ id: "LLMProvider" });
 type LLMProvider = z.infer<typeof LLMProvider>;

--- a/assistant/src/providers/baseten/client.ts
+++ b/assistant/src/providers/baseten/client.ts
@@ -4,39 +4,36 @@ import {
 } from "../openai/api-key-validation.js";
 import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
 
-export interface AtlasCloudProviderOptions {
-  apiKey?: string;
+export interface BasetenProviderOptions {
+  baseURL?: string;
   streamTimeoutMs?: number;
 }
 
-/**
- * Atlas Cloud exposes a single OpenAI-compatible endpoint. Unlike MiniMax it
- * has no regional fallback host, so validation targets this URL only.
- */
-const DEFAULT_ATLASCLOUD_BASE_URL = "https://api.atlascloud.ai/v1";
+/** Baseten Model APIs expose a single OpenAI-compatible serverless endpoint. */
+const DEFAULT_BASETEN_BASE_URL = "https://inference.baseten.co/v1";
 
-export async function validateAtlasCloudApiKey(
+export async function validateBasetenApiKey(
   apiKey: string,
 ): Promise<ApiKeyValidationResult> {
   return validateOpenAICompatibleApiKey({
     apiKey,
-    baseURL: DEFAULT_ATLASCLOUD_BASE_URL,
-    providerLabel: "Atlas Cloud",
+    baseURL: DEFAULT_BASETEN_BASE_URL,
+    providerLabel: "Baseten",
   });
 }
 
-export class AtlasCloudProvider extends OpenAIChatCompletionsProvider {
+export class BasetenProvider extends OpenAIChatCompletionsProvider {
   constructor(
     apiKey: string,
     model: string,
-    options: AtlasCloudProviderOptions = {},
+    options: BasetenProviderOptions = {},
   ) {
     super(apiKey, model, {
-      baseURL: DEFAULT_ATLASCLOUD_BASE_URL,
-      providerName: "atlascloud",
-      providerLabel: "Atlas Cloud",
+      baseURL: options.baseURL?.trim() || DEFAULT_BASETEN_BASE_URL,
+      providerName: "baseten",
+      providerLabel: "Baseten",
       streamTimeoutMs: options.streamTimeoutMs,
-      // Atlas Cloud hosts reasoning models (e.g. DeepSeek) that emit chain of
+      // Baseten hosts reasoning models (e.g. Inkling) that emit chain of
       // thought via `reasoning_content` rather than inline `<think>` tags. The
       // base provider parses this field into thinking blocks and replays it on
       // multi-turn requests.

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -20,6 +20,7 @@
 
 import { AnthropicProvider } from "../anthropic/client.js";
 import { AtlasCloudProvider } from "../atlascloud/client.js";
+import { BasetenProvider } from "../baseten/client.js";
 import { FireworksProvider } from "../fireworks/client.js";
 import { GeminiProvider } from "../gemini/client.js";
 import { MinimaxProvider } from "../minimax/client.js";
@@ -138,6 +139,11 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
       streamTimeoutMs,
       ...(baseURL ? { baseURL } : {}),
     }),
+  baseten: ({ apiKey, model, streamTimeoutMs, baseURL }) =>
+    new BasetenProvider(apiKey, model, {
+      streamTimeoutMs,
+      ...(baseURL ? { baseURL } : {}),
+    }),
 };
 
 /**
@@ -178,7 +184,9 @@ export function buildProviderAdapter(
   opts: AdapterCreateOpts,
 ): Provider | null {
   const factory = ADAPTER_FACTORIES[providerId];
-  if (!factory) return null;
+  if (!factory) {
+    return null;
+  }
   return factory(opts);
 }
 
@@ -207,7 +215,9 @@ export function createAdapterFromConnection(
 ): Provider | null {
   const provider = opts.provider ?? connection.provider;
   const entry = PROVIDER_CATALOG.find((e) => e.id === provider);
-  if (!entry) return null;
+  if (!entry) {
+    return null;
+  }
   const isKeyless = entry.setupMode === "keyless";
   // openai-compatible is dual-mode: local endpoints (LM Studio, vLLM) are
   // keyless, hosted ones keyed — none auth is valid for it.
@@ -238,7 +248,9 @@ export function createAdapterFromConnection(
     useNativeWebSearch: opts.useNativeWebSearch ?? false,
     codexSubscription,
   });
-  if (!adapter) return null;
+  if (!adapter) {
+    return null;
+  }
 
   // Usage-attribution headers (`X-Vellum-*`) are only meaningful when the
   // request is routed through the Vellum-managed proxy — they carry billing

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1945,6 +1945,40 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     apiKeyUrl: "https://www.atlascloud.ai/console",
     apiKeyPlaceholder: "apikey-...",
   },
+  {
+    id: "baseten",
+    displayName: "Baseten",
+    subtitle: "Open models served by Baseten. Requires a Baseten API key.",
+    setupMode: "api-key",
+    setupHint: "Enter your Baseten API key to enable Baseten models.",
+    envVar: "BASETEN_API_KEY",
+    credentialsGuide: {
+      description: "Sign in to the Baseten dashboard and create an API key.",
+      url: "https://app.baseten.co/settings/api_keys",
+      linkLabel: "Open Baseten Dashboard",
+    },
+    models: [
+      {
+        id: "thinkingmachines/inkling",
+        displayName: "Inkling",
+        // Baseten serves Inkling with a 1,048K-token input window.
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 32768,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 1.0,
+          outputPer1mTokens: 4.05,
+          cacheReadPer1mTokens: 0.17,
+        },
+      },
+    ],
+    defaultModel: "thinkingmachines/inkling",
+    apiKeyUrl: "https://app.baseten.co/settings/api_keys",
+    apiKeyPlaceholder: "Your Baseten API key",
+  },
 ];
 
 export const PROVIDER_CATALOG: ProviderCatalogEntry[] =

--- a/assistant/src/providers/openai/api-key-validation.ts
+++ b/assistant/src/providers/openai/api-key-validation.ts
@@ -1,0 +1,70 @@
+import OpenAI from "openai";
+
+import { getLogger } from "../../util/logger.js";
+
+const log = getLogger("provider-key-validation");
+
+/** Validation-specific timeout (10s) so a stalled network doesn't block key submission. */
+const VALIDATION_TIMEOUT_MS = 10_000;
+
+export type ApiKeyValidationResult =
+  | { valid: true }
+  | { valid: false; reason: string };
+
+export interface OpenAICompatibleKeyValidation {
+  apiKey: string;
+  /** The provider's OpenAI-compatible endpoint to list models against. */
+  baseURL: string;
+  /** Human-readable provider name used in error messages and logs. */
+  providerLabel: string;
+}
+
+/**
+ * Validate an API key by listing models against an OpenAI-compatible
+ * endpoint. Definitive auth failures (401/403) reject the key; transient
+ * errors (429, 5xx, network) allow the key to be stored so a flaky network
+ * doesn't block setup.
+ */
+export async function validateOpenAICompatibleApiKey({
+  apiKey,
+  baseURL,
+  providerLabel,
+}: OpenAICompatibleKeyValidation): Promise<ApiKeyValidationResult> {
+  try {
+    const client = new OpenAI({
+      apiKey,
+      baseURL,
+      timeout: VALIDATION_TIMEOUT_MS,
+      maxRetries: 0,
+    });
+    await client.models.list();
+    return { valid: true };
+  } catch (error) {
+    if (error instanceof OpenAI.APIError) {
+      if (error.status === 401) {
+        return { valid: false, reason: "API key is invalid or expired." };
+      }
+      if (error.status === 403) {
+        return {
+          valid: false,
+          reason: `${providerLabel} API error (${error.status}): ${error.message}`,
+        };
+      }
+      // Transient errors (429, 5xx, etc.) — allow the key to be stored.
+      log.warn(
+        { provider: providerLabel, status: error.status },
+        "API returned a transient error during key validation — allowing key",
+      );
+      return { valid: true };
+    }
+    // Network errors — allow the key to be stored.
+    log.warn(
+      {
+        provider: providerLabel,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Network error during key validation — allowing key",
+    );
+    return { valid: true };
+  }
+}

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -26,6 +26,7 @@ import { clearEmbeddingBackendCache } from "../../persistence/embeddings/embeddi
 import { maybeReseedCapabilitiesAfterManagedCredential } from "../../plugins/defaults/memory/v2/memory-v2-startup.js";
 import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
 import { validateAtlasCloudApiKey } from "../../providers/atlascloud/client.js";
+import { validateBasetenApiKey } from "../../providers/baseten/client.js";
 import { validateGeminiApiKey } from "../../providers/gemini/client.js";
 import { validateMinimaxApiKey } from "../../providers/minimax/client.js";
 import { validateOpenAIApiKey } from "../../providers/openai/client.js";
@@ -209,6 +210,15 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
         }
       } else if (name === "atlascloud") {
         const validation = await validateAtlasCloudApiKey(value);
+        if (!validation.valid) {
+          log.warn(
+            { provider: name, reason: validation.reason },
+            "API key validation failed",
+          );
+          return { success: false, error: validation.reason };
+        }
+      } else if (name === "baseten") {
+        const validation = await validateBasetenApiKey(value);
         if (!validation.valid) {
           log.warn(
             { provider: name, reason: validation.reason },

--- a/cli/src/lib/provider-secrets.ts
+++ b/cli/src/lib/provider-secrets.ts
@@ -75,6 +75,7 @@ const PROVIDER_LABELS: Record<LlmProviderId, string> = {
   minimax: "MiniMax",
   atlascloud: "Atlas Cloud",
   together: "Together AI",
+  baseten: "Baseten",
 };
 
 export function formatProviderName(provider: LlmProviderId): string {
@@ -189,6 +190,9 @@ export function inferProviderFromModel(model: string): string | undefined {
   }
   if (model.startsWith("deepseek-ai/")) {
     return "atlascloud";
+  }
+  if (model.startsWith("thinkingmachines/")) {
+    return "baseten";
   }
   if (model.includes("/")) {
     return "openrouter";

--- a/cli/src/shared/provider-env-vars.ts
+++ b/cli/src/shared/provider-env-vars.ts
@@ -30,6 +30,7 @@ export const LLM_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
   minimax: "MINIMAX_API_KEY",
   atlascloud: "ATLASCLOUD_API_KEY",
   together: "TOGETHER_API_KEY",
+  baseten: "BASETEN_API_KEY",
 };
 
 /** Search-provider env var names. Mirrors `SEARCH_PROVIDER_CATALOG` BYOK entries. */

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -835,6 +835,16 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
   ],
+  baseten: [
+    {
+      id: "thinkingmachines/inkling",
+      displayName: "Inkling",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 32_768,
+      supportsThinking: true,
+    },
+  ],
   "openai-compatible": [],
 } as const satisfies Record<string, readonly LlmCatalogModel[]>;
 
@@ -851,6 +861,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
   "vercel-ai-gateway": "anthropic/claude-sonnet-4.6",
   minimax: "MiniMax-M2.7",
   atlascloud: "deepseek-ai/deepseek-v4-pro",
+  baseten: "thinkingmachines/inkling",
   "openai-compatible": "",
 };
 
@@ -876,6 +887,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   "openai-compatible": "OpenAI-compatible",
   minimax: "MiniMax",
   atlascloud: "Atlas Cloud",
+  baseten: "Baseten",
 };
 
 /**
@@ -897,6 +909,7 @@ export const PROVIDER_SUPPORTS_PLATFORM_AUTH: Record<string, boolean> = {
   "openai-compatible": false,
   minimax: false,
   atlascloud: false,
+  baseten: false,
 };
 
 export const MANAGED_MODELS = MODELS_BY_PROVIDER.anthropic;

--- a/clients/web/src/domains/settings/ai/constants.ts
+++ b/clients/web/src/domains/settings/ai/constants.ts
@@ -20,6 +20,7 @@ export const INFERENCE_PROVIDERS = [
   "ollama",
   "minimax",
   "atlascloud",
+  "baseten",
 ] as const;
 
 /**

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -152,6 +152,7 @@ const TOP_P_OPENAI_COMPAT_PROVIDERS = new Set([
   "fireworks",
   "minimax",
   "atlascloud",
+  "baseten",
   "ollama",
   "openrouter",
   "together",

--- a/clients/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/clients/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -33,6 +33,7 @@ export const CONNECTION_PROVIDERS: ConnectionProvider[] = [
   "vercel-ai-gateway",
   "minimax",
   "atlascloud",
+  "baseten",
   "openai-compatible",
 ];
 

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1990,6 +1990,41 @@
           "supportsToolUse": true
         }
       ]
+    },
+    {
+      "id": "baseten",
+      "displayName": "Baseten",
+      "subtitle": "Open models served by Baseten. Requires a Baseten API key.",
+      "setupMode": "api-key",
+      "setupHint": "Enter your Baseten API key to enable Baseten models.",
+      "envVar": "BASETEN_API_KEY",
+      "apiKeyPlaceholder": "Your Baseten API key",
+      "credentialsGuide": {
+        "description": "Sign in to the Baseten dashboard and create an API key.",
+        "url": "https://app.baseten.co/settings/api_keys",
+        "linkLabel": "Open Baseten Dashboard"
+      },
+      "supportsPlatformAuth": false,
+      "defaultModel": "thinkingmachines/inkling",
+      "models": [
+        {
+          "id": "thinkingmachines/inkling",
+          "displayName": "Inkling",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 32768,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1,
+            "outputPer1mTokens": 4.05,
+            "cacheReadPer1mTokens": 0.17
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- New `baseten` BYOK provider (OpenAI-compatible, `https://inference.baseten.co/v1`) whose first and default model is Thinking Machines' **Inkling** (`thinkingmachines/inkling`): 1,048K context, 32K max output, tool use + vision, reasoning streamed via `reasoning_content`, $1.00/$4.05 per 1M input/output ($0.17 cached input, so `supportsCaching` is on).
- Wires the full provider surface: catalog entry, adapter factory, `LLMProvider` config enum, secret-route key validation, CLI env-var/label/model-inference mirrors, web model-catalog + settings-picker + top-p visibility mirrors, and regenerated `meta/llm-provider-catalog.json`, `assistant/openapi.yaml`, and web daemon types.
- Extracts a shared `validateOpenAICompatibleApiKey` helper (`providers/openai/api-key-validation.ts`); the atlascloud and baseten validators now delegate to it instead of duplicating the models.list() probe.

**Decisions worth knowing:**
- **Why Baseten, not a first-party Thinking Machines provider:** TML has no production inference API for base Inkling — Tinker's OpenAI-compatible endpoint is beta, low-traffic, and only accepts `tinker://` fine-tune checkpoint paths. Of the day-0 hosts, Fireworks serves Inkling on-demand-GPU only (no serverless), Together/OpenRouter don't serve it yet; Baseten is live serverless. Direction confirmed with Sidd in-session.
- **Effort passthrough intentionally off:** `baseten` is not in `EFFORT_SUPPORTED_PROVIDERS`, so `reasoning_effort` is stripped and Inkling reasons at its default effort (UI hides the knob, matching atlascloud/minimax). Follow-up: enable + set `maxEffort` once forwarding is verified with a live key.
- Catalog numbers (context/output/pricing) come from Baseten's Model APIs docs and pricing page as of 2026-07-16.

**Verification:** `tsgo --noEmit` clean in assistant + cli; web `tsc` error count identical to main (pre-existing worktree noise only). Green: llm-catalog-parity, provider-env-vars, provider-secret-catalog, adapter-factory, secret-routes-platform-proxy (assistant); env-var + model-inference parity (cli); llm-model-catalog + profile-param-visibility (web).

**Follow-ups:** add Inkling model blocks to `openrouter`/`together` when those hosts serve it serverless; revisit a true `thinkingmachines` provider when TML ships production inference; verify effort forwarding.

## Original prompt
Sidd asked to add support for the newly released Inkling model from Thinking Machines (BYOK only, expecting a new provider). Planning research showed TML's first-party endpoint can't serve base Inkling, so with his sign-off the provider added is Baseten — the live day-0 serverless host — following the atlascloud BYOK template.