### PR TITLE
fix(web): sweep conversation navigations through navigateToConversation

### DIFF
--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/domains/settings/utils/schedule-formatters";
 import { captureError } from "@/lib/sentry/capture-error";
 import { schedulesByIdRunsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 import { Button, Typography, cn } from "@vellumai/design-library";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -469,7 +470,7 @@ export function ScheduleDetailPanel({
             isLoading={isLoading}
             disableDirectOpen={schedule.mode === "script"}
             onOpenConversation={(conversationId) =>
-              navigate(routes.conversation(conversationId))
+              navigateToConversation(navigate, conversationId)
             }
           />
         </section>

--- a/clients/web/src/domains/settings/components/recent-runs-card.tsx
+++ b/clients/web/src/domains/settings/components/recent-runs-card.tsx
@@ -11,7 +11,7 @@ import {
   getOpenableScheduleRunConversationId,
   hasRunText,
 } from "@/domains/settings/utils/schedule-formatters";
-import { routes } from "@/utils/routes";
+import { navigateToConversation } from "@/utils/conversation-navigation";
 import { Button } from "@vellumai/design-library/components/button";
 import { PanelItem } from "@vellumai/design-library/components/panel-item";
 
@@ -99,7 +99,7 @@ export function RecentRunsCard({
                   }
                   onSelect={
                     conversationId
-                      ? () => navigate(routes.conversation(conversationId))
+                      ? () => navigateToConversation(navigate, conversationId)
                       : hasLocalDetails
                         ? () =>
                             setExpandedRunId(isExpanded ? null : run.id)

--- a/clients/web/src/domains/settings/components/schedule-components.test.ts
+++ b/clients/web/src/domains/settings/components/schedule-components.test.ts
@@ -7,6 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { createElement } from "react";
+import type { NavigateFunction } from "react-router";
 
 import * as schedulesApi from "@/domains/settings/api/schedules";
 import { routes } from "@/utils/routes";
@@ -48,6 +49,15 @@ mock.module("@/domains/settings/api/schedules", () => ({
   ...schedulesApi,
   createSchedule: createScheduleMock,
   fetchScheduleUsageSummary: fetchScheduleUsageSummaryMock,
+}));
+mock.module("@/utils/conversation-navigation", () => ({
+  // Behavioral stub: performs the route change the navigation test asserts,
+  // without the real module's store resets and haptics.
+  navigateToConversation: mock(
+    (navigate: NavigateFunction, conversationId: string) => {
+      void navigate(routes.conversation(conversationId));
+    },
+  ),
 }));
 
 const {

--- a/clients/web/src/domains/settings/pages/bookmarks-page.tsx
+++ b/clients/web/src/domains/settings/pages/bookmarks-page.tsx
@@ -6,7 +6,7 @@ import {
   useBookmarks,
   useBookmarkToggle,
 } from "@/hooks/use-bookmarks";
-import { routes } from "@/utils/routes";
+import { navigateToConversation } from "@/utils/conversation-navigation";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 
@@ -167,14 +167,11 @@ export function BookmarksPage() {
             key={bookmark.id}
             bookmark={bookmark}
             isFirst={index === 0}
-            onOpen={() => {
-              navigate(
-                routes.conversationAtMessage(
-                  bookmark.conversationId,
-                  bookmark.messageId,
-                ),
-              );
-            }}
+            onOpen={() =>
+              navigateToConversation(navigate, bookmark.conversationId, {
+                messageId: bookmark.messageId,
+              })
+            }
             onRemove={() => {
               void toggleBookmark(
                 bookmark.messageId,

--- a/clients/web/src/domains/settings/pages/debug-page.tsx
+++ b/clients/web/src/domains/settings/pages/debug-page.tsx
@@ -9,7 +9,7 @@ import { DebugControlsPanel } from "@/domains/settings/components/panels/debug-c
 import { DoctorPanel } from "@/domains/settings/components/panels/doctor-panel";
 import { resolveDebugTabParam } from "@/domains/settings/pages/debug-page.helpers";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
-import { routes } from "@/utils/routes";
+import { navigateToConversation } from "@/utils/conversation-navigation";
 import { Tabs } from "@vellumai/design-library/components/tabs";
 
 const ALL_TABS = [
@@ -30,7 +30,7 @@ export function DebugPage() {
 
   const handleOpenConversation = useCallback(
     (conversationId: string) => {
-      void navigate(routes.conversation(conversationId));
+      navigateToConversation(navigate, conversationId);
     },
     [navigate],
   );

--- a/clients/web/src/home-page-route.tsx
+++ b/clients/web/src/home-page-route.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/hooks/conversation-queries";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { mergeConversationLists } from "@/utils/conversation-cache";
+import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 import { Typography } from "@vellumai/design-library";
 
@@ -75,7 +76,7 @@ export function HomePageRoute() {
       navigationKey={location.key}
       onInitialFeedItemConsumed={handleInitialFeedItemConsumed}
       onOpenConversation={(conversationId) =>
-        navigate(routes.conversation(conversationId))
+        navigateToConversation(navigate, conversationId)
       }
       onViewSchedule={(scheduleId) =>
         navigate(routes.schedules.detail(scheduleId))

--- a/clients/web/src/utils/conversation-navigation.ts
+++ b/clients/web/src/utils/conversation-navigation.ts
@@ -13,20 +13,26 @@ import { getSoundManager } from "@/lib/sounds/sound-manager";
 
 /**
  * Navigate to an existing conversation, resetting subagent state and updating
- * the active conversation in the store.
+ * the active conversation in the store. Pass `messageId` to anchor the
+ * transcript to a specific message on load.
  *
  * Pure imperative function — reads stores via `.getState()`, no React hooks.
  */
 export function navigateToConversation(
   navigate: NavigateFunction,
   conversationId: string,
+  options?: { messageId?: string },
 ): void {
   haptic.light();
   useViewerStore.getState().setMainView("chat");
   useSubagentStore.getState().reset();
   useWorkflowStore.getState().reset();
   useConversationStore.getState().setActiveConversationId(conversationId);
-  void navigate(routes.conversation(conversationId));
+  void navigate(
+    options?.messageId
+      ? routes.conversationAtMessage(conversationId, options.messageId)
+      : routes.conversation(conversationId),
+  );
 }
 
 export interface NavigateToNewConversationOptions {


### PR DESCRIPTION
## Summary

Routes the remaining imperative "navigate the current window to a conversation" call sites through the shared `navigateToConversation()` navigator, so each resets stale viewer state (subagent panel, workflow panel, main view) and updates the active-conversation store before navigating — the same stale-viewer bug class fixed for usage-breakdown rows in #38411 (test-mock follow-up in #38416).

## Converted call sites

- `home-page-route.tsx` — activity feed `onOpenConversation`
- `domains/schedules/components/schedule-detail-panel.tsx` — recent-runs `onOpenConversation`
- `domains/settings/pages/debug-page.tsx` — all-conversations `onOpenConversation`
- `domains/settings/components/recent-runs-card.tsx` — run row `onSelect`
- `domains/settings/pages/bookmarks-page.tsx` — bookmark "Open"

## Helper change

`bookmarks-page` navigates to a specific message via `routes.conversationAtMessage`, which the navigator didn't support. Extended `navigateToConversation(navigate, conversationId, { messageId })` with an optional `messageId` that anchors the transcript to that message on load. This keeps the bookmark's scroll-to-message behavior while adding the viewer resets, instead of duplicating the reset sequence in the page. Existing two-arg callers are unaffected (backward compatible).

## Tests

Added a `@/utils/conversation-navigation` module mock to `schedule-components.test.ts` (mirroring #38416) — a behavioral stub that performs the route change the `RecentRunsCard` navigation test asserts, without the real store resets/haptics. `schedule-components.test.ts` passes (21/21). `bunx tsc --noEmit` and `eslint` on the touched files are clean.

## Deliberately left alone (not this bug class)

- **New-tab opens** — `chat-layout.tsx` / `use-conversation-secondary-actions.ts` `window.open(..., "_blank")`.
- **URL/href builders** — `to={routes.conversation(...)}` links (usage-tab, skill-lineage-link, inspect-page), the `<Navigate>` redirect (conversation-redirect), and `?prompt=` / `conversationWithPrompt` draft-relay sites (root-layout, research-\*, document-viewer, app-viewer-actions relay).
- **Return-to-active / URL-sync** — `chat-layout.tsx` `currentConversation` and `nav-gate-bubble.tsx` navigate to the *already-active* conversation (with a `routes.assistant` fallback); resetting viewer state there would drop live panels for the conversation the user is staying in.
- **Framework-agnostic contexts** — `app-viewer-actions.ts` (`ctx.navigate: (to: string) => void`) and `stream-handlers/navigation-handlers.ts` (`ctx.router.push`) aren't react-router `NavigateFunction`s; `navigation-handlers.handleOpenConversation` already inlines the identical reset sequence for the stream-handler context.
- **Chat-domain lifecycle nav** — the conversation-loader's own `switchConversation` / `startNewConversation` already inline the resets, and the `{ replace: true }` bootstrap / draft / onboarding / send flows carry semantics (`replace`, draft creation) the plain-push navigator doesn't express.
- **Fork** (`use-conversation-secondary-actions.handleForkConversation`) — already fires its own `haptic.light()` at action start; routing through the navigator would double the haptic or delay feedback, and it is chat-domain-internal lifecycle nav consistent with the loader's inlined helpers. Left as a focused follow-up if the team wants fork to reset viewer state.

## Risk

Low — mechanical routing change plus a backward-compatible optional param on the shared navigator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)