### PR TITLE
fix(inspector): let the deliberate compaction card link win the attribution race

### DIFF
--- a/assistant/src/__tests__/llm-request-log-turn-query.test.ts
+++ b/assistant/src/__tests__/llm-request-log-turn-query.test.ts
@@ -572,4 +572,55 @@ describe("compaction-call attribution", () => {
     expect(logs).toHaveLength(1);
     expect(logs[0]?.id).toBe(compactionLogId!);
   });
+
+  test("recovery on the prior turn cannot defeat the deliberate card link", async () => {
+    const conv = createConversation("link-race");
+    await addMessage(conv.id, "user", "Chat away", { skipIndexing: true });
+    recordRequestLog(conv.id, '{"turn":"main"}', '{"answer":"sure"}');
+    const reply = await addMessage(conv.id, "assistant", "Sure!", {
+      skipIndexing: true,
+    });
+    backfillMessageIdOnLogs(conv.id, reply.id);
+
+    // The compaction call is recorded unlinked, before its result card
+    // persists — its createdAt falls inside the prior turn's open time window.
+    const compactionLogId = recordRequestLog(
+      conv.id,
+      '{"compaction":true}',
+      '{"summary":"..."}',
+      undefined,
+      "openrouter",
+      "compactionAgent",
+    );
+
+    // Race: the inspector queries the prior turn in the window between the
+    // compaction call and the card link. Recovery may sweep the unlinked
+    // compaction row into the view, but it must NOT durably stamp it onto this
+    // turn — otherwise the IS-NULL-guarded link below would no-op.
+    getRequestLogsByMessageId(reply.id);
+    const afterRecovery = logsDb()
+      .select({ messageId: llmRequestLogs.messageId })
+      .from(llmRequestLogs)
+      .where(sql`${llmRequestLogs.id} = ${compactionLogId!}`)
+      .get();
+    expect(afterRecovery?.messageId).toBeNull();
+
+    // The card persists and the route deliberately links the compaction row.
+    const card = await addMessage(conv.id, "assistant", "**Compacted**", {
+      metadata: { messageKind: "system_card" },
+      skipIndexing: true,
+    });
+    linkRequestLogsToMessage([compactionLogId!], card.id);
+
+    // The deliberate link wins: the compaction call belongs to the card…
+    const cardLogs = getRequestLogsByMessageId(card.id);
+    expect(cardLogs).toHaveLength(1);
+    expect(cardLogs[0]?.id).toBe(compactionLogId!);
+    expect(cardLogs[0]?.messageId).toBe(card.id);
+
+    // …and the prior turn keeps only its own mainAgent call.
+    const turnLogs = getRequestLogsByMessageId(reply.id);
+    expect(turnLogs).toHaveLength(1);
+    expect(turnLogs[0]?.messageId).toBe(reply.id);
+  });
 });

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -15,7 +15,10 @@ import {
 } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE } from "../api/constants/call-sites.js";
+import {
+  CALL_SITE_COMPACTION_AGENT,
+  CALL_SITE_SYNTHETIC_AGENT_ERROR_MESSAGE,
+} from "../api/constants/call-sites.js";
 import { getConfigReadOnly } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { AssistantError, ProviderError } from "../util/errors.js";
@@ -656,7 +659,7 @@ export function getPreviousNonCompactionCallCreatedAt(
         lt(llmRequestLogs.createdAt, beforeCreatedAt),
         or(
           isNull(llmRequestLogs.callSite),
-          ne(llmRequestLogs.callSite, "compactionAgent"),
+          ne(llmRequestLogs.callSite, CALL_SITE_COMPACTION_AGENT),
         ),
       ),
     )
@@ -697,7 +700,7 @@ export function getCompactionLogsBetween(
   const db = logsDb();
   const predicates = [
     eq(llmRequestLogs.conversationId, conversationId),
-    eq(llmRequestLogs.callSite, "compactionAgent"),
+    eq(llmRequestLogs.callSite, CALL_SITE_COMPACTION_AGENT),
     lt(llmRequestLogs.createdAt, beforeCreatedAt),
   ];
   if (afterCreatedAt !== null) {
@@ -782,9 +785,12 @@ export function getRequestLogById(logId: string): LogRow | null {
  * Authoritative post-persist linkage: stamp `message_id` onto rows a flow
  * inserted unlinked because its user-facing message persists afterwards
  * (the /compact and summarize-up-to result cards). Dispatched through the
- * IS-NULL-guarded {@link LlmRequestLogWriter.backfillMessageIdOnRecoveredLogs}
- * so a concurrent inspector-recovery stamp is never overwritten. Non-fatal —
- * an unlinked row degrades to time-window recovery, not data loss.
+ * IS-NULL-guarded {@link LlmRequestLogWriter.backfillMessageIdOnRecoveredLogs}.
+ * The inspector's time-window recovery deliberately skips `compactionAgent`
+ * rows (see {@link getRequestLogsByMessageId}), so it can never durably stamp
+ * one onto an enclosing turn first and defeat this guarded link — the row is
+ * still NULL when this runs, so the link wins. Non-fatal — an unlinked row
+ * degrades to time-window recovery, not data loss.
  */
 export function linkRequestLogsToMessage(
   logIds: string[],
@@ -855,12 +861,21 @@ export function getRequestLogsByMessageId(messageId: string): LogRow[] {
       // hit the fast indexed-by-messageId path. Dispatched through the
       // active write backend like every other table writer — INSERT-only
       // backends no-op.
-      if (unlinkedLogs.length > 0 && turnMessageIds.length > 0) {
+      //
+      // Compaction rows are excluded: the /compact and summarize-up-to routes
+      // link them to their result card via the IS-NULL-guarded
+      // linkRequestLogsToMessage. Stamping one onto this enclosing turn here
+      // (swept in during the window before the card persists) would make that
+      // deliberate link a no-op and pin the call to the wrong turn forever.
+      // They still surface in this turn's view via the merge above.
+      const backfillIds = unlinkedLogs
+        .filter((l) => l.callSite !== CALL_SITE_COMPACTION_AGENT)
+        .map((l) => l.id);
+      if (backfillIds.length > 0 && turnMessageIds.length > 0) {
         try {
-          const ids = unlinkedLogs.map((l) => l.id);
           const targetMessageId = turnMessageIds[turnMessageIds.length - 1]!;
           resolveLlmRequestLogWriter().backfillMessageIdOnRecoveredLogs(
-            ids,
+            backfillIds,
             targetMessageId,
           );
         } catch {


### PR DESCRIPTION
## Summary

Follow-up to #38272 addressing Codex review feedback (verified still true on main).

A compaction request-log row stays `message_id = NULL` until `linkRequestLogsToMessage` runs after its result card persists. If the LLM inspector queries the prior/enclosing turn during that window, `getRequestLogsByMessageId`'s unlinked-row recovery durably stamps the row onto that turn via `backfillMessageIdOnRecoveredLogs`. The later deliberate card link then no-ops — it only updates rows `WHERE message_id IS NULL` — so the misattribution becomes permanent, re-introducing exactly the prior-turn pollution #38272 fixed.

## Fix

Exclude `compactionAgent` rows from the recovery backfill (option (c)). Compaction rows are linked deliberately to their `/compact` or summarize-up-to result card, so recovery must never durably stamp them onto an enclosing turn. They still surface transiently in that turn's view via the existing merge — they're just never stamped, so the IS-NULL-guarded card link always wins regardless of race ordering.

- The emergency (auto) compaction path — no card, relies on recovery to display under its enclosing turn — is unaffected: merge display is preserved, only the opportunistic durable stamp is skipped.
- The fork-source fallback is untouched.
- Also routes the two existing `"compactionAgent"` literals in this file through the canonical `CALL_SITE_COMPACTION_AGENT` constant.

## Test

Adds a regression test reproducing the race: recovery stamps the prior turn first, then the deliberate link must still win. Asserts the compaction row stays NULL through recovery, ends up on the card after linking, and the prior turn keeps only its `mainAgent` call. Fails on the pre-fix code (recovery stamp wins), passes after.