### PR TITLE
style(web): brace control statements in onboarding resume-guard tests

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -74,7 +74,9 @@ function armDelayedEstablishedCheck() {
   });
 }
 const checkEstablishedAssistantMock = mock(async (_id: string) => {
-  if (establishedCheckGate) await establishedCheckGate;
+  if (establishedCheckGate) {
+    await establishedCheckGate;
+  }
   return establishedResult;
 });
 
@@ -266,7 +268,9 @@ mock.module("@/domains/onboarding/screens/research-result-steps", () => ({
         data-testid="letschat-start"
         disabled={props.disabled}
         onClick={() => {
-          if (props.disabled) return;
+          if (props.disabled) {
+            return;
+          }
           void props.onStart();
         }}
       >

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -987,7 +987,9 @@ export function LetsChatReadyStep({
   }, [noteY, flown]);
 
   const handleStart = () => {
-    if (starting || disabled) return;
+    if (starting || disabled) {
+      return;
+    }
     setStarting(true);
     // If the handoff rejects, re-enable the button so the user can retry.
     void Promise.resolve()


### PR DESCRIPTION
Follow-up to #38428: add braces to the three single-line control statements that change introduced (per the repo curly rule — brace any control statement you touch). No behavior change; the 8 route tests still pass.