### PR TITLE
feat(providers): enable reasoning-effort passthrough for Baseten Inkling

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1968,6 +1968,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
+        // Baseten's reasoning_effort for Inkling tops out at "xhigh" (no
+        // "max"), matching the chat-completions client's default ceiling.
+        maxEffort: "xhigh",
         pricing: {
           inputPer1mTokens: 1.0,
           outputPer1mTokens: 4.05,

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -55,6 +55,7 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
   "vercel-ai-gateway",
   "fireworks",
   "together",
+  "baseten",
 ]);
 
 // For these providers, disabling reasoning is encoded through the same effort
@@ -66,6 +67,7 @@ const DISABLED_THINKING_USES_EFFORT_PROVIDERS = new Set([
   "together",
   "openrouter",
   "vercel-ai-gateway",
+  "baseten",
 ]);
 
 // Whether a disabled `thinking` config must be encoded as `effort: "none"`

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
@@ -50,6 +50,13 @@ describe("resolveProfileParamVisibility", () => {
     expect(VISIBILITY_NONE.topP).toBe(false);
   });
 
+  test("baseten inkling enables effort and topP without the thinking toggle", () => {
+    const vis = resolveProfileParamVisibility("baseten", "thinkingmachines/inkling");
+    expect(vis.effort).toBe(true);
+    expect(vis.topP).toBe(true);
+    expect(vis.thinking).toBe(false);
+  });
+
   test("anthropic haiku disables effort but supports thinking", () => {
     const vis = resolveProfileParamVisibility("anthropic", "claude-3-5-haiku-20241022");
     expect(vis.effort).toBe(false);

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -132,10 +132,7 @@ function supportsEffort(provider: string, modelId: string, supportsThinking: boo
     }
     return supportsThinking;
   }
-  if (provider === "fireworks") {
-    return supportsThinking;
-  }
-  if (provider === "together") {
+  if (provider === "fireworks" || provider === "together" || provider === "baseten") {
     return supportsThinking;
   }
   return false;


### PR DESCRIPTION
## Summary
- Wires the effort knob for the `baseten` provider, closing the follow-up called out in #38268: `baseten` joins `EFFORT_SUPPORTED_PROVIDERS` (effort reaches the wire as `reasoning_effort`) and `DISABLED_THINKING_USES_EFFORT_PROVIDERS` (thinking-off encodes as `reasoning_effort: "none"`, which [Baseten's docs](https://docs.baseten.co/inference/model-apis/reasoning#control-reasoning-depth) state is the **only** way to disable thinking on Inkling).
- Inkling accepts `none|minimal|low|medium|high|xhigh` (no `max`). The chat-completions client's default `maxReasoningEffort` is already `"xhigh"`, so Vellum's `max` tier clamps correctly with no client change; the ceiling is recorded as catalog `maxEffort` and the regenerated `meta/llm-provider-catalog.json`.
- Web profile editor now shows the effort control for baseten (grouped with the fireworks/together branch in `supportsEffort`), with a new visibility test.

**Verification:** assistant `tsgo` clean; green: llm-catalog-parity (20), retry-callsite (38), retry-thinking-tool-choice (12), web profile-param-visibility + llm-model-catalog (61).

## Original prompt
Follow-up to the Baseten/Inkling provider PR #38268, which shipped with effort passthrough deliberately disabled pending verification. Sidd linked Baseten's reasoning docs confirming `reasoning_effort` support and per-model values, so this enables the passthrough and the matching UI control.