### PR TITLE
Echo-adaptive barge-in for live-voice open-mic mode (JARVIS-1296)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -825,6 +825,8 @@ describe("AssistantConfigSchema", () => {
         silenceThresholdMs: 1200,
         maxTurnDurationMs: 30000,
         bargeInMinSpeechMs: 250,
+        echoBargeInMargin: 1.5,
+        echoEmaHalfLifeMs: 400,
       },
       maxSessionDurationSeconds: 1800,
       archiveAudio: false,

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -827,6 +827,7 @@ describe("AssistantConfigSchema", () => {
         bargeInMinSpeechMs: 250,
         echoBargeInMargin: 1.5,
         echoEmaHalfLifeMs: 400,
+        echoDrainSlackMs: 300,
       },
       maxSessionDurationSeconds: 1800,
       archiveAudio: false,

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -14,6 +14,8 @@ describe("LiveVoiceVadConfigSchema", () => {
       silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
       bargeInMinSpeechMs: 250,
+      echoBargeInMargin: 1.5,
+      echoEmaHalfLifeMs: 400,
     });
   });
 
@@ -55,6 +57,29 @@ describe("LiveVoiceVadConfigSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("accepts a fractional echoBargeInMargin", () => {
+    const parsed = LiveVoiceVadConfigSchema.parse({ echoBargeInMargin: 2.25 });
+    expect(parsed.echoBargeInMargin).toBe(2.25);
+  });
+
+  test("rejects non-positive echoBargeInMargin", () => {
+    expect(
+      LiveVoiceVadConfigSchema.safeParse({ echoBargeInMargin: 0 }).success,
+    ).toBe(false);
+    expect(
+      LiveVoiceVadConfigSchema.safeParse({ echoBargeInMargin: -1.5 }).success,
+    ).toBe(false);
+  });
+
+  test("rejects non-positive or non-integer echoEmaHalfLifeMs", () => {
+    expect(
+      LiveVoiceVadConfigSchema.safeParse({ echoEmaHalfLifeMs: 0 }).success,
+    ).toBe(false);
+    expect(
+      LiveVoiceVadConfigSchema.safeParse({ echoEmaHalfLifeMs: 250.5 }).success,
+    ).toBe(false);
+  });
 });
 
 describe("LiveVoiceConfigSchema", () => {
@@ -67,6 +92,8 @@ describe("LiveVoiceConfigSchema", () => {
         silenceThresholdMs: 1200,
         maxTurnDurationMs: 30_000,
         bargeInMinSpeechMs: 250,
+        echoBargeInMargin: 1.5,
+        echoEmaHalfLifeMs: 400,
       },
       maxSessionDurationSeconds: 1800,
       // Off by default: voice turns carry only their transcript, no audio

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -16,6 +16,7 @@ describe("LiveVoiceVadConfigSchema", () => {
       bargeInMinSpeechMs: 250,
       echoBargeInMargin: 1.5,
       echoEmaHalfLifeMs: 400,
+      echoDrainSlackMs: 300,
     });
   });
 
@@ -94,6 +95,7 @@ describe("LiveVoiceConfigSchema", () => {
         bargeInMinSpeechMs: 250,
         echoBargeInMargin: 1.5,
         echoEmaHalfLifeMs: 400,
+        echoDrainSlackMs: 300,
       },
       maxSessionDurationSeconds: 1800,
       // Off by default: voice turns carry only their transcript, no audio

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -42,6 +42,21 @@ export const LiveVoiceVadConfigSchema = z
       .describe(
         "Sustained speech (ms) required before speech during assistant playback interrupts it — the default 'interrupt sensitivity' (higher = harder to interrupt). 0 disables the guard. Clients may override it per-session via the start frame. Raised from 60 so brief TTS bleed through imperfect echo cancellation no longer self-interrupts the assistant.",
       ),
+    echoBargeInMargin: z
+      .number({ error: "liveVoice.vad.echoBargeInMargin must be a number" })
+      .positive("liveVoice.vad.echoBargeInMargin must be a positive number")
+      .default(1.5)
+      .describe(
+        "Multiplier over the observed echo energy level (an EMA of mic energy tracked while assistant audio is playing) that input must exceed to count as speech during playback; the effective threshold is max(speechEnergyThreshold, echoBargeInMargin × echo EMA). Higher = harder to barge in over loud speakers.",
+      ),
+    echoEmaHalfLifeMs: z
+      .number({ error: "liveVoice.vad.echoEmaHalfLifeMs must be a number" })
+      .int("liveVoice.vad.echoEmaHalfLifeMs must be an integer")
+      .positive("liveVoice.vad.echoEmaHalfLifeMs must be a positive integer")
+      .default(400)
+      .describe(
+        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients.",
+      ),
   })
   .describe(
     "Voice-activity-detection tuning for live voice sessions (open-mic turn segmentation)",

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -47,7 +47,7 @@ export const LiveVoiceVadConfigSchema = z
       .positive("liveVoice.vad.echoBargeInMargin must be a positive number")
       .default(1.5)
       .describe(
-        "Multiplier over the observed echo energy level (an EMA of mic energy tracked while assistant audio is playing) that input must exceed to count as speech during playback; the effective threshold is max(speechEnergyThreshold, echoBargeInMargin × echo EMA). Higher = harder to barge in over loud speakers.",
+        "Multiplier over the observed echo energy level (an EMA of mic energy tracked while assistant audio is playing) that input must exceed to count as speech during playback; the effective threshold is max(speechEnergyThreshold, echoBargeInMargin × echo EMA). Higher = harder to barge in over loud speakers; values well below 1 pin the effective threshold at speechEnergyThreshold, disabling echo suppression.",
       ),
     echoEmaHalfLifeMs: z
       .number({ error: "liveVoice.vad.echoEmaHalfLifeMs must be a number" })
@@ -55,7 +55,7 @@ export const LiveVoiceVadConfigSchema = z
       .positive("liveVoice.vad.echoEmaHalfLifeMs must be a positive integer")
       .default(400)
       .describe(
-        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients.",
+        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients. Also sets the gate's onset warm-up: the first half-life/2 of playback audio learns at a quarter-half-life attack rate and defers barge-in trips until warm. Keep half-life/2 below bargeInMinSpeechMs (true at the defaults: 200 vs 250) so genuine onset barge-ins are never deferred.",
       ),
   })
   .describe(

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -55,7 +55,15 @@ export const LiveVoiceVadConfigSchema = z
       .positive("liveVoice.vad.echoEmaHalfLifeMs must be a positive integer")
       .default(400)
       .describe(
-        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients. Also sets the gate's onset warm-up: the first half-life/2 of playback audio learns at a quarter-half-life attack rate and defers barge-in trips until warm. Keep half-life/2 below bargeInMinSpeechMs (true at the defaults: 200 vs 250) so genuine onset barge-ins are never deferred.",
+        "Half-life (ms) of the echo-level EMA; smaller adapts faster to TTS loudness changes, larger is steadier against speech transients. Also sets the gate's onset warm-up: the first half-life/2 of each playback burst's audio learns at a quarter-half-life attack rate with speech classification suppressed (presumed echo), so barge-in during a burst's first half-life/2 requires speaking past the warm-up.",
+      ),
+    echoDrainSlackMs: z
+      .number({ error: "liveVoice.vad.echoDrainSlackMs must be a number" })
+      .int("liveVoice.vad.echoDrainSlackMs must be an integer")
+      .nonnegative("liveVoice.vad.echoDrainSlackMs must be nonnegative")
+      .default(300)
+      .describe(
+        "Slack (ms) past the client playback-drain estimate during which assistant echo is still expected at the mic (one-way transport latency + client jitter buffer). The echo gate's window — and its barge-in protections — extend this far beyond the last sent audio chunk's estimated drain.",
       ),
   })
   .describe(

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -254,6 +254,10 @@ function createMultiCycleHarness(startVoiceTurn: LiveVoiceTurnStarter) {
   const session = createLiveVoiceSession(context, {
     // Credential-free harness: every leg is injected, so skip the preflight.
     resolveCredentialReadiness: null,
+    // Echo-gate window pinned shut: these cycle-mechanics tests drive
+    // discrete chunks with no continuous mic flow, so the drain slack would
+    // otherwise hold a cold window open across utterances.
+    echoDrainSlackMs: 0,
     resolveTranscriber,
     startVoiceTurn,
     streamTtsAudio,
@@ -289,6 +293,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
     });
     const { context, frames } = createContext();
     const session = createLiveVoiceSession(context, {
+      // Echo-gate window pinned shut: these cycle-mechanics tests drive
+      // discrete chunks with no continuous mic flow, so the drain slack
+      // would otherwise hold a cold window open across utterances.
+      echoDrainSlackMs: 0,
       resolveCredentialReadiness: null,
       resolveTranscriber: mock(async () => transcriber),
       startVoiceTurn,
@@ -473,6 +481,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
       () => frames.filter((frame) => frame.type === "tts_done").length === 1,
     );
 
+    // Let the drained echo window (tiny tts chunk + zero slack) close on the
+    // wall clock so the next utterance is judged out-of-window at the base
+    // threshold rather than suppressed as presumed onset echo.
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await session.handleBinaryAudio(secondUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(
@@ -545,6 +557,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
     const { context, frames } = createContext(VAD_START_FRAME);
     let turnCount = 0;
     const session = createLiveVoiceSession(context, {
+      // Echo-gate window pinned shut: these cycle-mechanics tests drive
+      // discrete chunks with no continuous mic flow, so the drain slack
+      // would otherwise hold a cold window open across utterances.
+      echoDrainSlackMs: 0,
       resolveCredentialReadiness: null,
       resolveTranscriber,
       startVoiceTurn,
@@ -566,6 +582,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
       () => frames.filter((frame) => frame.type === "tts_done").length === 1,
     );
 
+    // Let the drained echo window (tiny tts chunk + zero slack) close on the
+    // wall clock so the next utterance is judged out-of-window at the base
+    // threshold rather than suppressed as presumed onset echo.
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await session.handleBinaryAudio(secondUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(
@@ -639,6 +659,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
     );
     expect(abort).toHaveBeenCalledTimes(1);
 
+    // Let the drained echo window (tiny tts chunk + zero slack) close on the
+    // wall clock so the next utterance is judged out-of-window at the base
+    // threshold rather than suppressed as presumed onset echo.
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await session.handleBinaryAudio(secondUtteranceAudio);
     await session.handleClientFrame({ type: "ptt_release" });
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -123,6 +123,8 @@ function createHarness(options: {
   turnDetectorConfig?: TurnDetectorConfig;
   speechEnergyThreshold?: number;
   bargeInMinSpeechMs?: number;
+  echoEmaHalfLifeMs?: number;
+  echoBargeInMargin?: number;
   emitMetrics?: boolean;
   metricsClock?: () => number;
   // Return a promise to hold a frame's transport write open (a backed-up
@@ -185,6 +187,8 @@ function createHarness(options: {
       (options.viaFactory ? undefined : { silenceThresholdMs: 40 }),
     speechEnergyThreshold: options.speechEnergyThreshold,
     bargeInMinSpeechMs: options.bargeInMinSpeechMs,
+    echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
+    echoBargeInMargin: options.echoBargeInMargin,
     ...(options.spawnBackgroundContinuation
       ? { spawnBackgroundContinuation: options.spawnBackgroundContinuation }
       : {}),
@@ -1802,6 +1806,8 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   // detector timers stay out of the guard's audio-duration accounting.
   function createSpeakingTurnHarness(options: {
     bargeInMinSpeechMs: number;
+    echoEmaHalfLifeMs?: number;
+    echoBargeInMargin?: number;
     finals?: string[];
     startFrame?: LiveVoiceClientStartFrame;
   }) {
@@ -1820,6 +1826,8 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       startVoiceTurn,
       streamTtsAudio,
       bargeInMinSpeechMs: options.bargeInMinSpeechMs,
+      echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
+      echoBargeInMargin: options.echoBargeInMargin,
       turnDetectorConfig: { silenceThresholdMs: 5_000 },
       ...(options.startFrame ? { startFrame: options.startFrame } : {}),
     });
@@ -1879,8 +1887,15 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   });
 
   test("sustained speech reaching the guard flushes playback and cancels the turn", async () => {
+    // Tiny margin + half-life neutralize the echo-adaptive gate (threshold
+    // pinned to the 800 floor, warm-up over after one chunk) so this test
+    // isolates the guard's accumulation mechanics.
     const { frames, session, abort, speakFirstReply } =
-      createSpeakingTurnHarness({ bargeInMinSpeechMs: 60 });
+      createSpeakingTurnHarness({
+        bargeInMinSpeechMs: 60,
+        echoBargeInMargin: 0.001,
+        echoEmaHalfLifeMs: 4,
+      });
     await speakFirstReply();
 
     // 50 ms of consecutive speech: one chunk short of the 60 ms guard.
@@ -1911,8 +1926,11 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   });
 
   test("a non-speech chunk resets the sustained-speech run", async () => {
+    // Tiny margin + half-life neutralize the echo-adaptive gate — see above.
     const { frames, session, speakFirstReply } = createSpeakingTurnHarness({
       bargeInMinSpeechMs: 60,
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
     });
     await speakFirstReply();
 
@@ -1990,6 +2008,11 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       startVoiceTurn,
       streamTtsAudio,
       bargeInMinSpeechMs: 60,
+      // Tiny margin + half-life neutralize the echo-adaptive gate (threshold
+      // pinned to the floor, warm-up over after one chunk) so this test
+      // isolates the guard's playback-tail coverage.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       turnDetectorConfig: { silenceThresholdMs: 5_000 },
     });
 
@@ -2045,5 +2068,187 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       frames.find((frame) => frame.type === "turn_cancelled"),
     ).toMatchObject({ type: "turn_cancelled", turnId: "live-turn-1" });
     await waitFor(() => abort.mock.calls.length === 1);
+  });
+
+  // JARVIS-1296: while assistant audio is playing, a chunk only counts as
+  // speech above max(speechEnergyThreshold, echoBargeInMargin × echo EMA), so
+  // loud TTS echo leaking through imperfect client echo cancellation cannot
+  // self-interrupt the reply, while a user talking over it still can. Tests
+  // compress echoEmaHalfLifeMs to 5 ms so one 10 ms echo chunk converges the
+  // EMA far enough (alpha 0.75 → EMA 2250 for a 3000 chunk, threshold 3375
+  // at the default 1.5 margin) that steady echo sits under its own margin.
+  describe("echo-adaptive gate", () => {
+    test("steady loud echo during playback never fires speech_started or cancels the turn", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 5,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // 400 ms of steady synthetic echo at 3000 — well above the 800 floor
+      // and far past the 60 ms guard. The onset chunk folds into the EMA
+      // before the guard arms; every later chunk sits under 1.5 × EMA and
+      // classifies as silence, so the guard never accumulates.
+      for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("abrupt loud echo at playback onset is absorbed by the warm-up, not fired as barge-in", async () => {
+      // Cold-start case: steady loud echo from the very first in-window
+      // chunk. The onset chunk arms the guard, but the warm-up (half-life/2
+      // = 20 ms of audio here) keeps the reference learning at the fast
+      // attack rate despite the armed guard, so it overtakes the echo and
+      // zeroes the run before the 60 ms guard can trip — no deferred trip
+      // ever fires. Mirrors 250 ms guard vs 200 ms warm-up at the 400 ms
+      // production half-life.
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      for (let index = 0; index < 30; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("sustained speech above the echo margin still barges in", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 5,
+        });
+      await speakFirstReply();
+
+      // Steady echo at 3000 converges the reference (suppressed, as above).
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // The user talks over the echo: 6000 clears the 3375 threshold and
+      // sustains past the guard, so the deferred speech_started flushes
+      // playback and the turn cancels.
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(6_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      expect(
+        frames.find((frame) => frame.type === "turn_cancelled"),
+      ).toMatchObject({ type: "turn_cancelled", turnId: "live-turn-1" });
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("a thinking (pre-TTS) turn keeps base-threshold barge-in sensitivity", async () => {
+      const abort = mock();
+      const startVoiceTurn = mock(async () => ({
+        turnId: "bridge-turn",
+        abort,
+      }));
+      const { frames, session } = createHarness({
+        finals: ["what's the weather", "actually never mind"],
+        startVoiceTurn,
+        bargeInMinSpeechMs: 60,
+        echoEmaHalfLifeMs: 5,
+        turnDetectorConfig: { silenceThresholdMs: 5_000 },
+      });
+      await session.start();
+      await session.handleBinaryAudio(LOUD_CHUNK);
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+      // No assistant audio is playing yet, so the echo gate is inert: 70 ms
+      // at 3000 clears the 800 floor and cancels the thinking turn exactly
+      // as without the gate (JARVIS-1266 feel unchanged).
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("the echo reference resets when the window closes", async () => {
+      const { frames, session, speakFirstReply, completeFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 5,
+          finals: ["what's the weather", "   "],
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // Sub-floor echo at 790 converges the reference without ever arming
+      // the guard; amplitude-1000 chunks then sit under 1.5 × EMA (~1180)
+      // and stay classified as silence while the reply is playing.
+      for (let index = 0; index < 4; index += 1) {
+        await session.handleBinaryAudio(pcm(790));
+      }
+      for (let index = 0; index < 3; index += 1) {
+        await session.handleBinaryAudio(pcm(1_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "speech_started")).toBe(baseline);
+
+      // The reply completes and the tiny playback tail drains: the echo
+      // window closes and the reference resets.
+      completeFirstReply();
+      await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+      // The same amplitude-1000 chunk is speech immediately at the 800
+      // floor — a stale reference would have swallowed it.
+      await session.handleBinaryAudio(pcm(1_000));
+      await waitFor(() => countType(frames, "speech_started") === baseline + 1);
+    });
+
+    test("the echo reference freezes while the barge-in guard is armed", async () => {
+      const { frames, session, speakFirstReply } = createSpeakingTurnHarness({
+        bargeInMinSpeechMs: 60,
+        echoEmaHalfLifeMs: 5,
+      });
+      await speakFirstReply();
+
+      // The onset chunk arms the guard and seeds the reference during the
+      // single-chunk warm-up (fast attack converges EMA to ~2400, threshold
+      // ~3600); the warm-up then ends and the reference freezes while the
+      // guard stays armed.
+      await session.handleBinaryAudio(pcm(2_400));
+      // 100 ms at 3300 sits under the frozen ~3600 threshold (silence).
+      // Were the EMA still tracking, it would converge to ~3300 and lift
+      // the threshold to ~4950 — swallowing the 4000 override below.
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(pcm(3_300));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // 4000 clears the frozen ~3600 threshold and sustains past the guard —
+      // the reference did not move while the guard was armed.
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(4_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+    });
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -2498,10 +2498,12 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       for (let index = 0; index < 10; index += 1) {
         await session.handleBinaryAudio(pcm(3_000));
       }
-      // A sub-slack drain gap: 300 ms of sub-base silence. Silence carries
-      // no echo-level information, so the reference must hold rather than
-      // decay toward the noise floor.
-      for (let index = 0; index < 30; index += 1) {
+      // A sub-slack drain gap: 200 ms of sub-base silence — under the
+      // 300 ms reference-expiry bound. Silence carries no echo-level
+      // information, so the reference must hold rather than decay toward
+      // the noise floor. (A longer sub-base run intentionally EXPIRES the
+      // reference instead — covered by the early-barger recovery test.)
+      for (let index = 0; index < 20; index += 1) {
         await session.handleBinaryAudio(pcm(200));
       }
       // Resumed echo at the same level sits under the HELD margin. Were the
@@ -2544,6 +2546,64 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       expect(countType(frames, "speech_started")).toBe(baseline);
       expect(countType(frames, "turn_cancelled")).toBe(0);
       expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("quiet playback (echo below base) leaves barge-in at full base-threshold sensitivity", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+
+      // Effective client AEC: the playback never registers at the mic.
+      // Past the 300 ms eligibility bound the echo-first assumption lapses
+      // and the gate goes inert at the base threshold.
+      for (let index = 0; index < 31; index += 1) {
+        await session.handleBinaryAudio(pcm(200));
+      }
+      // The user barges in at ordinary loudness: heard immediately at the
+      // 800 floor and trips the 60 ms guard — no warm-up absorption.
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("an early barger absorbed as presumed echo recovers after a pause (reference expiry)", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+
+      // The user starts talking within the eligibility bound of a
+      // quiet-playback window: echo-first absorbs their voice into the
+      // reference and their run dissolves under its own margin.
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // They pause: a sub-base run past the 300 ms bound expires the
+      // absorbed reference (real echo never gaps that long while audio
+      // drains), with eligibility already spent.
+      for (let index = 0; index < 31; index += 1) {
+        await session.handleBinaryAudio(pcm(200));
+      }
+      // Their retry is judged at the base threshold and trips normally.
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
     });
 
     test("warm-up echo is dropped, not pre-rolled into the next utterance's STT audio", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1687,6 +1687,8 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
       silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
       bargeInMinSpeechMs: 250,
+      echoBargeInMargin: 1.5,
+      echoEmaHalfLifeMs: 400,
     });
 
     const { frames, session } = createHarness({ viaFactory: true });

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -347,6 +347,11 @@ describe("LiveVoiceSession server VAD", () => {
       return makeTtsResult("assistant audio");
     });
     const { frames, session, transcribers } = createHarness({
+      // Neutralize the echo-adaptive gate (threshold pinned to the 800
+      // floor, warm-up over after one chunk) — this test is about barge-in
+      // mechanics, not echo suppression.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       finals: ["what's the weather", "actually never mind"],
       startVoiceTurn,
       streamTtsAudio,
@@ -361,6 +366,10 @@ describe("LiveVoiceSession server VAD", () => {
 
     // Sustained speech over the assistant's audio meets the default guard.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    // The sustained chunk is the first in-window audio, so its trip is
+    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
+    // the accumulated run.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -411,6 +420,11 @@ describe("LiveVoiceSession server VAD", () => {
     });
     let releaseDeltaSend: (() => void) | undefined;
     const { frames, session } = createHarness({
+      // Neutralize the echo-adaptive gate (threshold pinned to the 800
+      // floor, warm-up over after one chunk) — this test is about barge-in
+      // mechanics, not echo suppression.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       finals: ["what's the weather", "wait actually", "stop please"],
       startVoiceTurn,
       streamTtsAudio,
@@ -450,6 +464,10 @@ describe("LiveVoiceSession server VAD", () => {
     // Once audio has genuinely gone out, new sustained speech barge-ins.
     await waitFor(() => countType(frames, "utterance_end") === 2);
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    // The sustained chunk is the first in-window audio, so its trip is
+    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
+    // the accumulated run.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -833,6 +851,11 @@ describe("LiveVoiceSession server VAD", () => {
       return makeTtsResult("assistant audio");
     });
     const { frames, session } = createHarness({
+      // Neutralize the echo-adaptive gate (threshold pinned to the 800
+      // floor, warm-up over after one chunk) — this test is about barge-in
+      // mechanics, not echo suppression.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       finals: ["first question", "second question"],
       startVoiceTurn,
       streamTtsAudio,
@@ -851,6 +874,10 @@ describe("LiveVoiceSession server VAD", () => {
 
     // Barge in over the playing, already-complete reply.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    // The sustained chunk is the first in-window audio, so its trip is
+    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
+    // the accumulated run.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -1282,6 +1309,11 @@ describe("LiveVoiceSession server VAD", () => {
       return makeTtsResult(options.text);
     });
     const { frames, session } = createHarness({
+      // Neutralize the echo-adaptive gate (threshold pinned to the 800
+      // floor, warm-up over after one chunk) — this test is about barge-in
+      // mechanics, not echo suppression.
+      echoBargeInMargin: 0.001,
+      echoEmaHalfLifeMs: 4,
       finals: ["what's the weather", "actually never mind"],
       startVoiceTurn,
       streamTtsAudio,
@@ -1295,6 +1327,11 @@ describe("LiveVoiceSession server VAD", () => {
       makeTextDelta("It is sunny today."),
     );
     await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    // Age the echo window past its (pinned-tiny) warm-up with a silent
+    // chunk, so the barge-in below trips synchronously inside
+    // handleBinaryAudio and can race the queued completion.
+    await session.handleBinaryAudio(SILENT_CHUNK);
 
     // The LLM finishes just as the user barges in: message_complete queues
     // the completion continuation and the abort fires before it runs.
@@ -1955,10 +1992,19 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
 
   test("bargeInMinSpeechMs 0 restores instant barge-in", async () => {
     const { frames, session, abort, speakFirstReply } =
-      createSpeakingTurnHarness({ bargeInMinSpeechMs: 0 });
+      createSpeakingTurnHarness({
+        bargeInMinSpeechMs: 0,
+        // Neutralize the echo gate's threshold; its onset warm-up still
+        // shields the first in-window chunk via the deferral guard.
+        echoBargeInMargin: 0.001,
+        echoEmaHalfLifeMs: 4,
+      });
     await speakFirstReply();
 
-    // A single 10 ms onset chunk cancels immediately — no accumulation.
+    // The onset chunk arms the warm-up deferral guard; the next chunk fires
+    // with no sustained-run accumulation — the instant contract under the
+    // echo gate.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
@@ -2056,10 +2102,16 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
         // …but the start-frame override disables the guard, so barge-in is
         // instant.
         startFrame: { ...VAD_START_FRAME, bargeInMinSpeechMs: 0 },
+        // Neutralize the echo gate's threshold; its onset warm-up still
+        // shields the first in-window chunk via the deferral guard.
+        echoBargeInMargin: 0.001,
+        echoEmaHalfLifeMs: 4,
       });
     await speakFirstReply();
 
-    // A single speech chunk barges in immediately — proving the frame's 0 won.
+    // The chunk after onset barges in with no accumulated run — proving the
+    // frame's 0 won over the 5s option.
+    await session.handleBinaryAudio(LOUD_CHUNK);
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
@@ -2074,9 +2126,11 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   // speech above max(speechEnergyThreshold, echoBargeInMargin × echo EMA), so
   // loud TTS echo leaking through imperfect client echo cancellation cannot
   // self-interrupt the reply, while a user talking over it still can. Tests
-  // compress echoEmaHalfLifeMs to 5 ms so one 10 ms echo chunk converges the
-  // EMA far enough (alpha 0.75 → EMA 2250 for a 3000 chunk, threshold 3375
-  // at the default 1.5 margin) that steady echo sits under its own margin.
+  // compress echoEmaHalfLifeMs to 5 ms: the first 10 ms chunk lands in the
+  // onset warm-up (half-life/2 = 2.5 ms, quartered attack half-life 1.25 ms,
+  // alpha ≈ 0.996), so a 3000 chunk converges the EMA to ≈ 2988 — threshold
+  // ≈ 4482 at the default 1.5 margin — and steady echo sits under its own
+  // margin from the second chunk on.
   describe("echo-adaptive gate", () => {
     test("steady loud echo during playback never fires speech_started or cancels the turn", async () => {
       const { frames, session, abort, speakFirstReply } =
@@ -2142,7 +2196,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       await flushAsyncCallbacks();
       expect(countType(frames, "turn_cancelled")).toBe(0);
 
-      // The user talks over the echo: 6000 clears the 3375 threshold and
+      // The user talks over the echo: 6000 clears the ≈ 4482 threshold and
       // sustains past the guard, so the deferred speech_started flushes
       // playback and the turn cancels.
       for (let index = 0; index < 7; index += 1) {
@@ -2218,6 +2272,142 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       // floor — a stale reference would have swallowed it.
       await session.handleBinaryAudio(pcm(1_000));
       await waitFor(() => countType(frames, "speech_started") === baseline + 1);
+    });
+
+    test("a guard trip reached during warm-up is deferred and dissolved by the converging reference", async () => {
+      // With the guard (20 ms) SHORTER than the warm-up (half-life/2 =
+      // 20 ms of audio), onset echo accumulates to the trip while its chunks
+      // are still judged against a warming reference — the per-chunk
+      // deferral holds the trip, and the reference overtakes the echo on the
+      // next chunk, zeroing the run before it can ever fire.
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 20,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      for (let index = 0; index < 30; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("instant barge-in (guard disabled) is still shielded from onset echo, then fires instantly once warm", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 0,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+
+      // Onset echo: the warm-up arms a deferral guard even with
+      // bargeInMinSpeechMs 0, and the converging reference absorbs the echo
+      // — without this shield the very first chunk would cancel the turn.
+      for (let index = 0; index < 30; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // Post-warm-up, instant behavior is back: the first chunk clearing the
+      // converged margin fires without accumulating a sustained run.
+      await session.handleBinaryAudio(pcm(8_000));
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("a live speech run crossing into playback (turn collision) keeps user-first semantics and trips", async () => {
+      let callbacks: VoiceTurnCallbacks | undefined;
+      const abort = mock();
+      const startVoiceTurn = mock(async (turnOptions: VoiceTurnOptions) => {
+        callbacks ??= turnOptions.callbacks;
+        return { turnId: "bridge-turn", abort };
+      });
+      const streamTtsAudio = mock(async (ttsOptions: LiveVoiceTtsOptions) => {
+        ttsOptions.onAudioChunk(makeTtsChunk("assistant audio"));
+        return makeTtsResult("assistant audio");
+      });
+      const { frames, session } = createHarness({
+        finals: ["what's the weather", "actually never mind"],
+        startVoiceTurn,
+        streamTtsAudio,
+        bargeInMinSpeechMs: 60,
+        echoEmaHalfLifeMs: 400,
+        turnDetectorConfig: { silenceThresholdMs: 5_000 },
+      });
+      await session.start();
+      await session.handleBinaryAudio(LOUD_CHUNK);
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+      // 30 ms of live speech arms the guard while the turn is thinking...
+      for (let index = 0; index < 3; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      // ...then TTS starts mid-run. The carried-over guard keeps user-first
+      // semantics: frozen reference, base threshold, normal trip at 60 ms —
+      // the onset warm-up must not defer or absorb the colliding user.
+      callbacks?.assistant_text_delta?.(makeTextDelta("It is sunny today."));
+      await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+      for (let index = 0; index < 4; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("a pre-playback noise blip whose run already ended does not block echo learning", async () => {
+      let callbacks: VoiceTurnCallbacks | undefined;
+      const abort = mock();
+      const startVoiceTurn = mock(async (turnOptions: VoiceTurnOptions) => {
+        callbacks ??= turnOptions.callbacks;
+        return { turnId: "bridge-turn", abort };
+      });
+      const streamTtsAudio = mock(async (ttsOptions: LiveVoiceTtsOptions) => {
+        ttsOptions.onAudioChunk(makeTtsChunk("assistant audio"));
+        return makeTtsResult("assistant audio");
+      });
+      const { frames, session } = createHarness({
+        finals: ["what's the weather", "actually never mind"],
+        startVoiceTurn,
+        streamTtsAudio,
+        bargeInMinSpeechMs: 60,
+        echoEmaHalfLifeMs: 40,
+        turnDetectorConfig: { silenceThresholdMs: 5_000 },
+      });
+      await session.start();
+      await session.handleBinaryAudio(LOUD_CHUNK);
+      await session.handleClientFrame({ type: "ptt_release" });
+      await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+      // A cough during thinking arms the guard, then a silent chunk zeroes
+      // its run — the guard object itself stays armed.
+      for (let index = 0; index < 2; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await session.handleBinaryAudio(SILENT_CHUNK);
+      // TTS starts: the armed-but-settled guard is NOT a turn collision, so
+      // the onset warm-up learns the echo and steady loud echo cannot run
+      // out the lingering guard against the base threshold.
+      callbacks?.assistant_text_delta?.(makeTextDelta("It is sunny today."));
+      await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+      const baseline = countType(frames, "turn_cancelled");
+      for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(baseline);
+      expect(abort).not.toHaveBeenCalled();
     });
 
     test("the echo reference freezes while the barge-in guard is armed", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1327,10 +1327,12 @@ describe("LiveVoiceSession server VAD", () => {
     );
     await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
 
-    // Age the echo window past its (pinned-tiny) warm-up with a silent
-    // chunk, so the barge-in below trips synchronously inside
-    // handleBinaryAudio and can race the queued completion.
-    await session.handleBinaryAudio(SILENT_CHUNK);
+    // Age the echo window past its (pinned-tiny) warm-up with a chunk at
+    // exactly the base threshold — signal-bearing (advances the warm-up
+    // clock) but not speech (strict > comparison) — so the barge-in below
+    // trips synchronously inside handleBinaryAudio and can race the queued
+    // completion.
+    await session.handleBinaryAudio(pcm(800));
 
     // The LLM finishes just as the user barges in: message_complete queues
     // the completion continuation and the abort fires before it runs.
@@ -2180,7 +2182,6 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       }
       await flushAsyncCallbacks();
 
-      console.log("FRAMES:", frameTypes(frames).join(","));
       expect(countType(frames, "speech_started")).toBe(baseline);
       expect(countType(frames, "turn_cancelled")).toBe(0);
       expect(abort).not.toHaveBeenCalled();
@@ -2482,6 +2483,97 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       await flushAsyncCallbacks();
       expect(countType(frames, "turn_cancelled")).toBe(baseline);
       expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("a drain gap shorter than the slack does not decay the reference against resumed echo", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // Converge on the burst's echo.
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      // A sub-slack drain gap: 300 ms of sub-base silence. Silence carries
+      // no echo-level information, so the reference must hold rather than
+      // decay toward the noise floor.
+      for (let index = 0; index < 30; index += 1) {
+        await session.handleBinaryAudio(pcm(200));
+      }
+      // Resumed echo at the same level sits under the HELD margin. Were the
+      // reference decaying through the gap, this would classify as speech
+      // and run out the guard.
+      for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("transport-lag silence before the first echo does not burn the warm-up", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // 150 ms of sub-base silence: the window is open (audio sent) but the
+      // burst's echo has not reached the mic yet. The warm-up clock counts
+      // signal-bearing audio only, so it must not tick here.
+      for (let index = 0; index < 15; index += 1) {
+        await session.handleBinaryAudio(pcm(200));
+      }
+      // The echo finally arrives and gets the FULL warm-up: learned and
+      // suppressed, never tripping the guard. Were the warm-up burned by the
+      // lag silence, this echo would be judged post-warm-up against a cold
+      // reference at the base threshold and cancel the turn.
+      for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("warm-up echo is dropped, not pre-rolled into the next utterance's STT audio", async () => {
+      const { frames, session, transcribers, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+        });
+      await speakFirstReply();
+
+      // Two warm-up chunks of presumed onset echo: suppressed AND dropped
+      // (not held as pre-roll "leading context").
+      const echoChunk = pcm(3_000);
+      await session.handleBinaryAudio(echoChunk);
+      await session.handleBinaryAudio(echoChunk);
+      // The user barges in loudly enough to clear the converged margin; the
+      // pre-roll flush must not prepend the assistant's own echo to their
+      // utterance's transcription audio.
+      for (let index = 0; index < 7; index += 1) {
+        await session.handleBinaryAudio(pcm(6_000));
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+
+      const echoBuffer = Buffer.from(echoChunk);
+      const echoForwarded = transcribers.some((transcriber) =>
+        transcriber.received.some((buffer) => buffer.equals(echoBuffer)),
+      );
+      expect(echoForwarded).toBe(false);
     });
 
     test("the echo reference freezes while the barge-in guard is armed", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -125,6 +125,7 @@ function createHarness(options: {
   bargeInMinSpeechMs?: number;
   echoEmaHalfLifeMs?: number;
   echoBargeInMargin?: number;
+  echoDrainSlackMs?: number;
   emitMetrics?: boolean;
   metricsClock?: () => number;
   // Return a promise to hold a frame's transport write open (a backed-up
@@ -189,6 +190,7 @@ function createHarness(options: {
     bargeInMinSpeechMs: options.bargeInMinSpeechMs,
     echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
     echoBargeInMargin: options.echoBargeInMargin,
+    echoDrainSlackMs: options.echoDrainSlackMs,
     ...(options.spawnBackgroundContinuation
       ? { spawnBackgroundContinuation: options.spawnBackgroundContinuation }
       : {}),
@@ -366,10 +368,9 @@ describe("LiveVoiceSession server VAD", () => {
 
     // Sustained speech over the assistant's audio meets the default guard.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
-    // The sustained chunk is the first in-window audio, so its trip is
-    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
-    // the accumulated run.
-    await session.handleBinaryAudio(LOUD_CHUNK);
+    // The first in-window chunk is suppressed as presumed onset echo; the
+    // second sustained chunk arms and satisfies the guard in one piece.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -464,10 +465,9 @@ describe("LiveVoiceSession server VAD", () => {
     // Once audio has genuinely gone out, new sustained speech barge-ins.
     await waitFor(() => countType(frames, "utterance_end") === 2);
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
-    // The sustained chunk is the first in-window audio, so its trip is
-    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
-    // the accumulated run.
-    await session.handleBinaryAudio(LOUD_CHUNK);
+    // The first in-window chunk is suppressed as presumed onset echo; the
+    // second sustained chunk arms and satisfies the guard in one piece.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -874,10 +874,9 @@ describe("LiveVoiceSession server VAD", () => {
 
     // Barge in over the playing, already-complete reply.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
-    // The sustained chunk is the first in-window audio, so its trip is
-    // deferred by the echo gate's onset warm-up; the follow-up chunk fires
-    // the accumulated run.
-    await session.handleBinaryAudio(LOUD_CHUNK);
+    // The first in-window chunk is suppressed as presumed onset echo; the
+    // second sustained chunk arms and satisfies the guard in one piece.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),
     );
@@ -1730,6 +1729,7 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
       bargeInMinSpeechMs: 250,
       echoBargeInMargin: 1.5,
       echoEmaHalfLifeMs: 400,
+      echoDrainSlackMs: 300,
     });
 
     const { frames, session } = createHarness({ viaFactory: true });
@@ -1845,6 +1845,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     bargeInMinSpeechMs: number;
     echoEmaHalfLifeMs?: number;
     echoBargeInMargin?: number;
+    echoDrainSlackMs?: number;
     finals?: string[];
     startFrame?: LiveVoiceClientStartFrame;
   }) {
@@ -1854,7 +1855,9 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       callbacks ??= turnOptions.callbacks;
       return { turnId: "bridge-turn", abort };
     });
+    let ttsSink: ((chunk: LiveVoiceTtsAudioChunk) => void) | undefined;
     const streamTtsAudio = mock(async (ttsOptions: LiveVoiceTtsOptions) => {
+      ttsSink = ttsOptions.onAudioChunk;
       ttsOptions.onAudioChunk(makeTtsChunk("assistant audio"));
       return makeTtsResult("assistant audio");
     });
@@ -1865,6 +1868,10 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       bargeInMinSpeechMs: options.bargeInMinSpeechMs,
       echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
       echoBargeInMargin: options.echoBargeInMargin,
+      // The window must stay open for the whole driven-chunk sequence
+      // regardless of wall clock; tests that exercise window CLOSING pass
+      // a small slack explicitly.
+      echoDrainSlackMs: options.echoDrainSlackMs ?? 60_000,
       turnDetectorConfig: { silenceThresholdMs: 5_000 },
       ...(options.startFrame ? { startFrame: options.startFrame } : {}),
     });
@@ -1886,19 +1893,41 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       callbacks?.message_complete?.(makeMessageComplete());
     }
 
-    return { ...harness, abort, speakFirstReply, completeFirstReply };
+    // Re-emit an audio chunk on the captured TTS sink: playback resuming
+    // after a synthesis stall, extending the drain estimate. Awaited so the
+    // tail extension lands before the caller drives mic chunks — matching
+    // production ordering, where the server extends the estimate at send
+    // time, strictly before that audio's echo can arrive back at the mic.
+    async function emitTtsChunk(): Promise<void> {
+      await ttsSink?.(makeTtsChunk("assistant audio"));
+      await flushAsyncCallbacks();
+    }
+
+    return {
+      ...harness,
+      abort,
+      speakFirstReply,
+      completeFirstReply,
+      emitTtsChunk,
+    };
   }
 
   test("speech shorter than the guard leaves the speaking turn untouched", async () => {
     const { frames, session, abort, speakFirstReply, completeFirstReply } =
       createSpeakingTurnHarness({
         bargeInMinSpeechMs: 60,
+        // Neutralize the echo gate (threshold pinned to the 800 floor,
+        // warm-up over after one chunk); the first chunk is suppressed as
+        // presumed onset echo, so drive one extra to keep 30 ms of speech.
+        echoBargeInMargin: 0.001,
+        echoEmaHalfLifeMs: 4,
         finals: ["what's the weather", "   "],
       });
     await speakFirstReply();
 
-    // 30 ms of speech then silence: never reaches the 60 ms guard.
-    for (let index = 0; index < 3; index += 1) {
+    // 30 ms of post-warm-up speech then silence: never reaches the 60 ms
+    // guard (the first chunk is suppressed as presumed onset echo).
+    for (let index = 0; index < 4; index += 1) {
       await session.handleBinaryAudio(LOUD_CHUNK);
     }
     await session.handleBinaryAudio(SILENT_CHUNK);
@@ -1935,8 +1964,9 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       });
     await speakFirstReply();
 
-    // 50 ms of consecutive speech: one chunk short of the 60 ms guard.
-    for (let index = 0; index < 5; index += 1) {
+    // 50 ms of post-warm-up consecutive speech: one chunk short of the
+    // 60 ms guard (the first chunk is suppressed as presumed onset echo).
+    for (let index = 0; index < 6; index += 1) {
       await session.handleBinaryAudio(LOUD_CHUNK);
     }
     await flushAsyncCallbacks();
@@ -1944,7 +1974,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     expect(countType(frames, "speech_started")).toBe(1);
     expect(abort).not.toHaveBeenCalled();
 
-    // The 6th consecutive chunk reaches 60 ms: the deferred speech_started
+    // The next consecutive chunk reaches 60 ms: the deferred speech_started
     // flushes playback and the turn cancels.
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
@@ -2150,6 +2180,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       }
       await flushAsyncCallbacks();
 
+      console.log("FRAMES:", frameTypes(frames).join(","));
       expect(countType(frames, "speech_started")).toBe(baseline);
       expect(countType(frames, "turn_cancelled")).toBe(0);
       expect(abort).not.toHaveBeenCalled();
@@ -2185,21 +2216,24 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       const { frames, session, abort, speakFirstReply } =
         createSpeakingTurnHarness({
           bargeInMinSpeechMs: 60,
-          echoEmaHalfLifeMs: 5,
+          echoEmaHalfLifeMs: 400,
         });
       await speakFirstReply();
 
-      // Steady echo at 3000 converges the reference (suppressed, as above).
-      for (let index = 0; index < 10; index += 1) {
+      // Steady echo at 3000: the 200 ms warm-up (20 chunks) converges the
+      // reference to ~2250 (threshold ~3375); later echo chunks classify as
+      // silence and only drift the unfrozen reference slowly.
+      for (let index = 0; index < 25; index += 1) {
         await session.handleBinaryAudio(pcm(3_000));
       }
       await flushAsyncCallbacks();
       expect(countType(frames, "turn_cancelled")).toBe(0);
 
-      // The user talks over the echo: 6000 clears the ≈ 4482 threshold and
-      // sustains past the guard, so the deferred speech_started flushes
-      // playback and the turn cancels.
-      for (let index = 0; index < 7; index += 1) {
+      // The user talks over the echo: 6000 clears the ~3500 threshold, arms
+      // the guard (freezing the reference), and sustains past the 60 ms
+      // guard, so the deferred speech_started flushes playback and the turn
+      // cancels.
+      for (let index = 0; index < 8; index += 1) {
         await session.handleBinaryAudio(pcm(6_000));
       }
       await waitFor(() =>
@@ -2246,6 +2280,9 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
         createSpeakingTurnHarness({
           bargeInMinSpeechMs: 60,
           echoEmaHalfLifeMs: 5,
+          // A real (small) slack so the drain-scoped window actually closes
+          // once the tiny tts chunk plus slack elapse on the wall clock.
+          echoDrainSlackMs: 150,
           finals: ["what's the weather", "   "],
         });
       await speakFirstReply();
@@ -2263,15 +2300,52 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       await flushAsyncCallbacks();
       expect(countType(frames, "speech_started")).toBe(baseline);
 
-      // The reply completes and the tiny playback tail drains: the echo
-      // window closes and the reference resets.
+      // The reply completes and the tiny playback tail plus slack drain on
+      // the wall clock: the echo window closes and the reference resets.
       completeFirstReply();
       await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+      await new Promise((resolve) => setTimeout(resolve, 200));
 
       // The same amplitude-1000 chunk is speech immediately at the 800
       // floor — a stale reference would have swallowed it.
       await session.handleBinaryAudio(pcm(1_000));
       await waitFor(() => countType(frames, "speech_started") === baseline + 1);
+    });
+
+    test("a TTS pause closes the window; resumed playback re-warms against fresh echo", async () => {
+      const { frames, session, abort, speakFirstReply, emitTtsChunk } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 60,
+          echoEmaHalfLifeMs: 40,
+          echoDrainSlackMs: 100,
+        });
+      await speakFirstReply();
+      const baseline = countType(frames, "speech_started");
+
+      // First burst: onset echo converges into the fresh warm-up.
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // Synthesis stall: the client drains (tiny chunk + 100 ms slack) and
+      // the window closes, resetting the decayed reference instead of
+      // leaving it stale against the next burst.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Playback resumes: the window re-opens with a fresh warm-up, so the
+      // resumed echo is re-learned instead of tripping the guard against a
+      // stale reference.
+      await emitTtsChunk();
+      for (let index = 0; index < 30; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "speech_started")).toBe(baseline);
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
     });
 
     test("a guard trip reached during warm-up is deferred and dissolved by the converging reference", async () => {
@@ -2413,27 +2487,29 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     test("the echo reference freezes while the barge-in guard is armed", async () => {
       const { frames, session, speakFirstReply } = createSpeakingTurnHarness({
         bargeInMinSpeechMs: 60,
-        echoEmaHalfLifeMs: 5,
+        echoEmaHalfLifeMs: 400,
       });
       await speakFirstReply();
 
-      // The onset chunk arms the guard and seeds the reference during the
-      // single-chunk warm-up (fast attack converges EMA to ~2400, threshold
-      // ~3600); the warm-up then ends and the reference freezes while the
-      // guard stays armed.
-      await session.handleBinaryAudio(pcm(2_400));
-      // 100 ms at 3300 sits under the frozen ~3600 threshold (silence).
-      // Were the EMA still tracking, it would converge to ~3300 and lift
-      // the threshold to ~4950 — swallowing the 4000 override below.
+      // Steady echo converges the reference to ~2250 inside the warm-up;
+      // post-warm-up echo chunks are silent and only drift it slowly.
+      for (let index = 0; index < 25; index += 1) {
+        await session.handleBinaryAudio(pcm(3_000));
+      }
+      // 100 ms at 3300 sits under the ~3400 threshold (silence). The
+      // unfrozen reference drifts toward 3300 only at the slow configured
+      // half-life, so the threshold stays under 4000.
       for (let index = 0; index < 10; index += 1) {
         await session.handleBinaryAudio(pcm(3_300));
       }
       await flushAsyncCallbacks();
       expect(countType(frames, "turn_cancelled")).toBe(0);
 
-      // 4000 clears the frozen ~3600 threshold and sustains past the guard —
-      // the reference did not move while the guard was armed.
-      for (let index = 0; index < 7; index += 1) {
+      // 4000 clears the threshold and arms the guard, freezing the
+      // reference; the run then sustains the 60 ms guard at a STABLE
+      // threshold and trips. Were the reference still tracking during the
+      // armed run, it would chase 4000 upward against the user.
+      for (let index = 0; index < 8; index += 1) {
         await session.handleBinaryAudio(pcm(4_000));
       }
       await waitFor(() =>

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -901,8 +901,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Idle mic: hold silent chunks in the bounded pre-roll instead of
     // collecting or streaming them; flushed on speech onset so the
     // transcriber still gets leading context ahead of the first syllable.
+    // Warm-up-suppressed chunks are presumed assistant echo, not leading
+    // user context: pre-rolling them would flush transcribable assistant
+    // audio into the next genuine utterance's STT and archive, so they are
+    // dropped instead.
     if (!hasSpeech && !detector.isActive) {
-      this.pushVadPreRoll(chunk, false);
+      if (!this.echoGateChunkWarmingUp) {
+        this.pushVadPreRoll(chunk, false);
+      }
       return;
     }
 
@@ -918,8 +924,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       if (!this.canArmNextUtterance(utterance)) {
         // Speech in the release→turn-start window: hold it in the pre-roll
-        // ring so it flushes into the next utterance once it arms.
-        this.pushVadPreRoll(chunk, hasSpeech);
+        // ring so it flushes into the next utterance once it arms. Warm-up
+        // chunks are presumed echo and dropped, as above.
+        if (!this.echoGateChunkWarmingUp) {
+          this.pushVadPreRoll(chunk, hasSpeech);
+        }
         return;
       }
       // Sets currentUtterance synchronously; the transcriber resolves async
@@ -984,8 +993,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // fresh warm-up — the reference never goes stale against resumed echo. A
   // user starting to speak inside a warm-up is absorbed into the reference
   // (echo-first assumption) and recovers by pausing and speaking again once
-  // the gate is warm. Warm-up is measured in processed audio time, the same
-  // clock that drives EMA convergence.
+  // the gate is warm. Warm-up is measured in SIGNAL-BEARING audio time
+  // (chunks at or above the base threshold): silence carries no echo-level
+  // information, so drain-gap or transport-lag silence neither decays the
+  // reference nor burns the warm-up before echo has arrived to be learned.
+  //
+  // Known limitation (accepted): within one continuous burst, a slow
+  // crescendo (~300 ms+ ramp from sub-threshold) or a dip that stays above
+  // the base threshold can leave the armed-guard-frozen reference below the
+  // live echo level, and sustained echo can then run out the guard. Real
+  // TTS onsets attack far faster than the warm-up learns, so this needs an
+  // unusually shaped burst; the alternatives (letting the reference chase
+  // upward while armed) raise the bar for genuine barge-ins to ~2× echo,
+  // which is worse.
   //
   // Turn collision: a guard with a LIVE speech run when the window opens is
   // the user already talking across the turn boundary — humans cannot react
@@ -1026,22 +1046,31 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       !this.echoWindowGuardCarryover &&
       this.echoWindowAudioMs < this.echoEmaHalfLifeMs / 2;
     this.echoGateChunkWarmingUp = warmingUp;
-    const chunkMs = pcm16DurationMs(
-      chunk.byteLength,
-      this.context.startFrame.audio.sampleRate,
-    );
-    if (this.pendingBargeIn === null || warmingUp) {
-      // Attack fast during warm-up (quarter half-life) so the reference
-      // overtakes steady onset echo inside the warm-up window; settle to the
-      // configured half-life afterwards for stability against transients.
-      const halfLifeMs = warmingUp
-        ? this.echoEmaHalfLifeMs / 4
-        : this.echoEmaHalfLifeMs;
-      const alpha = 1 - 0.5 ** (chunkMs / halfLifeMs);
-      this.echoEnergyEma =
-        alpha * meanAmplitude + (1 - alpha) * this.echoEnergyEma;
+    // Sub-base chunks carry no echo-level information: in-window silence —
+    // a drain gap shorter than the slack, or the transport lag before the
+    // first echo of a burst reaches the mic — must neither decay the
+    // reference toward the noise floor (resumed echo would then beat a
+    // stale, lowered threshold) nor burn the warm-up clock before any echo
+    // has arrived to be learned. Only signal-bearing chunks advance either.
+    if (meanAmplitude >= baseThreshold) {
+      const chunkMs = pcm16DurationMs(
+        chunk.byteLength,
+        this.context.startFrame.audio.sampleRate,
+      );
+      if (this.pendingBargeIn === null || warmingUp) {
+        // Attack fast during warm-up (quarter half-life) so the reference
+        // overtakes steady onset echo inside the warm-up window; settle to
+        // the configured half-life afterwards for stability against
+        // transients.
+        const halfLifeMs = warmingUp
+          ? this.echoEmaHalfLifeMs / 4
+          : this.echoEmaHalfLifeMs;
+        const alpha = 1 - 0.5 ** (chunkMs / halfLifeMs);
+        this.echoEnergyEma =
+          alpha * meanAmplitude + (1 - alpha) * this.echoEnergyEma;
+      }
+      this.echoWindowAudioMs += chunkMs;
     }
-    this.echoWindowAudioMs += chunkMs;
     return threshold;
   }
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -111,6 +111,16 @@ const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
 // schema defaults.
 const DEFAULT_ECHO_BARGE_IN_MARGIN = 1.5;
 const DEFAULT_ECHO_EMA_HALF_LIFE_MS = 400;
+// Bound (audio ms) on the echo-first assumption within a window: a burst's
+// echo reaches the mic within transport latency + jitter of the window
+// opening, so if nothing at or above the base threshold arrives within this
+// much in-window audio, the playback is effectively silent at the mic (good
+// AEC / low volume) and the gate goes inert at the base threshold — a user
+// barging over quiet playback must not be absorbed as presumed echo. The
+// same bound expires a learned reference after a sub-base run longer than
+// any real in-window echo gap, so an absorbed early barger recovers by
+// pausing and retrying.
+const ECHO_ONSET_ELIGIBILITY_MS = 300;
 // Slack (ms) past the client playback-drain estimate during which echo is
 // still expected at the mic: covers one-way transport latency + the client
 // jitter buffer, so the echo window outlives the send-time estimate by the
@@ -419,9 +429,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // EMA of observed mic-chunk energy while assistant audio is playing (the
   // echo reference); 0 outside the echo window.
   private echoEnergyEma = 0;
-  // Audio time (ms) processed since the echo window opened — drives the
-  // gate's warm-up (see effectiveSpeechThreshold); 0 outside the echo window.
+  // Signal-bearing audio time (ms) processed since the echo window opened —
+  // drives the gate's warm-up (see effectiveSpeechThreshold); 0 outside the
+  // echo window.
   private echoWindowAudioMs = 0;
+  // Total in-window audio time (ms), signal-bearing or not — bounds the
+  // echo-first eligibility (see ECHO_ONSET_ELIGIBILITY_MS).
+  private echoWindowTotalAudioMs = 0;
+  // Consecutive sub-base in-window audio (ms) — expires the learned
+  // reference (see ECHO_ONSET_ELIGIBILITY_MS).
+  private echoSubBaseRunMs = 0;
+  // Sticky once true for the window's remainder: the echo-first assumption
+  // lapsed (no signal within the eligibility bound, or the reference
+  // expired), so no further input may be absorbed as presumed echo.
+  private echoOnsetLapsed = false;
   // A guard whose speech run predates the echo window is the user talking
   // across the turn boundary (turn collision) — see effectiveSpeechThreshold.
   private echoWindowGuardCarryover = false;
@@ -898,17 +919,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     detector.onMediaChunk(hasSpeech);
     this.trackBargeInGuard(hasSpeech, chunk);
 
+    // Warm-up chunks are presumed assistant echo, not user audio: after
+    // feeding the detector's silence timing and the guard above, drop them
+    // entirely — they must not be pre-rolled as leading context NOR routed
+    // into a still-active utterance (a noise-blip silence-timer hangover
+    // spanning TTS onset), where they would stream transcribable assistant
+    // audio to STT and the archive.
+    if (this.echoGateChunkWarmingUp) {
+      return;
+    }
+
     // Idle mic: hold silent chunks in the bounded pre-roll instead of
     // collecting or streaming them; flushed on speech onset so the
     // transcriber still gets leading context ahead of the first syllable.
-    // Warm-up-suppressed chunks are presumed assistant echo, not leading
-    // user context: pre-rolling them would flush transcribable assistant
-    // audio into the next genuine utterance's STT and archive, so they are
-    // dropped instead.
     if (!hasSpeech && !detector.isActive) {
-      if (!this.echoGateChunkWarmingUp) {
-        this.pushVadPreRoll(chunk, false);
-      }
+      this.pushVadPreRoll(chunk, false);
       return;
     }
 
@@ -924,11 +949,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       if (!this.canArmNextUtterance(utterance)) {
         // Speech in the release→turn-start window: hold it in the pre-roll
-        // ring so it flushes into the next utterance once it arms. Warm-up
-        // chunks are presumed echo and dropped, as above.
-        if (!this.echoGateChunkWarmingUp) {
-          this.pushVadPreRoll(chunk, hasSpeech);
-        }
+        // ring so it flushes into the next utterance once it arms.
+        this.pushVadPreRoll(chunk, hasSpeech);
         return;
       }
       // Sets currentUtterance synchronously; the transcriber resolves async
@@ -992,11 +1014,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // TTS pause closes the window and every speech burst re-opens it with a
   // fresh warm-up — the reference never goes stale against resumed echo. A
   // user starting to speak inside a warm-up is absorbed into the reference
-  // (echo-first assumption) and recovers by pausing and speaking again once
-  // the gate is warm. Warm-up is measured in SIGNAL-BEARING audio time
-  // (chunks at or above the base threshold): silence carries no echo-level
-  // information, so drain-gap or transport-lag silence neither decays the
-  // reference nor burns the warm-up before echo has arrived to be learned.
+  // (echo-first assumption) and recovers via the reference expiry below.
+  // Warm-up is measured in SIGNAL-BEARING audio time (chunks at or above
+  // the base threshold): silence carries no echo-level information, so
+  // drain-gap or transport-lag silence neither decays the reference nor
+  // burns the warm-up before echo has arrived to be learned. The echo-first
+  // assumption itself is BOUNDED (ECHO_ONSET_ELIGIBILITY_MS): if no signal
+  // reaches the mic within the window's first 300 ms of audio, the playback
+  // is silent at the mic (good AEC — the common case) and the gate goes
+  // inert at the base threshold; and a sub-base run longer than that bound
+  // expires the learned reference, so an absorbed early barger recovers by
+  // pausing and retrying.
   //
   // Known limitation (accepted): within one continuous burst, a slow
   // crescendo (~300 ms+ ramp from sub-threshold) or a dip that stays above
@@ -1023,6 +1051,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (!this.isAssistantAudioPlaying()) {
       this.echoEnergyEma = 0;
       this.echoWindowAudioMs = 0;
+      this.echoWindowTotalAudioMs = 0;
+      this.echoSubBaseRunMs = 0;
+      this.echoOnsetLapsed = false;
       this.echoWindowGuardCarryover = false;
       this.echoGateChunkWarmingUp = false;
       return baseThreshold;
@@ -1042,21 +1073,45 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       baseThreshold,
       this.echoBargeInMargin * this.echoEnergyEma,
     );
+    // The echo-first assumption is bounded: a burst's echo reaches the mic
+    // within transport latency + jitter of the window opening, so echo
+    // learning may only BEGIN while the window is younger than the
+    // eligibility bound (or once signal has already been learned). A window
+    // whose playback is silent at the mic (good AEC, low volume) passes the
+    // bound with a zero reference and the gate goes inert at the base
+    // threshold — a user barging over quiet playback is heard instantly.
+    if (
+      !this.echoOnsetLapsed &&
+      this.echoEnergyEma === 0 &&
+      this.echoWindowTotalAudioMs >= ECHO_ONSET_ELIGIBILITY_MS
+    ) {
+      // Nothing signal-bearing reached the mic in the window's first
+      // eligibility span: quiet playback. Sticky — later input (the user!)
+      // seeding the reference must not re-open the echo-first assumption.
+      this.echoOnsetLapsed = true;
+    }
     const warmingUp =
       !this.echoWindowGuardCarryover &&
+      !this.echoOnsetLapsed &&
       this.echoWindowAudioMs < this.echoEmaHalfLifeMs / 2;
     this.echoGateChunkWarmingUp = warmingUp;
+    const chunkMs = pcm16DurationMs(
+      chunk.byteLength,
+      this.context.startFrame.audio.sampleRate,
+    );
     // Sub-base chunks carry no echo-level information: in-window silence —
     // a drain gap shorter than the slack, or the transport lag before the
     // first echo of a burst reaches the mic — must neither decay the
     // reference toward the noise floor (resumed echo would then beat a
     // stale, lowered threshold) nor burn the warm-up clock before any echo
     // has arrived to be learned. Only signal-bearing chunks advance either.
+    // A sub-base run longer than the eligibility bound EXPIRES the learned
+    // reference: real in-window echo never pauses that long while audio
+    // drains, so whatever was learned (possibly an absorbed early barger's
+    // own voice) no longer describes the playback — and with eligibility
+    // spent, the gate goes inert rather than re-absorbing.
     if (meanAmplitude >= baseThreshold) {
-      const chunkMs = pcm16DurationMs(
-        chunk.byteLength,
-        this.context.startFrame.audio.sampleRate,
-      );
+      this.echoSubBaseRunMs = 0;
       if (this.pendingBargeIn === null || warmingUp) {
         // Attack fast during warm-up (quarter half-life) so the reference
         // overtakes steady onset echo inside the warm-up window; settle to
@@ -1070,7 +1125,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           alpha * meanAmplitude + (1 - alpha) * this.echoEnergyEma;
       }
       this.echoWindowAudioMs += chunkMs;
+    } else {
+      this.echoSubBaseRunMs += chunkMs;
+      if (this.echoSubBaseRunMs >= ECHO_ONSET_ELIGIBILITY_MS) {
+        this.echoEnergyEma = 0;
+        this.echoWindowAudioMs = 0;
+        this.echoOnsetLapsed = true;
+      }
     }
+    this.echoWindowTotalAudioMs += chunkMs;
     return threshold;
   }
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -36,7 +36,10 @@ import {
 } from "../providers/speech-to-text/provider-catalog.js";
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
 import { publishConversationListAndMetadataChanged } from "../runtime/sync/resource-sync-events.js";
-import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
+import {
+  DEFAULT_SPEECH_ENERGY_THRESHOLD,
+  pcm16MeanAmplitude,
+} from "../stt/speech-energy.js";
 import type {
   StreamingTranscriber,
   SttStreamServerErrorEvent,
@@ -103,6 +106,10 @@ const FINALIZE_GRACE_MS = 1_000;
 // liveVoice.vad.bargeInMinSpeechMs schema default; 0 disables the guard for
 // instant barge-in.
 const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
+// Echo-adaptive gate knobs (see effectiveSpeechThreshold). Mirror the
+// liveVoice.vad.echoBargeInMargin / echoEmaHalfLifeMs schema defaults.
+const DEFAULT_ECHO_BARGE_IN_MARGIN = 1.5;
+const DEFAULT_ECHO_EMA_HALF_LIFE_MS = 400;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one
 // prefetching job. The prefetch buffers its chunks in memory until promoted;
@@ -188,6 +195,21 @@ export interface LiveVoiceSessionOptions {
    * defaults to `DEFAULT_BARGE_IN_MIN_SPEECH_MS`.
    */
   bargeInMinSpeechMs?: number;
+  /**
+   * Overrides the echo-adaptive gate's margin: the multiplier over the
+   * observed echo-energy EMA that a server-VAD chunk must exceed to count
+   * as speech while assistant audio is playing. The production factory
+   * seeds this from `liveVoice.vad.echoBargeInMargin` config when unset;
+   * defaults to `DEFAULT_ECHO_BARGE_IN_MARGIN`.
+   */
+  echoBargeInMargin?: number;
+  /**
+   * Overrides the half-life (ms) of the echo-energy EMA tracked while
+   * assistant audio is playing. The production factory seeds this from
+   * `liveVoice.vad.echoEmaHalfLifeMs` config when unset; defaults to
+   * `DEFAULT_ECHO_EMA_HALF_LIFE_MS`.
+   */
+  echoEmaHalfLifeMs?: number;
   /**
    * Overrides the bounded wait for the shared transcriber's finalize
    * flush in persistent mode (test hook). Defaults to `FINALIZE_GRACE_MS`.
@@ -372,9 +394,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private sessionEndMetricsEmitted = false;
   // Non-null iff the start frame requested turnDetection "server_vad".
   private readonly turnDetector: MediaTurnDetector | null;
-  // Energy gate for server-VAD speech classification; undefined defers to
-  // DEFAULT_SPEECH_ENERGY_THRESHOLD.
+  // Base energy gate for server-VAD speech classification; undefined defers
+  // to DEFAULT_SPEECH_ENERGY_THRESHOLD. While assistant audio is playing the
+  // effective gate is echo-adaptive (see effectiveSpeechThreshold).
   private readonly speechEnergyThreshold: number | undefined;
+  // Echo-adaptive gate knobs (see effectiveSpeechThreshold): margin over the
+  // echo-energy EMA a chunk must exceed to count as speech during assistant
+  // playback, and that EMA's half-life.
+  private readonly echoBargeInMargin: number;
+  private readonly echoEmaHalfLifeMs: number;
+  // EMA of observed mic-chunk energy while assistant audio is playing (the
+  // echo reference); 0 outside the echo window.
+  private echoEnergyEma = 0;
+  // Audio time (ms) processed since the echo window opened — drives the
+  // gate's warm-up (see isEchoGateWarmingUp); 0 outside the echo window.
+  private echoWindowAudioMs = 0;
+  // True when the sustained-speech guard was already armed at the moment the
+  // echo window opened: speech that PREDATES playback is the user talking
+  // across the turn boundary (turn collision), not echo — humans cannot
+  // react to playback onset faster than the warm-up. That guard keeps
+  // user-first semantics (frozen reference, normal trips).
+  private echoWindowGuardCarryover = false;
   // Mutable so a mid-session `update_config` frame can retune "interrupt
   // sensitivity" live (see applyConfigUpdate).
   private bargeInMinSpeechMs: number;
@@ -471,6 +511,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       context.startFrame.bargeInMinSpeechMs ??
       options.bargeInMinSpeechMs ??
       DEFAULT_BARGE_IN_MIN_SPEECH_MS;
+    this.echoBargeInMargin =
+      options.echoBargeInMargin ?? DEFAULT_ECHO_BARGE_IN_MARGIN;
+    this.echoEmaHalfLifeMs =
+      options.echoEmaHalfLifeMs ?? DEFAULT_ECHO_EMA_HALF_LIFE_MS;
     this.finalizeGraceMs = options.finalizeGraceMs ?? FINALIZE_GRACE_MS;
     const turnDetectorConfig: TurnDetectorConfig = {
       ...(options.turnDetectorConfig ?? {}),
@@ -826,10 +870,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
-    const hasSpeech = detectPcm16SpeechActivity(
-      chunk,
-      this.speechEnergyThreshold,
-    );
+    const meanAmplitude = pcm16MeanAmplitude(chunk);
+    const hasSpeech =
+      meanAmplitude > this.effectiveSpeechThreshold(chunk, meanAmplitude);
     detector.onMediaChunk(hasSpeech);
     this.trackBargeInGuard(hasSpeech, chunk);
 
@@ -870,6 +913,113 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       await this.routeVadAudio(utterance, preRollChunk);
     }
     await this.routeVadAudio(utterance, chunk);
+  }
+
+  // The echo window: the only time the speakers can be emitting assistant
+  // audio — a turn that has audibly started speaking, or the post-tts_done
+  // drain tail the client is still playing. A thinking (pre-TTS) turn plays
+  // nothing, so it keeps base-threshold sensitivity and pre-TTS barge-in
+  // (JARVIS-1266) is unaffected.
+  private isAssistantAudioPlaying(): boolean {
+    const turn = this.activeAssistantTurn;
+    if (turn?.ttsAudioStarted && !turn.finalized) {
+      return true;
+    }
+    return Date.now() < this.assistantPlaybackTailUntilMs;
+  }
+
+  // Energy gate for classifying a server-VAD chunk as speech. While assistant
+  // audio is playing, the mic hears the assistant's own TTS through imperfect
+  // client echo cancellation, and at high speaker volume that echo exceeds
+  // any fixed threshold — no constant separates loud echo from speech. What
+  // does separate them: genuine user speech adds energy on top of the echo
+  // the mic is already hearing. So during playback the gate tracks an EMA of
+  // observed chunk energy (the echo reference) and only counts a chunk as
+  // speech above echoBargeInMargin × that reference (never below the base
+  // threshold). Steady echo converges into the EMA and cannot clear its own
+  // margin; a user talking over it still does. The EMA freezes while the
+  // sustained-speech guard is armed — the user's own accumulating speech must
+  // not inflate the reference against them — and resets outside the echo
+  // window so a loud turn's reference never leaks into the next one.
+  //
+  // The freeze has a cold-start hole: at playback onset the very first loud
+  // echo chunk arms the guard, which would freeze the reference near zero and
+  // let steady onset echo complete a full guard run against the base
+  // threshold. So the window opens with a WARM-UP — the first
+  // echoEmaHalfLifeMs / 2 of in-window audio (200 ms at the 400 ms default) —
+  // during which the EMA learns at a fast attack rate (quarter half-life)
+  // and keeps learning even with the guard armed: echo, not speech, is the
+  // expected first signal at TTS onset. Guard trips are deferred (the run
+  // accumulates, it doesn't fire) until warm; at the default 250 ms trip the
+  // warm-up ends first, so real barge-in latency is untouched. Steady onset
+  // echo converges past its own margin inside the warm-up and its run is
+  // zeroed before it can fire. Warm-up is measured in processed audio time,
+  // the same clock that drives EMA convergence.
+  private effectiveSpeechThreshold(
+    chunk: Buffer,
+    meanAmplitude: number,
+  ): number {
+    const baseThreshold =
+      this.speechEnergyThreshold ?? DEFAULT_SPEECH_ENERGY_THRESHOLD;
+    if (!this.isAssistantAudioPlaying()) {
+      this.echoEnergyEma = 0;
+      this.echoWindowAudioMs = 0;
+      this.echoWindowGuardCarryover = false;
+      return baseThreshold;
+    }
+    if (this.echoWindowAudioMs === 0) {
+      // Window opening: a guard armed before any assistant audio played is
+      // the user mid-utterance (turn collision), not echo.
+      this.echoWindowGuardCarryover = this.pendingBargeIn !== null;
+    } else if (this.pendingBargeIn === null) {
+      // The carried-over guard settled; onset semantics resume for any
+      // later speech in this window.
+      this.echoWindowGuardCarryover = false;
+    }
+    // Judge the chunk against the reference as it stood before the chunk
+    // arrived — a chunk must not raise the bar it is judged against.
+    const threshold = Math.max(
+      baseThreshold,
+      this.echoBargeInMargin * this.echoEnergyEma,
+    );
+    const chunkMs = pcm16DurationMs(
+      chunk.byteLength,
+      this.context.startFrame.audio.sampleRate,
+    );
+    const warmingUp = this.echoOnsetWarmupActive();
+    if (this.pendingBargeIn === null || warmingUp) {
+      // Attack fast during warm-up (quarter half-life) so the reference
+      // overtakes steady onset echo inside the warm-up window; settle to the
+      // configured half-life afterwards for stability against transients.
+      const halfLifeMs = warmingUp
+        ? this.echoEmaHalfLifeMs / 4
+        : this.echoEmaHalfLifeMs;
+      const alpha = 1 - 0.5 ** (chunkMs / halfLifeMs);
+      this.echoEnergyEma =
+        alpha * meanAmplitude + (1 - alpha) * this.echoEnergyEma;
+    }
+    this.echoWindowAudioMs += chunkMs;
+    return threshold;
+  }
+
+  // True while the echo window has processed less than echoEmaHalfLifeMs / 2
+  // of audio (200 ms at the 400 ms default) — with the warm-up's quarter-
+  // half-life attack rate that is 2 attack half-lives, enough for the
+  // reference to reach ~75% of a steady echo level, putting margin × EMA
+  // above it. See effectiveSpeechThreshold.
+  private isEchoGateWarmingUp(): boolean {
+    return (
+      this.isAssistantAudioPlaying() &&
+      this.echoWindowAudioMs < this.echoEmaHalfLifeMs / 2
+    );
+  }
+
+  // Onset-echo semantics (fast unfrozen EMA learning + deferred guard trips)
+  // apply only during the warm-up AND when the speech run did not predate
+  // playback — a guard carried across the window boundary is the user, and
+  // keeps user-first semantics.
+  private echoOnsetWarmupActive(): boolean {
+    return !this.echoWindowGuardCarryover && this.isEchoGateWarmingUp();
   }
 
   private async routeVadAudio(
@@ -1034,6 +1184,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.context.startFrame.audio.sampleRate,
     );
     if (guard.speechMs < this.bargeInMinSpeechMs) {
+      return;
+    }
+    // Defer trips while the echo gate's onset warm-up is active (see
+    // effectiveSpeechThreshold): the run keeps accumulating, and a genuine
+    // user run fires on the first speech chunk after warm-up, while onset
+    // echo's run is zeroed once the converged reference reclassifies it. A
+    // guard carried over from before playback started (turn collision) is
+    // the user and trips normally.
+    if (this.echoOnsetWarmupActive()) {
       return;
     }
     this.pendingBargeIn = null;
@@ -2792,6 +2951,10 @@ export function createLiveVoiceSession(
       options.speechEnergyThreshold ?? vadConfig?.speechEnergyThreshold,
     bargeInMinSpeechMs:
       options.bargeInMinSpeechMs ?? vadConfig?.bargeInMinSpeechMs,
+    echoBargeInMargin:
+      options.echoBargeInMargin ?? vadConfig?.echoBargeInMargin,
+    echoEmaHalfLifeMs:
+      options.echoEmaHalfLifeMs ?? vadConfig?.echoEmaHalfLifeMs,
     resolveCredentialReadiness:
       options.resolveCredentialReadiness === undefined
         ? defaultResolveLiveVoiceCredentialReadiness

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -107,9 +107,15 @@ const FINALIZE_GRACE_MS = 1_000;
 // instant barge-in.
 const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
 // Echo-adaptive gate knobs (see effectiveSpeechThreshold). Mirror the
-// liveVoice.vad.echoBargeInMargin / echoEmaHalfLifeMs schema defaults.
+// liveVoice.vad.echoBargeInMargin / echoEmaHalfLifeMs / echoDrainSlackMs
+// schema defaults.
 const DEFAULT_ECHO_BARGE_IN_MARGIN = 1.5;
 const DEFAULT_ECHO_EMA_HALF_LIFE_MS = 400;
+// Slack (ms) past the client playback-drain estimate during which echo is
+// still expected at the mic: covers one-way transport latency + the client
+// jitter buffer, so the echo window outlives the send-time estimate by the
+// same margin real playback does. Mirrors liveVoice.vad.echoDrainSlackMs.
+const DEFAULT_ECHO_DRAIN_SLACK_MS = 300;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one
 // prefetching job. The prefetch buffers its chunks in memory until promoted;
@@ -210,6 +216,12 @@ export interface LiveVoiceSessionOptions {
    * `DEFAULT_ECHO_EMA_HALF_LIFE_MS`.
    */
   echoEmaHalfLifeMs?: number;
+  /**
+   * Slack (ms) past the client playback-drain estimate during which echo is
+   * still expected; seeds from `liveVoice.vad.echoDrainSlackMs` config when
+   * unset; defaults to DEFAULT_ECHO_DRAIN_SLACK_MS.
+   */
+  echoDrainSlackMs?: number;
   /**
    * Overrides the bounded wait for the shared transcriber's finalize
    * flush in persistent mode (test hook). Defaults to `FINALIZE_GRACE_MS`.
@@ -403,6 +415,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // playback, and that EMA's half-life.
   private readonly echoBargeInMargin: number;
   private readonly echoEmaHalfLifeMs: number;
+  private readonly echoDrainSlackMs: number;
   // EMA of observed mic-chunk energy while assistant audio is playing (the
   // echo reference); 0 outside the echo window.
   private echoEnergyEma = 0;
@@ -413,9 +426,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // across the turn boundary (turn collision) — see effectiveSpeechThreshold.
   private echoWindowGuardCarryover = false;
   // Warm-up state of the most recently classified in-window chunk (set by
-  // effectiveSpeechThreshold; consulted by handleVadSpeechStart and
-  // trackBargeInGuard) so classification and trip deferral agree per chunk
-  // regardless of ingress chunk size; false outside the echo window.
+  // effectiveSpeechThreshold; consulted by handleServerVadAudio's speech
+  // classification to suppress presumed-echo chunks); false outside the
+  // echo window.
   private echoGateChunkWarmingUp = false;
   // Mutable so a mid-session `update_config` frame can retune "interrupt
   // sensitivity" live (see applyConfigUpdate).
@@ -517,6 +530,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       options.echoBargeInMargin ?? DEFAULT_ECHO_BARGE_IN_MARGIN;
     this.echoEmaHalfLifeMs =
       options.echoEmaHalfLifeMs ?? DEFAULT_ECHO_EMA_HALF_LIFE_MS;
+    this.echoDrainSlackMs =
+      options.echoDrainSlackMs ?? DEFAULT_ECHO_DRAIN_SLACK_MS;
     this.finalizeGraceMs = options.finalizeGraceMs ?? FINALIZE_GRACE_MS;
     const turnDetectorConfig: TurnDetectorConfig = {
       ...(options.turnDetectorConfig ?? {}),
@@ -873,8 +888,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     const meanAmplitude = pcm16MeanAmplitude(chunk);
+    const speechThreshold = this.effectiveSpeechThreshold(chunk, meanAmplitude);
+    // Presumed-echo suppression: a chunk judged while the gate is warming is
+    // never speech — it must not trip barge-in, arm an utterance, or stream
+    // to STT (else the assistant's own onset echo transcribes into a ghost
+    // follow-up turn). See effectiveSpeechThreshold.
     const hasSpeech =
-      meanAmplitude > this.effectiveSpeechThreshold(chunk, meanAmplitude);
+      meanAmplitude > speechThreshold && !this.echoGateChunkWarmingUp;
     detector.onMediaChunk(hasSpeech);
     this.trackBargeInGuard(hasSpeech, chunk);
 
@@ -917,17 +937,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     await this.routeVadAudio(utterance, chunk);
   }
 
-  // The echo window: the only time the speakers can be emitting assistant
-  // audio — a turn that has audibly started speaking, or the post-tts_done
-  // drain tail the client is still playing. A thinking (pre-TTS) turn plays
-  // nothing, so it keeps base-threshold sensitivity and pre-TTS barge-in
-  // (JARVIS-1266) is unaffected.
+  // The echo window: the client is (estimated to be) audibly draining
+  // assistant audio. Scoped to the live playback-drain estimate — which
+  // grows with every sent tts_audio chunk — plus a slack that covers
+  // one-way transport latency and the client jitter buffer, NOT to the
+  // whole turn: a synthesis stall or inter-sentence pause drains the client
+  // and closes the window, so each speech burst re-opens it with a fresh
+  // warm-up instead of letting the reference decay against a stale open
+  // window. A thinking (pre-TTS or mid-pause) turn plays nothing, so it
+  // keeps base-threshold sensitivity and pre-TTS barge-in (JARVIS-1266) is
+  // unaffected.
   private isAssistantAudioPlaying(): boolean {
-    const turn = this.activeAssistantTurn;
-    if (turn?.ttsAudioStarted && !turn.finalized) {
-      return true;
-    }
-    return Date.now() < this.assistantPlaybackTailUntilMs;
+    return (
+      Date.now() < this.assistantPlaybackTailUntilMs + this.echoDrainSlackMs
+    );
   }
 
   // Energy gate for classifying a server-VAD chunk as speech. While assistant
@@ -944,25 +967,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // not inflate the reference against them — and resets outside the echo
   // window so a loud turn's reference never leaks into the next one.
   //
-  // The freeze has a cold-start hole: at playback onset the very first loud
-  // echo chunk arms the guard, which would freeze the reference near zero and
-  // let steady onset echo complete a full guard run against the base
-  // threshold. So the window opens with a WARM-UP — the first
-  // echoEmaHalfLifeMs / 2 of in-window audio (200 ms at the 400 ms default,
-  // under the 250 ms default trip, so real barge-in latency is untouched) —
-  // during which the EMA learns despite the armed guard, at a quarter-
+  // Cold start: the reference knows nothing at window open, so the window
+  // opens with a WARM-UP — its first echoEmaHalfLifeMs / 2 of audio (200 ms
+  // at the 400 ms default) — during which the EMA learns at a quarter-
   // half-life attack rate (two attack half-lives per warm-up brings the
   // reference to ~75% of a steady echo level, putting margin × EMA above
-  // it): echo, not speech, is the expected first signal at TTS onset. Guard
-  // trips are deferred (the run accumulates, it doesn't fire) while the
-  // tripping chunk was judged against a warming reference — a per-chunk flag
-  // (echoGateChunkWarmingUp), so large ingress chunks cannot outrun the
-  // window clock. Onset echo's run is zeroed once the reference overtakes
-  // it; a genuine user run that outlasts the warm-up fires on its first warm
-  // chunk. The same warm-up floor guards the instant-barge-in config
-  // (bargeInMinSpeechMs 0), which otherwise bypasses the guard entirely (see
-  // handleVadSpeechStart). Warm-up is measured in processed audio time, the
-  // same clock that drives EMA convergence.
+  // it) and chunks are SUPPRESSED from speech classification entirely
+  // (handleServerVadAudio): echo, not speech, is the expected first signal
+  // when playback starts, and warm-up echo must not trip barge-in, arm an
+  // utterance, or stream to STT as user audio (a transcribed echo fragment
+  // would launch a ghost follow-up turn). The per-chunk flag
+  // (echoGateChunkWarmingUp) is captured before the window clock advances,
+  // so large ingress chunks cannot outrun it. Because the window is scoped
+  // to the client playback-drain estimate (isAssistantAudioPlaying), every
+  // TTS pause closes the window and every speech burst re-opens it with a
+  // fresh warm-up — the reference never goes stale against resumed echo. A
+  // user starting to speak inside a warm-up is absorbed into the reference
+  // (echo-first assumption) and recovers by pausing and speaking again once
+  // the gate is warm. Warm-up is measured in processed audio time, the same
+  // clock that drives EMA convergence.
   //
   // Turn collision: a guard with a LIVE speech run when the window opens is
   // the user already talking across the turn boundary — humans cannot react
@@ -1149,17 +1172,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // The client can still be draining audible playback after tts_done
     // (the turn is already cleared server-side) — that tail deserves the
     // same guard, or a noise blip clips the reply's last words.
-    const drainingPlayback = Date.now() < this.assistantPlaybackTailUntilMs;
+    const drainingPlayback = this.isAssistantAudioPlaying();
 
-    if (
-      (bargeableTurn || drainingPlayback) &&
-      (this.bargeInMinSpeechMs > 0 || this.echoGateChunkWarmingUp)
-    ) {
+    if ((bargeableTurn || drainingPlayback) && this.bargeInMinSpeechMs > 0) {
       // Onset audio keeps flowing into the cycle/pre-roll while the guard
       // accumulates (trackBargeInGuard), so no speech is lost either way.
-      // Instant barge-in (bargeInMinSpeechMs 0) still arms the guard while
-      // the echo gate is warming up — otherwise the first onset-echo chunk
-      // would cancel every turn — and resumes instant behavior once warm.
+      // Instant barge-in (bargeInMinSpeechMs 0) needs no warm-up handling
+      // here: warm-up chunks are suppressed at classification, so a speech
+      // onset cannot fire while the gate is warming.
       this.pendingBargeIn = { turn: bargeableTurn, speechMs: 0 };
       return;
     }
@@ -1197,11 +1217,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.context.startFrame.audio.sampleRate,
     );
     if (guard.speechMs < this.bargeInMinSpeechMs) {
-      return;
-    }
-    // Defer trips fed by a chunk judged against a warming echo reference —
-    // see effectiveSpeechThreshold. Turn-collision guards trip normally.
-    if (this.echoGateChunkWarmingUp) {
       return;
     }
     this.pendingBargeIn = null;
@@ -2964,6 +2979,7 @@ export function createLiveVoiceSession(
       options.echoBargeInMargin ?? vadConfig?.echoBargeInMargin,
     echoEmaHalfLifeMs:
       options.echoEmaHalfLifeMs ?? vadConfig?.echoEmaHalfLifeMs,
+    echoDrainSlackMs: options.echoDrainSlackMs ?? vadConfig?.echoDrainSlackMs,
     resolveCredentialReadiness:
       options.resolveCredentialReadiness === undefined
         ? defaultResolveLiveVoiceCredentialReadiness

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -407,14 +407,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // echo reference); 0 outside the echo window.
   private echoEnergyEma = 0;
   // Audio time (ms) processed since the echo window opened — drives the
-  // gate's warm-up (see isEchoGateWarmingUp); 0 outside the echo window.
+  // gate's warm-up (see effectiveSpeechThreshold); 0 outside the echo window.
   private echoWindowAudioMs = 0;
-  // True when the sustained-speech guard was already armed at the moment the
-  // echo window opened: speech that PREDATES playback is the user talking
-  // across the turn boundary (turn collision), not echo — humans cannot
-  // react to playback onset faster than the warm-up. That guard keeps
-  // user-first semantics (frozen reference, normal trips).
+  // A guard whose speech run predates the echo window is the user talking
+  // across the turn boundary (turn collision) — see effectiveSpeechThreshold.
   private echoWindowGuardCarryover = false;
+  // Warm-up state of the most recently classified in-window chunk (set by
+  // effectiveSpeechThreshold; consulted by handleVadSpeechStart and
+  // trackBargeInGuard) so classification and trip deferral agree per chunk
+  // regardless of ingress chunk size; false outside the echo window.
+  private echoGateChunkWarmingUp = false;
   // Mutable so a mid-session `update_config` frame can retune "interrupt
   // sensitivity" live (see applyConfigUpdate).
   private bargeInMinSpeechMs: number;
@@ -946,15 +948,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // echo chunk arms the guard, which would freeze the reference near zero and
   // let steady onset echo complete a full guard run against the base
   // threshold. So the window opens with a WARM-UP — the first
-  // echoEmaHalfLifeMs / 2 of in-window audio (200 ms at the 400 ms default) —
-  // during which the EMA learns at a fast attack rate (quarter half-life)
-  // and keeps learning even with the guard armed: echo, not speech, is the
-  // expected first signal at TTS onset. Guard trips are deferred (the run
-  // accumulates, it doesn't fire) until warm; at the default 250 ms trip the
-  // warm-up ends first, so real barge-in latency is untouched. Steady onset
-  // echo converges past its own margin inside the warm-up and its run is
-  // zeroed before it can fire. Warm-up is measured in processed audio time,
-  // the same clock that drives EMA convergence.
+  // echoEmaHalfLifeMs / 2 of in-window audio (200 ms at the 400 ms default,
+  // under the 250 ms default trip, so real barge-in latency is untouched) —
+  // during which the EMA learns despite the armed guard, at a quarter-
+  // half-life attack rate (two attack half-lives per warm-up brings the
+  // reference to ~75% of a steady echo level, putting margin × EMA above
+  // it): echo, not speech, is the expected first signal at TTS onset. Guard
+  // trips are deferred (the run accumulates, it doesn't fire) while the
+  // tripping chunk was judged against a warming reference — a per-chunk flag
+  // (echoGateChunkWarmingUp), so large ingress chunks cannot outrun the
+  // window clock. Onset echo's run is zeroed once the reference overtakes
+  // it; a genuine user run that outlasts the warm-up fires on its first warm
+  // chunk. The same warm-up floor guards the instant-barge-in config
+  // (bargeInMinSpeechMs 0), which otherwise bypasses the guard entirely (see
+  // handleVadSpeechStart). Warm-up is measured in processed audio time, the
+  // same clock that drives EMA convergence.
+  //
+  // Turn collision: a guard with a LIVE speech run when the window opens is
+  // the user already talking across the turn boundary — humans cannot react
+  // to playback onset within the warm-up — and keeps user-first semantics
+  // (frozen reference, normal trips). An armed guard whose run already
+  // zeroed is a settled noise blip and gets onset semantics. If a colliding
+  // user pauses mid-window, the collision is over and the warm-up restarts
+  // (see trackBargeInGuard) so the echo underneath is finally learned.
   private effectiveSpeechThreshold(
     chunk: Buffer,
     meanAmplitude: number,
@@ -965,12 +981,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.echoEnergyEma = 0;
       this.echoWindowAudioMs = 0;
       this.echoWindowGuardCarryover = false;
+      this.echoGateChunkWarmingUp = false;
       return baseThreshold;
     }
     if (this.echoWindowAudioMs === 0) {
-      // Window opening: a guard armed before any assistant audio played is
-      // the user mid-utterance (turn collision), not echo.
-      this.echoWindowGuardCarryover = this.pendingBargeIn !== null;
+      // Window opening: only a guard with a live run is a turn collision.
+      this.echoWindowGuardCarryover =
+        this.pendingBargeIn !== null && this.pendingBargeIn.speechMs > 0;
     } else if (this.pendingBargeIn === null) {
       // The carried-over guard settled; onset semantics resume for any
       // later speech in this window.
@@ -982,11 +999,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       baseThreshold,
       this.echoBargeInMargin * this.echoEnergyEma,
     );
+    const warmingUp =
+      !this.echoWindowGuardCarryover &&
+      this.echoWindowAudioMs < this.echoEmaHalfLifeMs / 2;
+    this.echoGateChunkWarmingUp = warmingUp;
     const chunkMs = pcm16DurationMs(
       chunk.byteLength,
       this.context.startFrame.audio.sampleRate,
     );
-    const warmingUp = this.echoOnsetWarmupActive();
     if (this.pendingBargeIn === null || warmingUp) {
       // Attack fast during warm-up (quarter half-life) so the reference
       // overtakes steady onset echo inside the warm-up window; settle to the
@@ -1000,26 +1020,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     this.echoWindowAudioMs += chunkMs;
     return threshold;
-  }
-
-  // True while the echo window has processed less than echoEmaHalfLifeMs / 2
-  // of audio (200 ms at the 400 ms default) — with the warm-up's quarter-
-  // half-life attack rate that is 2 attack half-lives, enough for the
-  // reference to reach ~75% of a steady echo level, putting margin × EMA
-  // above it. See effectiveSpeechThreshold.
-  private isEchoGateWarmingUp(): boolean {
-    return (
-      this.isAssistantAudioPlaying() &&
-      this.echoWindowAudioMs < this.echoEmaHalfLifeMs / 2
-    );
-  }
-
-  // Onset-echo semantics (fast unfrozen EMA learning + deferred guard trips)
-  // apply only during the warm-up AND when the speech run did not predate
-  // playback — a guard carried across the window boundary is the user, and
-  // keeps user-first semantics.
-  private echoOnsetWarmupActive(): boolean {
-    return !this.echoWindowGuardCarryover && this.isEchoGateWarmingUp();
   }
 
   private async routeVadAudio(
@@ -1151,9 +1151,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // same guard, or a noise blip clips the reply's last words.
     const drainingPlayback = Date.now() < this.assistantPlaybackTailUntilMs;
 
-    if ((bargeableTurn || drainingPlayback) && this.bargeInMinSpeechMs > 0) {
+    if (
+      (bargeableTurn || drainingPlayback) &&
+      (this.bargeInMinSpeechMs > 0 || this.echoGateChunkWarmingUp)
+    ) {
       // Onset audio keeps flowing into the cycle/pre-roll while the guard
       // accumulates (trackBargeInGuard), so no speech is lost either way.
+      // Instant barge-in (bargeInMinSpeechMs 0) still arms the guard while
+      // the echo gate is warming up — otherwise the first onset-echo chunk
+      // would cancel every turn — and resumes instant behavior once warm.
       this.pendingBargeIn = { turn: bargeableTurn, speechMs: 0 };
       return;
     }
@@ -1177,6 +1183,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     if (!hasSpeech) {
       guard.speechMs = 0;
+      if (this.echoWindowGuardCarryover) {
+        // The colliding user paused: the collision is over. Restart the
+        // onset warm-up so whatever follows (echo, or the user again) gets
+        // onset semantics and the echo underneath is finally learned.
+        this.echoWindowGuardCarryover = false;
+        this.echoWindowAudioMs = 0;
+      }
       return;
     }
     guard.speechMs += pcm16DurationMs(
@@ -1186,13 +1199,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (guard.speechMs < this.bargeInMinSpeechMs) {
       return;
     }
-    // Defer trips while the echo gate's onset warm-up is active (see
-    // effectiveSpeechThreshold): the run keeps accumulating, and a genuine
-    // user run fires on the first speech chunk after warm-up, while onset
-    // echo's run is zeroed once the converged reference reclassifies it. A
-    // guard carried over from before playback started (turn collision) is
-    // the user and trips normally.
-    if (this.echoOnsetWarmupActive()) {
+    // Defer trips fed by a chunk judged against a warming echo reference —
+    // see effectiveSpeechThreshold. Turn-collision guards trip normally.
+    if (this.echoGateChunkWarmingUp) {
       return;
     }
     this.pendingBargeIn = null;

--- a/assistant/src/stt/__tests__/speech-energy.test.ts
+++ b/assistant/src/stt/__tests__/speech-energy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_SPEECH_ENERGY_THRESHOLD,
   detectPcm16SpeechActivity,
+  pcm16MeanAmplitude,
 } from "../speech-energy.js";
 
 /** Build a PCM16LE buffer from an array of sample values. */
@@ -64,5 +65,49 @@ describe("detectPcm16SpeechActivity", () => {
     expect(detectPcm16SpeechActivity(quiet)).toBe(false);
     expect(detectPcm16SpeechActivity(quiet, 400)).toBe(true);
     expect(detectPcm16SpeechActivity(quiet, 500)).toBe(false);
+  });
+});
+
+describe("pcm16MeanAmplitude", () => {
+  test("empty buffer returns 0", () => {
+    expect(pcm16MeanAmplitude(Buffer.alloc(0))).toBe(0);
+  });
+
+  test("constant-amplitude buffer returns the exact mean", () => {
+    expect(pcm16MeanAmplitude(pcm16(new Array(100).fill(1234)))).toBe(1234);
+  });
+
+  test("negative samples contribute their absolute value", () => {
+    const samples = Array.from({ length: 160 }, (_, i) =>
+      i % 2 === 0 ? 2000 : -2000,
+    );
+    expect(pcm16MeanAmplitude(pcm16(samples))).toBe(2000);
+  });
+
+  test("odd-length buffer ignores the trailing byte", () => {
+    const constant = pcm16(new Array(50).fill(3000));
+    const withTrailing = Buffer.concat([constant, Buffer.from([0x01])]);
+    expect(pcm16MeanAmplitude(withTrailing)).toBe(3000);
+  });
+
+  test("detectPcm16SpeechActivity is equivalent to comparing the mean against the threshold", () => {
+    const buffers = [
+      Buffer.alloc(0),
+      pcm16(new Array(160).fill(0)),
+      pcm16(new Array(100).fill(500)),
+      pcm16(new Array(100).fill(DEFAULT_SPEECH_ENERGY_THRESHOLD)),
+      pcm16(new Array(100).fill(DEFAULT_SPEECH_ENERGY_THRESHOLD + 1)),
+      pcm16(
+        Array.from({ length: 160 }, (_, i) => (i % 2 === 0 ? 10000 : -10000)),
+      ),
+    ];
+    const thresholds = [400, 500, DEFAULT_SPEECH_ENERGY_THRESHOLD, 12000];
+    for (const chunk of buffers) {
+      for (const threshold of thresholds) {
+        expect(detectPcm16SpeechActivity(chunk, threshold)).toBe(
+          pcm16MeanAmplitude(chunk) > threshold,
+        );
+      }
+    }
   });
 });

--- a/assistant/src/stt/speech-energy.ts
+++ b/assistant/src/stt/speech-energy.ts
@@ -19,6 +19,27 @@
 export const DEFAULT_SPEECH_ENERGY_THRESHOLD = 800;
 
 /**
+ * Mean absolute sample amplitude of a chunk of little-endian signed
+ * 16-bit mono PCM, on the 16-bit linear scale. Returns 0 for empty
+ * buffers; a trailing odd byte is ignored.
+ *
+ * @param chunk - Raw PCM16LE audio.
+ * @returns Mean absolute amplitude on the 16-bit linear scale.
+ */
+export function pcm16MeanAmplitude(chunk: Buffer): number {
+  const sampleCount = Math.floor(chunk.length / 2);
+  if (sampleCount === 0) {
+    return 0;
+  }
+
+  let totalAmplitude = 0;
+  for (let i = 0; i < sampleCount; i++) {
+    totalAmplitude += Math.abs(chunk.readInt16LE(i * 2));
+  }
+  return totalAmplitude / sampleCount;
+}
+
+/**
  * Detect speech activity in a chunk of little-endian signed 16-bit mono
  * PCM samples.
  *
@@ -34,16 +55,5 @@ export function detectPcm16SpeechActivity(
   chunk: Buffer,
   threshold = DEFAULT_SPEECH_ENERGY_THRESHOLD,
 ): boolean {
-  const sampleCount = Math.floor(chunk.length / 2);
-  if (sampleCount === 0) {
-    return false;
-  }
-
-  let totalAmplitude = 0;
-  for (let i = 0; i < sampleCount; i++) {
-    totalAmplitude += Math.abs(chunk.readInt16LE(i * 2));
-  }
-  const avgAmplitude = totalAmplitude / sampleCount;
-
-  return avgAmplitude > threshold;
+  return pcm16MeanAmplitude(chunk) > threshold;
 }

--- a/assistant/src/stt/speech-energy.ts
+++ b/assistant/src/stt/speech-energy.ts
@@ -24,7 +24,6 @@ export const DEFAULT_SPEECH_ENERGY_THRESHOLD = 800;
  * buffers; a trailing odd byte is ignored.
  *
  * @param chunk - Raw PCM16LE audio.
- * @returns Mean absolute amplitude on the 16-bit linear scale.
  */
 export function pcm16MeanAmplitude(chunk: Buffer): number {
   const sampleCount = Math.floor(chunk.length / 2);


### PR DESCRIPTION
## Summary
Open-mic live voice no longer barges in on itself at high speaker volume. The energy VAD's speech gate becomes echo-adaptive while assistant audio is audibly draining at the client: an EMA of mic energy (the echo reference) sets the effective threshold at `max(speechEnergyThreshold, echoBargeInMargin × EMA)`, so steady echo converges under its own margin while genuine user speech — which stacks on top of the echo — still barges in. The window is scoped to the per-chunk client playback-drain estimate (+ `echoDrainSlackMs`), each burst opens with a fast-attack warm-up whose chunks are suppressed as presumed echo (no barge-in trips, no utterance arming, no STT ghost turns), and the echo-first assumption is bounded (`ECHO_ONSET_ELIGIBILITY_MS`): under effective client AEC — the common case — the gate goes inert and barge-in keeps full base-threshold sensitivity. Turn collisions (user talking across the reply boundary) keep user-first semantics; an absorbed early barger recovers via reference expiry on pause-and-retry.

New config: `liveVoice.vad.echoBargeInMargin` (1.5), `echoEmaHalfLifeMs` (400), `echoDrainSlackMs` (300). The 250ms `bargeInMinSpeechMs` guard is unchanged.

**Known accepted residual** (documented in the gate's canonical comment): within one continuous loud burst, an unusually shaped echo profile (slow ~300ms+ crescendo from sub-threshold, or a dip that stays above base) can leave the armed-guard-frozen reference below live echo and let it run out the guard. Real TTS onsets attack far faster than this; the alternatives measurably worsen genuine barge-in.

## Self-review result
GAPS FOUND → fixed across 4 rounds / 4 fix PRs (each round's adversarial state-machine trace found and closed real holes: cold-start freeze, chunk granularity, ghost utterances, drain-gap decay, transport-lag warm-up burn, quiet-playback lockout). All Codex review threads resolved.

## PRs merged into feature branch
- #38319: feat(voice): expose pcm16 mean amplitude and echo-adaptive VAD config
- #38325: fix(voice): echo-adaptive barge-in — loud speaker echo no longer self-interrupts (JARVIS-1296)

### Fix PRs
- #38333: close the carryover, instant-mode, and chunk-granularity holes
- #38341: drain-scoped echo window, warm-up speech suppression, tail slack
- #38344: signal-gated echo learning; drop warm-up echo from pre-roll
- #38347: bounded echo-first eligibility restores quiet-playback barge-in

Part of plan: echo-adaptive-bargein.md

Closes JARVIS-1296