### PR TITLE
fix(tests): raise retriever test hook timeouts for initializeDb migration cost

### DIFF
--- a/assistant/src/plugins/defaults/memory/graph/retriever.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/retriever.test.ts
@@ -126,7 +126,7 @@ function makeCapabilityNode(content: string, capId: string): NewNode {
 describe("loadContextMemory — query/sparse vector surfacing", () => {
   beforeAll(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   beforeEach(async () => {
     embedShouldThrow = false;
@@ -136,7 +136,7 @@ describe("loadContextMemory — query/sparse vector surfacing", () => {
     searchRouter = null;
     resetDbForTesting();
     await initializeDb();
-  });
+  }, 30_000);
 
   test("returns the dense queryVector when embedding succeeds", async () => {
     embedVector = [0.42, 0.5, 0.7];
@@ -179,7 +179,7 @@ describe("loadContextMemory — query/sparse vector surfacing", () => {
 describe("retrieveForTurn — query/sparse vector surfacing", () => {
   beforeAll(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   beforeEach(async () => {
     embedShouldThrow = false;
@@ -189,7 +189,7 @@ describe("retrieveForTurn — query/sparse vector surfacing", () => {
     searchRouter = null;
     resetDbForTesting();
     await initializeDb();
-  });
+  }, 30_000);
 
   test("returns the dense queryVector when embedding succeeds", async () => {
     embedVector = [0.9, 0.8, 0.7];
@@ -312,7 +312,7 @@ describe("retrieveForTurn — topic-pivot recovery", () => {
 
   beforeAll(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   beforeEach(() => {
     embedShouldThrow = false;
@@ -462,7 +462,7 @@ describe("loadContextMemory — dual-query capability ranking", () => {
 
   beforeAll(async () => {
     await initializeDb();
-  });
+  }, 30_000);
 
   beforeEach(() => {
     embedShouldThrow = false;


### PR DESCRIPTION
## Summary
- Add the repo-standard `30_000` ms timeout to all six `beforeAll`/`beforeEach` hooks in `assistant/src/plugins/defaults/memory/graph/retriever.test.ts` that run `initializeDb()`.
- These hooks run the full DB migration chain on a fresh SQLite database; under peak CI parallel load the first init occasionally exceeds bun's 5s default hook timeout, failing the file (observed on main: the `loadContextMemory — query/sparse vector surfacing` block timed out at ~5.27s, skipping its 3 tests).
- Matches the existing pattern used by ~40 other `initializeDb()` hooks (e.g. `bootstrap.test.ts`, `embedding.test.ts`, `message-lexical.test.ts`).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29488871273/job/87589852602 — the `Test` job of `CI Main Assistant Checks` on main failed with a `beforeEach/afterEach hook timed out` in `retriever.test.ts`; scope the fix to that failure alone.