### PR TITLE
fix(voice): wait for the interrupted turn's teardown before forking the duplex continuation

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -94,7 +94,7 @@ const pendingTurnTeardowns = new Map<string, Promise<void>>();
  * when the signal aborts mid-wait. Timer and abort listener are removed on
  * every exit path.
  */
-async function waitForPriorTurnTeardown(
+export async function waitForPriorTurnTeardown(
   teardown: Promise<void>,
   timeoutMs: number,
   signal?: AbortSignal,
@@ -125,6 +125,24 @@ async function waitForPriorTurnTeardown(
       resolve(true);
     });
   });
+}
+
+/**
+ * The pending teardown promise for a conversation's most recent turn, or
+ * `undefined` when no turn is currently tearing down. The live-voice barge-in
+ * path reads this synchronously at interrupt time — before the next utterance's
+ * `startVoiceTurn` overwrites the per-conversation entry — to capture the
+ * interrupted turn's teardown, then awaits it before forking a background
+ * continuation. That guarantees the fork snapshots history only after the
+ * interrupted turn's completed tool calls have settled into it, so a
+ * side-effecting continuation cannot repeat a call the interrupted turn already
+ * ran. It is turn-scoped: it resolves once THIS turn's teardown finishes, and
+ * does not block on any later turn's work.
+ */
+export function getConversationTurnTeardown(
+  conversationId: string,
+): Promise<void> | undefined {
+  return pendingTurnTeardowns.get(conversationId);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -137,6 +137,7 @@ function createHarness(options: {
   // config path is exercised: unset thresholds come from getConfig().
   viaFactory?: boolean;
   spawnBackgroundContinuation?: LiveVoiceBackgroundContinuationSpawner;
+  getTurnTeardown?: (conversationId: string) => Promise<void> | undefined;
 }) {
   const sequencer = createLiveVoiceServerFrameSequencer();
   const frames: LiveVoiceServerFrame[] = [];
@@ -187,6 +188,9 @@ function createHarness(options: {
     bargeInMinSpeechMs: options.bargeInMinSpeechMs,
     ...(options.spawnBackgroundContinuation
       ? { spawnBackgroundContinuation: options.spawnBackgroundContinuation }
+      : {}),
+    ...(options.getTurnTeardown
+      ? { getTurnTeardown: options.getTurnTeardown }
       : {}),
   };
   const session = options.viaFactory
@@ -855,6 +859,101 @@ describe("LiveVoiceSession server VAD", () => {
     // Nothing to continue: no background subagent is spawned.
     expect(spawnBackgroundContinuation).not.toHaveBeenCalled();
     releaseTts?.();
+  });
+
+  test("voice-duplex-handoff on: the continuation fork waits for the interrupted turn's teardown to settle", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const spawnBackgroundContinuation = mock(
+      async (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }) => {},
+    );
+    // Hold the interrupted turn's teardown open. Its partial (completed tool
+    // calls) is only in forked history once the teardown settles, so the fork
+    // must not spawn before then.
+    let resolveTeardown: (() => void) | undefined;
+    const teardown = new Promise<void>((resolve) => {
+      resolveTeardown = resolve;
+    });
+    const getTurnTeardown = mock((_conversationId: string) => teardown);
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+      getTurnTeardown,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge in during thinking; the detach captures the teardown promise
+    // synchronously but blocks the fork on it.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    await flushAsyncCallbacks();
+    // Teardown still pending -> no fork yet.
+    expect(getTurnTeardown).toHaveBeenCalledWith("conversation-123");
+    expect(spawnBackgroundContinuation).not.toHaveBeenCalled();
+
+    // Teardown settles -> the fork proceeds.
+    resolveTeardown?.();
+    await waitFor(() => spawnBackgroundContinuation.mock.calls.length === 1);
+  });
+
+  test("voice-duplex-handoff on: a client interrupt during the teardown wait skips the continuation", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const spawnBackgroundContinuation = mock(
+      async (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }) => {},
+    );
+    // Never resolves: the detach is parked in the teardown wait until the stop
+    // aborts it.
+    let resolveTeardown: (() => void) | undefined;
+    const teardown = new Promise<void>((resolve) => {
+      resolveTeardown = resolve;
+    });
+    const getTurnTeardown = mock((_conversationId: string) => teardown);
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+      getTurnTeardown,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    await flushAsyncCallbacks();
+    expect(spawnBackgroundContinuation).not.toHaveBeenCalled();
+
+    // The stop aborts the detach's controller mid-wait; the fork is skipped
+    // even once the teardown later settles.
+    await session.handleClientFrame({ type: "interrupt" });
+    resolveTeardown?.();
+    await flushAsyncCallbacks();
+    expect(spawnBackgroundContinuation).not.toHaveBeenCalled();
   });
 
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -138,6 +138,7 @@ function createHarness(options: {
   viaFactory?: boolean;
   spawnBackgroundContinuation?: LiveVoiceBackgroundContinuationSpawner;
   getTurnTeardown?: (conversationId: string) => Promise<void> | undefined;
+  detachTeardownSettleTimeoutMs?: number;
 }) {
   const sequencer = createLiveVoiceServerFrameSequencer();
   const frames: LiveVoiceServerFrame[] = [];
@@ -191,6 +192,9 @@ function createHarness(options: {
       : {}),
     ...(options.getTurnTeardown
       ? { getTurnTeardown: options.getTurnTeardown }
+      : {}),
+    ...(options.detachTeardownSettleTimeoutMs !== undefined
+      ? { detachTeardownSettleTimeoutMs: options.detachTeardownSettleTimeoutMs }
       : {}),
   };
   const session = options.viaFactory
@@ -908,6 +912,48 @@ describe("LiveVoiceSession server VAD", () => {
     // Teardown settles -> the fork proceeds.
     resolveTeardown?.();
     await waitFor(() => spawnBackgroundContinuation.mock.calls.length === 1);
+  });
+
+  test("voice-duplex-handoff on: the continuation is skipped when the teardown wait times out", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const spawnBackgroundContinuation = mock(
+      async (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }) => {},
+    );
+    // A teardown that never settles: the bounded wait times out, and the fork
+    // must be skipped rather than snapshot history that may still be missing the
+    // interrupted turn's completed tool calls.
+    const getTurnTeardown = mock(
+      (_conversationId: string) => new Promise<void>(() => {}),
+    );
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question"],
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+      getTurnTeardown,
+      // Tiny timeout so the bounded wait elapses within the test.
+      detachTeardownSettleTimeoutMs: 10,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    // Wait comfortably past the bounded teardown timeout, then confirm the
+    // detach fell through without forking.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(spawnBackgroundContinuation).not.toHaveBeenCalled();
   });
 
   test("voice-duplex-handoff on: a client interrupt during the teardown wait skips the continuation", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -31,6 +31,7 @@ import {
 } from "../calls/voice-triage-escalate.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
+import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
@@ -212,6 +213,12 @@ export interface LiveVoiceSessionOptions {
    * promise to exercise the ordering.
    */
   getTurnTeardown?: (conversationId: string) => Promise<void> | undefined;
+  /**
+   * Overrides the bounded wait for the interrupted turn's teardown before the
+   * background continuation forks (test hook). Defaults to
+   * `DETACH_TEARDOWN_SETTLE_TIMEOUT_MS`.
+   */
+  detachTeardownSettleTimeoutMs?: number;
 }
 
 type LiveVoiceUtterancePhase =
@@ -358,11 +365,13 @@ function buildDuplexContinuationObjective(interruptedRequest: string): string {
 }
 
 // Upper bound on how long a barge-in waits for the interrupted turn's teardown
-// to settle before forking the continuation anyway. Teardown normally settles
-// in well under this; the cap keeps the fork from blocking indefinitely on a
-// stuck teardown (the continuation's "don't repeat finished tool calls"
-// objective is the backstop if the snapshot is ever slightly early).
-const DETACH_TEARDOWN_SETTLE_TIMEOUT_MS = 2000;
+// to settle before giving up on the continuation. The teardown settles once the
+// aborted turn's agent loop reaches its `finally` — bounded by the abort-unwind
+// watchdog plus the history/DB flush tail — so a cap just past the watchdog lets
+// a legitimately slow abort still fork, while a genuinely wedged teardown times
+// out. On timeout the fork is SKIPPED (not run against stale history); see
+// detachInterruptedTurn.
+const DETACH_TEARDOWN_SETTLE_TIMEOUT_MS = ABORT_WATCHDOG_MS + 1000;
 
 export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly context: LiveVoiceSessionFactoryContext;
@@ -377,6 +386,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly getTurnTeardown:
     | ((conversationId: string) => Promise<void> | undefined)
     | null;
+  private readonly detachTeardownSettleTimeoutMs: number;
   // Abort handles for background continuations started when a barge-in detached
   // an interrupted turn (voice-duplex-handoff). Each controller is registered
   // synchronously before its spawn, so interrupt()/close() abort a continuation
@@ -479,6 +489,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.spawnBackgroundContinuation =
       options.spawnBackgroundContinuation ?? null;
     this.getTurnTeardown = options.getTurnTeardown ?? null;
+    this.detachTeardownSettleTimeoutMs =
+      options.detachTeardownSettleTimeoutMs ??
+      DETACH_TEARDOWN_SETTLE_TIMEOUT_MS;
     this.emitMetrics = options.emitMetrics ?? false;
     this.createTurnId = options.createTurnId ?? randomUUID;
     this.conversationId =
@@ -1158,18 +1171,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // turn-scoped — it waits for THIS turn only (captured at barge-in), not
         // the conversation's overall idle state, so the interrupting turn's own
         // work still proceeds in parallel (conversation.waitForIdle would block
-        // on it and defeat the background handoff). Bounded by the timeout; a
-        // stop landing during the wait aborts the controller, which surfaces as
-        // the rejection swallowed below and is re-checked before the fork.
+        // on it and defeat the background handoff).
         if (teardownWait) {
+          let settled = false;
           try {
-            await waitForPriorTurnTeardown(
+            settled = await waitForPriorTurnTeardown(
               teardownWait,
-              DETACH_TEARDOWN_SETTLE_TIMEOUT_MS,
+              this.detachTeardownSettleTimeoutMs,
               controller.signal,
             );
           } catch {
-            // Aborted mid-wait; the signal re-check below skips the fork.
+            // Aborted mid-wait (stop/interrupt); handled by the skip below.
+          }
+          // Fork only once the teardown has settled. On timeout (false) or
+          // abort (throw) we cannot guarantee the fork would see the interrupted
+          // turn's completed tool calls, so skip the continuation rather than
+          // snapshot stale history and risk repeating a side effect — the bridge
+          // refuses the next turn on an unsettled teardown for the same reason.
+          // The continuation is best-effort, so a rare dropped one is the safe
+          // trade.
+          if (!settled) {
+            return;
           }
         }
         if (controller.signal.aborted || this.isClosed) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -17,6 +17,7 @@ import type {
 } from "../calls/voice-session-bridge.js";
 import {
   getConversationTurnTeardown,
+  resolveProcessingWaitMs,
   VOICE_NO_SETUP_FLOWS_RULE,
   waitForPriorTurnTeardown,
 } from "../calls/voice-session-bridge.js";
@@ -215,8 +216,8 @@ export interface LiveVoiceSessionOptions {
   getTurnTeardown?: (conversationId: string) => Promise<void> | undefined;
   /**
    * Overrides the bounded wait for the interrupted turn's teardown before the
-   * background continuation forks (test hook). Defaults to
-   * `DETACH_TEARDOWN_SETTLE_TIMEOUT_MS`.
+   * background continuation forks (test hook). Defaults to the bridge's
+   * teardown budget (`resolveProcessingWaitMs`).
    */
   detachTeardownSettleTimeoutMs?: number;
 }
@@ -366,12 +367,18 @@ function buildDuplexContinuationObjective(interruptedRequest: string): string {
 
 // Upper bound on how long a barge-in waits for the interrupted turn's teardown
 // to settle before giving up on the continuation. The teardown settles once the
-// aborted turn's agent loop reaches its `finally` — bounded by the abort-unwind
-// watchdog plus the history/DB flush tail — so a cap just past the watchdog lets
-// a legitimately slow abort still fork, while a genuinely wedged teardown times
-// out. On timeout the fork is SKIPPED (not run against stale history); see
-// detachInterruptedTurn.
-const DETACH_TEARDOWN_SETTLE_TIMEOUT_MS = ABORT_WATCHDOG_MS + 1000;
+// aborted turn's agent loop reaches its `finally`, which can wait out BOTH the
+// abort-unwind watchdog and the turn-boundary commit — so bound the wait by the
+// same budget the bridge uses to wait for a prior turn's teardown
+// (resolveProcessingWaitMs). That lets a legitimately slow abort+commit still
+// fork, while a genuinely wedged teardown times out — and on timeout the fork is
+// SKIPPED (not run against stale history); see detachInterruptedTurn.
+function defaultDetachTeardownSettleTimeoutMs(): number {
+  return resolveProcessingWaitMs(
+    getConfig().workspaceGit?.turnCommitMaxWaitMs ?? 4000,
+    ABORT_WATCHDOG_MS,
+  );
+}
 
 export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly context: LiveVoiceSessionFactoryContext;
@@ -491,7 +498,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.getTurnTeardown = options.getTurnTeardown ?? null;
     this.detachTeardownSettleTimeoutMs =
       options.detachTeardownSettleTimeoutMs ??
-      DETACH_TEARDOWN_SETTLE_TIMEOUT_MS;
+      defaultDetachTeardownSettleTimeoutMs();
     this.emitMetrics = options.emitMetrics ?? false;
     this.createTurnId = options.createTurnId ?? randomUUID;
     this.conversationId =

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -15,7 +15,11 @@ import type {
   VoiceTurnHandle,
   VoiceTurnOptions,
 } from "../calls/voice-session-bridge.js";
-import { VOICE_NO_SETUP_FLOWS_RULE } from "../calls/voice-session-bridge.js";
+import {
+  getConversationTurnTeardown,
+  VOICE_NO_SETUP_FLOWS_RULE,
+  waitForPriorTurnTeardown,
+} from "../calls/voice-session-bridge.js";
 import {
   ESCALATION_CONTINUATION_CONTENT,
   ESCALATION_PROFILE,
@@ -199,6 +203,15 @@ export interface LiveVoiceSessionOptions {
    * SubagentManager-backed implementation; tests inject a stub.
    */
   spawnBackgroundContinuation?: LiveVoiceBackgroundContinuationSpawner;
+  /**
+   * Returns the pending teardown promise for a conversation's most recent
+   * turn. The barge-in path awaits it before forking the background
+   * continuation so the fork snapshots history only after the interrupted
+   * turn's completed tool calls have settled in. The factory wires the
+   * bridge's `getConversationTurnTeardown`; tests inject a controllable
+   * promise to exercise the ordering.
+   */
+  getTurnTeardown?: (conversationId: string) => Promise<void> | undefined;
 }
 
 type LiveVoiceUtterancePhase =
@@ -344,6 +357,13 @@ function buildDuplexContinuationObjective(interruptedRequest: string): string {
     : base;
 }
 
+// Upper bound on how long a barge-in waits for the interrupted turn's teardown
+// to settle before forking the continuation anyway. Teardown normally settles
+// in well under this; the cap keeps the fork from blocking indefinitely on a
+// stuck teardown (the continuation's "don't repeat finished tool calls"
+// objective is the backstop if the snapshot is ever slightly early).
+const DETACH_TEARDOWN_SETTLE_TIMEOUT_MS = 2000;
+
 export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly context: LiveVoiceSessionFactoryContext;
   private readonly resolveTranscriber: LiveVoiceStreamingTranscriberResolver;
@@ -352,6 +372,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly streamTtsAudio: LiveVoiceTtsStreamer | null;
   private readonly archiveAudio: LiveVoiceSessionAudioArchiver | null;
   private readonly spawnBackgroundContinuation: LiveVoiceBackgroundContinuationSpawner | null;
+  // Reads the interrupted turn's teardown promise so the barge-in path can wait
+  // for it to settle before forking the continuation (voice-duplex-handoff).
+  private readonly getTurnTeardown:
+    | ((conversationId: string) => Promise<void> | undefined)
+    | null;
   // Abort handles for background continuations started when a barge-in detached
   // an interrupted turn (voice-duplex-handoff). Each controller is registered
   // synchronously before its spawn, so interrupt()/close() abort a continuation
@@ -453,6 +478,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.archiveAudio = options.archiveAudio ?? null;
     this.spawnBackgroundContinuation =
       options.spawnBackgroundContinuation ?? null;
+    this.getTurnTeardown = options.getTurnTeardown ?? null;
     this.emitMetrics = options.emitMetrics ?? false;
     this.createTurnId = options.createTurnId ?? randomUUID;
     this.conversationId =
@@ -1060,6 +1086,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       interruptedRequest.length > 0 ? interruptedRequest : null;
     turn.abortController.abort();
     this.metrics.markBargeIn(turn.turnId);
+    // Capture the interrupted turn's teardown promise synchronously, before the
+    // barge-in utterance's own startVoiceTurn overwrites the bridge's
+    // per-conversation entry (that utterance is not transcribed yet, so its turn
+    // has not started — this read is race-free). The detach awaits it so the
+    // fork snapshots history only after this turn's completed tool calls have
+    // settled in (see detachInterruptedTurn).
+    const teardownWait = this.getTurnTeardown?.(this.conversationId);
     // Snapshot the stop generation before the async teardown: a stop that lands
     // during it must cancel the pending detach (checked in detachInterruptedTurn).
     const stopGeneration = this.detachStopGeneration;
@@ -1072,21 +1105,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       );
       await this.sendFrame({ type: "turn_cancelled", turnId: turn.turnId });
       await this.cancelAssistantTurn("barge_in");
-      // Teardown has settled, so the interrupted turn's partial is in history;
-      // keep its work alive on a background subagent (voice-duplex-handoff).
-      this.detachInterruptedTurn(turn, stopGeneration);
+      // Keep the interrupted turn's work alive on a background subagent
+      // (voice-duplex-handoff); the detach waits for its teardown to settle the
+      // partial into history before forking.
+      this.detachInterruptedTurn(turn, stopGeneration, teardownWait);
     })().catch(() => {});
   }
 
   // True-duplex handoff (voice-duplex-handoff): keep a barged-in turn's work
   // alive by continuing it on a background subagent instead of discarding it.
-  // Called after the barge-in teardown settles so the interrupted turn's
-  // partial (including any completed tool calls) is already in the conversation
-  // the subagent forks from. Resurfacing the subagent's result is a follow-up;
-  // for now it runs silently and a later stop/interrupt aborts it.
+  // Waits for the interrupted turn's bridge teardown (captured at barge-in) to
+  // settle before forking, so its partial — including any completed tool calls —
+  // is already in the conversation the subagent forks from and a side-effecting
+  // continuation cannot repeat a call the interrupted turn already ran.
+  // Resurfacing the subagent's result is a follow-up; for now it runs silently
+  // and a later stop/interrupt aborts it.
   private detachInterruptedTurn(
     turn: ActiveAssistantTurn,
     stopGeneration: number,
+    teardownWait: Promise<void> | undefined,
   ): void {
     const spawn = this.spawnBackgroundContinuation;
     if (
@@ -1114,13 +1151,37 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // controller.abort(), which the spawn's signal wiring honors).
     const controller = new AbortController();
     this.detachControllers.add(controller);
-    void spawn({
-      parentConversationId: this.conversationId,
-      objective: buildDuplexContinuationObjective(interruptedRequest),
-      label: `voice-continue-${turn.turnId}`,
-      signal: controller.signal,
-    })
-      .catch((err) => {
+    void (async () => {
+      try {
+        // Wait for the interrupted turn's teardown to settle its partial into
+        // conversation history before the fork snapshots it. This is
+        // turn-scoped — it waits for THIS turn only (captured at barge-in), not
+        // the conversation's overall idle state, so the interrupting turn's own
+        // work still proceeds in parallel (conversation.waitForIdle would block
+        // on it and defeat the background handoff). Bounded by the timeout; a
+        // stop landing during the wait aborts the controller, which surfaces as
+        // the rejection swallowed below and is re-checked before the fork.
+        if (teardownWait) {
+          try {
+            await waitForPriorTurnTeardown(
+              teardownWait,
+              DETACH_TEARDOWN_SETTLE_TIMEOUT_MS,
+              controller.signal,
+            );
+          } catch {
+            // Aborted mid-wait; the signal re-check below skips the fork.
+          }
+        }
+        if (controller.signal.aborted || this.isClosed) {
+          return;
+        }
+        await spawn({
+          parentConversationId: this.conversationId,
+          objective: buildDuplexContinuationObjective(interruptedRequest),
+          label: `voice-continue-${turn.turnId}`,
+          signal: controller.signal,
+        });
+      } catch (err) {
         // A stop/interrupt aborts via the signal; that rejection is expected.
         if (!controller.signal.aborted) {
           log.warn(
@@ -1128,10 +1189,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             "Voice duplex handoff continuation failed",
           );
         }
-      })
-      .finally(() => {
+      } finally {
         this.detachControllers.delete(controller);
-      });
+      }
+    })();
   }
 
   // Abort every background continuation this session started and drop its
@@ -2803,6 +2864,7 @@ export function createLiveVoiceSession(
         : options.streamTtsAudio,
     spawnBackgroundContinuation:
       options.spawnBackgroundContinuation ?? defaultSpawnBackgroundContinuation,
+    getTurnTeardown: options.getTurnTeardown ?? getConversationTurnTeardown,
     // Off by default (see the `liveVoice.archiveAudio` schema): voice turns
     // persist only their transcribed text, so the recorded audio never lands
     // as an attachment on the conversation messages. Enable via config for


### PR DESCRIPTION
## Summary
- On a live-voice barge-in, the true-duplex handoff (`voice-duplex-handoff`) now waits for the interrupted turn's bridge teardown to settle before forking the background continuation, so the fork snapshots conversation history only after that turn's completed tool calls have landed. A side-effecting continuation can no longer repeat a call the interrupted turn already ran (Codex finding #6 / P1 on #38308).
- The wait is **turn-scoped**: `getConversationTurnTeardown` is captured synchronously at barge-in (before the next utterance overwrites the bridge's per-conversation teardown entry) and awaited via the existing bounded `waitForPriorTurnTeardown` — it never blocks on the interrupting turn's own work the way `conversation.waitForIdle` would. Bounded by a 2s cap; a stop landing during the wait aborts the detach and skips the fork.
- Adds two regression tests (the fork waits for the teardown to settle; an interrupt during the wait skips the fork) via an injected `getTurnTeardown` seam.

## Original prompt
Follow-up to the merged detach-and-continue foundation (PR #38308, plan `.private/plans/voice-true-duplex-detach-resurface.md`, JARVIS-1249). That PR's review flagged a P1 partial-capture timing hole: the background continuation could fork before the interrupted turn's completed tool calls settled into history, risking double-execution of side effects. This is **PR 2** of the plan — the focused teardown-timing safety fix. Resurfacing the continuation's result to the user is deliberately left to PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
