### PR TITLE
docs(plugins): update Creatorland sub-header copy

### DIFF
--- a/assistant/src/cli/lib/bundled-marketplace.json
+++ b/assistant/src/cli/lib/bundled-marketplace.json
@@ -130,7 +130,7 @@
         "path": "plugins/creatorland-data",
         "ref": "9cdbb1553645bbb746918f43d60e0df17ae91fa0"
       },
-      "description": "Creatorland Data MCP and companion skill catalog: brief-to-shortlist, transcript-to-shortlist, brief builder, fair-price negotiation, one-number rate cards, and a guided onboarding tour for creator marketing workflows.",
+      "description": "Creatorland turns your Vellum assistant into an influencer marketer in a box: find the right creators, benchmark rates, analyze competitors, build campaign shortlists, and launch outreach from your brand context. The plugin kit includes guided workflows for brief-to-shortlist, transcript-to-shortlist, brief building, fair-price negotiation, one-number rate cards, and creator marketing onboarding.",
       "category": "marketing",
       "homepage": "https://github.com/creatorland/creatorland-mcp-skills/tree/main/plugins/creatorland-data",
       "license": "MIT",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -130,7 +130,7 @@
         "path": "plugins/creatorland-data",
         "ref": "9cdbb1553645bbb746918f43d60e0df17ae91fa0"
       },
-      "description": "Creatorland Data MCP and companion skill catalog: brief-to-shortlist, transcript-to-shortlist, brief builder, fair-price negotiation, one-number rate cards, and a guided onboarding tour for creator marketing workflows.",
+      "description": "Creatorland turns your Vellum assistant into an influencer marketer in a box: find the right creators, benchmark rates, analyze competitors, build campaign shortlists, and launch outreach from your brand context. The plugin kit includes guided workflows for brief-to-shortlist, transcript-to-shortlist, brief building, fair-price negotiation, one-number rate cards, and creator marketing onboarding.",
       "category": "marketing",
       "homepage": "https://github.com/creatorland/creatorland-mcp-skills/tree/main/plugins/creatorland-data",
       "license": "MIT",


### PR DESCRIPTION
## Prompt / plan

Requested change to the Creatorland plugin's sub-header/description copy shown on `vellum.ai/plugins/creatorland`. The old copy led with the technical framing ("Creatorland Data MCP and companion skill catalog: …"). The new copy leads with a benefit-driven "influencer marketer in a box" framing while preserving the list of guided workflows.

**Before:**
> Creatorland Data MCP and companion skill catalog: brief-to-shortlist, transcript-to-shortlist, brief builder, fair-price negotiation, one-number rate cards, and a guided onboarding tour for creator marketing workflows.

**After:**
> Creatorland turns your Vellum assistant into an influencer marketer in a box: find the right creators, benchmark rates, analyze competitors, build campaign shortlists, and launch outreach from your brand context. The plugin kit includes guided workflows for brief-to-shortlist, transcript-to-shortlist, brief building, fair-price negotiation, one-number rate cards, and creator marketing onboarding.

The canonical source is `plugins/marketplace.json`; `assistant/src/cli/lib/bundled-marketplace.json` is a bundled copy regenerated via `meta/sync-bundled-copies.ts`, which I re-ran so both stay in sync.

## Test plan

- `bun run meta/sync-bundled-copies.ts` to regenerate the bundled copy.
- `bun run meta/sync-bundled-copies.ts --check` passes — committed bundled copies match their canonical sources (this is what the `pr-marketplace` CI drift guard checks).


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9iGCM3Tewji7dF6Ph9Mw3)_