### PR TITLE
Fix Gmail OAuth connection flow

### DIFF
--- a/assistant/src/cli/commands/__tests__/notifications.test.ts
+++ b/assistant/src/cli/commands/__tests__/notifications.test.ts
@@ -29,9 +29,15 @@ let ipcResponse: {
 };
 
 const exitCodeFromIpcResult = (r: { statusCode?: number }): number => {
-  if (r.statusCode === undefined) return 10;
-  if (r.statusCode >= 500) return 3;
-  if (r.statusCode >= 400) return 2;
+  if (r.statusCode === undefined) {
+    return 10;
+  }
+  if (r.statusCode >= 500) {
+    return 3;
+  }
+  if (r.statusCode >= 400) {
+    return 2;
+  }
   return 1;
 };
 
@@ -516,6 +522,21 @@ describe("notifications list", () => {
 
     expect(ipcCalls).toHaveLength(1);
     expect(ipcCalls[0].method).toBe("list_home_feed");
+  });
+
+  test("list help disambiguates Vellum notifications from email inboxes", async () => {
+    const { stdout, exitCode } = await runRawCommand([
+      "notifications",
+      "list",
+      "--help",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const normalizedHelp = stdout.replace(/\s+/g, " ");
+    expect(normalizedHelp).toContain("Vellum Home feed");
+    expect(normalizedHelp).toContain("does not read email inboxes");
+    expect(normalizedHelp).toContain("Gmail");
+    expect(normalizedHelp).toContain("Outlook");
   });
 
   test("list returns items from IPC", async () => {

--- a/assistant/src/cli/commands/notifications.help.ts
+++ b/assistant/src/cli/commands/notifications.help.ts
@@ -48,9 +48,9 @@ source channel, event name, and attention hints. The decision engine evaluates
 whether and where to deliver the notification based on connected channels,
 urgency, and user preferences.
 
-Minimal usage: only --message is required. Add --urgent for a push + visual
-flag in the inbox. Source channel/event name fall back to assistant_tool /
-assistant.share when omitted.
+Minimal usage: only --message is required. Add --urgent for a push +
+visual flag in the Vellum Home feed. Source channel/event name fall back
+to assistant_tool / assistant.share when omitted.
 
 Examples:
   $ assistant notifications send --message "Build finished"
@@ -71,7 +71,7 @@ Examples:
         {
           flags: "--urgent",
           description:
-            "Mark this notification as urgent (fires push + visual flag in inbox)",
+            "Mark this notification as urgent (fires push + visual flag in Vellum Home)",
           defaultValue: false,
         },
         {
@@ -176,7 +176,7 @@ Examples:
     {
       name: "list",
       description:
-        "List notifications surfaced to the user via the home feed. Excludes dismissed items by default.",
+        "List Vellum Home feed notifications surfaced by the assistant. Excludes dismissed items by default.",
       options: [
         {
           flags: "--all",
@@ -231,11 +231,11 @@ Examples:
         },
       ],
       helpText: `
-Reads the home feed at $VELLUM_WORKSPACE_DIR/data/home-feed.json — the
-user's notification inbox. Items are ordered by priority then recency,
-matching what the user sees in the macOS Home page. The home feed covers
-background/async notifications mirrored from the unified pipeline;
-real-time chat pushes that did not mirror to the feed will not appear.
+Reads Vellum's Home feed at $VELLUM_WORKSPACE_DIR/data/home-feed.json.
+Items are ordered by priority then recency, matching what the user sees
+in the macOS Home page. This is only the assistant's Vellum notification
+feed; it does not read email inboxes, Gmail, Outlook, or other external
+message providers. Use OAuth/provider-specific commands for external mail.
 
 Examples:
   $ assistant notifications list

--- a/assistant/src/cli/commands/oauth/connect-surface-guidance.test.ts
+++ b/assistant/src/cli/commands/oauth/connect-surface-guidance.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildOAuthConnectSurfaceRedirect,
+  isModelSpawnedConversationShell,
+  oauthConnectSurfaceHint,
+} from "./connect-surface-guidance.js";
+
+describe("OAuth connect surface guidance", () => {
+  test("builds the oauth_connect next action payload", () => {
+    expect(buildOAuthConnectSurfaceRedirect("google")).toEqual({
+      ok: false,
+      code: "use_oauth_connect_surface",
+      provider: "google",
+      hint: oauthConnectSurfaceHint("google"),
+      nextAction: {
+        type: "ui_show",
+        surfaceType: "oauth_connect",
+        data: { providerKey: "google" },
+      },
+    });
+  });
+
+  test("detects model-spawned conversation shells", () => {
+    expect(
+      isModelSpawnedConversationShell({ __CONVERSATION_ID: "conv-123" }),
+    ).toBe(true);
+    expect(isModelSpawnedConversationShell({ __CONVERSATION_ID: "   " })).toBe(
+      false,
+    );
+    expect(isModelSpawnedConversationShell({})).toBe(false);
+  });
+
+  test("hint tells the model not to paste OAuth URLs", () => {
+    const hint = oauthConnectSurfaceHint("google");
+    expect(hint).toContain('surface_type "oauth_connect"');
+    expect(hint).toContain('data.providerKey "google"');
+    expect(hint).toContain("paste an OAuth URL");
+  });
+});

--- a/assistant/src/cli/commands/oauth/connect-surface-guidance.ts
+++ b/assistant/src/cli/commands/oauth/connect-surface-guidance.ts
@@ -1,0 +1,54 @@
+export interface OAuthConnectSurfaceNextAction {
+  type: "ui_show";
+  surfaceType: "oauth_connect";
+  data: { providerKey: string };
+}
+
+export interface OAuthConnectSurfaceRedirect {
+  ok: false;
+  code: "use_oauth_connect_surface";
+  provider: string;
+  hint: string;
+  nextAction: OAuthConnectSurfaceNextAction;
+}
+
+export function oauthConnectSurfaceHint(provider: string): string {
+  return (
+    `To let the user connect, render the connect button: call ` +
+    `\`ui_show\` with surface_type "oauth_connect" and ` +
+    `data.providerKey "${provider}". That surface is always available — do ` +
+    `not run further \`oauth\`/\`channels\` commands, paste an OAuth URL, or ` +
+    `load a setup skill just to display it.`
+  );
+}
+
+export function buildOAuthConnectSurfaceNextAction(
+  provider: string,
+): OAuthConnectSurfaceNextAction {
+  return {
+    type: "ui_show",
+    surfaceType: "oauth_connect",
+    data: { providerKey: provider },
+  };
+}
+
+export function buildOAuthConnectSurfaceRedirect(
+  provider: string,
+): OAuthConnectSurfaceRedirect {
+  return {
+    ok: false,
+    code: "use_oauth_connect_surface",
+    provider,
+    hint: oauthConnectSurfaceHint(provider),
+    nextAction: buildOAuthConnectSurfaceNextAction(provider),
+  };
+}
+
+export function isModelSpawnedConversationShell(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    typeof env.__CONVERSATION_ID === "string" &&
+    env.__CONVERSATION_ID.trim().length > 0
+  );
+}

--- a/assistant/src/cli/commands/oauth/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/connect.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const ipcCalls: Array<{ method: string; params?: Record<string, unknown> }> =
+  [];
+const openedUrls: string[] = [];
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (method === "oauth_providers_by_providerKey_get") {
+      return {
+        ok: true,
+        result: {
+          provider: { authUrl: "https://accounts.example.com/oauth" },
+        },
+      };
+    }
+    if (method === "oauth_mode_get") {
+      return { ok: true, result: { ok: true, mode: "managed" } };
+    }
+    if (method === "oauth_managed_connect_start") {
+      return {
+        ok: true,
+        result: { ok: true, connect_url: "https://connect.example.com" },
+      };
+    }
+    return { ok: false, error: `Unexpected IPC method ${method}` };
+  },
+  exitFromIpcResult: (r: { error?: string }) => {
+    throw new Error(r.error ?? "IPC error");
+  },
+}));
+
+mock.module("../../lib/open-browser.js", () => ({
+  openInHostBrowser: (url: string) => {
+    openedUrls.push(url);
+  },
+}));
+
+mock.module("../../logger.js", () => ({
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+import { Command } from "commander";
+
+import { applyCommandHelp } from "../../lib/cli-command-help.js";
+import { registerConnectCommand } from "./connect.js";
+import { oauthHelp } from "./index.help.js";
+
+const originalConversationId = process.env.__CONVERSATION_ID;
+
+beforeEach(() => {
+  ipcCalls.length = 0;
+  openedUrls.length = 0;
+  process.exitCode = 0;
+  process.env.__CONVERSATION_ID = "conv-123";
+});
+
+afterEach(() => {
+  if (originalConversationId === undefined) {
+    delete process.env.__CONVERSATION_ID;
+  } else {
+    process.env.__CONVERSATION_ID = originalConversationId;
+  }
+  process.exitCode = 0;
+});
+
+async function runConnectCommand(): Promise<{
+  stdout: string;
+  exitCode: number;
+}> {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((chunk: string | Buffer) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    const oauth = program.command("oauth").description(oauthHelp.description);
+    applyCommandHelp(oauth, oauthHelp);
+    registerConnectCommand(oauth);
+    await program.parseAsync([
+      "node",
+      "test",
+      "oauth",
+      "--json",
+      "connect",
+      "google",
+    ]);
+  } catch {
+    // Commander may throw under exitOverride for parse errors; the assertions
+    // below verify the command behavior we care about.
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  return { stdout: chunks.join(""), exitCode: Number(process.exitCode ?? 0) };
+}
+
+describe("oauth connect", () => {
+  test("managed provider in a conversation shell returns oauth_connect guidance without opening a browser", async () => {
+    const { stdout, exitCode } = await runConnectCommand();
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(parsed.code).toBe("use_oauth_connect_surface");
+    expect(parsed.nextAction).toEqual({
+      type: "ui_show",
+      surfaceType: "oauth_connect",
+      data: { providerKey: "google" },
+    });
+    expect(openedUrls).toEqual([]);
+    expect(ipcCalls.map((call) => call.method)).toEqual([
+      "oauth_providers_by_providerKey_get",
+      "oauth_mode_get",
+    ]);
+  });
+});

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -5,6 +5,10 @@ import { subcommand } from "../../lib/cli-command-help.js";
 import { openInHostBrowser } from "../../lib/open-browser.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+import {
+  buildOAuthConnectSurfaceRedirect,
+  isModelSpawnedConversationShell,
+} from "./connect-surface-guidance.js";
 
 const log = getCliLogger("cli");
 
@@ -125,7 +129,9 @@ export function registerConnectCommand(oauth: Command): void {
             queryParams: { provider },
           });
 
-          if (!modeResult.ok) return exitFromIpcResult(modeResult);
+          if (!modeResult.ok) {
+            return exitFromIpcResult(modeResult);
+          }
 
           const managed = modeResult.result?.mode === "managed";
 
@@ -133,6 +139,13 @@ export function registerConnectCommand(oauth: Command): void {
             // =============================================================
             // MANAGED PATH
             // =============================================================
+
+            if (isModelSpawnedConversationShell()) {
+              const redirect = buildOAuthConnectSurfaceRedirect(provider);
+              writeOutput(cmd, redirect);
+              process.exitCode = 1;
+              return;
+            }
 
             if (opts.clientId) {
               log.info(
@@ -152,7 +165,9 @@ export function registerConnectCommand(oauth: Command): void {
               body: startBody,
             });
 
-            if (!startResult.ok) return exitFromIpcResult(startResult);
+            if (!startResult.ok) {
+              return exitFromIpcResult(startResult);
+            }
 
             const connectUrl = startResult.result!.connect_url;
 
@@ -169,7 +184,9 @@ export function registerConnectCommand(oauth: Command): void {
                 queryParams: { provider },
               });
 
-              if (!snapshotResult.ok) return exitFromIpcResult(snapshotResult);
+              if (!snapshotResult.ok) {
+                return exitFromIpcResult(snapshotResult);
+              }
 
               const snapshotIds = new Set(
                 (snapshotResult.result?.connections ?? []).map((e) => e.id),
@@ -207,7 +224,9 @@ export function registerConnectCommand(oauth: Command): void {
                   queryParams: { provider },
                 });
 
-                if (!currentResult.ok || !currentResult.result) continue;
+                if (!currentResult.ok || !currentResult.result) {
+                  continue;
+                }
 
                 const found = currentResult.result.connections.find(
                   (e) => !snapshotIds.has(e.id),
@@ -282,8 +301,12 @@ export function registerConnectCommand(oauth: Command): void {
               service: provider,
               callbackTransport: opts.callbackTransport,
             };
-            if (opts.clientId) startBody.clientId = opts.clientId;
-            if (opts.scopes) startBody.requestedScopes = opts.scopes;
+            if (opts.clientId) {
+              startBody.clientId = opts.clientId;
+            }
+            if (opts.scopes) {
+              startBody.requestedScopes = opts.scopes;
+            }
 
             const startResult = await cliIpcCall<{
               auth_url: string;

--- a/assistant/src/cli/commands/oauth/index.help.ts
+++ b/assistant/src/cli/commands/oauth/index.help.ts
@@ -655,7 +655,7 @@ Examples:
       name: "connect",
       args: "<provider>",
       description:
-        "Initiate an OAuth authorization flow for a specified provider",
+        "Initiate a terminal/headless OAuth authorization flow for a specified provider",
       options: [
         {
           flags: "--scopes <scopes...>",
@@ -686,6 +686,12 @@ defaults entirely (use full scope URLs).
 By default, the browser opens automatically and the command waits for
 completion. Use --no-browser to print the URL instead (useful for headless
 or SSH sessions).
+
+Important for chat/UI turns: do not run this command just to let the user
+connect a managed provider. Render the first-class connect surface instead:
+call \`ui_show\` with surface_type "oauth_connect" and data.providerKey set to
+the provider (for example, "google"). That surface starts the managed OAuth UI
+and avoids pasting raw authorization links into the conversation.
 
 Examples:
   $ assistant oauth connect google

--- a/assistant/src/cli/commands/oauth/status.test.ts
+++ b/assistant/src/cli/commands/oauth/status.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { noConnectionsMessage } from "./status.js";
+import { oauthHelp } from "./index.help.js";
+import { decorateStatusJsonForModel, noConnectionsMessage } from "./status.js";
 
 const original = process.env.__RESOLVED_MODEL;
 
 afterEach(() => {
-  if (original === undefined) delete process.env.__RESOLVED_MODEL;
-  else process.env.__RESOLVED_MODEL = original;
+  if (original === undefined) {
+    delete process.env.__RESOLVED_MODEL;
+  } else {
+    process.env.__RESOLVED_MODEL = original;
+  }
 });
 
 describe("noConnectionsMessage", () => {
@@ -31,6 +35,49 @@ describe("noConnectionsMessage", () => {
     const msg = await noConnectionsMessage("google");
     expect(msg).toContain('surface_type "oauth_connect"');
     expect(msg).toContain('data.providerKey "google"');
+    expect(msg).toContain("paste an OAuth URL");
     expect(msg).not.toContain("assistant oauth connect google");
+  });
+
+  test("weak open model JSON status includes oauth_connect next action", async () => {
+    process.env.__RESOLVED_MODEL = "accounts/fireworks/models/glm-5p2";
+    const result = await decorateStatusJsonForModel({
+      ok: true,
+      provider: "google",
+      mode: "managed",
+      connections: [],
+    });
+    expect(result.hint).toContain('surface_type "oauth_connect"');
+    expect(result.hint).toContain("paste an OAuth URL");
+    expect(result.nextAction).toEqual({
+      type: "ui_show",
+      surfaceType: "oauth_connect",
+      data: { providerKey: "google" },
+    });
+  });
+
+  test("capable model JSON status stays compact", async () => {
+    process.env.__RESOLVED_MODEL = "claude-opus-4-8";
+    const result = await decorateStatusJsonForModel({
+      ok: true,
+      provider: "google",
+      mode: "managed",
+      connections: [],
+    });
+    expect(result.hint).toBeUndefined();
+    expect(result.nextAction).toBeUndefined();
+  });
+});
+
+describe("oauth connect help", () => {
+  test("steers chat turns to the oauth_connect surface", () => {
+    const connectHelp = oauthHelp.subcommands?.find(
+      (command) => command.name === "connect",
+    );
+    expect(connectHelp?.description).toContain("terminal/headless");
+    expect(connectHelp?.helpText).toContain('surface_type "oauth_connect"');
+    expect(connectHelp?.helpText).toContain(
+      "avoids pasting raw authorization links",
+    );
   });
 });

--- a/assistant/src/cli/commands/oauth/status.test.ts
+++ b/assistant/src/cli/commands/oauth/status.test.ts
@@ -39,6 +39,13 @@ describe("noConnectionsMessage", () => {
     expect(msg).not.toContain("assistant oauth connect google");
   });
 
+  test("weak open models are not steered to oauth_connect for BYO mode", async () => {
+    process.env.__RESOLVED_MODEL = "accounts/fireworks/models/minimax-m3";
+    const msg = await noConnectionsMessage("google", "byo");
+    expect(msg).not.toContain('surface_type "oauth_connect"');
+    expect(msg).toContain("assistant oauth connect google");
+  });
+
   test("weak open model JSON status includes oauth_connect next action", async () => {
     process.env.__RESOLVED_MODEL = "accounts/fireworks/models/glm-5p2";
     const result = await decorateStatusJsonForModel({
@@ -54,6 +61,18 @@ describe("noConnectionsMessage", () => {
       surfaceType: "oauth_connect",
       data: { providerKey: "google" },
     });
+  });
+
+  test("weak open model JSON status stays compact for BYO mode", async () => {
+    process.env.__RESOLVED_MODEL = "accounts/fireworks/models/glm-5p2";
+    const result = await decorateStatusJsonForModel({
+      ok: true,
+      provider: "google",
+      mode: "byo",
+      connections: [],
+    });
+    expect(result.hint).toBeUndefined();
+    expect(result.nextAction).toBeUndefined();
   });
 
   test("capable model JSON status stays compact", async () => {

--- a/assistant/src/cli/commands/oauth/status.ts
+++ b/assistant/src/cli/commands/oauth/status.ts
@@ -3,6 +3,11 @@ import type { Command } from "commander";
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
 import { subcommand } from "../../lib/cli-command-help.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+import {
+  buildOAuthConnectSurfaceNextAction,
+  oauthConnectSurfaceHint,
+  type OAuthConnectSurfaceNextAction,
+} from "./connect-surface-guidance.js";
 
 /**
  * Message shown when a provider has no active connections. Weak open models
@@ -16,13 +21,7 @@ export async function noConnectionsMessage(provider: string): Promise<string> {
   const { isWeakOpenModel } =
     await import("../../../providers/weak-open-model.js");
   if (isWeakOpenModel(process.env.__RESOLVED_MODEL)) {
-    return (
-      `${base}\nTo let the user connect, render the connect button: call ` +
-      `\`ui_show\` with surface_type "oauth_connect" and ` +
-      `data.providerKey "${provider}". That surface is always available — do ` +
-      `not run further \`oauth\`/\`channels\` commands or load a setup skill ` +
-      `just to display it.\n`
-    );
+    return `${base}\n${oauthConnectSurfaceHint(provider)}\n`;
   }
   return `${base}\nConnect with \`assistant oauth connect ${provider}\`.\n`;
 }
@@ -38,6 +37,39 @@ interface ConnectionSummary {
   status: string;
   expiresAt?: string | null;
   hasRefreshToken?: boolean;
+}
+
+interface OAuthStatusResponse {
+  ok: boolean;
+  provider: string;
+  mode: string;
+  connections: ConnectionSummary[];
+  hint?: string;
+  nextAction?: OAuthConnectSurfaceNextAction;
+}
+
+/**
+ * JSON status output is often fed back to the model. For weak open models,
+ * include the same next-action steering as the human text path so a follow-up
+ * "yes" renders the first-class OAuth surface instead of a raw CLI URL.
+ */
+export async function decorateStatusJsonForModel(
+  result: OAuthStatusResponse,
+): Promise<OAuthStatusResponse> {
+  if (result.connections.length > 0) {
+    return result;
+  }
+  const { isWeakOpenModel } =
+    await import("../../../providers/weak-open-model.js");
+  if (!isWeakOpenModel(process.env.__RESOLVED_MODEL)) {
+    return result;
+  }
+  return {
+    ...result,
+    hint: result.hint ?? oauthConnectSurfaceHint(result.provider),
+    nextAction:
+      result.nextAction ?? buildOAuthConnectSurfaceNextAction(result.provider),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -86,11 +118,11 @@ export function registerStatusCommand(oauth: Command): void {
           return exitFromIpcResult(r);
         }
 
-        const result = r.result!;
+        const result = r.result! as OAuthStatusResponse;
         const { connections, mode } = result;
 
         if (shouldOutputJson(cmd)) {
-          writeOutput(cmd, result);
+          writeOutput(cmd, await decorateStatusJsonForModel(result));
           return;
         }
 

--- a/assistant/src/cli/commands/oauth/status.ts
+++ b/assistant/src/cli/commands/oauth/status.ts
@@ -16,11 +16,14 @@ import {
  * they get an explicit single next action: render the core `oauth_connect`
  * surface directly. Capable models keep the terse default.
  */
-export async function noConnectionsMessage(provider: string): Promise<string> {
+export async function noConnectionsMessage(
+  provider: string,
+  mode = "managed",
+): Promise<string> {
   const base = `No active connections for ${provider}.`;
   const { isWeakOpenModel } =
     await import("../../../providers/weak-open-model.js");
-  if (isWeakOpenModel(process.env.__RESOLVED_MODEL)) {
+  if (mode === "managed" && isWeakOpenModel(process.env.__RESOLVED_MODEL)) {
     return `${base}\n${oauthConnectSurfaceHint(provider)}\n`;
   }
   return `${base}\nConnect with \`assistant oauth connect ${provider}\`.\n`;
@@ -57,6 +60,9 @@ export async function decorateStatusJsonForModel(
   result: OAuthStatusResponse,
 ): Promise<OAuthStatusResponse> {
   if (result.connections.length > 0) {
+    return result;
+  }
+  if (result.mode !== "managed") {
     return result;
   }
   const { isWeakOpenModel } =
@@ -128,7 +134,7 @@ export function registerStatusCommand(oauth: Command): void {
 
         // Text output
         if (connections.length === 0) {
-          process.stdout.write(await noConnectionsMessage(provider));
+          process.stdout.write(await noConnectionsMessage(provider, mode));
           return;
         }
 


### PR DESCRIPTION
## Summary

- Disambiguate `assistant notifications list` help so the Vellum Home feed is not described as an email inbox.
- Add managed OAuth connect guidance for weak open models in `oauth status` text and JSON output.
- Prevent model-spawned conversation shells from launching `assistant oauth connect` for managed providers; they now return an `oauth_connect` surface instruction instead of opening/pasting a raw OAuth URL.

## Root Cause

A user asking for an inbox summary could be routed to the Vellum notification feed because the CLI help called it a notification inbox. After the user clarified Gmail, the assistant could still run the terminal OAuth command from bash, bypassing the chat `oauth_connect` surface and opening the wrong OAuth flow.

## Validation

- `cd assistant && bun test src/cli/commands/oauth/connect.test.ts src/cli/commands/oauth/status.test.ts src/cli/commands/oauth/connect-surface-guidance.test.ts src/cli/commands/__tests__/notifications.test.ts`
- `cd assistant && bun run typecheck:fast`
- `git diff --check`
- Commit hooks: secrets check, generic-examples check, Prettier, ESLint, assistant typecheck
- Pre-push hook: assistant typecheck and lint passed