### PR TITLE
feat(gateway): ingest inbound email attachments into the workspace

### DIFF
--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -14,11 +14,13 @@ describe("config: hardcoded defaults", () => {
     expect(config.runtimeMaxRetries).toBe(2);
     expect(config.runtimeInitialBackoffMs).toBe(500);
     expect(config.maxWebhookPayloadBytes).toBe(1024 * 1024);
+    expect(config.maxEmailWebhookPayloadBytes).toBe(350 * 1024 * 1024);
     expect(config.maxAttachmentBytes).toEqual({
       telegram: 20 * 1024 * 1024,
       telegramOutbound: 50 * 1024 * 1024,
       slack: 100 * 1024 * 1024,
       whatsapp: 16 * 1024 * 1024,
+      email: 25 * 1024 * 1024,
       default: 100 * 1024 * 1024,
     });
     expect(config.maxAttachmentConcurrency).toBe(3);

--- a/gateway/src/__tests__/email-inbound-pipeline.test.ts
+++ b/gateway/src/__tests__/email-inbound-pipeline.test.ts
@@ -26,6 +26,22 @@ mock.module("../routing/resolve-assistant.js", () => ({
   isRejection: (routing: Record<string, unknown>) => "reason" in routing,
 }));
 
+let uploadCounter = 0;
+const uploadAttachmentMock = mock(() =>
+  Promise.resolve({ id: `att-${++uploadCounter}` }),
+);
+mock.module("../runtime/client.js", () => ({
+  uploadAttachment: uploadAttachmentMock,
+  AttachmentValidationError: class extends Error {},
+  CircuitBreakerOpenError: class extends Error {},
+  resetConversation: mock(() => Promise.resolve()),
+}));
+
+const attachmentConfig = {
+  maxAttachmentBytes: { email: 25 * 1024 * 1024, default: 100 * 1024 * 1024 },
+  maxAttachmentConcurrency: 3,
+} as unknown as GatewayConfig;
+
 const { runEmailInboundPipeline } =
   await import("../email/inbound-pipeline.js");
 
@@ -76,6 +92,11 @@ beforeEach(() => {
   resolveAssistantMock.mockImplementation(() => ({
     assistantId: "assistant-1",
   }));
+  uploadCounter = 0;
+  uploadAttachmentMock.mockClear();
+  uploadAttachmentMock.mockImplementation(() =>
+    Promise.resolve({ id: `att-${++uploadCounter}` }),
+  );
 });
 
 describe("runEmailInboundPipeline", () => {
@@ -236,6 +257,59 @@ describe("runEmailInboundPipeline", () => {
     const response = await runEmailInboundPipeline(pipelineOpts());
     expect(response.status).toBe(200);
     expect(recordDenialReplyIfAllowedMock).not.toHaveBeenCalled();
+  });
+
+  it("uploads inline attachments and forwards their ids", async () => {
+    const response = await runEmailInboundPipeline(
+      pipelineOpts({
+        config: attachmentConfig,
+        vellumPayload: {
+          ...payload,
+          attachments: [
+            {
+              filename: "receipt.pdf",
+              contentType: "application/pdf",
+              size: 5,
+              content: Buffer.from("hello").toString("base64"),
+            },
+          ],
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(uploadAttachmentMock).toHaveBeenCalledTimes(1);
+    const forwardOptions = (
+      handleInboundMock.mock.calls[0] as unknown[]
+    )[2] as { attachmentIds?: string[] };
+    expect(forwardOptions.attachmentIds).toEqual(["att-1"]);
+  });
+
+  it("returns 500 and unreserves the dedup key on transient upload failure", async () => {
+    uploadAttachmentMock.mockImplementation(() =>
+      Promise.reject(new Error("runtime 503")),
+    );
+    const dedupCache = new StringDedupCache(60_000);
+    dedupCache.reserve("key-1");
+    const response = await runEmailInboundPipeline(
+      pipelineOpts({
+        config: attachmentConfig,
+        dedupCache,
+        vellumPayload: {
+          ...payload,
+          attachments: [
+            {
+              filename: "receipt.pdf",
+              contentType: "application/pdf",
+              size: 5,
+              content: Buffer.from("hello").toString("base64"),
+            },
+          ],
+        },
+      }),
+    );
+    expect(response.status).toBe(500);
+    expect(handleInboundMock).not.toHaveBeenCalled();
+    expect(dedupCache.reserve("key-1")).toBe(true);
   });
 
   it("returns 500 and unreserves the dedup key on forwarding failure", async () => {

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -20,6 +20,14 @@ export type GatewayConfig = {
     Record<string, number>;
   maxAttachmentConcurrency: number;
   maxWebhookPayloadBytes: number;
+  /**
+   * Body cap for the inbound email webhook (`/webhooks/email`). Email
+   * attachments arrive inlined as base64 in the payload, so this ceiling is
+   * much larger than {@link maxWebhookPayloadBytes} to fit the platform's
+   * per-file / per-message attachment cap. Optional — callers fall back to
+   * {@link maxWebhookPayloadBytes} when unset.
+   */
+  maxEmailWebhookPayloadBytes?: number;
   port: number;
   routingEntries: RoutingEntry[];
   runtimeInitialBackoffMs: number;
@@ -215,10 +223,14 @@ export function loadConfig(): GatewayConfig {
       telegramOutbound: 50 * 1024 * 1024, // Telegram Bot API sendDocument (upload) limit
       slack: 100 * 1024 * 1024, // Slack standard plan
       whatsapp: 16 * 1024 * 1024, // WhatsApp Business API limit
+      email: 25 * 1024 * 1024, // Platform inbound-attachment per-file cap
       default: 100 * 1024 * 1024, // Fallback; capped by runtime MAX_UPLOAD_BYTES (100 MB)
     },
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1024 * 1024,
+    // Fits the platform's inbound-attachment cap (25 MB/file × 10 files),
+    // expanded by base64 (~4/3) plus body/JSON overhead.
+    maxEmailWebhookPayloadBytes: 350 * 1024 * 1024,
     port,
     routingEntries,
     runtimeInitialBackoffMs: 500,

--- a/gateway/src/email/attachments.test.ts
+++ b/gateway/src/email/attachments.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Logger } from "pino";
+import type { GatewayConfig } from "../config.js";
+import type { EmailAttachment } from "./normalize.js";
+
+// --- Mocks ----------------------------------------------------------------
+
+class MockAttachmentValidationError extends Error {}
+
+let uploadCounter = 0;
+const uploadAttachmentMock = mock(() =>
+  Promise.resolve({ id: `att-${++uploadCounter}` }),
+);
+
+mock.module("../runtime/client.js", () => ({
+  uploadAttachment: uploadAttachmentMock,
+  AttachmentValidationError: MockAttachmentValidationError,
+  CircuitBreakerOpenError: class extends Error {},
+  resetConversation: mock(() => Promise.resolve()),
+}));
+
+const { ingestEmailAttachments, appendFailedEmailAttachmentNotice } =
+  await import("./attachments.js");
+
+// --- Helpers --------------------------------------------------------------
+
+const silentLog = {
+  info: () => {},
+  warn: () => {},
+  debug: () => {},
+  error: () => {},
+} as unknown as Logger;
+
+const config = {
+  maxAttachmentBytes: {
+    telegram: 20 * 1024 * 1024,
+    slack: 100 * 1024 * 1024,
+    whatsapp: 16 * 1024 * 1024,
+    email: 25 * 1024 * 1024,
+    default: 100 * 1024 * 1024,
+  },
+  maxAttachmentConcurrency: 3,
+} as unknown as GatewayConfig;
+
+function att(overrides?: Partial<EmailAttachment>): EmailAttachment {
+  return {
+    filename: "receipt.pdf",
+    contentType: "application/pdf",
+    content: Buffer.from("hello").toString("base64"),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  uploadCounter = 0;
+  uploadAttachmentMock.mockClear();
+  uploadAttachmentMock.mockImplementation(() =>
+    Promise.resolve({ id: `att-${++uploadCounter}` }),
+  );
+});
+
+// --- Tests ----------------------------------------------------------------
+
+describe("ingestEmailAttachments", () => {
+  it("returns empty result for undefined or empty attachments", async () => {
+    expect(await ingestEmailAttachments(config, undefined, silentLog)).toEqual({
+      attachmentIds: [],
+      failedAttachmentNames: [],
+    });
+    expect(await ingestEmailAttachments(config, [], silentLog)).toEqual({
+      attachmentIds: [],
+      failedAttachmentNames: [],
+    });
+    expect(uploadAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  it("uploads attachments and returns their ids", async () => {
+    const result = await ingestEmailAttachments(
+      config,
+      [
+        att({ filename: "a.pdf" }),
+        att({ filename: "b.png", contentType: "image/png" }),
+      ],
+      silentLog,
+    );
+    expect(result.attachmentIds).toEqual(["att-1", "att-2"]);
+    expect(result.failedAttachmentNames).toEqual([]);
+    expect(uploadAttachmentMock).toHaveBeenCalledTimes(2);
+
+    // Maps email fields to the attachment-store upload shape.
+    const firstCall = uploadAttachmentMock.mock.calls[0] as unknown[];
+    expect(firstCall[1]).toEqual({
+      filename: "a.pdf",
+      mimeType: "application/pdf",
+      data: att().content,
+    });
+  });
+
+  it("skips oversized attachments by reported size", async () => {
+    const result = await ingestEmailAttachments(
+      config,
+      [
+        att({ filename: "small.pdf", size: 1000 }),
+        att({ filename: "huge.pdf", size: 30 * 1024 * 1024 }),
+      ],
+      silentLog,
+    );
+    expect(result.attachmentIds).toEqual(["att-1"]);
+    expect(result.failedAttachmentNames).toEqual(["huge.pdf"]);
+    expect(uploadAttachmentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips validation-rejected attachments without dropping the rest", async () => {
+    uploadAttachmentMock.mockImplementationOnce(() =>
+      Promise.reject(new MockAttachmentValidationError("bad type")),
+    );
+    const result = await ingestEmailAttachments(
+      config,
+      [att({ filename: "bad.exe" }), att({ filename: "good.pdf" })],
+      silentLog,
+    );
+    expect(result.attachmentIds).toEqual(["att-1"]);
+    expect(result.failedAttachmentNames).toEqual(["bad.exe"]);
+  });
+
+  it("propagates transient upload failures so the caller can retry", async () => {
+    uploadAttachmentMock.mockImplementation(() =>
+      Promise.reject(new Error("upstream 503")),
+    );
+    await expect(
+      ingestEmailAttachments(config, [att()], silentLog),
+    ).rejects.toThrow("upstream 503");
+  });
+
+  it("falls back to the default cap when no email cap is configured", async () => {
+    const noEmailCap = {
+      maxAttachmentBytes: { default: 10 },
+      maxAttachmentConcurrency: 3,
+    } as unknown as GatewayConfig;
+    const result = await ingestEmailAttachments(
+      noEmailCap,
+      [att({ filename: "over.pdf", size: 20 })],
+      silentLog,
+    );
+    expect(result.attachmentIds).toEqual([]);
+    expect(result.failedAttachmentNames).toEqual(["over.pdf"]);
+  });
+});
+
+describe("appendFailedEmailAttachmentNotice", () => {
+  it("returns content unchanged when nothing failed", () => {
+    expect(appendFailedEmailAttachmentNotice("hello", [])).toBe("hello");
+  });
+
+  it("appends a notice listing failed attachments", () => {
+    const out = appendFailedEmailAttachmentNotice("hello", ["a.pdf", "b.png"]);
+    expect(out).toContain("hello");
+    expect(out).toContain('"a.pdf"');
+    expect(out).toContain('"b.png"');
+  });
+
+  it("uses the notice as the whole content when the body is empty", () => {
+    const out = appendFailedEmailAttachmentNotice("", ["a.pdf"]);
+    expect(out.startsWith("[The user attached")).toBe(true);
+  });
+});

--- a/gateway/src/email/attachments.ts
+++ b/gateway/src/email/attachments.ts
@@ -1,0 +1,118 @@
+import type { Logger } from "pino";
+import type { GatewayConfig } from "../config.js";
+import {
+  AttachmentValidationError,
+  uploadAttachment,
+} from "../runtime/client.js";
+import type { EmailAttachment } from "./normalize.js";
+
+export interface EmailAttachmentIngestResult {
+  /** Attachment store ids for successfully uploaded attachments. */
+  attachmentIds: string[];
+  /** Display names of attachments that were skipped (oversized or rejected). */
+  failedAttachmentNames: string[];
+}
+
+/**
+ * Estimate the decoded byte size of a base64 string without allocating the
+ * decoded buffer. Every 4 base64 chars encode 3 bytes; trailing `=` padding
+ * shortens the final group.
+ */
+function estimateBase64Bytes(base64: string): number {
+  const len = base64.length;
+  if (len === 0) {
+    return 0;
+  }
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.floor((len * 3) / 4) - padding;
+}
+
+/**
+ * Upload inline base64 email attachments to the assistant's attachment store
+ * and return the resulting ids for forwarding to the runtime, which stores
+ * them in the conversation workspace.
+ *
+ * Attachments larger than the email per-file cap are skipped. Validation
+ * failures (unsupported MIME type, dangerous extension) are skipped so a
+ * single bad attachment never drops the user's email; transient failures
+ * (upload 5xx, network) are propagated so the caller can surface an error and
+ * let the upstream retry the delivery.
+ */
+export async function ingestEmailAttachments(
+  config: GatewayConfig,
+  attachments: EmailAttachment[] | undefined,
+  log: Logger,
+): Promise<EmailAttachmentIngestResult> {
+  const attachmentIds: string[] = [];
+  const failedAttachmentNames: string[] = [];
+
+  if (!attachments || attachments.length === 0) {
+    return { attachmentIds, failedAttachmentNames };
+  }
+
+  const maxBytes =
+    config.maxAttachmentBytes.email ?? config.maxAttachmentBytes.default;
+
+  const eligible = attachments.filter((att) => {
+    const bytes = att.size ?? estimateBase64Bytes(att.content);
+    if (bytes > maxBytes) {
+      log.warn(
+        { filename: att.filename, bytes, limit: maxBytes },
+        "Skipping oversized email attachment",
+      );
+      failedAttachmentNames.push(att.filename);
+      return false;
+    }
+    return true;
+  });
+
+  // Bounded concurrency mirrors the other channel webhooks so a message with
+  // many attachments does not open an unbounded number of upstream requests.
+  for (let i = 0; i < eligible.length; i += config.maxAttachmentConcurrency) {
+    const batch = eligible.slice(i, i + config.maxAttachmentConcurrency);
+    const results = await Promise.allSettled(
+      batch.map((att) =>
+        uploadAttachment(config, {
+          filename: att.filename,
+          mimeType: att.contentType,
+          data: att.content,
+        }),
+      ),
+    );
+    for (let j = 0; j < results.length; j++) {
+      const result = results[j];
+      if (result.status === "fulfilled") {
+        attachmentIds.push(result.value.id);
+      } else if (result.reason instanceof AttachmentValidationError) {
+        log.warn(
+          { err: result.reason, filename: batch[j].filename },
+          "Skipping email attachment with validation error",
+        );
+        failedAttachmentNames.push(batch[j].filename);
+      } else {
+        // Transient failure — propagate so the caller returns an error and the
+        // upstream retries the whole delivery rather than silently dropping.
+        throw result.reason;
+      }
+    }
+  }
+
+  return { attachmentIds, failedAttachmentNames };
+}
+
+/**
+ * Append a note to the message content listing attachments that could not be
+ * ingested so the assistant can tell the user to re-send if the content
+ * mattered. Returns the content unchanged when nothing failed.
+ */
+export function appendFailedEmailAttachmentNotice(
+  content: string,
+  failedAttachmentNames: string[],
+): string {
+  if (failedAttachmentNames.length === 0) {
+    return content;
+  }
+  const nameList = failedAttachmentNames.map((n) => `"${n}"`).join(", ");
+  const notice = `[The user attached file(s) that could not be processed: ${nameList}. Ask them to re-send if the content is important.]`;
+  return content.length > 0 ? `${content}\n\n${notice}` : notice;
+}

--- a/gateway/src/email/inbound-pipeline.ts
+++ b/gateway/src/email/inbound-pipeline.ts
@@ -9,6 +9,10 @@ import {
   handleCircuitBreakerError,
   processInboundResult,
 } from "../webhook-pipeline.js";
+import {
+  appendFailedEmailAttachmentNotice,
+  ingestEmailAttachments,
+} from "./attachments.js";
 import type { VellumEmailPayload } from "./normalize.js";
 import { normalizeEmailWebhook } from "./normalize.js";
 
@@ -85,7 +89,12 @@ export async function runEmailInboundPipeline(
     return Response.json({ ok: true });
   }
 
-  const { event: gatewayEvent, eventId, recipientAddress } = normalized;
+  const {
+    event: gatewayEvent,
+    eventId,
+    recipientAddress,
+    attachments,
+  } = normalized;
   const senderAddress = gatewayEvent.actor.actorExternalId;
 
   log.info(
@@ -121,7 +130,19 @@ export async function runEmailInboundPipeline(
   const replySubject = `Re: ${vellumPayload.subject ?? "(no subject)"}`;
 
   try {
+    // Ingest inline base64 attachments into the assistant's attachment store
+    // (stored in the conversation workspace) and forward the ids. A transient
+    // upload failure throws into the catch below → 500 so the provider retries.
+    const ingested = await ingestEmailAttachments(config, attachments, log);
+    const attachmentIds =
+      ingested.attachmentIds.length > 0 ? ingested.attachmentIds : undefined;
+    gatewayEvent.message.content = appendFailedEmailAttachmentNotice(
+      gatewayEvent.message.content,
+      ingested.failedAttachmentNames,
+    );
+
     const result = await handleInbound(config, gatewayEvent, {
+      ...(attachmentIds ? { attachmentIds } : {}),
       transportMetadata: buildEmailTransportMetadata({
         senderAddress,
         recipientAddress,

--- a/gateway/src/email/normalize.test.ts
+++ b/gateway/src/email/normalize.test.ts
@@ -152,4 +152,59 @@ describe("normalizeEmailWebhook", () => {
     );
     expect(result!.senderAuthenticated).toBeUndefined();
   });
+
+  it("omits attachments when the payload carries none", () => {
+    const result = normalizeEmailWebhook(makePayload());
+    expect(result!.attachments).toBeUndefined();
+  });
+
+  it("parses well-formed attachments", () => {
+    const result = normalizeEmailWebhook(
+      makePayload({
+        attachments: [
+          {
+            filename: "receipt.pdf",
+            contentType: "application/pdf",
+            size: 12345,
+            content: "YmFzZTY0",
+            contentId: "img001@example.com",
+          },
+        ],
+      }),
+    );
+    expect(result!.attachments).toEqual([
+      {
+        filename: "receipt.pdf",
+        contentType: "application/pdf",
+        size: 12345,
+        content: "YmFzZTY0",
+        contentId: "img001@example.com",
+      },
+    ]);
+  });
+
+  it("drops attachments missing required fields but keeps valid ones", () => {
+    const result = normalizeEmailWebhook(
+      makePayload({
+        attachments: [
+          { filename: "no-content.pdf", contentType: "application/pdf" },
+          { contentType: "application/pdf", content: "YmFzZTY0" },
+          {
+            filename: "ok.pdf",
+            contentType: "application/pdf",
+            content: "YmE=",
+          },
+          "not-an-object",
+        ],
+      }),
+    );
+    expect(result!.attachments).toEqual([
+      { filename: "ok.pdf", contentType: "application/pdf", content: "YmE=" },
+    ]);
+  });
+
+  it("omits attachments when the field is not an array", () => {
+    const result = normalizeEmailWebhook(makePayload({ attachments: "nope" }));
+    expect(result!.attachments).toBeUndefined();
+  });
 });

--- a/gateway/src/email/normalize.ts
+++ b/gateway/src/email/normalize.ts
@@ -1,6 +1,26 @@
 import type { GatewayInboundEvent } from "../types.js";
 
 /**
+ * A single inbound email attachment, inlined as base64 by the upstream
+ * caller (the Vellum platform fetches the blob from the provider's
+ * Attachments API and embeds it here, bounded by a per-file / per-message
+ * cap). The gateway uploads each attachment to the assistant's attachment
+ * store so it lands in the conversation workspace.
+ */
+export interface EmailAttachment {
+  /** Original filename as sent by the email client (e.g. "receipt.pdf"). */
+  filename: string;
+  /** MIME type declared by the sender (e.g. "application/pdf"). */
+  contentType: string;
+  /** Decoded byte size, when the upstream caller reports it. */
+  size?: number;
+  /** Base64-encoded attachment bytes. */
+  content: string;
+  /** RFC 2392 Content-ID for inline (cid:) references, when present. */
+  contentId?: string;
+}
+
+/**
  * Shape of a normalized inbound email event as sent by the Vellum
  * platform (or any upstream caller).
  *
@@ -40,6 +60,14 @@ export interface VellumEmailPayload {
    * guardian/trusted_contact trust.
    */
   senderAuthenticated?: boolean;
+  /**
+   * Inbound attachments, inlined as base64 by the upstream caller. Additive
+   * and optional — payloads without attachments (or from callers that do not
+   * fetch them) simply omit the field. The gateway uploads each to the
+   * assistant's attachment store and forwards the resulting ids so they land
+   * in the conversation workspace.
+   */
+  attachments?: EmailAttachment[];
 }
 
 export interface NormalizedEmailEvent {
@@ -54,6 +82,55 @@ export interface NormalizedEmailEvent {
    * the payload carried no boolean value.
    */
   senderAuthenticated?: boolean;
+  /**
+   * Validated inbound attachments parsed from the payload. Only well-formed
+   * entries (string `filename`, `contentType`, and base64 `content`) survive;
+   * omitted when the payload carried none.
+   */
+  attachments?: EmailAttachment[];
+}
+
+/**
+ * Parse and validate the payload's `attachments` array. Drops entries that
+ * are missing the fields the attachment store requires (`filename`,
+ * `contentType`, base64 `content`); coerces `size`/`contentId` when present.
+ * Returns undefined when there are no usable attachments.
+ */
+function parseEmailAttachments(raw: unknown): EmailAttachment[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const parsed: EmailAttachment[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const att = entry as Record<string, unknown>;
+    const filename = att.filename;
+    const contentType = att.contentType;
+    const content = att.content;
+    if (
+      typeof filename !== "string" ||
+      filename.length === 0 ||
+      typeof contentType !== "string" ||
+      contentType.length === 0 ||
+      typeof content !== "string"
+    ) {
+      continue;
+    }
+    parsed.push({
+      filename,
+      contentType,
+      content,
+      ...(typeof att.size === "number" && Number.isFinite(att.size)
+        ? { size: att.size }
+        : {}),
+      ...(typeof att.contentId === "string" && att.contentId.length > 0
+        ? { contentId: att.contentId }
+        : {}),
+    });
+  }
+  return parsed.length > 0 ? parsed : undefined;
 }
 
 /**
@@ -100,6 +177,7 @@ export function normalizeEmailWebhook(
     typeof payload.senderAuthenticated === "boolean"
       ? payload.senderAuthenticated
       : undefined;
+  const attachments = parseEmailAttachments(payload.attachments);
 
   const event: GatewayInboundEvent = {
     version: "v1",
@@ -126,5 +204,6 @@ export function normalizeEmailWebhook(
     eventId: messageId,
     recipientAddress: to,
     ...(senderAuthenticated !== undefined ? { senderAuthenticated } : {}),
+    ...(attachments ? { attachments } : {}),
   };
 }

--- a/gateway/src/http/routes/email-webhook.test.ts
+++ b/gateway/src/http/routes/email-webhook.test.ts
@@ -22,14 +22,21 @@ const handleInboundMock = mock(
 
 const resetConversationMock = mock(() => Promise.resolve());
 
+class MockAttachmentValidationError extends Error {}
+
+let uploadCounter = 0;
+const uploadAttachmentMock = mock(() =>
+  Promise.resolve({ id: `att-${++uploadCounter}` }),
+);
+
 mock.module("../../handlers/handle-inbound.js", () => ({
   handleInbound: handleInboundMock,
 }));
 
 mock.module("../../runtime/client.js", () => ({
   resetConversation: resetConversationMock,
-  uploadAttachment: mock(() => Promise.resolve({ id: "att-1" })),
-  AttachmentValidationError: class extends Error {},
+  uploadAttachment: uploadAttachmentMock,
+  AttachmentValidationError: MockAttachmentValidationError,
   CircuitBreakerOpenError: class extends Error {},
 }));
 
@@ -82,6 +89,7 @@ function makeEmailPayload(overrides?: {
   references?: string;
   conversationId?: string;
   timestamp?: string;
+  attachments?: unknown;
 }) {
   return JSON.stringify({
     from: overrides?.from ?? "sender@example.com",
@@ -97,6 +105,9 @@ function makeEmailPayload(overrides?: {
     references: overrides?.references,
     conversationId: overrides?.conversationId ?? "conv-abc",
     timestamp: overrides?.timestamp ?? "2026-04-03T01:00:00.000Z",
+    ...(overrides?.attachments !== undefined
+      ? { attachments: overrides.attachments }
+      : {}),
   });
 }
 
@@ -130,6 +141,11 @@ describe("email-webhook", () => {
   beforeEach(() => {
     handleInboundMock.mockClear();
     handleInboundMock.mockResolvedValue({ forwarded: true, rejected: false });
+    uploadCounter = 0;
+    uploadAttachmentMock.mockClear();
+    uploadAttachmentMock.mockImplementation(() =>
+      Promise.resolve({ id: `att-${++uploadCounter}` }),
+    );
   });
 
   it("rejects non-POST requests with 405", async () => {
@@ -461,5 +477,105 @@ describe("email-webhook", () => {
     const res = await handler(req);
     // This was the stale variable bug — it used to return 409 here
     expect(res.status).toBe(403);
+  });
+
+  it("uploads inline attachments and forwards their ids to the runtime", async () => {
+    const { handler } = createEmailWebhookHandler(baseConfig, makeCaches());
+    const body = makeEmailPayload({
+      messageId: "<with-attachment@example.com>",
+      attachments: [
+        {
+          filename: "receipt.pdf",
+          contentType: "application/pdf",
+          size: 5,
+          content: Buffer.from("hello").toString("base64"),
+        },
+      ],
+    });
+    const res = await handler(postRequest(body));
+    expect(res.status).toBe(200);
+
+    expect(uploadAttachmentMock).toHaveBeenCalledTimes(1);
+    const uploadArg = (uploadAttachmentMock.mock.calls[0] as unknown[])[1] as {
+      filename: string;
+      mimeType: string;
+      data: string;
+    };
+    expect(uploadArg.filename).toBe("receipt.pdf");
+    expect(uploadArg.mimeType).toBe("application/pdf");
+
+    const options = handleInboundMock.mock.calls[0][2] as {
+      attachmentIds?: string[];
+    };
+    expect(options.attachmentIds).toEqual(["att-1"]);
+  });
+
+  it("forwards without attachmentIds when no attachments are present", async () => {
+    const { handler } = createEmailWebhookHandler(baseConfig, makeCaches());
+    const body = makeEmailPayload({ messageId: "<no-attachment@example.com>" });
+    const res = await handler(postRequest(body));
+    expect(res.status).toBe(200);
+    expect(uploadAttachmentMock).not.toHaveBeenCalled();
+    const options = handleInboundMock.mock.calls[0][2] as {
+      attachmentIds?: string[];
+    };
+    expect(options.attachmentIds).toBeUndefined();
+  });
+
+  it("notes validation-rejected attachments in the message content", async () => {
+    uploadAttachmentMock.mockImplementationOnce(() =>
+      Promise.reject(new MockAttachmentValidationError("unsupported type")),
+    );
+    const { handler } = createEmailWebhookHandler(baseConfig, makeCaches());
+    const body = makeEmailPayload({
+      messageId: "<rejected-attachment@example.com>",
+      attachments: [
+        {
+          filename: "malware.exe",
+          contentType: "application/octet-stream",
+          size: 5,
+          content: Buffer.from("hello").toString("base64"),
+        },
+      ],
+    });
+    const res = await handler(postRequest(body));
+    expect(res.status).toBe(200);
+
+    const event = handleInboundMock.mock.calls[0][1] as {
+      message: { content: string };
+    };
+    expect(event.message.content).toContain('"malware.exe"');
+    const options = handleInboundMock.mock.calls[0][2] as {
+      attachmentIds?: string[];
+    };
+    expect(options.attachmentIds).toBeUndefined();
+  });
+
+  it("returns 500 and unreserves the dedup key on transient upload failure", async () => {
+    uploadAttachmentMock.mockImplementation(() =>
+      Promise.reject(new Error("runtime 503")),
+    );
+    const { handler, dedupCache } = createEmailWebhookHandler(
+      baseConfig,
+      makeCaches(),
+    );
+    const body = makeEmailPayload({
+      messageId: "<transient-upload-fail@example.com>",
+      attachments: [
+        {
+          filename: "receipt.pdf",
+          contentType: "application/pdf",
+          size: 5,
+          content: Buffer.from("hello").toString("base64"),
+        },
+      ],
+    });
+    const res = await handler(postRequest(body));
+    expect(res.status).toBe(500);
+    expect(handleInboundMock).not.toHaveBeenCalled();
+    // Unreserved so the platform's retry delivery can be processed.
+    expect(dedupCache.reserve("<transient-upload-fail@example.com>")).toBe(
+      true,
+    );
   });
 });

--- a/gateway/src/http/routes/email-webhook.ts
+++ b/gateway/src/http/routes/email-webhook.ts
@@ -8,6 +8,10 @@ import {
   verifySecretWithRefresh,
 } from "../../credential-refresh.js";
 import { StringDedupCache } from "../../dedup-cache.js";
+import {
+  appendFailedEmailAttachmentNotice,
+  ingestEmailAttachments,
+} from "../../email/attachments.js";
 import { normalizeEmailWebhook } from "../../email/normalize.js";
 import { verifyEmailWebhookSignature } from "../../email/verify.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
@@ -42,9 +46,11 @@ export function createEmailWebhookHandler(
 
     // Cap body buffering before the (unauthenticated) signature check; a
     // header-only guard is bypassable via chunked / absent Content-Length.
+    // Email payloads carry inlined base64 attachments, so this route uses a
+    // larger ceiling than the generic webhook cap.
     const bodyResult = await readLimitedBody(
       req,
-      config.maxWebhookPayloadBytes,
+      config.maxEmailWebhookPayloadBytes ?? config.maxWebhookPayloadBytes,
     );
     if (bodyResult.status === "too_large") {
       tlog.warn("Email webhook payload too large");
@@ -98,8 +104,13 @@ export function createEmailWebhookHandler(
       return Response.json({ ok: true });
     }
 
-    const { event, eventId, recipientAddress, senderAuthenticated } =
-      normalized;
+    const {
+      event,
+      eventId,
+      recipientAddress,
+      senderAuthenticated,
+      attachments,
+    } = normalized;
 
     // Dedup by event ID
     if (!dedupCache.reserve(eventId)) {
@@ -141,6 +152,35 @@ export function createEmailWebhookHandler(
       return Response.json({ ok: true });
     }
 
+    // Ingest inline base64 attachments into the assistant's attachment store
+    // (which stores them in the conversation workspace) and forward the ids.
+    // A transient upload failure surfaces as 500 so the platform retries.
+    let attachmentIds: string[] | undefined;
+    try {
+      const ingested = await ingestEmailAttachments(config, attachments, tlog);
+      if (ingested.attachmentIds.length > 0) {
+        attachmentIds = ingested.attachmentIds;
+      }
+      event.message.content = appendFailedEmailAttachmentNotice(
+        event.message.content,
+        ingested.failedAttachmentNames,
+      );
+    } catch (err) {
+      const cbResponse = handleCircuitBreakerError(
+        err,
+        dedupCache,
+        eventId,
+        tlog,
+      );
+      if (cbResponse) return cbResponse;
+      tlog.error(
+        { err, eventId },
+        "Failed to ingest inbound email attachments",
+      );
+      dedupCache.unreserve(eventId);
+      return Response.json({ error: "Internal error" }, { status: 500 });
+    }
+
     // Forward to runtime
     try {
       const inReplyTo =
@@ -149,6 +189,7 @@ export function createEmailWebhookHandler(
         typeof payload.subject === "string" ? payload.subject : undefined;
 
       const result = await handleInbound(config, event, {
+        ...(attachmentIds ? { attachmentIds } : {}),
         transportMetadata: buildEmailTransportMetadata({
           senderAddress: event.actor.actorExternalId,
           recipientAddress: recipientAddress,


### PR DESCRIPTION
## Prompt / plan

Consumer side of end-to-end inbound-email-attachment support. The platform side is done in `vellum-assistant-platform` PR #9095, which makes the Django webhook fetch each inbound attachment from Resend's Attachments API, download the blob (bounded by a 25 MB per-file / 10-file cap), and inline it as base64 into the `VellumEmailPayload` JSON dispatched to the gateway. This PR is the gateway consumer: read those attachments off the inbound email payload and store them in the assistant's workspace so the assistant can use them.

### Approach

Rather than build a parallel attachment path, this reuses the exact mechanism every other channel already uses. Telegram/Slack/WhatsApp webhooks download media, `uploadAttachment()` it to the assistant's attachment store, and forward the resulting `attachmentIds` to the runtime via `handleInbound`. The runtime then links those attachments to the inbound message and the conversation disk-view projects them into `conversations/<dir>/attachments/` in the workspace. Email attachments arrive already base64-inlined, so there's no download step — just the upload.

### Changes

- **`email/normalize.ts`** — add an additive, optional `attachments` array to `VellumEmailPayload` (`EmailAttachment` = `filename`, `contentType`, `size?`, `content` base64, `contentId?`), plus validation that drops malformed entries during normalization and surfaces the parsed set on `NormalizedEmailEvent`.
- **`email/attachments.ts`** (new, single source of truth) — `ingestEmailAttachments()` filters oversized attachments against the email per-file cap, uploads with bounded concurrency, skips validation-rejected files (unsupported MIME / dangerous extension) with a message notice, and propagates transient upload failures so the upstream retries. `appendFailedEmailAttachmentNotice()` adds the "could not be processed, re-send if important" note.
- **`http/routes/email-webhook.ts`** (platform path) and **`email/inbound-pipeline.ts`** (shared resend/mailgun path) — call the helper after routing passes, forward `attachmentIds` to `handleInbound`, and append the failed-attachment notice to the message content. Both surface transient upload failures as HTTP 500 with the dedup key unreserved so the delivery is retried.
- **`config.ts`** — add an `email` per-file cap (25 MB, matching the platform limit) and a larger `maxEmailWebhookPayloadBytes` body cap for the `/webhooks/email` route only (base64-inlined attachments blow the 1 MB generic webhook cap). Other webhooks are unaffected.

No runtime (`assistant/`) changes are needed — the `attachmentIds → workspace` path already exists and is channel-agnostic.

## Test plan

- New `email/attachments.test.ts`: upload/id-mapping, oversize skip, validation-rejection skip, transient-failure propagation, default-cap fallback, and the failure-notice builder.
- Extended `email/normalize.test.ts`: attachment parsing, dropping malformed entries, non-array handling, and the no-attachments case.
- Extended `http/routes/email-webhook.test.ts`: forwards `attachmentIds`, no ids when absent, failure notice in content, and 500 + dedup-unreserve on transient upload failure.
- Extended `email-inbound-pipeline.test.ts`: attachment forwarding and transient-failure 500 for the resend/mailgun path.
- Updated `config.test.ts` for the new cap values.
- `bunx tsc --noEmit` clean, `eslint` clean, 70 tests pass across the affected suites (existing email/resend/mailgun/whatsapp/telegram webhook tests still green).

<!-- This PR adds no new IPC routes under assistant/src/runtime/routes/, so the CLI verb checklist does not apply. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CriiGDjrivjFaRGcQ3St5)_