### PR TITLE
fix(web): map a workspace-theme 404 to the unthemed state

### DIFF
--- a/clients/web/docs/BACKWARDS_COMPAT.md
+++ b/clients/web/docs/BACKWARDS_COMPAT.md
@@ -128,7 +128,11 @@ these hold:
   mutate state a newer assistant ignores),
 - an older assistant's **404 degrades to exactly the feature-off
   state** — the UI renders identically to "feature absent," with no
-  error surfaced to the user, and
+  error surfaced to the user. Because React Query keeps the
+  last-successful data on error, a read that can succeed before a
+  later 404 (e.g. a rollback to a version without the route) must
+  **map the 404 to the feature-off value in its `queryFn`** rather
+  than let it throw, or the stale success is stranded, and
 - the request stays quiet under failure: the app QueryClient **never
   retries 4xx** (see `providers.tsx`), and the query disables refetch
   triggers that would re-issue the failing request (e.g.

--- a/clients/web/src/hooks/use-workspace-theme.test.ts
+++ b/clients/web/src/hooks/use-workspace-theme.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Pins the read contract the workspace-theme hook leans on: an assistant
+ * without the route (older, or rolled back from a themed version) 404s the
+ * read, which resolves to `null` so a refetch overwrites the last-applied
+ * theme and the hook clears the tokens. Every other failure throws so a
+ * transient error keeps the last-good theme and retries.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { WorkspaceTheme } from "@/domains/settings/utils/workspace-theme-tokens";
+
+const workspaceThemeGetMock = mock(
+  async (): Promise<{ data?: unknown; error?: unknown; response: unknown }> => ({
+    data: { theme: null, source: "none", issues: [] },
+    response: { ok: true, status: 200 },
+  }),
+);
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  workspaceThemeGet: workspaceThemeGetMock,
+}));
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  workspaceThemeGetQueryKey: () => [{ _id: "workspaceThemeGet" }],
+}));
+
+const { fetchWorkspaceTheme } = await import("./use-workspace-theme");
+
+const THEME: WorkspaceTheme = { version: 1, tokens: { accent: "#abcdef" } };
+
+beforeEach(() => {
+  workspaceThemeGetMock.mockClear();
+});
+
+describe("fetchWorkspaceTheme", () => {
+  test("returns the theme from a 200 response", async () => {
+    workspaceThemeGetMock.mockResolvedValueOnce({
+      data: { theme: THEME, source: "workspace", issues: [] },
+      response: { ok: true, status: 200 },
+    });
+
+    expect(await fetchWorkspaceTheme("assistant-1")).toEqual(THEME);
+  });
+
+  test("returns null when a 200 response carries no theme", async () => {
+    expect(await fetchWorkspaceTheme("assistant-1")).toBeNull();
+  });
+
+  test("maps a 404 to null so a rolled-back assistant clears its theme", async () => {
+    workspaceThemeGetMock.mockResolvedValueOnce({
+      error: { detail: "Not found" },
+      response: { ok: false, status: 404 },
+    });
+
+    expect(await fetchWorkspaceTheme("assistant-1")).toBeNull();
+  });
+
+  test("throws on a non-404 failure so the query keeps the last-good theme", async () => {
+    workspaceThemeGetMock.mockResolvedValueOnce({
+      error: { detail: "boom" },
+      response: { ok: false, status: 500 },
+    });
+
+    await expect(fetchWorkspaceTheme("assistant-1")).rejects.toThrow();
+  });
+
+  test("throws on a network failure with no response", async () => {
+    workspaceThemeGetMock.mockResolvedValueOnce({ response: undefined });
+
+    await expect(fetchWorkspaceTheme("assistant-1")).rejects.toThrow();
+  });
+});

--- a/clients/web/src/hooks/use-workspace-theme.ts
+++ b/clients/web/src/hooks/use-workspace-theme.ts
@@ -7,9 +7,10 @@
  *
  *  1. Fetch the validated theme from `GET /v1/workspace/theme` and push its
  *     token overrides onto the document root. Deliberately not version-gated:
- *     an older assistant 404s the read-only query, which the app QueryClient
- *     never retries (4xx rule) and which degrades to exactly the unthemed
- *     state — see "When a gate is unnecessary" in BACKWARDS_COMPAT.md.
+ *     an assistant without the route (older, or rolled back from a themed
+ *     version) 404s the read, which `fetchWorkspaceTheme` maps to the unthemed
+ *     state so a rollback clears any applied theme rather than stranding a
+ *     stale one — see "When a gate is unnecessary" in BACKWARDS_COMPAT.md.
  *  2. Refetch on the `assistant:self:theme` sync tag and on non-fresh SSE
  *     reconnect, so a theme the assistant (or another client) writes shows up
  *     without a reload — the daemon's config watcher emits the invalidation.
@@ -27,10 +28,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { toast } from "@vellumai/design-library/components/toast";
 
-import {
-  workspaceThemeGetOptions,
-  workspaceThemeGetQueryKey,
-} from "@/generated/daemon/@tanstack/react-query.gen";
+import { workspaceThemeGet } from "@/generated/daemon/sdk.gen";
+import { workspaceThemeGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { SYNC_TAGS } from "@/lib/sync/types";
 import { getClientId } from "@/lib/telemetry/client-identity";
@@ -39,6 +38,31 @@ import {
   type WorkspaceTheme,
 } from "@/domains/settings/utils/workspace-theme-tokens";
 
+/**
+ * Read the validated workspace theme, mapping a 404 to the unthemed state.
+ *
+ * An assistant that lacks the route 404s this read, which resolves to `null` so
+ * a refetch overwrites the last-applied theme instead of stranding it. Other
+ * failures throw, so a transient error keeps the last-good theme and retries.
+ */
+export async function fetchWorkspaceTheme(
+  assistantId: string,
+  signal?: AbortSignal,
+): Promise<WorkspaceTheme | null> {
+  const { data, error, response } = await workspaceThemeGet({
+    path: { assistant_id: assistantId },
+    throwOnError: false,
+    signal,
+  });
+  if (!response || !response.ok) {
+    if (response?.status === 404) {
+      return null;
+    }
+    throw error ?? new Error("Failed to fetch workspace theme.");
+  }
+  return (data?.theme ?? null) as WorkspaceTheme | null;
+}
+
 export function useWorkspaceTheme(
   assistantId: string | null,
   isAssistantActive: boolean,
@@ -46,15 +70,14 @@ export function useWorkspaceTheme(
   const queryClient = useQueryClient();
   const enabled = isAssistantActive && !!assistantId;
 
-  const { data } = useQuery({
-    ...workspaceThemeGetOptions({
+  const { data: theme } = useQuery({
+    queryKey: workspaceThemeGetQueryKey({
       path: { assistant_id: assistantId ?? "" },
     }),
+    queryFn: ({ signal }) => fetchWorkspaceTheme(assistantId ?? "", signal),
     enabled,
     refetchOnWindowFocus: false,
   });
-
-  const theme = (data?.theme ?? null) as WorkspaceTheme | null;
 
   // Apply on every resolved theme; clearing when the theme is removed, or when
   // the hook is disabled (assistant inactive / switched away), reverts to the


### PR DESCRIPTION
Follow-up to #37771 addressing Codex review feedback.

## Problem

useWorkspaceTheme read the theme from a query whose generated queryFn throws on error (throwOnError: true). React Query keeps the last-successful data on a subsequent error, so after a successful theme fetch a later legacy 404 (assistant rolled back to a version without /v1/workspace/theme) left the stale theme applied — contradicting the documented contract that a 404 degrades to exactly the unthemed state.

## Fix

- Add fetchWorkspaceTheme, a 404-tolerant reader (mirrors fetchOperationalStatus / fetchPersonalitySliders): it calls the SDK with throwOnError: false and maps a 404 to a null theme, so a post-rollback refetch overwrites the stale success and the hook clears the applied tokens. Other failures still throw, so a transient 5xx/network error keeps the last-good theme and retries.
- Point the query queryFn at it; the query key is unchanged (workspaceThemeGetQueryKey).
- Add use-workspace-theme.test.ts covering 200-with-theme, 200-null, 404-to-null (the regression), 5xx-throws, and network-throws.
- Clarify BACKWARDS_COMPAT.md "When a gate is unnecessary": a read that can succeed then 404 must map the 404 in its queryFn, or React Query strands the stale success.

Judgement call: mapped only 404, not any error. A 404 is the permanent feature-off signal; 5xx/network errors are transient and should retain the last-good theme rather than flicker it off.