### PR TITLE
feat(memory): implement assistant memory retrospective list subcommand

### DIFF
--- a/assistant/src/cli/commands/memory/index.help.ts
+++ b/assistant/src/cli/commands/memory/index.help.ts
@@ -755,7 +755,9 @@ process imports the retrospective machinery and calls it in-process, so no
 running daemon is required.
 
 Examples:
-  $ assistant memory retrospective run <conversationId>`,
+  $ assistant memory retrospective run <conversationId>
+  $ assistant memory retrospective list
+  $ assistant memory retrospective list --limit 20 --json`,
       subcommands: [
         {
           name: "run",
@@ -780,6 +782,31 @@ CLI process — no IPC round-trip to the daemon.
 
 Examples:
   $ assistant memory retrospective run abc123`,
+        },
+        {
+          name: "list",
+          description: "List the most-recently-run retrospective state rows",
+          options: [
+            {
+              flags: "--limit <n>",
+              description: "Max rows to return (default 10, max 200)",
+            },
+            {
+              flags: "--json",
+              description: "Machine-readable compact JSON output",
+            },
+          ],
+          helpText: `
+Reads the memory_retrospective_state table directly from the workspace SQLite
+database and prints the most-recently-run state rows, newest first. No daemon
+required. Each row shows the source conversation ID, when the retrospective last
+ran, how many memories were saved across all passes, and whether any pass has
+yet succeeded (status "ok") or only failed attempts exist ("pending").
+
+Examples:
+  $ assistant memory retrospective list
+  $ assistant memory retrospective list --limit 20
+  $ assistant memory retrospective list --json`,
         },
       ],
     },

--- a/assistant/src/cli/commands/memory/index.help.ts
+++ b/assistant/src/cli/commands/memory/index.help.ts
@@ -800,8 +800,10 @@ Examples:
 Reads the memory_retrospective_state table directly from the workspace SQLite
 database and prints the most-recently-run state rows, newest first. No daemon
 required. Each row shows the source conversation ID, when the retrospective last
-ran, how many memories were saved across all passes, and whether any pass has
-yet succeeded (status "ok") or only failed attempts exist ("pending").
+ran, how many memory entries are currently retained in the dedup log (capped at
+100 entries / 8 KB — older entries are dropped as new ones arrive, so RETAINED
+reflects the live dedup window, not a cumulative save count), and whether any
+pass has yet succeeded (status "ok") or only failed attempts exist ("pending").
 
 Examples:
   $ assistant memory retrospective list

--- a/assistant/src/cli/commands/memory/memory-retrospective.ts
+++ b/assistant/src/cli/commands/memory/memory-retrospective.ts
@@ -103,10 +103,10 @@ function renderList(rows: RetrospectiveStateRow[]): void {
 
   const DATE_WIDTH = 20;
   const CONV_WIDTH = 12;
-  const MEM_WIDTH = 8;
+  const MEM_WIDTH = 10;
 
   console.log(
-    `${"CONVERSATION".padEnd(CONV_WIDTH)}  ${"LAST RUN".padEnd(DATE_WIDTH)}  ${"MEMORIES".padEnd(MEM_WIDTH)}  STATUS`,
+    `${"CONVERSATION".padEnd(CONV_WIDTH)}  ${"LAST RUN".padEnd(DATE_WIDTH)}  ${"RETAINED".padEnd(MEM_WIDTH)}  STATUS`,
   );
 
   for (const row of rows) {
@@ -118,10 +118,10 @@ function renderList(rows: RetrospectiveStateRow[]): void {
       hour: "numeric",
       minute: "2-digit",
     });
-    const memories = String(row.rememberedLog.length).padEnd(MEM_WIDTH);
+    const retained = String(row.rememberedLog.length).padEnd(MEM_WIDTH);
     const status =
       row.lastProcessedMessageId === "" ? "pending (no success yet)" : "ok";
-    console.log(`${conv}  ${runAt.padEnd(DATE_WIDTH)}  ${memories}  ${status}`);
+    console.log(`${conv}  ${runAt.padEnd(DATE_WIDTH)}  ${retained}  ${status}`);
   }
 
   console.log(`\n${rows.length} row${rows.length === 1 ? "" : "s"}`);

--- a/assistant/src/cli/commands/memory/memory-retrospective.ts
+++ b/assistant/src/cli/commands/memory/memory-retrospective.ts
@@ -8,7 +8,7 @@
  * Subcommands:
  *
  *   - `run <conversationId>` — run a fork-based retrospective on a conversation.
- *   - `list` — list the last five retrospectives (TODO).
+ *   - `list` — list the most-recently-run retrospective state rows.
  */
 
 import type { Command } from "commander";
@@ -54,11 +54,78 @@ export function registerMemoryRetrospectiveCommand(memory: Command): void {
       renderOutcome(outcome);
     },
   );
+
+  // ── list ──────────────────────────────────────────────────────────────
+
+  subcommand(retro, "list")
+    .alias("ls")
+    .action(async (opts: { limit?: string; json?: boolean }, cmd: Command) => {
+      const limit = Math.min(
+        200,
+        Math.max(1, opts.limit !== undefined ? parseInt(opts.limit, 10) : 10),
+      );
+      if (isNaN(limit)) {
+        log.error("--limit must be a number.");
+        process.exitCode = 1;
+        return;
+      }
+
+      const { listRetrospectiveStates } =
+        await import("../../../plugins/defaults/memory/memory-retrospective-state.js");
+      const rows = listRetrospectiveStates(limit);
+
+      if (opts.json) {
+        writeOutput(cmd, { rows, total: rows.length });
+        return;
+      }
+
+      renderList(rows);
+    });
 }
 
 // ---------------------------------------------------------------------------
 // Human-readable rendering
 // ---------------------------------------------------------------------------
+
+interface RetrospectiveStateRow {
+  conversationId: string;
+  lastProcessedMessageId: string;
+  lastRunAt: number;
+  rememberedLog: string[];
+}
+
+function renderList(rows: RetrospectiveStateRow[]): void {
+  if (rows.length === 0) {
+    log.info("No retrospective state found. Run a retrospective first with:");
+    log.info("  assistant memory retrospective run <conversationId>");
+    return;
+  }
+
+  const DATE_WIDTH = 20;
+  const CONV_WIDTH = 12;
+  const MEM_WIDTH = 8;
+
+  console.log(
+    `${"CONVERSATION".padEnd(CONV_WIDTH)}  ${"LAST RUN".padEnd(DATE_WIDTH)}  ${"MEMORIES".padEnd(MEM_WIDTH)}  STATUS`,
+  );
+
+  for (const row of rows) {
+    const conv = row.conversationId.slice(0, CONV_WIDTH - 1).padEnd(CONV_WIDTH);
+    const runAt = new Date(row.lastRunAt).toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    const memories = String(row.rememberedLog.length).padEnd(MEM_WIDTH);
+    const status =
+      row.lastProcessedMessageId === "" ? "pending (no success yet)" : "ok";
+    console.log(`${conv}  ${runAt.padEnd(DATE_WIDTH)}  ${memories}  ${status}`);
+  }
+
+  console.log(`\n${rows.length} row${rows.length === 1 ? "" : "s"}`);
+}
 
 function renderOutcome(outcome: MemoryRetrospectiveOutcome): void {
   switch (outcome.kind) {

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -23,7 +23,7 @@
 // The schema enforces the foreign key with ON DELETE CASCADE, so deleting a
 // conversation collects its state row automatically.
 
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
 import { type DrizzleDb, getDb } from "../../../persistence/db-connection.js";
 import { memoryRetrospectiveState } from "../../../persistence/schema/index.js";
@@ -86,6 +86,26 @@ function parseRememberedLog(raw: string | null): string[] {
 
 function serializeRememberedLog(log: string[]): string | null {
   return log.length === 0 ? null : JSON.stringify(log);
+}
+
+/**
+ * Return the `limit` most-recently-run retrospective state rows, newest first.
+ */
+export function listRetrospectiveStates(
+  limit: number,
+): MemoryRetrospectiveState[] {
+  const rows = getDb()
+    .select()
+    .from(memoryRetrospectiveState)
+    .orderBy(desc(memoryRetrospectiveState.lastRunAt))
+    .limit(limit)
+    .all();
+  return rows.map((row) => ({
+    conversationId: row.conversationId,
+    lastProcessedMessageId: row.lastProcessedMessageId,
+    lastRunAt: row.lastRunAt,
+    rememberedLog: parseRememberedLog(row.rememberedLog),
+  }));
 }
 
 /**

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -195,6 +195,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "memory v3 eval",
   "memory retrospective",
   "memory retrospective run",
+  "memory retrospective list",
   "memory worker",
   "memory worker start",
   "memory worker stop",


### PR DESCRIPTION
Adds `assistant memory retrospective list` (alias `ls`) to surface the per-conversation retrospective state table directly from the workspace SQLite DB — no daemon required.

• `memory-retrospective-state.ts` — adds `listRetrospectiveStates(limit)`
  querying `memory_retrospective_state` ordered by `last_run_at DESC`.
• `memory-retrospective.ts` — wires the `list` subcommand with `--limit`
  (default 10, max 200) and `--json`; renders a four-column table showing
  conversation ID, last-run timestamp, cumulative memory count, and
  success/pending status derived from `lastProcessedMessageId`.
• `index.help.ts` — adds the `list` declaration under `retrospective`
  (help text, options, examples) and updates the parent group examples.
• `assistant.ts` (gateway registry) — registers `"memory retrospective list"`.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
