### PR TITLE
fix(onboarding): platform privacy Back lands on in-SPA start screen

### DIFF
--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -162,3 +162,47 @@ describe("PrivacyScreen — Start navigation", () => {
     expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hatching);
   });
 });
+
+describe("PrivacyScreen — Back navigation", () => {
+  const assignMock = mock((_url: string) => {});
+
+  beforeEach(() => {
+    navigateMock.mockClear();
+    assignMock.mockClear();
+    nativePlatform = false;
+    localMode = false;
+    searchParamsValue = new URLSearchParams();
+    // window.location.assign drives the platform-mode Back (a full-document nav
+    // to the marketing landing page, which the SPA does not own).
+    Object.defineProperty(window, "location", {
+      value: { assign: assignMock },
+      configurable: true,
+      writable: true,
+    });
+  });
+  afterEach(() => {
+    cleanup();
+    nativePlatform = false;
+    localMode = false;
+  });
+
+  test("local mode: Back returns to the hosting screen deterministically", () => {
+    localMode = true;
+    render(<PrivacyScreen />);
+
+    fireEvent.click(screen.getByText("Back"));
+
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hosting);
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  test("platform mode: Back leaves onboarding for the marketing landing page", () => {
+    localMode = false;
+    render(<PrivacyScreen />);
+
+    fireEvent.click(screen.getByText("Back"));
+
+    expect(assignMock).toHaveBeenCalledWith("/");
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -172,8 +172,8 @@ describe("PrivacyScreen — Back navigation", () => {
     nativePlatform = false;
     localMode = false;
     searchParamsValue = new URLSearchParams();
-    // window.location.assign drives the platform-mode Back (a full-document nav
-    // to the marketing landing page, which the SPA does not own).
+    // Guard against regressions: Back must stay inside the SPA and never reach
+    // for a full-document navigation to the marketing host.
     Object.defineProperty(window, "location", {
       value: { assign: assignMock },
       configurable: true,
@@ -196,13 +196,29 @@ describe("PrivacyScreen — Back navigation", () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
-  test("platform mode: Back leaves onboarding for the marketing landing page", () => {
+  test("platform mode: Back lands on the in-SPA onboarding start screen", () => {
     localMode = false;
     render(<PrivacyScreen />);
 
     fireEvent.click(screen.getByText("Back"));
 
-    expect(assignMock).toHaveBeenCalledWith("/");
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.start);
+    // Must not leave the SPA for the marketing host — that would switch a
+    // Capacitor staging/dev shell onto production.
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  test("native platform shell: Back stays in-SPA (no marketing-host escape)", () => {
+    // The environment-preservation case Codex flagged: on Capacitor
+    // staging/dev, isLocalMode() is false, so platform-mode Back applies. It
+    // must remain an in-SPA navigation, never a full-document nav to `/`.
+    localMode = false;
+    nativePlatform = true;
+    render(<PrivacyScreen />);
+
+    fireEvent.click(screen.getByText("Back"));
+
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.start);
+    expect(assignMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -162,25 +162,29 @@ export function PrivacyScreen() {
             Start
           </Button>
           {/*
-           * Back's destination is mode-specific. In local mode hosting is the
-           * screen that leads here (welcome → hosting → privacy), so go there
-           * deterministically rather than `navigate(-1)`. In platform mode privacy
-           * IS the onboarding entrypoint — there's nothing before it inside
-           * onboarding, and hosting is local-only (`enforceModeBoundary` bounces a
-           * platform user off it to `/assistant`, which then trips a non-onboarding
-           * hatch). So platform mode leaves onboarding entirely, back to the
-           * marketing landing page. `/` is served by the marketing app (the SPA
-           * only owns `/assistant/*`), so this needs a full-document navigation,
-           * not react-router `navigate`.
+           * Back's destination is mode-specific, but always stays inside the SPA
+           * (react-router `navigate`, never a full-document nav). In local mode
+           * hosting is the screen that leads here (welcome → hosting → privacy),
+           * so go there deterministically rather than `navigate(-1)`. In platform
+           * mode privacy IS the funnel entrypoint — hosting is local-only
+           * (`enforceModeBoundary` bounces a platform user off it to `/assistant`,
+           * which trips a non-onboarding hatch) — so Back lands on the onboarding
+           * `start` welcome screen instead. It must NOT leave the SPA for the
+           * marketing host (`/`): on a Capacitor staging/dev shell that host's CTA
+           * points at production `www.vellum.ai/assistant`, so a full-document nav
+           * would switch the native app off its own environment. `start` keeps the
+           * running environment intact on web and native alike.
            */}
           <Button
             variant="outlined"
             size="regular"
             fullWidth
             onClick={() =>
-              isLocalMode()
-                ? navigate(routes.onboarding.hosting)
-                : window.location.assign("/")
+              navigate(
+                isLocalMode()
+                  ? routes.onboarding.hosting
+                  : routes.onboarding.start,
+              )
             }
             className={electron ? undefined : "h-11 text-base"}
           >

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -162,26 +162,30 @@ export function PrivacyScreen() {
             Start
           </Button>
           {/*
-           * Back is local-mode only. In local mode hosting is the screen that
-           * leads here (welcome → hosting → privacy), so go there deterministically
-           * rather than `navigate(-1)`. In platform mode privacy IS the onboarding
-           * entrypoint — there's nothing before it — and hosting is local-only
-           * (`enforceModeBoundary` bounces a platform user off it to `/assistant`,
-           * which then trips a non-onboarding hatch). So platform gets no Back,
-           * which also keeps the post-retire redirect (`resolvePostRetire` →
-           * privacy) from escaping onboarding.
+           * Back's destination is mode-specific. In local mode hosting is the
+           * screen that leads here (welcome → hosting → privacy), so go there
+           * deterministically rather than `navigate(-1)`. In platform mode privacy
+           * IS the onboarding entrypoint — there's nothing before it inside
+           * onboarding, and hosting is local-only (`enforceModeBoundary` bounces a
+           * platform user off it to `/assistant`, which then trips a non-onboarding
+           * hatch). So platform mode leaves onboarding entirely, back to the
+           * marketing landing page. `/` is served by the marketing app (the SPA
+           * only owns `/assistant/*`), so this needs a full-document navigation,
+           * not react-router `navigate`.
            */}
-          {isLocalMode() ? (
-            <Button
-              variant="outlined"
-              size="regular"
-              fullWidth
-              onClick={() => navigate(routes.onboarding.hosting)}
-              className={electron ? undefined : "h-11 text-base"}
-            >
-              Back
-            </Button>
-          ) : null}
+          <Button
+            variant="outlined"
+            size="regular"
+            fullWidth
+            onClick={() =>
+              isLocalMode()
+                ? navigate(routes.onboarding.hosting)
+                : window.location.assign("/")
+            }
+            className={electron ? undefined : "h-11 text-base"}
+          >
+            Back
+          </Button>
         </div>
 
       </div>

--- a/clients/web/src/domains/onboarding/pages/start-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/start-screen.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { routes } from "@/utils/routes";
+
+const navigateMock = mock((..._args: unknown[]) => {});
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+// Light passthroughs so the screen renders in happy-dom.
+mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
+  OnboardingLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
+}));
+
+const { StartScreen } = await import(
+  "@/domains/onboarding/pages/start-screen"
+);
+
+describe("StartScreen", () => {
+  beforeEach(() => navigateMock.mockClear());
+  afterEach(cleanup);
+
+  test("the single CTA re-enters the funnel at the privacy screen", () => {
+    render(<StartScreen />);
+
+    fireEvent.click(screen.getByText("Create your assistant"));
+
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.privacy);
+  });
+});

--- a/clients/web/src/domains/onboarding/pages/start-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/start-screen.tsx
@@ -1,0 +1,60 @@
+import { useNavigate } from "react-router";
+
+import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { routes } from "@/utils/routes";
+import { Button } from "@vellumai/design-library/components/button";
+
+/**
+ * Platform onboarding welcome / front door.
+ *
+ * This is the in-SPA landing spot for "Back" out of the privacy screen in
+ * platform mode. Privacy is the onboarding entrypoint there and its only
+ * happy-path predecessor (hosting) is local-only, so before this screen a
+ * platform Back had nowhere in-SPA to go — sending it to the marketing host
+ * (`/`) would have navigated a Capacitor staging/dev shell onto production
+ * (its CTA points at `www.vellum.ai/assistant`). Keeping Back inside the SPA
+ * preserves the running environment on every platform.
+ *
+ * It is deliberately a single-CTA welcome: the button re-enters the funnel at
+ * privacy (consent), which then hatches the assistant. Not wired as the funnel
+ * entrypoint — reached only via Back — so the happy path is unchanged.
+ */
+export function StartScreen() {
+  const navigate = useNavigate();
+
+  return (
+    <OnboardingLayout>
+      <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center px-6 pb-40 text-[var(--content-default)]">
+        <div className="flex flex-1 flex-col items-center justify-center">
+          <h1
+            className="text-3xl font-semibold tracking-tight"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
+          >
+            Welcome to Vellum
+          </h1>
+          <p
+            className="mt-3 text-center text-body-medium-lighter text-[var(--content-tertiary)]"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
+          >
+            Your own personal intelligence is just a step away.
+          </p>
+
+          <div
+            className="mt-10 flex w-full max-w-sm flex-col"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+          >
+            <Button
+              variant="primary"
+              size="regular"
+              fullWidth
+              className="h-11 text-base"
+              onClick={() => void navigate(routes.onboarding.privacy)}
+            >
+              Create your assistant
+            </Button>
+          </div>
+        </div>
+      </div>
+    </OnboardingLayout>
+  );
+}

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -247,6 +247,10 @@ export const routeTree = [
               ],
             },
             {
+              path: "onboarding/start",
+              lazy: { Component: () => import("@/domains/onboarding/pages/start-screen").then((m) => m.StartScreen) },
+            },
+            {
               path: "onboarding/privacy",
               lazy: { Component: () => import("@/domains/onboarding/pages/privacy-screen").then((m) => m.PrivacyScreen) },
             },

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -106,6 +106,10 @@ export const routes = {
   reviewTerms: r("/assistant/review-terms"),
 
   onboarding: {
+    // Platform onboarding welcome/front door. Not the funnel entrypoint
+    // (privacy still is) — it's the in-SPA landing spot for "Back" out of the
+    // privacy screen in platform mode, with a single CTA back into the flow.
+    start: r("/assistant/onboarding/start"),
     hosting: r("/assistant/onboarding/hosting"),
     apiKey: r("/assistant/onboarding/api-key"),
     privacy: r("/assistant/onboarding/privacy"),


### PR DESCRIPTION
## Why

Follow-up to #38278, which hid the privacy-screen **Back** button entirely in platform mode (privacy is the funnel entrypoint there, and its only happy-path predecessor — hosting — is local-only). That left platform users with no way back off the privacy screen.

The first attempt sent platform-mode Back to the marketing landing page (`/`). Codex flagged a **P1**: on a Capacitor staging/dev shell `isLocalMode()` is false, so that branch would navigate the WKWebView to the marketing host, whose CTA redirects to production `www.vellum.ai/assistant` — switching the native app off its own environment.

## What

Keep Back **inside the SPA** on every platform instead of special-casing native.

- **New screen** `/assistant/onboarding/start` — a platform onboarding welcome / front door with a single **"Create your assistant"** CTA that re-enters the funnel at privacy (consent → hatch).
- **Platform-mode Back** now react-router `navigate()`s to `start` instead of doing a full-document nav to `/`. No `window.location.assign` anywhere.
- **Local-mode Back** unchanged — still returns to the hosting screen.
- Both branches are in-SPA navigations now, so web and native (incl. staging/dev) preserve the running environment. The marketing-host escape can't happen.

## Scope / invariants

- `start` is reached **only via Back** — the funnel entrypoint is unchanged (still privacy), so the happy path (`privacy → research → hatch`) and post-retire/gate/signup routing are untouched.
- `start` is allowed through the route guard by the existing `allowSetupRoutes` step (any `/assistant/onboarding/*` path), so **no navigation-resolver changes** were needed.

## Tests

- `start-screen.test.tsx`: the single CTA navigates to privacy.
- `privacy-screen.test.tsx` Back coverage: local → hosting, platform → start, and the **native-platform** case (`nativePlatform = true`, `isLocalMode()` false) asserting it lands on `start` and never calls `location.assign`.
- `bun test` green (8/8 across both files); `bunx tsc` clean via pre-commit; no new lint warnings.

## Possible follow-up

If we'd rather `start` be the real platform onboarding front door (happy path `start → privacy`), that means changing `onboardingEntrypoint()` / `resolvePostRetire` / `resolvePostAuth` / `gate.ts` / native-auth — a larger, funnel-behavior change I left out of this PR since the ask was just a safe Back destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)