### PR TITLE
fix(schedule): default recurring cron/RRULE timezone to the user's configured/detected zone

### DIFF
--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -192,7 +192,7 @@ Phrases like "at the 45 minute mark", "at the top of the hour", "at noon", or "2
 
 3. **Ask only if truly ambiguous** - if neither rule resolves, ask for clarification. Never silently default to "from now."
 
-- Timezones default to the system timezone if omitted. Use IANA timezone identifiers (e.g. "America/Los_Angeles").
+- Timezones default to your configured timezone (falling back to the zone your client last reported); the assistant's own clock is used only when none is known. Pass an explicit IANA timezone identifier (e.g. "America/Los_Angeles") to override.
 - Prefer RRULE for complex patterns that cron cannot express (e.g. "every other Tuesday", "last weekday of the month").
 
 ## Capability Preflight

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -32,7 +32,7 @@
           },
           "timezone": {
             "type": "string",
-            "description": "IANA timezone (e.g. \"America/Los_Angeles\"). Defaults to system timezone if omitted."
+            "description": "IANA timezone (e.g. \"America/Los_Angeles\"). Defaults to your configured/detected timezone; the assistant's own clock only if unknown."
           },
           "message": {
             "type": "string",

--- a/assistant/src/schedule/__tests__/schedule-timezone.test.ts
+++ b/assistant/src/schedule/__tests__/schedule-timezone.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let mockUi: {
+  userTimezone?: string | null;
+  detectedTimezone?: string | null;
+} = {};
+
+mock.module("../../config/loader.js", () => ({
+  getConfigReadOnly: () => ({ ui: mockUi }),
+}));
+
+const { resolveScheduleTimezone, expressionCarriesOwnTimezone } =
+  await import("../schedule-timezone.js");
+
+afterEach(() => {
+  mockUi = {};
+});
+
+describe("resolveScheduleTimezone", () => {
+  test("an explicit value wins and is canonicalized", () => {
+    mockUi = { userTimezone: "America/New_York" };
+    expect(resolveScheduleTimezone("America/Los_Angeles")).toBe(
+      "America/Los_Angeles",
+    );
+  });
+
+  test("falls back to the configured user timezone (beats detected)", () => {
+    mockUi = {
+      userTimezone: "America/New_York",
+      detectedTimezone: "America/Chicago",
+    };
+    expect(resolveScheduleTimezone(null)).toBe("America/New_York");
+  });
+
+  test("falls back to the detected timezone when no user timezone is set", () => {
+    mockUi = { detectedTimezone: "America/Chicago" };
+    expect(resolveScheduleTimezone(undefined)).toBe("America/Chicago");
+  });
+
+  test("returns null when nothing is known (host-local is preserved)", () => {
+    mockUi = {};
+    expect(resolveScheduleTimezone(null)).toBeNull();
+  });
+
+  test("ignores an invalid explicit value and falls back", () => {
+    mockUi = { userTimezone: "America/New_York" };
+    expect(resolveScheduleTimezone("Not/AZone")).toBe("America/New_York");
+  });
+});
+
+describe("expressionCarriesOwnTimezone", () => {
+  test("cron never carries its own zone", () => {
+    expect(expressionCarriesOwnTimezone("cron", "30 8 * * *")).toBe(false);
+  });
+
+  test("a plain RRULE does not carry its own zone", () => {
+    expect(expressionCarriesOwnTimezone("rrule", "FREQ=DAILY;BYHOUR=8")).toBe(
+      false,
+    );
+  });
+
+  test("an RRULE with embedded DTSTART;TZID carries its own zone (not clobbered)", () => {
+    expect(
+      expressionCarriesOwnTimezone(
+        "rrule",
+        "DTSTART;TZID=America/Chicago:20240101T083000\nRRULE:FREQ=DAILY",
+      ),
+    ).toBe(true);
+  });
+
+  test("an RRULE with a Z-anchored UTC DTSTART carries its own zone", () => {
+    expect(
+      expressionCarriesOwnTimezone(
+        "rrule",
+        "DTSTART:20240101T083000Z\nRRULE:FREQ=DAILY",
+      ),
+    ).toBe(true);
+  });
+
+  test("an RRULE set-construct is treated as carrying its own zone", () => {
+    // rrulestr does not thread a caller-supplied tzid into a constructed
+    // RRuleSet, so resolving a zone for a set-construct would not change firing;
+    // we therefore leave the timezone field alone for these.
+    expect(
+      expressionCarriesOwnTimezone(
+        "rrule",
+        "RRULE:FREQ=DAILY\nRDATE:20240101T083000",
+      ),
+    ).toBe(true);
+  });
+
+  // Deeper guarantee behind the set-construct exclusion above: the recurrence
+  // engine's computeNextRunAt must not shift when a set-construct expression is
+  // given an explicit timezone (proving the field genuinely has no effect, so a
+  // future rrule upgrade that changes this is caught). Convert to a real test
+  // when a set-construct fixture with a known epoch is added.
+  test.todo(
+    "computeNextRunAt is unaffected by an explicit tz on a set-construct expression",
+    () => {},
+  );
+});

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -13,6 +13,10 @@ import {
   isValidScheduleExpression,
 } from "./recurrence-engine.js";
 import type { ScheduleSyntax } from "./recurrence-types.js";
+import {
+  expressionCarriesOwnTimezone,
+  resolveScheduleTimezone,
+} from "./schedule-timezone.js";
 
 const logger = getLogger("schedule-store");
 
@@ -154,7 +158,14 @@ export async function createSchedule(params: {
   const id = uuid();
   const now = Date.now();
   const enabled = params.enabled ?? true;
-  const timezone = params.timezone ?? null;
+  // A recurring wall-clock schedule with no zone otherwise evaluates in the host
+  // clock (UTC on managed containers). Default it to the user's configured/detected
+  // zone so it fires at the intended local hour. One-shot schedules (absolute epoch)
+  // and expressions that carry their own zone keep the caller's value verbatim.
+  const timezone =
+    isOneShot || expressionCarriesOwnTimezone(syntax, expression)
+      ? (params.timezone ?? null)
+      : resolveScheduleTimezone(params.timezone);
   const mode = params.mode ?? "execute";
   const routingIntent = params.routingIntent ?? "all_channels";
   const routingHints = params.routingHints ?? {};

--- a/assistant/src/schedule/schedule-timezone.ts
+++ b/assistant/src/schedule/schedule-timezone.ts
@@ -1,0 +1,63 @@
+/**
+ * Resolve the timezone a recurring schedule should be evaluated in.
+ *
+ * A cron/RRULE wall-clock recurrence needs a zone to disambiguate; when none is
+ * supplied the recurrence engine falls back to the daemon host clock (UTC on a
+ * managed container), firing at the wrong hour. The rest of the assistant grounds
+ * time via the user's configured/detected zone (see `resolveTurnTimezoneContext`
+ * in `daemon/date-context.ts`); this brings recurring schedules in line.
+ */
+
+import { getConfigReadOnly } from "../config/loader.js";
+import { canonicalizeTimeZone } from "../daemon/date-context.js";
+import { hasSetConstructs } from "./recurrence-engine.js";
+import type { ScheduleSyntax } from "./recurrence-types.js";
+
+/**
+ * True when the expression already determines its own evaluation zone, so the
+ * `timezone` field must not be resolved/overridden:
+ * - an RRULE with an embedded `DTSTART;TZID=…` or a Z-anchored UTC `DTSTART`; or
+ * - an RRULE set-construct (RDATE/EXDATE/multi-RRULE). `rrulestr` does not thread
+ *   a caller-supplied tzid into a constructed `RRuleSet`, so a resolved zone would
+ *   have no effect on firing — persisting one would be misleading.
+ *
+ * Cron never carries its own zone.
+ */
+export function expressionCarriesOwnTimezone(
+  syntax: ScheduleSyntax,
+  expression: string | null | undefined,
+): boolean {
+  if (syntax !== "rrule" || !expression) {
+    return false;
+  }
+  if (
+    /TZID=/i.test(expression) ||
+    /DTSTART[^:]*:\d{8}T\d{6}Z/i.test(expression)
+  ) {
+    return true;
+  }
+  return hasSetConstructs(expression);
+}
+
+/**
+ * Resolve the effective zone for a recurring schedule. An explicit caller value
+ * wins (canonicalized); otherwise the user's configured zone, then the
+ * client-detected zone. Returns null only when nothing is known — preserving
+ * host-local evaluation for local installs where the host clock is the user's.
+ *
+ * Precedence mirrors `resolveTurnTimezoneContext` (configured beats detected).
+ */
+export function resolveScheduleTimezone(
+  explicit: string | null | undefined,
+): string | null {
+  const explicitTz = canonicalizeTimeZone(explicit);
+  if (explicitTz) {
+    return explicitTz;
+  }
+  const ui = getConfigReadOnly().ui;
+  return (
+    canonicalizeTimeZone(ui.userTimezone) ??
+    canonicalizeTimeZone(ui.detectedTimezone) ??
+    null
+  );
+}


### PR DESCRIPTION
## Summary

- A recurring cron/RRULE schedule created without a timezone was evaluated in the daemon **host clock** (UTC on managed containers), so `30 8 * * *` fired at 08:30 UTC (04:30 ET) forever, and every tick recomputed from the stored null zone so it never self-corrected. The rest of the assistant grounds time via the user's configured/detected zone; this brings **new** recurring schedules in line by defaulting the zone to `ui.userTimezone ?? ui.detectedTimezone` (canonicalized), falling back to host-local only when nothing is known (preserving local-desktop behavior where the host clock *is* the user's).
- The fix lives in `createSchedule` — all create paths (tool, HTTP, IPC) converge on the store — via a new `schedule-timezone.ts` resolver. One-shot schedules (absolute epoch) and expressions that carry their own zone are left untouched: an RRULE with an embedded `DTSTART;TZID=`/Z-anchored UTC start, and — per review — RRULE **set-constructs** (RDATE/EXDATE/multi-RRULE), which `rrulestr` won't thread an external tzid into, so resolving one would be a no-op that misleads.
- Doc copy (`schedule/SKILL.md` + `TOOLS.json`) now describes the default in user terms: "your configured/detected timezone; the assistant's own clock only if unknown."

Scoped to the forward path per the product decision: **no migration** — existing null-timezone rows are not rewritten (they keep firing host-local until re-saved with a zone), and an `enabled`-toggle or edit does not silently heal them. No feature flag (a correctness fix). The resolver's precedence mirrors `resolveTurnTimezoneContext` (configured beats detected); `getConfigReadOnly().ui` is always present.

## Original prompt

From the v0.10.8 sweep: recurring cron schedules created with no timezone run at UTC host-local (wrong hour). Default the zone to the user's already-known configured/detected timezone for new schedules (matching the assistant's turn-time grounding), leaving host-local behavior when nothing is known — applying the review-required RRULE set-construct and embedded-TZID handling, and, per the product decision, shipping the forward-fix only with no backfill migration so existing schedules are left untouched.