### PR TITLE
fix(permissions): bounded retry for transient classify_risk gateway blips (still fail-closed)

### DIFF
--- a/assistant/src/__tests__/mock-gateway-ipc.ts
+++ b/assistant/src/__tests__/mock-gateway-ipc.ts
@@ -44,6 +44,15 @@ let ipcResults: Record<string, unknown> = {};
 /** Whether the fake ipcCall should simulate a connection error. */
 let simulateError = false;
 
+/** Throw a transient (retryable) error for the first N persistent calls, then succeed. */
+let failFirstN = 0;
+
+/** When set, the simulated persistent-call failure is a non-retryable IpcCallError. */
+let failWithIpcCallError = false;
+
+/** Per-method persistent-client `.call` counter, so retry tests can assert attempts. */
+const persistentCallCounts: Record<string, number> = {};
+
 // ---------------------------------------------------------------------------
 // FakePersistentIpcClient — mirrors PersistentIpcClient API
 // ---------------------------------------------------------------------------
@@ -52,7 +61,16 @@ class FakePersistentIpcClient extends EventEmitter {
   async call(
     method: string,
     _params?: Record<string, unknown>,
+    _timeoutMs?: number,
   ): Promise<unknown> {
+    persistentCallCounts[method] = (persistentCallCounts[method] ?? 0) + 1;
+    if (failFirstN > 0) {
+      failFirstN--;
+      if (failWithIpcCallError) {
+        throw new FakeIpcCallError("Mock deterministic gateway error");
+      }
+      throw new Error("Mock IPC socket error");
+    }
     if (simulateError) {
       throw new Error("Mock IPC socket error");
     }
@@ -139,7 +157,15 @@ export function installGatewayIpcMock(): void {
  */
 export function mockGatewayIpc(
   flags?: Record<string, boolean> | null,
-  opts?: { error?: boolean; code?: string; results?: Record<string, unknown> },
+  opts?: {
+    error?: boolean;
+    code?: string;
+    results?: Record<string, unknown>;
+    /** Throw a transient (retryable) error for the first N persistent calls. */
+    failFirstN?: number;
+    /** Make the simulated persistent-call failure a non-retryable IpcCallError. */
+    ipcCallError?: boolean;
+  },
 ): void {
   if (flags != null) {
     ipcResults["get_feature_flags"] = flags;
@@ -150,6 +176,20 @@ export function mockGatewayIpc(
   if (opts?.error) {
     simulateError = true;
   }
+  if (opts?.failFirstN !== undefined) {
+    failFirstN = opts.failFirstN;
+  }
+  if (opts?.ipcCallError) {
+    failWithIpcCallError = true;
+  }
+}
+
+/**
+ * Number of persistent-client `.call(method)` invocations since the last reset.
+ * Lets retry tests assert the exact attempt count.
+ */
+export function getMockPersistentCallCount(method: string): number {
+  return persistentCallCounts[method] ?? 0;
 }
 
 /**
@@ -158,4 +198,9 @@ export function mockGatewayIpc(
 export function resetMockGatewayIpc(): void {
   ipcResults = {};
   simulateError = false;
+  failFirstN = 0;
+  failWithIpcCallError = false;
+  for (const key of Object.keys(persistentCallCounts)) {
+    delete persistentCallCounts[key];
+  }
 }

--- a/assistant/src/ipc/gateway-client.test.ts
+++ b/assistant/src/ipc/gateway-client.test.ts
@@ -9,12 +9,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
+  getMockPersistentCallCount,
   mockGatewayIpc,
   resetMockGatewayIpc,
 } from "../__tests__/mock-gateway-ipc.js";
 import {
   ipcCall,
   ipcCallPersistent,
+  ipcClassifyRisk,
   ipcGetFeatureFlags,
   resetPersistentClient,
 } from "./gateway-client.js";
@@ -130,5 +132,62 @@ describe("ipcGetFeatureFlags", () => {
 
     const flags = await ipcGetFeatureFlags();
     expect(flags).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ipcClassifyRisk retry semantics
+// ---------------------------------------------------------------------------
+
+describe("ipcClassifyRisk retry", () => {
+  const CLASSIFY_OK = {
+    risk: "low",
+    reason: "safe",
+    matchType: "none",
+    scopeOptions: [],
+  };
+  const emptyParams = {} as unknown as Parameters<typeof ipcClassifyRisk>[0];
+
+  test("retries a transient failure and then succeeds", async () => {
+    mockGatewayIpc(null, {
+      failFirstN: 1,
+      results: { classify_risk: CLASSIFY_OK },
+    });
+
+    const result = await ipcClassifyRisk(emptyParams);
+    expect(result?.risk).toBe("low");
+    expect(getMockPersistentCallCount("classify_risk")).toBe(2);
+  });
+
+  test("returns undefined after exhausting retries (3 attempts)", async () => {
+    mockGatewayIpc(null, { error: true });
+
+    const result = await ipcClassifyRisk(emptyParams);
+    expect(result).toBeUndefined();
+    expect(getMockPersistentCallCount("classify_risk")).toBe(3);
+  });
+
+  test("does NOT retry a structured IpcCallError (fails after 1 attempt)", async () => {
+    mockGatewayIpc(null, {
+      failFirstN: 3,
+      ipcCallError: true,
+      results: { classify_risk: CLASSIFY_OK },
+    });
+
+    const result = await ipcClassifyRisk(emptyParams);
+    expect(result).toBeUndefined();
+    expect(getMockPersistentCallCount("classify_risk")).toBe(1);
+  });
+
+  test("stops retrying once the signal is aborted", async () => {
+    mockGatewayIpc(null, { error: true });
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await ipcClassifyRisk(emptyParams, controller.signal);
+    expect(result).toBeUndefined();
+    // An already-aborted signal short-circuits the retry loop after the first
+    // failed attempt rather than exhausting all three.
+    expect(getMockPersistentCallCount("classify_risk")).toBe(1);
   });
 });

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -12,6 +12,7 @@
 
 import {
   ipcCall as packageIpcCall,
+  IpcCallError,
   PersistentIpcClient as PackagePersistentIpcClient,
 } from "@vellumai/gateway-client/ipc-client";
 
@@ -20,6 +21,7 @@ import type {
   ClassifyRiskParams,
 } from "../permissions/ipc-risk-types.js";
 import { getLogger } from "../util/logger.js";
+import { abortableSleep, computeRetryDelay } from "../util/retry.js";
 import { resolveIpcSocketPath } from "./socket-path.js";
 
 const log = getLogger("gateway-ipc-client");
@@ -138,6 +140,19 @@ export async function ipcGetVelayStatus(): Promise<VelayTunnelStatus | null> {
   };
 }
 
+// classify_risk is an idempotent, side-effect-free read, so a transient gateway
+// blip (socket dropped between calls, momentary unreachability) is safe to
+// retry — the persistent client re-establishes its socket on the next call. The
+// budget is deliberately sized for SUB-SECOND blips, not restart-class outages:
+// each attempt uses a tighter timeout than the transport default so a wedged-
+// but-reachable gateway cannot multiply the worst-case wait, and total latency
+// against a hard-down gateway stays close to the single-attempt ceiling.
+// Deterministic failures — a structured IpcCallError, or a returned-but-
+// malformed payload — are NOT retried; they fail closed immediately.
+const CLASSIFY_RISK_MAX_RETRIES = 2; // 3 attempts total
+const CLASSIFY_RISK_RETRY_BASE_MS = 100; // ~[50,100] then ~[100,200] ms backoff
+const CLASSIFY_RISK_ATTEMPT_TIMEOUT_MS = 1_500; // per-attempt cap (< 5s default)
+
 /**
  * Classify risk for a tool invocation via the gateway's persistent IPC
  * connection.
@@ -146,41 +161,69 @@ export async function ipcGetVelayStatus(): Promise<VelayTunnelStatus | null> {
  * classification is on the hot path for every tool invocation and the
  * persistent connection avoids per-call connect overhead.
  *
- * Returns `undefined` when the gateway is unreachable, the response is
- * malformed, or the call fails for any reason — callers should throw
- * since there is no local fallback (gateway is a hard dependency).
+ * A transient transport failure is retried with bounded backoff (see the
+ * constants above) before giving up; a structured `IpcCallError` or a
+ * malformed payload fails fast without retrying. Returns `undefined` when the
+ * gateway is unreachable or the response is unusable after retries — callers
+ * should throw since there is no local fallback (gateway is a hard dependency).
+ * When a `signal` is supplied, retries stop as soon as it aborts.
  */
 export async function ipcClassifyRisk(
   params: ClassifyRiskParams,
+  signal?: AbortSignal,
 ): Promise<ClassificationResult | undefined> {
-  try {
-    const result = await ipcCallPersistent(
-      "classify_risk",
-      params as unknown as Record<string, unknown>,
-    );
-
-    // Validate the response has at minimum a `risk` field
-    if (!result || typeof result !== "object" || Array.isArray(result)) {
-      log.warn(
-        { result },
-        "ipcClassifyRisk: gateway returned non-object response",
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const result = await ipcCallPersistent(
+        "classify_risk",
+        params as unknown as Record<string, unknown>,
+        CLASSIFY_RISK_ATTEMPT_TIMEOUT_MS,
       );
+
+      // Returned-but-malformed responses are deterministic, not transient:
+      // fail closed immediately (no retry).
+      if (!result || typeof result !== "object" || Array.isArray(result)) {
+        log.warn(
+          { result },
+          "ipcClassifyRisk: gateway returned non-object response",
+        );
+        return undefined;
+      }
+
+      const obj = result as Record<string, unknown>;
+      if (typeof obj.risk !== "string") {
+        log.warn(
+          { result },
+          "ipcClassifyRisk: gateway response missing 'risk' field",
+        );
+        return undefined;
+      }
+
+      return result as ClassificationResult;
+    } catch (err) {
+      // A structured gateway error means the gateway was reachable and
+      // deterministically rejected the request — not a transient blip.
+      const retryable = !(err instanceof IpcCallError);
+      if (
+        retryable &&
+        attempt < CLASSIFY_RISK_MAX_RETRIES &&
+        !signal?.aborted
+      ) {
+        log.warn(
+          { err, attempt },
+          "ipcClassifyRisk: transient IPC failure, retrying after backoff",
+        );
+        await abortableSleep(
+          computeRetryDelay(attempt, CLASSIFY_RISK_RETRY_BASE_MS),
+          signal,
+        );
+        if (!signal?.aborted) {
+          continue;
+        }
+      }
+      log.warn({ err }, "ipcClassifyRisk: persistent IPC call failed");
       return undefined;
     }
-
-    const obj = result as Record<string, unknown>;
-    if (typeof obj.risk !== "string") {
-      log.warn(
-        { result },
-        "ipcClassifyRisk: gateway response missing 'risk' field",
-      );
-      return undefined;
-    }
-
-    return result as ClassificationResult;
-  } catch (err) {
-    log.warn({ err }, "ipcClassifyRisk: persistent IPC call failed");
-    return undefined;
   }
 }
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -721,7 +721,10 @@ export async function classifyRisk(
     workingDir,
     manifestOverride,
   );
-  const gatewayResult = await ipcClassifyRisk(ipcParams);
+  const gatewayResult = await ipcClassifyRisk(ipcParams, signal);
+  // A mid-retry cancellation should surface as an AbortError, not the
+  // misleading fail-closed "gateway unreachable" message.
+  signal?.throwIfAborted();
 
   if (!gatewayResult) {
     throw new Error(


### PR DESCRIPTION
## Summary

- `classify_risk` (the gateway risk classification that gates every risk-classified tool call — `bash`, `file_write`, `recall`, `skill_load`) failed closed with "gateway is unreachable or returned an invalid response" on a **momentary** gateway blip in background/scheduled runs, aborting the tool call. Fail-closed is correct, but the classifier is a pure, idempotent read and the persistent client re-establishes its socket on the next call, so a transient blip is safe to retry.
- Add bounded retry + backoff **inside `ipcClassifyRisk`** (2 retries / 3 attempts) — scoped to this idempotent read, deliberately not the shared `PersistentIpcClient.call` (which also carries non-idempotent writes like `guardian_requests_decide`). A structured `IpcCallError` (gateway reachable, deterministic rejection) or a malformed payload fails **fast** without retrying. Still fail-closed — never fails open.
- **Sized honestly for sub-second blips, not restart-class outages.** Each attempt passes a tighter `timeoutMs` (1500ms, below the 5s transport default) so a wedged-but-reachable gateway can't multiply the worst case — total latency against a hard-down gateway stays ≈ `3 × 1.5s` + small backoff, close to today's single-attempt ceiling rather than `3 × 5s`. A genuine gateway restart (socket watchdog re-binds on a ~5s interval) is intentionally **out of scope** for this retry budget.
- Thread the caller's `AbortSignal` through `classifyRisk → ipcClassifyRisk` so a cancelled interactive tool-approval stops retrying promptly and surfaces an `AbortError` rather than the misleading fail-closed message. The retry budget is two tunable module constants.

## Original prompt

Fix the `classify_risk` fail-closed behavior found in the v0.10.8 sweep: a transient gateway blip in background/scheduled turns aborts risk-classified tool calls even though the classifier is an idempotent read that would succeed on an immediate retry. Add bounded retry/backoff before the existing fail-closed throw (never fail open), and — per review — bound each attempt with an explicit timeout so a hard-down gateway can't multiply worst-case latency, scope the fix honestly to sub-second blips, and assert the exact attempt counts in tests.