### PR TITLE
fix(openai): anchor image-only user turns in the GPT-5.6 cache ladder

### DIFF
--- a/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
+++ b/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
@@ -68,6 +68,23 @@ function userMsg(text: string): Message {
   return { role: "user", content: [{ type: "text", text }] };
 }
 
+/** A user turn whose only content is an image — no text part. */
+function imageUserMsg(): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "iVBORw0KGgo=",
+        },
+      },
+    ],
+  };
+}
+
 function assistantMsg(text: string): Message {
   return { role: "assistant", content: [{ type: "text", text }] };
 }
@@ -158,6 +175,34 @@ describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
     );
 
     expect(breakpointedItemIndexes()).toEqual([0, 2, 4]);
+  });
+
+  test("image-only user turn is anchored on its trailing image part", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage([imageUserMsg()], {
+      config: { promptCacheKey: "conv-1" },
+    });
+
+    // No text part, but the trailing input_image is stampable — so the turn
+    // anchors the ladder instead of dropping off it entirely.
+    expect(breakpointedItemIndexes()).toEqual([0]);
+    const input = (lastStreamParams?.input ?? []) as WireItem[];
+    const parts = input[0].content ?? [];
+    const last = parts[parts.length - 1];
+    expect(last?.type).toBe("input_image");
+    expect(last?.prompt_cache_breakpoint).toEqual({ mode: "explicit" });
+  });
+
+  test("multi-turn with an image-only turn: every user item is marked", async () => {
+    const provider = makeProvider("gpt-5.6-sol");
+    await provider.sendMessage(
+      [imageUserMsg(), assistantMsg("r1"), userMsg("t2")],
+      { config: { promptCacheKey: "conv-1" } },
+    );
+
+    // Wire items: [user image, assistant r1, user t2]. Both user items anchor
+    // the ladder even though the first carries no text.
+    expect(breakpointedItemIndexes()).toEqual([0, 2]);
   });
 
   test("marker ladder caps at 50 boundaries, dropping the oldest", async () => {

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -744,8 +744,9 @@ export class OpenAIResponsesProvider implements Provider {
 
   /**
    * Stamp explicit prompt-cache breakpoints onto the built Responses input
-   * items: the last stampable part of every user item carrying real text,
-   * newest first, up to {@link PROMPT_CACHE_MAX_BREAKPOINTS}.
+   * items: the last stampable part of every user item that carries real text
+   * or ends in an image/file attachment, newest first, up to
+   * {@link PROMPT_CACHE_MAX_BREAKPOINTS}.
    *
    * Cache reads only consider markers present in the *current* request —
    * boundaries written by earlier requests match only if re-marked here
@@ -780,18 +781,43 @@ export class OpenAIResponsesProvider implements Provider {
     opts: { mutableLatestUserMessage: boolean; disableTurnStartCache: boolean },
   ): void {
     const items = input as ResponsesMessageItem[];
-    // Marker candidates need a real text part (mirror of the Anthropic
-    // client's findUserTextMsgIdx).
-    const isUserTextItem = (it: ResponsesMessageItem | undefined): boolean =>
-      it?.type === "message" &&
-      it.role === "user" &&
-      Array.isArray(it.content) &&
-      it.content.some(
-        (p) =>
-          p.type === "input_text" &&
-          typeof p.text === "string" &&
-          p.text.length > 0,
+
+    // The item's final content part when it can carry a marker
+    // (STAMPABLE_PART_TYPES), else undefined. Selection and stamping both key
+    // off this, so the selector never nominates an item the stamper would skip.
+    const stampableLastPart = (
+      it: ResponsesMessageItem | undefined,
+    ): Record<string, unknown> | undefined => {
+      const content = it?.content;
+      if (!Array.isArray(content) || content.length === 0) {
+        return undefined;
+      }
+      const last = content[content.length - 1];
+      return last && STAMPABLE_PART_TYPES.has(last.type as string)
+        ? last
+        : undefined;
+    };
+
+    // A user item anchors when its trailing part is markable: a non-empty text
+    // part, or an image/file attachment. Attachment-only turns must anchor too,
+    // or an image-only turn drops off the ladder and the whole prefix before it
+    // re-bills every tool-loop iteration. Mirrors the Anthropic client's
+    // findUserTextMsgIdx.
+    const isMarkableUserItem = (
+      it: ResponsesMessageItem | undefined,
+    ): boolean => {
+      if (it?.type !== "message" || it.role !== "user") {
+        return false;
+      }
+      const last = stampableLastPart(it);
+      if (!last) {
+        return false;
+      }
+      return (
+        last.type !== "input_text" ||
+        (typeof last.text === "string" && last.text.length > 0)
       );
+    };
 
     const candidates: number[] = [];
     for (
@@ -799,7 +825,7 @@ export class OpenAIResponsesProvider implements Provider {
       i >= 0 && candidates.length < PROMPT_CACHE_MAX_BREAKPOINTS;
       i--
     ) {
-      if (isUserTextItem(items[i])) {
+      if (isMarkableUserItem(items[i])) {
         candidates.push(i);
       }
     }
@@ -820,19 +846,15 @@ export class OpenAIResponsesProvider implements Provider {
 
     for (const idx of candidates) {
       // `disableTurnStartCache` suppresses the marker on the turn-start
-      // (newest user-text) item — one-shot call sites whose prompts never
+      // (newest user) item — one-shot call sites whose prompts never
       // recur would otherwise pay a write with no future read. Older
       // boundaries stay marked, matching the Anthropic client's semantics
       // (its previous-turn anchor is not gated by this flag).
       if (opts.disableTurnStartCache && idx === candidates[0]) {
         continue;
       }
-      const content = items[idx]?.content;
-      if (!Array.isArray(content) || content.length === 0) {
-        continue;
-      }
-      const last = content[content.length - 1];
-      if (last && STAMPABLE_PART_TYPES.has(last.type as string)) {
+      const last = stampableLastPart(items[idx]);
+      if (last) {
         last.prompt_cache_breakpoint = { mode: "explicit" };
       }
     }


### PR DESCRIPTION
Follow-up to #37862 (Codex review).

The explicit prompt-cache anchor selector required an `input_text` part, so an image-/file-only user turn was never nominated as a breakpoint — even though `STAMPABLE_PART_TYPES` and the stamper already accept `input_image`/`input_file`. An image-only turn therefore got no marker, leaving the whole prefix before it to re-bill on every tool-loop iteration.

Fix: extend the anchor-candidate predicate (renamed to `isMarkableUserItem`) to also accept user items whose trailing content part is a stampable image/file attachment, not only non-empty text. Selection and stamping now key off a shared `stampableLastPart` helper, so the selector can no longer nominate an item the stamper would skip (the root of the reported inconsistency).

Tests: added image-only coverage to the prompt-cache suite — a lone image-only turn anchors on its trailing image, and an earlier image-only turn joins a multi-turn ladder alongside a text turn.