### PR TITLE
fix(providers): detect OpenRouter-wrapped reasoning opt-out rejections

### DIFF
--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import OpenAI from "openai";
+
 import { isPlaceholderSentinelText } from "../../placeholder-sentinels.js";
 import {
   EMPTY_ASSISTANT_TURN_PLACEHOLDER,
@@ -578,6 +580,51 @@ describe("reasoning opt-out rejection fallback", () => {
       [rejection("reasoning_effort 'none' is not supported for this model")],
       okChunks,
     );
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { config: { effort: "none" } },
+    );
+
+    expect(requests).toHaveLength(2);
+    const first = requests[0] as { reasoning_effort?: string };
+    const second = requests[1] as {
+      reasoning_effort?: string;
+      reasoning?: unknown;
+    };
+    expect(first.reasoning_effort).toBe("none");
+    expect(second.reasoning_effort).toBeUndefined();
+    expect(second.reasoning).toBeUndefined();
+    const text = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(text?.text).toBe("ok");
+  });
+
+  test("retries once for an OpenRouter-wrapped reasoning rejection (detail in metadata.raw)", async () => {
+    // OpenRouter's SDK APIError.message is the generic wrapper
+    // ("400 Provider returned error"); the real reason lives only in
+    // error.error.metadata.raw, which normalizeOpenAIAPIError promotes into the
+    // normalized message. Matching error.message alone would miss it and the
+    // opt-out rejection would hard-fail instead of retrying.
+    const wrapped = new OpenAI.APIError(
+      400,
+      {
+        code: 400,
+        message: "Provider returned error",
+        metadata: {
+          raw: "reasoning_effort 'none' is not supported for this reasoning model",
+          provider_name: "deepseek",
+        },
+      },
+      undefined,
+      new Headers(),
+    );
+    // Guard: the wrapper message carries no reasoning signal, so the fallback
+    // can only fire off the normalized upstream detail.
+    expect(/reasoning/i.test(wrapped.message)).toBe(false);
+
+    const { provider, requests } = stubProviderWithErrors([wrapped], okChunks);
 
     const response = await provider.sendMessage(
       [{ role: "user", content: [{ type: "text", text: "hi" }] }],

--- a/assistant/src/providers/openai/api-error-normalization.ts
+++ b/assistant/src/providers/openai/api-error-normalization.ts
@@ -38,6 +38,17 @@ export interface NormalizedOpenAIAPIError {
 }
 
 /**
+ * All human-readable text from a normalized error — message, detail, and raw
+ * body — joined for case-insensitive substring/regex scanning. Classifying off
+ * the intact upstream payload (not the SDK's lossy `error.message`) is what lets
+ * OpenRouter's wrapped errors be matched, where the real reason lives in
+ * `metadata.raw`.
+ */
+export function normalizedErrorText(n: NormalizedOpenAIAPIError): string {
+  return `${n.message} ${n.detail ?? ""} ${n.rawBody ?? ""}`;
+}
+
+/**
  * Map an OpenAI-compatible error to a semantic {@link ProviderErrorReason}.
  * Order matters — the model-restriction check precedes the generic 401/403
  * credential branch, and billing precedes credentials.
@@ -46,7 +57,7 @@ export function deriveReason(
   n: NormalizedOpenAIAPIError,
   status: number | undefined,
 ): ProviderErrorReason {
-  const haystack = `${n.message} ${n.detail ?? ""} ${n.rawBody ?? ""}`;
+  const haystack = normalizedErrorText(n);
 
   if (
     status === 403 &&

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -28,6 +28,7 @@ import {
 import {
   captureRawErrorBodyFetch,
   formatNormalizedOpenAIAPIError,
+  normalizedErrorText,
   normalizeOpenAIAPIError,
 } from "./api-error-normalization.js";
 import {
@@ -216,8 +217,18 @@ function isReasoningOptOutRejection(error: unknown, params: unknown): boolean {
   if (typeof status !== "number" || status < 400 || status >= 500) {
     return false;
   }
-  const message = error instanceof Error ? error.message : String(error);
-  return /reasoning/i.test(message);
+  // OpenRouter wraps upstream 4xxs in a generic "Provider returned error" and
+  // stashes the real reason under `metadata.raw`, which `normalizeOpenAIAPIError`
+  // promotes into the normalized fields. Scan those, not just `error.message` —
+  // otherwise the wrapped reasoning rejection is missed and this one-shot
+  // fallback never fires.
+  const haystack =
+    error instanceof OpenAI.APIError
+      ? normalizedErrorText(normalizeOpenAIAPIError(error))
+      : error instanceof Error
+        ? error.message
+        : String(error);
+  return /reasoning/i.test(haystack);
 }
 
 /**


### PR DESCRIPTION
Follow-up to #37611 (review feedback from Codex).

## Problem
`isReasoningOptOutRejection` ran its `/reasoning/i` match only against `error.message`. OpenRouter wraps upstream 400s in a generic `Provider returned error` and carries the real detail in `metadata.raw`, so the one-shot strip-reasoning-params fallback added in #37611 never fired on OpenRouter — reasoning-only rejections (e.g. DeepSeek R1 refusing `reasoning_effort: none`) hard-failed instead of retrying.

## Fix
For an `OpenAI.APIError`, the predicate now scans the normalized error text (`message` + `detail` + captured `rawBody` via `normalizeOpenAIAPIError`), which promotes `metadata.raw` into the message. Non-API errors still fall back to `error.message`. The predicate stays conservative: unchanged opt-out + 4xx gating, still a single retry.

The `message + detail + rawBody` haystack was already hand-rolled inside `deriveReason`; extracted it into a shared `normalizedErrorText` helper so both call sites use one implementation.

## Tests
Extended the predicate's tests with an OpenRouter-shaped wrapped `OpenAI.APIError` whose `.message` carries no reasoning signal (only `metadata.raw` does) and asserted the fallback fires and retries without reasoning params.