### PR TITLE
fix(subagent): surface attempted-but-denied tools in the parent terminal notification

### DIFF
--- a/assistant/src/__tests__/subagent-terminal-message.test.ts
+++ b/assistant/src/__tests__/subagent-terminal-message.test.ts
@@ -96,4 +96,54 @@ describe("buildSubagentTerminalMessage", () => {
     expect(msg).toContain("Error: boom");
     expect(msg).toContain("Do NOT re-spawn or retry");
   });
+
+  test("appends a denied-tools note to an inlined completion", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "write-report",
+      subagentId: "sa-7",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "Here is what I found.",
+      deniedTools: ["file_write"],
+    });
+
+    expect(msg).toContain("Here is what I found.");
+    expect(msg).toContain("attempted file_write");
+    expect(msg).toContain("does not permit it");
+    expect(msg).toContain("re-spawn with a role that includes it");
+    expect(msg).toContain("coder");
+  });
+
+  test("appends a pluralized denied-tools note to a read-pointer completion", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "empty-write",
+      subagentId: "sa-8",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "   ",
+      deniedTools: ["file_write", "file_edit"],
+    });
+
+    expect(msg).toContain('subagent_read with subagent_id "sa-8"');
+    expect(msg).toContain("attempted file_write, file_edit");
+    expect(msg).toContain("does not permit them");
+    expect(msg).toContain("re-spawn with a role that includes them");
+  });
+
+  test("omits the denied-tools note when none were denied", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "clean",
+      subagentId: "sa-9",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "All done.",
+      deniedTools: [],
+    });
+
+    expect(msg).not.toContain("does not permit");
+    expect(msg).not.toContain("re-spawn");
+  });
 });

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -365,6 +365,79 @@ describe("createToolExecutor — execution-layer allowlist gate", () => {
     expect(calls[0]!.name).toBe("remember");
   });
 
+  test("execution mode: a denied call is recorded on subagentDeniedToolNames", async () => {
+    const denied = new Set<string>();
+    const { executor } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentAllowedTools: new Set(["remember"]),
+        subagentToolGateMode: "execution",
+        subagentDeniedToolNames: denied,
+      }),
+    );
+
+    await toolFn("bash", { command: "echo hi" });
+
+    expect([...denied]).toEqual(["bash"]);
+  });
+
+  test("skill_execute records the resolved inner tool, not the wrapper", async () => {
+    const denied = new Set<string>();
+    const { executor } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentAllowedTools: new Set(["remember"]),
+        subagentToolGateMode: "execution",
+        subagentDeniedToolNames: denied,
+      }),
+    );
+
+    await toolFn("skill_execute", {
+      tool: "bash",
+      input: { command: "echo hi" },
+    });
+
+    expect(denied.has("bash")).toBe(true);
+    expect(denied.has("skill_execute")).toBe(false);
+  });
+
+  test("records a non-allowlisted attempt even in wire gate mode (observation only)", async () => {
+    const denied = new Set<string>();
+    const { executor } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      // No subagentToolGateMode → "wire": the executor does not reject here, but
+      // the out-of-allowlist attempt is still recorded for parent reporting.
+      makeSetupCtx({
+        subagentAllowedTools: new Set(["remember"]),
+        subagentDeniedToolNames: denied,
+      }),
+    );
+
+    await toolFn("bash", { command: "echo hi" });
+
+    expect(denied.has("bash")).toBe(true);
+  });
+
+  test("an allowlisted call records nothing", async () => {
+    const denied = new Set<string>();
+    const { executor } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentAllowedTools: new Set(["remember"]),
+        subagentToolGateMode: "execution",
+        subagentDeniedToolNames: denied,
+      }),
+    );
+
+    await toolFn("remember", { content: "a fact" });
+
+    expect([...denied]).toEqual([]);
+  });
+
   test("execution mode: skill_execute gates the resolved inner tool, executor never invoked", async () => {
     const { executor, calls } = makeCapturingExecutor();
     const toolFn = makeToolFn(

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -199,10 +199,16 @@ export function createToolExecutor(
   const rejectNonAllowlistedTool = (
     toolName: string,
   ): ToolExecutionResult | null => {
+    const allowlist = ctx.subagentAllowedTools;
+    // Record any attempt at a tool outside the subagent's role allowlist — in
+    // both wire and execution gate modes — so the parent can be told what the
+    // subagent needed but lacked. Pure observation; the gating is below.
+    if (allowlist !== undefined && !allowlist.has(toolName)) {
+      ctx.subagentDeniedToolNames?.add(toolName);
+    }
     if (ctx.subagentToolGateMode !== "execution") {
       return null;
     }
-    const allowlist = ctx.subagentAllowedTools;
     if (!allowlist || allowlist.has(toolName)) {
       return null;
     }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -320,6 +320,14 @@ export class Conversation {
   /** @internal */ preactivatedSkillIds?: string[];
   /** @internal */ subagentAllowedTools?: Set<string>;
   /**
+   * Tool names a subagent attempted but that its role allowlist
+   * ({@link subagentAllowedTools}) denied. Recorded by the tool executor;
+   * surfaced to the parent in the terminal notification so it can re-spawn with
+   * a role that includes them. Ephemeral, never persisted.
+   * @internal
+   */
+  subagentDeniedToolNames = new Set<string>();
+  /**
    * How {@link subagentAllowedTools} is enforced — see
    * {@link SubagentToolGateMode}. Set and restored alongside the allowlist
    * by `scopeWakeAllowedTools`.

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -81,6 +81,12 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   /** When set, the subagent/wake tool allowlist (see {@link subagentToolGateMode}). */
   subagentAllowedTools?: Set<string>;
   /**
+   * Collects tool names the subagent attempted but that
+   * {@link subagentAllowedTools} denied, for parent-visible reporting. The
+   * executor records into this Set (shared by reference with the Conversation).
+   */
+  subagentDeniedToolNames?: Set<string>;
+  /**
    * How {@link subagentAllowedTools} is enforced. Absent or `"wire"` keeps
    * the historical behavior (definitions filtered before the provider
    * request); `"execution"` keeps the full tool surface on the wire and

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -153,6 +153,8 @@ export function buildSubagentTerminalMessage(opts: {
   error?: string;
   /** A follow-up turn is still queued, so the current synthesis is a snapshot. */
   deferred?: boolean;
+  /** Tools the subagent attempted but that its role allowlist denied. */
+  deniedTools?: string[];
 }): string {
   const {
     label,
@@ -163,8 +165,18 @@ export function buildSubagentTerminalMessage(opts: {
     finalText,
     error,
     deferred,
+    deniedTools,
   } = opts;
   const prefix = isFork ? "Fork" : "Subagent";
+
+  // When the subagent reached for tools its role does not permit, tell the
+  // parent so it re-spawns with a capable role instead of blindly retrying (a
+  // read-only role produces nothing). Only attached to completed outcomes.
+  const many = (deniedTools?.length ?? 0) > 1;
+  const deniedNote =
+    deniedTools && deniedTools.length > 0
+      ? `\n\nNote: this ${prefix.toLowerCase()} attempted ${deniedTools.join(", ")} but its role does not permit ${many ? "them" : "it"}. If the objective requires ${many ? "those" : "that"}, re-spawn with a role that includes ${many ? "them" : "it"} (e.g. \`coder\`).`
+      : "";
 
   if (outcome === "failed") {
     return (
@@ -181,7 +193,8 @@ export function buildSubagentTerminalMessage(opts: {
       `${trimmed}\n\n` +
       (silent
         ? `(Use these findings internally; do not relay the raw ${prefix.toLowerCase()} output to the user.)`
-        : `(Incorporate this into your reply to the user as appropriate.)`)
+        : `(Incorporate this into your reply to the user as appropriate.)`) +
+      deniedNote
     );
   }
 
@@ -195,7 +208,8 @@ export function buildSubagentTerminalMessage(opts: {
   return (
     `[${prefix} "${label}" completed]\n\n` +
     `${reason}. Use subagent_read with subagent_id "${subagentId}"${lastN} for the latest output.` +
-    (silent ? ` Keep the result internal.` : ``)
+    (silent ? ` Keep the result internal.` : ``) +
+    deniedNote
   );
 }
 
@@ -773,6 +787,9 @@ export class SubagentManager {
       // Capture the trailing assistant text before any release nulls the
       // conversation reference. The fire-and-forget caller ignores the return.
       finalText = extractFinalAssistantText(conversation.messages);
+      // Capture any tools the subagent reached for but its role denied, before a
+      // release nulls the conversation reference, so we can tell the parent.
+      const deniedTools = [...conversation.subagentDeniedToolNames];
       // Copy usage stats from the conversation before sending status (which includes usage).
       managed.state.usage = { ...conversation.usageStats };
       // Only update state + notify if still non-terminal (guards against abort race).
@@ -787,7 +804,12 @@ export class SubagentManager {
         // round-trip. Skipped on the synchronous path — the awaiting caller
         // receives the final text directly.
         if (!managed.synchronous) {
-          this.notifyParentTerminal(managed, "completed", finalText);
+          this.notifyParentTerminal(
+            managed,
+            "completed",
+            finalText,
+            deniedTools,
+          );
         }
       }
     } catch (err) {
@@ -1398,6 +1420,7 @@ export class SubagentManager {
     managed: ManagedSubagent,
     outcome: "completed" | "failed",
     finalText?: string,
+    deniedTools?: string[],
   ): void {
     const { config } = managed.state;
     const isFork = managed.state.isFork;
@@ -1418,6 +1441,7 @@ export class SubagentManager {
       // A queued follow-up turn means the snapshot we hold is stale; defer to a
       // read pointer so the parent picks up the queued turn's output instead.
       deferred: managed.hadEnqueuedMessages === true,
+      deniedTools,
     });
 
     const notification: SubagentNotificationInfo = {


### PR DESCRIPTION
## Summary

- Follow-up to the subagent write-guidance PR: a **mechanical, parent-visible backstop** for when a subagent *does* reach for a tool its role denies. The executor now records each attempted-but-denied tool onto an ephemeral `subagentDeniedToolNames` Set on the conversation, and the terminal notification tells the parent — e.g. _"this subagent attempted file_write but its role does not permit it. If the objective requires that, re-spawn with a role that includes it (e.g. `coder`)."_
- Recording lives in the **single denial choke point** (`rejectNonAllowlistedTool` inside `createToolExecutor`), so it covers both the direct dispatch path and the `skill_execute` inner path, in both wire and execution gate modes — pure observation, no control-flow change. Guarded strictly on `subagentAllowedTools && !has(name)`, so it never records for non-subagent conversations or for allowed tools.
- The conversation *is* the executor's `ToolSetupContext` (`this as ToolSetupContext`), so the Set is shared by reference — `manager.ts` reads `conversation.subagentDeniedToolNames` at completion and threads it through `notifyParentTerminal` → `buildSubagentTerminalMessage` (a new `deniedTools?` opt, attached only to completed outcomes, pluralized). Ephemeral, never persisted — no migration, no feature flag.

Per review, the `subagent-tool-gate-mode.test.ts` suite (which exercises `createToolExecutor`, including the `skill_execute` inner-gate path) is in the regression run and gains the new tracking tests (execution-mode denial, skill_execute inner name, wire-mode observation, allowed-tool no-op).

## Original prompt

Second of the two subagent-researcher-write PRs (Change 3): after PR1's prevention + blocked-signal guidance, add a mechanical backstop that surfaces to the parent which tools a subagent attempted but its role denied, so the parent re-spawns with a write-capable role instead of blindly retrying a read-only one. Records at the single allowlist choke point (covering both dispatch paths and both gate modes) and reports it in the terminal notification — with `subagent-tool-gate-mode.test.ts` in the regression run per review.