### PR TITLE
fix(web): drop orphaned AppearanceSection left by the v0.10.10 release merge

### DIFF
--- a/clients/web/src/domains/settings/components/preferences-modal.tsx
+++ b/clients/web/src/domains/settings/components/preferences-modal.tsx
@@ -6,67 +6,8 @@ import { getLaunchAtLogin, setLaunchAtLogin } from "@/runtime/launch-at-login";
 import { isMacOSBrowser } from "@/runtime/platform-detection";
 import { cmdEnterToSend } from "@/utils/composer-settings";
 import { isPointerCoarse } from "@/utils/pointer";
-import { type ThemePreference } from "@/utils/theme-preferences";
-import { useThemePreference } from "@/hooks/use-theme-preference";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Toggle } from "@vellumai/design-library/components/toggle";
-
-/**
- * Theme picker (System / Light / Dark, plus Velvet when the flag is on).
- * Lives in Preferences alongside the other per-device preferences. Unlike the
- * other sections it is not Electron-gated — theme applies on every platform —
- * so it also gives the modal meaningful content on web and iOS.
- *
- * Shares the `useThemePreference` hook with the sidebar `ThemeToggle` so the
- * two surfaces stay in sync.
- */
-function AppearanceSection() {
-  const velvet = useClientFeatureFlagStore.use.velvet();
-  const { theme, setThemePreference } = useThemePreference();
-
-  const themeItems = [
-    {
-      value: "system" as const,
-      label: "System",
-      icon: <Monitor className="h-4 w-4" />,
-    },
-    {
-      value: "light" as const,
-      label: "Light",
-      icon: <Sun className="h-4 w-4" />,
-    },
-    {
-      value: "dark" as const,
-      label: "Dark",
-      icon: <Moon className="h-4 w-4" />,
-    },
-    ...(velvet
-      ? [
-          {
-            value: "velvet" as const,
-            label: "Velvet",
-            icon: <Heart className="h-4 w-4" />,
-          },
-        ]
-      : []),
-  ];
-
-  return (
-    <section>
-      <h3 className="text-title-small text-[var(--content-emphasised)]">
-        Appearance
-      </h3>
-      <div className="mt-2 max-w-[360px]">
-        <SegmentControl<ThemePreference>
-          ariaLabel="Theme"
-          value={theme}
-          onChange={setThemePreference}
-          items={themeItems}
-        />
-      </div>
-    </section>
-  );
-}
 
 /**
  * Preferences section for the composer's Enter-key behavior, at parity with


### PR DESCRIPTION
## Summary
- Delete the orphaned `AppearanceSection` component (and the two imports only it used) from `preferences-modal.tsx`, restoring the file byte-for-byte to the state #38340 shipped.
- The v0.10.10 release merge (#38361) mis-resolved the conflict between the release branch's cherry-pick of #38303 (which refactored the section in place) and main's #38340 (which moved the theme picker to `appearance-card.tsx`): it kept the component body but main's import list, leaving an unrendered component referencing six unimported names.
- This broke `CI Main Web` on main — six `TS2304` errors in Type Check and one `no-unused-vars` error in Lint (first surfaced on run 29538422897).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29538422897

🤖 Generated with [Claude Code](https://claude.com/claude-code)