### PR TITLE
fix(daemon): thread resolved app id to side-effect hooks via typed channel

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -4,8 +4,8 @@
  *
  * Tests verify that app_refresh, app_update, app_create, app_delete, and
  * app_generate_icon hooks fire correctly — including recovering an omitted
- * app_id from the executor's echoed result — and that non-hooked tools
- * (app_file_edit, app_file_write) do not trigger side effects.
+ * app_id from the executor's typed `resolvedAppId` side channel — and that
+ * non-hooked tools (app_file_edit, app_file_write) do not trigger side effects.
  *
  * File-change detection for file_write/file_edit is handled by
  * AppSourceWatcher (see app-source-watcher.test.ts).
@@ -223,13 +223,15 @@ describe("session-tool-setup app refresh side effects", () => {
       expect(updatePublishedSpy).not.toHaveBeenCalled();
     });
 
-    test("recovers appId from the result when input omits app_id", async () => {
+    test("recovers appId from resolvedAppId when input omits app_id", async () => {
       // app_id is optional: the skill script resolves the active app and the
-      // executor echoes it back as `appId`. The hook must act on that resolved
-      // id so an omitted-id refresh still refreshes surfaces and re-deploys.
+      // executor reports the id it used via the typed `resolvedAppId` channel.
+      // The hook must act on that id — without parsing `content` — so an
+      // omitted-id refresh still refreshes surfaces and re-deploys.
       const ctx = makeCtx();
       const executor = makeFakeExecutor({
-        content: '{"refreshed":true,"appId":"app-resolved"}',
+        content: '{"refreshed":true}',
+        resolvedAppId: "app-resolved",
         isError: false,
       });
 
@@ -318,10 +320,11 @@ describe("session-tool-setup app refresh side effects", () => {
       expect(updatePublishedSpy).not.toHaveBeenCalled();
     });
 
-    test("recovers appId from the result when input omits app_id", async () => {
+    test("recovers appId from resolvedAppId when input omits app_id", async () => {
       const ctx = makeCtx();
       const executor = makeFakeExecutor({
-        content: '{"updated":true,"appId":"app-resolved-u"}',
+        content: '{"updated":true}',
+        resolvedAppId: "app-resolved-u",
         isError: false,
       });
 
@@ -370,6 +373,7 @@ describe("session-tool-setup app refresh side effects", () => {
       const ctx = makeCtx();
       const executor = makeFakeExecutor({
         content: JSON.stringify({ id: "new-app-1", name: "My App" }),
+        resolvedAppId: "new-app-1",
         isError: false,
       });
 
@@ -394,6 +398,7 @@ describe("session-tool-setup app refresh side effects", () => {
       const ctx = makeCtx({ allowedToolNames: new Set(["app_create"]) });
       const executor = makeFakeExecutor({
         content: JSON.stringify({ id: "alias-app-1", name: "Alias App" }),
+        resolvedAppId: "alias-app-1",
         isError: false,
       });
 
@@ -507,6 +512,7 @@ describe("session-tool-setup app refresh side effects", () => {
           compiled: false,
           compile_errors: [{ text: "syntax error" }],
         }),
+        resolvedAppId: "new-app-err",
         isError: false,
       });
 
@@ -594,10 +600,11 @@ describe("session-tool-setup app refresh side effects", () => {
       expect(updatePublishedSpy).not.toHaveBeenCalled();
     });
 
-    test("recovers appId from the result when input omits app_id", async () => {
+    test("recovers appId from resolvedAppId when input omits app_id", async () => {
       const ctx = makeCtx();
       const executor = makeFakeExecutor({
-        content: '{"generated":true,"appId":"icon-resolved"}',
+        content: '{"generated":true}',
+        resolvedAppId: "icon-resolved",
         isError: false,
       });
 

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -9,7 +9,7 @@
 
 import { isAbsolute, resolve, sep } from "node:path";
 
-import { addAppConversationId } from "../apps/app-store.js";
+import { addAppConversationId, getApp } from "../apps/app-store.js";
 import { findActiveSession } from "../channels/gateway-verification-sessions.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
 import { invalidateEdgeIndex } from "../plugins/defaults/memory/v2/edge-index.js";
@@ -75,10 +75,12 @@ function broadcastAppFilesChanged(appId: string): void {
  *
  * `app_id` is optional for the app-builder fallback tools (`app_update`,
  * `app_refresh`, `app_generate_icon`): when the model omits it, the skill
- * script resolves the conversation's active app and the executor echoes that
- * id back as `appId` in its result. Prefer the explicit tool input; fall back
- * to the resolved id the result carries so an omitted-id call still refreshes
- * surfaces, rebroadcasts, and re-deploys instead of silently no-op'ing.
+ * script resolves the conversation's active app and the executor operates on
+ * that id. Prefer the explicit tool input; otherwise use the id the executor
+ * reports through the typed `resolvedAppId` side channel, so an omitted-id call
+ * still refreshes surfaces, rebroadcasts, and re-deploys instead of silently
+ * no-op'ing. The hook must not infer the id by re-parsing the LLM-facing
+ * `result.content` (see assistant/AGENTS.md § Post-execution hooks).
  */
 function resolveHookAppId(
   input: Record<string, unknown>,
@@ -88,15 +90,7 @@ function resolveHookAppId(
   if (typeof explicit === "string" && explicit.trim().length > 0) {
     return explicit;
   }
-  try {
-    const parsed = JSON.parse(result.content) as { appId?: unknown };
-    if (typeof parsed.appId === "string" && parsed.appId.length > 0) {
-      return parsed.appId;
-    }
-  } catch {
-    // Result wasn't valid JSON — no resolved id to recover.
-  }
-  return undefined;
+  return result.resolvedAppId;
 }
 
 // ── Registry ─────────────────────────────────────────────────────────
@@ -121,41 +115,31 @@ function registerHook(
 // (e.g. macOS "Things" sidebar) refresh their app list immediately.
 // Also kicks off async icon generation via Gemini.
 registerHook("app_create", (_name, _input, result, { ctx }) => {
+  const appId = result.resolvedAppId;
+  if (!appId) {
+    return;
+  }
   try {
-    const parsed = JSON.parse(result.content) as {
-      id?: string;
-      name?: string;
-      description?: string;
-    };
-    if (parsed.id) {
-      try {
-        addAppConversationId(parsed.id, ctx.conversationId);
-      } catch (err) {
-        log.warn(
-          { err, appId: parsed.id },
-          "Failed to track conversation ID on app_create",
-        );
-      }
+    addAppConversationId(appId, ctx.conversationId);
+  } catch (err) {
+    log.warn({ err, appId }, "Failed to track conversation ID on app_create");
+  }
 
-      ensureAppSourceWatcher();
+  ensureAppSourceWatcher();
 
-      notifyAppChanged(ctx, parsed.id);
+  notifyAppChanged(ctx, appId);
 
-      if (parsed.name) {
-        void generateAppIcon(parsed.id, parsed.name, parsed.description)
-          .then(() => {
-            broadcastAppFilesChanged(parsed.id!);
-          })
-          .catch((err) => {
-            log.warn(
-              { err, appId: parsed.id },
-              "Background icon generation failed",
-            );
-          });
-      }
-    }
-  } catch {
-    // Result wasn't valid JSON — skip the broadcast.
+  // Seed background icon generation from the created app's canonical record
+  // (its name/description) rather than the LLM-facing result payload.
+  const app = getApp(appId);
+  if (app?.name) {
+    void generateAppIcon(appId, app.name, app.description)
+      .then(() => {
+        broadcastAppFilesChanged(appId);
+      })
+      .catch((err) => {
+        log.warn({ err, appId }, "Background icon generation failed");
+      });
   }
 });
 

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -23,6 +23,13 @@ export interface ExecutorResult {
   isError: boolean;
   /** Optional status message for display (e.g. progress indicator). */
   status?: string;
+  /**
+   * App id this executor operated on, threaded to the post-execution
+   * side-effect hooks as a typed channel so they need not re-parse `content`
+   * to recover an id the skill script resolved from the active app. See
+   * `ToolExecutionResult.resolvedAppId`.
+   */
+  resolvedAppId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -302,6 +309,7 @@ render(<App />, document.getElementById('app')!);
         ...nextStepsField,
       }),
       isError: false,
+      resolvedAppId: app.id,
     };
   }
 
@@ -327,6 +335,7 @@ render(<App />, document.getElementById('app')!);
             ...nextStepsField,
           }),
           isError: false,
+          resolvedAppId: app.id,
         };
       }
       return {
@@ -337,6 +346,7 @@ render(<App />, document.getElementById('app')!);
           ...nextStepsField,
         }),
         isError: false,
+        resolvedAppId: app.id,
       };
     } catch {
       // Preview emission failure is non-fatal - the app was created successfully.
@@ -349,6 +359,7 @@ render(<App />, document.getElementById('app')!);
           ...nextStepsField,
         }),
         isError: false,
+        resolvedAppId: app.id,
       };
     }
   }
@@ -359,6 +370,7 @@ render(<App />, document.getElementById('app')!);
       ...nextStepsField,
     }),
     isError: false,
+    resolvedAppId: app.id,
   };
 }
 
@@ -418,6 +430,7 @@ export async function executeAppRefresh(
       ...compileResultPayload(compileResult),
     }),
     isError: false,
+    resolvedAppId: updated.id,
   };
 }
 
@@ -485,6 +498,7 @@ export async function executeAppUpdate(
       ...compileResultPayload(compileResult),
     }),
     isError: false,
+    resolvedAppId: updated.id,
   };
 }
 
@@ -535,6 +549,7 @@ export async function executeAppGenerateIcon(
     return {
       content: JSON.stringify({ generated: true, appId: input.app_id }),
       isError: false,
+      resolvedAppId: input.app_id,
     };
   }
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -63,6 +63,17 @@ export interface ToolExecutionResult {
   /** Optional short status message for client display (e.g. `"truncated"`, `"timed out"`). */
   status?: string;
   /**
+   * Typed side channel from the app-builder executors to their post-execution
+   * side-effect hooks (`daemon/tool-side-effects.ts`): the exact app id the
+   * executor operated on. `app_id` is optional for the fallback tools
+   * (`app_update`, `app_refresh`, `app_generate_icon`) — when the model omits
+   * it the skill script resolves the conversation's active app — so hooks read
+   * this authoritative id instead of re-parsing the LLM-facing `content`
+   * payload, whose shape must stay decoupled from daemon logic (see
+   * assistant/AGENTS.md § Post-execution hooks). Set only by the app_* executors.
+   */
+  resolvedAppId?: string;
+  /**
    * When true, the agent loop should yield control back to the user after
    * returning this result — tool results are pushed to history and the loop
    * breaks without another LLM call. Two callers set this: interactive


### PR DESCRIPTION
## Summary

Addresses Codex P1 review feedback on #38410.

#38410 fixed app mutation side-effect hooks silently no-op'ing when `app_id` is
omitted (optional since #38397 — the app-builder skill script resolves the
conversation's active app). Its fix added `resolveHookAppId`, which fell back to
`JSON.parse(result.content).appId`. Codex flagged this as a violation of
`assistant/AGENTS.md` § Post-execution hooks: hooks must not coordinate behaviour
by re-parsing a tool's LLM-facing JSON response, so a harmless response-shape
change in `app_refresh`/`app_update`/`app_generate_icon` would silently drop the
refresh/broadcast/redeploy side effects again.

## Fix

Carry the resolved app id through a typed side channel instead of a JSON round-trip:

- Add `resolvedAppId?: string` to `ExecutorResult` and `ToolExecutionResult`.
- The app-builder executors (`executeAppCreate`, `executeAppRefresh`,
  `executeAppUpdate`, `executeAppGenerateIcon`) populate it with the exact id
  they operated on. These tools run as bundled **host** skills (in-process), so
  the executor's result object reaches the hooks unchanged — end-to-end typing.
- `resolveHookAppId` now returns `input.app_id ?? result.resolvedAppId`; the
  `JSON.parse(result.content)` fallback is gone.
- Also migrated the pre-existing `app_create` hook off `JSON.parse(result.content)`:
  it uses `result.resolvedAppId` for the id and reads name/description from the
  app-store (`getApp`, the canonical source) to seed background icon generation.
  No hook in `tool-side-effects.ts` parses `result.content` for app identity now.

## Testing

- `bun test src/__tests__/conversation-tool-setup-app-refresh.test.ts` — 23 pass.
  The "recovers appId when input omits app_id" cases now set `resolvedAppId` with
  **no** `appId` in `content`, proving the payload is no longer parsed.
- `bun test src/__tests__/app-executors.test.ts` (20 pass),
  `app-builder-tool-scripts.test.ts` (20 pass),
  `tool-side-effects-slack-dm.test.ts` (9 pass).
- `bun run typecheck:fast` clean.

Related to #38410.