### PR TITLE
feat(telemetry): strongly type /v1/telemetry/ingest body from the wire schema

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29095,29 +29095,111 @@ paths:
         content:
           application/json:
             schema:
+              oneOf:
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      const: onboarding_research
+                    fields:
+                      type: object
+                      properties:
+                        conversation_id:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 64
+                            - type: "null"
+                        status:
+                          type: string
+                          minLength: 1
+                          maxLength: 32
+                        self_reported_occupation:
+                          anyOf:
+                            - type: string
+                              maxLength: 256
+                            - type: "null"
+                        self_reported_hobbies:
+                          maxItems: 32
+                          type: array
+                          items:
+                            type: string
+                            minLength: 1
+                            maxLength: 128
+                        self_reported_timezone:
+                          anyOf:
+                            - type: string
+                              maxLength: 64
+                            - type: "null"
+                        claims:
+                          maxItems: 20
+                          type: array
+                          items:
+                            $ref: "#/components/schemas/__schema0"
+                        claim_count:
+                          type: integer
+                          minimum: 0
+                          maximum: 9007199254740991
+                        claims_confident:
+                          type: integer
+                          minimum: 0
+                          maximum: 9007199254740991
+                        claims_maybe:
+                          type: integer
+                          minimum: 0
+                          maximum: 9007199254740991
+                        claims_guessing:
+                          type: integer
+                          minimum: 0
+                          maximum: 9007199254740991
+                        suggestions:
+                          maxItems: 20
+                          type: array
+                          items:
+                            $ref: "#/components/schemas/__schema0"
+                        suggestion_count:
+                          type: integer
+                          minimum: 0
+                          maximum: 9007199254740991
+                        plugins:
+                          maxItems: 20
+                          type: array
+                          items:
+                            type: string
+                            minLength: 1
+                            maxLength: 128
+                        installed_plugins:
+                          maxItems: 20
+                          type: array
+                          items:
+                            type: string
+                            minLength: 1
+                            maxLength: 128
+                      required:
+                        - status
+                        - claims
+                        - claim_count
+                        - claims_confident
+                        - claims_maybe
+                        - claims_guessing
+                        - suggestions
+                        - suggestion_count
+                        - plugins
+                        - installed_plugins
+                      description:
+                        Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
+                        assistant_version).
+                    daemon_event_id:
+                      description:
+                        "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
+                        per-row id."
+                      type: string
+                      minLength: 1
+                      maxLength: 128
+                  required:
+                    - type
+                    - fields
               type: object
-              properties:
-                type:
-                  type: string
-                  description: Wire event type; must be a client-reportable telemetry event.
-                fields:
-                  type: object
-                  propertyNames:
-                    type: string
-                  additionalProperties: {}
-                  description:
-                    Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
-                    assistant_version).
-                daemon_event_id:
-                  description:
-                    "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
-                    per-row id."
-                  type: string
-                  minLength: 1
-                  maxLength: 128
-              required:
-                - type
-                - fields
       responses:
         "200":
           description: Successful response
@@ -32039,6 +32121,20 @@ components:
           minLength: 1
       required:
         - id
+    __schema0:
+      anyOf:
+        - type: string
+        - type: number
+        - type: boolean
+        - type: "null"
+        - type: array
+          items:
+            $ref: "#/components/schemas/__schema0"
+        - type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            $ref: "#/components/schemas/__schema0"
     ConfigGetResponse:
       type: object
       properties:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29081,13 +29081,13 @@ paths:
   /v1/telemetry/ingest:
     post:
       operationId: telemetry_ingest_post
-      summary: Record a client-reportable telemetry event
+      summary: Record an outbox-backed telemetry event
       description:
-        "Record any client-reportable outbox-backed telemetry event by its wire `type` + `fields`.
-        Client-orchestrated: for events the daemon can't observe on its own (e.g. onboarding_research). The type must be
-        on the daemon's client-reportable allowlist and the payload must pass the platform wire schema. Gated on
-        share_analytics consent like every other outbox-backed event; the platform re-checks the owner's consent
-        server-side at ingest."
+        Record any outbox-backed telemetry event by its wire `type` + `fields`. For events a client observes and
+        the daemon can't detect on its own (e.g. onboarding_research). The type must be an outbox-backed event — the
+        watermark types (turn, llm_usage, tool_executed) have no variant — and the payload must pass the platform wire
+        schema. Gated on share_analytics consent like every other outbox-backed event; the platform re-checks the
+        owner's consent server-side at ingest.
       tags:
         - telemetry
       requestBody:
@@ -29096,6 +29096,298 @@ paths:
           application/json:
             schema:
               oneOf:
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      const: lifecycle
+                    fields:
+                      type: object
+                      properties:
+                        event_name:
+                          type: string
+                          minLength: 1
+                          maxLength: 64
+                      required:
+                        - event_name
+                      description:
+                        Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
+                        assistant_version).
+                    daemon_event_id:
+                      description:
+                        "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
+                        per-row id."
+                      type: string
+                      minLength: 1
+                      maxLength: 128
+                  required:
+                    - type
+                    - fields
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      const: onboarding
+                    fields:
+                      type: object
+                      properties:
+                        screen:
+                          type: string
+                          minLength: 1
+                          maxLength: 64
+                        tools:
+                          type: array
+                          items:
+                            type: string
+                            minLength: 1
+                            maxLength: 128
+                        tasks:
+                          type: array
+                          items:
+                            type: string
+                            minLength: 1
+                            maxLength: 128
+                        tone:
+                          type: string
+                          minLength: 1
+                          maxLength: 64
+                        google_connected:
+                          type: boolean
+                        google_scopes:
+                          type: array
+                          items:
+                            type: string
+                            minLength: 1
+                            maxLength: 256
+                        ab_variant:
+                          type: string
+                          minLength: 1
+                          maxLength: 64
+                        session_id:
+                          type: string
+                          minLength: 1
+                          maxLength: 128
+                        step_name:
+                          type: string
+                          minLength: 1
+                          maxLength: 128
+                        step_index:
+                          type: integer
+                          minimum: 0
+                          maximum: 9007199254740991
+                        completed_at:
+                          type: string
+                          minLength: 1
+                          maxLength: 64
+                        funnel_version:
+                          type: string
+                          minLength: 1
+                          maxLength: 128
+                        user_id:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 64
+                            - type: "null"
+                        outcome:
+                          type: string
+                          minLength: 1
+                          maxLength: 32
+                      description:
+                        Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
+                        assistant_version).
+                    daemon_event_id:
+                      description:
+                        "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
+                        per-row id."
+                      type: string
+                      minLength: 1
+                      maxLength: 128
+                  required:
+                    - type
+                    - fields
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      const: auth_fallback
+                    fields:
+                      type: object
+                      properties:
+                        guard:
+                          type: string
+                          minLength: 1
+                          maxLength: 64
+                        failure_kind:
+                          type: string
+                          minLength: 1
+                          maxLength: 64
+                        path:
+                          type: string
+                          minLength: 1
+                          maxLength: 2048
+                        count:
+                          type: integer
+                          minimum: 0
+                          maximum: 9007199254740991
+                        window_start:
+                          type: integer
+                          minimum: 0
+                          maximum: 9007199254740991
+                        window_end:
+                          type: integer
+                          minimum: 0
+                          maximum: 9007199254740991
+                      required:
+                        - guard
+                        - failure_kind
+                        - path
+                        - count
+                        - window_start
+                        - window_end
+                      description:
+                        Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
+                        assistant_version).
+                    daemon_event_id:
+                      description:
+                        "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
+                        per-row id."
+                      type: string
+                      minLength: 1
+                      maxLength: 128
+                  required:
+                    - type
+                    - fields
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      const: skill_loaded
+                    fields:
+                      type: object
+                      properties:
+                        provider:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 64
+                            - type: "null"
+                        model:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 128
+                            - type: "null"
+                        inference_profile:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 255
+                            - type: "null"
+                        inference_profile_source:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 255
+                            - type: "null"
+                        skill_name:
+                          type: string
+                          minLength: 1
+                          maxLength: 255
+                        skill_updated_at:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 64
+                            - type: "null"
+                        conversation_id:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 128
+                            - type: "null"
+                      required:
+                        - skill_name
+                      description:
+                        Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
+                        assistant_version).
+                    daemon_event_id:
+                      description:
+                        "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
+                        per-row id."
+                      type: string
+                      minLength: 1
+                      maxLength: 128
+                  required:
+                    - type
+                    - fields
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      const: watchdog
+                    fields:
+                      type: object
+                      properties:
+                        check_name:
+                          type: string
+                          minLength: 1
+                          maxLength: 128
+                        value:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        detail:
+                          anyOf:
+                            - $ref: "#/components/schemas/TelemetryJsonValue"
+                            - type: "null"
+                      required:
+                        - check_name
+                      description:
+                        Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
+                        assistant_version).
+                    daemon_event_id:
+                      description:
+                        "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
+                        per-row id."
+                      type: string
+                      minLength: 1
+                      maxLength: 128
+                  required:
+                    - type
+                    - fields
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      const: config_setting
+                    fields:
+                      type: object
+                      properties:
+                        config_key:
+                          type: string
+                          minLength: 1
+                          maxLength: 128
+                        config_value:
+                          type: string
+                          minLength: 1
+                          maxLength: 256
+                      required:
+                        - config_key
+                        - config_value
+                      description:
+                        Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
+                        assistant_version).
+                    daemon_event_id:
+                      description:
+                        "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
+                        per-row id."
+                      type: string
+                      minLength: 1
+                      maxLength: 128
+                  required:
+                    - type
+                    - fields
                 - type: object
                   properties:
                     type:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29135,7 +29135,7 @@ paths:
                           maxItems: 20
                           type: array
                           items:
-                            $ref: "#/components/schemas/__schema0"
+                            $ref: "#/components/schemas/TelemetryJsonValue"
                         claim_count:
                           type: integer
                           minimum: 0
@@ -29156,7 +29156,7 @@ paths:
                           maxItems: 20
                           type: array
                           items:
-                            $ref: "#/components/schemas/__schema0"
+                            $ref: "#/components/schemas/TelemetryJsonValue"
                         suggestion_count:
                           type: integer
                           minimum: 0
@@ -32121,7 +32121,7 @@ components:
           minLength: 1
       required:
         - id
-    __schema0:
+    TelemetryJsonValue:
       anyOf:
         - type: string
         - type: number
@@ -32129,12 +32129,12 @@ components:
         - type: "null"
         - type: array
           items:
-            $ref: "#/components/schemas/__schema0"
+            $ref: "#/components/schemas/TelemetryJsonValue"
         - type: object
           propertyNames:
             type: string
           additionalProperties:
-            $ref: "#/components/schemas/__schema0"
+            $ref: "#/components/schemas/TelemetryJsonValue"
     ConfigGetResponse:
       type: object
       properties:

--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -30,6 +30,14 @@ import type {
 } from "zod-openapi";
 import { createDocument } from "zod-openapi";
 
+import { jsonValueSchema } from "../src/telemetry/telemetry-wire.generated.js";
+
+// The recursive wire JSON-value schema (`claims`/`suggestions` item type) must
+// be hoisted into a named component so it can `$ref` itself; without a
+// registered id zod-openapi falls back to an anonymous `__schema0`. Name it
+// explicitly so the spec + generated SDK read as `TelemetryJsonValue`.
+z.globalRegistry.add(jsonValueSchema, { id: "TelemetryJsonValue" });
+
 const ROOT = resolve(import.meta.dir, "..");
 const ROUTES_DIR = join(ROOT, "src/runtime/routes");
 const PLUGIN_DEFAULTS_DIR = join(ROOT, "src/plugins/defaults");

--- a/assistant/src/__tests__/telemetry-routes.test.ts
+++ b/assistant/src/__tests__/telemetry-routes.test.ts
@@ -122,7 +122,7 @@ describe("telemetry-routes: ingest", () => {
     expect(pendingPayloads().length).toBe(0);
   });
 
-  test("rejects a payload that fails the wire schema without persisting", () => {
+  test("rejects malformed fields (missing or mistyped) without persisting", () => {
     // Missing the required derived counts.
     const { claim_count: _c, suggestion_count: _s, ...missingCounts } =
       VALID_FIELDS;
@@ -145,5 +145,15 @@ describe("telemetry-routes: ingest", () => {
     expect(() => call({ type: "onboarding_research" })).toThrow(RouteError);
     expect(() => call({ fields: VALID_FIELDS })).toThrow(RouteError);
     expect(pendingPayloads().length).toBe(0);
+  });
+
+  test("strips unknown fields keys (typed schema, not a passthrough record)", () => {
+    call({
+      type: "onboarding_research",
+      fields: { ...VALID_FIELDS, bogus_extra: "nope" },
+    });
+    const payloads = pendingPayloads();
+    expect(payloads.length).toBe(1);
+    expect(payloads[0]).not.toHaveProperty("bogus_extra");
   });
 });

--- a/assistant/src/__tests__/telemetry-routes.test.ts
+++ b/assistant/src/__tests__/telemetry-routes.test.ts
@@ -113,13 +113,31 @@ describe("telemetry-routes: ingest", () => {
     expect(pendingPayloads().length).toBe(1);
   });
 
-  test("rejects a type not on the client-reportable allowlist", () => {
-    // `turn` is a real wire type but daemon-authoritative — a client must never
-    // be able to inject it.
+  test("rejects a non-outbox (watermark) or unknown type", () => {
+    // `turn` is a real wire type but watermark-flushed, not outbox-backed, so it
+    // has no ingest variant and a client can't inject it.
     expect(() => call({ type: "turn", fields: {} })).toThrow(RouteError);
     // An unknown type is rejected the same way.
     expect(() => call({ type: "not_a_type", fields: {} })).toThrow(RouteError);
     expect(pendingPayloads().length).toBe(0);
+  });
+
+  test("accepts any outbox-backed type, e.g. config_setting", () => {
+    const result = call({
+      type: "config_setting",
+      fields: { config_key: "voice.provider", config_value: "elevenlabs" },
+    });
+    expect(result).toEqual({ id: expect.any(String) });
+
+    const payloads = pendingOutboxPayloads<{ config_key: string }>(
+      "config_setting",
+    );
+    expect(payloads.length).toBe(1);
+    expect(payloads[0]).toMatchObject({
+      type: "config_setting",
+      config_key: "voice.provider",
+      config_value: "elevenlabs",
+    });
   });
 
   test("rejects malformed fields (missing or mistyped) without persisting", () => {

--- a/assistant/src/runtime/routes/telemetry-routes.ts
+++ b/assistant/src/runtime/routes/telemetry-routes.ts
@@ -10,12 +10,15 @@ import { z } from "zod";
 
 import { recordLifecycleEvent } from "../../persistence/lifecycle-events-store.js";
 import { recordTelemetryOutboxEvent } from "../../telemetry/telemetry-events-outbox.js";
-import { getWireSchemaForType } from "../../telemetry/telemetry-wire-validation.js";
-import type { TelemetryEvent } from "../../telemetry/types.js";
 import {
-  CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES,
-  isClientReportableTelemetryEventName,
+  getWireFieldsSchema,
+  getWireSchemaForType,
+} from "../../telemetry/telemetry-wire-validation.js";
+import type {
+  ClientReportableTelemetryEventName,
+  TelemetryEvent,
 } from "../../telemetry/types.js";
+import { CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES } from "../../telemetry/types.js";
 import { getUsageTelemetryReporter } from "../../telemetry/usage-telemetry-reporter.js";
 import { getLogger } from "../../util/logger.js";
 import { APP_VERSION } from "../../version.js";
@@ -27,32 +30,56 @@ const log = getLogger("telemetry-routes");
 
 const VALID_EVENT_NAMES = new Set(["app_open", "hatch"]);
 
+const ingestDaemonEventIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .optional()
+  .describe(
+    "Optional collapse key: rows sharing an id collapse downstream " +
+      "(e.g. a retried report). Defaults to a fresh per-row id.",
+  );
+
 /**
- * Request shape for `POST /v1/telemetry/ingest`. `fields` carries every wire
- * field EXCEPT the daemon-stamped base fields (`type`, `daemon_event_id`,
- * `recorded_at`, `assistant_version`); the handler assembles the full event and
- * validates it against the wire schema for `type`.
+ * One request variant per client-reportable type: `{ type, fields, daemon_event_id? }`
+ * where `fields` is the wire schema for that type minus the daemon-stamped base
+ * fields. Throws at module load if a client-reportable name has no wire schema
+ * (the allowlist and wire contract drifted).
  */
-const telemetryIngestRequestSchema = z.object({
-  type: z
-    .string()
-    .describe("Wire event type; must be a client-reportable telemetry event."),
-  fields: z
-    .record(z.string(), z.unknown())
-    .describe(
+function buildIngestVariant(name: ClientReportableTelemetryEventName) {
+  const fields = getWireFieldsSchema(name);
+  if (!fields) {
+    throw new Error(
+      `No wire schema for client-reportable telemetry type "${name}".`,
+    );
+  }
+  return z.object({
+    type: z.literal(name),
+    fields: fields.describe(
       "Wire event fields, excluding the daemon-stamped base fields " +
         "(type, daemon_event_id, recorded_at, assistant_version).",
     ),
-  daemon_event_id: z
-    .string()
-    .min(1)
-    .max(128)
-    .optional()
-    .describe(
-      "Optional collapse key: rows sharing an id collapse downstream " +
-        "(e.g. a retried report). Defaults to a fresh per-row id.",
-    ),
-});
+    daemon_event_id: ingestDaemonEventIdSchema,
+  });
+}
+
+/**
+ * Request shape for `POST /v1/telemetry/ingest`: a discriminated union over the
+ * client-reportable event types, each carrying that type's wire `fields`.
+ * Derived from the wire contract, so the generated SDK body is strongly typed
+ * and stays in sync as the allowlist and wire schemas evolve.
+ */
+const telemetryIngestRequestSchema = z.discriminatedUnion(
+  "type",
+  // `.map` widens to `ZodObject[]`, but `discriminatedUnion` wants a non-empty
+  // tuple. The allowlist is a non-empty const, and the RUNTIME schema (not this
+  // static type) is what codegen introspects, so the cast doesn't affect the
+  // emitted OpenAPI/SDK types.
+  CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES.map(buildIngestVariant) as [
+    ReturnType<typeof buildIngestVariant>,
+    ...ReturnType<typeof buildIngestVariant>[],
+  ],
+);
 
 /** Placeholder id satisfying the wire schema's `daemon_event_id` bound during
  * the up-front validation pass; the real id is stamped at record time. */
@@ -93,11 +120,13 @@ async function handleTelemetryFlush() {
  *
  * Three guarantees before a row lands:
  *   1. `type` must be on the {@link CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES}
- *      allowlist — a client can never inject a daemon-authoritative type
- *      (`turn`, `config_setting`, …) and corrupt the event stream.
- *   2. The assembled event (base fields stamped) must pass the platform wire
- *      schema for `type` — a malformed payload 400s here instead of being
- *      silently dropped at flush.
+ *      allowlist and `fields` must match the type's wire shape — both enforced
+ *      by the discriminated-union parse, so a client can never inject a
+ *      daemon-authoritative type (`turn`, `config_setting`, …) nor a malformed
+ *      payload.
+ *   2. The assembled event must additionally pass the full wire schema for the
+ *      byte-bound superRefines the request `fields` schema drops (oversize
+ *      claims/suggestions).
  *   3. Consent is enforced by {@link recordTelemetryOutboxEvent} (the
  *      `share_analytics` gate), same as every daemon-internal emitter.
  *
@@ -114,23 +143,19 @@ function handleTelemetryIngest({ body }: RouteHandlerArgs) {
   }
   const { type, fields, daemon_event_id: daemonEventId } = parsed.data;
 
-  if (!isClientReportableTelemetryEventName(type)) {
-    throw new BadRequestError(
-      `type must be one of: ${CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES.join(", ")}`,
+  // `type` is allowlisted (the parse matched a union variant), so a wire schema
+  // is guaranteed — its absence is an invariant breach, not a client error.
+  const wireSchema = getWireSchemaForType(type);
+  if (!wireSchema) {
+    throw new Error(
+      `No wire schema registered for client-reportable type "${type}".`,
     );
   }
 
-  // Every client-reportable type is in the wire contract, so a schema is
-  // guaranteed; guard rather than assert.
-  const wireSchema = getWireSchemaForType(type);
-  if (!wireSchema) {
-    throw new BadRequestError(`No wire schema registered for type "${type}".`);
-  }
-
-  // Validate the assembled event up front (with placeholder base values) so a
-  // malformed payload 400s regardless of consent — the record path below
-  // short-circuits on an opt-out before it would otherwise validate. The
-  // `.trim()`-transformed parse output is discarded: `fields` are recorded
+  // Re-validate the assembled event against the full wire schema for the
+  // byte-bound superRefines the request `fields` schema drops. Up front (with
+  // placeholder base values) so an oversize payload 400s regardless of consent.
+  // The `.trim()`-transformed parse output is discarded: `fields` are recorded
   // verbatim, matching pre-flush validation's non-mutating contract.
   const validation = wireSchema.safeParse({
     ...fields,
@@ -144,7 +169,9 @@ function handleTelemetryIngest({ body }: RouteHandlerArgs) {
   }
 
   const conversationId =
-    typeof fields.conversation_id === "string" ? fields.conversation_id : null;
+    "conversation_id" in fields && typeof fields.conversation_id === "string"
+      ? fields.conversation_id
+      : null;
 
   const event = recordTelemetryOutboxEvent(
     type,

--- a/assistant/src/runtime/routes/telemetry-routes.ts
+++ b/assistant/src/runtime/routes/telemetry-routes.ts
@@ -2,8 +2,8 @@
  * Route handlers for telemetry lifecycle events.
  *
  * POST /v1/telemetry/lifecycle — record a lifecycle event (app_open, hatch).
- * POST /v1/telemetry/ingest — record any client-reportable outbox-backed
- * telemetry event by its wire `type` + `fields`.
+ * POST /v1/telemetry/ingest — record any outbox-backed telemetry event by its
+ * wire `type` + `fields`.
  */
 
 import { z } from "zod";
@@ -15,10 +15,10 @@ import {
   getWireSchemaForType,
 } from "../../telemetry/telemetry-wire-validation.js";
 import type {
-  ClientReportableTelemetryEventName,
+  OutboxTelemetryEventName,
   TelemetryEvent,
 } from "../../telemetry/types.js";
-import { CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES } from "../../telemetry/types.js";
+import { OUTBOX_TELEMETRY_EVENT_NAMES } from "../../telemetry/types.js";
 import { getUsageTelemetryReporter } from "../../telemetry/usage-telemetry-reporter.js";
 import { getLogger } from "../../util/logger.js";
 import { APP_VERSION } from "../../version.js";
@@ -41,17 +41,15 @@ const ingestDaemonEventIdSchema = z
   );
 
 /**
- * One request variant per client-reportable type: `{ type, fields, daemon_event_id? }`
+ * One request variant per outbox-backed type: `{ type, fields, daemon_event_id? }`
  * where `fields` is the wire schema for that type minus the daemon-stamped base
- * fields. Throws at module load if a client-reportable name has no wire schema
- * (the allowlist and wire contract drifted).
+ * fields. Throws at module load if an outbox name has no wire schema (an
+ * impossible drift between the outbox name list and the wire contract).
  */
-function buildIngestVariant(name: ClientReportableTelemetryEventName) {
+function buildIngestVariant(name: OutboxTelemetryEventName) {
   const fields = getWireFieldsSchema(name);
   if (!fields) {
-    throw new Error(
-      `No wire schema for client-reportable telemetry type "${name}".`,
-    );
+    throw new Error(`No wire schema for outbox telemetry type "${name}".`);
   }
   return z.object({
     type: z.literal(name),
@@ -64,18 +62,18 @@ function buildIngestVariant(name: ClientReportableTelemetryEventName) {
 }
 
 /**
- * Request shape for `POST /v1/telemetry/ingest`: a discriminated union over the
- * client-reportable event types, each carrying that type's wire `fields`.
+ * Request shape for `POST /v1/telemetry/ingest`: a discriminated union over
+ * every outbox-backed event type, each carrying that type's wire `fields`.
  * Derived from the wire contract, so the generated SDK body is strongly typed
- * and stays in sync as the allowlist and wire schemas evolve.
+ * and stays in sync as the wire schemas evolve.
  */
 const telemetryIngestRequestSchema = z.discriminatedUnion(
   "type",
   // `.map` widens to `ZodObject[]`, but `discriminatedUnion` wants a non-empty
-  // tuple. The allowlist is a non-empty const, and the RUNTIME schema (not this
+  // tuple. The outbox name list is non-empty, and the RUNTIME schema (not this
   // static type) is what codegen introspects, so the cast doesn't affect the
   // emitted OpenAPI/SDK types.
-  CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES.map(buildIngestVariant) as [
+  OUTBOX_TELEMETRY_EVENT_NAMES.map(buildIngestVariant) as [
     ReturnType<typeof buildIngestVariant>,
     ...ReturnType<typeof buildIngestVariant>[],
   ],
@@ -111,19 +109,16 @@ async function handleTelemetryFlush() {
 }
 
 /**
- * Record any client-reportable outbox-backed telemetry event.
- *
- * Client-orchestrated events are ones the daemon can't observe on its own —
- * only the client knows when they happened and what they produced (today just
- * `onboarding_research`). This is the generic bridge that exposes the daemon's
- * in-process `recordTelemetryEvent` recorder to clients over HTTP/IPC.
+ * Record any outbox-backed telemetry event reported by a client. This is the
+ * generic bridge that exposes the daemon's in-process `recordTelemetryEvent`
+ * recorder to clients over HTTP/IPC — for events the client observes and the
+ * daemon can't detect on its own (e.g. `onboarding_research`).
  *
  * Three guarantees before a row lands:
- *   1. `type` must be on the {@link CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES}
- *      allowlist and `fields` must match the type's wire shape — both enforced
- *      by the discriminated-union parse, so a client can never inject a
- *      daemon-authoritative type (`turn`, `config_setting`, …) nor a malformed
- *      payload.
+ *   1. `type` must be an outbox-backed event and `fields` must match that
+ *      type's wire shape — both enforced by the discriminated-union parse. The
+ *      watermark types (`turn`, `llm_usage`, `tool_executed`) are excluded
+ *      structurally: they aren't outbox-backed, so they have no variant.
  *   2. The assembled event must additionally pass the full wire schema for the
  *      byte-bound superRefines the request `fields` schema drops (oversize
  *      claims/suggestions).
@@ -143,13 +138,11 @@ function handleTelemetryIngest({ body }: RouteHandlerArgs) {
   }
   const { type, fields, daemon_event_id: daemonEventId } = parsed.data;
 
-  // `type` is allowlisted (the parse matched a union variant), so a wire schema
+  // `type` matched a union variant (an outbox-backed event), so a wire schema
   // is guaranteed — its absence is an invariant breach, not a client error.
   const wireSchema = getWireSchemaForType(type);
   if (!wireSchema) {
-    throw new Error(
-      `No wire schema registered for client-reportable type "${type}".`,
-    );
+    throw new Error(`No wire schema registered for outbox type "${type}".`);
   }
 
   // Re-validate the assembled event against the full wire schema for the
@@ -261,9 +254,9 @@ export const ROUTES: RouteDefinition[] = [
       requiredScopes: ["settings.write"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
-    summary: "Record a client-reportable telemetry event",
+    summary: "Record an outbox-backed telemetry event",
     description:
-      "Record any client-reportable outbox-backed telemetry event by its wire `type` + `fields`. Client-orchestrated: for events the daemon can't observe on its own (e.g. onboarding_research). The type must be on the daemon's client-reportable allowlist and the payload must pass the platform wire schema. Gated on share_analytics consent like every other outbox-backed event; the platform re-checks the owner's consent server-side at ingest.",
+      "Record any outbox-backed telemetry event by its wire `type` + `fields`. For events a client observes and the daemon can't detect on its own (e.g. onboarding_research). The type must be an outbox-backed event — the watermark types (turn, llm_usage, tool_executed) have no variant — and the payload must pass the platform wire schema. Gated on share_analytics consent like every other outbox-backed event; the platform re-checks the owner's consent server-side at ingest.",
     tags: ["telemetry"],
     requestBody: telemetryIngestRequestSchema,
     responseBody: z.union([

--- a/assistant/src/telemetry/telemetry-wire-validation.ts
+++ b/assistant/src/telemetry/telemetry-wire-validation.ts
@@ -14,7 +14,7 @@
  * events.
  */
 
-import type { z } from "zod";
+import { z } from "zod";
 
 import type { getLogger } from "../util/logger.js";
 import { telemetryEventSchema } from "./telemetry-wire.generated.js";
@@ -26,12 +26,23 @@ type Logger = ReturnType<typeof getLogger>;
  * discriminated union (`.options` + each member's `type` literal), so a new
  * generated event type is validated with zero hand edits here.
  */
-const wireSchemaByType: ReadonlyMap<string, z.ZodType> = new Map(
+const wireSchemaByType: ReadonlyMap<string, z.ZodObject> = new Map(
   telemetryEventSchema.options.map((option) => [
     option.shape.type.value,
     option,
   ]),
 );
+
+/**
+ * Base fields stamped by the daemon at record time, never supplied by a client.
+ * Stripped when deriving the client-facing `fields` schema for a wire type.
+ */
+const TELEMETRY_BASE_FIELD_KEYS = {
+  type: true,
+  daemon_event_id: true,
+  recorded_at: true,
+  assistant_version: true,
+} as const;
 
 /**
  * Event types already warned about as absent from the wire contract.
@@ -52,8 +63,24 @@ export function resetUnknownTypeWarningsForTests(): void {
  * (`POST /v1/telemetry/ingest`) reject a malformed payload up front with the
  * same schema pre-flush validation would have logged a silent drop for.
  */
-export function getWireSchemaForType(type: string): z.ZodType | undefined {
+export function getWireSchemaForType(type: string): z.ZodObject | undefined {
   return wireSchemaByType.get(type);
+}
+
+/**
+ * Client-facing `fields` schema for a wire type: the wire object minus the
+ * daemon-stamped base fields. Rebuilt from `.shape` because `.omit()` rejects
+ * the refined wire schemas; this drops the claims/suggestions byte-bound
+ * superRefines, which aren't expressible in the request type anyway — the
+ * handler still validates the assembled event against the full wire schema
+ * ({@link getWireSchemaForType}) for those bounds. Undefined when the platform
+ * contract has no serializer for `type`.
+ */
+export function getWireFieldsSchema(type: string): z.ZodObject | undefined {
+  const schema = wireSchemaByType.get(type);
+  return schema
+    ? z.object(schema.shape).omit(TELEMETRY_BASE_FIELD_KEYS)
+    : undefined;
 }
 
 /**

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -735,12 +735,3 @@ export const CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES = [
 
 export type ClientReportableTelemetryEventName =
   (typeof CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES)[number];
-
-/** Whether an arbitrary string is a client-reportable telemetry event name. */
-export function isClientReportableTelemetryEventName(
-  name: string,
-): name is ClientReportableTelemetryEventName {
-  return (
-    CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES as readonly string[]
-  ).includes(name);
-}

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -713,25 +713,3 @@ export const OUTBOX_TELEMETRY_EVENT_NAMES: readonly OutboxTelemetryEventName[] =
 /** Wire event type for one outbox event name. */
 export type OutboxTelemetryEventOf<N extends OutboxTelemetryEventName> =
   Extract<TelemetryEvent, { type: N }>;
-
-/**
- * Event names a CLIENT is allowed to report over `POST /v1/telemetry/ingest`.
- *
- * This is a deliberately curated allowlist — NOT every outbox-backed type. Most
- * outbox events are recorded by the daemon itself from trusted in-process state
- * (`config_setting`, `skill_loaded`, `auth_fallback`, `watchdog`, …), and the
- * watermark types (`turn`, `llm_usage`, `tool_executed`) come off their own
- * tables; letting an untrusted client inject any of those would corrupt the
- * event stream. A type joins this set only when a client is the sole party that
- * can observe the event it reports (client-orchestrated), like
- * `onboarding_research` — the daemon never detects that turn on its own.
- *
- * The `satisfies` clause pins every entry to a real outbox name, so a watermark
- * type (or a typo) can never be added here.
- */
-export const CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES = [
-  "onboarding_research",
-] as const satisfies readonly OutboxTelemetryEventName[];
-
-export type ClientReportableTelemetryEventName =
-  (typeof CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES)[number];


### PR DESCRIPTION
## Summary
- Replace the untyped `fields: z.record(z.string(), z.unknown())` request bag on `POST /v1/telemetry/ingest` with a `z.discriminatedUnion("type", …)` **derived from the wire contract** — one variant per `CLIENT_REPORTABLE_TELEMETRY_EVENT_NAMES` entry, each carrying that type's wire `fields` (the wire object minus the daemon-stamped base fields). The generated OpenAPI `requestBody` becomes a typed `oneOf`, so `TelemetryIngestPostData["body"]` in the web SDK now has a fully-typed `fields` object instead of `{ [k: string]: unknown }`.
- New `getWireFieldsSchema(type)` in `telemetry-wire-validation` rebuilds `z.object(schema.shape).omit(BASE_FIELDS)` (`.omit()` rejects the refined wire schemas, so it rebuilds from `.shape`). This drops the claims/suggestions byte-bound superRefines — not expressible in the request type anyway — so the handler keeps re-validating the assembled event against the full wire schema for those bounds. The typed parse also now enforces the allowlist + per-field shape and strips unknown keys, so the old `isClientReportableTelemetryEventName` guard is removed as dead.
- Derived, not hand-restated: as the allowlist grows or the wire contract syncs, the request union (and SDK types) stay in sync automatically. Web client needed no change — it already sent the correct shape and now type-checks against the strict body.

## Original prompt
Follow-up to PR #38314 (the generic `/v1/telemetry/ingest` route), which left the request `fields` as an untyped `Record`, giving web SDK callers zero compile-time safety on the payload. Strongly type the `telemetry_ingest_post` body in the OpenAPI spec by deriving it from the telemetry wire schemas, keeping the `{ type, fields }` envelope. `claims`/`suggestions` stay opaque JSON arrays, faithful to the wire contract (the platform serializer treats them the same way).