### PR TITLE
fix(memory): implement supersession durability inheritance in graph extraction

### DIFF
--- a/assistant/src/plugins/defaults/memory/graph/extraction.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/extraction.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseExtractionResponse } from "./extraction.js";
+import type { DeferredEdge } from "./extraction.js";
+import {
+  applySupersessionDurability,
+  parseExtractionResponse,
+} from "./extraction.js";
+import type { MemoryDiff, MemoryNode, NewNode } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1217,5 +1222,325 @@ describe("parseExtractionResponse — robustness", () => {
   test("handles missing reinforce_node_ids gracefully", () => {
     const { diff } = parse({ create_nodes: [] });
     expect(diff.reinforceNodeIds).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applySupersessionDurability
+// ---------------------------------------------------------------------------
+
+function mockNode(overrides: Partial<MemoryNode> = {}): MemoryNode {
+  return {
+    id: "node-x",
+    content: "Some fact.",
+    type: "semantic",
+    created: NOW,
+    lastAccessed: NOW,
+    lastConsolidated: NOW,
+    eventDate: null,
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0,
+    },
+    fidelity: "vivid",
+    confidence: 0.8,
+    significance: 0.5,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: NOW,
+    sourceConversations: [CONV_ID],
+    sourceType: "direct",
+    narrativeRole: null,
+    partOfStory: null,
+    imageRefs: null,
+    ...overrides,
+  };
+}
+
+function emptyDiff(): MemoryDiff {
+  return {
+    createNodes: [],
+    updateNodes: [],
+    deleteNodeIds: [],
+    createEdges: [],
+    deleteEdgeIds: [],
+    createTriggers: [],
+    deleteTriggerIds: [],
+    reinforceNodeIds: [],
+  };
+}
+
+function newNodeStub(overrides: Partial<NewNode> = {}): NewNode {
+  return {
+    content: "New fact.",
+    type: "semantic",
+    created: NOW,
+    lastAccessed: NOW,
+    lastConsolidated: NOW,
+    eventDate: null,
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0,
+    },
+    fidelity: "vivid",
+    confidence: 0.8,
+    significance: 0.5,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: NOW,
+    sourceConversations: [CONV_ID],
+    sourceType: "direct",
+    narrativeRole: null,
+    partOfStory: null,
+    imageRefs: null,
+    ...overrides,
+  };
+}
+
+describe("applySupersessionDurability — new→existing", () => {
+  test("new node inherits stability from superseded node when old is higher", () => {
+    const diff = emptyDiff();
+    diff.createNodes.push(newNodeStub({ stability: 14 }));
+
+    const deferredEdges: DeferredEdge[] = [
+      {
+        source: { kind: "new", newNodeIndex: 0 },
+        target: { kind: "existing", nodeId: "old-1" },
+        relationship: "supersedes",
+        weight: 1,
+      },
+    ];
+
+    const nodeMap = new Map([
+      ["old-1", mockNode({ id: "old-1", stability: 45 })],
+    ]);
+
+    applySupersessionDurability(diff, deferredEdges, nodeMap);
+
+    expect(diff.createNodes[0].stability).toBe(45);
+  });
+
+  test("new node keeps its own higher stability when it exceeds old node", () => {
+    const diff = emptyDiff();
+    diff.createNodes.push(newNodeStub({ stability: 60 }));
+
+    const deferredEdges: DeferredEdge[] = [
+      {
+        source: { kind: "new", newNodeIndex: 0 },
+        target: { kind: "existing", nodeId: "old-1" },
+        relationship: "supersedes",
+        weight: 1,
+      },
+    ];
+
+    const nodeMap = new Map([
+      ["old-1", mockNode({ id: "old-1", stability: 30 })],
+    ]);
+
+    applySupersessionDurability(diff, deferredEdges, nodeMap);
+
+    expect(diff.createNodes[0].stability).toBe(60);
+  });
+
+  test("new node inherits reinforcementCount from superseded node", () => {
+    const diff = emptyDiff();
+    diff.createNodes.push(newNodeStub({ reinforcementCount: 0 }));
+
+    const deferredEdges: DeferredEdge[] = [
+      {
+        source: { kind: "new", newNodeIndex: 0 },
+        target: { kind: "existing", nodeId: "old-1" },
+        relationship: "supersedes",
+        weight: 1,
+      },
+    ];
+
+    const nodeMap = new Map([
+      ["old-1", mockNode({ id: "old-1", reinforcementCount: 3 })],
+    ]);
+
+    applySupersessionDurability(diff, deferredEdges, nodeMap);
+
+    expect(diff.createNodes[0].reinforcementCount).toBe(3);
+  });
+
+  test("new node significance becomes max of new and old", () => {
+    const diff = emptyDiff();
+    diff.createNodes.push(newNodeStub({ significance: 0.4 }));
+
+    const deferredEdges: DeferredEdge[] = [
+      {
+        source: { kind: "new", newNodeIndex: 0 },
+        target: { kind: "existing", nodeId: "old-1" },
+        relationship: "supersedes",
+        weight: 1,
+      },
+    ];
+
+    const nodeMap = new Map([
+      ["old-1", mockNode({ id: "old-1", significance: 0.8 })],
+    ]);
+
+    applySupersessionDurability(diff, deferredEdges, nodeMap);
+
+    expect(diff.createNodes[0].significance).toBe(0.8);
+  });
+
+  test("non-supersedes edges are not touched", () => {
+    const diff = emptyDiff();
+    diff.createNodes.push(
+      newNodeStub({ stability: 14, reinforcementCount: 0 }),
+    );
+
+    const deferredEdges: DeferredEdge[] = [
+      {
+        source: { kind: "new", newNodeIndex: 0 },
+        target: { kind: "existing", nodeId: "old-1" },
+        relationship: "caused-by",
+        weight: 1,
+      },
+    ];
+
+    const nodeMap = new Map([
+      [
+        "old-1",
+        mockNode({ id: "old-1", stability: 50, reinforcementCount: 5 }),
+      ],
+    ]);
+
+    applySupersessionDurability(diff, deferredEdges, nodeMap);
+
+    expect(diff.createNodes[0].stability).toBe(14);
+    expect(diff.createNodes[0].reinforcementCount).toBe(0);
+  });
+
+  test("skips gracefully when target not in candidate map", () => {
+    const diff = emptyDiff();
+    diff.createNodes.push(newNodeStub({ stability: 14 }));
+
+    const deferredEdges: DeferredEdge[] = [
+      {
+        source: { kind: "new", newNodeIndex: 0 },
+        target: { kind: "existing", nodeId: "ghost-id" },
+        relationship: "supersedes",
+        weight: 1,
+      },
+    ];
+
+    applySupersessionDurability(diff, deferredEdges, new Map());
+
+    expect(diff.createNodes[0].stability).toBe(14);
+  });
+});
+
+describe("applySupersessionDurability — existing→existing", () => {
+  test("adds updateNode entry for superseding existing node", () => {
+    const diff = emptyDiff();
+    diff.createEdges.push({
+      sourceNodeId: "new-fact",
+      targetNodeId: "old-fact",
+      relationship: "supersedes",
+      weight: 1,
+      created: NOW,
+    });
+
+    const nodeMap = new Map([
+      [
+        "new-fact",
+        mockNode({
+          id: "new-fact",
+          stability: 14,
+          reinforcementCount: 0,
+          significance: 0.5,
+        }),
+      ],
+      [
+        "old-fact",
+        mockNode({
+          id: "old-fact",
+          stability: 40,
+          reinforcementCount: 2,
+          significance: 0.7,
+        }),
+      ],
+    ]);
+
+    applySupersessionDurability(diff, [], nodeMap);
+
+    expect(diff.updateNodes).toHaveLength(1);
+    const update = diff.updateNodes[0];
+    expect(update.id).toBe("new-fact");
+    expect(update.changes.stability).toBe(40);
+    expect(update.changes.reinforcementCount).toBe(2);
+    expect(update.changes.significance).toBe(0.7);
+  });
+
+  test("merges into existing updateNode rather than adding a duplicate", () => {
+    const diff = emptyDiff();
+    diff.updateNodes.push({
+      id: "new-fact",
+      changes: { content: "Corrected content.", significance: 0.9 },
+    });
+    diff.createEdges.push({
+      sourceNodeId: "new-fact",
+      targetNodeId: "old-fact",
+      relationship: "supersedes",
+      weight: 1,
+      created: NOW,
+    });
+
+    const nodeMap = new Map([
+      [
+        "new-fact",
+        mockNode({
+          id: "new-fact",
+          stability: 14,
+          reinforcementCount: 0,
+          significance: 0.6,
+        }),
+      ],
+      [
+        "old-fact",
+        mockNode({
+          id: "old-fact",
+          stability: 35,
+          reinforcementCount: 4,
+          significance: 0.7,
+        }),
+      ],
+    ]);
+
+    applySupersessionDurability(diff, [], nodeMap);
+
+    expect(diff.updateNodes).toHaveLength(1);
+    const update = diff.updateNodes[0];
+    expect(update.changes.content).toBe("Corrected content.");
+    expect(update.changes.stability).toBe(35);
+    expect(update.changes.reinforcementCount).toBe(4);
+    // LLM said 0.9, old had 0.7 — max wins
+    expect(update.changes.significance).toBe(0.9);
+  });
+
+  test("skips gracefully when target not in candidate map", () => {
+    const diff = emptyDiff();
+    diff.createEdges.push({
+      sourceNodeId: "new-fact",
+      targetNodeId: "ghost",
+      relationship: "supersedes",
+      weight: 1,
+      created: NOW,
+    });
+
+    const nodeMap = new Map([["new-fact", mockNode({ id: "new-fact" })]]);
+
+    applySupersessionDurability(diff, [], nodeMap);
+
+    expect(diff.updateNodes).toHaveLength(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory/graph/extraction.ts
+++ b/assistant/src/plugins/defaults/memory/graph/extraction.ts
@@ -38,6 +38,7 @@ import type {
   Fidelity,
   ImageRef,
   MemoryDiff,
+  MemoryNode,
   MemoryType,
   NewEdge,
   NewNode,
@@ -580,6 +581,109 @@ export interface DeferredEdge {
   target: DeferredEdgeEndpoint;
   relationship: string;
   weight: number;
+}
+
+/**
+ * Inherit durability from the superseded (old) node into the superseding
+ * (new/updated) node. Called after parsing the LLM diff but before applying
+ * it to the store.
+ *
+ * Without this, a superseding node starts with zero reinforcement history and
+ * decays faster than the stale fact it was meant to retire — the old memory
+ * wins the next significance race even though it has been explicitly replaced.
+ *
+ * Two cases handled:
+ *   1. existing→existing edge in diff.createEdges: the source (superseding)
+ *      existing node gets an updateNode entry that carries over stability,
+ *      reinforcementCount, and significance (taking the max of both nodes so
+ *      the superseding node is never downgraded).
+ *   2. new→existing edge in deferredEdges: the new node in diff.createNodes is
+ *      mutated in place before applyDiff runs.
+ */
+export function applySupersessionDurability(
+  diff: MemoryDiff,
+  deferredEdges: DeferredEdge[],
+  candidateNodeMap: Map<string, MemoryNode>,
+): void {
+  // Case 1: existing→existing supersession (both endpoints in candidateNodes)
+  for (const edge of diff.createEdges) {
+    if (edge.relationship !== "supersedes") {
+      continue;
+    }
+    const target = candidateNodeMap.get(edge.targetNodeId);
+    if (!target) {
+      continue;
+    }
+    const source = candidateNodeMap.get(edge.sourceNodeId);
+
+    const inheritedStability = Math.max(
+      source?.stability ?? 14,
+      target.stability,
+    );
+    const inheritedCount = Math.max(
+      source?.reinforcementCount ?? 0,
+      target.reinforcementCount,
+    );
+    const inheritedSignificance = Math.max(
+      source?.significance ?? 0,
+      target.significance,
+    );
+
+    const existing = diff.updateNodes.find((u) => u.id === edge.sourceNodeId);
+    if (existing) {
+      existing.changes.stability = Math.max(
+        (existing.changes.stability as number | undefined) ??
+          source?.stability ??
+          14,
+        inheritedStability,
+      );
+      existing.changes.reinforcementCount = Math.max(
+        (existing.changes.reinforcementCount as number | undefined) ??
+          source?.reinforcementCount ??
+          0,
+        inheritedCount,
+      );
+      existing.changes.significance = Math.max(
+        (existing.changes.significance as number | undefined) ??
+          source?.significance ??
+          0,
+        inheritedSignificance,
+      );
+    } else {
+      diff.updateNodes.push({
+        id: edge.sourceNodeId,
+        changes: {
+          stability: inheritedStability,
+          reinforcementCount: inheritedCount,
+          significance: inheritedSignificance,
+        },
+      });
+    }
+  }
+
+  // Case 2: new→existing supersession (the typical case from extraction)
+  for (const de of deferredEdges) {
+    if (de.relationship !== "supersedes") {
+      continue;
+    }
+    if (de.source.kind !== "new" || de.target.kind !== "existing") {
+      continue;
+    }
+    const target = candidateNodeMap.get(de.target.nodeId);
+    if (!target) {
+      continue;
+    }
+    const newNode = diff.createNodes[de.source.newNodeIndex];
+    if (!newNode) {
+      continue;
+    }
+    newNode.stability = Math.max(newNode.stability, target.stability);
+    newNode.reinforcementCount = Math.max(
+      newNode.reinforcementCount,
+      target.reinforcementCount,
+    );
+    newNode.significance = Math.max(newNode.significance, target.significance);
+  }
 }
 
 export function parseExtractionResponse(
@@ -1140,21 +1244,9 @@ export async function runGraphExtraction(
     conversationTimestamp,
   );
 
-  // 7. Handle supersession (inherit durability before applying diff)
-  // TODO: full supersession is not yet implemented. When it lands, iterate
-  // BOTH `diff.createEdges` (existing → existing) AND `deferredEdges`
-  // (new → existing, the typical supersession case).
-  // Tracked by https://github.com/vellum-ai/vellum-assistant/pull/27057 (Devin).
-  for (const edge of diff.createEdges) {
-    if (edge.relationship === "supersedes") {
-      // Placeholder — see TODO above.
-    }
-  }
-  for (const de of deferredEdges) {
-    if (de.relationship === "supersedes") {
-      // Placeholder — see TODO above.
-    }
-  }
+  // 7. Inherit durability from superseded nodes before applying the diff.
+  const candidateNodeMap = new Map(candidateNodes.map((n) => [n.id, n]));
+  applySupersessionDurability(diff, deferredEdges, candidateNodeMap);
 
   // 8. Apply the diff
   const result = applyDiff(diff, { conversationId });

--- a/assistant/src/plugins/defaults/memory/graph/store.ts
+++ b/assistant/src/plugins/defaults/memory/graph/store.ts
@@ -681,6 +681,8 @@ export function applyDiff(
       if (c.confidence !== undefined) updates.confidence = c.confidence;
       if (c.significance !== undefined) updates.significance = c.significance;
       if (c.stability !== undefined) updates.stability = c.stability;
+      if (c.reinforcementCount !== undefined)
+        updates.reinforcementCount = c.reinforcementCount;
       if (c.narrativeRole !== undefined)
         updates.narrativeRole = c.narrativeRole;
       if (c.partOfStory !== undefined) updates.partOfStory = c.partOfStory;


### PR DESCRIPTION
When the LLM produces a supersedes edge during extraction, the superseding node now inherits the accumulated durability (stability, reinforcementCount, significance) from the node it replaces.

Without this, a brand-new superseding node starts at zero reinforcement history and decays faster than the stale fact it was meant to retire — the old memory wins the next significance race even though it has been explicitly replaced by the LLM.

Two cases are handled:
- new->existing (typical): new node in diff.createNodes is mutated before applyDiff so the inherited fields are persisted on creation.
- existing->existing: an updateNode entry is added (or merged) for the superseding node so it receives the durability boost in the same transaction.

The logic is extracted into applySupersessionDurability(), a pure helper that is independently unit-tested in extraction.test.ts.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
