### PR TITLE
fix(empty-response): pair Slack refusal quarantine by thread provenance

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -6211,6 +6211,84 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(serialized).toContain("hi assistant");
     expect(serialized).toContain("back to normal");
   });
+
+  test("quarantines the refused exchange across an interleaved sibling thread", () => {
+    // Multi-party channel: @alice's flagged prompt roots a thread, the
+    // assistant's refusal fallback replies inside it (`threadTs` = the prompt's
+    // ts), and @bob posts in a different thread in between. Chronological
+    // adjacency would pair the fallback with @bob's unrelated post — dropping
+    // it and stranding the actual refused prompt, which then re-trips the
+    // classifier every turn. Thread provenance pairs the fallback with @alice's
+    // prompt instead and leaves @bob's post in place.
+    const CHANNEL_ID = "C0MULTI01";
+    const SLACK_CAPS_CHANNEL: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+    const T_HI = "1699971900.000100";
+    const T_PROMPT = "1699972000.000200"; // roots @alice's thread
+    const T_BOB = "1699972030.000300"; // sibling-thread post, interleaved
+    const T_FALLBACK = "1699972060.000400"; // assistant refusal, in @alice's thread
+    const T_LATER = "1699972200.000500";
+    const meta = (
+      channelTs: string,
+      displayName: string,
+      threadTs?: string,
+    ): SlackMessageMetadata => ({
+      source: "slack",
+      channelId: CHANNEL_ID,
+      channelTs,
+      ...(threadTs ? { threadTs } : {}),
+      eventKind: "message",
+      displayName,
+    });
+    const rows: SlackTranscriptInputRow[] = [
+      row(
+        "user",
+        "hi assistant",
+        1699971900_000,
+        metadataEnvelope(meta(T_HI, "@alice")),
+      ),
+      row(
+        "user",
+        "disallowed question",
+        1699972000_000,
+        metadataEnvelope(meta(T_PROMPT, "@alice")),
+      ),
+      row(
+        "user",
+        "what's for lunch",
+        1699972030_000,
+        metadataEnvelope(meta(T_BOB, "@bob")),
+      ),
+      row(
+        "assistant",
+        REFUSAL_FALLBACK_TEXT,
+        1699972060_000,
+        metadataEnvelope(meta(T_FALLBACK, "@assistant", T_PROMPT)),
+      ),
+      row(
+        "user",
+        "back to normal",
+        1699972200_000,
+        metadataEnvelope(meta(T_LATER, "@alice")),
+      ),
+    ];
+
+    const result = assembleSlackChronologicalMessages(rows, SLACK_CAPS_CHANNEL);
+    const serialized = JSON.stringify(result);
+    // The refusal and the prompt that tripped it are both gone …
+    expect(serialized).not.toContain(REFUSAL_FALLBACK_TEXT);
+    expect(serialized).not.toContain("disallowed question");
+    // … the interleaved sibling-thread post from another user is untouched …
+    expect(serialized).toContain("what's for lunch");
+    // … as are the benign turns on either side.
+    expect(serialized).toContain("hi assistant");
+    expect(serialized).toContain("back to normal");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/context/refusal-quarantine.ts
+++ b/assistant/src/context/refusal-quarantine.ts
@@ -66,18 +66,56 @@ export function isRefusalFallbackMessage(message: Message): boolean {
 /**
  * Indices of every message belonging to a previously-refused exchange: for each
  * assistant message that is exactly the refusal fallback, its own index plus the
- * contiguous run back to (and including) the nearest genuine user prompt — the
+ * run back to (and including) the genuine user prompt that tripped it — the
  * flagged prompt and any tool exchange in that run.
+ *
+ * Pairing the fallback with its true prompt:
+ *
+ * - By default (no `threadKeys`) the walk-back is pure array adjacency: the
+ *   nearest preceding genuine user prompt. Correct for a single-party history
+ *   (the in-memory working set, a Slack DM) where turns strictly alternate.
+ * - In a multi-party Slack channel, another party's post can land between the
+ *   refused prompt and the fallback in chronological order, so adjacency would
+ *   pair the fallback with that unrelated post and leave the actual refused
+ *   prompt behind. `threadKeys` (a per-message Slack thread identity aligned
+ *   1:1 with `messages`, `threadTs ?? channelTs`) fixes this: when the
+ *   fallback's thread is shared by another message — i.e. it is a real thread,
+ *   not a lone top-level/DM row whose key is just its own `channelTs` — the
+ *   walk-back skips over messages from other threads and pairs the fallback
+ *   with the nearest genuine prompt in its own thread. A `null` key (non-Slack
+ *   / legacy rows with no provenance) always uses adjacency.
  *
  * Exposed as a set of indices (rather than only the filtered messages) so a
  * caller holding an array rendered in lockstep with `messages` — e.g. the Slack
  * chronological transcript, whose per-message compaction provenance rides in a
  * sibling array — can drop the same exchanges from both and keep them aligned.
  */
-export function computeRefusedExchangeDrops(messages: Message[]): {
+export function computeRefusedExchangeDrops(
+  messages: Message[],
+  opts: { threadKeys?: ReadonlyArray<string | null> } = {},
+): {
   dropIndices: Set<number>;
   droppedExchanges: number;
 } {
+  const { threadKeys } = opts;
+  // A thread key only carries pairing signal when it is shared: a lone
+  // top-level or DM row has its own `channelTs` as its key, so treating it as a
+  // one-message "thread" would strand the prompt. Count keys once so each
+  // fallback can tell whether it sits in a real (multi-row) thread.
+  const sharedThreadKeys = new Set<string>();
+  if (threadKeys) {
+    const seen = new Set<string>();
+    for (const key of threadKeys) {
+      if (key === null) {
+        continue;
+      }
+      if (seen.has(key)) {
+        sharedThreadKeys.add(key);
+      } else {
+        seen.add(key);
+      }
+    }
+  }
   const dropIndices = new Set<number>();
   let droppedExchanges = 0;
   for (let r = 0; r < messages.length; r++) {
@@ -85,17 +123,24 @@ export function computeRefusedExchangeDrops(messages: Message[]): {
       continue;
     }
     dropIndices.add(r);
-    // Walk back over tool-result / assistant tool churn to the genuine prompt.
-    let s = r - 1;
-    while (
-      s >= 0 &&
-      !(messages[s].role === "user" && !isToolResultMessage(messages[s]))
-    ) {
+    const fallbackThreadKey = threadKeys?.[r] ?? null;
+    // Scope the walk-back to the fallback's own thread only when that thread is
+    // real — shared by another row. A lone top-level/DM row (keyed by its own
+    // channelTs) or a provenance-less null key falls through to adjacency.
+    const threadScope =
+      fallbackThreadKey !== null && sharedThreadKeys.has(fallbackThreadKey)
+        ? threadKeys
+        : undefined;
+    // Walk back to the genuine prompt over tool-result / assistant tool churn,
+    // skipping (leaving in place) any interleaved message from another thread.
+    for (let s = r - 1; s >= 0; s--) {
+      if (threadScope && (threadScope[s] ?? null) !== fallbackThreadKey) {
+        continue;
+      }
       dropIndices.add(s);
-      s--;
-    }
-    if (s >= 0) {
-      dropIndices.add(s); // the genuine user prompt that was refused
+      if (messages[s].role === "user" && !isToolResultMessage(messages[s])) {
+        break; // the genuine user prompt that was refused
+      }
     }
     droppedExchanges++;
   }

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1304,6 +1304,30 @@ export function getSlackWatermarkAdvanceForRowPrefix(
   return ts;
 }
 
+/**
+ * Map each row's Slack `channelTs` to its thread key (`threadTs ?? channelTs`).
+ *
+ * A rendered transcript message carries its source row's `channelTs` in
+ * `sourceChannelTs`, so this map lets the refusal-exchange sweep resolve each
+ * rendered message's thread and pair a persisted refusal fallback with the
+ * prompt in its own thread — rather than the nearest chronological neighbour,
+ * which in a multi-party channel can be an unrelated sibling-thread post.
+ */
+function buildSlackThreadKeyByChannelTs(
+  rows: SlackTranscriptInputRow[],
+): Map<string, string> {
+  const byChannelTs = new Map<string, string>();
+  for (const row of rows) {
+    const meta = readSlackMetadataFromMessageMetadata(row.metadata, {
+      allowFlatLegacy: true,
+    });
+    if (meta?.channelTs) {
+      byChannelTs.set(meta.channelTs, meta.threadTs ?? meta.channelTs);
+    }
+  }
+  return byChannelTs;
+}
+
 function assembleSlackChronologicalContext(
   rows: SlackTranscriptInputRow[],
   capabilities: ChannelCapabilities,
@@ -1319,9 +1343,20 @@ function assembleSlackChronologicalContext(
   // Drop previously-refused exchanges — a persisted safety-classifier refusal
   // and the prompt that tripped it — so the model isn't re-fed a refusal it
   // will just repeat (the dead-end `empty-response` sweeps off Slack turns).
-  // `renderedMessages` is filtered by the same indices to stay aligned with the
-  // `messages` projection compaction slices.
-  const { dropIndices } = computeRefusedExchangeDrops(rendered.messages);
+  // Pairing is thread-aware: each rendered message's Slack thread is resolved
+  // from its `sourceChannelTs`, so an interleaved sibling-thread post that
+  // landed between the refused prompt and the fallback is neither dropped nor
+  // mistaken for the prompt. `renderedMessages` is filtered by the same indices
+  // to stay aligned with the `messages` projection compaction slices.
+  const threadKeyByChannelTs = buildSlackThreadKeyByChannelTs(rows);
+  const threadKeys = rendered.renderedMessages.map((entry) =>
+    entry.sourceChannelTs !== null
+      ? (threadKeyByChannelTs.get(entry.sourceChannelTs) ?? null)
+      : null,
+  );
+  const { dropIndices } = computeRefusedExchangeDrops(rendered.messages, {
+    threadKeys,
+  });
   const renderedMessages =
     dropIndices.size > 0
       ? rendered.renderedMessages.filter((_, i) => !dropIndices.has(i))


### PR DESCRIPTION
Addresses Codex feedback on #38401 (verified valid by triage).

## Problem

`computeRefusedExchangeDrops` pairs a persisted refusal fallback with "the nearest preceding user message" by walking rendered-array adjacency. In a multi-party Slack channel the rendered transcript is chronological across *all* threads, so another user's post can land between the refused prompt and the fallback. Adjacency then drops that unrelated post + the fallback while the **actual** refused prompt stays in the transcript — losing valid context AND leaving the refusal re-triggerable, defeating the fix in exactly the multi-party context it targets.

## Fix

Pair the fallback with its true prompt via Slack thread provenance instead of adjacency. Traced the persistence chain: an assistant reply row's `slackMeta.threadTs` equals the triggering prompt's thread key (`prompt.threadTs ?? prompt.channelTs`) on every channel / app_mention turn — the gateway roots a new thread at a top-level prompt's own ts (`event.thread_ts ?? event.ts`) and stamps that identically on both the prompt and the reply row. This is the strongest linkage available: the `messages` table has no turn/parent/run id, and the delivery-layer `channel_inbound_events.replyMessageId` link is best-effort `rawPayload` bookkeeping (no column, wiped for secret-bearing turns), whereas the quarantine deliberately treats the transcript as source of truth.

- `assembleSlackChronologicalContext` derives a per-rendered-message thread key (`threadTs ?? channelTs`, resolved through each message's existing `sourceChannelTs` provenance) and passes it to `computeRefusedExchangeDrops`.
- The walk-back scopes to the fallback's own thread **only when that thread is real** — its key is shared by another row. A lone top-level/DM row (keyed by its own `channelTs`), a provenance-less legacy/non-Slack `null` key, or a stale/absent `threadTs` (restart/concurrency edge) all fall through to the original adjacency walk. So DMs (single-party, no interleaving) and legacy rows behave exactly as before.

## Limitation (adjacency fallback, called out per the ask)

`threadTs` identifies the thread, not the specific prompt; within one thread carrying multiple prompts it pairs with the nearest same-thread prompt (top-level channel prompts are 1:1, since each roots its own thread). That is strictly better than cross-thread adjacency and is the best the persisted transcript supports without adding new storage.

## Tests

Extended `conversation-runtime-assembly.test.ts` with an interleaved multi-party channel case: @alice's flagged prompt + its in-thread refusal fallback, with @bob's sibling-thread post landing in between. It asserts the refusal and @alice's prompt are quarantined while @bob's post survives. Verified it fails on the pre-fix adjacency path (drops @bob, strands the prompt). The existing DM quarantine test (adjacency) and the 29 empty-response-hook tests stay green; full assembly suite (201) green; typecheck / prettier / eslint clean.