### PR TITLE
fix(voice): friendly STT/TTS errors + forgiving STT provider aliases (Tier 1)

### DIFF
--- a/assistant/src/config/schemas/__tests__/stt.test.ts
+++ b/assistant/src/config/schemas/__tests__/stt.test.ts
@@ -41,6 +41,31 @@ describe("SttServiceSchema", () => {
   test("VALID_STT_PROVIDERS includes deepgram", () => {
     expect(VALID_STT_PROVIDERS).toContain("deepgram");
   });
+
+  test("normalizes the openai/whisper aliases to openai-whisper", () => {
+    expect(SttServiceSchema.parse({ provider: "openai" }).provider).toBe(
+      "openai-whisper",
+    );
+    expect(SttServiceSchema.parse({ provider: "whisper" }).provider).toBe(
+      "openai-whisper",
+    );
+    // Case- and whitespace-tolerant.
+    expect(SttServiceSchema.parse({ provider: "  OpenAI  " }).provider).toBe(
+      "openai-whisper",
+    );
+  });
+
+  test("a canonical provider is unchanged by the alias preprocessor", () => {
+    expect(
+      SttServiceSchema.parse({ provider: "openai-whisper" }).provider,
+    ).toBe("openai-whisper");
+  });
+
+  test("rejects an unknown provider with a helpful message", () => {
+    expect(() => SttServiceSchema.parse({ provider: "nope" })).toThrow(
+      /must be one of/,
+    );
+  });
 });
 
 describe("managed mode", () => {
@@ -70,9 +95,9 @@ describe("managed mode", () => {
   });
 
   test("effectiveSttProvider routes provider vellum and managed mode to vellum, preserves BYOK otherwise", () => {
-    expect(
-      effectiveSttProvider({ mode: "your-own", provider: "vellum" }),
-    ).toBe("vellum");
+    expect(effectiveSttProvider({ mode: "your-own", provider: "vellum" })).toBe(
+      "vellum",
+    );
     expect(
       effectiveSttProvider({ mode: "managed", provider: "deepgram" }),
     ).toBe("vellum");

--- a/assistant/src/config/schemas/stt.ts
+++ b/assistant/src/config/schemas/stt.ts
@@ -13,6 +13,19 @@ export const VALID_STT_PROVIDERS = [
 ] as const;
 
 /**
+ * Forgiving aliases normalized to a canonical provider id before the enum
+ * check, so a natural value like `openai` or `whisper` is accepted rather than
+ * silently reset (which cascades into a full `services` section reset).
+ */
+const STT_PROVIDER_ALIASES: Record<
+  string,
+  (typeof VALID_STT_PROVIDERS)[number]
+> = {
+  openai: "openai-whisper",
+  whisper: "openai-whisper",
+};
+
+/**
  * Sparse provider config map under `services.stt.providers`.
  *
  * This is a forward-compatible record that accepts any provider ID as key
@@ -51,9 +64,18 @@ export const SttServiceSchema = z
         'STT service mode -- "your-own" uses the configured provider with your API key; "managed" transcribes through your Vellum account',
       ),
     provider: z
-      .enum(VALID_STT_PROVIDERS, {
-        error: `services.stt.provider must be one of: ${VALID_STT_PROVIDERS.join(", ")}`,
-      })
+      .preprocess(
+        (v) => {
+          if (typeof v !== "string") {
+            return v;
+          }
+          const k = v.trim().toLowerCase();
+          return STT_PROVIDER_ALIASES[k] ?? k;
+        },
+        z.enum(VALID_STT_PROVIDERS, {
+          error: `services.stt.provider must be one of: ${VALID_STT_PROVIDERS.join(", ")} (aliases: openai/whisper -> openai-whisper)`,
+        }),
+      )
       .describe("Active STT provider used for speech-to-text transcription"),
     providers: SttProvidersSchema.default({}),
   })

--- a/assistant/src/providers/voice-error-copy.ts
+++ b/assistant/src/providers/voice-error-copy.ts
@@ -1,0 +1,47 @@
+/**
+ * Single source of truth for user- and model-facing voice (STT/TTS) failure
+ * copy. Provider adapters reject with raw upstream bodies (kept in logs only);
+ * these helpers turn a normalized error into friendly, actionable text that
+ * never leaks raw JSON or HTTP status noise into a conversation or the UI.
+ */
+
+import type { SttError, SttProviderId } from "../stt/types.js";
+import { getProviderEntry } from "./speech-to-text/provider-catalog.js";
+
+function sttProviderLabel(providerId?: SttProviderId): string {
+  const displayName = providerId
+    ? getProviderEntry(providerId)?.displayName
+    : undefined;
+  return displayName ?? "the speech-to-text provider";
+}
+
+/**
+ * Friendly, model-actionable copy for a normalized STT failure. Names the
+ * provider (when known) so the model can point the user at the right fix.
+ */
+export function describeSttFailure(
+  err: SttError,
+  providerId?: SttProviderId,
+): string {
+  const provider = sttProviderLabel(providerId);
+  switch (err.category) {
+    case "auth":
+      return `${provider} rejected the configured API key — it may be expired or invalid. Check the speech-to-text API key in Settings → Voice.`;
+    case "rate-limit":
+      return `${provider} is rate-limiting transcription requests right now. Try again shortly.`;
+    case "timeout":
+      return "Transcription timed out.";
+    case "invalid-audio":
+      return "The audio could not be transcribed (unsupported or corrupted format).";
+    default:
+      return `${provider} returned an error while transcribing.`;
+  }
+}
+
+/**
+ * Friendly copy for a TTS authentication failure (HTTP 401/403). Shared with
+ * the STT auth copy's "check the API key in Settings → Voice" guidance.
+ */
+export function describeTtsAuthFailure(providerDisplayName: string): string {
+  return `${providerDisplayName} rejected the configured API key (authentication failed) — check the ${providerDisplayName} API key in Settings → Voice.`;
+}

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
@@ -151,7 +151,7 @@ describe("tryTranscribeAudioAttachments", () => {
     expect(reason).not.toContain("OpenAI");
   });
 
-  test("API failure returns error with reason", async () => {
+  test("API failure returns a friendly, non-raw reason naming the provider", async () => {
     const audio = makeAudioAttachment("a1");
     mockAttachments = [audio];
     mockTranscriber = {
@@ -165,9 +165,37 @@ describe("tryTranscribeAudioAttachments", () => {
     const result = await tryTranscribeAudioAttachments(["a1"]);
 
     expect(result.status).toBe("error");
-    expect((result as { reason: string }).reason).toBe(
-      "API rate limit exceeded",
-    );
+    const reason = (result as { reason: string }).reason;
+    // Friendly copy replaces the raw provider string.
+    expect(reason).not.toContain("API rate limit exceeded");
+    expect(reason).toContain("OpenAI Whisper");
+  });
+
+  test("auth failure returns a friendly, JSON-free reason that names the API key", async () => {
+    const audio = makeAudioAttachment("a1");
+    mockAttachments = [audio];
+    mockTranscriber = {
+      providerId: "deepgram",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        // Mocked normalizeSttError returns an SttError as-is, so throw the
+        // categorized error directly (a plain 401 string would classify as
+        // provider-error under the simplified mock).
+        throw new SttError(
+          "auth",
+          'Deepgram API error (401): {"err_code":"INVALID_AUTH"}',
+        );
+      },
+    };
+
+    const result = await tryTranscribeAudioAttachments(["a1"]);
+
+    expect(result.status).toBe("error");
+    const reason = (result as { reason: string }).reason;
+    expect(reason).not.toContain("{");
+    expect(reason).not.toContain("INVALID_AUTH");
+    expect(reason).toContain("API key");
+    expect(reason).toContain("Deepgram");
   });
 
   test("30-second timeout fires and returns error without blocking", async () => {
@@ -184,7 +212,7 @@ describe("tryTranscribeAudioAttachments", () => {
     const result = await tryTranscribeAudioAttachments(["a1"]);
 
     expect(result.status).toBe("error");
-    expect((result as { reason: string }).reason).toBe(
+    expect((result as { reason: string }).reason).toContain(
       "Transcription timed out",
     );
   });

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
@@ -12,7 +12,9 @@ import {
   getAttachmentsByIds,
 } from "../../../persistence/attachments-store.js";
 import { resolveBatchTranscriber } from "../../../providers/speech-to-text/resolve.js";
+import { describeSttFailure } from "../../../providers/voice-error-copy.js";
 import { normalizeSttError } from "../../../stt/daemon-batch-transcriber.js";
+import type { SttProviderId } from "../../../stt/types.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("transcribe-audio");
@@ -37,6 +39,8 @@ export type TranscribeResult =
 export async function tryTranscribeAudioAttachments(
   attachmentIds: string[],
 ): Promise<TranscribeResult> {
+  // Hoisted so the catch can name the provider in a friendly failure message.
+  let providerId: SttProviderId | undefined;
   try {
     // Look up attachments and filter to audio MIME types
     const resolved = getAttachmentsByIds(attachmentIds);
@@ -57,6 +61,7 @@ export async function tryTranscribeAudioAttachments(
           "No speech-to-text provider configured. Add an API key for your STT service to enable voice message transcription.",
       };
     }
+    providerId = transcriber.providerId;
 
     // Transcribe each audio attachment with a shared timeout
     const abortController = new AbortController();
@@ -103,11 +108,7 @@ export async function tryTranscribeAudioAttachments(
     }
   } catch (err: unknown) {
     const sttErr = normalizeSttError(err);
-    const reason =
-      sttErr.category === "timeout"
-        ? "Transcription timed out"
-        : sttErr.message;
     log.warn({ err }, "Audio transcription failed");
-    return { status: "error", reason };
+    return { status: "error", reason: describeSttFailure(sttErr, providerId) };
   }
 }

--- a/assistant/src/stt/stt-stream-session.ts
+++ b/assistant/src/stt/stt-stream-session.ts
@@ -34,10 +34,12 @@ import {
   listProviderIds,
   supportsBoundary,
 } from "../providers/speech-to-text/provider-catalog.js";
+import { describeSttFailure } from "../providers/voice-error-copy.js";
 import { getLogger } from "../util/logger.js";
+import { normalizeSttError } from "./daemon-batch-transcriber.js";
 import {
   type StreamingTranscriber,
-  SttError,
+  type SttProviderId,
   type SttStreamServerEvent,
 } from "./types.js";
 
@@ -228,17 +230,17 @@ export class SttStreamSession {
         "STT stream session started",
       );
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      // normalizeSttError preserves an adapter-thrown SttError's category
+      // (e.g. a relay auth rejection at dial time) and classifies raw errors.
+      const sttErr = normalizeSttError(err);
       log.error(
-        { provider: this.provider, error: message },
+        { provider: this.provider, error: sttErr.message },
         "Failed to start STT stream session",
       );
       this.sendEvent({
         type: "error",
-        // Adapters reject with SttError when they know better than the
-        // generic bucket (e.g. a relay auth rejection at dial time).
-        category: err instanceof SttError ? err.category : "provider-error",
-        message: `Failed to start streaming session: ${message}`,
+        category: sttErr.category,
+        message: describeSttFailure(sttErr, this.provider as SttProviderId),
       });
       this.sendEvent({ type: "closed" });
       this.state = "closed";
@@ -254,7 +256,9 @@ export class SttStreamSession {
    * {@link handleBinaryAudio}.
    */
   handleMessage(raw: string): void {
-    if (this.state === "closed") {return;}
+    if (this.state === "closed") {
+      return;
+    }
 
     this.resetIdleTimer();
 
@@ -267,7 +271,9 @@ export class SttStreamSession {
       return;
     }
 
-    if (!parsed || typeof parsed !== "object") {return;}
+    if (!parsed || typeof parsed !== "object") {
+      return;
+    }
 
     const event = parsed as {
       type?: string;
@@ -312,7 +318,9 @@ export class SttStreamSession {
    * frames rather than base64-encoded JSON.
    */
   handleBinaryAudio(data: Buffer | ArrayBuffer | Uint8Array): void {
-    if (this.state !== "active") {return;}
+    if (this.state !== "active") {
+      return;
+    }
 
     this.resetIdleTimer();
 
@@ -328,7 +336,9 @@ export class SttStreamSession {
    * Tears down the provider session and cleans up resources.
    */
   handleClose(code: number, reason?: string): void {
-    if (this.state === "closed") {return;}
+    if (this.state === "closed") {
+      return;
+    }
 
     log.info(
       { provider: this.provider, code, reason },
@@ -343,7 +353,9 @@ export class SttStreamSession {
    * ensure deterministic cleanup of all active sessions.
    */
   destroy(): void {
-    if (this.state === "closed") {return;}
+    if (this.state === "closed") {
+      return;
+    }
 
     log.info({ provider: this.provider }, "STT stream session destroyed");
     this.teardown();
@@ -395,7 +407,9 @@ export class SttStreamSession {
    * Handle events emitted by the streaming transcriber.
    */
   private handleTranscriberEvent(event: SttStreamServerEvent): void {
-    if (this.state === "closed") {return;}
+    if (this.state === "closed") {
+      return;
+    }
 
     this.sendEvent(event);
 
@@ -436,10 +450,14 @@ export class SttStreamSession {
   private resetIdleTimer(): void {
     this.clearIdleTimer();
 
-    if (this.state === "closed" || this.state === "stopping") {return;}
+    if (this.state === "closed" || this.state === "stopping") {
+      return;
+    }
 
     this.idleTimer = setTimeout(() => {
-      if (this.state === "closed") {return;}
+      if (this.state === "closed") {
+        return;
+      }
 
       log.warn({ provider: this.provider }, "STT stream session idle timeout");
       this.sendEvent({
@@ -469,7 +487,9 @@ export class SttStreamSession {
    * Idempotent — safe to call multiple times.
    */
   private teardown(): void {
-    if (this.state === "closed") {return;}
+    if (this.state === "closed") {
+      return;
+    }
     this.state = "closed";
 
     this.clearIdleTimer();

--- a/assistant/src/tts/__tests__/provider-adapters.test.ts
+++ b/assistant/src/tts/__tests__/provider-adapters.test.ts
@@ -1520,6 +1520,24 @@ describe("Deepgram TTS provider adapter", () => {
     }
   });
 
+  test("surfaces a friendly, JSON-free message on a 401 auth failure", async () => {
+    mockFetchError(401, '{"err_code":"INVALID_AUTH","err_msg":"expired"}');
+
+    const provider = createDeepgramProvider();
+
+    try {
+      await provider.synthesize(makeRequest());
+      throw new Error("Expected synthesize to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeepgramTtsError);
+      const message = (err as DeepgramTtsError).message;
+      expect(message).not.toContain("{");
+      expect(message).not.toContain("INVALID_AUTH");
+      expect(message).toContain("API key");
+      expect(message).toContain("Settings");
+    }
+  });
+
   test("throws DEEPGRAM_TTS_EMPTY_RESPONSE on empty audio body", async () => {
     mockFetchReturning(new Uint8Array(0));
 

--- a/assistant/src/tts/providers/deepgram-provider.ts
+++ b/assistant/src/tts/providers/deepgram-provider.ts
@@ -12,6 +12,7 @@
 
 import { getConfig } from "../../config/loader.js";
 import type { TtsDeepgramProviderConfig } from "../../config/schemas/tts.js";
+import { describeTtsAuthFailure } from "../../providers/voice-error-copy.js";
 import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import { resolvePcmOutputSampleRateHz } from "../pcm-sample-rates.js";
@@ -208,9 +209,17 @@ async function performTtsRequest(
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => "");
+    log.debug(
+      { status: response.status, body: errorText.slice(0, 300) },
+      "Deepgram TTS non-200 response",
+    );
+    const message =
+      response.status === 401 || response.status === 403
+        ? describeTtsAuthFailure("Deepgram")
+        : `Deepgram text-to-speech failed (HTTP ${response.status}).`;
     throw new DeepgramTtsError(
       "DEEPGRAM_TTS_HTTP_ERROR",
-      `Deepgram TTS returned ${response.status}: ${errorText}`,
+      message,
       response.status,
     );
   }


### PR DESCRIPTION
## Summary

- Voice STT/TTS failures leaked raw provider bodies. An expired Deepgram key surfaced `Deepgram API error (401): {"err_code":"INVALID_AUTH",...}` **into the conversation** (batch STT), into the WebSocket `error` event (streaming STT — chat composer / dictation overlay), and into the CLI/desktop (TTS). This replaces all three with friendly, category-based, provider-named copy; raw detail stays in `log.warn`/`log.debug` only.
- The STT provider enum is now forgiving: `openai`/`whisper` normalize to `openai-whisper` (and values are trimmed/lowercased) via a parse-time `z.preprocess` before the enum check — so a natural value is accepted rather than silently dropped, which previously cascaded into a full `services` config-section reset with only a generic notice.
- New `providers/voice-error-copy.ts` is the single source of truth for the shared "provider rejected the API key — check Settings → Voice" copy (STT auth + TTS auth), per the second-occurrence extraction rule.

This is **Tier 1** of the voice-fallback plan (the unambiguous bugs). Auto-failover (Tier 2) is deliberately deferred. No migration, no feature flag — the alias is pure parse-time input normalization (canonical stored values unchanged) and the copy changes are runtime-only. Reviewer-required items applied: the streaming-STT leak site (`stt-stream-session.ts`) is covered by routing through `normalizeSttError` + `describeSttFailure`; the friendly TTS fix lives at the `deepgram-provider.ts` throw site (covering all TTS call paths — CLI, calls, live-voice) rather than a dead `formatTtsFailureMessage` statusCode branch (`TtsSynthesisError` carries no statusCode); and the auth-category STT test throws a categorized `SttError` (the mocked `normalizeSttError` buckets plain 401 strings as provider-error).

## Original prompt

From the v0.10.8 sweep: Deepgram voice (STT + TTS) 401s leaked raw provider JSON into conversations and surfaces, the `services.stt.provider` enum was unforgiving (rejecting `openai`/`whisper`), and there was no friendly error. Ship the clear bug fixes — friendly category-based copy behind a shared SSOT module, forgiving STT aliases — and defer the auto-failover feature (Tier 2), which carries a privacy/UX product decision.