### PR TITLE
fix(ci): re-record subagent SKILL.md docs-sync fingerprint

### DIFF
--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -55,7 +55,7 @@
     },
     "subagent": {
       "docsSlug": "subagent",
-      "sha256": "c0bb5268d5dc18b38375f2db4e379a941c4ab5082c1375720fcb8949e3f7e09e"
+      "sha256": "c6c75fd2b200c09f7c12b60a87846ffbc6b8021723532f2d4b13bdd87c4683b2"
     },
     "transcribe": {
       "docsSlug": "transcribe",


### PR DESCRIPTION
## Summary
- Re-records the `subagent` fingerprint in `scripts/skill-docs-sync.manifest.json`, fixing the `skill-docs-sync-guard.test.ts` failure on main introduced by #38350 (which changed `subagent/SKILL.md` without the acknowledgment bump).
- The public reference page (https://www.vellum.ai/docs/skills-reference/subagent) was reviewed per the guard's workflow: its Roles table already marks researcher/planner/investigator as read-only and describes Coder as the role for writing files and running commands, so the SKILL.md change (assistant-side routing guidance + internal blocked-signal constraint) requires no platform docs update.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29532644802/job/87736364225 — the Test job of "CI Main Assistant Checks" on main, which failed because the subagent SKILL.md changed in #38350 without re-recording its docs-sync fingerprint.