### PR TITLE
fix(runtime): install abort controller so Stop cancels summarize cleanly

### DIFF
--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -625,6 +625,42 @@ describe("Conversation.summarizeUpToMessage", () => {
     );
     expect(compactCalls).toHaveLength(0);
   });
+
+  test("a Stop-aborted summary does not trip the compaction circuit breaker", async () => {
+    const conversation = makeConversation();
+    // Stop fired: the summarize route installed an abort controller and aborted
+    // it. The compactor reports the aborted provider call as summaryFailed —
+    // a cancellation, not a genuine compaction failure.
+    const controller = new AbortController();
+    controller.abort();
+    conversation.abortController = controller;
+    mockCompactResult = { ...makeNoopResult(), summaryFailed: true };
+
+    const recordOutcome = mock(async () => {});
+    conversation.agentLoop.compactionCircuit.recordOutcome = recordOutcome;
+
+    const result = await conversation.summarizeUpToMessage("m4");
+
+    // No breaker outcome recorded for a cancellation, and nothing applied.
+    expect(recordOutcome).not.toHaveBeenCalled();
+    expect(result.compacted).toBe(false);
+    // The aborted signal still reached the compactor's summary call.
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0].signal?.aborted).toBe(true);
+  });
+
+  test("a genuine summary failure (no abort) still records a breaker outcome", async () => {
+    const conversation = makeConversation();
+    mockCompactResult = { ...makeNoopResult(), summaryFailed: true };
+
+    const recordOutcome = mock(async () => {});
+    conversation.agentLoop.compactionCircuit.recordOutcome = recordOutcome;
+
+    await conversation.summarizeUpToMessage("m4");
+
+    expect(recordOutcome).toHaveBeenCalledTimes(1);
+    expect(recordOutcome).toHaveBeenCalledWith(true, expect.anything());
+  });
 });
 
 describe("formatSummarizeUpToResult", () => {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2152,8 +2152,14 @@ export class Conversation {
     // still trips the breaker. `summaryFailed` is `undefined` on
     // early-return paths (no eligible messages, disabled, below the auto
     // threshold, etc.) — skip those so they don't silently reset the
-    // counter.
-    if (result.summaryFailed !== undefined) {
+    // counter. A user Stop aborts the summary's provider call, which the
+    // compactor reports as `summaryFailed: true`; that is a cancellation, not
+    // a genuine failure, so skip recording when the signal is aborted rather
+    // than tripping the breaker on user cancels.
+    if (
+      result.summaryFailed !== undefined &&
+      !this.abortController?.signal.aborted
+    ) {
       await this.agentLoop.compactionCircuit.recordOutcome(
         result.summaryFailed,
         this.sendToClient,

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -21,6 +21,7 @@
 
 import { z } from "zod";
 
+import { isUserCancellation } from "../../daemon/conversation-error.js";
 import { formatSummarizeUpToResult } from "../../daemon/conversation-process.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import {
@@ -224,6 +225,13 @@ async function handleSummarizeConversation({
     );
   }
   conversation.setProcessing(true);
+  // Install an abort controller before the long summary call so Stop can
+  // actually cancel it — mirroring the send path (`persistUserMessage`).
+  // Without one, `abortConversation` finds no live controller, force-clears the
+  // processing flag, and lets the summary keep running so it can apply/persist
+  // after cancel and race the next turn.
+  const abortController = new AbortController();
+  conversation.abortController = abortController;
 
   const originClientId = headers?.["x-vellum-client-id"]?.trim() || undefined;
 
@@ -253,13 +261,25 @@ async function handleSummarizeConversation({
     // idle — the result card's `message_complete` covers the happy path,
     // but the hard-error path persists no card, so the idle emit in
     // `finally` is what guarantees the indicator always clears.
-    let terminalReason: "message_complete" | "error_terminal" =
-      "message_complete";
+    let terminalReason:
+      | "message_complete"
+      | "error_terminal"
+      | "generation_cancelled" = "message_complete";
     try {
       conversation.emitActivityState("thinking", "context_compacting", {
         statusText: "Summarizing conversation",
       });
       const result = await conversation.summarizeUpToMessage(beforeMessageId);
+      // Stop aborted the in-flight summary: the compactor reports the aborted
+      // provider call as a non-compacted result (it swallows the abort rather
+      // than throwing), so detect cancellation via the signal. A cancelled
+      // summary applies nothing — surface a clean cancellation instead of a
+      // "skipped" card. A summary that already compacted before a late Stop
+      // still shows its card; that work is already persisted.
+      if (!result.compacted && abortController.signal.aborted) {
+        terminalReason = "generation_cancelled";
+        return;
+      }
       const cardId = await persistCard(formatSummarizeUpToResult(result));
       // Attribute the compaction LLM call to the card it produced, so the
       // inspector shows it there instead of the unlinked-row recovery
@@ -268,6 +288,17 @@ async function handleSummarizeConversation({
         linkRequestLogsToMessage([result.summaryRequestLogId], cardId);
       }
     } catch (err) {
+      // A Stop that surfaces as a thrown abort (rather than the compactor's
+      // swallowed no-op) is still a clean cancellation, not an error card.
+      if (
+        isUserCancellation(err, {
+          phase: "handler",
+          aborted: abortController.signal.aborted,
+        })
+      ) {
+        terminalReason = "generation_cancelled";
+        return;
+      }
       // Boundary/mapping UserErrors are expected user-facing outcomes, not
       // failures: surface them as a skipped card rather than an error event.
       if (err instanceof UserError) {
@@ -289,6 +320,12 @@ async function handleSummarizeConversation({
       });
     } finally {
       conversation.emitActivityState("idle", terminalReason);
+      // Null our controller before clearing the flag so a racing Stop takes
+      // `abortConversation`'s force-clear branch instead of signalling a dead
+      // controller. Identity-guarded: a newer turn may already own the field.
+      if (conversation.abortController === abortController) {
+        conversation.abortController = null;
+      }
       conversation.setProcessing(false);
       silentlyWithLog(
         conversation.drainQueue(),


### PR DESCRIPTION
Addresses Codex review feedback on #36906 (POST /v1/conversations/summarize).

## Problem
The summarize route marked the conversation processing but never installed `conversation.abortController` before the long summarize call. Stop (`abortConversation`) therefore found no live controller, took the force-clear branch, and cleared the processing flag while the summary kept running — so the summary could apply/persist **after** cancel and race a newly started turn. Only the send/turn path (`persistUserMessage`) installed a controller.

## Fix
- **Install a controller before the summarize call and tear it down in `finally`** — nulled **before** `setProcessing(false)` and identity-guarded so a newer turn's controller is never clobbered, mirroring the send path. Stop now aborts the summary's provider call, and a cancelled run applies nothing (`compacted: false` skips `applyCompactionResult`).
- **Surface an aborted summary as a clean cancellation.** The compactor swallows the aborted provider call into a non-compacted result (it does not re-throw), so cancellation is detected via the signal and emits `idle`/`generation_cancelled` instead of a "Summarization skipped"/error card. A thrown abort is also handled via the canonical `isUserCancellation` helper.
- **Don't let a user cancel trip the compaction circuit breaker.** An aborted summary reports `summaryFailed: true`, which is a cancellation rather than a genuine failure, so `runCompaction` skips `recordOutcome` when the signal is aborted. (Making summarize abortable would otherwise newly introduce this regression.)

## Files
- `assistant/src/runtime/routes/conversation-management-routes.ts` — controller install/teardown + clean-cancellation handling in the summarize route.
- `assistant/src/daemon/conversation.ts` — skip the compaction circuit-breaker outcome when the run was aborted.
- `assistant/src/__tests__/conversation-summarize-up-to.test.ts` — two regression tests pinning the circuit-breaker guard.

## Testing
`cd assistant && bun test src/__tests__/conversation-summarize-up-to.test.ts` — 17 pass.

## Review focus
Core-loop conversation abort semantics. Focus on the `finally` ordering (null controller before clearing the processing flag, identity-guarded) and the circuit-breaker guard, which is shared by the auto/forced compaction paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)