### PR TITLE
fix(web): hold onboarding handoff until a resumed done-journey guard settles

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -63,9 +63,20 @@ let establishedResult: { established: boolean; assistantName: string | null } =
     established: false,
     assistantName: null,
   };
-const checkEstablishedAssistantMock = mock(
-  async (_id: string) => establishedResult,
-);
+// When armed, the established-assistant check blocks on this gate so a test can
+// hold the verdict — exercising the window where the resumed terminal step is
+// already on screen but the guard hasn't settled — then release it on demand.
+let establishedCheckGate: Promise<void> | null = null;
+let releaseEstablishedCheck: () => void = () => {};
+function armDelayedEstablishedCheck() {
+  establishedCheckGate = new Promise<void>((resolve) => {
+    releaseEstablishedCheck = resolve;
+  });
+}
+const checkEstablishedAssistantMock = mock(async (_id: string) => {
+  if (establishedCheckGate) await establishedCheckGate;
+  return establishedResult;
+});
 
 const backgroundHatch = {
   start: () => {},
@@ -242,7 +253,27 @@ mock.module("@/domains/onboarding/screens/research-result-steps", () => ({
   FinishingUpStep: () => <div data-testid="finishing-step" />,
   ResearchResultsStep: () => <div data-testid="results-step" />,
   SuggestionsStep: () => <div data-testid="suggestions-step" />,
-  LetsChatReadyStep: () => <div data-testid="letschat-ready-step" />,
+  // Renders the real step's contract: a "Let's chat" CTA that the parent can
+  // hold via `disabled`. Mirrors the component's own guard (native disable +
+  // the handleStart no-op) so a disabled CTA can't fire the handoff.
+  LetsChatReadyStep: (props: {
+    onStart: () => void | Promise<void>;
+    disabled?: boolean;
+  }) => (
+    <div data-testid="letschat-ready-step">
+      <button
+        type="button"
+        data-testid="letschat-start"
+        disabled={props.disabled}
+        onClick={() => {
+          if (props.disabled) return;
+          void props.onStart();
+        }}
+      >
+        Let&apos;s chat
+      </button>
+    </div>
+  ),
 }));
 
 mock.module("@/domains/onboarding/screens/existing-assistant-step", () => ({
@@ -294,6 +325,8 @@ beforeEach(() => {
   localStorage.clear();
   researchStatus = "idle";
   establishedResult = { established: false, assistantName: null };
+  establishedCheckGate = null;
+  releaseEstablishedCheck = () => {};
   navigateMock.mockClear();
   startResearchMock.mockClear();
   hydrateResearchMock.mockClear();
@@ -390,6 +423,72 @@ describe("ResearchOnboardingRoute resume guard", () => {
     );
     // A fresh verdict must not divert, and a done journey never re-fires.
     expect(screen.queryByTestId("existing-step")).toBeNull();
+    expect(startResearchMock).not.toHaveBeenCalled();
+  });
+
+  // The completed snapshot lands on the terminal handoff synchronously, but the
+  // established check settles asynchronously. Until the verdict lands the "Let's
+  // chat" CTA must stay held — otherwise a click races past the guard, clears
+  // the snapshot, and navigates away before `setStep("existing")` can divert.
+  test("holds the 'Let's chat' handoff while a resumed done journey awaits the guard, then diverts when established", async () => {
+    armDelayedEstablishedCheck();
+    establishedResult = { established: true, assistantName: "Viper" };
+    researchStatus = "done";
+    writeResearchSnapshot(USER_ID, doneSnapshot());
+
+    render(<ResearchOnboardingRoute />);
+
+    // The terminal step is on screen, but the guard hasn't settled → CTA held.
+    await waitFor(() =>
+      expect(screen.getByTestId("letschat-start")).toBeTruthy(),
+    );
+    expect(
+      (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    // Clicking the held CTA does nothing: no handoff navigation, snapshot intact.
+    fireEvent.click(screen.getByTestId("letschat-start"));
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(readResearchSnapshot(USER_ID)).not.toBeNull();
+
+    // Releasing an established verdict still diverts to the keep/redo screen.
+    releaseEstablishedCheck();
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-step")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("existing-step").textContent).toBe("Viper");
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(startResearchMock).not.toHaveBeenCalled();
+  });
+
+  test("releases the held handoff once a resumed done journey's guard resolves fresh", async () => {
+    armDelayedEstablishedCheck();
+    establishedResult = { established: false, assistantName: null };
+    researchStatus = "done";
+    writeResearchSnapshot(USER_ID, doneSnapshot());
+
+    render(<ResearchOnboardingRoute />);
+
+    // Held while the verdict is pending.
+    await waitFor(() =>
+      expect(screen.getByTestId("letschat-start")).toBeTruthy(),
+    );
+    expect(
+      (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    // A fresh verdict releases the hold — no divert, and the CTA becomes usable.
+    releaseEstablishedCheck();
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+    expect(screen.queryByTestId("existing-step")).toBeNull();
+
+    // And now clicking it actually hands off to the chat.
+    fireEvent.click(screen.getByTestId("letschat-start"));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled());
     expect(startResearchMock).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -212,6 +212,14 @@ export function ResearchOnboardingRoute() {
   const [gatedFormValues, setGatedFormValues] =
     useState<ResearchOnboardingValues | null>(null);
   const guardOverriddenRef = useRef(false);
+  // Holds the terminal "Let's chat" handoff while a RESUMED completed journey
+  // waits for the established-assistant guard. A done snapshot hydrates straight
+  // onto the suggestions step, whose handoff would otherwise clear the snapshot
+  // and navigate away before the async verdict lands — skipping the keep/redo
+  // choice for an established assistant. Set in the restore pass (before first
+  // paint, no gap) and cleared on every settle path below, so a genuinely-new
+  // user is never stuck.
+  const [resumeGuardPending, setResumeGuardPending] = useState(false);
   const [faceValues, setFaceValues] = useState<GiveMeAFaceValues | null>(null);
   // Personality sliders live here (not in the step) so they survive a step-back
   // and stay shown once locked. `personalityLocked` flips true on the first
@@ -420,6 +428,10 @@ export function ResearchOnboardingRoute() {
         // dispatched the correction, don't re-send it; if it didn't, the effect
         // below re-fires once the resumed suggestions step renders.
         syncDroppedClaimsScrubbed(snapshot.droppedClaimsScrubbed ?? false);
+        // A completed journey resumes straight onto the terminal handoff step
+        // (resolveResumeStep → "suggestions"); hold that CTA here, synchronously,
+        // until the resume-guard effect below settles the verdict.
+        setResumeGuardPending(true);
       }
       // A snapshot written before the calendar steps were dropped from the
       // local flow (or by a signed-in web session) may resume onto them —
@@ -531,11 +543,14 @@ export function ResearchOnboardingRoute() {
           setForwardStack([]);
           setFormValues(null);
           setStep("existing");
+          setResumeGuardPending(false);
           return;
         }
       }
-      // Only the idle path re-fires the search; a hydrated "done" journey keeps
-      // its restored results.
+      // Fresh/unknown verdict (or the guard was already overridden): release the
+      // handoff hold so the CTA is usable. Only the idle path re-fires the
+      // search; a hydrated "done" journey keeps its restored results.
+      setResumeGuardPending(false);
       if (wasIdle) {
         startResearch({
           awaitAssistantId: awaitHatchReady,
@@ -551,6 +566,9 @@ export function ResearchOnboardingRoute() {
     })();
     return () => {
       cancelled = true;
+      // Abandoned before it settled (unmount, or a dep-change re-run): drop the
+      // hold so the handoff is never left stuck disabled.
+      setResumeGuardPending(false);
     };
   }, [
     restored,
@@ -996,6 +1014,9 @@ export function ResearchOnboardingRoute() {
           <LetsChatReadyStep
             installedPlugins={research.installedPlugins}
             pluginCatalog={research.pluginCatalog}
+            // Hold the handoff until a resumed done journey's guard settles, so
+            // it can't fire against an established assistant before the verdict.
+            disabled={resumeGuardPending}
             onStart={async () => {
               // Terminal step: the handoff leaves via enterAssistant, not
               // goForwardTo, so emit the completion here (mirrors SuggestionsStep).

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -901,6 +901,7 @@ export function LetsChatReadyStep({
   onStart,
   onBack,
   onForward,
+  disabled = false,
 }: {
   /**
    * Capabilities installed for the assistant this run (deterministic floor +
@@ -919,6 +920,12 @@ export function LetsChatReadyStep({
   onBack: () => void;
   /** Redo into this step — only set when the user has stepped back. */
   onForward?: () => void;
+  /**
+   * Externally hold the "Let's chat" CTA (e.g. a resumed completed journey
+   * still waiting on the established-assistant guard). Disables the button and
+   * no-ops the handoff until cleared, so the CTA can't fire before the verdict.
+   */
+  disabled?: boolean;
 }) {
   // Constant dark surface for the UI (the plugin cards match the facts cards).
   const tone = DARK_TONE;
@@ -980,7 +987,7 @@ export function LetsChatReadyStep({
   }, [noteY, flown]);
 
   const handleStart = () => {
-    if (starting) return;
+    if (starting || disabled) return;
     setStarting(true);
     // If the handoff rejects, re-enable the button so the user can retry.
     void Promise.resolve()
@@ -1080,7 +1087,7 @@ export function LetsChatReadyStep({
         <button
           type="button"
           onClick={handleStart}
-          disabled={starting}
+          disabled={starting || disabled}
           className="mt-16 flex cursor-pointer h-11 w-[200px] items-center justify-center gap-2 rounded-[10px] text-body-medium-default transition duration-150 enabled:active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
           style={{
             backgroundColor: tone.isLight ? "#1A1A1A" : "#FFFFFF",


### PR DESCRIPTION
## Summary

Follow-up to #38420 addressing the Codex P2 review: closes the async-guard-vs-immediate-render race on the research-onboarding resume path.

When a **completed** snapshot is restored, the restore `useLayoutEffect` hydrates research to `"done"` and `resolveResumeStep` lands the flow on the terminal suggestions / "Let's chat" step **synchronously, before paint**. The established-assistant guard, however, runs in an async effect that awaits `resolveEstablishedGate()` (up to the 4s fail-open timeout). In that window the handoff CTA was live: a click ran `enterAssistant`, which clears the snapshot and navigates away, so the later `setStep("existing")` was too late — the keep/redo choice was still skipped for an established assistant.

## Fix

- New `resumeGuardPending` state holds the terminal handoff for a resumed done-journey. It is set **synchronously in the restore pass** (before first paint, so there's no gap where the CTA is live), and the resume-guard effect clears it on **every** settle path — established → divert, fresh/unknown → allow, and effect cleanup/cancellation — so the guard's fail-open semantics are preserved and a genuinely-new user is never stuck.
- `LetsChatReadyStep` gains a `disabled` prop that both disables the button and no-ops `handleStart` (mirroring its existing `starting` guard). The route passes `disabled={resumeGuardPending}`.
- The idle-resume path is unchanged: it renders no handoff (it re-fires the search only after the guard clears), so it needs no hold.

## Tests

Extended `research-onboarding-route.test.tsx` with a controllable delayed established check:

- With a done snapshot and a **pending** verdict, the "Let's chat" CTA is disabled and clicking it does nothing (no navigation, snapshot intact).
- Releasing an **established** verdict still diverts to the existing-assistant (keep/redo) step.
- Releasing a **fresh** verdict releases the hold, and the handoff then hands off normally.

All 8 tests in the file pass. Web typecheck is clean for the touched files (the broad `tsc` noise is the known fresh-worktree / ungenerated-`src/generated` artifact).