### PR TITLE
test(subagent): stub subagentDeniedToolNames on fake subagent conversations

### DIFF
--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -22,6 +22,7 @@ interface FakeManagedSubagent {
       outputTokens: number;
       estimatedCost: number;
     };
+    subagentDeniedToolNames: Set<string>;
   } | null;
   state: SubagentState;
   parentSendToClient: (msg: ServerMessage) => void;
@@ -51,6 +52,7 @@ function makeFakeConversation(): NonNullable<
     messages: [],
     sendToClient: () => {},
     usageStats: { inputTokens: 100, outputTokens: 50, estimatedCost: 0.005 },
+    subagentDeniedToolNames: new Set<string>(),
   };
 }
 

--- a/assistant/src/__tests__/subagent-fork-notifications.test.ts
+++ b/assistant/src/__tests__/subagent-fork-notifications.test.ts
@@ -51,6 +51,7 @@ interface FakeManagedSubagent {
       outputTokens: number;
       estimatedCost: number;
     };
+    subagentDeniedToolNames: Set<string>;
   } | null;
   state: SubagentState;
   parentSendToClient: (msg: ServerMessage) => void;
@@ -80,6 +81,7 @@ function injectFakeSubagent(
     messages: [],
     sendToClient: () => {},
     usageStats: { inputTokens: 100, outputTokens: 50, estimatedCost: 0.005 },
+    subagentDeniedToolNames: new Set<string>(),
   };
 
   const internals = asInternals(manager);

--- a/assistant/src/__tests__/subagent-fork-spawn.test.ts
+++ b/assistant/src/__tests__/subagent-fork-spawn.test.ts
@@ -28,6 +28,7 @@ interface FakeManagedSubagent {
       outputTokens: number;
       estimatedCost: number;
     };
+    subagentDeniedToolNames: Set<string>;
   } | null;
   state: SubagentState;
   parentSendToClient: (msg: ServerMessage) => void;
@@ -57,6 +58,7 @@ function makeFakeConversation(): NonNullable<
     messages: [],
     sendToClient: () => {},
     usageStats: { inputTokens: 100, outputTokens: 50, estimatedCost: 0.005 },
+    subagentDeniedToolNames: new Set<string>(),
   };
 }
 

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -51,6 +51,7 @@ interface FakeManagedSubagent {
       outputTokens: number;
       estimatedCost: number;
     };
+    subagentDeniedToolNames: Set<string>;
   } | null;
   state: SubagentState;
   parentSendToClient: (msg: ServerMessage) => void;
@@ -84,6 +85,7 @@ function injectFakeSubagent(
     messages: [],
     sendToClient: () => {},
     usageStats: { inputTokens: 100, outputTokens: 50, estimatedCost: 0.005 },
+    subagentDeniedToolNames: new Set<string>(),
   };
 
   const internals = asInternals(manager);

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -56,6 +56,7 @@ let lastPersistedUserMessage: string | undefined;
 class FakeConversation {
   messages: Message[];
   usageStats = { inputTokens: 10, outputTokens: 5, estimatedCost: 0.001 };
+  subagentDeniedToolNames = new Set<string>();
   conversationType = "background";
   hasSystemPromptOverride = false;
 


### PR DESCRIPTION
## Summary
- Fixes the red `Test` job on main ([run 29533297342](https://github.com/vellum-ai/vellum-assistant/actions/runs/29533297342/job/87738474498)): four subagent test files failed after #38352 because `runSubagent` now spreads `conversation.subagentDeniedToolNames`, which the test fakes lacked — the spread threw (`Spread syntax requires ...iterable not be null or undefined`) and the catch path flipped `completed` outcomes to `failed`.
- Adds `subagentDeniedToolNames: new Set<string>()` to every fake conversation that flows through `runSubagent`, mirroring the existing `usageStats` stubs: `subagent-spawn-and-await`, `subagent-fork-notifications`, `subagent-disposal`, `subagent-manager-notify`, plus `subagent-fork-spawn`, which exercises the same path but happened to pass because its assertions never touch the affected branch.
- Test-only change; the production `Conversation` class already initializes the field, so runtime behavior is unchanged.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29533297342/job/87738474498 — the `Test` job of "CI Main Assistant Checks" on main, which went red after #38352 merged. Scope limited to making that job green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)