### PR TITLE
fix(daemon): dedup at-least-once ingress redeliveries (double-emit-reply PR-a)

### DIFF
--- a/assistant/src/daemon/__tests__/process-message-idempotency.test.ts
+++ b/assistant/src/daemon/__tests__/process-message-idempotency.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { deriveIngressIdempotencyKey } from "../process-message.js";
+
+describe("deriveIngressIdempotencyKey", () => {
+  test("an explicit clientMessageId wins", () => {
+    expect(
+      deriveIngressIdempotencyKey({ clientMessageId: "web-nonce-123" }),
+    ).toBe("web-nonce-123");
+  });
+
+  test("synthesizes a namespaced key from Slack channelId + channelTs", () => {
+    expect(
+      deriveIngressIdempotencyKey({
+        slackInbound: { channelId: "C123", channelTs: "1700000000.000100" },
+      }),
+    ).toBe("slack:C123:1700000000.000100");
+  });
+
+  test("an explicit key takes precedence over the Slack transport id", () => {
+    expect(
+      deriveIngressIdempotencyKey({
+        clientMessageId: "explicit",
+        slackInbound: { channelId: "C123", channelTs: "1700000000.000100" },
+      }),
+    ).toBe("explicit");
+  });
+
+  test("returns undefined when no stable id is available (behavior unchanged)", () => {
+    expect(deriveIngressIdempotencyKey(undefined)).toBeUndefined();
+    expect(deriveIngressIdempotencyKey({})).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -59,7 +59,10 @@ import {
   mergeConversationOptions,
 } from "./conversation-store.js";
 import { getDbMigrationReadiness } from "./daemon-readiness.js";
-import type { ConversationCreateOptions } from "./handlers/shared.js";
+import type {
+  ConversationCreateOptions,
+  SlackInboundMessageMetadata,
+} from "./handlers/shared.js";
 import { HostAppControlProxy } from "./host-app-control-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import {
@@ -115,7 +118,38 @@ type ProcessMessageOptions = ConversationCreateOptions & {
    * search. Every other message in the turn indexes normally.
    */
   skipUserMessageIndexing?: boolean;
+  /**
+   * Stable idempotency key for this ingress turn. Threaded to
+   * `persistUserMessage` as `clientMessageId` so an at-least-once redelivery of
+   * the same logical turn dedups on the `client_message_id` partial unique index
+   * instead of running the agent loop a second time. When omitted, a key is
+   * synthesized from the transport's native per-message id where one exists (see
+   * {@link deriveIngressIdempotencyKey}).
+   */
+  clientMessageId?: string;
 };
+
+/**
+ * Derive a stable idempotency key for a server-side ingress turn so an
+ * at-least-once redelivery (gateway/channel retry) dedups on the
+ * `client_message_id` partial unique index rather than running a second turn.
+ * An explicit caller key wins; otherwise it is synthesized from the transport's
+ * native per-message id, namespaced so it can never collide with a web-client
+ * nonce. Returns undefined when no stable id exists (behavior unchanged).
+ */
+export function deriveIngressIdempotencyKey(options?: {
+  clientMessageId?: string;
+  slackInbound?: SlackInboundMessageMetadata;
+}): string | undefined {
+  if (options?.clientMessageId) {
+    return options.clientMessageId;
+  }
+  const slack = options?.slackInbound;
+  if (slack) {
+    return `slack:${slack.channelId}:${slack.channelTs}`;
+  }
+  return undefined;
+}
 
 function buildEventEmitter(
   observer?: (msg: ServerMessage) => void,
@@ -626,15 +660,29 @@ export async function processMessage(
   const persistMetadata = options?.slackInbound
     ? { slackInbound: options.slackInbound }
     : undefined;
-  const { id: messageId } = await conversation.persistUserMessage({
-    content: resolvedContent,
-    attachments,
-    requestId,
-    metadata: persistMetadata,
-    displayContent: options?.displayContent,
-    ...(options?.skipUserMessageIndexing ? { skipIndexing: true } : {}),
-  });
+  const ingressKey = deriveIngressIdempotencyKey(options);
+  const { id: messageId, deduplicated } = await conversation.persistUserMessage(
+    {
+      content: resolvedContent,
+      attachments,
+      requestId,
+      metadata: persistMetadata,
+      displayContent: options?.displayContent,
+      ...(options?.skipUserMessageIndexing ? { skipIndexing: true } : {}),
+      ...(ingressKey ? { clientMessageId: ingressKey } : {}),
+    },
+  );
   publishConversationMessagesChanged(conversationId);
+
+  if (deduplicated) {
+    // This exact ingress (same idempotency key) already ran a turn; skip the
+    // loop so an at-least-once redelivery does not emit a second reply.
+    log.info(
+      { conversationId, messageId },
+      "Skipping agent loop for deduplicated ingress message",
+    );
+    return { messageId, turnFailure: readTurnFailure(messageId) };
+  }
 
   if (options?.isInteractive === true) {
     conversation.updateClient(broadcastMessage, false);
@@ -700,14 +748,27 @@ export async function processMessageInBackground(
   const persistMetadata = options?.slackInbound
     ? { slackInbound: options.slackInbound }
     : undefined;
-  const { id: messageId } = await conversation.persistUserMessage({
-    content,
-    attachments,
-    requestId,
-    metadata: persistMetadata,
-    displayContent: options?.displayContent,
-  });
+  const ingressKey = deriveIngressIdempotencyKey(options);
+  const { id: messageId, deduplicated } = await conversation.persistUserMessage(
+    {
+      content,
+      attachments,
+      requestId,
+      metadata: persistMetadata,
+      displayContent: options?.displayContent,
+      ...(ingressKey ? { clientMessageId: ingressKey } : {}),
+    },
+  );
   publishConversationMessagesChanged(conversationId);
+
+  if (deduplicated) {
+    // At-least-once redelivery of a turn that already ran — skip the loop.
+    log.info(
+      { conversationId, messageId },
+      "Skipping background agent loop for deduplicated ingress message",
+    );
+    return { messageId };
+  }
 
   if (options?.isInteractive === true) {
     conversation.updateClient(broadcastMessage, false);


### PR DESCRIPTION
## Summary

- **Validated root cause** (this session): the double-emit is *two agent-loop runs for one logical turn*, not a mid-stream retry — `loop.ts:1676` emits one `llm_call_started` per `sendMessage`, and `RetryProvider` (`retry.ts:762`) loops *inside* that one call, so a retry yields one row. Two persisted final replies ⇒ two `run()`s. The only per-turn guard is the `clientMessageId` dedup on the `client_message_id` partial unique index (migration 266), but channel/internal ingress (`process-message.ts`) both **omits the key** *and* **ignores the returned `deduplicated` flag** — so an at-least-once redelivery (gateway redelivery, Slack retry) inserts a duplicate row *and* runs a second loop.
- This PR closes that server-side hole for the `process-message.ts` ingress path: (1) synthesize a **namespaced** idempotency key from the transport's native per-message id (`slack:<channelId>:<channelTs>`) — or an explicit `options.clientMessageId` — and thread it to `persistUserMessage`; (2) capture `deduplicated` and **skip `runAgentLoop` on a dedup hit** in both `processMessage` and `processMessageInBackground`, mirroring the existing guard at `conversation-process.ts:970`.
- **Behavior is unchanged for callers without a stable id**: no key ⇒ no `clientMessageId` ⇒ `deduplicated` is always false ⇒ identical to today. Keys are namespaced (`slack:`) so they can never collide with web-client nonces. **No migration, no feature flag.**

**Scope** — this is PR-a of the reviewer's required 3-way split: the decision-free ingress-key + dedup-check core. Deferred to follow-ups (each needs key-alignment or a product decision): the `channel-retry-sweep` key (must reproduce the *original* turn's key to dedup against it), the identical `conversation-process.ts:2021` guard bundled with threading keys to its callers so the check lands live (not inert), voice per-utterance id, and the TOCTOU/coalesce hardening (Changes 3+4, which carry the coalesce product decision). The **onboarding/web-nonce cluster is explicitly not addressed here** — the web client mints a fresh nonce per send, so it needs the client-nonce-contract decision.

## Original prompt

From the v0.10.8 `double-emit-reply` investigation (root cause validated this session): the assistant occasionally double-emits its final reply. Confirmed as two un-deduped agent-loop runs for one logical turn (retry excluded), because server-side ingress omits a stable idempotency key and ignores the persist-layer `deduplicated` flag. Ship the decision-free core — synthesize + thread a namespaced idempotency key for channel/internal ingress and skip the loop on a dedup hit — deferring the paths that need key-alignment or a product decision.