### PR TITLE
fix(voice): sanitized reconnect copy for bare managed STT auth failures

### DIFF
--- a/assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts
@@ -71,6 +71,7 @@ describe("sttErrorFromManagedSpeech", () => {
     category: string;
     userFacing: boolean;
     messageIncludes?: string;
+    messageExcludes?: string[];
   }> = [
     {
       name: "unavailable → auth, user-facing reconnect copy",
@@ -134,9 +135,11 @@ describe("sttErrorFromManagedSpeech", () => {
     },
     // No platform `detail`: the generic "(platform returned N)" fallback stays
     // non-user-facing so describeSttFailure emits friendly category copy
-    // instead of leaking a raw HTTP status.
+    // instead of leaking a raw HTTP status — except a bare auth status, whose
+    // friendly copy would be the wrong BYOK "check your API key" guidance, so it
+    // gets a sanitized platform-connection message surfaced verbatim.
     {
-      name: "401 without detail → auth, not user-facing",
+      name: "401 without detail → auth, user-facing sanitized reconnect copy",
       failure: {
         ok: false,
         kind: "platform-error",
@@ -144,10 +147,12 @@ describe("sttErrorFromManagedSpeech", () => {
         message: "Managed speech transcription failed (platform returned 401).",
       },
       category: "auth",
-      userFacing: false,
+      userFacing: true,
+      messageIncludes: "reconnect your Vellum account",
+      messageExcludes: ["API key", "platform returned"],
     },
     {
-      name: "403 without detail → auth, not user-facing",
+      name: "403 without detail → auth, user-facing sanitized reconnect copy",
       failure: {
         ok: false,
         kind: "platform-error",
@@ -155,7 +160,9 @@ describe("sttErrorFromManagedSpeech", () => {
         message: "Managed speech transcription failed (platform returned 403).",
       },
       category: "auth",
-      userFacing: false,
+      userFacing: true,
+      messageIncludes: "reconnect your Vellum account",
+      messageExcludes: ["API key", "platform returned"],
     },
     {
       name: "429 without detail → rate-limit, not user-facing",
@@ -198,6 +205,7 @@ describe("sttErrorFromManagedSpeech", () => {
     category,
     userFacing,
     messageIncludes,
+    messageExcludes,
   } of cases) {
     test(name, () => {
       const err = sttErrorFromManagedSpeech(
@@ -205,11 +213,15 @@ describe("sttErrorFromManagedSpeech", () => {
       );
       expect(err).toBeInstanceOf(SttError);
       expect(err.category).toBe(category as SttError["category"]);
-      // Verbatim only when the failure carries real remediation; a bare
-      // HTTP-status fallback stays non-user-facing for friendly rewrite.
+      // User-facing when the failure carries real remediation (or a sanitized
+      // managed-auth message); a bare non-auth status stays non-user-facing for
+      // friendly category rewrite.
       expect(err.userFacing).toBe(userFacing);
       if (messageIncludes) {
         expect(err.message).toContain(messageIncludes);
+      }
+      for (const excluded of messageExcludes ?? []) {
+        expect(err.message).not.toContain(excluded);
       }
     });
   }
@@ -239,5 +251,21 @@ describe("describeSttFailure over managed STT failures", () => {
     const copy = describeSttFailure(err, "vellum");
     expect(copy).not.toContain("platform returned 429");
     expect(copy).toContain("rate-limiting");
+  });
+
+  test("bare auth failure gets sanitized reconnect copy, not the BYOK rewrite", () => {
+    const err = sttErrorFromManagedSpeech({
+      ok: false,
+      kind: "platform-error",
+      status: 401,
+      message: "Managed speech transcription failed (platform returned 401).",
+    });
+    const copy = describeSttFailure(err, "vellum");
+    // Managed STT holds no local key: the "check your API key in Settings →
+    // Voice" guidance is wrong, and the raw HTTP status must not leak.
+    expect(copy).toContain("reconnect your Vellum account");
+    expect(copy).not.toContain("API key");
+    expect(copy).not.toContain("Settings → Voice");
+    expect(copy).not.toContain("platform returned 401");
   });
 });

--- a/assistant/src/providers/speech-to-text/vellum-managed.ts
+++ b/assistant/src/providers/speech-to-text/vellum-managed.ts
@@ -35,20 +35,23 @@ export async function vellumManagedSpeechAvailable(): Promise<boolean> {
  *
  * Managed speech has no provider API key on this machine, so the BYOK "check
  * your API key" rewrite never applies. A failure is flagged `userFacing` —
- * surfaced verbatim by `describeSttFailure` — only when it already carries
- * actionable remediation: a platform reconnect (`unavailable`), a credit
- * top-up (`insufficient_balance`), or the platform's own `detail` message. A
- * failure that fell back to a bare HTTP status (no `detail`) is left
- * non-user-facing so `describeSttFailure` emits friendly category copy instead
- * of leaking the raw status.
+ * surfaced verbatim by `describeSttFailure` — when it carries actionable
+ * remediation: a platform reconnect (`unavailable`), a credit top-up
+ * (`insufficient_balance`), or the platform's own `detail` message. A failure
+ * that fell back to a bare HTTP status (no `detail`) is left non-user-facing so
+ * `describeSttFailure` emits friendly category copy instead of leaking the raw
+ * status — except a bare auth status (401/403), which would be rewritten to the
+ * wrong BYOK "check your API key" guidance, so it gets its own sanitized
+ * platform-connection message.
  */
 export function sttErrorFromManagedSpeech(
   failure: ManagedSpeechFailure,
 ): SttError {
+  const hasDetail = failure.detail !== undefined;
   const userFacing =
     failure.kind === "unavailable" ||
     failure.code === "insufficient_balance" ||
-    failure.detail !== undefined;
+    hasDetail;
   const managed = (category: SttErrorCategory, message: string): SttError =>
     new SttError(category, message, { userFacing });
 
@@ -64,7 +67,17 @@ export function sttErrorFromManagedSpeech(
   switch (failure.status) {
     case 401:
     case 403:
-      return managed("auth", failure.message);
+      // A bare auth failure must stay user-facing so describeSttFailure skips
+      // its BYOK "check your API key" rewrite — managed STT has no local key.
+      // `managed()` would be non-user-facing here (see `userFacing` above), so
+      // construct the sanitized platform-connection message directly.
+      return hasDetail
+        ? managed("auth", failure.message)
+        : new SttError(
+            "auth",
+            "Vellum couldn't authenticate with the platform while transcribing — reconnect your Vellum account, then retry.",
+            { userFacing: true },
+          );
     case 429:
       return managed("rate-limit", failure.message);
     case 413:


### PR DESCRIPTION
## Summary

Addresses Codex feedback on #38413. A bare managed STT auth failure — platform 401/403 with no JSON `detail` (e.g. from auth middleware or a non-JSON platform error) — was categorized `auth` but left non-`userFacing`, so `describeSttFailure(..., "vellum")` rewrote it to the BYOK "rejected the configured API key … Check the speech-to-text API key in Settings → Voice" guidance. That is the wrong remediation for managed STT, which holds no local provider key — exactly the copy base PR #38392 existed to eliminate.

`sttErrorFromManagedSpeech` now gives a bare managed 401/403 its own sanitized, `userFacing` platform-connection message:

> Vellum couldn't authenticate with the platform while transcribing — reconnect your Vellum account, then retry.

No raw HTTP status and no API-key language leak, preserving **both** prior fixes:

- #38392 — managed failures never get the BYOK "check your API key" rewrite.
- #38413 — bare HTTP-status fallbacks never leak raw "platform returned N" text.

Detail-bearing auth failures still surface the platform's `detail` verbatim; bare 429/413/5xx still fall through to friendly category copy, unchanged.

## Testing

- `bun test src/providers/speech-to-text/__tests__/vellum-managed.test.ts` — 17 pass
- `bun run typecheck:fast` — clean

Addresses review feedback on #38413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)