### PR TITLE
fix(voice): close the echo gate's carryover, instant-mode, and chunk-granularity holes

### DIFF
--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -47,7 +47,7 @@ export const LiveVoiceVadConfigSchema = z
       .positive("liveVoice.vad.echoBargeInMargin must be a positive number")
       .default(1.5)
       .describe(
-        "Multiplier over the observed echo energy level (an EMA of mic energy tracked while assistant audio is playing) that input must exceed to count as speech during playback; the effective threshold is max(speechEnergyThreshold, echoBargeInMargin × echo EMA). Higher = harder to barge in over loud speakers.",
+        "Multiplier over the observed echo energy level (an EMA of mic energy tracked while assistant audio is playing) that input must exceed to count as speech during playback; the effective threshold is max(speechEnergyThreshold, echoBargeInMargin × echo EMA). Higher = harder to barge in over loud speakers; values well below 1 pin the effective threshold at speechEnergyThreshold, disabling echo suppression.",
       ),
     echoEmaHalfLifeMs: z
       .number({ error: "liveVoice.vad.echoEmaHalfLifeMs must be a number" })
@@ -55,7 +55,7 @@ export const LiveVoiceVadConfigSchema = z
       .positive("liveVoice.vad.echoEmaHalfLifeMs must be a positive integer")
       .default(400)
       .describe(
-        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients.",
+        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients. Also sets the gate's onset warm-up: the first half-life/2 of playback audio learns at a quarter-half-life attack rate and defers barge-in trips until warm. Keep half-life/2 below bargeInMinSpeechMs (true at the defaults: 200 vs 250) so genuine onset barge-ins are never deferred.",
       ),
   })
   .describe(

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -347,6 +347,11 @@ describe("LiveVoiceSession server VAD", () => {
       return makeTtsResult("assistant audio");
     });
     const { frames, session, transcribers } = createHarness({
+      // Neutralize the echo-adaptive gate (threshold pinned to the 800
+      // floor, warm-up over after one chunk) — this test is about barge-in
+      // mechanics, not echo suppression.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       finals: ["what's the weather", "actually never mind"],
       startVoiceTurn,
       streamTtsAudio,
@@ -361,6 +366,10 @@ describe("LiveVoiceSession server VAD", () => {
 
     // Sustained speech over the assistant's audio meets the default guard.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    // The sustained chunk is the first in-window audio, so its trip is
+    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
+    // the accumulated run.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -411,6 +420,11 @@ describe("LiveVoiceSession server VAD", () => {
     });
     let releaseDeltaSend: (() => void) | undefined;
     const { frames, session } = createHarness({
+      // Neutralize the echo-adaptive gate (threshold pinned to the 800
+      // floor, warm-up over after one chunk) — this test is about barge-in
+      // mechanics, not echo suppression.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       finals: ["what's the weather", "wait actually", "stop please"],
       startVoiceTurn,
       streamTtsAudio,
@@ -450,6 +464,10 @@ describe("LiveVoiceSession server VAD", () => {
     // Once audio has genuinely gone out, new sustained speech barge-ins.
     await waitFor(() => countType(frames, "utterance_end") === 2);
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    // The sustained chunk is the first in-window audio, so its trip is
+    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
+    // the accumulated run.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -833,6 +851,11 @@ describe("LiveVoiceSession server VAD", () => {
       return makeTtsResult("assistant audio");
     });
     const { frames, session } = createHarness({
+      // Neutralize the echo-adaptive gate (threshold pinned to the 800
+      // floor, warm-up over after one chunk) — this test is about barge-in
+      // mechanics, not echo suppression.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       finals: ["first question", "second question"],
       startVoiceTurn,
       streamTtsAudio,
@@ -851,6 +874,10 @@ describe("LiveVoiceSession server VAD", () => {
 
     // Barge in over the playing, already-complete reply.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    // The sustained chunk is the first in-window audio, so its trip is
+    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
+    // the accumulated run.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -1282,6 +1309,11 @@ describe("LiveVoiceSession server VAD", () => {
       return makeTtsResult(options.text);
     });
     const { frames, session } = createHarness({
+      // Neutralize the echo-adaptive gate (threshold pinned to the 800
+      // floor, warm-up over after one chunk) — this test is about barge-in
+      // mechanics, not echo suppression.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       finals: ["what's the weather", "actually never mind"],
       startVoiceTurn,
       streamTtsAudio,
@@ -1295,6 +1327,11 @@ describe("LiveVoiceSession server VAD", () => {
       makeTextDelta("It is sunny today."),
     );
     await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    // Age the echo window past its (pinned-tiny) warm-up with a silent
+    // chunk, so the barge-in below trips synchronously inside
+    // handleBinaryAudio and can race the queued completion.
+    await session.handleBinaryAudio(SILENT_CHUNK);
 
     // The LLM finishes just as the user barges in: message_complete queues
     // the completion continuation and the abort fires before it runs.
@@ -1955,10 +1992,19 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
 
   test("bargeInMinSpeechMs 0 restores instant barge-in", async () => {
     const { frames, session, abort, speakFirstReply } =
-      createSpeakingTurnHarness({ bargeInMinSpeechMs: 0 });
+      createSpeakingTurnHarness({
+        bargeInMinSpeechMs: 0,
+        // Neutralize the echo gate's threshold; its onset warm-up still
+        // shields the first in-window chunk via the deferral guard.
+        echoBargeInMargin: 0.001,
+        echoEmaHalfLifeMs: 4,
+      });
     await speakFirstReply();
 
-    // A single 10 ms onset chunk cancels immediately — no accumulation.
+    // The onset chunk arms the warm-up deferral guard; the next chunk fires
+    // with no sustained-run accumulation — the instant contract under the
+    // echo gate.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
@@ -2056,10 +2102,16 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
         // …but the start-frame override disables the guard, so barge-in is
         // instant.
         startFrame: { ...VAD_START_FRAME, bargeInMinSpeechMs: 0 },
+        // Neutralize the echo gate's threshold; its onset warm-up still
+        // shields the first in-window chunk via the deferral guard.
+        echoBargeInMargin: 0.001,
+        echoEmaHalfLifeMs: 4,
       });
     await speakFirstReply();
 
-    // A single speech chunk barges in immediately — proving the frame's 0 won.
+    // The chunk after onset barges in with no accumulated run — proving the
+    // frame's 0 won over the 5s option.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
@@ -2074,9 +2126,11 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   // speech above max(speechEnergyThreshold, echoBargeInMargin × echo EMA), so
   // loud TTS echo leaking through imperfect client echo cancellation cannot
   // self-interrupt the reply, while a user talking over it still can. Tests
-  // compress echoEmaHalfLifeMs to 5 ms so one 10 ms echo chunk converges the
-  // EMA far enough (alpha 0.75 → EMA 2250 for a 3000 chunk, threshold 3375
-  // at the default 1.5 margin) that steady echo sits under its own margin.
+  // compress echoEmaHalfLifeMs to 5 ms: the first 10 ms chunk lands in the
+  // onset warm-up (half-life/2 = 2.5 ms, quartered attack half-life 1.25 ms,
+  // alpha ≈ 0.996), so a 3000 chunk converges the EMA to ≈ 2988 — threshold
+  // ≈ 4482 at the default 1.5 margin — and steady echo sits under its own
+  // margin from the second chunk on.
   describe("echo-adaptive gate", () => {
     test("steady loud echo during playback never fires speech_started or cancels the turn", async () => {
       const { frames, session, abort, speakFirstReply } =
@@ -2142,7 +2196,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       await flushAsyncCallbacks();
       expect(countType(frames, "turn_cancelled")).toBe(0);
 
-      // The user talks over the echo: 6000 clears the 3375 threshold and
+      // The user talks over the echo: 6000 clears the ≈ 4482 threshold and
       // sustains past the guard, so the deferred speech_started flushes
       // playback and the turn cancels.
       for (let index = 0; index < 7; index += 1) {
@@ -2218,6 +2272,142 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       // floor — a stale reference would have swallowed it.
       await session.handleBinaryAudio(pcm(1_000));
       await waitFor(() => countType(frames, "speech_started") === baseline + 1);
+    });
+
+    test("a guard trip reached during warm-up is deferred and dissolved by the converging reference", async () => {
+      // With the guard (20 ms) SHORTER than the warm-up (half-life/2 =
+      // 20 ms of audio), onset echo accumulates to the trip while its chunks
+      // are still judged against a warming reference — the per-chunk
+      // deferral holds the trip, and the reference overtakes the echo on the
+      // next chunk, zeroing the run before it can ever fire.
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 20,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      for (let index = 0; index < 30; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("instant barge-in (guard disabled) is still shielded from onset echo, then fires instantly once warm", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 0,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+
+      // Onset echo: the warm-up arms a deferral guard even with
+      // bargeInMinSpeechMs 0, and the converging reference absorbs the echo
+      // — without this shield the very first chunk would cancel the turn.
+      for (let index = 0; index < 30; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // Post-warm-up, instant behavior is back: the first chunk clearing the
+      // converged margin fires without accumulating a sustained run.
+      await session.handleBinaryAudio(pcm(8_000));
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("a live speech run crossing into playback (turn collision) keeps user-first semantics and trips", async () => {
+      let callbacks: VoiceTurnCallbacks | undefined;
+      const abort = mock();
+      const startVoiceTurn = mock(async (turnOptions: VoiceTurnOptions) => {
+        callbacks ??= turnOptions.callbacks;
+        return { turnId: "bridge-turn", abort };
+      });
+      const streamTtsAudio = mock(async (ttsOptions: LiveVoiceTtsOptions) => {
+        ttsOptions.onAudioChunk(makeTtsChunk("assistant audio"));
+        return makeTtsResult("assistant audio");
+      });
+      const { frames, session } = createHarness({
+        finals: ["what's the weather", "actually never mind"],
+        startVoiceTurn,
+        streamTtsAudio,
+        bargeInMinSpeechMs: 60,
+        echoEmaHalfLifeMs: 400,
+        turnDetectorConfig: { silenceThresholdMs: 5_000 },
+      });
+      await session.start();
+      await session.handleBinaryAudio(LOUD_CHUNK);
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+      // 30 ms of live speech arms the guard while the turn is thinking...
+      for (let index = 0; index < 3; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      // ...then TTS starts mid-run. The carried-over guard keeps user-first
+      // semantics: frozen reference, base threshold, normal trip at 60 ms —
+      // the onset warm-up must not defer or absorb the colliding user.
+      callbacks?.assistant_text_delta?.(makeTextDelta("It is sunny today."));
+      await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+      for (let index = 0; index < 4; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("a pre-playback noise blip whose run already ended does not block echo learning", async () => {
+      let callbacks: VoiceTurnCallbacks | undefined;
+      const abort = mock();
+      const startVoiceTurn = mock(async (turnOptions: VoiceTurnOptions) => {
+        callbacks ??= turnOptions.callbacks;
+        return { turnId: "bridge-turn", abort };
+      });
+      const streamTtsAudio = mock(async (ttsOptions: LiveVoiceTtsOptions) => {
+        ttsOptions.onAudioChunk(makeTtsChunk("assistant audio"));
+        return makeTtsResult("assistant audio");
+      });
+      const { frames, session } = createHarness({
+        finals: ["what's the weather", "actually never mind"],
+        startVoiceTurn,
+        streamTtsAudio,
+        bargeInMinSpeechMs: 60,
+        echoEmaHalfLifeMs: 40,
+        turnDetectorConfig: { silenceThresholdMs: 5_000 },
+      });
+      await session.start();
+      await session.handleBinaryAudio(LOUD_CHUNK);
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+      // A cough during thinking arms the guard, then a silent chunk zeroes
+      // its run — the guard object itself stays armed.
+      for (let index = 0; index < 2; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await session.handleBinaryAudio(SILENT_CHUNK);
+      // TTS starts: the armed-but-settled guard is NOT a turn collision, so
+      // the onset warm-up learns the echo and steady loud echo cannot run
+      // out the lingering guard against the base threshold.
+      callbacks?.assistant_text_delta?.(makeTextDelta("It is sunny today."));
+      await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+      const baseline = countType(frames, "turn_cancelled");
+      for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(baseline);
+      expect(abort).not.toHaveBeenCalled();
     });
 
     test("the echo reference freezes while the barge-in guard is armed", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -407,14 +407,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // echo reference); 0 outside the echo window.
   private echoEnergyEma = 0;
   // Audio time (ms) processed since the echo window opened — drives the
-  // gate's warm-up (see isEchoGateWarmingUp); 0 outside the echo window.
+  // gate's warm-up (see effectiveSpeechThreshold); 0 outside the echo window.
   private echoWindowAudioMs = 0;
-  // True when the sustained-speech guard was already armed at the moment the
-  // echo window opened: speech that PREDATES playback is the user talking
-  // across the turn boundary (turn collision), not echo — humans cannot
-  // react to playback onset faster than the warm-up. That guard keeps
-  // user-first semantics (frozen reference, normal trips).
+  // A guard whose speech run predates the echo window is the user talking
+  // across the turn boundary (turn collision) — see effectiveSpeechThreshold.
   private echoWindowGuardCarryover = false;
+  // Warm-up state of the most recently classified in-window chunk (set by
+  // effectiveSpeechThreshold; consulted by handleVadSpeechStart and
+  // trackBargeInGuard) so classification and trip deferral agree per chunk
+  // regardless of ingress chunk size; false outside the echo window.
+  private echoGateChunkWarmingUp = false;
   // Mutable so a mid-session `update_config` frame can retune "interrupt
   // sensitivity" live (see applyConfigUpdate).
   private bargeInMinSpeechMs: number;
@@ -946,15 +948,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // echo chunk arms the guard, which would freeze the reference near zero and
   // let steady onset echo complete a full guard run against the base
   // threshold. So the window opens with a WARM-UP — the first
-  // echoEmaHalfLifeMs / 2 of in-window audio (200 ms at the 400 ms default) —
-  // during which the EMA learns at a fast attack rate (quarter half-life)
-  // and keeps learning even with the guard armed: echo, not speech, is the
-  // expected first signal at TTS onset. Guard trips are deferred (the run
-  // accumulates, it doesn't fire) until warm; at the default 250 ms trip the
-  // warm-up ends first, so real barge-in latency is untouched. Steady onset
-  // echo converges past its own margin inside the warm-up and its run is
-  // zeroed before it can fire. Warm-up is measured in processed audio time,
-  // the same clock that drives EMA convergence.
+  // echoEmaHalfLifeMs / 2 of in-window audio (200 ms at the 400 ms default,
+  // under the 250 ms default trip, so real barge-in latency is untouched) —
+  // during which the EMA learns despite the armed guard, at a quarter-
+  // half-life attack rate (two attack half-lives per warm-up brings the
+  // reference to ~75% of a steady echo level, putting margin × EMA above
+  // it): echo, not speech, is the expected first signal at TTS onset. Guard
+  // trips are deferred (the run accumulates, it doesn't fire) while the
+  // tripping chunk was judged against a warming reference — a per-chunk flag
+  // (echoGateChunkWarmingUp), so large ingress chunks cannot outrun the
+  // window clock. Onset echo's run is zeroed once the reference overtakes
+  // it; a genuine user run that outlasts the warm-up fires on its first warm
+  // chunk. The same warm-up floor guards the instant-barge-in config
+  // (bargeInMinSpeechMs 0), which otherwise bypasses the guard entirely (see
+  // handleVadSpeechStart). Warm-up is measured in processed audio time, the
+  // same clock that drives EMA convergence.
+  //
+  // Turn collision: a guard with a LIVE speech run when the window opens is
+  // the user already talking across the turn boundary — humans cannot react
+  // to playback onset within the warm-up — and keeps user-first semantics
+  // (frozen reference, normal trips). An armed guard whose run already
+  // zeroed is a settled noise blip and gets onset semantics. If a colliding
+  // user pauses mid-window, the collision is over and the warm-up restarts
+  // (see trackBargeInGuard) so the echo underneath is finally learned.
   private effectiveSpeechThreshold(
     chunk: Buffer,
     meanAmplitude: number,
@@ -965,12 +981,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.echoEnergyEma = 0;
       this.echoWindowAudioMs = 0;
       this.echoWindowGuardCarryover = false;
+      this.echoGateChunkWarmingUp = false;
       return baseThreshold;
     }
     if (this.echoWindowAudioMs === 0) {
-      // Window opening: a guard armed before any assistant audio played is
-      // the user mid-utterance (turn collision), not echo.
-      this.echoWindowGuardCarryover = this.pendingBargeIn !== null;
+      // Window opening: only a guard with a live run is a turn collision.
+      this.echoWindowGuardCarryover =
+        this.pendingBargeIn !== null && this.pendingBargeIn.speechMs > 0;
     } else if (this.pendingBargeIn === null) {
       // The carried-over guard settled; onset semantics resume for any
       // later speech in this window.
@@ -982,11 +999,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       baseThreshold,
       this.echoBargeInMargin * this.echoEnergyEma,
     );
+    const warmingUp =
+      !this.echoWindowGuardCarryover &&
+      this.echoWindowAudioMs < this.echoEmaHalfLifeMs / 2;
+    this.echoGateChunkWarmingUp = warmingUp;
     const chunkMs = pcm16DurationMs(
       chunk.byteLength,
       this.context.startFrame.audio.sampleRate,
     );
-    const warmingUp = this.echoOnsetWarmupActive();
     if (this.pendingBargeIn === null || warmingUp) {
       // Attack fast during warm-up (quarter half-life) so the reference
       // overtakes steady onset echo inside the warm-up window; settle to the
@@ -1000,26 +1020,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     this.echoWindowAudioMs += chunkMs;
     return threshold;
-  }
-
-  // True while the echo window has processed less than echoEmaHalfLifeMs / 2
-  // of audio (200 ms at the 400 ms default) — with the warm-up's quarter-
-  // half-life attack rate that is 2 attack half-lives, enough for the
-  // reference to reach ~75% of a steady echo level, putting margin × EMA
-  // above it. See effectiveSpeechThreshold.
-  private isEchoGateWarmingUp(): boolean {
-    return (
-      this.isAssistantAudioPlaying() &&
-      this.echoWindowAudioMs < this.echoEmaHalfLifeMs / 2
-    );
-  }
-
-  // Onset-echo semantics (fast unfrozen EMA learning + deferred guard trips)
-  // apply only during the warm-up AND when the speech run did not predate
-  // playback — a guard carried across the window boundary is the user, and
-  // keeps user-first semantics.
-  private echoOnsetWarmupActive(): boolean {
-    return !this.echoWindowGuardCarryover && this.isEchoGateWarmingUp();
   }
 
   private async routeVadAudio(
@@ -1151,9 +1151,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // same guard, or a noise blip clips the reply's last words.
     const drainingPlayback = Date.now() < this.assistantPlaybackTailUntilMs;
 
-    if ((bargeableTurn || drainingPlayback) && this.bargeInMinSpeechMs > 0) {
+    if (
+      (bargeableTurn || drainingPlayback) &&
+      (this.bargeInMinSpeechMs > 0 || this.echoGateChunkWarmingUp)
+    ) {
       // Onset audio keeps flowing into the cycle/pre-roll while the guard
       // accumulates (trackBargeInGuard), so no speech is lost either way.
+      // Instant barge-in (bargeInMinSpeechMs 0) still arms the guard while
+      // the echo gate is warming up — otherwise the first onset-echo chunk
+      // would cancel every turn — and resumes instant behavior once warm.
       this.pendingBargeIn = { turn: bargeableTurn, speechMs: 0 };
       return;
     }
@@ -1177,6 +1183,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     if (!hasSpeech) {
       guard.speechMs = 0;
+      if (this.echoWindowGuardCarryover) {
+        // The colliding user paused: the collision is over. Restart the
+        // onset warm-up so whatever follows (echo, or the user again) gets
+        // onset semantics and the echo underneath is finally learned.
+        this.echoWindowGuardCarryover = false;
+        this.echoWindowAudioMs = 0;
+      }
       return;
     }
     guard.speechMs += pcm16DurationMs(
@@ -1186,13 +1199,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (guard.speechMs < this.bargeInMinSpeechMs) {
       return;
     }
-    // Defer trips while the echo gate's onset warm-up is active (see
-    // effectiveSpeechThreshold): the run keeps accumulating, and a genuine
-    // user run fires on the first speech chunk after warm-up, while onset
-    // echo's run is zeroed once the converged reference reclassifies it. A
-    // guard carried over from before playback started (turn collision) is
-    // the user and trips normally.
-    if (this.echoOnsetWarmupActive()) {
+    // Defer trips fed by a chunk judged against a warming echo reference —
+    // see effectiveSpeechThreshold. Turn-collision guards trip normally.
+    if (this.echoGateChunkWarmingUp) {
       return;
     }
     this.pendingBargeIn = null;

--- a/assistant/src/stt/speech-energy.ts
+++ b/assistant/src/stt/speech-energy.ts
@@ -24,7 +24,6 @@ export const DEFAULT_SPEECH_ENERGY_THRESHOLD = 800;
  * buffers; a trailing odd byte is ignored.
  *
  * @param chunk - Raw PCM16LE audio.
- * @returns Mean absolute amplitude on the 16-bit linear scale.
  */
 export function pcm16MeanAmplitude(chunk: Buffer): number {
   const sampleCount = Math.floor(chunk.length / 2);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for echo-adaptive-bargein.md.

- **Stuck carryover**: only a guard with a LIVE speech run at window open is a turn collision; a settled pre-playback noise blip no longer pins the reference at 0 (which reintroduced echo self-interrupt); a colliding user's pause now restarts the onset warm-up
- **Instant mode**: bargeInMinSpeechMs 0 arms the warm-up deferral guard instead of instantly cancelling on the first onset-echo chunk; instant behavior resumes once warm
- **Chunk granularity**: warm-up state is captured per chunk at classification time, so a large ingress chunk judged against a cold reference can never fire a trip
- Schema docs: echoEmaHalfLifeMs now documents the derived warm-up/attack/deferral and the keep-warm-up-below-trip coupling; echoBargeInMargin documents the disable hint
- Tests: 4 new cases (deferred-trip, instant-mode shield + post-warm-up fire, turn-collision trip, settled-blip regression); stale pre-warm-up arithmetic in comments corrected; barge-in mechanics tests pin gate-neutralizing knobs