### PR TITLE
feat(calls): track playback drain via sequenced end-of-turn marks

### DIFF
--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -1673,6 +1673,50 @@ describe("MediaStreamOutput", () => {
       await expect(drained).resolves.toBeUndefined();
     });
 
+    test("a waiter armed AFTER a flush does not hang on the flushed mark", async () => {
+      // Barge-in flushes an outstanding end-of-turn mark before any waiter
+      // exists. A later awaitPlaybackDrained() targeting that flushed seq
+      // must resolve (the audio was cleared, never to be echoed) rather than
+      // wait forever.
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true); // enqueues end-of-turn:1
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      output.clearAudio(); // flushes end-of-turn:1 with no waiter present
+
+      await expect(output.awaitPlaybackDrained()).resolves.toBeUndefined();
+    });
+
+    test("a late cleared-mark echo does not prematurely resolve a fresh turn", async () => {
+      // After a flush advances the drained seq, a stale echo for the cleared
+      // mark is a no-op, and the next turn's waiter still pends until its own
+      // (higher-seq) mark is echoed.
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true); // end-of-turn:1
+      await drain(() => countEvents(sent, "mark") > 0);
+      output.clearAudio(); // flush; drained seq advances to 1
+
+      output.sendTextToken("", true); // end-of-turn:2 (next turn)
+      await drain(() => countEvents(sent, "mark") > 1);
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      // Stale echo for the cleared mark must not resolve the seq-2 waiter.
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drain();
+      expect(resolved).toBe(false);
+
+      // The genuine seq-2 echo resolves it.
+      output.notePlaybackMarkEcho("end-of-turn:2");
+      await drain(() => resolved);
+      expect(resolved).toBe(true);
+    });
+
     test("endSession releases a pending waiter", async () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -250,9 +250,9 @@ describe("MediaStreamOutput", () => {
       expect(events).toContain("media");
       expect(events).toContain("mark");
 
-      // The mark should be end-of-turn
+      // The mark should be the first sequenced end-of-turn mark
       const markMsg = sent.find((s) => JSON.parse(s).event === "mark");
-      expect(JSON.parse(markMsg!).mark.name).toBe("end-of-turn");
+      expect(JSON.parse(markMsg!).mark.name).toBe("end-of-turn:1");
     });
 
     test("empty token with last: true sends only end-of-turn mark (no synthesis)", async () => {
@@ -266,7 +266,7 @@ describe("MediaStreamOutput", () => {
       expect(sent).toHaveLength(1);
       const parsed = JSON.parse(sent[0]);
       expect(parsed.event).toBe("mark");
-      expect(parsed.mark.name).toBe("end-of-turn");
+      expect(parsed.mark.name).toBe("end-of-turn:1");
 
       // Synthesis should NOT have been called
       expect(mockSynthesize).not.toHaveBeenCalled();
@@ -1565,6 +1565,147 @@ describe("MediaStreamOutput", () => {
       good.close();
       await drain(() => countEvents(sent, "media") > 0);
       expect(countEvents(sent, "media")).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Playback drain tracking (sequenced end-of-turn marks)
+  // ---------------------------------------------------------------------------
+
+  describe("playback drain", () => {
+    /** Extract the names of all sent mark events, in order. */
+    function markNames(sent: string[]): string[] {
+      return sent
+        .map((s) => JSON.parse(s))
+        .filter((m) => m.event === "mark")
+        .map((m) => m.mark.name);
+    }
+
+    test("end-of-turn marks are sequenced in order", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      output.sendTextToken("", true);
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") >= 3);
+
+      expect(markNames(sent)).toEqual([
+        "end-of-turn:1",
+        "end-of-turn:2",
+        "end-of-turn:3",
+      ]);
+    });
+
+    test("resolves immediately when no end-of-turn mark is outstanding", async () => {
+      const { ws } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      // Never enqueued a turn — nothing outstanding.
+      await expect(output.awaitPlaybackDrained()).resolves.toBeUndefined();
+    });
+
+    test("resolves immediately when the output is already closed", async () => {
+      const { ws } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true); // outstanding seq 1, never echoed
+      output.endSession();
+      await expect(output.awaitPlaybackDrained()).resolves.toBeUndefined();
+    });
+
+    test("stays pending until the matching end-of-turn mark is echoed", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      let resolved = false;
+      const drained = output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      await drain();
+      expect(resolved).toBe(false);
+
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drained;
+      expect(resolved).toBe(true);
+    });
+
+    test("a higher-seq echo also resolves a waiter", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      const drained = output.awaitPlaybackDrained();
+      output.notePlaybackMarkEcho("end-of-turn:5");
+      await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("a stale lower-seq echo does not resolve a higher-seq waiter", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") >= 2);
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drain();
+      expect(resolved).toBe(false);
+
+      output.notePlaybackMarkEcho("end-of-turn:2");
+      await drain(() => resolved);
+      expect(resolved).toBe(true);
+    });
+
+    test("flushing the playback queue releases a pending waiter", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      const drained = output.awaitPlaybackDrained();
+      output.clearAudio(); // flushes the playback queue
+      await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("endSession releases a pending waiter", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      const drained = output.awaitPlaybackDrained();
+      output.endSession();
+      await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("ignores non-end-of-turn and malformed mark names without throwing", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      // Unrelated mark name, wrong prefix, and non-numeric seq are ignored.
+      output.notePlaybackMarkEcho("some-other-mark");
+      output.notePlaybackMarkEcho("end-of-turn");
+      output.notePlaybackMarkEcho("end-of-turn:not-a-number");
+      await drain();
+      expect(resolved).toBe(false);
+
+      // The real echo still resolves.
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drain(() => resolved);
+      expect(resolved).toBe(true);
     });
   });
 });

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -906,7 +906,7 @@ describe("media-stream output egress", () => {
     expect(markMessages.length).toBeGreaterThan(0);
 
     const markParsed = JSON.parse(markMessages[0]);
-    expect(markParsed.mark.name).toBe("end-of-turn");
+    expect(markParsed.mark.name).toBe("end-of-turn:1");
   });
 
   test("empty sendTextToken (end-of-turn signal) sends only a mark, no media", async () => {

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -702,8 +702,12 @@ export class MediaStreamOutput implements CallTransport {
       this.activePlaybackAbort.abort();
       this.activePlaybackAbort = null;
     }
-    // A flushed queue will never echo its pending end-of-turn marks, so
-    // release any drain waiters rather than leave them hanging.
+    // A flushed queue will never (genuinely) echo its pending end-of-turn
+    // marks — Twilio drops the buffered audio on `clear`. Treat every
+    // outstanding mark as drained so existing waiters resolve now and any
+    // *future* awaitPlaybackDrained() targeting a flushed seq doesn't hang.
+    // It also makes a late cleared-mark echo a no-op (seq <= echoed).
+    this.echoedEndOfTurnSeq = this.enqueuedEndOfTurnSeq;
     this.releaseAllDrainWaiters();
   }
 

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -57,6 +57,9 @@ import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
 
 const log = getLogger("media-stream-output");
 
+/** Prefix for the sequenced end-of-turn playback marks Twilio echoes back. */
+const END_OF_TURN_MARK_PREFIX = "end-of-turn";
+
 /** Twilio media streams consume 8 kHz mono mu-law. */
 const TELEPHONY_SAMPLE_RATE_HZ = 8000;
 
@@ -335,6 +338,15 @@ export class MediaStreamOutput implements CallTransport {
    */
   private audioStartCallback: (() => void) | null = null;
 
+  /** Incremented per end-of-turn mark enqueued. */
+  private enqueuedEndOfTurnSeq = 0;
+
+  /** Highest end-of-turn seq echoed back by Twilio. */
+  private echoedEndOfTurnSeq = 0;
+
+  /** Pending {@link awaitPlaybackDrained} waiters, each with its target seq. */
+  private drainWaiters: Array<{ targetSeq: number; resolve: () => void }> = [];
+
   /**
    * The media-stream transport requires raw PCM audio because its
    * mu-law transcoder cannot decode compressed formats (mp3, opus).
@@ -378,9 +390,13 @@ export class MediaStreamOutput implements CallTransport {
     }
 
     if (last) {
-      // Always send an end-of-turn mark so the media-stream server
-      // can detect turn boundaries.
-      this.enqueuePlayback({ type: "mark", name: "end-of-turn" });
+      // Always send a sequenced end-of-turn mark so the media-stream server
+      // can detect turn boundaries and drain waiters can track playback.
+      const seq = ++this.enqueuedEndOfTurnSeq;
+      this.enqueuePlayback({
+        type: "mark",
+        name: `${END_OF_TURN_MARK_PREFIX}:${seq}`,
+      });
       this.turnSegmentEnqueued = false;
     }
   }
@@ -438,6 +454,9 @@ export class MediaStreamOutput implements CallTransport {
       return;
     }
     this.state = "closed";
+
+    // Release drain waiters immediately so teardown never leaves one pending.
+    this.releaseAllDrainWaiters();
 
     // Cancel any in-flight playback
     this.flushPlaybackQueue();
@@ -508,6 +527,35 @@ export class MediaStreamOutput implements CallTransport {
         "Failed to send mark command",
       );
     }
+  }
+
+  /**
+   * Record a mark echoed back by Twilio. When it is an end-of-turn mark,
+   * advance the echoed sequence and resolve any drain waiters whose target
+   * has now been reached (played out to the caller).
+   */
+  notePlaybackMarkEcho(name: string): void {
+    if (!name.startsWith(`${END_OF_TURN_MARK_PREFIX}:`)) return;
+    const seq = Number(name.slice(END_OF_TURN_MARK_PREFIX.length + 1));
+    if (!Number.isFinite(seq)) return;
+    if (seq > this.echoedEndOfTurnSeq) this.echoedEndOfTurnSeq = seq;
+    this.resolveDrainWaiters();
+  }
+
+  /**
+   * Resolve once the most-recently-enqueued end-of-turn mark has been
+   * echoed by Twilio (all queued speech has played out to the caller).
+   * Resolves immediately if nothing is outstanding or the output is closed.
+   * Also resolves if the playback queue is later flushed (barge-in / teardown)
+   * so callers never hang.
+   */
+  awaitPlaybackDrained(): Promise<void> {
+    if (this.state === "closed") return Promise.resolve();
+    const targetSeq = this.enqueuedEndOfTurnSeq;
+    if (this.echoedEndOfTurnSeq >= targetSeq) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.drainWaiters.push({ targetSeq, resolve });
+    });
   }
 
   /**
@@ -610,6 +658,24 @@ export class MediaStreamOutput implements CallTransport {
     return this.state === "closed";
   }
 
+  // ── Private: playback drain waiters ─────────────────────────────────
+
+  private resolveDrainWaiters(): void {
+    if (this.drainWaiters.length === 0) return;
+    const remaining: typeof this.drainWaiters = [];
+    for (const w of this.drainWaiters) {
+      if (this.echoedEndOfTurnSeq >= w.targetSeq) w.resolve();
+      else remaining.push(w);
+    }
+    this.drainWaiters = remaining;
+  }
+
+  private releaseAllDrainWaiters(): void {
+    const waiters = this.drainWaiters;
+    this.drainWaiters = [];
+    for (const w of waiters) w.resolve();
+  }
+
   // ── Private: playback queue management ──────────────────────────────
 
   private enqueuePlayback(item: PlaybackItem): void {
@@ -636,6 +702,9 @@ export class MediaStreamOutput implements CallTransport {
       this.activePlaybackAbort.abort();
       this.activePlaybackAbort = null;
     }
+    // A flushed queue will never echo its pending end-of-turn marks, so
+    // release any drain waiters rather than leave them hanging.
+    this.releaseAllDrainWaiters();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Sequence end-of-turn marks (`end-of-turn:<n>`) and track the highest echoed seq
- Add `notePlaybackMarkEcho()` and `awaitPlaybackDrained()` to `MediaStreamOutput`
- Release drain waiters on flush/close so callers never hang

Part of plan: endcall-drain.md (PR 2 of 5)