### PR TITLE
fix(web): persist onboarding personality sliders + Schedules empty state

### DIFF
--- a/clients/web/src/assistant/personality-sliders.ts
+++ b/clients/web/src/assistant/personality-sliders.ts
@@ -1,22 +1,25 @@
 /**
- * Persistence for the personality page's slider values.
+ * Persistence for the personality slider values — shared by research
+ * onboarding's "Create my personality" step and the About Assistant
+ * personality page.
  *
  * The rewrite prompt carries the values into the assistant's identity
  * files as prose, so the raw dial positions would otherwise be lost the
  * moment the page unmounts. They're kept as a JSON sidecar in the
  * assistant's workspace (like the avatar's `character-traits.json`), so
- * the sliders reopen where the user left them — on any device.
+ * the sliders reopen where the user left them — on any device — and the
+ * overview's Personality card can plot them as a radar.
  */
 
 import { workspaceFileGet, workspaceWritePost } from "@/generated/daemon/sdk.gen";
 import { assertHasResponse } from "@/utils/api-errors";
 
-import {
-  PERSONALITY_AXES,
-  PERSONALITY_AXIS_DEFAULT,
-} from "./personality-axes";
+import { PERSONALITY_AXIS_IDS } from "./personality-rewrite";
 
 export const PERSONALITY_SLIDERS_PATH = "data/personality-sliders.json";
+
+/** Sliders start centered — no axis is nudged either way until the user acts. */
+export const PERSONALITY_SLIDER_DEFAULT = 50;
 
 export type PersonalitySliderValues = Record<string, number>;
 
@@ -40,9 +43,9 @@ export function completeSliderValues(
   values: PersonalitySliderValues,
 ): PersonalitySliderValues {
   return Object.fromEntries(
-    PERSONALITY_AXES.map((axis) => [
-      axis.id,
-      values[axis.id] ?? PERSONALITY_AXIS_DEFAULT,
+    Object.values(PERSONALITY_AXIS_IDS).map((axisId) => [
+      axisId,
+      values[axisId] ?? PERSONALITY_SLIDER_DEFAULT,
     ]),
   );
 }

--- a/clients/web/src/domains/intelligence/identity-actions/personality-axes.ts
+++ b/clients/web/src/domains/intelligence/identity-actions/personality-axes.ts
@@ -6,6 +6,8 @@
  * with 0 = the left label and 100 = the right label.
  */
 
+import { PERSONALITY_SLIDER_DEFAULT } from "@/assistant/personality-sliders";
+
 export interface PersonalityAxisDefinition {
   id: string;
   left: string;
@@ -21,4 +23,4 @@ export const PERSONALITY_AXES: PersonalityAxisDefinition[] = [
 ];
 
 /** Sliders start centered — no axis is nudged either way until the user acts. */
-export const PERSONALITY_AXIS_DEFAULT = 50;
+export const PERSONALITY_AXIS_DEFAULT = PERSONALITY_SLIDER_DEFAULT;

--- a/clients/web/src/domains/intelligence/personality-page.tsx
+++ b/clients/web/src/domains/intelligence/personality-page.tsx
@@ -18,6 +18,12 @@ import { useNavigate } from "react-router";
 
 import { toast } from "@vellumai/design-library";
 
+import {
+  completeSliderValues,
+  fetchPersonalitySliders,
+  personalitySlidersQueryKey,
+  savePersonalitySliders,
+} from "@/assistant/personality-sliders";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { routes } from "@/utils/routes";
@@ -29,12 +35,6 @@ import {
   PERSONALITY_AXES,
   PERSONALITY_AXIS_DEFAULT,
 } from "./identity-actions/personality-axes";
-import {
-  completeSliderValues,
-  fetchPersonalitySliders,
-  personalitySlidersQueryKey,
-  savePersonalitySliders,
-} from "./identity-actions/personality-sliders";
 import {
   assistantIdentityDetailsQueryKey,
   useAssistantIdentityDetails,

--- a/clients/web/src/domains/intelligence/use-identity-section-stats.ts
+++ b/clients/web/src/domains/intelligence/use-identity-section-stats.ts
@@ -8,6 +8,11 @@
 import { useQuery } from "@tanstack/react-query";
 
 import {
+  completeSliderValues,
+  fetchPersonalitySliders,
+  personalitySlidersQueryKey,
+} from "@/assistant/personality-sliders";
+import {
   channelsReadinessGetOptions,
   contactsGetOptions,
   schedulesGetQueryKey,
@@ -16,12 +21,6 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { installedPluginsQueryOptions } from "@/lib/installed-plugins-query";
 import { fetchSchedules } from "@/utils/schedules";
-
-import {
-  completeSliderValues,
-  fetchPersonalitySliders,
-  personalitySlidersQueryKey,
-} from "./identity-actions/personality-sliders";
 
 export interface SchedulePreview {
   id: string;
@@ -168,14 +167,16 @@ export function useIdentitySectionStats(
         : undefined,
     schedules:
       schedules.data !== undefined
-        ? {
-            value: schedules.data.count,
-            label: "active",
-            schedules: {
-              items: schedules.data.items,
-              more: schedules.data.count - schedules.data.items.length,
-            },
-          }
+        ? schedules.data.count === 0
+          ? { text: "Nothing scheduled yet" }
+          : {
+              value: schedules.data.count,
+              label: "active",
+              schedules: {
+                items: schedules.data.items,
+                more: schedules.data.count - schedules.data.items.length,
+              },
+            }
         : undefined,
   };
 }

--- a/clients/web/src/domains/onboarding/apply-personality-save.test.ts
+++ b/clients/web/src/domains/onboarding/apply-personality-save.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Pins that `applyPersonality` persists the raw dial positions as the
+ * `data/personality-sliders.json` workspace sidecar — the About Assistant
+ * personality page and the overview's radar read it, so skipping the save
+ * left both empty after onboarding (the prose rewrite alone loses the
+ * numbers). Kept separate from `apply-personality.test.ts` so the pure
+ * message-builder tests stay free of module mocks.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const conversationsPostMock = mock(async () => ({
+  data: { id: "conv-1" },
+  response: { ok: true },
+}));
+const messagesPostMock = mock(async () => ({ response: { ok: true } }));
+const messagesGetMock = mock(async () => ({
+  data: {
+    processing: false,
+    messages: [
+      {
+        role: "assistant",
+        contentBlocks: [{ type: "text", text: "All rewritten!" }],
+      },
+    ],
+  },
+}));
+const archivePostMock = mock(async () => ({ response: { ok: true } }));
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  conversationsPost: conversationsPostMock,
+  messagesPost: messagesPostMock,
+  messagesGet: messagesGetMock,
+  conversationsByIdArchivePost: archivePostMock,
+}));
+
+const saveSlidersMock = mock(async () => true);
+mock.module("@/assistant/personality-sliders", () => ({
+  completeSliderValues: (values: Record<string, number>) => ({
+    "companion-coworker": 50,
+    ...values,
+  }),
+  savePersonalitySliders: saveSlidersMock,
+}));
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
+}));
+
+const { applyPersonality } = await import("./apply-personality");
+
+beforeEach(() => {
+  conversationsPostMock.mockClear();
+  messagesPostMock.mockClear();
+  saveSlidersMock.mockClear();
+});
+
+describe("applyPersonality slider persistence", () => {
+  test("saves the completed slider values once the rewrite message posts", async () => {
+    await applyPersonality({
+      awaitAssistantId: async () => "ast-1",
+      values: { "playful-serious": 80 },
+    });
+
+    expect(saveSlidersMock).toHaveBeenCalledTimes(1);
+    expect(saveSlidersMock.mock.calls[0]).toEqual([
+      "ast-1",
+      { "companion-coworker": 50, "playful-serious": 80 },
+    ] as never);
+  });
+
+  test("skips the save when the rewrite message fails to post", async () => {
+    messagesPostMock.mockResolvedValueOnce({ response: { ok: false } });
+
+    await applyPersonality({
+      awaitAssistantId: async () => "ast-1",
+      values: { "playful-serious": 80 },
+    });
+
+    expect(saveSlidersMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/onboarding/apply-personality.ts
+++ b/clients/web/src/domains/onboarding/apply-personality.ts
@@ -26,6 +26,10 @@ import {
   shouldSettlePersonalityPoll,
 } from "@/assistant/personality-rewrite";
 import {
+  completeSliderValues,
+  savePersonalitySliders,
+} from "@/assistant/personality-sliders";
+import {
   conversationsByIdArchivePost,
   conversationsPost,
   messagesGet,
@@ -98,6 +102,11 @@ export async function applyPersonality({
       throwOnError: false,
     });
     if (!posted.response?.ok) return;
+
+    // Persist the raw dial positions as the workspace sidecar the About
+    // Assistant personality page and the overview's radar read — the prose
+    // rewrite alone would lose them. Best-effort, like the rest of the flow.
+    await savePersonalitySliders(assistantId, completeSliderValues(values));
 
     // Let the rewrite turn run before hiding the thread — archiving mid-turn
     // could drop the identity edits, and the chat handoff awaits this promise


### PR DESCRIPTION
## Summary

Two fixes for the assistant overview page:

**Personality sliders from onboarding were never persisted.** The onboarding personality step sent the slider values to the assistant as the prose identity-rewrite prompt, but never wrote the `data/personality-sliders.json` workspace sidecar — the only thing the overview's Personality radar and the personality page actually read. So after onboarding the Personality card rendered empty and the personality page reopened centered.

- Lifted the sidecar persistence module from `domains/intelligence/identity-actions/personality-sliders.ts` to the shared `src/assistant/personality-sliders.ts` (onboarding → intelligence imports are banned by the cross-domain lint rule; the shared `personality-rewrite.ts` both surfaces use already lives there). `completeSliderValues` now keys off `PERSONALITY_AXIS_IDS` instead of the intelligence-domain axis definitions.
- `applyPersonality` (onboarding) now saves the completed slider values once the rewrite message posts — best-effort, like the rest of the flow.

**Schedules card empty state.** With zero active schedules the card showed a bare "0 / active" display numeral. It now shows a quiet "Nothing scheduled yet" text stat instead — the same pattern the Plugins card uses ("None yet") — flowing through all three card variants (bento, mini strip, stacked mobile grid).

Note: assistants onboarded before this fix still have no sidecar, so their Personality card stays empty until the user runs "Update personality" once on the personality page (which saves it).

## Testing

- New `apply-personality-save.test.ts` pins that the sidecar saves with completed values after a successful post, and is skipped when the post fails
- Existing onboarding + intelligence tests pass (the batch-run failures are identical on `main` — known cross-file mock leakage in non-isolated runs)
- `bunx tsc --noEmit`, lint (0 errors), and production build all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)