### PR TITLE
fix(daemon): resume interrupted turns under reconstructed resting trust

### DIFF
--- a/assistant/src/__tests__/interrupted-turn-reconciler.test.ts
+++ b/assistant/src/__tests__/interrupted-turn-reconciler.test.ts
@@ -1,13 +1,17 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  type InterruptedResumeTarget,
   MAX_RESUME_ATTEMPTS,
   reconcileInterruptedConversations,
+  resumeInterruptedConversations,
 } from "../daemon/interrupted-turn-reconciler.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import {
   createConversation,
   incrementProcessingResumeAttempts,
   listInterruptedConversations,
+  setConversationOriginChannelIfUnset,
   setConversationProcessingStartedAt,
 } from "../persistence/conversation-crud.js";
 import { getDb, getSqliteFrom } from "../persistence/db-connection.js";
@@ -34,6 +38,11 @@ function readRow(id: string): {
   return row;
 }
 
+/** A local conversation (no origin channel) resumes under guardian trust. */
+function guardianTarget(conversationId: string): InterruptedResumeTarget {
+  return { conversationId, trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT };
+}
+
 function seedInterrupted(id: string, resumeAttempts = 0): void {
   createConversation({ id });
   setConversationProcessingStartedAt(id, Date.now());
@@ -58,23 +67,53 @@ describe("interrupted-turn reconciler", () => {
     expect(result.cleared).toBe(2);
     expect(result.resume).toEqual([]);
     expect(result.capped).toEqual([]);
+    expect(result.trustUnrecoverable).toEqual([]);
     expect(readRow("conv-a").processing_started_at).toBeNull();
     expect(readRow("conv-b").processing_started_at).toBeNull();
     expect(readRow("conv-a").processing_resume_attempts).toBe(0);
   });
 
-  test("resume enabled: clears flags, selects interrupted conversations, and charges an attempt", () => {
+  test("resume enabled: clears flags and selects local conversations under guardian trust", () => {
     seedInterrupted("conv-a");
     createConversation({ id: "conv-idle" });
 
     const result = reconcileInterruptedConversations(true);
 
     expect(result.cleared).toBe(1);
-    expect(result.resume).toEqual(["conv-a"]);
+    expect(result.resume).toEqual([guardianTarget("conv-a")]);
     expect(result.capped).toEqual([]);
+    expect(result.trustUnrecoverable).toEqual([]);
     expect(readRow("conv-a").processing_started_at).toBeNull();
-    expect(readRow("conv-a").processing_resume_attempts).toBe(1);
+    // Selection no longer charges the attempt — that happens as each wake
+    // starts, so a crash mid-resume can't burn un-attempted budgets.
+    expect(readRow("conv-a").processing_resume_attempts).toBe(0);
     expect(readRow("conv-idle").processing_resume_attempts).toBe(0);
+  });
+
+  test("the internal vellum channel is treated as a guardian-owned local conversation", () => {
+    seedInterrupted("conv-vellum");
+    setConversationOriginChannelIfUnset("conv-vellum", "vellum");
+
+    const result = reconcileInterruptedConversations(true);
+
+    expect(result.resume).toEqual([guardianTarget("conv-vellum")]);
+    expect(result.trustUnrecoverable).toEqual([]);
+  });
+
+  test("remote-channel conversations are cleared but skipped when trust can't be recovered", () => {
+    seedInterrupted("conv-remote");
+    setConversationOriginChannelIfUnset("conv-remote", "telegram");
+    seedInterrupted("conv-local");
+
+    const result = reconcileInterruptedConversations(true);
+
+    expect(result.cleared).toBe(2);
+    expect(result.resume).toEqual([guardianTarget("conv-local")]);
+    expect(result.capped).toEqual([]);
+    expect(result.trustUnrecoverable).toEqual(["conv-remote"]);
+    expect(readRow("conv-remote").processing_started_at).toBeNull();
+    // A skipped conversation is never charged an attempt.
+    expect(readRow("conv-remote").processing_resume_attempts).toBe(0);
   });
 
   test("conversations at the attempt cap are cleared but not resumed", () => {
@@ -84,23 +123,35 @@ describe("interrupted-turn reconciler", () => {
     const result = reconcileInterruptedConversations(true);
 
     expect(result.cleared).toBe(2);
-    expect(result.resume).toEqual(["conv-fresh"]);
+    expect(result.resume).toEqual([guardianTarget("conv-fresh")]);
     expect(result.capped).toEqual(["conv-capped"]);
+    expect(result.trustUnrecoverable).toEqual([]);
     expect(readRow("conv-capped").processing_started_at).toBeNull();
     expect(readRow("conv-capped").processing_resume_attempts).toBe(
       MAX_RESUME_ATTEMPTS,
     );
   });
 
-  test("attempt counter survives the flag clear so the cap holds across boots", () => {
+  test("attempts charged at wake start make the cap hold across boots", () => {
     seedInterrupted("conv-a");
 
-    expect(reconcileInterruptedConversations(true).resume).toEqual(["conv-a"]);
-    // Simulate the resumed turn dying mid-flight on the next boot.
-    setConversationProcessingStartedAt("conv-a", Date.now());
-    expect(reconcileInterruptedConversations(true).resume).toEqual(["conv-a"]);
+    // Boot 1: selected for resume; the wake charges the attempt, then the
+    // resumed turn dies mid-flight and re-sets the processing flag.
+    expect(reconcileInterruptedConversations(true).resume).toEqual([
+      guardianTarget("conv-a"),
+    ]);
+    incrementProcessingResumeAttempts("conv-a");
     setConversationProcessingStartedAt("conv-a", Date.now());
 
+    // Boot 2: same again.
+    expect(reconcileInterruptedConversations(true).resume).toEqual([
+      guardianTarget("conv-a"),
+    ]);
+    incrementProcessingResumeAttempts("conv-a");
+    setConversationProcessingStartedAt("conv-a", Date.now());
+
+    // Boot 3: the counter reached the cap, so the flag is cleared but no
+    // resume is selected.
     const third = reconcileInterruptedConversations(true);
     expect(third.resume).toEqual([]);
     expect(third.capped).toEqual(["conv-a"]);
@@ -122,5 +173,85 @@ describe("interrupted-turn reconciler", () => {
     expect(listInterruptedConversations()).toEqual([
       { id: "conv-a", resumeAttempts: 1 },
     ]);
+  });
+});
+
+describe("resumeInterruptedConversations", () => {
+  beforeEach(() => {
+    getDb().run("DELETE FROM messages");
+    getDb().run("DELETE FROM conversations");
+  });
+
+  test("charges each attempt only as its own wake begins and threads trust", async () => {
+    createConversation({ id: "conv-a" });
+    createConversation({ id: "conv-b" });
+
+    // Snapshot both counters at the instant each conversation's wake runs, so
+    // we can prove a conversation still queued behind another has not been
+    // charged yet — a crash mid-resume must not burn its budget.
+    const attemptsWhenWoken: Record<string, { a: number; b: number }> = {};
+    const wakeCalls: Array<Record<string, unknown>> = [];
+    const wakeMock = mock(async (opts: Record<string, unknown>) => {
+      const conversationId = opts.conversationId as string;
+      attemptsWhenWoken[conversationId] = {
+        a: readRow("conv-a").processing_resume_attempts,
+        b: readRow("conv-b").processing_resume_attempts,
+      };
+      wakeCalls.push(opts);
+      return { invoked: true, producedToolCalls: false };
+    });
+    mock.module("../runtime/agent-wake.js", () => ({
+      wakeAgentForOpportunity: wakeMock,
+    }));
+
+    await resumeInterruptedConversations([
+      guardianTarget("conv-a"),
+      guardianTarget("conv-b"),
+    ]);
+
+    // conv-a is charged before its own wake; conv-b is still at 0 while conv-a
+    // runs, and is charged only when its own wake begins.
+    expect(attemptsWhenWoken["conv-a"]).toEqual({ a: 1, b: 0 });
+    expect(attemptsWhenWoken["conv-b"]).toEqual({ a: 1, b: 1 });
+    expect(readRow("conv-a").processing_resume_attempts).toBe(1);
+    expect(readRow("conv-b").processing_resume_attempts).toBe(1);
+
+    expect(wakeCalls).toHaveLength(2);
+    expect(wakeCalls[0]).toMatchObject({
+      conversationId: "conv-a",
+      source: "interrupted-turn-resume",
+      trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
+      clientless: true,
+      persistTriggerAsEvent: true,
+    });
+  });
+
+  test("a failing wake still charges its own attempt and continues to the next", async () => {
+    createConversation({ id: "conv-bad" });
+    createConversation({ id: "conv-good" });
+
+    const wakeCalls: string[] = [];
+    const wakeMock = mock(async (opts: Record<string, unknown>) => {
+      const conversationId = opts.conversationId as string;
+      wakeCalls.push(conversationId);
+      if (conversationId === "conv-bad") {
+        throw new Error("wake blew up");
+      }
+      return { invoked: true, producedToolCalls: false };
+    });
+    mock.module("../runtime/agent-wake.js", () => ({
+      wakeAgentForOpportunity: wakeMock,
+    }));
+
+    await resumeInterruptedConversations([
+      guardianTarget("conv-bad"),
+      guardianTarget("conv-good"),
+    ]);
+
+    // The bad conversation was attempted (so it was charged), and the failure
+    // did not block the remaining conversation.
+    expect(wakeCalls).toEqual(["conv-bad", "conv-good"]);
+    expect(readRow("conv-bad").processing_resume_attempts).toBe(1);
+    expect(readRow("conv-good").processing_resume_attempts).toBe(1);
   });
 });

--- a/assistant/src/daemon/interrupted-turn-reconciler.ts
+++ b/assistant/src/daemon/interrupted-turn-reconciler.ts
@@ -12,14 +12,21 @@
  * lets it decide what still needs doing, rather than mechanically replaying
  * the dead turn (tool side effects are not idempotent, and the transcript
  * already contains whatever the interrupted turn persisted).
+ *
+ * Each resume runs under the conversation's reconstructed resting trust (see
+ * {@link recoverRestingTrustContext}); conversations whose trust can't be
+ * rebuilt from persisted state are cleared but left un-resumed.
  */
 
 import {
   clearStaleProcessingFlags,
+  getConversationOriginChannel,
   incrementProcessingResumeAttempts,
   listInterruptedConversations,
 } from "../persistence/conversation-crud.js";
 import { getLogger } from "../util/logger.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "./trust-context.js";
+import type { TrustContext } from "./trust-context-types.js";
 
 const log = getLogger("interrupted-turns");
 
@@ -45,20 +52,64 @@ const INTERRUPTED_TURN_RESUME_HINT =
   "a brief note acknowledging the reply was cut short so the conversation " +
   "isn't left hanging.";
 
+/**
+ * A conversation selected for an auto-resume wake, paired with the resting
+ * trust context the woken turn must run under.
+ */
+export interface InterruptedResumeTarget {
+  conversationId: string;
+  trustContext: TrustContext;
+}
+
 export interface InterruptedTurnReconciliation {
   /** Rows whose stale processing flag was cleared. */
   cleared: number;
-  /** Conversation ids selected for an auto-resume wake. */
-  resume: string[];
+  /** Conversations selected for an auto-resume wake, with their resting trust. */
+  resume: InterruptedResumeTarget[];
   /** Conversation ids left idle because they hit {@link MAX_RESUME_ATTEMPTS}. */
   capped: string[];
+  /**
+   * Conversation ids left un-resumed because their resting trust could not be
+   * reconstructed from persisted state (a remote-channel turn whose per-actor
+   * gateway verdict is not stored). Their stale flag is still cleared.
+   */
+  trustUnrecoverable: string[];
 }
 
 /**
- * Clear every stale processing flag and, when `resumeEnabled` is set, pick
- * the conversations to resume. Each selected conversation's persisted
- * resume-attempt counter is bumped before its id is returned, so a resume
- * that dies mid-turn is charged even though the wake itself happens later.
+ * Rebuild the trust context an interrupted conversation must resume under, or
+ * `null` when it can't be recovered.
+ *
+ * Only the guardian's own local conversations are recoverable at rest: a
+ * remote-channel turn's trust class is stamped per inbound message from the
+ * gateway verdict and never persisted, so it cannot be reconstructed here.
+ * Local conversations — `originChannel` unset (a desktop/web/CLI turn that
+ * never carried a channel message) or the internal `vellum` channel — belong
+ * to the guardian owner, so they resume under
+ * {@link INTERNAL_GUARDIAN_TRUST_CONTEXT}: the trust class `loadFromDb` needs
+ * to rehydrate their guardian-provenance history instead of filtering it to
+ * empty. Any other origin returns `null` so the caller skips the resume rather
+ * than run the turn under a fabricated context — which would either grant a
+ * low-trust turn guardian capability or bury the reply under `unknown`
+ * provenance.
+ */
+function recoverRestingTrustContext(
+  conversationId: string,
+): TrustContext | null {
+  const originChannel = getConversationOriginChannel(conversationId);
+  if (originChannel === null || originChannel === "vellum") {
+    return INTERNAL_GUARDIAN_TRUST_CONTEXT;
+  }
+  return null;
+}
+
+/**
+ * Clear every stale processing flag and, when `resumeEnabled` is set, pick the
+ * conversations to resume together with the resting trust each wake runs
+ * under. Conversations whose resting trust can't be recovered are cleared but
+ * skipped. The resume-attempt counter is NOT bumped here — it is charged as
+ * each wake starts (see {@link resumeInterruptedConversations}), so a crash
+ * mid-resume never burns the budget of conversations that were never attempted.
  *
  * Pure DB work — safe to run during startup as soon as migrations settle.
  * The wakes themselves must wait for full startup (providers, CES) and run
@@ -70,19 +121,24 @@ export function reconcileInterruptedConversations(
   const interrupted = resumeEnabled ? listInterruptedConversations() : [];
   const cleared = clearStaleProcessingFlags();
   if (!resumeEnabled) {
-    return { cleared, resume: [], capped: [] };
+    return { cleared, resume: [], capped: [], trustUnrecoverable: [] };
   }
-  const resume: string[] = [];
+  const resume: InterruptedResumeTarget[] = [];
   const capped: string[] = [];
+  const trustUnrecoverable: string[] = [];
   for (const row of interrupted) {
     if (row.resumeAttempts >= MAX_RESUME_ATTEMPTS) {
       capped.push(row.id);
       continue;
     }
-    incrementProcessingResumeAttempts(row.id);
-    resume.push(row.id);
+    const trustContext = recoverRestingTrustContext(row.id);
+    if (!trustContext) {
+      trustUnrecoverable.push(row.id);
+      continue;
+    }
+    resume.push({ conversationId: row.id, trustContext });
   }
-  return { cleared, resume, capped };
+  return { cleared, resume, capped, trustUnrecoverable };
 }
 
 /**
@@ -91,27 +147,39 @@ export function reconcileInterruptedConversations(
  * carry several interrupted conversations, and running them one at a time
  * avoids a thundering herd of concurrent LLM turns right after startup.
  *
+ * The persisted resume-attempt counter is bumped immediately before each
+ * conversation's wake — never up-front for the whole batch — so a resume that
+ * takes the process down again only charges the conversation actually being
+ * attempted, leaving the rest of the budget intact across the next boots.
+ *
  * Each wake runs clientless (background policy: side-effecting tools are
  * denied at the default threshold instead of stalling on an absent client)
- * and without a trust elevation — the turn runs under the conversation's own
- * resting trust, so resuming an interrupted low-trust turn can never grant
- * it guardian-class capability. Failures are logged and skipped so one bad
- * conversation doesn't block the rest.
+ * under the conversation's reconstructed resting trust ({@link
+ * InterruptedResumeTarget}), so resuming a conversation can never grant it more
+ * capability than its own resting trust. Failures are logged and skipped so
+ * one bad conversation doesn't block the rest.
  *
  * `agent-wake` is imported lazily: this module is loaded during early daemon
  * startup, and the wake machinery statically pulls in the agent-loop stack,
  * which must not join the lifecycle import graph (daemon ↔ runtime cycles).
  */
 export async function resumeInterruptedConversations(
-  conversationIds: string[],
+  targets: InterruptedResumeTarget[],
 ): Promise<void> {
   const { wakeAgentForOpportunity } = await import("../runtime/agent-wake.js");
-  for (const conversationId of conversationIds) {
+  for (const { conversationId, trustContext } of targets) {
+    // Charge the attempt as the wake begins, before the turn runs. The cap
+    // exists to stop a resumed turn that keeps killing the process, so the
+    // counter must be durably incremented before that turn can crash the
+    // daemon; a sequential increment here also means a crash mid-resume never
+    // charges the conversations still queued behind it.
+    incrementProcessingResumeAttempts(conversationId);
     try {
       const result = await wakeAgentForOpportunity({
         conversationId,
         hint: INTERRUPTED_TURN_RESUME_HINT,
         source: "interrupted-turn-resume",
+        trustContext,
         clientless: true,
         persistTriggerAsEvent: true,
       });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -75,6 +75,7 @@ import { initializePlugins } from "./external-plugins-bootstrap.js";
 import { backfillSlackInjectionTemplates } from "./handlers/config-slack-channel.js";
 import { installAssistantSymlink } from "./install-symlink.js";
 import {
+  type InterruptedResumeTarget,
   MAX_RESUME_ATTEMPTS,
   reconcileInterruptedConversations,
   resumeInterruptedConversations,
@@ -499,7 +500,7 @@ export async function runDaemon(): Promise<void> {
   // `conversations.resumeProcessingOnStartup` is enabled the reconciler also
   // selects conversations to resume once startup completes (the wakes need
   // providers/CES, so they are kicked off next to `setStartupComplete()`).
-  let conversationsToResume: string[] = [];
+  let conversationsToResume: InterruptedResumeTarget[] = [];
   if (dbReady) {
     try {
       const reconciled = reconcileInterruptedConversations(
@@ -522,6 +523,12 @@ export async function runDaemon(): Promise<void> {
             maxAttempts: MAX_RESUME_ATTEMPTS,
           },
           "Left interrupted conversations un-resumed after repeated interruptions",
+        );
+      }
+      if (reconciled.trustUnrecoverable.length > 0) {
+        log.warn(
+          { conversationIds: reconciled.trustUnrecoverable },
+          "Left interrupted conversations un-resumed: resting trust could not be reconstructed",
         );
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Addresses the two Codex findings on #37599 (interrupted-turn reconcile + auto-resume, gated behind the default-off `resumeProcessingOnStartup` flag).

### 1. Resume wakes now carry a reconstructed resting trust context
The resume wake passed no `trustContext`, so `getOrCreateConversation()` hydrated the conversation with `trustContext === undefined`. `Conversation.loadFromDb()` treats that as untrusted and filters out every guardian-provenance message — the resumed model saw only the synthetic background event, not the conversation it was meant to finish, and persisted its reply under `unknown` provenance.

`recoverRestingTrustContext()` rebuilds the trust each conversation must resume under:
- **Local conversations** (`originChannel` unset, or the internal `vellum` channel) belong to the guardian owner and resume under `INTERNAL_GUARDIAN_TRUST_CONTEXT` — the trust class `loadFromDb` needs to rehydrate their full history. Mirrors the existing owner-self-maintenance pattern in `pointer-conversation-trust.ts` / `resolveMetaSlashCommand`.
- **Remote-channel conversations** (Slack, Telegram, email, …) get their trust class from the gateway's per-inbound-message verdict, which is not persisted and can't be rebuilt at startup. Their resting trust is unrecoverable, so they are cleared but left un-resumed (`trustUnrecoverable`) rather than run under a fabricated context — never elevating a low-trust turn to guardian.

### 2. Resume-attempt counter charged at wake start, not up-front
The counter was bumped for every selected conversation during `reconcile`, before any wake ran. Because resumes run sequentially after startup, a crash during an early wake charged conversations that were never attempted, capping them out across boots. The increment now happens immediately before each conversation's own wake.

## Tests
Extended `interrupted-turn-reconciler.test.ts`: guardian trust for local + `vellum` conversations, remote channels skipped as `trustUnrecoverable` (never charged), the increment moved to wake start (reconcile leaves attempts at 0), the cap still holding across boots, and `resumeInterruptedConversations` charging each attempt only as its own wake begins (crash-safety) plus continuing past a failing wake.

Addresses review feedback on #37599.