### PR TITLE
fix(daemon): recover deduped redelivery reply stuck in the crash window

### DIFF
--- a/assistant/src/persistence/delivery-status.ts
+++ b/assistant/src/persistence/delivery-status.ts
@@ -6,7 +6,7 @@
  * retryable and dead-lettered events, and replaying dead letters.
  */
 
-import { and, eq, lte, or } from "drizzle-orm";
+import { and, eq, lte, ne, or } from "drizzle-orm";
 
 import { getDb } from "./db-connection.js";
 import {
@@ -273,6 +273,34 @@ export function getRetryableDeliveryEvents(limit = 20): Array<{
     )
     .limit(limit)
     .all();
+}
+
+/**
+ * Fetch the `deliveryStatus` of every OTHER inbound event linked to the given
+ * user message (excluding `excludeEventId`).
+ *
+ * An at-least-once redelivery that deduplicates against the original turn is
+ * `linkMessage`d to that turn's `messageId`, so the original and the
+ * redelivered event become siblings sharing `messageId`. The dedup dispatch
+ * path reads these statuses to tell an already-owned delivery from the crash
+ * window where the reply was persisted but never delivered.
+ */
+export function getSiblingEventDeliveryStatuses(
+  messageId: string,
+  excludeEventId: string,
+): string[] {
+  const db = getDb();
+  return db
+    .select({ deliveryStatus: channelInboundEvents.deliveryStatus })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.messageId, messageId),
+        ne(channelInboundEvents.id, excludeEventId),
+      ),
+    )
+    .all()
+    .map((row) => row.deliveryStatus);
 }
 
 /** Fetch dead-lettered events. */

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -23,6 +23,7 @@ const replyDeliveryCalls: Array<{
   startFromSegment?: number;
   messageTs?: string;
 }> = [];
+let siblingDeliveryStatuses: string[] = [];
 let deliverChannelReplyImpl: (
   callbackUrl: string,
   payload: Record<string, unknown>,
@@ -62,6 +63,7 @@ mock.module("../../../persistence/delivery-status.js", () => ({
     operationOrder.push("processing-failure");
     processingFailureEvents.push(eventId);
   },
+  getSiblingEventDeliveryStatuses: () => siblingDeliveryStatuses,
 }));
 
 mock.module("../../gateway-client.js", () => ({
@@ -118,6 +120,7 @@ beforeEach(() => {
   storedReplyMessageIds.length = 0;
   storedStreamedReplyTs.length = 0;
   replyDeliveryCalls.length = 0;
+  siblingDeliveryStatuses = [];
   deliverChannelReplyImpl = async () => ({ ok: true });
   deliverReplyViaCallbackImpl = async () => {};
 });
@@ -337,12 +340,15 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
     clearThreadTs(conversationId);
   });
 
-  test("suppresses reply delivery when the ingress deduplicated against a prior turn", async () => {
-    const conversationId = "conv-dedup-ingress";
-    const channelId = "C-DEDUP-INGRESS";
+  test("suppresses reply delivery when a deduplicated redelivery's prior attempt already delivered", async () => {
+    const conversationId = "conv-dedup-delivered";
+    const channelId = "C-DEDUP-DELIVERED";
 
     // At-least-once redelivery: the persist layer dedups on the idempotency
     // key, so processMessage skips the agent loop and returns `deduplicated`.
+    // The original sibling event already reached `delivered`, so re-emitting
+    // the reply would duplicate it.
+    siblingDeliveryStatuses = ["delivered"];
     const processMessage: MessageProcessor = async () => ({
       messageId: "user-msg-dedup",
       deduplicated: true,
@@ -351,7 +357,7 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
     processChannelMessageInBackground({
       processMessage,
       conversationId,
-      eventId: "evt-dedup",
+      eventId: "evt-dedup-delivered",
       content: "redelivered message",
       sourceChannel: "slack",
       sourceInterface: "slack",
@@ -365,10 +371,86 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
 
     // The redelivery is recorded as processed, but the original reply is not
     // re-delivered — no durable delivery, no terminal delivery transition.
-    expect(markedProcessedEvents).toEqual(["evt-dedup"]);
+    expect(markedProcessedEvents).toEqual(["evt-dedup-delivered"]);
     expect(replyDeliveryCalls).toEqual([]);
     expect(deliveredEvents).toEqual([]);
     expect(deliveredChannelReplies).toEqual([]);
+
+    clearThreadTs(conversationId);
+  });
+
+  test("skips reply delivery when a deduplicated redelivery's prior attempt failed (sweep owns recovery)", async () => {
+    const conversationId = "conv-dedup-failed";
+    const channelId = "C-DEDUP-FAILED";
+
+    // The original sibling event's delivery failed and is owned by the
+    // delivery-retry sweep; the redelivery must not race it.
+    siblingDeliveryStatuses = ["failed"];
+    const processMessage: MessageProcessor = async () => ({
+      messageId: "user-msg-dedup",
+      deduplicated: true,
+    });
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-dedup-failed",
+      content: "redelivered message",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    expect(markedProcessedEvents).toEqual(["evt-dedup-failed"]);
+    expect(replyDeliveryCalls).toEqual([]);
+    expect(deliveredEvents).toEqual([]);
+    expect(deliveredChannelReplies).toEqual([]);
+
+    clearThreadTs(conversationId);
+  });
+
+  test("recovers the reply when a deduplicated redelivery's prior attempt is stuck pending (crash window)", async () => {
+    const conversationId = "conv-dedup-pending";
+    const channelId = "C-DEDUP-PENDING";
+
+    // The first process persisted the turn but died before recording a
+    // delivery outcome, leaving the original sibling event stuck `pending`.
+    // The sweep only selects `failed`, so this redelivery is the only path
+    // that can recover the undelivered reply.
+    siblingDeliveryStatuses = ["pending"];
+    const processMessage: MessageProcessor = async () => ({
+      messageId: "user-msg-dedup",
+      deduplicated: true,
+    });
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-dedup-pending",
+      content: "redelivered message",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    // finalizeEventDelivery runs: it re-delivers the original turn's reply via
+    // `sinceMessageId` (no targeted `messageId`, since no agent loop ran) and
+    // marks this event delivered.
+    expect(markedProcessedEvents).toEqual(["evt-dedup-pending"]);
+    expect(replyDeliveryCalls).toEqual([
+      { messageId: undefined, startFromSegment: 0 },
+    ]);
+    expect(deliveredEvents).toEqual(["evt-dedup-pending"]);
 
     clearThreadTs(conversationId);
   });

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -30,6 +30,7 @@ import {
   storeStreamedReplyTs,
 } from "../../../persistence/delivery-crud.js";
 import {
+  getSiblingEventDeliveryStatuses,
   markProcessed,
   recordProcessingFailure,
 } from "../../../persistence/delivery-status.js";
@@ -326,13 +327,32 @@ export function processChannelMessageInBackground(
         return;
       }
 
-      if (deduplicatedIngress) {
-        // The original turn already delivered its reply; a redelivery of the
-        // same ingress must not re-emit it. `finalizeEventDelivery` would
-        // re-deliver via `sinceMessageId: userMessageId`, so skip it entirely.
+      // An at-least-once redelivery that deduplicated against the original turn
+      // must not blindly re-deliver: `finalizeEventDelivery` would re-emit the
+      // reply via `sinceMessageId: userMessageId`. Consult the sibling events
+      // linked to the same user message (they share `messageId` because the
+      // deduped turn returns the original message id and this redelivery was
+      // `linkMessage`d to it). `deliveryStatus` goes `pending` → `delivered` |
+      // `failed` | `dead_letter`; only `pending` is non-terminal:
+      //   - `delivered`            → reply already emitted → skip (would duplicate).
+      //   - `failed`/`dead_letter` → a delivery attempt is recorded; the retry
+      //     sweep (which selects `deliveryStatus='failed'`) or dead-letter replay
+      //     owns recovery → skip to avoid racing it.
+      //   - all siblings `pending` → the first process persisted the turn but
+      //     died before recording a delivery outcome. The sweep never selects
+      //     `pending`, so this redelivery is the only path that can recover the
+      //     undelivered reply → fall through and deliver.
+      const priorDeduplicatedDeliveryOwned =
+        deduplicatedIngress &&
+        userMessageId !== undefined &&
+        getSiblingEventDeliveryStatuses(userMessageId, eventId).some(
+          (status) => status !== "pending",
+        );
+
+      if (priorDeduplicatedDeliveryOwned) {
         log.info(
           { conversationId, eventId },
-          "Skipping channel reply delivery for deduplicated ingress event",
+          "Skipping channel reply delivery for deduplicated ingress event; a prior attempt owns delivery",
         );
       } else if (replyCallbackUrl) {
         try {


### PR DESCRIPTION
Follow-up to #38412 addressing Codex P2 review feedback.

## Problem

#38412 made a deduplicated at-least-once channel redelivery skip reply delivery entirely, to prevent a double-emit of the original turn's reply. But if the first attempt persisted the turn and the process then died **before** `finalizeEventDelivery` recorded a delivery outcome, the original event is left `delivery_status='pending'`. The delivery-retry sweep (`getRetryableDeliveryEvents`) selects only `deliveryStatus='failed'`, so a `pending` row is never swept — and with #38412 the redelivery also skipped delivery, so the user **never** received the reply.

## Fix

Preserve the double-emit fix, but consult the delivery state of the sibling events (which share `messageId` because the deduped turn returns the original message id and the redelivered event is `linkMessage`d to it) before skipping:

- a sibling reached `delivered` → skip (reply already emitted; re-delivering duplicates it)
- a sibling reached `failed` / `dead_letter` → skip (a delivery attempt is recorded; the retry sweep or dead-letter replay owns recovery — don't race it)
- **all** siblings still `pending` → the crash window; proceed with `finalizeEventDelivery` so the redelivery recovers the undelivered reply via `sinceMessageId`

## Changes

- `getSiblingEventDeliveryStatuses(messageId, excludeEventId)` helper in `delivery-status.ts`.
- `background-dispatch.ts` gates the dedup skip on that sibling state instead of skipping unconditionally.
- Tests for all three states: prior `delivered` → skip, prior `failed` → skip, prior `pending` → recover (re-delivers via `sinceMessageId`).

## Known limitation

If the first attempt is still mid-delivery (its row momentarily `pending`) when a redelivery with a *fresh transport id* arrives, both may deliver. That window is small (bounded by one callback round-trip) and strictly preferable to silently dropping the reply after a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)