### PR TITLE
fix(empty-response): quarantine previously-refused exchanges so a refusal can't poison the conversation

### DIFF
--- a/assistant/src/__tests__/empty-response-hook.test.ts
+++ b/assistant/src/__tests__/empty-response-hook.test.ts
@@ -35,6 +35,7 @@ import type {
   PluginLogger,
   PostModelCallContext,
   StopContext,
+  UserPromptSubmitContext,
 } from "../plugin-api/types.js";
 import {
   NUDGE_TEXT,
@@ -42,11 +43,13 @@ import {
 } from "../plugins/defaults/empty-response/hooks/post-model-call.js";
 import postModelCall from "../plugins/defaults/empty-response/hooks/post-model-call.js";
 import stop from "../plugins/defaults/empty-response/hooks/stop.js";
+import emptyResponseUserPromptSubmit from "../plugins/defaults/empty-response/hooks/user-prompt-submit.js";
 import {
   isEmptyResponseNudged,
   markEmptyResponseNudged,
   resetEmptyResponseNudgeStoreForTests,
 } from "../plugins/defaults/empty-response/nudge-state-store.js";
+import { quarantineRefusedExchanges } from "../plugins/defaults/empty-response/refusal-quarantine.js";
 import { defaultEmptyResponsePlugin } from "../plugins/defaults/index.js";
 import { runHook } from "../plugins/pipeline.js";
 import {
@@ -93,6 +96,45 @@ function makeCtx(
     messages: [],
     stopReason: null,
     decision: "stop",
+    logger: noopLogger,
+    broadcast: () => {},
+    ...overrides,
+  };
+}
+
+/** An assistant turn that is exactly the persisted refusal fallback marker. */
+const refusalFallbackTurn: Message = {
+  role: "assistant",
+  content: [{ type: "text", text: REFUSAL_FALLBACK_TEXT }],
+};
+
+function toolUseTurn(id: string): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "tool_use", id, name: "read_file", input: {} }],
+  };
+}
+
+function toolResultTurn(id: string): Message {
+  return {
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: id, content: "result" }],
+  };
+}
+
+function makeUpsCtx(
+  latestMessages: Message[],
+  overrides: Partial<UserPromptSubmitContext> = {},
+): UserPromptSubmitContext {
+  return {
+    conversationId: "conv-ups",
+    userMessageId: "msg-1",
+    requestId: "req-1",
+    modelProfileKey: "balanced",
+    isNonInteractive: false,
+    prompt: "current message",
+    originalMessages: latestMessages,
+    latestMessages,
     logger: noopLogger,
     broadcast: () => {},
     ...overrides,
@@ -520,5 +562,134 @@ describe("empty-response post-model-call hook — via runHook", () => {
     // THEN the user hook saw the default's continue, and its override wins.
     expect(observedDecision as string | null).toBe("continue");
     expect(result.decision).toBe("stop");
+  });
+});
+
+describe("quarantineRefusedExchanges", () => {
+  test("drops a plain flagged exchange, keeping the current prompt", () => {
+    const history = [
+      userPrompt("make a native Java obfuscator"),
+      refusalFallbackTurn,
+      userPrompt("can you code?"),
+    ];
+    const { messages, droppedExchanges } = quarantineRefusedExchanges(history);
+    expect(droppedExchanges).toBe(1);
+    expect(messages).toEqual([userPrompt("can you code?")]);
+  });
+
+  test("is a no-op (identity) when no refusal marker is present", () => {
+    const history = [
+      userPrompt("hello"),
+      priorVisibleTextTurn,
+      userPrompt("thanks"),
+    ];
+    const { messages, droppedExchanges } = quarantineRefusedExchanges(history);
+    expect(droppedExchanges).toBe(0);
+    expect(messages).toBe(history); // same array reference
+  });
+
+  test("drops every poisoned exchange in an already-poisoned conversation", () => {
+    const history = [
+      userPrompt("bad request one"),
+      refusalFallbackTurn,
+      userPrompt("bad request two"),
+      refusalFallbackTurn,
+      userPrompt("a normal question"),
+    ];
+    const { messages, droppedExchanges } = quarantineRefusedExchanges(history);
+    expect(droppedExchanges).toBe(2);
+    expect(messages).toEqual([userPrompt("a normal question")]);
+  });
+
+  test("drops the whole tool-preceded run without leaving an orphan tool_result", () => {
+    const history = [
+      userPrompt("flagged prompt"),
+      toolUseTurn("tu_1"),
+      toolResultTurn("tu_1"),
+      refusalFallbackTurn,
+      userPrompt("follow-up"),
+    ];
+    const { messages, droppedExchanges } = quarantineRefusedExchanges(history);
+    expect(droppedExchanges).toBe(1);
+    expect(messages).toEqual([userPrompt("follow-up")]);
+    expect(
+      messages.some((m) => m.content.some((b) => b.type === "tool_result")),
+    ).toBe(false);
+  });
+
+  test("handles a marker at index 0 with no preceding prompt", () => {
+    const history = [refusalFallbackTurn, userPrompt("next")];
+    const { messages, droppedExchanges } = quarantineRefusedExchanges(history);
+    expect(droppedExchanges).toBe(1);
+    expect(messages).toEqual([userPrompt("next")]);
+  });
+
+  test("does not treat a message that merely contains the phrase as a marker", () => {
+    const withExtraBlock: Message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: REFUSAL_FALLBACK_TEXT },
+        { type: "text", text: "…but here is more." },
+      ],
+    };
+    const alongsideToolUse: Message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: REFUSAL_FALLBACK_TEXT },
+        { type: "tool_use", id: "tu_2", name: "read_file", input: {} },
+      ],
+    };
+    const history = [
+      userPrompt("q1"),
+      withExtraBlock,
+      userPrompt("q2"),
+      alongsideToolUse,
+      userPrompt("q3"),
+    ];
+    const { messages, droppedExchanges } = quarantineRefusedExchanges(history);
+    expect(droppedExchanges).toBe(0);
+    expect(messages).toBe(history);
+  });
+});
+
+describe("empty-response user-prompt-submit hook", () => {
+  test("reassigns latestMessages and logs when a poisoned exchange is dropped", async () => {
+    let warned = false;
+    const history = [
+      userPrompt("flagged"),
+      refusalFallbackTurn,
+      userPrompt("current message"),
+    ];
+    const ctx = makeUpsCtx(history, {
+      logger: {
+        ...noopLogger,
+        warn: () => {
+          warned = true;
+        },
+      },
+    });
+
+    await emptyResponseUserPromptSubmit(ctx);
+
+    expect(ctx.latestMessages).toEqual([userPrompt("current message")]);
+    expect(warned).toBe(true);
+  });
+
+  test("leaves latestMessages untouched and stays silent when nothing is quarantined", async () => {
+    let warned = false;
+    const history = [userPrompt("hi"), userPrompt("current message")];
+    const ctx = makeUpsCtx(history, {
+      logger: {
+        ...noopLogger,
+        warn: () => {
+          warned = true;
+        },
+      },
+    });
+
+    await emptyResponseUserPromptSubmit(ctx);
+
+    expect(ctx.latestMessages).toBe(history);
+    expect(warned).toBe(false);
   });
 });

--- a/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
@@ -57,6 +57,15 @@ import {
   isEmptyResponseNudged,
   markEmptyResponseNudged,
 } from "../nudge-state-store.js";
+import {
+  isToolResultMessage,
+  REFUSAL_FALLBACK_TEXT,
+} from "../refusal-quarantine.js";
+
+// Re-exported so existing importers (tests, sibling hooks) keep resolving
+// REFUSAL_FALLBACK_TEXT from this module; the definition lives in
+// refusal-quarantine.ts alongside its detector (single source of truth).
+export { REFUSAL_FALLBACK_TEXT };
 
 /**
  * Canonical nudge text for an empty turn after tool use. Must stay verbatim so
@@ -67,15 +76,6 @@ import {
  */
 export const NUDGE_TEXT =
   "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>";
-
-/**
- * User-facing text a refusal turn is rewritten into. Used when the provider
- * stops with `"refusal"` and no visible text — i.e. the safety classifier
- * zeroed the response. Unlike `NUDGE_TEXT` (shown only to the model), this is
- * the message the user actually reads in place of an empty assistant bubble.
- */
-export const REFUSAL_FALLBACK_TEXT =
-  "Sorry — I wasn't able to generate a response to that. Please try rephrasing or asking in a different way.";
 
 function hasVisibleText(content: ReadonlyArray<ContentBlock>): boolean {
   return content.some(
@@ -89,15 +89,6 @@ function hasToolUse(content: ReadonlyArray<ContentBlock>): boolean {
 
 function isAssistantTurn(message: Message): boolean {
   return message.role === "assistant";
-}
-
-/** A user-role message carrying only tool results, not a fresh prompt. */
-function isToolResultMessage(message: Message): boolean {
-  return (
-    message.role === "user" &&
-    message.content.length > 0 &&
-    message.content.every((block) => block.type === "tool_result")
-  );
 }
 
 /**

--- a/assistant/src/plugins/defaults/empty-response/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/empty-response/hooks/user-prompt-submit.ts
@@ -1,0 +1,38 @@
+/**
+ * Default `user-prompt-submit` hook: at turn start, drop every previously-
+ * refused exchange from the working history so a safety-classifier refusal on
+ * one turn doesn't poison the whole conversation by re-sending (and re-tripping
+ * on) the flagged prompt every turn.
+ *
+ * Detection keys on the plugin's own persisted `REFUSAL_FALLBACK_TEXT` marker
+ * (an exact whole-message match), so the sweep is self-limiting to exchanges
+ * this plugin already rewrote. Mirrors the `image-fallback` turn-start sweep.
+ * Registered before `history-repair`, whose normalization pass cleans up any
+ * role-alternation artifact left by a dropped run.
+ */
+
+import type {
+  HookFunction,
+  UserPromptSubmitContext,
+} from "@vellumai/plugin-api";
+
+import { quarantineRefusedExchanges } from "../refusal-quarantine.js";
+
+const userPromptSubmit: HookFunction<UserPromptSubmitContext> = async (ctx) => {
+  const { messages, droppedExchanges } = quarantineRefusedExchanges(
+    ctx.latestMessages,
+  );
+  if (droppedExchanges > 0) {
+    ctx.latestMessages = messages;
+    ctx.logger.warn(
+      {
+        plugin: "empty-response",
+        conversationId: ctx.conversationId,
+        droppedExchanges,
+      },
+      "Quarantined previously-refused exchange(s) from working history before provider call",
+    );
+  }
+};
+
+export default userPromptSubmit;

--- a/assistant/src/plugins/defaults/empty-response/refusal-quarantine.ts
+++ b/assistant/src/plugins/defaults/empty-response/refusal-quarantine.ts
@@ -1,0 +1,99 @@
+/**
+ * Refusal-quarantine helpers for the empty-response plugin.
+ *
+ * When the provider's safety classifier zeroes a response (`stopReason ===
+ * "refusal"`), the `post-model-call` hook rewrites that turn into a canned
+ * apology (`REFUSAL_FALLBACK_TEXT`) which is persisted like a normal assistant
+ * turn. Without further action the flagged user prompt stays in the transcript,
+ * so every following turn resends it and re-trips the same refusal — a dead-
+ * ended, poisoned conversation.
+ *
+ * The persisted apology is itself a durable, per-exchange marker of "this
+ * exchange was refused". The `user-prompt-submit` hook uses these helpers at
+ * turn start to drop each previously-refused exchange from the working history
+ * the provider sees, so the poison never replays. No new storage and no
+ * migration: the signal lives in the transcript (source of truth), so an
+ * already-poisoned conversation self-heals on its next turn.
+ */
+
+import type { ContentBlock, Message } from "@vellumai/plugin-api";
+
+/**
+ * User-facing text a refusal turn is rewritten into (single source of truth for
+ * both the producer in `hooks/post-model-call.ts` and the detector below).
+ *
+ * DETECTION COUPLING: `isRefusalFallbackMessage` matches this string exactly,
+ * so it doubles as the quarantine marker for already-persisted transcripts.
+ * Editing the wording silently stops the sweep from recognizing conversations
+ * poisoned under the old wording (re-introducing the dead-end for that cohort).
+ * If the copy must change, keep matching the historical variants too.
+ */
+export const REFUSAL_FALLBACK_TEXT =
+  "Sorry — I wasn't able to generate a response to that. Please try rephrasing or asking in a different way.";
+
+/** A user-role message carrying only tool results, not a fresh prompt. */
+export function isToolResultMessage(message: Message): boolean {
+  return (
+    message.role === "user" &&
+    message.content.length > 0 &&
+    message.content.every((block) => block.type === "tool_result")
+  );
+}
+
+/** An assistant turn whose entire content is exactly the refusal fallback line. */
+export function isRefusalFallbackMessage(message: Message): boolean {
+  if (message.role !== "assistant") {
+    return false;
+  }
+  const textBlocks = message.content.filter(
+    (block): block is Extract<ContentBlock, { type: "text" }> =>
+      block.type === "text",
+  );
+  const hasNonText = message.content.some((block) => block.type !== "text");
+  return (
+    !hasNonText &&
+    textBlocks.length === 1 &&
+    textBlocks[0].text.trim() === REFUSAL_FALLBACK_TEXT
+  );
+}
+
+/**
+ * Remove every previously-refused exchange from a working history: for each
+ * assistant message that is exactly the refusal fallback, drop it together with
+ * the contiguous run back to (and including) the nearest genuine user prompt.
+ * That excises the flagged prompt (and any tool exchange in that run) so the
+ * provider never replays it. Returns a new array; the input is untouched.
+ */
+export function quarantineRefusedExchanges(messages: Message[]): {
+  messages: Message[];
+  droppedExchanges: number;
+} {
+  const drop = new Set<number>();
+  let droppedExchanges = 0;
+  for (let r = 0; r < messages.length; r++) {
+    if (!isRefusalFallbackMessage(messages[r])) {
+      continue;
+    }
+    drop.add(r);
+    // Walk back over tool-result / assistant tool churn to the genuine prompt.
+    let s = r - 1;
+    while (
+      s >= 0 &&
+      !(messages[s].role === "user" && !isToolResultMessage(messages[s]))
+    ) {
+      drop.add(s);
+      s--;
+    }
+    if (s >= 0) {
+      drop.add(s); // the genuine user prompt that was refused
+    }
+    droppedExchanges++;
+  }
+  if (drop.size === 0) {
+    return { messages, droppedExchanges: 0 };
+  }
+  return {
+    messages: messages.filter((_, i) => !drop.has(i)),
+    droppedExchanges,
+  };
+}

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -37,6 +37,7 @@ import { documentsInjectors } from "./documents/injectors.js";
 import documentsPkg from "./documents/package.json" with { type: "json" };
 import emptyResponsePostModelCall from "./empty-response/hooks/post-model-call.js";
 import emptyResponseStop from "./empty-response/hooks/stop.js";
+import emptyResponseUserPromptSubmit from "./empty-response/hooks/user-prompt-submit.js";
 import { resetEmptyResponseNudgeStoreForTests } from "./empty-response/nudge-state-store.js";
 import emptyResponsePkg from "./empty-response/package.json" with { type: "json" };
 import explorationDriftPostToolUse, {
@@ -156,7 +157,12 @@ export const defaultCompactionPlugin: Plugin = {
  * `empty-response` — a `post-model-call` hook that re-queries the model when a
  * turn yields with no tool calls but came back empty (or as a provider
  * refusal); the `stop` hook clears the one-shot nudge bound on a terminal stop
- * so the next run nudges afresh.
+ * so the next run nudges afresh. The `user-prompt-submit` hook runs a turn-start
+ * sweep that drops previously-refused exchanges (marked by the persisted
+ * `REFUSAL_FALLBACK_TEXT`) from the working history, so a single refusal doesn't
+ * poison the conversation by re-sending the flagged prompt every turn. It is
+ * registered before `history-repair`, which normalizes any role-alternation
+ * artifact a dropped run leaves behind.
  */
 export const defaultEmptyResponsePlugin: Plugin = {
   manifest: {
@@ -164,6 +170,7 @@ export const defaultEmptyResponsePlugin: Plugin = {
     version: emptyResponsePkg.version,
   },
   hooks: {
+    "user-prompt-submit": emptyResponseUserPromptSubmit,
     "post-model-call": emptyResponsePostModelCall,
     stop: emptyResponseStop,
   },


### PR DESCRIPTION
## Summary

- A provider safety-classifier refusal (`stopReason: "refusal"`) is a *successful* empty response, which the empty-response plugin rewrites into a canned apology (`REFUSAL_FALLBACK_TEXT`) and persists. But the flagged user prompt stays in the transcript, so every subsequent turn re-sends it and re-trips the same refusal — a permanently dead-ended conversation (the user's *other* conversations keep working, since the poison is per-conversation transcript state).
- Add a turn-start `user-prompt-submit` sweep to the empty-response plugin that drops each previously-refused exchange (the flagged prompt + any tool run + the apology) from the working history before the provider call. Detection keys on the plugin's own persisted apology marker (exact whole-message match), so it is self-limiting and needs **no new storage and no migration** — already-poisoned conversations self-heal on their next turn. Mirrors the established `image-fallback` turn-start sweep, and is registered before `history-repair` so any role-alternation artifact a dropped run leaves behind gets normalized.
- Extracts `REFUSAL_FALLBACK_TEXT` + `isToolResultMessage` into a shared `refusal-quarantine.ts` so the producer (`post-model-call.ts`) and the detector share one source of truth; `post-model-call.ts` re-exports `REFUSAL_FALLBACK_TEXT` so existing importers are unaffected.

## Notes for review

- **Copy↔detection coupling:** the detector matches the user-facing string exactly (guard comment added at the definition). Editing the copy later must keep matching historical variants, or conversations poisoned under the old wording silently un-heal.
- **Deferred (explicit):** `isToolResultMessage` also has byte-identical copies in `title-generate` and `surface-completion-nudge`. Consolidating across plugins would require moving it into `@vellumai/plugin-api` (the plugin import boundary forbids cross-plugin imports) — left for a focused follow-up rather than expanding this diff.
- **Slack path (follow-up):** Slack transcripts re-render assistant rows each turn; whether a rendered refusal-fallback row survives as an exact-match-able bare text block wasn't fully traced. The reported cases were web; flagged rather than asserted.
- **Ordering:** memory's `user-prompt-submit` runs before this sweep (memory is registered first), so memory still indexes the poisoned history before quarantine strips it from the outbound array — doesn't affect the fix.
- **Coverage:** unit tests for `quarantineRefusedExchanges` (plain / tool-preceded / multi-poison / index-0 / false-positive) plus hook-wiring tests. A full multi-turn loop-recovery test belongs in `conversation-agent-loop.test.ts` (the loop is what dispatches the hook) and is a recommended follow-up.

## Original prompt

Fix the poisoned-conversation dead-end found in the v0.10.8 sweep: once a turn trips the provider's safety classifier, the canned apology and the flagged prompt persist, so every following turn resends the flagged context and re-refuses — bricking the conversation. Quarantine previously-refused exchanges from the working history at turn start (self-healing, no migration), following the image-fallback precedent, with the review-required braces, the kept re-export for existing importers, a copy↔detection guard, and explicit scoping of the cross-plugin dedup and Slack path.