### PR TITLE
fix(billing): use the free plan's 4 GiB storage baseline in upgrade deltas

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -153,7 +153,9 @@ describe("PlanCard", () => {
     expect(html).toContain("2 vCPU");
     expect(html).not.toContain("Small →");
     expect(html).not.toContain("Standard");
-    // Storage really changes 0 → 10 GB, so the arrow form is kept.
-    expect(html).toContain("0 → 10 GB");
+    // Storage really changes (free's 4 GiB baseline → Mighty's 10), so the
+    // arrow form is kept.
+    expect(html).toContain("4 → 10 GB");
+    expect(html).not.toContain("0 → 10 GB");
   });
 });

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -123,6 +123,13 @@ function PlanHeading() {
  */
 const STANDARD_MACHINE = { sizeLabel: "Small", vcpu: "2" } as const;
 
+/**
+ * Storage included with the free/base plan. The plan catalog's BasePlan entry
+ * carries no storage field, so the baseline comes from the pricing spec
+ * (Free = 4 GiB).
+ */
+const FREE_STORAGE_GIB = 4;
+
 /** Machine size label + vCPU count for a package (or the standard machine). */
 function machineInfo(pkg: ProPackage | null): {
     sizeLabel: string;
@@ -155,7 +162,7 @@ function buildDeltas(
 ): ResourceDelta[] {
     const from = machineInfo(currentPackage);
     const to = machineInfo(recommended);
-    const fromStorage = currentPackage?.storage_gib ?? 0;
+    const fromStorage = currentPackage?.storage_gib ?? FREE_STORAGE_GIB;
     return [
         { icon: Computer, label: `${arrow(from.sizeLabel, to.sizeLabel)} Machine` },
         {


### PR DESCRIPTION
## Summary

The recommended-upgrade banner's storage chip showed "0 → 10 GB" for free-plan users. Free actually includes 4 GiB of storage, so the delta should read "4 → 10 GB".

## Root cause

`buildDeltas` fell back to `0` for the current-plan storage baseline when there's no current package. The plan catalog's `BasePlan` entry carries no storage field, so there was nothing to read from the API — but 0 is wrong per the pricing spec (Free = 4 GiB, as shown on the pricing page).

## Fix

Ground the baseline in a named `FREE_STORAGE_GIB = 4` constant (documented as coming from the pricing spec, since the API has no field for it), used only when the subscriber has no package pin. Machine/vCPU chips were already correct.

## Test plan

- [x] plan-card tests 6/6 — the delta test now asserts "4 → 10 GB" and rejects "0 → 10 GB"
- [x] typecheck + eslint clean
- [ ] Manual: with `pro-packages` on, the Mighty banner chips read "Small Machine", "2 vCPU's", "4 → 10 GB"

🤖 Generated with [Claude Code](https://claude.com/claude-code)