### PR TITLE
fix(memory): add rescheduleMemoryJob to disk-pressure test jobs-store mock

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -149,6 +149,7 @@ mock.module("../persistence/jobs-store.js", () => ({
     manual: "manual",
   },
   MESSAGE_LEXICAL_JOB_TYPES: [],
+  rescheduleMemoryJob: mock(() => {}),
   resetRunningJobsToPending: mock(() => 0),
   SLOW_LLM_JOB_TYPES: [],
   upsertDebouncedJob: mock(() => "job-debounced"),


### PR DESCRIPTION
## Summary
- Add `rescheduleMemoryJob` to the enumerated `jobs-store.js` mock factory in `background-workers-disk-pressure.test.ts`.
- #38427 added a `rescheduleMemoryJob` import to the memory jobs-worker. This test registers its mocks first and dynamically imports the worker afterward, so the mock factory is the entire module namespace — the missing key failed ESM named-import validation (`Export named 'rescheduleMemoryJob' not found`) and broke the `Test` job of `CI Main Assistant Checks` on main ([failing run](https://github.com/vellum-ai/vellum-assistant/actions/runs/29570016117/job/87851324340)).
- Verified the test file passes solo after the change.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29570016117/job/87851324340

🤖 Generated with [Claude Code](https://claude.com/claude-code)