### PR TITLE
feat(ui-surface): slim ui_show docs to hot types + teach-on-error index

### DIFF
--- a/assistant/src/__tests__/ui-shape-teaching.test.ts
+++ b/assistant/src/__tests__/ui-shape-teaching.test.ts
@@ -60,6 +60,22 @@ describe("ui_show unknown surface_type teaching", () => {
     expect(proxied).toBe(false);
   });
 
+  test("retired types (list, task_preferences) teach instead of proxying", async () => {
+    for (const retired of ["list", "task_preferences"]) {
+      let proxied = false;
+      const result = await uiShowTool.execute(
+        { surface_type: retired, data: {} },
+        makeContext(() => {
+          proxied = true;
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(`"${retired}" is not a surface type`);
+      expect(proxied).toBe(false);
+    }
+  });
+
   test("prototype-chain keys are not surface types", async () => {
     let proxied = false;
     const result = await uiShowTool.execute(
@@ -122,7 +138,6 @@ describe("ui_show missing-content teaching", () => {
     },
     { surfaceType: "form", data: {}, expectInError: "`data.fields`" },
     { surfaceType: "confirmation", data: {}, expectInError: "confirmLabel" },
-    { surfaceType: "list", data: { items: [] }, expectInError: "`data.items`" },
     { surfaceType: "work_result", data: {}, expectInError: "summary" },
     { surfaceType: "oauth_connect", data: {}, expectInError: "providerKey" },
     {
@@ -171,10 +186,6 @@ describe("ui_show displayable payloads proxy through", () => {
         surfaceType:
           "card (lenient — top-level fields are normalized downstream)",
         input: { surface_type: "card", title: "Status", data: {} },
-      },
-      {
-        surfaceType: "task_preferences",
-        input: { surface_type: "task_preferences", data: {} },
       },
       {
         surfaceType: "file_upload",
@@ -233,6 +244,12 @@ describe("uiShowTeachingError", () => {
     for (const name of SURFACE_TYPE_NAMES) {
       expect(SURFACE_SHAPE_DOCS[name]!.purpose.length).toBeGreaterThan(0);
       expect(SURFACE_SHAPE_DOCS[name]!.shape.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every documented type appears in the tool description", () => {
+    for (const name of SURFACE_TYPE_NAMES) {
+      expect(uiShowTool.description).toContain(name);
     }
   });
 });

--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -83,7 +83,7 @@ These are enforcement rules, not advice.
 
 Identity writes (IDENTITY.md, SOUL.md), user-profile writes, journal entries: all wait until the rail produces real signal, which is Moment 1 output at the earliest. None of them delay a user-visible response. None of them happen alongside the opening turn.
 
-The base BOOTSTRAP task_preferences fallback is not on this rail. Your opener is the Port pitch.
+Your opener is the Port pitch — no other intake surface precedes it.
 
 ## Telemetry: tag your `ui_show` surfaces
 

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -2,7 +2,7 @@
  * UI surface tool definitions.
  *
  * These tools allow the model to show, update, and dismiss just-in-time UI
- * surfaces (cards, forms, lists, confirmations) on a connected macOS client.
+ * surfaces (cards, tables, forms, confirmations) on a connected macOS client.
  * They are proxy tools -- execution is forwarded to the client and never
  * handled locally by the daemon.
  */
@@ -19,6 +19,7 @@ import {
   asRecord,
   hasContent,
   SURFACE_TYPE_NAMES,
+  UI_SHOW_TYPE_DOCS,
   uiShowTeachingError,
 } from "./surface-shape-docs.js";
 
@@ -222,21 +223,7 @@ export const uiShowTool = {
   name: "ui_show",
   description:
     'Surface structured data or UI in the conversation. For long-form writing use the document skill. For interactive apps, dashboards, games, calculators, or durable tools, call `skill_load` with `skill: "app-builder"` and use the app-builder workflow; do not use `dynamic_page` as a substitute for a persistent app. App-like `dynamic_page` calls are rejected.\n\n' +
-    "Surface types (data shapes):\n" +
-    '- card: { title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Templates: "weather_forecast" (native weather widget), "task_progress" (live step tracker - update via ui_update on data.templateData; shape: { title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] })\n' +
-    "- copy_block: { text, label?, language? }. Shows copyable text with a visible copy button; use for prompts, commands, paths, or snippets the user should copy.\n" +
-    '- choice: { description?, options: [{ id, title, description?, recommended?, data? }], selectionMode?: "single"|"multiple", commitOnSelect?, submitLabel? }. Single-select choices commit on option click by default. Use for outcome offers and follow-up choices; mark the strongest option with recommended: true.\n' +
-    "- oauth_connect: { providerKey, displayName?, description?, logoUrl? }. Shows a managed OAuth connection CTA in chat; use when the current task needs a managed integration account (Google, Linear, GitHub, etc.) instead of asking the user to visit settings or attempting OAuth through shell/tools. The client supplies the CTA label. Do not include OAuth scopes in the surface; managed providers use the platform's configured scopes.\n" +
-    '- table: { columns: [{ id, label }], rows: [{ id, cells: Record<id, string | { text, icon?, iconColor?: "success"|"warning"|"error"|"muted" }>, selectable?, selected? }], selectionMode?: "none"|"single"|"multiple", caption? }\n' +
-    '- form: { description?, fields: [{ id, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label, placeholder?, required?, defaultValue?, options?: [{ label, value }] }], submitLabel? }. Multi-page: { pages: [{ id, title, description?, fields }], pageLabels?: { next?, back?, submit? }, submitLabel? }\n' +
-    '- list: { items: [{ id, title, subtitle?, icon?, selected? }], selectionMode: "single"|"multiple"|"none" }\n' +
-    "- confirmation: { message, detail?, confirmLabel?, confirmedLabel?, cancelLabel?, destructive? }\n" +
-    "- dynamic_page: { html, width?, height?, preview?: { title, subtitle?, description?, icon?, metrics?: [{ label, value }] } }\n" +
-    "- file_upload: { prompt, acceptedTypes?, maxFiles? }\n" +
-    "- task_preferences: {} (no data needed — categories are rendered client-side)\n" +
-    '- work_result: { eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] }. Shows a structured receipt after real work: what changed, what was skipped, proof points, and next actions. Keep display-only unless explicit follow-up buttons are needed.\n' +
-    '- channel_setup: { channel: "slack" | "telegram" | "phone" }. Opens the channel setup panel in a side drawer. Returns success only after a connected client confirms the panel rendered (an error means the user does NOT see the panel — never claim it is open after an error). The user then completes credential entry at their own pace. Slack shows a full setup wizard; Telegram and Phone show credential forms (the assistant handles remaining setup steps like webhooks in chat after the user saves credentials).\n\n' +
-    "For multi-step or long-running turns (web searches, file operations, research), show a task_progress card early and keep its steps updated as work progresses. Coarse steps are fine, and you can add or revise them as the work takes shape — a rough card beats no signal.",
+    UI_SHOW_TYPE_DOCS,
   category: "ui-surface",
   defaultRiskLevel: RiskLevel.Low,
   executionTarget: "host",
@@ -251,7 +238,7 @@ export const uiShowTool = {
       },
       title: {
         type: "string",
-        description: "Optional title for the surface window",
+        description: "Optional surface title",
       },
       data: {
         type: "object",
@@ -263,12 +250,11 @@ export const uiShowTool = {
         items: {
           type: "object",
           properties: {
-            id: { type: "string", description: "Unique action identifier" },
-            label: { type: "string", description: "Button label text" },
+            id: { type: "string" },
+            label: { type: "string" },
             style: {
               type: "string",
               enum: ["primary", "secondary", "destructive"],
-              description: "Visual style of the button",
             },
           },
           required: ["id", "label"],
@@ -279,17 +265,17 @@ export const uiShowTool = {
         type: "string",
         enum: ["inline", "panel"],
         description:
-          'Where to render the surface. "inline" embeds it in the chat message. "panel" shows a floating window. Defaults to "inline". Prefer inline — only use panel when a separate window is explicitly requested.',
+          'Where to render: "inline" (default, embedded in chat) or "panel" (floating window; only when explicitly requested)',
       },
       await_action: {
         type: "boolean",
         description:
-          "Whether to block until an action is selected. Defaults to true when actions are provided.",
+          "Block until an action is selected. Defaults to true when actions are provided.",
       },
       persistent: {
         type: "boolean",
         description:
-          "When true, clicking an action does not dismiss the surface — the card stays visible and only the clicked action is marked as spent. Use for launcher or menu-style cards where multiple buttons may be clicked. Defaults to false.",
+          "Keep the surface visible after an action is clicked (clicked actions are marked spent). For launcher/menu cards. Defaults to false.",
       },
       activation_moment: {
         type: "string",

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -59,8 +59,8 @@ interface SurfaceShapeDoc {
   /**
    * Returns a description of the missing load-bearing content, or null when
    * the payload has enough to render. Absent for types the daemon normalizes
-   * leniently (card), that render fine with defaults (file_upload,
-   * task_preferences), or that have bespoke handling (dynamic_page).
+   * leniently (card), that render fine with defaults (file_upload), or that
+   * have bespoke handling (dynamic_page).
    */
   missingContent?: (data: Record<string, unknown>) => string | null;
 }
@@ -69,11 +69,12 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   card: {
     purpose: "structured info card, supports templates like task_progress",
     shape:
-      '{ title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Templates: "task_progress" (live step tracker — update via ui_update on data.templateData; shape: { title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] }), "weather_forecast" (native weather widget)',
+      '{ title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Template "task_progress" renders a live step tracker — templateData: { title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] }; advance it via ui_update as steps finish. Other card templates are documented by the skills that use them',
   },
   copy_block: {
     purpose: "copyable text with a visible copy button",
-    shape: "{ text, label?, language? }",
+    shape:
+      "{ text, label?, language? } — shows copyable text with a visible copy button; use for prompts, commands, paths, or snippets the user should copy",
     missingContent: (data) =>
       isNonEmptyString(data.text)
         ? null
@@ -100,7 +101,7 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   work_result: {
     purpose: "structured receipt after completed work",
     shape:
-      '{ eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] }',
+      '{ eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] } — structured receipt after real work; keep display-only unless follow-up buttons are needed',
     missingContent: (data) =>
       hasContent(data)
         ? null
@@ -109,7 +110,7 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   oauth_connect: {
     purpose: "managed OAuth connection button for an integration account",
     shape:
-      "{ providerKey, displayName?, description?, logoUrl? }. Do not include OAuth scopes; managed providers use the platform's configured scopes",
+      "{ providerKey, displayName?, description?, logoUrl? } — managed OAuth connection CTA; use when the task needs a managed integration account (Google, Linear, GitHub, ...) instead of settings or shell OAuth. Do not include OAuth scopes; managed providers use the platform's configured scopes",
     missingContent: (data) =>
       isNonEmptyString(data.providerKey)
         ? null
@@ -133,15 +134,6 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
         ? null
         : "`data.message` must be a non-empty string",
   },
-  list: {
-    purpose: "selectable item list",
-    shape:
-      '{ items: [{ id, title, subtitle?, icon?, selected? }], selectionMode: "single"|"multiple"|"none" }',
-    missingContent: (data) =>
-      isNonEmptyArray(data.items)
-        ? null
-        : "`data.items` must be a non-empty array",
-  },
   file_upload: {
     purpose: "prompt the user to upload files",
     shape: "{ prompt, acceptedTypes?, maxFiles? }",
@@ -149,7 +141,7 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   dynamic_page: {
     purpose: "custom HTML page for transient UI only, never app-like builds",
     shape:
-      "{ html, width?, height?, preview?: { title, subtitle?, description?, icon?, metrics?: [{ label, value }] } }",
+      "{ html, width?, height?, preview?: { title, subtitle?, description?, icon?, metrics?: [{ label, value }] } } — custom visual HTML for transient surfaces only, never app-like builds",
   },
   channel_setup: {
     purpose: "open the Slack/Telegram/Phone setup panel",
@@ -161,10 +153,6 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
         ? null
         : '`data.channel` must be one of "slack", "telegram", "phone"',
   },
-  task_preferences: {
-    purpose: "task-preference picker",
-    shape: "{} (no data needed — categories are rendered client-side)",
-  },
 };
 
 /** Model-facing surface_type enum, derived so docs and schema cannot drift. */
@@ -173,6 +161,37 @@ export const SURFACE_TYPE_NAMES = Object.keys(SURFACE_SHAPE_DOCS);
 const SURFACE_TYPE_INDEX = SURFACE_TYPE_NAMES.map(
   (name) => `${name} (${SURFACE_SHAPE_DOCS[name]!.purpose})`,
 ).join("; ");
+
+/**
+ * Types whose full shape rides in the always-present tool description —
+ * together they cover ~95% of fleet ui_show calls. The rest appear there as
+ * a one-line index and get their shape from the teaching error on first
+ * misuse.
+ */
+const HOT_SURFACE_TYPES = [
+  "card",
+  "copy_block",
+  "choice",
+  "table",
+  "work_result",
+  "oauth_connect",
+  "dynamic_page",
+] as const;
+
+const COLD_SURFACE_INDEX = SURFACE_TYPE_NAMES.filter(
+  (name) => !(HOT_SURFACE_TYPES as readonly string[]).includes(name),
+)
+  .map((name) => `${name} (${SURFACE_SHAPE_DOCS[name]!.purpose})`)
+  .join(", ");
+
+/** The surface-types section of the ui_show tool description. */
+export const UI_SHOW_TYPE_DOCS = [
+  "Surface types (data shapes):",
+  ...HOT_SURFACE_TYPES.map(
+    (name) => `- ${name}: ${SURFACE_SHAPE_DOCS[name]!.shape}`,
+  ),
+  `Other types: ${COLD_SURFACE_INDEX}. Send your best-guess data — if required content is missing, the error returns the exact shape.`,
+].join("\n");
 
 /**
  * Teaching error for a ui_show payload that would render nothing, or null


### PR DESCRIPTION
## Summary
- Slims the `ui_show` tool description from 4,027 to ~2,500 chars: the seven hot surface types (~95% of fleet calls) keep full inline shapes, built from `SURFACE_SHAPE_DOCS` so the description and the teaching errors share one source; the four cold types (form, confirmation, file_upload, channel_setup) become a one-line index — their exact shape comes back via the #38266 teaching error on first misuse.
- Retires `task_preferences` (0 fleet uses in 14d, instructed by nothing) and `list` (3 uses; table/choice cover it) from the model-facing enum and docs. Daemon handling and client renderers stay so persisted surfaces keep rendering; a model attempting them now gets the valid-type index error.
- Cuts duplicated guidance: the channel_setup success-semantics paragraph (already enforced verbatim by the execute-path errors at `conversation-surfaces.ts:3063-3079`), the trailing task_progress paragraph (already in the always-present `01-progress-surface` system-prompt section), the `weather_forecast` template detail (documented by `skills/weather/SKILL.md`), and verbose schema prose (`actions` sub-descriptions, `display`/`persistent`/`await_action`).

Measured wire size (name+description+input_schema): `ui_show` 6,149 → 4,484 chars (~1,660 → ~1,210 tokens); three-tool total 6,924 → 5,259 chars (~450 tokens saved on every request on dynamic-UI transports). Remaining schema fat is `activation_moment`, removed in PR 4.

PR 2 of 4 of the UI-surface-tools token reduction plan (backstop shipped in #38266; next: Slack-specific projection, then rail-conditional `activation_moment`).

## Original prompt
Fleet telemetry showed the three UI surface tools cost ~1,870 tokens on every request while ~78% of `ui_show` usage is three shapes (task_progress cards, copy_block, plain card). The user approved a 4-PR reduction plan and asked to run all four in sequence via `/do`. This PR is step 2: cut the always-present description to hot-type shapes plus a cold-type index, prune the two dead surface types, and drop guidance duplicated by point-of-use errors, system prompt, and skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)