### PR TITLE
refactor: remove the GA'd summarize-up-to-here feature flag

### DIFF
--- a/assistant/src/__tests__/conversation-summarize-route.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-route.test.ts
@@ -10,7 +10,6 @@
  *   conversation_error.
  * - Unexpected errors broadcast a retryable conversation_error.
  * - Processing is cleared and the queue drained on every outcome.
- * - The `summarize-up-to-here` flag hides the endpoint (404) when disabled.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -19,15 +18,6 @@ import { z } from "zod";
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   hasUngatedHttpAuthDisabled: () => false,
-}));
-
-// The endpoint is gated behind the `summarize-up-to-here` flag (default
-// off). The suite's baseline is flag ON; the flag-off test flips this to
-// assert the endpoint hides as a 404.
-let summarizeFlagEnabled = true;
-mock.module("../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (key: string) =>
-    key === "summarize-up-to-here" && summarizeFlagEnabled,
 }));
 
 const formatSummarizeUpToResultMock = mock(
@@ -221,7 +211,6 @@ async function settle() {
 }
 
 beforeEach(() => {
-  summarizeFlagEnabled = true;
   addMessageMock.mockClear();
   getConversationMock.mockClear();
   formatSummarizeUpToResultMock.mockClear();
@@ -304,33 +293,6 @@ describe("POST /v1/conversations/summarize", () => {
 
     expect(ctx.conversation.isProcessing()).toBe(false);
     expect(ctx.drainQueue).toHaveBeenCalledTimes(1);
-  });
-
-  test("feature flag off → 404 as if the endpoint does not exist", async () => {
-    summarizeFlagEnabled = false;
-    const ctx = makeConversation();
-    activeConversation = ctx.conversation;
-
-    const res = await callHandler(
-      summarizeHandler,
-      makeRequest({
-        conversationId: "conv-summarize-test",
-        beforeMessageId: "msg-42",
-      }),
-      undefined,
-      202,
-    );
-
-    expect(res.status).toBe(404);
-    // Same body shape as the router's unknown-endpoint 404 — the surface is
-    // indistinguishable from a missing route.
-    const body = (await res.json()) as {
-      error: { code: string; message: string };
-    };
-    expect(body.error.message).toBe("Not found");
-    expect(ctx.setProcessing).not.toHaveBeenCalled();
-    expect(ctx.summarizeUpToMessage).not.toHaveBeenCalled();
-    expect(getConversationMock).not.toHaveBeenCalled();
   });
 
   test("busy conversation → 409 without claiming processing", async () => {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -21,8 +21,6 @@
 
 import { z } from "zod";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getConfig } from "../../config/loader.js";
 import { formatSummarizeUpToResult } from "../../daemon/conversation-process.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import {
@@ -92,12 +90,6 @@ function resolveOrThrow(rawId: string): string {
   const id = resolveConversationId(rawId);
   if (!id) throw new NotFoundError(`Conversation ${rawId} not found`);
   return id;
-}
-
-const SUMMARIZE_UP_TO_HERE_FLAG = "summarize-up-to-here" as const;
-
-function isSummarizeUpToHereEnabled(): boolean {
-  return isAssistantFeatureFlagEnabled(SUMMARIZE_UP_TO_HERE_FLAG, getConfig());
 }
 
 async function cancelScheduleIfLast(conversationId: string): Promise<void> {
@@ -206,11 +198,6 @@ async function handleSummarizeConversation({
   body = {},
   headers,
 }: RouteHandlerArgs) {
-  // Flag-off behaves as an unknown endpoint — same body shape as the
-  // router's 404 — so the surface is invisible until the flag ships.
-  if (!isSummarizeUpToHereEnabled()) {
-    throw new NotFoundError("Not found");
-  }
   const rawConversationId = body.conversationId;
   if (!rawConversationId || typeof rawConversationId !== "string") {
     throw new BadRequestError("Missing conversationId");

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -21,7 +21,6 @@ import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useAutoGreetGate } from "@/domains/chat/hooks/use-auto-greet-gate";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useAuthStore } from "@/stores/auth-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -402,12 +401,7 @@ export function ActiveChatView() {
   // "Summarize up to here" confirm dialog. The hover action only records the
   // target message; the POST fires from the dialog's confirm button — a
   // misfired summarize mutates the assistant's live context with no undo, so
-  // it always goes through an explicit confirmation. Gated by the
-  // `summarize-up-to-here` flag at the callback source: with the flag off no
-  // `onSummarizeUpToHere` is provided, so the hover button never renders and
-  // the dialog is unreachable.
-  const summarizeUpToHereEnabled =
-    useClientFeatureFlagStore.use.summarizeUpToHere();
+  // it always goes through an explicit confirmation.
   const [pendingSummarizeMessageId, setPendingSummarizeMessageId] =
     useState<string | null>(null);
   const [summarizePending, setSummarizePending] = useState(false);
@@ -491,9 +485,7 @@ export function ActiveChatView() {
 
     // Conversation secondary actions
     handleForkConversation,
-    onSummarizeUpToHere: summarizeUpToHereEnabled
-      ? handleSummarizeUpToHere
-      : undefined,
+    onSummarizeUpToHere: handleSummarizeUpToHere,
     handleInspectMessage: showLlmInspector ? handleInspectMessage : undefined,
 
     // History pagination

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -2,16 +2,11 @@ import { describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 // Drive flag values via a module stub (never setState — SSR renders read
-// the store through `use.*` selector hooks). `summarizeUpToHere` defaults
-// ON so the presence-gating tests exercise the callback dimension; the
-// flag-off test flips it.
-const summarizeFlagRef = { value: true };
-
+// the store through `use.*` selector hooks).
 mock.module("@/stores/client-feature-flag-store", () => {
   const store = () => null;
   store.use = {
     bookmarks: () => false,
-    summarizeUpToHere: () => summarizeFlagRef.value,
   };
   return { useClientFeatureFlagStore: store };
 });
@@ -72,27 +67,5 @@ describe("MessageHoverActions", () => {
     const html = renderToStaticMarkup(<MessageHoverActions message={message} />);
 
     expect(html).not.toContain('title="Summarize up to here"');
-  });
-
-  test("omits summarize action when the feature flag is off even with a callback", () => {
-    summarizeFlagRef.value = false;
-    try {
-      const message: DisplayMessage = {
-        id: "m5",
-        role: "assistant",
-        timestamp: Date.UTC(2026, 0, 2, 12, 34),
-        ...textBody("hello"),
-      };
-      const html = renderToStaticMarkup(
-        <MessageHoverActions
-          message={message}
-          onSummarizeUpToHere={() => {}}
-        />,
-      );
-
-      expect(html).not.toContain('title="Summarize up to here"');
-    } finally {
-      summarizeFlagRef.value = true;
-    }
   });
 });

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -9,7 +9,6 @@ import {
   useBookmarkToggle,
   useIsBookmarked,
 } from "@/hooks/use-bookmarks";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 export type MessageHoverActionsProps = {
   /** The message whose text is copied and whose role/timestamp drive the row. */
@@ -110,13 +109,6 @@ export function MessageHoverActions({
     Boolean(conversationId) &&
     Boolean(message.id) &&
     !message.isOptimistic;
-
-  // Summarize is feature-flag gated like bookmarks: the button renders only
-  // when a caller provides the callback AND the `summarize-up-to-here` flag
-  // is on (callers also withhold the callback when the flag is off — this is
-  // the render-site half of that gate).
-  const summarizeUpToHereEnabled =
-    useClientFeatureFlagStore.use.summarizeUpToHere();
 
   // Flat plain-text body derived from the message's text blocks; this is the
   // copy payload and mirrors the daemon's `joinWithSpacing`.
@@ -220,7 +212,7 @@ export function MessageHoverActions({
         </button>
       )}
 
-      {onSummarizeUpToHere && summarizeUpToHereEnabled && (
+      {onSummarizeUpToHere && (
         <button
           type="button"
           onClick={onSummarizeUpToHere}

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-long-press-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-long-press-actions.tsx
@@ -17,7 +17,6 @@ import {
   useBookmarkToggle,
   useIsBookmarked,
 } from "@/hooks/use-bookmarks";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { BottomSheet, PanelItem } from "@vellumai/design-library";
 
 type MessageLongPressActionsProps = MessageHoverActionsProps & {
@@ -52,9 +51,6 @@ export function MessageLongPressActions({
     Boolean(conversationId) &&
     Boolean(message.id) &&
     !message.isOptimistic;
-
-  const summarizeUpToHereEnabled =
-    useClientFeatureFlagStore.use.summarizeUpToHere();
 
   const content = useMemo(() => messagePlainText(message), [message]);
 
@@ -144,7 +140,7 @@ export function MessageLongPressActions({
     );
   }
 
-  if (onSummarizeUpToHere && summarizeUpToHereEnabled) {
+  if (onSummarizeUpToHere) {
     items.push(
       buildItem({
         key: "summarize",

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -55,9 +55,9 @@ describe("feature flag catalog", () => {
     expect(ASSISTANT_FLAG_DEFAULTS.mcpAddServer).toBe(false);
   });
 
-  test("exposes summarize-up-to-here to client and assistant flag stores", () => {
-    expect(CLIENT_FLAG_DEFAULTS.summarizeUpToHere).toBe(false);
-    expect(ASSISTANT_FLAG_DEFAULTS.summarizeUpToHere).toBe(false);
+  test("does not expose GA summarize-up-to-here as a feature flag", () => {
+    expect("summarizeUpToHere" in CLIENT_FLAG_DEFAULTS).toBe(false);
+    expect("summarizeUpToHere" in ASSISTANT_FLAG_DEFAULTS).toBe(false);
   });
 });
 

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -355,14 +355,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "summarize-up-to-here",
-      "scope": "both",
-      "key": "summarize-up-to-here",
-      "label": "Summarize Up To Here",
-      "description": "Show the per-message Summarize up to here action and enable the conversation summarize endpoint",
-      "defaultEnabled": false
-    },
-    {
       "id": "chat-credential-reveal",
       "scope": "assistant",
       "key": "chat-credential-reveal",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -355,14 +355,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "summarize-up-to-here",
-      "scope": "both",
-      "key": "summarize-up-to-here",
-      "label": "Summarize Up To Here",
-      "description": "Show the per-message Summarize up to here action and enable the conversation summarize endpoint",
-      "defaultEnabled": false
-    },
-    {
       "id": "chat-credential-reveal",
       "scope": "assistant",
       "key": "chat-credential-reveal",


### PR DESCRIPTION
## Summary
- Delete the `summarize-up-to-here` entry from the canonical flag registry and the synced web bundled copy — the feature ships on for everyone.
- Remove the daemon-side flag gate (404) on `POST /v1/conversations/summarize` and the three web UI flag reads (callback source in `active-chat-view`, hover action, long-press action); the action now renders whenever the callback is provided.
- Update tests: drop the flag mocks and flag-off cases, and convert the catalog assertion into the standard GA-regression lock (`summarizeUpToHere` no longer exposed in the flag catalogs).

Follow-up (non-blocking): retire the platform-side flag in `vellum-assistant-platform` Terraform; once undeclared locally, a remote value for it is ignored.

## Original prompt
The "summarize up to here" feature is ready for GA — make it on by default and remove the feature flag. Planned as a full flag removal following the established pattern (registry deletion + bundled-copy sync, daemon and web gate removal, test updates), then executed via /do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)