### PR TITLE
test(memory-v3): exercise the gate against its shipped thresholds

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/gate.test.ts
@@ -10,12 +10,10 @@ import {
 import type { SectionNeedleScoredHit } from "../section-needle.js";
 
 /**
- * The SHIPPED `memory.v3.gate` tuning, parsed from the schema rather than
- * restated. A hand-copied set lived here and drifted when the schema was
- * retuned, leaving every threshold path below asserting against numbers
- * production never used — the tests stayed green and stopped meaning anything.
- * Parsing keeps them honest by construction; `parse({})` to materialize the
- * defaults is the same idiom the schema itself uses to seed `memory.v3.gate`.
+ * The SHIPPED `memory.v3.gate` tuning. Parsed from the schema, never restated:
+ * a hardcoded copy can diverge from the defaults silently, leaving these tests
+ * green while asserting against thresholds nothing runs. `parse({})` is the same
+ * idiom the schema uses to seed `memory.v3.gate`.
  *
  * The score fixtures below are chosen relative to these values, so retuning a
  * default may require revisiting them. That is intended: a threshold move

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/gate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { MemoryV3GateSchema } from "../../../../../config/schemas/memory-v3.js";
 import type { DenseHitScored } from "../dense.js";
 import {
   checkV3Gate,
@@ -8,20 +9,20 @@ import {
 } from "../gate.js";
 import type { SectionNeedleScoredHit } from "../section-needle.js";
 
-/** Schema tuning defaults (memory.v3.gate) plus the effective `enabled` flag. */
+/**
+ * The SHIPPED `memory.v3.gate` tuning, parsed from the schema rather than
+ * restated. A hand-copied set lived here and drifted when the schema was
+ * retuned, leaving every threshold path below asserting against numbers
+ * production never used — the tests stayed green and stopped meaning anything.
+ * Parsing keeps them honest by construction; `parse({})` to materialize the
+ * defaults is the same idiom the schema itself uses to seed `memory.v3.gate`.
+ *
+ * The score fixtures below are chosen relative to these values, so retuning a
+ * default may require revisiting them. That is intended: a threshold move
+ * should force a look at whether each case still exercises the path it names.
+ */
 function baseConfig(overrides: Partial<V3GateConfig> = {}): V3GateConfig {
-  return {
-    enabled: true,
-    denseThreshold: 0.52,
-    sparseThreshold: 0.35,
-    sparseOnlyThreshold: 0.45,
-    denseClusterThreshold: 0.47,
-    denseClusterMaxDelta: 0.04,
-    topK: 5,
-    bm25NormK: null,
-    bypassForCore: false,
-    ...overrides,
-  };
+  return { ...MemoryV3GateSchema.parse({}), ...overrides };
 }
 
 let articleSeq = 0;
@@ -36,48 +37,51 @@ describe("checkV3Gate", () => {
   test("dense_pass: top-1 dense clears the dense threshold", () => {
     const result = checkV3Gate({
       needleHits: [],
-      denseHits: [mkDense(0.6), mkDense(0.3)],
+      denseHits: [mkDense(0.7), mkDense(0.3)], // 0.7 >= denseThreshold 0.66
       config: baseConfig(),
     });
     expect(result.pass).toBe(true);
     expect(result.reason).toBe("dense_pass");
-    expect(result.topDenseScore).toBe(0.6);
+    expect(result.topDenseScore).toBe(0.7);
   });
 
   test("dense_cluster: borderline top-3 dense cluster passes", () => {
     const result = checkV3Gate({
+      // All three clear denseClusterThreshold 0.6 within denseClusterMaxDelta
+      // 0.02 (spread 0.01), while top-1 stays under denseThreshold 0.66.
       needleHits: [],
-      denseHits: [mkDense(0.5), mkDense(0.48), mkDense(0.47)],
+      denseHits: [mkDense(0.65), mkDense(0.64), mkDense(0.64)],
       config: baseConfig(),
     });
     expect(result.pass).toBe(true);
     expect(result.reason).toBe("dense_cluster");
     // Top-1 is below denseThreshold, so this is a cluster pass, not a dense pass.
-    expect(result.topDenseScore).toBe(0.5);
+    expect(result.topDenseScore).toBe(0.65);
   });
 
   test("sparse_only_strong: dense fails but normalized BM25F clears the high bar", () => {
     const result = checkV3Gate({
-      needleHits: [mkNeedle(9)], // norm = 9 / (9 + 9) = 0.5 >= 0.45
+      // sparseOnlyThreshold 0.75 needs raw >= 27 at normK 9; 40 clears with room.
+      needleHits: [mkNeedle(40)], // norm = 40 / (40 + 9) ≈ 0.816 >= 0.75
       denseHits: [mkDense(0.3), mkDense(0.25)],
       config: baseConfig(),
     });
     expect(result.pass).toBe(true);
     expect(result.reason).toBe("sparse_only_strong");
-    expect(result.topSparseScore).toBe(9);
-    expect(result.topNormSparseScore).toBeCloseTo(0.5, 10);
+    expect(result.topSparseScore).toBe(40);
+    expect(result.topNormSparseScore).toBeCloseTo(40 / 49, 10);
   });
 
   test("fail_dense_below_and_sparse_weak: sparse passes the floor but not the sparse-only bar", () => {
     const result = checkV3Gate({
-      needleHits: [mkNeedle(5.52)], // norm = 5.52 / 14.52 ≈ 0.380 (≥ 0.35, < 0.45)
+      needleHits: [mkNeedle(9)], // norm = 9 / 18 = 0.5 (≥ 0.35, < 0.75)
       denseHits: [mkDense(0.3)],
       config: baseConfig(),
     });
     expect(result.pass).toBe(false);
     expect(result.reason).toBe("fail_dense_below_and_sparse_weak");
     expect(result.topNormSparseScore!).toBeGreaterThanOrEqual(0.35);
-    expect(result.topNormSparseScore!).toBeLessThan(0.45);
+    expect(result.topNormSparseScore!).toBeLessThan(0.75);
   });
 
   test("fail_no_signal: dense below and sparse essentially nil", () => {


### PR DESCRIPTION
## The bug

`baseConfig` in `gate.test.ts` describes itself as *"Schema tuning defaults (memory.v3.gate)"*. It hadn't been for some time:

| | Test fixture | Schema ships |
|---|---|---|
| `denseThreshold` | 0.52 | **0.66** |
| `sparseOnlyThreshold` | 0.45 | **0.75** |
| `denseClusterThreshold` | 0.47 | **0.6** |
| `denseClusterMaxDelta` | 0.04 | **0.02** |

So every threshold path in the file was asserting against numbers production never uses. The tests stayed green the entire time and **stopped meaning anything**: a wrong threshold could not fail them, and anyone reasoning about the gate from its unit tests — which is a reasonable thing to do — would reach wrong conclusions. It cost me a detour while investigating the gate's dashboard numbers.

The distortion isn't cosmetic. `sparse_only_strong`'s real bar (0.75) needs a raw BM25F of **≥ 27** at normK 9; the old fixture's raw 9 (norm 0.5) cleared the fake 0.45 bar but isn't remotely close to the shipped one. The test named the path but never exercised it.

## The fix

Parse the defaults from `MemoryV3GateSchema` rather than restating them, using the same `parse({})` idiom the schema itself uses to seed `memory.v3.gate` (`memory-v3.ts:401`). The fixture now can't drift again — it *is* the shipped tuning.

Score fixtures re-picked against the real bars:
- `dense_pass` → 0.7 (clears 0.66; the old 0.6 would not).
- `dense_cluster` → 0.65/0.64/0.64. The real window is far tighter than the old fixture implied — 0.02 spread, not 0.04.
- `sparse_only_strong` → raw 40 (norm ≈ 0.816), clearing 0.75 with margin.
- `fail_dense_below_and_sparse_weak` → raw 9 (norm 0.5), which under the real thresholds is exactly the "clears the floor, misses sparse-only" band.

The other six tests are threshold-independent (hard floor, disabled, empty hits, normK math, purity) and needed no changes — I verified each still exercises its intended path under the real values.

## Verification

Not just "10 pass" — green was the problem. **Mutation-tested:** bumping `denseThreshold` to 0.8 now fails `dense_pass`. Before this change, that same mutation was invisible to the suite.

`bun test gate.test.ts` 10 pass; `deployment-context-defaults.test.ts` 6 pass; `tsc --noEmit` clean.

## Note

I deliberately did not re-pin the literal values here — `deployment-context-defaults.test.ts:215` already asserts `denseThreshold === 0.66`, so a retune stays a visible diff in exactly one place rather than being duplicated into a second copy that can rot the same way.

Retuning a default may now require revisiting the score fixtures. That's intended: a threshold move *should* force a look at whether each case still exercises the path it names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)