### PR TITLE
feat(calls): wire Twilio mark echoes into the media-stream output drain tracker

### DIFF
--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -1630,15 +1630,43 @@ describe("MediaStreamOutput", () => {
       expect(resolved).toBe(true);
     });
 
-    test("a higher-seq echo also resolves a waiter", async () => {
+    test("a higher-seq echo (still within enqueued) resolves an earlier waiter", async () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
-      output.sendTextToken("", true);
+      output.sendTextToken("", true); // enqueues end-of-turn:1
       await drain(() => countEvents(sent, "mark") > 0);
 
-      const drained = output.awaitPlaybackDrained();
-      output.notePlaybackMarkEcho("end-of-turn:5");
+      const drained = output.awaitPlaybackDrained(); // targets seq 1
+      output.sendTextToken("", true); // enqueues end-of-turn:2
+      await drain(() => countEvents(sent, "mark") >= 2);
+
+      // Echoing seq 2 (which was enqueued) satisfies the seq-1 waiter too.
+      output.notePlaybackMarkEcho("end-of-turn:2");
       await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("ignores an echo for a seq beyond what was enqueued", async () => {
+      // A stale/forged future echo must not advance the high-water mark, or
+      // later real turns would drain immediately before their audio played.
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true); // enqueues end-of-turn:1
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      // Out-of-range echo before we ever queued seq 3 — ignored.
+      output.notePlaybackMarkEcho("end-of-turn:3");
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+      await drain();
+      expect(resolved).toBe(false); // seq-1 waiter still pending
+
+      // The genuine seq-1 echo resolves it.
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drain(() => resolved);
+      expect(resolved).toBe(true);
     });
 
     test("a stale lower-seq echo does not resolve a higher-seq waiter", async () => {

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -833,6 +833,27 @@ describe("MediaStreamCallSession", () => {
       session.handleMessage(makeMarkMessage("end-of-turn"));
     });
 
+    test("inbound mark echo is routed into the output drain tracker", () => {
+      const mock = createMockWs();
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      const noteEcho = jest.spyOn(session.getOutput(), "notePlaybackMarkEcho");
+
+      session.handleMessage(makeMarkMessage("end-of-turn:3"));
+
+      expect(noteEcho).toHaveBeenCalledWith("end-of-turn:3");
+    });
+
+    test("mark echo after disposal does not touch the output", () => {
+      const mock = createMockWs();
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      const noteEcho = jest.spyOn(session.getOutput(), "notePlaybackMarkEcho");
+
+      session.destroy();
+      session.handleMessage(makeMarkMessage("end-of-turn:3"));
+
+      expect(noteEcho).not.toHaveBeenCalled();
+    });
+
     test("stop events are forwarded to the STT session", () => {
       const mock = createMockWs();
       mockSessions.set("call-1", {

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -538,6 +538,10 @@ export class MediaStreamOutput implements CallTransport {
     if (!name.startsWith(`${END_OF_TURN_MARK_PREFIX}:`)) return;
     const seq = Number(name.slice(END_OF_TURN_MARK_PREFIX.length + 1));
     if (!Number.isFinite(seq)) return;
+    // Ignore echoes for marks we never enqueued (stale/forged/out-of-range).
+    // Accepting a future seq would advance the high-water mark and make later
+    // real turns' awaitPlaybackDrained() resolve before their audio played.
+    if (seq > this.enqueuedEndOfTurnSeq) return;
     if (seq > this.echoedEndOfTurnSeq) this.echoedEndOfTurnSeq = seq;
     this.resolveDrainWaiters();
   }

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -208,6 +208,7 @@ export class MediaStreamCallSession {
       onTranscriptFinal: (text, durationMs) =>
         this.handleTranscriptFinal(text, durationMs),
       onDtmf: (digit) => this.handleDtmf(digit),
+      onMark: (name) => this.handleMarkEcho(name),
       onStop: () => this.handleStreamStop(),
       onError: (category, message) => this.handleSttError(category, message),
     };
@@ -254,7 +255,9 @@ export class MediaStreamCallSession {
    * audio processing.
    */
   handleMessage(raw: string): void {
-    if (this.disposed) {return;}
+    if (this.disposed) {
+      return;
+    }
 
     // Intercept `start` to bootstrap the session before forwarding.
     const parseResult = parseMediaStreamFrame(raw);
@@ -277,7 +280,9 @@ export class MediaStreamCallSession {
    * in a terminal state.
    */
   handleTransportClosed(code?: number, reason?: string): void {
-    if (this.disposed) {return;}
+    if (this.disposed) {
+      return;
+    }
 
     // Tear down an in-flight setup flow first: clears its timers and emits
     // the guardian-wait callback handoff when the caller opted in.
@@ -286,7 +291,9 @@ export class MediaStreamCallSession {
     setupFlow?.dispose("transport_closed");
 
     const session = getCallSession(this.callSessionId);
-    if (!session) {return;}
+    if (!session) {
+      return;
+    }
     if (isTerminalState(session.status)) {
       // A hangup during a flow-terminal goodbye: dispose above swallowed the
       // flow's pending complete(), so finalize + revoke grants here. Normal
@@ -373,7 +380,9 @@ export class MediaStreamCallSession {
    * Dispose of the session, cleaning up all resources.
    */
   destroy(): void {
-    if (this.disposed) {return;}
+    if (this.disposed) {
+      return;
+    }
     this.disposed = true;
 
     this.sttSession.dispose();
@@ -427,7 +436,9 @@ export class MediaStreamCallSession {
         session.status !== "waiting_on_user"
       ) {
         updates.status = "in_progress";
-        if (!session.startedAt) {updates.startedAt = Date.now();}
+        if (!session.startedAt) {
+          updates.startedAt = Date.now();
+        }
       }
       updateCallSession(this.callSessionId, updates);
     }
@@ -750,9 +761,7 @@ export class MediaStreamCallSession {
     // end-of-turn mark it enqueues survives the queue flush.
     if (this.output && this.controller) {
       const output = this.output;
-      const accepted = this.controller.handleBargeIn(() =>
-        output.clearAudio(),
-      );
+      const accepted = this.controller.handleBargeIn(() => output.clearAudio());
       if (accepted) {
         this.bargeInAccepted++;
         log.info(
@@ -775,7 +784,9 @@ export class MediaStreamCallSession {
   }
 
   private handleTranscriptFinal(text: string, _durationMs: number): void {
-    if (!text.trim()) {return;}
+    if (!text.trim()) {
+      return;
+    }
 
     // Drop transcripts arriving while setup routing is still pending so a
     // not-yet-authorized / floor-denied caller's speech is never persisted
@@ -863,6 +874,15 @@ export class MediaStreamCallSession {
     // While a setup flow is active, digits feed its code-collection
     // sub-flows (the flow itself records no per-digit events).
     this.setupFlow?.pushDtmfDigit(digit);
+  }
+
+  private handleMarkEcho(name: string): void {
+    if (this.disposed) {
+      return;
+    }
+    // Twilio echoes each queued mark once its preceding audio has played
+    // out; forward to the output so drain waiters resolve on real playback.
+    this.output.notePlaybackMarkEcho(name);
   }
 
   private handleStreamStop(): void {


### PR DESCRIPTION
## Summary
- Wire the STT session's onMark callback to MediaStreamOutput.notePlaybackMarkEcho
- Drain waiters now resolve on real Twilio playback echoes during live calls

Part of plan: endcall-drain.md (PR 3 of 5)