### PR TITLE
fix(scheduler): liveness watchdog + respawn for the silently-dying schedule worker

### DIFF
--- a/assistant/src/runtime/routes/__tests__/schedule-worker-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/schedule-worker-routes.test.ts
@@ -20,6 +20,7 @@ let stopImpl: () => { status: "running" | "not_running"; pid?: number };
 let workerProbe: { status: "running" | "not_running"; pid?: number } = {
   status: "not_running",
 };
+const adminStoppedCalls: boolean[] = [];
 
 mock.module("../../../schedule/worker-control.js", () => ({
   ScheduleWorkerSpawnError: FakeSpawnError,
@@ -32,6 +33,9 @@ mock.module("../../../schedule/worker-control.js", () => ({
   },
   stopScheduleWorkerProcess: () => stopImpl(),
   probeScheduleWorker: () => workerProbe,
+  setScheduleWorkerAdministrativelyStopped: (value: boolean) => {
+    adminStoppedCalls.push(value);
+  },
 }));
 
 const { ROUTES } = await import("../schedule-worker-routes.js");
@@ -49,6 +53,7 @@ beforeEach(() => {
   spawnImpl = async () => ({ pid: 4242, alreadyRunning: false });
   stopImpl = () => ({ status: "not_running" });
   workerProbe = { status: "not_running" };
+  adminStoppedCalls.length = 0;
 });
 
 describe("schedules_worker_start", () => {
@@ -82,6 +87,11 @@ describe("schedules_worker_start", () => {
       "worker exited during startup",
     );
   });
+
+  test("clears the administratively-stopped flag so the watchdog resumes", async () => {
+    await handler("schedules_worker_start")();
+    expect(adminStoppedCalls).toContain(false);
+  });
 });
 
 describe("schedules_worker_stop", () => {
@@ -99,6 +109,11 @@ describe("schedules_worker_stop", () => {
     const res = await handler("schedules_worker_stop")();
 
     expect(res).toEqual({ workerWasRunning: false });
+  });
+
+  test("sets the administratively-stopped flag so the watchdog does not respawn", async () => {
+    await handler("schedules_worker_stop")();
+    expect(adminStoppedCalls).toContain(true);
   });
 });
 

--- a/assistant/src/runtime/routes/schedule-worker-routes.ts
+++ b/assistant/src/runtime/routes/schedule-worker-routes.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import {
   probeScheduleWorker,
   ScheduleWorkerSpawnError,
+  setScheduleWorkerAdministrativelyStopped,
   spawnScheduleWorkerProcess,
   stopScheduleWorkerProcess,
 } from "../../schedule/worker-control.js";
@@ -59,6 +60,10 @@ async function startScheduleWorker() {
     throw new InternalError(message);
   }
 
+  // A successful start clears any prior operator stop so the watchdog resumes
+  // supervising the worker.
+  setScheduleWorkerAdministrativelyStopped(false);
+
   return {
     pid: result.pid,
     alreadyRunning: result.alreadyRunning,
@@ -79,6 +84,10 @@ function stopScheduleWorker() {
     log.warn({ err }, "Failed to signal schedule worker process");
     throw new InternalError(message);
   }
+
+  // Mark as administratively stopped so the liveness watchdog does not respawn
+  // the worker the operator just told it to stop (cleared by start / restart).
+  setScheduleWorkerAdministrativelyStopped(true);
 
   return {
     workerWasRunning: before.status === "running",

--- a/assistant/src/schedule/__tests__/worker-watchdog.test.ts
+++ b/assistant/src/schedule/__tests__/worker-watchdog.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createWorkerSupervisor,
+  type WorkerProcessStatus,
+} from "../../util/worker-process.js";
+
+const RUNNING: WorkerProcessStatus = { status: "running", pid: 100 };
+const NOT_RUNNING: WorkerProcessStatus = { status: "not_running" };
+
+describe("createWorkerSupervisor", () => {
+  test("does not respawn a running worker", async () => {
+    let respawns = 0;
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => RUNNING,
+      respawn: async () => {
+        respawns++;
+        return { pid: 1, alreadyRunning: false };
+      },
+    });
+
+    await sup.ensureAlive();
+
+    expect(respawns).toBe(0);
+  });
+
+  test("respawns a dead worker and fires onRespawn with the pid", async () => {
+    let respawns = 0;
+    let respawnedPid: number | undefined;
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => NOT_RUNNING,
+      respawn: async () => {
+        respawns++;
+        return { pid: 42, alreadyRunning: false };
+      },
+      onRespawn: (pid) => {
+        respawnedPid = pid;
+      },
+    });
+
+    await sup.ensureAlive();
+
+    expect(respawns).toBe(1);
+    expect(respawnedPid).toBe(42);
+  });
+
+  test("does not fire onRespawn when the worker was already running", async () => {
+    let onRespawnCalls = 0;
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => NOT_RUNNING,
+      respawn: async () => ({ pid: 42, alreadyRunning: true }),
+      onRespawn: () => {
+        onRespawnCalls++;
+      },
+    });
+
+    await sup.ensureAlive();
+
+    expect(onRespawnCalls).toBe(0);
+  });
+
+  test("backs off after a failed respawn and skips attempts within the window", async () => {
+    let respawns = 0;
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => NOT_RUNNING,
+      respawn: async () => {
+        respawns++;
+        throw new Error("spawn failed");
+      },
+      minBackoffMs: 1000,
+      maxBackoffMs: 10_000,
+    });
+
+    await sup.ensureAlive(0); // attempt 1 fails → nextAttemptAt = 1000
+    expect(respawns).toBe(1);
+    await sup.ensureAlive(500); // within backoff → skipped
+    expect(respawns).toBe(1);
+    await sup.ensureAlive(1500); // past backoff → attempt 2
+    expect(respawns).toBe(2);
+  });
+
+  test("fires onPersistentFailure exactly once at the threshold", async () => {
+    let persistentCalls = 0;
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => NOT_RUNNING,
+      respawn: async () => {
+        throw new Error("nope");
+      },
+      minBackoffMs: 1,
+      maxBackoffMs: 1,
+      persistentFailureThreshold: 3,
+      onPersistentFailure: () => {
+        persistentCalls++;
+      },
+    });
+
+    await sup.ensureAlive(0); // fail 1
+    await sup.ensureAlive(10); // fail 2
+    await sup.ensureAlive(20); // fail 3 → fires
+    await sup.ensureAlive(30); // fail 4 → no additional fire
+
+    expect(persistentCalls).toBe(1);
+  });
+
+  test("a later successful respawn resets the failure counters", async () => {
+    let mode: "fail" | "ok" = "fail";
+    let persistentCalls = 0;
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => NOT_RUNNING,
+      respawn: async () => {
+        if (mode === "fail") {
+          throw new Error("nope");
+        }
+        return { pid: 7, alreadyRunning: false };
+      },
+      minBackoffMs: 1,
+      maxBackoffMs: 1,
+      persistentFailureThreshold: 2,
+      onPersistentFailure: () => {
+        persistentCalls++;
+      },
+    });
+
+    await sup.ensureAlive(0); // fail 1
+    mode = "ok";
+    await sup.ensureAlive(10); // success → resets counter
+    mode = "fail";
+    await sup.ensureAlive(20); // fail 1 again (counter was reset)
+
+    expect(persistentCalls).toBe(0);
+  });
+
+  test("does not respawn while suppressed (operator stop)", async () => {
+    let respawns = 0;
+    let suppressed = true;
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => NOT_RUNNING,
+      respawn: async () => {
+        respawns++;
+        return { pid: 1, alreadyRunning: false };
+      },
+      isSuppressed: () => suppressed,
+    });
+
+    await sup.ensureAlive();
+    expect(respawns).toBe(0);
+
+    suppressed = false;
+    await sup.ensureAlive();
+    expect(respawns).toBe(1);
+  });
+
+  test("dispose mid-respawn kills the child that resolves after disposal", async () => {
+    let releaseRespawn: () => void = () => {};
+    const respawnGate = new Promise<void>((resolve) => {
+      releaseRespawn = resolve;
+    });
+    let killedPid: number | undefined;
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => NOT_RUNNING,
+      respawn: async () => {
+        await respawnGate;
+        return { pid: 99, alreadyRunning: false };
+      },
+      killChild: (pid) => {
+        killedPid = pid;
+      },
+    });
+
+    const inflight = sup.ensureAlive(); // starts respawn, awaits the gate
+    sup.dispose(); // dispose while the respawn is in flight
+    releaseRespawn(); // respawn resolves now
+    await inflight;
+
+    expect(killedPid).toBe(99);
+  });
+
+  test("concurrent ensureAlive calls do not double-spawn", async () => {
+    let respawns = 0;
+    let releaseRespawn: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseRespawn = resolve;
+    });
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => NOT_RUNNING,
+      respawn: async () => {
+        respawns++;
+        await gate;
+        return { pid: 1, alreadyRunning: false };
+      },
+    });
+
+    const a = sup.ensureAlive();
+    const b = sup.ensureAlive(); // skipped by the inFlight guard
+    releaseRespawn();
+    await Promise.all([a, b]);
+
+    expect(respawns).toBe(1);
+  });
+});

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -16,7 +16,12 @@ import { runBackgroundJob } from "../runtime/background-job-runner.js";
 import { publishConversationListChanged } from "../runtime/sync/resource-sync-events.js";
 import { runSequencesOnce } from "../sequence/engine.js";
 import type { TurnFailure } from "../telemetry/turn-outcome.js";
+import { recordWatchdogEvent } from "../telemetry/watchdog-events-store.js";
 import { getLogger } from "../util/logger.js";
+import {
+  createWorkerSupervisor,
+  type WorkerSupervisor,
+} from "../util/worker-process.js";
 import { runWatchersOnce } from "../watcher/engine.js";
 import { normalizeCapabilityManifest } from "../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
@@ -37,7 +42,13 @@ import {
   scheduleRetry,
   setScheduleRunConversationId,
 } from "./schedule-store.js";
-import { startScheduleWorker, stopScheduleWorker } from "./worker-control.js";
+import {
+  isScheduleWorkerAdministrativelyStopped,
+  probeScheduleWorker,
+  spawnScheduleWorkerProcess,
+  startScheduleWorker,
+  stopScheduleWorker,
+} from "./worker-control.js";
 
 const log = getLogger("scheduler");
 
@@ -227,12 +238,88 @@ async function handleExecutionFailure(params: {
 /** The running scheduler, retained so shutdown can stop it. */
 let instance: SchedulerHandle | null = null;
 
+/** The schedule worker liveness watchdog, disposed by {@link stopScheduler}. */
+let scheduleWorkerSupervisor: WorkerSupervisor | null = null;
+
+/**
+ * Notify the user once per outage when the worker cannot be respawned after
+ * repeated attempts, so schedules being paused is not silent. A stable
+ * hourly dedupe key keeps it to one notification per outage window rather than
+ * one per tick.
+ */
+function emitScheduleWorkerDownNotification(consecutiveFailures: number): void {
+  void emitNotificationSignal({
+    sourceEventName: "activity.failed",
+    sourceChannel: "scheduler",
+    sourceContextId: "schedule-worker",
+    dedupeKey: `schedule-worker-down:${Math.floor(Date.now() / 3_600_000)}`,
+    contextPayload: {
+      jobName: "Scheduled tasks",
+      errorMessage:
+        "The assistant could not restart its schedule runner, so scheduled tasks are paused. They resume automatically once it recovers.",
+      errorKind: "exception",
+      consecutiveFailures,
+    },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "medium",
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+  }).catch((emitErr) => {
+    log.warn(
+      { err: emitErr },
+      "Failed to emit schedule-worker-down notification",
+    );
+  });
+}
+
 export function startScheduler(): SchedulerHandle {
   // Schedule execution is owned by the schedule worker process; spawn it now as
   // a child of the daemon so it is running immediately. Fire-and-forget — a
   // worker failure must never block boot. The daemon's own tick below runs only
   // watchers and sequences.
   startScheduleWorker();
+
+  // Liveness watchdog: the worker calls process.exit() on any uncaught error
+  // and nothing respawned it, so schedules could stop for days silently. Probe
+  // and respawn off the existing tick — recovery latency drops from days to
+  // ~one tick. Detects process death, not a wedged-but-alive worker.
+  scheduleWorkerSupervisor = createWorkerSupervisor({
+    label: "Schedule worker",
+    probe: probeScheduleWorker,
+    respawn: () => spawnScheduleWorkerProcess({ detached: false }),
+    isSuppressed: isScheduleWorkerAdministrativelyStopped,
+    killChild: (pid) => {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+        // Worker already gone — nothing to kill.
+      }
+    },
+    onRespawn: (pid) => {
+      log.warn(
+        { pid },
+        "Schedule worker was not running — respawned by watchdog",
+      );
+      recordWatchdogEvent({
+        checkName: "schedule_worker_respawn",
+        detail: { pid },
+      });
+    },
+    onPersistentFailure: (consecutiveFailures, err) => {
+      log.error(
+        { err, consecutiveFailures },
+        "Schedule worker repeatedly failed to respawn — schedules are paused",
+      );
+      recordWatchdogEvent({
+        checkName: "schedule_worker_down",
+        value: consecutiveFailures,
+        detail: { consecutiveFailures },
+      });
+      emitScheduleWorkerDownNotification(consecutiveFailures);
+    },
+  });
 
   let stopped = false;
   let tickRunning = false;
@@ -243,6 +330,9 @@ export function startScheduler(): SchedulerHandle {
     }
     tickRunning = true;
     try {
+      // Respawn the schedule worker if it has died (fire-and-forget; never
+      // throws). Idempotent — a live PID file short-circuits to alreadyRunning.
+      void scheduleWorkerSupervisor?.ensureAlive();
       await runScheduleOnce();
     } catch (err) {
       log.error({ err }, "Schedule tick failed");
@@ -284,12 +374,16 @@ export function startScheduler(): SchedulerHandle {
  * worker process if one is running.
  */
 export function stopScheduler(): void {
-  stopScheduleWorker();
-  if (!instance) {
-    return;
+  // Stop the tick FIRST so no tick can respawn the worker we are about to kill.
+  if (instance) {
+    instance.stop();
+    instance = null;
   }
-  instance.stop();
-  instance = null;
+  // No further respawns; a respawn already in flight kills its child on resolve.
+  scheduleWorkerSupervisor?.dispose();
+  scheduleWorkerSupervisor = null;
+  // Then SIGTERM the running worker via its PID file.
+  stopScheduleWorker();
 }
 
 /** The running scheduler, or null if one was never started. */

--- a/assistant/src/schedule/worker-control.ts
+++ b/assistant/src/schedule/worker-control.ts
@@ -22,6 +22,25 @@ import {
 const log = getLogger("schedule-worker-control");
 
 /**
+ * True when an operator explicitly stopped the worker (via
+ * `assistant schedules worker stop`). The liveness watchdog must not respawn it
+ * while this is set, or a manual stop would be silently undone within one tick.
+ * Process-local: it resets to false on daemon restart and is cleared by the
+ * `schedules worker start` route — a restart is treated as a fresh start.
+ */
+let administrativelyStopped = false;
+
+/** Whether the schedule worker has been administratively stopped by an operator. */
+export function isScheduleWorkerAdministrativelyStopped(): boolean {
+  return administrativelyStopped;
+}
+
+/** Set/clear the administratively-stopped flag (set by stop, cleared by start). */
+export function setScheduleWorkerAdministrativelyStopped(value: boolean): void {
+  administrativelyStopped = value;
+}
+
+/**
  * Inspect the PID file to determine whether the schedule worker process is
  * alive. A stale PID file (pointing at a dead process) is cleaned up and
  * reported as not_running.

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -273,3 +273,108 @@ export function stopWorkerProcess(pidPath: string): WorkerProcessStatus {
   }
   return current;
 }
+
+// ---------------------------------------------------------------------------
+// Liveness supervisor
+// ---------------------------------------------------------------------------
+
+/**
+ * A liveness supervisor that probes a worker process and respawns it when it
+ * has died, subject to exponential backoff and a suppression hook. Detects
+ * process *death* (via the PID-file probe) — not a worker that is alive but
+ * wedged.
+ */
+export interface WorkerSupervisor {
+  /** Probe liveness; respawn if dead (subject to backoff/suppression). Never throws. */
+  ensureAlive(now?: number): Promise<void>;
+  /**
+   * Stop supervising: no further respawns, and a respawn already in flight is
+   * killed via {@link WorkerSupervisorOptions.killChild} when it resolves.
+   */
+  dispose(): void;
+}
+
+export interface WorkerSupervisorOptions {
+  label: string;
+  probe: () => WorkerProcessStatus;
+  respawn: () => Promise<{ pid: number; alreadyRunning: boolean }>;
+  /**
+   * Kill a child respawned after {@link WorkerSupervisor.dispose} was called
+   * (closes the shutdown race where a respawn was already in flight).
+   */
+  killChild?: (pid: number) => void;
+  /**
+   * When it returns true, `ensureAlive` skips respawning — e.g. an operator
+   * administratively stopped the worker and the watchdog must not undo that.
+   */
+  isSuppressed?: () => boolean;
+  /** Fired after a respawn actually started a new process (not `alreadyRunning`). */
+  onRespawn?: (pid: number) => void;
+  /** Fires once when consecutiveFailures first reaches the threshold. */
+  onPersistentFailure?: (consecutiveFailures: number, err: unknown) => void;
+  minBackoffMs?: number; // default 15_000 (one tick)
+  maxBackoffMs?: number; // default 300_000 (5 min)
+  persistentFailureThreshold?: number; // default 3
+}
+
+export function createWorkerSupervisor(
+  opts: WorkerSupervisorOptions,
+): WorkerSupervisor {
+  let consecutiveFailures = 0;
+  let nextAttemptAt = 0;
+  let inFlight = false;
+  let stopping = false;
+  const minBackoff = opts.minBackoffMs ?? 15_000;
+  const maxBackoff = opts.maxBackoffMs ?? 300_000;
+  const threshold = opts.persistentFailureThreshold ?? 3;
+
+  return {
+    async ensureAlive(now = Date.now()): Promise<void> {
+      if (stopping || inFlight) {
+        return;
+      }
+      // Operator stop wins over the watchdog — never respawn while suppressed.
+      if (opts.isSuppressed?.()) {
+        return;
+      }
+      if (opts.probe().status === "running") {
+        consecutiveFailures = 0;
+        nextAttemptAt = 0;
+        return;
+      }
+      if (now < nextAttemptAt) {
+        return; // in a backoff window after a failed respawn
+      }
+      inFlight = true;
+      try {
+        const { pid, alreadyRunning } = await opts.respawn();
+        consecutiveFailures = 0;
+        nextAttemptAt = 0;
+        if (stopping) {
+          // Disposed mid-respawn: kill the child we just created so it is not
+          // orphaned past shutdown.
+          opts.killChild?.(pid);
+          return;
+        }
+        if (!alreadyRunning) {
+          opts.onRespawn?.(pid);
+        }
+      } catch (err) {
+        consecutiveFailures += 1;
+        const backoff = Math.min(
+          maxBackoff,
+          minBackoff * 2 ** (consecutiveFailures - 1),
+        );
+        nextAttemptAt = now + backoff;
+        if (consecutiveFailures === threshold) {
+          opts.onPersistentFailure?.(consecutiveFailures, err);
+        }
+      } finally {
+        inFlight = false;
+      }
+    },
+    dispose(): void {
+      stopping = true;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- The schedule worker is the sole executor of every schedule, and it calls `process.exit(1)` on any uncaught error with nothing to respawn it — so schedules could stop for **days** with no alert (the only alert can't fire, because a dead worker runs zero jobs). This adds a daemon-side liveness watchdog hung off the existing 15s tick: it probes the worker's PID file and respawns it, dropping recovery latency from days to ~one tick. Respawn is idempotent (a live PID file short-circuits to `alreadyRunning`) and bounded by exponential backoff (15s→5min).
- On persistent failure (3 respawns fail) it records a watchdog telemetry event and emits one user-facing "scheduled tasks are paused" notification per outage (hourly dedupe key). Uses `recordWatchdogEvent` (buffered, retried, restart-surviving) — **not** the SQLite-corruption-only `emitWatchdogEventDirect` bypass, per review.
- Reviewer-required guards: (1) the shutdown race is closed for real — `stopScheduler` stops the tick first, then `dispose()`s the supervisor (which SIGTERMs a respawn that completes *after* disposal via `killChild`), then SIGTERMs the worker; (2) an **administratively-stopped** flag set by `schedules worker stop` and cleared by `start`/daemon restart, checked before every respawn, so the watchdog never silently undoes an operator's manual stop.

Deliberate non-changes: the worker keeps exiting on uncaught errors (fail-fast + respawn is correct); **no kill-switch flag** (it would reintroduce the flag-fragility class that made this incident possible); respawn-only, **no in-process fallback** for v1. Scope is explicit: the watchdog detects process *death* (PID-file liveness), not a wedged-but-alive worker. The optional stale-run recovery in `onRespawn` was deferred (daemon-startup recovery already covers it, and the reviewer flagged the zero-threshold hazard). The admin-stop flag is process-local — a daemon restart resumes supervision (fresh start). No migration, no feature flag.

## Original prompt

From the v0.10.8 sweep: the in-process schedule worker silently dies and all schedules stop for days with no alert. Add a daemon-side liveness watchdog that respawns the worker off the existing tick (recovery in ~15s), with a once-per-outage user notification on persistent failure — applying the review-required shutdown-race dispose path, the operator-stop suppression flag, and `recordWatchdogEvent`, and shipping it on-by-default with no kill-switch (respawn-only for v1).