### PR TITLE
fix(scheduler): close two schedule-worker watchdog spawn races

### DIFF
--- a/assistant/src/schedule/__tests__/worker-control.test.ts
+++ b/assistant/src/schedule/__tests__/worker-control.test.ts
@@ -167,6 +167,45 @@ describe("spawnScheduleWorkerProcess", () => {
     }
   });
 
+  test("coalesces concurrent spawns onto a single OS process", async () => {
+    let spawnCount = 0;
+    let writePidFile: () => void = () => {};
+    const restore = stubBunSpawn(() => {
+      spawnCount++;
+      // A cold worker writes its PID file only after the caller has started
+      // waiting, so a racing spawn cannot see it via the PID-file guard.
+      writePidFile = () => writeFileSync(pidPath, "4242");
+      return {
+        unref: () => {},
+        kill: () => {},
+        pid: 4242,
+        exited: neverExits(),
+      };
+    });
+    try {
+      // The daemon's boot spawn goes in flight before the worker writes its PID.
+      const boot = spawnScheduleWorkerProcess({
+        pidWaitTimeoutMs: 1_000,
+        pidPollIntervalMs: 5,
+      });
+      // The watchdog's first tick fires a second spawn during that window.
+      const watchdog = spawnScheduleWorkerProcess({
+        pidWaitTimeoutMs: 1_000,
+        pidPollIntervalMs: 5,
+      });
+      writePidFile(); // the single worker finally reports readiness
+      const [bootResult, watchdogResult] = await Promise.all([boot, watchdog]);
+
+      expect(spawnCount).toBe(1); // only one OS process was ever started
+      expect(bootResult).toEqual({ pid: 4242, alreadyRunning: false });
+      // The coalesced caller reports alreadyRunning so the watchdog logs no
+      // spurious respawn for the boot spawn's worker.
+      expect(watchdogResult).toEqual({ pid: 4242, alreadyRunning: true });
+    } finally {
+      restore();
+    }
+  });
+
   test("reuses an already-running worker without spawning", async () => {
     writeFileSync(pidPath, String(process.pid));
     let spawned = false;

--- a/assistant/src/schedule/__tests__/worker-watchdog.test.ts
+++ b/assistant/src/schedule/__tests__/worker-watchdog.test.ts
@@ -183,6 +183,39 @@ describe("createWorkerSupervisor", () => {
     expect(killedPid).toBe(99);
   });
 
+  test("suppression mid-respawn kills the child and skips onRespawn (operator stop)", async () => {
+    let releaseRespawn: () => void = () => {};
+    const respawnGate = new Promise<void>((resolve) => {
+      releaseRespawn = resolve;
+    });
+    let suppressed = false;
+    let killedPid: number | undefined;
+    let onRespawnCalls = 0;
+    const sup = createWorkerSupervisor({
+      label: "t",
+      probe: () => NOT_RUNNING,
+      respawn: async () => {
+        await respawnGate;
+        return { pid: 77, alreadyRunning: false };
+      },
+      isSuppressed: () => suppressed,
+      killChild: (pid) => {
+        killedPid = pid;
+      },
+      onRespawn: () => {
+        onRespawnCalls++;
+      },
+    });
+
+    const inflight = sup.ensureAlive(); // probes dead, starts respawn, awaits gate
+    suppressed = true; // operator stop lands while the respawn is in flight
+    releaseRespawn(); // respawn resolves now
+    await inflight;
+
+    expect(killedPid).toBe(77);
+    expect(onRespawnCalls).toBe(0);
+  });
+
   test("concurrent ensureAlive calls do not double-spawn", async () => {
     let respawns = 0;
     let releaseRespawn: () => void = () => {};

--- a/assistant/src/schedule/worker-control.ts
+++ b/assistant/src/schedule/worker-control.ts
@@ -51,11 +51,22 @@ export function probeScheduleWorker(): WorkerProcessStatus {
 
 export class ScheduleWorkerSpawnError extends WorkerProcessSpawnError {}
 
+/** The single in-flight spawn attempt, or null when none is running. */
+let inFlightSpawn: Promise<{ pid: number; alreadyRunning: boolean }> | null =
+  null;
+
 /**
  * Spawn the schedule worker as a background process. If a worker is already
  * running, returns its PID with `alreadyRunning: true` rather than spawning a
  * second one. Throws {@link ScheduleWorkerSpawnError} if the child crashes
  * during startup or never writes its PID file within the wait window.
+ *
+ * Concurrent calls coalesce onto one in-flight spawn. The daemon's boot spawn
+ * and the liveness watchdog's first tick both run before a cold worker has
+ * written its PID file, so `spawnWorkerProcess`'s PID-file guard cannot see the
+ * sibling spawn; without this latch each would start a worker — double schedule
+ * execution plus an orphan on shutdown. Coalesced callers report
+ * `alreadyRunning: true`, so the watchdog logs no spurious respawn.
  *
  * See {@link SpawnWorkerProcessOptions} for the generic option semantics. The
  * daemon's boot spawn leaves `terminateOnTimeout` unset: a worker that comes up
@@ -63,6 +74,23 @@ export class ScheduleWorkerSpawnError extends WorkerProcessSpawnError {}
  */
 export async function spawnScheduleWorkerProcess(
   opts: SpawnWorkerProcessOptions = {},
+): Promise<{ pid: number; alreadyRunning: boolean }> {
+  const existing = inFlightSpawn;
+  if (existing) {
+    const { pid } = await existing;
+    return { pid, alreadyRunning: true };
+  }
+  const spawn = spawnScheduleWorkerProcessUncoalesced(opts);
+  inFlightSpawn = spawn;
+  try {
+    return await spawn;
+  } finally {
+    inFlightSpawn = null;
+  }
+}
+
+async function spawnScheduleWorkerProcessUncoalesced(
+  opts: SpawnWorkerProcessOptions,
 ): Promise<{ pid: number; alreadyRunning: boolean }> {
   try {
     return await spawnWorkerProcess({

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -299,8 +299,10 @@ export interface WorkerSupervisorOptions {
   probe: () => WorkerProcessStatus;
   respawn: () => Promise<{ pid: number; alreadyRunning: boolean }>;
   /**
-   * Kill a child respawned after {@link WorkerSupervisor.dispose} was called
-   * (closes the shutdown race where a respawn was already in flight).
+   * Kill a child brought up by a respawn that resolved after the worker was
+   * disposed ({@link WorkerSupervisor.dispose}) or administratively suppressed
+   * ({@link WorkerSupervisorOptions.isSuppressed}) — closes the race where a
+   * stop lands while a respawn is already in flight.
    */
   killChild?: (pid: number) => void;
   /**
@@ -350,9 +352,11 @@ export function createWorkerSupervisor(
         const { pid, alreadyRunning } = await opts.respawn();
         consecutiveFailures = 0;
         nextAttemptAt = 0;
-        if (stopping) {
-          // Disposed mid-respawn: kill the child we just created so it is not
-          // orphaned past shutdown.
+        if (stopping || opts.isSuppressed?.()) {
+          // A stop landed while this respawn was in flight — either disposal
+          // (shutdown) or an operator stop that set suppression. Kill the child
+          // we just brought up so the stop is not silently undone; otherwise
+          // the fresh worker survives past the stop.
           opts.killChild?.(pid);
           return;
         }


### PR DESCRIPTION
Follow-up to #38357 fixing two schedule-worker watchdog races Codex flagged in review (both verified still present on main).

**1. Startup double-spawn.** `startScheduler()` fires the boot spawn (`startScheduleWorker`) fire-and-forget, then runs the first watchdog tick synchronously. During a cold start the worker has not written its PID file yet, so `spawnWorkerProcess`'s `probeWorkerPidFile` guard cannot see the boot spawn in flight — the first `ensureAlive()` respawn started a *second* worker (double schedule execution + an orphan on shutdown). Fixed with an in-flight coalescing latch in `spawnScheduleWorkerProcess`, the single choke point every schedule-worker spawn path funnels through (boot, watchdog, operator-start). Concurrent callers await the one in-flight spawn and report `alreadyRunning: true`, so the watchdog logs no spurious respawn.

**2. Operator stop undone.** After `await opts.respawn()`, `createWorkerSupervisor` only checked `stopping` (set by `dispose()`), not administrative suppression. An operator `schedules worker stop` issued *during* an in-flight respawn sets `setScheduleWorkerAdministrativelyStopped(true)` but never disposes the supervisor, so the fresh child survived — the stop was silently undone. Fixed by also checking `opts.isSuppressed?.()` after the respawn resolves and killing the fresh child when suppressed.

Extended the worker-watchdog and worker-control tests to cover both races (controllable spawn/respawn promises per the existing patterns).

Addresses review feedback on #38357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)