### PR TITLE
fix(onboarding): scrub aggregator-only dropped claims from assistant memory

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -292,6 +292,10 @@ export function ResearchOnboardingRoute() {
   // minted — otherwise the rejected facts could still be pulled into its context.
   // Resolves immediately when nothing was corrected (never rejects).
   const researchCorrectionRef = useRef<Promise<void>>(Promise.resolve());
+  // Guards the one-shot dropped-claims correction (below) so a search that
+  // surfaced no card claims scrubs its hidden aggregator-only drops exactly
+  // once. Reset when a fresh research run starts (see fireResearch).
+  const droppedClaimsCorrectedRef = useRef(false);
   // Findings the user explicitly KEPT on the results step (claims minus the
   // X-ed ones), captured at the moment of confirmation. Null until the user
   // has actually reviewed the results — a "Skip to Chat" before that must not
@@ -371,6 +375,10 @@ export function ResearchOnboardingRoute() {
           {
             ...snapshot.research,
             pluginCatalog: snapshot.research.pluginCatalog ?? {},
+            // Not persisted: a fully-settled resume lands on the suggestions
+            // step (past the results correction), and the prior session already
+            // scrubbed any drops. Default to none so the state stays well-formed.
+            droppedClaims: [],
           },
           awaitHatchReady,
         );
@@ -474,6 +482,33 @@ export function ResearchOnboardingRoute() {
       setStep("suggestions");
     }
   }, [step, noClaims]);
+
+  // A search that surfaced no card claims still needs its aggregator-only drops
+  // scrubbed from the assistant's memory: the results step (where drops are
+  // folded into the correction) is skipped when there's nothing to show, so
+  // issue that correction here once research settles (done or timed-out error —
+  // matching how the results step itself renders on both). Gated to the
+  // empty-card case so it never double-fires with the results step, and once
+  // per run via the ref (reset in fireResearch).
+  useEffect(() => {
+    if (droppedClaimsCorrectedRef.current) return;
+    if (researchLoading || research.claims.length > 0) return;
+    if (research.droppedClaims.length === 0) return;
+    if (!researchConversationId || !hatchedAssistantId) return;
+    droppedClaimsCorrectedRef.current = true;
+    researchCorrectionRef.current = sendResearchCorrection({
+      assistantId: hatchedAssistantId,
+      conversationId: researchConversationId,
+      removedClaims: research.droppedClaims,
+      rejectedAll: false,
+    });
+  }, [
+    researchLoading,
+    research.claims.length,
+    research.droppedClaims,
+    researchConversationId,
+    hatchedAssistantId,
+  ]);
 
   // Build the pre-chat context and hand off to the chat pipeline. The chosen
   // name is applied via `assistantName`; the avatar traits are applied to the
@@ -595,6 +630,8 @@ export function ResearchOnboardingRoute() {
   // Fire the research turn; the runner awaits hatch readiness internally, so
   // it starts at the later of the caller's submit and the background hatch.
   function fireResearch(values: ResearchOnboardingValues) {
+    // A fresh run produces fresh drops — re-arm the one-shot scrub above.
+    droppedClaimsCorrectedRef.current = false;
     research.start({
       awaitAssistantId: awaitHatchReady,
       subject: researchSubjectFrom(values),
@@ -822,13 +859,20 @@ export function ResearchOnboardingRoute() {
               );
               // Pruned claims are wrong — tell the assistant to disregard them so
               // they don't leak into the real chat (the research turn taught its
-              // memory these facts). The chat handoff awaits this promise, so the
-              // correction is persisted before the first conversation is minted.
-              if (researchConversationId && hatchedAssistantId && removed.length > 0) {
+              // memory these facts). Fold in the aggregator-only claims the card
+              // hid: they live in the same memory but were never shown, so the
+              // user couldn't prune them. The chat handoff awaits this promise, so
+              // the correction is persisted before the first conversation is minted.
+              const toDisregard = [...removed, ...research.droppedClaims];
+              if (
+                researchConversationId &&
+                hatchedAssistantId &&
+                toDisregard.length > 0
+              ) {
                 researchCorrectionRef.current = sendResearchCorrection({
                   assistantId: hatchedAssistantId,
                   conversationId: researchConversationId,
-                  removedClaims: removed,
+                  removedClaims: toDisregard,
                   rejectedAll: false,
                 });
               }

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -300,6 +300,13 @@ export type ResearchStatus = "idle" | "running" | "done" | "error";
 export interface ResearchRunnerState {
   status: ResearchStatus;
   claims: ResearchFact[];
+  /**
+   * Claim texts the parser dropped from `claims` because every source was a
+   * people-search aggregator. Carried so the onboarding flow can scrub these
+   * hidden wrong-person facts from the assistant's memory alongside the ones the
+   * user prunes on the card.
+   */
+  droppedClaims: string[];
   suggestions: ResearchSuggestion[];
   /**
    * Capabilities being installed for the assistant this run — the deterministic
@@ -407,6 +414,7 @@ export function useResearchRunner(): UseResearchRunner {
   const [state, setState] = useState<ResearchRunnerState>({
     status: "idle",
     claims: [],
+    droppedClaims: [],
     suggestions: [],
     installedPlugins: [],
     pluginCatalog: {},
@@ -456,6 +464,7 @@ export function useResearchRunner(): UseResearchRunner {
       setState({
         status: "running",
         claims: [],
+        droppedClaims: [],
         suggestions: [],
         installedPlugins: [],
         pluginCatalog: {},
@@ -653,8 +662,14 @@ export function useResearchRunner(): UseResearchRunner {
             const messages = listed.data?.messages ?? [];
             const text = latestAssistantText(messages);
             if (text) {
-              const { claims, suggestions, plugins, pluginsResolved, complete } =
-                parseResearchResultStreaming(text);
+              const {
+                claims,
+                droppedClaims,
+                suggestions,
+                plugins,
+                pluginsResolved,
+                complete,
+              } = parseResearchResultStreaming(text);
               // Narrow the model's picks to the catalog we actually fetched so a
               // hallucinated name never hits the install route; fire each new one.
               const validPlugins = plugins.filter((name) => validNames.has(name));
@@ -682,6 +697,7 @@ export function useResearchRunner(): UseResearchRunner {
               setState({
                 status: "running",
                 claims,
+                droppedClaims,
                 suggestions,
                 installedPlugins,
                 pluginCatalog,

--- a/clients/web/src/domains/onboarding/send-research-correction.test.ts
+++ b/clients/web/src/domains/onboarding/send-research-correction.test.ts
@@ -74,6 +74,20 @@ describe("buildResearchCorrection", () => {
     expect(msg).toContain("disregard");
   });
 
+  test("builds a correction from folded drops even when the user pruned nothing", () => {
+    // A search can surface no card claims yet still leave aggregator-only drops
+    // in memory. The route folds those hidden drops into removedClaims (as if
+    // the user pruned them), so a non-empty list of drops alone still yields a
+    // real correction to scrub them — not a no-op.
+    const msg = buildResearchCorrection({
+      removedClaims: ["Lives in Dallas", "Founded Weird Canada"],
+      rejectedAll: false,
+    });
+    expect(msg).toContain("- Lives in Dallas");
+    expect(msg).toContain("- Founded Weird Canada");
+    expect(msg).toContain("disregard");
+  });
+
   test("returns null when nothing was removed (no correction to send)", () => {
     expect(
       buildResearchCorrection({ removedClaims: [], rejectedAll: false }),

--- a/clients/web/src/utils/research-facts.test.ts
+++ b/clients/web/src/utils/research-facts.test.ts
@@ -267,6 +267,93 @@ describe("parseResearchResultStreaming — claim evidence guards", () => {
   });
 });
 
+describe("parseResearchResultStreaming — dropped aggregator-only claims", () => {
+  const payload = (claims: unknown[]): string =>
+    JSON.stringify({ claims, suggestions: [] });
+
+  test("surfaces an aggregator-only claim's text in droppedClaims", () => {
+    // The claim is hidden from the card AND reported as dropped, so the flow can
+    // scrub the wrong-person fact from the assistant's memory (not just hide it).
+    const { claims, droppedClaims } = parseResearchResultStreaming(
+      payload([
+        {
+          claim: "Lives in Dallas",
+          confidence: "confident",
+          sources: [
+            "https://www.spokeo.com/example-user",
+            "https://profiles.beenverified.com/example-user",
+          ],
+        },
+        {
+          claim: "Founder",
+          confidence: "confident",
+          sources: ["https://linkedin.com/in/example-user"],
+        },
+      ]),
+    );
+
+    expect(claims.map((c) => c.claim)).toEqual(["Founder"]);
+    expect(droppedClaims).toEqual(["Lives in Dallas"]);
+  });
+
+  test("a claim with a real source beside an aggregator is kept, not dropped", () => {
+    const { claims, droppedClaims } = parseResearchResultStreaming(
+      payload([
+        {
+          claim: "Engineer at Acme",
+          confidence: "confident",
+          sources: [
+            "https://instantcheckmate.com/example-user",
+            "https://acme.example.com/team",
+          ],
+        },
+      ]),
+    );
+
+    expect(claims.map((c) => c.claim)).toEqual(["Engineer at Acme"]);
+    expect(droppedClaims).toEqual([]);
+  });
+
+  test("a sourceless claim is kept, never dropped", () => {
+    // Only claims that HAD sources — all of them aggregators — are dropped; a
+    // sourceless "guessing" claim is legitimate stated-info and stays.
+    const { claims, droppedClaims } = parseResearchResultStreaming(
+      payload([{ claim: "Into climbing", confidence: "guessing", sources: [] }]),
+    );
+
+    expect(claims.map((c) => c.claim)).toEqual(["Into climbing"]);
+    expect(droppedClaims).toEqual([]);
+  });
+
+  test("tracks drops on the streaming path too", () => {
+    // The hidden drop must be tracked even before the payload closes, so a
+    // mid-stream skip-to-suggestions still scrubs it from memory.
+    const partial =
+      '{ "claims": [ { "claim": "Lives in Dallas", "confidence": "confident", "sources": ["https://spokeo.com/x"] }, { "claim": "Founder", "confidence": "confident", "sources": [] }, { "claim": "half-writ';
+
+    const { claims, droppedClaims, complete } =
+      parseResearchResultStreaming(partial);
+
+    expect(complete).toBe(false);
+    expect(claims.map((c) => c.claim)).toEqual(["Founder"]);
+    expect(droppedClaims).toEqual(["Lives in Dallas"]);
+  });
+
+  test("droppedClaims is empty when nothing was dropped", () => {
+    const { droppedClaims } = parseResearchResultStreaming(
+      payload([
+        {
+          claim: "Founder",
+          confidence: "confident",
+          sources: ["https://linkedin.com/in/example-user"],
+        },
+      ]),
+    );
+
+    expect(droppedClaims).toEqual([]);
+  });
+});
+
 describe("pluginDisplayName", () => {
   test("title-cases a hyphenated install name", () => {
     expect(pluginDisplayName("marketing-expert")).toBe("Marketing Expert");

--- a/clients/web/src/utils/research-facts.ts
+++ b/clients/web/src/utils/research-facts.ts
@@ -166,26 +166,71 @@ function extractCompleteObjects(body: string): unknown[] {
   return objects;
 }
 
-function toFact(entry: unknown): ResearchFact | null {
+type ClassifiedClaim =
+  | { kind: "fact"; fact: ResearchFact }
+  | { kind: "dropped"; claim: string }
+  | null;
+
+/**
+ * Classify one raw claim entry: a card-worthy `fact`, an aggregator-only
+ * `dropped` claim (every source is a people-search directory), or `null` when
+ * there's no usable claim text. A drop keeps the claim text so callers can
+ * scrub the hidden wrong-person fact from memory, not just from the card.
+ */
+function classifyClaim(entry: unknown): ClassifiedClaim {
   if (!entry || typeof entry !== "object") return null;
   const claim = (entry as { claim?: unknown }).claim;
   if (typeof claim !== "string" || !claim.trim()) return null;
+  const trimmedClaim = claim.trim();
   const rawSources = normalizeSources((entry as { sources?: unknown }).sources);
   const sources = rawSources.filter((s) => !isAggregatorSource(s));
   // A web-sourced claim whose every source is an aggregator has no evidence
-  // worth showing — drop it rather than render it as if it were sourceless.
-  if (rawSources.length > 0 && sources.length === 0) return null;
+  // worth showing — drop it from the card, but keep its text so the flow can
+  // scrub it from assistant memory rather than silently leaving it there.
+  if (rawSources.length > 0 && sources.length === 0) {
+    return { kind: "dropped", claim: trimmedClaim };
+  }
   const confidence = normalizeConfidence(
     (entry as { confidence?: unknown }).confidence,
   );
   return {
-    claim: claim.trim(),
-    // Sourceless "confident" caps at "maybe" — the deterministic backstop for
-    // a model that inflates tiers past the prompt's evidence rubric.
-    confidence:
-      confidence === "confident" && sources.length === 0 ? "maybe" : confidence,
-    sources,
+    kind: "fact",
+    fact: {
+      claim: trimmedClaim,
+      // Sourceless "confident" caps at "maybe" — the deterministic backstop for
+      // a model that inflates tiers past the prompt's evidence rubric.
+      confidence:
+        confidence === "confident" && sources.length === 0
+          ? "maybe"
+          : confidence,
+      sources,
+    },
   };
+}
+
+/**
+ * Partition raw claim entries into the facts rendered on the card and the claim
+ * texts dropped from it because every source was an aggregator. Non-array input
+ * (or entries with no usable claim) contributes nothing.
+ */
+function collectClaims(raw: unknown): {
+  claims: ResearchFact[];
+  droppedClaims: string[];
+} {
+  const claims: ResearchFact[] = [];
+  const droppedClaims: string[] = [];
+  if (Array.isArray(raw)) {
+    for (const entry of raw) {
+      const classified = classifyClaim(entry);
+      if (!classified) continue;
+      if (classified.kind === "fact") {
+        claims.push(classified.fact);
+      } else {
+        droppedClaims.push(classified.claim);
+      }
+    }
+  }
+  return { claims, droppedClaims };
 }
 
 function toSuggestion(entry: unknown): ResearchSuggestion | null {
@@ -274,6 +319,14 @@ function arrayScopeFor(body: string, key: string): string | null {
 export interface ResearchResult {
   claims: ResearchFact[];
   /**
+   * Claim texts the parser dropped from `claims` because every source was a
+   * people-search aggregator (see `AGGREGATOR_SOURCE_DENYLIST`). Surfaced rather
+   * than silently discarded so the onboarding flow can scrub these hidden
+   * wrong-person facts from the assistant's memory — the research turn taught
+   * them, and hiding them from the card doesn't unteach them.
+   */
+  droppedClaims: string[];
+  /**
    * Concrete actions the assistant proposes it could do for the user. Each is
    * a `{ suggestion, prompt }` pair: the assistant-voiced offer shown on the
    * card and the user-voiced message sent when it's clicked.
@@ -342,6 +395,7 @@ export function parseResearchResultStreaming(text: string): ResearchResult {
   if (!text)
     return {
       claims: [],
+      droppedClaims: [],
       suggestions: [],
       plugins: [],
       pluginsResolved: false,
@@ -356,8 +410,10 @@ export function parseResearchResultStreaming(text: string): ResearchResult {
   // a half-written array.
   const whole = parseWholePayload(body);
   if (whole) {
+    const { claims, droppedClaims } = collectClaims(whole.claims);
     return {
-      claims: mapEntries(whole.claims, toFact),
+      claims,
+      droppedClaims,
       suggestions: mapEntries(whole.suggestions, toSuggestion),
       plugins: normalizePlugins(whole.plugins),
       pluginsResolved: true,
@@ -374,12 +430,9 @@ export function parseResearchResultStreaming(text: string): ResearchResult {
       const open = body.indexOf("[");
       return open === -1 ? null : body.slice(open + 1);
     })();
-  const claims =
-    claimsBody === null
-      ? []
-      : extractCompleteObjects(claimsBody)
-          .map(toFact)
-          .filter((f): f is ResearchFact => f !== null);
+  const { claims, droppedClaims } = collectClaims(
+    claimsBody === null ? [] : extractCompleteObjects(claimsBody),
+  );
 
   const suggestionsScope = arrayScopeFor(body, "suggestions");
   const suggestions =
@@ -392,6 +445,7 @@ export function parseResearchResultStreaming(text: string): ResearchResult {
   const closedPlugins = parseClosedPluginsArray(body);
   return {
     claims,
+    droppedClaims,
     suggestions,
     plugins: closedPlugins ?? [],
     pluginsResolved: closedPlugins !== null,


### PR DESCRIPTION
## Summary
Follow-up addressing review feedback on #37604. Codex flagged (verified still true on main) a memory leak in the aggregator-only claim filter: when the parser drops a claim whose every source is a people-search aggregator (`research-facts.ts` `toFact`), it's removed from `research.claims` and hidden from the card — but the research turn already taught that (wrong-person) fact to the hatched assistant's shared memory. The user-correction path is built only from *displayed* claims (the ones the user X's out, or a full "This is not me" rejection), so it can never clear a hidden drop. A wrong-person fact the filter hid could still leak into the first real chat.

## Fix
- **Parser** (`research-facts.ts`): the claim classifier surfaces aggregator-only drops instead of silently discarding them. `parseResearchResultStreaming` returns a new `droppedClaims: string[]` alongside `claims`, populated on both the whole-payload and streaming paths (a single-pass `collectClaims` replaces the old `map(toFact).filter()`).
- **Runner** (`research-runner.ts`): threads `droppedClaims` through `ResearchRunnerState`.
- **Route** (`research-onboarding-route.tsx`):
  - The results-step "Continue" correction folds `droppedClaims` into `removedClaims` (as if the user pruned them), keeping the existing correction payload shape/wording, and fires whenever there's anything to disregard.
  - A search that surfaces **no** card claims skips the results step entirely, so a one-shot effect issues the drop-scrub correction once research settles (done or timed-out error — matching how the results step renders on both). Guarded to the empty-card case so it never double-fires with the results step.
  - "This is not me" already disowns the whole search (`rejectedAll`), so hidden drops are covered there unchanged.

Not persisted across refresh: a fully-settled resume lands past the results correction, so the runner defaults `droppedClaims` to `[]` on hydrate.

## Tests
- `research-facts.test.ts`: `droppedClaims` surfacing on both parse paths; mixed-source claims kept; sourceless claims kept; empty when nothing dropped.
- `send-research-correction.test.ts`: a drops-only fold still yields a real correction (not a no-op).

Addresses review feedback on #37604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)