### PR TITLE
test(assistant): raise memory-jobs-worker-lanes file timeout past bun's 5s default

### DIFF
--- a/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
@@ -11,11 +11,26 @@
  * jobs alongside fast jobs and asserts that every fast job completes before
  * any slow job's promise resolves — proving the lanes are truly independent.
  */
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 
 import { eq } from "drizzle-orm";
 
 import { setConfig } from "./helpers/set-config.js";
+
+// beforeAll runs initializeDb(), which can exceed bun's 5s default hook
+// timeout when the CI runner is saturated (one bun process per test file,
+// workers = CPU count). Raise the file-level default so DB setup isn't
+// killed mid-flight. Each test file runs in its own process, so this
+// doesn't leak.
+setDefaultTimeout(30_000);
 
 // ── Config seed (before the tested module reads config) ────────────
 


### PR DESCRIPTION
## Summary
- Adds `setDefaultTimeout(30_000)` at module top of `assistant/src/__tests__/memory-jobs-worker-lanes.test.ts`, following the existing `app-compiler.test.ts` precedent.
- The file's `beforeAll` runs `initializeDb()`; under CI CPU contention (one bun process per test file, workers = CPU count) it can exceed bun's 5s default hook timeout — [main run 29551514458](https://github.com/vellum-ai/vellum-assistant/actions/runs/29551514458/job/87794837755) failed with `a beforeEach/afterEach hook timed out` at 5347ms.
- File-scoped rather than a global bunfig timeout bump so genuine hangs in other files still fail fast; each test file runs in its own process, so the raise doesn't leak.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29551514458/job/87794837755 — the Test job on main failed because the memory-jobs-worker-lanes test's setup hook timed out just past bun's 5s default; the triggering commit touched only db-async-query.ts and is unrelated, and adjacent main runs passed, so this is a flake to fix at the test-timeout level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)