### PR TITLE
fix(plugins): repair main CI plugin-boundary guard after #38419

### DIFF
--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -229,6 +229,11 @@ export {
   embedAndUpsert,
   selectedBackendSupportsMultimodal,
 } from "../persistence/embeddings/plugin-facade.js";
+// Graph-node orphan sweep — deletes `graph_node` Qdrant points whose backing
+// `memory_graph_nodes` row is gone (cacheless points the cache-driven sweep
+// cannot see). The memory plugin's `sweep_orphaned_graph_node_points` job
+// handler drains it once Qdrant is up.
+export { sweepOrphanedGraphNodePoints } from "../persistence/embeddings/graph-node-orphan-sweep.js";
 // Skills — the installed skill catalog with resolved states, and the remote
 // skill catalog. Host-resolved: catalog load, install-state resolution,
 // feature-flag gating, and install-meta reads are composed internally, so

--- a/assistant/src/plugins/defaults/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/index-maintenance.ts
@@ -1,8 +1,10 @@
-import { selectedBackendSupportsMultimodal } from "@vellumai/plugin-api";
+import {
+  selectedBackendSupportsMultimodal,
+  sweepOrphanedGraphNodePoints,
+} from "@vellumai/plugin-api";
 import { and, eq, isNotNull, like, ne } from "drizzle-orm";
 
 import { getDb } from "../../../../persistence/db-connection.js";
-import { sweepOrphanedGraphNodePoints } from "../../../../persistence/embeddings/graph-node-orphan-sweep.js";
 import { withQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
 import {
   asString,


### PR DESCRIPTION
## Summary

PR #38419 ("sweep cacheless orphaned graph-node Qdrant points") added the host-owned `sweepOrphanedGraphNodePoints` module in `persistence/embeddings/graph-node-orphan-sweep.ts` and imported it into the memory plugin's `job-handlers/index-maintenance.ts` via a direct relative path (`../../../../persistence/embeddings/graph-node-orphan-sweep.js`). That is a **new escaping import** beyond the committed baseline, so `plugin-import-boundary-guard.test.ts` fails on main ("CI Main Assistant Checks").

Following the precedent in `b3565e9fdb` — and the resolution the guard itself documents ("If @vellumai/plugin-api already exports this symbol, import it from there") — route the plugin's access through the sanctioned public API instead of growing the ratchet baseline:

- **`plugin-api/index.ts`**: re-export `sweepOrphanedGraphNodePoints` from the host-owned `persistence/embeddings/graph-node-orphan-sweep.js`, alongside the existing embeddings facade exports.
- **`index-maintenance.ts`**: import it from `@vellumai/plugin-api`, dropping the direct relative import.

The sweep logic stays host-owned in `persistence/embeddings/`; the plugin no longer reaches outside itself except through the public plugin API. No baseline entry added — the point of the guard is to stop new escapes, and memory's host coupling is being reduced, not grown.

## Tests (from `assistant/`)

- `bun test src/__tests__/plugin-import-boundary-guard.test.ts` ✅
- `bun test src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.test.ts` ✅
- `bun test src/__tests__/job-handler-registration-guard.test.ts` ✅
- `bun test src/__tests__/plugin-import-boundary-reverse-guard.test.ts` ✅ (sanity — no host→plugin edge introduced)
- `bun run typecheck:fast` ✅ (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)