### PR TITLE
feat(memory-v3): record corpus size with each injection-gate run

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -1345,6 +1345,70 @@ describe("orchestrate — injection gate", () => {
     });
   });
 
+  test("records the corpus size on a scored run", async () => {
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        denseK: 100,
+        realConceptPageCount: 42,
+        gateConfig: gateConfigOf(),
+      }),
+    );
+
+    expect(recordedGateEvents[0]!.detail).toMatchObject({
+      reason: "dense_pass",
+      real_concept_page_count: 42,
+    });
+  });
+
+  test("records the corpus size on a dense_disabled run", async () => {
+    const lanes = await buildLanes();
+    // The sub-threshold cohort is the whole reason the field exists: without it
+    // `dense_disabled` says only "below the threshold", not how far below.
+    const needle = {
+      query: () => [],
+      queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
+      bestSection: () => -1,
+      idf: () => 0,
+    };
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        needle,
+        denseK: 0,
+        realConceptPageCount: 3,
+        gateConfig: gateConfigOf(),
+      }),
+    );
+
+    expect(recordedGateEvents[0]!.detail).toMatchObject({
+      reason: "dense_disabled",
+      real_concept_page_count: 3,
+    });
+  });
+
+  test("omits the corpus size when the dep is not threaded", async () => {
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(recordedGateEvents).toHaveLength(1);
+    expect(recordedGateEvents[0]!.detail).not.toHaveProperty(
+      "real_concept_page_count",
+    );
+  });
+
   test("no gate telemetry when the gate is disabled or omitted", async () => {
     const lanes = await buildLanes();
     denseHits = [{ article: "topic-b", section: 0, score: 0.1 }];

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -89,9 +89,10 @@ const log = getLogger("memory-v3-injection-gate");
 export const MEMORY_V3_INJECTION_GATE_CHECK_NAME = "memory_v3_injection_gate";
 
 /** Record one injection-gate run to usage telemetry. `detail` keys are the
- *  platform-side contract (snake_case, scores and reason codes only — never
- *  conversation content). Never throws: the gate is pass-open by design, and a
- *  telemetry failure must not cost the turn its memory either.
+ *  platform-side contract (snake_case; scores, reason codes, and corpus-size
+ *  counts only — never page titles, slugs, or conversation content). Never
+ *  throws: the gate is pass-open by design, and a telemetry failure must not
+ *  cost the turn its memory either.
  *
  *  `detail.scored` says whether checkV3Gate actually weighed scores this run, as
  *  opposed to the run taking a pass-open shortcut (dense off, dense unavailable,
@@ -190,6 +191,12 @@ export interface OrchestrateDeps {
    *  `enabled`, assembled in observeTurn). Omitted/disabled → the gate never
    *  runs and every turn proceeds to selectPool as before. */
   gateConfig?: V3GateConfig;
+  /** Real concept-page count at lane build — the same corpus-size signal
+   *  `resolveV3Tuning` switches the lean/full profile on. Reported with each
+   *  gate run so the reason distribution can be read against
+   *  `MEMORY_V3_FULL_PROFILE_MIN_PAGES`; omitted drops the field from the
+   *  telemetry detail (the gate itself never reads it). */
+  realConceptPageCount?: number;
 }
 
 /** A finder-lane candidate: the slug, the descriptor that justified it, and
@@ -456,6 +463,17 @@ export async function orchestrate(
   //                        swallows these to `[]`), or only stale deleted-page
   //                        points. Dense SHOULD have scored this turn and did
   //                        not, so this one is worth alerting on.
+  //
+  // Every run carries the corpus size, so the reason mix can be read against the
+  // profile threshold rather than guessed at: `dense_disabled` is sub-threshold
+  // by construction, and whether those assistants sit at 1 page or 9 is the
+  // difference between "empty" and "about to cross".
+  const recordGate = (detail: Record<string, unknown>): void =>
+    recordGateRun(
+      deps.realConceptPageCount === undefined
+        ? detail
+        : { ...detail, real_concept_page_count: deps.realConceptPageCount },
+    );
   if (deps.gateConfig?.enabled) {
     if (liveDensed.length === 0) {
       const reason = denseEnabled ? "dense_unavailable" : "dense_disabled";
@@ -470,7 +488,7 @@ export async function orchestrate(
           ? "memory-v3 injection gate: dense lane unavailable, passing open"
           : "memory-v3 injection gate: dense lane disabled, passing open",
       );
-      recordGateRun({ pass: true, reason, scored: false });
+      recordGate({ pass: true, reason, scored: false });
     } else {
       let gate: V3GateResult | null = null;
       try {
@@ -487,7 +505,7 @@ export async function orchestrate(
           },
           "memory-v3 injection gate threw; passing open (proceeding with selection)",
         );
-        recordGateRun({ pass: true, reason: "gate_error", scored: false });
+        recordGate({ pass: true, reason: "gate_error", scored: false });
       }
       if (gate) {
         log.info(
@@ -498,7 +516,7 @@ export async function orchestrate(
           },
           "memory-v3 injection gate decision",
         );
-        recordGateRun({
+        recordGate({
           pass: gate.pass,
           reason: gate.reason,
           scored: true,

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -649,6 +649,7 @@ export async function observeTurn(
       prefixCards: lanes.prefixCards,
       needleK: tuning.needleK,
       denseK: tuning.denseK,
+      realConceptPageCount: lanes.realConceptPageCount,
       entityCap: v3.entity.cap,
       replyQueryK: tuning.replyQueryK,
       edgeSeeds: tuning.edgeSeedCount,


### PR DESCRIPTION
Follow-up to #38324 (merged). Independent of it now — rebased onto main.

## Why

`MEMORY_V3_FULL_PROFILE_MIN_PAGES = 10` decides whether an assistant gets the full retrieval machinery or the lean profile — and the lean profile turns off the dense lane *and* the selector entirely. It governs the experience for the large majority of assistants (1,004 of 1,044 are currently sub-threshold), and **nothing validates that 10 is the right number.**

`tuning-profile.ts` calls it "the single knob for where 'doesn't have much memory' ends" and argues BM25 alone covers a small corpus. That's plausible, and it's untested. The telemetry can't check it either: the gate detail carries scores and reason codes but never the corpus size the profile actually switched on.

This adds it. `realConceptPageCount` is already computed at lane build and is already the input to `resolveV3Tuning` — it just wasn't threaded into orchestrate.

## What it unlocks

**Is 10 right?** Pass/close mix bucketed by corpus size answers whether dense is earning its cost at 10–15 pages or whether it's noise until well past that. Right now that's a guess.

**Which assistants are eligible?** Today eligibility is only *inferrable* — from whether a run scored. With the count it's a direct filter. That also makes a proper assistant-level pass-rate chart possible; vellum-ai/vellum-assistant-platform#9206 could only proxy it at run level.

**The sub-threshold cohort stops being a single bar.** `dense_disabled` currently says "below 10" and nothing more. An assistant sitting at 9 pages is a completely different story from one at 1 — one is about to cross into the full profile, the other is empty. That distribution is the input to any decision about moving the threshold.

## Notes

- **Raw count, not a bucket.** Bucketing would blur resolution exactly where it's needed, right around 10.
- **Not conversation content.** A page count is corpus metadata — no titles, no slugs, no text. The `recordGateRun` contract comment said "scores and reason codes only", so this widens it explicitly rather than quietly.
- **Recorded via a local wrapper** so every gate run carries the field, rather than three call sites each getting a chance to forget one.
- **The gate never reads it** — `checkV3Gate` stays pure and is untouched. Omitting the dep just drops the field.
- **No platform change needed.** `detail` is free-form, so the field lands in BigQuery and is queryable immediately. Charting it is a separate follow-up.

## Testing

`bun test orchestrate.test.ts` — 52 pass (3 new: recorded on a scored run, recorded on a `dense_disabled` run, omitted when the dep isn't threaded). `shadow-plugin.test.ts` 30 pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)