### PR TITLE
fix(memory): preactivate skill-management so the retrospective fork's authoring tools are active from turn 1

### DIFF
--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -342,28 +342,37 @@ export async function persistWakeTriggerMessage(
  * inputs for tool-definition resolution — see {@link WakeToolContextPin}.
  * Its `requestOrigin`, when set, is stamped onto the conversation's per-turn
  * origin so the permission checker's origin-scoped auto-grants fire for the
- * wake. All are set and restored alongside the allowlist.
+ * wake. `preactivateSkillIds`, when non-empty, activates those skills' bundled
+ * tools in the turn's active set (`allowedToolNames`) for the wake so they are
+ * callable without a prior `skill_load`. All are set and restored alongside the
+ * allowlist.
  */
 export function scopeWakeAllowedTools(
   conversation: Conversation,
   tools: ReadonlySet<string>,
   gateMode: SubagentToolGateMode = "wire",
   toolContextPin?: WakeToolContextPin,
+  preactivateSkillIds?: readonly string[],
 ): () => void {
   const previous = conversation.subagentAllowedTools;
   const previousGateMode = conversation.subagentToolGateMode;
   const previousToolContextPin = conversation.toolContextPin;
   const previousRequestOrigin = conversation.currentTurnRequestOrigin;
+  const previousPreactivated = conversation.preactivatedSkillIds;
   conversation.setSubagentAllowedTools(new Set(tools));
   conversation.subagentToolGateMode = gateMode;
   conversation.toolContextPin = toolContextPin;
   if (toolContextPin?.requestOrigin !== undefined) {
     conversation.currentTurnRequestOrigin = toolContextPin.requestOrigin;
   }
+  if (preactivateSkillIds && preactivateSkillIds.length > 0) {
+    conversation.setPreactivatedSkillIds([...preactivateSkillIds]);
+  }
   return () => {
     conversation.setSubagentAllowedTools(previous);
     conversation.subagentToolGateMode = previousGateMode;
     conversation.toolContextPin = previousToolContextPin;
     conversation.currentTurnRequestOrigin = previousRequestOrigin;
+    conversation.setPreactivatedSkillIds(previousPreactivated);
   };
 }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -6,7 +6,10 @@ import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { loadSkillCatalog, resolveSkillSelector } from "../config/skills.js";
 import { ipcClassifyRisk } from "../ipc/gateway-client.js";
-import { MEMORY_RETROSPECTIVE_ORIGIN } from "../plugins/defaults/memory/memory-retrospective-constants.js";
+import {
+  MEMORY_RETROSPECTIVE_ORIGIN,
+  SKILL_MANAGEMENT_SKILL_ID,
+} from "../plugins/defaults/memory/memory-retrospective-constants.js";
 import { indexCatalogById } from "../skills/include-graph.js";
 import { getSkillRoots } from "../skills/path-classifier.js";
 import { computeTransitiveSkillVersionHash } from "../skills/transitive-version-hash.js";
@@ -799,8 +802,6 @@ export async function classifyRisk(
 // The grant is intentionally narrow: it matches exactly these tools AND the
 // retrospective origin on a v3-live assistant, so no interactive session, other
 // origin, or non-v3-live install is affected.
-const SKILL_MANAGEMENT_SKILL_ID = "skill-management";
-
 function isRetrospectiveSkillAuthoringGrant(
   toolName: string,
   input: Record<string, unknown>,

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -642,6 +642,9 @@ describe("memoryRetrospectiveJob", () => {
       "skill_load",
       "find_similar_skills",
     ]);
+    // skill-management is preactivated so the authoring trio is in the turn's
+    // active set from turn 1 (not merely on the execution allowlist).
+    expect(opts.preactivateSkillIds).toEqual(["skill-management"]);
     expect(opts.suppressWakeSurface).toBe(true);
     // Sanity: the other fork-specific opts the handler relies on are still set.
     expect(opts.skipHintInjection).toBe(true);
@@ -656,6 +659,8 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls).toHaveLength(1);
     // The authoring trio is not even named on the allowlist when inactive.
     expect(wakeCalls[0]!.opts.allowedTools).toEqual(["remember"]);
+    // And skill-management is not preactivated, so its tools never go active.
+    expect(wakeCalls[0]!.opts.preactivateSkillIds).toBeUndefined();
   });
 
   test("wake pins the memory_retrospective origin on the tool-context pin so the checker's grant can fire", async () => {
@@ -1800,10 +1805,11 @@ describe("memoryRetrospectiveJob", () => {
 
     const instructionText = persistedInstructionText();
 
-    // Available-tools line names the skill-authoring trio.
+    // Available-tools line names the skill-authoring pair; skill-management is
+    // preactivated, so no `skill_load` step is instructed.
     expect(instructionText).toContain("find_similar_skills");
     expect(instructionText).toContain("scaffold_managed_skill");
-    expect(instructionText).toContain("skill_load skill-management");
+    expect(instructionText).not.toContain("skill_load skill-management");
 
     // Permissive relevance pre-check keyed on actually-executed procedures.
     expect(instructionText).toContain("a PROCEDURE you actually carried out");

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
@@ -99,8 +99,11 @@ For everything else in your review window, use the \`remember\` tool on facts, p
   test("proc-to-skills active: tool line widens and the authoring section is appended", () => {
     const out = buildForkInstruction(makeArgs({ procToSkillsActive: true }));
     expect(out).toContain(
-      "Only `remember`, `find_similar_skills`, `scaffold_managed_skill`, and `skill_load skill-management` are available for this pass",
+      "Only `remember`, `find_similar_skills`, and `scaffold_managed_skill` are available for this pass",
     );
+    // skill-management is preactivated for the wake, so the prompt no longer
+    // instructs a `skill_load` step.
+    expect(out).not.toContain("skill_load skill-management");
     expect(out).toContain(
       "\n---\n\nIf your review window contains a PROCEDURE you actually carried out",
     );

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
@@ -70,3 +70,11 @@ export const SKILL_CARD_MESSAGE_KIND = "skill-authored-card";
  * the `"memory_retrospective"` member of `TitleOrigin`.
  */
 export const MEMORY_RETROSPECTIVE_ORIGIN = "memory_retrospective";
+
+/**
+ * Bundled skill that provides the retrospective's authoring tools
+ * (`find_similar_skills`, `scaffold_managed_skill`, and the `skill_load`
+ * target). Preactivated for the fork wake so those tools join the turn's active
+ * set from turn 1, and matched by the permission checker's origin-scoped grant.
+ */
+export const SKILL_MANAGEMENT_SKILL_ID = "skill-management";

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -87,6 +87,7 @@ import {
   MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
   MEMORY_RETROSPECTIVE_ORIGIN,
   MEMORY_RETROSPECTIVE_SOURCE,
+  SKILL_MANAGEMENT_SKILL_ID,
 } from "./memory-retrospective-constants.js";
 import { loadRetrospectiveRunMessages } from "./memory-retrospective-fork-boundary.js";
 import { buildForkInstruction } from "./memory-retrospective-prompt.js";
@@ -435,6 +436,14 @@ export async function runForkBasedRetrospective(
       // {@link SubagentToolGateMode} and {@link WakeToolContextPin}.
       toolGateMode: "execution" as const,
       toolContextPin,
+      // Preactivate skill-management so its authoring tools (`find_similar_skills`
+      // / `scaffold_managed_skill` / the `skill_load` target) are in the turn's
+      // active set from turn 1; the checker's origin-scoped grant then makes them
+      // callable without an interactive prompt. Same `procToSkillsActive` gate as
+      // the allowlist above.
+      preactivateSkillIds: procToSkillsActive
+        ? [SKILL_MANAGEMENT_SKILL_ID]
+        : undefined,
       // Message-tier cache-prefix parity — reproducing the source's
       // `<background_turn>` / `<channel_capabilities>` / `<non_interactive_context>`
       // blocks — is handled by metadata rehydration, not by re-running runtime

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
@@ -165,7 +165,7 @@ export function buildForkInstruction({
     : `Your review window starts at ${anchorDescription} and ends just before this instruction message. If you cannot locate that anchoring turn in your visible history (for example, it is behind the compaction summary), fail closed: review only the most recent visible messages after the summary, not the whole conversation.`;
 
   const availableToolsLine = procToSkillsActive
-    ? "Only `remember`, `find_similar_skills`, `scaffold_managed_skill`, and `skill_load skill-management` are available for this pass — any other tool call will be rejected, so don't attempt one."
+    ? "Only `remember`, `find_similar_skills`, and `scaffold_managed_skill` are available for this pass — any other tool call will be rejected, so don't attempt one."
     : "Only the `remember` tool is available for this pass — any other tool call will be rejected, so don't attempt one.";
 
   const override = loadPromptOverride({

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -292,6 +292,14 @@ export interface WakeOptions {
    */
   toolContextPin?: WakeToolContextPin;
   /**
+   * Skill IDs to preactivate for the wake so their bundled tools join the
+   * turn's active set (`allowedToolNames`) without a prior `skill_load`.
+   * Applied and restored alongside `allowedTools`; ignored when `allowedTools`
+   * is absent. Used by fork-based memory retrospectives to make the
+   * skill-management authoring tools callable directly.
+   */
+  preactivateSkillIds?: readonly string[];
+  /**
    * Explicit persona/channel slugs for the wake's system-prompt build,
    * applied to the conversation for the duration of the run and restored
    * afterwards. Wakes bypass the orchestrator's turn-start persona snapshot,
@@ -1232,6 +1240,7 @@ export async function wakeAgentForOpportunity(
           new Set(opts.allowedTools),
           opts.toolGateMode,
           opts.toolContextPin,
+          opts.preactivateSkillIds,
         );
         return true;
       } catch (err) {


### PR DESCRIPTION
## Summary

- The memory-retrospective fork is designed to call `find_similar_skills` / `scaffold_managed_skill`, but those `skill-management`-owned tools were only on the wake's *execution* allowlist (`subagentAllowedTools`), never in the turn's *active* set (`allowedToolNames`). So the active-set gate rejected every call (`Tool "…" is not currently active. Load the "skill-management" skill…`) before the permission checker's origin-scoped auto-grant could ever fire. This was the single highest-frequency tool-error row in product telemetry — 100% background, so no user-facing impact, but it wasted a tool turn (and a full inference) on every retrospective pass.
- Thread a `preactivateSkillIds` option through the wake (`WakeOptions` → `applyWakeAllowedTools` → `scopeWakeAllowedTools` → `Conversation.setPreactivatedSkillIds`, restored in the wake teardown) and have the retrospective job pass `["skill-management"]`, gated on the existing `procToSkillsActive` (`memory.v3.live`) predicate — mirroring the established `DEFAULT_PREACTIVATED_SKILL_IDS` / subagent-role precedent. Drop the now-unnecessary `skill_load skill-management` step from the fork prompt.
- Cannot widen capability: `delete_managed_skill` (also owned by `skill-management`) becomes active but stays blocked by the wake's execution allowlist. Folds the duplicate `SKILL_MANAGEMENT_SKILL_ID` literal (previously a local const in `checker.ts`) into the shared constants module. No migration, no feature flag — in-memory only, inert on non-v3 installs.

## Original prompt

Turn the highest-frequency tool-error surfaced by the v0.10.8 session sweep into a fix: the memory-retrospective fork's skill-authoring tools fail on every call because the `skill-management` skill that provides them is never activated for the wake. The fix preactivates that skill so the tools are active from turn 1 (letting the existing checker auto-grant work as designed), and includes the two review-required follow-ups — updating the prompt-assertion tests that referenced the removed `skill_load skill-management` phrase, and de-duplicating the `SKILL_MANAGEMENT_SKILL_ID` constant into a single source of truth.