### PR TITLE
fix(gateway): treat Microsoft dmarc=bestguesspass as a no-DMARC fallback verdict

### DIFF
--- a/gateway/src/email/normalize.test.ts
+++ b/gateway/src/email/normalize.test.ts
@@ -309,6 +309,28 @@ describe("evaluateSenderAuthentication", () => {
     );
   });
 
+  it("falls back to aligned DKIM on Microsoft's dmarc=bestguesspass", () => {
+    // Microsoft 365 stamps `dmarc=bestguesspass` when the From: domain
+    // publishes no DMARC record but an implicit policy would have passed — a
+    // non-failure no-determination verdict, so the aligned-DKIM fallback still
+    // applies.
+    const authResults =
+      "spf=pass (sender ip is 203.0.113.5) smtp.mailfrom=example.com; " +
+      "dkim=pass (signature was verified) header.d=example.com; " +
+      "dmarc=bestguesspass action=none header.from=example.com";
+    expect(evaluateSenderAuthentication({ authResults, fromEmail: FROM })).toBe(
+      true,
+    );
+  });
+
+  it("still requires DKIM alignment on dmarc=bestguesspass", () => {
+    const authResults =
+      "mx.resend.com; dkim=pass header.d=attacker.net; dmarc=bestguesspass";
+    expect(evaluateSenderAuthentication({ authResults, fromEmail: FROM })).toBe(
+      false,
+    );
+  });
+
   it("treats a DKIM pass for an unaligned domain as unauthenticated", () => {
     // DKIM passed, but for the attacker's own domain — not the From:.
     const authResults =

--- a/gateway/src/email/normalize.ts
+++ b/gateway/src/email/normalize.ts
@@ -188,7 +188,8 @@ function domainsAligned(fromDomain: string, authDomain: string): boolean {
  *
  * Returns:
  *  - `true`  — DMARC passed, or (when the receiver reported no DMARC
- *              determination — `dmarc=none` or no `dmarc=` verdict at all) DKIM
+ *              determination — `dmarc=none`, Microsoft 365's
+ *              `dmarc=bestguesspass`, or no `dmarc=` verdict at all) DKIM
  *              passed for a domain aligned with the `From:` domain.
  *  - `false` — authentication results were present but did not authenticate the
  *              `From:` address (spoofable sender). A present non-pass DMARC
@@ -221,6 +222,9 @@ export function evaluateSenderAuthentication(args: {
   //  - `none` → the domain publishes no DMARC policy, i.e. no determination
   //    exists (materially the same as an absent header); fall through to the
   //    aligned-DKIM check, which is exactly the signal the fallback exists for.
+  //  - `bestguesspass` → Microsoft 365's verdict for the same no-policy
+  //    situation (no DMARC record published, but an implicit policy would have
+  //    passed) — a non-failure, so it also falls through.
   //  - anything else (`fail`, `temperror`, `permerror`, …) → the receiver did
   //    not affirm the From:, so we must NOT substitute our own alignment
   //    heuristic and re-authenticate a sender it declined. Fail closed.
@@ -230,14 +234,14 @@ export function evaluateSenderAuthentication(args: {
     if (verdict === "pass") {
       return true;
     }
-    if (verdict !== "none") {
+    if (verdict !== "none" && verdict !== "bestguesspass") {
       return false;
     }
   }
 
   // Fallback: a DKIM pass whose signing domain aligns with the From: domain.
   // Reached only when the receiver made no DMARC determination (no `dmarc=`
-  // token, or `dmarc=none`). Methods in Authentication-Results are
+  // token, `dmarc=none`, or `dmarc=bestguesspass`). Methods in Authentication-Results are
   // `;`-separated (RFC 8601), so scope each DKIM verdict to the domain in its
   // own method chunk.
   const fromDomain = domainOfEmail(args.fromEmail);


### PR DESCRIPTION
Follow-up to #38415. Codex review on the platform port (vellum-ai/vellum-assistant-platform#9245) caught that Microsoft 365's documented `dmarc=bestguesspass` verdict — stamped when the From: domain publishes **no DMARC record** but an implicit policy would have passed — was being treated as a hard failure by the strict non-pass branch, hard-failing legitimate no-DMARC senders whose mail carries Microsoft-stamped headers instead of letting the aligned-DKIM fallback evaluate them.

`bestguesspass` now joins `none` as a no-determination verdict that falls through to the aligned-DKIM check. Explicit `fail`/`temperror`/`permerror` verdicts remain authoritative and fail closed. Two new tests mirror the platform PR's cases (aligned → authenticated, unaligned → not).

Keeps the gateway and platform sender-auth implementations in agreement.