### PR TITLE
feat(memory-v3): record what the selector did, per gate reason

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -1502,6 +1502,42 @@ describe("orchestrate — injection gate", () => {
     ).toBeGreaterThan(0);
   });
 
+  test("an empty pool is not a selector judgment", async () => {
+    const lanes = await buildLanes();
+    // `selectPool` returns [] before it ever reaches the provider when the pool
+    // is empty, so a candidate-less turn must not count as "the selector found
+    // nothing relevant" — that would drag the relevance rate down with turns the
+    // selector never saw.
+    const needle = {
+      query: () => [],
+      queryScored: () => [],
+      bestSection: () => -1,
+      idf: () => 0,
+    };
+    denseHits = [];
+    providerStub = selectProvider([]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        needle,
+        denseK: 0,
+        coreSlugs: [],
+        hotSlugs: [],
+        freshSlugs: [],
+        selectorEnabled: true,
+        gateConfig: gateConfigOf(),
+      }),
+    );
+
+    expect(recordedSelectionEvents).toHaveLength(1);
+    expect(recordedSelectionEvents[0]!.detail).toMatchObject({
+      selector_ran: false,
+      selected_count: 0,
+      pool_size: 0,
+    });
+  });
+
   test("a hard-closed gate records a zero selection with selector_ran: false", async () => {
     const lanes = await buildLanes();
     // Zero BY CONSTRUCTION — the selector was never asked. Must not be counted

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -93,11 +93,16 @@ const realWatchdogStore = {
   ...(await import("../../../../../telemetry/watchdog-events-store.js")),
 };
 let watchdogMockActive = false;
-let recordedGateEvents: Array<{
+type RecordedEvent = {
   checkName: string;
   value?: number | null;
   detail?: Record<string, unknown> | null;
-}> = [];
+};
+let recordedGateEvents: RecordedEvent[] = [];
+// Split by check_name rather than into one bucket: orchestrate emits a gate
+// event AND a selection event per turn, and the gate assertions below count
+// their events exactly.
+let recordedSelectionEvents: RecordedEvent[] = [];
 mock.module("../../../../../telemetry/watchdog-events-store.js", () => ({
   ...realWatchdogStore,
   recordWatchdogEvent: (
@@ -105,6 +110,10 @@ mock.module("../../../../../telemetry/watchdog-events-store.js", () => ({
   ) => {
     if (!watchdogMockActive) {
       return realWatchdogStore.recordWatchdogEvent(record);
+    }
+    if (record.checkName === MEMORY_V3_SELECTION_CHECK_NAME) {
+      recordedSelectionEvents.push(record);
+      return;
     }
     recordedGateEvents.push(record);
   },
@@ -115,6 +124,7 @@ const {
   DEFAULT_NEEDLE_K,
   DEFAULT_DENSE_K,
   MEMORY_V3_INJECTION_GATE_CHECK_NAME,
+  MEMORY_V3_SELECTION_CHECK_NAME,
 } = await import("../orchestrate.js");
 
 // ---------------------------------------------------------------------------
@@ -309,6 +319,7 @@ beforeEach(() => {
   denseHits = [];
   denseCalls = [];
   recordedGateEvents = [];
+  recordedSelectionEvents = [];
   lastPool = [];
   lastPoolLines = [];
   lastPrefixBlock = null;
@@ -1407,6 +1418,126 @@ describe("orchestrate — injection gate", () => {
     expect(recordedGateEvents[0]!.detail).not.toHaveProperty(
       "real_concept_page_count",
     );
+  });
+
+  test("a passed gate that selects NOTHING is recorded as a zero selection", async () => {
+    const lanes = await buildLanes();
+    // The case the gate's own pass rate cannot see: retrieval was confident
+    // enough to spend the selector call, and the selector judged that no
+    // candidate was relevant. Pass rate says 100%; injection rate says 0%.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = selectProvider([]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(recordedGateEvents[0]!.detail).toMatchObject({
+      pass: true,
+      reason: "dense_pass",
+    });
+    expect(recordedSelectionEvents).toHaveLength(1);
+    const event = recordedSelectionEvents[0]!;
+    expect(event.checkName).toBe(MEMORY_V3_SELECTION_CHECK_NAME);
+    expect(event.value).toBe(0);
+    expect(event.detail).toMatchObject({
+      gate_reason: "dense_pass",
+      gate_pass: true,
+      selector_ran: true,
+      selected_count: 0,
+    });
+  });
+
+  test("the selection event carries the gate reason and a non-zero count", async () => {
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        denseK: 100,
+        realConceptPageCount: 42,
+        gateConfig: gateConfigOf(),
+      }),
+    );
+
+    expect(recordedSelectionEvents).toHaveLength(1);
+    expect(recordedSelectionEvents[0]!.value).toBe(1);
+    expect(recordedSelectionEvents[0]!.detail).toMatchObject({
+      gate_reason: "dense_pass",
+      selector_ran: true,
+      selected_count: 1,
+      real_concept_page_count: 42,
+    });
+    expect(
+      Number(recordedSelectionEvents[0]!.detail!.pool_size),
+    ).toBeGreaterThan(0);
+  });
+
+  test("selectorEnabled: false marks the passthrough as selector_ran: false", async () => {
+    const lanes = await buildLanes();
+    // The lean profile passes the whole pool through without consulting the
+    // selector, so `selected_count` there is pool size, not a relevance
+    // judgment. Without this flag those turns would read as a 100% hit rate.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        denseK: 100,
+        coreSlugs: ["topic-a"],
+        selectorEnabled: false,
+        gateConfig: gateConfigOf(),
+      }),
+    );
+
+    expect(recordedSelectionEvents).toHaveLength(1);
+    expect(recordedSelectionEvents[0]!.detail).toMatchObject({
+      selector_ran: false,
+    });
+    expect(
+      Number(recordedSelectionEvents[0]!.detail!.selected_count),
+    ).toBeGreaterThan(0);
+  });
+
+  test("a hard-closed gate records a zero selection with selector_ran: false", async () => {
+    const lanes = await buildLanes();
+    // Zero BY CONSTRUCTION — the selector was never asked. Must not be counted
+    // as "the selector found nothing relevant".
+    denseHits = [{ article: "topic-b", section: 0, score: 0.1 }];
+    providerStub = selectProvider([]);
+
+    await orchestrate(
+      makeTurn(1, "zzzz nomatch"),
+      depsOf(lanes, { denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(recordedSelectionEvents).toHaveLength(1);
+    expect(recordedSelectionEvents[0]!.detail).toMatchObject({
+      gate_reason: "fail_no_signal",
+      gate_pass: false,
+      selector_ran: false,
+      selected_count: 0,
+      pool_size: 0,
+    });
+  });
+
+  test("gate_reason is null on a selection when the gate never ran", async () => {
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(makeTurn(1, "apple"), depsOf(lanes, { denseK: 100 }));
+
+    expect(recordedGateEvents).toEqual([]);
+    expect(recordedSelectionEvents).toHaveLength(1);
+    expect(recordedSelectionEvents[0]!.detail).toMatchObject({
+      gate_reason: null,
+      gate_pass: null,
+      selected_count: 1,
+    });
   });
 
   test("no gate telemetry when the gate is disabled or omitted", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -513,19 +513,27 @@ export async function orchestrate(
   // run; the selector is told to return `[]` when no candidate is relevant, so
   // it is the real injection decision and the pass rate is an upper bound on it.
   //
-  // `selector_ran` distinguishes a judgment from a passthrough: the lean profile
-  // sets `selectorEnabled: false`, and `selectAllPoolCandidates` then returns the
-  // whole pool, so `selected_count` there is pool size, not relevance. Filter on
-  // it before reading any of these counts as a signal.
+  // `selector_ran` marks the turns where the selector actually JUDGED the pool,
+  // and is the filter that keeps a relevance rate honest. Three ways a turn can
+  // report zero selections without the selector having been asked, all of which
+  // must stay out of that rate:
+  //   - the lean profile sets `selectorEnabled: false`, so
+  //     `selectAllPoolCandidates` returns the whole pool untouched (would read
+  //     as a 100% hit rate),
+  //   - a closed gate hard-skips selection entirely (a 0%),
+  //   - the pool is empty, and `selectPool` returns `[]` before it ever reaches
+  //     the provider (also a 0%).
+  // The last is why `poolSize` decides this rather than each call site: an empty
+  // pool is not a judgment that nothing was relevant, and no caller has to
+  // remember that.
   const recordSelection = (
     selections: SelectedPage[],
     poolSize: number,
-    selectorRan: boolean,
   ): void => {
     const detail: Record<string, unknown> = {
       gate_reason: gateOutcome?.reason ?? null,
       gate_pass: gateOutcome?.pass ?? null,
-      selector_ran: selectorRan,
+      selector_ran: deps.selectorEnabled !== false && poolSize > 0,
       selected_count: selections.length,
       pool_size: poolSize,
     };
@@ -610,17 +618,13 @@ export async function orchestrate(
               stable: stableOnly,
               finder: [],
             });
-            recordSelection(
-              bypassed,
-              stableOnly.length,
-              deps.selectorEnabled !== false,
-            );
+            recordSelection(bypassed, stableOnly.length);
             return closed(bypassed);
           }
           // Hard skip: the selector is never consulted, so this is a zero
           // selection BY CONSTRUCTION, not a judgment that nothing was relevant.
           // `selector_ran: false` keeps it out of any relevance rate.
-          recordSelection([], 0, false);
+          recordSelection([], 0);
           return closed([]);
         }
       }
@@ -714,11 +718,7 @@ export async function orchestrate(
   // scaffold; `undefined` falls through to the bundled default.
   const pool = { stable, finder: finderTail };
   const selections = await runSelection(pool);
-  recordSelection(
-    selections,
-    stable.length + finderTail.length,
-    deps.selectorEnabled !== false,
-  );
+  recordSelection(selections, stable.length + finderTail.length);
 
   return {
     selections,

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -114,6 +114,35 @@ function recordGateRun(detail: Record<string, unknown>): void {
   }
 }
 
+/** `check_name` of the `watchdog` telemetry event recorded once per orchestrated
+ *  turn, carrying what the SELECTOR did. Keep this string stable — the platform's
+ *  memory admin analytics filter on it. */
+export const MEMORY_V3_SELECTION_CHECK_NAME = "memory_v3_selection";
+
+/** Record one turn's selection outcome. Deliberately a SEPARATE event from
+ *  {@link MEMORY_V3_INJECTION_GATE_CHECK_NAME} rather than extra keys on it: the
+ *  gate records at decision time, before selection has run, so folding the
+ *  outcome in would mean deferring the gate event until after `selectPool` — and
+ *  losing every gate run whenever selection throws, which is exactly the
+ *  incident we would want the gate telemetry for. This event carries
+ *  `gate_reason` so the two still group together without a join.
+ *
+ *  `value` is the selection count. Never throws, same as the gate counter. */
+function recordSelectionRun(
+  value: number,
+  detail: Record<string, unknown>,
+): void {
+  try {
+    recordWatchdogEvent({
+      checkName: MEMORY_V3_SELECTION_CHECK_NAME,
+      value,
+      detail,
+    });
+  } catch {
+    // Same contract as recordGateRun: telemetry must never cost a turn.
+  }
+}
+
 /** Default number of BM25 needle articles to fold into the pool. */
 export const DEFAULT_NEEDLE_K = 12;
 /** Default number of dense-lane articles to fold into the pool. */
@@ -474,6 +503,37 @@ export async function orchestrate(
         ? detail
         : { ...detail, real_concept_page_count: deps.realConceptPageCount },
     );
+
+  // This turn's gate decision, carried to the selection event so the two group
+  // together without a join. Null when the gate never ran (disabled/omitted).
+  let gateOutcome: { reason: string; pass: boolean } | null = null;
+
+  // What the SELECTOR did with the pool the gate let through — the outcome the
+  // gate's own pass rate cannot see. A passed gate only means selectPool got to
+  // run; the selector is told to return `[]` when no candidate is relevant, so
+  // it is the real injection decision and the pass rate is an upper bound on it.
+  //
+  // `selector_ran` distinguishes a judgment from a passthrough: the lean profile
+  // sets `selectorEnabled: false`, and `selectAllPoolCandidates` then returns the
+  // whole pool, so `selected_count` there is pool size, not relevance. Filter on
+  // it before reading any of these counts as a signal.
+  const recordSelection = (
+    selections: SelectedPage[],
+    poolSize: number,
+    selectorRan: boolean,
+  ): void => {
+    const detail: Record<string, unknown> = {
+      gate_reason: gateOutcome?.reason ?? null,
+      gate_pass: gateOutcome?.pass ?? null,
+      selector_ran: selectorRan,
+      selected_count: selections.length,
+      pool_size: poolSize,
+    };
+    if (deps.realConceptPageCount !== undefined) {
+      detail.real_concept_page_count = deps.realConceptPageCount;
+    }
+    recordSelectionRun(selections.length, detail);
+  };
   if (deps.gateConfig?.enabled) {
     if (liveDensed.length === 0) {
       const reason = denseEnabled ? "dense_unavailable" : "dense_disabled";
@@ -488,6 +548,7 @@ export async function orchestrate(
           ? "memory-v3 injection gate: dense lane unavailable, passing open"
           : "memory-v3 injection gate: dense lane disabled, passing open",
       );
+      gateOutcome = { reason, pass: true };
       recordGate({ pass: true, reason, scored: false });
     } else {
       let gate: V3GateResult | null = null;
@@ -505,6 +566,7 @@ export async function orchestrate(
           },
           "memory-v3 injection gate threw; passing open (proceeding with selection)",
         );
+        gateOutcome = { reason: "gate_error", pass: true };
         recordGate({ pass: true, reason: "gate_error", scored: false });
       }
       if (gate) {
@@ -516,6 +578,7 @@ export async function orchestrate(
           },
           "memory-v3 injection gate decision",
         );
+        gateOutcome = { reason: gate.reason, pass: gate.pass };
         recordGate({
           pass: gate.pass,
           reason: gate.reason,
@@ -542,10 +605,22 @@ export async function orchestrate(
             // explicitly configured with `selectorEnabled: false` AND
             // `denseK > 0` (the dense-gated gate only runs with dense hits; the
             // new-user profile sets `denseK: 0`, so the gate never runs for it).
-            return closed(
-              await runSelection({ stable: buildStable(), finder: [] }),
+            const stableOnly = buildStable();
+            const bypassed = await runSelection({
+              stable: stableOnly,
+              finder: [],
+            });
+            recordSelection(
+              bypassed,
+              stableOnly.length,
+              deps.selectorEnabled !== false,
             );
+            return closed(bypassed);
           }
+          // Hard skip: the selector is never consulted, so this is a zero
+          // selection BY CONSTRUCTION, not a judgment that nothing was relevant.
+          // `selector_ran: false` keeps it out of any relevance rate.
+          recordSelection([], 0, false);
           return closed([]);
         }
       }
@@ -639,6 +714,11 @@ export async function orchestrate(
   // scaffold; `undefined` falls through to the bundled default.
   const pool = { stable, finder: finderTail };
   const selections = await runSelection(pool);
+  recordSelection(
+    selections,
+    stable.length + finderTail.length,
+    deps.selectorEnabled !== false,
+  );
 
   return {
     selections,


### PR DESCRIPTION
## The gap

**The gate's pass rate is not the injection rate, and the gate is all we measure.**

A passed gate only means `selectPool` got to *run*. The selector prompt then says:

> return `[]` when candidates are present but none are relevant

So there's a second, semantic filter downstream, and it's instructed to reject. The 78.7% on the Memory dashboard is an **upper bound** on injection, not a measure of it. We instrumented the cheap mechanical filter and left the meaningful one dark — nothing anywhere records whether memory was actually selected.

## What this adds

`memory_v3_selection`, one event per orchestrated turn: `selected_count`, `pool_size`, `gate_reason`, `gate_pass`, `selector_ran`, and the corpus size from #38328.

Grouping `selected_count` by `gate_reason` answers what the gate telemetry can't:

- **What's the real injection rate?** The number we thought we had.
- **Is each reason earning its keep?** If `dense_pass` leads to a selection most of the time and `dense_cluster` almost never does, that's evidence `dense_cluster` passes noise — with data instead of argument. Worth noting: `denseLaneScored` dedupes to *distinct articles*, so `dense_cluster`'s tight top-3 is three different pages scoring alike, not one page's signal split across sections as the comment implies. Three unrelated pages matching equally well is a plausible signature of a *generic* query. This gives us the way to check.
- **Does relevance track corpus size?** Top-1 dense is a max over N draws, so a fixed absolute threshold gets more permissive as the corpus grows. Combined with #38328's page count, this supplies the outcome axis to test that.

## Design notes

**A separate event, not extra keys on the gate's.** The gate records at decision time, before selection exists. Folding the outcome in would mean deferring the gate event until after `selectPool` — and losing every gate run whenever selection throws, which is exactly the incident we'd want gate telemetry for. This event carries `gate_reason`, so the two still group without a join.

**`selector_ran` is load-bearing.** The lean profile passes the whole pool through via `selectAllPoolCandidates` without consulting the selector, and a hard-closed gate never asks it at all. Both would otherwise pollute any relevance rate — one as a 100% hit rate, the other as a 0%. The platform queries filter on it.

**Emitted on every orchestrated turn**, including gate-off ones (`gate_reason: null`), so there's a baseline to compare gated turns against.

## Testing

`bun test orchestrate.test.ts` — 57 pass, 5 new, including the case that motivated this: a **passed gate that selects nothing** (pass rate 100%, injection rate 0%), plus passthrough-vs-judgment and hard-close-vs-judgment.

The test watchdog mock now splits events by `check_name` — orchestrate emits two per turn, and the existing gate tests count theirs exactly.

`shadow-plugin.test.ts` 30 pass, `shadow-integration.test.ts` 7 pass, `gate.test.ts` 10 pass, `tsc --noEmit` clean.

Dashboard side: vellum-ai/vellum-assistant-platform#9217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)