### PR TITLE
fix(voice): signal-gated echo learning closes drain-gap decay and transport-lag warm-up burn

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1327,10 +1327,12 @@ describe("LiveVoiceSession server VAD", () => {
     );
     await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
 
-    // Age the echo window past its (pinned-tiny) warm-up with a silent
-    // chunk, so the barge-in below trips synchronously inside
-    // handleBinaryAudio and can race the queued completion.
-    await session.handleBinaryAudio(SILENT_CHUNK);
+    // Age the echo window past its (pinned-tiny) warm-up with a chunk at
+    // exactly the base threshold — signal-bearing (advances the warm-up
+    // clock) but not speech (strict > comparison) — so the barge-in below
+    // trips synchronously inside handleBinaryAudio and can race the queued
+    // completion.
+    await session.handleBinaryAudio(pcm(800));
 
     // The LLM finishes just as the user barges in: message_complete queues
     // the completion continuation and the abort fires before it runs.
@@ -2180,7 +2182,6 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       }
       await flushAsyncCallbacks();
 
-      console.log("FRAMES:", frameTypes(frames).join(","));
       expect(countType(frames, "speech_started")).toBe(baseline);
       expect(countType(frames, "turn_cancelled")).toBe(0);
       expect(abort).not.toHaveBeenCalled();
@@ -2482,6 +2483,97 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       await flushAsyncCallbacks();
       expect(countType(frames, "turn_cancelled")).toBe(baseline);
       expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("a drain gap shorter than the slack does not decay the reference against resumed echo", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // Converge on the burst's echo.
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      // A sub-slack drain gap: 300 ms of sub-base silence. Silence carries
+      // no echo-level information, so the reference must hold rather than
+      // decay toward the noise floor.
+      for (let index = 0; index < 30; index += 1) {
+        await session.handleBinaryAudio(pcm(200));
+      }
+      // Resumed echo at the same level sits under the HELD margin. Were the
+      // reference decaying through the gap, this would classify as speech
+      // and run out the guard.
+      for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("transport-lag silence before the first echo does not burn the warm-up", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // 150 ms of sub-base silence: the window is open (audio sent) but the
+      // burst's echo has not reached the mic yet. The warm-up clock counts
+      // signal-bearing audio only, so it must not tick here.
+      for (let index = 0; index < 15; index += 1) {
+        await session.handleBinaryAudio(pcm(200));
+      }
+      // The echo finally arrives and gets the FULL warm-up: learned and
+      // suppressed, never tripping the guard. Were the warm-up burned by the
+      // lag silence, this echo would be judged post-warm-up against a cold
+      // reference at the base threshold and cancel the turn.
+      for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("warm-up echo is dropped, not pre-rolled into the next utterance's STT audio", async () => {
+      const { frames, session, transcribers, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+
+      // Two warm-up chunks of presumed onset echo: suppressed AND dropped
+      // (not held as pre-roll "leading context").
+      const echoChunk = pcm(3_000);
+      await session.handleBinaryAudio(echoChunk);
+      await session.handleBinaryAudio(echoChunk);
+      // The user barges in loudly enough to clear the converged margin; the
+      // pre-roll flush must not prepend the assistant's own echo to their
+      // utterance's transcription audio.
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(6_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+
+      const echoBuffer = Buffer.from(echoChunk);
+      const echoForwarded = transcribers.some((transcriber) =>
+        transcriber.received.some((buffer) => buffer.equals(echoBuffer)),
+      );
+      expect(echoForwarded).toBe(false);
     });
 
     test("the echo reference freezes while the barge-in guard is armed", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -901,8 +901,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Idle mic: hold silent chunks in the bounded pre-roll instead of
     // collecting or streaming them; flushed on speech onset so the
     // transcriber still gets leading context ahead of the first syllable.
+    // Warm-up-suppressed chunks are presumed assistant echo, not leading
+    // user context: pre-rolling them would flush transcribable assistant
+    // audio into the next genuine utterance's STT and archive, so they are
+    // dropped instead.
     if (!hasSpeech && !detector.isActive) {
-      this.pushVadPreRoll(chunk, false);
+      if (!this.echoGateChunkWarmingUp) {
+        this.pushVadPreRoll(chunk, false);
+      }
       return;
     }
 
@@ -918,8 +924,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       if (!this.canArmNextUtterance(utterance)) {
         // Speech in the release→turn-start window: hold it in the pre-roll
-        // ring so it flushes into the next utterance once it arms.
-        this.pushVadPreRoll(chunk, hasSpeech);
+        // ring so it flushes into the next utterance once it arms. Warm-up
+        // chunks are presumed echo and dropped, as above.
+        if (!this.echoGateChunkWarmingUp) {
+          this.pushVadPreRoll(chunk, hasSpeech);
+        }
         return;
       }
       // Sets currentUtterance synchronously; the transcriber resolves async
@@ -984,8 +993,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // fresh warm-up — the reference never goes stale against resumed echo. A
   // user starting to speak inside a warm-up is absorbed into the reference
   // (echo-first assumption) and recovers by pausing and speaking again once
-  // the gate is warm. Warm-up is measured in processed audio time, the same
-  // clock that drives EMA convergence.
+  // the gate is warm. Warm-up is measured in SIGNAL-BEARING audio time
+  // (chunks at or above the base threshold): silence carries no echo-level
+  // information, so drain-gap or transport-lag silence neither decays the
+  // reference nor burns the warm-up before echo has arrived to be learned.
+  //
+  // Known limitation (accepted): within one continuous burst, a slow
+  // crescendo (~300 ms+ ramp from sub-threshold) or a dip that stays above
+  // the base threshold can leave the armed-guard-frozen reference below the
+  // live echo level, and sustained echo can then run out the guard. Real
+  // TTS onsets attack far faster than the warm-up learns, so this needs an
+  // unusually shaped burst; the alternatives (letting the reference chase
+  // upward while armed) raise the bar for genuine barge-ins to ~2× echo,
+  // which is worse.
   //
   // Turn collision: a guard with a LIVE speech run when the window opens is
   // the user already talking across the turn boundary — humans cannot react
@@ -1026,22 +1046,31 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       !this.echoWindowGuardCarryover &&
       this.echoWindowAudioMs < this.echoEmaHalfLifeMs / 2;
     this.echoGateChunkWarmingUp = warmingUp;
-    const chunkMs = pcm16DurationMs(
-      chunk.byteLength,
-      this.context.startFrame.audio.sampleRate,
-    );
-    if (this.pendingBargeIn === null || warmingUp) {
-      // Attack fast during warm-up (quarter half-life) so the reference
-      // overtakes steady onset echo inside the warm-up window; settle to the
-      // configured half-life afterwards for stability against transients.
-      const halfLifeMs = warmingUp
-        ? this.echoEmaHalfLifeMs / 4
-        : this.echoEmaHalfLifeMs;
-      const alpha = 1 - 0.5 ** (chunkMs / halfLifeMs);
-      this.echoEnergyEma =
-        alpha * meanAmplitude + (1 - alpha) * this.echoEnergyEma;
+    // Sub-base chunks carry no echo-level information: in-window silence —
+    // a drain gap shorter than the slack, or the transport lag before the
+    // first echo of a burst reaches the mic — must neither decay the
+    // reference toward the noise floor (resumed echo would then beat a
+    // stale, lowered threshold) nor burn the warm-up clock before any echo
+    // has arrived to be learned. Only signal-bearing chunks advance either.
+    if (meanAmplitude >= baseThreshold) {
+      const chunkMs = pcm16DurationMs(
+        chunk.byteLength,
+        this.context.startFrame.audio.sampleRate,
+      );
+      if (this.pendingBargeIn === null || warmingUp) {
+        // Attack fast during warm-up (quarter half-life) so the reference
+        // overtakes steady onset echo inside the warm-up window; settle to
+        // the configured half-life afterwards for stability against
+        // transients.
+        const halfLifeMs = warmingUp
+          ? this.echoEmaHalfLifeMs / 4
+          : this.echoEmaHalfLifeMs;
+        const alpha = 1 - 0.5 ** (chunkMs / halfLifeMs);
+        this.echoEnergyEma =
+          alpha * meanAmplitude + (1 - alpha) * this.echoEnergyEma;
+      }
+      this.echoWindowAudioMs += chunkMs;
     }
-    this.echoWindowAudioMs += chunkMs;
     return threshold;
   }
 


### PR DESCRIPTION
## Summary
Fixes round-3 review gaps for echo-adaptive-bargein.md.

- **Signal-gated EMA + warm-up clock**: only chunks at/above the base threshold update the echo reference or advance the warm-up — silence carries no echo-level information. Closes two holes with one rule: a sub-slack drain gap can no longer decay the reference toward the noise floor (resumed echo then beat a stale threshold), and transport-lag silence before a burst's echo arrives can no longer burn the warm-up (leaving onset echo judged against a cold reference)
- **Pre-roll purity (Codex P2 on #38341)**: warm-up-suppressed chunks are presumed assistant echo, not leading user context — dropped instead of pre-rolled, so they can no longer prepend transcribed assistant audio to the next genuine utterance's STT/archive
- Removes a leaked debug console.log in the VAD test
- Documents the accepted in-burst residual (slow crescendo / above-base dip vs the armed-guard freeze) in the canonical gate comment
- Tests: sub-slack-gap hold, transport-lag warm-up, and pre-roll purity cases (all discriminating against the prior code)