### PR TITLE
test(persistence): guard db-async-query test cleanup via shared removeTestDbFiles

### DIFF
--- a/assistant/src/plugins/defaults/memory/__tests__/db-async-query.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-async-query.test.ts
@@ -16,11 +16,13 @@
  *   4. Errors from sqlite3 surface as `ok: false` with the stderr
  *      preserved in `error`.
  */
-import { rmSync, statSync } from "node:fs";
+import { statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { beforeEach, describe, expect, test } from "bun:test";
+
+import { removeTestDbFiles } from "../../../../__tests__/assert-not-live-db.js";
 
 const { getSqlite } = await import("../../../../persistence/db-connection.js");
 const { initializeDb } = await import("../../../../persistence/db-init.js");
@@ -185,12 +187,6 @@ function tempDbPath(tag: string): string {
   return join(tmpdir(), `async-attach-${tag}-${process.pid}-${Date.now()}.db`);
 }
 
-function removeDbFiles(path: string): void {
-  for (const suffix of ["", "-wal", "-shm"]) {
-    rmSync(`${path}${suffix}`, { force: true });
-  }
-}
-
 describe("runAsyncSqlite attach mode", () => {
   test("attachStatements attaches the alias and sets it to synchronous=NORMAL", () => {
     // Both backends build their ATTACH SQL from this one helper, so a unit
@@ -234,7 +230,7 @@ describe("runAsyncSqlite attach mode", () => {
         // report FULL === 2 (the default), fsyncing every cross-DB commit.
         expect(parseChangesFromStdout(result.stdout)).toBe(1);
       } finally {
-        removeDbFiles(targetPath);
+        removeTestDbFiles(targetPath);
       }
     },
   );
@@ -270,7 +266,7 @@ describe("runAsyncSqlite attach mode", () => {
       verify.close();
       expect(count).toBe(1);
     } finally {
-      removeDbFiles(targetPath);
+      removeTestDbFiles(targetPath);
     }
   });
 });


### PR DESCRIPTION
Addresses Codex review feedback on #38385.

The attach-mode cleanup in `db-async-query.test.ts` used a local `removeDbFiles` helper that called `rmSync` on a database plus its `-wal`/`-shm` files with no `assertNotLiveDb(path)` guard — the belt that assistant/AGENTS.md mandates immediately before any destructive test delete. It also re-implemented the existing guarded `removeTestDbFiles` helper (a Single Source of Truth violation).

Delete the duplicated local helper and reuse the shared `removeTestDbFiles` from `src/__tests__/assert-not-live-db.ts`, matching the sibling `db-logs-attach.test.ts` / `db-memory-attach.test.ts` tests. This restores the live-DB guard and removes the duplication. Drops the now-unused `rmSync` import.

Test: `bun test src/plugins/defaults/memory/__tests__/db-async-query.test.ts` — 11 pass.