### PR TITLE
fix(daemon): guard resume-counter write per conversation

### DIFF
--- a/assistant/src/__tests__/interrupted-turn-reconciler.test.ts
+++ b/assistant/src/__tests__/interrupted-turn-reconciler.test.ts
@@ -19,6 +19,9 @@ import { initializeDb } from "../persistence/db-init.js";
 
 await initializeDb();
 
+const actualConversationCrud =
+  await import("../persistence/conversation-crud.js");
+
 function readRow(id: string): {
   processing_started_at: number | null;
   processing_resume_attempts: number;
@@ -252,6 +255,49 @@ describe("resumeInterruptedConversations", () => {
     // did not block the remaining conversation.
     expect(wakeCalls).toEqual(["conv-bad", "conv-good"]);
     expect(readRow("conv-bad").processing_resume_attempts).toBe(1);
+    expect(readRow("conv-good").processing_resume_attempts).toBe(1);
+  });
+
+  test("a failing counter write is isolated to its conversation and does not abort the rest", async () => {
+    createConversation({ id: "conv-bad" });
+    createConversation({ id: "conv-good" });
+
+    // A transient counter-write failure (e.g. a locked SQLite db during
+    // startup) must be logged and skipped for that conversation, exactly like a
+    // failing wake — never rejected out of the loop, which would strand every
+    // conversation queued behind it.
+    // Captured before mock.module: the namespace binding is live post-mock, so
+    // delegating through it would recurse into this override.
+    const realIncrement =
+      actualConversationCrud.incrementProcessingResumeAttempts;
+    mock.module("../persistence/conversation-crud.js", () => ({
+      ...actualConversationCrud,
+      incrementProcessingResumeAttempts: (id: string) => {
+        if (id === "conv-bad") {
+          throw new Error("counter write failed");
+        }
+        return realIncrement(id);
+      },
+    }));
+
+    const wakeCalls: string[] = [];
+    const wakeMock = mock(async (opts: Record<string, unknown>) => {
+      wakeCalls.push(opts.conversationId as string);
+      return { invoked: true, producedToolCalls: false };
+    });
+    mock.module("../runtime/agent-wake.js", () => ({
+      wakeAgentForOpportunity: wakeMock,
+    }));
+
+    await resumeInterruptedConversations([
+      guardianTarget("conv-bad"),
+      guardianTarget("conv-good"),
+    ]);
+
+    // conv-bad's counter threw before its wake ran, so it was skipped and never
+    // charged; conv-good still resumed and charged its own attempt.
+    expect(wakeCalls).toEqual(["conv-good"]);
+    expect(readRow("conv-bad").processing_resume_attempts).toBe(0);
     expect(readRow("conv-good").processing_resume_attempts).toBe(1);
   });
 });

--- a/assistant/src/daemon/interrupted-turn-reconciler.ts
+++ b/assistant/src/daemon/interrupted-turn-reconciler.ts
@@ -168,13 +168,16 @@ export async function resumeInterruptedConversations(
 ): Promise<void> {
   const { wakeAgentForOpportunity } = await import("../runtime/agent-wake.js");
   for (const { conversationId, trustContext } of targets) {
-    // Charge the attempt as the wake begins, before the turn runs. The cap
-    // exists to stop a resumed turn that keeps killing the process, so the
-    // counter must be durably incremented before that turn can crash the
-    // daemon; a sequential increment here also means a crash mid-resume never
-    // charges the conversations still queued behind it.
-    incrementProcessingResumeAttempts(conversationId);
     try {
+      // Charge the attempt before the wake runs. The cap exists to stop a
+      // resumed turn that keeps killing the process, so the counter must be
+      // durably incremented before that turn can crash the daemon; charging it
+      // per-conversation (never up-front for the batch) also means a crash
+      // mid-resume never burns the budget of conversations still queued behind
+      // it. Doing it inside this guarded block keeps a transient counter-write
+      // failure scoped to its own conversation instead of aborting every
+      // resume still queued.
+      incrementProcessingResumeAttempts(conversationId);
       const result = await wakeAgentForOpportunity({
         conversationId,
         hint: INTERRUPTED_TURN_RESUME_HINT,


### PR DESCRIPTION
Addresses Codex review feedback on #38393.

## Problem

`resumeInterruptedConversations()` charged the resume-attempt counter via `incrementProcessingResumeAttempts()` *outside* the per-conversation `try`. A transient SQLite error on that write (e.g. a locked db during startup resume) rejected the whole function. Because lifecycle invokes it as `void resumeInterruptedConversations(...)`, every conversation queued behind the failing one was silently stranded — bypassing the intended "one bad conversation doesn't block the rest" skip/log behavior.

## Fix

Move `incrementProcessingResumeAttempts()` inside the guarded `try`, still before the wake so the crash-loop guard ordering is preserved (the counter is durably incremented before the resumed turn can crash the daemon). A counter-write failure is now logged and skipped for that conversation, and the loop continues to the next.

## Tests

Extends `interrupted-turn-reconciler.test.ts` with a regression test that forces the counter write to throw for one conversation and asserts the next conversation still resumes and charges its own attempt. Ran only that file: 11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)