### PR TITLE
fix(providers): classify OpenRouter 403 'Key limit exceeded' (spend cap) as billing, not invalid key

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -15,6 +15,7 @@ import {
   isUserCancellation,
 } from "../daemon/conversation-error.js";
 import { ConnectionResolutionError } from "../providers/connection-resolution.js";
+import { normalizeOpenAIAPIError } from "../providers/openai/api-error-normalization.js";
 import {
   type AbortReasonKind,
   createAbortReason,
@@ -810,6 +811,36 @@ describe("classifyConversationError", () => {
         expect(result.errorCategory).toBe("provider_billing");
         expect(result.retryable).toBe(false);
       }
+    });
+
+    it("classifies OpenRouter 403 spend-cap ('Key limit exceeded') as provider_billing, not invalid key", () => {
+      providerRoutingSources.openrouter = "user-key";
+      // Derive the reason the way the provider does — run the raw 403 body
+      // through normalizeOpenAIAPIError — so this exercises the deriveReason
+      // spend-cap regex end to end rather than asserting a hardcoded reason. A
+      // reason-less 403 would otherwise short-circuit to the invalid-key path.
+      const normalized = normalizeOpenAIAPIError(
+        {
+          status: 403,
+          message: "403 status code",
+          headers: new Headers(),
+        } as unknown as Parameters<typeof normalizeOpenAIAPIError>[0],
+        '{"error":{"code":403,"message":"Key limit exceeded"}}',
+      );
+      expect(normalized.reason).toBe("insufficient_credits");
+
+      const err = new ProviderError(
+        "OpenRouter API error (403): Key limit exceeded",
+        "openrouter",
+        403,
+        { reason: normalized.reason },
+      );
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_BILLING");
+      expect(result.errorCategory).toBe("provider_billing");
+      expect(result.retryable).toBe(false);
+      expect(result.code).not.toBe("PROVIDER_INVALID_KEY");
     });
 
     it("classifies managed-proxy OpenRouter insufficient_balance bodies as credits_exhausted", () => {

--- a/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
+++ b/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
@@ -322,7 +322,9 @@ describe("captureRawErrorBodyFetch", () => {
   });
 });
 
-function n(over: Partial<NormalizedOpenAIAPIError> = {}): NormalizedOpenAIAPIError {
+function n(
+  over: Partial<NormalizedOpenAIAPIError> = {},
+): NormalizedOpenAIAPIError {
   return { message: "boom", ...over };
 }
 
@@ -389,6 +391,24 @@ describe("deriveReason", () => {
     );
   });
 
+  test("403 spend-cap 'Key limit exceeded' → insufficient_credits", () => {
+    // OpenRouter returns 403 with this body when a key's configured credit
+    // limit is reached — a billing condition, not a rejected key. The billing
+    // gate precedes the 401/403 credential branch, so it routes to credits.
+    expect(deriveReason(n({ message: "Key limit exceeded" }), 403)).toBe(
+      "insufficient_credits",
+    );
+    expect(
+      deriveReason(
+        n({
+          message: "Forbidden",
+          rawBody: '{"error":{"code":403,"message":"Key limit exceeded"}}',
+        }),
+        403,
+      ),
+    ).toBe("insufficient_credits");
+  });
+
   test("429 → rate_limited", () => {
     expect(deriveReason(n(), 429)).toBe("rate_limited");
   });
@@ -414,6 +434,8 @@ describe("deriveReason", () => {
   });
 
   test("no status, no signal → unknown", () => {
-    expect(deriveReason(n({ message: "who knows" }), undefined)).toBe("unknown");
+    expect(deriveReason(n({ message: "who knows" }), undefined)).toBe(
+      "unknown",
+    );
   });
 });

--- a/assistant/src/util/provider-error-patterns.ts
+++ b/assistant/src/util/provider-error-patterns.ts
@@ -14,8 +14,14 @@ export const VISION_NOT_SUPPORTED_PATTERNS = [
   /multi-?modal.*not.*support/i,
 ];
 
-// Vendor-neutral (OpenRouter/Anthropic-style) credit-exhaustion prose.
+// Vendor-neutral (OpenRouter/Anthropic-style) credit-exhaustion prose. Also
+// covers per-key spend caps: OpenRouter returns 403 "Key limit exceeded" when a
+// key's configured credit limit is reached — a billing/budget condition that
+// routes to the billing classification alongside other credit exhaustion. The
+// phrase is anchored on the contiguous "key limit" so it cannot swallow
+// rate-limit prose ("rate limit exceeded") or generic invalid-key text.
 export const INSUFFICIENT_CREDITS_PATTERNS = [
   /credit balance is too low/i,
   /insufficient.*credits?/i,
+  /key limit (?:has been )?(?:exceeded|reached)/i,
 ];


### PR DESCRIPTION
## Summary

- OpenRouter returns HTTP 403 with `{"error":{"message":"Key limit exceeded"}}` when a BYOK key reaches its configured credit (spend) cap. `deriveReason` classified this via the generic 401/403 branch as `invalid_credentials`, producing "Your API key was rejected by the provider. Update it in Settings…" — telling the user to **replace a valid key** instead of adding funds / raising the cap.
- Add a `key limit (has been )?(exceeded|reached)` pattern to the shared `INSUFFICIENT_CREDITS_PATTERNS`. The billing gate in `deriveReason` runs *before* the 401/403 credential branch, so the 403 now derives `insufficient_credits` → `PROVIDER_BILLING` with the correct "add funds / update the key" guidance. One-line addition to the leaf module that all three reason-derivers and the daemon reason-less fallback already consume — no new reason enum, no wiring. Anchored on the contiguous "key limit" so it can't swallow rate-limit ("rate limit exceeded") or generic invalid-key prose.
- **Verified the literal upstream string before merging** (the assistant's own error narration in telemetry quotes `403 "Key limit exceeded"`), so the reclassification actually fires rather than silently no-op'ing.

Downstream `.code`-keyed consumers were reviewed and all now see `PROVIDER_BILLING` for this case (the intended behavior): the memory consolidation retry-backoff curve, the memory-v3 pool-select billing notice, and `shouldPersistProviderErrorAsAssistantMessage` (for managed-proxy OpenRouter this flips the failure from not-persisted to a persisted `PROVIDER_BILLING` message). `retryable` stays `false → false`, so retry/backoff behavior is unchanged.

## Original prompt

Fix the OpenRouter spend-cap misclassification found in the v0.10.8 session sweep: a 403 "Key limit exceeded" (a per-key credit cap, a billing condition) was being reported to BYOK users as a rejected API key, sending them to replace a key that is actually valid. Route spend-cap 403s to the billing classification with the correct guidance, and — per review — confirm the exact upstream wording from telemetry first and make the end-to-end test derive the reason through the real normalize path rather than asserting a hardcoded one.