### PR TITLE
fix(apps): gate app_open on a render-capable client and reach its app_id fallback

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
 
 import type { AppDefinition } from "../apps/app-store.js";
@@ -53,8 +55,13 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 
 const mockStore = makeMockStore();
 
+// Mutable per-conversation app list backing `listAppsByConversation`, which
+// `resolveAppId` consults when a tool's app_id is omitted. Tests set it directly.
+let appsByConversation: AppDefinition[] = [];
+
 mock.module("../apps/app-store.js", () => ({
   ...mockStore,
+  listAppsByConversation: (_conversationId: string) => appsByConversation,
   getAppsDir: () => "/tmp/test-apps",
   getAppDirPath: (appId: string) => `/tmp/test-apps/${appId}`,
   resolveAppDir: (id: string) => ({
@@ -79,6 +86,7 @@ mock.module("../bundler/app-compiler.js", () => ({
 
 import * as appCreateScript from "../config/bundled-skills/app-builder/tools/app-create.js";
 import * as appDeleteScript from "../config/bundled-skills/app-builder/tools/app-delete.js";
+import * as appOpenScript from "../config/bundled-skills/app-builder/tools/app-open.js";
 import * as appRefreshScript from "../config/bundled-skills/app-builder/tools/app-refresh.js";
 import * as appUpdateScript from "../config/bundled-skills/app-builder/tools/app-update.js";
 
@@ -190,5 +198,118 @@ describe("app-builder skill tool scripts", () => {
       expect(parsed.appId).toBe("app-1");
       expect(parsed.name).toBe("Renamed");
     });
+  });
+
+  // ---- app-open ----------------------------------------------------------
+
+  describe("app-open", () => {
+    test("exports a run function", () => {
+      expect(typeof appOpenScript.run).toBe("function");
+    });
+
+    test("resolves the active app when app_id is omitted", async () => {
+      appsByConversation = [makeApp({ id: "active-app" })];
+      const calls: Array<{ name: string; input: Record<string, unknown> }> = [];
+      const proxy: ToolContext["proxyToolResolver"] = async (name, input) => {
+        calls.push({ name, input });
+        return { content: "opened", isError: false };
+      };
+
+      const result = await appOpenScript.run(
+        {},
+        makeContext({ proxyToolResolver: proxy }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].name).toBe("app_open");
+      expect(calls[0].input.app_id).toBe("active-app");
+    });
+
+    test("forwards an explicit app_id unchanged", async () => {
+      appsByConversation = [makeApp({ id: "active-app" })];
+      const calls: Array<{ input: Record<string, unknown> }> = [];
+      const proxy: ToolContext["proxyToolResolver"] = async (_name, input) => {
+        calls.push({ input });
+        return { content: "opened", isError: false };
+      };
+
+      await appOpenScript.run(
+        { app_id: "explicit-app", open_mode: "workspace" },
+        makeContext({ proxyToolResolver: proxy }),
+      );
+
+      expect(calls[0].input.app_id).toBe("explicit-app");
+    });
+
+    test("errors when app_id is omitted and no active app exists", async () => {
+      appsByConversation = [];
+      const proxy: ToolContext["proxyToolResolver"] = async () => ({
+        content: "opened",
+        isError: false,
+      });
+
+      const result = await appOpenScript.run(
+        {},
+        makeContext({ proxyToolResolver: proxy }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content).error).toContain("app_create");
+    });
+
+    test("errors when no client proxy resolver is available", async () => {
+      appsByConversation = [makeApp({ id: "active-app" })];
+      const result = await appOpenScript.run(
+        { app_id: "app-1" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("connected client");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manifest guard: app_id must stay optional for the tools whose executor falls
+// back to the conversation's active app, or schema validation rejects the
+// omission before resolveAppId can run.
+// ---------------------------------------------------------------------------
+
+describe("app-builder TOOLS.json app_id optionality", () => {
+  const manifest = JSON.parse(
+    readFileSync(
+      resolve(
+        import.meta.dirname,
+        "../config/bundled-skills/app-builder/TOOLS.json",
+      ),
+      "utf8",
+    ),
+  ) as {
+    tools: Array<{ name: string; input_schema: { required?: string[] } }>;
+  };
+
+  function requiredFor(name: string): string[] {
+    const tool = manifest.tools.find((t) => t.name === name);
+    if (!tool) {
+      throw new Error(`tool ${name} not found in manifest`);
+    }
+    return tool.input_schema.required ?? [];
+  }
+
+  for (const name of [
+    "app_open",
+    "app_update",
+    "app_refresh",
+    "app_generate_icon",
+  ]) {
+    test(`${name} does not require app_id`, () => {
+      expect(requiredFor(name)).not.toContain("app_id");
+    });
+  }
+
+  test("app_delete still requires app_id (no active-app fallback)", () => {
+    expect(requiredFor("app_delete")).toContain("app_id");
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-app-open.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-open.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createSurfaceMutex,
+  type SurfaceConversationContext,
+  surfaceProxyResolver,
+} from "../daemon/conversation-surfaces.js";
+import type {
+  ServerMessage,
+  SurfaceData,
+  SurfaceType,
+} from "../daemon/message-protocol.js";
+
+interface ContextOptions {
+  hasNoClient?: boolean;
+  channelCapabilities?: { channel: string; supportsDynamicUi: boolean };
+}
+
+function makeContext(
+  sent: ServerMessage[] = [],
+  options: ContextOptions = {},
+): SurfaceConversationContext {
+  return {
+    conversationId: "session-1",
+    hasNoClient: options.hasNoClient,
+    channelCapabilities: options.channelCapabilities,
+    sendToClient: (msg) => sent.push(msg),
+    pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
+    lastSurfaceAction: new Map<
+      string,
+      { actionId: string; data?: Record<string, unknown> }
+    >(),
+    surfaceState: new Map<
+      string,
+      { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    >(),
+    surfaceUndoStacks: new Map<string, string[]>(),
+    accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "req-1" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "ok",
+    withSurface: createSurfaceMutex(),
+  };
+}
+
+describe("app_open render-capability gate", () => {
+  test("returns an error without broadcasting on a clientless turn", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, { hasNoClient: true });
+
+    const result = await surfaceProxyResolver(ctx, "app_open", {
+      app_id: "app-1",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("connected client");
+    expect(sent).toHaveLength(0);
+  });
+
+  test("returns an error on a channel without dynamic UI (e.g. Slack)", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent, {
+      channelCapabilities: { channel: "slack", supportsDynamicUi: false },
+    });
+
+    const result = await surfaceProxyResolver(ctx, "app_open", {
+      app_id: "app-1",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -98,7 +98,7 @@
         "properties": {
           "app_id": {
             "type": "string",
-            "description": "The ID of the app to update"
+            "description": "The ID of the app to update. Omit to update the conversation's most recently updated app."
           },
           "name": {
             "type": "string",
@@ -120,7 +120,7 @@
             }
           }
         },
-        "required": ["app_id"]
+        "required": []
       },
       "executor": "tools/app-update.ts",
       "execution_target": "host"
@@ -153,10 +153,10 @@
         "properties": {
           "app_id": {
             "type": "string",
-            "description": "The ID of the app to refresh"
+            "description": "The ID of the app to refresh. Omit to refresh the conversation's most recently updated app."
           }
         },
-        "required": ["app_id"]
+        "required": []
       },
       "executor": "tools/app-refresh.ts",
       "execution_target": "host"
@@ -171,14 +171,14 @@
         "properties": {
           "app_id": {
             "type": "string",
-            "description": "The ID of the app to generate an icon for"
+            "description": "The ID of the app to generate an icon for. Omit to use the conversation's most recently updated app."
           },
           "description": {
             "type": "string",
             "description": "Optional description to guide icon generation (e.g. 'a blue calendar with a checkmark'). If omitted, the app name and description are used."
           }
         },
-        "required": ["app_id"]
+        "required": []
       },
       "executor": "tools/app-generate-icon.ts",
       "execution_target": "host"
@@ -211,7 +211,7 @@
         "properties": {
           "app_id": {
             "type": "string",
-            "description": "The ID of the app to open"
+            "description": "The ID of the app to open. Omit to open the conversation's most recently updated app."
           },
           "open_mode": {
             "type": "string",
@@ -219,7 +219,7 @@
             "description": "Display mode. 'preview' shows an inline preview card in chat. 'workspace' opens the full app in a workspace panel. Defaults to 'workspace'."
           }
         },
-        "required": ["app_id"]
+        "required": []
       },
       "executor": "tools/app-open.ts",
       "execution_target": "host"

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -3427,6 +3427,18 @@ export async function surfaceProxyResolver(
   }
 
   if (toolName === "app_open") {
+    // An app surface only renders on a connected client that supports dynamic
+    // UI. On clientless, background, or non-dynamic-UI channels (e.g. Slack)
+    // the ui_surface_show below reaches no renderer, so fail closed with an
+    // actionable error rather than reporting a surface the user cannot see.
+    if (!canShowInteractiveUi(ctx)) {
+      return {
+        content:
+          "app_open needs a connected client that can display app surfaces (the Vellum macOS or web app), and none is available for this conversation. The app is saved — the user can open it from a connected client.",
+        isError: true,
+      };
+    }
+
     // Weaker models routinely omit app_id even though the active app is in
     // context. Fall back to the conversation's most-recently-updated app
     // rather than failing with "Invalid ID: undefined".


### PR DESCRIPTION
## Summary

Addresses two review findings on #38264 (verified still present on main).

1. **`app_open` reported false success on clientless / Slack / background turns.**
   The `app_open` branch in `surfaceProxyResolver` had no render-capability
   check (unlike `ui_show`), and `proxyToolResolver` is unconditionally
   supplied, so on a turn with no render-capable client it broadcast
   `ui_surface_show` into the void and returned `{isError:false}` — the model
   believed the app opened. The branch now fails closed via the existing
   `canShowInteractiveUi(ctx)` helper (false when `hasNoClient`, or the channel
   lacks `supportsDynamicUi`), returning an actionable error instead.
   `executeAppCreate`'s auto-open already maps an `app_open` error to
   `auto_opened:false`, so the create-preview path degrades cleanly.

2. **The `resolveAppId` active-app fallback was dead code.** Skill tools are
   schema-validated before `run()`, and `app_id` was marked required, so an
   omitted `app_id` was rejected before the executor's `resolveAppId` fallback
   could run. `app_id` is now optional in the app-builder `TOOLS.json` for
   `app_open` and the siblings that share the same fallback (`app_update`,
   `app_refresh`, `app_generate_icon`). `app_delete` keeps it required —
   deleting an inferred app is unsafe, and its executor has no fallback.
   Descriptions now document the omit-to-use-active-app behavior.

## Tests

- Clientless and Slack `app_open` return an error without broadcasting
  (resolver level).
- Omitted `app_id` resolves the conversation's most-recently-updated app, and
  an explicit `app_id` is forwarded unchanged (executor level).
- A manifest guard freezes `app_id` as optional for the four fallback tools and
  required for `app_delete`.

Touched tests run green solo: `conversation-surfaces-app-open`,
`app-builder-tool-scripts`, `resolve-app-id`, `ui-choice-copy-surfaces`,
`conversation-tool-setup-app-refresh`, `app-executors`, `registry`,
`skill-tool-manifest`, `conversation-skill-tools`.