### PR TITLE
fix(providers): scope weak-open-model Kimi classification to the K2 generation

### DIFF
--- a/assistant/src/__tests__/task-progress-nudge-hook.test.ts
+++ b/assistant/src/__tests__/task-progress-nudge-hook.test.ts
@@ -253,7 +253,7 @@ describe("task-progress-nudge post-tool-use hook", () => {
   });
 
   test("skips non-target models", async () => {
-    for (const model of ["claude-opus-4-8", "gpt-5.5"]) {
+    for (const model of ["claude-opus-4-8", "gpt-5.5", "moonshotai/kimi-k3"]) {
       const { messages, currentToolUseId } = turnWithRounds(
         TASK_PROGRESS_NUDGE_ROUND_THRESHOLD + 2,
       );

--- a/assistant/src/__tests__/weak-open-model.test.ts
+++ b/assistant/src/__tests__/weak-open-model.test.ts
@@ -17,7 +17,14 @@ describe("isWeakOpenModel", () => {
   });
 
   test("does not match capable models", () => {
-    for (const model of ["claude-opus-4-8", "claude-sonnet-4-6", "gpt-5.5"]) {
+    for (const model of [
+      "claude-opus-4-8",
+      "claude-sonnet-4-6",
+      "gpt-5.5",
+      "moonshotai/kimi-k3",
+      "accounts/fireworks/models/kimi-k3",
+      "moonshotai/kimi-latest",
+    ]) {
       expect(isWeakOpenModel(model)).toBe(false);
     }
   });

--- a/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
@@ -71,14 +71,16 @@ export const TASK_PROGRESS_NUDGE_TEXT =
 export const TASK_PROGRESS_NUDGE_ROUND_THRESHOLD = 3;
 
 /**
- * Weaker open-weight model families (Kimi, DeepSeek, MiniMax, GLM) that tend to
+ * Weaker open-weight models (Kimi K2, DeepSeek, MiniMax, GLM) that tend to
  * disregard the static progress-card instruction and so benefit from the
- * mid-turn nudge. This is the plugin's own coaching policy, kept local and
- * matched against `ctx.model` rather than read off a shared context flag —
- * "weak" / "needs steering" is a judgement specific to this nudge, not a
- * general property of the turn, and the set is the plugin owner's to tune.
+ * mid-turn nudge. Kimi is scoped to the K2 generation — K3+ is frontier-class
+ * and follows static instructions. This is the plugin's own coaching policy,
+ * kept local and matched against `ctx.model` rather than read off a shared
+ * context flag — "weak" / "needs steering" is a judgement specific to this
+ * nudge, not a general property of the turn, and the set is the plugin
+ * owner's to tune.
  */
-const NUDGE_TARGET_MODEL_PATTERN = /kimi|deepseek|minimax|glm/i;
+const NUDGE_TARGET_MODEL_PATTERN = /kimi-k2|deepseek|minimax|glm/i;
 
 /**
  * Round count at the last nudge, per conversation. A non-zero entry means the

--- a/assistant/src/providers/weak-open-model.ts
+++ b/assistant/src/providers/weak-open-model.ts
@@ -1,20 +1,23 @@
 /**
- * Family-level classification of "weak open models" — open-weight models
- * (Kimi, DeepSeek, MiniMax, GLM) that disregard static instructions and have
- * capability gaps that capable models (Claude, GPT) do not. Used by harness
- * levers that coach or redirect these models without touching capable-model
- * behavior: the task-progress-nudge plugin and the empty-dynamic_page surface
- * redirect.
+ * Classification of "weak open models" — open-weight models (Kimi K2,
+ * DeepSeek, MiniMax, GLM) that disregard static instructions and have
+ * capability gaps that capable models (Claude, GPT, Kimi K3+) do not. Used by
+ * harness levers that coach or redirect these models without touching
+ * capable-model behavior: the task-progress-nudge plugin and the
+ * empty-dynamic_page surface redirect.
  *
- * Family-level matching spans provider naming conventions: OpenRouter
+ * Matching spans provider naming conventions: OpenRouter
  * `moonshotai/kimi-k2.6`, `deepseek/deepseek-chat`, `minimax/minimax-m3`;
- * Fireworks `accounts/fireworks/models/minimax-m3`, `kimi-k2p6`. Extend the
- * pattern as other open models show the same gaps.
+ * Fireworks `accounts/fireworks/models/minimax-m3`, `kimi-k2p6`. The Kimi
+ * branch is scoped to the K2 generation: frontier-class successors
+ * (`kimi-k3`, and OpenRouter's `kimi-latest` alias that resolves to it) do
+ * not show these gaps and are deliberately unmatched. Membership is
+ * evidence-based — extend the pattern only as models show the same gaps.
  *
  * Distinct from exploration-drift's narrower `LOOP_PRONE_MODEL_PATTERN`, which
- * targets specific loop-prone versions rather than the whole capability family.
+ * targets specific loop-prone versions rather than the whole capability class.
  */
-export const WEAK_OPEN_MODEL_PATTERN = /kimi|deepseek|minimax|glm/i;
+export const WEAK_OPEN_MODEL_PATTERN = /kimi-k2|deepseek|minimax|glm/i;
 
 /** True when `model` is a weak open model (see {@link WEAK_OPEN_MODEL_PATTERN}). */
 export function isWeakOpenModel(model: string | null | undefined): boolean {


### PR DESCRIPTION
## Summary

- Scope the Kimi branch of `WEAK_OPEN_MODEL_PATTERN` (and the task-progress-nudge plugin's deliberately local copy, `NUDGE_TARGET_MODEL_PATTERN`) from the whole family to the K2 generation: `/kimi-k2|deepseek|minimax|glm/i`. Kimi K3 is frontier-class (GPT-5.5/Opus-tier benchmarks) and only matched by substring collision with its K2 ancestors — it was never evaluated against the pattern's documented inclusion bar ("models that show the same gaps"). `kimi-k2` still covers both provider spellings (`moonshotai/kimi-k2.5`/`kimi-k2.6`, Fireworks `kimi-k2p5`/`kimi-k2p6`).
- Consumers inherit the fix with no changes: K3 now gets the capable-model `ui_show` empty-dynamic_page HTML hint instead of the remedial declarative redirect, skips the mid-turn task-progress nudge, and gets standard managed-mode oauth-status copy. Exploration-drift's `LOOP_PRONE_MODEL_PATTERN` is already generation-pinned and unaffected.
- Tests: K3 (both provider spellings) and `moonshotai/kimi-latest` (an alias that resolves to K3) assert as capable/not-nudged; K2-generation and DeepSeek/MiniMax/GLM positives unchanged.

If K3 turns out to exhibit the K2-era gaps in the field, re-adding it is a one-line pattern change — but inclusion should follow observed behavior, per the pattern's own criterion.

## Original prompt

Follow-up to #38364 (Kimi K3 catalog entry): Sidd flagged that the `/kimi/i`-keyed weak-open-model treatment shouldn't apply to K3 given it benchmarks above Opus 4.8. Investigation confirmed the flag gates coaching/redirect levers (task-progress nudges, ui_show error-copy variants, oauth-status copy) designed for K2-era instruction-following gaps, and that K3 inherited it purely by family-substring match — so the ask was to scope the classification to the K2 generation rather than the Kimi family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)