### PR TITLE
feat(voice): fold a background continuation's result into the next turn (resurface)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -660,7 +660,7 @@ describe("LiveVoiceSession server VAD", () => {
         objective: string;
         label: string;
         signal: AbortSignal;
-      }) => {},
+      }): Promise<string> => "",
     );
     const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
       options.onAudioChunk(makeTtsChunk("assistant audio"));
@@ -699,9 +699,9 @@ describe("LiveVoiceSession server VAD", () => {
         objective: string;
         label: string;
         signal: AbortSignal;
-      }) =>
-        new Promise<void>((resolve) => {
-          args.signal.addEventListener("abort", () => resolve(), {
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          args.signal.addEventListener("abort", () => resolve(""), {
             once: true,
           });
         }),
@@ -739,7 +739,7 @@ describe("LiveVoiceSession server VAD", () => {
         objective: string;
         label: string;
         signal: AbortSignal;
-      }) => {},
+      }): Promise<string> => "",
     );
     const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
       options.onAudioChunk(makeTtsChunk("assistant audio"));
@@ -789,7 +789,7 @@ describe("LiveVoiceSession server VAD", () => {
         objective: string;
         label: string;
         signal: AbortSignal;
-      }) => {},
+      }): Promise<string> => "",
     );
     const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
       options.onAudioChunk(makeTtsChunk("assistant audio"));
@@ -821,7 +821,7 @@ describe("LiveVoiceSession server VAD", () => {
         objective: string;
         label: string;
         signal: AbortSignal;
-      }) => {},
+      }): Promise<string> => "",
     );
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
       callbacks ??= options.callbacks;
@@ -873,7 +873,7 @@ describe("LiveVoiceSession server VAD", () => {
         objective: string;
         label: string;
         signal: AbortSignal;
-      }) => {},
+      }): Promise<string> => "",
     );
     // Hold the interrupted turn's teardown open. Its partial (completed tool
     // calls) is only in forked history once the teardown settles, so the fork
@@ -922,7 +922,7 @@ describe("LiveVoiceSession server VAD", () => {
         objective: string;
         label: string;
         signal: AbortSignal;
-      }) => {},
+      }): Promise<string> => "",
     );
     // A teardown that never settles: the bounded wait times out, and the fork
     // must be skipped rather than snapshot history that may still be missing the
@@ -964,7 +964,7 @@ describe("LiveVoiceSession server VAD", () => {
         objective: string;
         label: string;
         signal: AbortSignal;
-      }) => {},
+      }): Promise<string> => "",
     );
     // Never resolves: the detach is parked in the teardown wait until the stop
     // aborts it.
@@ -1000,6 +1000,180 @@ describe("LiveVoiceSession server VAD", () => {
     resolveTeardown?.();
     await flushAsyncCallbacks();
     expect(spawnBackgroundContinuation).not.toHaveBeenCalled();
+  });
+
+  // A startVoiceTurn stub that keeps the first turn "thinking" (so a barge-in
+  // can land on it) but auto-completes every later turn so the single-turn lock
+  // frees for the next utterance. Records each turn's options for inspection.
+  function makeResurfaceTurnStarter(): {
+    startVoiceTurn: LiveVoiceTurnStarter;
+    calls: VoiceTurnOptions[];
+  } {
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      calls.push(options);
+      if (options.content !== "first question") {
+        options.callbacks?.assistant_text_delta?.(makeTextDelta("ok"));
+        options.callbacks?.message_complete?.(makeMessageComplete());
+      }
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+    });
+    return { startVoiceTurn, calls };
+  }
+
+  test("voice-duplex-handoff on: a completed continuation's result folds into the next turn's control prompt", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    // Control the continuation's resolution so we know exactly when its result
+    // is stashed relative to the turns we inspect.
+    let resolveContinuation: ((result: string) => void) | undefined;
+    const spawnBackgroundContinuation = mock(
+      (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          resolveContinuation = resolve;
+        }),
+    );
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: [
+        "first question",
+        "second question",
+        "third question",
+        "fourth question",
+      ],
+      startVoiceTurn,
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge in during thinking: turn 1 is cancelled and its continuation spawns
+    // (but has not resolved). The barge-in follow-up turn launches meanwhile,
+    // carrying the merge note but no continuation result yet.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => resolveContinuation !== undefined);
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+    const followUp = calls.find((c) => c.content === "second question");
+    expect(followUp?.voiceControlPrompt).toContain("interrupted");
+    expect(followUp?.voiceControlPrompt).not.toContain("THE_RESULT");
+
+    // The continuation finishes; its answer is stashed for the next turn.
+    resolveContinuation?.("THE_RESULT");
+    await flushAsyncCallbacks();
+
+    // The next turn the user starts folds the continuation's answer in as
+    // context (never spoken on its own).
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const resurfaced = calls.find((c) => c.content === "third question");
+    expect(resurfaced?.voiceControlPrompt).toContain("THE_RESULT");
+    expect(resurfaced?.voiceControlPrompt).toContain("background");
+
+    // Consume-once: a later turn does not repeat it.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "fourth question"));
+    const later = calls.find((c) => c.content === "fourth question");
+    expect(later?.voiceControlPrompt).not.toContain("THE_RESULT");
+  });
+
+  test("voice-duplex-handoff on: a client interrupt drops a stashed continuation result", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    let resolveContinuation: ((result: string) => void) | undefined;
+    const spawnBackgroundContinuation = mock(
+      (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          resolveContinuation = resolve;
+        }),
+    );
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    // The barge-in utterance transcribes to nothing, so no follow-up turn
+    // consumes the stash before the interrupt lands.
+    const { frames, session } = createHarness({
+      finals: ["first question", "", "third question"],
+      startVoiceTurn,
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => resolveContinuation !== undefined);
+
+    // The continuation finishes and stashes its result...
+    resolveContinuation?.("THE_RESULT");
+    await flushAsyncCallbacks();
+
+    // ...but a client interrupt is a hard stop that drops it.
+    await session.handleClientFrame({ type: "interrupt" });
+    await flushAsyncCallbacks();
+
+    // The next turn carries no resurfaced result.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const later = calls.find((c) => c.content === "third question");
+    expect(later?.voiceControlPrompt).not.toContain("THE_RESULT");
+  });
+
+  test("voice-duplex-handoff on: an empty continuation result adds no context to the next turn", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    // Continuation ends with no answer text (e.g. it stopped on a tool call):
+    // there is nothing to fold in.
+    const spawnBackgroundContinuation = mock(
+      async (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> => "",
+    );
+    const { startVoiceTurn, calls } = makeResurfaceTurnStarter();
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: ["first question", "second question", "third question"],
+      startVoiceTurn,
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => spawnBackgroundContinuation.mock.calls.length === 1);
+    // Let the barge-in follow-up turn launch and complete before the next
+    // utterance, so the follow-on turn forms cleanly.
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+    await flushAsyncCallbacks();
+
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    const later = calls.find((c) => c.content === "third question");
+    expect(later?.voiceControlPrompt).not.toContain("background you finished");
   });
 
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1246,6 +1246,72 @@ describe("LiveVoiceSession server VAD", () => {
     expect(resurfaced?.voiceControlPrompt).not.toContain("OLDER_RESULT");
   });
 
+  test("voice-duplex-handoff on: an empty newer continuation supersedes an older stashed result", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const resolvers: Array<(result: string) => void> = [];
+    const spawnBackgroundContinuation = mock(
+      (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      calls.push(options);
+      if (
+        options.content !== "first question" &&
+        options.content !== "second question"
+      ) {
+        options.callbacks?.assistant_text_delta?.(makeTextDelta("ok"));
+        options.callbacks?.message_complete?.(makeMessageComplete());
+      }
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: [
+        "first question",
+        "second question",
+        "third question",
+        "fourth question",
+      ],
+      startVoiceTurn,
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    await waitFor(() => resolvers.length === 2);
+
+    // The older continuation stashes a result, then the newer one finishes with
+    // no text and must supersede it — nothing should resurface.
+    resolvers[0]?.("OLDER_RESULT");
+    resolvers[1]?.("");
+    await flushAsyncCallbacks();
+
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "fourth question"));
+    const resurfaced = calls.find((c) => c.content === "fourth question");
+    expect(resurfaced?.voiceControlPrompt).not.toContain("OLDER_RESULT");
+    expect(resurfaced?.voiceControlPrompt).not.toContain(
+      "background you finished",
+    );
+  });
+
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1246,7 +1246,7 @@ describe("LiveVoiceSession server VAD", () => {
     expect(resurfaced?.voiceControlPrompt).not.toContain("OLDER_RESULT");
   });
 
-  test("voice-duplex-handoff on: an older continuation is rejected once a newer detach has started", async () => {
+  test("voice-duplex-handoff on: a rapid second barge-in invalidates a first continuation that finishes after it", async () => {
     setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
     const resolvers: Array<(result: string) => void> = [];
     const spawnBackgroundContinuation = mock(
@@ -1291,18 +1291,22 @@ describe("LiveVoiceSession server VAD", () => {
     await session.start();
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+    // Barge #1 detaches continuation A (older); its follow-up turn stays thinking
+    // so barge #2 can land on it.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => resolvers.length === 1);
     await waitFor(() => calls.some((c) => c.content === "second question"));
+    // Barge #2 is a rapid second interruption: it bumps the sequence
+    // synchronously, so A is invalidated even before barge #2's own async detach
+    // runs.
     await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
-    await waitFor(() => calls.some((c) => c.content === "third question"));
-    await waitFor(() => resolvers.length === 2);
-
-    // Only the OLDER continuation finishes; the NEWER one is still running. The
-    // older answer must NOT surface, because a newer interruption already
-    // superseded it (rejected without waiting for the newer to complete).
+    // A finishes AFTER barge #2 and must be rejected. The newer continuation is
+    // left pending so it can't mask the bug by superseding A itself.
     resolvers[0]?.("OLDER_RESULT");
     await flushAsyncCallbacks();
 
+    // A later turn carries no stale older result.
+    await waitFor(() => calls.some((c) => c.content === "third question"));
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() => calls.some((c) => c.content === "fourth question"));
     const resurfaced = calls.find((c) => c.content === "fourth question");
@@ -1312,6 +1316,7 @@ describe("LiveVoiceSession server VAD", () => {
     );
 
     // Cleanup the still-pending newer continuation.
+    await waitFor(() => resolvers.length === 2);
     resolvers[1]?.("");
   });
 

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1176,6 +1176,76 @@ describe("LiveVoiceSession server VAD", () => {
     expect(later?.voiceControlPrompt).not.toContain("background you finished");
   });
 
+  test("voice-duplex-handoff on: a newer continuation's result survives an older one finishing later", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    // Capture each continuation's resolver in spawn (detach) order.
+    const resolvers: Array<(result: string) => void> = [];
+    const spawnBackgroundContinuation = mock(
+      (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    // Keep the first two turns "thinking" so both can be barged; auto-complete
+    // the rest so the lock frees for later utterances.
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      calls.push(options);
+      if (
+        options.content !== "first question" &&
+        options.content !== "second question"
+      ) {
+        options.callbacks?.assistant_text_delta?.(makeTextDelta("ok"));
+        options.callbacks?.message_complete?.(makeMessageComplete());
+      }
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: [
+        "first question",
+        "second question",
+        "third question",
+        "fourth question",
+      ],
+      startVoiceTurn,
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge #1 detaches the older continuation; its follow-up turn stays thinking
+    // so barge #2 can detach the newer continuation.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    await waitFor(() => resolvers.length === 2);
+
+    // The newer continuation finishes first, then the older one finishes late.
+    // The sequence guard keeps the newer result regardless of completion order.
+    resolvers[1]?.("NEWER_RESULT");
+    resolvers[0]?.("OLDER_RESULT");
+    await flushAsyncCallbacks();
+
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "fourth question"));
+    const resurfaced = calls.find((c) => c.content === "fourth question");
+    expect(resurfaced?.voiceControlPrompt).toContain("NEWER_RESULT");
+    expect(resurfaced?.voiceControlPrompt).not.toContain("OLDER_RESULT");
+  });
+
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1246,7 +1246,7 @@ describe("LiveVoiceSession server VAD", () => {
     expect(resurfaced?.voiceControlPrompt).not.toContain("OLDER_RESULT");
   });
 
-  test("voice-duplex-handoff on: an empty newer continuation supersedes an older stashed result", async () => {
+  test("voice-duplex-handoff on: an older continuation is rejected once a newer detach has started", async () => {
     setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
     const resolvers: Array<(result: string) => void> = [];
     const spawnBackgroundContinuation = mock(
@@ -1297,10 +1297,10 @@ describe("LiveVoiceSession server VAD", () => {
     await waitFor(() => calls.some((c) => c.content === "third question"));
     await waitFor(() => resolvers.length === 2);
 
-    // The older continuation stashes a result, then the newer one finishes with
-    // no text and must supersede it — nothing should resurface.
+    // Only the OLDER continuation finishes; the NEWER one is still running. The
+    // older answer must NOT surface, because a newer interruption already
+    // superseded it (rejected without waiting for the newer to complete).
     resolvers[0]?.("OLDER_RESULT");
-    resolvers[1]?.("");
     await flushAsyncCallbacks();
 
     await session.handleBinaryAudio(LOUD_CHUNK);
@@ -1310,6 +1310,9 @@ describe("LiveVoiceSession server VAD", () => {
     expect(resurfaced?.voiceControlPrompt).not.toContain(
       "background you finished",
     );
+
+    // Cleanup the still-pending newer continuation.
+    resolvers[1]?.("");
   });
 
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -1315,6 +1315,74 @@ describe("LiveVoiceSession server VAD", () => {
     resolvers[1]?.("");
   });
 
+  test("voice-duplex-handoff on: a new barge-in drops an already-stashed continuation result", async () => {
+    setCachedOverrides({ "voice-duplex-handoff": true }, { fromGateway: true });
+    const resolvers: Array<(result: string) => void> = [];
+    const spawnBackgroundContinuation = mock(
+      (_args: {
+        parentConversationId: string;
+        objective: string;
+        label: string;
+        signal: AbortSignal;
+      }): Promise<string> =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      calls.push(options);
+      if (
+        options.content !== "first question" &&
+        options.content !== "second question"
+      ) {
+        options.callbacks?.assistant_text_delta?.(makeTextDelta("ok"));
+        options.callbacks?.message_complete?.(makeMessageComplete());
+      }
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk("assistant audio"));
+      return makeTtsResult("assistant audio");
+    });
+    const { frames, session } = createHarness({
+      finals: [
+        "first question",
+        "second question",
+        "third question",
+        "fourth question",
+      ],
+      startVoiceTurn,
+      streamTtsAudio,
+      spawnBackgroundContinuation,
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    // Barge #1 detaches continuation A; it finishes and stashes while it is the
+    // latest detach.
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "second question"));
+    await waitFor(() => resolvers.length === 1);
+    resolvers[0]?.("A_RESULT");
+    await flushAsyncCallbacks();
+
+    // Barge #2 is a fresh interruption: it must drop A's already-stashed result
+    // (and detach the newer continuation).
+    await session.handleBinaryAudio(SUSTAINED_LOUD_CHUNK);
+    await waitFor(() => calls.some((c) => c.content === "third question"));
+    await waitFor(() => resolvers.length === 2);
+
+    // The barge #2 follow-up turn carries no stale A result.
+    const followUp = calls.find((c) => c.content === "third question");
+    expect(followUp?.voiceControlPrompt).not.toContain("A_RESULT");
+
+    // Cleanup the still-pending newer continuation.
+    resolvers[1]?.("");
+  });
+
   test("a late assistant_text_delta after a thinking barge-in never reaches the client", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const abort = mock();

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1145,6 +1145,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       .trim();
     this.pendingInterruptedRequest =
       interruptedRequest.length > 0 ? interruptedRequest : null;
+    // A fresh interruption supersedes any already-stashed continuation result:
+    // drop it synchronously here so the barge-in follow-up (or any later) turn
+    // can't consume an older answer before this barge-in's own continuation
+    // completes. Cleared even when no continuation ultimately detaches.
+    this.pendingContinuationResult = null;
     turn.abortController.abort();
     this.metrics.markBargeIn(turn.turnId);
     // Capture the interrupted turn's teardown promise synchronously, before the

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1259,19 +1259,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         });
         // Fold the completed continuation's answer into the next turn the user
         // starts (never spoken unprompted). Re-check the stop guards after the
-        // await: an interrupt/close during the run must suppress it. Only a
-        // newer-or-equal detach may overwrite the stash, so an older continuation
-        // finishing out of order can't clobber a more recent answer.
-        const answer = resultText.trim();
+        // await: an interrupt/close during the run must suppress it. A
+        // newer-or-equal detach supersedes any older stash by advancing the
+        // sequence even when it produced no text — so an older continuation
+        // finishing out of order can't surface a stale answer behind a more
+        // recent interruption. Only non-empty text is actually surfaced.
         if (
-          answer.length > 0 &&
           !controller.signal.aborted &&
           !this.isClosed &&
           this.detachStopGeneration === stopGeneration &&
           detachSeq >= this.pendingContinuationResultSeq
         ) {
-          this.pendingContinuationResult = answer;
+          const answer = resultText.trim();
           this.pendingContinuationResultSeq = detachSeq;
+          this.pendingContinuationResult = answer.length > 0 ? answer : null;
         }
       } catch (err) {
         // A stop/interrupt aborts via the signal; that rejection is expected.

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -132,16 +132,17 @@ export type LiveVoiceTtsStreamer = (
 ) => Promise<LiveVoiceTtsResult>;
 
 // Runs an interrupted live-voice turn to completion on a background subagent
-// (true-duplex handoff, gated behind voice-duplex-handoff). The run is silent
-// (no parent notification) until the resurface flow lands, and aborts when
-// `signal` fires. Injected for testability; the factory wires the real
-// SubagentManager-backed implementation.
+// (true-duplex handoff, gated behind voice-duplex-handoff). The run stays silent
+// (no parent notification, never spoken unprompted); it RESOLVES with the
+// continuation's final answer text, which the session folds into the next turn
+// the user starts as context. Aborts when `signal` fires (rejecting). Injected
+// for testability; the factory wires the real SubagentManager-backed impl.
 export type LiveVoiceBackgroundContinuationSpawner = (args: {
   parentConversationId: string;
   objective: string;
   label: string;
   signal: AbortSignal;
-}) => Promise<void>;
+}) => Promise<string>;
 
 export interface LiveVoiceSessionArchiveAudioInput {
   messageId?: string | null;
@@ -314,6 +315,11 @@ interface ActiveAssistantTurn {
   // merges it with this turn's utterance instead of treating that utterance as
   // a fresh follow-up. Null for an ordinary (non-barge-in) turn.
   interruptedRequest: string | null;
+  // The completed background continuation's answer (voice-duplex-handoff),
+  // folded into this turn's control prompt as context so the model can deliver
+  // or reference it in reply to the user, without ever speaking it unprompted.
+  // Null when no continuation result is pending for this turn.
+  continuationResult: string | null;
   // Triage-and-escalate (Voice Mode): the front-door leg emitted [ESCALATE]
   // and the strong "escalated" leg has taken over this same turn. Guards the
   // front-door leg's trailing completion from finalizing the turn, and makes
@@ -349,6 +355,31 @@ const LIVE_VOICE_CONTROL_PROMPT =
 // not a user message and never renders as a transcript bubble.
 function buildInterruptionMergeNote(interruptedRequest: string): string {
   return `The user interrupted your previous, unfinished reply. Their earlier request was: "${interruptedRequest}". Treat their current message as a continuation of that request and address both together, or stay silent if they only want you to stop.`;
+}
+
+// System-level guidance appended to the NEXT turn's control prompt after a
+// background continuation (voice-duplex-handoff) finished the reply the user
+// interrupted. Folds the completed answer in as context so the model can
+// deliver or reference it in reply to the user; it must never be spoken
+// unprompted (live-voice is non-interactive, JARVIS-1291). Reaches the model
+// only; it is not a user message and never renders as a transcript bubble.
+function buildResurfaceContextNote(continuationResult: string): string {
+  return `Earlier the user interrupted you, and in the background you finished the reply they cut off. What you worked out was: "${continuationResult}". If their current message relates to it, use it to answer; otherwise you may briefly offer it or leave it aside, and do not repeat it verbatim if it no longer fits.`;
+}
+
+// Assemble a turn's model-facing control prompt: the base live-voice rules plus
+// any pending barge-in merge context and/or completed-continuation context. A
+// turn can carry both (a barge-in follow-up that also has a continuation result
+// waiting); the notes are model-only and never render as user bubbles.
+function buildVoiceControlPrompt(turn: ActiveAssistantTurn): string {
+  let prompt = LIVE_VOICE_CONTROL_PROMPT;
+  if (turn.interruptedRequest) {
+    prompt = `${prompt}\n\n${buildInterruptionMergeNote(turn.interruptedRequest)}`;
+  }
+  if (turn.continuationResult) {
+    prompt = `${prompt}\n\n${buildResurfaceContextNote(turn.continuationResult)}`;
+  }
+  return prompt;
 }
 
 // Objective handed to the background subagent that continues a barged-in turn.
@@ -444,6 +475,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // Consumed (and cleared) when that turn launches; cleared if the barge-in
   // utterance is discarded, so it can never attach to a later, unrelated turn.
   private pendingInterruptedRequest: string | null = null;
+  // Set when a background continuation (voice-duplex-handoff) finishes the reply
+  // a barge-in cut off: its final answer, folded into the next turn the user
+  // starts as context. Consumed (and cleared) when that turn launches; cleared
+  // on a hard stop (abortDetachedRuns) so a stale result never surfaces later.
+  private pendingContinuationResult: string | null = null;
   private readonly maxPendingAudioBytes: number;
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
@@ -1204,12 +1240,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         if (controller.signal.aborted || this.isClosed) {
           return;
         }
-        await spawn({
+        const resultText = await spawn({
           parentConversationId: this.conversationId,
           objective: buildDuplexContinuationObjective(interruptedRequest),
           label: `voice-continue-${turn.turnId}`,
           signal: controller.signal,
         });
+        // Fold the completed continuation's answer into the next turn the user
+        // starts (never spoken unprompted). Re-check the stop guards after the
+        // await: an interrupt/close during the run must suppress it. Latest
+        // result wins if another continuation already stashed one.
+        const answer = resultText.trim();
+        if (
+          answer.length > 0 &&
+          !controller.signal.aborted &&
+          !this.isClosed &&
+          this.detachStopGeneration === stopGeneration
+        ) {
+          this.pendingContinuationResult = answer;
+        }
       } catch (err) {
         // A stop/interrupt aborts via the signal; that rejection is expected.
         if (!controller.signal.aborted) {
@@ -1235,6 +1284,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       controller.abort();
     }
     this.detachControllers.clear();
+    // A hard stop also drops any completed continuation's result still waiting
+    // to fold into the next turn, so it can't surface after the user reset.
+    this.pendingContinuationResult = null;
   }
 
   // VAD closed the utterance — the analog of ptt_release: emit
@@ -1747,11 +1799,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
-    // Consume any pending barge-in merge context for this turn (one barge-in
-    // feeds exactly the next launched turn).
+    // Consume any pending barge-in merge context and completed-continuation
+    // context for this turn (each feeds exactly the next launched turn).
     const interruptedRequest = this.pendingInterruptedRequest;
     this.pendingInterruptedRequest = null;
-    await this.launchAssistantTurn(utterance, content, { interruptedRequest });
+    const continuationResult = this.pendingContinuationResult;
+    this.pendingContinuationResult = null;
+    await this.launchAssistantTurn(utterance, content, {
+      interruptedRequest,
+      continuationResult,
+    });
   }
 
   // Build the ActiveAssistantTurn for a released utterance and drive its model
@@ -1763,6 +1820,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Set on a barge-in follow-up turn: the interrupted request's transcript,
       // appended to the turn's control prompt so the model merges the two.
       interruptedRequest?: string | null;
+      // Set when a background continuation finished the interrupted reply: its
+      // answer, appended to the turn's control prompt as context.
+      continuationResult?: string | null;
     },
   ): Promise<void> {
     utterance.assistantTurnStarted = true;
@@ -1781,6 +1841,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ttsAudioStarted: false,
       finalized: false,
       interruptedRequest: opts?.interruptedRequest ?? null,
+      continuationResult: opts?.continuationResult ?? null,
       escalationHandedOff: false,
       ttsBuffer: "",
       ttsSegmentEnqueued: false,
@@ -1913,11 +1974,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         assistantMessageChannel: "vellum",
         userMessageInterface: "macos",
         assistantMessageInterface: "macos",
-        voiceControlPrompt: activeTurn.interruptedRequest
-          ? `${LIVE_VOICE_CONTROL_PROMPT}\n\n${buildInterruptionMergeNote(
-              activeTurn.interruptedRequest,
-            )}`
-          : LIVE_VOICE_CONTROL_PROMPT,
+        voiceControlPrompt: buildVoiceControlPrompt(activeTurn),
         content: leg.content,
         isInbound: true,
         signal: activeTurn.abortController.signal,
@@ -2914,21 +2971,22 @@ export function createLiveVoiceSession(
 // (which include the interrupted turn's completed tool calls after teardown),
 // so it resumes without repeating them. Uses spawnAndAwait (synchronous mode)
 // so the terminal parent-notification is skipped — the continuation stays
-// silent until the resurface flow lands, and this call ignores its result. The
-// `signal` aborts the child on a stop/interrupt.
+// silent (never spoken unprompted); its final answer is RETURNED so the session
+// can fold it into the next turn the user starts. The `signal` aborts the child
+// on a stop/interrupt (spawnAndAwait then rejects).
 async function defaultSpawnBackgroundContinuation(args: {
   parentConversationId: string;
   objective: string;
   label: string;
   signal: AbortSignal;
-}): Promise<void> {
+}): Promise<string> {
   const parentConversation = findConversation(args.parentConversationId);
   if (!parentConversation) {
     throw new Error(
       `Cannot detach interrupted voice turn: conversation ${args.parentConversationId} is not resident.`,
     );
   }
-  await getSubagentManager().spawnAndAwait(
+  return await getSubagentManager().spawnAndAwait(
     {
       parentConversationId: args.parentConversationId,
       label: args.label,
@@ -2938,7 +2996,8 @@ async function defaultSpawnBackgroundContinuation(args: {
       parentMessages: [...parentConversation.messages],
       parentSystemPrompt: parentConversation.getCurrentSystemPrompt(),
     },
-    // No client-facing events: the continuation is silent until resurface.
+    // No client-facing events: the continuation is silent; its result is folded
+    // into the next user turn as context, never spoken on its own.
     () => {},
     { signal: args.signal },
   );

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -434,10 +434,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // before its async teardown; if it has changed by the time the detach would
   // spawn, a stop landed during the gap and the continuation is not started.
   private detachStopGeneration = 0;
-  // Monotonic id assigned to each detached continuation in barge-in order.
-  // Only the latest-started detach (detachSeq === detachSequence) may populate
-  // the pending result, so once a newer barge-in starts, an older continuation
-  // completing (before OR after it) can't surface a stale answer.
+  // Bumped SYNCHRONOUSLY at each barge-in (in barge order), before the async
+  // detach runs. Only the latest-started detach (detachSeq === detachSequence)
+  // may populate the pending result, so once a newer barge-in starts, an older
+  // continuation completing (before OR after it) can't surface a stale answer.
   private detachSequence = 0;
   private readonly emitMetrics: boolean;
   private readonly metrics: LiveVoiceMetricsCollector;
@@ -1150,6 +1150,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // can't consume an older answer before this barge-in's own continuation
     // completes. Cleared even when no continuation ultimately detaches.
     this.pendingContinuationResult = null;
+    // Order this barge-in among concurrent detaches SYNCHRONOUSLY, in barge
+    // order — the actual detach runs after an async teardown chain, and those
+    // chains can interleave, so bumping there could assign sequences out of
+    // order and let an older continuation re-stash. A higher sequence here
+    // immediately invalidates every earlier still-running continuation.
+    const detachSeq = ++this.detachSequence;
     turn.abortController.abort();
     this.metrics.markBargeIn(turn.turnId);
     // Capture the interrupted turn's teardown promise synchronously, before the
@@ -1174,7 +1180,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Keep the interrupted turn's work alive on a background subagent
       // (voice-duplex-handoff); the detach waits for its teardown to settle the
       // partial into history before forking.
-      this.detachInterruptedTurn(turn, stopGeneration, teardownWait);
+      this.detachInterruptedTurn(turn, stopGeneration, teardownWait, detachSeq);
     })().catch(() => {});
   }
 
@@ -1190,6 +1196,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     turn: ActiveAssistantTurn,
     stopGeneration: number,
     teardownWait: Promise<void> | undefined,
+    detachSeq: number,
   ): void {
     const spawn = this.spawnBackgroundContinuation;
     if (
@@ -1212,9 +1219,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const interruptedRequest = turn.utterance.finalTranscriptSegments
       .join(" ")
       .trim();
-    // Order this continuation among concurrent detaches so a later-completing
-    // older one can't overwrite a newer one's stashed result.
-    const detachSeq = ++this.detachSequence;
     // Register the abort handle synchronously so a stop that lands while the
     // continuation is still spawning still aborts it (abortDetachedRuns fires
     // controller.abort(), which the spawn's signal wiring honors).

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -434,6 +434,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // before its async teardown; if it has changed by the time the detach would
   // spawn, a stop landed during the gap and the continuation is not started.
   private detachStopGeneration = 0;
+  // Monotonic id assigned to each detached continuation in barge-in order, so a
+  // later-completing OLDER continuation can't overwrite a newer one's stashed
+  // result (see pendingContinuationResultSeq).
+  private detachSequence = 0;
   private readonly emitMetrics: boolean;
   private readonly metrics: LiveVoiceMetricsCollector;
   private readonly createTurnId: () => string;
@@ -480,6 +484,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // starts as context. Consumed (and cleared) when that turn launches; cleared
   // on a hard stop (abortDetachedRuns) so a stale result never surfaces later.
   private pendingContinuationResult: string | null = null;
+  // The detachSequence of the continuation whose result is currently stashed (0
+  // when none). Only a continuation at least as recent may overwrite it, so an
+  // older continuation completing out of order can't clobber a newer answer.
+  private pendingContinuationResultSeq = 0;
   private readonly maxPendingAudioBytes: number;
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
@@ -1202,6 +1210,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const interruptedRequest = turn.utterance.finalTranscriptSegments
       .join(" ")
       .trim();
+    // Order this continuation among concurrent detaches so a later-completing
+    // older one can't overwrite a newer one's stashed result.
+    const detachSeq = ++this.detachSequence;
     // Register the abort handle synchronously so a stop that lands while the
     // continuation is still spawning still aborts it (abortDetachedRuns fires
     // controller.abort(), which the spawn's signal wiring honors).
@@ -1248,16 +1259,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         });
         // Fold the completed continuation's answer into the next turn the user
         // starts (never spoken unprompted). Re-check the stop guards after the
-        // await: an interrupt/close during the run must suppress it. Latest
-        // result wins if another continuation already stashed one.
+        // await: an interrupt/close during the run must suppress it. Only a
+        // newer-or-equal detach may overwrite the stash, so an older continuation
+        // finishing out of order can't clobber a more recent answer.
         const answer = resultText.trim();
         if (
           answer.length > 0 &&
           !controller.signal.aborted &&
           !this.isClosed &&
-          this.detachStopGeneration === stopGeneration
+          this.detachStopGeneration === stopGeneration &&
+          detachSeq >= this.pendingContinuationResultSeq
         ) {
           this.pendingContinuationResult = answer;
+          this.pendingContinuationResultSeq = detachSeq;
         }
       } catch (err) {
         // A stop/interrupt aborts via the signal; that rejection is expected.
@@ -2643,6 +2657,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // finalizes through finalizeAssistantTurn, not here, so this never clears a
     // request that the barge-in follow-up turn is still about to consume.
     this.pendingInterruptedRequest = null;
+    // `pendingContinuationResult` is deliberately NOT cleared here. Unlike the
+    // merge context (bound to the immediate barge-in follow-up), a completed
+    // continuation's answer targets the next REAL turn, and hands-free server-VAD
+    // routinely discards noise/empty-transcript utterances between turns; wiping
+    // it on each such discard would frequently drop a valid result before the
+    // user's next question. It is bounded instead by consume-once, the hard-stop
+    // clear (abortDetachedRuns), and the model's "use only if relevant" framing.
     utterance.completed = true;
     const turnId = utterance.turnId;
     if (!turnId) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -434,9 +434,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // before its async teardown; if it has changed by the time the detach would
   // spawn, a stop landed during the gap and the continuation is not started.
   private detachStopGeneration = 0;
-  // Monotonic id assigned to each detached continuation in barge-in order, so a
-  // later-completing OLDER continuation can't overwrite a newer one's stashed
-  // result (see pendingContinuationResultSeq).
+  // Monotonic id assigned to each detached continuation in barge-in order.
+  // Only the latest-started detach (detachSeq === detachSequence) may populate
+  // the pending result, so once a newer barge-in starts, an older continuation
+  // completing (before OR after it) can't surface a stale answer.
   private detachSequence = 0;
   private readonly emitMetrics: boolean;
   private readonly metrics: LiveVoiceMetricsCollector;
@@ -484,10 +485,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // starts as context. Consumed (and cleared) when that turn launches; cleared
   // on a hard stop (abortDetachedRuns) so a stale result never surfaces later.
   private pendingContinuationResult: string | null = null;
-  // The detachSequence of the continuation whose result is currently stashed (0
-  // when none). Only a continuation at least as recent may overwrite it, so an
-  // older continuation completing out of order can't clobber a newer answer.
-  private pendingContinuationResultSeq = 0;
   private readonly maxPendingAudioBytes: number;
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
@@ -1259,19 +1256,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         });
         // Fold the completed continuation's answer into the next turn the user
         // starts (never spoken unprompted). Re-check the stop guards after the
-        // await: an interrupt/close during the run must suppress it. A
-        // newer-or-equal detach supersedes any older stash by advancing the
-        // sequence even when it produced no text — so an older continuation
-        // finishing out of order can't surface a stale answer behind a more
-        // recent interruption. Only non-empty text is actually surfaced.
+        // await: an interrupt/close during the run must suppress it. Only the
+        // latest-started detach may populate the result, so once a newer
+        // barge-in has started, an older continuation completing (before or
+        // after it, empty or not) can't surface a stale answer. Only non-empty
+        // text is actually surfaced.
         if (
           !controller.signal.aborted &&
           !this.isClosed &&
           this.detachStopGeneration === stopGeneration &&
-          detachSeq >= this.pendingContinuationResultSeq
+          detachSeq === this.detachSequence
         ) {
           const answer = resultText.trim();
-          this.pendingContinuationResultSeq = detachSeq;
           this.pendingContinuationResult = answer.length > 0 ? answer : null;
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- Completes the true-duplex loop (PR 3 of the plan): when a barged-in turn's background continuation (`voice-duplex-handoff`) finishes the reply the user cut off, its answer is now **folded into the next turn the user starts** as model-facing context, instead of being discarded. Live-voice stays **non-interactive** (JARVIS-1291) — the result is never spoken unprompted; the model only delivers or references it in reply to the user's next message, and can leave it aside if it no longer fits.
- Mirrors the existing barge-in merge-note machinery: `LiveVoiceBackgroundContinuationSpawner` now resolves with the continuation's final text; the session stashes it in `pendingContinuationResult`, consumes it **once** on the next launched turn (appended to that turn's `voiceControlPrompt` via `buildResurfaceContextNote`, never a user bubble), and **drops it on a hard stop** (interrupt/close, via `abortDetachedRuns`).
- Gated behind the existing `voice-duplex-handoff` flag (the stash only populates when a continuation ran). 3 new tests: fold-into-next-turn + consume-once, interrupt drops a stashed result, and empty result adds nothing.

## Approach note
The originally-planned spoken-resume rail (`resumeWithText`) was **removed from `main` last week** by #38194 ("Make live-voice mode non-interactive like phone", JARVIS-1291). Per that product direction, this PR delivers the continuation result via **next-turn context** rather than reintroducing self-initiated spoken delivery.

## Original prompt
Third and final PR of the voice true-duplex plan (`.private/plans/voice-true-duplex-detach-resurface.md`, JARVIS-1249), following the merged detach-and-continue foundation (#38308) and teardown-settle safety fix (#38320). Delivers "resurface": get the completed background continuation's result back to the user. Given #38194 made voice non-interactive, delivery is fold-into-next-turn (no unprompted speech), chosen explicitly by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
