### PR TITLE
fix(memory): breaker-wrap graph-node sweep scroll and hold it pending under v2

### DIFF
--- a/assistant/src/persistence/embeddings/graph-node-orphan-sweep.ts
+++ b/assistant/src/persistence/embeddings/graph-node-orphan-sweep.ts
@@ -43,14 +43,18 @@ export interface GraphNodeSweepResult {
  *
  * Idempotent: a second run finds no orphans. Deletion is by Qdrant payload
  * (`target_type` + `target_id`) via `deleteByTarget`, so it removes cacheless
- * points a cache lookup could never surface. Each delete goes through the Qdrant
- * circuit breaker; a transient Qdrant failure propagates so the caller (the
- * memory worker) can retry the sweep on a later cycle.
+ * points a cache lookup could never surface. Both the initial scroll and each
+ * delete go through the Qdrant circuit breaker: an already-open circuit surfaces
+ * as `QdrantCircuitOpenError` so the caller (the memory worker) defers the sweep
+ * instead of spending its bounded retries, and a transient failure propagates
+ * for retry on a later cycle.
  */
 export async function sweepOrphanedGraphNodePoints(
   qdrant: GraphNodeSweepClient,
 ): Promise<GraphNodeSweepResult> {
-  const points = await qdrant.scrollByTargetType(GRAPH_NODE_TARGET_TYPE);
+  const points = await withQdrantBreaker(() =>
+    qdrant.scrollByTargetType(GRAPH_NODE_TARGET_TYPE),
+  );
 
   const indexedTargetIds = new Set<string>();
   for (const { payload } of points) {

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -800,6 +800,23 @@ export function deferMemoryJob(id: string): "deferred" | "failed" {
   return "deferred";
 }
 
+/**
+ * Move a running job back to pending after `delayMs` WITHOUT advancing the
+ * attempt or deferral counters. For a job intentionally postponed by a stable
+ * config condition rather than a failure: it must survive an unbounded number of
+ * postponements, so neither {@link failMemoryJob}'s attempt budget nor
+ * {@link deferMemoryJob}'s deferral cap may dead-letter it. It simply re-runs
+ * once the condition clears.
+ */
+export function rescheduleMemoryJob(id: string, delayMs: number): void {
+  const now = Date.now();
+  memoryDb()
+    .update(memoryJobs)
+    .set({ status: "pending", runAfter: now + delayMs, updatedAt: now })
+    .where(eq(memoryJobs.id, id))
+    .run();
+}
+
 export function failMemoryJob(
   id: string,
   error: string,

--- a/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.test.ts
+++ b/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.test.ts
@@ -18,8 +18,13 @@ const { migrateSweepCachelessGraphNodeVectors } =
   await import("./341-sweep-cacheless-graph-node-vectors.js");
 const { sweepOrphanedGraphNodePoints } =
   await import("../embeddings/graph-node-orphan-sweep.js");
+const { withQdrantBreaker, QdrantCircuitOpenError, _resetQdrantBreaker } =
+  await import("../embeddings/qdrant-circuit-breaker.js");
 
 await initializeDb();
+
+/** Consecutive failures that open the breaker (mirrors its FAILURE_THRESHOLD). */
+const BREAKER_FAILURE_THRESHOLD = 5;
 
 const SWEEP_JOB_ID = "migration-341-sweep-cacheless-graph-node-vectors";
 
@@ -80,6 +85,7 @@ function fakeQdrant(indexedTargetIds: string[]) {
 beforeEach(() => {
   mainRaw().run("DELETE FROM memory_graph_nodes");
   getMemorySqlite()!.run("DELETE FROM memory_jobs");
+  _resetQdrantBreaker();
 });
 
 describe("migration 341: enqueue cacheless graph-node vector sweep", () => {
@@ -161,5 +167,32 @@ describe("sweepOrphanedGraphNodePoints", () => {
 
     expect(second.deleted).toEqual([]);
     expect(result).toEqual({ scanned: 1, deleted: 0 });
+  });
+
+  test("an already-open circuit fails the scroll fast with QdrantCircuitOpenError", async () => {
+    // Trip the breaker open so the next Qdrant op fails fast.
+    for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) {
+      await withQdrantBreaker(async () => {
+        throw new Error("qdrant unavailable");
+      }).catch(() => {});
+    }
+
+    let scrollCalled = false;
+    const client = {
+      scrollByTargetType: async () => {
+        scrollCalled = true;
+        return [];
+      },
+      deleteByTarget: async () => {},
+    };
+
+    // The scroll is breaker-wrapped, so an open circuit surfaces as
+    // QdrantCircuitOpenError before the scroll runs — the worker's
+    // `handleJobError` maps this to a defer, not a bounded retry that would burn
+    // the one-shot sweep.
+    await expect(sweepOrphanedGraphNodePoints(client)).rejects.toBeInstanceOf(
+      QdrantCircuitOpenError,
+    );
+    expect(scrollCalled).toBe(false);
   });
 });

--- a/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.ts
+++ b/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.ts
@@ -19,9 +19,9 @@ const SWEEP_JOB_ID = "migration-341-sweep-cacheless-graph-node-vectors";
  * init. So this migration only enqueues a durable
  * `sweep_orphaned_graph_node_points` job on the memory database, mirroring how
  * migration 340 and the live delete path defer Qdrant work to the memory worker.
- * The worker — running once Qdrant is up, and short-circuited under memory v2
- * where the v1 collection is intentionally absent — scrolls every `graph_node`
- * point and deletes those whose backing node row is gone (see
+ * The worker — running once Qdrant is up, and held pending under memory v2 where
+ * the v1 collection is intentionally absent — scrolls every `graph_node` point
+ * and deletes those whose backing node row is gone (see
  * `sweepOrphanedGraphNodePoints`).
  *
  * Registered after migration 340, so it catches exactly the cacheless orphans

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-sweep-defer.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v2-sweep-defer.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression: the one-shot `sweep_orphaned_graph_node_points` cleanup
+ * (migration 341) must NOT be completed as a no-op when `memory.v2.enabled` is
+ * true. It has no re-enqueue, so completing it under v2 would permanently lose
+ * the cleanup — startup leaves the v1 collection on disk, so a later v2→v1
+ * rollback still needs the sweep to run against the cacheless orphan points.
+ * Instead the worker holds the job pending (future `run_after`, no attempt or
+ * deferral spent) so it survives an arbitrarily long v2 window and runs once v1
+ * is active again.
+ *
+ * The other `V1_QDRANT_JOB_TYPES` keep their no-op completion under v2 — their
+ * live write paths re-enqueue them, so draining stale backlog rows is correct.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+// `memory.enabled` and `memory.v2.enabled` both default true, so the real
+// loader reading this file's (empty) workspace config already yields the
+// v2-enabled state this regression needs — no seeding required.
+
+mock.module("../graph/graph-search.js", () => ({
+  searchGraphNodes: async () => [],
+  embedGraphNodeDirect: async () => {},
+  embedGraphNodeJob: async (): Promise<void> => {},
+  enqueueGraphNodeEmbed: () => {},
+  embedGraphTriggerJob: async (): Promise<void> => {},
+  enqueueGraphTriggerEmbed: () => {},
+}));
+
+mock.module("../../../../persistence/db-maintenance.js", () => ({
+  maybeRunDbMaintenance: async () => {},
+  maybeRunPassiveWalCheckpoint: async () => {},
+}));
+
+const tmpWorkspace = mkdtempSync(join(tmpdir(), "jobs-worker-v2-sweep-defer-"));
+const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+import { getMemoryDb } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import { _resetQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
+import { enqueueMemoryJob } from "../../../../persistence/jobs-store.js";
+import { memoryJobs } from "../../../../persistence/schema/index.js";
+import { registerMemoryPluginJobHandlers } from "../job-handler-registration.js";
+import { runMemoryJobsOnce } from "../jobs-worker.js";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+function jobRow(jobId: string) {
+  return getMemoryDb()!
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.id, jobId))
+    .get();
+}
+
+describe("V1 Qdrant job dispatch under memory v2", () => {
+  beforeAll(async () => {
+    registerMemoryPluginJobHandlers();
+    await initializeDb();
+  });
+
+  afterAll(() => {
+    if (previousWorkspaceEnv === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+    }
+    rmSync(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+    _resetQdrantBreaker();
+  });
+
+  test("holds the cacheless graph-node sweep pending, spending no attempt or deferral", async () => {
+    const jobId = enqueueMemoryJob("sweep_orphaned_graph_node_points", {});
+
+    await runMemoryJobsOnce();
+
+    const row = jobRow(jobId);
+    expect(row?.status).toBe("pending");
+    // Rescheduled a generous window out — not a hot loop, and not dead-lettered.
+    expect(row!.runAfter).toBeGreaterThan(Date.now() + ONE_HOUR_MS);
+    // The postpone must not burn the retry/deferral budgets that would
+    // eventually fail the job if v2 stays enabled for months.
+    expect(row!.attempts).toBe(0);
+    expect(row!.deferrals).toBe(0);
+  });
+
+  test("still completes other v1 Qdrant job types as a no-op", async () => {
+    const jobId = enqueueMemoryJob("delete_qdrant_vectors", {
+      targetType: "graph_node",
+      targetId: "node-1",
+    });
+
+    await runMemoryJobsOnce();
+
+    expect(jobRow(jobId)?.status).toBe("completed");
+  });
+});

--- a/assistant/src/plugins/defaults/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers/index-maintenance.ts
@@ -126,8 +126,8 @@ export async function deleteQdrantVectorsJob(job: MemoryJob): Promise<void> {
  *
  * `requireQdrantClient` throws a retryable `BackendUnavailableError` when the v1
  * Qdrant client is not initialized, so the job defers instead of failing; under
- * memory v2 the worker short-circuits this type (`V1_QDRANT_JOB_TYPES`) before
- * dispatch, so it never reaches here.
+ * memory v2 the worker holds this job pending before dispatch (it is not in
+ * `V1_QDRANT_JOB_TYPES`), so the handler runs only once v1 is active.
  */
 export async function sweepOrphanedGraphNodePointsJob(): Promise<void> {
   const qdrant = requireQdrantClient();

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -49,6 +49,7 @@ import {
   type MemoryJob,
   type MemoryJobType,
   MESSAGE_LEXICAL_JOB_TYPES,
+  rescheduleMemoryJob,
   resetRunningJobsToPending,
   SLOW_LLM_JOB_TYPES,
 } from "../../../persistence/jobs-store.js";
@@ -97,6 +98,13 @@ export const MIN_BUFFER_LINES_FOR_CONSOLIDATION = 10;
  * throw `BackendUnavailableError` and accumulate as a deferred backlog. Stale
  * rows from indexer.ts and other unguarded enqueue sites must short-circuit
  * here for the same reason `graph_extract` does below.
+ *
+ * Completing these as a no-op under v2 is safe: their live write paths keep
+ * re-enqueuing them, so nothing is lost. The one-shot
+ * `sweep_orphaned_graph_node_points` cleanup is deliberately NOT in this set —
+ * it has no re-enqueue, so `processJob` holds it pending under v2 (see
+ * {@link SweepPostponedUnderV2Error}) instead of losing it to a no-op
+ * completion.
  */
 const V1_QDRANT_JOB_TYPES = new Set<MemoryJobType>([
   "embed_segment",
@@ -107,8 +115,29 @@ const V1_QDRANT_JOB_TYPES = new Set<MemoryJobType>([
   "embed_pkb_file",
   "rebuild_index",
   "delete_qdrant_vectors",
-  "sweep_orphaned_graph_node_points",
 ]);
+
+/**
+ * The one-shot cacheless graph-node sweep (migration 341) can only run against
+ * the v1 Qdrant collection. Thrown from {@link processJob} when the job is
+ * claimed while `memory.v2.enabled` is on, so {@link handleJobError} reschedules
+ * it — keeping it pending with no attempt or deferral spent — until v1 is active
+ * again, rather than completing it as a no-op and losing the cleanup on a later
+ * v2→v1 rollback.
+ */
+class SweepPostponedUnderV2Error extends Error {
+  constructor() {
+    super("Cacheless graph-node sweep postponed while memory v2 is enabled");
+    this.name = "SweepPostponedUnderV2Error";
+  }
+}
+
+/**
+ * Reschedule window for the postponed cacheless graph-node sweep under v2: long
+ * enough that re-checking the flag costs only a trivial claim a few times a day,
+ * short enough that a v2→v1 rollback runs the cleanup within the same day.
+ */
+const SWEEP_POSTPONE_UNDER_V2_MS = 6 * 60 * 60 * 1000;
 
 /**
  * Job types whose handlers have been removed. Existing rows may still sit in
@@ -501,6 +530,15 @@ async function runLanePool(
 // ── Job error handling ─────────────────────────────────────────────
 
 function handleJobError(job: MemoryJob, err: unknown): void {
+  if (err instanceof SweepPostponedUnderV2Error) {
+    rescheduleMemoryJob(job.id, SWEEP_POSTPONE_UNDER_V2_MS);
+    log.debug(
+      { jobId: job.id, type: job.type },
+      "Cacheless graph-node sweep held pending while memory v2 is enabled",
+    );
+    return;
+  }
+
   if (err instanceof EmbeddingBillingBlockError) {
     const result = deferMemoryJob(job.id);
     if (result === "failed") {
@@ -591,8 +629,13 @@ async function processJob(
   job: MemoryJob,
   config: AssistantConfig,
 ): Promise<void> {
-  if (config.memory.v2.enabled && V1_QDRANT_JOB_TYPES.has(job.type)) {
-    return;
+  if (config.memory.v2.enabled) {
+    if (V1_QDRANT_JOB_TYPES.has(job.type)) {
+      return;
+    }
+    if (job.type === "sweep_orphaned_graph_node_points") {
+      throw new SweepPostponedUnderV2Error();
+    }
   }
   const handler = jobHandlers.get(job.type);
   if (handler) {


### PR DESCRIPTION
## Summary

Addresses both Codex P2 review comments on #38419 (the migration-341 cacheless graph-node vector sweep).

## Fixes

1. **Breaker-wrap the initial scroll** (`graph-node-orphan-sweep.ts`). The sweep's first `scrollByTargetType` bypassed `withQdrantBreaker`, so an already-open Qdrant circuit surfaced as an ordinary retryable failure and burned `RETRY_MAX_ATTEMPTS` on the one-shot job before it could ever reach the (already breaker-wrapped) deletes. The scroll now goes through the breaker too, so an open circuit raises `QdrantCircuitOpenError` and the worker defers instead of permanently failing the cleanup.

2. **Hold the one-shot sweep pending under memory v2** (`jobs-worker.ts`, `jobs-store.ts`). `sweep_orphaned_graph_node_points` was in `V1_QDRANT_JOB_TYPES`, so under v2 `processJob` completed it as a no-op — permanently losing the cleanup on a later v2 to v1 rollback (startup intentionally leaves the v1 collection on disk). It is removed from that set and special-cased: under v2 `processJob` throws `SweepPostponedUnderV2Error`, and `handleJobError` reschedules it through a new no-counter `rescheduleMemoryJob` (6h `run_after` bump). This keeps it pending without hot-looping and without spending the attempt/deferral budgets, so it survives an arbitrarily long v2 window and runs once v1 is active again. The other v1 types keep their intentional no-op completion (their live write paths re-enqueue them, so nothing is lost).

## Tests

- `341-sweep-cacheless-graph-node-vectors.test.ts`: an already-open circuit fails the scroll fast with `QdrantCircuitOpenError` (proving the scroll is breaker-wrapped, and the scroll never runs).
- New `jobs-worker-v2-sweep-defer.test.ts`: under memory v2 the sweep stays `pending` with a future `run_after` and zero attempts/deferrals, while `delete_qdrant_vectors` still completes as a no-op.

Addresses review feedback on #38419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)