### PR TITLE
fix(gateway): a present non-pass DMARC verdict blocks the DKIM sender-auth fallback

### DIFF
--- a/gateway/src/email/normalize.test.ts
+++ b/gateway/src/email/normalize.test.ts
@@ -234,6 +234,40 @@ describe("evaluateSenderAuthentication", () => {
     );
   });
 
+  it("treats dmarc=fail as authoritative even when an aligned DKIM passes", () => {
+    // The receiver applied the From: domain's own DMARC policy and reported
+    // failure, so the aligned `dkim=pass` must not re-authenticate the visible
+    // From: — a fail verdict overrides the DKIM-alignment fallback.
+    const authResults =
+      "mx.resend.com; dkim=pass header.d=example.com; " +
+      "dmarc=fail header.from=mail.example.com";
+    expect(
+      evaluateSenderAuthentication({
+        authResults,
+        // generic-examples:ignore-next-line — reason: relaxed DMARC alignment needs a subdomain of the reserved example.com
+        fromEmail: "alice@mail.example.com",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a DMARC permerror as unauthenticated despite an aligned DKIM", () => {
+    // An evaluation error is not a clean pass: the receiver could not confirm
+    // the domain's policy, so we do not substitute our alignment heuristic.
+    const authResults =
+      "mx.resend.com; dkim=pass header.d=example.com; dmarc=permerror";
+    expect(evaluateSenderAuthentication({ authResults, fromEmail: FROM })).toBe(
+      false,
+    );
+  });
+
+  it("treats a DMARC temperror as unauthenticated despite an aligned DKIM", () => {
+    const authResults =
+      "mx.resend.com; dkim=pass header.d=example.com; dmarc=temperror";
+    expect(evaluateSenderAuthentication({ authResults, fromEmail: FROM })).toBe(
+      false,
+    );
+  });
+
   it("returns undefined when there is no Authentication-Results header", () => {
     // No signal → undefined so the caller omits it and handleInbound preserves
     // existing behavior rather than downgrading every sender on missing data.
@@ -251,6 +285,27 @@ describe("evaluateSenderAuthentication", () => {
       "dkim=pass header.d=example.com header.s=sel";
     expect(evaluateSenderAuthentication({ authResults, fromEmail: FROM })).toBe(
       true,
+    );
+  });
+
+  it("falls back to aligned DKIM when DMARC reports no policy (dmarc=none)", () => {
+    // `dmarc=none` means the From: domain publishes no DMARC policy — no
+    // determination — so an aligned DKIM pass still authenticates, exactly as
+    // when the header carries no DMARC verdict at all.
+    const authResults =
+      "mx.resend.com; dkim=pass header.d=example.com; dmarc=none";
+    expect(evaluateSenderAuthentication({ authResults, fromEmail: FROM })).toBe(
+      true,
+    );
+  });
+
+  it("still requires DKIM alignment when DMARC reports no policy (dmarc=none)", () => {
+    // `dmarc=none` is not a free pass: without an aligned DKIM the From:
+    // remains unauthenticated.
+    const authResults =
+      "mx.resend.com; dkim=pass header.d=attacker.net; dmarc=none";
+    expect(evaluateSenderAuthentication({ authResults, fromEmail: FROM })).toBe(
+      false,
     );
   });
 

--- a/gateway/src/email/normalize.ts
+++ b/gateway/src/email/normalize.ts
@@ -187,10 +187,14 @@ function domainsAligned(fromDomain: string, authDomain: string): boolean {
  * trust.
  *
  * Returns:
- *  - `true`  — DMARC passed, or DKIM passed for a domain aligned with the
- *              `From:` domain.
+ *  - `true`  — DMARC passed, or (when the receiver reported no DMARC
+ *              determination — `dmarc=none` or no `dmarc=` verdict at all) DKIM
+ *              passed for a domain aligned with the `From:` domain.
  *  - `false` — authentication results were present but did not authenticate the
- *              `From:` address (spoofable sender).
+ *              `From:` address (spoofable sender). A present non-pass DMARC
+ *              verdict (`fail`/`temperror`/`permerror`) is authoritative and is
+ *              NOT overridden by an aligned DKIM pass — the receiver, which read
+ *              the domain's own policy, declined to affirm the visible `From:`.
  *  - `undefined` — no `Authentication-Results` header, so authentication could
  *              not be evaluated (e.g. the receiving-API fetch failed). Callers
  *              omit the signal so `handleInbound` preserves existing behavior
@@ -209,16 +213,33 @@ export function evaluateSenderAuthentication(args: {
   }
   const results = raw.toLowerCase();
 
-  // DMARC validates the visible RFC5322.From domain, so a pass is
-  // authoritative for "this From: is not spoofed".
+  // The receiver's DMARC verdict is authoritative for the visible RFC5322.From
+  // domain: it applied that domain's own published policy (including its
+  // alignment mode), which the relaxed DKIM-alignment heuristic below cannot
+  // see. So honor a present verdict before falling back:
+  //  - `pass` → the From: is authenticated.
+  //  - `none` → the domain publishes no DMARC policy, i.e. no determination
+  //    exists (materially the same as an absent header); fall through to the
+  //    aligned-DKIM check, which is exactly the signal the fallback exists for.
+  //  - anything else (`fail`, `temperror`, `permerror`, …) → the receiver did
+  //    not affirm the From:, so we must NOT substitute our own alignment
+  //    heuristic and re-authenticate a sender it declined. Fail closed.
   const dmarc = results.match(/\bdmarc=(\w+)/);
-  if (dmarc && dmarc[1] === "pass") {
-    return true;
+  if (dmarc) {
+    const verdict = dmarc[1];
+    if (verdict === "pass") {
+      return true;
+    }
+    if (verdict !== "none") {
+      return false;
+    }
   }
 
   // Fallback: a DKIM pass whose signing domain aligns with the From: domain.
-  // Methods in Authentication-Results are `;`-separated (RFC 8601), so scope
-  // each DKIM verdict to the domain in its own method chunk.
+  // Reached only when the receiver made no DMARC determination (no `dmarc=`
+  // token, or `dmarc=none`). Methods in Authentication-Results are
+  // `;`-separated (RFC 8601), so scope each DKIM verdict to the domain in its
+  // own method chunk.
   const fromDomain = domainOfEmail(args.fromEmail);
   for (const chunk of results.split(";")) {
     const dkim = chunk.match(/\bdkim=(\w+)/);


### PR DESCRIPTION
## Summary

Follow-up addressing Codex review feedback on #38389 (authenticate native Mailgun/Resend email senders before trust).

`evaluateSenderAuthentication` special-cased only the DMARC **pass** case, then fell through to the aligned-DKIM fallback for every other DMARC state. So a header the receiver explicitly failed — `dkim=pass header.d=example.com; dmarc=fail header.from=mail.example.com` — was re-authenticated by the aligned `dkim=pass` and evaluated as authenticated, letting a message the receiver flagged as spoofed keep guardian/`trusted_contact` trust (self-approve tools, unsandboxed shell, memory access).

## Fix

The receiver's DMARC verdict is authoritative for the visible `From:` domain: it applied that domain's own published policy (including strict/relaxed alignment mode), which our relaxed DKIM-alignment heuristic cannot see. So a present verdict is honored before the fallback runs:

- `dmarc=pass` → authenticated (unchanged).
- `dmarc=fail` / `temperror` / `permerror` (any present non-`pass`, non-`none` verdict) → **not** authenticated; the aligned-DKIM fallback is skipped.
- `dmarc=none` → the domain publishes no DMARC policy (no determination — materially identical to an absent header), so the aligned-DKIM fallback still runs. This is exactly the population the fallback exists for; blocking it would downgrade legitimate no-DMARC-domain contacts to stranger and, at email's `trusted_contacts` admission floor, deny their mail.
- No `dmarc=` token → aligned-DKIM fallback runs (unchanged).

### Deliberate call on `permerror` / `temperror` (per review request)

Both are treated as **not authenticated** (fallback skipped), unlike `none`. `none` is a completed evaluation that found no policy; `permerror`/`temperror` mean the receiver was actively evaluating a policy that exists and couldn't finish, so its alignment mode is unknown and substituting our relaxed heuristic could re-authenticate something the real (strict) policy would reject. There is no spoofing upside to the laxity either way — a spoofer cannot forge an aligned `dkim=pass` in any DMARC state — so failing closed on an *errored* verdict is the conservative choice that matches the trust-boundary intent.

## Strictly tightening — cannot loosen any accept path

The only `return true` paths are `dmarc=pass` (condition unchanged) and the aligned-DKIM fallback, which is now **gated** so it runs in a strict subset of the prior cases (`none`/absent only, never `fail`/error). No prior `false` becomes `true`. The single behavior change is `dmarc ∈ {fail, temperror, permerror}` + aligned DKIM: previously `true`, now `false`. `dmarc=none` behavior is unchanged.

The first-match `dmarc=` parse is unchanged and remains safe: the webhook layer feeds only the receiver's authentic `Authentication-Results` (Resend: the receiving-API headers; Mailgun: the first, receiver-prepended entry), so a sender-forged duplicate never reaches this function.

## Companion-platform parity (follow-up needed)

`vellum-assistant-platform`'s `evaluate_sender_authentication` (`django/app/email/resend.py`) has the **identical** structure and the same gap — it special-cases only `pass` then falls through to DKIM. Native and platform paths are meant to agree, so the platform needs the same tightening in a companion PR. Flagging rather than fixing here — that lives in a separate repo, out of scope for this gateway change.

## Tests

Extended the `evaluateSenderAuthentication` matrix in `gateway/src/email/normalize.test.ts`:

- `dmarc=fail` + aligned `dkim=pass` → **not** authenticated (the exact Codex case).
- `dmarc=permerror` / `dmarc=temperror` + aligned `dkim=pass` → **not** authenticated.
- `dmarc=none` + aligned `dkim=pass` → authenticated; `dmarc=none` + unaligned DKIM → not authenticated (the fallback still requires alignment).
- No DMARC verdict + aligned `dkim=pass` → authenticated (unchanged fallback, pre-existing test).

Ran `gateway/src/email/normalize.test.ts` (32 pass) plus the Mailgun/Resend webhook and inbound-pipeline suites that exercise this path (51 pass total); `tsc --noEmit` clean.

Related to #38389