### PR TITLE
fix(onboarding): gate resumed done snapshots and stop persisting parked-guard journeys

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -10,6 +10,12 @@
  * assistant resumes exactly as before. A form-submit case guards the shared-gate
  * refactor.
  *
+ * They also cover the two follow-ups from Codex on #38405: the guard runs for a
+ * snapshot hydrated straight to "done" (not just an idle one), and parking on
+ * the guard from a resume never persists a resumable `step: "existing"` snapshot
+ * — so a refresh re-lands on the keep/redo choice instead of auto-resuming past
+ * it.
+ *
  * Self-contained mocks (run this file solo — `mock.module` leaks across a shared
  * `bun test` run).
  */
@@ -25,6 +31,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { type ReactNode } from "react";
 
 import {
+  readResearchSnapshot,
   writeResearchSnapshot,
   type ResearchOnboardingSnapshot,
 } from "@/domains/onboarding/research-onboarding-persistence";
@@ -332,6 +339,78 @@ describe("ResearchOnboardingRoute resume guard", () => {
 
     fireEvent.click(await screen.findByTestId("form-submit"));
 
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-step")).toBeTruthy(),
+    );
+    expect(startResearchMock).not.toHaveBeenCalled();
+  });
+
+  // A completed snapshot hydrates the runner to "done" and resolveResumeStep
+  // lands it on the suggestions step. That is NOT idle, so the pre-fix resume
+  // effect returned early and never consulted the guard — the user could walk a
+  // done journey into the chat handoff against an established assistant.
+  const doneSnapshot = (): ResearchOnboardingSnapshot =>
+    postFormSnapshot({
+      step: "suggestions",
+      research: {
+        status: "done",
+        claims: [],
+        droppedClaims: [],
+        suggestions: [],
+        installedPlugins: [],
+        pluginCatalog: {},
+      },
+    });
+
+  test("a restored completed snapshot diverts to the decision screen when the assistant is established", async () => {
+    establishedResult = { established: true, assistantName: "Viper" };
+    researchStatus = "done";
+    writeResearchSnapshot(USER_ID, doneSnapshot());
+
+    render(<ResearchOnboardingRoute />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-step")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("existing-step").textContent).toBe("Viper");
+    // A hydrated "done" journey never re-fires research either way.
+    expect(startResearchMock).not.toHaveBeenCalled();
+  });
+
+  test("a restored completed snapshot resumes without the guard when the assistant is fresh", async () => {
+    establishedResult = { established: false, assistantName: null };
+    researchStatus = "done";
+    writeResearchSnapshot(USER_ID, doneSnapshot());
+
+    render(<ResearchOnboardingRoute />);
+
+    // personalityEnabled → the suggestions step renders the "Let's chat" screen.
+    await waitFor(() =>
+      expect(screen.getByTestId("letschat-ready-step")).toBeTruthy(),
+    );
+    // A fresh verdict must not divert, and a done journey never re-fires.
+    expect(screen.queryByTestId("existing-step")).toBeNull();
+    expect(startResearchMock).not.toHaveBeenCalled();
+  });
+
+  test("parking on the guard from a resume never persists a resumable 'existing' snapshot", async () => {
+    establishedResult = { established: true, assistantName: "Viper" };
+    writeResearchSnapshot(USER_ID, postFormSnapshot());
+
+    render(<ResearchOnboardingRoute />);
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-step")).toBeTruthy(),
+    );
+
+    // The parked-on-guard journey clears formValues, so the persistence effect
+    // can't write a `step: "existing"` snapshot carrying post-form values — the
+    // persisted step stays the pre-guard one.
+    expect(readResearchSnapshot(USER_ID)?.step).not.toBe("existing");
+
+    // A refresh (fresh mount, same snapshot) re-lands on the keep/redo choice
+    // rather than auto-resuming past the guard.
+    cleanup();
+    render(<ResearchOnboardingRoute />);
     await waitFor(() =>
       expect(screen.getByTestId("existing-step")).toBeTruthy(),
     );

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -493,26 +493,33 @@ export function ResearchOnboardingRoute() {
     droppedClaimsScrubbed,
   ]);
 
-  // Mid-flow resume: we restored a journey whose research turn hadn't settled.
-  // Resume it once from the restored subject. When the prior session got far
-  // enough to mint the research conversation, re-attach to that SAME thread
-  // (`resumeConversationId`) — the turn keeps generating server-side across the
-  // reload, so we poll it instead of running a second search; only if it's gone
-  // (or was never minted) does the runner fall back to a fresh run. Only fires
-  // when results are absent (status "idle") — a fresh visit has no `formValues`
-  // until the form is submitted (which fires the search itself), and a completed
-  // resume hydrates the status to "done". The meeting is never re-booked here:
-  // that only fires from the calendar step, which a resume skips past.
+  // Resume a restored post-form journey through the SAME established-assistant
+  // guard the form submit applies. A snapshot persisted before the verdict
+  // settled (or after a transient fail-open) must not let the flow proceed
+  // against an assistant that already has a life without the keep/redo choice.
+  // This covers BOTH resumable entry points:
+  //   - a still-idle turn: re-fired below from the restored subject. When the
+  //     prior session minted the research conversation, the re-fire re-attaches
+  //     to that SAME thread (`resumeConversationId`) — the turn keeps generating
+  //     server-side across the reload, so the runner polls it instead of running
+  //     a second search, falling back to a fresh run only if it's gone.
+  //   - a turn hydrated straight to "done" from the snapshot: nothing re-fires,
+  //     but it lands on a later step and could otherwise walk into the chat
+  //     handoff ungated — so the guard still runs.
+  // (Running/error are transient, not resume entry points.) The meeting is never
+  // re-booked here: that only fires from the calendar step, which a resume skips.
   //
-  // The same established-assistant guard the form submit applies runs first: a
-  // restored post-form snapshot (persisted before the verdict settled, or after
-  // a transient fail-open) must not silently re-run research against an
-  // assistant that already has a life. When established, divert to the same
-  // keep/redo decision screen instead of re-firing; fail open (resume) on a
-  // fresh/unknown verdict, so a genuinely-new user never sees the guard.
+  // When established, divert to the keep/redo screen and move the values into
+  // `gatedFormValues` — clearing `formValues` so the persistence effect can't
+  // snapshot this parked-on-the-guard journey (a `step: "existing"` snapshot
+  // with post-form values would, on refresh, auto-resume past the guard). With
+  // `formValues` cleared the persisted step stays the pre-guard one, so a
+  // refresh re-runs the guard. Fail open (resume) on a fresh/unknown verdict so
+  // a genuinely-new user never sees the guard.
   useEffect(() => {
-    if (!restored) return;
-    if (!formValues || research.status !== "idle") return;
+    if (!restored || !formValues) return;
+    if (research.status !== "idle" && research.status !== "done") return;
+    const wasIdle = research.status === "idle";
     const values = formValues;
     let cancelled = false;
     void (async () => {
@@ -522,20 +529,25 @@ export function ResearchOnboardingRoute() {
         if (check?.established) {
           setGatedFormValues(values);
           setForwardStack([]);
+          setFormValues(null);
           setStep("existing");
           return;
         }
       }
-      startResearch({
-        awaitAssistantId: awaitHatchReady,
-        subject: researchSubjectFrom(values),
-        conversationTitle: researchTitleFor(values),
-        ...(researchConversationId
-          ? { resumeConversationId: researchConversationId }
-          : {}),
-        onConversationCreated: setResearchConversationId,
-        includeSuggestions: !personalityEnabled,
-      });
+      // Only the idle path re-fires the search; a hydrated "done" journey keeps
+      // its restored results.
+      if (wasIdle) {
+        startResearch({
+          awaitAssistantId: awaitHatchReady,
+          subject: researchSubjectFrom(values),
+          conversationTitle: researchTitleFor(values),
+          ...(researchConversationId
+            ? { resumeConversationId: researchConversationId }
+            : {}),
+          onConversationCreated: setResearchConversationId,
+          includeSuggestions: !personalityEnabled,
+        });
+      }
     })();
     return () => {
       cancelled = true;


### PR DESCRIPTION
Follow-up to #38405, addressing both Codex review comments on that PR. File: `clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx`. Built on top of #38418's dropped-claims persistence (already on main).

## Comment A — the guard skipped hydrated "done" resumes
When a restored snapshot already includes completed research, the layout restore hydrates the runner to `status: "done"`, so the mid-flow resume effect's `status !== "idle"` early return bypassed the established-assistant gate. A stale / fail-open done snapshot let the user land on later steps and walk into the chat handoff against an established assistant with no keep/redo choice.

The resume effect now runs the gate for BOTH resumable entry points — idle (re-fires research) and done (keeps its restored results) — and diverts to the keep/redo screen when established. Only the idle path re-fires the search. This also adds defense-in-depth: a submit-time gate that failed open but later settles established is now caught before the handoff.

## Comment B — parking on the guard from a resume persisted a resumable snapshot
Unlike the form-submit path (which never sets `formValues` until the gate passes), the resume divert left `formValues` populated, so the persistence effect wrote a `step: "existing"` snapshot carrying post-form values. On refresh `resolveResumeStep` maps `existing` → `form`, but the populated `formValues` made the resume effect auto-start research after a fail-open timeout — skipping the keep/redo choice.

The divert now clears `formValues` (moving them into `gatedFormValues`, matching the form-submit invariant), so no parked-on-guard snapshot is written and a refresh re-lands on the keep/redo choice.

## Preserved behavior
The established-assistant guard still runs on the normal mid-flow (idle) resume path.

## Tests
Extends the route-level regression suite (`research-onboarding-route.test.tsx`):
- a restored **done** snapshot diverts to the decision screen when established, never re-firing research;
- a done snapshot resumes without the guard when fresh;
- parking on the guard from a resume persists no `step: "existing"` snapshot, and a refresh re-lands on keep/redo.

Existing idle-resume + form-submit cases still pass (6/6 in this file).