### PR TITLE
feat(ui-surface): project a task_progress-only ui_show variant for Slack

### DIFF
--- a/assistant/src/__tests__/ui-channel-variants.test.ts
+++ b/assistant/src/__tests__/ui-channel-variants.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ToolDefinition } from "../providers/types.js";
+import { projectUiToolsForChannel } from "../tools/ui-surface/channel-variants.js";
+import {
+  uiDismissTool,
+  uiShowTool,
+  uiUpdateTool,
+} from "../tools/ui-surface/definitions.js";
+
+const defs: ToolDefinition[] = [
+  uiShowTool,
+  uiUpdateTool,
+  uiDismissTool,
+  {
+    name: "bash",
+    description: "run a command",
+    input_schema: { type: "object" },
+  },
+];
+
+function surfaceTypeEnum(def: ToolDefinition): string[] {
+  return (
+    def.input_schema as { properties: { surface_type: { enum: string[] } } }
+  ).properties.surface_type.enum;
+}
+
+describe("projectUiToolsForChannel", () => {
+  test("returns the same array for channels without a variant", () => {
+    for (const channel of [undefined, "macos", "telegram", "phone"]) {
+      expect(projectUiToolsForChannel(defs, channel)).toBe(defs);
+    }
+  });
+
+  test("slack gets a task_progress-only ui_show", () => {
+    const projected = projectUiToolsForChannel(defs, "slack");
+    const uiShow = projected.find((d) => d.name === "ui_show")!;
+
+    expect(surfaceTypeEnum(uiShow)).toEqual(["card"]);
+    expect(uiShow.description).toContain("task_progress");
+    expect(uiShow.description).toContain(
+      "the only surface this channel renders",
+    );
+    expect(uiShow.description).not.toContain("oauth_connect");
+    expect(uiShow.description).not.toContain("dynamic_page");
+    expect(uiShow.description!.length).toBeLessThan(
+      uiShowTool.description.length / 2,
+    );
+  });
+
+  test("slack projection keeps execute and leaves other tools untouched", () => {
+    const projected = projectUiToolsForChannel(defs, "slack");
+    const uiShow = projected.find((d) => d.name === "ui_show") as {
+      execute?: unknown;
+    };
+
+    expect(uiShow.execute).toBe(uiShowTool.execute);
+    expect(projected.find((d) => d.name === "ui_update")).toBe(uiUpdateTool);
+    expect(projected.find((d) => d.name === "ui_dismiss")).toBe(uiDismissTool);
+    expect(projected.find((d) => d.name === "bash")).toBe(defs[3]);
+  });
+
+  test("projection never mutates the shared definitions", () => {
+    const descriptionBefore = uiShowTool.description;
+    const schemaBefore = JSON.stringify(uiShowTool.input_schema);
+
+    projectUiToolsForChannel(defs, "slack");
+
+    expect(uiShowTool.description).toBe(descriptionBefore);
+    expect(JSON.stringify(uiShowTool.input_schema)).toBe(schemaBefore);
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -50,6 +50,7 @@ import {
   type ToolContext,
   type ToolExecutionResult,
 } from "../tools/types.js";
+import { projectUiToolsForChannel } from "../tools/ui-surface/channel-variants.js";
 import { loadWorkspaceTools } from "../tools/workspace-tools/loader.js";
 import {
   resolveUsageAttribution,
@@ -822,11 +823,19 @@ export function createResolveToolsCallback(
       ? currentWorkspaceDefs.filter((d) => wireAllowlist.has(d.name))
       : currentWorkspaceDefs;
     const excluded = new Set(getConfig().tools.exclude);
-    const allBaseDefs = [
-      ...scopedCoreDefs,
-      ...scopedWorkspaceDefs,
-      ...scopedMcpDefs,
-    ].filter((d) => !excluded.has(d.name));
+    // Swap UI surface tools for channel-appropriate variants (e.g. Slack's
+    // task_progress-only ui_show). Mirrors the pin handling in
+    // `isToolActiveForContext`: execution-gate-mode wakes pin channel
+    // capabilities to undefined, which resolves to the unprojected defs.
+    const channelForUiTools = ctx.toolContextPin
+      ? undefined
+      : ctx.channelCapabilities?.channel;
+    const allBaseDefs = projectUiToolsForChannel(
+      [...scopedCoreDefs, ...scopedWorkspaceDefs, ...scopedMcpDefs].filter(
+        (d) => !excluded.has(d.name),
+      ),
+      channelForUiTools,
+    );
 
     const effectivePreactivated = [
       ...DEFAULT_PREACTIVATED_SKILL_IDS,

--- a/assistant/src/tools/ui-surface/channel-variants.ts
+++ b/assistant/src/tools/ui-surface/channel-variants.ts
@@ -1,0 +1,61 @@
+/**
+ * Per-channel projections of the UI surface tool definitions.
+ *
+ * Slack renders exactly one surface — the task_progress card (everything else
+ * is rejected at execution; see `isSlackTaskProgressUiException` in
+ * `daemon/conversation-surfaces.ts`) — so Slack conversations get a `ui_show`
+ * variant documenting only that shape instead of the full multi-surface docs.
+ *
+ * Projection contract: shared definition objects are never mutated (variants
+ * are module-level constants swapped in via spread-copy), and the projected
+ * set is a pure function of per-conversation-stable channel state, so a
+ * conversation's tools+system prompt-cache prefix stays stable across turns.
+ */
+
+import type { ToolDefinition } from "../../providers/types.js";
+import { TASK_PROGRESS_TEMPLATE_SHAPE } from "./surface-shape-docs.js";
+
+const SLACK_UI_SHOW_DESCRIPTION = `Show a live task-progress card for the current work — the only surface this channel renders. data: { template: "task_progress", templateData: ${TASK_PROGRESS_TEMPLATE_SHAPE} }. Show it early on multi-step turns and advance step statuses via ui_update as work progresses.`;
+
+const SLACK_UI_SHOW_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    surface_type: {
+      type: "string",
+      enum: ["card"],
+      description: "Always card on this channel",
+    },
+    title: {
+      type: "string",
+      description: "Optional surface title",
+    },
+    data: {
+      type: "object",
+      description:
+        'Card data: { template: "task_progress", templateData: { title, status, steps } }',
+    },
+  },
+  required: ["surface_type", "data"],
+};
+
+/**
+ * Swap UI surface tool definitions for channel-appropriate variants. Returns
+ * the input array unchanged (same identity) for channels without a variant.
+ */
+export function projectUiToolsForChannel(
+  definitions: ToolDefinition[],
+  channel: string | undefined,
+): ToolDefinition[] {
+  if (channel !== "slack") {
+    return definitions;
+  }
+  return definitions.map((def) =>
+    def.name === "ui_show"
+      ? {
+          ...def,
+          description: SLACK_UI_SHOW_DESCRIPTION,
+          input_schema: SLACK_UI_SHOW_INPUT_SCHEMA,
+        }
+      : def,
+  );
+}

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -65,11 +65,14 @@ interface SurfaceShapeDoc {
   missingContent?: (data: Record<string, unknown>) => string | null;
 }
 
+/** templateData shape of a task_progress card (shared with channel variants). */
+export const TASK_PROGRESS_TEMPLATE_SHAPE =
+  '{ title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] }';
+
 export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   card: {
     purpose: "structured info card, supports templates like task_progress",
-    shape:
-      '{ title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Template "task_progress" renders a live step tracker — templateData: { title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] }; advance it via ui_update as steps finish. Other card templates are documented by the skills that use them',
+    shape: `{ title, subtitle?, body, metadata?: [{ label, value }], template?, templateData? }. Template "task_progress" renders a live step tracker — templateData: ${TASK_PROGRESS_TEMPLATE_SHAPE}; advance it via ui_update as steps finish. Other card templates are documented by the skills that use them`,
   },
   copy_block: {
     purpose: "copyable text with a visible copy button",


### PR DESCRIPTION
## Summary
- Adds `projectUiToolsForChannel()` (`assistant/src/tools/ui-surface/channel-variants.ts`): Slack conversations get a `ui_show` documenting only the task_progress card — the single surface Slack renders (everything else is already rejected at execution by `isSlackTaskProgressUiException`). Measured: 4,484 → 791 chars (~1,210 → ~215 tokens) on every Slack-conversation request. Other channels return the input array untouched (same identity).
- Applies the projection where `allBaseDefs` is assembled in `createResolveToolsCallback`, so the wire defs, the disk-pressure branch, and the durable `registeredToolDefinitions` snapshot stay consistent. Mirrors the `toolContextPin` handling from `isToolActiveForContext` (pinned wake forks resolve to unprojected defs, preserving wire parity).
- Projection contract (same as `injectActivityField`): shared definition objects are never mutated — variants are module-level constants swapped in via spread-copy — and the projected set is a pure function of per-conversation-stable channel state, so the tools+system prompt-cache prefix stays stable across turns.
- Extracts `TASK_PROGRESS_TEMPLATE_SHAPE` so the card docs and the Slack variant share one copy of the templateData shape.

PR 3 of 4 of the UI-surface-tools token reduction plan (#38266 teaching errors, #38269 slim docs; next: rail-conditional `activation_moment`).

## Original prompt
Fleet telemetry showed Slack conversations receive the full multi-surface `ui_show` docs while execution rejects everything except task_progress cards — ~1,200 tokens describing surfaces the channel refuses. The user approved a 4-PR reduction plan and asked to run all four in sequence via `/do`. This PR is step 3: introduce the per-channel projection mechanism and the Slack task_progress-only variant, keeping shared defs immutable and prompt-cache-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)