### PR TITLE
fix(web): carry HTTP status on non-404 workspace-theme fetch failures

### DIFF
--- a/clients/web/src/hooks/use-workspace-theme.test.ts
+++ b/clients/web/src/hooks/use-workspace-theme.test.ts
@@ -2,12 +2,16 @@
  * Pins the read contract the workspace-theme hook leans on: an assistant
  * without the route (older, or rolled back from a themed version) 404s the
  * read, which resolves to `null` so a refetch overwrites the last-applied
- * theme and the hook clears the tokens. Every other failure throws so a
- * transient error keeps the last-good theme and retries.
+ * theme and the hook clears the tokens. Every other HTTP failure throws a
+ * status-carrying {@link ApiError} so the global retry predicate can honour the
+ * no-retry-4xx policy, while a network error (no response) rethrows raw and
+ * stays retryable.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { ApiError } from "@/utils/api-errors";
+import { httpStatusFromError, shouldRetryQuery } from "@/utils/query-retry";
 import type { WorkspaceTheme } from "@/domains/settings/utils/workspace-theme-tokens";
 
 const workspaceThemeGetMock = mock(
@@ -54,18 +58,35 @@ describe("fetchWorkspaceTheme", () => {
     expect(await fetchWorkspaceTheme("assistant-1")).toBeNull();
   });
 
-  test("throws on a non-404 failure so the query keeps the last-good theme", async () => {
+  test("throws a status-carrying error on a non-404 failure so the query keeps the last-good theme", async () => {
     workspaceThemeGetMock.mockResolvedValueOnce({
       error: { detail: "boom" },
       response: { ok: false, status: 500 },
     });
 
-    await expect(fetchWorkspaceTheme("assistant-1")).rejects.toThrow();
+    const err = await fetchWorkspaceTheme("assistant-1").catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(httpStatusFromError(err)).toBe(500);
   });
 
-  test("throws on a network failure with no response", async () => {
+  test("a rate-limited (429) failure throws an error the global retry predicate won't retry", async () => {
+    workspaceThemeGetMock.mockResolvedValueOnce({
+      error: { detail: "Too Many Requests" },
+      response: { ok: false, status: 429 },
+    });
+
+    const err = await fetchWorkspaceTheme("assistant-1").catch((e) => e);
+    expect(httpStatusFromError(err)).toBe(429);
+    expect(shouldRetryQuery(0, err)).toBe(false);
+  });
+
+  test("rethrows a network failure (no response) as a retryable error", async () => {
     workspaceThemeGetMock.mockResolvedValueOnce({ response: undefined });
 
-    await expect(fetchWorkspaceTheme("assistant-1")).rejects.toThrow();
+    const err = await fetchWorkspaceTheme("assistant-1").catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    // No HTTP status → the global retry predicate treats it as transient.
+    expect(httpStatusFromError(err)).toBeUndefined();
+    expect(shouldRetryQuery(0, err)).toBe(true);
   });
 });

--- a/clients/web/src/hooks/use-workspace-theme.ts
+++ b/clients/web/src/hooks/use-workspace-theme.ts
@@ -33,6 +33,7 @@ import { workspaceThemeGetQueryKey } from "@/generated/daemon/@tanstack/react-qu
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { SYNC_TAGS } from "@/lib/sync/types";
 import { getClientId } from "@/lib/telemetry/client-identity";
+import { toApiError } from "@/utils/api-errors";
 import {
   applyWorkspaceThemeTokens,
   type WorkspaceTheme,
@@ -43,7 +44,11 @@ import {
  *
  * An assistant that lacks the route 404s this read, which resolves to `null` so
  * a refetch overwrites the last-applied theme instead of stranding it. Other
- * failures throw, so a transient error keeps the last-good theme and retries.
+ * HTTP failures throw a status-carrying error via {@link toApiError} — the
+ * `throwOnError: false` read bypasses the client's error interceptor, so the
+ * status must be attached here for the global retry predicate to honour the
+ * no-retry-4xx policy (e.g. a 429 from the request limiter). A network error
+ * (no response) rethrows raw so it retries as a transient failure.
  */
 export async function fetchWorkspaceTheme(
   assistantId: string,
@@ -57,6 +62,9 @@ export async function fetchWorkspaceTheme(
   if (!response || !response.ok) {
     if (response?.status === 404) {
       return null;
+    }
+    if (response) {
+      throw toApiError(error, response);
     }
     throw error ?? new Error("Failed to fetch workspace theme.");
   }

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -35,7 +35,7 @@ import { client as daemonClient } from "@/generated/daemon/client.gen";
 import { client as gatewayClient } from "@/generated/gateway/client.gen";
 import { ensureCsrfCookie, getCsrfToken } from "@/lib/auth/csrf";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
-import { ApiError, extractErrorMessage } from "@/utils/api-errors";
+import { ApiError, toApiError } from "@/utils/api-errors";
 import {
   isLocalMode,
   isPlatformDisabled,
@@ -470,10 +470,7 @@ export function daemonErrorInterceptor(
   if (!options.throwOnError) return error;
   if (error instanceof ApiError) return error;
   if (!response || response.ok) return error;
-  return new ApiError(
-    response.status,
-    extractErrorMessage(error, response, `HTTP ${response.status}`),
-  );
+  return toApiError(error, response);
 }
 
 daemonClient.interceptors.request.use(daemonRequestInterceptor);

--- a/clients/web/src/utils/api-errors.ts
+++ b/clients/web/src/utils/api-errors.ts
@@ -110,3 +110,16 @@ export class ApiError extends Error {
     this.status = status;
   }
 }
+
+/**
+ * Wrap a non-OK response and its raw error body into a status-carrying
+ * {@link ApiError}. The daemon client's error interceptor uses this, and so do
+ * `throwOnError: false` reads that bypass that interceptor but still need the
+ * thrown error to carry the HTTP status the global retry predicate inspects.
+ */
+export function toApiError(error: unknown, response: Response): ApiError {
+  return new ApiError(
+    response.status,
+    extractErrorMessage(error, response, `HTTP ${response.status}`),
+  );
+}


### PR DESCRIPTION
Addresses Codex review feedback on #38391 ("fix(web): map a workspace-theme 404 to the unthemed state").

#38391 switched the workspace-theme fetch to \`throwOnError: false\` so it could map a 404 → unthemed state. But for non-404 HTTP failures it then threw the raw HeyAPI error body, which carries no HTTP status. That raw body bypasses the daemon client's error interceptor (which only wraps \`throwOnError: true\` calls into status-carrying \`ApiError\`s), so the app's global React Query retry predicate (\`shouldRetryQuery\` → \`httpStatusFromError\`) could no longer see the status and retried 4xx responses — including a 429 from the request limiter — as if they were transient. That broke the documented no-retry-4xx policy and amplified rate-limit responses.

## Fix
- For non-OK, non-404 responses, \`fetchWorkspaceTheme\` now throws a status-carrying \`ApiError\` — the exact shape the interceptor produces and the retry predicate understands. A genuine network error (no \`response\`) still rethrows raw so it stays retryable as a transient failure. The 404 → unthemed mapping is unchanged.
- Extracted the interceptor's identical "wrap a non-OK response into an \`ApiError\`" construction into a shared \`toApiError(error, response)\` helper in \`api-errors.ts\`, and routed both the interceptor and the hook through it — single source of truth so the two copies can't drift.

## Tests
- Strengthened \`use-workspace-theme.test.ts\`: a 500 failure throws an \`ApiError\` whose status \`httpStatusFromError\` reads; a 429 failure throws an error the global \`shouldRetryQuery\` predicate will NOT retry; a network failure (no response) stays retryable. 6 pass.
- \`api-interceptors.test.ts\` unchanged and green (69 pass) — the extraction is behavior-preserving.