### PR TITLE
fix(providers): give OpenRouter a per-model reasoning-effort ceiling for Grok 4.5

### DIFF
--- a/assistant/src/__tests__/openrouter-provider-only.test.ts
+++ b/assistant/src/__tests__/openrouter-provider-only.test.ts
@@ -231,4 +231,66 @@ describe("OpenRouter provider.only plumbing", () => {
       });
     });
   });
+
+  describe("per-model reasoning-effort ceiling", () => {
+    test("clamps an inherited max effort down to high for grok-4.5", () => {
+      const provider = new ProbeOpenRouterProvider("fake-key", "x-ai/grok-4.5");
+      const extras = provider.probeExtras({
+        config: { thinking: { enabled: true }, effort: "max" },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true, effort: "high", summary: "detailed" },
+      });
+    });
+
+    test("clamps an inherited xhigh effort down to high for grok-4.5", () => {
+      const provider = new ProbeOpenRouterProvider("fake-key", "x-ai/grok-4.5");
+      const extras = provider.probeExtras({
+        config: { thinking: { enabled: true }, effort: "xhigh" },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true, effort: "high", summary: "detailed" },
+      });
+    });
+
+    test("leaves an effort at or below the grok-4.5 ceiling untouched", () => {
+      const provider = new ProbeOpenRouterProvider("fake-key", "x-ai/grok-4.5");
+      const extras = provider.probeExtras({
+        config: { thinking: { enabled: true }, effort: "low" },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true, effort: "low", summary: "detailed" },
+      });
+    });
+
+    test("leaves models without a catalog ceiling on the provider default (xhigh)", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "x-ai/grok-4.20",
+      );
+      const extras = provider.probeExtras({
+        config: { thinking: { enabled: true }, effort: "max" },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true, effort: "xhigh", summary: "detailed" },
+      });
+    });
+
+    test("keys the ceiling off a per-call model override, not the constructor model", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "moonshotai/kimi-k2.6",
+      );
+      const extras = provider.probeExtras({
+        config: {
+          model: "x-ai/grok-4.5",
+          thinking: { enabled: true },
+          effort: "max",
+        },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true, effort: "high", summary: "detailed" },
+      });
+    });
+  });
 });

--- a/assistant/src/providers/fireworks/client.ts
+++ b/assistant/src/providers/fireworks/client.ts
@@ -1,4 +1,4 @@
-import { PROVIDER_CATALOG } from "../model-catalog.js";
+import { modelEffortCeilings } from "../model-catalog.js";
 import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
 
 export interface FireworksProviderOptions {
@@ -9,14 +9,7 @@ export interface FireworksProviderOptions {
 
 const DEFAULT_FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 
-const FIREWORKS_MODEL_EFFORT_CEILINGS: ReadonlyMap<
-  string,
-  "high" | "xhigh" | "max"
-> = new Map(
-  PROVIDER_CATALOG.find((p) => p.id === "fireworks")?.models.flatMap((m) =>
-    m.maxEffort ? ([[m.id, m.maxEffort]] as const) : [],
-  ) ?? [],
-);
+const FIREWORKS_MODEL_EFFORT_CEILINGS = modelEffortCeilings("fireworks");
 
 export class FireworksProvider extends OpenAIChatCompletionsProvider {
   constructor(

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1299,6 +1299,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: true,
         supportsToolUse: true,
+        // xAI's Grok 4.5 API accepts only low|medium|high reasoning effort;
+        // clamp Vellum's xhigh/max tiers down so inherited efforts don't 4xx.
+        maxEffort: "high",
         pricing: {
           inputPer1mTokens: 2,
           outputPer1mTokens: 6,
@@ -2026,6 +2029,23 @@ export const PROMPT_CACHE_BREAKPOINT_MODEL_IDS: ReadonlySet<string> = new Set(
     p.models.flatMap((m) => (m.supportsPromptCacheBreakpoints ? [m.id] : [])),
   ),
 );
+
+/**
+ * Per-model `reasoning_effort` ceilings for a provider, keyed by model ID and
+ * derived from each model's `maxEffort`. Providers whose per-model APIs accept
+ * a narrower effort range than the provider default (e.g. Fireworks, OpenRouter)
+ * consult this in `resolveMaxReasoningEffort` to clamp Vellum's xhigh/max tiers
+ * down. Models without `maxEffort` are absent and inherit the provider default.
+ */
+export function modelEffortCeilings(
+  providerId: string,
+): ReadonlyMap<string, "high" | "xhigh" | "max"> {
+  return new Map(
+    PROVIDER_CATALOG.find((p) => p.id === providerId)?.models.flatMap((m) =>
+      m.maxEffort ? ([[m.id, m.maxEffort]] as const) : [],
+    ) ?? [],
+  );
+}
 
 /**
  * Return the catalog provider that owns a model ID, if known. When multiple

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -4,7 +4,10 @@ import {
   retagDelegateError,
   toAnthropicMessagesBaseURL,
 } from "../anthropic-gateway-shared.js";
-import { PROMPT_CACHE_BREAKPOINT_MODEL_IDS } from "../model-catalog.js";
+import {
+  modelEffortCeilings,
+  PROMPT_CACHE_BREAKPOINT_MODEL_IDS,
+} from "../model-catalog.js";
 import {
   clampReasoningEffort,
   EFFORT_TO_REASONING_EFFORT,
@@ -30,6 +33,8 @@ const OPENROUTER_APP_ATTRIBUTION_HEADERS = {
   "X-OpenRouter-Title": "Vellum Assistant",
   "X-OpenRouter-Categories": "personal-agent,cli-agent",
 };
+
+const OPENROUTER_MODEL_EFFORT_CEILINGS = modelEffortCeilings("openrouter");
 
 /**
  * Extract the normalized `openrouter.only` list from a per-call config. Returns
@@ -228,6 +233,18 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       extras.provider = { ...existingProvider, only };
     }
     return extras;
+  }
+
+  // Consult the catalog for a per-model effort ceiling before falling back to
+  // the provider-wide default. Keeps grok-4.5 (low|medium|high only) from
+  // receiving Vellum's xhigh/max efforts, which its API rejects.
+  protected override resolveMaxReasoningEffort(
+    model: string,
+  ): "high" | "xhigh" | "max" {
+    return (
+      OPENROUTER_MODEL_EFFORT_CEILINGS.get(model) ??
+      super.resolveMaxReasoningEffort(model)
+    );
   }
 
   private resolveEffectiveModel(options?: SendMessageOptions): string {


### PR DESCRIPTION
## Summary
- Add a catalog-driven per-model reasoning-effort ceiling to the OpenRouter provider, mirroring the Fireworks pattern: `OpenRouterProvider.resolveMaxReasoningEffort` now consults the catalog's `maxEffort` before falling back to the provider-wide default.
- Set `maxEffort: "high"` on `x-ai/grok-4.5`. xAI's Grok 4.5 API accepts only low/medium/high reasoning effort (verified in #37682), so a profile inheriting the default `max` effort was sending `reasoning.effort: "xhigh"` and getting rejected. It now clamps down to `high`. The disabled-thinking `none` opt-out fallback (#37611/#38380) did not cover this case.
- Extract the ceiling-map construction (previously copy-pasted between Fireworks and OpenRouter) into a shared `modelEffortCeilings(providerId)` helper in `model-catalog.ts`.
- Extend the OpenRouter provider tests: inherited max/xhigh clamp to high for grok-4.5; efforts at/below the ceiling untouched; models without a ceiling stay on the provider default (xhigh); ceiling keys off a per-call model override.

## Scope notes
- `maxEffort` is a daemon-only catalog field (not projected by `sync-llm-catalog.ts`), so no meta/web catalog regeneration is needed — verified `sync:llm-catalog --check` stays green.
- Only grok-4.5 gets a ceiling. Kimi K3 accepts only `max` (per #38364), so a clamp — which only lowers efforts — can't help it. grok-4.3/4.20 effort ranges aren't documented, so they stay on the provider default per the "when unsure, ship just grok-4.5" guidance.

Addresses Codex review feedback on #37682.