### PR TITLE
docs(web): present-tense the privacy-screen preview test comment

### DIFF
--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -116,15 +116,14 @@ describe("PrivacyScreen — Start navigation", () => {
 
     clickStart();
 
-    // Developer "Replay Onboarding": the legacy pre-chat step that used to
-    // follow privacy is gone and hatching has real side effects, so preview
-    // Start is a no-op — it neither navigates nor persists consent.
+    // Developer "Replay Onboarding": preview mode allows only non-side-effecting
+    // routes, so Start is a no-op — it neither navigates nor persists consent.
     expect(navigateMock).not.toHaveBeenCalled();
     expect(saveConsentMock).not.toHaveBeenCalled();
     expect(emitFunnelStepCompletedMock).not.toHaveBeenCalled();
   });
 
-  test("web persists consent and advances to the research flow (now the default), preserving hosting", () => {
+  test("web persists consent and advances to the research flow, preserving hosting", () => {
     nativePlatform = false;
     searchParamsValue = new URLSearchParams("hosting=managed");
     render(<PrivacyScreen />);


### PR DESCRIPTION
## Summary
Follow-up to #38311. That PR's final comment-cleanup commit lost a 1-second merge race and didn't make it into the squash, so `main` still carries a temporal/history comment (and test name) in `privacy-screen.test.tsx` that violates AGENTS.md "Code Comments" (present-tense, no diff-history) — the exact item Codex flagged.

This applies that missed fix: the preview no-op test's comment and name now describe the current preview contract (preview allows only non-side-effecting routes, so Start is a no-op) instead of the removed pre-chat step.

Comment-only; no behavior change.