### PR TITLE
fix(web): stub navigateToConversation in usage-tab test module mock

### DIFF
--- a/clients/web/src/domains/settings/billing/usage/usage-tab.test.tsx
+++ b/clients/web/src/domains/settings/billing/usage/usage-tab.test.tsx
@@ -8,7 +8,12 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { createElement, type ReactElement } from "react";
-import { createMemoryRouter, RouterProvider, useParams } from "react-router";
+import {
+  createMemoryRouter,
+  RouterProvider,
+  useParams,
+  type NavigateFunction,
+} from "react-router";
 
 import { usageSeriesKeyForGroupValue } from "@/domains/settings/billing/usage/usage-series";
 import type {
@@ -16,6 +21,7 @@ import type {
   UsageSeriesResponse,
   UsageTotals,
 } from "@/domains/settings/billing/usage/usage-types";
+import { routes } from "@/utils/routes";
 import type { AssistantSchedule } from "@/utils/schedules";
 
 const defaultSchedules = [
@@ -211,6 +217,13 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   usageBreakdownGet: usageBreakdownGetMock,
 }));
 mock.module("@/utils/conversation-navigation", () => ({
+  // Behavioral stub: performs the route change (the contract the navigation
+  // tests assert) without the real module's store resets and haptics.
+  navigateToConversation: mock(
+    (navigate: NavigateFunction, conversationId: string) => {
+      void navigate(routes.conversation(conversationId));
+    },
+  ),
   navigateToNewConversation: mock(() => {}),
 }));
 mock.module("@/utils/schedules", () => ({


### PR DESCRIPTION
## Summary
- Fixes the `CI Main Web` / Test failure on main ([run 29558067955](https://github.com/vellum-ai/vellum-assistant/actions/runs/29558067955/job/87814479930)): `usage-tab.test.tsx` failed to load with `SyntaxError: Export named 'navigateToConversation' not found` because its `mock.module("@/utils/conversation-navigation", ...)` factory only provided `navigateToNewConversation`, while #38411 added a `navigateToConversation` import to `usage-tab.tsx`.
- Adds `navigateToConversation` to the mock factory as a behavioral stub that forwards to the passed `navigate` with `routes.conversation(id)`, so the existing row-click test still asserts a real route transition to the conversation-page probe without pulling in the real module's store/haptics side effects.

## Original prompt
The `CI Main Web` Test job started failing on main after #38411 routed usage breakdown conversation rows through the shared conversation navigator. The task was to fix the specific CI issue in that failing job only — no broader changes.