### PR TITLE
fix(ui-surface): reject fieldless multi-page form payloads at the ui_show guard

### DIFF
--- a/assistant/src/__tests__/ui-shape-teaching.test.ts
+++ b/assistant/src/__tests__/ui-shape-teaching.test.ts
@@ -137,6 +137,21 @@ describe("ui_show missing-content teaching", () => {
       expectInError: "`data.columns`",
     },
     { surfaceType: "form", data: {}, expectInError: "`data.fields`" },
+    {
+      surfaceType: "form",
+      data: { pages: [{ id: "p1", title: "Page 1" }] },
+      expectInError: "at least one page with a non-empty",
+    },
+    {
+      // A valid top-level `fields` must not mask malformed pages: the renderer
+      // prefers `pages` when present, so a fieldless page still breaks.
+      surfaceType: "form",
+      data: {
+        fields: [{ id: "a", type: "text", label: "A" }],
+        pages: [{ id: "p1", title: "Page 1" }],
+      },
+      expectInError: "at least one page with a non-empty",
+    },
     { surfaceType: "confirmation", data: {}, expectInError: "confirmLabel" },
     { surfaceType: "work_result", data: {}, expectInError: "summary" },
     { surfaceType: "oauth_connect", data: {}, expectInError: "providerKey" },
@@ -186,6 +201,39 @@ describe("ui_show displayable payloads proxy through", () => {
         surfaceType:
           "card (lenient — top-level fields are normalized downstream)",
         input: { surface_type: "card", title: "Status", data: {} },
+      },
+      {
+        surfaceType: "form (multi-page with fields)",
+        input: {
+          surface_type: "form",
+          data: {
+            pages: [
+              {
+                id: "p1",
+                title: "Page 1",
+                fields: [{ id: "a", type: "text", label: "A" }],
+              },
+            ],
+          },
+        },
+      },
+      {
+        // At least one page carries fields; the renderer treats the fieldless
+        // page as empty rather than crashing, so the guard lets it through.
+        surfaceType: "form (mixed pages, one has fields)",
+        input: {
+          surface_type: "form",
+          data: {
+            pages: [
+              {
+                id: "p1",
+                title: "Page 1",
+                fields: [{ id: "a", type: "text", label: "A" }],
+              },
+              { id: "p2", title: "Page 2" },
+            ],
+          },
+        },
       },
       {
         surfaceType: "file_upload",

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -47,7 +47,7 @@ function isNonEmptyString(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function isNonEmptyArray(value: unknown): boolean {
+function isNonEmptyArray(value: unknown): value is unknown[] {
   return Array.isArray(value) && value.length > 0;
 }
 
@@ -123,10 +123,23 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
     purpose: "input form, single or multi-page",
     shape:
       '{ description?, fields: [{ id, type: "text"|"textarea"|"select"|"toggle"|"number"|"password", label, placeholder?, required?, defaultValue?, options?: [{ label, value }] }], submitLabel? }. Multi-page: { pages: [{ id, title, description?, fields }], pageLabels?: { next?, back?, submit? }, submitLabel? }',
-    missingContent: (data) =>
-      isNonEmptyArray(data.fields) || isNonEmptyArray(data.pages)
+    missingContent: (data) => {
+      // Mirror the renderer's precedence: a non-empty `pages` array selects
+      // multi-page mode and ignores top-level `fields`, so a valid top-level
+      // `fields` must not mask fieldless pages. A multi-page form with no
+      // fields anywhere renders blank, so require at least one page to carry
+      // a non-empty `fields` array.
+      if (isNonEmptyArray(data.pages)) {
+        return data.pages.some((page) =>
+          isNonEmptyArray(asRecord(page)?.fields),
+        )
+          ? null
+          : "multi-page `data.pages` needs at least one page with a non-empty `fields` array";
+      }
+      return isNonEmptyArray(data.fields)
         ? null
-        : "`data.fields` (or `data.pages`) must be a non-empty array",
+        : "`data.fields` (or `data.pages`) must be a non-empty array";
+    },
   },
   confirmation: {
     purpose: "confirm/cancel prompt",

--- a/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
@@ -32,7 +32,7 @@ export interface FormPage {
   id: string;
   title: string;
   description?: string;
-  fields: FormField[];
+  fields?: FormField[];
 }
 
 interface FormSurfaceData {
@@ -186,7 +186,7 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
   const [values, setValues] = useState<Record<string, string | number | boolean>>(() => {
     const initial: Record<string, string | number | boolean> = {};
     for (const page of allPages) {
-      for (const field of page.fields) {
+      for (const field of page.fields ?? []) {
         if (field.defaultValue !== undefined) {
           initial[field.id] = field.defaultValue;
         } else if (field.type === "toggle") {
@@ -216,7 +216,7 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
       const page = allPages[pageIndex];
       if (!page) return true;
       const errors: Record<string, string> = {};
-      for (const field of page.fields) {
+      for (const field of page.fields ?? []) {
         if (field.required) {
           const val = values[field.id];
           if (val === undefined || val === "" || val === null) {
@@ -267,7 +267,7 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
   if (!currentPageData) return null;
   const isLastPage = currentPage === totalPages - 1;
   const hasPasswordFields = allPages.some((page) =>
-    page.fields.some((field) => field.type === "password"),
+    (page.fields ?? []).some((field) => field.type === "password"),
   );
 
   const nextLabel = formData.pageLabels?.next ?? "Next";
@@ -315,7 +315,7 @@ export function FormSurface({ surface, onAction }: FormSurfaceProps) {
       )}
 
       <form onSubmit={handleSubmit} className="space-y-3">
-        {currentPageData.fields.map((field) => (
+        {(currentPageData.fields ?? []).map((field) => (
           <div key={field.id}>
             <label className="mb-1 block text-body-medium-default text-[var(--content-strong)]">
               {field.label}


### PR DESCRIPTION
Follow-up to #38266 addressing Codex review feedback (verified still true on main).

**Problem:** The `ui_show` form guard accepted any non-empty `data.pages` without checking that pages carry fields, and its `data.fields || data.pages` short-circuit let a valid top-level `fields` mask a malformed `pages`. The web renderer enters multi-page mode whenever `pages.length > 0` (ignoring top-level `fields`) and iterates `page.fields` unguarded, so `{ pages: [{ id, title }] }` (a fieldless page) bypassed the teaching error and threw a `TypeError` in the renderer.

**Fix (contract point — assistant guard):** The form guard now mirrors the renderer's precedence — when `pages` is a non-empty array it validates the pages branch (requiring at least one page with a non-empty `fields` array) and no longer lets a top-level `fields` mask malformed pages. The teaching error names precisely what was missing. Also promotes `isNonEmptyArray` to a type predicate so the validated `pages` array needs no cast.

**Defense in depth (web renderer):** `FormPage.fields` is now optional (reflecting untrusted wire data) and every `page.fields` access is guarded with `?? []`, consistent with the file's existing `formData.fields ?? []` pattern — a partially-malformed payload degrades to a blank page instead of crashing.

**Tests:** Extended `ui-shape-teaching.test.ts` with fieldless-page payloads (single fieldless page; valid top-level `fields` + fieldless pages) that now teach, plus valid multi-page and mixed-page payloads that still proxy through.