### PR TITLE
fix(design-library): make button-backed SideMenu items span the rail width

### DIFF
--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -570,7 +570,10 @@ function SideMenuItem({
   const collapsed = isCollapsedRail(ctx);
 
   const rowClasses = cn(
-    "group relative flex items-center",
+    // `w-full` matters for the `<button>` render path: buttons keep
+    // fit-content sizing even as flex containers, so without it a
+    // button-backed item shrink-wraps while anchor-backed items fill the rail.
+    "group relative flex w-full items-center",
     "rounded-[6px]",
     "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
     "cursor-pointer select-none",


### PR DESCRIPTION
## Summary

The sidebar footer's Preferences item (the user-name row that opens the preferences menu) renders shrink-wrapped to its content instead of spanning the rail.

## Root cause

`SideMenu.Item` renders as an `<a>` for nav links but a `<button>` for `onSelect` items. Buttons keep fit-content sizing even when made flex containers, so anchor-backed items fill the rail while button-backed ones (like the Preferences trigger) hug their label — the trailing chevron also ends up glued to the text instead of right-aligned.

## Fix

Add `w-full` to the shared row classes. Every `SideMenu.Item` consumer is a rail/menu row inside the menu's stretch flex column, so full width is correct universally; it's a no-op for the anchor path, which already filled.

## Test plan

- [x] design-library `bun run test` — full suite green (side-menu 22/22)
- [x] design-library + clients/web typecheck — clean
- [ ] Manual: sidebar footer Preferences row spans the rail; chevron right-aligned; conversation/nav rows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)