### PR TITLE
fix(providers): route connection-less profiles through the provider's own connection

### DIFF
--- a/assistant/src/__tests__/call-site-routing-connection-auto-resolve.test.ts
+++ b/assistant/src/__tests__/call-site-routing-connection-auto-resolve.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Verifies `CallSiteRoutingProvider` auto-resolves a connection for
+ * connection-less profiles even when the resolved provider matches the
+ * default provider's name.
+ *
+ * On platform-hosted installs the default transport rides the managed
+ * (platform-billed) `vellum` connection while presenting the upstream
+ * provider's name (e.g. "anthropic"). A BYOK profile `{provider:
+ * "anthropic"}` with no explicit `provider_connection` must route through
+ * the user's own connection when one exists — reusing the default on a bare
+ * name match silently bills managed credits for a BYOK-intent profile.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realDb from "../persistence/db-connection.js";
+import * as realConnections from "../providers/inference/connections.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
+import { setConfig } from "./helpers/set-config.js";
+
+let connectionRows: Array<Record<string, unknown>> = [];
+
+mock.module("../providers/inference/connections.js", () => ({
+  ...realConnections,
+  listConnections: () => connectionRows,
+}));
+
+mock.module("../persistence/db-connection.js", () => ({
+  ...realDb,
+  getDb: () => ({}),
+}));
+
+const { CallSiteRoutingProvider } =
+  await import("../providers/call-site-routing.js");
+
+const DUMMY_MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+];
+
+function makeProvider(name: string, onCall: () => void): Provider {
+  return {
+    name,
+    async sendMessage(
+      _messages: Message[],
+      _options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      onCall();
+      return {
+        content: [{ type: "text", text: "ok" }],
+        model: name,
+        usage: { inputTokens: 1, outputTokens: 1 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+}
+
+const PERSONAL_CONNECTION = {
+  name: "anthropic-personal",
+  provider: "anthropic",
+  auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+};
+
+beforeEach(() => {
+  connectionRows = [];
+  // Same provider name as the default transport; no provider_connection on
+  // the profile — the managed-install shape that must not silently reuse
+  // the default transport.
+  setConfig("llm", {
+    default: {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      provider_connection: "vellum",
+    },
+    profiles: {
+      byok: { provider: "anthropic", model: "claude-fable-5" },
+    },
+    callSites: {
+      memoryRetrieval: { profile: "byok" },
+    },
+  });
+});
+
+describe("CallSiteRoutingProvider connection auto-resolve", () => {
+  test("routes a connection-less same-provider profile through the user's own connection", async () => {
+    connectionRows = [PERSONAL_CONNECTION];
+
+    const calls = { default: 0, personal: 0 };
+    const defaultProvider = makeProvider("anthropic", () => {
+      calls.default++;
+    });
+    const personalProvider = makeProvider("anthropic", () => {
+      calls.personal++;
+    });
+
+    const resolvedNames: string[] = [];
+    const wrapped = new CallSiteRoutingProvider(
+      defaultProvider,
+      async (connectionName: string) => {
+        resolvedNames.push(connectionName);
+        return connectionName === "anthropic-personal"
+          ? personalProvider
+          : null;
+      },
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "memoryRetrieval" },
+    });
+
+    expect(resolvedNames).toEqual(["anthropic-personal"]);
+    expect(calls.personal).toBe(1);
+    expect(calls.default).toBe(0);
+  });
+
+  test("reuses the default transport when no connection exists for the provider", async () => {
+    connectionRows = [];
+
+    const calls = { default: 0 };
+    const defaultProvider = makeProvider("anthropic", () => {
+      calls.default++;
+    });
+
+    const resolvedNames: string[] = [];
+    const wrapped = new CallSiteRoutingProvider(
+      defaultProvider,
+      async (connectionName: string) => {
+        resolvedNames.push(connectionName);
+        return null;
+      },
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "memoryRetrieval" },
+    });
+
+    expect(resolvedNames).toEqual([]);
+    expect(calls.default).toBe(1);
+  });
+
+  test("falls back to the default transport when the auto-resolved connection soft-fails", async () => {
+    connectionRows = [PERSONAL_CONNECTION];
+
+    const calls = { default: 0 };
+    const defaultProvider = makeProvider("anthropic", () => {
+      calls.default++;
+    });
+
+    const wrapped = new CallSiteRoutingProvider(
+      defaultProvider,
+      async () => null,
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "memoryRetrieval" },
+    });
+
+    expect(calls.default).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/provider-connections-backfill.test.ts
+++ b/assistant/src/__tests__/provider-connections-backfill.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Boot-time provider_connection backfill: an existing user connection for
+ * the entry's provider must win over the mode-derived default.
+ *
+ * On managed (platform-hosted) installs the mode default is the billed
+ * `vellum` connection — stamping it onto a connection-less BYOK-intent
+ * profile permanently routes the user's own-key setup through managed
+ * billing. On your-own installs the mode default creates a parallel
+ * `<provider>-personal` row with an empty credential slot even when a
+ * custom-named connection already exists.
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+
+import { loadRawConfig } from "../config/loader.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { providerConnections } from "../persistence/schema/index.js";
+import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
+import {
+  createConnection,
+  getConnection,
+  listConnections,
+} from "../providers/inference/connections.js";
+
+await initializeDb();
+
+const originalIsPlatform = process.env.IS_PLATFORM;
+
+function seedConfig(profiles: Record<string, unknown>): void {
+  writeFileSync(
+    join(process.env.VELLUM_WORKSPACE_DIR!, "config.json"),
+    JSON.stringify({ llm: { profiles } }),
+  );
+}
+
+function backfilledConnection(profileName: string): unknown {
+  const llm = loadRawConfig().llm as {
+    profiles?: Record<string, Record<string, unknown>>;
+  };
+  return llm.profiles?.[profileName]?.provider_connection;
+}
+
+beforeEach(() => {
+  getDb().delete(providerConnections).run();
+});
+
+afterEach(() => {
+  if (originalIsPlatform === undefined) {
+    delete process.env.IS_PLATFORM;
+  } else {
+    process.env.IS_PLATFORM = originalIsPlatform;
+  }
+});
+
+test("managed mode prefers an existing user connection over the vellum default", () => {
+  process.env.IS_PLATFORM = "true";
+  const created = createConnection(getDb(), {
+    name: "anthropic-personal",
+    provider: "anthropic",
+    auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+  });
+  expect(created.ok).toBe(true);
+  seedConfig({ byok: { provider: "anthropic", model: "claude-fable-5" } });
+
+  runProviderConnectionsBackfill(getDb());
+
+  expect(backfilledConnection("byok")).toBe("anthropic-personal");
+});
+
+test("managed mode still stamps vellum when no user connection exists", () => {
+  process.env.IS_PLATFORM = "true";
+  seedConfig({ byok: { provider: "anthropic", model: "claude-fable-5" } });
+
+  runProviderConnectionsBackfill(getDb());
+
+  expect(backfilledConnection("byok")).toBe("vellum");
+});
+
+test("your-own mode reuses a custom-named connection instead of creating -personal", () => {
+  delete process.env.IS_PLATFORM;
+  const created = createConnection(getDb(), {
+    name: "my-anthropic",
+    provider: "anthropic",
+    auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+  });
+  expect(created.ok).toBe(true);
+  seedConfig({ byok: { provider: "anthropic", model: "claude-fable-5" } });
+
+  runProviderConnectionsBackfill(getDb());
+
+  expect(backfilledConnection("byok")).toBe("my-anthropic");
+  expect(getConnection(getDb(), "anthropic-personal")).toBeNull();
+  // Exactly the user's connection — no parallel row was created.
+  expect(
+    listConnections(getDb(), { provider: "anthropic" }).map((c) => c.name),
+  ).toEqual(["my-anthropic"]);
+});

--- a/assistant/src/__tests__/provider-connections-backfill.test.ts
+++ b/assistant/src/__tests__/provider-connections-backfill.test.ts
@@ -79,7 +79,7 @@ test("managed mode still stamps vellum when no user connection exists", () => {
   expect(backfilledConnection("byok")).toBe("vellum");
 });
 
-test("managed-source entries keep the vellum stamp even when a user connection exists", () => {
+test("managed-owned entries keep the vellum stamp even when a user connection exists", () => {
   process.env.IS_PLATFORM = "true";
   const created = createConnection(getDb(), {
     name: "anthropic-personal",
@@ -93,12 +93,27 @@ test("managed-source entries keep the vellum stamp even when a user connection e
       provider: "anthropic",
       model: "claude-sonnet-4-6",
     },
+    // Legacy seeders wrote canonical entries without `source` — still
+    // managed-owned (workspace migration 109's rule).
+    "quality-optimized": {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+    },
+    // An explicit user source on a canonical name is a shadow the user took
+    // ownership of — the preference applies.
+    "cost-optimized": {
+      source: "user",
+      provider: "anthropic",
+      model: "claude-haiku-4-5-20251001",
+    },
     byok: { provider: "anthropic", model: "claude-fable-5" },
   });
 
   runProviderConnectionsBackfill(getDb());
 
   expect(backfilledConnection("balanced")).toBe("vellum");
+  expect(backfilledConnection("quality-optimized")).toBe("vellum");
+  expect(backfilledConnection("cost-optimized")).toBe("anthropic-personal");
   expect(backfilledConnection("byok")).toBe("anthropic-personal");
 });
 

--- a/assistant/src/__tests__/provider-connections-backfill.test.ts
+++ b/assistant/src/__tests__/provider-connections-backfill.test.ts
@@ -79,6 +79,29 @@ test("managed mode still stamps vellum when no user connection exists", () => {
   expect(backfilledConnection("byok")).toBe("vellum");
 });
 
+test("managed-source entries keep the vellum stamp even when a user connection exists", () => {
+  process.env.IS_PLATFORM = "true";
+  const created = createConnection(getDb(), {
+    name: "anthropic-personal",
+    provider: "anthropic",
+    auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+  });
+  expect(created.ok).toBe(true);
+  seedConfig({
+    balanced: {
+      source: "managed",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    },
+    byok: { provider: "anthropic", model: "claude-fable-5" },
+  });
+
+  runProviderConnectionsBackfill(getDb());
+
+  expect(backfilledConnection("balanced")).toBe("vellum");
+  expect(backfilledConnection("byok")).toBe("anthropic-personal");
+});
+
 test("your-own mode reuses a custom-named connection instead of creating -personal", () => {
   delete process.env.IS_PLATFORM;
   const created = createConnection(getDb(), {

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -181,11 +181,16 @@ export class CallSiteRoutingProvider implements Provider {
    *      Soft credential failures fall back to the default Provider so
    *      a transient credential blip does not take a conversation
    *      offline.
-   *   3. Resolved profile's `provider` matches the default's name → reuse
-   *      the default provider instance (no connection-aware lookup
-   *      needed; the default IS the connection-aware route).
-   *   4. Resolved profile's `provider` differs from the default but no
-   *      `provider_connection` is set → throw. This is a configuration
+   *   3. No `provider_connection` → auto-resolve a connection for the
+   *      resolved provider and route through it. This runs even when the
+   *      provider matches the default's name: the default transport may
+   *      ride the managed (platform-billed) connection while the profile's
+   *      intent is the user's own key, so a bare name match must not stand
+   *      in for connection resolution.
+   *   4. No connection exists for the provider and it matches the
+   *      default's name → reuse the default provider instance.
+   *   5. Resolved profile's `provider` differs from the default but no
+   *      connection could be resolved → throw. This is a configuration
    *      bug: alternate-provider routing requires a connection.
    */
   private async selectProvider(
@@ -212,14 +217,18 @@ export class CallSiteRoutingProvider implements Provider {
 
     let connectionName = resolved.provider_connection;
 
-    // When no connection is set and the provider differs from the default,
-    // auto-resolve a connection for the provider (handles the case where the
-    // profile set provider but not provider_connection, and the merge didn't
-    // inherit one).
+    // When no connection is set, auto-resolve one for the resolved provider —
+    // including when the provider matches the default's name. The default
+    // transport may ride the managed (platform-billed) connection, so reusing
+    // it on a bare name match would silently bill managed credits for a
+    // profile whose intent is the user's own key. Mirrors
+    // `resolveConfiguredProvider`, which never takes a name shortcut; when no
+    // connection exists for the provider, the same-name fallthrough below
+    // still reuses the default transport.
     let autoResolveCandidates:
       | import("./inference/auth.js").ProviderConnection[]
       | undefined;
-    if (!connectionName && resolved.provider !== this.defaultProvider.name) {
+    if (!connectionName) {
       try {
         autoResolveCandidates = listConnections(getDb(), {
           provider: resolved.provider,

--- a/assistant/src/providers/inference/backfill.ts
+++ b/assistant/src/providers/inference/backfill.ts
@@ -17,6 +17,7 @@
  * default profile and on any legacy bare-`provider` callsite override.
  */
 
+import { MANAGED_PROFILE_NAMES } from "../../config/default-profile-catalog.js";
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type { DrizzleDb } from "../../persistence/db-connection.js";
 import { credentialKey } from "../../security/credential-key.js";
@@ -194,17 +195,24 @@ function ensureProviderConnection(
   // parallel `-personal` row (pointing at an empty credential slot) when a
   // custom-named connection already exists.
   //
-  // Managed-owned entries (`source: "managed"`, the legacy upgrade-path
-  // shape) are excluded: a managed preset must stay on the platform-managed
-  // route, not start dispatching against a key the user brought for their
-  // own profiles.
+  // Managed-owned entries are excluded: a managed preset must stay on the
+  // platform-managed route, not start dispatching against a key the user
+  // brought for their own profiles. Managed-owned means `source: "managed"`
+  // or a canonical managed name without an explicit `source: "user"` —
+  // legacy seeders wrote canonical entries source-less, and only an explicit
+  // user source marks a shadow the user took ownership of (mirrors
+  // workspace migration 109). `entryLabel` is the profile name for the
+  // `llm.profiles.*` walk; the other walks pass bracketed labels that never
+  // collide with canonical names.
+  const isManagedOwned =
+    entry.source === "managed" ||
+    (entry.source !== "user" && MANAGED_PROFILE_NAMES.has(entryLabel));
   const entryModel = typeof entry.model === "string" ? entry.model : undefined;
-  const existingForProvider =
-    entry.source === "managed"
-      ? undefined
-      : listConnections(db, { provider }).find((c) =>
-          isConnectionCompatibleWithModel(c, entryModel),
-        );
+  const existingForProvider = isManagedOwned
+    ? undefined
+    : listConnections(db, { provider }).find((c) =>
+        isConnectionCompatibleWithModel(c, entryModel),
+      );
   if (existingForProvider) {
     connectionName = existingForProvider.name;
   } else if (

--- a/assistant/src/providers/inference/backfill.ts
+++ b/assistant/src/providers/inference/backfill.ts
@@ -185,18 +185,26 @@ function ensureProviderConnection(
 
   let connectionName: string;
 
-  // An existing connection for the entry's provider always wins over the
-  // mode-derived default. Only user-brought connections can match — the
-  // canonical `vellum` row carries the `vellum` sentinel provider, never a
-  // concrete upstream. Without this, the managed branch would silently
-  // switch a connection-less BYOK-intent profile onto the billed managed
-  // connection, and the your-own branch would create a parallel `-personal`
-  // row (pointing at an empty credential slot) when a custom-named
-  // connection already exists.
+  // For user-owned entries, an existing connection for the entry's provider
+  // wins over the mode-derived default. Only user-brought connections can
+  // match — the canonical `vellum` row carries the `vellum` sentinel
+  // provider, never a concrete upstream. Without this, the managed branch
+  // would silently switch a connection-less BYOK-intent profile onto the
+  // billed managed connection, and the your-own branch would create a
+  // parallel `-personal` row (pointing at an empty credential slot) when a
+  // custom-named connection already exists.
+  //
+  // Managed-owned entries (`source: "managed"`, the legacy upgrade-path
+  // shape) are excluded: a managed preset must stay on the platform-managed
+  // route, not start dispatching against a key the user brought for their
+  // own profiles.
   const entryModel = typeof entry.model === "string" ? entry.model : undefined;
-  const existingForProvider = listConnections(db, { provider }).find((c) =>
-    isConnectionCompatibleWithModel(c, entryModel),
-  );
+  const existingForProvider =
+    entry.source === "managed"
+      ? undefined
+      : listConnections(db, { provider }).find((c) =>
+          isConnectionCompatibleWithModel(c, entryModel),
+        );
   if (existingForProvider) {
     connectionName = existingForProvider.name;
   } else if (

--- a/assistant/src/providers/inference/backfill.ts
+++ b/assistant/src/providers/inference/backfill.ts
@@ -21,11 +21,13 @@ import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type { DrizzleDb } from "../../persistence/db-connection.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getLogger } from "../../util/logger.js";
+import { isConnectionCompatibleWithModel } from "../connection-model-compat.js";
 import { MANAGED_ROUTABLE_PROVIDERS } from "../vellum-model-routing.js";
 import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "./auth.js";
 import {
   createConnection,
   getConnection,
+  listConnections,
   seedCanonicalConnections,
   VELLUM_MANAGED_CONNECTION_NAME,
 } from "./connections.js";
@@ -183,7 +185,24 @@ function ensureProviderConnection(
 
   let connectionName: string;
 
-  if (globalMode === "managed" && MANAGED_ROUTABLE_PROVIDERS.has(provider)) {
+  // An existing connection for the entry's provider always wins over the
+  // mode-derived default. Only user-brought connections can match — the
+  // canonical `vellum` row carries the `vellum` sentinel provider, never a
+  // concrete upstream. Without this, the managed branch would silently
+  // switch a connection-less BYOK-intent profile onto the billed managed
+  // connection, and the your-own branch would create a parallel `-personal`
+  // row (pointing at an empty credential slot) when a custom-named
+  // connection already exists.
+  const entryModel = typeof entry.model === "string" ? entry.model : undefined;
+  const existingForProvider = listConnections(db, { provider }).find((c) =>
+    isConnectionCompatibleWithModel(c, entryModel),
+  );
+  if (existingForProvider) {
+    connectionName = existingForProvider.name;
+  } else if (
+    globalMode === "managed" &&
+    MANAGED_ROUTABLE_PROVIDERS.has(provider)
+  ) {
     // All managed-routable providers share the single provider-agnostic
     // `vellum` connection; the upstream is recovered per-request from the
     // profile's `provider` field.


### PR DESCRIPTION
## What

Two fixes so a BYOK-intent profile (provider set, no explicit `provider_connection`) never silently routes through the managed (platform-billed) connection:

1. **Dispatch** (`call-site-routing.ts`): `selectProvider` skipped connection auto-resolution whenever the resolved profile's provider matched the default transport's *name*, reusing the default transport instance. Auto-resolution now runs whenever the profile names no connection — mirroring `resolveConfiguredProvider`, which never takes the name shortcut. The default transport is still reused when no connection exists for the provider.
2. **Boot backfill** (`inference/backfill.ts`): the backfill derived the stamped connection purely from the global inference mode — managed installs stamped the billed `vellum` connection onto any connection-less managed-routable profile (making the billing *permanent* on the next restart), and your-own installs created a parallel `<provider>-personal` row with an empty credential slot even when a custom-named connection existed. An existing user connection for the entry's provider now always wins. Only user-brought connections can match: the canonical `vellum` row carries the provider-agnostic `"vellum"` sentinel, so a provider-filtered lookup never returns it.

## Why

Observed live on dev: a user with a personal Anthropic key + active custom profile drew ~$0.30/turn of platform credits; every `mainAgent` event in `billing_usage_events` routed through the managed runtime proxy (`inference_profile_source: "active"`) despite the BYOK setup. The profile was created mid-session, so it was connection-less until the next boot — fix 1 covers that window at dispatch time; fix 2 makes the boot stamping land on the user's own connection instead of locking in managed billing.

## Behavior changes

- Connection-less profile, user connection for its provider exists → routes through / gets stamped with the user's connection (was: managed transport at dispatch; `vellum` stamp at boot on managed installs).
- Connection-less profile, no connection for the provider → unchanged (managed default transport at dispatch; mode-derived stamp at boot). Managed presets carry `provider_connection: "vellum"` explicitly and are unaffected.
- Known remaining gap (separate issue): a soft credential failure on a resolved connection still silently falls back to the default transport, which can be the billed managed route — that fallback should become observable.

## Testing

- New `call-site-routing-connection-auto-resolve.test.ts`: BYOK auto-resolve on name match, default reuse when no connection exists, soft-fail fallback.
- New `provider-connections-backfill.test.ts`: managed-mode prefers user connection, managed-mode vellum stamp without one, your-own reuses custom-named connection without creating `-personal`.
- Existing routing/retry/satellite/inference suites pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAsjMpNDNpnTC8mdLzVCGJ