### PR TITLE
fix(persistence): set synchronous=NORMAL on ATTACHed schemas in async SQL

### DIFF
--- a/assistant/src/persistence/db-async-query.ts
+++ b/assistant/src/persistence/db-async-query.ts
@@ -102,6 +102,32 @@ export interface RunAsyncSqliteOptions {
 
 let warnedAboutFallback = false;
 
+/**
+ * SQL statements that `ATTACH` one extra database and bring the attached schema
+ * to `synchronous=NORMAL`.
+ *
+ * `synchronous` is schema-scoped: the connection-level `PRAGMA
+ * synchronous=NORMAL` applied to `main` does not reach an `ATTACH`ed file, which
+ * keeps the CLI/library default of FULL. Without the per-alias pragma every
+ * cross-database write (e.g. the relocation copy batches inserting into the
+ * attached target) fsyncs the WAL inside the commit's write-lock window — the
+ * exact contention the NORMAL posture exists to avoid (see the {@link runViaCli}
+ * prelude for the WAL-mode durability rationale).
+ *
+ * Returned as discrete statements — the single source both backends build their
+ * ATTACH SQL from: the sqlite3-CLI backend joins them into its piped prelude and
+ * the in-process fallback `exec`s each in turn.
+ */
+export function attachStatements(entry: {
+  path: string;
+  alias: string;
+}): string[] {
+  return [
+    `ATTACH DATABASE '${entry.path.replace(/'/g, "''")}' AS ${entry.alias}`,
+    `PRAGMA ${entry.alias}.synchronous=NORMAL`,
+  ];
+}
+
 export async function runAsyncSqlite(
   sql: string,
   label: string,
@@ -114,10 +140,8 @@ export async function runAsyncSqlite(
   let result: AsyncSqliteResult;
   if (sqlite3Path && forced !== "in-process-blocking") {
     const attachPrefix = (options.attach ?? [])
-      .map(
-        (a) =>
-          `ATTACH DATABASE '${a.path.replace(/'/g, "''")}' AS ${a.alias};\n`,
-      )
+      .flatMap(attachStatements)
+      .map((stmt) => `${stmt};\n`)
       .join("");
     result = await runViaCli(
       sqlite3Path,
@@ -294,10 +318,11 @@ async function runInProcessBlocking(
       // has both set via applyConnectionPragmas.)
       transient.exec(`PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}`);
       transient.exec("PRAGMA synchronous=NORMAL");
-      for (const a of options.attach ?? []) {
-        transient.exec(
-          `ATTACH DATABASE '${a.path.replace(/'/g, "''")}' AS ${a.alias}`,
-        );
+      // ATTACH each extra database and bring it to synchronous=NORMAL as well;
+      // synchronous is schema-scoped, so the main-schema pragma above does not
+      // reach an attached file (see attachStatements).
+      for (const stmt of (options.attach ?? []).flatMap(attachStatements)) {
+        transient.exec(stmt);
       }
       sqlite = transient;
     } else {

--- a/assistant/src/plugins/defaults/memory/__tests__/db-async-query.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-async-query.test.ts
@@ -16,13 +16,21 @@
  *   4. Errors from sqlite3 surface as `ok: false` with the stderr
  *      preserved in `error`.
  */
-import { statSync } from "node:fs";
+import { rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { beforeEach, describe, expect, test } from "bun:test";
 
 const { getSqlite } = await import("../../../../persistence/db-connection.js");
 const { initializeDb } = await import("../../../../persistence/db-init.js");
-const { runAsyncSqlite, _resetFallbackWarning, spawnDetachedWalCheckpoint } =
-  await import("../../../../persistence/db-async-query.js");
+const {
+  runAsyncSqlite,
+  _resetFallbackWarning,
+  spawnDetachedWalCheckpoint,
+  attachStatements,
+  parseChangesFromStdout,
+} = await import("../../../../persistence/db-async-query.js");
 const { findSqlite3 } = await import("../../../../util/sqlite3-runtime.js");
 const { getDbPath } = await import("../../../../util/platform.js");
 
@@ -171,6 +179,100 @@ describe("runAsyncSqlite", () => {
     },
     60_000,
   );
+});
+
+function tempDbPath(tag: string): string {
+  return join(tmpdir(), `async-attach-${tag}-${process.pid}-${Date.now()}.db`);
+}
+
+function removeDbFiles(path: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    rmSync(`${path}${suffix}`, { force: true });
+  }
+}
+
+describe("runAsyncSqlite attach mode", () => {
+  test("attachStatements attaches the alias and sets it to synchronous=NORMAL", () => {
+    // Both backends build their ATTACH SQL from this one helper, so a unit
+    // test here covers the per-alias pragma on both the CLI and in-process
+    // paths.
+    expect(
+      attachStatements({ path: "/tmp/target.db", alias: "_reloc_target" }),
+    ).toEqual([
+      "ATTACH DATABASE '/tmp/target.db' AS _reloc_target",
+      "PRAGMA _reloc_target.synchronous=NORMAL",
+    ]);
+  });
+
+  test("attachStatements escapes single quotes in the attached path", () => {
+    expect(attachStatements({ path: "/tmp/o'brien.db", alias: "t" })).toEqual([
+      "ATTACH DATABASE '/tmp/o''brien.db' AS t",
+      "PRAGMA t.synchronous=NORMAL",
+    ]);
+  });
+
+  test.if(sqlite3Available)(
+    "the attached schema runs at synchronous=NORMAL (CLI backend)",
+    async () => {
+      const targetPath = tempDbPath("cli");
+      // Materialize a real WAL database so ATTACH opens it the way a relocation
+      // target file is opened in production.
+      const seed = new Database(targetPath);
+      seed.exec("PRAGMA journal_mode=WAL");
+      seed.exec("CREATE TABLE probe (x)");
+      seed.close();
+      try {
+        const result = await runAsyncSqlite(
+          "PRAGMA _reloc_target.synchronous;",
+          "test:attach-synchronous-cli",
+          { attach: [{ path: targetPath, alias: "_reloc_target" }] },
+        );
+        expect(result.ok).toBe(true);
+        expect(result.backend).toBe("sqlite3-cli");
+        // PRAGMA synchronous prints its numeric level as the trailing line:
+        // NORMAL === 1. Without the per-alias pragma the attached schema would
+        // report FULL === 2 (the default), fsyncing every cross-DB commit.
+        expect(parseChangesFromStdout(result.stdout)).toBe(1);
+      } finally {
+        removeDbFiles(targetPath);
+      }
+    },
+  );
+
+  test("in-process fallback runs the ATTACH prelude and writes across databases", async () => {
+    const targetPath = tempDbPath("inproc");
+    const seed = new Database(targetPath);
+    seed.exec("CREATE TABLE attach_probe (id INTEGER PRIMARY KEY)");
+    seed.close();
+    try {
+      // `attach_probe` exists only in the attached target, so the unqualified
+      // write resolves there — exercising the in-process ATTACH branch that
+      // brings the attached schema to synchronous=NORMAL alongside `main`.
+      const result = await runAsyncSqlite(
+        "INSERT INTO attach_probe (id) VALUES (1); SELECT changes();",
+        "test:attach-synchronous-in-process",
+        {
+          forceBackend: "in-process-blocking",
+          attach: [{ path: targetPath, alias: "_reloc_target" }],
+        },
+      );
+      expect(result.ok).toBe(true);
+      expect(result.backend).toBe("in-process-blocking");
+      expect(result.stdout).toBe("1\n");
+
+      // The row is durable in the attached file.
+      const verify = new Database(targetPath);
+      const count = (
+        verify.query("SELECT count(*) AS c FROM attach_probe").get() as {
+          c: number;
+        }
+      ).c;
+      verify.close();
+      expect(count).toBe(1);
+    } finally {
+      removeDbFiles(targetPath);
+    }
+  });
 });
 
 describe("spawnDetachedWalCheckpoint", () => {


### PR DESCRIPTION
## Summary

`synchronous` is schema-scoped in SQLite, so the unqualified `PRAGMA synchronous=NORMAL` added in #37754 only reaches the `main` schema. When `runAsyncSqlite` is called with `options.attach` — the relocation copy-batch path in `migrations/helpers/relocation.ts` — the ATTACHed target schema stayed at the CLI/library default of `FULL`. Every bulk `INSERT` into the attached `_reloc_target` therefore still fsynced the WAL inside the commit's write-lock window: exactly the contention #37754 set out to cut.

## Fix

Emit `PRAGMA <alias>.synchronous=NORMAL` after each `ATTACH`, on both backends:

- **sqlite3-CLI backend** — the ATTACH prefix now carries the per-alias pragma.
- **In-process fallback** — the transient ATTACH loop execs it too.

Both backends build their ATTACH SQL from a single shared `attachStatements()` helper, which also removes the path-escaping that was duplicated across the two code paths.

## Tests

Extends `db-async-query.test.ts` with an attach-mode block:

- Unit test on `attachStatements` (the one source both backends derive from), including single-quote path escaping.
- CLI end-to-end test asserting `PRAGMA _reloc_target.synchronous` reports `NORMAL` (1) on the attached schema — `FULL` would report 2.
- In-process attach test exercising the cross-database write path.

All 11 tests in the file pass.

Addresses Codex review feedback on #37754.