### PR TITLE
feat(ui-surface): inject activation_moment param only for activation-rail conversations

### DIFF
--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -36,7 +36,11 @@ Flow, end to end:
    `assistant/src/onboarding/onboarding-events-store.ts`:
    - emission is **deterministic, tied to a `ui_show` surface** — there is no
      model-facing tool. The model tags the surface it is already rendering for a
-     rail move with an optional `activation_moment` parameter on `ui_show`; the
+     rail move with an optional `activation_moment` parameter on `ui_show` (the
+     param is present in ui_show's schema only for activation-rail
+     conversations — `injectActivationMomentParam` in
+     `tools/ui-surface/channel-variants.ts`, applied at tool resolution when
+     `isActivationSession` is true); the
      daemon captures that tag on the surface's server-side state and records the
      milestone (gated on `isActivationSession`). **Timing is per-moment**
      (`ACTIVATION_MOMENT_EMIT_AT` in `activation-funnel.ts`): most moments record

--- a/assistant/src/__tests__/ui-channel-variants.test.ts
+++ b/assistant/src/__tests__/ui-channel-variants.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ToolDefinition } from "../providers/types.js";
-import { projectUiToolsForChannel } from "../tools/ui-surface/channel-variants.js";
+import { ACTIVATION_MOMENT_PARAMS } from "../telemetry/activation-funnel.js";
+import {
+  injectActivationMomentParam,
+  projectUiToolsForChannel,
+} from "../tools/ui-surface/channel-variants.js";
 import {
   uiDismissTool,
   uiShowTool,
@@ -68,5 +72,37 @@ describe("projectUiToolsForChannel", () => {
 
     expect(uiShowTool.description).toBe(descriptionBefore);
     expect(JSON.stringify(uiShowTool.input_schema)).toBe(schemaBefore);
+  });
+});
+
+describe("injectActivationMomentParam", () => {
+  function properties(def: ToolDefinition): Record<string, unknown> {
+    return (def.input_schema as { properties: Record<string, unknown> })
+      .properties;
+  }
+
+  test("the standard ui_show schema does not carry activation_moment", () => {
+    expect(properties(uiShowTool).activation_moment).toBeUndefined();
+  });
+
+  test("adds the optional param to ui_show only, leaving required unchanged", () => {
+    const projected = injectActivationMomentParam(defs);
+    const uiShow = projected.find((d) => d.name === "ui_show")!;
+
+    const param = properties(uiShow).activation_moment as { enum: string[] };
+    expect(param).toBeDefined();
+    expect(param.enum).toEqual([...ACTIVATION_MOMENT_PARAMS]);
+    expect((uiShow.input_schema as { required: string[] }).required).toEqual([
+      "surface_type",
+      "data",
+    ]);
+    expect(projected.find((d) => d.name === "ui_update")).toBe(uiUpdateTool);
+    expect(projected.find((d) => d.name === "bash")).toBe(defs[3]);
+  });
+
+  test("injection never mutates the shared definition", () => {
+    const before = JSON.stringify(uiShowTool.input_schema);
+    injectActivationMomentParam(defs);
+    expect(JSON.stringify(uiShowTool.input_schema)).toBe(before);
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -16,6 +16,7 @@ import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { getBindingByConversation } from "../persistence/external-conversation-store.js";
 import { getAllDefaultPluginNames } from "../plugins/defaults/main.js";
+import { isActivationSession } from "../plugins/defaults/memory/activation-session-store.js";
 import { isPluginDisabled } from "../plugins/disabled-state.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
@@ -50,7 +51,10 @@ import {
   type ToolContext,
   type ToolExecutionResult,
 } from "../tools/types.js";
-import { projectUiToolsForChannel } from "../tools/ui-surface/channel-variants.js";
+import {
+  injectActivationMomentParam,
+  projectUiToolsForChannel,
+} from "../tools/ui-surface/channel-variants.js";
 import { loadWorkspaceTools } from "../tools/workspace-tools/loader.js";
 import {
   resolveUsageAttribution,
@@ -830,12 +834,19 @@ export function createResolveToolsCallback(
     const channelForUiTools = ctx.toolContextPin
       ? undefined
       : ctx.channelCapabilities?.channel;
-    const allBaseDefs = projectUiToolsForChannel(
+    let allBaseDefs = projectUiToolsForChannel(
       [...scopedCoreDefs, ...scopedWorkspaceDefs, ...scopedMcpDefs].filter(
         (d) => !excluded.has(d.name),
       ),
       channelForUiTools,
     );
+    // Activation-rail conversations carry the optional `activation_moment`
+    // telemetry param on ui_show. The marker is written before the first
+    // tool resolution (see `applyBootstrapTemplate` in system-prompt.ts), so
+    // the projected schema is stable for the conversation's lifetime.
+    if (isActivationSession(ctx.conversationId)) {
+      allBaseDefs = injectActivationMomentParam(allBaseDefs);
+    }
 
     const effectivePreactivated = [
       ...DEFAULT_PREACTIVATED_SKILL_IDS,

--- a/assistant/src/tools/ui-surface/channel-variants.ts
+++ b/assistant/src/tools/ui-surface/channel-variants.ts
@@ -1,18 +1,22 @@
 /**
- * Per-channel projections of the UI surface tool definitions.
+ * Per-conversation wire projections of the UI surface tool definitions.
  *
  * Slack renders exactly one surface — the task_progress card (everything else
  * is rejected at execution; see `isSlackTaskProgressUiException` in
  * `daemon/conversation-surfaces.ts`) — so Slack conversations get a `ui_show`
  * variant documenting only that shape instead of the full multi-surface docs.
+ * Activation-rail conversations additionally get the `activation_moment`
+ * telemetry param, which no other conversation pays schema tokens for (the
+ * emit path is gated on `isActivationSession` regardless).
  *
  * Projection contract: shared definition objects are never mutated (variants
  * are module-level constants swapped in via spread-copy), and the projected
- * set is a pure function of per-conversation-stable channel state, so a
+ * set is a pure function of per-conversation-stable state, so a
  * conversation's tools+system prompt-cache prefix stays stable across turns.
  */
 
 import type { ToolDefinition } from "../../providers/types.js";
+import { ACTIVATION_MOMENT_PARAMS } from "../../telemetry/activation-funnel.js";
 import { TASK_PROGRESS_TEMPLATE_SHAPE } from "./surface-shape-docs.js";
 
 const SLACK_UI_SHOW_DESCRIPTION = `Show a live task-progress card for the current work — the only surface this channel renders. data: { template: "task_progress", templateData: ${TASK_PROGRESS_TEMPLATE_SHAPE} }. Show it early on multi-step turns and advance step statuses via ui_update as work progresses.`;
@@ -58,4 +62,40 @@ export function projectUiToolsForChannel(
         }
       : def,
   );
+}
+
+const ACTIVATION_MOMENT_PROPERTY = {
+  type: "string",
+  enum: ACTIVATION_MOMENT_PARAMS,
+  description:
+    "Activation-rail telemetry tag. Set this when this surface IS one of the activation funnel moments; the milestone is recorded automatically when the user commits the surface. Omit for all non-activation surfaces.",
+};
+
+/**
+ * Add the optional `activation_moment` param to ui_show's schema. Applied
+ * only for activation-rail conversations (`isActivationSession`) — the rail
+ * bootstrap prompt instructs the tagging, and the daemon's emit path reads
+ * the tag from tool input independently of this schema.
+ */
+export function injectActivationMomentParam(
+  definitions: ToolDefinition[],
+): ToolDefinition[] {
+  return definitions.map((def) => {
+    if (def.name !== "ui_show") {
+      return def;
+    }
+    const schema = def.input_schema as {
+      properties?: Record<string, unknown>;
+    };
+    return {
+      ...def,
+      input_schema: {
+        ...schema,
+        properties: {
+          ...schema.properties,
+          activation_moment: ACTIVATION_MOMENT_PROPERTY,
+        },
+      },
+    };
+  });
 }

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -9,7 +9,6 @@
 
 import { RiskLevel } from "../../permissions/types.js";
 import { isWeakOpenModel } from "../../providers/weak-open-model.js";
-import { ACTIVATION_MOMENT_PARAMS } from "../../telemetry/activation-funnel.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -276,12 +275,6 @@ export const uiShowTool = {
         type: "boolean",
         description:
           "Keep the surface visible after an action is clicked (clicked actions are marked spent). For launcher/menu cards. Defaults to false.",
-      },
-      activation_moment: {
-        type: "string",
-        enum: ACTIVATION_MOMENT_PARAMS,
-        description:
-          "Activation-rail telemetry tag (cohort only). Set this when this surface IS one of the activation funnel moments; the milestone is recorded automatically when the user commits the surface. Omit for all non-activation surfaces.",
       },
     },
     required: ["surface_type", "data"],


### PR DESCRIPTION
## Summary
- Removes the `activation_moment` property (5-token enum + description, ~100 tokens) from the always-present `ui_show` schema; `injectActivationMomentParam` in `channel-variants.ts` adds it back at tool resolution only when `isActivationSession(conversationId)` is true. The marker is written before the first tool resolution (`applyBootstrapTemplate` → `markActivationSession` in `system-prompt.ts`), so the projected schema is stable for a conversation's lifetime and prompt-cache-safe.
- The emit path is untouched — `conversation-surfaces.ts` reads the tag from tool input and was already gated on `isActivationSession`, so rail tagging behavior is identical (the full activation-emit suite passes unchanged). Non-rail conversations simply stop paying schema tokens for a param that fleet telemetry shows was never set once in 14 days.
- Updates `docs/activation-funnel-telemetry.md` to document the rail-conditional schema.

Final measured state of the 4-PR series (name+description+input_schema, chars): three-tool total 6,924 → 4,893 (~1,870 → ~1,320 tokens, −29%) on standard transports; Slack `ui_show` 6,149 → 791 (−87%).

Note for follow-up (not this PR): zero fleet usage of `activation_moment` in 14d may mean the rail's tagging instruction is inert (cohort off or models ignoring it) — worth checking whether the funnel is recording at all.

PR 4 of 4 of the UI-surface-tools token reduction plan (#38266 teaching errors, #38269 slim docs, #38271 Slack variant).

## Original prompt
Fleet telemetry showed `activation_moment` — an onboarding-rail-only telemetry tag — shipping in every conversation's ui_show schema while never being used. The user approved a 4-PR reduction plan and asked to run all four in sequence via `/do`. This PR is the final step: make the param rail-conditional via the projection layer introduced in PR 3, keeping the daemon emit path and telemetry contract unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)