### PR TITLE
fix(compaction): guard Slack watermark advance against dropping legacy kept rows

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -119,6 +119,7 @@ import {
   assembleSlackChronologicalMessages,
   buildSubagentStatusBlock,
   getSlackCompactionWatermarkForPrefix,
+  getSlackWatermarkAdvanceForRowPrefix,
   injectChannelCapabilityContext,
   injectChannelCommandContext,
   isGroupChatType,
@@ -4038,6 +4039,51 @@ describe("Slack channel chronological rendering — multi-thread", () => {
       result!.renderedMessages.map((entry) => entry.sourceChannelTs),
     ).toEqual([null, T2]);
     expect(getSlackCompactionWatermarkForPrefix(result, 1)).toBe(T2);
+  });
+
+  // A legacy kept-tail row carries no `channelTs`, so the guard must fall back
+  // to `createdAt/1000` — as the projection filter does — or it advances past a
+  // row the filter then drops while the summary never covered it: silent loss.
+  describe("getSlackWatermarkAdvanceForRowPrefix — legacy kept rows", () => {
+    test("skips the advance when a legacy kept row sits at or before the candidate", () => {
+      const rows: MessageRow[] = [
+        userRow({
+          id: "summarized-prefix",
+          createdAt: 1700000030_000,
+          text: "summarized prefix",
+          slackMeta: buildSlackMeta({ channelTs: T2, displayName: "carol" }),
+        }),
+        // No slackMeta → legacy row; createdAt/1000 = 1700000020 <= T2, so
+        // advancing to T2 would drop it from the projection uncovered.
+        userRow({
+          id: "legacy-kept-tail",
+          createdAt: 1700000020_000,
+          text: "legacy kept tail",
+        }),
+      ];
+
+      expect(getSlackWatermarkAdvanceForRowPrefix(rows, 1, null)).toBeNull();
+    });
+
+    test("advances when a legacy kept row sits strictly after the candidate", () => {
+      const rows: MessageRow[] = [
+        userRow({
+          id: "summarized-prefix",
+          createdAt: 1700000000_000,
+          text: "summarized prefix",
+          slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+        }),
+        // No slackMeta → legacy row; createdAt/1000 = 1700000050 > T0, so the
+        // projection keeps it and the advance is safe.
+        userRow({
+          id: "legacy-kept-tail-after",
+          createdAt: 1700000050_000,
+          text: "legacy kept tail after",
+        }),
+      ];
+
+      expect(getSlackWatermarkAdvanceForRowPrefix(rows, 1, null)).toBe(T0);
+    });
   });
 
   test("active-thread focus filters pre-watermark and legacy compacted rows", () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1191,7 +1191,7 @@ function maxSlackTs(values: readonly (string | null)[]): string | null {
 }
 
 function legacyRowIsAfterWatermark(
-  row: SlackTranscriptInputRow,
+  row: { createdAt: number },
   watermarkTs: string,
 ): boolean {
   return compareSlackTs(String(row.createdAt / 1000), watermarkTs) > 0;
@@ -1260,10 +1260,13 @@ export function getSlackCompactionWatermarkForPrefix(
  * rows), so a kept-tail row past the boundary can carry an OLDER `channelTs`
  * than the prefix max. Advancing anyway would drop that row from every
  * future projection (`isSlackTsAfter` keeps strictly-after) while the
- * summary doesn't cover it either — silent loss. When any kept row's
- * `channelTs` sits at or before the candidate, the advance is skipped
- * entirely, degrading to bounded duplication of already-summarized rows: the
- * conservative direction.
+ * summary doesn't cover it either — silent loss. When any kept row sits at or
+ * before the candidate, the advance is skipped entirely, degrading to bounded
+ * duplication of already-summarized rows: the conservative direction. Legacy
+ * kept rows without `slackMeta` carry no `channelTs`, so they are compared via
+ * `createdAt/1000` — the same fallback `filterRowsAfterSlackCompactionBoundary`
+ * uses to drop them, keeping the guard and the filter from disagreeing about
+ * which legacy rows an advance would silently drop.
  */
 export function getSlackWatermarkAdvanceForRowPrefix(
   rows: MessageRow[],
@@ -1286,7 +1289,11 @@ export function getSlackWatermarkAdvanceForRowPrefix(
   }
   for (const row of rows.slice(endExclusive)) {
     const keptTs = channelTsForRow(row);
-    if (keptTs !== null && !isSlackTsAfter(keptTs, ts)) {
+    const survivesAdvance =
+      keptTs !== null
+        ? isSlackTsAfter(keptTs, ts)
+        : legacyRowIsAfterWatermark(row, ts);
+    if (!survivesAdvance) {
       return null;
     }
   }


### PR DESCRIPTION
Follow-up to #36928 addressing Codex review feedback (verified still true on main).

`getSlackWatermarkAdvanceForRowPrefix`'s inversion guard only checked kept-tail rows whose `channelTs` parses. A legacy kept row without `slackMeta` reads a null `channelTs`, so the guard skipped it and let the watermark advance — yet `filterRowsAfterSlackCompactionBoundary` still drops such a row via its `createdAt/1000` fallback (`legacyRowIsAfterWatermark`) once a watermark exists. Net effect: a legacy kept row with `createdAt/1000` ≤ the candidate watermark was silently dropped from future Slack projections while the new summary (prefix rows only) never covered it.

## Fix
In the guard's kept-tail loop, rows with a null `channelTs` now fall back to the same `legacyRowIsAfterWatermark` (`createdAt/1000`) comparison the filter uses, skipping the advance when any such row sits at or before the candidate. This keeps the guard and the filter from disagreeing about which legacy rows an advance would drop. `legacyRowIsAfterWatermark` is widened to accept any `{ createdAt: number }` so both `MessageRow` and `SlackTranscriptInputRow` callers share the one helper.

## Test
Adds a regression test with a legacy (no-`slackMeta`) kept row that would previously have been dropped (guard now returns null), plus a positive case confirming a genuinely later legacy row still allows the advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)