### PR TITLE
fix(plugins): stop internal continuation-nudge scaffolding from leaking into user replies

### DIFF
--- a/assistant/src/__tests__/empty-response-hook.test.ts
+++ b/assistant/src/__tests__/empty-response-hook.test.ts
@@ -30,7 +30,10 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { HOOKS } from "../plugin-api/constants.js";
+import {
+  HOOKS,
+  INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
+} from "../plugin-api/constants.js";
 import type {
   PluginLogger,
   PostModelCallContext,
@@ -146,6 +149,17 @@ beforeEach(() => {
 });
 
 // ─── Default decisions ───────────────────────────────────────────────────────
+
+describe("empty-response NUDGE_TEXT — internal-notice suppression", () => {
+  test("appends the shared suppression clause inside the notice wrapper", () => {
+    expect(NUDGE_TEXT).toContain(INTERNAL_NUDGE_OUTPUT_SUPPRESSION);
+    expect(NUDGE_TEXT.startsWith("<system_notice>")).toBe(true);
+    expect(NUDGE_TEXT.endsWith("</system_notice>")).toBe(true);
+    // The recovery instruction still leads — the clause forbids narrating the
+    // notice, it does not license an empty reply.
+    expect(NUDGE_TEXT).toContain("respond to the user with a summary");
+  });
+});
 
 describe("empty-response post-model-call hook — default decisions", () => {
   test("empty turn after a prior tool-use turn → continue with canonical nudge", async () => {

--- a/assistant/src/__tests__/max-tokens-continue-hook.test.ts
+++ b/assistant/src/__tests__/max-tokens-continue-hook.test.ts
@@ -20,6 +20,7 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { INTERNAL_NUDGE_OUTPUT_SUPPRESSION } from "../plugin-api/constants.js";
 import type {
   PluginLogger,
   PostModelCallContext,
@@ -71,6 +72,24 @@ beforeEach(() => {
 });
 
 // ─── Decisions ───────────────────────────────────────────────────────────────
+
+describe("max-tokens-continue NUDGE_TEXT — internal-notice suppression", () => {
+  test("appends the shared suppression clause inside the notice wrapper", () => {
+    expect(MAX_TOKENS_CONTINUE_NUDGE_TEXT).toContain(
+      INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
+    );
+    expect(MAX_TOKENS_CONTINUE_NUDGE_TEXT.startsWith("<system_notice>")).toBe(
+      true,
+    );
+    expect(MAX_TOKENS_CONTINUE_NUDGE_TEXT.endsWith("</system_notice>")).toBe(
+      true,
+    );
+    // The continue instruction still leads (a truncated turn has content).
+    expect(MAX_TOKENS_CONTINUE_NUDGE_TEXT).toContain(
+      "Continue exactly where you stopped",
+    );
+  });
+});
 
 describe("max-tokens-continue post-model-call hook", () => {
   test("truncated main-agent turn → continue with the turn and nudge appended", async () => {

--- a/assistant/src/__tests__/surface-completion-nudge-hook.test.ts
+++ b/assistant/src/__tests__/surface-completion-nudge-hook.test.ts
@@ -22,6 +22,7 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { INTERNAL_NUDGE_OUTPUT_SUPPRESSION } from "../plugin-api/constants.js";
 import type {
   PluginLogger,
   PostModelCallContext,
@@ -151,6 +152,24 @@ beforeEach(() => {
 });
 
 // ─── Nudges when a progress surface is left open ──────────────────────────────
+
+describe("surface-completion-nudge — internal-notice suppression", () => {
+  test("appends the shared suppression clause inside the notice wrapper", () => {
+    expect(SURFACE_COMPLETION_NUDGE_TEXT).toContain(
+      INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
+    );
+    expect(SURFACE_COMPLETION_NUDGE_TEXT.startsWith("<system_notice>")).toBe(
+      true,
+    );
+    expect(SURFACE_COMPLETION_NUDGE_TEXT.endsWith("</system_notice>")).toBe(
+      true,
+    );
+    // The surface-advance + final-reply instruction still leads.
+    expect(SURFACE_COMPLETION_NUDGE_TEXT).toContain(
+      "Then give your final reply",
+    );
+  });
+});
 
 describe("surface-completion-nudge — nudges on a dangling progress surface", () => {
   test("task_progress card shown and never completed → continue with nudge", async () => {

--- a/assistant/src/plugin-api/constants.ts
+++ b/assistant/src/plugin-api/constants.ts
@@ -36,3 +36,15 @@ export const HOOKS = {
 
 /** Union of every hook name declared in {@link HOOKS}. */
 export type HookName = (typeof HOOKS)[keyof typeof HOOKS];
+
+/**
+ * Appended (inside the `<system_notice>` wrapper) to the internal continuation /
+ * completion nudge strings that re-query the model. Those notices are injected
+ * as user-role turns; weaker models without a separate reasoning channel
+ * otherwise narrate or answer the notice as visible text, leaking agent-loop
+ * scaffolding into the user-facing reply. This clause forbids that narration
+ * without licensing an empty reply — each nudge's own instruction still drives
+ * the expected output (summary / final reply / continuation).
+ */
+export const INTERNAL_NUDGE_OUTPUT_SUPPRESSION =
+  " This notice is internal: do not repeat, quote, describe, or acknowledge it, and do not narrate whether you will continue or whether the turn is done. Reply with only the content the user should see.";

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -67,7 +67,7 @@
  */
 
 export type { HookName } from "./constants.js";
-export { HOOKS } from "./constants.js";
+export { HOOKS, INTERNAL_NUDGE_OUTPUT_SUPPRESSION } from "./constants.js";
 // Conversation message/content shapes. A hook receives the live message
 // history (e.g. `PostToolUseContext.latestMessages: Message[]`), so plugins
 // that inspect or narrow content blocks — reading a `tool_use` block's input,

--- a/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
@@ -46,11 +46,12 @@
  * ignores the decision — so the hook returns early for both.
  */
 
-import type {
-  ContentBlock,
-  HookFunction,
-  Message,
-  PostModelCallContext,
+import {
+  type ContentBlock,
+  type HookFunction,
+  INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
+  type Message,
+  type PostModelCallContext,
 } from "@vellumai/plugin-api";
 
 import {
@@ -75,7 +76,9 @@ export { REFUSAL_FALLBACK_TEXT };
  * model behavior but not end-user UX directly.
  */
 export const NUDGE_TEXT =
-  "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text.</system_notice>";
+  "<system_notice>Your previous response was empty. You must respond to the user with a summary of what you found or did. Do not use any tools — just respond with text." +
+  INTERNAL_NUDGE_OUTPUT_SUPPRESSION +
+  "</system_notice>";
 
 function hasVisibleText(content: ReadonlyArray<ContentBlock>): boolean {
   return content.some(

--- a/assistant/src/plugins/defaults/max-tokens-continue/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/max-tokens-continue/hooks/post-model-call.ts
@@ -32,6 +32,7 @@
 
 import {
   type HookFunction,
+  INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
   isMaxTokensStopReason,
   type PostModelCallContext,
 } from "@vellumai/plugin-api";
@@ -46,7 +47,9 @@ import {
  * the LLM, not the user — edits here affect model behavior, not end-user UX.
  */
 export const MAX_TOKENS_CONTINUE_NUDGE_TEXT =
-  "<system_notice>Your previous response was cut off because it reached the maximum output length. Continue exactly where you stopped — do not repeat content you already sent and do not start over.</system_notice>";
+  "<system_notice>Your previous response was cut off because it reached the maximum output length. Continue exactly where you stopped — do not repeat content you already sent and do not start over." +
+  INTERNAL_NUDGE_OUTPUT_SUPPRESSION +
+  "</system_notice>";
 
 const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
   if (ctx.error) return;

--- a/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
@@ -45,11 +45,12 @@
  * the `post-model-call` chain — later hooks see (and may override) its decision.
  */
 
-import type {
-  ContentBlock,
-  HookFunction,
-  Message,
-  PostModelCallContext,
+import {
+  type ContentBlock,
+  type HookFunction,
+  INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
+  type Message,
+  type PostModelCallContext,
 } from "@vellumai/plugin-api";
 
 import {
@@ -64,7 +65,9 @@ import {
  * is genuinely still running.
  */
 export const SURFACE_COMPLETION_NUDGE_TEXT =
-  '<system_notice>You showed the user a progress surface this turn (a task_progress card or a work_result) and are about to end the turn with it still marked in_progress. If that work is finished, advance it to a terminal state now — call ui_update to set its status to "completed" (or "failed"), or ui_dismiss it — so the user is not left watching a card spin forever. Do this only if the work it represents is actually done; if it is genuinely still running, leave it. Then give your final reply.</system_notice>';
+  '<system_notice>You showed the user a progress surface this turn (a task_progress card or a work_result) and are about to end the turn with it still marked in_progress. If that work is finished, advance it to a terminal state now — call ui_update to set its status to "completed" (or "failed"), or ui_dismiss it — so the user is not left watching a card spin forever. Do this only if the work it represents is actually done; if it is genuinely still running, leave it. Then give your final reply.' +
+  INTERNAL_NUDGE_OUTPUT_SUPPRESSION +
+  "</system_notice>";
 
 /**
  * Surface statuses that mean the progress surface has reached a terminal state


### PR DESCRIPTION
## Summary

- Weaker open-weight models (which the recovery/nudge plugins target) sometimes narrate the internal `<system_notice>` continuation nudges as visible text, leaking agent-loop scaffolding into the user-facing reply (e.g. "Requests actually saying to continue: … No further action needed." prepended to a real answer, or a redundant "The turn is already done — Nothing left to do here."). In a persona product these fourth-wall breaks are disproportionately damaging.
- Fix at the correct layer — **instruct the model not to narrate the notice** — rather than classifying/stripping model output in the loop (which CLAUDE.md "Assistant-Driven Judgement" discourages, and which can't split the prepended-in-one-message case anyway). Add one shared `INTERNAL_NUDGE_OUTPUT_SUPPRESSION` clause to `@vellumai/plugin-api` and append it (inside the `<system_notice>` wrapper) to the three **re-query** nudges: `empty-response`, `surface-completion-nudge`, and `max-tokens-continue`.
- The clause forbids narrating/acknowledging the notice but does **not** license an empty reply — each nudge's own instruction (summary / final reply / continuation) still drives the expected output. This deliberately uses a single no-silence clause rather than a variant ending in "if you have nothing to add, add nothing": for the empty-response and max-tokens recovery nudges, licensing silence would re-authorize the exact empty-reply failure they exist to prevent (the concern raised in review).

## Notes for review

- **SSOT / boundary:** the clause lives in `@vellumai/plugin-api` — satisfies single-source-of-truth without breaching the plugin import boundary (all three plugins already import from it). The `plugin-import-boundary-guard` passes.
- **Scope (explicit decision):** applied to the three re-query nudges — the ones that produce a user-facing terminal/summary reply, which is where narration leaks and where the reported evidence sits. The three `additionalContext` nudges — `task-progress`, `tool-error`, `exploration-drift` — inject mid-turn context rather than re-querying for a terminal reply, so a "reply with only user-facing content" clause doesn't cleanly fit them, and no leak from them appears in the telemetry. Left for a separate focused change if telemetry shows residual leakage there.
- **Nature of the fix:** prompt-level (probabilistic) mitigation, not a hard guarantee for the weakest models — verify post-release via telemetry that the leaked phrases stop recurring. It's a no-op for strong models that already route meta-reasoning to the thinking channel, and it reaches every provider/model (BYOK included) since these nudges are ungated by model family — plain natural-language guidance.
- The sibling "double-emit final reply" finding shares the re-query mechanism but has a distinct root cause and is out of scope here.

## Original prompt

Fix the agent-loop scaffolding that leaks into user replies (found in the v0.10.8 sweep): weak models narrate the internal continuation/completion `<system_notice>` nudges as visible text, breaking the fourth wall. Suppress that narration at the prompt layer by appending a shared clause to the injected nudge strings — per review, without the "nothing to add" fallback that would license an empty reply for the recovery nudges, dropping the stray import from the plan's snippet, running lint, and making an explicit call on the mid-turn `additionalContext` nudges.