### PR TITLE
feat(telemetry): flush CLI reports persisted/dropped counts + --json

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29052,8 +29052,20 @@ paths:
                       flushed:
                         type: boolean
                         const: true
+                      sent:
+                        type: number
+                        description: Events POSTed to the platform
+                      persisted:
+                        type: number
+                        description: Events the platform confirmed written
+                      dropped:
+                        type: number
+                        description: Events that did not land (sent - persisted)
                     required:
                       - flushed
+                      - sent
+                      - persisted
+                      - dropped
                     additionalProperties: false
                   - type: object
                     properties:

--- a/assistant/src/cli/commands/telemetry.help.ts
+++ b/assistant/src/cli/commands/telemetry.help.ts
@@ -9,6 +9,19 @@ export const telemetryHelp: CliCommandHelp = {
     {
       name: "flush",
       description: "Force-flush all pending telemetry events to the platform",
+      helpText: `
+Reports how many events reached the platform: 'sent' (POSTed), 'persisted'
+(confirmed written), and 'dropped' (sent - persisted — server-side drops plus
+events skipped at ingest validation). When nothing ships, prints why (e.g.
+nothing pending, opted out, not signed in).
+
+Pass --json for the raw summary:
+  { "flushed": true, "sent": 44, "persisted": 40, "dropped": 4 }
+  { "flushed": false, "reason": "opted-out" }
+
+Examples:
+  $ assistant telemetry flush
+  $ assistant telemetry flush --json`,
     },
   ],
 };

--- a/assistant/src/cli/commands/telemetry.ts
+++ b/assistant/src/cli/commands/telemetry.ts
@@ -1,10 +1,45 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import type { TelemetryFlushSummary } from "../../telemetry/usage-telemetry-reporter.js";
 import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
 import { telemetryHelp } from "./telemetry.help.js";
+
+function describeSkip(reason: string): string {
+  switch (reason) {
+    case "nothing-pending":
+      return "No pending telemetry events to flush.";
+    case "opted-out":
+      return "Telemetry flush skipped: analytics sharing is opted out.";
+    case "no-credentials":
+      return "Telemetry flush skipped: not signed in to the platform yet.";
+    case "unknown-consent":
+      return "Telemetry flush skipped: consent not yet resolved (will retry).";
+    case "checkpoint-unavailable":
+      return "Telemetry flush skipped: telemetry store unavailable (will retry).";
+    case "disabled":
+      return "Telemetry flush skipped: telemetry is disabled.";
+    case "post-failed":
+      return "Telemetry flush failed: the platform rejected the request.";
+    default:
+      return `Telemetry flush skipped: ${reason}`;
+  }
+}
+
+function describeFlushed(r: {
+  sent: number;
+  persisted: number;
+  dropped: number;
+}): string {
+  const events = r.sent === 1 ? "event" : "events";
+  if (r.dropped === 0) {
+    return `Flushed ${r.sent} ${events} — all persisted.`;
+  }
+  return `Flushed ${r.sent} ${events} — ${r.persisted} persisted, ${r.dropped} dropped.`;
+}
 
 export function registerTelemetryCommand(program: Command): void {
   registerCommand(program, {
@@ -16,9 +51,10 @@ export function registerTelemetryCommand(program: Command): void {
 
       subcommand(telemetry, "flush").action(
         async (_opts: Record<string, unknown>, cmd: Command) => {
-          const r = await cliIpcCall<
-            { flushed: true } | { flushed: false; reason: string }
-          >("telemetry_flush", {});
+          const r = await cliIpcCall<TelemetryFlushSummary>(
+            "telemetry_flush",
+            {},
+          );
           if (!r.ok)
             return exitFromIpcResult(
               {
@@ -30,10 +66,14 @@ export function registerTelemetryCommand(program: Command): void {
             );
 
           const result = r.result!;
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, result);
+            return;
+          }
           if (result.flushed) {
-            log.info("Telemetry flushed successfully.");
+            log.info(describeFlushed(result));
           } else {
-            log.info(`Telemetry flush skipped: ${result.reason}`);
+            log.info(describeSkip(result.reason));
           }
         },
       );

--- a/assistant/src/runtime/routes/telemetry-routes.ts
+++ b/assistant/src/runtime/routes/telemetry-routes.ts
@@ -70,8 +70,7 @@ async function handleTelemetryFlush() {
   if (!reporter) {
     return { flushed: false, reason: "disabled" };
   }
-  await reporter.flush();
-  return { flushed: true };
+  return reporter.flush();
 }
 
 function handleRecordOnboardingResearchEvent({ body }: RouteHandlerArgs) {
@@ -145,7 +144,14 @@ export const ROUTES: RouteDefinition[] = [
       "Force-flush the telemetry events owned by the assistant process (turn events) to the platform. Other event types are flushed on their own cycle by the resource monitor process.",
     tags: ["telemetry"],
     responseBody: z.union([
-      z.object({ flushed: z.literal(true) }),
+      z.object({
+        flushed: z.literal(true),
+        sent: z.number().describe("Events POSTed to the platform"),
+        persisted: z.number().describe("Events the platform confirmed written"),
+        dropped: z
+          .number()
+          .describe("Events that did not land (sent - persisted)"),
+      }),
       z.object({
         flushed: z.literal(false),
         reason: z.string(),

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -570,6 +570,126 @@ describe("UsageTelemetryReporter", () => {
     expect(mockFetch).toHaveBeenCalledTimes(10);
   });
 
+  test("flush summary reports sent/persisted/dropped from the ingest response", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([
+      makeUsageEvent(),
+      makeUsageEvent(),
+      makeUsageEvent(),
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          '{"accepted":3,"persisted":2,"dropped":{"analytics_opt_out":1}}',
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const reporter = makeReporter();
+    const summary = await reporter.flush();
+
+    expect(summary).toEqual({
+      flushed: true,
+      sent: 3,
+      persisted: 2,
+      dropped: 1,
+    });
+  });
+
+  test("flush summary falls back to persisted=sent when the body omits persisted", async () => {
+    // Older platform returns only `accepted` — assume everything landed.
+    mockQueryUnreportedUsageEvents.mockReturnValue([
+      makeUsageEvent(),
+      makeUsageEvent(),
+    ]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = makeReporter();
+    const summary = await reporter.flush();
+
+    expect(summary).toEqual({
+      flushed: true,
+      sent: 2,
+      persisted: 2,
+      dropped: 0,
+    });
+  });
+
+  test("flush summary accumulates counts across the batch recursion", async () => {
+    const fullBatch = Array.from({ length: 500 }, (_, i) =>
+      makeUsageEvent({ id: `evt-acc-${i}`, createdAt: 1700000000000 + i }),
+    );
+    // First collect fills a batch (recurse); second returns a short batch (stop).
+    mockQueryUnreportedUsageEvents
+      .mockReturnValueOnce(fullBatch)
+      .mockReturnValue([makeUsageEvent({ id: "evt-acc-tail" })]);
+    // First POST drops 10; second persists its single event.
+    mockFetch
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          new Response('{"accepted":500,"persisted":490}', { status: 200 }),
+        ),
+      )
+      .mockImplementation(() =>
+        Promise.resolve(new Response('{"persisted":1}', { status: 200 })),
+      );
+
+    const reporter = makeReporter();
+    const summary = await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(summary).toEqual({
+      flushed: true,
+      sent: 501,
+      persisted: 491,
+      dropped: 10,
+    });
+  });
+
+  test("flush summary reports skip reasons without shipping", async () => {
+    const reporter = makeReporter();
+
+    // nothing-pending: no events across any source.
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    expect(await reporter.flush()).toEqual({
+      flushed: false,
+      reason: "nothing-pending",
+    });
+
+    // opted-out: confirmed share_analytics opt-out.
+    mockGetRawShareAnalytics.mockReturnValue(false);
+    mockQueryUnreportedUsageEvents.mockReturnValue([makeUsageEvent()]);
+    expect(await reporter.flush()).toEqual({
+      flushed: false,
+      reason: "opted-out",
+    });
+    mockGetRawShareAnalytics.mockReturnValue(true);
+
+    // no-credentials: authenticated-only, no platform client resolved.
+    mockPlatformClient = null;
+    expect(await reporter.flush()).toEqual({
+      flushed: false,
+      reason: "no-credentials",
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("flush summary reports post-failed on a non-2xx response", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([makeUsageEvent()]);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("error", { status: 500 })),
+    );
+
+    const reporter = makeReporter();
+    expect(await reporter.flush()).toEqual({
+      flushed: false,
+      reason: "post-failed",
+    });
+  });
+
   test("stop() performs final flush", async () => {
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -69,6 +69,43 @@ const BATCH_SIZE = 500;
 const MAX_CONSECUTIVE_BATCHES = 10;
 const TELEMETRY_PATH = "/v1/telemetry/ingest/";
 
+/**
+ * Outcome of a {@link UsageTelemetryReporter.flush} call. `flushed: true` means
+ * at least one batch reached the platform (2xx). `sent` is the count the daemon
+ * POSTed; `persisted` is the count the platform confirmed written; `dropped` is
+ * `sent - persisted` — folding server-side drops (opt-out, unauthenticated) and
+ * events silently skipped at ingest validation (unknown/invalid type) into one
+ * "did not land" number. `flushed: false` carries a kebab-case skip reason.
+ */
+export type TelemetryFlushSummary =
+  | { flushed: true; sent: number; persisted: number; dropped: number }
+  | { flushed: false; reason: string };
+
+interface FlushAccumulator {
+  sent: number;
+  persisted: number;
+}
+
+/**
+ * Read `persisted` from an ingest response body. Falls back to `fallback`
+ * (the POSTed count — assume all landed) on a malformed body or an older
+ * platform that omits the field. Never throws.
+ */
+function parsePersistedCount(body: string, fallback: number): number {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (parsed && typeof parsed === "object") {
+      const p = (parsed as { persisted?: unknown }).persisted;
+      if (typeof p === "number" && Number.isFinite(p) && p >= 0) {
+        return p;
+      }
+    }
+  } catch {
+    // Malformed/empty body — assume everything persisted.
+  }
+  return fallback;
+}
+
 // ---------------------------------------------------------------------------
 // Singleton access
 // ---------------------------------------------------------------------------
@@ -197,7 +234,7 @@ export function initToolExecutedWatermarkIfAbsent(
 export class UsageTelemetryReporter {
   private initialFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
-  private activeFlush: Promise<void> | null = null;
+  private activeFlush: Promise<TelemetryFlushSummary> | null = null;
   private readonly sources: readonly TelemetryEventSource[];
   private readonly checkpoints: FlushCheckpointStore;
 
@@ -252,22 +289,36 @@ export class UsageTelemetryReporter {
     await this.flush();
   }
 
-  async flush(): Promise<void> {
+  async flush(): Promise<TelemetryFlushSummary> {
     if (this.activeFlush) {
-      return; // overlap guard
+      return this.activeFlush; // overlap guard — share the in-flight result
     }
     this.activeFlush = this._doFlush();
     try {
-      await this.activeFlush;
+      return await this.activeFlush;
     } finally {
       this.activeFlush = null;
     }
   }
 
-  private async _doFlush(batchCount = 0): Promise<void> {
+  private async _doFlush(
+    batchCount = 0,
+    acc: FlushAccumulator = { sent: 0, persisted: 0 },
+  ): Promise<TelemetryFlushSummary> {
+    // Once any batch has shipped (acc.sent > 0), a later skip/defer/error is
+    // just the natural end of the flush — report what landed, not a failure.
+    const flushed = (): TelemetryFlushSummary => ({
+      flushed: true,
+      sent: acc.sent,
+      persisted: acc.persisted,
+      dropped: Math.max(0, acc.sent - acc.persisted),
+    });
+    const settle = (reason: string): TelemetryFlushSummary =>
+      acc.sent > 0 ? flushed() : { flushed: false, reason };
+
     try {
       if (batchCount >= MAX_CONSECUTIVE_BATCHES) {
-        return;
+        return flushed();
       }
 
       // Age-bound the ack-mode outbox before any skip gate (platform,
@@ -293,7 +344,7 @@ export class UsageTelemetryReporter {
       // is a deployment/local-mode toggle, not a privacy opt-out, so the unsent
       // backlog ships once the flag is cleared.
       if (!arePlatformFeaturesEnabled()) {
-        return;
+        return settle("disabled");
       }
 
       // Skip when the flush-checkpoint store (telemetry DB) is unreachable.
@@ -304,7 +355,7 @@ export class UsageTelemetryReporter {
         log.warn(
           "Telemetry flush: flush-checkpoint store unavailable — skipping, will retry next cycle",
         );
-        return;
+        return settle("checkpoint-unavailable");
       }
 
       // Tri-state consent gate: `true` ships, `false` purges, `"unknown"`
@@ -323,7 +374,7 @@ export class UsageTelemetryReporter {
         log.debug(
           "Telemetry flush: share_analytics consent unknown — skipping, will retry next cycle",
         );
-        return;
+        return settle("unknown-consent");
       }
 
       // Respect a confirmed opt-out: if the platform owner declined
@@ -362,7 +413,7 @@ export class UsageTelemetryReporter {
           this.checkpoints.set(keys.at, now);
           this.checkpoints.set(keys.id, OPT_OUT_WATERMARK_ID_SENTINEL);
         }
-        return;
+        return settle("opted-out");
       }
 
       // Read each source's watermark (compound cursor: createdAt + id) and
@@ -411,7 +462,7 @@ export class UsageTelemetryReporter {
       }
 
       if (batches.every(({ batch }) => batch.events.length === 0)) {
-        return;
+        return settle("nothing-pending");
       }
 
       // Resolve auth context. We send authenticated-only: if no platform
@@ -428,7 +479,7 @@ export class UsageTelemetryReporter {
           },
           "Telemetry flush: no platform credentials — skipping, will retry next cycle",
         );
-        return;
+        return settle("no-credentials");
       }
       log.debug(
         {
@@ -477,9 +528,14 @@ export class UsageTelemetryReporter {
           { status: resp.status, body },
           "Usage telemetry POST failed — will retry next cycle",
         );
-        return;
+        return settle("post-failed");
       }
-      await resp.text(); // consume body to release connection
+
+      // Read the ingest response so `persisted` reflects what actually landed;
+      // consuming the body also releases the connection.
+      const body = await resp.text();
+      acc.sent += typedEvents.length;
+      acc.persisted += parsePersistedCount(body, typedEvents.length);
 
       // Acknowledge each source's shipped rows: ack-mode sources delete them
       // (never touching flush_checkpoints), watermark-mode sources advance
@@ -496,12 +552,15 @@ export class UsageTelemetryReporter {
         }
       }
 
-      // If any source produced a full batch, there may be more — recurse.
+      // If any source produced a full batch, there may be more — recurse,
+      // threading the accumulator so counts span every batch in this flush.
       if (batches.some(({ batch }) => batch.fullBatch)) {
-        await this._doFlush(batchCount + 1);
+        return this._doFlush(batchCount + 1, acc);
       }
+      return flushed();
     } catch (err) {
       log.warn({ err }, "Usage telemetry flush error — non-fatal, will retry");
+      return settle("error");
     }
   }
 }


### PR DESCRIPTION
## Summary

- `assistant telemetry flush` now reports how many events actually reached the platform: **sent** (POSTed), **persisted** (confirmed written), **dropped** (`sent - persisted`). Previously it only printed "Telemetry flushed successfully."
- Adds `--json` (the global flag) for a machine-readable summary: `{ "flushed": true, "sent": 44, "persisted": 40, "dropped": 4 }` or `{ "flushed": false, "reason": "opted-out" }`.
- **Truthful-outcome fix:** `flush()` previously returned `flushed: true` even when the POST failed, nothing was pending, or consent deferred the send. It now returns `flushed: false` with a kebab-case reason (`nothing-pending`, `opted-out`, `no-credentials`, `unknown-consent`, `checkpoint-unavailable`, `post-failed`, `disabled`) for every non-shipping path, and `flushed: true` with accumulated counts once any batch has shipped.

## How it works

`flush()`/`_doFlush()` now return a `TelemetryFlushSummary`, threading an accumulator through the batch recursion so counts span every POST in a flush. The platform ingest response (`{ accepted, persisted, dropped }`) is parsed instead of discarded; a defensive guard falls back to `persisted = sent` on a malformed body or an older platform that omits the field.

`dropped` deliberately folds two things into one "did not land" number: the platform's server-side `dropped` reasons **and** the `sent - accepted` gap from events the platform silently skips at ingest validation (unknown/invalid/platform-managed types). The real relationship is `sent >= accepted >= persisted`; the CLI just cares how many reached the platform.

## Scope

Daemon + CLI only — they ship together, so there's no version skew to shim. No platform or wire-contract changes (this only reads the existing ingest response).

## Original prompt

While looking at what the `telemetry flush` CLI command responds with, we found it only printed a static success string and threw away the ingest response body. The ask: enrich it to report persisted-vs-dropped counts the platform already returns, simplify the payload down to what the CLI actually cares about, and add a `--json` flag (human-readable otherwise). Along the way this fixes that `flushed: true` was returned even when nothing shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)