### PR TITLE
feat(workspace): add download button to image/video preview header

### DIFF
--- a/clients/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -48,6 +48,77 @@ import { Button } from "@vellumai/design-library/components/button";
 
 import type { WorkspaceViewMode } from "@/domains/workspace/components/workspace-browser";
 
+/**
+ * Download state for a single workspace file — shared by the binary-fallback
+ * card and the preview header's download affordance so both surfaces report
+ * in-progress and failure the same way.
+ */
+function useWorkspaceFileDownload(opts: {
+  assistantId: string;
+  path: string;
+  name: string;
+  showHidden?: boolean;
+}) {
+  const { assistantId, path, name, showHidden } = opts;
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const download = useCallback(async () => {
+    setError(false);
+    setIsDownloading(true);
+    try {
+      await downloadWorkspaceFile({ assistantId, path, filename: name, showHidden });
+    } catch {
+      setError(true);
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [assistantId, path, name, showHidden]);
+
+  return { isDownloading, error, download };
+}
+
+/**
+ * Icon-only download button for a previewed file's header. Images, video, and
+ * other inline-rendered files have no other download path, so this lives in the
+ * header's top-right corner alongside any view-mode controls.
+ */
+function HeaderDownloadButton({
+  assistantId,
+  path,
+  name,
+  showHidden,
+}: {
+  assistantId: string;
+  path: string;
+  name: string;
+  showHidden?: boolean;
+}) {
+  const { isDownloading, error, download } = useWorkspaceFileDownload({
+    assistantId,
+    path,
+    name,
+    showHidden,
+  });
+  return (
+    <Button
+      variant="ghost"
+      size="regular"
+      iconOnly={
+        isDownloading ? (
+          <Loader2 className="animate-spin" aria-hidden />
+        ) : (
+          <Download aria-hidden />
+        )
+      }
+      onClick={() => void download()}
+      disabled={isDownloading}
+      aria-label={`Download ${name}`}
+      tooltip={error ? "Download failed. Try again." : "Download"}
+    />
+  );
+}
+
 function workspaceFileRetrieveOptions(opts: {
   path: { assistant_id: string };
   query: { path: string; showHidden?: boolean };
@@ -271,20 +342,8 @@ function BinaryFileCard({
   modifiedAt?: string | null;
   showHidden?: boolean;
 }) {
-  const [isDownloading, setIsDownloading] = useState(false);
-  const [error, setError] = useState(false);
-
-  const handleDownload = useCallback(async () => {
-    setError(false);
-    setIsDownloading(true);
-    try {
-      await downloadWorkspaceFile({ assistantId, path, filename: name, showHidden });
-    } catch {
-      setError(true);
-    } finally {
-      setIsDownloading(false);
-    }
-  }, [assistantId, path, name, showHidden]);
+  const { isDownloading, error, download: handleDownload } =
+    useWorkspaceFileDownload({ assistantId, path, name, showHidden });
 
   return (
     <div className="flex h-full flex-col">
@@ -707,7 +766,19 @@ export function WorkspaceFileViewer({
   if (mimeType.startsWith("image/") || mimeType.startsWith("video/")) {
     return (
       <div className="flex h-full flex-col">
-        <FileHeader name={name} mimeType={mimeType} size={data.size} />
+        <FileHeader
+          name={name}
+          mimeType={mimeType}
+          size={data.size}
+          rightContent={
+            <HeaderDownloadButton
+              assistantId={assistantId}
+              path={selectedPath}
+              name={name}
+              showHidden={showHidden}
+            />
+          }
+        />
         <div className="flex-1 overflow-auto">
           <BinaryContentViewer
             assistantId={assistantId}


### PR DESCRIPTION
## Prompt / plan

> workspace files with previews like gif don't have ways for me to download it, which we should include in the top right

Previewable workspace files (images, GIFs, video) are rendered inline by `BinaryContentViewer` under a `FileHeader`, but only the binary-**fallback** card (non-previewable files) exposed a Download action. So a GIF or image you could see had no way to be saved.

This adds an icon-only Download button to the **top-right** of the preview header for image/video files, alongside where the view-mode toggle sits for other file types.

Approach:
- New `HeaderDownloadButton` — a ghost, icon-only button (with a loading spinner and a "Download failed. Try again." tooltip on error) placed in the header's `rightContent` for the image/video branch.
- Extracted the existing download-with-state logic (in-progress + failure flags) out of `BinaryFileCard` into a shared `useWorkspaceFileDownload` hook, so the header button and the fallback card report progress/failure identically and there's a single source of truth. Both go through the existing `downloadWorkspaceFile` util (browser download on web, native Share Sheet on iOS).

## Test plan

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (only pre-existing `curly` style warnings in the touched file)
- `bun test src/domains/workspace/` — 17 pass / 0 fail
- Pre-commit hook (lint + type-check across `clients/web`) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX3e7yggkB3e8rCoudk8GU)_