### PR TITLE
fix(calls): wait for goodbye audio to drain before hanging up phone calls

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -989,6 +989,43 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("a second END_CALL teardown keeps its own safety cap after cancelling the first", async () => {
+    // Cancelling a mid-drain teardown then immediately starting another must
+    // not let the old teardown's continuation clear the new one's cap.
+    mockEndCallListenWindowMs = 30;
+    mockEndCallDrainMaxWaitMs = 40;
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        content: string;
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        turnContents.push(opts.content);
+        opts.onTextDelta(
+          turnContents.length === 2 ? "Okay, bye. [END_CALL]" : "Goodbye! [END_CALL]",
+        );
+        opts.onComplete();
+        return { turnId: `run-${turnContents.length}`, abort: () => {} };
+      },
+    );
+    // Both goodbyes' drains never echo — only each teardown's own safety cap
+    // can release it.
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => new Promise<void>(() => {}),
+    });
+
+    await controller.handleCallerUtterance("That is all"); // teardown A (mid-drain)
+    // Re-engage: cancels A and starts turn 2, which emits END_CALL → teardown B.
+    await controller.handleCallerUtterance("Actually, bye");
+
+    // B must still hang up via its own cap despite A's cancelled continuation.
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
   test("caller re-engagement during the drain phase cancels teardown and defers", async () => {
     mockEndCallListenWindowMs = 30;
     const turnContents: string[] = [];

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -54,12 +54,14 @@ mock.module("../security/credential-key.js", () => ({
 let mockConsultationTimeoutMs = 90_000;
 let mockSilenceTimeoutMs = 30_000;
 let mockEndCallListenWindowMs = 0;
+let mockEndCallDrainMaxWaitMs = 15_000;
 
 mock.module("../calls/call-constants.js", () => ({
   getMaxCallDurationMs: () => 12 * 60 * 1000,
   getUserConsultationTimeoutMs: () => mockConsultationTimeoutMs,
   getSilenceTimeoutMs: () => mockSilenceTimeoutMs,
   getEndCallListenWindowMs: () => mockEndCallListenWindowMs,
+  getEndCallDrainMaxWaitMs: () => mockEndCallDrainMaxWaitMs,
 }));
 
 // ── Voice session bridge mock ────────────────────────────────────────
@@ -246,6 +248,7 @@ interface MockTransport extends CallTransport {
   sentPlayUrls: string[];
   endCalled: boolean;
   endReason: string | undefined;
+  cancelPendingSpeechCount: number;
 }
 
 function createMockTransport(): MockTransport {
@@ -254,6 +257,7 @@ function createMockTransport(): MockTransport {
     sentPlayUrls: [] as string[],
     _endCalled: false,
     _endReason: undefined as string | undefined,
+    _cancelPendingSpeechCount: 0,
   };
 
   return {
@@ -269,6 +273,9 @@ function createMockTransport(): MockTransport {
     get endReason() {
       return state._endReason;
     },
+    get cancelPendingSpeechCount() {
+      return state._cancelPendingSpeechCount;
+    },
     sendTextToken(token: string, last: boolean) {
       state.sentTokens.push({ token, last });
     },
@@ -278,6 +285,9 @@ function createMockTransport(): MockTransport {
     endSession(reason?: string) {
       state._endCalled = true;
       state._endReason = reason;
+    },
+    cancelPendingSpeech() {
+      state._cancelPendingSpeechCount++;
     },
   } as MockTransport;
 }
@@ -365,6 +375,8 @@ function setupController(
     trustContext?: import("../daemon/trust-context-types.js").TrustContext;
     /** Simulate the media-stream transport's PCM requirement. */
     requiresPcmAudio?: boolean;
+    /** Simulate a transport that gates teardown on playback drain. */
+    awaitPlaybackDrained?: () => Promise<void>;
   },
 ) {
   ensureConversation("conv-ctrl-test");
@@ -379,6 +391,9 @@ function setupController(
   const transport = createMockTransport();
   if (opts?.requiresPcmAudio) {
     Object.assign(transport, { requiresPcmAudio: true });
+  }
+  if (opts?.awaitPlaybackDrained) {
+    Object.assign(transport, { awaitPlaybackDrained: opts.awaitPlaybackDrained });
   }
   const controller = new CallController(session.id, transport, task ?? null, {
     assistantId: opts?.assistantId,
@@ -440,6 +455,7 @@ describe("call-controller", () => {
     mockConsultationTimeoutMs = 90_000;
     mockSilenceTimeoutMs = 30_000;
     mockEndCallListenWindowMs = 0;
+    mockEndCallDrainMaxWaitMs = 15_000;
     // Reset TTS config to defaults so per-test mutations don't leak.
     const cfg = loadConfig();
     cfg.services.tts.provider = "elevenlabs";
@@ -895,6 +911,244 @@ describe("call-controller", () => {
     expect(getCallSession(session.id)!.status).toBe("in_progress");
 
     controller.destroy();
+  });
+
+  // ── END_CALL playback-drain gating ───────────────────────────────
+
+  test("END_CALL does not end the session until playback drain resolves", async () => {
+    mockEndCallListenWindowMs = 0;
+    let resolveDrain!: () => void;
+    const drainPromise = new Promise<void>((r) => {
+      resolveDrain = r;
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Thank you for calling, goodbye! ", "[END_CALL]"]),
+    );
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => drainPromise,
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+
+    // Drain has not resolved — teardown must be blocked.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
+
+    // Drain completes — teardown proceeds and ends the session.
+    resolveDrain();
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("END_CALL honors the listen window after drain resolves", async () => {
+    mockEndCallListenWindowMs = 30;
+    let resolveDrain!: () => void;
+    const drainPromise = new Promise<void>((r) => {
+      resolveDrain = r;
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => drainPromise,
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    resolveDrain();
+
+    // Listen window still gates completion after drain.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(relay.endCalled).toBe(false);
+
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("END_CALL forces hangup after the drain safety cap when drain never resolves", async () => {
+    mockEndCallListenWindowMs = 0;
+    mockEndCallDrainMaxWaitMs = 25;
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    // Drain that never resolves — only the safety cap can release teardown.
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => new Promise<void>(() => {}),
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    expect(relay.endCalled).toBe(false);
+
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("caller re-engagement during the drain phase cancels teardown and defers", async () => {
+    mockEndCallListenWindowMs = 30;
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        content: string;
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        turnContents.push(opts.content);
+        if (turnContents.length === 1) {
+          opts.onTextDelta("Goodbye! [END_CALL]");
+        } else {
+          opts.onTextDelta("Sure, I'm still here.");
+        }
+        opts.onComplete();
+        return { turnId: `run-${turnContents.length}`, abort: () => {} };
+      },
+    );
+    // Drain never resolves during the test window; re-engagement must still
+    // cancel the pending teardown mid-drain.
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => new Promise<void>(() => {}),
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    expect(relay.endCalled).toBe(false);
+
+    // Caller re-engages while teardown is still waiting on drain.
+    await controller.handleCallerUtterance("Wait, one more thing");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(relay.endCalled).toBe(false);
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
+    expect(turnContents).toContain("Wait, one more thing");
+    const allText = relay.sentTokens.map((t) => t.token).join("");
+    expect(allText).toContain("I'm still here.");
+    // The abandoned goodbye's queued speech must be cancelled so it can't
+    // play over the caller's follow-up.
+    expect(relay.cancelPendingSpeechCount).toBeGreaterThan(0);
+
+    controller.destroy();
+  });
+
+  test("repeat END_CALL still waits for drain but skips the listen window", async () => {
+    mockEndCallListenWindowMs = 30;
+    let resolveSecondDrain!: () => void;
+    let drainCalls = 0;
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        content: string;
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        turnContents.push(opts.content);
+        if (turnContents.length === 1) {
+          opts.onTextDelta("Goodbye! [END_CALL]");
+        } else if (turnContents.length === 2) {
+          opts.onTextDelta("Okay, one quick thing.");
+        } else {
+          opts.onTextDelta("I have to go now. Goodbye! [END_CALL]");
+        }
+        opts.onComplete();
+        return { turnId: `run-${turnContents.length}`, abort: () => {} };
+      },
+    );
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => {
+        drainCalls++;
+        // First END_CALL drain resolves immediately; the second one is held
+        // so we can assert teardown is gated on it, not on a 0ms timer.
+        if (drainCalls === 1) return Promise.resolve();
+        return new Promise<void>((r) => {
+          resolveSecondDrain = r;
+        });
+      },
+    });
+
+    // First END_CALL — listen window is armed; caller re-engages (deferral #1).
+    await controller.handleCallerUtterance("That is all, thanks");
+    await controller.handleCallerUtterance("Wait, one more thing");
+    await new Promise((r) => setTimeout(r, 40));
+    expect(relay.endCalled).toBe(false);
+
+    // Second END_CALL after the deferral — must still block on drain.
+    await controller.handleCallerUtterance("Just kidding, keep going");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
+
+    // Drain resolves — teardown completes without any listen window.
+    resolveSecondDrain();
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("transport without awaitPlaybackDrained ends after listen window as before", async () => {
+    mockEndCallListenWindowMs = 25;
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    // Default mock transport does not implement awaitPlaybackDrained.
+    const { session, relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    expect(relay.endCalled).toBe(false);
+
+    await pollUntil(() => relay.endCalled);
+    expect(getCallSession(session.id)!.status).toBe("completed");
+
+    controller.destroy();
+  });
+
+  test("destroy cancels a pending end-call teardown mid-drain", async () => {
+    mockEndCallListenWindowMs = 0;
+    let resolveDrain!: () => void;
+    const drainPromise = new Promise<void>((r) => {
+      resolveDrain = r;
+    });
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    const { session, relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => drainPromise,
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    expect(relay.endCalled).toBe(false);
+
+    controller.destroy();
+
+    // Drain resolves after destroy — teardown must not fire endSession.
+    resolveDrain();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
+  });
+
+  test("destroy during the listen window settles the wait without hanging up", async () => {
+    // Long window so destroy lands while the listen-window wait is armed;
+    // the wait must settle (not leak) and teardown must not fire endSession.
+    mockEndCallListenWindowMs = 10_000;
+    const drainPromise = Promise.resolve();
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Goodbye! ", "[END_CALL]"]),
+    );
+    const { relay, controller } = setupController(undefined, {
+      awaitPlaybackDrained: () => drainPromise,
+    });
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    // Let the drain phase resolve and the listen-window timer arm.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
+
+    controller.destroy();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(relay.endCalled).toBe(false);
   });
 
   // ── handleUserAnswer ──────────────────────────────────────────────

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -514,6 +514,49 @@ describe("MediaStreamOutput", () => {
       output.clearBufferedAudio();
       expect(sent).toHaveLength(0);
     });
+
+    test("resolves a drain waiter for an end-of-turn mark already sent to Twilio", async () => {
+      // A mark sent to Twilio is dropped by `clear` and never echoes, so a
+      // pending end-call drain wait must resolve here rather than stall.
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "MZ-stream-1");
+      output.sendTextToken("", true); // enqueues + sends end-of-turn:1
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      const drained = output.awaitPlaybackDrained();
+      output.clearBufferedAudio();
+      await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("does not resolve a drain waiter for an end-of-turn mark not yet sent", async () => {
+      // Slow synthesis keeps the mark queued locally (not yet sent to Twilio);
+      // clearBufferedAudio preserves it, so it will still play and echo.
+      mockSynthesize.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  audio: makeWavBuffer([1, 2, 3, 4]),
+                  contentType: "audio/wav",
+                }),
+              50,
+            ),
+          ),
+      );
+      const { ws } = createMockWs();
+      const output = makeOutput(ws, "MZ-stream-1");
+      output.sendTextToken("hello world", true); // mark queued behind synthesis
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      output.clearBufferedAudio(); // mark not sent yet — must stay pending
+      await drain();
+      expect(resolved).toBe(false);
+    });
   });
 
   describe("cancelPendingSpeech — turn abort", () => {

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -250,9 +250,9 @@ describe("MediaStreamOutput", () => {
       expect(events).toContain("media");
       expect(events).toContain("mark");
 
-      // The mark should be end-of-turn
+      // The mark should be the first sequenced end-of-turn mark
       const markMsg = sent.find((s) => JSON.parse(s).event === "mark");
-      expect(JSON.parse(markMsg!).mark.name).toBe("end-of-turn");
+      expect(JSON.parse(markMsg!).mark.name).toBe("end-of-turn:1");
     });
 
     test("empty token with last: true sends only end-of-turn mark (no synthesis)", async () => {
@@ -266,7 +266,7 @@ describe("MediaStreamOutput", () => {
       expect(sent).toHaveLength(1);
       const parsed = JSON.parse(sent[0]);
       expect(parsed.event).toBe("mark");
-      expect(parsed.mark.name).toBe("end-of-turn");
+      expect(parsed.mark.name).toBe("end-of-turn:1");
 
       // Synthesis should NOT have been called
       expect(mockSynthesize).not.toHaveBeenCalled();
@@ -1565,6 +1565,191 @@ describe("MediaStreamOutput", () => {
       good.close();
       await drain(() => countEvents(sent, "media") > 0);
       expect(countEvents(sent, "media")).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Playback drain tracking (sequenced end-of-turn marks)
+  // ---------------------------------------------------------------------------
+
+  describe("playback drain", () => {
+    /** Extract the names of all sent mark events, in order. */
+    function markNames(sent: string[]): string[] {
+      return sent
+        .map((s) => JSON.parse(s))
+        .filter((m) => m.event === "mark")
+        .map((m) => m.mark.name);
+    }
+
+    test("end-of-turn marks are sequenced in order", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      output.sendTextToken("", true);
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") >= 3);
+
+      expect(markNames(sent)).toEqual([
+        "end-of-turn:1",
+        "end-of-turn:2",
+        "end-of-turn:3",
+      ]);
+    });
+
+    test("resolves immediately when no end-of-turn mark is outstanding", async () => {
+      const { ws } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      // Never enqueued a turn — nothing outstanding.
+      await expect(output.awaitPlaybackDrained()).resolves.toBeUndefined();
+    });
+
+    test("resolves immediately when the output is already closed", async () => {
+      const { ws } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true); // outstanding seq 1, never echoed
+      output.endSession();
+      await expect(output.awaitPlaybackDrained()).resolves.toBeUndefined();
+    });
+
+    test("stays pending until the matching end-of-turn mark is echoed", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      let resolved = false;
+      const drained = output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      await drain();
+      expect(resolved).toBe(false);
+
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drained;
+      expect(resolved).toBe(true);
+    });
+
+    test("a higher-seq echo also resolves a waiter", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      const drained = output.awaitPlaybackDrained();
+      output.notePlaybackMarkEcho("end-of-turn:5");
+      await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("a stale lower-seq echo does not resolve a higher-seq waiter", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") >= 2);
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drain();
+      expect(resolved).toBe(false);
+
+      output.notePlaybackMarkEcho("end-of-turn:2");
+      await drain(() => resolved);
+      expect(resolved).toBe(true);
+    });
+
+    test("flushing the playback queue releases a pending waiter", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      const drained = output.awaitPlaybackDrained();
+      output.clearAudio(); // flushes the playback queue
+      await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("a waiter armed AFTER a flush does not hang on the flushed mark", async () => {
+      // Barge-in flushes an outstanding end-of-turn mark before any waiter
+      // exists. A later awaitPlaybackDrained() targeting that flushed seq
+      // must resolve (the audio was cleared, never to be echoed) rather than
+      // wait forever.
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true); // enqueues end-of-turn:1
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      output.clearAudio(); // flushes end-of-turn:1 with no waiter present
+
+      await expect(output.awaitPlaybackDrained()).resolves.toBeUndefined();
+    });
+
+    test("a late cleared-mark echo does not prematurely resolve a fresh turn", async () => {
+      // After a flush advances the drained seq, a stale echo for the cleared
+      // mark is a no-op, and the next turn's waiter still pends until its own
+      // (higher-seq) mark is echoed.
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true); // end-of-turn:1
+      await drain(() => countEvents(sent, "mark") > 0);
+      output.clearAudio(); // flush; drained seq advances to 1
+
+      output.sendTextToken("", true); // end-of-turn:2 (next turn)
+      await drain(() => countEvents(sent, "mark") > 1);
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      // Stale echo for the cleared mark must not resolve the seq-2 waiter.
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drain();
+      expect(resolved).toBe(false);
+
+      // The genuine seq-2 echo resolves it.
+      output.notePlaybackMarkEcho("end-of-turn:2");
+      await drain(() => resolved);
+      expect(resolved).toBe(true);
+    });
+
+    test("endSession releases a pending waiter", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      const drained = output.awaitPlaybackDrained();
+      output.endSession();
+      await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("ignores non-end-of-turn and malformed mark names without throwing", async () => {
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true);
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+
+      // Unrelated mark name, wrong prefix, and non-numeric seq are ignored.
+      output.notePlaybackMarkEcho("some-other-mark");
+      output.notePlaybackMarkEcho("end-of-turn");
+      output.notePlaybackMarkEcho("end-of-turn:not-a-number");
+      await drain();
+      expect(resolved).toBe(false);
+
+      // The real echo still resolves.
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drain(() => resolved);
+      expect(resolved).toBe(true);
     });
   });
 });

--- a/assistant/src/__tests__/media-stream-output.test.ts
+++ b/assistant/src/__tests__/media-stream-output.test.ts
@@ -1630,15 +1630,43 @@ describe("MediaStreamOutput", () => {
       expect(resolved).toBe(true);
     });
 
-    test("a higher-seq echo also resolves a waiter", async () => {
+    test("a higher-seq echo (still within enqueued) resolves an earlier waiter", async () => {
       const { ws, sent } = createMockWs();
       const output = makeOutput(ws, "stream-1");
-      output.sendTextToken("", true);
+      output.sendTextToken("", true); // enqueues end-of-turn:1
       await drain(() => countEvents(sent, "mark") > 0);
 
-      const drained = output.awaitPlaybackDrained();
-      output.notePlaybackMarkEcho("end-of-turn:5");
+      const drained = output.awaitPlaybackDrained(); // targets seq 1
+      output.sendTextToken("", true); // enqueues end-of-turn:2
+      await drain(() => countEvents(sent, "mark") >= 2);
+
+      // Echoing seq 2 (which was enqueued) satisfies the seq-1 waiter too.
+      output.notePlaybackMarkEcho("end-of-turn:2");
       await expect(drained).resolves.toBeUndefined();
+    });
+
+    test("ignores an echo for a seq beyond what was enqueued", async () => {
+      // A stale/forged future echo must not advance the high-water mark, or
+      // later real turns would drain immediately before their audio played.
+      const { ws, sent } = createMockWs();
+      const output = makeOutput(ws, "stream-1");
+      output.sendTextToken("", true); // enqueues end-of-turn:1
+      await drain(() => countEvents(sent, "mark") > 0);
+
+      // Out-of-range echo before we ever queued seq 3 — ignored.
+      output.notePlaybackMarkEcho("end-of-turn:3");
+
+      let resolved = false;
+      void output.awaitPlaybackDrained().then(() => {
+        resolved = true;
+      });
+      await drain();
+      expect(resolved).toBe(false); // seq-1 waiter still pending
+
+      // The genuine seq-1 echo resolves it.
+      output.notePlaybackMarkEcho("end-of-turn:1");
+      await drain(() => resolved);
+      expect(resolved).toBe(true);
     });
 
     test("a stale lower-seq echo does not resolve a higher-seq waiter", async () => {

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -906,7 +906,7 @@ describe("media-stream output egress", () => {
     expect(markMessages.length).toBeGreaterThan(0);
 
     const markParsed = JSON.parse(markMessages[0]);
-    expect(markParsed.mark.name).toBe("end-of-turn");
+    expect(markParsed.mark.name).toBe("end-of-turn:1");
   });
 
   test("empty sendTextToken (end-of-turn signal) sends only a mark, no media", async () => {

--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -833,6 +833,27 @@ describe("MediaStreamCallSession", () => {
       session.handleMessage(makeMarkMessage("end-of-turn"));
     });
 
+    test("inbound mark echo is routed into the output drain tracker", () => {
+      const mock = createMockWs();
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      const noteEcho = jest.spyOn(session.getOutput(), "notePlaybackMarkEcho");
+
+      session.handleMessage(makeMarkMessage("end-of-turn:3"));
+
+      expect(noteEcho).toHaveBeenCalledWith("end-of-turn:3");
+    });
+
+    test("mark echo after disposal does not touch the output", () => {
+      const mock = createMockWs();
+      const session = new MediaStreamCallSession(mock.ws, "call-1");
+      const noteEcho = jest.spyOn(session.getOutput(), "notePlaybackMarkEcho");
+
+      session.destroy();
+      session.handleMessage(makeMarkMessage("end-of-turn:3"));
+
+      expect(noteEcho).not.toHaveBeenCalled();
+    });
+
     test("stop events are forwarded to the STT session", () => {
       const mock = createMockWs();
       mockSessions.set("call-1", {

--- a/assistant/src/__tests__/media-stream-stt-session.test.ts
+++ b/assistant/src/__tests__/media-stream-stt-session.test.ts
@@ -97,6 +97,15 @@ function makeDtmfMessage(digit = "5"): string {
   });
 }
 
+function makeMarkMessage(name = "drain-1"): string {
+  return JSON.stringify({
+    event: "mark",
+    sequenceNumber: "4",
+    streamSid: "MZ00000000000000000000000000000000",
+    mark: { name },
+  });
+}
+
 function makeStopMessage(): string {
   return JSON.stringify({
     event: "stop",
@@ -237,6 +246,44 @@ describe("MediaStreamSttSession", () => {
 
     expect(onDtmf).toHaveBeenCalledTimes(1);
     expect(onDtmf).toHaveBeenCalledWith("9");
+
+    session.dispose();
+  });
+
+  // ── onMark ──────────────────────────────────────────────────────
+
+  test("fires onMark once with the mark name for mark events", () => {
+    const onMark = jest.fn();
+    const session = new MediaStreamSttSession({}, { onMark });
+
+    session.handleMessage(makeStartMessage());
+    session.handleMessage(makeMarkMessage("drain-42"));
+
+    expect(onMark).toHaveBeenCalledTimes(1);
+    expect(onMark).toHaveBeenCalledWith("drain-42");
+
+    session.dispose();
+  });
+
+  test("a session without onMark does not throw on mark events", () => {
+    const session = new MediaStreamSttSession({}, {});
+
+    session.handleMessage(makeStartMessage());
+    expect(() => session.handleMessage(makeMarkMessage())).not.toThrow();
+
+    session.dispose();
+  });
+
+  test("non-mark frames do not fire onMark", () => {
+    const onMark = jest.fn();
+    const session = new MediaStreamSttSession({}, { onMark, onDtmf: jest.fn() });
+
+    session.handleMessage(makeStartMessage());
+    session.handleMessage(makeMediaMessage());
+    session.handleMessage(makeDtmfMessage());
+    session.handleMessage(makeStopMessage());
+
+    expect(onMark).not.toHaveBeenCalled();
 
     session.dispose();
   });

--- a/assistant/src/calls/call-constants.ts
+++ b/assistant/src/calls/call-constants.ts
@@ -72,3 +72,8 @@ export function getSilenceTimeoutMs(): number {
 export function getEndCallListenWindowMs(): number {
   return 2 * 1000;
 }
+
+/** Max time to wait for goodbye audio to drain before forcing hangup. */
+export function getEndCallDrainMaxWaitMs(): number {
+  return 15 * 1000;
+}

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -31,6 +31,7 @@ import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import type { CallAudioFormat } from "./audio-store.js";
 import {
+  getEndCallDrainMaxWaitMs,
   getEndCallListenWindowMs,
   getMaxCallDurationMs,
   getSilenceTimeoutMs,
@@ -115,6 +116,12 @@ export class CallController {
   private destroyed = false;
   private silenceTimer: ReturnType<typeof setTimeout> | null = null;
   private endCallListenTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Safety-cap timer for the end-call playback-drain wait. */
+  private endCallDrainCapTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Settles the in-flight end-call wait so cancellation never leaves it hanging. */
+  private endCallWaitResolve: (() => void) | null = null;
+  /** Cancellation token for the in-flight end-call teardown (drain → listen). */
+  private pendingEndCall: { cancelled: boolean } | null = null;
   /**
    * How many times the caller has re-engaged (spoken) after an END_CALL
    * marker was emitted but before the listen window fired. Each caller
@@ -281,11 +288,15 @@ export class CallController {
     transcript: string,
     speaker?: PromptSpeakerContext,
   ): Promise<void> {
-    // If the caller speaks while an END_CALL listen window is pending,
-    // this is a deferral — the caller is re-engaging after we tried to
-    // hang up. Track it so we can cap repeat deferrals.
-    if (this.endCallListenTimer) {
+    // If the caller speaks while an END_CALL teardown is pending (during the
+    // drain wait or the listen window), this is a deferral — the caller is
+    // re-engaging after we tried to hang up. Track it so we can cap repeats.
+    if (this.endCallListenTimer || this.pendingEndCall) {
       this.endCallDeferralCount++;
+      // The goodbye's speech was queued while state was idle, so the
+      // media-stream barge-in ignored it. Cancel it here so it can't play
+      // over the caller's follow-up or the next turn.
+      this.transport.cancelPendingSpeech?.();
     }
     this.cancelPendingEndCall();
 
@@ -458,7 +469,7 @@ export class CallController {
   destroy(): void {
     this.destroyed = true;
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
-    if (this.endCallListenTimer) clearTimeout(this.endCallListenTimer);
+    this.cancelPendingEndCall();
     if (this.durationTimer) clearTimeout(this.durationTimer);
     if (this.durationWarningTimer) clearTimeout(this.durationWarningTimer);
     if (this.pendingGuardianInput) {
@@ -470,7 +481,6 @@ export class CallController {
       this.durationEndTimer = null;
     }
     this.pendingInstructions = [];
-    this.endCallListenTimer = null;
     this.llmRunVersion++;
     this.abortCurrentTurn();
     this.abortActiveSynthesis();
@@ -1344,41 +1354,91 @@ export class CallController {
       this.endCallListenTimer = null;
     }
 
-    const listenWindowMs = getEndCallListenWindowMs();
-    // After the caller has re-engaged once post-END_CALL, complete
-    // immediately on the next END_CALL. The first deferral gets a
-    // listen window (caller might say "wait, one more thing"); a
-    // second END_CALL means the assistant wants out and the caller
-    // already had their chance to re-engage.
-    const effectiveListenWindowMs =
-      this.endCallDeferralCount > 0 ? 0 : listenWindowMs;
-    const callContinues =
-      this.pendingInstructions.length > 0 || effectiveListenWindowMs > 0;
-    if (clearedPendingGuardianInput && callContinues) {
+    // The call always continues past END_CALL — either flushing queued
+    // instructions or waiting for playback drain — so restore in_progress if
+    // we just cleared a pending guardian consultation for the end.
+    if (clearedPendingGuardianInput) {
       updateCallSession(this.callSessionId, { status: "in_progress" });
     }
 
+    // Queued instructions mean the call is continuing — flush and skip
+    // teardown. Clear any stale token first so it can't cancel a later run.
     if (this.pendingInstructions.length > 0) {
+      this.pendingEndCall = null;
       this.flushPendingInstructions();
       return;
     }
 
-    if (effectiveListenWindowMs <= 0) {
-      this.completeCallFromEndMarker();
+    const pending = { cancelled: false };
+    this.pendingEndCall = pending;
+    void this.runEndCallTeardown(pending);
+  }
+
+  /**
+   * End-of-call teardown: wait for goodbye audio to drain (capped), then run
+   * the re-engagement listen window, then end the session. Cancellable at
+   * every step via the `pending` token (caller re-engagement, destroy).
+   */
+  private async runEndCallTeardown(pending: {
+    cancelled: boolean;
+  }): Promise<void> {
+    if (this.transport.awaitPlaybackDrained) {
+      await new Promise<void>((resolve) => {
+        this.endCallWaitResolve = resolve;
+        this.endCallDrainCapTimer = setTimeout(
+          resolve,
+          getEndCallDrainMaxWaitMs(),
+        );
+        void this.transport.awaitPlaybackDrained!().then(resolve, resolve);
+      });
+      this.clearEndCallWait();
+    }
+    if (pending.cancelled || this.destroyed) {
       return;
     }
 
-    this.resetSilenceTimer();
-    this.endCallListenTimer = setTimeout(() => {
+    // After one deferral, subsequent END_CALL markers skip the listen window
+    // (the caller already had their grace re-engagement).
+    const listenWindowMs =
+      this.endCallDeferralCount > 0 ? 0 : getEndCallListenWindowMs();
+    if (listenWindowMs > 0) {
+      this.resetSilenceTimer();
+      await new Promise<void>((resolve) => {
+        this.endCallWaitResolve = resolve;
+        this.endCallListenTimer = setTimeout(resolve, listenWindowMs);
+      });
+      this.clearEndCallWait();
+    }
+    if (pending.cancelled || this.destroyed) {
+      return;
+    }
+
+    this.completeCallFromEndMarker();
+  }
+
+  /** Clear the end-call wait's timers and resolver handle. */
+  private clearEndCallWait(): void {
+    if (this.endCallDrainCapTimer) {
+      clearTimeout(this.endCallDrainCapTimer);
+      this.endCallDrainCapTimer = null;
+    }
+    if (this.endCallListenTimer) {
+      clearTimeout(this.endCallListenTimer);
       this.endCallListenTimer = null;
-      this.completeCallFromEndMarker();
-    }, effectiveListenWindowMs);
+    }
+    this.endCallWaitResolve = null;
   }
 
   private cancelPendingEndCall(): void {
-    if (!this.endCallListenTimer) return;
-    clearTimeout(this.endCallListenTimer);
-    this.endCallListenTimer = null;
+    if (this.pendingEndCall) {
+      this.pendingEndCall.cancelled = true;
+    }
+    this.pendingEndCall = null;
+    // Settle any in-flight drain/listen wait so runEndCallTeardown unblocks
+    // and returns instead of leaking a pending promise.
+    const resolve = this.endCallWaitResolve;
+    this.clearEndCallWait();
+    resolve?.();
   }
 
   private clearPendingGuardianInputForCallEnd(): boolean {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -106,6 +106,12 @@ interface PendingGuardianInput {
   timer: ReturnType<typeof setTimeout>;
 }
 
+interface PendingEndCall {
+  cancelled: boolean;
+  /** Settles the teardown's current in-flight wait (drain cap or listen window). */
+  wake: (() => void) | null;
+}
+
 export class CallController {
   private callSessionId: string;
   private transport: CallTransport;
@@ -115,13 +121,12 @@ export class CallController {
   private currentTurnPromise: Promise<void> | null = null;
   private destroyed = false;
   private silenceTimer: ReturnType<typeof setTimeout> | null = null;
-  private endCallListenTimer: ReturnType<typeof setTimeout> | null = null;
-  /** Safety-cap timer for the end-call playback-drain wait. */
-  private endCallDrainCapTimer: ReturnType<typeof setTimeout> | null = null;
-  /** Settles the in-flight end-call wait so cancellation never leaves it hanging. */
-  private endCallWaitResolve: (() => void) | null = null;
-  /** Cancellation token for the in-flight end-call teardown (drain → listen). */
-  private pendingEndCall: { cancelled: boolean } | null = null;
+  /**
+   * Cancellation token for the in-flight end-call teardown (drain → listen).
+   * `wake` settles the teardown's current wait; all wait state lives on the
+   * token so a superseding teardown never clobbers a prior one's timers.
+   */
+  private pendingEndCall: PendingEndCall | null = null;
   /**
    * How many times the caller has re-engaged (spoken) after an END_CALL
    * marker was emitted but before the listen window fired. Each caller
@@ -291,7 +296,7 @@ export class CallController {
     // If the caller speaks while an END_CALL teardown is pending (during the
     // drain wait or the listen window), this is a deferral — the caller is
     // re-engaging after we tried to hang up. Track it so we can cap repeats.
-    if (this.endCallListenTimer || this.pendingEndCall) {
+    if (this.pendingEndCall) {
       this.endCallDeferralCount++;
       // The goodbye's speech was queued while state was idle, so the
       // media-stream barge-in ignored it. Cancel it here so it can't play
@@ -1349,10 +1354,9 @@ export class CallController {
     this.state = "idle";
     this.currentTurnHandle = null;
 
-    if (this.endCallListenTimer) {
-      clearTimeout(this.endCallListenTimer);
-      this.endCallListenTimer = null;
-    }
+    // Cancel any teardown still in flight from a prior END_CALL so it can't
+    // fire or cancel a later run.
+    this.cancelPendingEndCall();
 
     // The call always continues past END_CALL — either flushing queued
     // instructions or waiting for playback drain — so restore in_progress if
@@ -1361,15 +1365,13 @@ export class CallController {
       updateCallSession(this.callSessionId, { status: "in_progress" });
     }
 
-    // Queued instructions mean the call is continuing — flush and skip
-    // teardown. Clear any stale token first so it can't cancel a later run.
+    // Queued instructions mean the call is continuing — flush and skip teardown.
     if (this.pendingInstructions.length > 0) {
-      this.pendingEndCall = null;
       this.flushPendingInstructions();
       return;
     }
 
-    const pending = { cancelled: false };
+    const pending: PendingEndCall = { cancelled: false, wake: null };
     this.pendingEndCall = pending;
     void this.runEndCallTeardown(pending);
   }
@@ -1379,19 +1381,13 @@ export class CallController {
    * the re-engagement listen window, then end the session. Cancellable at
    * every step via the `pending` token (caller re-engagement, destroy).
    */
-  private async runEndCallTeardown(pending: {
-    cancelled: boolean;
-  }): Promise<void> {
+  private async runEndCallTeardown(pending: PendingEndCall): Promise<void> {
     if (this.transport.awaitPlaybackDrained) {
-      await new Promise<void>((resolve) => {
-        this.endCallWaitResolve = resolve;
-        this.endCallDrainCapTimer = setTimeout(
-          resolve,
-          getEndCallDrainMaxWaitMs(),
-        );
+      await this.awaitCancellable(pending, (resolve) => {
+        const cap = setTimeout(resolve, getEndCallDrainMaxWaitMs());
         void this.transport.awaitPlaybackDrained!().then(resolve, resolve);
+        return () => clearTimeout(cap);
       });
-      this.clearEndCallWait();
     }
     if (pending.cancelled || this.destroyed) {
       return;
@@ -1403,11 +1399,10 @@ export class CallController {
       this.endCallDeferralCount > 0 ? 0 : getEndCallListenWindowMs();
     if (listenWindowMs > 0) {
       this.resetSilenceTimer();
-      await new Promise<void>((resolve) => {
-        this.endCallWaitResolve = resolve;
-        this.endCallListenTimer = setTimeout(resolve, listenWindowMs);
+      await this.awaitCancellable(pending, (resolve) => {
+        const timer = setTimeout(resolve, listenWindowMs);
+        return () => clearTimeout(timer);
       });
-      this.clearEndCallWait();
     }
     if (pending.cancelled || this.destroyed) {
       return;
@@ -1416,29 +1411,39 @@ export class CallController {
     this.completeCallFromEndMarker();
   }
 
-  /** Clear the end-call wait's timers and resolver handle. */
-  private clearEndCallWait(): void {
-    if (this.endCallDrainCapTimer) {
-      clearTimeout(this.endCallDrainCapTimer);
-      this.endCallDrainCapTimer = null;
-    }
-    if (this.endCallListenTimer) {
-      clearTimeout(this.endCallListenTimer);
-      this.endCallListenTimer = null;
-    }
-    this.endCallWaitResolve = null;
+  /**
+   * Await a wait that {@link cancelPendingEndCall} can settle early. `arm`
+   * starts the wait and returns a cleanup for its timers. The resolver lives
+   * on the `pending` token (not shared instance state) so a superseding
+   * teardown's wait is never clobbered by a prior teardown's continuation.
+   */
+  private awaitCancellable(
+    pending: PendingEndCall,
+    arm: (resolve: () => void) => () => void,
+  ): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let cleanup: (() => void) | null = null;
+      const done = (): void => {
+        if (pending.wake === done) {
+          pending.wake = null;
+        }
+        cleanup?.();
+        resolve();
+      };
+      pending.wake = done;
+      cleanup = arm(done);
+    });
   }
 
   private cancelPendingEndCall(): void {
-    if (this.pendingEndCall) {
-      this.pendingEndCall.cancelled = true;
-    }
+    const pending = this.pendingEndCall;
     this.pendingEndCall = null;
-    // Settle any in-flight drain/listen wait so runEndCallTeardown unblocks
-    // and returns instead of leaking a pending promise.
-    const resolve = this.endCallWaitResolve;
-    this.clearEndCallWait();
-    resolve?.();
+    if (pending) {
+      pending.cancelled = true;
+      // Settle its in-flight wait so runEndCallTeardown unblocks and returns
+      // instead of leaking a pending promise.
+      pending.wake?.();
+    }
   }
 
   private clearPendingGuardianInputForCallEnd(): boolean {
@@ -1468,6 +1473,9 @@ export class CallController {
   }
 
   private completeCallFromEndMarker(): void {
+    // The teardown has run to completion; drop the token so a later utterance
+    // can't read it as a still-pending end-call.
+    this.pendingEndCall = null;
     if (this.destroyed) return;
 
     const currentSession = getCallSession(this.callSessionId);

--- a/assistant/src/calls/call-transport.ts
+++ b/assistant/src/calls/call-transport.ts
@@ -72,4 +72,13 @@ export interface CallTransport {
    * this.
    */
   cancelPendingSpeech?(): void;
+
+  /**
+   * Resolve once all queued speech has played out to the caller (the most
+   * recent end-of-turn boundary has been echoed back by the downstream
+   * transport). Used to gate end-of-call teardown so a goodbye is never cut
+   * off mid-sentence. Transports that play speech synchronously may omit
+   * this — the controller then treats playback as already drained.
+   */
+  awaitPlaybackDrained?(): Promise<void>;
 }

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -538,6 +538,10 @@ export class MediaStreamOutput implements CallTransport {
     if (!name.startsWith(`${END_OF_TURN_MARK_PREFIX}:`)) return;
     const seq = Number(name.slice(END_OF_TURN_MARK_PREFIX.length + 1));
     if (!Number.isFinite(seq)) return;
+    // Ignore echoes for marks we never enqueued (stale/forged/out-of-range).
+    // Accepting a future seq would advance the high-water mark and make later
+    // real turns' awaitPlaybackDrained() resolve before their audio played.
+    if (seq > this.enqueuedEndOfTurnSeq) return;
     if (seq > this.echoedEndOfTurnSeq) this.echoedEndOfTurnSeq = seq;
     this.resolveDrainWaiters();
   }

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -341,6 +341,9 @@ export class MediaStreamOutput implements CallTransport {
   /** Incremented per end-of-turn mark enqueued. */
   private enqueuedEndOfTurnSeq = 0;
 
+  /** Highest end-of-turn seq actually sent to Twilio (buffered downstream). */
+  private sentEndOfTurnSeq = 0;
+
   /** Highest end-of-turn seq echoed back by Twilio. */
   private echoedEndOfTurnSeq = 0;
 
@@ -455,10 +458,7 @@ export class MediaStreamOutput implements CallTransport {
     }
     this.state = "closed";
 
-    // Release drain waiters immediately so teardown never leaves one pending.
-    this.releaseAllDrainWaiters();
-
-    // Cancel any in-flight playback
+    // Cancel any in-flight playback (also releases drain waiters).
     this.flushPlaybackQueue();
 
     log.info(
@@ -521,6 +521,10 @@ export class MediaStreamOutput implements CallTransport {
 
     try {
       this.ws.send(JSON.stringify(command));
+      const seq = this.parseEndOfTurnSeq(name);
+      if (seq !== null && seq > this.sentEndOfTurnSeq) {
+        this.sentEndOfTurnSeq = seq;
+      }
     } catch (err) {
       log.error(
         { err, streamSid: this.streamSid },
@@ -535,15 +539,29 @@ export class MediaStreamOutput implements CallTransport {
    * has now been reached (played out to the caller).
    */
   notePlaybackMarkEcho(name: string): void {
-    if (!name.startsWith(`${END_OF_TURN_MARK_PREFIX}:`)) return;
-    const seq = Number(name.slice(END_OF_TURN_MARK_PREFIX.length + 1));
-    if (!Number.isFinite(seq)) return;
+    const seq = this.parseEndOfTurnSeq(name);
+    if (seq === null) {
+      return;
+    }
     // Ignore echoes for marks we never enqueued (stale/forged/out-of-range).
     // Accepting a future seq would advance the high-water mark and make later
     // real turns' awaitPlaybackDrained() resolve before their audio played.
-    if (seq > this.enqueuedEndOfTurnSeq) return;
-    if (seq > this.echoedEndOfTurnSeq) this.echoedEndOfTurnSeq = seq;
+    if (seq > this.enqueuedEndOfTurnSeq) {
+      return;
+    }
+    if (seq > this.echoedEndOfTurnSeq) {
+      this.echoedEndOfTurnSeq = seq;
+    }
     this.resolveDrainWaiters();
+  }
+
+  /** Parse the sequence from an `end-of-turn:<n>` mark name, else null. */
+  private parseEndOfTurnSeq(name: string): number | null {
+    if (!name.startsWith(`${END_OF_TURN_MARK_PREFIX}:`)) {
+      return null;
+    }
+    const seq = Number(name.slice(END_OF_TURN_MARK_PREFIX.length + 1));
+    return Number.isFinite(seq) ? seq : null;
   }
 
   /**
@@ -604,6 +622,14 @@ export class MediaStreamOutput implements CallTransport {
       return;
     }
     this.sendClearCommand();
+    // Twilio drops its buffered audio (and the marks within it) on `clear`, so
+    // any end-of-turn mark already sent will never echo. Treat those as drained
+    // so a pending end-call drain wait resolves instead of stalling on the cap.
+    // Marks still queued locally are preserved and will echo when they play.
+    if (this.sentEndOfTurnSeq > this.echoedEndOfTurnSeq) {
+      this.echoedEndOfTurnSeq = this.sentEndOfTurnSeq;
+      this.resolveDrainWaiters();
+    }
   }
 
   private sendClearCommand(): void {

--- a/assistant/src/calls/media-stream-output.ts
+++ b/assistant/src/calls/media-stream-output.ts
@@ -57,6 +57,9 @@ import { resolveCallTtsProvider } from "./resolve-call-tts-provider.js";
 
 const log = getLogger("media-stream-output");
 
+/** Prefix for the sequenced end-of-turn playback marks Twilio echoes back. */
+const END_OF_TURN_MARK_PREFIX = "end-of-turn";
+
 /** Twilio media streams consume 8 kHz mono mu-law. */
 const TELEPHONY_SAMPLE_RATE_HZ = 8000;
 
@@ -335,6 +338,15 @@ export class MediaStreamOutput implements CallTransport {
    */
   private audioStartCallback: (() => void) | null = null;
 
+  /** Incremented per end-of-turn mark enqueued. */
+  private enqueuedEndOfTurnSeq = 0;
+
+  /** Highest end-of-turn seq echoed back by Twilio. */
+  private echoedEndOfTurnSeq = 0;
+
+  /** Pending {@link awaitPlaybackDrained} waiters, each with its target seq. */
+  private drainWaiters: Array<{ targetSeq: number; resolve: () => void }> = [];
+
   /**
    * The media-stream transport requires raw PCM audio because its
    * mu-law transcoder cannot decode compressed formats (mp3, opus).
@@ -378,9 +390,13 @@ export class MediaStreamOutput implements CallTransport {
     }
 
     if (last) {
-      // Always send an end-of-turn mark so the media-stream server
-      // can detect turn boundaries.
-      this.enqueuePlayback({ type: "mark", name: "end-of-turn" });
+      // Always send a sequenced end-of-turn mark so the media-stream server
+      // can detect turn boundaries and drain waiters can track playback.
+      const seq = ++this.enqueuedEndOfTurnSeq;
+      this.enqueuePlayback({
+        type: "mark",
+        name: `${END_OF_TURN_MARK_PREFIX}:${seq}`,
+      });
       this.turnSegmentEnqueued = false;
     }
   }
@@ -438,6 +454,9 @@ export class MediaStreamOutput implements CallTransport {
       return;
     }
     this.state = "closed";
+
+    // Release drain waiters immediately so teardown never leaves one pending.
+    this.releaseAllDrainWaiters();
 
     // Cancel any in-flight playback
     this.flushPlaybackQueue();
@@ -508,6 +527,35 @@ export class MediaStreamOutput implements CallTransport {
         "Failed to send mark command",
       );
     }
+  }
+
+  /**
+   * Record a mark echoed back by Twilio. When it is an end-of-turn mark,
+   * advance the echoed sequence and resolve any drain waiters whose target
+   * has now been reached (played out to the caller).
+   */
+  notePlaybackMarkEcho(name: string): void {
+    if (!name.startsWith(`${END_OF_TURN_MARK_PREFIX}:`)) return;
+    const seq = Number(name.slice(END_OF_TURN_MARK_PREFIX.length + 1));
+    if (!Number.isFinite(seq)) return;
+    if (seq > this.echoedEndOfTurnSeq) this.echoedEndOfTurnSeq = seq;
+    this.resolveDrainWaiters();
+  }
+
+  /**
+   * Resolve once the most-recently-enqueued end-of-turn mark has been
+   * echoed by Twilio (all queued speech has played out to the caller).
+   * Resolves immediately if nothing is outstanding or the output is closed.
+   * Also resolves if the playback queue is later flushed (barge-in / teardown)
+   * so callers never hang.
+   */
+  awaitPlaybackDrained(): Promise<void> {
+    if (this.state === "closed") return Promise.resolve();
+    const targetSeq = this.enqueuedEndOfTurnSeq;
+    if (this.echoedEndOfTurnSeq >= targetSeq) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.drainWaiters.push({ targetSeq, resolve });
+    });
   }
 
   /**
@@ -610,6 +658,24 @@ export class MediaStreamOutput implements CallTransport {
     return this.state === "closed";
   }
 
+  // ── Private: playback drain waiters ─────────────────────────────────
+
+  private resolveDrainWaiters(): void {
+    if (this.drainWaiters.length === 0) return;
+    const remaining: typeof this.drainWaiters = [];
+    for (const w of this.drainWaiters) {
+      if (this.echoedEndOfTurnSeq >= w.targetSeq) w.resolve();
+      else remaining.push(w);
+    }
+    this.drainWaiters = remaining;
+  }
+
+  private releaseAllDrainWaiters(): void {
+    const waiters = this.drainWaiters;
+    this.drainWaiters = [];
+    for (const w of waiters) w.resolve();
+  }
+
   // ── Private: playback queue management ──────────────────────────────
 
   private enqueuePlayback(item: PlaybackItem): void {
@@ -636,6 +702,13 @@ export class MediaStreamOutput implements CallTransport {
       this.activePlaybackAbort.abort();
       this.activePlaybackAbort = null;
     }
+    // A flushed queue will never (genuinely) echo its pending end-of-turn
+    // marks — Twilio drops the buffered audio on `clear`. Treat every
+    // outstanding mark as drained so existing waiters resolve now and any
+    // *future* awaitPlaybackDrained() targeting a flushed seq doesn't hang.
+    // It also makes a late cleared-mark echo a no-op (seq <= echoed).
+    this.echoedEndOfTurnSeq = this.enqueuedEndOfTurnSeq;
+    this.releaseAllDrainWaiters();
   }
 
   /**

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -208,6 +208,7 @@ export class MediaStreamCallSession {
       onTranscriptFinal: (text, durationMs) =>
         this.handleTranscriptFinal(text, durationMs),
       onDtmf: (digit) => this.handleDtmf(digit),
+      onMark: (name) => this.handleMarkEcho(name),
       onStop: () => this.handleStreamStop(),
       onError: (category, message) => this.handleSttError(category, message),
     };
@@ -254,7 +255,9 @@ export class MediaStreamCallSession {
    * audio processing.
    */
   handleMessage(raw: string): void {
-    if (this.disposed) {return;}
+    if (this.disposed) {
+      return;
+    }
 
     // Intercept `start` to bootstrap the session before forwarding.
     const parseResult = parseMediaStreamFrame(raw);
@@ -277,7 +280,9 @@ export class MediaStreamCallSession {
    * in a terminal state.
    */
   handleTransportClosed(code?: number, reason?: string): void {
-    if (this.disposed) {return;}
+    if (this.disposed) {
+      return;
+    }
 
     // Tear down an in-flight setup flow first: clears its timers and emits
     // the guardian-wait callback handoff when the caller opted in.
@@ -286,7 +291,9 @@ export class MediaStreamCallSession {
     setupFlow?.dispose("transport_closed");
 
     const session = getCallSession(this.callSessionId);
-    if (!session) {return;}
+    if (!session) {
+      return;
+    }
     if (isTerminalState(session.status)) {
       // A hangup during a flow-terminal goodbye: dispose above swallowed the
       // flow's pending complete(), so finalize + revoke grants here. Normal
@@ -373,7 +380,9 @@ export class MediaStreamCallSession {
    * Dispose of the session, cleaning up all resources.
    */
   destroy(): void {
-    if (this.disposed) {return;}
+    if (this.disposed) {
+      return;
+    }
     this.disposed = true;
 
     this.sttSession.dispose();
@@ -427,7 +436,9 @@ export class MediaStreamCallSession {
         session.status !== "waiting_on_user"
       ) {
         updates.status = "in_progress";
-        if (!session.startedAt) {updates.startedAt = Date.now();}
+        if (!session.startedAt) {
+          updates.startedAt = Date.now();
+        }
       }
       updateCallSession(this.callSessionId, updates);
     }
@@ -750,9 +761,7 @@ export class MediaStreamCallSession {
     // end-of-turn mark it enqueues survives the queue flush.
     if (this.output && this.controller) {
       const output = this.output;
-      const accepted = this.controller.handleBargeIn(() =>
-        output.clearAudio(),
-      );
+      const accepted = this.controller.handleBargeIn(() => output.clearAudio());
       if (accepted) {
         this.bargeInAccepted++;
         log.info(
@@ -775,7 +784,9 @@ export class MediaStreamCallSession {
   }
 
   private handleTranscriptFinal(text: string, _durationMs: number): void {
-    if (!text.trim()) {return;}
+    if (!text.trim()) {
+      return;
+    }
 
     // Drop transcripts arriving while setup routing is still pending so a
     // not-yet-authorized / floor-denied caller's speech is never persisted
@@ -863,6 +874,15 @@ export class MediaStreamCallSession {
     // While a setup flow is active, digits feed its code-collection
     // sub-flows (the flow itself records no per-digit events).
     this.setupFlow?.pushDtmfDigit(digit);
+  }
+
+  private handleMarkEcho(name: string): void {
+    if (this.disposed) {
+      return;
+    }
+    // Twilio echoes each queued mark once its preceding audio has played
+    // out; forward to the output so drain waiters resolve on real playback.
+    this.output.notePlaybackMarkEcho(name);
   }
 
   private handleStreamStop(): void {

--- a/assistant/src/calls/media-stream-stt-session.ts
+++ b/assistant/src/calls/media-stream-stt-session.ts
@@ -137,6 +137,12 @@ export interface MediaStreamSttSessionCallbacks {
   onDtmf?: (digit: string) => void;
 
   /**
+   * Called when Twilio echoes an outbound mark back — i.e. the caller's
+   * playback has reached that mark. Used to detect real playback drain.
+   */
+  onMark?: (name: string) => void;
+
+  /**
    * Called when the media stream stops.
    */
   onStop?: () => void;
@@ -264,7 +270,7 @@ export class MediaStreamSttSession {
         this.callbacks.onDtmf?.(event.dtmf.digit);
         break;
       case "mark":
-        // Marks are informational — no action needed in the STT session.
+        this.callbacks.onMark?.(event.mark.name);
         break;
       case "stop":
         this.handleStop();


### PR DESCRIPTION
## Summary
Phone calls hang up mid-goodbye because `[END_CALL]` teardown was gated on a fixed 2-second timer measured from when the LLM finished generating *text*, not from when the caller had actually *heard* the goodbye. This wires Twilio's playback `mark` echo into a real "audio drained" signal and gates teardown on it, with a 15s safety cap and re-engagement cancellation.

The chain: STT session surfaces Twilio `mark` echoes → media-stream server routes them into `MediaStreamOutput.notePlaybackMarkEcho` → `MediaStreamOutput` exposes `awaitPlaybackDrained()` on the `CallTransport` interface → `CallController` awaits real playback drain before ending the session. Transports without the signal fall back to prior behavior.

## Self-review result
PASS after remediation. Self-review (4 fresh-eyes passes) found a real regression + minor gaps beyond the per-PR Codex reviews; all fixed in the remediation PR (#38336) and verified closed by a focused re-review.

## PRs merged into feature branch
- #38315: declare optional `awaitPlaybackDrained` on `CallTransport`
- #38316: surface Twilio mark echoes from the media-stream STT session
- #38318: track playback drain via sequenced end-of-turn marks
- #38321: wire Twilio mark echoes into the media-stream output drain tracker
- #38327: wait for goodbye audio to drain before hanging up (controller gating)

### Fix PR (self-review remediation)
- #38336: resolve end-call drain on a buffered barge-in `clear`; teardown lifecycle/race cleanups

## Review-driven hardening (from Codex + self-review)
- Sequenced marks + clamp: ignore echoes for seqs never enqueued (stale/forged).
- Flush advances the drained seq so a waiter armed after a barge-in flush never hangs.
- Ignored barge-in `clearBufferedAudio` advances the drained seq up to marks actually sent to Twilio (dropped by `clear`), so a VAD false-positive mid-goodbye doesn't stall on the safety cap.
- Cancel queued goodbye speech on re-engagement so it can't play over the caller.
- Per-token wait state (`awaitCancellable`) so a superseding teardown never clears a prior one's safety cap.

Part of plan: endcall-drain.md