### PR TITLE
chore(openapi): regenerate spec for the plugins upgrade route text

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22859,20 +22859,24 @@ paths:
   /v1/plugins/{name}/upgrade:
     post:
       operationId: plugins_by_name_upgrade_post
-      summary: Upgrade a plugin to the marketplace pin
+      summary: Upgrade a plugin to its source's current revision
       description:
-        'Move an installed plugin to the marketplace''s current pinned commit, re-materializing it under
-        `<workspaceDir>/plugins/<name>/`. Always resolves against the curated marketplace pin (no caller-supplied ref),
-        mirroring `plugins install`''s curation boundary. A no-op (`outcome: "already-up-to-date"`) when the installed
-        commit already equals the pin; pass `dryRun` to preview the move (`outcome: "would-upgrade"`) without touching
-        the install. Installs lacking provenance are re-pinned to the current SHA. The upgraded code is picked up live
-        on the next read (no restart required). `strategy` controls how local edits are reconciled: `overwrite`
-        (default) discards them and re-installs the pin wholesale; `ours`/`theirs`/`assistant` perform a three-way merge
-        against the re-materialized install commit, carrying non-conflicting edits from both sides forward and resolving
-        conflicting hunks toward the local edit (`ours`) or the pin (`theirs`), or writing git conflict markers into the
-        file and reporting them in `conflicts`/`binaryConflicts` for the assistant to resolve (`assistant`). A merge
-        strategy whose install-time baseline cannot be reconstructed returns 409. Mirrors the CLI''s `assistant plugins
-        upgrade <name> [--strategy <s>]`.'
+        'Move an installed plugin to its source''s current revision, re-materializing it under
+        `<workspaceDir>/plugins/<name>/`. A marketplace plugin advances to the curated pin; a plugin installed directly
+        from a GitHub URL (untrusted, not in the marketplace) advances to whatever its recorded ref now resolves to — a
+        pinned SHA is immutable (a no-op), a branch/tag/HEAD moves as upstream does — re-materialized verbatim with no
+        curated adapter overlay, exactly as the original untrusted install was. The target ref is never taken from the
+        request (no caller-supplied ref), mirroring `plugins install`''s curation boundary. A no-op (`outcome:
+        "already-up-to-date"`) when the installed commit already equals the target; pass `dryRun` to preview the move
+        (`outcome: "would-upgrade"`) without touching the install. Installs lacking provenance are re-pinned to the
+        current SHA. The upgraded code is picked up live on the next read (no restart required). `strategy` controls how
+        local edits are reconciled: `overwrite` (default) discards them and re-installs the target wholesale;
+        `ours`/`theirs`/`assistant` perform a three-way merge against the re-materialized install commit, carrying
+        non-conflicting edits from both sides forward and resolving conflicting hunks toward the local edit (`ours`) or
+        the target (`theirs`), or writing git conflict markers into the file and reporting them in
+        `conflicts`/`binaryConflicts` for the assistant to resolve (`assistant`). A merge strategy whose install-time
+        baseline cannot be reconstructed returns 409. Mirrors the CLI''s `assistant plugins upgrade <name> [--strategy
+        <s>]`.'
       tags:
         - plugins
       parameters:
@@ -23001,8 +23005,8 @@ paths:
           description: No copy of the plugin is installed, or its source resolves to nothing.
         "409":
           description:
-            The install exists but has no marketplace entry to advance to, or a merge strategy was requested whose
-            install-time baseline cannot be reconstructed.
+            The install has neither a marketplace entry nor a recorded GitHub source to advance to, or a merge strategy
+            was requested whose install-time baseline cannot be reconstructed.
         "503":
           description: The plugin source (GitHub) was temporarily unavailable; the upgrade is retryable.
   /v1/plugins/{name}/versions:


### PR DESCRIPTION
## Prompt / plan

> [#38228] Merged - but open api checks were failing so fix that in a followup

### Why

#38228 (upgrade untrusted GitHub-URL installs) updated the `plugins_upgrade` route's `summary`, `description`, and `409` response text in `plugins-routes.ts`, but the committed `assistant/openapi.yaml` was not regenerated from that source — so the generated-spec drift check went red.

### What changed

Ran `bun run generate:openapi` in `assistant/`. The diff is confined to the `/v1/plugins/{name}/upgrade` operation's prose:

- `summary`: "Upgrade a plugin to the marketplace pin" → "Upgrade a plugin to its source's current revision"
- `description`: now covers direct (untrusted GitHub-URL) installs advancing against their recorded ref
- `409` response: "…has neither a marketplace entry nor a recorded GitHub source to advance to…"

No schema, path, or behavior changes — documentation regeneration only.

## Test plan

- `bun run generate:openapi` (assistant) produces exactly this diff and no other; re-running it is a no-op (spec now matches source).
- Prettier/secrets/generic-examples pre-commit hooks pass.

## CLI verb checklist

No new routes. Generated-artifact sync only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bebi83sSFqAMYbM7s7PU9

---
_Generated by [Claude Code](https://claude.ai/code/session_014bebi83sSFqAMYbM7s7PU9)_