### PR TITLE
feat(tts): voice selection and previews for Vellum managed TTS

### DIFF
--- a/assistant/src/config/schemas/tts.ts
+++ b/assistant/src/config/schemas/tts.ts
@@ -212,13 +212,16 @@ export type TtsXaiProviderConfig = z.infer<typeof TtsXaiProviderConfigSchema>;
 
 /**
  * Vellum managed provider configuration under `services.tts.providers`.
- *
- * Intentionally empty: the platform pins the voice and model, so there is
- * nothing to configure yet. The block exists to satisfy the
- * catalog-completeness guard and to give future options a home.
  */
 const TtsVellumProviderConfigSchema = z
-  .object({})
+  .object({
+    model: z
+      .string()
+      .optional()
+      .describe(
+        "Managed TTS voice model (e.g. aura-2-thalia-en). Unset means the platform's default voice. The platform rejects voices it does not offer.",
+      ),
+  })
   .describe("Vellum managed provider configuration under services.tts");
 
 export type TtsVellumProviderConfig = z.infer<

--- a/assistant/src/platform/managed-speech.test.ts
+++ b/assistant/src/platform/managed-speech.test.ts
@@ -174,6 +174,24 @@ describe("managedSpeechSynthesize", () => {
     });
   });
 
+  test("includes the voice model in the body only when provided", async () => {
+    await managedSpeechSynthesize({
+      text: "hello",
+      format: "mp3",
+      model: "aura-2-zeus-en",
+    });
+    const [, init] = mockClient!.fetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      text: "hello",
+      format: "mp3",
+      model: "aura-2-zeus-en",
+    });
+
+    await managedSpeechSynthesize({ text: "hello", format: "mp3" });
+    const [, second] = mockClient!.fetch.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(second.body as string)).not.toHaveProperty("model");
+  });
+
   test("falls back to audio/mpeg when no content type is returned", async () => {
     mockClient!.fetch = mock(
       async () => new Response(new Uint8Array(MP3_BYTES), { status: 200 }),

--- a/assistant/src/platform/managed-speech.ts
+++ b/assistant/src/platform/managed-speech.ts
@@ -132,6 +132,8 @@ export async function managedSpeechTranscribe(input: {
 export async function managedSpeechSynthesize(input: {
   text: string;
   format: ManagedSpeechTtsFormat;
+  /** Voice model (e.g. "aura-2-thalia-en"); omitted = platform default. */
+  model?: string;
   signal?: AbortSignal;
 }): Promise<ManagedSpeechResult<ManagedSpeechSynthesis>> {
   const resolved = await resolveClient();
@@ -145,7 +147,11 @@ export async function managedSpeechSynthesize(input: {
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: input.text, format: input.format }),
+      body: JSON.stringify({
+        text: input.text,
+        format: input.format,
+        ...(input.model !== undefined ? { model: input.model } : {}),
+      }),
       signal: input.signal,
     },
   );

--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -200,7 +200,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
     "vellum",
     {
       id: "vellum",
-      displayName: "Vellum Managed",
+      displayName: "Vellum",
       subtitle:
         "Speech-to-text through your Vellum account — billed to Vellum credits, no separate API key needed.",
       setupMode: "connection",

--- a/assistant/src/tts/__tests__/vellum-provider.test.ts
+++ b/assistant/src/tts/__tests__/vellum-provider.test.ts
@@ -236,7 +236,9 @@ describe("vellum TTS definition", () => {
     expect(vellumTtsProviderDefinition.mediaStreamPlayback.outputFormat).toBe(
       "pcm",
     );
-    expect(vellumTtsProviderDefinition.supportsVoiceSelection).toBe(false);
+    // True since managed voice selection: clients gate their voice dropdown
+    // on this flag (old daemons report false and show no selector).
+    expect(vellumTtsProviderDefinition.supportsVoiceSelection).toBe(true);
   });
 
   test("requires only the platform connection credential", () => {

--- a/assistant/src/tts/providers/vellum-provider.ts
+++ b/assistant/src/tts/providers/vellum-provider.ts
@@ -15,6 +15,7 @@
  * messages rather than returning silence.
  */
 
+import { getConfig } from "../../config/loader.js";
 import {
   type ManagedSpeechResult,
   managedSpeechSynthesize,
@@ -59,6 +60,14 @@ function resolveManagedFormat(
   return request.outputFormat === "pcm" ? "pcm_16000" : "mp3";
 }
 
+/**
+ * The configured managed voice, if any. A request-level voiceId wins over
+ * config; undefined means the platform's default voice.
+ */
+function resolveManagedVoice(request: TtsSynthesisRequest): string | undefined {
+  return request.voiceId ?? getConfig().services.tts.providers.vellum.model;
+}
+
 function synthesisError(failure: ManagedSpeechFailure): Error {
   if (failure.code === "insufficient_balance") {
     return new Error(
@@ -79,6 +88,7 @@ async function performSynthesis(
   const result = await managedSpeechSynthesize({
     text: request.text,
     format: resolveManagedFormat(request),
+    model: resolveManagedVoice(request),
     signal: request.signal,
   });
   if (!result.ok) {
@@ -121,6 +131,10 @@ async function performStreamingSynthesis(
     // consumes headerless PCM, so RIFF header bytes would play as static.
     container: "none",
   });
+  const voice = resolveManagedVoice(request);
+  if (voice) {
+    params.set("model", voice);
+  }
   const url = `${connection.wsBaseUrl}${TTS_STREAM_PATH}?${params.toString()}`;
 
   log.info(

--- a/assistant/src/tts/providers/vellum-provider.ts
+++ b/assistant/src/tts/providers/vellum-provider.ts
@@ -211,7 +211,7 @@ export function createVellumProvider(): TtsProvider {
  */
 export const vellumTtsProviderDefinition: TtsProviderDefinition = {
   id: "vellum",
-  displayName: "Vellum Managed",
+  displayName: "Vellum",
   subtitle:
     "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
   // Advertises managed voice selection (`services.tts.providers.vellum.model`)

--- a/assistant/src/tts/providers/vellum-provider.ts
+++ b/assistant/src/tts/providers/vellum-provider.ts
@@ -167,10 +167,17 @@ async function performStreamingSynthesis(
     }
     // A rejected upgrade hides the relay's {code, detail}; replay the gate
     // as a plain GET (the gateway probes velay's own gate too) so auth and
-    // balance failures surface with their mapped messages.
-    const probeKey = encodeURIComponent(connection.mintServiceToken());
+    // balance failures surface with their mapped messages. The probe must
+    // carry the same voice model — a model-specific rejection (e.g.
+    // missing_price) only reproduces when the probe asks for that model.
+    const probeParams = new URLSearchParams({
+      key: connection.mintServiceToken(),
+    });
+    if (voice) {
+      probeParams.set("model", voice);
+    }
     const rejection = await probeVelayRejection(
-      `${connection.httpBaseUrl}${TTS_STREAM_PATH}?key=${probeKey}`,
+      `${connection.httpBaseUrl}${TTS_STREAM_PATH}?${probeParams.toString()}`,
     );
     if (rejection) {
       throw new Error(mapVelayError(rejection).message);
@@ -207,7 +214,10 @@ export const vellumTtsProviderDefinition: TtsProviderDefinition = {
   displayName: "Vellum Managed",
   subtitle:
     "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
-  supportsVoiceSelection: false,
+  // Advertises managed voice selection (`services.tts.providers.vellum.model`)
+  // to clients; web gates its voice dropdown on this flag, so daemons that
+  // predate the field never show a selector whose writes they would ignore.
+  supportsVoiceSelection: true,
   apiKeyPlaceholder: "Connected via your Vellum account",
   credentialsGuide: {
     description:

--- a/clients/web/src/domains/settings/ai/managed-voice-catalog.ts
+++ b/clients/web/src/domains/settings/ai/managed-voice-catalog.ts
@@ -1,17 +1,30 @@
 /**
- * Curated voices offered by Vellum managed TTS (Deepgram Aura-2).
+ * Curated voices offered by Vellum managed TTS.
  *
  * The platform gates voices by its billing rate card, so this list must stay
  * a subset of the rate-carded models in vellum-assistant-platform
  * (`BILLING_MANAGED_SPEECH_RATE_CARDS`) — an unlisted model is rejected with
- * `missing_price`. Sample URLs are Deepgram's public hosted previews.
+ * `missing_price`. Sample URLs are the upstream provider's public hosted
+ * previews.
  */
+
+/**
+ * Upstream provider a managed voice is synthesized by. Extend as the
+ * managed catalog grows (e.g. "elevenlabs").
+ */
+export type ManagedVoiceSource = "deepgram";
+
+export const MANAGED_VOICE_SOURCE_LABELS: Record<ManagedVoiceSource, string> = {
+  deepgram: "Deepgram",
+};
+
 export interface ManagedVoice {
-  /** Deepgram model id, e.g. "aura-2-thalia-en". */
+  /** Upstream model id, e.g. "aura-2-thalia-en". */
   model: string;
   label: string;
   description: string;
   sampleUrl: string;
+  source: ManagedVoiceSource;
 }
 
 export const DEFAULT_MANAGED_VOICE = "aura-2-thalia-en";
@@ -25,72 +38,84 @@ export const MANAGED_VOICES: ManagedVoice[] = [
     model: "aura-2-thalia-en",
     label: "Thalia (default)",
     description: "American · clear, confident, energetic",
+    source: "deepgram",
     sampleUrl: sample("thalia"),
   },
   {
     model: "aura-2-andromeda-en",
     label: "Andromeda",
     description: "American · casual, expressive, comfortable",
+    source: "deepgram",
     sampleUrl: sample("andromeda"),
   },
   {
     model: "aura-2-helena-en",
     label: "Helena",
     description: "American · caring, natural, friendly",
+    source: "deepgram",
     sampleUrl: sample("helena"),
   },
   {
     model: "aura-2-athena-en",
     label: "Athena",
     description: "American · calm, smooth, professional",
+    source: "deepgram",
     sampleUrl: sample("athena"),
   },
   {
     model: "aura-2-luna-en",
     label: "Luna",
     description: "American · friendly, natural, engaging",
+    source: "deepgram",
     sampleUrl: sample("luna"),
   },
   {
     model: "aura-2-pandora-en",
     label: "Pandora",
     description: "British · smooth, calm, melodic",
+    source: "deepgram",
     sampleUrl: sample("pandora"),
   },
   {
     model: "aura-2-theia-en",
     label: "Theia",
     description: "Australian · expressive, polite, sincere",
+    source: "deepgram",
     sampleUrl: sample("theia"),
   },
   {
     model: "aura-2-apollo-en",
     label: "Apollo",
     description: "American · confident, comfortable, casual",
+    source: "deepgram",
     sampleUrl: sample("apollo"),
   },
   {
     model: "aura-2-arcas-en",
     label: "Arcas",
     description: "American · natural, smooth, clear",
+    source: "deepgram",
     sampleUrl: sample("arcas"),
   },
   {
     model: "aura-2-zeus-en",
     label: "Zeus",
     description: "American · deep, trustworthy, smooth",
+    source: "deepgram",
     sampleUrl: sample("zeus"),
   },
   {
     model: "aura-2-draco-en",
     label: "Draco",
     description: "British · warm, approachable, baritone",
+    source: "deepgram",
     sampleUrl: sample("draco"),
   },
   {
     model: "aura-2-hyperion-en",
     label: "Hyperion",
     description: "Australian · caring, warm, empathetic",
+    source: "deepgram",
     sampleUrl: sample("hyperion"),
   },
 ];

--- a/clients/web/src/domains/settings/ai/managed-voice-catalog.ts
+++ b/clients/web/src/domains/settings/ai/managed-voice-catalog.ts
@@ -1,0 +1,96 @@
+/**
+ * Curated voices offered by Vellum managed TTS (Deepgram Aura-2).
+ *
+ * The platform gates voices by its billing rate card, so this list must stay
+ * a subset of the rate-carded models in vellum-assistant-platform
+ * (`BILLING_MANAGED_SPEECH_RATE_CARDS`) — an unlisted model is rejected with
+ * `missing_price`. Sample URLs are Deepgram's public hosted previews.
+ */
+export interface ManagedVoice {
+  /** Deepgram model id, e.g. "aura-2-thalia-en". */
+  model: string;
+  label: string;
+  description: string;
+  sampleUrl: string;
+}
+
+export const DEFAULT_MANAGED_VOICE = "aura-2-thalia-en";
+
+function sample(name: string): string {
+  return `https://static.deepgram.com/examples/Aura-2-${name}.wav`;
+}
+
+export const MANAGED_VOICES: ManagedVoice[] = [
+  {
+    model: "aura-2-thalia-en",
+    label: "Thalia (default)",
+    description: "American · clear, confident, energetic",
+    sampleUrl: sample("thalia"),
+  },
+  {
+    model: "aura-2-andromeda-en",
+    label: "Andromeda",
+    description: "American · casual, expressive, comfortable",
+    sampleUrl: sample("andromeda"),
+  },
+  {
+    model: "aura-2-helena-en",
+    label: "Helena",
+    description: "American · caring, natural, friendly",
+    sampleUrl: sample("helena"),
+  },
+  {
+    model: "aura-2-athena-en",
+    label: "Athena",
+    description: "American · calm, smooth, professional",
+    sampleUrl: sample("athena"),
+  },
+  {
+    model: "aura-2-luna-en",
+    label: "Luna",
+    description: "American · friendly, natural, engaging",
+    sampleUrl: sample("luna"),
+  },
+  {
+    model: "aura-2-pandora-en",
+    label: "Pandora",
+    description: "British · smooth, calm, melodic",
+    sampleUrl: sample("pandora"),
+  },
+  {
+    model: "aura-2-theia-en",
+    label: "Theia",
+    description: "Australian · expressive, polite, sincere",
+    sampleUrl: sample("theia"),
+  },
+  {
+    model: "aura-2-apollo-en",
+    label: "Apollo",
+    description: "American · confident, comfortable, casual",
+    sampleUrl: sample("apollo"),
+  },
+  {
+    model: "aura-2-arcas-en",
+    label: "Arcas",
+    description: "American · natural, smooth, clear",
+    sampleUrl: sample("arcas"),
+  },
+  {
+    model: "aura-2-zeus-en",
+    label: "Zeus",
+    description: "American · deep, trustworthy, smooth",
+    sampleUrl: sample("zeus"),
+  },
+  {
+    model: "aura-2-draco-en",
+    label: "Draco",
+    description: "British · warm, approachable, baritone",
+    sampleUrl: sample("draco"),
+  },
+  {
+    model: "aura-2-hyperion-en",
+    label: "Hyperion",
+    description: "Australian · caring, warm, empathetic",
+    sampleUrl: sample("hyperion"),
+  },
+];

--- a/clients/web/src/domains/settings/ai/provider-catalogs.ts
+++ b/clients/web/src/domains/settings/ai/provider-catalogs.ts
@@ -32,7 +32,7 @@ export interface TTSProvider {
 export const TTS_PROVIDERS: readonly TTSProvider[] = [
   {
     id: "vellum",
-    displayName: "Vellum Managed",
+    displayName: "Vellum",
     subtitle:
       "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
     // Deliberately false in the static fallback: this entry stands in for

--- a/clients/web/src/domains/settings/ai/provider-catalogs.ts
+++ b/clients/web/src/domains/settings/ai/provider-catalogs.ts
@@ -35,6 +35,10 @@ export const TTS_PROVIDERS: readonly TTSProvider[] = [
     displayName: "Vellum Managed",
     subtitle:
       "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
+    // Deliberately false in the static fallback: this entry stands in for
+    // daemons whose live catalog is unavailable or predates managed voice
+    // selection, and those daemons ignore `providers.vellum.model` writes.
+    // New daemons advertise true via the live catalog fetch.
     supportsVoiceSelection: false,
     apiKeyPlaceholder: "Connected via your Vellum account",
     credentialsGuide: {

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -223,7 +223,7 @@ describe("TextToSpeechCard — Vellum provider", () => {
   test("selecting Vellum saves provider vellum and stores no credential", async () => {
     renderCard();
 
-    selectProvider("Vellum Managed");
+    selectProvider("Vellum");
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
@@ -294,7 +294,7 @@ describe("TextToSpeechCard — Vellum provider", () => {
     const options = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
     ).map((o) => o.textContent?.trim());
-    expect(options).toContain("Vellum Managed");
+    expect(options).toContain("Vellum");
     expect(options).toContain("ElevenLabs");
   });
 });

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -408,6 +408,9 @@ export function TextToSpeechCard() {
               }))}
               aria-label="Managed voice"
             />
+            <p className="text-body-small-default text-[var(--content-tertiary)]">
+              Voices by Deepgram
+            </p>
           </div>
         )}
 

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -30,6 +30,10 @@ import {
   LS_TTS_PROVIDER,
   LS_TTS_VOICE_ID_PREFIX,
 } from "@/domains/settings/ai/local-storage-keys";
+import {
+  DEFAULT_MANAGED_VOICE,
+  MANAGED_VOICES,
+} from "@/domains/settings/ai/managed-voice-catalog";
 import { TTS_PROVIDERS } from "@/domains/settings/ai/provider-catalogs";
 
 /**
@@ -82,7 +86,12 @@ export function TextToSpeechCard() {
   // `services.tts` falls under the ConfigGetResponse index signature (`unknown`),
   // so narrow it explicitly to read the provider.
   const daemonTts = daemonConfig?.services?.tts as
-    { provider?: string; mode?: string } | undefined;
+    | {
+        provider?: string;
+        mode?: string;
+        providers?: { vellum?: { model?: string } };
+      }
+    | undefined;
   // A config written by the legacy mode toggle marks managed via `mode` while
   // `provider` holds the BYOK restore value — the daemon routes it to Vellum,
   // so the card must render it as Vellum too.
@@ -106,6 +115,13 @@ export function TextToSpeechCard() {
   const [providerHasKey, setProviderHasKey] = useState(false);
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
+
+  // Managed (Vellum) voice selection. Server value comes from daemon config;
+  // absent means the platform default voice.
+  const serverManagedVoice =
+    daemonTts?.providers?.vellum?.model ?? DEFAULT_MANAGED_VOICE;
+  const [draftManagedVoice, setDraftManagedVoice] =
+    useDraftOverride(serverManagedVoice);
 
   const selectedProvider = useMemo(() => {
     return providers.find((p) => p.id === draftProvider) ?? providers[0]!;
@@ -131,8 +147,20 @@ export function TextToSpeechCard() {
     const providerChanged = draftProvider !== serverProvider;
     const hasNewKey = apiKeyText.trim().length > 0;
     const voiceIdChanged = voiceIdText.trim() !== initialVoiceId;
-    return providerChanged || hasNewKey || voiceIdChanged;
-  }, [draftProvider, serverProvider, apiKeyText, voiceIdText, initialVoiceId]);
+    const managedVoiceChanged =
+      draftProvider === "vellum" && draftManagedVoice !== serverManagedVoice;
+    return (
+      providerChanged || hasNewKey || voiceIdChanged || managedVoiceChanged
+    );
+  }, [
+    draftProvider,
+    serverProvider,
+    apiKeyText,
+    voiceIdText,
+    initialVoiceId,
+    draftManagedVoice,
+    serverManagedVoice,
+  ]);
 
   const handleSave = useCallback(async () => {
     const trimmedKey = apiKeyText.trim();
@@ -202,6 +230,9 @@ export function TextToSpeechCard() {
               providers: { [activeProvider]: { [voiceField]: trimmedVoiceId } },
             }
           : {}),
+        ...(activeProvider === "vellum"
+          ? { providers: { vellum: { model: draftManagedVoice } } }
+          : {}),
       };
       if (Object.keys(ttsBody).length > 0) {
         const { response: cfgRes } = await configPatch({
@@ -235,6 +266,7 @@ export function TextToSpeechCard() {
   }, [
     assistantId,
     draftProvider,
+    draftManagedVoice,
     apiKeyText,
     voiceIdText,
     selectedProvider,
@@ -242,6 +274,29 @@ export function TextToSpeechCard() {
     daemonHasProvider,
     queryClient,
   ]);
+
+  // Managed voices preview via Deepgram's public hosted samples — no key,
+  // no billing, works before saving.
+  const [previewing, setPreviewing] = useState(false);
+  const handlePreviewVoice = useCallback(async () => {
+    const voice = MANAGED_VOICES.find((v) => v.model === draftManagedVoice);
+    if (!voice) {
+      return;
+    }
+    setPreviewing(true);
+    try {
+      const audio = new Audio(voice.sampleUrl);
+      await audio.play();
+      await new Promise<void>((resolve) => {
+        audio.onended = () => resolve();
+        audio.onerror = () => resolve();
+      });
+    } catch {
+      toast.error("Could not play the voice sample.");
+    } finally {
+      setPreviewing(false);
+    }
+  }, [draftManagedVoice]);
 
   const handleReset = useCallback(() => {
     setLocalSetting(LS_TTS_API_KEY_PREFIX + draftProvider, "");
@@ -339,6 +394,23 @@ export function TextToSpeechCard() {
           </div>
         )}
 
+        {isManaged && (
+          <div className="space-y-1">
+            <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              Voice
+            </label>
+            <Dropdown
+              value={draftManagedVoice}
+              onChange={setDraftManagedVoice}
+              options={MANAGED_VOICES.map((v) => ({
+                value: v.model,
+                label: `${v.label} — ${v.description}`,
+              }))}
+              aria-label="Managed voice"
+            />
+          </div>
+        )}
+
         {selectedProvider.supportsVoiceSelection && (
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
@@ -360,6 +432,15 @@ export function TextToSpeechCard() {
           {!isManaged && (
             <Button variant="outlined" onClick={handleTest} disabled={testing}>
               {testing ? "Testing…" : "Test"}
+            </Button>
+          )}
+          {isManaged && (
+            <Button
+              variant="outlined"
+              onClick={handlePreviewVoice}
+              disabled={previewing}
+            >
+              {previewing ? "Playing…" : "Preview voice"}
             </Button>
           )}
           <div className="ml-auto flex items-center gap-2">

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -148,7 +148,9 @@ export function TextToSpeechCard() {
     const hasNewKey = apiKeyText.trim().length > 0;
     const voiceIdChanged = voiceIdText.trim() !== initialVoiceId;
     const managedVoiceChanged =
-      draftProvider === "vellum" && draftManagedVoice !== serverManagedVoice;
+      draftProvider === "vellum" &&
+      selectedProvider.supportsVoiceSelection &&
+      draftManagedVoice !== serverManagedVoice;
     return (
       providerChanged || hasNewKey || voiceIdChanged || managedVoiceChanged
     );
@@ -160,6 +162,7 @@ export function TextToSpeechCard() {
     initialVoiceId,
     draftManagedVoice,
     serverManagedVoice,
+    selectedProvider,
   ]);
 
   const handleSave = useCallback(async () => {
@@ -230,7 +233,13 @@ export function TextToSpeechCard() {
               providers: { [activeProvider]: { [voiceField]: trimmedVoiceId } },
             }
           : {}),
-        ...(activeProvider === "vellum"
+        // Only written when the daemon supports it AND the user changed it:
+        // never writing on an untouched default keeps "unset = platform
+        // default" configs unset, and old daemons never receive a field they
+        // would silently drop.
+        ...(activeProvider === "vellum" &&
+        selectedProvider.supportsVoiceSelection &&
+        draftManagedVoice !== serverManagedVoice
           ? { providers: { vellum: { model: draftManagedVoice } } }
           : {}),
       };
@@ -267,6 +276,7 @@ export function TextToSpeechCard() {
     assistantId,
     draftProvider,
     draftManagedVoice,
+    serverManagedVoice,
     apiKeyText,
     voiceIdText,
     selectedProvider,
@@ -357,6 +367,13 @@ export function TextToSpeechCard() {
   // Vellum authenticates via the platform connection, so it has no key to enter
   // and nothing for the client-side Test path (a direct provider call) to use.
   const isManaged = draftProvider === "vellum";
+  // Managed voice selection needs a daemon that persists
+  // `services.tts.providers.vellum.model`. Old daemons (and the static
+  // fallback catalog used before the live catalog loads) report
+  // supportsVoiceSelection: false for vellum, hiding the selector so the UI
+  // never claims to save a voice the daemon would ignore.
+  const managedVoiceSupported =
+    isManaged && selectedProvider.supportsVoiceSelection;
 
   return (
     <ByoServiceCard
@@ -394,7 +411,7 @@ export function TextToSpeechCard() {
           </div>
         )}
 
-        {isManaged && (
+        {managedVoiceSupported && (
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
               Voice
@@ -414,7 +431,7 @@ export function TextToSpeechCard() {
           </div>
         )}
 
-        {selectedProvider.supportsVoiceSelection && (
+        {selectedProvider.supportsVoiceSelection && !isManaged && (
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
               Voice ID
@@ -437,7 +454,7 @@ export function TextToSpeechCard() {
               {testing ? "Testing…" : "Test"}
             </Button>
           )}
-          {isManaged && (
+          {managedVoiceSupported && (
             <Button
               variant="outlined"
               onClick={handlePreviewVoice}

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/domains/settings/ai/local-storage-keys";
 import {
   DEFAULT_MANAGED_VOICE,
+  MANAGED_VOICE_SOURCE_LABELS,
   MANAGED_VOICES,
 } from "@/domains/settings/ai/managed-voice-catalog";
 import { TTS_PROVIDERS } from "@/domains/settings/ai/provider-catalogs";
@@ -426,7 +427,14 @@ export function TextToSpeechCard() {
               aria-label="Managed voice"
             />
             <p className="text-body-small-default text-[var(--content-tertiary)]">
-              Voices by Deepgram
+              {`Voice by ${
+                MANAGED_VOICE_SOURCE_LABELS[
+                  (
+                    MANAGED_VOICES.find((v) => v.model === draftManagedVoice) ??
+                    MANAGED_VOICES[0]!
+                  ).source
+                ]
+              }`}
             </p>
           </div>
         )}

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -123,10 +123,21 @@ export function TextToSpeechCard() {
     daemonTts?.providers?.vellum?.model ?? DEFAULT_MANAGED_VOICE;
   const [draftManagedVoice, setDraftManagedVoice] =
     useDraftOverride(serverManagedVoice);
+  const selectedManagedVoice =
+    MANAGED_VOICES.find((v) => v.model === draftManagedVoice) ??
+    MANAGED_VOICES[0]!;
 
   const selectedProvider = useMemo(() => {
     return providers.find((p) => p.id === draftProvider) ?? providers[0]!;
   }, [draftProvider, providers]);
+
+  // Written to config only when true: never writing on an untouched default
+  // keeps "unset = platform default" configs unset, and daemons that predate
+  // managed voice selection never receive a field they would silently drop.
+  const managedVoiceChanged =
+    draftProvider === "vellum" &&
+    selectedProvider.supportsVoiceSelection &&
+    draftManagedVoice !== serverManagedVoice;
 
   const loadProviderState = useCallback((providerId: string) => {
     const storedKey = getLocalSetting(LS_TTS_API_KEY_PREFIX + providerId, "");
@@ -148,10 +159,6 @@ export function TextToSpeechCard() {
     const providerChanged = draftProvider !== serverProvider;
     const hasNewKey = apiKeyText.trim().length > 0;
     const voiceIdChanged = voiceIdText.trim() !== initialVoiceId;
-    const managedVoiceChanged =
-      draftProvider === "vellum" &&
-      selectedProvider.supportsVoiceSelection &&
-      draftManagedVoice !== serverManagedVoice;
     return (
       providerChanged || hasNewKey || voiceIdChanged || managedVoiceChanged
     );
@@ -161,9 +168,7 @@ export function TextToSpeechCard() {
     apiKeyText,
     voiceIdText,
     initialVoiceId,
-    draftManagedVoice,
-    serverManagedVoice,
-    selectedProvider,
+    managedVoiceChanged,
   ]);
 
   const handleSave = useCallback(async () => {
@@ -234,13 +239,7 @@ export function TextToSpeechCard() {
               providers: { [activeProvider]: { [voiceField]: trimmedVoiceId } },
             }
           : {}),
-        // Only written when the daemon supports it AND the user changed it:
-        // never writing on an untouched default keeps "unset = platform
-        // default" configs unset, and old daemons never receive a field they
-        // would silently drop.
-        ...(activeProvider === "vellum" &&
-        selectedProvider.supportsVoiceSelection &&
-        draftManagedVoice !== serverManagedVoice
+        ...(managedVoiceChanged
           ? { providers: { vellum: { model: draftManagedVoice } } }
           : {}),
       };
@@ -277,7 +276,7 @@ export function TextToSpeechCard() {
     assistantId,
     draftProvider,
     draftManagedVoice,
-    serverManagedVoice,
+    managedVoiceChanged,
     apiKeyText,
     voiceIdText,
     selectedProvider,
@@ -290,13 +289,9 @@ export function TextToSpeechCard() {
   // no billing, works before saving.
   const [previewing, setPreviewing] = useState(false);
   const handlePreviewVoice = useCallback(async () => {
-    const voice = MANAGED_VOICES.find((v) => v.model === draftManagedVoice);
-    if (!voice) {
-      return;
-    }
     setPreviewing(true);
     try {
-      const audio = new Audio(voice.sampleUrl);
+      const audio = new Audio(selectedManagedVoice.sampleUrl);
       await audio.play();
       await new Promise<void>((resolve) => {
         audio.onended = () => resolve();
@@ -307,7 +302,7 @@ export function TextToSpeechCard() {
     } finally {
       setPreviewing(false);
     }
-  }, [draftManagedVoice]);
+  }, [selectedManagedVoice]);
 
   const handleReset = useCallback(() => {
     setLocalSetting(LS_TTS_API_KEY_PREFIX + draftProvider, "");
@@ -427,14 +422,8 @@ export function TextToSpeechCard() {
               aria-label="Managed voice"
             />
             <p className="text-body-small-default text-[var(--content-tertiary)]">
-              {`Voice by ${
-                MANAGED_VOICE_SOURCE_LABELS[
-                  (
-                    MANAGED_VOICES.find((v) => v.model === draftManagedVoice) ??
-                    MANAGED_VOICES[0]!
-                  ).source
-                ]
-              }`}
+              Voice by{" "}
+              {MANAGED_VOICE_SOURCE_LABELS[selectedManagedVoice.source]}
             </p>
           </div>
         )}

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -3,7 +3,7 @@
   "providers": [
     {
       "id": "vellum",
-      "displayName": "Vellum Managed",
+      "displayName": "Vellum",
       "subtitle": "Text-to-speech through your Vellum account \u2014 billed to Vellum credits, no separate API key needed.",
       "setupMode": "cli",
       "setupHint": "Connect your Vellum account to enable managed speech.",

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -1,15 +1,15 @@
 {
-  "version": 5,
+  "version": 6,
   "providers": [
     {
       "id": "vellum",
       "displayName": "Vellum Managed",
-      "subtitle": "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
+      "subtitle": "Text-to-speech through your Vellum account \u2014 billed to Vellum credits, no separate API key needed.",
       "setupMode": "cli",
       "setupHint": "Connect your Vellum account to enable managed speech.",
       "credentialMode": "credential",
       "credentialNamespace": "vellum",
-      "supportsVoiceSelection": false,
+      "supportsVoiceSelection": true,
       "credentialsGuide": {
         "description": "Connect this assistant to your Vellum account; managed speech uses that connection instead of a provider API key.",
         "url": "https://platform.vellum.ai/",


### PR DESCRIPTION
## What

Adds voice selection for the **Vellum Managed** TTS provider, with in-app previews.

### Web settings (Voice & Sounds → Services → Text-to-Speech)
- When the provider is Vellum Managed, a **Voice** dropdown offers 12 curated Deepgram Aura-2 English voices (Thalia default; American/British/Australian accents, feminine/masculine mix) — see `managed-voice-catalog.ts`.
- A **Preview voice** button plays Deepgram's public hosted sample for the selected voice (`static.deepgram.com`) — no API key, no billing, works before saving.
- Save persists via the existing config PATCH to `services.tts.providers.vellum.model`.

### Daemon
- New optional config field `services.tts.providers.vellum.model` (the previously-empty vellum block).
- The vellum provider forwards the voice as `model` on the batch synthesize body (`managed-speech.ts`) and as a query param on the speech-relay WS dial, so read-aloud and live voice both honor it. A request-level `voiceId` overrides config.

## Dependencies / rollout

**Merge after** [vellum-assistant-platform#9241](https://github.com/vellum-ai/vellum-assistant-platform/pull/9241) is deployed — the platform gates voices by its managed-speech rate card (unpriced voice → `missing_price`), and an old velay rejects the WS `model` param. Compatibility is safe in the interim: the daemon only sends `model` when a voice is explicitly configured, and an older platform's batch endpoint ignores the extra body field.

The catalog here must stay a subset of the platform's rate-carded voices; both files carry cross-references.

## Checks

- `bunx tsc --noEmit` clean in `assistant/` and `clients/web/`.
- `managed-speech` tests (incl. new model-passthrough test), `text-to-speech-card` tests, and config schema tests pass; pre-existing unrelated failures on main are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wzyf9DgGaff6ALaUnwcdzh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->