### PR TITLE
fix(memory): sweep orphaned graph-node Qdrant vectors/embeddings from scope purge

### DIFF
--- a/assistant/src/persistence/migrations/323-delete-non-default-memory-scopes.ts
+++ b/assistant/src/persistence/migrations/323-delete-non-default-memory-scopes.ts
@@ -7,8 +7,15 @@ import type { DrizzleDb } from "../db-connection.js";
  * with non-default `scope_id` values (e.g. `subagent:<id>`). Reads query the
  * single workspace memory pool without filtering on `scope_id`, so these rows
  * would surface into recall, consolidation, and starter generation and inflate
- * node counts. Deleting them keeps them invisible, exactly matching the
- * behavior the `scope_id = 'default'` read filters produced.
+ * node counts. Deleting them removes them from every SQL read path, matching
+ * the behavior the `scope_id = 'default'` read filters produced.
+ *
+ * This SQL delete does not touch a graph node's Qdrant `graph_node` point or
+ * its cached `memory_embeddings` row — those persist and would still surface in
+ * `searchGraphNodes` (which has no scope filter). They are purged by the orphan
+ * sweep in migration 340 (`340-sweep-orphaned-graph-node-vectors.ts`), which
+ * runs later in the same boot and covers both the rows this migration deletes
+ * and any left behind on installs that already applied it.
  *
  * Deleting graph nodes cascades to their edges, triggers, and edits via the
  * `ON DELETE CASCADE` foreign keys (foreign_keys pragma is ON).

--- a/assistant/src/persistence/migrations/340-sweep-orphaned-graph-node-vectors.test.ts
+++ b/assistant/src/persistence/migrations/340-sweep-orphaned-graph-node-vectors.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for migration 340: sweeping orphaned `graph_node` vector state left by
+ * hard-deletes of memory graph nodes (e.g. migration 323's non-default-scope
+ * purge).
+ *
+ * Runs against real workspace databases (`initializeDb()`) because the sweep
+ * reads `memory_embeddings` / `memory_graph_nodes` from the main DB while
+ * enqueuing `delete_qdrant_vectors` jobs on the dedicated memory DB.
+ * `initializeDb()` already ran the step once (a no-op on the empty seed), so
+ * each test seeds the tables directly and calls the exported function.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+const { getDb, getMemorySqlite, getSqliteFrom } =
+  await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { migrateSweepOrphanedGraphNodeVectors } =
+  await import("./340-sweep-orphaned-graph-node-vectors.js");
+
+await initializeDb();
+
+function mainRaw() {
+  return getSqliteFrom(getDb());
+}
+
+/** Insert a memory_graph_nodes row (fidelity `gone` models a soft delete). */
+function seedNode(id: string, fidelity = "vivid"): void {
+  mainRaw()
+    .query(
+      `INSERT INTO memory_graph_nodes (
+        id, content, type, created, last_accessed, last_consolidated,
+        emotional_charge, fidelity, confidence, significance, stability,
+        reinforcement_count, last_reinforced, source_conversations,
+        source_type, scope_id
+      ) VALUES (?, ?, 'semantic', 0, 0, 0,
+        '{"kind":"neutral","intensity":0}', ?, 0.9, 0.8, 14, 0, 0, '[]',
+        'inferred', 'default')`,
+    )
+    .run(id, `content ${id}`, fidelity);
+}
+
+function seedEmbedding(
+  id: string,
+  targetType: string,
+  targetId: string,
+  provider = "p",
+  model = "m",
+): void {
+  mainRaw()
+    .query(
+      `INSERT INTO memory_embeddings (
+        id, target_type, target_id, provider, model, dimensions,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, 3, 0, 0)`,
+    )
+    .run(id, targetType, targetId, provider, model);
+}
+
+function embeddingIds(): string[] {
+  return (
+    mainRaw()
+      .query(`SELECT id FROM memory_embeddings ORDER BY id`)
+      .all() as Array<{ id: string }>
+  ).map((row) => row.id);
+}
+
+/** Distinct targetIds of pending delete_qdrant_vectors jobs, sorted. */
+function qdrantDeletionTargets(): string[] {
+  return (
+    getMemorySqlite()!
+      .query(
+        `SELECT json_extract(payload, '$.targetId') AS t
+         FROM memory_jobs
+         WHERE type = 'delete_qdrant_vectors' AND status = 'pending'
+         ORDER BY t`,
+      )
+      .all() as Array<{ t: string }>
+  ).map((row) => row.t);
+}
+
+function jobIds(): string[] {
+  return (
+    getMemorySqlite()!
+      .query(
+        `SELECT id FROM memory_jobs
+         WHERE type = 'delete_qdrant_vectors' ORDER BY id`,
+      )
+      .all() as Array<{ id: string }>
+  ).map((row) => row.id);
+}
+
+beforeEach(() => {
+  const raw = mainRaw();
+  raw.run("DELETE FROM memory_embeddings");
+  raw.run("DELETE FROM memory_graph_nodes");
+  getMemorySqlite()!.run("DELETE FROM memory_jobs");
+});
+
+describe("migration 340: sweep orphaned graph-node vectors", () => {
+  test("sweeps orphan embeddings and enqueues their Qdrant deletion, preserving live, soft-deleted, and non-graph_node rows", () => {
+    // Live node + its embedding — backing row present, not an orphan.
+    seedNode("live", "vivid");
+    seedEmbedding("emb-live", "graph_node", "live");
+    // Soft-deleted node keeps its SQL row, so its embedding is not an orphan.
+    seedNode("soft", "gone");
+    seedEmbedding("emb-soft", "graph_node", "soft");
+    // Two embeddings for one hard-deleted node (distinct provider/model) plus a
+    // second hard-deleted node — these are the orphans.
+    seedEmbedding("emb-orphan-a1", "graph_node", "orphan-a");
+    seedEmbedding("emb-orphan-a2", "graph_node", "orphan-a", "p2", "m2");
+    seedEmbedding("emb-orphan-b", "graph_node", "orphan-b");
+    // Wrong target_type: a summary embedding whose target is absent from
+    // memory_graph_nodes must not be swept by a graph-node sweep.
+    seedEmbedding("emb-summary", "summary", "orphan-a");
+
+    migrateSweepOrphanedGraphNodeVectors(getDb());
+
+    // Orphan graph_node embeddings gone; everything else retained.
+    expect(embeddingIds()).toEqual(["emb-live", "emb-soft", "emb-summary"]);
+    // One job per distinct orphan target (orphan-a deduped across its two rows).
+    expect(qdrantDeletionTargets()).toEqual(["orphan-a", "orphan-b"]);
+    expect(jobIds()).toEqual([
+      "migration-340-sweep-orphan-graph-node-vector:orphan-a",
+      "migration-340-sweep-orphan-graph-node-vector:orphan-b",
+    ]);
+  });
+
+  test("is idempotent", () => {
+    seedEmbedding("emb-orphan", "graph_node", "orphan-a");
+
+    migrateSweepOrphanedGraphNodeVectors(getDb());
+    const afterFirstEmbeddings = embeddingIds();
+    const afterFirstJobs = jobIds();
+    migrateSweepOrphanedGraphNodeVectors(getDb());
+
+    expect(embeddingIds()).toEqual(afterFirstEmbeddings);
+    expect(jobIds()).toEqual(afterFirstJobs);
+    expect(jobIds()).toEqual([
+      "migration-340-sweep-orphan-graph-node-vector:orphan-a",
+    ]);
+  });
+
+  test("no orphans → no jobs enqueued and no rows deleted", () => {
+    seedNode("live", "vivid");
+    seedEmbedding("emb-live", "graph_node", "live");
+
+    migrateSweepOrphanedGraphNodeVectors(getDb());
+
+    expect(embeddingIds()).toEqual(["emb-live"]);
+    expect(qdrantDeletionTargets()).toEqual([]);
+  });
+});

--- a/assistant/src/persistence/migrations/340-sweep-orphaned-graph-node-vectors.ts
+++ b/assistant/src/persistence/migrations/340-sweep-orphaned-graph-node-vectors.ts
@@ -1,0 +1,88 @@
+import {
+  type DrizzleDb,
+  getMemorySqlite,
+  getSqliteFrom,
+} from "../db-connection.js";
+
+/**
+ * Purge orphaned `graph_node` vector state left behind when a memory graph
+ * node's SQL row is hard-deleted.
+ *
+ * `searchGraphNodes` queries Qdrant with no scope filter and hydrates the hits
+ * from `memory_graph_nodes`; a vector whose backing node row is gone consumes a
+ * fixed top-K slot and is then silently dropped during hydration, starving
+ * default-scope recall. A bare `DELETE FROM memory_graph_nodes` (migration 323's
+ * non-default-scope purge) removes the SQL row but leaves the node's Qdrant
+ * `graph_node` point and its cached `memory_embeddings` row behind as exactly
+ * such orphans.
+ *
+ * Every `graph_node` Qdrant point is written alongside a `memory_embeddings`
+ * row (see `embedAndUpsert`), so an embedding row whose `target_id` no longer
+ * exists in `memory_graph_nodes` uniquely identifies an orphan. For each, this
+ * enqueues a `delete_qdrant_vectors` job on the memory database — the same
+ * primitive the live delete path and migration 229 use — so the worker drops
+ * the Qdrant point through its circuit breaker, then deletes the stale cache
+ * row. The normal delete path soft-deletes (`fidelity = 'gone'`, row retained),
+ * so live-deleted nodes keep their row and are not swept.
+ *
+ * Registered after migration 323, so on a not-yet-migrated database it sweeps
+ * the rows 323 deletes in the same boot; on an already-migrated database (323
+ * checkpointed) it sweeps the orphans 323 left on an earlier boot.
+ *
+ * Idempotent: deterministic job ids are INSERT OR IGNOREd, and once the orphan
+ * embedding rows are deleted a re-run finds nothing. Throws when the memory
+ * database is unavailable so the runner defers and retries on a later boot,
+ * rather than deleting cache rows without enqueuing the matching Qdrant
+ * deletions.
+ */
+export function migrateSweepOrphanedGraphNodeVectors(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const ORPHAN_PREDICATE = /*sql*/ `target_type = 'graph_node'
+      AND target_id NOT IN (SELECT id FROM memory_graph_nodes)`;
+
+  let orphanIds: string[];
+  try {
+    orphanIds = (
+      raw
+        .query(
+          /*sql*/ `SELECT DISTINCT target_id FROM memory_embeddings WHERE ${ORPHAN_PREDICATE}`,
+        )
+        .all() as Array<{ target_id: string }>
+    ).map((row) => row.target_id);
+  } catch {
+    // memory_embeddings or memory_graph_nodes absent — nothing to sweep.
+    return;
+  }
+
+  if (orphanIds.length === 0) {
+    return;
+  }
+
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring orphaned graph-node vector sweep",
+    );
+  }
+
+  // Enqueue the Qdrant point deletions before dropping the cache rows: a crash
+  // in between re-reads the same orphans next boot (nothing checkpointed) and
+  // the deterministic ids INSERT OR IGNORE, so no work is lost or duplicated.
+  const enqueue = memoryRaw.query(/*sql*/ `INSERT OR IGNORE INTO memory_jobs
+       (id, type, payload, status, attempts, run_after, created_at, updated_at)
+     VALUES (?, 'delete_qdrant_vectors', ?, 'pending', 0, 0, 0, 0)`);
+  const enqueueAll = memoryRaw.transaction((ids: string[]) => {
+    for (const id of ids) {
+      enqueue.run(
+        `migration-340-sweep-orphan-graph-node-vector:${id}`,
+        JSON.stringify({ targetType: "graph_node", targetId: id }),
+      );
+    }
+  });
+  enqueueAll(orphanIds);
+
+  raw.run(/*sql*/ `DELETE FROM memory_embeddings WHERE ${ORPHAN_PREDICATE}`);
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -447,6 +447,7 @@ import { migrateMoveMemoryV2ActivationLogsToMemoryDb } from "./migrations/336-mo
 import { migrateMoveMemoryRecallLogsToMemoryDb } from "./migrations/337-move-memory-recall-logs-to-memory-db.js";
 import { migrateMoveMemoryV3SelectionsToMemoryDb } from "./migrations/338-move-memory-v3-selections-to-memory-db.js";
 import { migrateMoveActivationSessionsToMemoryDb } from "./migrations/339-move-activation-sessions-to-memory-db.js";
+import { migrateSweepOrphanedGraphNodeVectors } from "./migrations/340-sweep-orphaned-graph-node-vectors.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1393,4 +1394,5 @@ export const migrationSteps: MigrationStep[] = [
     run: migrateMoveActivationSessionsToMemoryDb,
     dependsOn: ["createActivationSessionsTable"],
   },
+  migrateSweepOrphanedGraphNodeVectors,
 ];


### PR DESCRIPTION
## Summary

Follow-up to #37755 (Codex review). Migration 323 (`323-delete-non-default-memory-scopes`) hard-deletes non-default-scope `memory_graph_nodes` rows with a bare `DELETE`, but leaves each node's Qdrant `graph_node` point and its cached `memory_embeddings` row behind. On v1 installs `searchGraphNodes` has no scope filter, so those orphaned vectors surface in search, consume fixed top-K slots, and are then silently dropped during `getNodesByIds` hydration — starving default-scope recall.

## Fix

New migration **340** (`340-sweep-orphaned-graph-node-vectors.ts`), registered at the end of `migrationSteps`:

- Finds every `memory_embeddings` row of `target_type = 'graph_node'` whose `target_id` no longer exists in `memory_graph_nodes`. Every `graph_node` Qdrant point is written 1:1 with a `memory_embeddings` row (`embedAndUpsert`), so this uniquely identifies an orphan.
- Enqueues a `delete_qdrant_vectors` job on the **memory DB** (`memory_jobs` moved there in migration 298) with a deterministic id + `INSERT OR IGNORE`, so the worker drops the Qdrant point through its circuit breaker — the same primitive migration 229 and the live delete path use.
- Deletes the stale `memory_embeddings` rows from the main DB.

The normal delete path soft-deletes (`fidelity = 'gone'`, row retained), so live-deleted nodes keep their row and are **not** swept — only hard-deletes (229/323) produce orphans, which the `target_id NOT IN memory_graph_nodes` criterion targets precisely.

## Why one sweep migration instead of also amending 323's SQL

Migration 340 is registered **after** 323, so it covers every install population:

- **Fresh / not-yet-migrated:** 323 hard-deletes in the same boot, then 340 sweeps exactly those orphans.
- **Already-migrated (323 checkpointed):** 340 sweeps the orphans 323 left on an earlier boot.

340 has no `dependsOn` and is not checkpointed on failure, so it retries every boot until the memory DB is available — it runs exactly once, successfully, on every install. Amending 323's executable SQL to self-clean (mirroring 229) would be **redundant** with 340 for fresh installs, and would force 323's fast in-memory unit test onto the heavier real-DB pattern while adding a cross-DB defer path into already-shipped, already-checkpointed code. Instead, 323's docstring is corrected — it previously claimed the delete "keeps them invisible," which is false for the Qdrant search path — and now points at the 340 sweep.

(The reviewer's "editing 323 alone only helps fresh installs" is correct; the point they didn't account for is that 340, running *after* 323, covers fresh installs too — so the second migration alone is a complete fix rather than half of a two-part one.)

## Idempotency / crash-safety

- Deterministic job ids `INSERT OR IGNORE`; once the orphan rows are deleted, a re-run finds nothing.
- Enqueue happens **before** the embeddings delete: a crash in between re-reads the same orphans next boot (nothing checkpointed) and re-enqueues the same deterministic ids — no work lost or duplicated.
- Throws when the memory DB is unavailable so the runner defers and retries, never deleting cache rows without the matching Qdrant deletions enqueued.
- Append-only: fresh prefix 340, registered as its own step in `steps.ts` (checkpointed by function name).

## Testing

`340-sweep-orphaned-graph-node-vectors.test.ts` (real-DB pattern like migration 335): orphan `graph_node` embeddings are swept with one deduped `delete_qdrant_vectors` job per distinct target; live, soft-deleted (`fidelity = 'gone'`), and non-`graph_node` rows are preserved; idempotent on re-run; no-op when there are no orphans. 6/6 pass (including the untouched 323 test).

## Residual risk

None for the described bug — all install populations are covered by 340. Orphaned Qdrant points whose `memory_embeddings` row was *also* already deleted are out of scope: 323 leaves both the point and the embedding row, so its orphans always retain the embedding row that 340 keys on.

Addresses review feedback on #37755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)