### PR TITLE
fix(empty-response): drop null-keyed tool churn from thread-scoped refusal quarantine

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -6289,6 +6289,117 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(serialized).toContain("hi assistant");
     expect(serialized).toContain("back to normal");
   });
+
+  test("quarantines a threaded refusal that followed a tool call, leaving no orphan tool churn", () => {
+    // @alice's flagged prompt roots a thread; the assistant posts an interim
+    // "let me check" reply carrying a `tool_use` (Slack-visible, so it keys to
+    // @alice's thread), the tool runs (a synthetic `tool_result` row with NO
+    // Slack provenance — it keys `null`), and the refusal fallback lands back
+    // in @alice's thread. @bob posts in a sibling thread in between.
+    //
+    // Thread-scoped pairing drops the prompt/fallback and the Slack-visible
+    // `tool_use`, but a naive walk skips the `null`-keyed synthetic
+    // `tool_result` as "another thread". Orphan-tool pruning already ran during
+    // rendering, so that stranded `tool_result` — now missing its `tool_use` —
+    // would ship to the provider and hard-fail the request. Null-keyed tool
+    // churn must be treated as part of the refused exchange and dropped.
+    const CHANNEL_ID = "C0MULTI02";
+    const SLACK_CAPS_CHANNEL: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+    const T_HI = "1699971900.000100";
+    const T_PROMPT = "1699972000.000200"; // roots @alice's thread
+    const T_TOOLUSE = "1699972010.000250"; // assistant interim + tool_use, in @alice's thread
+    const T_BOB = "1699972020.000300"; // sibling-thread post, interleaved
+    const T_FALLBACK = "1699972060.000400"; // assistant refusal, in @alice's thread
+    const T_LATER = "1699972200.000500";
+    const meta = (
+      channelTs: string,
+      displayName: string,
+      threadTs?: string,
+    ): SlackMessageMetadata => ({
+      source: "slack",
+      channelId: CHANNEL_ID,
+      channelTs,
+      ...(threadTs ? { threadTs } : {}),
+      eventKind: "message",
+      displayName,
+    });
+    const rows: SlackTranscriptInputRow[] = [
+      row(
+        "user",
+        "hi assistant",
+        1699971900_000,
+        metadataEnvelope(meta(T_HI, "@alice")),
+      ),
+      row(
+        "user",
+        "disallowed question",
+        1699972000_000,
+        metadataEnvelope(meta(T_PROMPT, "@alice")),
+      ),
+      // Assistant interim reply + tool_use — Slack-visible, threaded under the
+      // prompt, so it keys to @alice's thread.
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "let me check" },
+          { type: "tool_use", id: "tu_ref", name: "search", input: { q: "x" } },
+        ]),
+        createdAt: 1699972010_000,
+        metadata: metadataEnvelope(meta(T_TOOLUSE, "@assistant", T_PROMPT)),
+      },
+      row(
+        "user",
+        "what's for lunch",
+        1699972020_000,
+        metadataEnvelope(meta(T_BOB, "@bob")),
+      ),
+      // Synthetic tool_result — NOT sent to Slack, so no slackMeta (keys null).
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu_ref", content: "result" },
+        ]),
+        createdAt: 1699972030_000,
+        metadata: metadataEnvelope(null),
+      },
+      row(
+        "assistant",
+        REFUSAL_FALLBACK_TEXT,
+        1699972060_000,
+        metadataEnvelope(meta(T_FALLBACK, "@assistant", T_PROMPT)),
+      ),
+      row(
+        "user",
+        "back to normal",
+        1699972200_000,
+        metadataEnvelope(meta(T_LATER, "@alice")),
+      ),
+    ];
+
+    const result = assembleSlackChronologicalMessages(rows, SLACK_CAPS_CHANNEL);
+    expect(result).not.toBeNull();
+    const blocks = result!.flatMap((m) => m.content);
+    // No tool churn from the refused turn survives — neither the orphaned
+    // tool_result nor its (now dropped) tool_use.
+    expect(blocks.some((b) => b.type === "tool_result")).toBe(false);
+    expect(blocks.some((b) => b.type === "tool_use")).toBe(false);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("tu_ref");
+    // The refusal and the prompt that tripped it are both gone …
+    expect(serialized).not.toContain(REFUSAL_FALLBACK_TEXT);
+    expect(serialized).not.toContain("disallowed question");
+    // … the interleaved sibling-thread post from another user is untouched …
+    expect(serialized).toContain("what's for lunch");
+    // … as are the benign turns on either side.
+    expect(serialized).toContain("hi assistant");
+    expect(serialized).toContain("back to normal");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/empty-response-hook.test.ts
+++ b/assistant/src/__tests__/empty-response-hook.test.ts
@@ -30,7 +30,10 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { quarantineRefusedExchanges } from "../context/refusal-quarantine.js";
+import {
+  computeRefusedExchangeDrops,
+  quarantineRefusedExchanges,
+} from "../context/refusal-quarantine.js";
 import {
   HOOKS,
   INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
@@ -663,6 +666,59 @@ describe("quarantineRefusedExchanges", () => {
     const { messages, droppedExchanges } = quarantineRefusedExchanges(history);
     expect(droppedExchanges).toBe(0);
     expect(messages).toBe(history);
+  });
+});
+
+describe("computeRefusedExchangeDrops — thread-scoped pairing", () => {
+  test("drops null-keyed tool churn from the refused exchange, leaving a sibling-thread post", () => {
+    // Slack thread P: flagged prompt → assistant interim tool_use (Slack-
+    // visible, keyed P) → sibling-thread post (keyed B) → synthetic tool_result
+    // (no provenance, keyed null) → refusal fallback (keyed P). The null-keyed
+    // tool_result belongs to this refused turn: dropping the tool_use but
+    // leaving the tool_result would strand a half-pair (the transcript's
+    // orphan-tool prune has already run), so it must be dropped too.
+    const messages = [
+      userPrompt("flagged prompt"),
+      toolUseTurn("tu_1"),
+      userPrompt("sibling-thread post"),
+      toolResultTurn("tu_1"),
+      refusalFallbackTurn,
+    ];
+    const threadKeys = ["P", "P", "B", null, "P"];
+    const { dropIndices, droppedExchanges } = computeRefusedExchangeDrops(
+      messages,
+      { threadKeys },
+    );
+    expect(droppedExchanges).toBe(1);
+    // Prompt, tool_use, synthetic tool_result, and fallback all go; only the
+    // sibling-thread post survives.
+    expect([...dropIndices].sort((a, b) => a - b)).toEqual([0, 1, 3, 4]);
+    const kept = messages.filter((_, i) => !dropIndices.has(i));
+    expect(kept).toEqual([userPrompt("sibling-thread post")]);
+    expect(
+      kept.some((m) => m.content.some((b) => b.type === "tool_result")),
+    ).toBe(false);
+  });
+
+  test("leaves a null-keyed genuine prompt in place and terminates on the same-thread prompt", () => {
+    // A provenance-less genuine prompt (legacy row, keyed null) sitting between
+    // the same-thread prompt and the fallback is someone else's turn, not the
+    // refused one — it must be left in place while the walk continues to the
+    // same-thread prompt.
+    const messages = [
+      userPrompt("same-thread flagged"),
+      userPrompt("legacy provenance-less prompt"),
+      refusalFallbackTurn,
+    ];
+    const threadKeys = ["P", null, "P"];
+    const { dropIndices, droppedExchanges } = computeRefusedExchangeDrops(
+      messages,
+      { threadKeys },
+    );
+    expect(droppedExchanges).toBe(1);
+    expect([...dropIndices].sort((a, b) => a - b)).toEqual([0, 2]);
+    const kept = messages.filter((_, i) => !dropIndices.has(i));
+    expect(kept).toEqual([userPrompt("legacy provenance-less prompt")]);
   });
 });
 

--- a/assistant/src/context/refusal-quarantine.ts
+++ b/assistant/src/context/refusal-quarantine.ts
@@ -81,9 +81,19 @@ export function isRefusalFallbackMessage(message: Message): boolean {
  *   1:1 with `messages`, `threadTs ?? channelTs`) fixes this: when the
  *   fallback's thread is shared by another message — i.e. it is a real thread,
  *   not a lone top-level/DM row whose key is just its own `channelTs` — the
- *   walk-back skips over messages from other threads and pairs the fallback
- *   with the nearest genuine prompt in its own thread. A `null` key (non-Slack
- *   / legacy rows with no provenance) always uses adjacency.
+ *   walk-back keeps only the refused exchange and leaves the rest in place:
+ *     - a row in another (non-null) thread is a genuine interleaved post —
+ *       left in place;
+ *     - a null-keyed row has no Slack provenance. Synthetic tool churn
+ *       (assistant `tool_use` turns and their `tool_result` rows) is never
+ *       Slack-visible, so it always keys `null` even mid-thread; it belongs to
+ *       the refused exchange and is dropped. Leaving it behind would strand
+ *       half a tool pair, and the Slack transcript's orphan-tool prune runs
+ *       *before* this sweep, so nothing would repair the resulting invalid
+ *       history. A null-keyed genuine user prompt is a different turn
+ *       (legacy/provenance-less), so it is left in place and the walk continues
+ *       to the same-thread prompt.
+ *   A `null` fallback key (non-Slack / legacy) always uses adjacency.
  *
  * Exposed as a set of indices (rather than only the filtered messages) so a
  * caller holding an array rendered in lockstep with `messages` — e.g. the Slack
@@ -131,14 +141,24 @@ export function computeRefusedExchangeDrops(
       fallbackThreadKey !== null && sharedThreadKeys.has(fallbackThreadKey)
         ? threadKeys
         : undefined;
-    // Walk back to the genuine prompt over tool-result / assistant tool churn,
-    // skipping (leaving in place) any interleaved message from another thread.
+    // Walk back to the genuine prompt over tool-result / assistant tool churn.
     for (let s = r - 1; s >= 0; s--) {
-      if (threadScope && (threadScope[s] ?? null) !== fallbackThreadKey) {
-        continue;
+      const isGenuinePrompt =
+        messages[s].role === "user" && !isToolResultMessage(messages[s]);
+      // Under thread scope, leave rows outside the fallback's thread in place —
+      // genuine interleaved posts from other (non-null) threads, and
+      // provenance-less genuine prompts (someone else's turn). Drop only
+      // null-keyed tool churn: this refused exchange's own synthetic
+      // tool_use / tool_result rows, which would otherwise strand half a tool
+      // pair past the earlier orphan prune.
+      if (threadScope) {
+        const key = threadScope[s] ?? null;
+        if (key !== fallbackThreadKey && (key !== null || isGenuinePrompt)) {
+          continue;
+        }
       }
       dropIndices.add(s);
-      if (messages[s].role === "user" && !isToolResultMessage(messages[s])) {
+      if (isGenuinePrompt) {
         break; // the genuine user prompt that was refused
       }
     }


### PR DESCRIPTION
## Problem

Addresses Codex P2 feedback on merged PR #38417 (thread-aware Slack refusal quarantine).

When a Slack-threaded refusal follows a tool call, the intervening synthetic tool rows have no Slack provenance (`sourceChannelTs`/thread key is `null` — they are never sent to Slack). The thread-scoped walk-back in `computeRefusedExchangeDrops` skipped every row whose key differed from the fallback's — including those `null`-keyed rows. If the assistant's `tool_use` turn carried the thread's key (Slack-visible interim reply) it was dropped, while the `null`-keyed `tool_result` was left behind → an **orphan `tool_result`**. Orphan-tool pruning runs *before* quarantine in the assembly pipeline, so nothing repaired it and the invalid history hard-fails the provider. When both tool rows were `null`-keyed, an intact-but-stale pair belonging to the refused turn survived and misled the model.

## Fix — Option A (exchange semantics)

In the thread-scoped walk-back, only `continue` (leave in place) over rows that are genuinely **not** part of the refused exchange:
- a row in another **non-null** thread — a real interleaved sibling-thread post;
- a **null-keyed genuine user prompt** — a provenance-less/legacy turn that is someone else's, not the refused prompt (skipped so the walk still terminates on the same-thread prompt).

Everything else in the walk-back — same-thread rows **and null-keyed tool churn** (synthetic `tool_use`/`tool_result`) — is dropped as part of the refused exchange. This removes the orphan, and also excises stale-but-intact tool pairs from the refused turn.

**Why A over B:** Option B (re-run the existing `filterOrphanToolPairs` after quarantine) is a simpler safety net but only removes orphans — it leaves intact stale pairs and would require threading both `messages`/`renderedMessages` arrays through a filter that lives in `render-transcript.ts`. Option A fixes the exchange semantics precisely in the one place that already owns the walk-back, preserving the PR's thread-aware pairing (sibling-thread user posts still survive).

## Tests
- `conversation-runtime-assembly.test.ts`: threaded refusal-after-tool-call with an interleaved sibling-thread post — asserts no orphaned/stale tool churn survives, the sibling post survives, and prompt+fallback are dropped. Verified it **fails** on the pre-fix walk-back (orphan `tool_result` survives).
- `empty-response-hook.test.ts`: two unit cases directly on `computeRefusedExchangeDrops({ threadKeys })` — (1) null-keyed tool churn is dropped leaving a sibling-thread post; (2) a null-keyed genuine prompt is left in place while the walk terminates on the same-thread prompt.

Both test files pass solo; `typecheck:fast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)