### PR TITLE
fix(web): center onboarding carousel text with the avatar's first line

### DIFF
--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -94,6 +94,11 @@ export function MiniAssistant({
   );
 }
 
+// Heading text shown beside the 64px avatar in the top-aligned rows below.
+// The top padding — (4rem avatar − 2.6rem line) / 2 — centers the first line
+// against the avatar while wrapped lines flow below without moving it.
+const AVATAR_HEADING_CLASS = "pt-[0.7rem] text-[2.6rem] leading-none";
+
 // ---------------------------------------------------------------------------
 // Meeting Created
 // ---------------------------------------------------------------------------
@@ -208,7 +213,7 @@ export function MeetingCreatedStep({
           )}
         </div>
         <motion.span
-          className="text-[2.6rem] leading-none"
+          className={AVATAR_HEADING_CLASS}
           style={{ fontFamily: "var(--font-serif)" }}
           initial={reduce ? false : { opacity: 0, x: -8 }}
           animate={{ opacity: 1, x: 0 }}
@@ -301,13 +306,14 @@ export function LookingYouUpStep({
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
       <OnboardingTopBar onBack={onBack} onNext={onForward} />
       {/* Top-align so the avatar stays put as messages change line count
-          (centering would bob it up and down between carousel lines). */}
+          (row-centering would bob it up and down between carousel lines);
+          AVATAR_HEADING_CLASS centers the first line against the avatar. */}
       <div className="absolute left-1/2 top-[14%] sm:top-[26%] flex w-full max-w-xl -translate-x-1/2 items-start gap-3 px-6">
         <MiniAssistant isAssistantBusy />
         <AnimatePresence mode="wait">
           <motion.p
             key={index}
-            className="text-[2.6rem] leading-none"
+            className={AVATAR_HEADING_CLASS}
             style={{ fontFamily: "var(--font-serif)" }}
             initial={{ y: 12, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
@@ -373,7 +379,7 @@ export function FinishingUpStep({
         <AnimatePresence mode="wait">
           <motion.p
             key={index}
-            className="text-[2.6rem] leading-none"
+            className={AVATAR_HEADING_CLASS}
             style={{ fontFamily: "var(--font-serif)" }}
             initial={{ y: 12, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}


### PR DESCRIPTION
## Summary
- The onboarding loading carousels (LookingYouUpStep, FinishingUpStep) and the MeetingCreatedStep title top-aligned the rotating status text against the 64px avatar, so the text sat visibly above the avatar's center.
- Added a shared `AVATAR_HEADING_CLASS` that pads the heading down by `(4rem − 2.6rem) / 2` so the first line of text is vertically centered with the avatar — and stays centered on the first line when a message wraps to two lines (the row keeps `items-start`, so the avatar never bobs between carousel lines).
- Applied consistently to all three steps that share this layout and updated the stale top-alignment comment.

## Original prompt
Slack feedback from Noa on the onboarding loader: the rotating status text ("Piecing it together…") should be vertically centered with the little avatar, and when a message wraps to two lines it should still be centered with the first line rather than the whole block. The row was intentionally top-aligned to stop the avatar bobbing as carousel messages change line count, so the fix keeps top alignment and instead offsets the text so its first line centers against the avatar.