### PR TITLE
fix(voice): drain-scoped echo window + warm-up suppression close the gate's remaining self-interrupt paths

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -827,6 +827,7 @@ describe("AssistantConfigSchema", () => {
         bargeInMinSpeechMs: 250,
         echoBargeInMargin: 1.5,
         echoEmaHalfLifeMs: 400,
+        echoDrainSlackMs: 300,
       },
       maxSessionDurationSeconds: 1800,
       archiveAudio: false,

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -16,6 +16,7 @@ describe("LiveVoiceVadConfigSchema", () => {
       bargeInMinSpeechMs: 250,
       echoBargeInMargin: 1.5,
       echoEmaHalfLifeMs: 400,
+      echoDrainSlackMs: 300,
     });
   });
 
@@ -94,6 +95,7 @@ describe("LiveVoiceConfigSchema", () => {
         bargeInMinSpeechMs: 250,
         echoBargeInMargin: 1.5,
         echoEmaHalfLifeMs: 400,
+        echoDrainSlackMs: 300,
       },
       maxSessionDurationSeconds: 1800,
       // Off by default: voice turns carry only their transcript, no audio

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -55,7 +55,15 @@ export const LiveVoiceVadConfigSchema = z
       .positive("liveVoice.vad.echoEmaHalfLifeMs must be a positive integer")
       .default(400)
       .describe(
-        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients. Also sets the gate's onset warm-up: the first half-life/2 of playback audio learns at a quarter-half-life attack rate and defers barge-in trips until warm. Keep half-life/2 below bargeInMinSpeechMs (true at the defaults: 200 vs 250) so genuine onset barge-ins are never deferred.",
+        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients. Also sets the gate's onset warm-up: the first half-life/2 of each playback burst's audio learns at a quarter-half-life attack rate with speech classification suppressed (presumed echo), so barge-in during a burst's first half-life/2 requires speaking past the warm-up.",
+      ),
+    echoDrainSlackMs: z
+      .number({ error: "liveVoice.vad.echoDrainSlackMs must be a number" })
+      .int("liveVoice.vad.echoDrainSlackMs must be an integer")
+      .nonnegative("liveVoice.vad.echoDrainSlackMs must be nonnegative")
+      .default(300)
+      .describe(
+        "Slack (ms) past the client playback-drain estimate during which assistant echo is still expected at the mic (one-way transport latency + client jitter buffer). The echo gate's window — and its barge-in protections — extend this far beyond the last sent audio chunk's estimated drain.",
       ),
   })
   .describe(

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -254,6 +254,10 @@ function createMultiCycleHarness(startVoiceTurn: LiveVoiceTurnStarter) {
   const session = createLiveVoiceSession(context, {
     // Credential-free harness: every leg is injected, so skip the preflight.
     resolveCredentialReadiness: null,
+    // Echo-gate window pinned shut: these cycle-mechanics tests drive
+    // discrete chunks with no continuous mic flow, so the drain slack would
+    // otherwise hold a cold window open across utterances.
+    echoDrainSlackMs: 0,
     resolveTranscriber,
     startVoiceTurn,
     streamTtsAudio,
@@ -289,6 +293,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
     });
     const { context, frames } = createContext();
     const session = createLiveVoiceSession(context, {
+      // Echo-gate window pinned shut: these cycle-mechanics tests drive
+      // discrete chunks with no continuous mic flow, so the drain slack
+      // would otherwise hold a cold window open across utterances.
+      echoDrainSlackMs: 0,
       resolveCredentialReadiness: null,
       resolveTranscriber: mock(async () => transcriber),
       startVoiceTurn,
@@ -473,6 +481,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
       () => frames.filter((frame) => frame.type === "tts_done").length === 1,
     );
 
+    // Let the drained echo window (tiny tts chunk + zero slack) close on the
+    // wall clock so the next utterance is judged out-of-window at the base
+    // threshold rather than suppressed as presumed onset echo.
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await session.handleBinaryAudio(secondUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(
@@ -545,6 +557,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
     const { context, frames } = createContext(VAD_START_FRAME);
     let turnCount = 0;
     const session = createLiveVoiceSession(context, {
+      // Echo-gate window pinned shut: these cycle-mechanics tests drive
+      // discrete chunks with no continuous mic flow, so the drain slack
+      // would otherwise hold a cold window open across utterances.
+      echoDrainSlackMs: 0,
       resolveCredentialReadiness: null,
       resolveTranscriber,
       startVoiceTurn,
@@ -566,6 +582,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
       () => frames.filter((frame) => frame.type === "tts_done").length === 1,
     );
 
+    // Let the drained echo window (tiny tts chunk + zero slack) close on the
+    // wall clock so the next utterance is judged out-of-window at the base
+    // threshold rather than suppressed as presumed onset echo.
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await session.handleBinaryAudio(secondUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(
@@ -639,6 +659,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
     );
     expect(abort).toHaveBeenCalledTimes(1);
 
+    // Let the drained echo window (tiny tts chunk + zero slack) close on the
+    // wall clock so the next utterance is judged out-of-window at the base
+    // threshold rather than suppressed as presumed onset echo.
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await session.handleBinaryAudio(secondUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -125,6 +125,7 @@ function createHarness(options: {
   bargeInMinSpeechMs?: number;
   echoEmaHalfLifeMs?: number;
   echoBargeInMargin?: number;
+  echoDrainSlackMs?: number;
   emitMetrics?: boolean;
   metricsClock?: () => number;
   // Return a promise to hold a frame's transport write open (a backed-up
@@ -189,6 +190,7 @@ function createHarness(options: {
     bargeInMinSpeechMs: options.bargeInMinSpeechMs,
     echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
     echoBargeInMargin: options.echoBargeInMargin,
+    echoDrainSlackMs: options.echoDrainSlackMs,
     ...(options.spawnBackgroundContinuation
       ? { spawnBackgroundContinuation: options.spawnBackgroundContinuation }
       : {}),
@@ -366,10 +368,9 @@ describe("LiveVoiceSession server VAD", () => {
 
     // Sustained speech over the assistant's audio meets the default guard.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
-    // The sustained chunk is the first in-window audio, so its trip is
-    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
-    // the accumulated run.
-    await session.handleBinaryAudio(LOUD_CHUNK);
+    // The first in-window chunk is suppressed as presumed onset echo; the
+    // second sustained chunk arms and satisfies the guard in one piece.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -464,10 +465,9 @@ describe("LiveVoiceSession server VAD", () => {
     // Once audio has genuinely gone out, new sustained speech barge-ins.
     await waitFor(() => countType(frames, "utterance_end") === 2);
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
-    // The sustained chunk is the first in-window audio, so its trip is
-    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
-    // the accumulated run.
-    await session.handleBinaryAudio(LOUD_CHUNK);
+    // The first in-window chunk is suppressed as presumed onset echo; the
+    // second sustained chunk arms and satisfies the guard in one piece.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -874,10 +874,9 @@ describe("LiveVoiceSession server VAD", () => {
 
     // Barge in over the playing, already-complete reply.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
-    // The sustained chunk is the first in-window audio, so its trip is
-    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
-    // the accumulated run.
-    await session.handleBinaryAudio(LOUD_CHUNK);
+    // The first in-window chunk is suppressed as presumed onset echo; the
+    // second sustained chunk arms and satisfies the guard in one piece.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -1730,6 +1729,7 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
       bargeInMinSpeechMs: 250,
       echoBargeInMargin: 1.5,
       echoEmaHalfLifeMs: 400,
+      echoDrainSlackMs: 300,
     });
 
     const { frames, session } = createHarness({ viaFactory: true });
@@ -1845,6 +1845,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     bargeInMinSpeechMs: number;
     echoEmaHalfLifeMs?: number;
     echoBargeInMargin?: number;
+    echoDrainSlackMs?: number;
     finals?: string[];
     startFrame?: LiveVoiceClientStartFrame;
   }) {
@@ -1854,7 +1855,9 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       callbacks ??= turnOptions.callbacks;
       return { turnId: "bridge-turn", abort };
     });
+    let ttsSink: ((chunk: LiveVoiceTtsAudioChunk) => void) | undefined;
     const streamTtsAudio = mock(async (ttsOptions: LiveVoiceTtsOptions) => {
+      ttsSink = ttsOptions.onAudioChunk;
       ttsOptions.onAudioChunk(makeTtsChunk("assistant audio"));
       return makeTtsResult("assistant audio");
     });
@@ -1865,6 +1868,10 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       bargeInMinSpeechMs: options.bargeInMinSpeechMs,
       echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
       echoBargeInMargin: options.echoBargeInMargin,
+      // The window must stay open for the whole driven-chunk sequence
+      // regardless of wall clock; tests that exercise window CLOSING pass
+      // a small slack explicitly.
+      echoDrainSlackMs: options.echoDrainSlackMs ?? 60_000,
       turnDetectorConfig: { silenceThresholdMs: 5_000 },
       ...(options.startFrame ? { startFrame: options.startFrame } : {}),
     });
@@ -1886,19 +1893,41 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       callbacks?.message_complete?.(makeMessageComplete());
     }
 
-    return { ...harness, abort, speakFirstReply, completeFirstReply };
+    // Re-emit an audio chunk on the captured TTS sink: playback resuming
+    // after a synthesis stall, extending the drain estimate. Awaited so the
+    // tail extension lands before the caller drives mic chunks — matching
+    // production ordering, where the server extends the estimate at send
+    // time, strictly before that audio's echo can arrive back at the mic.
+    async function emitTtsChunk(): Promise<void> {
+      await ttsSink?.(makeTtsChunk("assistant audio"));
+      await flushAsyncCallbacks();
+    }
+
+    return {
+      ...harness,
+      abort,
+      speakFirstReply,
+      completeFirstReply,
+      emitTtsChunk,
+    };
   }
 
   test("speech shorter than the guard leaves the speaking turn untouched", async () => {
     const { frames, session, abort, speakFirstReply, completeFirstReply } =
       createSpeakingTurnHarness({
         bargeInMinSpeechMs: 60,
+        // Neutralize the echo gate (threshold pinned to the 800 floor,
+        // warm-up over after one chunk); the first chunk is suppressed as
+        // presumed onset echo, so drive one extra to keep 30 ms of speech.
+        echoBargeInMargin: 0.001,
+        echoEmaHalfLifeMs: 4,
         finals: ["what's the weather", "   "],
       });
     await speakFirstReply();
 
-    // 30 ms of speech then silence: never reaches the 60 ms guard.
-    for (let index = 0; index < 3; index += 1) {
+    // 30 ms of post-warm-up speech then silence: never reaches the 60 ms
+    // guard (the first chunk is suppressed as presumed onset echo).
+    for (let index = 0; index < 4; index += 1) {
       await session.handleBinaryAudio(LOUD_CHUNK);
     }
     await session.handleBinaryAudio(SILENT_CHUNK);
@@ -1935,8 +1964,9 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       });
     await speakFirstReply();
 
-    // 50 ms of consecutive speech: one chunk short of the 60 ms guard.
-    for (let index = 0; index < 5; index += 1) {
+    // 50 ms of post-warm-up consecutive speech: one chunk short of the
+    // 60 ms guard (the first chunk is suppressed as presumed onset echo).
+    for (let index = 0; index < 6; index += 1) {
       await session.handleBinaryAudio(LOUD_CHUNK);
     }
     await flushAsyncCallbacks();
@@ -1944,7 +1974,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     expect(countType(frames, "speech_started")).toBe(1);
     expect(abort).not.toHaveBeenCalled();
 
-    // The 6th consecutive chunk reaches 60 ms: the deferred speech_started
+    // The next consecutive chunk reaches 60 ms: the deferred speech_started
     // flushes playback and the turn cancels.
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
@@ -2150,6 +2180,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       }
       await flushAsyncCallbacks();
 
+      console.log("FRAMES:", frameTypes(frames).join(","));
       expect(countType(frames, "speech_started")).toBe(baseline);
       expect(countType(frames, "turn_cancelled")).toBe(0);
       expect(abort).not.toHaveBeenCalled();
@@ -2185,21 +2216,24 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       const { frames, session, abort, speakFirstReply } =
         createSpeakingTurnHarness({
           bargeInMinSpeechMs: 60,
-          echoEmaHalfLifeMs: 5,
+          echoEmaHalfLifeMs: 400,
         });
       await speakFirstReply();
 
-      // Steady echo at 3000 converges the reference (suppressed, as above).
-      for (let index = 0; index < 10; index += 1) {
+      // Steady echo at 3000: the 200 ms warm-up (20 chunks) converges the
+      // reference to ~2250 (threshold ~3375); later echo chunks classify as
+      // silence and only drift the unfrozen reference slowly.
+      for (let index = 0; index < 25; index += 1) {
         await session.handleBinaryAudio(pcm(3_000));
       }
       await flushAsyncCallbacks();
       expect(countType(frames, "turn_cancelled")).toBe(0);
 
-      // The user talks over the echo: 6000 clears the ≈ 4482 threshold and
-      // sustains past the guard, so the deferred speech_started flushes
-      // playback and the turn cancels.
-      for (let index = 0; index < 7; index += 1) {
+      // The user talks over the echo: 6000 clears the ~3500 threshold, arms
+      // the guard (freezing the reference), and sustains past the 60 ms
+      // guard, so the deferred speech_started flushes playback and the turn
+      // cancels.
+      for (let index = 0; index < 8; index += 1) {
         await session.handleBinaryAudio(pcm(6_000));
       }
       await waitFor(() =>
@@ -2246,6 +2280,9 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
         createSpeakingTurnHarness({
           bargeInMinSpeechMs: 60,
           echoEmaHalfLifeMs: 5,
+          // A real (small) slack so the drain-scoped window actually closes
+          // once the tiny tts chunk plus slack elapse on the wall clock.
+          echoDrainSlackMs: 150,
           finals: ["what's the weather", "   "],
         });
       await speakFirstReply();
@@ -2263,15 +2300,52 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       await flushAsyncCallbacks();
       expect(countType(frames, "speech_started")).toBe(baseline);
 
-      // The reply completes and the tiny playback tail drains: the echo
-      // window closes and the reference resets.
+      // The reply completes and the tiny playback tail plus slack drain on
+      // the wall clock: the echo window closes and the reference resets.
       completeFirstReply();
       await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+      await new Promise((resolve) => setTimeout(resolve, 200));
 
       // The same amplitude-1000 chunk is speech immediately at the 800
       // floor — a stale reference would have swallowed it.
       await session.handleBinaryAudio(pcm(1_000));
       await waitFor(() => countType(frames, "speech_started") === baseline + 1);
+    });
+
+    test("a TTS pause closes the window; resumed playback re-warms against fresh echo", async () => {
+      const { frames, session, abort, speakFirstReply, emitTtsChunk } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+          echoDrainSlackMs: 100,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // First burst: onset echo converges into the fresh warm-up.
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // Synthesis stall: the client drains (tiny chunk + 100 ms slack) and
+      // the window closes, resetting the decayed reference instead of
+      // leaving it stale against the next burst.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Playback resumes: the window re-opens with a fresh warm-up, so the
+      // resumed echo is re-learned instead of tripping the guard against a
+      // stale reference.
+      await emitTtsChunk();
+      for (let index = 0; index < 30; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
     });
 
     test("a guard trip reached during warm-up is deferred and dissolved by the converging reference", async () => {
@@ -2413,27 +2487,29 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     test("the echo reference freezes while the barge-in guard is armed", async () => {
       const { frames, session, speakFirstReply } = createSpeakingTurnHarness({
         bargeInMinSpeechMs: 60,
-        echoEmaHalfLifeMs: 5,
+        echoEmaHalfLifeMs: 400,
       });
       await speakFirstReply();
 
-      // The onset chunk arms the guard and seeds the reference during the
-      // single-chunk warm-up (fast attack converges EMA to ~2400, threshold
-      // ~3600); the warm-up then ends and the reference freezes while the
-      // guard stays armed.
-      await session.handleBinaryAudio(pcm(2_400));
-      // 100 ms at 3300 sits under the frozen ~3600 threshold (silence).
-      // Were the EMA still tracking, it would converge to ~3300 and lift
-      // the threshold to ~4950 — swallowing the 4000 override below.
+      // Steady echo converges the reference to ~2250 inside the warm-up;
+      // post-warm-up echo chunks are silent and only drift it slowly.
+      for (let index = 0; index < 25; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      // 100 ms at 3300 sits under the ~3400 threshold (silence). The
+      // unfrozen reference drifts toward 3300 only at the slow configured
+      // half-life, so the threshold stays under 4000.
       for (let index = 0; index < 10; index += 1) {
         await session.handleBinaryAudio(pcm(3_300));
       }
       await flushAsyncCallbacks();
       expect(countType(frames, "turn_cancelled")).toBe(0);
 
-      // 4000 clears the frozen ~3600 threshold and sustains past the guard —
-      // the reference did not move while the guard was armed.
-      for (let index = 0; index < 7; index += 1) {
+      // 4000 clears the threshold and arms the guard, freezing the
+      // reference; the run then sustains the 60 ms guard at a STABLE
+      // threshold and trips. Were the reference still tracking during the
+      // armed run, it would chase 4000 upward against the user.
+      for (let index = 0; index < 8; index += 1) {
         await session.handleBinaryAudio(pcm(4_000));
       }
       await waitFor(() =>

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -107,9 +107,15 @@ const FINALIZE_GRACE_MS = 1_000;
 // instant barge-in.
 const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
 // Echo-adaptive gate knobs (see effectiveSpeechThreshold). Mirror the
-// liveVoice.vad.echoBargeInMargin / echoEmaHalfLifeMs schema defaults.
+// liveVoice.vad.echoBargeInMargin / echoEmaHalfLifeMs / echoDrainSlackMs
+// schema defaults.
 const DEFAULT_ECHO_BARGE_IN_MARGIN = 1.5;
 const DEFAULT_ECHO_EMA_HALF_LIFE_MS = 400;
+// Slack (ms) past the client playback-drain estimate during which echo is
+// still expected at the mic: covers one-way transport latency + the client
+// jitter buffer, so the echo window outlives the send-time estimate by the
+// same margin real playback does. Mirrors liveVoice.vad.echoDrainSlackMs.
+const DEFAULT_ECHO_DRAIN_SLACK_MS = 300;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one
 // prefetching job. The prefetch buffers its chunks in memory until promoted;
@@ -210,6 +216,12 @@ export interface LiveVoiceSessionOptions {
    * `DEFAULT_ECHO_EMA_HALF_LIFE_MS`.
    */
   echoEmaHalfLifeMs?: number;
+  /**
+   * Slack (ms) past the client playback-drain estimate during which echo is
+   * still expected; seeds from `liveVoice.vad.echoDrainSlackMs` config when
+   * unset; defaults to DEFAULT_ECHO_DRAIN_SLACK_MS.
+   */
+  echoDrainSlackMs?: number;
   /**
    * Overrides the bounded wait for the shared transcriber's finalize
    * flush in persistent mode (test hook). Defaults to `FINALIZE_GRACE_MS`.
@@ -403,6 +415,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // playback, and that EMA's half-life.
   private readonly echoBargeInMargin: number;
   private readonly echoEmaHalfLifeMs: number;
+  private readonly echoDrainSlackMs: number;
   // EMA of observed mic-chunk energy while assistant audio is playing (the
   // echo reference); 0 outside the echo window.
   private echoEnergyEma = 0;
@@ -413,9 +426,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // across the turn boundary (turn collision) — see effectiveSpeechThreshold.
   private echoWindowGuardCarryover = false;
   // Warm-up state of the most recently classified in-window chunk (set by
-  // effectiveSpeechThreshold; consulted by handleVadSpeechStart and
-  // trackBargeInGuard) so classification and trip deferral agree per chunk
-  // regardless of ingress chunk size; false outside the echo window.
+  // effectiveSpeechThreshold; consulted by handleServerVadAudio's speech
+  // classification to suppress presumed-echo chunks); false outside the
+  // echo window.
   private echoGateChunkWarmingUp = false;
   // Mutable so a mid-session `update_config` frame can retune "interrupt
   // sensitivity" live (see applyConfigUpdate).
@@ -517,6 +530,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       options.echoBargeInMargin ?? DEFAULT_ECHO_BARGE_IN_MARGIN;
     this.echoEmaHalfLifeMs =
       options.echoEmaHalfLifeMs ?? DEFAULT_ECHO_EMA_HALF_LIFE_MS;
+    this.echoDrainSlackMs =
+      options.echoDrainSlackMs ?? DEFAULT_ECHO_DRAIN_SLACK_MS;
     this.finalizeGraceMs = options.finalizeGraceMs ?? FINALIZE_GRACE_MS;
     const turnDetectorConfig: TurnDetectorConfig = {
       ...(options.turnDetectorConfig ?? {}),
@@ -873,8 +888,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     const meanAmplitude = pcm16MeanAmplitude(chunk);
+    const speechThreshold = this.effectiveSpeechThreshold(chunk, meanAmplitude);
+    // Presumed-echo suppression: a chunk judged while the gate is warming is
+    // never speech — it must not trip barge-in, arm an utterance, or stream
+    // to STT (else the assistant's own onset echo transcribes into a ghost
+    // follow-up turn). See effectiveSpeechThreshold.
     const hasSpeech =
-      meanAmplitude > this.effectiveSpeechThreshold(chunk, meanAmplitude);
+      meanAmplitude > speechThreshold && !this.echoGateChunkWarmingUp;
     detector.onMediaChunk(hasSpeech);
     this.trackBargeInGuard(hasSpeech, chunk);
 
@@ -917,17 +937,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.routeVadAudio(utterance, chunk);
   }
 
-  // The echo window: the only time the speakers can be emitting assistant
-  // audio — a turn that has audibly started speaking, or the post-tts_done
-  // drain tail the client is still playing. A thinking (pre-TTS) turn plays
-  // nothing, so it keeps base-threshold sensitivity and pre-TTS barge-in
-  // (JARVIS-1266) is unaffected.
+  // The echo window: the client is (estimated to be) audibly draining
+  // assistant audio. Scoped to the live playback-drain estimate — which
+  // grows with every sent tts_audio chunk — plus a slack that covers
+  // one-way transport latency and the client jitter buffer, NOT to the
+  // whole turn: a synthesis stall or inter-sentence pause drains the client
+  // and closes the window, so each speech burst re-opens it with a fresh
+  // warm-up instead of letting the reference decay against a stale open
+  // window. A thinking (pre-TTS or mid-pause) turn plays nothing, so it
+  // keeps base-threshold sensitivity and pre-TTS barge-in (JARVIS-1266) is
+  // unaffected.
   private isAssistantAudioPlaying(): boolean {
-    const turn = this.activeAssistantTurn;
-    if (turn?.ttsAudioStarted && !turn.finalized) {
-      return true;
-    }
-    return Date.now() < this.assistantPlaybackTailUntilMs;
+    return (
+      Date.now() < this.assistantPlaybackTailUntilMs + this.echoDrainSlackMs
+    );
   }
 
   // Energy gate for classifying a server-VAD chunk as speech. While assistant
@@ -944,25 +967,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // not inflate the reference against them — and resets outside the echo
   // window so a loud turn's reference never leaks into the next one.
   //
-  // The freeze has a cold-start hole: at playback onset the very first loud
-  // echo chunk arms the guard, which would freeze the reference near zero and
-  // let steady onset echo complete a full guard run against the base
-  // threshold. So the window opens with a WARM-UP — the first
-  // echoEmaHalfLifeMs / 2 of in-window audio (200 ms at the 400 ms default,
-  // under the 250 ms default trip, so real barge-in latency is untouched) —
-  // during which the EMA learns despite the armed guard, at a quarter-
+  // Cold start: the reference knows nothing at window open, so the window
+  // opens with a WARM-UP — its first echoEmaHalfLifeMs / 2 of audio (200 ms
+  // at the 400 ms default) — during which the EMA learns at a quarter-
   // half-life attack rate (two attack half-lives per warm-up brings the
   // reference to ~75% of a steady echo level, putting margin × EMA above
-  // it): echo, not speech, is the expected first signal at TTS onset. Guard
-  // trips are deferred (the run accumulates, it doesn't fire) while the
-  // tripping chunk was judged against a warming reference — a per-chunk flag
-  // (echoGateChunkWarmingUp), so large ingress chunks cannot outrun the
-  // window clock. Onset echo's run is zeroed once the reference overtakes
-  // it; a genuine user run that outlasts the warm-up fires on its first warm
-  // chunk. The same warm-up floor guards the instant-barge-in config
-  // (bargeInMinSpeechMs 0), which otherwise bypasses the guard entirely (see
-  // handleVadSpeechStart). Warm-up is measured in processed audio time, the
-  // same clock that drives EMA convergence.
+  // it) and chunks are SUPPRESSED from speech classification entirely
+  // (handleServerVadAudio): echo, not speech, is the expected first signal
+  // when playback starts, and warm-up echo must not trip barge-in, arm an
+  // utterance, or stream to STT as user audio (a transcribed echo fragment
+  // would launch a ghost follow-up turn). The per-chunk flag
+  // (echoGateChunkWarmingUp) is captured before the window clock advances,
+  // so large ingress chunks cannot outrun it. Because the window is scoped
+  // to the client playback-drain estimate (isAssistantAudioPlaying), every
+  // TTS pause closes the window and every speech burst re-opens it with a
+  // fresh warm-up — the reference never goes stale against resumed echo. A
+  // user starting to speak inside a warm-up is absorbed into the reference
+  // (echo-first assumption) and recovers by pausing and speaking again once
+  // the gate is warm. Warm-up is measured in processed audio time, the same
+  // clock that drives EMA convergence.
   //
   // Turn collision: a guard with a LIVE speech run when the window opens is
   // the user already talking across the turn boundary — humans cannot react
@@ -1149,17 +1172,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // The client can still be draining audible playback after tts_done
     // (the turn is already cleared server-side) — that tail deserves the
     // same guard, or a noise blip clips the reply's last words.
-    const drainingPlayback = Date.now() < this.assistantPlaybackTailUntilMs;
+    const drainingPlayback = this.isAssistantAudioPlaying();
 
-    if (
-      (bargeableTurn || drainingPlayback) &&
-      (this.bargeInMinSpeechMs > 0 || this.echoGateChunkWarmingUp)
-    ) {
+    if ((bargeableTurn || drainingPlayback) && this.bargeInMinSpeechMs > 0) {
       // Onset audio keeps flowing into the cycle/pre-roll while the guard
       // accumulates (trackBargeInGuard), so no speech is lost either way.
-      // Instant barge-in (bargeInMinSpeechMs 0) still arms the guard while
-      // the echo gate is warming up — otherwise the first onset-echo chunk
-      // would cancel every turn — and resumes instant behavior once warm.
+      // Instant barge-in (bargeInMinSpeechMs 0) needs no warm-up handling
+      // here: warm-up chunks are suppressed at classification, so a speech
+      // onset cannot fire while the gate is warming.
       this.pendingBargeIn = { turn: bargeableTurn, speechMs: 0 };
       return;
     }
@@ -1197,11 +1217,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.context.startFrame.audio.sampleRate,
     );
     if (guard.speechMs < this.bargeInMinSpeechMs) {
-      return;
-    }
-    // Defer trips fed by a chunk judged against a warming echo reference —
-    // see effectiveSpeechThreshold. Turn-collision guards trip normally.
-    if (this.echoGateChunkWarmingUp) {
       return;
     }
     this.pendingBargeIn = null;
@@ -2964,6 +2979,7 @@ export function createLiveVoiceSession(
       options.echoBargeInMargin ?? vadConfig?.echoBargeInMargin,
     echoEmaHalfLifeMs:
       options.echoEmaHalfLifeMs ?? vadConfig?.echoEmaHalfLifeMs,
+    echoDrainSlackMs: options.echoDrainSlackMs ?? vadConfig?.echoDrainSlackMs,
     resolveCredentialReadiness:
       options.resolveCredentialReadiness === undefined
         ? defaultResolveLiveVoiceCredentialReadiness


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for echo-adaptive-bargein.md.

- **Ghost turns (Codex P2 on #38325)**: warm-up chunks are now suppressed at the single speech-classification point — presumed onset echo can no longer arm a VAD utterance and stream to STT (which transcribed the assistant's own words into a ghost follow-up turn), and the now-dead trip-deferral and instant-mode arm-condition machinery is removed
- **Stale reference on TTS pauses**: the echo window is scoped to the live client playback-drain estimate (per-sent-chunk) instead of the whole turn — a synthesis stall or inter-sentence pause closes the window and each speech burst re-opens it with a fresh warm-up, so resumed echo is re-learned instead of tripping the guard against a decayed reference
- **Tail clipping**: new `echoDrainSlackMs` (default 300, schema knob) extends the window past the send-time drain estimate by one-way latency + jitter-buffer, so residual echo after estimated expiry can no longer flush the reply's last words
- Tests: pause-resume burst re-warm case; echo suite migrated to production half-life (tiny half-lives distort the unfrozen-until-armed reference); cycle-mechanics tests pin the gate/window shut with rationale comments