### PR TITLE
test(stt): assert friendly copy on transcriber start failure

### DIFF
--- a/assistant/src/__tests__/stt-stream-session.test.ts
+++ b/assistant/src/__tests__/stt-stream-session.test.ts
@@ -321,11 +321,12 @@ describe("SttStreamSession", () => {
       const frames = ws.frames;
       expect(frames[0].type).toBe("error");
       expect(frames[0].category).toBe("provider-error");
-      expect(
-        (frames[0].message as string).includes(
-          "Mock provider connection refused",
-        ),
-      ).toBe(true);
+      // Friendly copy names the provider; the raw upstream error stays in
+      // logs and must not leak to the client.
+      expect(frames[0].message as string).toContain("Deepgram");
+      expect(frames[0].message as string).not.toContain(
+        "Mock provider connection refused",
+      );
       expect(frames[1].type).toBe("closed");
       expect(session.isClosed).toBe(true);
       expect(ws.closed).toBe(true);


### PR DESCRIPTION
## Summary
- Fix the `Test` job failing on main since #38356: `stt-stream-session.test.ts > provider start failure` still asserted the raw provider error ("Mock provider connection refused") in the WebSocket error frame.
- #38356 routes start-failure messages through `describeSttFailure()`, which intentionally emits friendly provider-named copy instead of raw upstream errors — the test now asserts the friendly message contains "Deepgram" and that the raw error does not leak, matching the assertion style of #38356's own tests.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29536098705/job/87747678018 (the `Test` job of CI Main Assistant Checks failing on main after #38356 merged).