### PR TITLE
fix(web): sanitize failed-image previewUrl across the gallery sibling array

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -6,13 +6,21 @@ mock.module(
   () => ({
     AttachmentPreviewModal: ({
       attachment,
+      siblingAttachments,
     }: {
       attachment: { id: string; previewUrl: string | null };
+      siblingAttachments?: Array<{ id: string; previewUrl: string | null }>;
     }) => (
       <div
         data-testid="preview-modal"
         data-attachment-id={attachment.id}
         data-preview-url={String(attachment.previewUrl)}
+        data-sibling-preview-urls={JSON.stringify(
+          (siblingAttachments ?? []).map((a) => ({
+            id: a.id,
+            previewUrl: a.previewUrl,
+          })),
+        )}
       />
     ),
   }),
@@ -154,5 +162,36 @@ describe("BubbleAttachments", () => {
     const modal = getByTestId("preview-modal");
     expect(modal.getAttribute("data-attachment-id")).toBe("img-4");
     expect(modal.getAttribute("data-preview-url")).toBe("null");
+  });
+
+  test("strips a failed sibling's previewUrl in the gallery array so arrow navigation refetches stored bytes", () => {
+    const undecodable: DisplayAttachment = {
+      id: "img-5",
+      filename: "IMG_1234.HEIC",
+      mimeType: "image/heic",
+      sizeBytes: 3_072,
+      previewUrl: "blob:undecodable-heic",
+    };
+    const { getByRole, getByTestId } = render(
+      <BubbleAttachments attachments={[undecodable, imageWithPreview]} />,
+    );
+
+    // The HEIC renders inline first; its decode fails and it's marked failed.
+    fireEvent.error(getByRole("button", { name: "IMG_1234.HEIC" }));
+
+    // Open the preview from the still-good sibling. The modal's gallery array
+    // (siblingAttachments) must carry the failed image with a null previewUrl,
+    // so arrowing back to it fetches stored bytes instead of the dead blob.
+    fireEvent.click(getByRole("button", { name: "photo.png" }));
+
+    const siblings = JSON.parse(
+      getByTestId("preview-modal").getAttribute("data-sibling-preview-urls") ??
+        "[]",
+    ) as Array<{ id: string; previewUrl: string | null }>;
+    expect(siblings.find((a) => a.id === "img-5")?.previewUrl).toBeNull();
+    // The healthy sibling keeps its previewUrl for inline rendering.
+    expect(siblings.find((a) => a.id === "img-1")?.previewUrl).toBe(
+      "https://example.com/photo.png",
+    );
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -1,5 +1,5 @@
 
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { FC } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
@@ -30,8 +30,6 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
   attachments,
   assistantId,
 }) => {
-  const { openPreview, previewModal } = useAttachmentPreview(assistantId, attachments);
-
   // Ids whose previewUrl the browser failed to decode (e.g. a HEIC blob on a
   // Chromium renderer). Those fall back to the chip instead of the browser's
   // broken-image glyph.
@@ -39,6 +37,23 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
   const markImageFailed = useCallback((id: string) => {
     setFailedImageIds((prev) => new Set(prev).add(id));
   }, []);
+
+  // A failed inline decode leaves a dead previewUrl (e.g. an undecodable HEIC
+  // blob on Chromium). Nulling it by id across the whole array — which is also
+  // forwarded as the modal's `siblingAttachments` — makes the chip, the modal,
+  // and gallery navigation all refetch stored bytes instead of the broken blob.
+  const previewAttachments = useMemo(
+    () =>
+      attachments.map((att) =>
+        failedImageIds.has(att.id) ? { ...att, previewUrl: null } : att,
+      ),
+    [attachments, failedImageIds],
+  );
+
+  const { openPreview, previewModal } = useAttachmentPreview(
+    assistantId,
+    previewAttachments,
+  );
 
   const handleDownload = useCallback(
     (att: DisplayAttachment) => {
@@ -54,12 +69,10 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
   return (
     <>
       <div className="flex flex-col gap-2">
-        {attachments.map((att) => {
-          const imageFailed = failedImageIds.has(att.id);
+        {previewAttachments.map((att, index) => {
           const isInlineImage =
             classifyAttachment(att.mimeType, att.filename) === "image" &&
-            att.previewUrl != null &&
-            !imageFailed;
+            att.previewUrl != null;
 
           if (isInlineImage) {
             return (
@@ -84,24 +97,19 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
             );
           }
 
-          // A failed inline decode leaves a dead previewUrl (e.g. an
-          // undecodable HEIC blob on Chromium). Sanitize it so the chip and
-          // the full-screen modal both fall back to fetching stored bytes
-          // instead of reusing the broken blob.
-          const previewAttachment = imageFailed
-            ? { ...att, previewUrl: null }
-            : att;
-
           return (
             <MessageAttachmentSquare
               key={att.id}
               filename={att.filename}
               mimeType={att.mimeType}
               sizeBytes={att.sizeBytes}
-              previewUrl={previewAttachment.previewUrl}
+              previewUrl={att.previewUrl}
               thumbnailUrl={att.thumbnailUrl}
-              onPreview={() => openPreview(previewAttachment)}
-              onDownload={() => handleDownload(att)}
+              onPreview={() => openPreview(att)}
+              // Download falls back to previewUrl when the daemon content fetch
+              // is unavailable, so it takes the unsanitized attachment — a blob
+              // that can't be *rendered* is still valid bytes to save.
+              onDownload={() => handleDownload(attachments[index]!)}
             />
           );
         })}


### PR DESCRIPTION
Addresses Codex review feedback on #36942. That PR sanitized only the clicked attachment's dead previewUrl, but BubbleAttachments still passed the raw attachments array to useAttachmentPreview, which forwards it as the modal's siblingAttachments. Because the preview modal's shouldFetch gates on the previewUrl being absent, arrow-keying back to a failed inline image (e.g. an undecodable HEIC blob on Chromium) restored the dead blob previewUrl instead of refetching the stored bytes.

Fix: derive one sanitized array (previewUrl nulled by id for images whose inline decode failed) and pass it to useAttachmentPreview, so both the clicked target and every gallery sibling carry sanitized entries and gallery navigation refetches stored bytes. This collapses the previously duplicated per-item sanitization into a single memoized source of truth. Download still uses the unsanitized attachment, since a blob that cannot be rendered is still valid bytes to save when the daemon content fetch is unavailable.

Extends bubble-attachments.test.tsx with a sibling-array assertion.