### PR TITLE
fix(ui-surface): teach the file_upload shape when a payload mis-names keys

### DIFF
--- a/assistant/src/__tests__/ui-shape-teaching.test.ts
+++ b/assistant/src/__tests__/ui-shape-teaching.test.ts
@@ -160,6 +160,24 @@ describe("ui_show missing-content teaching", () => {
       data: { channel: "email" },
       expectInError: '"slack", "telegram", "phone"',
     },
+    {
+      // Snake_case constraint keys are stripped by the schema, so without the
+      // guard the uploader would render silently unconstrained.
+      surfaceType: "file_upload",
+      data: { accepted_types: ["application/pdf"], max_files: 1 },
+      expectInError: "`accepted_types`",
+    },
+    {
+      // A valid prompt must not mask a mis-named constraint: the snake_case
+      // key still drops silently, so the guard fires even with prompt present.
+      surfaceType: "file_upload",
+      data: {
+        prompt: "Upload your resume",
+        maxFiles: 2,
+        allowedFormats: ["pdf"],
+      },
+      expectInError: "`allowedFormats`",
+    },
   ];
 
   for (const { surfaceType, data, expectInError } of cases) {
@@ -236,8 +254,37 @@ describe("ui_show displayable payloads proxy through", () => {
         },
       },
       {
-        surfaceType: "file_upload",
+        // Empty data still renders a functional uploader (context can come from
+        // a top-level title), and carries no unknown keys, so it proxies.
+        surfaceType: "file_upload (empty)",
         input: { surface_type: "file_upload", data: {} },
+      },
+      {
+        surfaceType: "file_upload (prompt only)",
+        input: {
+          surface_type: "file_upload",
+          data: { prompt: "Upload your resume" },
+        },
+      },
+      {
+        surfaceType: "file_upload (camelCase constraints)",
+        input: {
+          surface_type: "file_upload",
+          data: {
+            prompt: "Upload your resume",
+            acceptedTypes: ["application/pdf"],
+            maxFiles: 1,
+          },
+        },
+      },
+      {
+        // maxSizeBytes is a real schema field the renderer honors even though
+        // it is not advertised in the shape doc, so it must not be flagged.
+        surfaceType: "file_upload (maxSizeBytes)",
+        input: {
+          surface_type: "file_upload",
+          data: { prompt: "Upload a photo", maxSizeBytes: 1_000_000 },
+        },
       },
       {
         surfaceType: "channel_setup",

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -16,6 +16,8 @@
  * stay accepted, so card has no guard here.
  */
 
+import { FileUploadSurfaceDataSchema } from "../../api/surfaces.js";
+
 export function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object"
     ? (value as Record<string, unknown>)
@@ -57,10 +59,10 @@ interface SurfaceShapeDoc {
   /** Full `data` shape spec, shown in per-type teaching errors. */
   shape: string;
   /**
-   * Returns a description of the missing load-bearing content, or null when
-   * the payload has enough to render. Absent for types the daemon normalizes
-   * leniently (card), that render fine with defaults (file_upload), or that
-   * have bespoke handling (dynamic_page).
+   * Returns a description of what keeps the payload from rendering as intended
+   * — missing load-bearing content, or keys that would be silently dropped —
+   * or null when the payload is fine. Absent for types the daemon normalizes
+   * leniently (card) or that have bespoke handling (dynamic_page).
    */
   missingContent?: (data: Record<string, unknown>) => string | null;
 }
@@ -68,6 +70,11 @@ interface SurfaceShapeDoc {
 /** templateData shape of a task_progress card (shared with channel variants). */
 export const TASK_PROGRESS_TEMPLATE_SHAPE =
   '{ title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] }';
+
+/** Data keys the file_upload renderer reads; any other key is silently stripped. */
+const FILE_UPLOAD_KEYS = new Set<string>(
+  Object.keys(FileUploadSurfaceDataSchema.shape),
+);
 
 export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   card: {
@@ -153,6 +160,23 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
   file_upload: {
     purpose: "prompt the user to upload files",
     shape: "{ prompt, acceptedTypes?, maxFiles? }",
+    missingContent: (data) => {
+      // As a cold type, file_upload's shape reaches the model only through this
+      // teaching error. The canonical schema strips unrecognized keys, so a
+      // best-guess payload that mis-names a constraint (snake_case
+      // `accepted_types`/`max_files`, or any other unknown key) would silently
+      // render an unconstrained uploader. Flag dropped keys so the model
+      // relearns the shape; a prompt-only or empty payload still renders
+      // (context can also come from the top-level `title`), so it passes.
+      const unknownKeys = Object.keys(data).filter(
+        (key) => !FILE_UPLOAD_KEYS.has(key),
+      );
+      if (unknownKeys.length === 0) {
+        return null;
+      }
+      const keyList = unknownKeys.map((key) => `\`${key}\``).join(", ");
+      return `${unknownKeys.length === 1 ? "key" : "keys"} ${keyList} would be dropped (file_upload reads only \`prompt\`, \`acceptedTypes\`, \`maxFiles\`)`;
+    },
   },
   dynamic_page: {
     purpose: "custom HTML page for transient UI only, never app-like builds",


### PR DESCRIPTION
## Summary

`file_upload` became a cold `ui_show` type in #38269, so its `{ prompt, acceptedTypes?, maxFiles? }` shape left the always-present tool docs — but its `SURFACE_SHAPE_DOCS` entry had no `missingContent` guard. `uiShowTeachingError` therefore returned `null` for it, and a best-guess payload with unrecognized keys (e.g. snake_case `accepted_types`/`max_files`) was silently stripped by `FileUploadSurfaceDataSchema` (Zod strip mode), rendering an unconstrained uploader with no teaching error and no shape-discovery path. The teach-on-error backstop the PR's design leans on did not cover file_upload.

## Fix

Add a `missingContent` guard for `file_upload` that flags any `data` key not recognized by the canonical schema (`prompt`, `acceptedTypes`, `maxFiles`, `maxSizeBytes`). When it fires, `proxyExecute` returns the teaching error — which names the exact expected shape — and never proxies, so the surface is genuinely not shown until the model resends with the correct keys.

Why flag unrecognized keys rather than require a `prompt`:

- **Requiring `prompt` would not fix the bug.** `{ prompt, accepted_types, max_files }` carries a prompt yet still silently drops the snake_case constraints.
- **It would over-reject.** The renderer draws context from the top-level `title` (which the guard never sees), so `{ title: "Upload your resume", data: {} }` is a valid, renderable surface that a prompt requirement would wrongly reject.
- Unrecognized keys are the precise "guessed the cold shape wrong" signal. Prompt-only, empty data, valid camelCase constraints, and the supported-but-unadvertised `maxSizeBytes` all pass.

The recognized-key set is derived from `FileUploadSurfaceDataSchema.shape`, so it stays in sync with the schema (single source of truth).

## Tests

Extend `ui-shape-teaching.test.ts`:

- Wrong-shape payloads (snake_case `accepted_types`/`max_files`; and a valid prompt paired with a mis-named `allowedFormats`) → teaching error that names the expected shape, without proxying.
- Valid payloads (prompt-only, camelCase constraints, empty data, `maxSizeBytes`) → proxy through untouched.

Addresses Codex review feedback on #38269. Diff is scoped to `file_upload` (leaves the form guard from #38384 untouched).