### PR TITLE
fix(tests): baseline conversation-tool-setup memory import in reverse guard

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
@@ -91,6 +91,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "src/daemon/conversation-lifecycle.ts",
     "src/daemon/conversation-runtime-assembly.ts",
     "src/daemon/conversation-surfaces.ts",
+    "src/daemon/conversation-tool-setup.ts",
     "src/daemon/conversation-turn-finalize.ts",
     "src/daemon/conversation.ts",
     "src/daemon/embedding-reconcile.ts",


### PR DESCRIPTION
## Summary
- Adds `src/daemon/conversation-tool-setup.ts` to the `memory` entry of the host→plugin reverse-guard baseline, fixing the `plugin-import-boundary-reverse-guard.test.ts` failure on main ([failing job](https://github.com/vellum-ai/vellum-assistant/actions/runs/29488283780/job/87587939212)).
- The edge was introduced by #38273, which gates `activation_moment` param injection on `isActivationSession()` from the memory plugin's activation-session store. The coupling is intentional and mirrors the already-baselined `conversation-surfaces.ts` import of the same module; extracting the memory plugin's daemon coupling is tracked separately, so per the guard's own guidance the edge is baselined rather than rerouted.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29488283780/job/87587939212 — the Test job on main, where the reverse import-boundary guard flags a new host→plugin import that #38273 introduced without updating the baseline.