### PR TITLE
fix(voice): preserve managed STT error messages instead of the BYOK rewrite

### DIFF
--- a/assistant/src/__tests__/stt-stream-session.test.ts
+++ b/assistant/src/__tests__/stt-stream-session.test.ts
@@ -18,9 +18,10 @@ import {
   SttStreamSession,
   type SttStreamSocket,
 } from "../stt/stt-stream-session.js";
-import type {
-  StreamingTranscriber,
-  SttStreamServerEvent,
+import {
+  type StreamingTranscriber,
+  SttError,
+  type SttStreamServerEvent,
 } from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
@@ -127,6 +128,29 @@ class FailingTranscriber implements StreamingTranscriber {
 
   async start(_onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
     throw new Error("Mock provider connection refused");
+  }
+
+  sendAudio(_audio: Buffer, _mimeType: string): void {
+    throw new Error("Should not be called");
+  }
+
+  stop(): void {
+    throw new Error("Should not be called");
+  }
+}
+
+/**
+ * Mock managed transcriber whose start() throws a userFacing SttError,
+ * mirroring the managed relay's mapped dial rejection.
+ */
+class ManagedFailingTranscriber implements StreamingTranscriber {
+  readonly providerId = "vellum" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+
+  constructor(private readonly message: string) {}
+
+  async start(_onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    throw new SttError("auth", this.message, { userFacing: true });
   }
 
   sendAudio(_audio: Buffer, _mimeType: string): void {
@@ -330,6 +354,27 @@ describe("SttStreamSession", () => {
       expect(frames[1].type).toBe("closed");
       expect(session.isClosed).toBe(true);
       expect(ws.closed).toBe(true);
+    });
+
+    test("managed start failure surfaces its remediation verbatim", async () => {
+      const { ws, session } = createSession("vellum");
+      const managedMessage =
+        "Managed speech needs a working Vellum platform connection — reconnect with 'assistant platform connect'.";
+
+      await session.start(
+        async () => new ManagedFailingTranscriber(managedMessage),
+      );
+
+      const frames = ws.frames;
+      expect(frames[0].type).toBe("error");
+      expect(frames[0].category).toBe("auth");
+      // The managed remediation passes through; the BYOK "check your API key"
+      // rewrite must not clobber it for a connection-backed provider.
+      expect(frames[0].message).toBe(managedMessage);
+      expect(frames[0].message as string).not.toContain("API key");
+      expect(frames[0].message as string).not.toContain("Settings → Voice");
+      expect(frames[1].type).toBe("closed");
+      expect(session.isClosed).toBe(true);
     });
   });
 

--- a/assistant/src/providers/__tests__/voice-error-copy.test.ts
+++ b/assistant/src/providers/__tests__/voice-error-copy.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+
+import { SttError } from "../../stt/types.js";
+import { describeSttFailure } from "../voice-error-copy.js";
+
+describe("describeSttFailure", () => {
+  describe("BYOK providers (no userFacing marker)", () => {
+    test("auth failure points the user at the provider API key", () => {
+      const copy = describeSttFailure(
+        new SttError(
+          "auth",
+          'Deepgram API error (401): {"err":"INVALID_AUTH"}',
+        ),
+        "deepgram",
+      );
+      // Raw upstream JSON never leaks; friendly copy names the key + provider.
+      expect(copy).not.toContain("{");
+      expect(copy).not.toContain("INVALID_AUTH");
+      expect(copy).toContain("API key");
+      expect(copy).toContain("Settings → Voice");
+      expect(copy).toContain("Deepgram");
+    });
+
+    test("provider-error is generic and names the provider", () => {
+      const copy = describeSttFailure(
+        new SttError("provider-error", "connection reset by peer"),
+        "openai-whisper",
+      );
+      expect(copy).not.toContain("connection reset by peer");
+      expect(copy).toContain("OpenAI Whisper");
+    });
+
+    test("timeout uses provider-agnostic copy", () => {
+      const copy = describeSttFailure(
+        new SttError("timeout", "The operation was aborted"),
+        "vellum",
+      );
+      // A managed timeout (AbortError) carries no marker, so it still gets the
+      // friendly copy rather than the raw abort string.
+      expect(copy).toBe("Transcription timed out.");
+    });
+
+    test("unknown provider falls back to a generic label", () => {
+      const copy = describeSttFailure(
+        new SttError("rate-limit", "429 Too Many Requests"),
+        undefined,
+      );
+      expect(copy).toContain("the speech-to-text provider");
+      expect(copy).not.toContain("429");
+    });
+  });
+
+  describe("managed speech (userFacing marker)", () => {
+    test("auth failure surfaces the reconnect remediation verbatim", () => {
+      const message =
+        "Managed speech needs a working Vellum platform connection — reconnect with 'assistant platform connect'.";
+      const copy = describeSttFailure(
+        new SttError("auth", message, { userFacing: true }),
+        "vellum",
+      );
+      // The BYOK "check your API key in Settings → Voice" rewrite must not
+      // clobber managed remediation — managed users hold no speech key.
+      expect(copy).toBe(message);
+      expect(copy).not.toContain("API key");
+      expect(copy).not.toContain("Settings → Voice");
+    });
+
+    test("credits-exhausted message survives the provider-error branch", () => {
+      const message =
+        "Vellum credits are exhausted — add funds to your Vellum account to continue using managed transcription.";
+      const copy = describeSttFailure(
+        new SttError("provider-error", message, { userFacing: true }),
+        "vellum",
+      );
+      expect(copy).toBe(message);
+      expect(copy).not.toContain("returned an error while transcribing");
+    });
+
+    test("passthrough does not depend on the provider label", () => {
+      const message = "Managed speech relay error: upstream_error";
+      const copy = describeSttFailure(
+        new SttError("provider-error", message, { userFacing: true }),
+        undefined,
+      );
+      expect(copy).toBe(message);
+    });
+  });
+});

--- a/assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts
@@ -113,6 +113,9 @@ describe("sttErrorFromManagedSpeech", () => {
       );
       expect(err).toBeInstanceOf(SttError);
       expect(err.category).toBe(category as SttError["category"]);
+      // Managed messages carry their own remediation — flagged so
+      // describeSttFailure surfaces them verbatim, not the BYOK rewrite.
+      expect(err.userFacing).toBe(true);
       if (messageIncludes) {
         expect(err.message).toContain(messageIncludes);
       }

--- a/assistant/src/providers/speech-to-text/vellum-managed-realtime.ts
+++ b/assistant/src/providers/speech-to-text/vellum-managed-realtime.ts
@@ -109,8 +109,12 @@ export class VellumManagedRealtimeTranscriber implements StreamingTranscriber {
       if (rejection) {
         // Typed so the stream session preserves the mapped category —
         // an auth/setup failure must not surface as a provider outage.
+        // `userFacing` keeps the mapped remediation (reconnect, top up
+        // credits) from being rewritten to BYOK "check your API key" copy.
         const mapped = mapVelayError(rejection);
-        throw new SttError(mapped.category, mapped.message);
+        throw new SttError(mapped.category, mapped.message, {
+          userFacing: true,
+        });
       }
       throw err;
     }

--- a/assistant/src/providers/speech-to-text/vellum-managed.ts
+++ b/assistant/src/providers/speech-to-text/vellum-managed.ts
@@ -10,7 +10,11 @@ import {
   type ManagedSpeechResult,
   managedSpeechTranscribe,
 } from "../../platform/managed-speech.js";
-import { SttError, type SttTranscribeResult } from "../../stt/types.js";
+import {
+  SttError,
+  type SttErrorCategory,
+  type SttTranscribeResult,
+} from "../../stt/types.js";
 
 type ManagedSpeechFailure = Extract<ManagedSpeechResult<never>, { ok: false }>;
 
@@ -28,15 +32,24 @@ export async function vellumManagedSpeechAvailable(): Promise<boolean> {
  *
  * `insufficient_balance` gets a user-actionable message — the fix is topping
  * up Vellum credits, not editing provider config.
+ *
+ * Every returned error is flagged `userFacing`: managed speech has no provider
+ * API key on this machine, so the messages here (reconnect the platform,
+ * top up credits, the platform's own detail) already carry the correct
+ * remediation. `describeSttFailure` surfaces them verbatim instead of
+ * rewriting to the BYOK "check your API key" copy that never applies.
  */
 export function sttErrorFromManagedSpeech(
   failure: ManagedSpeechFailure,
 ): SttError {
+  const managed = (category: SttErrorCategory, message: string): SttError =>
+    new SttError(category, message, { userFacing: true });
+
   if (failure.kind === "unavailable") {
-    return new SttError("auth", failure.message);
+    return managed("auth", failure.message);
   }
   if (failure.code === "insufficient_balance") {
-    return new SttError(
+    return managed(
       "provider-error",
       "Vellum credits are exhausted — add funds to your Vellum account to continue using managed transcription.",
     );
@@ -44,13 +57,13 @@ export function sttErrorFromManagedSpeech(
   switch (failure.status) {
     case 401:
     case 403:
-      return new SttError("auth", failure.message);
+      return managed("auth", failure.message);
     case 429:
-      return new SttError("rate-limit", failure.message);
+      return managed("rate-limit", failure.message);
     case 413:
-      return new SttError("invalid-audio", failure.message);
+      return managed("invalid-audio", failure.message);
     default:
-      return new SttError("provider-error", failure.message);
+      return managed("provider-error", failure.message);
   }
 }
 

--- a/assistant/src/providers/voice-error-copy.ts
+++ b/assistant/src/providers/voice-error-copy.ts
@@ -23,6 +23,14 @@ export function describeSttFailure(
   err: SttError,
   providerId?: SttProviderId,
 ): string {
+  // Adapters that already produce user-facing, provider-appropriate copy
+  // (managed speech: reconnect the platform, top up Vellum credits) mark the
+  // error so its remediation survives verbatim instead of being rewritten to
+  // the BYOK "check your API key" copy — which is wrong for managed users, who
+  // hold no speech-to-text key.
+  if (err.userFacing) {
+    return err.message;
+  }
   const provider = sttProviderLabel(providerId);
   switch (err.category) {
     case "auth":

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
@@ -32,7 +32,9 @@ mock.module("../../../providers/speech-to-text/resolve.js", () => ({
 
 mock.module("../../../stt/daemon-batch-transcriber.js", () => ({
   normalizeSttError: (err: unknown): SttError => {
-    if (err instanceof SttError) return err;
+    if (err instanceof SttError) {
+      return err;
+    }
     const message = err instanceof Error ? err.message : String(err);
     if (err instanceof Error && err.name === "AbortError") {
       return new SttError("timeout", message);
@@ -196,6 +198,54 @@ describe("tryTranscribeAudioAttachments", () => {
     expect(reason).not.toContain("INVALID_AUTH");
     expect(reason).toContain("API key");
     expect(reason).toContain("Deepgram");
+  });
+
+  test("managed auth failure surfaces its remediation, not the BYOK API-key rewrite", async () => {
+    const audio = makeAudioAttachment("a1");
+    mockAttachments = [audio];
+    const managedMessage =
+      "Managed speech needs a working Vellum platform connection — reconnect with 'assistant platform connect'.";
+    mockTranscriber = {
+      providerId: "vellum",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        // Managed adapters flag their SttError userFacing so the friendly
+        // copy layer passes the message through verbatim.
+        throw new SttError("auth", managedMessage, { userFacing: true });
+      },
+    };
+
+    const result = await tryTranscribeAudioAttachments(["a1"]);
+
+    expect(result.status).toBe("error");
+    const reason = (result as { reason: string }).reason;
+    expect(reason).toBe(managedMessage);
+    // Managed users have no STT key — the BYOK rewrite must not appear.
+    expect(reason).not.toContain("API key");
+    expect(reason).not.toContain("Settings → Voice");
+  });
+
+  test("managed credits-exhausted failure is not hidden behind generic copy", async () => {
+    const audio = makeAudioAttachment("a1");
+    mockAttachments = [audio];
+    const creditsMessage =
+      "Vellum credits are exhausted — add funds to your Vellum account to continue using managed transcription.";
+    mockTranscriber = {
+      providerId: "vellum",
+      boundaryId: "daemon-batch",
+      transcribe: async () => {
+        throw new SttError("provider-error", creditsMessage, {
+          userFacing: true,
+        });
+      },
+    };
+
+    const result = await tryTranscribeAudioAttachments(["a1"]);
+
+    expect(result.status).toBe("error");
+    const reason = (result as { reason: string }).reason;
+    expect(reason).toBe(creditsMessage);
+    expect(reason).not.toContain("returned an error while transcribing");
   });
 
   test("30-second timeout fires and returns error without blocking", async () => {

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -150,10 +150,24 @@ export type SttErrorCategory =
 export class SttError extends Error {
   readonly category: SttErrorCategory;
 
-  constructor(category: SttErrorCategory, message: string) {
+  /**
+   * When true, {@link message} is already user-facing, provider-appropriate
+   * copy and must be surfaced verbatim rather than rewritten by
+   * `describeSttFailure`. Set by adapters (e.g. managed speech) whose failures
+   * carry specific remediation — a credit top-up or platform reconnect — that
+   * the generic BYOK "check your API key" copy would erase.
+   */
+  readonly userFacing: boolean;
+
+  constructor(
+    category: SttErrorCategory,
+    message: string,
+    options?: { userFacing?: boolean },
+  ) {
     super(message);
     this.name = "SttError";
     this.category = category;
+    this.userFacing = options?.userFacing ?? false;
   }
 }
 


### PR DESCRIPTION
Addresses the Codex review on #38356 (verified still true on main).

## Problem
Managed (vellum) speech errors already return safe, specific remediation from `sttErrorFromManagedSpeech` ("reconnect the platform connection", "Vellum credits are exhausted — add funds…"). But both STT catch paths — batch (`transcribe-audio.ts`) and streaming (`stt-stream-session.ts`) — route through `describeSttFailure`, whose `auth` branch rewrote everything to BYOK copy ("check the API key in Settings → Voice") that is wrong for managed users (they hold no STT key), and whose `provider-error` branch hid the credits message behind generic copy. This regressed managed messages that previously surfaced verbatim.

## Fix
Mark managed-origin `SttError`s as `userFacing` (a new optional flag on `SttError`). `sttErrorFromManagedSpeech` and the managed relay's mapped dial rejection (`vellum-managed-realtime.ts`) set it; `describeSttFailure` returns `err.message` verbatim when the flag is set, otherwise keeps the friendly BYOK rewrite for genuine BYOK providers.

A marker (not a provider-id check) is used deliberately: a managed timeout (AbortError → `SttError("timeout", …)`) or a raw network error normalized to `provider-error` also carries `providerId === "vellum"`, so a pure provider check would leak raw text and lose the friendly "Transcription timed out." copy. Only errors originating from the already-friendly managed adapters pass through.

## TTS
Checked — no equivalent regression. TTS copy is provider-local: the managed provider (`vellum-provider.ts`) throws its own friendly messages, `describeTtsAuthFailure` is called only inside the BYOK Deepgram provider, and `synthesize-text.ts` preserves the provider message (wraps, never category-rewrites). No TTS change needed.

## Tests
New `voice-error-copy.test.ts` (BYOK rewrite vs userFacing passthrough, timeout stays friendly, provider labels), managed-failure cases in the batch and streaming catch-path tests, and a `userFacing` assertion in the managed-speech test.