### PR TITLE
feat(plugins): install a plugin's declared dependencies on install/upgrade

### DIFF
--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -78,14 +78,20 @@ function makeContentsFetch(opts: {
     const prefix = apiPath ? `${apiPath}/` : "";
     const direct = new Map<string, boolean>();
     for (const key of Object.keys(tree)) {
-      if (!key.startsWith(prefix)) {continue;}
+      if (!key.startsWith(prefix)) {
+        continue;
+      }
       const remainder = key.slice(prefix.length);
-      if (!remainder) {continue;}
+      if (!remainder) {
+        continue;
+      }
       const seg = remainder.split("/")[0]!;
       const isDir = remainder.includes("/") || tree[`${prefix}${seg}`] === null;
       direct.set(seg, (direct.get(seg) ?? false) || isDir);
     }
-    if (direct.size === 0) {return null;}
+    if (direct.size === 0) {
+      return null;
+    }
     return Array.from(direct.entries()).map(([name, isDir]) => {
       const path = `${prefix}${name}`;
       return isDir
@@ -157,7 +163,9 @@ function fakeGitRunner(opts: {
     opts.calls?.push([...args]);
     switch (args[0]) {
       case "fetch": {
-        if (opts.fetchError) {throw opts.fetchError;}
+        if (opts.fetchError) {
+          throw opts.fetchError;
+        }
         mkdirSync(join(cwd, ".git"), { recursive: true });
         writeFileSync(join(cwd, ".git", "config"), "[core]\n");
         for (const [rel, content] of Object.entries(opts.tree)) {
@@ -1281,6 +1289,90 @@ describe("installPlugin — direct (untrusted) install", () => {
     expect(pkg.name).toBe("manifest-less");
     expect(pkg.version).toBe("0.0.0");
     expect(pkg.peerDependencies["@vellumai/plugin-api"]).toBeDefined();
+  });
+});
+
+describe("installPlugin — dependency installation", () => {
+  let ws: string;
+  let pluginsDir: string;
+
+  beforeEach(() => {
+    ws = mkdtempSync(join(tmpdir(), "vellum-plugins-deps-"));
+    pluginsDir = join(ws, "plugins");
+    mkdirSync(pluginsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  test("installs the plugin's declared dependencies into the staged tree", async () => {
+    // GIVEN a plugin whose package.json declares a runtime dependency
+    const fetch = makeContentsFetch({ tree: {}, manifest: CAVEMAN_MANIFEST });
+    const runGit = fakeGitRunner({
+      tree: {
+        "package.json": JSON.stringify({
+          name: "caveman",
+          dependencies: { "date-fns": "3.0.0" },
+        }),
+      },
+      commit: CAVEMAN_SHA,
+    });
+
+    // AND a dependency installer that materializes a node_modules tree in the
+    // directory it is handed (standing in for a real `bun install`)
+    const installedInto: string[] = [];
+    const runInstallDeps = async ({ cwd }: { cwd: string }): Promise<void> => {
+      installedInto.push(cwd);
+      mkdirSync(join(cwd, "node_modules", "date-fns"), { recursive: true });
+      writeFileSync(join(cwd, "node_modules", "date-fns", "index.js"), "x");
+    };
+
+    // WHEN we install
+    await installPlugin(
+      { name: "caveman", ref: "main" },
+      { fetch, runGit, workspacePluginsDir: pluginsDir, runInstallDeps },
+    );
+
+    // THEN the installer ran against the staging dir, and its node_modules rode
+    // the atomic swap into the installed plugin
+    expect(installedInto).toHaveLength(1);
+    const target = join(pluginsDir, "caveman");
+    expect(
+      existsSync(join(target, "node_modules", "date-fns", "index.js")),
+    ).toBe(true);
+
+    // AND node_modules is excluded from the recorded fingerprint — it is a
+    // derived directory, not tracked source, so it never reads as drift
+    const meta = readInstallMeta(target);
+    const fingerprintPaths = Object.keys(meta?.fingerprint?.files ?? {});
+    expect(fingerprintPaths).toContain("package.json");
+    expect(fingerprintPaths.some((p) => p.startsWith("node_modules"))).toBe(
+      false,
+    );
+  });
+
+  test("skips dependency installation when the plugin declares none", async () => {
+    // GIVEN a plugin with no runtime dependencies
+    const fetch = makeContentsFetch({ tree: {}, manifest: CAVEMAN_MANIFEST });
+    const runGit = fakeGitRunner({
+      tree: { "package.json": '{"name":"caveman"}' },
+      commit: CAVEMAN_SHA,
+    });
+
+    let ran = false;
+    const runInstallDeps = async (): Promise<void> => {
+      ran = true;
+    };
+
+    // WHEN we install
+    await installPlugin(
+      { name: "caveman", ref: "main" },
+      { fetch, runGit, workspacePluginsDir: pluginsDir, runInstallDeps },
+    );
+
+    // THEN the dependency installer is never invoked
+    expect(ran).toBe(false);
   });
 });
 

--- a/assistant/src/cli/lib/__tests__/install-plugin-dependencies.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-plugin-dependencies.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for {@link installPluginDependencies}.
+ *
+ * The dependency install is driven through an injected {@link DependencyInstaller}
+ * so no real `bun install` subprocess is spawned: the fake records the directory
+ * it was asked to install into (or throws to exercise the fail-soft path). Only
+ * the decision to run — a plugin declares runtime `dependencies` — and the
+ * fail-soft contract are under test here; the wiring into the install/upgrade
+ * flow is covered by the install/upgrade suites.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  type DependencyInstaller,
+  installPluginDependencies,
+} from "../install-plugin-dependencies.js";
+
+describe("installPluginDependencies", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vellum-plugin-deps-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePkg(pkg: unknown): void {
+    writeFileSync(join(dir, "package.json"), JSON.stringify(pkg));
+  }
+
+  test("runs the installer when the plugin declares runtime dependencies", async () => {
+    writePkg({ name: "p", dependencies: { "date-fns": "3.0.0" } });
+    const calls: string[] = [];
+    const run: DependencyInstaller = async ({ cwd }) => {
+      calls.push(cwd);
+    };
+
+    await installPluginDependencies(dir, run);
+
+    expect(calls).toEqual([dir]);
+  });
+
+  test("skips the installer when there are no dependencies", async () => {
+    writePkg({ name: "p" });
+    let ran = false;
+    const run: DependencyInstaller = async () => {
+      ran = true;
+    };
+
+    await installPluginDependencies(dir, run);
+
+    expect(ran).toBe(false);
+  });
+
+  test("skips when the dependencies object is empty", async () => {
+    writePkg({ name: "p", dependencies: {} });
+    let ran = false;
+    const run: DependencyInstaller = async () => {
+      ran = true;
+    };
+
+    await installPluginDependencies(dir, run);
+
+    expect(ran).toBe(false);
+  });
+
+  test("skips when the package.json is missing", async () => {
+    // no package.json written
+    let ran = false;
+    const run: DependencyInstaller = async () => {
+      ran = true;
+    };
+
+    await installPluginDependencies(dir, run);
+
+    expect(ran).toBe(false);
+  });
+
+  test("skips when the package.json is unparseable", async () => {
+    writeFileSync(join(dir, "package.json"), "{ not json");
+    let ran = false;
+    const run: DependencyInstaller = async () => {
+      ran = true;
+    };
+
+    await installPluginDependencies(dir, run);
+
+    expect(ran).toBe(false);
+  });
+
+  test("does not devDependencies-only trigger an install", async () => {
+    writePkg({ name: "p", devDependencies: { typescript: "5.9.3" } });
+    let ran = false;
+    const run: DependencyInstaller = async () => {
+      ran = true;
+    };
+
+    await installPluginDependencies(dir, run);
+
+    expect(ran).toBe(false);
+  });
+
+  test("is fail-soft: an installer error is swallowed, not thrown", async () => {
+    writePkg({ name: "p", dependencies: { "date-fns": "3.0.0" } });
+    const run: DependencyInstaller = async () => {
+      throw new Error("network down");
+    };
+
+    // Resolves rather than rejecting — a dep-install failure must never abort
+    // the install that already materialized the plugin tree.
+    await expect(installPluginDependencies(dir, run)).resolves.toBeUndefined();
+  });
+});

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -45,6 +45,10 @@ import { ensureBun } from "../../util/bun-runtime.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import type { FetchLike } from "./fetch-like.js";
 import {
+  type DependencyInstaller,
+  installPluginDependencies,
+} from "./install-plugin-dependencies.js";
+import {
   computeContentHash,
   computeFingerprint,
   type Fingerprint,
@@ -159,6 +163,8 @@ export interface InstallPluginDeps {
   readonly runGit?: GitRunner;
   /** Override the runner used to execute a plugin's postinstall adapter. Falls back to {@link defaultPostinstallRunner}. */
   readonly runPostinstall?: PostinstallRunner;
+  /** Override the runner used to install a plugin's dependencies. Falls back to {@link defaultDependencyInstaller}. */
+  readonly runInstallDeps?: DependencyInstaller;
 }
 
 /** Successful install result. */
@@ -486,13 +492,14 @@ export async function installPlugin(
     throw new PluginNotFoundError(name, ref, sourceLabel(effectiveSource));
   }
 
-  finalizeStagedInstall(stagingDir, {
+  await finalizeStagedInstall(stagingDir, {
     name,
     source: effectiveSource,
     ref,
     commit,
     committedAt,
     pluginsDir,
+    installDependencies: deps.runInstallDeps,
   });
 
   return { name, target, fileCount, ref, commit, committedAt };
@@ -512,18 +519,24 @@ export interface FinalizeStagedInstallParams {
   readonly etag?: string;
   /** Served plugins directory; the staging dir is swapped into `<pluginsDir>/<name>`. */
   readonly pluginsDir: string;
+  /** Override the runner used to install the plugin's dependencies. Falls back to {@link defaultDependencyInstaller}. */
+  readonly installDependencies?: DependencyInstaller;
 }
 
 /**
- * Fingerprint a fully-populated `stagingDir`, write its provenance sidecar, and
- * atomically swap it into `<pluginsDir>/<name>`. Returns the final install path
- * and the fingerprint that was recorded.
+ * Install the plugin's declared dependencies, fingerprint the fully-populated
+ * `stagingDir`, write its provenance sidecar, and atomically swap it into
+ * `<pluginsDir>/<name>`. Returns the final install path and the fingerprint that
+ * was recorded.
  *
- * Shared by {@link installPlugin} (fresh materialization) and the merge-based
- * `plugins upgrade --strategy` path so both record identical provenance and use
- * the same atomic rm+rename swap.
+ * Shared by {@link installPlugin} (fresh materialization), the platform-endpoint
+ * install, and the merge-based `plugins upgrade --strategy` path so all record
+ * identical provenance, install dependencies the same way, and use the same
+ * atomic rm+rename swap. Dependencies land in `<stagingDir>/node_modules/` — a
+ * derived directory every plugin-tree walk excludes — so it does not pollute the
+ * fingerprint computed just below and rides the swap into place atomically.
  */
-export function finalizeStagedInstall(
+export async function finalizeStagedInstall(
   stagingDir: string,
   {
     name,
@@ -533,8 +546,14 @@ export function finalizeStagedInstall(
     committedAt,
     etag,
     pluginsDir,
+    installDependencies,
   }: FinalizeStagedInstallParams,
-): { target: string; fingerprint: Fingerprint } {
+): Promise<{ target: string; fingerprint: Fingerprint }> {
+  // Install the plugin's own runtime dependencies into the staged tree before
+  // it is fingerprinted and swapped, so its hooks/tools can resolve their bare
+  // imports. A no-op for a plugin that declares none.
+  await installPluginDependencies(stagingDir, installDependencies);
+
   // Hash the materialized tree before the sidecar is written (so the sidecar
   // never hashes itself) — the baseline `plugins inspect` uses to detect later
   // local edits. The per-file fingerprint answers "which files changed"; the
@@ -752,10 +771,7 @@ export async function materializePluginTree(
   if (cloned.fileCount > 0 && opts.stubRef !== null) {
     await applyAdapterStub(opts.name, opts.stubRef, opts.destDir, deps);
   }
-  if (
-    cloned.fileCount > 0 &&
-    !existsSync(join(opts.destDir, "package.json"))
-  ) {
+  if (cloned.fileCount > 0 && !existsSync(join(opts.destDir, "package.json"))) {
     synthesizeMinimalPackageJson(opts.name, opts.destDir);
   }
   return cloned;

--- a/assistant/src/cli/lib/install-from-platform.ts
+++ b/assistant/src/cli/lib/install-from-platform.ts
@@ -199,7 +199,7 @@ export async function installPluginFromPlatform(
   // the ETag documents exactly which bytes were verified.
   const source = buildFetchSource(meta);
   const ref = meta.ref ?? "";
-  finalizeStagedInstall(stagingDir, {
+  await finalizeStagedInstall(stagingDir, {
     name,
     source,
     ref,

--- a/assistant/src/cli/lib/install-plugin-dependencies.ts
+++ b/assistant/src/cli/lib/install-plugin-dependencies.ts
@@ -1,0 +1,164 @@
+/**
+ * Install a staged plugin's declared runtime dependencies.
+ *
+ * A plugin is materialized by cloning (or extracting) its source tree — the
+ * installer never ran `bun install`, so a plugin that declares its own
+ * `dependencies` in `package.json` shipped no way to resolve them: its hooks'
+ * and tools' bare imports (`import { ... } from "date-fns"`) had nothing to
+ * resolve against. The workspace-level shims cover only the tiny curated set
+ * (`@vellumai/plugin-api`, the whitelisted shared deps like `zod`); anything a
+ * plugin brings itself was unresolvable.
+ *
+ * This module closes that gap: after the tree is staged and before it is
+ * swapped into place, the plugin's own `dependencies` are installed into
+ * `<pluginDir>/node_modules/` so Node-style resolution walking up from a
+ * hook/tool file finds them. The install is:
+ *
+ * - **`--production`** — only runtime `dependencies`, never `devDependencies`
+ *   (a plugin's build-time tooling has no place in an installed copy).
+ * - **`--ignore-scripts`** — no dependency (or root) lifecycle script runs, so
+ *   installing a plugin never executes arbitrary `postinstall` code. Curated
+ *   adapter transforms run through their own vetted path (see
+ *   {@link ./install-from-github}), not here.
+ * - **`--no-save`** — `package.json` is left byte-for-byte as materialized and
+ *   no lockfile is written, so the only artifact is `node_modules/`, which every
+ *   plugin-tree walk already excludes (see `../../plugins/plugin-tree-walk.ts`).
+ *
+ * `node_modules/` is intentionally *not* fingerprinted, preserved across
+ * upgrades, or otherwise treated as source: it is derived from the pinned
+ * `package.json` and re-installed on every (re)install and upgrade.
+ *
+ * Designed for direct programmatic use with an injectable runner, mirroring the
+ * sibling plugin libraries; production callers fall back to
+ * {@link defaultDependencyInstaller}.
+ */
+
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+import { ensureBun } from "../../util/bun-runtime.js";
+import { getLogger } from "../../util/logger.js";
+
+const execFileAsync = promisify(execFile);
+
+const log = getLogger("plugin-deps");
+
+/** Cap on a single dependency install; a plugin's dependency set is small. */
+const DEPENDENCY_INSTALL_TIMEOUT_MS = 120_000;
+
+/**
+ * Installs a staged plugin's dependencies in `cwd`. Injected so tests can
+ * assert the install is invoked (and simulate its effects) without spawning a
+ * real subprocess; production callers fall back to
+ * {@link defaultDependencyInstaller}.
+ */
+export type DependencyInstaller = (opts: {
+  /** The staged plugin directory whose `dependencies` are installed. */
+  readonly cwd: string;
+}) => Promise<void>;
+
+/**
+ * Whether the plugin at `pluginDir` declares any runtime `dependencies`. A
+ * missing/unparseable manifest, or one with no (or an empty) `dependencies`
+ * object, means there is nothing to install — the common case for the many
+ * plugins that import only the plugin-api and whitelisted shared deps.
+ */
+function hasRuntimeDependencies(pluginDir: string): boolean {
+  const pkgPath = join(pluginDir, "package.json");
+  if (!existsSync(pkgPath)) {
+    return false;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(pkgPath, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) {
+      return false;
+    }
+    const deps = (parsed as { dependencies?: unknown }).dependencies;
+    return (
+      typeof deps === "object" &&
+      deps !== null &&
+      !Array.isArray(deps) &&
+      Object.keys(deps).length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Install the plugin's declared runtime dependencies into
+ * `<pluginDir>/node_modules/`, a no-op when it declares none.
+ *
+ * Fail-soft by design: a dependency-install failure (offline, an unresolvable
+ * version, a registry outage) is logged and swallowed rather than aborting the
+ * install. The plugin's code is already materialized; a plugin that then can't
+ * resolve a missing dependency fails at load with a clear module-not-found the
+ * user can act on by reinstalling once connectivity returns — strictly better
+ * than throwing away a completed materialization over a transient network
+ * error.
+ */
+export async function installPluginDependencies(
+  pluginDir: string,
+  run: DependencyInstaller = defaultDependencyInstaller,
+): Promise<void> {
+  if (!hasRuntimeDependencies(pluginDir)) {
+    return;
+  }
+  try {
+    await run({ cwd: pluginDir });
+    log.info({ pluginDir }, "installed plugin dependencies");
+  } catch (err) {
+    log.warn(
+      { err, pluginDir },
+      "plugin dependency install failed — imports of a missing dependency will fail at load; reinstall to retry",
+    );
+  }
+}
+
+/**
+ * Production dependency installer: runs `bun install` with a real `bun` binary
+ * resolved via {@link ensureBun}, under a timeout. `--production` skips
+ * devDependencies, `--ignore-scripts` blocks all lifecycle scripts, and
+ * `--no-save` leaves `package.json` untouched and writes no lockfile.
+ *
+ * `process.execPath` is unusable here: inside a `bun build --compile` binary it
+ * is the compiled assistant app, not the bun CLI (see `util/bun-runtime.ts`),
+ * so `ensureBun()` locates (or downloads) a standalone bun the same way every
+ * other subsystem that spawns bun does.
+ */
+export const defaultDependencyInstaller: DependencyInstaller = async ({
+  cwd,
+}) => {
+  const bun = await ensureBun();
+  await execFileAsync(
+    bun,
+    ["install", "--production", "--ignore-scripts", "--no-save"],
+    {
+      cwd,
+      encoding: "utf8",
+      timeout: DEPENDENCY_INSTALL_TIMEOUT_MS,
+      maxBuffer: 32 * 1024 * 1024,
+      env: dependencyInstallEnv(bun),
+    },
+  );
+};
+
+/**
+ * Environment for the `bun install` subprocess. The full process environment
+ * is inherited so registry/proxy configuration (`HTTPS_PROXY`, npm config, …)
+ * flows through — safe because `--ignore-scripts` means no dependency code
+ * runs — with the resolved bun's directory prepended to `PATH` so the runtime
+ * is found even when the daemon launched from a minimal-environment macOS
+ * `.app` bundle.
+ */
+function dependencyInstallEnv(bun: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  const bunDir = dirname(bun);
+  const current = (env.PATH ?? "").split(":").filter(Boolean);
+  if (!current.includes(bunDir)) {
+    env.PATH = [bunDir, ...current].join(":");
+  }
+  return env;
+}

--- a/assistant/src/cli/lib/plugin-fingerprint.ts
+++ b/assistant/src/cli/lib/plugin-fingerprint.ts
@@ -19,6 +19,7 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
 import {
+  EXCLUDED_DIRS_ANYWHERE,
   GENERATED_APP_BUILD_DIR,
   walkPluginTree,
 } from "../../plugins/plugin-tree-walk.js";
@@ -69,7 +70,10 @@ export function computeFingerprint(
   const files: Record<string, string> = {};
   walkPluginTree(
     root,
-    { excludeRootEntries: [...exclude, GENERATED_APP_BUILD_DIR] },
+    {
+      excludeRootEntries: [...exclude, GENERATED_APP_BUILD_DIR],
+      excludeDirsAnywhere: EXCLUDED_DIRS_ANYWHERE,
+    },
     (rel, abs) => {
       files[rel] = hashFile(abs);
     },
@@ -187,7 +191,10 @@ export function computeContentHash(
   const entries: Array<{ rel: string; abs: string }> = [];
   walkPluginTree(
     root,
-    { excludeRootEntries: [...exclude, GENERATED_APP_BUILD_DIR] },
+    {
+      excludeRootEntries: [...exclude, GENERATED_APP_BUILD_DIR],
+      excludeDirsAnywhere: EXCLUDED_DIRS_ANYWHERE,
+    },
     (rel, abs) => {
       entries.push({ rel, abs });
     },

--- a/assistant/src/cli/lib/upgrade-plugin.ts
+++ b/assistant/src/cli/lib/upgrade-plugin.ts
@@ -63,6 +63,7 @@ import {
   resolveRefCommit,
   sanitizePluginName,
 } from "./install-from-github.js";
+import type { DependencyInstaller } from "./install-plugin-dependencies.js";
 import { type ConflictLabels, mergePluginTree } from "./merge-plugin-tree.js";
 /**
  * How local edits to an installed plugin are reconciled with the marketplace
@@ -118,6 +119,8 @@ export interface UpgradePluginDeps {
   readonly runGit?: GitRunner;
   /** Override the postinstall adapter runner. Forwarded to {@link installPlugin}. */
   readonly runPostinstall?: PostinstallRunner;
+  /** Override the dependency-install runner. Forwarded to {@link installPlugin} and {@link finalizeStagedInstall}. */
+  readonly runInstallDeps?: DependencyInstaller;
 }
 
 /** Result of an upgrade attempt. */
@@ -364,6 +367,7 @@ export async function upgradePlugin(
       workspacePluginsDir: deps.workspacePluginsDir,
       runGit: deps.runGit,
       runPostinstall: deps.runPostinstall,
+      runInstallDeps: deps.runInstallDeps,
     },
   );
 
@@ -531,6 +535,7 @@ async function directUpgrade(
       workspacePluginsDir: deps.workspacePluginsDir,
       runGit: deps.runGit,
       runPostinstall: deps.runPostinstall,
+      runInstallDeps: deps.runInstallDeps,
     },
   );
 
@@ -682,13 +687,14 @@ async function mergeUpgrade(
 
     const toCommit = theirs.commit ?? ctx.toCommit;
     const toTimestamp = theirs.committedAt ?? ctx.toTimestamp;
-    finalizeStagedInstall(stagingDir, {
+    await finalizeStagedInstall(stagingDir, {
       name,
       source: theirsSource,
       ref: theirsSource.ref,
       commit: toCommit,
       committedAt: toTimestamp,
       pluginsDir,
+      installDependencies: deps.runInstallDeps,
     });
 
     return {

--- a/assistant/src/plugins/ensure-shared-dep-links.ts
+++ b/assistant/src/plugins/ensure-shared-dep-links.ts
@@ -5,12 +5,14 @@
  *
  *     import { z } from "zod";
  *
- * The plugin installer never runs `bun install`, so an installed plugin's
- * runtime dependencies are unresolvable — bare imports resolve Node-style
- * walking up from the plugin directory, and the assistant's own copies are
- * not on that path. This module bridges that gap by linking the real
- * package directories, not re-export shims: a plugin gets the actual zod
- * the assistant uses, subpaths and internal resolution included.
+ * A plugin's own declared dependencies are installed at install time (see
+ * `../cli/lib/install-plugin-dependencies.ts`). The whitelisted deps here are
+ * the ones a plugin may import *without* declaring — `zod` is de-facto plugin
+ * SDK surface the config-validation idiom leans on — so their bare imports
+ * resolve Node-style walking up from the plugin directory, where the
+ * assistant's own copies are not on the path. This module bridges that gap by
+ * linking the real package directories, not re-export shims: a plugin gets the
+ * actual zod the assistant uses, subpaths and internal resolution included.
  *
  * ## Why symlinks (not generated re-export shims)
  *

--- a/assistant/src/plugins/plugin-tree-walk.ts
+++ b/assistant/src/plugins/plugin-tree-walk.ts
@@ -41,6 +41,20 @@ export const PRESERVED_ENTRIES = [
 ] as const;
 
 /**
+ * Directory names skipped at any depth by every plugin-tree walk. `node_modules`
+ * holds a plugin's installed dependencies — derived from the pinned
+ * `package.json` and re-installed on every (re)install and upgrade (see
+ * `../cli/lib/install-plugin-dependencies.ts`), never tracked source. Excluding
+ * it keeps installed dependencies out of the install fingerprint / content hash
+ * (`../cli/lib/plugin-fingerprint.ts`) and the live-reload source fingerprint
+ * (`./source-fingerprint.ts`), so a re-materialized baseline — which has no
+ * `node_modules/` — still matches what install recorded.
+ */
+export const EXCLUDED_DIRS_ANYWHERE: ReadonlySet<string> = new Set([
+  "node_modules",
+]);
+
+/**
  * Generated app build output: `apps/<app>/dist`. This is compiled output (the
  * plugin source watcher builds each multi-file app's `src/` into its sibling
  * `dist/`), never tracked source, so — like {@link PRESERVED_ENTRIES} — every

--- a/assistant/src/plugins/source-fingerprint.ts
+++ b/assistant/src/plugins/source-fingerprint.ts
@@ -33,13 +33,11 @@
 import { realpathSync, statSync } from "node:fs";
 
 import {
+  EXCLUDED_DIRS_ANYWHERE,
   GENERATED_APP_BUILD_DIR,
   PRESERVED_ENTRIES,
   walkPluginTree,
 } from "./plugin-tree-walk.js";
-
-/** Directory names skipped at any depth. */
-const EXCLUDED_DIRS_ANYWHERE = new Set(["node_modules"]);
 
 /**
  * The result of one source walk over a plugin directory.

--- a/assistant/src/plugins/user-loader.ts
+++ b/assistant/src/plugins/user-loader.ts
@@ -89,10 +89,11 @@ export async function loadUserPlugins(
     );
   }
 
-  // Same treatment for whitelisted shared deps (zod, …): the installer never
-  // runs `bun install`, so a plugin's bare `import { z } from "zod"` only
-  // resolves if we symlink the assistant's own copy into the workspace's
-  // node_modules. ensureSharedDepLinks never throws for a single dep, but is
+  // Same treatment for whitelisted shared deps (zod, …): these are deps a
+  // plugin may use *without* declaring, so a plugin's bare `import { z } from
+  // "zod"` only resolves if we symlink the assistant's own copy into the
+  // workspace's node_modules (a plugin's own declared deps are installed at
+  // install time). ensureSharedDepLinks never throws for a single dep, but is
   // wrapped for the same never-block-startup reason as above.
   try {
     await ensureSharedDepLinks();


### PR DESCRIPTION
## Prompt / plan

> When we plugin install / plugin upgrade, we are not installing the dependencies that ship with the plugin, and we should.

**The gap.** Plugin install/upgrade materialized the plugin's source tree (git clone, platform tarball, or three-way merge) but never ran `bun install`. A plugin that declared its own runtime `dependencies` in `package.json` had no way to resolve them — its hooks/tools' bare imports (e.g. `import { format } from "date-fns"`) resolved Node-style walking up from the plugin directory and hit nothing. The workspace-level shims cover only a tiny curated set (`@vellumai/plugin-api`, and whitelisted shared deps like `zod` via `ensure-shared-dep-links.ts`); anything a plugin brought itself was unresolvable.

**The fix.** Install the plugin's declared `dependencies` into `<pluginDir>/node_modules/` at `finalizeStagedInstall` — the single chokepoint every real install path already converges on (GitHub/marketplace install, platform-endpoint install, and both merge and overwrite upgrade). Dependencies are installed into the staged tree before the atomic swap, so they land in place atomically with the rest of the plugin. The install is:

- `--production` — runtime `dependencies` only, never `devDependencies`.
- `--ignore-scripts` — installing a plugin never runs arbitrary dependency (or root) lifecycle code. Curated adapter transforms still run through their own vetted path, not this one.
- `--no-save` — `package.json` is left byte-for-byte as materialized and no lockfile is written, so the only artifact is `node_modules/`.

A plugin that declares no dependencies is a no-op (no subprocess spawned). The install is **fail-soft**: a dependency-install failure (offline, unresolvable version, registry outage) is logged, not fatal — the plugin's code is already materialized, and a missing dependency surfaces as a clear module-not-found at load rather than discarding a completed install over a transient network error.

**Fingerprint interaction.** `node_modules/` is a derived directory, not tracked source. It's excluded from the install fingerprint / content hash (`plugin-fingerprint.ts`) and the live-reload source fingerprint (`source-fingerprint.ts`) via a shared `EXCLUDED_DIRS_ANYWHERE` constant now hoisted into `plugin-tree-walk.ts` (previously duplicated locally in `source-fingerprint.ts`). This keeps installed deps from ever reading as local drift, and — critically — lets the merge-upgrade baseline check still pass: a re-materialized baseline has no `node_modules/`, so it must not be in the recorded fingerprint either.

`finalizeStagedInstall` is now `async`; the three call sites (`installPlugin`, `installPluginFromPlatform`, `mergeUpgrade`) await it.

## Test plan

- **New** `install-plugin-dependencies.test.ts` (7 tests): installer runs only when runtime `dependencies` are declared (skips empty / dev-only / missing / unparseable manifests); fail-soft swallows installer errors.
- **New** cases in `install-from-github.test.ts`: install invokes the injected dependency installer against the staging dir and its `node_modules/` rides the swap into the installed plugin while staying out of the recorded fingerprint; install skips the installer when no deps are declared.
- Ran individually (repo convention — combined runs share workspace state): `install-from-github` (41), `upgrade-plugin` (24), `install-from-platform` (15), `plugins-install-offline` (3), `diff-plugin` (9), `inspect-plugin` (15), `plugin-fingerprint` (18), `source-fingerprint` (6), `mtime-cache` (35), `install-plugin-dependencies` (7) — all green.
- End-to-end smoke: drove the real `defaultDependencyInstaller` against a temp plugin with a real dependency — `node_modules/` populated with the runtime dep + its transitive deps, devDependency correctly excluded, no lockfile, `package.json` untouched.
- `bunx tsc --noEmit`, `eslint`, and `prettier` clean on the changed files (pre-commit hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxCZhuSCqMLfu48or8NCJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxCZhuSCqMLfu48or8NCJv)_