### PR TITLE
fix(web): route usage breakdown conversation rows through shared navigator

### DIFF
--- a/clients/web/src/components/sidebar-tree.tsx
+++ b/clients/web/src/components/sidebar-tree.tsx
@@ -3,6 +3,7 @@ import { Fragment } from "react";
 import { useLocation, useNavigate } from "react-router";
 
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { isModifiedLinkClick } from "@/utils/link-click";
 import { SideMenu } from "@vellumai/design-library";
 
 export interface SidebarItem {
@@ -61,13 +62,7 @@ export function SidebarTree({
                   // so Cmd/Ctrl-click opens a new tab, Shift-click opens a
                   // window, and "Copy link address" works. Plain left-clicks
                   // become SPA navigation via react-router.
-                  if (
-                    e.metaKey ||
-                    e.ctrlKey ||
-                    e.shiftKey ||
-                    e.altKey ||
-                    e.button !== 0
-                  ) {
+                  if (isModifiedLinkClick(e)) {
                     return;
                   }
                   e.preventDefault();

--- a/clients/web/src/domains/settings/billing/usage/usage-tab.tsx
+++ b/clients/web/src/domains/settings/billing/usage/usage-tab.tsx
@@ -60,6 +60,8 @@ import {
     schedulesGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { PromptLaunchButton } from "@/components/prompt-launch-button";
+import { navigateToConversation } from "@/utils/conversation-navigation";
+import { isModifiedLinkClick } from "@/utils/link-click";
 import { extractUsageProfileMetadata } from "@/utils/profile-metadata";
 import { routes } from "@/utils/routes";
 import { fetchSchedules, type AssistantSchedule } from "@/utils/schedules";
@@ -920,7 +922,7 @@ function BreakdownTable({
                         if ((event.target as HTMLElement).closest("a")) {
                           return;
                         }
-                        navigate(routes.conversation(conversationId));
+                        navigateToConversation(navigate, conversationId);
                       }
                     : undefined
                 }
@@ -938,6 +940,18 @@ function BreakdownTable({
                       to={routes.conversation(conversationId)}
                       className="block truncate text-body-medium-lighter"
                       title={group.group}
+                      onClick={(event) => {
+                        // Modifier and middle clicks fall through to the
+                        // native <a> so Cmd/Ctrl-click opens a new tab and
+                        // "Copy link address" works. Plain left-clicks route
+                        // through the shared navigator, which resets viewer
+                        // state before navigating.
+                        if (isModifiedLinkClick(event)) {
+                          return;
+                        }
+                        event.preventDefault();
+                        navigateToConversation(navigate, conversationId);
+                      }}
                     >
                       {group.group}
                     </Link>

--- a/clients/web/src/utils/link-click.ts
+++ b/clients/web/src/utils/link-click.ts
@@ -1,0 +1,23 @@
+/**
+ * Whether a mouse click on a link should fall through to the browser's native
+ * anchor handling instead of being intercepted for client-side SPA navigation.
+ *
+ * True for modifier-key clicks (Cmd/Ctrl/Shift/Alt) and non-primary buttons
+ * (middle/right) — those must open a new tab or window, or the context menu,
+ * rather than trigger an in-app navigation. Plain left-clicks return false so
+ * the caller can `preventDefault()` and navigate via react-router.
+ */
+export function isModifiedLinkClick(
+  event: Pick<
+    MouseEvent,
+    "metaKey" | "ctrlKey" | "shiftKey" | "altKey" | "button"
+  >,
+): boolean {
+  return (
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey ||
+    event.button !== 0
+  );
+}


### PR DESCRIPTION
Addresses Codex review feedback on #38375.

The usage breakdown conversation rows navigated with `navigate(routes.conversation(...))` directly — both the row onClick and the group-name Link — skipping the viewer-state reset that `navigateToConversation()` performs (mainView -> "chat", reset subagent/workflow state, set active conversation). Opening Billing while a full-screen app viewer or detail panel was active left the transcript hidden behind the stale viewer store after clicking a row.

Both the programmatic navigate and the Link path now route through the shared `navigateToConversation()` helper. The Link keeps its href so Cmd/Ctrl-click still opens a new tab, "Copy link address" works, and it stays keyboard-accessible; a modifier/middle-click guard lets those fall through to the native anchor.

Extracted that modifier-click guard into `isModifiedLinkClick` (utils/link-click.ts), shared with sidebar-tree.tsx which had the same inline idiom (single source of truth).