### PR TITLE
fix(daemon): skip channel reply delivery for deduped ingress redeliveries

### DIFF
--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -410,6 +410,13 @@ export async function processMessage(
   messageId: string;
   assistantMessageId?: string;
   /**
+   * True when this ingress deduplicated against a prior turn (same idempotency
+   * key) and the agent loop was skipped. Channel finalization must skip reply
+   * delivery on this signal so an at-least-once redelivery does not re-emit the
+   * original turn's reply.
+   */
+  deduplicated?: boolean;
+  /**
    * The agent turn's failure outcome, or `null` when it replied normally. Set
    * when the turn failed (e.g. its LLM call failed with an invalid provider) —
    * that path persists a synthetic error message and returns normally rather
@@ -676,12 +683,18 @@ export async function processMessage(
 
   if (deduplicated) {
     // This exact ingress (same idempotency key) already ran a turn; skip the
-    // loop so an at-least-once redelivery does not emit a second reply.
+    // loop so an at-least-once redelivery does not emit a second reply. The
+    // `deduplicated` signal also stops channel finalization from re-delivering
+    // the original reply.
     log.info(
       { conversationId, messageId },
       "Skipping agent loop for deduplicated ingress message",
     );
-    return { messageId, turnFailure: readTurnFailure(messageId) };
+    return {
+      messageId,
+      deduplicated: true,
+      turnFailure: readTurnFailure(messageId),
+    };
   }
 
   if (options?.isInteractive === true) {

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -110,7 +110,17 @@ export type MessageProcessor = (
   conversationId: string,
   content: string,
   options?: RuntimeMessageConversationOptions,
-) => Promise<{ messageId: string; assistantMessageId?: string }>;
+) => Promise<{
+  messageId: string;
+  assistantMessageId?: string;
+  /**
+   * True when the persist layer deduplicated this ingress against a prior turn
+   * (same idempotency key) and no agent loop ran. Channel finalization must
+   * skip reply delivery on this signal so an at-least-once redelivery does not
+   * re-emit the original turn's reply.
+   */
+  deduplicated?: boolean;
+}>;
 
 /**
  * Dependencies for the POST /v1/messages handler.

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -337,6 +337,42 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
     clearThreadTs(conversationId);
   });
 
+  test("suppresses reply delivery when the ingress deduplicated against a prior turn", async () => {
+    const conversationId = "conv-dedup-ingress";
+    const channelId = "C-DEDUP-INGRESS";
+
+    // At-least-once redelivery: the persist layer dedups on the idempotency
+    // key, so processMessage skips the agent loop and returns `deduplicated`.
+    const processMessage: MessageProcessor = async () => ({
+      messageId: "user-msg-dedup",
+      deduplicated: true,
+    });
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-dedup",
+      content: "redelivered message",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    // The redelivery is recorded as processed, but the original reply is not
+    // re-delivered — no durable delivery, no terminal delivery transition.
+    expect(markedProcessedEvents).toEqual(["evt-dedup"]);
+    expect(replyDeliveryCalls).toEqual([]);
+    expect(deliveredEvents).toEqual([]);
+    expect(deliveredChannelReplies).toEqual([]);
+
+    clearThreadTs(conversationId);
+  });
+
   test("falls back to durable delivery for a non-threaded Slack DM", async () => {
     const conversationId = "conv-dm-no-thread";
     const channelId = "D-NO-THREAD";

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -261,6 +261,7 @@ export function processChannelMessageInBackground(
       };
 
       let userMessageId: string | undefined;
+      let deduplicatedIngress = false;
       try {
         const result = await processMessage(conversationId, content, {
           attachmentIds,
@@ -282,6 +283,7 @@ export function processChannelMessageInBackground(
           sourceInterface,
         });
         userMessageId = result.messageId;
+        deduplicatedIngress = result.deduplicated === true;
         linkMessage(eventId, userMessageId);
         markProcessed(eventId);
         replyMessageId ??= result.assistantMessageId;
@@ -324,7 +326,15 @@ export function processChannelMessageInBackground(
         return;
       }
 
-      if (replyCallbackUrl) {
+      if (deduplicatedIngress) {
+        // The original turn already delivered its reply; a redelivery of the
+        // same ingress must not re-emit it. `finalizeEventDelivery` would
+        // re-deliver via `sinceMessageId: userMessageId`, so skip it entirely.
+        log.info(
+          { conversationId, eventId },
+          "Skipping channel reply delivery for deduplicated ingress event",
+        );
+      } else if (replyCallbackUrl) {
         try {
           await finalizeEventDelivery({
             eventId,


### PR DESCRIPTION
## Problem

PR #38378 dedups at-least-once ingress redeliveries so a turn runs once, but the dedup branch in `processMessage` returned only the existing `messageId` — with **no signal** that the agent loop was skipped. `processChannelMessageInBackground` treats any successful `processMessage` result as deliverable and calls `finalizeEventDelivery` → `deliverReplyViaCallback({ sinceMessageId: userMessageId })`, which re-delivers the original turn's assistant reply.

So a redelivery with the same Slack `channelTs` (but a new inbound event) correctly skipped `runAgentLoop` yet still **re-emitted the reply** — the exact double-emit PR #38378 was meant to prevent.

## Fix

- `processMessage` now returns `deduplicated: true` from its dedup branch, surfaced on the shared `MessageProcessor` contract (`http-types.ts`).
- `processChannelMessageInBackground` skips `finalizeEventDelivery` on that signal while still recording the event as processed (`linkMessage` + `markProcessed`). Only the redundant delivery is suppressed; PR #38378's dedup behavior is preserved.

The retry-sweep path (`sweepFailedEvents`) also calls `finalizeEventDelivery`, but it threads no idempotency key into `processMessage`, so it can never dedup — a guard there would be unreachable. The `MessageProcessor.deduplicated` doc records the invariant for any future change that threads a key through the replay.

## Tests

Added a `background-dispatch` case asserting a deduped ingress is marked processed but performs **no** durable delivery and **no** terminal delivery transition.

Addresses Codex review feedback on #38378.