### PR TITLE
fix(web): repair the v0.10.10 merge-back typecheck break; move the theme picker into the Preferences card

### DIFF
--- a/clients/web/src/domains/settings/components/preferences-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/preferences-modal.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Tests for `PreferencesModal`.
  *
- * The theme picker is a separate `AppearanceCard` on Settings → General (see
- * `appearance-card.test.tsx`), not part of this modal. These tests mount the
+ * The theme picker lives inline in the Preferences card on Settings → General
+ * (see `theme-picker.test.tsx`), not in this modal. These tests mount the
  * modal as a web (non-Electron) client and assert it hosts the composer send
  * toggle but no Appearance/theme control.
  */

--- a/clients/web/src/domains/settings/components/preferences-modal.tsx
+++ b/clients/web/src/domains/settings/components/preferences-modal.tsx
@@ -6,67 +6,8 @@ import { getLaunchAtLogin, setLaunchAtLogin } from "@/runtime/launch-at-login";
 import { isMacOSBrowser } from "@/runtime/platform-detection";
 import { cmdEnterToSend } from "@/utils/composer-settings";
 import { isPointerCoarse } from "@/utils/pointer";
-import { type ThemePreference } from "@/utils/theme-preferences";
-import { useThemePreference } from "@/hooks/use-theme-preference";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Toggle } from "@vellumai/design-library/components/toggle";
-
-/**
- * Theme picker (System / Light / Dark, plus Velvet when the flag is on).
- * Lives in Preferences alongside the other per-device preferences. Unlike the
- * other sections it is not Electron-gated — theme applies on every platform —
- * so it also gives the modal meaningful content on web and iOS.
- *
- * Shares the `useThemePreference` hook with the sidebar `ThemeToggle` so the
- * two surfaces stay in sync.
- */
-function AppearanceSection() {
-  const velvet = useClientFeatureFlagStore.use.velvet();
-  const { theme, setThemePreference } = useThemePreference();
-
-  const themeItems = [
-    {
-      value: "system" as const,
-      label: "System",
-      icon: <Monitor className="h-4 w-4" />,
-    },
-    {
-      value: "light" as const,
-      label: "Light",
-      icon: <Sun className="h-4 w-4" />,
-    },
-    {
-      value: "dark" as const,
-      label: "Dark",
-      icon: <Moon className="h-4 w-4" />,
-    },
-    ...(velvet
-      ? [
-          {
-            value: "velvet" as const,
-            label: "Velvet",
-            icon: <Heart className="h-4 w-4" />,
-          },
-        ]
-      : []),
-  ];
-
-  return (
-    <section>
-      <h3 className="text-title-small text-[var(--content-emphasised)]">
-        Appearance
-      </h3>
-      <div className="mt-2 max-w-[360px]">
-        <SegmentControl<ThemePreference>
-          ariaLabel="Theme"
-          value={theme}
-          onChange={setThemePreference}
-          items={themeItems}
-        />
-      </div>
-    </section>
-  );
-}
 
 /**
  * Preferences section for the composer's Enter-key behavior, at parity with

--- a/clients/web/src/domains/settings/components/theme-picker.test.tsx
+++ b/clients/web/src/domains/settings/components/theme-picker.test.tsx
@@ -1,9 +1,9 @@
 /**
- * Tests for the `AppearanceCard` theme picker.
+ * Tests for the `ThemePicker` shown inline in the Preferences card.
  *
- * The card renders on every platform. `useThemePreference` and `SegmentControl`
- * are stubbed so the test exercises the card's option list and its delegation to
- * the shared theme setter.
+ * It renders on every platform. `useThemePreference` and `SegmentControl` are
+ * stubbed so the test exercises the option list and its delegation to the
+ * shared theme setter.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
@@ -52,9 +52,9 @@ mock.module("@/stores/client-feature-flag-store", () => ({
   },
 }));
 
-import { AppearanceCard } from "@/domains/settings/components/appearance-card";
+import { ThemePicker } from "@/domains/settings/components/theme-picker";
 
-describe("AppearanceCard", () => {
+describe("ThemePicker", () => {
   beforeEach(() => {
     setThemePreferenceMock.mockClear();
     velvetValue.current = false;
@@ -64,10 +64,10 @@ describe("AppearanceCard", () => {
     cleanup();
   });
 
-  test("renders the Appearance card with theme options", () => {
-    render(<AppearanceCard />);
+  test("renders the theme options under a Theme heading", () => {
+    render(<ThemePicker />);
 
-    expect(screen.getByText("Appearance")).toBeDefined();
+    expect(screen.getByText("Theme")).toBeDefined();
     expect(screen.getByLabelText("Theme")).toBeDefined();
     expect(screen.getByRole("button", { name: "System" })).toBeDefined();
     expect(screen.getByRole("button", { name: "Light" })).toBeDefined();
@@ -77,7 +77,7 @@ describe("AppearanceCard", () => {
   });
 
   test("choosing a theme delegates to the shared theme setter", () => {
-    render(<AppearanceCard />);
+    render(<ThemePicker />);
 
     fireEvent.click(screen.getByRole("button", { name: "Dark" }));
 
@@ -86,7 +86,7 @@ describe("AppearanceCard", () => {
 
   test("exposes the Velvet option when the flag is enabled", () => {
     velvetValue.current = true;
-    render(<AppearanceCard />);
+    render(<ThemePicker />);
 
     expect(screen.getByRole("button", { name: "Velvet" })).toBeDefined();
   });

--- a/clients/web/src/domains/settings/components/theme-picker.tsx
+++ b/clients/web/src/domains/settings/components/theme-picker.tsx
@@ -1,6 +1,5 @@
 import { Heart, Monitor, Moon, Sun } from "lucide-react";
 
-import { DetailCard } from "@/components/detail-card";
 import { useThemePreference } from "@/hooks/use-theme-preference";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { type ThemePreference } from "@/utils/theme-preferences";
@@ -8,11 +7,11 @@ import { SegmentControl } from "@vellumai/design-library/components/segment-cont
 
 /**
  * Theme picker (System / Light / Dark, plus Velvet when the flag is on), shown
- * as its own card on Settings → General. Not Electron-gated — theme applies on
- * every platform. Shares `useThemePreference` with the sidebar `ThemeToggle`,
- * so the two surfaces stay in sync.
+ * inline in the Preferences card on Settings → General. Not Electron-gated —
+ * theme applies on every platform. Shares `useThemePreference` with the
+ * sidebar `ThemeToggle`, so the two surfaces stay in sync.
  */
-export function AppearanceCard() {
+export function ThemePicker() {
   const velvet = useClientFeatureFlagStore.use.velvet();
   const { theme, setThemePreference } = useThemePreference();
 
@@ -44,8 +43,11 @@ export function AppearanceCard() {
   ];
 
   return (
-    <DetailCard title="Appearance">
-      <div className="max-w-[360px]">
+    <section>
+      <h3 className="text-title-small text-[var(--content-emphasised)]">
+        Theme
+      </h3>
+      <div className="mt-2 max-w-[360px]">
         <SegmentControl<ThemePreference>
           ariaLabel="Theme"
           value={theme}
@@ -53,6 +55,6 @@ export function AppearanceCard() {
           items={themeItems}
         />
       </div>
-    </DetailCard>
+    </section>
   );
 }

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor";
-import { AppearanceCard } from "@/domains/settings/components/appearance-card";
+import { ThemePicker } from "@/domains/settings/components/theme-picker";
 import { DetailCard } from "@/components/detail-card";
 import {
   DiskPressureBanner,
@@ -127,8 +127,10 @@ export function GeneralPage() {
   // returns null when gated, so the card must not render an empty shell.
   const showDeleteAccount = infraGate !== "gated";
   // The Preferences modal only has content on Electron (shortcuts, Launch at
-  // Login) or with a fine pointer (the composer send toggle), so its card is
-  // hidden on touch/non-Electron surfaces where the modal would be empty.
+  // Login) or with a fine pointer (the composer send toggle), so its Customize
+  // button and modal are hidden on touch/non-Electron surfaces where the modal
+  // would be empty. The card itself always renders — it hosts the theme picker,
+  // which applies on every platform.
   const showPreferences = isElectron() || !isPointerCoarse();
 
   return (
@@ -273,27 +275,27 @@ export function GeneralPage() {
         </DetailCard>
       )}
 
-      <AppearanceCard />
-
+      <DetailCard
+        title="Preferences"
+        subtitle="Customize how Vellum looks and behaves on this device."
+        accessory={
+          showPreferences ? (
+            <Button
+              variant="outlined"
+              onClick={() => setPreferencesOpen(true)}
+            >
+              Customize
+            </Button>
+          ) : undefined
+        }
+      >
+        <ThemePicker />
+      </DetailCard>
       {showPreferences && (
-        <>
-          <DetailCard
-            title="Preferences"
-            subtitle="Customize shortcuts and how Vellum behaves on this device."
-            accessory={
-              <Button
-                variant="outlined"
-                onClick={() => setPreferencesOpen(true)}
-              >
-                Customize
-              </Button>
-            }
-          />
-          <PreferencesModal
-            open={preferencesOpen}
-            onClose={() => setPreferencesOpen(false)}
-          />
-        </>
+        <PreferencesModal
+          open={preferencesOpen}
+          onClose={() => setPreferencesOpen(false)}
+        />
       )}
 
       {teleportEnabled && isElectron() && <TeleportCard />}


### PR DESCRIPTION
## Summary

Two commits:

1. **CI fix** — main's Type Check and Lint are red: the Release v0.10.10 merge-back (#38361, `3316121d`) resurrected the `AppearanceSection` that #38340 (`0c326a0f`) had deleted from `preferences-modal.tsx`, without its imports. Dead code with undefined names → `tsc --noEmit` and eslint fail on every branch merged with main (e.g. #38330). Commit 1 re-deletes the block, restoring the intended post-#38340 state.

2. **Theme picker placement** — the theme switcher should be visible in the **Preferences section** of Settings → General, not a separate Appearance card. `AppearanceCard` becomes `ThemePicker` (a "Theme" labeled SegmentControl) rendered inline inside the Preferences card body. The Preferences card now always renders — theme applies on every platform — while the Customize button and the Preferences modal keep the `isElectron() || !isPointerCoarse()` gate so an empty modal still can't open on touch/non-Electron surfaces. Card subtitle updated to "Customize how Vellum looks and behaves on this device."

## Test plan

- [x] `bun run typecheck` (clients/web) — exit 0
- [x] `bun test src/domains/settings/components/theme-picker.test.tsx` — 3/3 (options render under Theme heading, setter delegation, Velvet flag gating)
- [x] `bun test src/domains/settings/components/preferences-modal.test.tsx` — 2/2 (modal still hosts no Appearance section)
- [x] eslint clean on all touched files
- [ ] Manual: Settings → General shows the theme picker inside the Preferences card on web + Electron; touch/non-Electron shows the card with theme picker but no Customize button

🤖 Generated with [Claude Code](https://claude.com/claude-code)