### PR TITLE
fix(inspector): attribute compaction LLM calls to their result card

### DIFF
--- a/assistant/src/__tests__/conversation-summarize-route.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-route.test.ts
@@ -96,6 +96,14 @@ mock.module("../persistence/jobs-store.js", () => ({
   enqueueMemoryJob: () => {},
 }));
 
+const linkRequestLogsToMessageMock = mock(
+  (_logIds: string[], _messageId: string) => {},
+);
+
+mock.module("../persistence/llm-request-log-store.js", () => ({
+  linkRequestLogsToMessage: linkRequestLogsToMessageMock,
+}));
+
 mock.module("../schedule/schedule-store.js", () => ({
   deleteSchedule: async () => {},
 }));
@@ -170,6 +178,7 @@ function makeConversation(opts: { processing?: boolean } = {}) {
     summaryInputTokens: 500,
     summaryOutputTokens: 100,
     summaryModel: "test-model",
+    summaryRequestLogId: "compaction-log-1",
   }));
   const emitActivityState = mock(
     (_phase: string, _reason: string, _options?: { statusText?: string }) => {},
@@ -282,6 +291,12 @@ describe("POST /v1/conversations/summarize", () => {
     expect(delta).toBeUndefined();
     const complete = broadcastEvents.find((e) => e.type === "message_complete");
     expect(complete?.messageId).toBe("persisted-assistant-id");
+
+    // The compaction LLM call is attributed to the card it produced.
+    expect(linkRequestLogsToMessageMock).toHaveBeenCalledWith(
+      ["compaction-log-1"],
+      "persisted-assistant-id",
+    );
     expect(publishConversationMessagesChangedMock).toHaveBeenCalledWith(
       "conv-summarize-test",
       undefined,

--- a/assistant/src/__tests__/llm-request-log-turn-query.test.ts
+++ b/assistant/src/__tests__/llm-request-log-turn-query.test.ts
@@ -12,6 +12,7 @@ import { initializeDb } from "../persistence/db-init.js";
 import {
   backfillMessageIdOnLogs,
   getRequestLogsByMessageId,
+  linkRequestLogsToMessage,
   recordRequestLog,
   relinkLlmRequestLogs,
 } from "../persistence/llm-request-log-store.js";
@@ -462,5 +463,113 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     expect(logs).toHaveLength(2);
     expect(logs[0]?.messageId).toBe(a1.id);
     expect(logs[1]?.messageId).toBe(a1.id);
+  });
+});
+
+describe("compaction-call attribution", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("fork: an unlinked compactionAgent row does not eclipse the source turn's calls", async () => {
+    const source = createConversation("eclipse-source");
+    await addMessage(source.id, "user", "Original question", {
+      skipIndexing: true,
+    });
+    recordRequestLog(source.id, '{"turn":"src"}', '{"answer":"hi"}');
+    const reply = await addMessage(source.id, "assistant", "Answer", {
+      skipIndexing: true,
+    });
+    backfillMessageIdOnLogs(source.id, reply.id);
+
+    const fork = forkConversation({ conversationId: source.id });
+    const forkMessages = (
+      await import("../persistence/conversation-crud.js")
+    ).getMessages(fork.id);
+    const forkReply = forkMessages.filter((m) => m.role === "assistant").at(-1);
+    expect(forkReply).toBeDefined();
+
+    // A summarize-up-to compaction call lands in the fork, unlinked, inside
+    // the pre-fork turn's open-ended time window.
+    recordRequestLog(
+      fork.id,
+      '{"compaction":true}',
+      '{"summary":"..."}',
+      undefined,
+      "openrouter",
+      "compactionAgent",
+    );
+
+    const logs = getRequestLogsByMessageId(forkReply!.id);
+    const callSites = logs.map((l) => l.callSite);
+    // The recovery may claim the companion row into the window, but the
+    // fork-source fallback must still surface the turn's real call.
+    expect(callSites).toContain(null);
+    expect(logs.some((l) => l.conversationId === source.id)).toBe(true);
+  });
+
+  test("a linked compaction row belongs to the card's own group, not the prior turn", async () => {
+    const conv = createConversation("card-group");
+    await addMessage(conv.id, "user", "Chat away", { skipIndexing: true });
+    recordRequestLog(conv.id, '{"turn":"main"}', '{"answer":"sure"}');
+    const reply = await addMessage(conv.id, "assistant", "Sure!", {
+      skipIndexing: true,
+    });
+    backfillMessageIdOnLogs(conv.id, reply.id);
+
+    // Summarize-up-to persists a card and links the compaction row to it.
+    const compactionLogId = recordRequestLog(
+      conv.id,
+      '{"compaction":true}',
+      '{"summary":"..."}',
+      undefined,
+      "openrouter",
+      "compactionAgent",
+    );
+    const card = await addMessage(
+      conv.id,
+      "assistant",
+      "**Conversation summarized**",
+      {
+        metadata: { messageKind: "system_card" },
+        skipIndexing: true,
+      },
+    );
+    linkRequestLogsToMessage([compactionLogId!], card.id);
+
+    // The prior turn keeps only its own call…
+    const turnLogs = getRequestLogsByMessageId(reply.id);
+    expect(turnLogs).toHaveLength(1);
+    expect(turnLogs[0]?.messageId).toBe(reply.id);
+
+    // …and the card's group holds exactly the compaction call.
+    const cardLogs = getRequestLogsByMessageId(card.id);
+    expect(cardLogs).toHaveLength(1);
+    expect(cardLogs[0]?.id).toBe(compactionLogId!);
+    expect(cardLogs[0]?.messageId).toBe(card.id);
+  });
+
+  test("a card that is a user message's only reply is that turn's group (/compact shape)", async () => {
+    const conv = createConversation("compact-turn");
+    const userMsg = await addMessage(conv.id, "user", "/compact", {
+      skipIndexing: true,
+    });
+    const compactionLogId = recordRequestLog(
+      conv.id,
+      '{"compaction":true}',
+      '{"summary":"..."}',
+      undefined,
+      "openrouter",
+      "compactionAgent",
+    );
+    const card = await addMessage(conv.id, "assistant", "**Compacted**", {
+      metadata: { messageKind: "system_card" },
+      skipIndexing: true,
+    });
+    linkRequestLogsToMessage([compactionLogId!], card.id);
+
+    const logs = getRequestLogsByMessageId(userMsg.id);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.id).toBe(compactionLogId!);
   });
 });

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -82,10 +82,13 @@ function recordCompactionRequestLog(
   conversationId: string,
   response: ProviderResponse,
   provider: Provider,
-): void {
-  if (!response.rawRequest || !response.rawResponse) return;
+): string | null {
+  if (!response.rawRequest || !response.rawResponse) return null;
   try {
-    recordRequestLog(
+    // Inserted unlinked (no message id) — user-initiated compaction flows
+    // (/compact, summarize-up-to) link the row to their result card after
+    // it persists, via `linkRequestLogsToMessage`.
+    return recordRequestLog(
       conversationId,
       JSON.stringify(response.rawRequest),
       JSON.stringify(response.rawResponse),
@@ -98,6 +101,7 @@ function recordCompactionRequestLog(
       { err, conversationId },
       "Failed to persist compaction LLM request log (non-fatal)",
     );
+    return null;
   }
 }
 
@@ -313,6 +317,14 @@ export interface CompactionRunResult {
   summaryCacheCreationInputTokens?: number;
   summaryCacheReadInputTokens?: number;
   summaryRawResponses?: unknown[];
+  /**
+   * `llm_request_logs.id` of this pass's compaction call, `null` when the
+   * row was not written (logging disabled, missing raw payloads, DB error).
+   * User-initiated flows (/compact, summarize-up-to) link the row to their
+   * persisted result card so the inspector attributes the call to the card
+   * instead of the unlinked-row recovery guessing an enclosing turn.
+   */
+  summaryRequestLogId?: string | null;
   summaryText: string;
   /** Inline structured pending state from the model's `<key_state>` block. */
   keyState?: string;
@@ -1177,7 +1189,11 @@ export async function runAssistantDrivenCompaction(
 
   // Persist the compaction LLM call into `llm_request_logs` with
   // `call_site = "compactionAgent"`. Non-fatal on DB error — see helper.
-  recordCompactionRequestLog(args.conversationId, response, args.provider);
+  const summaryRequestLogId = recordCompactionRequestLog(
+    args.conversationId,
+    response,
+    args.provider,
+  );
 
   const rawText = extractTextFromResponse(response.content);
   const parsed = parseCompactionResult(rawText, {
@@ -1200,6 +1216,7 @@ export async function runAssistantDrivenCompaction(
       summaryCallSite: COMPACTION_CALL_SITE,
       summaryOverrideProfile: args.overrideProfile ?? null,
       summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
+      summaryRequestLogId,
       summaryCalls: 1,
     };
   }
@@ -1405,6 +1422,7 @@ export async function runAssistantDrivenCompaction(
       summaryCallSite: COMPACTION_CALL_SITE,
       summaryOverrideProfile: args.overrideProfile ?? null,
       summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
+      summaryRequestLogId,
       summaryCalls: 1,
     };
   }
@@ -1477,6 +1495,7 @@ export async function runAssistantDrivenCompaction(
       response.usage.cacheCreationInputTokens ?? 0,
     summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
     summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
+    summaryRequestLogId,
     summaryText: finalSummaryText,
     keyState: parsed.keyState,
     summaryFailed: false,

--- a/assistant/src/conversations/message-consolidation.ts
+++ b/assistant/src/conversations/message-consolidation.ts
@@ -32,7 +32,7 @@
  */
 
 import type { MessageRow } from "../persistence/conversation-crud.js";
-import { isSystemCardMetadata } from "../persistence/conversation-crud.js";
+import { isSystemCardMessage } from "../persistence/conversation-crud.js";
 import type { ContentBlock } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
@@ -45,16 +45,7 @@ const log = getLogger("message-consolidation");
  * fold into them.
  */
 export function isSystemCardRow(msg: MessageRow): boolean {
-  if (msg.role !== "assistant" || !msg.metadata) {
-    return false;
-  }
-  try {
-    return isSystemCardMetadata(
-      JSON.parse(msg.metadata) as Record<string, unknown>,
-    );
-  } catch {
-    return false;
-  }
+  return isSystemCardMessage(msg.role, msg.metadata);
 }
 
 // ── Block predicates ────────────────────────────────────────────────

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -321,6 +321,27 @@ export function isSystemCardMetadata(
 }
 
 /**
+ * Row-level variant of {@link isSystemCardMetadata} for callers holding the
+ * raw persisted `metadata` JSON string. The single place the parse lives so
+ * display merging and turn grouping agree on what a card is.
+ */
+export function isSystemCardMessage(
+  role: string,
+  metadata: string | null,
+): boolean {
+  if (role !== "assistant" || !metadata) {
+    return false;
+  }
+  try {
+    return isSystemCardMetadata(
+      JSON.parse(metadata) as Record<string, unknown>,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Parse a persisted message's metadata JSON against {@link messageMetadataSchema}
  * — the single source of truth for its shape — returning the validated fields,
  * or `undefined` when the column is absent, not valid JSON, or fails validation.
@@ -3859,6 +3880,12 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
     return [messageId];
   }
 
+  // A system card is its own single-row group — its linked calls (e.g. the
+  // summarize-up-to compaction call) never mix into a neighbouring turn.
+  if (isSystemCardMessage(target.role, target.metadata)) {
+    return [target.id];
+  }
+
   // Walk backward from the target message to find the turn boundary.
   // Limit to 50 rows — sufficient for even aggressive tool-use loops.
   const backwardRows = db
@@ -3867,6 +3894,7 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
       role: messages.role,
       content: messages.content,
       createdAt: messages.createdAt,
+      metadata: messages.metadata,
     })
     .from(messages)
     .where(
@@ -3884,6 +3912,12 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
 
   for (const row of backwardRows) {
     if (row.role === "assistant") {
+      if (isSystemCardMessage(row.role, row.metadata)) {
+        // A system card closes the groups on either side of it — rows
+        // before the card belong to an earlier display group.
+        boundaryCreatedAt = row.createdAt;
+        break;
+      }
       assistantIds.push(row.id);
     } else if (row.role === "user") {
       if (isToolResultMessage(row.role, row.content)) {
@@ -3905,6 +3939,7 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
       role: messages.role,
       content: messages.content,
       createdAt: messages.createdAt,
+      metadata: messages.metadata,
     })
     .from(messages)
     .where(
@@ -3919,6 +3954,15 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
 
   for (const row of forwardRows) {
     if (row.role === "assistant") {
+      if (isSystemCardMessage(row.role, row.metadata)) {
+        // A card that is the queried user message's only reply (e.g. the
+        // /compact result) IS the turn's response; otherwise the card
+        // closes the group.
+        if (assistantIds.length === 0) {
+          assistantIds.push(row.id);
+        }
+        break;
+      }
       if (!assistantIds.includes(row.id)) {
         assistantIds.push(row.id);
       }
@@ -3941,6 +3985,7 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
         id: messages.id,
         role: messages.role,
         createdAt: messages.createdAt,
+        metadata: messages.metadata,
       })
       .from(messages)
       .where(
@@ -3954,7 +3999,11 @@ export function getAssistantMessageIdsInTurn(messageId: string): string[] {
       .all();
 
     for (const row of gapRows) {
-      if (row.role === "assistant" && !assistantIds.includes(row.id)) {
+      if (
+        row.role === "assistant" &&
+        !isSystemCardMessage(row.role, row.metadata) &&
+        !assistantIds.includes(row.id)
+      ) {
         assistantIds.push(row.id);
       }
     }

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -778,11 +778,50 @@ export function getRequestLogById(logId: string): LogRow | null {
   );
 }
 
+/**
+ * Authoritative post-persist linkage: stamp `message_id` onto rows a flow
+ * inserted unlinked because its user-facing message persists afterwards
+ * (the /compact and summarize-up-to result cards). Dispatched through the
+ * IS-NULL-guarded {@link LlmRequestLogWriter.backfillMessageIdOnRecoveredLogs}
+ * so a concurrent inspector-recovery stamp is never overwritten. Non-fatal —
+ * an unlinked row degrades to time-window recovery, not data loss.
+ */
+export function linkRequestLogsToMessage(
+  logIds: string[],
+  messageId: string,
+): void {
+  if (logIds.length === 0) {
+    return;
+  }
+  try {
+    resolveLlmRequestLogWriter().backfillMessageIdOnRecoveredLogs(
+      logIds,
+      messageId,
+    );
+  } catch {
+    // non-fatal — the row stays unlinked and time-window recovery finds it
+  }
+}
+
+/**
+ * True when a log row was authored by the turn's own agent loop — a
+ * `mainAgent` row, or a legacy row from before call sites were stamped
+ * (`call_site` NULL). Companion rows a turn merely hosts (e.g.
+ * `compactionAgent`) don't count: a fork-local turn whose only rows are
+ * companions still needs the fork-source fallback to surface the turn's
+ * real calls.
+ */
+function isTurnAuthoredLog(row: LogRow): boolean {
+  return row.callSite == null || row.callSite === "mainAgent";
+}
+
 export function getRequestLogsByMessageId(messageId: string): LogRow[] {
   // Resolve all assistant message IDs in the same turn so the inspector
   // shows every LLM call from the entire agent turn, not just the queried message.
   const turnMessageIds = getAssistantMessageIdsInTurn(messageId);
   const turnLogs = selectLogsByMessageIds(turnMessageIds);
+  const seen = new Set(turnLogs.map((l) => l.id));
+  const merged = [...turnLogs];
 
   // Recovery: find logs in the turn's time window that the message-ID-based
   // query missed. Two categories:
@@ -805,65 +844,62 @@ export function getRequestLogsByMessageId(messageId: string): LogRow[] {
         bounds.endTime,
       );
 
-      if (orphanedLogs.length > 0 || unlinkedLogs.length > 0) {
-        const seen = new Set(turnLogs.map((l) => l.id));
-        const merged = [...turnLogs];
-        for (const log of [...orphanedLogs, ...unlinkedLogs]) {
+      for (const log of [...orphanedLogs, ...unlinkedLogs]) {
+        if (!seen.has(log.id)) {
+          merged.push(log);
+          seen.add(log.id);
+        }
+      }
+
+      // Opportunistically backfill recovered unlinked logs so future queries
+      // hit the fast indexed-by-messageId path. Dispatched through the
+      // active write backend like every other table writer — INSERT-only
+      // backends no-op.
+      if (unlinkedLogs.length > 0 && turnMessageIds.length > 0) {
+        try {
+          const ids = unlinkedLogs.map((l) => l.id);
+          const targetMessageId = turnMessageIds[turnMessageIds.length - 1]!;
+          resolveLlmRequestLogWriter().backfillMessageIdOnRecoveredLogs(
+            ids,
+            targetMessageId,
+          );
+        } catch {
+          // non-fatal — the recovery already returned the right data
+        }
+      }
+    }
+  }
+
+  // Fork-source fallback: pre-fork turns keep their calls under the SOURCE
+  // conversation's message ids, so a fork-local turn with no turn-authored
+  // row resolves the source turn and merges its calls. Gating on "no
+  // turn-authored row" (not "no rows at all") keeps the fallback alive when
+  // a companion row — e.g. a summarize-up-to compaction call landing inside
+  // the turn's time window — was claimed by the recovery above; without it
+  // that companion would eclipse the turn's real calls.
+  if (message?.metadata && !merged.some(isTurnAuthoredLog)) {
+    try {
+      const parsed = messageMetadataSchema.safeParse(
+        JSON.parse(message.metadata),
+      );
+      const sourceMessageId =
+        parsed.success && typeof parsed.data.forkSourceMessageId === "string"
+          ? parsed.data.forkSourceMessageId
+          : null;
+      if (sourceMessageId && sourceMessageId !== messageId) {
+        const sourceTurnIds = getAssistantMessageIdsInTurn(sourceMessageId);
+        for (const log of selectLogsByMessageIds(sourceTurnIds)) {
           if (!seen.has(log.id)) {
             merged.push(log);
             seen.add(log.id);
           }
         }
-        merged.sort(
-          (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
-        );
-
-        // Opportunistically backfill recovered unlinked logs so future queries
-        // hit the fast indexed-by-messageId path. Dispatched through the
-        // active write backend like every other table writer — INSERT-only
-        // backends no-op.
-        if (unlinkedLogs.length > 0 && turnMessageIds.length > 0) {
-          try {
-            const ids = unlinkedLogs.map((l) => l.id);
-            const targetMessageId = turnMessageIds[turnMessageIds.length - 1]!;
-            resolveLlmRequestLogWriter().backfillMessageIdOnRecoveredLogs(
-              ids,
-              targetMessageId,
-            );
-          } catch {
-            // non-fatal — the recovery already returned the right data
-          }
-        }
-
-        return merged;
       }
+    } catch {
+      // malformed metadata — no fork source to resolve
     }
   }
 
-  if (turnLogs.length > 0) {
-    return turnLogs;
-  }
-
-  // Fork-source fallback: if no logs found for the turn, check whether
-  // the queried message was forked from a source and resolve that source's turn.
-  if (!message?.metadata) {
-    return [];
-  }
-
-  try {
-    const parsed = messageMetadataSchema.safeParse(
-      JSON.parse(message.metadata),
-    );
-    const sourceMessageId =
-      parsed.success && typeof parsed.data.forkSourceMessageId === "string"
-        ? parsed.data.forkSourceMessageId
-        : null;
-    if (!sourceMessageId || sourceMessageId === messageId) {
-      return [];
-    }
-    const sourceTurnIds = getAssistantMessageIdsInTurn(sourceMessageId);
-    return selectLogsByMessageIds(sourceTurnIds);
-  } catch {
-    return [];
-  }
+  merged.sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
+  return merged;
 }

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -87,6 +87,8 @@ export interface ContextWindowResult {
   summaryCacheCreationInputTokens?: number;
   summaryCacheReadInputTokens?: number;
   summaryRawResponses?: unknown[];
+  /** See {@link CompactionRunResult.summaryRequestLogId}. */
+  summaryRequestLogId?: string | null;
   summaryText: string;
   reason?: string;
   summaryFailed?: boolean;

--- a/assistant/src/runtime/routes/canned-message-complete.ts
+++ b/assistant/src/runtime/routes/canned-message-complete.ts
@@ -51,6 +51,9 @@ export function emitCannedMessageComplete(
  * card), and the messages-changed sync invalidation that drives the client
  * refetch. No `assistant_text_delta` is emitted — a delta would stream the
  * card into the tail assistant bubble as if the persona were speaking.
+ *
+ * Returns the persisted card's message id so callers can link related
+ * records to it (e.g. the compaction `llm_request_logs` row).
  */
 export async function persistCannedAssistantCard(opts: {
   conversation: { getMessages(): Message[] };
@@ -58,7 +61,7 @@ export async function persistCannedAssistantCard(opts: {
   text: string;
   metadata: Record<string, unknown>;
   originClientId?: string;
-}): Promise<void> {
+}): Promise<string> {
   const { conversation, conversationId, text, metadata, originClientId } = opts;
   const assistantMsg = createAssistantMessage(text);
   const persistedAssistant = await addMessage(
@@ -75,4 +78,5 @@ export async function persistCannedAssistantCard(opts: {
   );
   recordConversationPersistedSeq(conversationId, getCurrentSeq());
   publishConversationMessagesChanged(conversationId, originClientId);
+  return persistedAssistant.id;
 }

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -56,6 +56,7 @@ import {
   setConversationKeyIfAbsent,
 } from "../../persistence/conversation-key-store.js";
 import { enqueueMemoryJob } from "../../persistence/jobs-store.js";
+import { linkRequestLogsToMessage } from "../../persistence/llm-request-log-store.js";
 import { deleteSchedule } from "../../schedule/schedule-store.js";
 import { UserError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
@@ -272,7 +273,13 @@ async function handleSummarizeConversation({
         statusText: "Summarizing conversation",
       });
       const result = await conversation.summarizeUpToMessage(beforeMessageId);
-      await persistCard(formatSummarizeUpToResult(result));
+      const cardId = await persistCard(formatSummarizeUpToResult(result));
+      // Attribute the compaction LLM call to the card it produced, so the
+      // inspector shows it there instead of the unlinked-row recovery
+      // guessing an enclosing turn.
+      if (result.summaryRequestLogId) {
+        linkRequestLogsToMessage([result.summaryRequestLogId], cardId);
+      }
     } catch (err) {
       // Boundary/mapping UserErrors are expected user-facing outcomes, not
       // failures: surface them as a skipped card rather than an error event.

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -124,6 +124,7 @@ import {
   getOrCreateConversation,
 } from "../../persistence/conversation-key-store.js";
 import { searchConversations } from "../../persistence/conversation-queries.js";
+import { linkRequestLogsToMessage } from "../../persistence/llm-request-log-store.js";
 import { MEMORY_RETROSPECTIVE_FORK_SOURCE } from "../../plugins/defaults/memory/memory-retrospective-constants.js";
 import { normalizeOnboardingContext } from "../../prompts/normalize-onboarding.js";
 import { writeOnboardingSection } from "../../prompts/persona-resolver.js";
@@ -2357,13 +2358,18 @@ export async function handleSendMessage(
         publishConversationMessagesChanged(conversationId, originClientId);
         conversation.emitActivityState("thinking", "context_compacting");
         const result = await conversation.forceCompact();
-        await persistCannedAssistantCard({
+        const cardId = await persistCannedAssistantCard({
           conversation,
           conversationId,
           text: formatCompactResult(result),
           metadata: channelMeta,
           originClientId,
         });
+        // Attribute the compaction LLM call to the card it produced — same
+        // linkage as the summarize-up-to route.
+        if (result.summaryRequestLogId) {
+          linkRequestLogsToMessage([result.summaryRequestLogId], cardId);
+        }
       } catch (err) {
         log.error({ err, conversationId }, "Compact command failed");
         broadcastMessage({


### PR DESCRIPTION
## Summary
- `recordCompactionRequestLog` returns the inserted row id, threaded through `CompactionRunResult`/`ContextWindowResult` as `summaryRequestLogId`; the summarize-up-to and /compact routes link it to their persisted result card via the new IS-NULL-guarded `linkRequestLogsToMessage` (`persistCannedAssistantCard` now returns the card id)
- `getAssistantMessageIdsInTurn` treats `system_card` rows as group boundaries: a card is its own single-row group (or a user message's only reply, the /compact shape), so a linked compaction call shows under the card instead of polluting the prior turn — shared `isSystemCardMessage(role, metadata)` predicate now backs both this walk and display merging
- `getRequestLogsByMessageId` runs the fork-source fallback whenever the merged local logs contain no turn-authored row (`call_site` NULL or `mainAgent`), merging source-turn calls instead of letting a recovered companion row (e.g. a compactionAgent call inside the turn's time window) eclipse them

## Original prompt
After running summarize-up-to-here in a forked conversation, the LLM context inspector scoped to the latest turn showed exactly one call — the compaction call — and the turn's real mainAgent call vanished (it lives under the fork-source conversation's message ids, and the recovery-claimed compaction row pre-empted the fork fallback, then got durably stamped onto the turn). Requested fix: deliberate attribution of compaction calls to the result card plus a fork fallback that can't be eclipsed.