### PR TITLE
fix(plugins): bound plugin init hooks with a timeout so a hang can't wedge startup

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22859,20 +22859,24 @@ paths:
   /v1/plugins/{name}/upgrade:
     post:
       operationId: plugins_by_name_upgrade_post
-      summary: Upgrade a plugin to the marketplace pin
+      summary: Upgrade a plugin to its source's current revision
       description:
-        'Move an installed plugin to the marketplace''s current pinned commit, re-materializing it under
-        `<workspaceDir>/plugins/<name>/`. Always resolves against the curated marketplace pin (no caller-supplied ref),
-        mirroring `plugins install`''s curation boundary. A no-op (`outcome: "already-up-to-date"`) when the installed
-        commit already equals the pin; pass `dryRun` to preview the move (`outcome: "would-upgrade"`) without touching
-        the install. Installs lacking provenance are re-pinned to the current SHA. The upgraded code is picked up live
-        on the next read (no restart required). `strategy` controls how local edits are reconciled: `overwrite`
-        (default) discards them and re-installs the pin wholesale; `ours`/`theirs`/`assistant` perform a three-way merge
-        against the re-materialized install commit, carrying non-conflicting edits from both sides forward and resolving
-        conflicting hunks toward the local edit (`ours`) or the pin (`theirs`), or writing git conflict markers into the
-        file and reporting them in `conflicts`/`binaryConflicts` for the assistant to resolve (`assistant`). A merge
-        strategy whose install-time baseline cannot be reconstructed returns 409. Mirrors the CLI''s `assistant plugins
-        upgrade <name> [--strategy <s>]`.'
+        'Move an installed plugin to its source''s current revision, re-materializing it under
+        `<workspaceDir>/plugins/<name>/`. A marketplace plugin advances to the curated pin; a plugin installed directly
+        from a GitHub URL (untrusted, not in the marketplace) advances to whatever its recorded ref now resolves to — a
+        pinned SHA is immutable (a no-op), a branch/tag/HEAD moves as upstream does — re-materialized verbatim with no
+        curated adapter overlay, exactly as the original untrusted install was. The target ref is never taken from the
+        request (no caller-supplied ref), mirroring `plugins install`''s curation boundary. A no-op (`outcome:
+        "already-up-to-date"`) when the installed commit already equals the target; pass `dryRun` to preview the move
+        (`outcome: "would-upgrade"`) without touching the install. Installs lacking provenance are re-pinned to the
+        current SHA. The upgraded code is picked up live on the next read (no restart required). `strategy` controls how
+        local edits are reconciled: `overwrite` (default) discards them and re-installs the target wholesale;
+        `ours`/`theirs`/`assistant` perform a three-way merge against the re-materialized install commit, carrying
+        non-conflicting edits from both sides forward and resolving conflicting hunks toward the local edit (`ours`) or
+        the target (`theirs`), or writing git conflict markers into the file and reporting them in
+        `conflicts`/`binaryConflicts` for the assistant to resolve (`assistant`). A merge strategy whose install-time
+        baseline cannot be reconstructed returns 409. Mirrors the CLI''s `assistant plugins upgrade <name> [--strategy
+        <s>]`.'
       tags:
         - plugins
       parameters:
@@ -23001,8 +23005,8 @@ paths:
           description: No copy of the plugin is installed, or its source resolves to nothing.
         "409":
           description:
-            The install exists but has no marketplace entry to advance to, or a merge strategy was requested whose
-            install-time baseline cannot be reconstructed.
+            The install has neither a marketplace entry nor a recorded GitHub source to advance to, or a merge strategy
+            was requested whose install-time baseline cannot be reconstructed.
         "503":
           description: The plugin source (GitHub) was temporarily unavailable; the upgrade is retryable.
   /v1/plugins/{name}/versions:

--- a/assistant/src/__tests__/plugin-init-hook-timeout.test.ts
+++ b/assistant/src/__tests__/plugin-init-hook-timeout.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests that a slow or hanging plugin `init` hook cannot wedge the daemon.
+ *
+ * Plugin activation awaits `runInitHook` on the startup path (`bootstrapPlugins`)
+ * and inside the mtime-cache reconcile, so an `init` that never resolves — e.g.
+ * a plugin that installs a language runtime into a managed venv synchronously —
+ * would otherwise stall the rest of startup and every subsequent plugin's
+ * activation. `runInitHook` bounds each invocation with a timeout and continues,
+ * upholding the "never block startup on a subsystem" rule.
+ */
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { resetHookCacheForTests, runInitHook } from "../hooks/hook-loader.js";
+
+const ROOT = join(
+  tmpdir(),
+  `vellum-plugin-init-timeout-${process.pid}-${Date.now()}`,
+);
+const PLUGINS_DIR = join(ROOT, "plugins");
+
+function writePlugin(name: string, initBody: string): string {
+  const dir = join(PLUGINS_DIR, name);
+  const hooksDir = join(dir, "hooks");
+  mkdirSync(hooksDir, { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name, version: "1.0.0" }),
+  );
+  writeFileSync(join(hooksDir, "init.ts"), initBody);
+  return dir;
+}
+
+beforeAll(() => {
+  process.env.VELLUM_WORKSPACE_DIR = ROOT;
+});
+
+beforeEach(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+  mkdirSync(PLUGINS_DIR, { recursive: true });
+  resetHookCacheForTests();
+});
+
+afterAll(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe("runInitHook — timeout resilience", () => {
+  test("a hanging init hook resolves via the timeout instead of blocking", async () => {
+    // An init that never resolves — the pathological case that wedged startup.
+    const dir = writePlugin(
+      "slow-init",
+      "export default () => new Promise<void>(() => {});\n",
+    );
+
+    // Race the bounded call against a generous guard: if the timeout works,
+    // runInitHook resolves promptly; a broken timeout would let the guard win
+    // (and fail the assertion) instead of hanging the whole test file.
+    const outcome = await Promise.race([
+      runInitHook("slow-init", dir, { timeoutMs: 50 }).then(() => "resolved"),
+      new Promise<string>((r) => setTimeout(() => r("hung"), 2000)),
+    ]);
+
+    expect(outcome).toBe("resolved");
+  });
+
+  test("a fast init hook still runs to completion", async () => {
+    const sentinel = join(ROOT, "ran.txt");
+    const dir = writePlugin(
+      "fast-init",
+      [
+        'import { writeFileSync } from "node:fs";',
+        "export default async () => {",
+        `  writeFileSync(${JSON.stringify(sentinel)}, "ok");`,
+        "};",
+      ].join("\n"),
+    );
+
+    await runInitHook("fast-init", dir, { timeoutMs: 5000 });
+
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  test("a throwing init hook is swallowed (continues)", async () => {
+    const dir = writePlugin(
+      "throwing-init",
+      'export default async () => { throw new Error("boom"); };\n',
+    );
+
+    // Resolves (does not reject) — the failure is logged and swallowed.
+    await expect(
+      runInitHook("throwing-init", dir, { timeoutMs: 5000 }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/assistant/src/hooks/hook-loader.ts
+++ b/assistant/src/hooks/hook-loader.ts
@@ -288,6 +288,21 @@ export function hasWorkspaceHooks(): boolean {
 }
 
 /**
+ * How long a single `init` invocation may run before the loader abandons the
+ * wait and moves on. Plugin activation is awaited on the daemon startup path
+ * (`bootstrapPlugins`) and inside the mtime-cache reconcile, so an `init` that
+ * hangs — or does pathologically slow synchronous setup, e.g. installing a
+ * language runtime into a managed venv — would otherwise stall the rest of
+ * startup and any subsequent plugin's activation. The bound is deliberately
+ * generous (an `init` may legitimately do real setup work) but finite, upholding
+ * the "never block startup on a subsystem" rule. On timeout the underlying work
+ * keeps running in the background (a JS promise cannot be cancelled); the daemon
+ * simply stops waiting, so a genuinely slow first-boot install completes off the
+ * critical path and later boots find it already done.
+ */
+const INIT_TIMEOUT_MS = 30_000;
+
+/**
  * Run the `init` hook for `ownerName` if the owner defines one. `init` can't
  * ride the whole-chain `runHook` the way dispatch hooks do because its context
  * is per-plugin (config, logger, storage dir), so it's dispatched per-owner
@@ -313,6 +328,7 @@ export function hasWorkspaceHooks(): boolean {
 export async function runInitHook(
   ownerName: string,
   pluginDir: string | null = null,
+  opts: { timeoutMs?: number } = {},
 ): Promise<void> {
   // A plugin always has a directory; only the workspace owner passes `null`.
   const kind: HookOwnerKind = pluginDir === null ? "workspace" : "plugin";
@@ -322,6 +338,7 @@ export async function runInitHook(
     return;
   }
 
+  const timeoutMs = opts.timeoutMs ?? INIT_TIMEOUT_MS;
   try {
     const initContext: InitContext = {
       config: resolvePluginConfig(ownerName, pluginDir),
@@ -329,12 +346,16 @@ export async function runInitHook(
       pluginStorageDir: resolvePluginStorageDir(ownerName, pluginDir),
       assistantVersion: APP_VERSION,
     };
-    await initHook(initContext);
+    await withTimeout(
+      Promise.resolve(initHook(initContext)),
+      timeoutMs,
+      `init hook for ${ownerName} exceeded ${timeoutMs}ms`,
+    );
     log.info({ plugin: ownerName }, "user hooks initialized");
   } catch (err) {
     log.error(
       { err, plugin: ownerName },
-      `User hooks for ${ownerName} init() failed — continuing`,
+      `User hooks for ${ownerName} init() failed or timed out — continuing`,
     );
   }
 }


### PR DESCRIPTION
## Prompt / plan

Follow-up hardening surfaced while QA'ing the cognee plugin: its `init` hook installs cognee into a managed Python venv, and in a bare environment that slow/hanging install wedged the daemon into a restart loop.

Root cause: plugin activation awaits `runInitHook` on the daemon **startup path** — `initializePlugins` → `bootstrapPlugins` (awaited in `lifecycle.ts`) and the mtime-cache reconcile that brings up user plugins. `runShutdownHook` already runs under `withTimeout`, but `runInitHook` awaited the hook **unbounded**. So an `init` that hangs or does pathologically slow synchronous setup stalled everything after it in startup and every subsequent plugin's activation, leaving the daemon unable to reach readiness (503) and prone to restart loops — a violation of the assistant's "never block startup on a subsystem" rule (`assistant/CLAUDE.md` → Daemon startup philosophy).

Fix: bound each `init` invocation with a 30s `withTimeout`, mirroring the shutdown path. Generous enough for legitimate setup work, but finite so a hung init can never block startup. On timeout the failure is logged and activation continues; the underlying work keeps running off the critical path (a JS promise can't be cancelled), so a genuinely slow first-boot install still completes and later boots find it already done. `withTimeout` attaches its own handlers to the abandoned promise, so a late resolution/rejection doesn't surface as an unhandled rejection.

`runInitHook` gains an optional `timeoutMs` override (defaulting to the constant), purely so the timeout is deterministically testable without a 30s wait — production callers use the default (this mirrors `buildExternalPlugin`'s existing `importTimeoutMs`).

## Test plan

- **New regression test** (`__tests__/plugin-init-hook-timeout.test.ts`, 3 cases): a hanging `init` resolves via the timeout instead of blocking (raced against a 2s guard so a broken timeout fails fast rather than hanging the file); a fast `init` still runs to completion; a throwing `init` is swallowed.
- No regression across the `runInitHook` callers/paths: plugin-config-data-migration (6), mtime-cache (35), plugin-bootstrap (12), plugin-hook-pipeline-hardening (11), hook-live-reload (6).
- `bunx tsc --noEmit` clean; eslint 0 errors; Prettier clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U9acFDET16R38truw2dFYU)_