### PR TITLE
feat(providers): add Kimi K3 to the OpenRouter model catalog

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1438,6 +1438,18 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       },
       // Moonshot
       {
+        id: "moonshotai/kimi-k3",
+        displayName: "Kimi K3",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        adaptiveThinkingOnly: true,
+        supportsCaching: false,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: { inputPer1mTokens: 3, outputPer1mTokens: 15 },
+      },
+      {
         id: "moonshotai/kimi-k2.6",
         displayName: "Kimi K2.6",
         contextWindowTokens: 262144,

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -575,6 +575,15 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 8_192,
     },
     {
+      id: "moonshotai/kimi-k3",
+      displayName: "Kimi K3",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
+      adaptiveThinkingOnly: true,
+    },
+    {
       id: "moonshotai/kimi-k2.6",
       displayName: "Kimi K2.6",
       contextWindowTokens: 262_144,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1389,6 +1389,23 @@
           }
         },
         {
+          "id": "moonshotai/kimi-k3",
+          "displayName": "Kimi K3",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "adaptiveThinkingOnly": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 3,
+            "outputPer1mTokens": 15
+          }
+        },
+        {
           "id": "moonshotai/kimi-k2.6",
           "displayName": "Kimi K2.6",
           "contextWindowTokens": 262144,


### PR DESCRIPTION
## Summary

- Add **Kimi K3** (`moonshotai/kimi-k3`) to the OpenRouter provider catalog: 1,048,576-token context (flat pricing, no long-context tier), 131,072 max output (Moonshot's documented default cap), vision + tool use, $3/M input / $15/M output. Default context window inherits the standard 200k.
- Flag it `supportsThinking` + `adaptiveThinkingOnly`: K3 always reasons (effort-only control, no disable), and the daemon's adaptive-only handling — dropping `thinking: disabled` and non-1 `temperature` before dispatch — matches Moonshot's API contract exactly (temperature/top_p are fixed server-side; OpenRouter doesn't forward them since they're absent from the endpoint's `supported_parameters`).
- Regenerate `meta/llm-provider-catalog.json` (`bun run sync:llm-catalog`) and mirror the entry in the web catalog (`clients/web/src/assistant/llm-model-catalog.ts`, parity-test enforced).

Caveats, verified against the OpenRouter API and Moonshot platform docs on launch day (2026-07-16):

- Moonshot currently accepts only the **max** reasoning-effort level (more levels announced as coming). Requests pinning a lower effort forward `reasoning_effort` as-is; harmless today since Moonshot defaults to max, but worth rechecking when they add levels.
- The `/kimi/i`-keyed `WEAK_OPEN_MODEL_PATTERN` and `suppress-cjk` logit-bias preset auto-apply to K3. The CJK token-ID list is derived from the K2 tokenizer and unverified for K3 — inert on this path regardless, because OpenRouter's K3 endpoint doesn't accept `logit_bias`.
- OpenRouter-only for now: Fireworks and Vercel AI Gateway blocks untouched (K3 not yet confirmed on those hosts).

## Original prompt

Kimi K3 launched today and the catalog only carried K2.5/K2.6. Sidd asked whether we support K3 and then to add it through OpenRouter for now. Model IDs are free-form so K3 already worked via custom profiles; this adds the catalog entry so it appears in model pickers with correct context-window, output-cap, thinking, and pricing metadata. Specs were verified live from `openrouter.ai/api/v1/models` + the per-endpoint listing and Moonshot's K3 quickstart docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)