### PR TITLE
fix(voice): echo-adaptive barge-in — loud speaker echo no longer self-interrupts (JARVIS-1296)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -124,6 +124,7 @@ function createHarness(options: {
   speechEnergyThreshold?: number;
   bargeInMinSpeechMs?: number;
   echoEmaHalfLifeMs?: number;
+  echoBargeInMargin?: number;
   emitMetrics?: boolean;
   metricsClock?: () => number;
   // Return a promise to hold a frame's transport write open (a backed-up
@@ -187,6 +188,7 @@ function createHarness(options: {
     speechEnergyThreshold: options.speechEnergyThreshold,
     bargeInMinSpeechMs: options.bargeInMinSpeechMs,
     echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
+    echoBargeInMargin: options.echoBargeInMargin,
     ...(options.spawnBackgroundContinuation
       ? { spawnBackgroundContinuation: options.spawnBackgroundContinuation }
       : {}),
@@ -1805,6 +1807,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   function createSpeakingTurnHarness(options: {
     bargeInMinSpeechMs: number;
     echoEmaHalfLifeMs?: number;
+    echoBargeInMargin?: number;
     finals?: string[];
     startFrame?: LiveVoiceClientStartFrame;
   }) {
@@ -1824,6 +1827,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       streamTtsAudio,
       bargeInMinSpeechMs: options.bargeInMinSpeechMs,
       echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
+      echoBargeInMargin: options.echoBargeInMargin,
       turnDetectorConfig: { silenceThresholdMs: 5_000 },
       ...(options.startFrame ? { startFrame: options.startFrame } : {}),
     });
@@ -1883,8 +1887,15 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   });
 
   test("sustained speech reaching the guard flushes playback and cancels the turn", async () => {
+    // Tiny margin + half-life neutralize the echo-adaptive gate (threshold
+    // pinned to the 800 floor, warm-up over after one chunk) so this test
+    // isolates the guard's accumulation mechanics.
     const { frames, session, abort, speakFirstReply } =
-      createSpeakingTurnHarness({ bargeInMinSpeechMs: 60 });
+      createSpeakingTurnHarness({
+        bargeInMinSpeechMs: 60,
+        echoBargeInMargin: 0.001,
+        echoEmaHalfLifeMs: 4,
+      });
     await speakFirstReply();
 
     // 50 ms of consecutive speech: one chunk short of the 60 ms guard.
@@ -1915,8 +1926,11 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   });
 
   test("a non-speech chunk resets the sustained-speech run", async () => {
+    // Tiny margin + half-life neutralize the echo-adaptive gate — see above.
     const { frames, session, speakFirstReply } = createSpeakingTurnHarness({
       bargeInMinSpeechMs: 60,
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
     });
     await speakFirstReply();
 
@@ -1994,6 +2008,11 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       startVoiceTurn,
       streamTtsAudio,
       bargeInMinSpeechMs: 60,
+      // Tiny margin + half-life neutralize the echo-adaptive gate (threshold
+      // pinned to the floor, warm-up over after one chunk) so this test
+      // isolates the guard's playback-tail coverage.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       turnDetectorConfig: { silenceThresholdMs: 5_000 },
     });
 
@@ -2073,6 +2092,32 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       // before the guard arms; every later chunk sits under 1.5 × EMA and
       // classifies as silence, so the guard never accumulates.
       for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("abrupt loud echo at playback onset is absorbed by the warm-up, not fired as barge-in", async () => {
+      // Cold-start case: steady loud echo from the very first in-window
+      // chunk. The onset chunk arms the guard, but the warm-up (half-life/2
+      // = 20 ms of audio here) keeps the reference learning at the fast
+      // attack rate despite the armed guard, so it overtakes the echo and
+      // zeroes the run before the 60 ms guard can trip — no deferred trip
+      // ever fires. Mirrors 250 ms guard vs 200 ms warm-up at the 400 ms
+      // production half-life.
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      for (let index = 0; index < 30; index += 1) {
         await session.handleBinaryAudio(pcm(3_000));
       }
       await flushAsyncCallbacks();
@@ -2182,19 +2227,21 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       });
       await speakFirstReply();
 
-      // The onset chunk arms the guard and freezes the reference at
-      // EMA 2250 (threshold 3375).
-      await session.handleBinaryAudio(pcm(3_000));
-      // 100 ms at 3300 sits under the frozen threshold (silence). Were the
-      // EMA still tracking, it would converge to ~3300 and lift the
-      // threshold to ~4950 — swallowing the 4000 override below.
+      // The onset chunk arms the guard and seeds the reference during the
+      // single-chunk warm-up (fast attack converges EMA to ~2400, threshold
+      // ~3600); the warm-up then ends and the reference freezes while the
+      // guard stays armed.
+      await session.handleBinaryAudio(pcm(2_400));
+      // 100 ms at 3300 sits under the frozen ~3600 threshold (silence).
+      // Were the EMA still tracking, it would converge to ~3300 and lift
+      // the threshold to ~4950 — swallowing the 4000 override below.
       for (let index = 0; index < 10; index += 1) {
         await session.handleBinaryAudio(pcm(3_300));
       }
       await flushAsyncCallbacks();
       expect(countType(frames, "turn_cancelled")).toBe(0);
 
-      // 4000 clears the frozen 3375 threshold and sustains past the guard —
+      // 4000 clears the frozen ~3600 threshold and sustains past the guard —
       // the reference did not move while the guard was armed.
       for (let index = 0; index < 7; index += 1) {
         await session.handleBinaryAudio(pcm(4_000));

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -123,6 +123,7 @@ function createHarness(options: {
   turnDetectorConfig?: TurnDetectorConfig;
   speechEnergyThreshold?: number;
   bargeInMinSpeechMs?: number;
+  echoEmaHalfLifeMs?: number;
   emitMetrics?: boolean;
   metricsClock?: () => number;
   // Return a promise to hold a frame's transport write open (a backed-up
@@ -185,6 +186,7 @@ function createHarness(options: {
       (options.viaFactory ? undefined : { silenceThresholdMs: 40 }),
     speechEnergyThreshold: options.speechEnergyThreshold,
     bargeInMinSpeechMs: options.bargeInMinSpeechMs,
+    echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
     ...(options.spawnBackgroundContinuation
       ? { spawnBackgroundContinuation: options.spawnBackgroundContinuation }
       : {}),
@@ -1802,6 +1804,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   // detector timers stay out of the guard's audio-duration accounting.
   function createSpeakingTurnHarness(options: {
     bargeInMinSpeechMs: number;
+    echoEmaHalfLifeMs?: number;
     finals?: string[];
     startFrame?: LiveVoiceClientStartFrame;
   }) {
@@ -1820,6 +1823,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       startVoiceTurn,
       streamTtsAudio,
       bargeInMinSpeechMs: options.bargeInMinSpeechMs,
+      echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
       turnDetectorConfig: { silenceThresholdMs: 5_000 },
       ...(options.startFrame ? { startFrame: options.startFrame } : {}),
     });
@@ -2045,5 +2049,159 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       frames.find((frame) => frame.type === "turn_cancelled"),
     ).toMatchObject({ type: "turn_cancelled", turnId: "live-turn-1" });
     await waitFor(() => abort.mock.calls.length === 1);
+  });
+
+  // JARVIS-1296: while assistant audio is playing, a chunk only counts as
+  // speech above max(speechEnergyThreshold, echoBargeInMargin × echo EMA), so
+  // loud TTS echo leaking through imperfect client echo cancellation cannot
+  // self-interrupt the reply, while a user talking over it still can. Tests
+  // compress echoEmaHalfLifeMs to 5 ms so one 10 ms echo chunk converges the
+  // EMA far enough (alpha 0.75 → EMA 2250 for a 3000 chunk, threshold 3375
+  // at the default 1.5 margin) that steady echo sits under its own margin.
+  describe("echo-adaptive gate", () => {
+    test("steady loud echo during playback never fires speech_started or cancels the turn", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 5,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // 400 ms of steady synthetic echo at 3000 — well above the 800 floor
+      // and far past the 60 ms guard. The onset chunk folds into the EMA
+      // before the guard arms; every later chunk sits under 1.5 × EMA and
+      // classifies as silence, so the guard never accumulates.
+      for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("sustained speech above the echo margin still barges in", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 5,
+        });
+      await speakFirstReply();
+
+      // Steady echo at 3000 converges the reference (suppressed, as above).
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // The user talks over the echo: 6000 clears the 3375 threshold and
+      // sustains past the guard, so the deferred speech_started flushes
+      // playback and the turn cancels.
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(6_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      expect(
+        frames.find((frame) => frame.type === "turn_cancelled"),
+      ).toMatchObject({ type: "turn_cancelled", turnId: "live-turn-1" });
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("a thinking (pre-TTS) turn keeps base-threshold barge-in sensitivity", async () => {
+      const abort = mock();
+      const startVoiceTurn = mock(async () => ({
+        turnId: "bridge-turn",
+        abort,
+      }));
+      const { frames, session } = createHarness({
+        finals: ["what's the weather", "actually never mind"],
+        startVoiceTurn,
+        bargeInMinSpeechMs: 60,
+        echoEmaHalfLifeMs: 5,
+        turnDetectorConfig: { silenceThresholdMs: 5_000 },
+      });
+      await session.start();
+      await session.handleBinaryAudio(LOUD_CHUNK);
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+      // No assistant audio is playing yet, so the echo gate is inert: 70 ms
+      // at 3000 clears the 800 floor and cancels the thinking turn exactly
+      // as without the gate (JARVIS-1266 feel unchanged).
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("the echo reference resets when the window closes", async () => {
+      const { frames, session, speakFirstReply, completeFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 5,
+          finals: ["what's the weather", "   "],
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // Sub-floor echo at 790 converges the reference without ever arming
+      // the guard; amplitude-1000 chunks then sit under 1.5 × EMA (~1180)
+      // and stay classified as silence while the reply is playing.
+      for (let index = 0; index < 4; index += 1) {
+        await session.handleBinaryAudio(pcm(790));
+      }
+      for (let index = 0; index < 3; index += 1) {
+        await session.handleBinaryAudio(pcm(1_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "speech_started")).toBe(baseline);
+
+      // The reply completes and the tiny playback tail drains: the echo
+      // window closes and the reference resets.
+      completeFirstReply();
+      await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+      // The same amplitude-1000 chunk is speech immediately at the 800
+      // floor — a stale reference would have swallowed it.
+      await session.handleBinaryAudio(pcm(1_000));
+      await waitFor(() => countType(frames, "speech_started") === baseline + 1);
+    });
+
+    test("the echo reference freezes while the barge-in guard is armed", async () => {
+      const { frames, session, speakFirstReply } = createSpeakingTurnHarness({
+        bargeInMinSpeechMs: 60,
+        echoEmaHalfLifeMs: 5,
+      });
+      await speakFirstReply();
+
+      // The onset chunk arms the guard and freezes the reference at
+      // EMA 2250 (threshold 3375).
+      await session.handleBinaryAudio(pcm(3_000));
+      // 100 ms at 3300 sits under the frozen threshold (silence). Were the
+      // EMA still tracking, it would converge to ~3300 and lift the
+      // threshold to ~4950 — swallowing the 4000 override below.
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(pcm(3_300));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // 4000 clears the frozen 3375 threshold and sustains past the guard —
+      // the reference did not move while the guard was armed.
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(4_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+    });
   });
 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -36,7 +36,10 @@ import {
 } from "../providers/speech-to-text/provider-catalog.js";
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
 import { publishConversationListAndMetadataChanged } from "../runtime/sync/resource-sync-events.js";
-import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
+import {
+  DEFAULT_SPEECH_ENERGY_THRESHOLD,
+  pcm16MeanAmplitude,
+} from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
   SttStreamServerErrorEvent,
@@ -103,6 +106,10 @@ const FINALIZE_GRACE_MS = 1_000;
 // liveVoice.vad.bargeInMinSpeechMs schema default; 0 disables the guard for
 // instant barge-in.
 const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
+// Echo-adaptive gate knobs (see effectiveSpeechThreshold). Mirror the
+// liveVoice.vad.echoBargeInMargin / echoEmaHalfLifeMs schema defaults.
+const DEFAULT_ECHO_BARGE_IN_MARGIN = 1.5;
+const DEFAULT_ECHO_EMA_HALF_LIFE_MS = 400;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one
 // prefetching job. The prefetch buffers its chunks in memory until promoted;
@@ -188,6 +195,21 @@ export interface LiveVoiceSessionOptions {
    * defaults to `DEFAULT_BARGE_IN_MIN_SPEECH_MS`.
    */
   bargeInMinSpeechMs?: number;
+  /**
+   * Overrides the echo-adaptive gate's margin: the multiplier over the
+   * observed echo-energy EMA that a server-VAD chunk must exceed to count
+   * as speech while assistant audio is playing. The production factory
+   * seeds this from `liveVoice.vad.echoBargeInMargin` config when unset;
+   * defaults to `DEFAULT_ECHO_BARGE_IN_MARGIN`.
+   */
+  echoBargeInMargin?: number;
+  /**
+   * Overrides the half-life (ms) of the echo-energy EMA tracked while
+   * assistant audio is playing. The production factory seeds this from
+   * `liveVoice.vad.echoEmaHalfLifeMs` config when unset; defaults to
+   * `DEFAULT_ECHO_EMA_HALF_LIFE_MS`.
+   */
+  echoEmaHalfLifeMs?: number;
   /**
    * Overrides the bounded wait for the shared transcriber's finalize
    * flush in persistent mode (test hook). Defaults to `FINALIZE_GRACE_MS`.
@@ -372,9 +394,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private sessionEndMetricsEmitted = false;
   // Non-null iff the start frame requested turnDetection "server_vad".
   private readonly turnDetector: MediaTurnDetector | null;
-  // Energy gate for server-VAD speech classification; undefined defers to
-  // DEFAULT_SPEECH_ENERGY_THRESHOLD.
+  // Base energy gate for server-VAD speech classification; undefined defers
+  // to DEFAULT_SPEECH_ENERGY_THRESHOLD. While assistant audio is playing the
+  // effective gate is echo-adaptive (see effectiveSpeechThreshold).
   private readonly speechEnergyThreshold: number | undefined;
+  // Echo-adaptive gate knobs (see effectiveSpeechThreshold): margin over the
+  // echo-energy EMA a chunk must exceed to count as speech during assistant
+  // playback, and that EMA's half-life.
+  private readonly echoBargeInMargin: number;
+  private readonly echoEmaHalfLifeMs: number;
+  // EMA of observed mic-chunk energy while assistant audio is playing (the
+  // echo reference); 0 outside the echo window.
+  private echoEnergyEma = 0;
   // Mutable so a mid-session `update_config` frame can retune "interrupt
   // sensitivity" live (see applyConfigUpdate).
   private bargeInMinSpeechMs: number;
@@ -471,6 +502,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       context.startFrame.bargeInMinSpeechMs ??
       options.bargeInMinSpeechMs ??
       DEFAULT_BARGE_IN_MIN_SPEECH_MS;
+    this.echoBargeInMargin =
+      options.echoBargeInMargin ?? DEFAULT_ECHO_BARGE_IN_MARGIN;
+    this.echoEmaHalfLifeMs =
+      options.echoEmaHalfLifeMs ?? DEFAULT_ECHO_EMA_HALF_LIFE_MS;
     this.finalizeGraceMs = options.finalizeGraceMs ?? FINALIZE_GRACE_MS;
     const turnDetectorConfig: TurnDetectorConfig = {
       ...(options.turnDetectorConfig ?? {}),
@@ -826,10 +861,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
-    const hasSpeech = detectPcm16SpeechActivity(
-      chunk,
-      this.speechEnergyThreshold,
-    );
+    const meanAmplitude = pcm16MeanAmplitude(chunk);
+    const hasSpeech =
+      meanAmplitude > this.effectiveSpeechThreshold(chunk, meanAmplitude);
     detector.onMediaChunk(hasSpeech);
     this.trackBargeInGuard(hasSpeech, chunk);
 
@@ -870,6 +904,60 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       await this.routeVadAudio(utterance, preRollChunk);
     }
     await this.routeVadAudio(utterance, chunk);
+  }
+
+  // The echo window: the only time the speakers can be emitting assistant
+  // audio — a turn that has audibly started speaking, or the post-tts_done
+  // drain tail the client is still playing. A thinking (pre-TTS) turn plays
+  // nothing, so it keeps base-threshold sensitivity and pre-TTS barge-in
+  // (JARVIS-1266) is unaffected.
+  private isAssistantAudioPlaying(): boolean {
+    const turn = this.activeAssistantTurn;
+    if (turn?.ttsAudioStarted && !turn.finalized) {
+      return true;
+    }
+    return Date.now() < this.assistantPlaybackTailUntilMs;
+  }
+
+  // Energy gate for classifying a server-VAD chunk as speech. While assistant
+  // audio is playing, the mic hears the assistant's own TTS through imperfect
+  // client echo cancellation, and at high speaker volume that echo exceeds
+  // any fixed threshold — no constant separates loud echo from speech. What
+  // does separate them: genuine user speech adds energy on top of the echo
+  // the mic is already hearing. So during playback the gate tracks an EMA of
+  // observed chunk energy (the echo reference) and only counts a chunk as
+  // speech above echoBargeInMargin × that reference (never below the base
+  // threshold). Steady echo converges into the EMA and cannot clear its own
+  // margin; a user talking over it still does. The EMA freezes while the
+  // sustained-speech guard is armed — the user's own accumulating speech must
+  // not inflate the reference against them — and resets outside the echo
+  // window so a loud turn's reference never leaks into the next one.
+  private effectiveSpeechThreshold(
+    chunk: Buffer,
+    meanAmplitude: number,
+  ): number {
+    const baseThreshold =
+      this.speechEnergyThreshold ?? DEFAULT_SPEECH_ENERGY_THRESHOLD;
+    if (!this.isAssistantAudioPlaying()) {
+      this.echoEnergyEma = 0;
+      return baseThreshold;
+    }
+    // Judge the chunk against the reference as it stood before the chunk
+    // arrived — a chunk must not raise the bar it is judged against.
+    const threshold = Math.max(
+      baseThreshold,
+      this.echoBargeInMargin * this.echoEnergyEma,
+    );
+    if (this.pendingBargeIn === null) {
+      const chunkMs = pcm16DurationMs(
+        chunk.byteLength,
+        this.context.startFrame.audio.sampleRate,
+      );
+      const alpha = 1 - 0.5 ** (chunkMs / this.echoEmaHalfLifeMs);
+      this.echoEnergyEma =
+        alpha * meanAmplitude + (1 - alpha) * this.echoEnergyEma;
+    }
+    return threshold;
   }
 
   private async routeVadAudio(
@@ -2792,6 +2880,10 @@ export function createLiveVoiceSession(
       options.speechEnergyThreshold ?? vadConfig?.speechEnergyThreshold,
     bargeInMinSpeechMs:
       options.bargeInMinSpeechMs ?? vadConfig?.bargeInMinSpeechMs,
+    echoBargeInMargin:
+      options.echoBargeInMargin ?? vadConfig?.echoBargeInMargin,
+    echoEmaHalfLifeMs:
+      options.echoEmaHalfLifeMs ?? vadConfig?.echoEmaHalfLifeMs,
     resolveCredentialReadiness:
       options.resolveCredentialReadiness === undefined
         ? defaultResolveLiveVoiceCredentialReadiness

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -406,6 +406,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // EMA of observed mic-chunk energy while assistant audio is playing (the
   // echo reference); 0 outside the echo window.
   private echoEnergyEma = 0;
+  // Audio time (ms) processed since the echo window opened — drives the
+  // gate's warm-up (see isEchoGateWarmingUp); 0 outside the echo window.
+  private echoWindowAudioMs = 0;
+  // True when the sustained-speech guard was already armed at the moment the
+  // echo window opened: speech that PREDATES playback is the user talking
+  // across the turn boundary (turn collision), not echo — humans cannot
+  // react to playback onset faster than the warm-up. That guard keeps
+  // user-first semantics (frozen reference, normal trips).
+  private echoWindowGuardCarryover = false;
   // Mutable so a mid-session `update_config` frame can retune "interrupt
   // sensitivity" live (see applyConfigUpdate).
   private bargeInMinSpeechMs: number;
@@ -932,6 +941,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // sustained-speech guard is armed — the user's own accumulating speech must
   // not inflate the reference against them — and resets outside the echo
   // window so a loud turn's reference never leaks into the next one.
+  //
+  // The freeze has a cold-start hole: at playback onset the very first loud
+  // echo chunk arms the guard, which would freeze the reference near zero and
+  // let steady onset echo complete a full guard run against the base
+  // threshold. So the window opens with a WARM-UP — the first
+  // echoEmaHalfLifeMs / 2 of in-window audio (200 ms at the 400 ms default) —
+  // during which the EMA learns at a fast attack rate (quarter half-life)
+  // and keeps learning even with the guard armed: echo, not speech, is the
+  // expected first signal at TTS onset. Guard trips are deferred (the run
+  // accumulates, it doesn't fire) until warm; at the default 250 ms trip the
+  // warm-up ends first, so real barge-in latency is untouched. Steady onset
+  // echo converges past its own margin inside the warm-up and its run is
+  // zeroed before it can fire. Warm-up is measured in processed audio time,
+  // the same clock that drives EMA convergence.
   private effectiveSpeechThreshold(
     chunk: Buffer,
     meanAmplitude: number,
@@ -940,7 +963,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.speechEnergyThreshold ?? DEFAULT_SPEECH_ENERGY_THRESHOLD;
     if (!this.isAssistantAudioPlaying()) {
       this.echoEnergyEma = 0;
+      this.echoWindowAudioMs = 0;
+      this.echoWindowGuardCarryover = false;
       return baseThreshold;
+    }
+    if (this.echoWindowAudioMs === 0) {
+      // Window opening: a guard armed before any assistant audio played is
+      // the user mid-utterance (turn collision), not echo.
+      this.echoWindowGuardCarryover = this.pendingBargeIn !== null;
+    } else if (this.pendingBargeIn === null) {
+      // The carried-over guard settled; onset semantics resume for any
+      // later speech in this window.
+      this.echoWindowGuardCarryover = false;
     }
     // Judge the chunk against the reference as it stood before the chunk
     // arrived — a chunk must not raise the bar it is judged against.
@@ -948,16 +982,44 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       baseThreshold,
       this.echoBargeInMargin * this.echoEnergyEma,
     );
-    if (this.pendingBargeIn === null) {
-      const chunkMs = pcm16DurationMs(
-        chunk.byteLength,
-        this.context.startFrame.audio.sampleRate,
-      );
-      const alpha = 1 - 0.5 ** (chunkMs / this.echoEmaHalfLifeMs);
+    const chunkMs = pcm16DurationMs(
+      chunk.byteLength,
+      this.context.startFrame.audio.sampleRate,
+    );
+    const warmingUp = this.echoOnsetWarmupActive();
+    if (this.pendingBargeIn === null || warmingUp) {
+      // Attack fast during warm-up (quarter half-life) so the reference
+      // overtakes steady onset echo inside the warm-up window; settle to the
+      // configured half-life afterwards for stability against transients.
+      const halfLifeMs = warmingUp
+        ? this.echoEmaHalfLifeMs / 4
+        : this.echoEmaHalfLifeMs;
+      const alpha = 1 - 0.5 ** (chunkMs / halfLifeMs);
       this.echoEnergyEma =
         alpha * meanAmplitude + (1 - alpha) * this.echoEnergyEma;
     }
+    this.echoWindowAudioMs += chunkMs;
     return threshold;
+  }
+
+  // True while the echo window has processed less than echoEmaHalfLifeMs / 2
+  // of audio (200 ms at the 400 ms default) — with the warm-up's quarter-
+  // half-life attack rate that is 2 attack half-lives, enough for the
+  // reference to reach ~75% of a steady echo level, putting margin × EMA
+  // above it. See effectiveSpeechThreshold.
+  private isEchoGateWarmingUp(): boolean {
+    return (
+      this.isAssistantAudioPlaying() &&
+      this.echoWindowAudioMs < this.echoEmaHalfLifeMs / 2
+    );
+  }
+
+  // Onset-echo semantics (fast unfrozen EMA learning + deferred guard trips)
+  // apply only during the warm-up AND when the speech run did not predate
+  // playback — a guard carried across the window boundary is the user, and
+  // keeps user-first semantics.
+  private echoOnsetWarmupActive(): boolean {
+    return !this.echoWindowGuardCarryover && this.isEchoGateWarmingUp();
   }
 
   private async routeVadAudio(
@@ -1122,6 +1184,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.context.startFrame.audio.sampleRate,
     );
     if (guard.speechMs < this.bargeInMinSpeechMs) {
+      return;
+    }
+    // Defer trips while the echo gate's onset warm-up is active (see
+    // effectiveSpeechThreshold): the run keeps accumulating, and a genuine
+    // user run fires on the first speech chunk after warm-up, while onset
+    // echo's run is zeroed once the converged reference reclassifies it. A
+    // guard carried over from before playback started (turn collision) is
+    // the user and trips normally.
+    if (this.echoOnsetWarmupActive()) {
       return;
     }
     this.pendingBargeIn = null;


### PR DESCRIPTION
## Summary
- While assistant audio is playing (TTS streaming or the post-tts_done drain tail), mic chunks count as speech only above max(speechEnergyThreshold, echoBargeInMargin × echo EMA) — steady speaker echo converges into the EMA and can never clear its own margin, so it cannot self-interrupt at any volume
- Genuine user speech stacks on top of the echo and still barges in; thinking-phase and listening sensitivity are unchanged (no audio playing → no echo → base threshold)
- EMA freezes while the 250ms sustained-speech guard is armed and resets when the echo window closes

Part of plan: echo-adaptive-bargein.md (PR 2 of 2)

Closes JARVIS-1296