### PR TITLE
fix(web): neutral radar on Personality card when no sliders persisted

### DIFF
--- a/clients/web/src/assistant/personality-sliders.test.ts
+++ b/clients/web/src/assistant/personality-sliders.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Pins the read contract the overview's Personality card leans on: a
+ * genuinely missing sidecar (404) resolves `null` so the card can plot the
+ * neutral radar, but every other failure throws so a transient read error
+ * degrades to a no-stat card instead of an all-centered radar over saved dials.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const workspaceFileGetMock = mock(
+  async (): Promise<{ data?: unknown; error?: unknown; response: unknown }> => ({
+    response: { ok: true, status: 200 },
+  }),
+);
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  workspaceFileGet: workspaceFileGetMock,
+  workspaceWritePost: mock(async () => ({ response: { ok: true, status: 200 } })),
+}));
+
+const { fetchPersonalitySliders } = await import("./personality-sliders");
+
+beforeEach(() => {
+  workspaceFileGetMock.mockClear();
+});
+
+describe("fetchPersonalitySliders", () => {
+  test("returns null when the sidecar was never persisted (404)", async () => {
+    workspaceFileGetMock.mockResolvedValueOnce({
+      response: { ok: false, status: 404 },
+    });
+
+    expect(await fetchPersonalitySliders("ast-1")).toBeNull();
+  });
+
+  test("returns the parsed values when the sidecar exists", async () => {
+    workspaceFileGetMock.mockResolvedValueOnce({
+      data: { content: JSON.stringify({ "playful-serious": 80 }) },
+      response: { ok: true, status: 200 },
+    });
+
+    expect(await fetchPersonalitySliders("ast-1")).toEqual({
+      "playful-serious": 80,
+    });
+  });
+
+  test("throws on a non-OK response that is not a 404", async () => {
+    workspaceFileGetMock.mockResolvedValueOnce({
+      response: { ok: false, status: 500 },
+    });
+
+    await expect(fetchPersonalitySliders("ast-1")).rejects.toThrow();
+  });
+
+  test("throws when the sidecar content is malformed", async () => {
+    workspaceFileGetMock.mockResolvedValueOnce({
+      data: { content: JSON.stringify({ "playful-serious": "loud" }) },
+      response: { ok: true, status: 200 },
+    });
+
+    await expect(fetchPersonalitySliders("ast-1")).rejects.toThrow();
+  });
+});

--- a/clients/web/src/assistant/personality-sliders.ts
+++ b/clients/web/src/assistant/personality-sliders.ts
@@ -50,28 +50,33 @@ export function completeSliderValues(
   );
 }
 
-/** Resolves `null` when the sidecar is missing or unreadable; never throws. */
+/**
+ * Resolves `null` only when the sidecar was never persisted (a 404); every
+ * other failure — non-OK response, network error, malformed JSON — throws.
+ * Callers rely on that split: a missing sidecar falls back to neutral
+ * defaults, but a transient read error must degrade to no-stat rather than
+ * overwrite a user's saved dials with an all-centered radar.
+ */
 export async function fetchPersonalitySliders(
   assistantId: string,
 ): Promise<PersonalitySliderValues | null> {
-  try {
-    const { data, error, response } = await workspaceFileGet({
-      path: { assistant_id: assistantId },
-      query: { path: PERSONALITY_SLIDERS_PATH },
-      throwOnError: false,
-    });
-    assertHasResponse(response, error, "Failed to fetch personality sliders");
-    if (!response.ok || !data) {
-      return null;
-    }
-    const parsed: unknown = JSON.parse(data.content);
-    if (!isSliderValues(parsed)) {
-      return null;
-    }
-    return parsed;
-  } catch {
+  const { data, error, response } = await workspaceFileGet({
+    path: { assistant_id: assistantId },
+    query: { path: PERSONALITY_SLIDERS_PATH },
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to fetch personality sliders");
+  if (response.status === 404) {
     return null;
   }
+  if (!response.ok || !data) {
+    throw new Error("Failed to fetch personality sliders");
+  }
+  const parsed: unknown = JSON.parse(data.content);
+  if (!isSliderValues(parsed)) {
+    throw new Error("Personality sliders sidecar is malformed");
+  }
+  return parsed;
 }
 
 /** Best-effort write; resolves `false` on failure, never throws. */

--- a/clients/web/src/domains/intelligence/use-identity-section-stats.ts
+++ b/clients/web/src/domains/intelligence/use-identity-section-stats.ts
@@ -135,10 +135,11 @@ export function useIdentitySectionStats(
 
   return {
     personality: {
-      // Once the fetch resolves, always plot a radar: assistants with no
-      // persisted sidecar (onboarded before it was saved, or never touched
-      // the sliders) fall back to the all-centered neutral shape rather than
-      // a blank card. `undefined` only while the fetch is still pending.
+      // `null` means the sidecar was never persisted (onboarded before it
+      // was saved, or never touched the sliders) — fall back to the
+      // all-centered neutral shape instead of a blank card. `undefined`
+      // covers still-loading and read errors, which stay a no-stat card so a
+      // transient failure never overwrites saved dials with a neutral radar.
       radar:
         sliders.data !== undefined
           ? completeSliderValues(sliders.data ?? {})

--- a/clients/web/src/domains/intelligence/use-identity-section-stats.ts
+++ b/clients/web/src/domains/intelligence/use-identity-section-stats.ts
@@ -135,7 +135,14 @@ export function useIdentitySectionStats(
 
   return {
     personality: {
-      radar: sliders.data ? completeSliderValues(sliders.data) : undefined,
+      // Once the fetch resolves, always plot a radar: assistants with no
+      // persisted sidecar (onboarded before it was saved, or never touched
+      // the sliders) fall back to the all-centered neutral shape rather than
+      // a blank card. `undefined` only while the fetch is still pending.
+      radar:
+        sliders.data !== undefined
+          ? completeSliderValues(sliders.data ?? {})
+          : undefined,
     },
     skills:
       skills.data !== undefined


### PR DESCRIPTION
## Summary

Follow-up to #38302. That PR started persisting the onboarding personality sliders, but assistants onboarded **before** it (or that never touched the sliders) still have no `data/personality-sliders.json` sidecar — so `fetchPersonalitySliders` resolves to `null` and the overview's **Personality card renders completely blank**.

This makes the card fall back to a neutral shape — the equivalent of every dimension centered — instead of nothing.

## Change

In `use-identity-section-stats.ts`, distinguish the two non-value states of the query:

- `data === undefined` → fetch still pending → no radar yet (unchanged; card degrades silently during load like the other stats)
- `data === null` → fetch resolved, no sidecar → fall back to `completeSliderValues({})`, the all-centered neutral pentagon

`completeSliderValues({})` fills every `PERSONALITY_AXIS_IDS` axis with the `50` default, which the existing `PersonalityRadar` renders as the mid-radius neutral pentagon.

## Testing

- `bunx tsc --noEmit` clean on the touched file (repo has unrelated pre-existing stale-codegen errors on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)