### PR TITLE
fix(voice): derive the cloud live-voice velay host from the platform environment

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
@@ -31,7 +31,6 @@ import {
   LiveVoiceTokenError,
   mintLiveVoiceToken,
   resolveLiveVoiceWsUrl,
-  velayHostForPlatformHost,
 } from "./connection";
 
 // ---------------------------------------------------------------------------
@@ -172,35 +171,6 @@ describe("buildLiveVoiceWsUrl", () => {
       buildLiveVoiceWsUrl({ assistantId: "assistant-1", token: "tok-abc" }),
     );
     expect(url.host).toBe("velay.vellum.ai");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// velayHostForPlatformHost — mirrors the gateway's velayOriginForPlatformHost
-// ---------------------------------------------------------------------------
-
-describe("velayHostForPlatformHost", () => {
-  test("maps the prod platform host to prod velay", () => {
-    expect(velayHostForPlatformHost("platform.vellum.ai")).toBe(
-      "velay.vellum.ai",
-    );
-  });
-
-  test("maps env-prefixed platform hosts to their env velay", () => {
-    expect(velayHostForPlatformHost("staging-platform.vellum.ai")).toBe(
-      "velay-staging.vellum.ai",
-    );
-    expect(velayHostForPlatformHost("dev-platform.vellum.ai")).toBe(
-      "velay-dev.vellum.ai",
-    );
-  });
-
-  test("returns null for hosts outside the deployment convention", () => {
-    expect(velayHostForPlatformHost("localhost")).toBeNull();
-    expect(velayHostForPlatformHost("platform.example.com")).toBeNull();
-    expect(
-      velayHostForPlatformHost("staging-platform.vellum.ai.evil.com"),
-    ).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
@@ -31,6 +31,7 @@ import {
   LiveVoiceTokenError,
   mintLiveVoiceToken,
   resolveLiveVoiceWsUrl,
+  velayHostForPlatformHost,
 } from "./connection";
 
 // ---------------------------------------------------------------------------
@@ -64,6 +65,7 @@ beforeEach(() => {
 afterEach(() => {
   client.post = originalPost;
   setSelfHostedConnection(null);
+  window.__VELLUM_CONFIG__ = undefined;
 });
 
 describe("mintLiveVoiceToken", () => {
@@ -151,6 +153,54 @@ describe("buildLiveVoiceWsUrl", () => {
     );
     expect(url.searchParams.get("token")).toBe("tok-abc");
     expect(url.searchParams.get("conversationId")).toBe("conv-xyz");
+  });
+
+  test("derives the velay host from the injected platform URL (Electron shell)", () => {
+    window.__VELLUM_CONFIG__ = {
+      platformUrl: "https://staging-platform.vellum.ai",
+    };
+    const url = new URL(
+      buildLiveVoiceWsUrl({ assistantId: "assistant-1", token: "tok-abc" }),
+    );
+    expect(url.protocol).toBe("wss:");
+    expect(url.host).toBe("velay-staging.vellum.ai");
+  });
+
+  test("falls back to the prod velay host for an off-convention platform URL", () => {
+    window.__VELLUM_CONFIG__ = { platformUrl: "http://localhost:8000" };
+    const url = new URL(
+      buildLiveVoiceWsUrl({ assistantId: "assistant-1", token: "tok-abc" }),
+    );
+    expect(url.host).toBe("velay.vellum.ai");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// velayHostForPlatformHost — mirrors the gateway's velayOriginForPlatformHost
+// ---------------------------------------------------------------------------
+
+describe("velayHostForPlatformHost", () => {
+  test("maps the prod platform host to prod velay", () => {
+    expect(velayHostForPlatformHost("platform.vellum.ai")).toBe(
+      "velay.vellum.ai",
+    );
+  });
+
+  test("maps env-prefixed platform hosts to their env velay", () => {
+    expect(velayHostForPlatformHost("staging-platform.vellum.ai")).toBe(
+      "velay-staging.vellum.ai",
+    );
+    expect(velayHostForPlatformHost("dev-platform.vellum.ai")).toBe(
+      "velay-dev.vellum.ai",
+    );
+  });
+
+  test("returns null for hosts outside the deployment convention", () => {
+    expect(velayHostForPlatformHost("localhost")).toBeNull();
+    expect(velayHostForPlatformHost("platform.example.com")).toBeNull();
+    expect(
+      velayHostForPlatformHost("staging-platform.vellum.ai.evil.com"),
+    ).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -4,7 +4,8 @@
  * Live voice picks its transport by deployment kind via
  * {@link resolveLiveVoiceWsUrl}:
  *
- * - **Cloud** — streams audio to velay (`velay.vellum.ai`), which is
+ * - **Cloud** — streams audio to the platform environment's velay (prod
+ *   `velay.vellum.ai`, staging `velay-staging.vellum.ai`, …), which is
  *   cross-origin from the `platform.vellum.ai` SPA. A same-origin cookie WS
  *   upgrade is NOT viable: velay does no user auth, and the channel gateway
  *   only accepts a local actor edge JWT. So the browser first mints a
@@ -39,13 +40,17 @@
 
 import { authLiveVoiceTokenCreate } from "@/generated/api/sdk.gen";
 import type { LiveVoiceTokenResponse } from "@/generated/api/types.gen";
+import { getPlatformRuntimeUrl } from "@/lib/local-mode";
 import {
   getSelfHostedActorToken,
   getSelfHostedIngressUrl,
 } from "@/lib/self-hosted/connection";
 import { assertHasResponse } from "@/utils/api-errors";
 
-/** Production velay host (no scheme). Overridable via `VITE_VELAY_HOST`. */
+/**
+ * Production velay host (no scheme). Fallback when neither the
+ * `VITE_VELAY_HOST` override nor the platform-host derivation applies.
+ */
 const DEFAULT_VELAY_HOST = "velay.vellum.ai";
 
 export class LiveVoiceTokenError extends Error {
@@ -96,9 +101,44 @@ export async function mintLiveVoiceToken(
   return data;
 }
 
-/** Resolve the velay host (no scheme), honouring the build-time override. */
+/**
+ * Map a Vellum platform host onto its environment's velay host, following the
+ * deployment naming convention (`platform.vellum.ai` → `velay.vellum.ai`,
+ * `{env}-platform.vellum.ai` → `velay-{env}.vellum.ai`). Returns null for
+ * hosts outside that convention (localhost, custom domains). Mirrors
+ * `velayOriginForPlatformHost` in the gateway's speech-relay route.
+ */
+export function velayHostForPlatformHost(host: string): string | null {
+  if (host === "platform.vellum.ai") {
+    return "velay.vellum.ai";
+  }
+  const match = /^([a-z0-9-]+)-platform\.vellum\.ai$/.exec(host);
+  return match ? `velay-${match[1]}.vellum.ai` : null;
+}
+
+/**
+ * Resolve the velay host (no scheme). An explicit `VITE_VELAY_HOST` always
+ * wins (local `vel up` velay); otherwise derive it from the platform runtime
+ * URL so one renderer build follows whichever platform environment it is
+ * connected to — the Electron web bundle is built without `VITE_VELAY_HOST`,
+ * and baking the prod default would send a staging assistant's token to prod
+ * velay, which rejects it on the WS upgrade.
+ */
 function getVelayHost(): string {
-  return import.meta.env.VITE_VELAY_HOST || DEFAULT_VELAY_HOST;
+  if (import.meta.env.VITE_VELAY_HOST) {
+    return import.meta.env.VITE_VELAY_HOST;
+  }
+  try {
+    const derived = velayHostForPlatformHost(
+      new URL(getPlatformRuntimeUrl()).hostname,
+    );
+    if (derived) {
+      return derived;
+    }
+  } catch {
+    // Unparseable platform URL — fall through to the prod default.
+  }
+  return DEFAULT_VELAY_HOST;
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -40,7 +40,7 @@
 
 import { authLiveVoiceTokenCreate } from "@/generated/api/sdk.gen";
 import type { LiveVoiceTokenResponse } from "@/generated/api/types.gen";
-import { getPlatformRuntimeUrl } from "@/lib/local-mode";
+import { getPlatformRuntimeUrl } from "@/lib/platform-runtime-url";
 import {
   getSelfHostedActorToken,
   getSelfHostedIngressUrl,

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -38,6 +38,8 @@
  * cookie + CSRF + `Vellum-Organization-Id`.
  */
 
+import { velayHostForPlatformHost } from "@vellumai/service-contracts/ingress";
+
 import { authLiveVoiceTokenCreate } from "@/generated/api/sdk.gen";
 import type { LiveVoiceTokenResponse } from "@/generated/api/types.gen";
 import { getPlatformRuntimeUrl } from "@/lib/platform-runtime-url";
@@ -99,21 +101,6 @@ export async function mintLiveVoiceToken(
     throw new LiveVoiceTokenError(0, "Live-voice token response was malformed");
   }
   return data;
-}
-
-/**
- * Map a Vellum platform host onto its environment's velay host, following the
- * deployment naming convention (`platform.vellum.ai` → `velay.vellum.ai`,
- * `{env}-platform.vellum.ai` → `velay-{env}.vellum.ai`). Returns null for
- * hosts outside that convention (localhost, custom domains). Mirrors
- * `velayOriginForPlatformHost` in the gateway's speech-relay route.
- */
-export function velayHostForPlatformHost(host: string): string | null {
-  if (host === "platform.vellum.ai") {
-    return "velay.vellum.ai";
-  }
-  const match = /^([a-z0-9-]+)-platform\.vellum\.ai$/.exec(host);
-  return match ? `velay-${match[1]}.vellum.ai` : null;
 }
 
 /**

--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -48,8 +48,10 @@ interface ImportMetaEnv {
   /** When truthy ("1", "true", "yes"), disables platform connectivity in local mode. */
   readonly VITE_VELLUM_DISABLE_PLATFORM?: string;
   /**
-   * Override for the live-voice velay host (no scheme), e.g. `velay.dev.vellum.ai`.
-   * Defaults to `velay.vellum.ai` when unset. See `domains/chat/voice/live-voice/connection.ts`.
+   * Override for the live-voice velay host (no scheme), e.g. `localhost:8501`
+   * for a local `vel up` velay. When unset the host is derived at runtime from
+   * the platform host (`velay.vellum.ai`, `velay-{env}.vellum.ai`). See
+   * `domains/chat/voice/live-voice/connection.ts`.
    */
   readonly VITE_VELAY_HOST?: string;
 
@@ -65,7 +67,11 @@ interface Window {
   /** Feature flag overrides injected by Electron preload or CLI script. */
   __VELLUM_FLAG_OVERRIDES__?: Record<string, boolean | string>;
   /** Runtime config injected by the shell (Electron preload, CLI, etc.). */
-  __VELLUM_CONFIG__?: { disablePlatform?: boolean; mode?: string };
+  __VELLUM_CONFIG__?: {
+    disablePlatform?: boolean;
+    mode?: string;
+    platformUrl?: string;
+  };
   /**
    * SDK-defined override for the session-replay recorder script URL. Set before
    * the replay SDK inits so it loads the recorder from our first-party proxy

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -9,6 +9,7 @@ import {
   getGatewayToken,
   getLocalTokenUrl,
 } from "@/lib/auth/gateway-session";
+import { getPlatformRuntimeUrl } from "@/lib/platform-runtime-url";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { useLockfileStore } from "@/stores/lockfile-store";
 import {
@@ -57,14 +58,7 @@ const EMPTY_LOCKFILE: Lockfile = { assistants: [], activeAssistant: null };
 
 const LOCKFILE_STORAGE_KEY = "vellum:local:lockfile";
 
-export function getPlatformRuntimeUrl(): string {
-  const injected = (
-    window as unknown as {
-      __VELLUM_CONFIG__?: { platformUrl?: string };
-    }
-  ).__VELLUM_CONFIG__;
-  return injected?.platformUrl || window.location.origin;
-}
+export { getPlatformRuntimeUrl };
 
 function getInjectedConfig(): {
   disablePlatform?: boolean;

--- a/clients/web/src/lib/platform-runtime-url.ts
+++ b/clients/web/src/lib/platform-runtime-url.ts
@@ -1,0 +1,12 @@
+/**
+ * The platform origin this app talks to at runtime: the shell-injected
+ * `__VELLUM_CONFIG__.platformUrl` (Electron preload, CLI) when present,
+ * else the page origin (the platform SPA is served from the platform host).
+ *
+ * Lives in its own leaf module — not `local-mode` — so transport-level
+ * consumers (e.g. the live-voice velay host derivation) don't pull the whole
+ * local-mode graph into theirs.
+ */
+export function getPlatformRuntimeUrl(): string {
+  return window.__VELLUM_CONFIG__?.platformUrl || window.location.origin;
+}

--- a/gateway/src/http/routes/speech-relay-websocket.ts
+++ b/gateway/src/http/routes/speech-relay-websocket.ts
@@ -22,6 +22,8 @@
 
 import type { OutgoingHttpHeaders } from "node:http";
 
+import { velayHostForPlatformHost } from "@vellumai/service-contracts/ingress";
+
 import { validateEdgeToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
@@ -110,17 +112,13 @@ function jsonError(status: number, code: string, detail: string): Response {
 }
 
 /**
- * Map a Vellum platform host onto its environment's velay origin, following
- * the deployment naming convention (`platform.vellum.ai` → `velay.vellum.ai`,
- * `{env}-platform.vellum.ai` → `velay-{env}.vellum.ai`). Returns null for
- * hosts outside that convention (localhost, custom domains).
+ * Map a Vellum platform host onto its environment's velay origin. The
+ * host-naming convention lives in `@vellumai/service-contracts/ingress`,
+ * shared with the web live-voice client; this wrapper adds the scheme.
  */
 export function velayOriginForPlatformHost(host: string): string | null {
-  if (host === "platform.vellum.ai") {
-    return "https://velay.vellum.ai";
-  }
-  const match = /^([a-z0-9-]+)-platform\.vellum\.ai$/.exec(host);
-  return match ? `https://velay-${match[1]}.vellum.ai` : null;
+  const velayHost = velayHostForPlatformHost(host);
+  return velayHost ? `https://${velayHost}` : null;
 }
 
 /**

--- a/packages/service-contracts/src/__tests__/ingress.test.ts
+++ b/packages/service-contracts/src/__tests__/ingress.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   normalizeHttpPublicBaseUrl,
   normalizePublicBaseUrl,
+  velayHostForPlatformHost,
 } from "../ingress.js";
 import {
   buildTwilioMediaStreamUrl,
@@ -10,6 +11,31 @@ import {
   buildTwilioVoiceWebhookUrl,
   resolveTwilioPublicBaseUrl,
 } from "../twilio-ingress.js";
+
+describe("velayHostForPlatformHost", () => {
+  test("maps the prod platform host to prod velay", () => {
+    expect(velayHostForPlatformHost("platform.vellum.ai")).toBe(
+      "velay.vellum.ai",
+    );
+  });
+
+  test("maps env-prefixed platform hosts to their env velay", () => {
+    expect(velayHostForPlatformHost("staging-platform.vellum.ai")).toBe(
+      "velay-staging.vellum.ai",
+    );
+    expect(velayHostForPlatformHost("dev-platform.vellum.ai")).toBe(
+      "velay-dev.vellum.ai",
+    );
+  });
+
+  test("returns null for hosts outside the deployment convention", () => {
+    expect(velayHostForPlatformHost("localhost")).toBeNull();
+    expect(velayHostForPlatformHost("platform.example.com")).toBeNull();
+    expect(
+      velayHostForPlatformHost("staging-platform.vellum.ai.evil.com"),
+    ).toBeNull();
+  });
+});
 
 describe("normalizePublicBaseUrl", () => {
   test("trims whitespace and trailing slashes", () => {

--- a/packages/service-contracts/src/ingress.ts
+++ b/packages/service-contracts/src/ingress.ts
@@ -1,3 +1,19 @@
+/**
+ * Map a Vellum platform host onto its environment's velay host, following the
+ * deployment naming convention (`platform.vellum.ai` → `velay.vellum.ai`,
+ * `{env}-platform.vellum.ai` → `velay-{env}.vellum.ai`). Returns null for
+ * hosts outside that convention (localhost, custom domains). Shared by the
+ * gateway speech relay and the web live-voice client so the two ends of the
+ * managed-speech transport can't drift.
+ */
+export function velayHostForPlatformHost(host: string): string | null {
+  if (host === "platform.vellum.ai") {
+    return "velay.vellum.ai";
+  }
+  const match = /^([a-z0-9-]+)-platform\.vellum\.ai$/.exec(host);
+  return match ? `velay-${match[1]}.vellum.ai` : null;
+}
+
 export function normalizePublicBaseUrl(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim().replace(/\/+$/, "");


### PR DESCRIPTION
## Summary
- Derive the cloud live-voice velay host at runtime from the assistant's platform runtime URL (`platform.vellum.ai` → `velay.vellum.ai`, `{env}-platform.vellum.ai` → `velay-{env}.vellum.ai`), porting the gateway speech relay's `velayOriginForPlatformHost` derivation (#38037) to `clients/web`; `VITE_VELAY_HOST` remains an explicit override for the local `vel up` velay.
- Fixes managed voice in the staging Electron app: its web bundle is built without `VITE_VELAY_HOST`, so it dialed prod velay with a staging-minted token and every connect failed with "Live-voice WebSocket error".
- Type `platformUrl` on the injected `window.__VELLUM_CONFIG__` (the Electron preload already exposes it) and cover the derivation with unit tests mirroring the gateway's.

## Original prompt
Debugging managed voice mode failing on a cloud assistant (Ziggy, staging-platform) in the staging Electron app traced the "Live-voice WebSocket error" to the renderer baking the prod default velay host: `getVelayHost()` only honoured build-time `VITE_VELAY_HOST`, which the Electron web build never sets (only the platform SPA deploy does). The ask was to port the gateway's `velayOriginForPlatformHost` env derivation to the web client's cloud live-voice path so the velay host follows the assistant's platform environment at runtime, keeping `VITE_VELAY_HOST` as the explicit override for the local `vel up` velay.