### PR TITLE
fix(providers): cap Inkling context window to Baseten's served 256k

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1973,8 +1973,8 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       {
         id: "thinkingmachines/inkling",
         displayName: "Inkling",
-        // Baseten serves Inkling with a 1,048K-token input window.
-        contextWindowTokens: 1048576,
+        // Baseten serves Inkling with a 256K-token (262,144) input window.
+        contextWindowTokens: 262144,
         maxOutputTokens: 32768,
         supportsThinking: true,
         supportsCaching: true,

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -848,7 +848,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "thinkingmachines/inkling",
       displayName: "Inkling",
-      contextWindowTokens: 1_048_576,
+      contextWindowTokens: 262_144,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 32_768,
       supportsThinking: true,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -2027,7 +2027,7 @@
         {
           "id": "thinkingmachines/inkling",
           "displayName": "Inkling",
-          "contextWindowTokens": 1048576,
+          "contextWindowTokens": 262144,
           "maxOutputTokens": 32768,
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",


### PR DESCRIPTION
Addresses Codex review feedback on #38268.

The Inkling model entry set contextWindowTokens to 1,048,576 (the native 1M model window), but Baseten serves Inkling with a 256k window. At the inflated limit the assistant could defer compaction until ~4x over the served limit and then hit upstream context-length failures.

Changes:
- assistant/src/providers/model-catalog.ts (source of truth): cap contextWindowTokens to 262,144 (256k) and fix the adjacent comment.
- meta/llm-provider-catalog.json: regenerated from source via bun run sync:llm-catalog.
- clients/web/src/assistant/llm-model-catalog.ts: hand-maintained mirror updated to match.

Verified 256k against the Baseten model page. maxOutputTokens (32,768) left unchanged: Baseten publishes no output-token ceiling that contradicts it. Derived defaultContextWindowTokens (200k) and longContextMode (native-model) are unaffected since 262,144 > 200,000.

Follow-up to #38268.