### PR TITLE
fix(gateway): release email dedup reservation when api_key resolution throws

### DIFF
--- a/gateway/src/email/inbound-pipeline.ts
+++ b/gateway/src/email/inbound-pipeline.ts
@@ -1,6 +1,8 @@
 import type { Logger } from "pino";
 import { buildEmailTransportMetadata } from "../channels/transport-hints.js";
 import type { GatewayConfig } from "../config.js";
+import type { CredentialCache } from "../credential-cache.js";
+import { resolveCredentialWithRefresh } from "../credential-refresh.js";
 import { recordDenialReplyIfAllowed } from "../db/denial-reply-rate-limiter.js";
 import type { StringDedupCache } from "../dedup-cache.js";
 import { handleInbound } from "../handlers/handle-inbound.js";
@@ -47,6 +49,46 @@ export interface EmailInboundPipelineOptions {
   sendReply: EmailReplySender | undefined;
   /** Extra fields for the received/forwarded log lines (e.g. Resend emailId). */
   logFields?: Record<string, unknown>;
+}
+
+/**
+ * Resolve a provider credential after the caller has already reserved
+ * `dedupKey`. `resolveCredentialWithRefresh` reads through the credential
+ * cache, which re-throws on a credential-backend failure; left unguarded that
+ * throw would strand the reservation — a {@link StringDedupCache} reservation
+ * has no TTL, so the provider's retries would dedup as duplicates and the
+ * email would be silently dropped. On a throw, release the reservation and
+ * return a 500 so the provider retries and the retry is processed. A missing
+ * credential is not an error: it resolves to `undefined` and the caller
+ * decides whether that is fatal.
+ */
+export async function resolveEmailCredentialOrRelease(opts: {
+  credentials: CredentialCache | undefined;
+  key: string;
+  dedupCache: StringDedupCache;
+  dedupKey: string;
+  log: Logger;
+  label: string;
+}): Promise<
+  { ok: true; value: string | undefined } | { ok: false; response: Response }
+> {
+  try {
+    const value = await resolveCredentialWithRefresh(
+      opts.credentials,
+      opts.key,
+    );
+    return { ok: true, value };
+  } catch (err) {
+    opts.log.error(
+      { err },
+      `Failed to resolve ${opts.label} credential — releasing dedup reservation for retry`,
+    );
+    opts.dedupCache.unreserve(opts.dedupKey);
+    return {
+      ok: false,
+      response: Response.json({ error: "Internal error" }, { status: 500 }),
+    };
+  }
 }
 
 /**

--- a/gateway/src/http/routes/mailgun-webhook.test.ts
+++ b/gateway/src/http/routes/mailgun-webhook.test.ts
@@ -1,0 +1,127 @@
+import { createHmac } from "node:crypto";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { GatewayConfig } from "../../config.js";
+import type { CredentialCache } from "../../credential-cache.js";
+import { credentialKey } from "../../credential-key.js";
+
+// --- Mocks ----------------------------------------------------------------
+
+const handleInboundMock = mock(() =>
+  Promise.resolve({ forwarded: true, rejected: false } as Record<
+    string,
+    unknown
+  >),
+);
+
+mock.module("../../handlers/handle-inbound.js", () => ({
+  handleInbound: handleInboundMock,
+}));
+mock.module("../../routing/resolve-assistant.js", () => ({
+  resolveAssistant: () => ({ assistantId: "assistant-1" }),
+  isRejection: (routing: Record<string, unknown>) => "reason" in routing,
+}));
+mock.module("../../db/denial-reply-rate-limiter.js", () => ({
+  recordDenialReplyIfAllowed: () => true,
+}));
+mock.module("../../runtime/client.js", () => ({
+  resetConversation: mock(() => Promise.resolve()),
+  uploadAttachment: mock(() => Promise.resolve({ id: "att-1" })),
+  AttachmentValidationError: class extends Error {},
+  CircuitBreakerOpenError: class extends Error {},
+}));
+
+// Import after mocks are registered
+const { createMailgunWebhookHandler } = await import("./mailgun-webhook.js");
+
+// --- Helpers ---------------------------------------------------------------
+
+const SIGNING_KEY = "test-mailgun-signing-key";
+
+const config = {
+  maxWebhookPayloadBytes: 1024 * 1024,
+  maxAttachmentBytes: { email: 25 * 1024 * 1024, default: 100 * 1024 * 1024 },
+  maxAttachmentConcurrency: 3,
+} as unknown as GatewayConfig;
+
+function makeCaches(opts?: { apiKey?: string; apiKeyThrows?: boolean }) {
+  const credentials = {
+    get: async (key: string) => {
+      if (key === credentialKey("mailgun", "webhook_signing_key")) {
+        return SIGNING_KEY;
+      }
+      if (key === credentialKey("mailgun", "api_key")) {
+        if (opts?.apiKeyThrows) {
+          throw new Error("credential backend unavailable");
+        }
+        return opts?.apiKey;
+      }
+      return undefined;
+    },
+    invalidate: () => {},
+  } as unknown as CredentialCache;
+  return { credentials };
+}
+
+function postRequest(token: string): Request {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const signature = createHmac("sha256", SIGNING_KEY)
+    .update(timestamp + token, "utf8")
+    .digest("hex");
+  const body = JSON.stringify({
+    from: "alice@example.com",
+    recipient: "assistant@example.org",
+    "Message-Id": `<${token}@example.com>`,
+    subject: "Hello",
+    "body-plain": "Hi there",
+    timestamp,
+    token,
+    signature,
+  });
+  return new Request("http://localhost:7830/webhooks/mailgun", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+beforeEach(() => {
+  handleInboundMock.mockClear();
+  handleInboundMock.mockImplementation(() =>
+    Promise.resolve({ forwarded: true, rejected: false }),
+  );
+});
+
+// --- Tests ----------------------------------------------------------------
+
+describe("mailgun-webhook API-key resolution", () => {
+  it("releases the reserved dedup token and returns 500 when the API-key read throws", async () => {
+    const { handler, dedupCache } = createMailgunWebhookHandler(
+      config,
+      makeCaches({ apiKeyThrows: true }),
+    );
+    const token = "throw-token-1";
+    const res = await handler(postRequest(token));
+
+    expect(res.status).toBe(500);
+    // The throw happens at API-key resolution, before the pipeline runs.
+    expect(handleInboundMock).not.toHaveBeenCalled();
+    // Released: Mailgun's retry delivery reserves the token again instead of
+    // being silently deduped and dropped (StringDedupCache reservations have
+    // no TTL, so a stranded reservation would be permanent).
+    expect(dedupCache.reserve(token)).toBe(true);
+  });
+
+  it("forwards through the pipeline and keeps the token deduped when the API key resolves", async () => {
+    const { handler, dedupCache } = createMailgunWebhookHandler(
+      config,
+      makeCaches({ apiKey: "mg-api-key" }),
+    );
+    const token = "ok-token-1";
+    const res = await handler(postRequest(token));
+
+    expect(res.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    // A processed delivery stays deduped: the retry reservation is refused.
+    expect(dedupCache.reserve(token)).toBe(false);
+  });
+});

--- a/gateway/src/http/routes/mailgun-webhook.ts
+++ b/gateway/src/http/routes/mailgun-webhook.ts
@@ -10,7 +10,10 @@ import {
 } from "../../credential-refresh.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import type { EmailReplySender } from "../../email/inbound-pipeline.js";
-import { runEmailInboundPipeline } from "../../email/inbound-pipeline.js";
+import {
+  resolveEmailCredentialOrRelease,
+  runEmailInboundPipeline,
+} from "../../email/inbound-pipeline.js";
 import type { VellumEmailPayload } from "../../email/normalize.js";
 import { parseEmailAddress } from "../../email/normalize.js";
 import { getLogger } from "../../logger.js";
@@ -305,10 +308,18 @@ export function createMailgunWebhookHandler(
 
     // ── Forward through the shared email pipeline ───────────────────
 
-    const apiKey = await resolveCredentialWithRefresh(
-      caches?.credentials,
-      credentialKey("mailgun", "api_key"),
-    );
+    const apiKeyResult = await resolveEmailCredentialOrRelease({
+      credentials: caches?.credentials,
+      key: credentialKey("mailgun", "api_key"),
+      dedupCache,
+      dedupKey: token,
+      log: tlog,
+      label: "Mailgun",
+    });
+    if (!apiKeyResult.ok) {
+      return apiKeyResult.response;
+    }
+    const apiKey = apiKeyResult.value;
     if (!apiKey) {
       tlog.debug("Mailgun API key not configured — replies disabled");
     }

--- a/gateway/src/http/routes/resend-webhook.test.ts
+++ b/gateway/src/http/routes/resend-webhook.test.ts
@@ -1,0 +1,139 @@
+import { createHmac } from "node:crypto";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { GatewayConfig } from "../../config.js";
+import type { CredentialCache } from "../../credential-cache.js";
+import { credentialKey } from "../../credential-key.js";
+
+// --- Mocks ----------------------------------------------------------------
+
+const handleInboundMock = mock(() =>
+  Promise.resolve({ forwarded: true, rejected: false } as Record<
+    string,
+    unknown
+  >),
+);
+
+mock.module("../../handlers/handle-inbound.js", () => ({
+  handleInbound: handleInboundMock,
+}));
+mock.module("../../routing/resolve-assistant.js", () => ({
+  resolveAssistant: () => ({ assistantId: "assistant-1" }),
+  isRejection: (routing: Record<string, unknown>) => "reason" in routing,
+}));
+mock.module("../../db/denial-reply-rate-limiter.js", () => ({
+  recordDenialReplyIfAllowed: () => true,
+}));
+mock.module("../../runtime/client.js", () => ({
+  resetConversation: mock(() => Promise.resolve()),
+  uploadAttachment: mock(() => Promise.resolve({ id: "att-1" })),
+  AttachmentValidationError: class extends Error {},
+  CircuitBreakerOpenError: class extends Error {},
+}));
+
+// Import after mocks are registered
+const { createResendWebhookHandler } = await import("./resend-webhook.js");
+
+// --- Helpers ---------------------------------------------------------------
+
+// Svix secrets are `whsec_<base64>`; the verifier base64-decodes the part
+// after the prefix and HMACs `${svix-id}.${svix-timestamp}.${rawBody}`.
+const SECRET_BYTES = Buffer.from("resend-webhook-secret-key-bytes");
+const WEBHOOK_SECRET = `whsec_${SECRET_BYTES.toString("base64")}`;
+
+const config = {
+  maxWebhookPayloadBytes: 1024 * 1024,
+  maxAttachmentBytes: { email: 25 * 1024 * 1024, default: 100 * 1024 * 1024 },
+  maxAttachmentConcurrency: 3,
+} as unknown as GatewayConfig;
+
+function makeCaches(opts?: { apiKey?: string; apiKeyThrows?: boolean }) {
+  const credentials = {
+    get: async (key: string) => {
+      if (key === credentialKey("resend", "webhook_secret")) {
+        return WEBHOOK_SECRET;
+      }
+      if (key === credentialKey("resend", "api_key")) {
+        if (opts?.apiKeyThrows) {
+          throw new Error("credential backend unavailable");
+        }
+        return opts?.apiKey;
+      }
+      return undefined;
+    },
+    invalidate: () => {},
+  } as unknown as CredentialCache;
+  return { credentials };
+}
+
+function postRequest(messageId: string): Request {
+  const svixId = `msg_${messageId}`;
+  const svixTimestamp = Math.floor(Date.now() / 1000).toString();
+  const body = JSON.stringify({
+    type: "email.received",
+    created_at: "2026-04-03T01:00:00.000Z",
+    data: {
+      email_id: `email_${messageId}`,
+      created_at: "2026-04-03T01:00:00.000Z",
+      from: "alice@example.com",
+      to: ["assistant@example.org"],
+      subject: "Hello",
+      message_id: messageId,
+    },
+  });
+  const signature = createHmac("sha256", SECRET_BYTES)
+    .update(`${svixId}.${svixTimestamp}.${body}`, "utf8")
+    .digest("base64");
+  return new Request("http://localhost:7830/webhooks/resend", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "svix-id": svixId,
+      "svix-timestamp": svixTimestamp,
+      "svix-signature": `v1,${signature}`,
+    },
+    body,
+  });
+}
+
+beforeEach(() => {
+  handleInboundMock.mockClear();
+  handleInboundMock.mockImplementation(() =>
+    Promise.resolve({ forwarded: true, rejected: false }),
+  );
+});
+
+// --- Tests ----------------------------------------------------------------
+
+describe("resend-webhook API-key resolution", () => {
+  it("releases the reserved dedup key and returns 500 when the API-key read throws", async () => {
+    const { handler, dedupCache } = createResendWebhookHandler(
+      config,
+      makeCaches({ apiKeyThrows: true }),
+    );
+    const messageId = "<throw-msg-1@example.com>";
+    const res = await handler(postRequest(messageId));
+
+    expect(res.status).toBe(500);
+    // The throw happens at API-key resolution, before the pipeline runs.
+    expect(handleInboundMock).not.toHaveBeenCalled();
+    // Released: Resend's retry delivery reserves the key again instead of
+    // being silently deduped and dropped.
+    expect(dedupCache.reserve(messageId)).toBe(true);
+  });
+
+  it("forwards through the pipeline and keeps the key deduped when the API key resolves", async () => {
+    // API key omitted (undefined): the body fetch is skipped but the event
+    // still forwards — a non-throwing resolution must not 500.
+    const { handler, dedupCache } = createResendWebhookHandler(
+      config,
+      makeCaches(),
+    );
+    const messageId = "<ok-msg-1@example.com>";
+    const res = await handler(postRequest(messageId));
+
+    expect(res.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    // A processed delivery stays deduped: the retry reservation is refused.
+    expect(dedupCache.reserve(messageId)).toBe(false);
+  });
+});

--- a/gateway/src/http/routes/resend-webhook.ts
+++ b/gateway/src/http/routes/resend-webhook.ts
@@ -10,7 +10,10 @@ import {
 } from "../../credential-refresh.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import type { EmailReplySender } from "../../email/inbound-pipeline.js";
-import { runEmailInboundPipeline } from "../../email/inbound-pipeline.js";
+import {
+  resolveEmailCredentialOrRelease,
+  runEmailInboundPipeline,
+} from "../../email/inbound-pipeline.js";
 import type { VellumEmailPayload } from "../../email/normalize.js";
 import { parseEmailAddress } from "../../email/normalize.js";
 import { getLogger } from "../../logger.js";
@@ -345,10 +348,18 @@ export function createResendWebhookHandler(
     // The webhook payload only has metadata — we need the API to get
     // the actual email body and headers.
 
-    const apiKey = await resolveCredentialWithRefresh(
-      caches?.credentials,
-      credentialKey("resend", "api_key"),
-    );
+    const apiKeyResult = await resolveEmailCredentialOrRelease({
+      credentials: caches?.credentials,
+      key: credentialKey("resend", "api_key"),
+      dedupCache,
+      dedupKey: messageId,
+      log: tlog,
+      label: "Resend",
+    });
+    if (!apiKeyResult.ok) {
+      return apiKeyResult.response;
+    }
+    const apiKey = apiKeyResult.value;
 
     let emailContent: Awaited<ReturnType<typeof fetchResendEmailContent>> =
       null;


### PR DESCRIPTION
## Summary

Codex flagged on #36917 that the Mailgun webhook reserves its dedup token and *then* resolves the Mailgun `api_key` via `resolveCredentialWithRefresh()` outside any try/catch. That read goes through the credential cache, which re-throws on a credential-backend failure. Because `StringDedupCache` reservations (the `processing` set) have no TTL, a transient throw permanently strands the token — Mailgun's retries then dedup as duplicates and the inbound email is silently dropped. The Resend webhook has the same shape (`api_key` resolved after reserving the message-id).

## Fix

- Add `resolveEmailCredentialOrRelease()` to `email/inbound-pipeline.ts`: it resolves the credential inside a try/catch, and on a throw it releases the reservation (`dedupCache.unreserve`) and returns 500 so the provider retries and the retry is actually processed.
- Both the Mailgun and Resend webhooks route their `api_key` lookup through it.
- A missing (non-throwing) credential still resolves to `undefined`, so the existing "replies disabled" (Mailgun) / "email body unavailable" (Resend) behavior is unchanged — only a *throw* now short-circuits to 500 + release.

## Tests

New `mailgun-webhook.test.ts` / `resend-webhook.test.ts` handler tests: a credential-read throw releases the reservation (the key is reservable again, so a retry is processed) and returns 500; a normal delivery still forwards to the runtime and stays deduped.

Addresses review feedback on #36917.