### PR TITLE
fix(assistant): make "summarize up to here" boundary mapping repair-aware

### DIFF
--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -2,9 +2,11 @@
  * Tests for Conversation.summarizeUpToMessage ("summarize up to here").
  *
  * Verifies the row→history boundary mapping (including the leading
- * context-summary message and the already-compacted row prefix), the guardian
- * trust swap around the fresh history load, the fail-safe mapping
- * verification, and that boundary-resolver UserErrors propagate untouched.
+ * context-summary message, the already-compacted row prefix, and load-time
+ * history-repair merges/insertions), the row-exact watermark advance and
+ * merged-boundary snap-back, the guardian trust swap around the fresh history
+ * load, the fail-safe mapping verification, and that boundary-resolver
+ * UserErrors propagate untouched.
  * The compaction plugin entry (`defaultCompact`) is mocked so no summary LLM
  * runs — the assertions target the CompactionContext it receives.
  */
@@ -261,6 +263,36 @@ function threeTurnRows(): MockRow[] {
     row("m3", "assistant", "a2"),
     row("m4", "user", "u3"),
     row("m5", "assistant", "a3"),
+  ];
+}
+
+/**
+ * An awaiting-user-action surface pause mid-history: the turn ends on a
+ * tool_result-only user row (m2) and the user's reply is the next row (m3),
+ * so load-time repair merges the pair into one in-memory message and history
+ * indices run one behind row indices from there on. Rows m0..m6 load as
+ * [u1, a1(tool_use), merged(m2+m3), a2, u3, a3].
+ */
+function awaitingUserActionRows(): MockRow[] {
+  return [
+    row("m0", "user", "u1"),
+    {
+      ...row("m1", "assistant", "a1"),
+      content: [
+        { type: "text", text: "a1" },
+        { type: "tool_use", id: "tu_1", name: "surface", input: {} },
+      ],
+    },
+    {
+      ...row("m2", "user", ""),
+      content: [
+        { type: "tool_result", tool_use_id: "tu_1", content: "displayed" },
+      ],
+    },
+    row("m3", "user", "u2"),
+    row("m4", "assistant", "a2"),
+    row("m5", "user", "u3"),
+    row("m6", "assistant", "a3"),
   ];
 }
 
@@ -594,10 +626,11 @@ describe("Conversation.summarizeUpToMessage", () => {
     expect(slackWatermarkCalls).toHaveLength(0);
   });
 
-  test("throws the retryable UserError and skips compaction when the mapping cannot be verified", async () => {
+  test("maps across a synthetic tool_result insertion from history repair", async () => {
     // History repair inserts a synthetic tool_result user message after the
-    // dangling tool_use, so in-memory indices run ahead of row indices and
-    // the mapped index lands on the wrong message.
+    // dangling tool_use, so in-memory indices run one ahead of row indices
+    // past the insertion point. The load's row→history mapping accounts for
+    // it: row 3 (u2) lands at history index 4.
     mockDbMessages = [
       row("m0", "user", "u1"),
       {
@@ -612,9 +645,118 @@ describe("Conversation.summarizeUpToMessage", () => {
     ];
     const conversation = makeConversation();
 
+    await conversation.summarizeUpToMessage("m3");
+
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0].fixedTailStartIndex).toBe(4);
+    expect(compactCalls[0].fixedBoundaryRowIndex).toBe(3);
+    // [u1, a1(tool_use), synthetic tool_result, continued, u2, a2]
+    expect(compactCalls[0].messages).toHaveLength(6);
+  });
+
+  test("maps across a merged user(tool_result)+user(text) pair from an awaiting-user-action pause", async () => {
+    // A surface pause ends the turn on a tool_result-only user row; the
+    // user's reply lands as a second consecutive user row. Load-time repair
+    // merges the pair into ONE in-memory message, so past that point history
+    // indices run one BEHIND row indices — offset arithmetic would land the
+    // boundary on the wrong message (the bug behind "Conversation history is
+    // being reorganized" on healthy conversations).
+    mockDbMessages = awaitingUserActionRows();
+    const conversation = makeConversation();
+
+    await conversation.summarizeUpToMessage("m5");
+
+    expect(compactCalls).toHaveLength(1);
+    // Row 5 (u3) sits at history index 4: [u1, a1, merged(m2+m3), a2, u3, a3].
+    expect(compactCalls[0].fixedTailStartIndex).toBe(4);
+    expect(compactCalls[0].fixedBoundaryRowIndex).toBe(5);
+    expect(compactCalls[0].messages).toHaveLength(6);
+  });
+
+  test("advances the row watermark to the exact boundary row despite repair merges", async () => {
+    // The compactor's generic compactedPersistedMessages counts in-memory
+    // messages (4 here), which under-advances the row watermark when repair
+    // merged rows in the summarized range. The fixed-boundary path must land
+    // the watermark exactly on the chosen row (5).
+    mockDbMessages = awaitingUserActionRows();
+    const conversation = makeConversation();
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      compactedMessages: 4,
+      compactedPersistedMessages: 4,
+      summaryText: "merged-range summary",
+    };
+
+    await conversation.summarizeUpToMessage("m5");
+
+    expect(mockConversation.contextCompactedMessageCount).toBe(5);
+  });
+
+  test("snaps the row boundary back when the clicked turn's row was merged into the pause row's message", async () => {
+    // Clicking the reply that follows the surface pause: its row (m3) shares
+    // an in-memory message with the pause's tool_result row (m2). The summary
+    // call reads messages[0..2), which excludes both rows' content — the row
+    // watermark must retreat to m2 so the unsummarized rows stay visible to
+    // future loads.
+    mockDbMessages = awaitingUserActionRows();
+    const conversation = makeConversation();
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      compactedMessages: 2,
+      compactedPersistedMessages: 2,
+      summaryText: "pre-pause summary",
+    };
+
+    await conversation.summarizeUpToMessage("m3");
+
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0].fixedTailStartIndex).toBe(2);
+    expect(compactCalls[0].fixedBoundaryRowIndex).toBe(2);
+    expect(mockConversation.contextCompactedMessageCount).toBe(2);
+  });
+
+  test("throws 'Nothing to summarize' when everything before the boundary merged into its own message", async () => {
+    // An error turn left two consecutive real user rows at the head; repair
+    // merges them, so the clicked second row's message IS the first message —
+    // there is no earlier content for the summary call to read.
+    mockDbMessages = [
+      row("m0", "user", "u1"),
+      row("m1", "user", "u2"),
+      row("m2", "assistant", "a1"),
+    ];
+    const conversation = makeConversation();
+
     let thrown: unknown;
     try {
-      await conversation.summarizeUpToMessage("m3");
+      await conversation.summarizeUpToMessage("m1");
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(UserError);
+    expect((thrown as UserError).message).toBe(
+      "Nothing to summarize before this message",
+    );
+    expect(compactCalls).toHaveLength(0);
+  });
+
+  test("throws the retryable UserError when the boundary row has no in-memory counterpart", async () => {
+    // Pre-clean stripping drops a fully-injected user row entirely, so the
+    // clicked row maps to nothing — fail safe rather than guess a boundary.
+    mockConversation.historyStrippedAt = 1_000_000;
+    mockDbMessages = [
+      row("m0", "user", "u1"),
+      row("m1", "assistant", "a1"),
+      row("m2", "user", "<system_reminder>injected-only row"),
+      row("m3", "assistant", "a2"),
+    ];
+    const conversation = makeConversation();
+
+    let thrown: unknown;
+    try {
+      await conversation.summarizeUpToMessage("m2");
     } catch (err) {
       thrown = err;
     }

--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -3,10 +3,11 @@
  *
  * Verifies the row→history boundary mapping (including the leading
  * context-summary message, the already-compacted row prefix, and load-time
- * history-repair merges/insertions), the row-exact watermark advance and
- * merged-boundary snap-back, the guardian trust swap around the fresh history
- * load, the fail-safe mapping verification, and that boundary-resolver
- * UserErrors propagate untouched.
+ * history-repair merges/insertions), the row-exact watermark accounting
+ * derived from the compactor's actual cut (merged boundaries, tool-pairing
+ * retreats), the guardian trust swap around the fresh history load, the
+ * fail-safe mapping verification, and that boundary-resolver UserErrors
+ * propagate untouched.
  * The compaction plugin entry (`defaultCompact`) is mocked so no summary LLM
  * runs — the assertions target the CompactionContext it receives.
  */
@@ -534,6 +535,55 @@ describe("Conversation.summarizeUpToMessage", () => {
     expect(slackWatermarkCalls).toHaveLength(2);
     expect(slackWatermarkCalls[1][0]).toBe("conv-1");
     expect(typeof slackWatermarkCalls[1][1]).toBe("string");
+  });
+
+  test("derives the row watermark from the compactor's actual cut when it retreats for tool pairing", async () => {
+    // The compactor walks a requested cut backward when the kept tail would
+    // open on a tool_result whose tool_use sits in the summarized prefix
+    // (adjustTailIndexForToolPairing), and reports the cut it actually used
+    // as `compactedMessages`. The persisted watermark must follow that cut —
+    // pinning it to the requested boundary row would hide the
+    // kept-but-unsummarized rows from every future load.
+    mockDbMessages = awaitingUserActionRows();
+    const conversation = makeConversation();
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      // The compactor retreated from the requested cut (4) to 3.
+      compactedMessages: 3,
+      compactedPersistedMessages: 3,
+      summaryText: "retreated summary",
+    };
+
+    await conversation.summarizeUpToMessage("m5");
+
+    expect(compactCalls[0].fixedTailStartIndex).toBe(4);
+    // History index 3 (a2) first draws from row 4 — the merge-aware inverse,
+    // not the message-space count (3) nor the requested boundary row (5).
+    expect(mockConversation.contextCompactedMessageCount).toBe(4);
+  });
+
+  test("Slack: the watermark follows a retreated cut, not the requested boundary", async () => {
+    mockDbMessages = slackThreeTurnRows();
+    const conversation = makeConversation();
+    conversation.setChannelCapabilities(slackCapabilities);
+    mockCompactResult = {
+      ...makeNoopResult(),
+      compacted: true,
+      // The compactor retreated from the requested cut (4) to 2.
+      compactedMessages: 2,
+      compactedPersistedMessages: 2,
+      summaryText: "slack summary",
+    };
+
+    await conversation.summarizeUpToMessage("m4");
+
+    // The prefix the summary actually covers is rows[0..2), topping out at
+    // m1's channelTs — advancing to the requested boundary's prefix max
+    // (m3's 1000.000400) would exclude the kept rows m2/m3 from every
+    // future projection while the summary does not cover them.
+    expect(slackWatermarkCalls).toHaveLength(1);
+    expect(slackWatermarkCalls[0][1]).toBe("1000.000200");
   });
 
   test("Slack: a fixed boundary advances an existing older watermark", async () => {

--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -931,6 +931,102 @@ describe("repairHistory", () => {
   });
 });
 
+describe("repairHistory inputToOutputIndex", () => {
+  test("identity mapping for a clean history", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hi" }] },
+      { role: "user", content: [{ type: "text", text: "More" }] },
+      { role: "assistant", content: [{ type: "text", text: "Sure" }] },
+    ];
+
+    const { inputToOutputIndex } = repairHistory(messages);
+
+    expect(inputToOutputIndex).toEqual([0, 1, 2, 3]);
+  });
+
+  test("consecutive same-role inputs map to the same output index", () => {
+    // The awaiting-user-action surface shape: the turn ends on a
+    // user(tool_result-only) row and the user's next real message lands as a
+    // second consecutive user row; the merge collapses them into one message.
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tu_1", name: "surface", input: {} }],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tu_1", content: "shown" },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Love it — keep going" }],
+      },
+      { role: "assistant", content: [{ type: "text", text: "Will do" }] },
+    ];
+
+    const { messages: repaired, inputToOutputIndex } = repairHistory(messages);
+
+    expect(repaired).toHaveLength(4);
+    expect(inputToOutputIndex).toEqual([0, 1, 2, 2, 3]);
+  });
+
+  test("synthetic tool_result insertion shifts later outputs without consuming input slots", () => {
+    // assistant(tool_use) followed directly by another assistant message —
+    // repair inserts a synthetic user(tool_result) between them, so every
+    // input from the second assistant on lands one output slot later.
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Run it" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "continued" }] },
+      { role: "user", content: [{ type: "text", text: "next" }] },
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ];
+
+    const { messages: repaired, inputToOutputIndex } = repairHistory(messages);
+
+    expect(repaired).toHaveLength(6);
+    expect(repaired[2].role).toBe("user");
+    expect(inputToOutputIndex).toEqual([0, 1, 3, 4, 5]);
+  });
+
+  test("trailing synthetic tool_result occupies no input slot", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Run it" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
+        ],
+      },
+    ];
+
+    const { messages: repaired, inputToOutputIndex } = repairHistory(messages);
+
+    expect(repaired).toHaveLength(3);
+    expect(inputToOutputIndex).toEqual([0, 1]);
+  });
+
+  test("deepRepairHistory returns no mapping — its pre-passes are untraceable", () => {
+    const messages: Message[] = [
+      { role: "assistant", content: [{ type: "text", text: "leading" }] },
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ];
+
+    const { inputToOutputIndex } = deepRepairHistory(messages);
+
+    expect(inputToOutputIndex).toBeUndefined();
+  });
+});
+
 describe("deepRepairHistory", () => {
   test("merges consecutive same-role messages", () => {
     const messages: Message[] = [

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -44,6 +44,7 @@ import type { UserDecision } from "../permissions/types.js";
 import {
   getConversation,
   getMessages,
+  type MessageRow,
   resolveOverrideProfile,
   setConversationEnabledPlugins,
   setConversationHistoryStrippedAt,
@@ -216,6 +217,27 @@ export interface CleanResult {
   estimatedInputTokens: number;
   maxInputTokens: number;
   preservedMessages: number;
+}
+
+/**
+ * Row-addressed view of the in-memory history a {@link Conversation.loadFromDb}
+ * pass just built, for callers that need to translate a persisted row position
+ * into a `messages` index (e.g. "summarize up to here").
+ */
+export interface LoadFromDbResult {
+  /** Full persisted row set the load read (before any trust filtering). */
+  rows: MessageRow[];
+  /**
+   * Persisted-row index (into `rows`) → index into the conversation's
+   * `messages`, folding in the compacted-prefix slice, injection-strip drops,
+   * history-repair merges/insertions, and the prepended summary message.
+   * Per-row `null` when the row has no in-memory counterpart (behind the
+   * compacted boundary, or dropped by the pre-clean injection strip); `null`
+   * overall when the load was trust-filtered (a filtered view has no stable
+   * row↔history correspondence). Valid only until the conversation next
+   * mutates — turns append to `messages` without updating any mapping.
+   */
+  rowToHistoryIndex: (number | null)[] | null;
 }
 
 /**
@@ -958,7 +980,7 @@ export class Conversation {
 
   // ── Lifecycle ────────────────────────────────────────────────────
 
-  async loadFromDb(): Promise<void> {
+  async loadFromDb(): Promise<LoadFromDbResult> {
     const loadStartedAt = performance.now();
     const trustClass = this.trustContext?.trustClass;
     const canAccessMemory = resolveCapabilities(trustClass).canAccessMemory;
@@ -1239,16 +1261,28 @@ export class Conversation {
     });
 
     // Strip pre-clean messages only; post-clean messages keep the fresh
-    // injections they were generated with.
-    const messagesBeforeRepair =
-      preStrippedCount === 0
-        ? parsedMessages
-        : [
-            ...stripInjectionsForCompaction(
-              parsedMessages.slice(0, preStrippedCount),
-            ),
-            ...parsedMessages.slice(preStrippedCount),
-          ];
+    // injections they were generated with. Applied per message — block
+    // filtering is message-local, so this composes identically to stripping
+    // the whole prefix as one array — to record which rows the strip drops
+    // entirely (a fully-injected user row strips to nothing), feeding the
+    // row→history mapping returned below.
+    const messagesBeforeRepair: Message[] = [];
+    // Sliced-row index → index into `messagesBeforeRepair`; null = dropped.
+    const preRepairIndexBySlicedRow: (number | null)[] = new Array(
+      parsedMessages.length,
+    );
+    for (const [index, message] of parsedMessages.entries()) {
+      const stripped =
+        index < preStrippedCount
+          ? stripInjectionsForCompaction([message])
+          : [message];
+      if (stripped.length === 0) {
+        preRepairIndexBySlicedRow[index] = null;
+        continue;
+      }
+      preRepairIndexBySlicedRow[index] = messagesBeforeRepair.length;
+      messagesBeforeRepair.push(stripped[0]);
+    }
 
     // Normalize the canonical persisted history once at load. Every consumer
     // of `this.messages` outside the agent loop (history edit/undo, PKB context
@@ -1257,8 +1291,11 @@ export class Conversation {
     // loop's pre-run repair only repairs the transient per-turn message list it
     // sends to the provider and never writes back here, so this pass is not
     // redundant with it.
-    const { messages: repairedMessages, stats } =
-      repairHistory(messagesBeforeRepair);
+    const {
+      messages: repairedMessages,
+      stats,
+      inputToOutputIndex,
+    } = repairHistory(messagesBeforeRepair);
     if (
       stats.assistantToolResultsMigrated > 0 ||
       stats.missingToolResultsInserted > 0 ||
@@ -1339,6 +1376,29 @@ export class Conversation {
 
     this.restoreSurfaceStateFromHistory();
     this.graphMemory.restoreState();
+
+    // Row→history correspondence for this load: slice offset, then the
+    // injection-strip drop map, then the repair merge/insertion map (the
+    // post-repair tool-result finalize passes rewrite blocks strictly
+    // per-message, so indices pass through them unchanged), then the summary
+    // head. Untrusted views are trust-filtered row subsets with no stable
+    // correspondence — callers get null.
+    const summaryHeadOffset = contextSummaryForHistory ? 1 : 0;
+    const rowToHistoryIndex = canAccessMemory
+      ? allDbMessages.map((_, rowIndex): number | null => {
+          const slicedIndex = rowIndex - inContextCompactedCount;
+          if (slicedIndex < 0) {
+            return null;
+          }
+          const preRepairIndex = preRepairIndexBySlicedRow[slicedIndex];
+          if (preRepairIndex == null) {
+            return null;
+          }
+          const historyIndex = inputToOutputIndex?.[preRepairIndex];
+          return historyIndex == null ? null : historyIndex + summaryHeadOffset;
+        })
+      : null;
+    return { rows: allDbMessages, rowToHistoryIndex };
   }
 
   /**
@@ -1966,31 +2026,32 @@ export class Conversation {
       this.setTrustContext(INTERNAL_GUARDIAN_TRUST_CONTEXT);
     }
     try {
-      // Fresh guardian-scoped load so `this.messages` and the persisted rows
-      // describe the same history (rare user action; the reload cost is
-      // acceptable).
-      await this.loadFromDb();
-      const rows = getMessages(this.conversationId);
+      // Fresh guardian-scoped load so `this.messages`, the row set, and the
+      // row→history mapping all describe the same instant (rare user action;
+      // the reload cost is acceptable).
+      const { rows, rowToHistoryIndex } = await this.loadFromDb();
       const { boundaryRowIndex } = resolveSummarizeBoundary(
         rows,
         beforeMessageId,
         this.contextCompactedMessageCount,
       );
-      // Row-space → history-space: `this.messages` starts past the
-      // already-compacted row prefix and carries one leading summary message
-      // when a non-blank context summary exists (matching the `loadFromDb`
-      // prepend condition).
-      const tailIndex =
-        (this.contextSummary?.trim() ? 1 : 0) +
-        (boundaryRowIndex - this.contextCompactedMessageCount);
+      // Row-space → history-space via the load's own mapping, which folds in
+      // history-repair merges/insertions and injection-strip drops. Offset
+      // arithmetic would drift by one for every repair upstream of the
+      // boundary — e.g. the user(tool_result-only) + user(text) row pair an
+      // awaiting-user-action surface pause persists, which repair merges into
+      // a single in-memory message.
+      const tailIndex = rowToHistoryIndex?.[boundaryRowIndex] ?? null;
       const boundaryRow = rows[boundaryRowIndex];
-      const mapped: Message | undefined = this.messages[tailIndex];
+      const mapped: Message | undefined =
+        tailIndex == null ? undefined : this.messages[tailIndex];
       const rowText = firstPersistedTextBlockText(boundaryRow.content);
-      // Injection rehydration PREPENDS blocks to user messages, so the row's
-      // text must appear somewhere among the in-memory message's text blocks
-      // — never assume block 0. A mismatch means the in-memory view diverged
-      // from the persisted rows (e.g. history repair inserted a synthetic
-      // message); fail safe rather than summarize at the wrong boundary.
+      // Injection rehydration PREPENDS blocks to user messages, and repair
+      // can merge a preceding continuation row's blocks in front of the
+      // boundary row's, so the row's text must appear somewhere among the
+      // mapped message's text blocks — never assume block 0. A mismatch
+      // means the in-memory view diverged from the mapping's invariants;
+      // fail safe rather than summarize at the wrong boundary.
       const matches =
         mapped !== undefined &&
         mapped.role === boundaryRow.role &&
@@ -1998,7 +2059,7 @@ export class Conversation {
           mapped.content.some(
             (b) => b.type === "text" && b.text.includes(rowText),
           ));
-      if (!matches) {
+      if (tailIndex == null || !matches) {
         log.warn(
           {
             conversationId: this.conversationId,
@@ -2017,16 +2078,34 @@ export class Conversation {
           "Conversation history is being reorganized — try again in a moment",
         );
       }
+      // When repair merged preceding continuation rows into the boundary's
+      // message, retreat the row watermark to the message's first
+      // contributing row. The summary call reads messages[0..tailIndex),
+      // which excludes the merged rows' content — advancing the watermark
+      // past them would hide rows the summary never covered.
+      let effectiveBoundaryRowIndex = boundaryRowIndex;
+      while (
+        effectiveBoundaryRowIndex > 0 &&
+        rowToHistoryIndex?.[effectiveBoundaryRowIndex - 1] === tailIndex
+      ) {
+        effectiveBoundaryRowIndex--;
+      }
+      // Everything between the compacted watermark and the clicked turn
+      // lives inside the boundary's own merged message (at most the summary
+      // head precedes it) — there is no earlier content to summarize.
+      if (tailIndex <= (this.contextSummary?.trim() ? 1 : 0)) {
+        throw new UserError("Nothing to summarize before this message");
+      }
       return await this.runCompaction(true, undefined, {
         fixedTailStartIndex: tailIndex,
-        fixedBoundaryRowIndex: boundaryRowIndex,
+        fixedBoundaryRowIndex: effectiveBoundaryRowIndex,
         // Slack projections gate on the persisted watermark, not on
         // `contextCompactedMessageCount` — without an advance, the summarized
         // rows would reappear verbatim in the projection alongside the new
         // summary. Null for non-Slack rows or a non-advancing boundary.
         fixedBoundarySlackWatermarkTs: getSlackWatermarkAdvanceForRowPrefix(
           rows,
-          boundaryRowIndex,
+          effectiveBoundaryRowIndex,
           this.slackContextCompactionWatermarkTs,
         ),
       });
@@ -2136,7 +2215,20 @@ export class Conversation {
         : null;
     const messagesToCompact =
       slackChronologicalContext?.messages ?? this.messages;
-    const result = await defaultCompact({
+    // Row-exact watermark advance for a caller-fixed boundary. The compactor's
+    // generic `compactedPersistedMessages` counts in-memory messages, which
+    // undercounts persisted rows whenever load-time history repair merged or
+    // the injection strip dropped rows in the summarized range — the watermark
+    // would land short of the caller's chosen row. The fixed boundary is
+    // already row-space, so the advance is derived from it directly.
+    const fixedPersistedRowCount =
+      opts?.fixedBoundaryRowIndex != null
+        ? Math.max(
+            0,
+            opts.fixedBoundaryRowIndex - this.contextCompactedMessageCount,
+          )
+        : null;
+    let result = await defaultCompact({
       conversationId: this.conversationId,
       messages: messagesToCompact,
       signal: this.abortController?.signal ?? undefined,
@@ -2146,6 +2238,12 @@ export class Conversation {
       fixedTailStartIndex: opts?.fixedTailStartIndex,
       fixedBoundaryRowIndex: opts?.fixedBoundaryRowIndex,
     });
+    if (result.compacted && fixedPersistedRowCount != null) {
+      result = {
+        ...result,
+        compactedPersistedMessages: fixedPersistedRowCount,
+      };
+    }
     // Track circuit-breaker state for every compaction that ran a summary
     // call — user-initiated `/compact`, other forced paths, and the wake's
     // auto gate — so a success clears a stuck counter and a run of failures

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2059,7 +2059,7 @@ export class Conversation {
           mapped.content.some(
             (b) => b.type === "text" && b.text.includes(rowText),
           ));
-      if (tailIndex == null || !matches) {
+      if (rowToHistoryIndex == null || tailIndex == null || !matches) {
         log.warn(
           {
             conversationId: this.conversationId,
@@ -2078,36 +2078,37 @@ export class Conversation {
           "Conversation history is being reorganized — try again in a moment",
         );
       }
-      // When repair merged preceding continuation rows into the boundary's
-      // message, retreat the row watermark to the message's first
-      // contributing row. The summary call reads messages[0..tailIndex),
-      // which excludes the merged rows' content — advancing the watermark
-      // past them would hide rows the summary never covered.
-      let effectiveBoundaryRowIndex = boundaryRowIndex;
-      while (
-        effectiveBoundaryRowIndex > 0 &&
-        rowToHistoryIndex?.[effectiveBoundaryRowIndex - 1] === tailIndex
-      ) {
-        effectiveBoundaryRowIndex--;
-      }
       // Everything between the compacted watermark and the clicked turn
       // lives inside the boundary's own merged message (at most the summary
       // head precedes it) — there is no earlier content to summarize.
       if (tailIndex <= (this.contextSummary?.trim() ? 1 : 0)) {
         throw new UserError("Nothing to summarize before this message");
       }
+      // First persisted row contributing to each in-memory message — the
+      // inverse of `rowToHistoryIndex` (descending walk so the earliest row
+      // wins a merged message's slot; summary-head/synthetic entries stay
+      // null). The compaction pipeline derives its persisted and Slack
+      // watermarks from this against the cut the compactor ACTUALLY uses,
+      // which may retreat from the requested boundary for tool pairing.
+      const firstRowByHistoryIndex: (number | null)[] = new Array(
+        this.messages.length,
+      ).fill(null);
+      for (let rowIndex = rows.length - 1; rowIndex >= 0; rowIndex--) {
+        const historyIndex = rowToHistoryIndex[rowIndex];
+        if (historyIndex != null) {
+          firstRowByHistoryIndex[historyIndex] = rowIndex;
+        }
+      }
       return await this.runCompaction(true, undefined, {
         fixedTailStartIndex: tailIndex,
-        fixedBoundaryRowIndex: effectiveBoundaryRowIndex,
-        // Slack projections gate on the persisted watermark, not on
-        // `contextCompactedMessageCount` — without an advance, the summarized
-        // rows would reappear verbatim in the projection alongside the new
-        // summary. Null for non-Slack rows or a non-advancing boundary.
-        fixedBoundarySlackWatermarkTs: getSlackWatermarkAdvanceForRowPrefix(
-          rows,
-          effectiveBoundaryRowIndex,
-          this.slackContextCompactionWatermarkTs,
-        ),
+        // When repair merged preceding continuation rows into the boundary's
+        // message, the row boundary retreats to the message's first
+        // contributing row: the summary call reads messages[0..tailIndex),
+        // which excludes the merged rows' content, so the image manifest and
+        // watermarks must not treat them as summarized.
+        fixedBoundaryRowIndex:
+          firstRowByHistoryIndex[tailIndex] ?? boundaryRowIndex,
+        fixedBoundaryRowView: { rows, firstRowByHistoryIndex },
       });
     } finally {
       // Only undo the temporary guardian context this method installed. If
@@ -2152,9 +2153,11 @@ export class Conversation {
    * index ("summarize up to here") instead of the token-budget cut;
    * `opts.fixedBoundaryRowIndex` is the same boundary in row space, which
    * bounds the compactor's image manifest to rows being summarized away;
-   * `opts.fixedBoundarySlackWatermarkTs` is that path's row-space-derived
-   * Slack watermark (the auto/forced Slack path derives its own from the
-   * chronological projection).
+   * `opts.fixedBoundaryRowView` carries the load's row set and the
+   * first-contributing-row inverse of its row→history mapping, from which
+   * this pipeline derives row-exact persisted and Slack watermarks against
+   * the cut the compactor actually used (the requested cut may retreat to
+   * keep tool_use/tool_result pairs together).
    */
   private async runCompaction(
     force: boolean,
@@ -2162,7 +2165,10 @@ export class Conversation {
     opts?: {
       fixedTailStartIndex?: number;
       fixedBoundaryRowIndex?: number;
-      fixedBoundarySlackWatermarkTs?: string | null;
+      fixedBoundaryRowView?: {
+        rows: MessageRow[];
+        firstRowByHistoryIndex: (number | null)[];
+      };
     },
   ): Promise<ContextWindowResult> {
     const overrideProfile = resolveOverrideProfile(this) ?? null;
@@ -2195,9 +2201,9 @@ export class Conversation {
     // `this.messages`; the Slack chronological projection is a different
     // array (watermark-sliced, actor-filtered, re-rendered) whose indices
     // don't correspond. Fixed-boundary runs therefore always compact
-    // `this.messages`; their Slack watermark arrives pre-derived in
-    // row-space via `opts.fixedBoundarySlackWatermarkTs` (a null context
-    // makes `getSlackCompactionWatermarkForPrefix` return null below).
+    // `this.messages`; their Slack watermark is derived post-hoc in
+    // row-space from the compactor's actual cut (a null context makes
+    // `getSlackCompactionWatermarkForPrefix` return null below).
     const slackChronologicalContext =
       opts?.fixedTailStartIndex == null &&
       this.channelCapabilities?.channel === "slack"
@@ -2215,19 +2221,7 @@ export class Conversation {
         : null;
     const messagesToCompact =
       slackChronologicalContext?.messages ?? this.messages;
-    // Row-exact watermark advance for a caller-fixed boundary. The compactor's
-    // generic `compactedPersistedMessages` counts in-memory messages, which
-    // undercounts persisted rows whenever load-time history repair merged or
-    // the injection strip dropped rows in the summarized range — the watermark
-    // would land short of the caller's chosen row. The fixed boundary is
-    // already row-space, so the advance is derived from it directly.
-    const fixedPersistedRowCount =
-      opts?.fixedBoundaryRowIndex != null
-        ? Math.max(
-            0,
-            opts.fixedBoundaryRowIndex - this.contextCompactedMessageCount,
-          )
-        : null;
+    const compactedRowCountAtCall = this.contextCompactedMessageCount;
     let result = await defaultCompact({
       conversationId: this.conversationId,
       messages: messagesToCompact,
@@ -2238,11 +2232,41 @@ export class Conversation {
       fixedTailStartIndex: opts?.fixedTailStartIndex,
       fixedBoundaryRowIndex: opts?.fixedBoundaryRowIndex,
     });
-    if (result.compacted && fixedPersistedRowCount != null) {
+    // Row-exact watermark accounting for a caller-fixed boundary, derived
+    // from the cut the compactor ACTUALLY used (`result.compactedMessages`
+    // is the kept tail's history-space start): the compactor may retreat
+    // the requested cut to keep tool_use/tool_result pairs together, and
+    // pinning the watermark to the requested row would hide those
+    // kept-but-unsummarized rows from every future load. The compactor's
+    // message-space count is equally unusable as a row count — it
+    // undercounts whenever load-time repair merged (or the injection strip
+    // dropped) rows in the summarized range. Mapping the actual cut through
+    // the load's first-contributing-row inverse handles both. The null
+    // fallback (a cut landing on an unmapped synthetic message) degrades to
+    // a zero advance — conservative: rows get re-summarized later rather
+    // than hidden.
+    let fixedBoundarySlackWatermarkTs: string | null = null;
+    if (result.compacted && opts?.fixedBoundaryRowView != null) {
+      const { rows, firstRowByHistoryIndex } = opts.fixedBoundaryRowView;
+      const rowBoundary =
+        firstRowByHistoryIndex[result.compactedMessages] ??
+        compactedRowCountAtCall;
       result = {
         ...result,
-        compactedPersistedMessages: fixedPersistedRowCount,
+        compactedPersistedMessages: Math.max(
+          0,
+          rowBoundary - compactedRowCountAtCall,
+        ),
       };
+      // Slack projections gate on the persisted watermark, not on
+      // `contextCompactedMessageCount` — without an advance, the summarized
+      // rows would reappear verbatim in the projection alongside the new
+      // summary. Null for non-Slack rows or a non-advancing boundary.
+      fixedBoundarySlackWatermarkTs = getSlackWatermarkAdvanceForRowPrefix(
+        rows,
+        rowBoundary,
+        this.slackContextCompactionWatermarkTs,
+      );
     }
     // Track circuit-breaker state for every compaction that ran a summary
     // call — user-initiated `/compact`, other forced paths, and the wake's
@@ -2260,7 +2284,7 @@ export class Conversation {
     if (result.compacted) {
       await applyCompactionResult(this, result, this.sendToClient, null, {
         slackContextCompactionWatermarkTs:
-          opts?.fixedBoundarySlackWatermarkTs ??
+          fixedBoundarySlackWatermarkTs ??
           getSlackCompactionWatermarkForPrefix(
             slackChronologicalContext,
             result.compactedMessages,

--- a/assistant/src/plugins/defaults/history-repair/terminal.ts
+++ b/assistant/src/plugins/defaults/history-repair/terminal.ts
@@ -30,6 +30,14 @@ interface RepairStats {
 interface RepairResult {
   messages: Message[];
   stats: RepairStats;
+  /**
+   * For each input message index, the index in `messages` of the output
+   * message that carries that input's content. Merges map several inputs to
+   * the same output; synthetic insertions occupy output slots no input maps
+   * to. Absent when input indices are not traceable through the transform
+   * ({@link deepRepairHistory} drops and merges messages in pre-passes).
+   */
+  inputToOutputIndex?: number[];
 }
 
 const SYNTHETIC_RESULT =
@@ -49,11 +57,14 @@ export function repairHistory(messages: Message[]): RepairResult {
   };
 
   const result: Message[] = [];
+  // Input index each `result` entry originated from; -1 for synthetic
+  // insertions. Feeds `inputToOutputIndex` through the merge pass below.
+  const resultSourceIndex: number[] = [];
   let pendingToolUseIds = new Set<string>();
   // tool_result blocks stripped from assistant messages, keyed by tool_use_id
   let recoveredResults = new Map<string, ToolResultContent>();
 
-  for (const msg of messages) {
+  for (const [msgIndex, msg] of messages.entries()) {
     if (msg.role === "assistant") {
       // If previous assistant had unfulfilled tool_use, inject user message
       // using recovered results where available, synthetic for the rest
@@ -61,6 +72,7 @@ export function repairHistory(messages: Message[]): RepairResult {
         result.push(
           buildResultMessage(pendingToolUseIds, recoveredResults, stats),
         );
+        resultSourceIndex.push(-1);
         pendingToolUseIds = new Set();
         recoveredResults = new Map();
       }
@@ -155,6 +167,7 @@ export function repairHistory(messages: Message[]): RepairResult {
       }
 
       result.push({ role: "assistant", content: repairedContent });
+      resultSourceIndex.push(msgIndex);
 
       // Only track client-side tool_use IDs as pending (not server_tool_use)
       pendingToolUseIds = new Set(
@@ -218,6 +231,7 @@ export function repairHistory(messages: Message[]): RepairResult {
         }
 
         result.push({ role: "user", content: newContent });
+        resultSourceIndex.push(msgIndex);
         pendingToolUseIds = new Set();
         recoveredResults = new Map();
       } else {
@@ -241,6 +255,7 @@ export function repairHistory(messages: Message[]): RepairResult {
         });
 
         result.push({ role: "user", content: newContent });
+        resultSourceIndex.push(msgIndex);
       }
     }
   }
@@ -248,6 +263,7 @@ export function repairHistory(messages: Message[]): RepairResult {
   // Trailing unfulfilled tool_use at end of history
   if (pendingToolUseIds.size > 0) {
     result.push(buildResultMessage(pendingToolUseIds, recoveredResults, stats));
+    resultSourceIndex.push(-1);
   }
 
   // Merge consecutive same-role messages. This can occur after a checkpoint
@@ -257,7 +273,8 @@ export function repairHistory(messages: Message[]): RepairResult {
   // always be merged. Undo semantics for mixed tool_result+text messages are
   // handled by isUndoableUserMessage in conversation.ts.
   const merged: Message[] = [];
-  for (const msg of result) {
+  const inputToOutputIndex = new Array<number>(messages.length);
+  for (const [resultIndex, msg] of result.entries()) {
     const prev = merged[merged.length - 1];
     if (prev && prev.role === msg.role) {
       prev.content = [...prev.content, ...msg.content];
@@ -265,9 +282,13 @@ export function repairHistory(messages: Message[]): RepairResult {
     } else {
       merged.push({ role: msg.role, content: [...msg.content] });
     }
+    const sourceIndex = resultSourceIndex[resultIndex];
+    if (sourceIndex >= 0) {
+      inputToOutputIndex[sourceIndex] = merged.length - 1;
+    }
   }
 
-  return { messages: merged, stats };
+  return { messages: merged, stats, inputToOutputIndex };
 }
 
 function buildResultMessage(
@@ -329,7 +350,9 @@ function formatWebSearchContent(content: unknown): string {
       const idx = entries.length + 1;
       entries.push(url ? `${idx}. ${title}\n   ${url}` : `${idx}. ${title}`);
     }
-    if (entries.length > 0) return entries.join("\n");
+    if (entries.length > 0) {
+      return entries.join("\n");
+    }
   }
   return "results unavailable";
 }
@@ -398,6 +421,9 @@ export function deepRepairHistory(messages: Message[]): RepairResult {
     }
   }
 
-  // 4. Apply standard tool-use/tool-result repair on top
-  return repairHistory(merged);
+  // 4. Apply standard tool-use/tool-result repair on top. The inner mapping
+  // is keyed to `merged`'s indices, not the caller's input — steps 1–3 drop
+  // and merge messages untracked — so it is not returned.
+  const { messages: repaired, stats } = repairHistory(merged);
+  return { messages: repaired, stats };
 }


### PR DESCRIPTION
## Problem

Clicking "summarize up to here" fails with **"Summarization skipped — Conversation history is being reorganized — try again in a moment"** on perfectly healthy conversations — and retrying never helps.

`summarizeUpToMessage` translated the clicked row index into an in-memory history index with offset arithmetic (`tailIndex = summaryOffset + boundaryRowIndex - contextCompactedMessageCount`), which assumes persisted rows and loaded messages correspond 1:1. Load-time history repair breaks that assumption:

- **Consecutive same-role rows are merged.** The common source is an awaiting-user-action surface pause: the turn ends on a `user(tool_result-only)` row, and the user's reply lands as a second consecutive user row. Repair merges the pair into one in-memory message on **every** load, so all later history indices run one behind row indices — the arithmetic lands on the wrong message, the fail-safe verification trips, and the feature is permanently dead for every boundary past the merge point. Any conversation that uses interactive surfaces accumulates these pairs.
- **Synthetic `tool_result` insertions** (dangling `tool_use` before a continuation) shift indices the other way.
- **Pre-clean injection stripping** can drop fully-injected rows entirely.

The error text was written for transient divergence (concurrent compaction), but these divergences are deterministic and permanent.

A second, quieter bug: the fixed-boundary compaction advanced the row watermark by the compactor's `compactedPersistedMessages`, which counts **in-memory messages**. With merges in the summarized range it under-advances, so the next load re-exposes a row the summary already covered (leading orphaned/merged artifacts).

## Fix

- `repairHistory` now also returns `inputToOutputIndex`, tracing each input message to the repaired message that carries its content (merges → shared output slot; synthetic insertions occupy slots no input maps to). Pure bookkeeping — no behavior change. `deepRepairHistory` omits the mapping (its pre-passes are untraceable).
- `loadFromDb` composes that with the compacted-prefix slice, the pre-clean injection-strip drops (now applied per message, which is semantically identical, to record dropped rows), and the summary head — and returns `{ rows, rowToHistoryIndex }`. Untrusted (trust-filtered) loads return a null mapping.
- `summarizeUpToMessage` resolves the boundary through the mapping instead of arithmetic, using the same single row fetch the load consumed (eliminating the load/fetch race window). The role/text verification stays as a fail-safe for genuine divergence. When the clicked turn's row was merged into a preceding continuation row's message, the row watermark snaps back to that message's first contributing row — advancing past those rows would hide content the summary never covered. If everything before the boundary collapsed into its own message, it throws "Nothing to summarize before this message".
- `runCompaction` overrides `compactedPersistedMessages` with the row-exact count derived from the fixed boundary, so the persisted watermark lands exactly on the chosen row.

## Verification

- New `repairHistory` mapping tests: identity, same-role merge, synthetic insertion, trailing synthetic, deep-repair omission.
- New `summarizeUpToMessage` tests: the surface-pause merge shape (boundary after the merge, boundary **on** the merged turn with snap-back, row-exact watermark), synthetic-insertion mapping (previously the fail-safe-error fixture — now resolves), collapse-to-nothing, and a dropped-row fail-safe case.
- Replayed a real 87-row conversation exhibiting the failure (one merged pair) through the new mapping: the boundary that previously mismatched (`rowRole: user` vs `mappedRole: assistant`) now resolves to the correct user message one index earlier.
- `bunx tsgo --noEmit`, eslint, and the full summarize/repair/compaction-adjacent test files all pass.

## Risk

`repairHistory` is on the per-turn hot path for every conversation load — the change is additive bookkeeping only, but reviewers should focus there. `loadFromDb`'s injection-strip loop is a refactor with identical per-message semantics (`stripUserTextBlocksByPrefix` filters blocks per message and drops emptied messages; applying it per message composes identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)