### PR TITLE
feat(web): link usage breakdown conversation rows to their conversations

### DIFF
--- a/clients/web/src/domains/settings/billing/usage/usage-tab.test.tsx
+++ b/clients/web/src/domains/settings/billing/usage/usage-tab.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { createElement, type ReactElement } from "react";
-import { createMemoryRouter, RouterProvider } from "react-router";
+import { createMemoryRouter, RouterProvider, useParams } from "react-router";
 
 import { usageSeriesKeyForGroupValue } from "@/domains/settings/billing/usage/usage-series";
 import type {
@@ -58,8 +58,40 @@ const usageTotalsGetMock = mock(
 
 const usageBreakdownGetMock = mock(
   async (opts: {
-    query?: { scheduleId?: string };
+    query?: { scheduleId?: string; groupBy?: string };
   }): Promise<{ data: UsageBreakdownResponse }> => {
+    if (opts.query?.groupBy === "conversation") {
+      return {
+        data: {
+          breakdown: [
+            {
+              group: "Trip planning",
+              groupId: "conv-123",
+              groupKey: null,
+              totalInputTokens: 120,
+              totalOutputTokens: 80,
+              totalCacheCreationTokens: 0,
+              totalCacheReadTokens: 0,
+              totalEstimatedCostUsd: 0.03,
+              eventCount: 2,
+              turnCount: 3,
+            },
+            {
+              group: "Other",
+              groupId: null,
+              groupKey: null,
+              totalInputTokens: 60,
+              totalOutputTokens: 40,
+              totalCacheCreationTokens: 0,
+              totalCacheReadTokens: 0,
+              totalEstimatedCostUsd: 0.01,
+              eventCount: 1,
+              turnCount: null,
+            },
+          ],
+        },
+      };
+    }
     const selectedScheduleId = sdkScheduleId(opts) ?? "schedule-123";
     const selectedSchedule = defaultSchedules.find(
       (schedule) => schedule.id === selectedScheduleId,
@@ -200,6 +232,16 @@ afterEach(() => {
   usageDailyGetMock.mockClear();
 });
 
+// Marker route target so tests can assert navigation out of the usage tab.
+function ConversationPageProbe() {
+  const { conversationId } = useParams();
+  return createElement(
+    "div",
+    { "data-testid": "conversation-page" },
+    conversationId,
+  );
+}
+
 function renderUsageTab(initialEntry: string) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -211,6 +253,10 @@ function renderUsageTab(initialEntry: string) {
       {
         path: "/assistant/settings/billing",
         element: createElement(UsageTab, { assistantId: "assistant-1" }),
+      },
+      {
+        path: "/assistant/conversations/:conversationId",
+        element: createElement(ConversationPageProbe),
       },
     ],
     { initialEntries: [initialEntry] },
@@ -317,5 +363,52 @@ describe("UsageTab", () => {
     // The mocked breakdown row has turnCount: null (a non-conversation
     // grouping), so the cell renders an em dash rather than a number.
     expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  test("links conversation breakdown rows to their conversations", async () => {
+    renderUsageTab(
+      "/assistant/settings/billing?range=7d&groupBy=conversation",
+    );
+
+    const conversationLink = await screen.findByRole("link", {
+      name: "Trip planning",
+    });
+    expect(conversationLink.getAttribute("href")).toBe(
+      "/assistant/conversations/conv-123",
+    );
+
+    // The "Other" bucket aggregates usage with no conversation to open.
+    expect(screen.getByText("Other")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Other" })).toBeNull();
+  });
+
+  test("navigates to the conversation when a breakdown row is clicked", async () => {
+    renderUsageTab(
+      "/assistant/settings/billing?range=7d&groupBy=conversation",
+    );
+
+    const conversationLink = await screen.findByRole("link", {
+      name: "Trip planning",
+    });
+    const row = conversationLink.closest("tr")!;
+    // Click a non-link cell (Cost) to exercise the whole-row affordance.
+    fireEvent.click(row.lastElementChild!);
+
+    const probe = await screen.findByTestId("conversation-page");
+    expect(probe.textContent).toBe("conv-123");
+  });
+
+  test("does not link rows for non-conversation groupings", async () => {
+    renderUsageTab("/assistant/settings/billing?range=7d&groupBy=schedule");
+
+    await waitFor(() =>
+      expect(usageBreakdownGetMock.mock.calls.length).toBeGreaterThan(0),
+    );
+
+    expect((await screen.findAllByText("Morning digest")).length)
+      .toBeGreaterThan(0);
+    expect(
+      screen.queryByRole("link", { name: "Morning digest" }),
+    ).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/usage/usage-tab.tsx
+++ b/clients/web/src/domains/settings/billing/usage/usage-tab.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle } from "lucide-react";
 import { useCallback, useMemo, useState, type ReactNode } from "react";
-import { useSearchParams } from "react-router";
+import { Link, useNavigate, useSearchParams } from "react-router";
 
 import { Dropdown } from "@vellumai/design-library";
 
@@ -61,6 +61,7 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { PromptLaunchButton } from "@/components/prompt-launch-button";
 import { extractUsageProfileMetadata } from "@/utils/profile-metadata";
+import { routes } from "@/utils/routes";
 import { fetchSchedules, type AssistantSchedule } from "@/utils/schedules";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 
@@ -775,6 +776,7 @@ function BreakdownSection({
           render={(breakdown) => (
             <BreakdownTable
               groups={decoratedGroups ?? breakdown.response.breakdown}
+              groupBy={breakdown.groupBy}
               showPct={visibleColumns.has("pct")}
               showTokens={visibleColumns.has("tokens")}
               showTurns={visibleColumns.has("turns")}
@@ -817,15 +819,19 @@ function ColumnToggle({
 
 function BreakdownTable({
   groups,
+  groupBy,
   showPct,
   showTokens,
   showTurns,
 }: {
   groups: UsageGroupBreakdown[];
+  groupBy: UsageGroupBy;
   showPct: boolean;
   showTokens: boolean;
   showTurns: boolean;
 }) {
+  const navigate = useNavigate();
+
   if (groups.length === 0) {
     return (
       <EmptyState
@@ -887,6 +893,11 @@ function BreakdownTable({
           {groups.map((group, index) => {
             const tokenDetail = formatBreakdownTokens(group);
             const tokenShort = formatBreakdownTokensShort(group);
+            // groupId carries the conversation id only for the conversation
+            // grouping ("Other" rows have none); other dimensions reuse it
+            // for their own identifiers.
+            const conversationId =
+              groupBy === "conversation" ? group.groupId : null;
             const costPct =
               totalCost > 0
                 ? Math.round(
@@ -898,6 +909,21 @@ function BreakdownTable({
                 key={
                   group.groupKey ?? group.groupId ?? `${group.group}-${index}`
                 }
+                className={
+                  conversationId
+                    ? "cursor-pointer hover:bg-[var(--surface-hover)]"
+                    : undefined
+                }
+                onClick={
+                  conversationId
+                    ? (event) => {
+                        if ((event.target as HTMLElement).closest("a")) {
+                          return;
+                        }
+                        navigate(routes.conversation(conversationId));
+                      }
+                    : undefined
+                }
                 style={{
                   borderTop:
                     index === 0 ? "none" : "1px solid var(--border-base)",
@@ -907,12 +933,22 @@ function BreakdownTable({
                   className="min-w-0 px-3 py-2"
                   style={{ color: "var(--content-default)" }}
                 >
-                  <span
-                    className="block truncate text-body-medium-lighter"
-                    title={group.group}
-                  >
-                    {group.group}
-                  </span>
+                  {conversationId ? (
+                    <Link
+                      to={routes.conversation(conversationId)}
+                      className="block truncate text-body-medium-lighter"
+                      title={group.group}
+                    >
+                      {group.group}
+                    </Link>
+                  ) : (
+                    <span
+                      className="block truncate text-body-medium-lighter"
+                      title={group.group}
+                    >
+                      {group.group}
+                    </span>
+                  )}
                 </td>
                 {showTokens ? (
                   <td


### PR DESCRIPTION
## Summary
- In Billing & Usage → Usage → Breakdown, rows grouped by **Conversation** now open the conversation: the title renders as a link (`routes.conversation(groupId)`, keyboard/cmd-click friendly) and the whole row is clickable, matching the bookmarks/recent-runs settings precedents.
- The "Other" bucket (`groupId: null` — usage not attributed to a conversation) and all other groupings stay inert, since `groupId` carries dimension-specific identifiers (model, schedule, call site) outside the conversation grouping.
- Client-only change — the conversation id was already returned as `groupId` in the breakdown response. Adds tests for the link href, whole-row navigation, and dimension gating.

Known limitation: breakdown rows carry no existence flag, so a row for a since-deleted conversation still links and opens an empty transcript (ChatPage tolerates unknown ids). Surfacing a `conversationExists` flag would need backend schema + OpenAPI churn; skipped for now.

## Original prompt
The usage breakdown table on the Billing & Usage settings page lists conversations with their cost, but rows were inert. The request: clicking a row should navigate to the actual conversation. Planned in-session: gate linking on the conversation grouping, reuse the canonical `routes.conversation()` helper and settings→conversation navigation pattern, keep "Other" non-clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)