### PR TITLE
fix(empty-response): quarantine refused Slack exchanges from the transcript

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -146,6 +146,7 @@ import type { MessageRow } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { conversations, messages } from "../persistence/schema/index.js";
+import { REFUSAL_FALLBACK_TEXT } from "../plugins/defaults/empty-response/refusal-quarantine.js";
 import { registerDefaultPluginInjectors } from "../plugins/defaults/index.js";
 import { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import postCompact from "../plugins/defaults/memory/hooks/post-compact.js";
@@ -5232,6 +5233,59 @@ describe("assembleSlackActiveThreadFocusBlock", () => {
     expect(result!).toContain("Lone reply");
     expect(result!).toContain("<active_thread>");
   });
+
+  test("drops a previously-refused exchange from the focus block", () => {
+    // A refusal persisted inside the active thread (the flagged prompt plus the
+    // canned apology the empty-response plugin rewrote the turn into) must not
+    // survive into the `<active_thread>` block. The block is appended to the
+    // user tail, so a surviving refusal line would let the safety classifier
+    // re-refuse every turn — the same dead-end quarantined off Slack.
+    const FLAGGED_TS = "1700000010.000002";
+    const REFUSAL_TS = "1700000011.000003";
+    const BENIGN_TS = "1700000020.000004";
+    const rows: SlackTranscriptInputRow[] = [
+      buildRow(
+        "user",
+        "Parent",
+        1_000,
+        buildMeta({ channelTs: PARENT_TS, displayName: "@alice" }),
+      ),
+      buildRow(
+        "user",
+        "disallowed question",
+        2_000,
+        buildMeta({
+          channelTs: FLAGGED_TS,
+          threadTs: PARENT_TS,
+          displayName: "@alice",
+        }),
+      ),
+      buildRow(
+        "assistant",
+        REFUSAL_FALLBACK_TEXT,
+        2_100,
+        buildMeta({ channelTs: REFUSAL_TS, threadTs: PARENT_TS }),
+      ),
+      buildRow(
+        "user",
+        "back to normal",
+        3_000,
+        buildMeta({
+          channelTs: BENIGN_TS,
+          threadTs: PARENT_TS,
+          displayName: "@alice",
+        }),
+      ),
+    ];
+    const result = assembleSlackActiveThreadFocusBlock(rows, SLACK_CAPS);
+    expect(result).not.toBeNull();
+    // Surrounding benign turns survive …
+    expect(result!).toContain("Parent");
+    expect(result!).toContain("back to normal");
+    // … but the refusal and the prompt that tripped it are gone.
+    expect(result!).not.toContain(REFUSAL_FALLBACK_TEXT);
+    expect(result!).not.toContain("disallowed question");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -6068,6 +6122,48 @@ describe("assembleSlackChronologicalMessages", () => {
         },
       ],
     });
+  });
+
+  test("quarantines a previously-refused exchange from the transcript", () => {
+    // A safety-classifier refusal persisted in Slack history — the flagged
+    // prompt plus the canned apology the empty-response plugin rewrote the turn
+    // into — must not be replayed to the model. Left in, the classifier
+    // re-refuses every turn, the poisoned dead-end the plugin's turn-start
+    // sweep prevents off Slack. The whole exchange is excised here so it never
+    // reaches the model request.
+    const TS_14_30 = "1699972200.000400"; // 14:30 UTC
+    const meta = (channelTs: string): SlackMessageMetadata => ({
+      source: "slack",
+      channelId: DM_CHANNEL_ID,
+      channelTs,
+      eventKind: "message",
+      displayName: "@alice",
+    });
+    const rows: SlackTranscriptInputRow[] = [
+      row("user", "hi assistant", MS_14_25, metadataEnvelope(meta(TS_14_25))),
+      row(
+        "user",
+        "disallowed question",
+        MS_14_26,
+        metadataEnvelope(meta(TS_14_26)),
+      ),
+      row(
+        "assistant",
+        REFUSAL_FALLBACK_TEXT,
+        MS_14_28,
+        metadataEnvelope(meta(TS_14_28)),
+      ),
+      row("user", "back to normal", MS_14_30, metadataEnvelope(meta(TS_14_30))),
+    ];
+
+    const result = assembleSlackChronologicalMessages(rows, DM_CAPS);
+    const serialized = JSON.stringify(result);
+    // The refusal and the prompt that tripped it are both gone …
+    expect(serialized).not.toContain(REFUSAL_FALLBACK_TEXT);
+    expect(serialized).not.toContain("disallowed question");
+    // … while the benign turns on either side survive.
+    expect(serialized).toContain("hi assistant");
+    expect(serialized).toContain("back to normal");
   });
 });
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -46,6 +46,10 @@ import {
 import { isBackgroundConversationType } from "../persistence/conversation-types.js";
 import { createContextSummaryMessage } from "../plugins/defaults/compaction/window-manager.js";
 import {
+  computeRefusedExchangeDrops,
+  quarantineRefusedExchanges,
+} from "../plugins/defaults/empty-response/refusal-quarantine.js";
+import {
   countMemoryPrefixBlocks,
   extractMemoryPrefixBlocks,
   getLiveGraphMemory,
@@ -1305,8 +1309,17 @@ function assembleSlackChronologicalContext(
   }
   const renderable = rowsToRenderableSlackMessages(rows);
   const rendered = renderSlackTranscriptWithProvenance(renderable);
+  // Drop previously-refused exchanges — a persisted safety-classifier refusal
+  // and the prompt that tripped it — so the model isn't re-fed a refusal it
+  // will just repeat (the dead-end `empty-response` sweeps off Slack turns).
+  // `renderedMessages` is filtered by the same indices to stay aligned with the
+  // `messages` projection compaction slices.
+  const { dropIndices } = computeRefusedExchangeDrops(rendered.messages);
+  const renderedMessages =
+    dropIndices.size > 0
+      ? rendered.renderedMessages.filter((_, i) => !dropIndices.has(i))
+      : rendered.renderedMessages;
   const contextSummary = options.contextSummary?.trim();
-  const renderedMessages = rendered.renderedMessages;
   if (contextSummary) {
     const withSummary: RenderedSlackTranscriptMessage[] = [
       {
@@ -1526,12 +1539,14 @@ function buildActiveThreadBlockFromRenderable(
   });
 
   const rendered = renderSlackTranscriptWithProvenance(labeledMembers);
-  if (rendered.renderedMessages.length === 0) {
+  // Exclude previously-refused exchanges: the block is appended to the user
+  // tail, so a surviving refusal line would let the model re-refuse just as
+  // replaying it in the chronological transcript would.
+  const { messages } = quarantineRefusedExchanges(rendered.messages);
+  if (messages.length === 0) {
     return null;
   }
-  const lines = rendered.renderedMessages
-    .map((entry) => extractTagLineTexts([entry.message])[0] ?? "")
-    .join("\n");
+  const lines = extractTagLineTexts(messages).join("\n");
   return `<active_thread>\n${lines}\n</active_thread>`;
 }
 

--- a/assistant/src/plugins/defaults/empty-response/refusal-quarantine.ts
+++ b/assistant/src/plugins/defaults/empty-response/refusal-quarantine.ts
@@ -58,6 +58,45 @@ export function isRefusalFallbackMessage(message: Message): boolean {
 }
 
 /**
+ * Indices of every message belonging to a previously-refused exchange: for each
+ * assistant message that is exactly the refusal fallback, its own index plus the
+ * contiguous run back to (and including) the nearest genuine user prompt — the
+ * flagged prompt and any tool exchange in that run.
+ *
+ * Exposed as a set of indices (rather than only the filtered messages) so a
+ * caller holding an array rendered in lockstep with `messages` — e.g. the Slack
+ * chronological transcript, whose per-message compaction provenance rides in a
+ * sibling array — can drop the same exchanges from both and keep them aligned.
+ */
+export function computeRefusedExchangeDrops(messages: Message[]): {
+  dropIndices: Set<number>;
+  droppedExchanges: number;
+} {
+  const dropIndices = new Set<number>();
+  let droppedExchanges = 0;
+  for (let r = 0; r < messages.length; r++) {
+    if (!isRefusalFallbackMessage(messages[r])) {
+      continue;
+    }
+    dropIndices.add(r);
+    // Walk back over tool-result / assistant tool churn to the genuine prompt.
+    let s = r - 1;
+    while (
+      s >= 0 &&
+      !(messages[s].role === "user" && !isToolResultMessage(messages[s]))
+    ) {
+      dropIndices.add(s);
+      s--;
+    }
+    if (s >= 0) {
+      dropIndices.add(s); // the genuine user prompt that was refused
+    }
+    droppedExchanges++;
+  }
+  return { dropIndices, droppedExchanges };
+}
+
+/**
  * Remove every previously-refused exchange from a working history: for each
  * assistant message that is exactly the refusal fallback, drop it together with
  * the contiguous run back to (and including) the nearest genuine user prompt.
@@ -68,32 +107,13 @@ export function quarantineRefusedExchanges(messages: Message[]): {
   messages: Message[];
   droppedExchanges: number;
 } {
-  const drop = new Set<number>();
-  let droppedExchanges = 0;
-  for (let r = 0; r < messages.length; r++) {
-    if (!isRefusalFallbackMessage(messages[r])) {
-      continue;
-    }
-    drop.add(r);
-    // Walk back over tool-result / assistant tool churn to the genuine prompt.
-    let s = r - 1;
-    while (
-      s >= 0 &&
-      !(messages[s].role === "user" && !isToolResultMessage(messages[s]))
-    ) {
-      drop.add(s);
-      s--;
-    }
-    if (s >= 0) {
-      drop.add(s); // the genuine user prompt that was refused
-    }
-    droppedExchanges++;
-  }
-  if (drop.size === 0) {
+  const { dropIndices, droppedExchanges } =
+    computeRefusedExchangeDrops(messages);
+  if (dropIndices.size === 0) {
     return { messages, droppedExchanges: 0 };
   }
   return {
-    messages: messages.filter((_, i) => !drop.has(i)),
+    messages: messages.filter((_, i) => !dropIndices.has(i)),
     droppedExchanges,
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to #38280 (flagged by Codex, verified still true on main): the refusal quarantine had **no effect on Slack turns**. On Slack, `applyRuntimeInjections` replaces the working history with a freshly-rendered chronological transcript (and appends an `<active_thread>` focus block) built from persisted rows — independently of the `latestMessages` array the empty-response `user-prompt-submit` sweep operates on. So the flagged prompt plus the persisted `REFUSAL_FALLBACK_TEXT` apology survived inside the injected transcript, and the safety classifier re-refused every turn: the same poisoned dead-end #38280 fixed for non-Slack turns.

Fix: apply the refusal quarantine where the Slack transcript is assembled, in daemon core.

- `assembleSlackChronologicalContext` (feeds the `slack-messages` injector) drops previously-refused exchanges from the rendered transcript. The provenance-carrying `renderedMessages` is filtered by the same indices so it stays aligned with the `messages` projection compaction slices.
- `buildActiveThreadBlockFromRenderable` (feeds the `<active_thread>` focus block) excludes them too, so the block can't reintroduce a refusal line into the user tail.
- Both the model-facing injector path and the compaction path funnel through these two functions, so they see one consistent quarantined view.

## Boundaries / single source of truth

`refusal-quarantine.ts` now exposes `computeRefusedExchangeDrops` (the drop-index set) alongside `quarantineRefusedExchanges`; daemon core reuses both rather than re-implementing refusal detection. This is **not** a plugin-to-plugin import — daemon core already consumes many `plugins/defaults/*` modules (compaction, memory, history-repair, image-recovery), and `plugin-import-boundary-guard` only constrains a plugin importing outside its own directory. The `channel` plugin is untouched.

## Tests

- `assembleSlackChronologicalMessages`: a transcript containing a refused exchange carries neither the flagged prompt nor `REFUSAL_FALLBACK_TEXT` into the model request; surrounding benign turns survive.
- `assembleSlackActiveThreadFocusBlock`: same for the focus block.
- Existing empty-response hook tests (29) still pass against the refactored helper; full `conversation-runtime-assembly` suite (198) green.