### PR TITLE
fix(memory): sweep cacheless orphaned graph-node Qdrant points

### DIFF
--- a/assistant/src/__tests__/job-handler-registration-guard.test.ts
+++ b/assistant/src/__tests__/job-handler-registration-guard.test.ts
@@ -13,6 +13,7 @@ const MEMORY_JOB_TYPES = [
   "backfill",
   "rebuild_index",
   "delete_qdrant_vectors",
+  "sweep_orphaned_graph_node_points",
   "embed_media",
   "embed_attachment",
   "embed_graph_node",

--- a/assistant/src/persistence/embeddings/graph-node-orphan-sweep.ts
+++ b/assistant/src/persistence/embeddings/graph-node-orphan-sweep.ts
@@ -1,0 +1,89 @@
+import { getDb } from "../db-connection.js";
+import { memoryGraphNodes } from "../schema/index.js";
+import { withQdrantBreaker } from "./qdrant-circuit-breaker.js";
+
+/** Qdrant point-payload `target_type` for memory graph nodes. */
+const GRAPH_NODE_TARGET_TYPE = "graph_node";
+
+/**
+ * The subset of the Qdrant client the orphan sweep needs, narrowed to an
+ * interface so the sweep can be unit-tested with a fake client.
+ */
+export interface GraphNodeSweepClient {
+  scrollByTargetType(
+    targetType: string,
+  ): Promise<Array<{ id: string; payload: Record<string, unknown> }>>;
+  deleteByTarget(targetType: string, targetId: string): Promise<void>;
+}
+
+export interface GraphNodeSweepResult {
+  /** Distinct `graph_node` target ids currently indexed in Qdrant. */
+  scanned: number;
+  /** Orphan target ids whose Qdrant points were deleted. */
+  deleted: number;
+}
+
+/**
+ * Delete `graph_node` Qdrant points whose backing `memory_graph_nodes` row no
+ * longer exists.
+ *
+ * `embedAndUpsert` treats the `memory_embeddings` cache write as best-effort: on
+ * a cache-write failure it logs and still upserts the Qdrant point, so a node
+ * can end up with a `graph_node` point but no cache row. Migration 340 discovers
+ * orphans only through cache rows, so those cacheless points survive its sweep;
+ * once migration 323 hard-deletes their backing nodes they keep consuming
+ * `searchGraphNodes` top-K slots (the query hydrates hits from
+ * `memory_graph_nodes` and silently drops rows that are gone).
+ *
+ * This enumerates the authoritative set of indexed `graph_node` points straight
+ * from Qdrant — the only place cacheless points are recorded — and deletes any
+ * whose `target_id` has no row in `memory_graph_nodes`. Membership is
+ * existence-based, matching migration 340: a soft-deleted node keeps its row
+ * (`fidelity = 'gone'`) and therefore its point.
+ *
+ * Idempotent: a second run finds no orphans. Deletion is by Qdrant payload
+ * (`target_type` + `target_id`) via `deleteByTarget`, so it removes cacheless
+ * points a cache lookup could never surface. Each delete goes through the Qdrant
+ * circuit breaker; a transient Qdrant failure propagates so the caller (the
+ * memory worker) can retry the sweep on a later cycle.
+ */
+export async function sweepOrphanedGraphNodePoints(
+  qdrant: GraphNodeSweepClient,
+): Promise<GraphNodeSweepResult> {
+  const points = await qdrant.scrollByTargetType(GRAPH_NODE_TARGET_TYPE);
+
+  const indexedTargetIds = new Set<string>();
+  for (const { payload } of points) {
+    const targetId = payload.target_id;
+    if (typeof targetId === "string" && targetId.length > 0) {
+      indexedTargetIds.add(targetId);
+    }
+  }
+  if (indexedTargetIds.size === 0) {
+    return { scanned: 0, deleted: 0 };
+  }
+
+  // A node row of any fidelity (including soft-deleted `gone`) keeps its point;
+  // only a fully absent row marks an orphan. Load the id column once and diff in
+  // memory rather than issuing one membership query per indexed point.
+  const liveNodeIds = new Set(
+    getDb()
+      .select({ id: memoryGraphNodes.id })
+      .from(memoryGraphNodes)
+      .all()
+      .map((row) => row.id),
+  );
+
+  let deleted = 0;
+  for (const targetId of indexedTargetIds) {
+    if (liveNodeIds.has(targetId)) {
+      continue;
+    }
+    await withQdrantBreaker(() =>
+      qdrant.deleteByTarget(GRAPH_NODE_TARGET_TYPE, targetId),
+    );
+    deleted++;
+  }
+
+  return { scanned: indexedTargetIds.size, deleted };
+}

--- a/assistant/src/persistence/job-utils.ts
+++ b/assistant/src/persistence/job-utils.ts
@@ -137,6 +137,21 @@ export function truncate(text: string, max: number): string {
   return `${text.slice(0, max - 3)}...`;
 }
 
+/**
+ * Get the initialized Qdrant client, converting the "not initialized" error
+ * into a retryable {@link BackendUnavailableError} so a background job defers and
+ * retries once Qdrant is up instead of failing fatally (the raw error classifies
+ * as fatal). Under memory v2 the worker short-circuits v1 Qdrant job types before
+ * dispatch, so a handler only reaches here when the client is expected to exist.
+ */
+export function requireQdrantClient(): ReturnType<typeof getQdrantClient> {
+  try {
+    return getQdrantClient();
+  } catch {
+    throw new BackendUnavailableError("Qdrant client not initialized");
+  }
+}
+
 // ── Embedding helper ───────────────────────────────────────────────
 
 export async function embedAndUpsert(
@@ -253,12 +268,7 @@ export async function embedAndUpsert(
     log.warn({ err, targetType, targetId }, "Failed to write embedding cache");
   }
 
-  let qdrant;
-  try {
-    qdrant = getQdrantClient();
-  } catch {
-    throw new BackendUnavailableError("Qdrant client not initialized");
-  }
+  const qdrant = requireQdrantClient();
 
   try {
     const modality = normalized.type;

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -40,6 +40,7 @@ export type MemoryJobType =
   | "backfill"
   | "rebuild_index"
   | "delete_qdrant_vectors"
+  | "sweep_orphaned_graph_node_points"
   | "media_processing"
   | "embed_media"
   | "embed_attachment"

--- a/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.test.ts
+++ b/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for migration 341: enqueuing the deferred sweep of cacheless
+ * `graph_node` Qdrant points — points with no `memory_embeddings` cache row that
+ * migration 340 cannot discover — plus the sweep function that the memory worker
+ * runs once Qdrant is up.
+ *
+ * The migration runs against real workspace databases (`initializeDb()`) because
+ * it enqueues a `sweep_orphaned_graph_node_points` job on the dedicated memory
+ * DB. The sweep function is exercised directly with a fake Qdrant client so its
+ * scroll → diff → delete logic is covered without a live Qdrant.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+const { getDb, getMemorySqlite, getSqliteFrom } =
+  await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { migrateSweepCachelessGraphNodeVectors } =
+  await import("./341-sweep-cacheless-graph-node-vectors.js");
+const { sweepOrphanedGraphNodePoints } =
+  await import("../embeddings/graph-node-orphan-sweep.js");
+
+await initializeDb();
+
+const SWEEP_JOB_ID = "migration-341-sweep-cacheless-graph-node-vectors";
+
+function mainRaw() {
+  return getSqliteFrom(getDb());
+}
+
+/** Insert a memory_graph_nodes row (fidelity `gone` models a soft delete). */
+function seedNode(id: string, fidelity = "vivid"): void {
+  mainRaw()
+    .query(
+      `INSERT INTO memory_graph_nodes (
+        id, content, type, created, last_accessed, last_consolidated,
+        emotional_charge, fidelity, confidence, significance, stability,
+        reinforcement_count, last_reinforced, source_conversations,
+        source_type, scope_id
+      ) VALUES (?, ?, 'semantic', 0, 0, 0,
+        '{"kind":"neutral","intensity":0}', ?, 0.9, 0.8, 14, 0, 0, '[]',
+        'inferred', 'default')`,
+    )
+    .run(id, `content ${id}`, fidelity);
+}
+
+/** Rows of the enqueued sweep job, id/type/status only, sorted by id. */
+function sweepJobRows(): Array<{ id: string; type: string; status: string }> {
+  return getMemorySqlite()!
+    .query(
+      `SELECT id, type, status FROM memory_jobs
+       WHERE type = 'sweep_orphaned_graph_node_points' ORDER BY id`,
+    )
+    .all() as Array<{ id: string; type: string; status: string }>;
+}
+
+/**
+ * Fake Qdrant client that reports `indexedTargetIds` as the indexed graph-node
+ * points and records every `deleteByTarget` target id.
+ */
+function fakeQdrant(indexedTargetIds: string[]) {
+  const deleted: string[] = [];
+  return {
+    deleted,
+    client: {
+      scrollByTargetType: async (targetType: string) => {
+        expect(targetType).toBe("graph_node");
+        return indexedTargetIds.map((targetId, i) => ({
+          id: `point-${i}`,
+          payload: { target_type: "graph_node", target_id: targetId },
+        }));
+      },
+      deleteByTarget: async (targetType: string, targetId: string) => {
+        expect(targetType).toBe("graph_node");
+        deleted.push(targetId);
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  mainRaw().run("DELETE FROM memory_graph_nodes");
+  getMemorySqlite()!.run("DELETE FROM memory_jobs");
+});
+
+describe("migration 341: enqueue cacheless graph-node vector sweep", () => {
+  test("enqueues a single deterministic pending sweep job", () => {
+    migrateSweepCachelessGraphNodeVectors(getDb());
+
+    expect(sweepJobRows()).toEqual([
+      {
+        id: SWEEP_JOB_ID,
+        type: "sweep_orphaned_graph_node_points",
+        status: "pending",
+      },
+    ]);
+  });
+
+  test("is idempotent — a second run enqueues no duplicate", () => {
+    migrateSweepCachelessGraphNodeVectors(getDb());
+    migrateSweepCachelessGraphNodeVectors(getDb());
+
+    expect(sweepJobRows()).toEqual([
+      {
+        id: SWEEP_JOB_ID,
+        type: "sweep_orphaned_graph_node_points",
+        status: "pending",
+      },
+    ]);
+  });
+});
+
+describe("sweepOrphanedGraphNodePoints", () => {
+  test("deletes points whose backing node row is gone, keeping live and soft-deleted", async () => {
+    // Live node keeps its point; soft-deleted node keeps its row (fidelity
+    // `gone`) so its point is retained too. `orphan-*` have no row at all.
+    seedNode("live", "vivid");
+    seedNode("soft", "gone");
+    const { client, deleted } = fakeQdrant([
+      "live",
+      "soft",
+      "orphan-a",
+      "orphan-b",
+    ]);
+
+    const result = await sweepOrphanedGraphNodePoints(client);
+
+    expect(deleted.sort()).toEqual(["orphan-a", "orphan-b"]);
+    expect(result).toEqual({ scanned: 4, deleted: 2 });
+  });
+
+  test("no indexed graph-node points → no deletes", async () => {
+    seedNode("live");
+    const { client, deleted } = fakeQdrant([]);
+
+    const result = await sweepOrphanedGraphNodePoints(client);
+
+    expect(deleted).toEqual([]);
+    expect(result).toEqual({ scanned: 0, deleted: 0 });
+  });
+
+  test("every indexed point backed by a live node → no deletes", async () => {
+    seedNode("a");
+    seedNode("b");
+    const { client, deleted } = fakeQdrant(["a", "b"]);
+
+    const result = await sweepOrphanedGraphNodePoints(client);
+
+    expect(deleted).toEqual([]);
+    expect(result).toEqual({ scanned: 2, deleted: 0 });
+  });
+
+  test("is idempotent — after the orphan point is gone, a re-run deletes nothing", async () => {
+    seedNode("live");
+    const first = fakeQdrant(["live", "orphan"]);
+    await sweepOrphanedGraphNodePoints(first.client);
+    expect(first.deleted).toEqual(["orphan"]);
+
+    // The orphan point no longer scrolls back on the second pass.
+    const second = fakeQdrant(["live"]);
+    const result = await sweepOrphanedGraphNodePoints(second.client);
+
+    expect(second.deleted).toEqual([]);
+    expect(result).toEqual({ scanned: 1, deleted: 0 });
+  });
+});

--- a/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.ts
+++ b/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.ts
@@ -1,0 +1,51 @@
+import { type DrizzleDb, getMemorySqlite } from "../db-connection.js";
+
+/** Deterministic id so re-runs INSERT OR IGNORE the same row (idempotent). */
+const SWEEP_JOB_ID = "migration-341-sweep-cacheless-graph-node-vectors";
+
+/**
+ * Enqueue a deferred sweep of `graph_node` Qdrant points that have neither a
+ * backing `memory_graph_nodes` row nor a `memory_embeddings` cache row.
+ *
+ * Migration 340 finds orphaned graph-node vectors through `memory_embeddings`
+ * cache rows, but `embedAndUpsert` treats that cache write as best-effort: a
+ * cache-write failure logs and still upserts the Qdrant point, leaving a
+ * `graph_node` point with no cache row. Those cacheless points are invisible to
+ * 340's cache-driven sweep, so once migration 323 hard-deletes their backing
+ * nodes they keep occupying `searchGraphNodes` top-K slots indefinitely.
+ *
+ * Finding them requires enumerating the collection directly from Qdrant, which
+ * is not initialized at migration time — the memory plugin brings it up after DB
+ * init. So this migration only enqueues a durable
+ * `sweep_orphaned_graph_node_points` job on the memory database, mirroring how
+ * migration 340 and the live delete path defer Qdrant work to the memory worker.
+ * The worker — running once Qdrant is up, and short-circuited under memory v2
+ * where the v1 collection is intentionally absent — scrolls every `graph_node`
+ * point and deletes those whose backing node row is gone (see
+ * `sweepOrphanedGraphNodePoints`).
+ *
+ * Registered after migration 340, so it catches exactly the cacheless orphans
+ * 340 cannot see. Idempotent: the job id is deterministic and INSERT OR IGNOREd,
+ * and the sweep handler is itself idempotent (a second run finds no orphans).
+ * Throws when the memory database is unavailable so the runner defers and
+ * retries on a later boot rather than silently skipping the sweep. The main
+ * `_database` is unused — the job queue lives on the memory database.
+ */
+export function migrateSweepCachelessGraphNodeVectors(
+  _database: DrizzleDb,
+): void {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring cacheless graph-node vector sweep",
+    );
+  }
+
+  memoryRaw
+    .query(
+      /*sql*/ `INSERT OR IGNORE INTO memory_jobs
+         (id, type, payload, status, attempts, run_after, created_at, updated_at)
+       VALUES (?, 'sweep_orphaned_graph_node_points', '{}', 'pending', 0, 0, 0, 0)`,
+    )
+    .run(SWEEP_JOB_ID);
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -448,6 +448,7 @@ import { migrateMoveMemoryRecallLogsToMemoryDb } from "./migrations/337-move-mem
 import { migrateMoveMemoryV3SelectionsToMemoryDb } from "./migrations/338-move-memory-v3-selections-to-memory-db.js";
 import { migrateMoveActivationSessionsToMemoryDb } from "./migrations/339-move-activation-sessions-to-memory-db.js";
 import { migrateSweepOrphanedGraphNodeVectors } from "./migrations/340-sweep-orphaned-graph-node-vectors.js";
+import { migrateSweepCachelessGraphNodeVectors } from "./migrations/341-sweep-cacheless-graph-node-vectors.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1395,4 +1396,5 @@ export const migrationSteps: MigrationStep[] = [
     dependsOn: ["createActivationSessionsTable"],
   },
   migrateSweepOrphanedGraphNodeVectors,
+  migrateSweepCachelessGraphNodeVectors,
 ];

--- a/assistant/src/plugins/defaults/memory/job-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers.ts
@@ -36,6 +36,7 @@ import {
 import {
   deleteQdrantVectorsJob,
   rebuildIndexJob,
+  sweepOrphanedGraphNodePointsJob,
 } from "./job-handlers/index-maintenance.js";
 import { embedConceptPageJob } from "./jobs/embed-concept-page.js";
 import { embedPkbFileJob } from "./jobs/embed-pkb-file.js";
@@ -124,6 +125,10 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
   {
     type: "delete_qdrant_vectors",
     handler: (job) => deleteQdrantVectorsJob(job),
+  },
+  {
+    type: "sweep_orphaned_graph_node_points",
+    handler: () => sweepOrphanedGraphNodePointsJob(),
   },
   { type: "embed_media", handler: (job) => embedMediaJob(job) },
   {

--- a/assistant/src/plugins/defaults/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/index-maintenance.ts
@@ -2,11 +2,11 @@ import { selectedBackendSupportsMultimodal } from "@vellumai/plugin-api";
 import { and, eq, isNotNull, like, ne } from "drizzle-orm";
 
 import { getDb } from "../../../../persistence/db-connection.js";
+import { sweepOrphanedGraphNodePoints } from "../../../../persistence/embeddings/graph-node-orphan-sweep.js";
 import { withQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
-import { getQdrantClient } from "../../../../persistence/embeddings/qdrant-client.js";
 import {
   asString,
-  BackendUnavailableError,
+  requireQdrantClient,
 } from "../../../../persistence/job-utils.js";
 import {
   enqueueMemoryJob,
@@ -108,16 +108,32 @@ export async function deleteQdrantVectorsJob(job: MemoryJob): Promise<void> {
     return;
   }
 
-  let qdrant;
-  try {
-    qdrant = getQdrantClient();
-  } catch {
-    throw new BackendUnavailableError("Qdrant client not initialized");
-  }
-
+  const qdrant = requireQdrantClient();
   await withQdrantBreaker(() => qdrant.deleteByTarget(targetType, targetId));
   log.info(
     { targetType, targetId },
     "Retried Qdrant vector deletion succeeded",
   );
+}
+
+/**
+ * Sweep `graph_node` Qdrant points whose backing `memory_graph_nodes` row no
+ * longer exists — the cacheless orphans migration 340's `memory_embeddings`
+ * cache-driven sweep cannot see (see `sweepOrphanedGraphNodePoints`). Enqueued
+ * once by migration 341 and drained here so the scroll runs after Qdrant is up.
+ *
+ * `requireQdrantClient` throws a retryable `BackendUnavailableError` when the v1
+ * Qdrant client is not initialized, so the job defers instead of failing; under
+ * memory v2 the worker short-circuits this type (`V1_QDRANT_JOB_TYPES`) before
+ * dispatch, so it never reaches here.
+ */
+export async function sweepOrphanedGraphNodePointsJob(): Promise<void> {
+  const qdrant = requireQdrantClient();
+  const { scanned, deleted } = await sweepOrphanedGraphNodePoints(qdrant);
+  if (deleted > 0) {
+    log.info(
+      { scanned, deleted },
+      "Swept cacheless orphaned graph-node Qdrant points",
+    );
+  }
 }

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -107,6 +107,7 @@ const V1_QDRANT_JOB_TYPES = new Set<MemoryJobType>([
   "embed_pkb_file",
   "rebuild_index",
   "delete_qdrant_vectors",
+  "sweep_orphaned_graph_node_points",
 ]);
 
 /**


### PR DESCRIPTION
Addresses Codex review feedback on merged PR #38400.

Migration 340 discovers orphaned graph-node vectors only through memory_embeddings cache rows, but embedAndUpsert treats that cache write as best-effort: on a cache-write failure it logs and still upserts the Qdrant point. Nodes that hit that path have a graph_node Qdrant point with no cache row, so 340's sweep misses them. After migration 323 hard-deleted the backing memory_graph_nodes rows, those cacheless points keep occupying searchGraphNodes top-K slots indefinitely (the query hydrates hits from memory_graph_nodes and silently drops rows that are gone).

Discovering them requires enumerating the collection directly from Qdrant, which is not initialized at migration time (the memory plugin brings it up after DB init). So new migration 341 only enqueues a durable sweep_orphaned_graph_node_points job on the memory database, mirroring how 340 and the live delete path defer Qdrant work to the memory worker. The new worker handler scrolls every graph_node point and deletes those whose backing node row is gone (existence-based, matching 340, so soft-deleted nodes keep their point). The job type is registered in V1_QDRANT_JOB_TYPES, so it short-circuits under memory v2 where the v1 collection is intentionally absent.

Idempotent (deterministic job id + INSERT OR IGNORE; the sweep re-scan finds nothing) and safe when Qdrant is unavailable (retryable BackendUnavailableError defers the job to a later worker cycle).

Simplify pass: extracted the now 3x-duplicated getQdrantClient-or-throw-BackendUnavailableError idiom into a shared requireQdrantClient() helper in job-utils.ts, applied to embedAndUpsert, deleteQdrantVectorsJob, and the new handler.

Tests: new 341 test covers the migration enqueue (idempotent) and the sweep function (orphan deletion; live and soft-deleted retention; empty and all-live no-ops; re-run idempotency). Prefix-guard, job-handler registration guard, embedding, and Qdrant-breaker tests pass.