### PR TITLE
feat(settings): gate the Vellum speech option on the platform session

### DIFF
--- a/assistant/src/providers/speech-to-text/provider-catalog.ts
+++ b/assistant/src/providers/speech-to-text/provider-catalog.ts
@@ -200,7 +200,7 @@ const CATALOG: ReadonlyMap<SttProviderId, SttProviderEntry> = new Map<
     "vellum",
     {
       id: "vellum",
-      displayName: "Vellum Managed",
+      displayName: "Vellum",
       subtitle:
         "Speech-to-text through your Vellum account — billed to Vellum credits, no separate API key needed.",
       setupMode: "connection",

--- a/assistant/src/tts/providers/vellum-provider.ts
+++ b/assistant/src/tts/providers/vellum-provider.ts
@@ -190,7 +190,7 @@ export function createVellumProvider(): TtsProvider {
  */
 export const vellumTtsProviderDefinition: TtsProviderDefinition = {
   id: "vellum",
-  displayName: "Vellum Managed",
+  displayName: "Vellum",
   subtitle:
     "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
   supportsVoiceSelection: false,

--- a/clients/web/src/domains/settings/ai/provider-catalogs.ts
+++ b/clients/web/src/domains/settings/ai/provider-catalogs.ts
@@ -32,7 +32,7 @@ export interface TTSProvider {
 export const TTS_PROVIDERS: readonly TTSProvider[] = [
   {
     id: "vellum",
-    displayName: "Vellum Managed",
+    displayName: "Vellum",
     subtitle:
       "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
     supportsVoiceSelection: false,

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -42,6 +42,17 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => false,
 }));
+let platformGate = "full";
+mock.module("@/hooks/use-platform-gate", () => ({
+  usePlatformGate: () => platformGate,
+}));
+// The real notice pulls in the router + onboarding-login flow; the cards only
+// need its presence to be observable.
+mock.module("@/components/platform-login-notice", () => ({
+  PlatformLoginNotice: ({ children }: { children?: unknown }) => (
+    <div data-testid="platform-login-notice">{children as never}</div>
+  ),
+}));
 
 // Controllable daemon config the config-get query resolves to. `initialData`
 // makes it available even though the query is `enabled: isOrgReady` (false),
@@ -126,6 +137,7 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     nativeDictationSupported = false;
     credentialsSetCalls.length = 0;
     configPatchCalls.length = 0;
+    platformGate = "full";
     daemonConfigData = { services: {} };
   });
 
@@ -250,6 +262,7 @@ describe("SpeechToTextCard — Vellum provider", () => {
     nativeDictationSupported = false;
     credentialsSetCalls.length = 0;
     configPatchCalls.length = 0;
+    platformGate = "full";
     daemonConfigData = { services: {} };
   });
 
@@ -328,6 +341,37 @@ describe("SpeechToTextCard — Vellum provider", () => {
     expect(configPatchCalls[0]!.body).toMatchObject({
       services: { stt: { provider: "deepgram", mode: "your-own" } },
     });
+  });
+
+  test("a gated platform hides the Vellum option entirely", () => {
+    // "gated" = the platform API is off in local mode; logging in cannot
+    // help, so offering the managed option would be a dead end.
+    platformGate = "gated";
+    renderCard();
+
+    openProviderDropdown();
+    expect(visibleOptions()).not.toContain("Vellum");
+  });
+
+  test("selecting Vellum while logged out shows the login notice and blocks Save", () => {
+    platformGate = "disabled";
+    renderCard();
+
+    openProviderDropdown();
+    selectOption("Vellum");
+
+    expect(screen.getByTestId("platform-login-notice")).toBeTruthy();
+    // Saving would persist a provider that cannot work without a session.
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+    expect(configPatchCalls).toHaveLength(0);
+  });
+
+  test("a logged-in session sees no login notice on Vellum", () => {
+    daemonConfigData = { services: { stt: { provider: "vellum" } } };
+    renderCard();
+
+    expect(screen.queryByTestId("platform-login-notice")).toBeNull();
   });
 
   test("leaving Vellum for native dictation writes a daemon-backed fallback", async () => {

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -137,7 +137,9 @@ export function SpeechToTextCard() {
   // ONLY the capability-dependent native id is corrected — legacy aliases
   // like "whisper" must survive untouched for normalizeSttProviderId() /
   // migrateLegacyLocalSttSettings() in stt-api.ts to map at transcribe
-  // time. Both deps are set-once, so this runs only on mount.
+  // time. The provider list recomputes when the platform gate changes, so
+  // the effect can re-run — the correction is idempotent, so extra runs
+  // are no-ops.
   useEffect(() => {
     const stored = getLocalSetting(LS_STT_PROVIDER, defaultProviderId);
     if (

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -12,12 +12,14 @@ import {
 import { configPatch, credentialsSetPost } from "@/generated/daemon/sdk.gen";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { isNativeDictationSupported } from "@/runtime/native-dictation-partials";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import {
   ByoServiceCard,
   CredentialsGuide,
@@ -74,13 +76,20 @@ export function SpeechToTextCard() {
   const assistantId = useActiveAssistantId();
   const isOrgReady = useIsOrgReady();
   const queryClient = useQueryClient();
-  // Capability is fixed for the renderer's lifetime, so compute the offered
-  // list once: the native provider only exists inside the macOS Electron
-  // shell, where the helper's SFSpeechRecognizer bridge is wired.
-  const [providers] = useState(() =>
-    STT_PROVIDERS.filter(
-      (p) => !p.requiresNativeDictation || isNativeDictationSupported(),
-    ),
+  const platformGate = usePlatformGate();
+  // The native-dictation capability is fixed for the renderer's lifetime, but
+  // the platform gate is not (logging in flips "disabled" to "full"), so the
+  // offered list is derived per render. "gated" means the platform API is off
+  // entirely — logging in cannot help, so the managed option is withheld
+  // rather than shown dead.
+  const providers = useMemo(
+    () =>
+      STT_PROVIDERS.filter(
+        (p) =>
+          (!p.requiresNativeDictation || isNativeDictationSupported()) &&
+          (p.id !== "vellum" || platformGate !== "gated"),
+      ),
+    [platformGate],
   );
   const defaultProviderId = DEFAULT_PROVIDER_ID;
 
@@ -158,6 +167,12 @@ export function SpeechToTextCard() {
     const hasNewKey = apiKeyText.trim().length > 0;
     return providerChanged || hasNewKey;
   }, [draftProvider, serverProvider, apiKeyText]);
+
+  // Vellum authenticates via the platform session; without one the save
+  // would persist a provider that cannot work, so it is blocked behind the
+  // login notice instead.
+  const vellumNeedsLogin =
+    draftProvider === "vellum" && platformGate === "disabled";
 
   const handleSave = useCallback(async () => {
     const trimmedKey = apiKeyText.trim();
@@ -326,14 +341,22 @@ export function SpeechToTextCard() {
           <CredentialsGuide guide={selectedProvider.credentialsGuide} />
         )}
 
-        {draftProvider === "vellum" && (
-          <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
-            Transcription runs through your Vellum account.
-          </p>
-        )}
+        {draftProvider === "vellum" &&
+          (vellumNeedsLogin ? (
+            <PlatformLoginNotice>
+              Log in to the Vellum platform to use managed transcription.
+            </PlatformLoginNotice>
+          ) : (
+            <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+              Transcription runs through your Vellum account.
+            </p>
+          ))}
 
         <div className="flex items-center justify-end gap-2">
-          <SaveButton onClick={handleSave} disabled={!hasChanges || saving} />
+          <SaveButton
+            onClick={handleSave}
+            disabled={!hasChanges || saving || vellumNeedsLogin}
+          />
           {providerHasKey && <ResetButton onClick={handleReset} />}
         </div>
       </div>

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -294,6 +294,34 @@ describe("TextToSpeechCard — Vellum provider", () => {
     expect(options).not.toContain("Vellum");
   });
 
+  test("a gated platform coerces a vellum config to a representable provider", async () => {
+    // The gated filter withholds vellum from the options, so a config still
+    // pointing at it must coerce to an offered value — otherwise the dropdown
+    // selects nothing while the card styles itself as managed. Saving must
+    // then force the provider write: the coerced serverProvider hides the
+    // divergence from the daemon, which would otherwise stay on vellum.
+    platformGate = "gated";
+    daemonConfigData = { services: { tts: { provider: "vellum" } } };
+    renderCard();
+
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="TTS provider"]',
+    );
+    expect(trigger?.textContent).toContain("ElevenLabs");
+    // BYOK controls are back — the card no longer styles itself as managed.
+    expect(screen.getByText("API Key")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("sk_…"), {
+      target: { value: "el-secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: { tts: { provider: "elevenlabs", mode: "your-own" } },
+    });
+  });
+
   test("a vellum selection while logged out shows the login notice and blocks Save", () => {
     platformGate = "disabled";
     daemonConfigData = { services: { tts: { provider: "vellum" } } };

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -29,6 +29,17 @@ mock.module("@vellumai/design-library/components/toast", () => ({
   Toaster: () => null,
   ToastContent: () => null,
 }));
+let platformGate = "full";
+mock.module("@/hooks/use-platform-gate", () => ({
+  usePlatformGate: () => platformGate,
+}));
+// The real notice pulls in the router + onboarding-login flow; the cards only
+// need its presence to be observable.
+mock.module("@/components/platform-login-notice", () => ({
+  PlatformLoginNotice: ({ children }: { children?: unknown }) => (
+    <div data-testid="platform-login-notice">{children as never}</div>
+  ),
+}));
 let orgReady = false;
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
@@ -108,6 +119,7 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     localStorage.clear();
     credentialsSetCalls.length = 0;
     configPatchCalls.length = 0;
+    platformGate = "full";
     daemonConfigData = { services: {} };
     orgReady = false;
     ttsCatalogData = undefined;
@@ -196,6 +208,7 @@ describe("TextToSpeechCard — Vellum provider", () => {
     localStorage.clear();
     credentialsSetCalls.length = 0;
     configPatchCalls.length = 0;
+    platformGate = "full";
     daemonConfigData = { services: {} };
     orgReady = false;
     ttsCatalogData = undefined;
@@ -265,6 +278,37 @@ describe("TextToSpeechCard — Vellum provider", () => {
     expect(configPatchCalls[0]!.body).toMatchObject({
       services: { tts: { provider: "fish-audio", mode: "your-own" } },
     });
+  });
+
+  test("a gated platform hides the Vellum option, grafted or not", () => {
+    platformGate = "gated";
+    renderCard();
+
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="TTS provider"]',
+    );
+    fireEvent.click(trigger!);
+    const options = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(options).not.toContain("Vellum Managed");
+  });
+
+  test("a vellum selection while logged out shows the login notice and blocks Save", () => {
+    platformGate = "disabled";
+    daemonConfigData = { services: { tts: { provider: "vellum" } } };
+    renderCard();
+
+    expect(screen.getByTestId("platform-login-notice")).toBeTruthy();
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+  });
+
+  test("a logged-in session sees no login notice on Vellum", () => {
+    daemonConfigData = { services: { tts: { provider: "vellum" } } };
+    renderCard();
+
+    expect(screen.queryByTestId("platform-login-notice")).toBeNull();
   });
 
   test("grafts the Vellum option onto a fetched catalog that lacks it", () => {

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -236,7 +236,7 @@ describe("TextToSpeechCard — Vellum provider", () => {
   test("selecting Vellum saves provider vellum and stores no credential", async () => {
     renderCard();
 
-    selectProvider("Vellum Managed");
+    selectProvider("Vellum");
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(configPatchCalls.length).toBe(1));
@@ -291,7 +291,7 @@ describe("TextToSpeechCard — Vellum provider", () => {
     const options = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
     ).map((o) => o.textContent?.trim());
-    expect(options).not.toContain("Vellum Managed");
+    expect(options).not.toContain("Vellum");
   });
 
   test("a vellum selection while logged out shows the login notice and blocks Save", () => {
@@ -338,7 +338,7 @@ describe("TextToSpeechCard — Vellum provider", () => {
     const options = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
     ).map((o) => o.textContent?.trim());
-    expect(options).toContain("Vellum Managed");
+    expect(options).toContain("Vellum");
     expect(options).toContain("ElevenLabs");
   });
 });

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -103,11 +103,14 @@ export function TextToSpeechCard() {
   // not `providers[0]` — the catalog leads with Vellum, and an unconfigured
   // client must not claim the managed provider on its own.
   const defaultProviderId = "elevenlabs";
-  const serverProvider = useMemo(
-    () =>
-      daemonTtsProvider ?? getLocalSetting(LS_TTS_PROVIDER, defaultProviderId),
-    [daemonTtsProvider, defaultProviderId],
-  );
+  const serverProvider = useMemo(() => {
+    const stored =
+      daemonTtsProvider ?? getLocalSetting(LS_TTS_PROVIDER, defaultProviderId);
+    // Keep the dropdown on an offered value: under a gated platform the
+    // vellum option is withheld, and a config still pointing at it would
+    // otherwise select nothing while the card styles itself as managed.
+    return providers.some((p) => p.id === stored) ? stored : defaultProviderId;
+  }, [daemonTtsProvider, providers, defaultProviderId]);
   const daemonHasProvider = !!daemonTtsProvider;
   const [draftProvider, setDraftProvider] = useDraftOverride(serverProvider);
   const [apiKeyText, setApiKeyText] = useState("");
@@ -193,8 +196,17 @@ export function TextToSpeechCard() {
       // Only PATCH the provider when it truly diverges from the persisted
       // value (or the daemon has none yet); otherwise a re-save with just a new
       // key/voice would silently switch a provider set elsewhere.
+      // When the daemon points at a provider the dropdown does not offer
+      // (vellum under a gated platform), `serverProvider` was coerced away
+      // from it, so a draft-vs-server comparison can no longer see the
+      // divergence — the write must be forced or the daemon stays on vellum.
+      const escapingUnofferedVellum =
+        daemonTtsProvider === "vellum" &&
+        !providers.some((p) => p.id === "vellum");
       const shouldSetProvider =
-        draftProvider !== serverProvider || !daemonHasProvider;
+        draftProvider !== serverProvider ||
+        !daemonHasProvider ||
+        escapingUnofferedVellum;
       const ttsBody = {
         // The provider is always written as a pair with `mode`, which keeps
         // the write valid on every daemon version: older schemas reject

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -12,6 +12,7 @@ import { configPatch, credentialsSetPost } from "@/generated/daemon/sdk.gen";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { synthesizeTTS } from "@/lib/tts-synthesize";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import { Button } from "@vellumai/design-library/components/button";
@@ -19,6 +20,7 @@ import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import {
   ByoServiceCard,
   CredentialsGuide,
@@ -57,20 +59,28 @@ export function TextToSpeechCard() {
     enabled: isOrgReady,
     staleTime: Infinity,
   });
+  const platformGate = usePlatformGate();
   const providers = useMemo(() => {
-    const fetched = catalogData?.providers;
-    if (!fetched) {
-      return TTS_PROVIDERS;
-    }
-    // Assistants running an older catalog omit vellum, but the managed option
-    // must still be offered (and a legacy managed config still renders as
-    // Vellum) — graft the static entry on.
-    if (fetched.some((p) => p.id === "vellum")) {
-      return fetched;
-    }
-    const vellum = TTS_PROVIDERS.find((p) => p.id === "vellum");
-    return vellum ? [vellum, ...fetched] : fetched;
-  }, [catalogData]);
+    const base = (() => {
+      const fetched = catalogData?.providers;
+      if (!fetched) {
+        return TTS_PROVIDERS;
+      }
+      // Assistants running an older catalog omit vellum, but the managed
+      // option must still be offered (and a legacy managed config still
+      // renders as Vellum) — graft the static entry on.
+      if (fetched.some((p) => p.id === "vellum")) {
+        return fetched;
+      }
+      const vellum = TTS_PROVIDERS.find((p) => p.id === "vellum");
+      return vellum ? [vellum, ...fetched] : fetched;
+    })();
+    // "gated" means the platform API is off entirely — logging in cannot
+    // help, so the managed option is withheld rather than shown dead.
+    return platformGate === "gated"
+      ? base.filter((p) => p.id !== "vellum")
+      : base;
+  }, [catalogData, platformGate]);
 
   // Seed the provider from the daemon's live config so a Save doesn't clobber a
   // provider configured elsewhere (CLI/other client) when localStorage is stale.
@@ -302,6 +312,9 @@ export function TextToSpeechCard() {
   // Vellum authenticates via the platform connection, so it has no key to enter
   // and nothing for the client-side Test path (a direct provider call) to use.
   const isManaged = draftProvider === "vellum";
+  // Without a platform session the save would persist a provider that cannot
+  // work, so it is blocked behind the login notice instead.
+  const vellumNeedsLogin = isManaged && platformGate === "disabled";
 
   return (
     <ByoServiceCard
@@ -356,6 +369,12 @@ export function TextToSpeechCard() {
 
         <CredentialsGuide guide={selectedProvider.credentialsGuide} />
 
+        {vellumNeedsLogin && (
+          <PlatformLoginNotice>
+            Log in to the Vellum platform to use managed speech synthesis.
+          </PlatformLoginNotice>
+        )}
+
         <div className="flex items-center gap-2">
           {!isManaged && (
             <Button variant="outlined" onClick={handleTest} disabled={testing}>
@@ -363,7 +382,10 @@ export function TextToSpeechCard() {
             </Button>
           )}
           <div className="ml-auto flex items-center gap-2">
-            <SaveButton onClick={handleSave} disabled={!hasChanges || saving} />
+            <SaveButton
+              onClick={handleSave}
+              disabled={!hasChanges || saving || vellumNeedsLogin}
+            />
             {providerHasKey && !isManaged && (
               <ResetButton onClick={handleReset} />
             )}

--- a/meta/tts-provider-catalog.json
+++ b/meta/tts-provider-catalog.json
@@ -3,7 +3,7 @@
   "providers": [
     {
       "id": "vellum",
-      "displayName": "Vellum Managed",
+      "displayName": "Vellum",
       "subtitle": "Text-to-speech through your Vellum account — billed to Vellum credits, no separate API key needed.",
       "setupMode": "cli",
       "setupHint": "Connect your Vellum account to enable managed speech.",


### PR DESCRIPTION
## What

The follow-up from the provider-dropdown redesign (#38248 → #38252 → #38236): a logged-out user could select Vellum in either speech card, save successfully, and only discover at runtime that managed speech needs a platform session.

Both cards now consult `usePlatformGate()`:

| Gate state | Meaning | Behavior |
|---|---|---|
| `full` | logged in | unchanged |
| `disabled` | platform reachable, no session | Vellum selectable; `PlatformLoginNotice` (shared component, working **Log In** button via `useOnboardingLogin`) renders in the slot the API-key input occupies for BYOK providers; **Save is blocked** |
| `gated` | platform API off (local mode) | Vellum withheld from the dropdown — logging in cannot help, so offering it would be a dead end |

This follows the established settings pattern (email card, billing, general page): `disabled` → notice with copy + login action, `gated` → surface removed.

## Notes

- The STT card's provider list moves from a set-once `useState` to a `useMemo`: the native-dictation capability genuinely is fixed for the renderer's lifetime, but the gate is not — completing login flips `disabled` → `full` live, and the card follows without a reload.
- The cards' fallback default stays the explicit BYOK constant and is **not** login-dependent — for logged-in users the daemon config is the source of truth (connect-time + startup auto-defaulting writes Vellum into it), and the constant must mirror what a sparse config actually routes to.
- A daemon already on Vellum viewed from a logged-out browser renders Vellum + the notice with Save blocked: the runtime state is the daemon's business; the notice explains why this browser can't manage it.
- Built in a worktree — the main checkout has another session's in-flight voice/gateway work.

## Testing

- 16 STT + 11 TTS card tests, including: gated hides Vellum (grafted or static), logged-out selection shows the notice and blocks Save (no PATCH fires), logged-in shows no notice
- `tsc --noEmit` clean, eslint clean

Closes out the speech provider-dropdown stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)