### PR TITLE
fix(web): simplify the mobile assistant overview and match nav item sizing

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -36,7 +36,6 @@ const EYES_WIDTH = 14;
 const PILL_PADDING_X = 6;
 /** Patrol stop on the right side: grown, cut off by the bottom edge. */
 const SIDE_SCALE = 2.1;
-const SIDE_PEEK_Y = 10;
 const SIDE_RIGHT_MARGIN = 14;
 
 const sleep = (ms: number): Promise<void> =>
@@ -70,6 +69,8 @@ export function AssistantNavItem({
   const pillHeight = isMobile ? MOBILE_PILL_HEIGHT : PILL_HEIGHT;
   /** How far down the eyes dive to fully exit the pill's bottom edge. */
   const diveY = pillHeight - 4;
+  /** Side-patrol stop: the grown eyes flush with the bottom edge. */
+  const sidePeekY = pillHeight - 20;
 
   useEffect(() => {
     if (reduce) {
@@ -112,7 +113,7 @@ export function AssistantNavItem({
         width - PILL_PADDING_X - SIDE_RIGHT_MARGIN - EYES_WIDTH * SIDE_SCALE,
       );
       eyesControls.set({ x: sideX, y: diveY, scale: SIDE_SCALE });
-      await move({ y: SIDE_PEEK_Y }, spring(360, 16));
+      await move({ y: sidePeekY }, spring(360, 16));
       await blink();
       await sleep(jitter(700, 900));
       await move({ y: diveY }, { duration: 0.3, ease: "easeIn" });
@@ -148,7 +149,7 @@ export function AssistantNavItem({
       cancelled = true;
       eyesControls.stop();
     };
-  }, [reduce, collapsed, eyesControls, diveY]);
+  }, [reduce, collapsed, eyesControls, diveY, sidePeekY]);
 
   const hex =
     (components &&
@@ -246,9 +247,9 @@ export function AssistantNavItem({
       </span>
       {!collapsed && (
         <span
-          className={`truncate text-body-medium-default max-md:text-body-large-default ${
-            active ? "font-bold" : ""
-          }`}
+          className={`truncate ${
+            isMobile ? "text-body-large-default" : "text-body-medium-default"
+          } ${active ? "font-bold" : ""}`}
         >
           {label}
         </span>

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -21,17 +21,19 @@ import { motion, useAnimationControls, useReducedMotion } from "motion/react";
 import { cn, SideMenu } from "@vellumai/design-library";
 
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { contrastForeground } from "@/utils/avatar-tone";
 import { pathBBox, unionBBox } from "@/utils/eye-bbox";
 
 const PILL_HEIGHT = 30;
+/** Mobile-overlay pill height, matching `SideMenu.Item`'s mobile row
+ *  (py-3 around the 20px body-large line). */
+const MOBILE_PILL_HEIGHT = 44;
 /** Eyes sized to the 14px leading-icon slot of `SideMenu.Item`, so the
  *  label aligns with the nav items below. */
 const EYES_WIDTH = 14;
 /** Horizontal padding of the pill (matches SideMenu.Item's p-[6px]). */
 const PILL_PADDING_X = 6;
-/** How far down the eyes dive to fully exit the pill's bottom edge. */
-const DIVE_Y = 26;
 /** Patrol stop on the right side: grown, cut off by the bottom edge. */
 const SIDE_SCALE = 2.1;
 const SIDE_PEEK_Y = 10;
@@ -60,9 +62,14 @@ export function AssistantNavItem({
 }: AssistantNavItemProps) {
   const { components, traits } = useAssistantAvatar(assistantId);
   const reduce = useReducedMotion();
+  const isMobile = useIsMobile();
   const eyesControls = useAnimationControls();
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const [blinking, setBlinking] = useState(false);
+
+  const pillHeight = isMobile ? MOBILE_PILL_HEIGHT : PILL_HEIGHT;
+  /** How far down the eyes dive to fully exit the pill's bottom edge. */
+  const diveY = pillHeight - 4;
 
   useEffect(() => {
     if (reduce) {
@@ -95,7 +102,7 @@ export function AssistantNavItem({
     // grown on the right side, blink, dive again, and slip back into the
     // icon slot.
     const patrol = async () => {
-      await move({ y: DIVE_Y }, { duration: 0.3, ease: "easeIn" });
+      await move({ y: diveY }, { duration: 0.3, ease: "easeIn" });
       if (cancelled) {
         return;
       }
@@ -104,12 +111,12 @@ export function AssistantNavItem({
         0,
         width - PILL_PADDING_X - SIDE_RIGHT_MARGIN - EYES_WIDTH * SIDE_SCALE,
       );
-      eyesControls.set({ x: sideX, y: DIVE_Y, scale: SIDE_SCALE });
+      eyesControls.set({ x: sideX, y: diveY, scale: SIDE_SCALE });
       await move({ y: SIDE_PEEK_Y }, spring(360, 16));
       await blink();
       await sleep(jitter(700, 900));
-      await move({ y: DIVE_Y }, { duration: 0.3, ease: "easeIn" });
-      eyesControls.set({ x: 0, y: DIVE_Y, scale: 1 });
+      await move({ y: diveY }, { duration: 0.3, ease: "easeIn" });
+      eyesControls.set({ x: 0, y: diveY, scale: 1 });
       await move({ y: 0 }, spring(320, 18));
     };
 
@@ -141,7 +148,7 @@ export function AssistantNavItem({
       cancelled = true;
       eyesControls.stop();
     };
-  }, [reduce, collapsed, eyesControls]);
+  }, [reduce, collapsed, eyesControls, diveY]);
 
   const hex =
     (components &&
@@ -191,7 +198,7 @@ export function AssistantNavItem({
         collapsed ? "justify-center px-0" : "px-[6px]",
       )}
       style={{
-        height: PILL_HEIGHT,
+        height: pillHeight,
         backgroundColor: hex,
         color: contrastForeground(hex),
       }}
@@ -201,7 +208,7 @@ export function AssistantNavItem({
       <span
         aria-hidden="true"
         className="pointer-events-none relative shrink-0"
-        style={{ width: EYES_WIDTH, height: PILL_HEIGHT }}
+        style={{ width: EYES_WIDTH, height: pillHeight }}
       >
         {eye && (
           <motion.span
@@ -209,7 +216,7 @@ export function AssistantNavItem({
             style={{
               width: EYES_WIDTH,
               height: eyesHeight,
-              top: (PILL_HEIGHT - eyesHeight) / 2,
+              top: (pillHeight - eyesHeight) / 2,
               transformOrigin: "50% 100%",
             }}
             initial={false}
@@ -239,7 +246,7 @@ export function AssistantNavItem({
       </span>
       {!collapsed && (
         <span
-          className={`truncate text-body-medium-default ${
+          className={`truncate text-body-medium-default max-md:text-body-large-default ${
             active ? "font-bold" : ""
           }`}
         >

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -288,7 +288,10 @@ function SectionCard({
   /** Compact one-row variant for the bottom-strip sections. */
   mini?: boolean;
   /** Uniform tile for the stacked (small-viewport) grid: every card gets
-   *  the same chrome — icon + title row, subtitle, small stat line. */
+   *  the same chrome — icon + title row, subtitle, small stat line. The
+   *  bento-only orchestration props (`hoverFill`, `flooded`, `floodOrigin`,
+   *  `linkRef`, `onHoverChange`) are ignored; the amoeba hover act never
+   *  runs in the stacked layout. */
   stacked?: boolean;
   /** The avatar has poured itself over this card — fill it with the
    *  avatar color and flip the content to the contrast tone. */

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -6,7 +6,8 @@
  * drill-down cards (Personality, Schedules, Skills, Plugins, Workspace,
  * Contacts, Channels — the replacement for the old tab bar), each carrying
  * one glanceable stat. On narrow or short viewports the mosaic collapses
- * to a stacked avatar + card grid.
+ * to a stacked avatar + card grid of uniform tiles (icon, title, subtitle,
+ * small stat line).
  */
 
 import { useQueryClient } from "@tanstack/react-query";
@@ -270,6 +271,7 @@ function SectionCard({
   cardStyle,
   hoverFill,
   mini,
+  stacked,
   flooded = false,
   floodOrigin,
   linkRef,
@@ -285,6 +287,9 @@ function SectionCard({
   hoverFill: boolean;
   /** Compact one-row variant for the bottom-strip sections. */
   mini?: boolean;
+  /** Uniform tile for the stacked (small-viewport) grid: every card gets
+   *  the same chrome — icon + title row, subtitle, small stat line. */
+  stacked?: boolean;
   /** The avatar has poured itself over this card — fill it with the
    *  avatar color and flip the content to the contrast tone. */
   flooded?: boolean;
@@ -332,6 +337,50 @@ function SectionCard({
       }
     />
   );
+
+  if (stacked) {
+    // Small-viewport tile: one shared template for every section — no
+    // feature-card wash, no radar or schedule previews, no display-size
+    // numerals — so the stacked grid reads as one calm, even surface.
+    const stackedStat =
+      stat?.value !== undefined
+        ? `${stat.value} ${stat.label ?? ""}`.trim()
+        : stat?.chips && stat.chips.length > 0
+          ? stat.chips.join(" · ")
+          : stat?.text;
+    return (
+      <Card.Root
+        asChild
+        bordered
+        elevated
+        clipContents
+        className="rounded-2xl bg-[var(--card-bg)]"
+      >
+        <Link
+          to={section.to}
+          className="relative flex h-full w-full cursor-pointer flex-col gap-1 p-4 text-left transition-all duration-150 hover:bg-[var(--card-hover)] active:scale-[0.98]"
+        >
+          <span className="flex items-center gap-2">
+            <Icon
+              className="h-5 w-5 shrink-0 text-[var(--content-default)]"
+              aria-hidden
+            />
+            <span className="truncate text-body-medium-default text-[var(--content-default)]">
+              {section.label}
+            </span>
+          </span>
+          <span className="text-[13px] text-[var(--content-secondary)]">
+            {section.description}
+          </span>
+          {stackedStat && (
+            <span className="mt-auto truncate pt-1 text-[12px] font-medium text-[var(--content-tertiary)]">
+              {stackedStat}
+            </span>
+          )}
+        </Link>
+      </Card.Root>
+    );
+  }
 
   if (mini) {
     const miniStat =
@@ -790,6 +839,7 @@ function OverviewBento({
               section={section}
               stat={stats[section.key]}
               hoverFill
+              stacked
             />
           ))}
         </div>

--- a/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
@@ -8,8 +8,8 @@
  * their full-bleed stage chrome — so no back link or heading appears.
  *
  * On mobile the title moves into the shared top-bar center slot (via
- * `setTopBarCenter`): the section label on section pages, "About <name>"
- * on the bare pages.
+ * `setTopBarCenter`): the section label on section pages; the bare pages
+ * set no title (the stage greeting already names the assistant).
  *
  * `useIsMobile` and the slots-store setter are mocked; the assistant name
  * is driven through the real identity store. `MemoryRouter` satisfies the
@@ -117,15 +117,17 @@ describe("IntelligenceLayout — bare pages (overview, personality)", () => {
     expect(container.querySelector("a")).toBeNull();
   });
 
-  test("on mobile, registers the About title for the overview", () => {
+  test("on mobile, the overview sets no top-bar title", () => {
     isMobileRef.value = true;
     renderLayoutAt("/assistant/identity");
 
-    const lastCall = setTopBarCenterMock.mock.calls.at(-1);
-    const node = lastCall?.[0];
-    expect(isValidElement(node)).toBe(true);
-    expect(renderToStaticMarkup(node as React.ReactElement)).toContain(
-      "About Ada",
-    );
+    expect(setTopBarCenterMock).toHaveBeenLastCalledWith(null);
+  });
+
+  test("on mobile, the personality page sets no top-bar title", () => {
+    isMobileRef.value = true;
+    renderLayoutAt("/assistant/personality");
+
+    expect(setTopBarCenterMock).toHaveBeenLastCalledWith(null);
   });
 });

--- a/clients/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.tsx
@@ -57,16 +57,15 @@ export function IntelligenceLayout() {
   const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
 
   const section = sectionForPath(pathname);
-  const mobileTitle = section
-    ? section.label
-    : `About ${assistantName || "Assistant"}`;
+  const mobileTitle = section?.label ?? null;
 
-  // On mobile the title moves out of the page body and into the shared top
-  // bar — centered between the hamburger menu and the search icon. Desktop
-  // keeps the in-body <h1> (section pages only) and leaves the top-bar
-  // center empty.
+  // On mobile the section title moves out of the page body and into the
+  // shared top bar — centered between the hamburger menu and the search
+  // icon. The bare pages (overview, personality) set no title: the
+  // greeting on the stage already names the assistant. Desktop keeps the
+  // in-body <h1> (section pages only) and leaves the top-bar center empty.
   useEffect(() => {
-    if (isMobile) {
+    if (isMobile && mobileTitle) {
       setTopBarCenter(
         <Typography
           variant="body-medium-default"


### PR DESCRIPTION
## What

Mobile polish for the assistant page and the overlay nav drawer:

- **Uniform overview cards on small viewports.** The stacked (mobile) layout of the assistant overview now renders every section with one shared card template: an icon + title row, a subtitle, and a small muted stat line (e.g. "25 installed", "1 active", plugin names joined with "·"). This replaces the bento's mixed treatments — tinted borderless feature cards, display-size serif numerals, plugin tag chips, and hand-varied corner radii — with a single `rounded-2xl` chrome. Desktop bento is unchanged.
- **No more "About \<name\>" mobile top-bar title.** The overview and personality pages set no top-bar center title on mobile — the stage greeting already names the assistant. Section pages (Skills, Plugins, …) keep their label in the top bar.
- **Assistant nav pill sized like the other nav items on mobile.** The custom avatar-colored pill was hardcoded to the 30px desktop rail height; in the mobile overlay drawer it now matches `SideMenu.Item`'s mobile row (44px, `text-body-large-default`). The eye-patrol dive distance is derived from the pill height, so the desktop animation geometry is unchanged (30 − 4 = the old `DIVE_Y` of 26) and the eyes still fully exit the taller mobile pill.

## Why

On mobile the overview read as a patchwork: two tinted title-only cards, giant serif numerals, chips on one card, four different corner treatments — and a redundant "About Ziggy" title above a page whose hero text already says "Hi, I'm Ziggy". The assistant nav item also sat visibly smaller than the Library/Activity rows in the drawer.

## Testing

- `bunx tsc --noEmit`, `bun run lint` (0 errors), `bun run build` — clean.
- `bun test src/domains/intelligence/intelligence-layout.test.tsx` — updated the mobile-title tests: section pages still register their label; overview/personality now assert the slot is cleared.
- Note: running the whole `src/domains/intelligence` folder in a single bun process shows 14 pre-existing failures from cross-file mock pollution (also present on a clean checkout); the same files pass when run isolated, matching how `test:ci` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)