### PR TITLE
feat(calls): declare optional awaitPlaybackDrained on CallTransport

### DIFF
--- a/assistant/src/calls/call-transport.ts
+++ b/assistant/src/calls/call-transport.ts
@@ -72,4 +72,13 @@ export interface CallTransport {
    * this.
    */
   cancelPendingSpeech?(): void;
+
+  /**
+   * Resolve once all queued speech has played out to the caller (the most
+   * recent end-of-turn boundary has been echoed back by the downstream
+   * transport). Used to gate end-of-call teardown so a goodbye is never cut
+   * off mid-sentence. Transports that play speech synchronously may omit
+   * this — the controller then treats playback as already drained.
+   */
+  awaitPlaybackDrained?(): Promise<void>;
 }


### PR DESCRIPTION
## Summary
- Add optional `awaitPlaybackDrained?(): Promise<void>` to the `CallTransport` interface

Part of plan: endcall-drain.md (PR 4 of 5)