### PR TITLE
fix(apps): reach app_id fallback from app mutation side-effect hooks

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -2,9 +2,10 @@
  * Regression tests for app surface refresh and eventing side effects in
  * createToolExecutor (conversation-tool-setup.ts).
  *
- * Tests verify that app_refresh, app_update, app_create, and app_delete hooks
- * fire correctly, and that non-hooked tools (app_file_edit, app_file_write) do
- * not trigger side effects.
+ * Tests verify that app_refresh, app_update, app_create, app_delete, and
+ * app_generate_icon hooks fire correctly — including recovering an omitted
+ * app_id from the executor's echoed result — and that non-hooked tools
+ * (app_file_edit, app_file_write) do not trigger side effects.
  *
  * File-change detection for file_write/file_edit is handled by
  * AppSourceWatcher (see app-source-watcher.test.ts).
@@ -222,7 +223,35 @@ describe("session-tool-setup app refresh side effects", () => {
       expect(updatePublishedSpy).not.toHaveBeenCalled();
     });
 
-    test("skips side effects when app_id is missing", async () => {
+    test("recovers appId from the result when input omits app_id", async () => {
+      // app_id is optional: the skill script resolves the active app and the
+      // executor echoes it back as `appId`. The hook must act on that resolved
+      // id so an omitted-id refresh still refreshes surfaces and re-deploys.
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: '{"refreshed":true,"appId":"app-resolved"}',
+        isError: false,
+      });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+      );
+
+      await toolFn("app_refresh", {});
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect((refreshSpy.mock.calls as unknown[][])[0][1]).toBe("app-resolved");
+      expectAppChangeBroadcast("app-resolved");
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      expect((updatePublishedSpy.mock.calls as unknown[][])[0][0]).toBe(
+        "app-resolved",
+      );
+    });
+
+    test("skips side effects when app_id is absent from input and result", async () => {
       const ctx = makeCtx();
       const executor = makeFakeExecutor({ content: "{}", isError: false });
 
@@ -289,7 +318,34 @@ describe("session-tool-setup app refresh side effects", () => {
       expect(updatePublishedSpy).not.toHaveBeenCalled();
     });
 
-    test("skips side effects when app_id is missing", async () => {
+    test("recovers appId from the result when input omits app_id", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: '{"updated":true,"appId":"app-resolved-u"}',
+        isError: false,
+      });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+      );
+
+      await toolFn("app_update", {});
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect((refreshSpy.mock.calls as unknown[][])[0][1]).toBe(
+        "app-resolved-u",
+      );
+      expectAppChangeBroadcast("app-resolved-u");
+      expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+      expect((updatePublishedSpy.mock.calls as unknown[][])[0][0]).toBe(
+        "app-resolved-u",
+      );
+    });
+
+    test("skips side effects when app_id is absent from input and result", async () => {
       const ctx = makeCtx();
       const executor = makeFakeExecutor({ content: "{}", isError: false });
 
@@ -506,6 +562,70 @@ describe("session-tool-setup app refresh side effects", () => {
       );
 
       await toolFn("app_delete", { app_id: "del-err" });
+
+      expect(broadcastSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── app_generate_icon side effects ──────────────────────────────────
+
+  describe("app_generate_icon side effects", () => {
+    test("broadcasts app_files_changed with explicit app_id", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: '{"generated":true,"appId":"icon-app"}',
+        isError: false,
+      });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+      );
+
+      await toolFn("app_generate_icon", { app_id: "icon-app" });
+
+      expect(broadcastSpy).toHaveBeenCalledTimes(2);
+      expectAppChangeBroadcast("icon-app");
+      // Icon regen only rebroadcasts the app list — it neither refreshes open
+      // surfaces nor re-deploys the published app.
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(updatePublishedSpy).not.toHaveBeenCalled();
+    });
+
+    test("recovers appId from the result when input omits app_id", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: '{"generated":true,"appId":"icon-resolved"}',
+        isError: false,
+      });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+      );
+
+      await toolFn("app_generate_icon", {});
+
+      expect(broadcastSpy).toHaveBeenCalledTimes(2);
+      expectAppChangeBroadcast("icon-resolved");
+    });
+
+    test("skips broadcast when app_id is absent from input and result", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({ content: "{}", isError: false });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+      );
+
+      await toolFn("app_generate_icon", {});
 
       expect(broadcastSpy).not.toHaveBeenCalled();
     });

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -70,6 +70,35 @@ function broadcastAppFilesChanged(appId: string): void {
   publishAppsChanged();
 }
 
+/**
+ * Resolve the app id a post-execution hook should act on.
+ *
+ * `app_id` is optional for the app-builder fallback tools (`app_update`,
+ * `app_refresh`, `app_generate_icon`): when the model omits it, the skill
+ * script resolves the conversation's active app and the executor echoes that
+ * id back as `appId` in its result. Prefer the explicit tool input; fall back
+ * to the resolved id the result carries so an omitted-id call still refreshes
+ * surfaces, rebroadcasts, and re-deploys instead of silently no-op'ing.
+ */
+function resolveHookAppId(
+  input: Record<string, unknown>,
+  result: ToolExecutionResult,
+): string | undefined {
+  const explicit = input.app_id;
+  if (typeof explicit === "string" && explicit.trim().length > 0) {
+    return explicit;
+  }
+  try {
+    const parsed = JSON.parse(result.content) as { appId?: unknown };
+    if (typeof parsed.appId === "string" && parsed.appId.length > 0) {
+      return parsed.appId;
+    }
+  } catch {
+    // Result wasn't valid JSON — no resolved id to recover.
+  }
+  return undefined;
+}
+
 // ── Registry ─────────────────────────────────────────────────────────
 
 /**
@@ -130,8 +159,8 @@ registerHook("app_create", (_name, _input, result, { ctx }) => {
   }
 });
 
-registerHook("app_generate_icon", (_name, input) => {
-  const appId = input.app_id as string | undefined;
+registerHook("app_generate_icon", (_name, input, result) => {
+  const appId = resolveHookAppId(input, result);
   if (appId) {
     broadcastAppFilesChanged(appId);
   }
@@ -144,31 +173,26 @@ registerHook("app_delete", (_name, input) => {
   }
 });
 
-registerHook("app_refresh", (_name, input, _result, { ctx }) => {
-  const appId = input.app_id as string | undefined;
-  if (!appId) return;
-  try {
-    addAppConversationId(appId, ctx.conversationId);
-  } catch (err) {
-    log.warn({ err, appId }, "Failed to track conversation ID on app_refresh");
-  }
-  notifyAppChanged(ctx, appId, { fileChange: true });
-});
-
-// app_update compiles internally (like app_refresh) but emits no events of its
-// own, so without this hook an updated app leaves open surfaces rendering the
-// stale dist and never re-deploys or invalidates the Library. The executor owns
-// the compile; notifyAppChanged only refreshes surfaces and broadcasts.
-registerHook("app_update", (_name, input, _result, { ctx }) => {
-  const appId = input.app_id as string | undefined;
-  if (!appId) return;
-  try {
-    addAppConversationId(appId, ctx.conversationId);
-  } catch (err) {
-    log.warn({ err, appId }, "Failed to track conversation ID on app_update");
-  }
-  notifyAppChanged(ctx, appId, { fileChange: true });
-});
+// app_refresh and app_update mutate an app's source but emit no events of their
+// own, so without a hook an updated app leaves open surfaces rendering the stale
+// dist and never re-deploys or invalidates the Library. The executor owns the
+// compile; notifyAppChanged only refreshes surfaces and broadcasts.
+function registerAppSurfaceRefreshHook(toolName: string): void {
+  registerHook(toolName, (name, input, result, { ctx }) => {
+    const appId = resolveHookAppId(input, result);
+    if (!appId) {
+      return;
+    }
+    try {
+      addAppConversationId(appId, ctx.conversationId);
+    } catch (err) {
+      log.warn({ err, appId }, `Failed to track conversation ID on ${name}`);
+    }
+    notifyAppChanged(ctx, appId, { fileChange: true });
+  });
+}
+registerAppSurfaceRefreshHook("app_refresh");
+registerAppSurfaceRefreshHook("app_update");
 
 registerHook("voice_config_update", (_name, input) => {
   const setting = input.setting as string | undefined;


### PR DESCRIPTION
## Summary

Addresses Codex review feedback on merged PR #38397.

#38397 made `app_id` **optional** for the app-builder fallback tools (`app_update`, `app_refresh`, `app_generate_icon`): when the model omits it, the skill script resolves the conversation's most-recently-updated app. But the post-execution side-effect hooks in `tool-side-effects.ts` still read the **original** tool input (`input.app_id`) and returned early when it was missing. So an omitted-id call succeeded but silently skipped `notifyAppChanged` — no open-surface refresh, no `app_files_changed` broadcast, and no `updatePublishedAppDeployment` after a successful edit (and no icon rebroadcast for `app_generate_icon`).

## Fix

The executors already echo the resolved id back as `appId` in their JSON result (`executeAppRefresh`/`executeAppUpdate`/`executeAppGenerateIcon`). A new `resolveHookAppId(input, result)` helper prefers an explicit `input.app_id` and falls back to the result's `appId` when it is absent — the same pattern the existing `app_create` hook already uses to read its id from the result. This uses the exact id the executor operated on (no extra DB query, no re-resolution race — the cleaner of the two options in the feedback).

Also folds the now-identical `app_refresh`/`app_update` hook bodies (resolve → track conversation → refresh surfaces/redeploy) into one `registerAppSurfaceRefreshHook` helper (SSOT), preserving the exact per-tool log strings.

`app_delete` is unchanged — #38397 kept its `app_id` required, so its input always carries the id.

## Tests

Extends `conversation-tool-setup-app-refresh.test.ts`: each of `app_refresh`/`app_update`/`app_generate_icon` now has a test proving the hook recovers `appId` from the result when the tool input omits it, plus a defensive test that side effects are skipped only when neither input nor result carries an id. Adds first-time hook coverage for `app_generate_icon`. 23 pass, 0 fail; `typecheck:fast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)