### PR TITLE
fix(chat): surface canned system cards on the initiating client

### DIFF
--- a/assistant/src/__tests__/conversation-summarize-route.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-route.test.ts
@@ -195,10 +195,13 @@ function makeConversation(opts: { processing?: boolean } = {}) {
   };
 }
 
-function makeRequest(body: Record<string, unknown>) {
+function makeRequest(
+  body: Record<string, unknown>,
+  extraHeaders: Record<string, string> = {},
+) {
   return new Request("http://localhost/v1/conversations/summarize", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...extraHeaders },
     body: JSON.stringify(body),
   });
 }
@@ -225,10 +228,14 @@ describe("POST /v1/conversations/summarize", () => {
 
     const res = await callHandler(
       summarizeHandler,
-      makeRequest({
-        conversationId: "conv-summarize-test",
-        beforeMessageId: "msg-42",
-      }),
+      makeRequest(
+        {
+          conversationId: "conv-summarize-test",
+          beforeMessageId: "msg-42",
+        },
+        // A real initiating client id — the card must still surface here.
+        { "X-Vellum-Client-Id": "web-client-xyz" },
+      ),
       undefined,
       202,
     );
@@ -286,10 +293,14 @@ describe("POST /v1/conversations/summarize", () => {
       ["compaction-log-1"],
       "persisted-assistant-id",
     );
-    expect(publishConversationMessagesChangedMock).toHaveBeenCalledWith(
+    // The card's messages-changed invalidation carries no origin client id
+    // despite the request's `X-Vellum-Client-Id`: the origin materializes the
+    // bodyless-`message_complete` card only by refetching, so suppressing its
+    // own invalidation would hide the card until a reload.
+    expect(publishConversationMessagesChangedMock).toHaveBeenCalledTimes(1);
+    expect(publishConversationMessagesChangedMock.mock.calls[0]).toEqual([
       "conv-summarize-test",
-      undefined,
-    );
+    ]);
 
     expect(ctx.conversation.isProcessing()).toBe(false);
     expect(ctx.drainQueue).toHaveBeenCalledTimes(1);

--- a/assistant/src/runtime/routes/canned-message-complete.ts
+++ b/assistant/src/runtime/routes/canned-message-complete.ts
@@ -48,9 +48,14 @@ export function emitCannedMessageComplete(
  *
  * Cards are announced with `message_complete` (persisted assistant id), the
  * persisted-seq anchor advance (so a stale /messages reseed cannot erase the
- * card), and the messages-changed sync invalidation that drives the client
- * refetch. No `assistant_text_delta` is emitted — a delta would stream the
- * card into the tail assistant bubble as if the persona were speaking.
+ * card), and the messages-changed sync invalidation that drives every client
+ * to refetch. That invalidation carries no origin-client id: the card body
+ * streams nowhere (`message_complete` is bodyless, no `assistant_text_delta`),
+ * so the initiating client materializes it only by refetching, and origin
+ * self-echo suppression (meant for content the origin already rendered) would
+ * otherwise hide the card from the initiator until a reload. A delta is
+ * deliberately omitted; it would stream the card into the tail assistant
+ * bubble as if the persona were speaking.
  *
  * Returns the persisted card's message id so callers can link related
  * records to it (e.g. the compaction `llm_request_logs` row).
@@ -60,9 +65,8 @@ export async function persistCannedAssistantCard(opts: {
   conversationId: string;
   text: string;
   metadata: Record<string, unknown>;
-  originClientId?: string;
 }): Promise<string> {
-  const { conversation, conversationId, text, metadata, originClientId } = opts;
+  const { conversation, conversationId, text, metadata } = opts;
   const assistantMsg = createAssistantMessage(text);
   const persistedAssistant = await addMessage(
     conversationId,
@@ -77,6 +81,6 @@ export async function persistCannedAssistantCard(opts: {
     persistedAssistant.id,
   );
   recordConversationPersistedSeq(conversationId, getCurrentSeq());
-  publishConversationMessagesChanged(conversationId, originClientId);
+  publishConversationMessagesChanged(conversationId);
   return persistedAssistant.id;
 }

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -194,10 +194,7 @@ async function handleForkConversation({
   }
 }
 
-async function handleSummarizeConversation({
-  body = {},
-  headers,
-}: RouteHandlerArgs) {
+async function handleSummarizeConversation({ body = {} }: RouteHandlerArgs) {
   const rawConversationId = body.conversationId;
   if (!rawConversationId || typeof rawConversationId !== "string") {
     throw new BadRequestError("Missing conversationId");
@@ -225,8 +222,6 @@ async function handleSummarizeConversation({
   }
   conversation.setProcessing(true);
 
-  const originClientId = headers?.["x-vellum-client-id"]?.trim() || undefined;
-
   // The summarize action only ships from the vellum web/desktop client; the
   // interface id is omitted because this management route (unlike the send
   // path) does not receive one from the client.
@@ -239,7 +234,6 @@ async function handleSummarizeConversation({
       conversationId,
       text,
       metadata: channelMeta,
-      originClientId,
     });
 
   // Fire-and-forget: return 202 immediately, run summarization async. The

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2381,7 +2381,6 @@ export async function handleSendMessage(
           conversationId,
           text: formatCompactResult(result),
           metadata: channelMeta,
-          originClientId,
         });
         // Attribute the compaction LLM call to the card it produced — same
         // linkage as the summarize-up-to route.
@@ -2461,7 +2460,6 @@ export async function handleSendMessage(
           conversationId,
           text: formatCleanResult(result),
           metadata: channelMeta,
-          originClientId,
         });
       } catch (err) {
         log.error({ err, conversationId }, "Clean command failed");


### PR DESCRIPTION
## Summary

Follow-up to #38265. The `/compact`, `/clean`, and "summarize up to here" result cards were invisible to the web/desktop client that triggered them until a reload — the very client that ran the command never saw the card.

## Root cause

`persistCannedAssistantCard` announces each card with a **bodyless** `message_complete` (id only, no text — a text delta would stream the card into the tail assistant bubble as persona speech) plus a messages-changed sync invalidation carrying `originClientId`. On the origin client:

- `finalizeMessageComplete` returns `prev` for a bodyless complete whose tail isn't an assistant bubble, so the card never materializes from the event; and
- the messages-changed `sync_changed` is self-echo-suppressed for the originating client, so it never refetches.

Net: the origin only picked up the card on a full reload.

## Fix (reviewer option a)

Publish the card's messages-changed invalidation **without** an origin id, so the initiating client refetches and materializes the standalone card exactly like every other client already does. Self-echo suppression exists to avoid re-rendering content the origin already streamed; a card streams nothing, so the refetch is the only path by which the origin ever sees it. The `message_complete` event is unchanged, so no other consumer is affected.

Applied at the single shared sink (`persistCannedAssistantCard`), which covers all three call sites (compact, clean, summarize-up-to). The separate **user-message** echo invalidations stay origin-suppressed — correct, since the origin renders the typed `/compact` · `/clean` command optimistically.

## Test

Strengthened the summarize-route test to send `X-Vellum-Client-Id` and assert the card's invalidation is published with no origin id. The prior assertion checked for `undefined` only because it sent no header, so it never actually guarded this regression.

## Coordination

Touches `conversation-management-routes.ts` minimally (drops the now-unused `originClientId`/`headers` in the summarize handler). Open PR #38388 inserts an abort controller a couple of lines above and edits the try/catch/finally below — different lines, so its rebase should stay clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)