### PR TITLE
fix(calls): resolve end-call drain on buffered barge-in; teardown cleanups

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -989,6 +989,43 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("a second END_CALL teardown keeps its own safety cap after cancelling the first", async () => {
+    // Cancelling a mid-drain teardown then immediately starting another must
+    // not let the old teardown's continuation clear the new one's cap.
+    mockEndCallListenWindowMs = 30;
+    mockEndCallDrainMaxWaitMs = 40;
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        content: string;
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        turnContents.push(opts.content);
+        opts.onTextDelta(
+          turnContents.length === 2 ? "Okay, bye. [END_CALL]" : "Goodbye! [END_CALL]",
+        );
+        opts.onComplete();
+        return { turnId: `run-${turnContents.length}`, abort: () => {} };
+      },
+    );
+    // Both goodbyes' drains never echo — only each teardown's own safety cap
+    // can release it.
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => new Promise<void>(() => {}),
+    });
+
+    await controller.handleCallerUtterance("That is all"); // teardown A (mid-drain)
+    // Re-engage: cancels A and starts turn 2, which emits END_CALL → teardown B.
+    await controller.handleCallerUtterance("Actually, bye");
+
+    // B must still hang up via its own cap despite A's cancelled continuation.
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
   test("caller re-engagement during the drain phase cancels teardown and defers", async () => {
     mockEndCallListenWindowMs = 30;
     const turnContents: string[] = [];

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -514,6 +514,49 @@ describe("MediaStreamOutput", () => {
       output.clearBufferedAudio();
       expect(sent).toHaveLength(0);
     });
+
+    test("resolves a drain waiter for an end-of-turn mark already sent to Twilio", async () => {
+      // A mark sent to Twilio is dropped by `clear` and never echoes, so a
+      // pending end-call drain wait must resolve here rather than stall.
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "MZ-stream-1");
+      output.sendTextToken("", true); // enqueues + sends end-of-turn:1
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      const drained = output.awaitPlaybackDrained();
+      output.clearBufferedAudio();
+      await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("does not resolve a drain waiter for an end-of-turn mark not yet sent", async () => {
+      // Slow synthesis keeps the mark queued locally (not yet sent to Twilio);
+      // clearBufferedAudio preserves it, so it will still play and echo.
+      mockSynthesize.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  audio: makeWavBuffer([1, 2, 3, 4]),
+                  contentType: "audio/wav",
+                }),
+              50,
+            ),
+          ),
+      );
+      const { ws } = createMockWs();
+      const output = makeOutput(ws, "MZ-stream-1");
+      output.sendTextToken("hello world", true); // mark queued behind synthesis
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      output.clearBufferedAudio(); // mark not sent yet — must stay pending
+      await drain();
+      expect(resolved).toBe(false);
+    });
   });
 
   describe("cancelPendingSpeech — turn abort", () => {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -291,7 +291,7 @@ export class CallController {
     // If the caller speaks while an END_CALL teardown is pending (during the
     // drain wait or the listen window), this is a deferral — the caller is
     // re-engaging after we tried to hang up. Track it so we can cap repeats.
-    if (this.endCallListenTimer || this.pendingEndCall) {
+    if (this.pendingEndCall) {
       this.endCallDeferralCount++;
       // The goodbye's speech was queued while state was idle, so the
       // media-stream barge-in ignored it. Cancel it here so it can't play
@@ -1349,10 +1349,9 @@ export class CallController {
     this.state = "idle";
     this.currentTurnHandle = null;
 
-    if (this.endCallListenTimer) {
-      clearTimeout(this.endCallListenTimer);
-      this.endCallListenTimer = null;
-    }
+    // Cancel any teardown still in flight from a prior END_CALL so it can't
+    // fire or cancel a later run.
+    this.cancelPendingEndCall();
 
     // The call always continues past END_CALL — either flushing queued
     // instructions or waiting for playback drain — so restore in_progress if
@@ -1361,10 +1360,8 @@ export class CallController {
       updateCallSession(this.callSessionId, { status: "in_progress" });
     }
 
-    // Queued instructions mean the call is continuing — flush and skip
-    // teardown. Clear any stale token first so it can't cancel a later run.
+    // Queued instructions mean the call is continuing — flush and skip teardown.
     if (this.pendingInstructions.length > 0) {
-      this.pendingEndCall = null;
       this.flushPendingInstructions();
       return;
     }
@@ -1468,6 +1465,9 @@ export class CallController {
   }
 
   private completeCallFromEndMarker(): void {
+    // The teardown has run to completion; drop the token so a later utterance
+    // can't read it as a still-pending end-call.
+    this.pendingEndCall = null;
     if (this.destroyed) return;
 
     const currentSession = getCallSession(this.callSessionId);

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -106,6 +106,12 @@ interface PendingGuardianInput {
   timer: ReturnType<typeof setTimeout>;
 }
 
+interface PendingEndCall {
+  cancelled: boolean;
+  /** Settles the teardown's current in-flight wait (drain cap or listen window). */
+  wake: (() => void) | null;
+}
+
 export class CallController {
   private callSessionId: string;
   private transport: CallTransport;
@@ -115,13 +121,12 @@ export class CallController {
   private currentTurnPromise: Promise<void> | null = null;
   private destroyed = false;
   private silenceTimer: ReturnType<typeof setTimeout> | null = null;
-  private endCallListenTimer: ReturnType<typeof setTimeout> | null = null;
-  /** Safety-cap timer for the end-call playback-drain wait. */
-  private endCallDrainCapTimer: ReturnType<typeof setTimeout> | null = null;
-  /** Settles the in-flight end-call wait so cancellation never leaves it hanging. */
-  private endCallWaitResolve: (() => void) | null = null;
-  /** Cancellation token for the in-flight end-call teardown (drain → listen). */
-  private pendingEndCall: { cancelled: boolean } | null = null;
+  /**
+   * Cancellation token for the in-flight end-call teardown (drain → listen).
+   * `wake` settles the teardown's current wait; all wait state lives on the
+   * token so a superseding teardown never clobbers a prior one's timers.
+   */
+  private pendingEndCall: PendingEndCall | null = null;
   /**
    * How many times the caller has re-engaged (spoken) after an END_CALL
    * marker was emitted but before the listen window fired. Each caller
@@ -1366,7 +1371,7 @@ export class CallController {
       return;
     }
 
-    const pending = { cancelled: false };
+    const pending: PendingEndCall = { cancelled: false, wake: null };
     this.pendingEndCall = pending;
     void this.runEndCallTeardown(pending);
   }
@@ -1376,19 +1381,13 @@ export class CallController {
    * the re-engagement listen window, then end the session. Cancellable at
    * every step via the `pending` token (caller re-engagement, destroy).
    */
-  private async runEndCallTeardown(pending: {
-    cancelled: boolean;
-  }): Promise<void> {
+  private async runEndCallTeardown(pending: PendingEndCall): Promise<void> {
     if (this.transport.awaitPlaybackDrained) {
-      await new Promise<void>((resolve) => {
-        this.endCallWaitResolve = resolve;
-        this.endCallDrainCapTimer = setTimeout(
-          resolve,
-          getEndCallDrainMaxWaitMs(),
-        );
+      await this.awaitCancellable(pending, (resolve) => {
+        const cap = setTimeout(resolve, getEndCallDrainMaxWaitMs());
         void this.transport.awaitPlaybackDrained!().then(resolve, resolve);
+        return () => clearTimeout(cap);
       });
-      this.clearEndCallWait();
     }
     if (pending.cancelled || this.destroyed) {
       return;
@@ -1400,11 +1399,10 @@ export class CallController {
       this.endCallDeferralCount > 0 ? 0 : getEndCallListenWindowMs();
     if (listenWindowMs > 0) {
       this.resetSilenceTimer();
-      await new Promise<void>((resolve) => {
-        this.endCallWaitResolve = resolve;
-        this.endCallListenTimer = setTimeout(resolve, listenWindowMs);
+      await this.awaitCancellable(pending, (resolve) => {
+        const timer = setTimeout(resolve, listenWindowMs);
+        return () => clearTimeout(timer);
       });
-      this.clearEndCallWait();
     }
     if (pending.cancelled || this.destroyed) {
       return;
@@ -1413,29 +1411,39 @@ export class CallController {
     this.completeCallFromEndMarker();
   }
 
-  /** Clear the end-call wait's timers and resolver handle. */
-  private clearEndCallWait(): void {
-    if (this.endCallDrainCapTimer) {
-      clearTimeout(this.endCallDrainCapTimer);
-      this.endCallDrainCapTimer = null;
-    }
-    if (this.endCallListenTimer) {
-      clearTimeout(this.endCallListenTimer);
-      this.endCallListenTimer = null;
-    }
-    this.endCallWaitResolve = null;
+  /**
+   * Await a wait that {@link cancelPendingEndCall} can settle early. `arm`
+   * starts the wait and returns a cleanup for its timers. The resolver lives
+   * on the `pending` token (not shared instance state) so a superseding
+   * teardown's wait is never clobbered by a prior teardown's continuation.
+   */
+  private awaitCancellable(
+    pending: PendingEndCall,
+    arm: (resolve: () => void) => () => void,
+  ): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let cleanup: (() => void) | null = null;
+      const done = (): void => {
+        if (pending.wake === done) {
+          pending.wake = null;
+        }
+        cleanup?.();
+        resolve();
+      };
+      pending.wake = done;
+      cleanup = arm(done);
+    });
   }
 
   private cancelPendingEndCall(): void {
-    if (this.pendingEndCall) {
-      this.pendingEndCall.cancelled = true;
-    }
+    const pending = this.pendingEndCall;
     this.pendingEndCall = null;
-    // Settle any in-flight drain/listen wait so runEndCallTeardown unblocks
-    // and returns instead of leaking a pending promise.
-    const resolve = this.endCallWaitResolve;
-    this.clearEndCallWait();
-    resolve?.();
+    if (pending) {
+      pending.cancelled = true;
+      // Settle its in-flight wait so runEndCallTeardown unblocks and returns
+      // instead of leaking a pending promise.
+      pending.wake?.();
+    }
   }
 
   private clearPendingGuardianInputForCallEnd(): boolean {

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -341,6 +341,9 @@ export class MediaStreamOutput implements CallTransport {
   /** Incremented per end-of-turn mark enqueued. */
   private enqueuedEndOfTurnSeq = 0;
 
+  /** Highest end-of-turn seq actually sent to Twilio (buffered downstream). */
+  private sentEndOfTurnSeq = 0;
+
   /** Highest end-of-turn seq echoed back by Twilio. */
   private echoedEndOfTurnSeq = 0;
 
@@ -455,10 +458,7 @@ export class MediaStreamOutput implements CallTransport {
     }
     this.state = "closed";
 
-    // Release drain waiters immediately so teardown never leaves one pending.
-    this.releaseAllDrainWaiters();
-
-    // Cancel any in-flight playback
+    // Cancel any in-flight playback (also releases drain waiters).
     this.flushPlaybackQueue();
 
     log.info(
@@ -521,6 +521,10 @@ export class MediaStreamOutput implements CallTransport {
 
     try {
       this.ws.send(JSON.stringify(command));
+      const seq = this.parseEndOfTurnSeq(name);
+      if (seq !== null && seq > this.sentEndOfTurnSeq) {
+        this.sentEndOfTurnSeq = seq;
+      }
     } catch (err) {
       log.error(
         { err, streamSid: this.streamSid },
@@ -535,15 +539,29 @@ export class MediaStreamOutput implements CallTransport {
    * has now been reached (played out to the caller).
    */
   notePlaybackMarkEcho(name: string): void {
-    if (!name.startsWith(`${END_OF_TURN_MARK_PREFIX}:`)) return;
-    const seq = Number(name.slice(END_OF_TURN_MARK_PREFIX.length + 1));
-    if (!Number.isFinite(seq)) return;
+    const seq = this.parseEndOfTurnSeq(name);
+    if (seq === null) {
+      return;
+    }
     // Ignore echoes for marks we never enqueued (stale/forged/out-of-range).
     // Accepting a future seq would advance the high-water mark and make later
     // real turns' awaitPlaybackDrained() resolve before their audio played.
-    if (seq > this.enqueuedEndOfTurnSeq) return;
-    if (seq > this.echoedEndOfTurnSeq) this.echoedEndOfTurnSeq = seq;
+    if (seq > this.enqueuedEndOfTurnSeq) {
+      return;
+    }
+    if (seq > this.echoedEndOfTurnSeq) {
+      this.echoedEndOfTurnSeq = seq;
+    }
     this.resolveDrainWaiters();
+  }
+
+  /** Parse the sequence from an `end-of-turn:<n>` mark name, else null. */
+  private parseEndOfTurnSeq(name: string): number | null {
+    if (!name.startsWith(`${END_OF_TURN_MARK_PREFIX}:`)) {
+      return null;
+    }
+    const seq = Number(name.slice(END_OF_TURN_MARK_PREFIX.length + 1));
+    return Number.isFinite(seq) ? seq : null;
   }
 
   /**
@@ -604,6 +622,14 @@ export class MediaStreamOutput implements CallTransport {
       return;
     }
     this.sendClearCommand();
+    // Twilio drops its buffered audio (and the marks within it) on `clear`, so
+    // any end-of-turn mark already sent will never echo. Treat those as drained
+    // so a pending end-call drain wait resolves instead of stalling on the cap.
+    // Marks still queued locally are preserved and will echo when they play.
+    if (this.sentEndOfTurnSeq > this.echoedEndOfTurnSeq) {
+      this.echoedEndOfTurnSeq = this.sentEndOfTurnSeq;
+      this.resolveDrainWaiters();
+    }
   }
 
   private sendClearCommand(): void {


### PR DESCRIPTION
## Summary
Self-review remediation for the endcall-drain plan (feature branch `noanflaherty/endcall-drain`).

- **Regression fix:** `clearBufferedAudio()` (ignored barge-in during the goodbye) sends Twilio `clear`, which drops the buffered end-of-turn mark so it never echoes. It now advances the drained sequence up to the marks actually **sent** to Twilio (tracked via `sentEndOfTurnSeq`) and releases drain waiters — so a VAD false-positive mid-goodbye no longer stalls teardown on the 15s safety cap. Marks still queued locally are preserved and echo naturally.
- Clear `pendingEndCall` after a completed teardown so a late utterance can't read it as still-pending.
- Replace the partial top-of-method timer clear in `scheduleEndCallAfterListenWindow` with `cancelPendingEndCall()` (fully cancels any in-flight teardown); simplify the now-dead re-engagement disjunct.
- Remove the redundant `releaseAllDrainWaiters()` in `endSession` (`flushPlaybackQueue` already releases).

Part of plan: endcall-drain.md (self-review remediation)