### PR TITLE
fix(calls): wait for goodbye audio to drain before hanging up

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -1129,6 +1129,28 @@ describe("call-controller", () => {
     expect(getCallSession(session.id)!.status).toBe("in_progress");
   });
 
+  test("destroy during the listen window settles the wait without hanging up", async () => {
+    // Long window so destroy lands while the listen-window wait is armed;
+    // the wait must settle (not leak) and teardown must not fire endSession.
+    mockEndCallListenWindowMs = 10_000;
+    const drainPromise = Promise.resolve();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    const { relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => drainPromise,
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    // Let the drain phase resolve and the listen-window timer arm.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
+
+    controller.destroy();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
+  });
+
   // ── handleUserAnswer ──────────────────────────────────────────────
 
   test("handleUserAnswer: returns true immediately and fires LLM asynchronously", async () => {

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -54,12 +54,14 @@ mock.module("../security/credential-key.js", () => ({
 let mockConsultationTimeoutMs = 90_000;
 let mockSilenceTimeoutMs = 30_000;
 let mockEndCallListenWindowMs = 0;
+let mockEndCallDrainMaxWaitMs = 15_000;
 
 mock.module("../calls/call-constants.js", () => ({
   getMaxCallDurationMs: () => 12 * 60 * 1000,
   getUserConsultationTimeoutMs: () => mockConsultationTimeoutMs,
   getSilenceTimeoutMs: () => mockSilenceTimeoutMs,
   getEndCallListenWindowMs: () => mockEndCallListenWindowMs,
+  getEndCallDrainMaxWaitMs: () => mockEndCallDrainMaxWaitMs,
 }));
 
 // ── Voice session bridge mock ────────────────────────────────────────
@@ -365,6 +367,8 @@ function setupController(
     trustContext?: import("../daemon/trust-context-types.js").TrustContext;
     /** Simulate the media-stream transport's PCM requirement. */
     requiresPcmAudio?: boolean;
+    /** Simulate a transport that gates teardown on playback drain. */
+    awaitPlaybackDrained?: () => Promise<void>;
   },
 ) {
   ensureConversation("conv-ctrl-test");
@@ -379,6 +383,9 @@ function setupController(
   const transport = createMockTransport();
   if (opts?.requiresPcmAudio) {
     Object.assign(transport, { requiresPcmAudio: true });
+  }
+  if (opts?.awaitPlaybackDrained) {
+    Object.assign(transport, { awaitPlaybackDrained: opts.awaitPlaybackDrained });
   }
   const controller = new CallController(session.id, transport, task ?? null, {
     assistantId: opts?.assistantId,
@@ -440,6 +447,7 @@ describe("call-controller", () => {
     mockConsultationTimeoutMs = 90_000;
     mockSilenceTimeoutMs = 30_000;
     mockEndCallListenWindowMs = 0;
+    mockEndCallDrainMaxWaitMs = 15_000;
     // Reset TTS config to defaults so per-test mutations don't leak.
     const cfg = loadConfig();
     cfg.services.tts.provider = "elevenlabs";
@@ -895,6 +903,219 @@ describe("call-controller", () => {
     expect(getCallSession(session.id)!.status).toBe("in_progress");
 
     controller.destroy();
+  });
+
+  // ── END_CALL playback-drain gating ───────────────────────────────
+
+  test("END_CALL does not end the session until playback drain resolves", async () => {
+    mockEndCallListenWindowMs = 0;
+    let resolveDrain!: () => void;
+    const drainPromise = new Promise<void>((r) => {
+      resolveDrain = r;
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Thank you for calling, goodbye! ", "[END_CALL]"]),
+    );
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => drainPromise,
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+
+    // Drain has not resolved — teardown must be blocked.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
+
+    // Drain completes — teardown proceeds and ends the session.
+    resolveDrain();
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("END_CALL honors the listen window after drain resolves", async () => {
+    mockEndCallListenWindowMs = 30;
+    let resolveDrain!: () => void;
+    const drainPromise = new Promise<void>((r) => {
+      resolveDrain = r;
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => drainPromise,
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    resolveDrain();
+
+    // Listen window still gates completion after drain.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(relay.endCalled).toBe(false);
+
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("END_CALL forces hangup after the drain safety cap when drain never resolves", async () => {
+    mockEndCallListenWindowMs = 0;
+    mockEndCallDrainMaxWaitMs = 25;
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    // Drain that never resolves — only the safety cap can release teardown.
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => new Promise<void>(() => {}),
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    expect(relay.endCalled).toBe(false);
+
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("caller re-engagement during the drain phase cancels teardown and defers", async () => {
+    mockEndCallListenWindowMs = 30;
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        content: string;
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        turnContents.push(opts.content);
+        if (turnContents.length === 1) {
+          opts.onTextDelta("Goodbye! [END_CALL]");
+        } else {
+          opts.onTextDelta("Sure, I'm still here.");
+        }
+        opts.onComplete();
+        return { turnId: `run-${turnContents.length}`, abort: () => {} };
+      },
+    );
+    // Drain never resolves during the test window; re-engagement must still
+    // cancel the pending teardown mid-drain.
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => new Promise<void>(() => {}),
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    expect(relay.endCalled).toBe(false);
+
+    // Caller re-engages while teardown is still waiting on drain.
+    await controller.handleCallerUtterance("Wait, one more thing");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(relay.endCalled).toBe(false);
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
+    expect(turnContents).toContain("Wait, one more thing");
+    const allText = relay.sentTokens.map((t) => t.token).join("");
+    expect(allText).toContain("I'm still here.");
+
+    controller.destroy();
+  });
+
+  test("repeat END_CALL still waits for drain but skips the listen window", async () => {
+    mockEndCallListenWindowMs = 30;
+    let resolveSecondDrain!: () => void;
+    let drainCalls = 0;
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        content: string;
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        turnContents.push(opts.content);
+        if (turnContents.length === 1) {
+          opts.onTextDelta("Goodbye! [END_CALL]");
+        } else if (turnContents.length === 2) {
+          opts.onTextDelta("Okay, one quick thing.");
+        } else {
+          opts.onTextDelta("I have to go now. Goodbye! [END_CALL]");
+        }
+        opts.onComplete();
+        return { turnId: `run-${turnContents.length}`, abort: () => {} };
+      },
+    );
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => {
+        drainCalls++;
+        // First END_CALL drain resolves immediately; the second one is held
+        // so we can assert teardown is gated on it, not on a 0ms timer.
+        if (drainCalls === 1) return Promise.resolve();
+        return new Promise<void>((r) => {
+          resolveSecondDrain = r;
+        });
+      },
+    });
+
+    // First END_CALL — listen window is armed; caller re-engages (deferral #1).
+    await controller.handleCallerUtterance("That is all, thanks");
+    await controller.handleCallerUtterance("Wait, one more thing");
+    await new Promise((r) => setTimeout(r, 40));
+    expect(relay.endCalled).toBe(false);
+
+    // Second END_CALL after the deferral — must still block on drain.
+    await controller.handleCallerUtterance("Just kidding, keep going");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
+
+    // Drain resolves — teardown completes without any listen window.
+    resolveSecondDrain();
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("transport without awaitPlaybackDrained ends after listen window as before", async () => {
+    mockEndCallListenWindowMs = 25;
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    // Default mock transport does not implement awaitPlaybackDrained.
+    const { session, relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    expect(relay.endCalled).toBe(false);
+
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("destroy cancels a pending end-call teardown mid-drain", async () => {
+    mockEndCallListenWindowMs = 0;
+    let resolveDrain!: () => void;
+    const drainPromise = new Promise<void>((r) => {
+      resolveDrain = r;
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => drainPromise,
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    expect(relay.endCalled).toBe(false);
+
+    controller.destroy();
+
+    // Drain resolves after destroy — teardown must not fire endSession.
+    resolveDrain();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
   });
 
   // ── handleUserAnswer ──────────────────────────────────────────────

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -248,6 +248,7 @@ interface MockTransport extends CallTransport {
   sentPlayUrls: string[];
   endCalled: boolean;
   endReason: string | undefined;
+  cancelPendingSpeechCount: number;
 }
 
 function createMockTransport(): MockTransport {
@@ -256,6 +257,7 @@ function createMockTransport(): MockTransport {
     sentPlayUrls: [] as string[],
     _endCalled: false,
     _endReason: undefined as string | undefined,
+    _cancelPendingSpeechCount: 0,
   };
 
   return {
@@ -271,6 +273,9 @@ function createMockTransport(): MockTransport {
     get endReason() {
       return state._endReason;
     },
+    get cancelPendingSpeechCount() {
+      return state._cancelPendingSpeechCount;
+    },
     sendTextToken(token: string, last: boolean) {
       state.sentTokens.push({ token, last });
     },
@@ -280,6 +285,9 @@ function createMockTransport(): MockTransport {
     endSession(reason?: string) {
       state._endCalled = true;
       state._endReason = reason;
+    },
+    cancelPendingSpeech() {
+      state._cancelPendingSpeechCount++;
     },
   } as MockTransport;
 }
@@ -1018,6 +1026,9 @@ describe("call-controller", () => {
     expect(turnContents).toContain("Wait, one more thing");
     const allText = relay.sentTokens.map((t) => t.token).join("");
     expect(allText).toContain("I'm still here.");
+    // The abandoned goodbye's queued speech must be cancelled so it can't
+    // play over the caller's follow-up.
+    expect(relay.cancelPendingSpeechCount).toBeGreaterThan(0);
 
     controller.destroy();
   });

--- a/assistant/src/calls/call-constants.ts
+++ b/assistant/src/calls/call-constants.ts
@@ -72,3 +72,8 @@ export function getSilenceTimeoutMs(): number {
 export function getEndCallListenWindowMs(): number {
   return 2 * 1000;
 }
+
+/** Max time to wait for goodbye audio to drain before forcing hangup. */
+export function getEndCallDrainMaxWaitMs(): number {
+  return 15 * 1000;
+}

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -289,6 +289,10 @@ export class CallController {
     // re-engaging after we tried to hang up. Track it so we can cap repeats.
     if (this.endCallListenTimer || this.pendingEndCall) {
       this.endCallDeferralCount++;
+      // The goodbye's speech was queued while state was idle, so the
+      // media-stream barge-in ignored it. Cancel it here so it can't play
+      // over the caller's follow-up or the next turn.
+      this.transport.cancelPendingSpeech?.();
     }
     this.cancelPendingEndCall();
 

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -31,6 +31,7 @@ import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import type { CallAudioFormat } from "./audio-store.js";
 import {
+  getEndCallDrainMaxWaitMs,
   getEndCallListenWindowMs,
   getMaxCallDurationMs,
   getSilenceTimeoutMs,
@@ -115,6 +116,8 @@ export class CallController {
   private destroyed = false;
   private silenceTimer: ReturnType<typeof setTimeout> | null = null;
   private endCallListenTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Cancellation token for the in-flight end-call teardown (drain → listen). */
+  private pendingEndCall: { cancelled: boolean } | null = null;
   /**
    * How many times the caller has re-engaged (spoken) after an END_CALL
    * marker was emitted but before the listen window fired. Each caller
@@ -281,10 +284,10 @@ export class CallController {
     transcript: string,
     speaker?: PromptSpeakerContext,
   ): Promise<void> {
-    // If the caller speaks while an END_CALL listen window is pending,
-    // this is a deferral — the caller is re-engaging after we tried to
-    // hang up. Track it so we can cap repeat deferrals.
-    if (this.endCallListenTimer) {
+    // If the caller speaks while an END_CALL teardown is pending (during the
+    // drain wait or the listen window), this is a deferral — the caller is
+    // re-engaging after we tried to hang up. Track it so we can cap repeats.
+    if (this.endCallListenTimer || this.pendingEndCall) {
       this.endCallDeferralCount++;
     }
     this.cancelPendingEndCall();
@@ -458,7 +461,7 @@ export class CallController {
   destroy(): void {
     this.destroyed = true;
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
-    if (this.endCallListenTimer) clearTimeout(this.endCallListenTimer);
+    this.cancelPendingEndCall();
     if (this.durationTimer) clearTimeout(this.durationTimer);
     if (this.durationWarningTimer) clearTimeout(this.durationWarningTimer);
     if (this.pendingGuardianInput) {
@@ -470,7 +473,6 @@ export class CallController {
       this.durationEndTimer = null;
     }
     this.pendingInstructions = [];
-    this.endCallListenTimer = null;
     this.llmRunVersion++;
     this.abortCurrentTurn();
     this.abortActiveSynthesis();
@@ -1344,41 +1346,71 @@ export class CallController {
       this.endCallListenTimer = null;
     }
 
-    const listenWindowMs = getEndCallListenWindowMs();
-    // After the caller has re-engaged once post-END_CALL, complete
-    // immediately on the next END_CALL. The first deferral gets a
-    // listen window (caller might say "wait, one more thing"); a
-    // second END_CALL means the assistant wants out and the caller
-    // already had their chance to re-engage.
-    const effectiveListenWindowMs =
-      this.endCallDeferralCount > 0 ? 0 : listenWindowMs;
-    const callContinues =
-      this.pendingInstructions.length > 0 || effectiveListenWindowMs > 0;
-    if (clearedPendingGuardianInput && callContinues) {
+    // The call always continues past END_CALL now — either flushing queued
+    // instructions or waiting for playback drain — so restore in_progress if
+    // we just cleared a pending guardian consultation for the end.
+    if (clearedPendingGuardianInput) {
       updateCallSession(this.callSessionId, { status: "in_progress" });
     }
 
+    // Queued instructions mean the call is continuing — flush and skip
+    // teardown. Clear any stale token first so it can't cancel a later run.
     if (this.pendingInstructions.length > 0) {
+      this.pendingEndCall = null;
       this.flushPendingInstructions();
       return;
     }
 
-    if (effectiveListenWindowMs <= 0) {
-      this.completeCallFromEndMarker();
-      return;
-    }
+    const pending = { cancelled: false };
+    this.pendingEndCall = pending;
+    void this.runEndCallTeardown(pending);
+  }
 
-    this.resetSilenceTimer();
-    this.endCallListenTimer = setTimeout(() => {
-      this.endCallListenTimer = null;
-      this.completeCallFromEndMarker();
-    }, effectiveListenWindowMs);
+  /**
+   * End-of-call teardown: wait for goodbye audio to drain (capped), then run
+   * the re-engagement listen window, then end the session. Cancellable at
+   * every step via the `pending` token (caller re-engagement, destroy).
+   */
+  private async runEndCallTeardown(pending: {
+    cancelled: boolean;
+  }): Promise<void> {
+    if (this.transport.awaitPlaybackDrained) {
+      let capTimer: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        this.transport.awaitPlaybackDrained(),
+        new Promise<void>((r) => {
+          capTimer = setTimeout(r, getEndCallDrainMaxWaitMs());
+        }),
+      ]);
+      if (capTimer) clearTimeout(capTimer);
+    }
+    if (pending.cancelled || this.destroyed) return;
+
+    // After one deferral, subsequent END_CALL markers skip the listen window
+    // (the caller already had their grace re-engagement).
+    const listenWindowMs =
+      this.endCallDeferralCount > 0 ? 0 : getEndCallListenWindowMs();
+    if (listenWindowMs > 0) {
+      this.resetSilenceTimer();
+      await new Promise<void>((resolve) => {
+        this.endCallListenTimer = setTimeout(() => {
+          this.endCallListenTimer = null;
+          resolve();
+        }, listenWindowMs);
+      });
+    }
+    if (pending.cancelled || this.destroyed) return;
+
+    this.completeCallFromEndMarker();
   }
 
   private cancelPendingEndCall(): void {
-    if (!this.endCallListenTimer) return;
-    clearTimeout(this.endCallListenTimer);
-    this.endCallListenTimer = null;
+    if (this.pendingEndCall) this.pendingEndCall.cancelled = true;
+    this.pendingEndCall = null;
+    if (this.endCallListenTimer) {
+      clearTimeout(this.endCallListenTimer);
+      this.endCallListenTimer = null;
+    }
   }
 
   private clearPendingGuardianInputForCallEnd(): boolean {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -1350,7 +1350,7 @@ export class CallController {
       this.endCallListenTimer = null;
     }
 
-    // The call always continues past END_CALL now — either flushing queued
+    // The call always continues past END_CALL — either flushing queued
     // instructions or waiting for playback drain — so restore in_progress if
     // we just cleared a pending guardian consultation for the end.
     if (clearedPendingGuardianInput) {
@@ -1386,9 +1386,13 @@ export class CallController {
           capTimer = setTimeout(r, getEndCallDrainMaxWaitMs());
         }),
       ]);
-      if (capTimer) clearTimeout(capTimer);
+      if (capTimer) {
+        clearTimeout(capTimer);
+      }
     }
-    if (pending.cancelled || this.destroyed) return;
+    if (pending.cancelled || this.destroyed) {
+      return;
+    }
 
     // After one deferral, subsequent END_CALL markers skip the listen window
     // (the caller already had their grace re-engagement).
@@ -1403,13 +1407,17 @@ export class CallController {
         }, listenWindowMs);
       });
     }
-    if (pending.cancelled || this.destroyed) return;
+    if (pending.cancelled || this.destroyed) {
+      return;
+    }
 
     this.completeCallFromEndMarker();
   }
 
   private cancelPendingEndCall(): void {
-    if (this.pendingEndCall) this.pendingEndCall.cancelled = true;
+    if (this.pendingEndCall) {
+      this.pendingEndCall.cancelled = true;
+    }
     this.pendingEndCall = null;
     if (this.endCallListenTimer) {
       clearTimeout(this.endCallListenTimer);

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -116,6 +116,10 @@ export class CallController {
   private destroyed = false;
   private silenceTimer: ReturnType<typeof setTimeout> | null = null;
   private endCallListenTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Safety-cap timer for the end-call playback-drain wait. */
+  private endCallDrainCapTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Settles the in-flight end-call wait so cancellation never leaves it hanging. */
+  private endCallWaitResolve: (() => void) | null = null;
   /** Cancellation token for the in-flight end-call teardown (drain → listen). */
   private pendingEndCall: { cancelled: boolean } | null = null;
   /**
@@ -1379,16 +1383,15 @@ export class CallController {
     cancelled: boolean;
   }): Promise<void> {
     if (this.transport.awaitPlaybackDrained) {
-      let capTimer: ReturnType<typeof setTimeout> | undefined;
-      await Promise.race([
-        this.transport.awaitPlaybackDrained(),
-        new Promise<void>((r) => {
-          capTimer = setTimeout(r, getEndCallDrainMaxWaitMs());
-        }),
-      ]);
-      if (capTimer) {
-        clearTimeout(capTimer);
-      }
+      await new Promise<void>((resolve) => {
+        this.endCallWaitResolve = resolve;
+        this.endCallDrainCapTimer = setTimeout(
+          resolve,
+          getEndCallDrainMaxWaitMs(),
+        );
+        void this.transport.awaitPlaybackDrained!().then(resolve, resolve);
+      });
+      this.clearEndCallWait();
     }
     if (pending.cancelled || this.destroyed) {
       return;
@@ -1401,11 +1404,10 @@ export class CallController {
     if (listenWindowMs > 0) {
       this.resetSilenceTimer();
       await new Promise<void>((resolve) => {
-        this.endCallListenTimer = setTimeout(() => {
-          this.endCallListenTimer = null;
-          resolve();
-        }, listenWindowMs);
+        this.endCallWaitResolve = resolve;
+        this.endCallListenTimer = setTimeout(resolve, listenWindowMs);
       });
+      this.clearEndCallWait();
     }
     if (pending.cancelled || this.destroyed) {
       return;
@@ -1414,15 +1416,29 @@ export class CallController {
     this.completeCallFromEndMarker();
   }
 
+  /** Clear the end-call wait's timers and resolver handle. */
+  private clearEndCallWait(): void {
+    if (this.endCallDrainCapTimer) {
+      clearTimeout(this.endCallDrainCapTimer);
+      this.endCallDrainCapTimer = null;
+    }
+    if (this.endCallListenTimer) {
+      clearTimeout(this.endCallListenTimer);
+      this.endCallListenTimer = null;
+    }
+    this.endCallWaitResolve = null;
+  }
+
   private cancelPendingEndCall(): void {
     if (this.pendingEndCall) {
       this.pendingEndCall.cancelled = true;
     }
     this.pendingEndCall = null;
-    if (this.endCallListenTimer) {
-      clearTimeout(this.endCallListenTimer);
-      this.endCallListenTimer = null;
-    }
+    // Settle any in-flight drain/listen wait so runEndCallTeardown unblocks
+    // and returns instead of leaking a pending promise.
+    const resolve = this.endCallWaitResolve;
+    this.clearEndCallWait();
+    resolve?.();
   }
 
   private clearPendingGuardianInputForCallEnd(): boolean {


### PR DESCRIPTION
## Summary
- Gate END_CALL teardown on transport.awaitPlaybackDrained() (real Twilio playback drain) instead of a fixed 2s-from-text timer
- Run the re-engagement listen window AFTER drain; cancel on caller re-engagement during either phase
- Safety cap (getEndCallDrainMaxWaitMs, 15s) so the call can't hang; transports without the signal fall back to prior behavior

Fixes phone calls hanging up mid-goodbye.

Part of plan: endcall-drain.md (PR 5 of 5)