### PR TITLE
fix(ci): re-record schedule SKILL.md docs-sync fingerprint

### DIFF
--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "b06c01162b98675eaa4409c788cd43788d46fe4f05a85255aece3ee20d6dab4e"
+      "sha256": "43b225449e003c3ee640a76777cd06d233d006f6f4fbb2cd7d8eed145d659195"
     },
     "skill-management": {
       "docsSlug": "skill-management",


### PR DESCRIPTION
## Summary
- Re-record the `schedule` skill's SKILL.md fingerprint in `scripts/skill-docs-sync.manifest.json` (via `bun run scripts/check-skill-docs-sync.ts --write`), fixing the `skill-docs-sync-guard.test.ts` failure in CI Main Assistant Checks on main.
- The guard tripped because #38359 reworded the schedule SKILL.md timezone-default line without re-recording the fingerprint after reconciling the public docs.
- Docs reconciliation done: the public page (https://www.vellum.ai/docs/skills-reference/schedule) only lists "Timezone-aware" and never documents a specific default, so the new user-timezone default requires no `vellum-assistant-platform` docs change.

## Original prompt
/do was invoked to fix the single failing CI job on main: run 29537114045 ("Test" job of CI Main Assistant Checks), which went red after #38359 (default recurring schedule timezone to the user's zone) merged. The scope was strictly this one CI issue — the skill ↔ public-docs sync guard flagging the schedule SKILL.md change.