### PR TITLE
feat(voice): expose pcm16 mean amplitude and echo-adaptive VAD config

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -825,6 +825,8 @@ describe("AssistantConfigSchema", () => {
         silenceThresholdMs: 1200,
         maxTurnDurationMs: 30000,
         bargeInMinSpeechMs: 250,
+        echoBargeInMargin: 1.5,
+        echoEmaHalfLifeMs: 400,
       },
       maxSessionDurationSeconds: 1800,
       archiveAudio: false,

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -14,6 +14,8 @@ describe("LiveVoiceVadConfigSchema", () => {
       silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
       bargeInMinSpeechMs: 250,
+      echoBargeInMargin: 1.5,
+      echoEmaHalfLifeMs: 400,
     });
   });
 
@@ -55,6 +57,29 @@ describe("LiveVoiceVadConfigSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("accepts a fractional echoBargeInMargin", () => {
+    const parsed = LiveVoiceVadConfigSchema.parse({ echoBargeInMargin: 2.25 });
+    expect(parsed.echoBargeInMargin).toBe(2.25);
+  });
+
+  test("rejects non-positive echoBargeInMargin", () => {
+    expect(
+      LiveVoiceVadConfigSchema.safeParse({ echoBargeInMargin: 0 }).success,
+    ).toBe(false);
+    expect(
+      LiveVoiceVadConfigSchema.safeParse({ echoBargeInMargin: -1.5 }).success,
+    ).toBe(false);
+  });
+
+  test("rejects non-positive or non-integer echoEmaHalfLifeMs", () => {
+    expect(
+      LiveVoiceVadConfigSchema.safeParse({ echoEmaHalfLifeMs: 0 }).success,
+    ).toBe(false);
+    expect(
+      LiveVoiceVadConfigSchema.safeParse({ echoEmaHalfLifeMs: 250.5 }).success,
+    ).toBe(false);
+  });
 });
 
 describe("LiveVoiceConfigSchema", () => {
@@ -67,6 +92,8 @@ describe("LiveVoiceConfigSchema", () => {
         silenceThresholdMs: 1200,
         maxTurnDurationMs: 30_000,
         bargeInMinSpeechMs: 250,
+        echoBargeInMargin: 1.5,
+        echoEmaHalfLifeMs: 400,
       },
       maxSessionDurationSeconds: 1800,
       // Off by default: voice turns carry only their transcript, no audio

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -42,6 +42,21 @@ export const LiveVoiceVadConfigSchema = z
       .describe(
         "Sustained speech (ms) required before speech during assistant playback interrupts it — the default 'interrupt sensitivity' (higher = harder to interrupt). 0 disables the guard. Clients may override it per-session via the start frame. Raised from 60 so brief TTS bleed through imperfect echo cancellation no longer self-interrupts the assistant.",
       ),
+    echoBargeInMargin: z
+      .number({ error: "liveVoice.vad.echoBargeInMargin must be a number" })
+      .positive("liveVoice.vad.echoBargeInMargin must be a positive number")
+      .default(1.5)
+      .describe(
+        "Multiplier over the observed echo energy level (an EMA of mic energy tracked while assistant audio is playing) that input must exceed to count as speech during playback; the effective threshold is max(speechEnergyThreshold, echoBargeInMargin × echo EMA). Higher = harder to barge in over loud speakers.",
+      ),
+    echoEmaHalfLifeMs: z
+      .number({ error: "liveVoice.vad.echoEmaHalfLifeMs must be a number" })
+      .int("liveVoice.vad.echoEmaHalfLifeMs must be an integer")
+      .positive("liveVoice.vad.echoEmaHalfLifeMs must be a positive integer")
+      .default(400)
+      .describe(
+        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients.",
+      ),
   })
   .describe(
     "Voice-activity-detection tuning for live voice sessions (open-mic turn segmentation)",

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1687,6 +1687,8 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
       silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
       bargeInMinSpeechMs: 250,
+      echoBargeInMargin: 1.5,
+      echoEmaHalfLifeMs: 400,
     });
 
     const { frames, session } = createHarness({ viaFactory: true });

--- a/assistant/src/stt/__tests__/speech-energy.test.ts
+++ b/assistant/src/stt/__tests__/speech-energy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_SPEECH_ENERGY_THRESHOLD,
   detectPcm16SpeechActivity,
+  pcm16MeanAmplitude,
 } from "../speech-energy.js";
 
 /** Build a PCM16LE buffer from an array of sample values. */
@@ -64,5 +65,49 @@ describe("detectPcm16SpeechActivity", () => {
     expect(detectPcm16SpeechActivity(quiet)).toBe(false);
     expect(detectPcm16SpeechActivity(quiet, 400)).toBe(true);
     expect(detectPcm16SpeechActivity(quiet, 500)).toBe(false);
+  });
+});
+
+describe("pcm16MeanAmplitude", () => {
+  test("empty buffer returns 0", () => {
+    expect(pcm16MeanAmplitude(Buffer.alloc(0))).toBe(0);
+  });
+
+  test("constant-amplitude buffer returns the exact mean", () => {
+    expect(pcm16MeanAmplitude(pcm16(new Array(100).fill(1234)))).toBe(1234);
+  });
+
+  test("negative samples contribute their absolute value", () => {
+    const samples = Array.from({ length: 160 }, (_, i) =>
+      i % 2 === 0 ? 2000 : -2000,
+    );
+    expect(pcm16MeanAmplitude(pcm16(samples))).toBe(2000);
+  });
+
+  test("odd-length buffer ignores the trailing byte", () => {
+    const constant = pcm16(new Array(50).fill(3000));
+    const withTrailing = Buffer.concat([constant, Buffer.from([0x01])]);
+    expect(pcm16MeanAmplitude(withTrailing)).toBe(3000);
+  });
+
+  test("detectPcm16SpeechActivity is equivalent to comparing the mean against the threshold", () => {
+    const buffers = [
+      Buffer.alloc(0),
+      pcm16(new Array(160).fill(0)),
+      pcm16(new Array(100).fill(500)),
+      pcm16(new Array(100).fill(DEFAULT_SPEECH_ENERGY_THRESHOLD)),
+      pcm16(new Array(100).fill(DEFAULT_SPEECH_ENERGY_THRESHOLD + 1)),
+      pcm16(
+        Array.from({ length: 160 }, (_, i) => (i % 2 === 0 ? 10000 : -10000)),
+      ),
+    ];
+    const thresholds = [400, 500, DEFAULT_SPEECH_ENERGY_THRESHOLD, 12000];
+    for (const chunk of buffers) {
+      for (const threshold of thresholds) {
+        expect(detectPcm16SpeechActivity(chunk, threshold)).toBe(
+          pcm16MeanAmplitude(chunk) > threshold,
+        );
+      }
+    }
   });
 });

--- a/assistant/src/stt/speech-energy.ts
+++ b/assistant/src/stt/speech-energy.ts
@@ -19,6 +19,27 @@
 export const DEFAULT_SPEECH_ENERGY_THRESHOLD = 800;
 
 /**
+ * Mean absolute sample amplitude of a chunk of little-endian signed
+ * 16-bit mono PCM, on the 16-bit linear scale. Returns 0 for empty
+ * buffers; a trailing odd byte is ignored.
+ *
+ * @param chunk - Raw PCM16LE audio.
+ * @returns Mean absolute amplitude on the 16-bit linear scale.
+ */
+export function pcm16MeanAmplitude(chunk: Buffer): number {
+  const sampleCount = Math.floor(chunk.length / 2);
+  if (sampleCount === 0) {
+    return 0;
+  }
+
+  let totalAmplitude = 0;
+  for (let i = 0; i < sampleCount; i++) {
+    totalAmplitude += Math.abs(chunk.readInt16LE(i * 2));
+  }
+  return totalAmplitude / sampleCount;
+}
+
+/**
  * Detect speech activity in a chunk of little-endian signed 16-bit mono
  * PCM samples.
  *
@@ -34,16 +55,5 @@ export function detectPcm16SpeechActivity(
   chunk: Buffer,
   threshold = DEFAULT_SPEECH_ENERGY_THRESHOLD,
 ): boolean {
-  const sampleCount = Math.floor(chunk.length / 2);
-  if (sampleCount === 0) {
-    return false;
-  }
-
-  let totalAmplitude = 0;
-  for (let i = 0; i < sampleCount; i++) {
-    totalAmplitude += Math.abs(chunk.readInt16LE(i * 2));
-  }
-  const avgAmplitude = totalAmplitude / sampleCount;
-
-  return avgAmplitude > threshold;
+  return pcm16MeanAmplitude(chunk) > threshold;
 }


### PR DESCRIPTION
## Summary
- Extract `pcm16MeanAmplitude` from `detectPcm16SpeechActivity` (identical classification; the raw value feeds the upcoming echo-level EMA)
- Add `liveVoice.vad.echoBargeInMargin` (default 1.5) and `liveVoice.vad.echoEmaHalfLifeMs` (default 400) config knobs — unconsumed until the next PR

Part of plan: echo-adaptive-bargein.md (PR 1 of 2)