### PR TITLE
fix(voice): keep friendly STT copy for managed failures without platform detail

### DIFF
--- a/assistant/src/platform/managed-speech.ts
+++ b/assistant/src/platform/managed-speech.ts
@@ -27,6 +27,14 @@ export type ManagedSpeechResult<T> =
       status?: number;
       /** Platform error code (e.g. `insufficient_balance`) when the body carried one. */
       code?: string;
+      /**
+       * Platform-supplied human-readable message, present only when the error
+       * body carried a `detail` field. Absent when the failure fell back to a
+       * bare HTTP status. `message` mirrors this when set; callers use the
+       * presence of `detail` to distinguish real platform copy (safe to surface
+       * verbatim) from the generic status fallback.
+       */
+      detail?: string;
       message: string;
     };
 
@@ -197,6 +205,7 @@ async function platformError(
     kind: "platform-error",
     status: response.status,
     code,
+    detail,
     message:
       detail ??
       `Managed speech ${operation} failed (platform returned ${response.status}).`,

--- a/assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { SttError } from "../../../stt/types.js";
+import { describeSttFailure } from "../../voice-error-copy.js";
 
 let mockTranscribeResult: unknown;
 let mockClient: { platformAssistantId: string } | null = null;
@@ -65,15 +66,21 @@ describe("vellumManagedTranscribe", () => {
 
 describe("sttErrorFromManagedSpeech", () => {
   const cases: Array<{
+    name: string;
     failure: Record<string, unknown>;
     category: string;
+    userFacing: boolean;
     messageIncludes?: string;
   }> = [
     {
+      name: "unavailable → auth, user-facing reconnect copy",
       failure: { ok: false, kind: "unavailable", message: "no connection" },
       category: "auth",
+      userFacing: true,
+      messageIncludes: "no connection",
     },
     {
+      name: "insufficient_balance → provider-error, user-facing credit copy",
       failure: {
         ok: false,
         kind: "platform-error",
@@ -82,43 +89,155 @@ describe("sttErrorFromManagedSpeech", () => {
         message: "balance",
       },
       category: "provider-error",
+      userFacing: true,
       messageIncludes: "Vellum credits",
     },
+    // Platform-supplied `detail` present: real remediation, surfaced verbatim.
     {
-      failure: { ok: false, kind: "platform-error", status: 401, message: "m" },
+      name: "401 with platform detail → auth, user-facing verbatim",
+      failure: {
+        ok: false,
+        kind: "platform-error",
+        status: 401,
+        detail: "Your session expired.",
+        message: "Your session expired.",
+      },
       category: "auth",
+      userFacing: true,
+      messageIncludes: "session expired",
     },
     {
-      failure: { ok: false, kind: "platform-error", status: 403, message: "m" },
-      category: "auth",
-    },
-    {
-      failure: { ok: false, kind: "platform-error", status: 429, message: "m" },
+      name: "429 with platform detail → rate-limit, user-facing verbatim",
+      failure: {
+        ok: false,
+        kind: "platform-error",
+        status: 429,
+        detail: "Too many requests, retry in 30s.",
+        message: "Too many requests, retry in 30s.",
+      },
       category: "rate-limit",
+      userFacing: true,
+      messageIncludes: "retry in 30s",
     },
     {
-      failure: { ok: false, kind: "platform-error", status: 413, message: "m" },
+      name: "413 with platform detail → invalid-audio, user-facing verbatim",
+      failure: {
+        ok: false,
+        kind: "platform-error",
+        status: 413,
+        detail: "Audio exceeds the 25 MB limit.",
+        message: "Audio exceeds the 25 MB limit.",
+      },
       category: "invalid-audio",
+      userFacing: true,
+      messageIncludes: "25 MB",
+    },
+    // No platform `detail`: the generic "(platform returned N)" fallback stays
+    // non-user-facing so describeSttFailure emits friendly category copy
+    // instead of leaking a raw HTTP status.
+    {
+      name: "401 without detail → auth, not user-facing",
+      failure: {
+        ok: false,
+        kind: "platform-error",
+        status: 401,
+        message: "Managed speech transcription failed (platform returned 401).",
+      },
+      category: "auth",
+      userFacing: false,
     },
     {
-      failure: { ok: false, kind: "platform-error", status: 502, message: "m" },
+      name: "403 without detail → auth, not user-facing",
+      failure: {
+        ok: false,
+        kind: "platform-error",
+        status: 403,
+        message: "Managed speech transcription failed (platform returned 403).",
+      },
+      category: "auth",
+      userFacing: false,
+    },
+    {
+      name: "429 without detail → rate-limit, not user-facing",
+      failure: {
+        ok: false,
+        kind: "platform-error",
+        status: 429,
+        message: "Managed speech transcription failed (platform returned 429).",
+      },
+      category: "rate-limit",
+      userFacing: false,
+    },
+    {
+      name: "413 without detail → invalid-audio, not user-facing",
+      failure: {
+        ok: false,
+        kind: "platform-error",
+        status: 413,
+        message: "Managed speech transcription failed (platform returned 413).",
+      },
+      category: "invalid-audio",
+      userFacing: false,
+    },
+    {
+      name: "502 without detail → provider-error, not user-facing",
+      failure: {
+        ok: false,
+        kind: "platform-error",
+        status: 502,
+        message: "Managed speech transcription failed (platform returned 502).",
+      },
       category: "provider-error",
+      userFacing: false,
     },
   ];
 
-  for (const { failure, category, messageIncludes } of cases) {
-    test(`${failure.kind}/${String(failure.code ?? failure.status ?? "-")} → ${category}`, () => {
+  for (const {
+    name,
+    failure,
+    category,
+    userFacing,
+    messageIncludes,
+  } of cases) {
+    test(name, () => {
       const err = sttErrorFromManagedSpeech(
         failure as Parameters<typeof sttErrorFromManagedSpeech>[0],
       );
       expect(err).toBeInstanceOf(SttError);
       expect(err.category).toBe(category as SttError["category"]);
-      // Managed messages carry their own remediation — flagged so
-      // describeSttFailure surfaces them verbatim, not the BYOK rewrite.
-      expect(err.userFacing).toBe(true);
+      // Verbatim only when the failure carries real remediation; a bare
+      // HTTP-status fallback stays non-user-facing for friendly rewrite.
+      expect(err.userFacing).toBe(userFacing);
       if (messageIncludes) {
         expect(err.message).toContain(messageIncludes);
       }
     });
   }
+});
+
+describe("describeSttFailure over managed STT failures", () => {
+  test("surfaces a platform-supplied detail verbatim", () => {
+    const err = sttErrorFromManagedSpeech({
+      ok: false,
+      kind: "platform-error",
+      status: 429,
+      detail: "Too many requests, retry in 30s.",
+      message: "Too many requests, retry in 30s.",
+    });
+    expect(describeSttFailure(err, "vellum")).toBe(
+      "Too many requests, retry in 30s.",
+    );
+  });
+
+  test("replaces a bare HTTP-status fallback with friendly category copy", () => {
+    const err = sttErrorFromManagedSpeech({
+      ok: false,
+      kind: "platform-error",
+      status: 429,
+      message: "Managed speech transcription failed (platform returned 429).",
+    });
+    const copy = describeSttFailure(err, "vellum");
+    expect(copy).not.toContain("platform returned 429");
+    expect(copy).toContain("rate-limiting");
+  });
 });

--- a/assistant/src/providers/speech-to-text/vellum-managed.ts
+++ b/assistant/src/providers/speech-to-text/vellum-managed.ts
@@ -33,17 +33,24 @@ export async function vellumManagedSpeechAvailable(): Promise<boolean> {
  * `insufficient_balance` gets a user-actionable message — the fix is topping
  * up Vellum credits, not editing provider config.
  *
- * Every returned error is flagged `userFacing`: managed speech has no provider
- * API key on this machine, so the messages here (reconnect the platform,
- * top up credits, the platform's own detail) already carry the correct
- * remediation. `describeSttFailure` surfaces them verbatim instead of
- * rewriting to the BYOK "check your API key" copy that never applies.
+ * Managed speech has no provider API key on this machine, so the BYOK "check
+ * your API key" rewrite never applies. A failure is flagged `userFacing` —
+ * surfaced verbatim by `describeSttFailure` — only when it already carries
+ * actionable remediation: a platform reconnect (`unavailable`), a credit
+ * top-up (`insufficient_balance`), or the platform's own `detail` message. A
+ * failure that fell back to a bare HTTP status (no `detail`) is left
+ * non-user-facing so `describeSttFailure` emits friendly category copy instead
+ * of leaking the raw status.
  */
 export function sttErrorFromManagedSpeech(
   failure: ManagedSpeechFailure,
 ): SttError {
+  const userFacing =
+    failure.kind === "unavailable" ||
+    failure.code === "insufficient_balance" ||
+    failure.detail !== undefined;
   const managed = (category: SttErrorCategory, message: string): SttError =>
-    new SttError(category, message, { userFacing: true });
+    new SttError(category, message, { userFacing });
 
   if (failure.kind === "unavailable") {
     return managed("auth", failure.message);


### PR DESCRIPTION
## Summary

Addresses Codex review feedback on #38392 ("fix(voice): preserve managed STT error messages instead of the BYOK rewrite").

#38392 marked **every** managed STT failure `userFacing` so real platform `detail` messages surface instead of the misleading BYOK "check your API key" rewrite. But when the platform returns a non-JSON error body or omits `detail`, `platformError()` falls back to a bare-status message like `Managed speech transcription failed (platform returned 429).` — and marking those `userFacing` too made `describeSttFailure()` surface that raw HTTP-status fallback verbatim, violating the file's contract to never leak raw HTTP statuses to users.

## Fix

- `platformError()` (in `platform/managed-speech.ts`) now records the platform-supplied `detail` on the failure result separately from the composed `message` (which stays `detail ?? "(platform returned N)"` fallback). The presence of `detail` is the signal for "real platform copy vs. generic status fallback".
- `sttErrorFromManagedSpeech()` (in `providers/speech-to-text/vellum-managed.ts`) flags a failure `userFacing` only when it carries actionable remediation: a platform reconnect (`unavailable`), a credit top-up (`insufficient_balance`), or a platform `detail`. Bare-status fallbacks stay non-user-facing, so `describeSttFailure()` produces its friendly rate-limit / invalid-audio / provider category copy instead of the raw status.

The PR's intent is preserved: genuine platform `detail` messages still surface verbatim.

## Tests

Split the managed-STT case table into detail-present (verbatim, user-facing) vs. detail-absent (friendly fallback, non-user-facing) across each status branch, and added end-to-end `describeSttFailure` coverage that locks the regression (bare-status 429 → friendly rate-limit copy, never `platform returned 429`).

Ran `assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts` (16 pass) and `tsgo --noEmit` (clean).

## Files

- `assistant/src/platform/managed-speech.ts`
- `assistant/src/providers/speech-to-text/vellum-managed.ts`
- `assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts`