### PR TITLE
fix(runtime): guard remaining process.memoryUsage().rss calls against Bun syscall bug

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
@@ -787,8 +787,19 @@ describe("streamCommitImport — memory ceiling", () => {
       // MB archive, RSS would spike by at least 100 MB; a streaming
       // importer's per-entry working set is bounded by ~one tar entry's
       // internal buffers (a few MB).
-      const baselineRss = process.memoryUsage().rss;
-      let peakRss = baselineRss;
+      //
+      // Bun 1.3.11 can throw `SystemError: Failed to get memory usage` from the
+      // underlying syscall; guard every sample so a spurious failure doesn't
+      // flake the run — a skipped sample just keeps the prior peak.
+      const sampleRss = (): number | null => {
+        try {
+          return process.memoryUsage().rss;
+        } catch {
+          return null;
+        }
+      };
+      const baselineRss = sampleRss();
+      let peakRss = baselineRss ?? 0;
       let progressCount = 0;
 
       const result = await streamCommitImport({
@@ -797,8 +808,8 @@ describe("streamCommitImport — memory ceiling", () => {
         workspaceDir,
         onProgress: () => {
           progressCount += 1;
-          const cur = process.memoryUsage().rss;
-          if (cur > peakRss) peakRss = cur;
+          const cur = sampleRss();
+          if (cur !== null && cur > peakRss) peakRss = cur;
         },
       });
 
@@ -810,7 +821,7 @@ describe("streamCommitImport — memory ceiling", () => {
       // The 64 MB delta bound is a rough guard proving "it doesn't buffer
       // the whole bundle" — if the importer were accumulating the 100 MB
       // archive in memory, RSS would jump well past this threshold.
-      const delta = peakRss - baselineRss;
+      const delta = peakRss - (baselineRss ?? 0);
       expect(delta).toBeLessThan(64 * 1024 * 1024);
     } finally {
       try {

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -33,16 +33,37 @@ interface MemoryInfo {
   maxMb: number;
 }
 
+/**
+ * Sample this process's resident set size (RSS) in bytes, returning `null` when
+ * the reading fails.
+ *
+ * Bun 1.3.11 can throw `SystemError: Failed to get memory usage, errno: 2` from
+ * the underlying getrusage syscall. The health payload is best-effort, so a
+ * failed sample must never propagate and turn the liveness probe into a 500 —
+ * fall back to `null` and let the caller substitute an alternative source.
+ */
+function sampleProcessRssBytes(): number | null {
+  try {
+    return process.memoryUsage().rss;
+  } catch {
+    return null;
+  }
+}
+
 function getMemoryInfo(): MemoryInfo {
   const bytesToMb = (b: number) => Math.round((b / (1024 * 1024)) * 100) / 100;
   // In platform-managed mode the daemon shares its Node process with whatever
   // the container is doing as a whole; `process.memoryUsage().rss` only sees
   // this process's resident set, which understates the container footprint
   // operators care about. Read the cgroup usage file directly so /v1/health
-  // matches what the StatefulSet's memory limit is enforced against.
+  // matches what the StatefulSet's memory limit is enforced against. When RSS
+  // can't be sampled, fall back to the cgroup usage (if any) before reporting 0
+  // — the metric is best-effort and must never fail the probe.
   const currentBytes =
     (getIsPlatform() ? getContainerMemoryUsageBytes() : null) ??
-    process.memoryUsage().rss;
+    sampleProcessRssBytes() ??
+    getContainerMemoryUsageBytes() ??
+    0;
   return {
     currentMb: bytesToMb(currentBytes),
     maxMb: bytesToMb(getContainerMemoryLimitBytes() ?? totalmem()),


### PR DESCRIPTION
## Prompt / plan

ATL-1008 — "Wrap all `process.memoryUsage().rss` calls in try/catch (bun 1311 syscall bug)".

Bun 1.3.11 can throw `SystemError: Failed to get memory usage, errno: 2` from the underlying `getrusage` syscall. RSS is only ever read for best-effort resource metrics, so a spurious throw must never propagate. This sweeps the codebase and guards the remaining unwrapped call sites:

- **`runtime/routes/identity-routes.ts`** — `getMemoryInfo()` (behind `GET /v1/health` / `/healthz`) sampled RSS unguarded. A throw here would turn the liveness/health probe into a 500, which k8s reads as the pod being down. RSS is now read through a fallible `sampleProcessRssBytes()` helper that returns `null` on failure; `getMemoryInfo` falls back to cgroup usage, then `0`, matching this file's existing convention of silently-degrading resource readers.
- **`runtime/migrations/__tests__/vbundle-streaming-importer.test.ts`** — the memory-ceiling test sampled RSS at baseline and inside `onProgress` unguarded. Both are now guarded so a spurious syscall failure skips the sample (keeping the prior peak) instead of flaking the run.

`tools/tool-profiler.ts` already wraps its call (`sampleRssBytes`), so after this change every `process.memoryUsage().rss` call in the repo is guarded.

## Test plan

- `bunx tsc --noEmit` — passes.
- `bun test src/__tests__/identity-routes.test.ts` — 28 pass / 0 fail.
- `bun test src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts -t "memory ceiling"` — 1 pass (run on Bun 1.3.11, the exact affected version).
- Pre-commit hooks (prettier, eslint, typecheck) pass with 0 errors.

<!-- CLI verb checklist omitted: no new routes added — this only hardens the existing health handler and a test. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171xaeJHqgMkhFgqhXvTLvY

---
_Generated by [Claude Code](https://claude.ai/code/session_0171xaeJHqgMkhFgqhXvTLvY)_