### PR TITLE
fix(plugins): repair main CI — host-owned refusal quarantine + image-fallback mock export

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -105,6 +105,7 @@ mock.module("../daemon/date-context.js", () => ({
 
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { LLMSchema } from "../config/schemas/llm.js";
+import { REFUSAL_FALLBACK_TEXT } from "../context/refusal-quarantine.js";
 import {
   clearConversations,
   setConversation,
@@ -147,7 +148,6 @@ import type { MessageRow } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { conversations, messages } from "../persistence/schema/index.js";
-import { REFUSAL_FALLBACK_TEXT } from "../plugins/defaults/empty-response/refusal-quarantine.js";
 import { registerDefaultPluginInjectors } from "../plugins/defaults/index.js";
 import { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import postCompact from "../plugins/defaults/memory/hooks/post-compact.js";

--- a/assistant/src/__tests__/empty-response-hook.test.ts
+++ b/assistant/src/__tests__/empty-response-hook.test.ts
@@ -30,6 +30,7 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { quarantineRefusedExchanges } from "../context/refusal-quarantine.js";
 import {
   HOOKS,
   INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
@@ -52,7 +53,6 @@ import {
   markEmptyResponseNudged,
   resetEmptyResponseNudgeStoreForTests,
 } from "../plugins/defaults/empty-response/nudge-state-store.js";
-import { quarantineRefusedExchanges } from "../plugins/defaults/empty-response/refusal-quarantine.js";
 import { defaultEmptyResponsePlugin } from "../plugins/defaults/index.js";
 import { runHook } from "../plugins/pipeline.js";
 import {

--- a/assistant/src/context/refusal-quarantine.ts
+++ b/assistant/src/context/refusal-quarantine.ts
@@ -1,26 +1,32 @@
 /**
- * Refusal-quarantine helpers for the empty-response plugin.
+ * Refusal-quarantine helpers.
  *
  * When the provider's safety classifier zeroes a response (`stopReason ===
- * "refusal"`), the `post-model-call` hook rewrites that turn into a canned
- * apology (`REFUSAL_FALLBACK_TEXT`) which is persisted like a normal assistant
- * turn. Without further action the flagged user prompt stays in the transcript,
- * so every following turn resends it and re-trips the same refusal — a dead-
- * ended, poisoned conversation.
+ * "refusal"`), the empty-response plugin's `post-model-call` hook rewrites that
+ * turn into a canned apology (`REFUSAL_FALLBACK_TEXT`) which is persisted like
+ * a normal assistant turn. Without further action the flagged user prompt stays
+ * in the transcript, so every following turn resends it and re-trips the same
+ * refusal — a dead-ended, poisoned conversation.
  *
  * The persisted apology is itself a durable, per-exchange marker of "this
- * exchange was refused". The `user-prompt-submit` hook uses these helpers at
- * turn start to drop each previously-refused exchange from the working history
- * the provider sees, so the poison never replays. No new storage and no
- * migration: the signal lives in the transcript (source of truth), so an
- * already-poisoned conversation self-heals on its next turn.
+ * exchange was refused". These helpers drop each previously-refused exchange
+ * from the working history the provider sees, so the poison never replays. No
+ * new storage and no migration: the signal lives in the transcript (source of
+ * truth), so an already-poisoned conversation self-heals on its next turn.
+ *
+ * Host-owned because both sides of the boundary consume it: the runtime
+ * assembly (`daemon/conversation-runtime-assembly.ts`) quarantines the message
+ * array and the lockstep Slack chronological transcript, and the empty-response
+ * plugin's hooks reach the producer/sweep pieces via `@vellumai/plugin-api`
+ * re-exports.
  */
 
-import type { ContentBlock, Message } from "@vellumai/plugin-api";
+import type { ContentBlock, Message } from "../providers/types.js";
 
 /**
  * User-facing text a refusal turn is rewritten into (single source of truth for
- * both the producer in `hooks/post-model-call.ts` and the detector below).
+ * both the producer — the empty-response plugin's `post-model-call` hook — and
+ * the detector below).
  *
  * DETECTION COUPLING: `isRefusalFallbackMessage` matches this string exactly,
  * so it doubles as the quarantine marker for already-persisted transcripts.

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -22,6 +22,10 @@ import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { LLMCallSite, LLMConfig } from "../config/schemas/llm.js";
 import { findContactInfoById } from "../contacts/contact-store.js";
 import {
+  computeRefusedExchangeDrops,
+  quarantineRefusedExchanges,
+} from "../context/refusal-quarantine.js";
+import {
   NOW_SCRATCHPAD_STRIP_PREFIXES,
   stripSpotlightInjections,
   stripUserTextBlocksByPrefix,
@@ -45,10 +49,6 @@ import {
 } from "../persistence/conversation-crud.js";
 import { isBackgroundConversationType } from "../persistence/conversation-types.js";
 import { createContextSummaryMessage } from "../plugins/defaults/compaction/window-manager.js";
-import {
-  computeRefusedExchangeDrops,
-  quarantineRefusedExchanges,
-} from "../plugins/defaults/empty-response/refusal-quarantine.js";
 import {
   countMemoryPrefixBlocks,
   extractMemoryPrefixBlocks,

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -195,6 +195,19 @@ export { isVisionNotSupportedError } from "../util/provider-error-patterns.js";
 // avoid touching stale tool-result media the sanitizer will replace with its
 // removed-media marker.
 export { lastToolResultUserMessageIndex } from "../context/outbound-sanitize.js";
+// Refusal quarantine — the canned apology a refusal turn is rewritten into
+// (`REFUSAL_FALLBACK_TEXT`, which doubles as the persisted per-exchange
+// "refused" marker), the tool-result-only user-message classifier the producer
+// shares with the detector, and the sweep that drops previously-refused
+// exchanges from a working history. The empty-response plugin's
+// `post-model-call` hook writes the marker and its `user-prompt-submit` hook
+// runs the sweep; the host runtime assembly applies the same helpers to the
+// provider-bound history.
+export {
+  isToolResultMessage,
+  quarantineRefusedExchanges,
+  REFUSAL_FALLBACK_TEXT,
+} from "../context/refusal-quarantine.js";
 // Identity reads — "who is the assistant and the user." A plugin that builds
 // its own prompts (e.g. for its own inference) names the actor via these.
 // Backed by the workspace `IDENTITY.md` / user profile; each returns null when

--- a/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/empty-response/hooks/post-model-call.ts
@@ -50,22 +50,21 @@ import {
   type ContentBlock,
   type HookFunction,
   INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
+  isToolResultMessage,
   type Message,
   type PostModelCallContext,
+  REFUSAL_FALLBACK_TEXT,
 } from "@vellumai/plugin-api";
 
 import {
   isEmptyResponseNudged,
   markEmptyResponseNudged,
 } from "../nudge-state-store.js";
-import {
-  isToolResultMessage,
-  REFUSAL_FALLBACK_TEXT,
-} from "../refusal-quarantine.js";
 
 // Re-exported so existing importers (tests, sibling hooks) keep resolving
-// REFUSAL_FALLBACK_TEXT from this module; the definition lives in
-// refusal-quarantine.ts alongside its detector (single source of truth).
+// REFUSAL_FALLBACK_TEXT from this module; the definition lives in the host's
+// `context/refusal-quarantine.ts` alongside its detector (single source of
+// truth).
 export { REFUSAL_FALLBACK_TEXT };
 
 /**

--- a/assistant/src/plugins/defaults/empty-response/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/empty-response/hooks/user-prompt-submit.ts
@@ -11,12 +11,11 @@
  * role-alternation artifact left by a dropped run.
  */
 
-import type {
-  HookFunction,
-  UserPromptSubmitContext,
+import {
+  type HookFunction,
+  quarantineRefusedExchanges,
+  type UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
-
-import { quarantineRefusedExchanges } from "../refusal-quarantine.js";
 
 const userPromptSubmit: HookFunction<UserPromptSubmitContext> = async (ctx) => {
   const { messages, droppedExchanges } = quarantineRefusedExchanges(

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
@@ -15,6 +15,11 @@ import type {
   UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
+// The current-turn boundary is the real host helper `caption-blocks.ts`
+// reaches through `@vellumai/plugin-api`; wire it into the mock so the sweep
+// tests exercise the shipped scope behavior rather than a stand-in.
+import { lastToolResultUserMessageIndex } from "../../../../context/outbound-sanitize.js";
+
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
 // Control doesSupportVision from the test: by profile key for the
@@ -53,6 +58,7 @@ mock.module("@vellumai/plugin-api", () => ({
   getModelProfiles: () => mockProfiles,
   resolveMediaSourceData: mockResolveMediaSourceData,
   getConfiguredProvider: async () => (providerResolves ? fakeProvider : null),
+  lastToolResultUserMessageIndex,
 }));
 
 // Mock the image-persist module to avoid filesystem side effects in tests.


### PR DESCRIPTION
## Summary
- Fixes the two failing test files in [main CI run 29551971540](https://github.com/vellum-ai/vellum-assistant/actions/runs/29551971540/job/87796263370).
- **Reverse boundary guard**: #38401 made host code (`daemon/conversation-runtime-assembly.ts`) import the empty-response plugin's `refusal-quarantine` internals. The pure module now lives host-side at `src/context/refusal-quarantine.ts` (with `strip-injections`/`outbound-sanitize`, its transcript-shaping siblings), and the plugin's hooks consume `REFUSAL_FALLBACK_TEXT` / `isToolResultMessage` / `quarantineRefusedExchanges` via `@vellumai/plugin-api` re-exports — the guard's sanctioned route and the established `lastToolResultUserMessageIndex` pattern. No baseline regeneration; the baseline keeps ratcheting toward empty.
- **image-fallback.test.ts**: #38398 added a `lastToolResultUserMessageIndex` import to `caption-blocks.ts`, but this test's full-replacement `mock.module("@vellumai/plugin-api", …)` factory was not updated, so the named import failed at load (`SyntaxError`). The real host helper is now passed through the mock, mirroring `vision-recovery.test.ts`.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29551971540/job/87796263370 — the assistant Test job on main, red after #38398 and #38401 merged. Both failing test files in that job are addressed; no other CI concerns touched.

## Verification
Solo runs (bun mock-pollution gotcha) all green: `plugin-import-boundary-reverse-guard.test.ts`, `plugin-import-boundary-guard.test.ts`, `image-fallback.test.ts` (31), `vision-recovery.test.ts` (10), `empty-response-hook.test.ts` (29), `conversation-runtime-assembly.test.ts` (200), plus a clean `tsgo --noEmit`.