### PR TITLE
feat(voice): evaluate managed-speech defaulting at daemon startup

### DIFF
--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -1,3 +1,4 @@
+import { maybeDefaultSpeechToManaged } from "../config/managed-speech-defaults.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getMcpServerManager } from "../mcp/manager.js";
@@ -31,6 +32,13 @@ export async function initializeProvidersAndTools(
   // managed proxy activation survives assistant restarts. The in-memory
   // overrides are normally only set by the secret-routes handlers at runtime.
   await rehydratePlatformCredentials();
+
+  // Speech defaulting normally fires when the platform credentials land
+  // (secret-routes); evaluating it once per boot also covers assistants whose
+  // connection predates that trigger, so voice works for every connected
+  // assistant with no configured speech credentials. Idempotent, and detached
+  // per the startup philosophy — must not block boot.
+  void maybeDefaultSpeechToManaged();
 
   await initializeProviders(config);
   // initializeTools() also loads workspace tool overrides from


### PR DESCRIPTION
## What

One call added to daemon startup (`providers-setup.ts`, right after platform-credential rehydration):

```ts
void maybeDefaultSpeechToManaged();
```

## Why

`maybeDefaultSpeechToManaged()` — connected + speech unconfigured + no working BYOK credential ⇒ default that service to managed — currently fires only when the platform credentials **land** (`secret-routes.ts`), i.e. at the moment of connecting. An assistant whose connection predates that trigger never gets the defaulting: it sits connected with sparse speech config, voice fails on a keyless BYOK schema default, and the settings card shows a provider the user never chose.

Evaluating the same check once per boot closes that: voice "just works" for every connected assistant that never configured speech, after its next restart (which app updates force anyway).

## Why this is safe

- **Idempotent + guarded**: no-ops unless connected; never touches a service with working BYOK credentials ("connecting Vellum must not silently reroute an existing voice setup" — that invariant is unchanged, just evaluated at boot as well as at connect); never downgrades an already-managed service.
- **Detached** (`void`), internal try/catch, no DB access — conforms to the never-block-startup rule and needs no migration-readiness gating.
- Runs after `rehydratePlatformCredentials()`, so the connected-check sees the restored credentials.

The behavior change to be aware of: users in the gap population start billing Vellum credits for voice instead of voice silently failing. That's the intent — deliberate product call from review discussion.

## Testing

Hook behavior is fully covered by `managed-speech-defaults.test.ts` (6 tests: defaulting, credential-resolves skip, already-managed skip, no-connection no-op). The wiring is one declarative line; no separate lifecycle test added. `tsc --noEmit` clean.

Independent of the speech provider-dropdown stack (#38252 + successors) — works with today's `mode` write path and with the provider-only form after the migration lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)