### PR TITLE
fix(telemetry): make Research{Fact,Suggestion} assignable to telemetry JSON fields

### DIFF
--- a/clients/web/src/utils/research-facts.ts
+++ b/clients/web/src/utils/research-facts.ts
@@ -32,14 +32,17 @@ export const REMOVAL_REASON_LABELS: Record<RemovalReason, string> = {
   not_relevant: "Not relevant",
 };
 
-export interface ResearchFact {
+// A `type` (not `interface`) so it carries an implicit index signature and
+// stays assignable to the telemetry `fields` JSON-value type — see the
+// `onboarding_research` reporter in research-runner.ts.
+export type ResearchFact = {
   claim: string;
   confidence: ResearchConfidence;
   /** Source URLs the assistant cited as evidence (rendered as proof favicons). */
   sources: string[];
-}
+};
 
-export interface ResearchSuggestion {
+export type ResearchSuggestion = {
   /**
    * The offer as the assistant would speak it — first-person, in the
    * assistant's voice ("I'll build you a training plan…"). This is what the
@@ -53,7 +56,7 @@ export interface ResearchSuggestion {
    * talking to itself.
    */
   prompt: string;
-}
+};
 
 /** Bare registrable domain from a URL (www stripped), or null if unparseable. */
 export function domainFromUrl(url: string): string | null {


### PR DESCRIPTION
## What

Main's **Type Check / Main Web** job went red ([run](https://github.com/vellum-ai/vellum-assistant/actions/runs/29529556430/job/87726323526)):

```
src/domains/onboarding/research-runner.ts(280,11): error TS2322: Type 'ResearchFact[]' is not assignable to type 'TelemetryJsonValue[]'.
src/domains/onboarding/research-runner.ts(285,11): error TS2322: Type 'ResearchSuggestion[]' is not assignable to type 'TelemetryJsonValue[]'.
```

## Why

#38329 strongly typed the `/v1/telemetry/ingest` body from the wire schema, so the `onboarding_research` event's `claims` / `suggestions` fields now require `Array<TelemetryJsonValue>`. `ResearchFact` and `ResearchSuggestion` are pure JSON shapes (strings / string arrays), but they were declared as `interface`s — and an `interface` carries no implicit index signature, so it isn't assignable to `{ [k: string]: TelemetryJsonValue }`. A `type` alias to the same object shape does get the implicit index signature.

## Fix

Convert both to `type` aliases. No casts, no shape change; nothing extends or merges these declarations. `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)