### PR TITLE
fix(memory-v3): split dense_disabled out of dense_unavailable in gate telemetry

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -1103,13 +1103,13 @@ describe("orchestrate — injection gate", () => {
     expect(result.lanes.finder).toEqual([]);
   });
 
-  test("gate stays inert when the dense lane produced no hits (denseK = 0 new-user/outage case)", async () => {
+  test("gate stays inert when the dense lane is off (denseK = 0 new-user profile)", async () => {
     const lanes = await buildLanes();
-    // denseK: 0 leaves `densed` empty — the new-user profile, or any embedding
-    // outage. A low-score needle hit (norm ≈ 0.011) would CLOSE the gate if it
-    // ran on sparse signal alone, but zero dense hits means dense is
-    // unavailable, not low-relevance: the gate is dense-gated and never runs, so
-    // selection proceeds and memory is not suppressed.
+    // denseK: 0 leaves `densed` empty — the lean new-user profile. A low-score
+    // needle hit (norm ≈ 0.011) would CLOSE the gate if it ran on sparse signal
+    // alone, but zero dense hits means dense is unavailable, not low-relevance:
+    // the gate is dense-gated and never runs, so selection proceeds and memory
+    // is not suppressed.
     const needle = {
       query: () => [],
       queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
@@ -1153,6 +1153,11 @@ describe("orchestrate — injection gate", () => {
     expect(result.selections.map((s) => s.slug)).toContain("topic-a");
     // The stale deleted page never reaches the pool either.
     expect(lastPool).not.toContain("gone-page");
+    // The lane WAS enabled, so this reports as an outage, not as disabled.
+    expect(recordedGateEvents[0]!.detail).toMatchObject({
+      pass: true,
+      reason: "dense_unavailable",
+    });
   });
 
   test("bypassForCore: true on a closed gate selects the stable prefix only (no finder lines)", async () => {
@@ -1264,6 +1269,7 @@ describe("orchestrate — injection gate", () => {
     expect(event.detail).toMatchObject({
       pass: true,
       reason: "dense_pass",
+      scored: true,
       top_dense_score: 0.9,
     });
   });
@@ -1286,9 +1292,11 @@ describe("orchestrate — injection gate", () => {
     });
   });
 
-  test("the dense-unavailable pass-open records reason dense_unavailable", async () => {
+  test("denseK: 0 records reason dense_disabled, not dense_unavailable", async () => {
     const lanes = await buildLanes();
-    // denseK: 0 → no live dense hits → the gate passes open without scoring.
+    // denseK: 0 → the lane never ran → the gate passes open without scoring.
+    // Deliberate configuration (the lean new-user profile), so it must NOT be
+    // reported as an outage.
     const needle = {
       query: () => [],
       queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
@@ -1305,7 +1313,35 @@ describe("orchestrate — injection gate", () => {
     expect(recordedGateEvents).toHaveLength(1);
     expect(recordedGateEvents[0]!.detail).toMatchObject({
       pass: true,
+      reason: "dense_disabled",
+      scored: false,
+    });
+  });
+
+  test("an enabled dense lane yielding no live hits records reason dense_unavailable", async () => {
+    const lanes = await buildLanes();
+    // denseK > 0 but the lane came back empty — a degraded embedding backend or
+    // a Qdrant error swallowed to [] by denseLaneScored. Dense SHOULD have
+    // scored this turn and didn't, so this is the alertable reason.
+    denseHits = [];
+    const needle = {
+      query: () => [],
+      queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
+      bestSection: () => -1,
+      idf: () => 0,
+    };
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { needle, denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(recordedGateEvents).toHaveLength(1);
+    expect(recordedGateEvents[0]!.detail).toMatchObject({
+      pass: true,
       reason: "dense_unavailable",
+      scored: false,
     });
   });
 

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -91,7 +91,15 @@ export const MEMORY_V3_INJECTION_GATE_CHECK_NAME = "memory_v3_injection_gate";
 /** Record one injection-gate run to usage telemetry. `detail` keys are the
  *  platform-side contract (snake_case, scores and reason codes only — never
  *  conversation content). Never throws: the gate is pass-open by design, and a
- *  telemetry failure must not cost the turn its memory either. */
+ *  telemetry failure must not cost the turn its memory either.
+ *
+ *  `detail.scored` says whether checkV3Gate actually weighed scores this run, as
+ *  opposed to the run taking a pass-open shortcut (dense off, dense unavailable,
+ *  gate threw). Pass rate is only meaningful over scored runs — the shortcuts are
+ *  all unconditional passes and would otherwise inflate it. It is derivable from
+ *  `reason`, but the daemon owns the reason set and adds to it freely, so it is
+ *  reported explicitly rather than left for the platform to re-derive from a
+ *  hardcoded list that would silently miscount the next reason we add. */
 function recordGateRun(detail: Record<string, unknown>): void {
   try {
     recordWatchdogEvent({
@@ -430,29 +438,39 @@ export async function orchestrate(
   //
   // The gate is dense-gated: it only runs when the live dense lane produced hits
   // (`liveDensed.length > 0`). In healthy operation dense returns top-k hits for
-  // any query, so zero live dense hits means dense is unavailable — denseK=0 (the
-  // new-user/small-corpus profile), a degraded embedding backend, a Qdrant error
-  // (`denseLaneScored` swallows these to `[]`), or only stale deleted-page points
-  // returned — NOT low relevance. checkV3Gate reads only finder scores and cannot
-  // tell those apart, so without live dense signal we pass open rather than
-  // suppress all memory (not even the core/hot/fresh prefix) on every
-  // lexically-weak turn.
+  // any query, so zero live dense hits means dense is unavailable, NOT low
+  // relevance. checkV3Gate reads only finder scores and cannot tell those apart,
+  // so without live dense signal we pass open rather than suppress all memory
+  // (not even the core/hot/fresh prefix) on every lexically-weak turn.
+  //
+  // Two very different situations reach that pass-open, and they carry distinct
+  // reason codes because only one of them is a problem:
+  //   - dense_disabled:    `denseK === 0`, so the lane never ran. The lean
+  //                        new-user profile (`MEMORY_V3_NEW_USER_TUNING`) sets it
+  //                        for sub-threshold corpora, and that same profile sets
+  //                        `selectorEnabled: false` — so there is no selectPool
+  //                        call for the gate to save and passing open is free.
+  //                        Expected, benign, and the bulk of gate runs.
+  //   - dense_unavailable: the lane ran and yielded nothing live — a degraded
+  //                        embedding backend, a Qdrant error (`denseLaneScored`
+  //                        swallows these to `[]`), or only stale deleted-page
+  //                        points. Dense SHOULD have scored this turn and did
+  //                        not, so this one is worth alerting on.
   if (deps.gateConfig?.enabled) {
     if (liveDensed.length === 0) {
-      // No live dense hits (denseK=0 / degraded backend / Qdrant error swallowed
-      // to [] / only stale deleted-page points returned). That means dense is
-      // unavailable, not low relevance, so pass open — but record it so rollout
-      // telemetry sees these turns instead of silently skipping the gate.
+      const reason = denseEnabled ? "dense_unavailable" : "dense_disabled";
       log.info(
         {
           conversationId: turn.conversationId,
           turnNumber: turn.turnNumber,
-          reason: "dense_unavailable",
+          reason,
           pass: true,
         },
-        "memory-v3 injection gate: dense lane unavailable, passing open",
+        denseEnabled
+          ? "memory-v3 injection gate: dense lane unavailable, passing open"
+          : "memory-v3 injection gate: dense lane disabled, passing open",
       );
-      recordGateRun({ pass: true, reason: "dense_unavailable" });
+      recordGateRun({ pass: true, reason, scored: false });
     } else {
       let gate: V3GateResult | null = null;
       try {
@@ -469,7 +487,7 @@ export async function orchestrate(
           },
           "memory-v3 injection gate threw; passing open (proceeding with selection)",
         );
-        recordGateRun({ pass: true, reason: "gate_error" });
+        recordGateRun({ pass: true, reason: "gate_error", scored: false });
       }
       if (gate) {
         log.info(
@@ -483,6 +501,7 @@ export async function orchestrate(
         recordGateRun({
           pass: gate.pass,
           reason: gate.reason,
+          scored: true,
           top_dense_score: gate.topDenseScore,
           top_norm_sparse_score: gate.topNormSparseScore,
           checked_articles: gate.checkedArticles,


### PR DESCRIPTION
## What

The injection gate's dense-gated pass-open recorded **one reason for four causes**. Split it into two, and report whether the gate actually scored the run.

**No runtime behavior change** — every path that passed open still passes open, with identical orchestration. This is observability only.

## Why

`dense_unavailable` is 65.5% of all gate runs on the admin Memory dashboard, across 1,004 of 1,044 assistants. That reads like a catastrophic dense-retrieval outage. It isn't.

The dominant cause is benign: the lean new-user profile (`MEMORY_V3_NEW_USER_TUNING`) sets `denseK: 0` below `MEMORY_V3_FULL_PROFILE_MIN_PAGES` (10 real concept pages), so the dense lane never runs. That same profile sets `selectorEnabled: false`, so there is no `selectPool` call for the gate to save and passing open costs nothing. Most assistants simply haven't accumulated 10 concept pages yet.

That benign case was drowning out the three causes that *are* problems and share the branch: a degraded embedding backend, a Qdrant error swallowed to `[]` by `denseLaneScored`, or only stale deleted-page points. A real embedding outage today is invisible inside a number you'd correctly dismiss as "that's just new users."

- `dense_disabled` — the lane never ran. Expected, benign, the bulk of runs.
- `dense_unavailable` — the lane ran and yielded nothing live. **Worth alerting on.**

## `detail.scored`

Also records whether `checkV3Gate` actually weighed scores, as opposed to taking a pass-open shortcut. The shortcuts are all unconditional passes, so counting them inflated the dashboard's pass rate to **92.6%** where the rate over real decisions is **~79%** (5,995 of 7,617 scored runs).

It's derivable from `reason`, but reported explicitly: the daemon owns the reason set and adds to it freely, so a hardcoded list in BigQuery would silently miscount the next reason we add.

## Platform side

vellum-ai/vellum-assistant-platform#9206 consumes both fields. **No deploy-ordering constraint** — the platform query falls back to the old reason codes for rows predating `scored`, so either can ship first and ~10 days of history reclassify correctly.

## Testing

`bun test` on `orchestrate.test.ts` (49), `gate.test.ts` + `gate-flag.test.ts` (14); `tsc --noEmit` clean.

The pre-existing `dense_unavailable` telemetry test was actually exercising `denseK: 0` — the *disabled* path — so it now asserts `dense_disabled`. Added a genuine outage test (`denseK: 100`, empty lane) that nothing covered before, and pinned the reason on the stale-deleted-page test, which is the second route into `dense_unavailable`.

## Note for reviewers

History won't retroactively split — pre-deploy runs stay merged under `dense_unavailable`, so expect a step change at cutover rather than a reclassification. Don't read the drop as an incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)