### PR TITLE
fix(assistant): sniff image magic bytes so mislabeled uploads stop 400ing

### DIFF
--- a/assistant/src/__tests__/attachment-upload-trusted-source.test.ts
+++ b/assistant/src/__tests__/attachment-upload-trusted-source.test.ts
@@ -23,6 +23,13 @@ import type { RouteHandlerArgs } from "../runtime/routes/types.js";
 const SMALL_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 
+// Non-image bytes: storage normalization sniffs image magic bytes and
+// overrides a disagreeing declared MIME, so a declared-MIME assertion needs a
+// payload that doesn't sniff as an image.
+const FAKE_VIDEO_BASE64 = Buffer.from("fake matroska payload").toString(
+  "base64",
+);
+
 const uploadRoute = ROUTES.find((r) => r.operationId === "attachment_upload")!;
 
 function makeUploadArgs(
@@ -59,7 +66,7 @@ describe("attachment upload — trustedSource flag", () => {
         {
           filename: "clip.mkv",
           mimeType: "video/x-matroska",
-          data: SMALL_PNG_BASE64,
+          data: FAKE_VIDEO_BASE64,
           trustedSource: true,
         },
         "svc_gateway",

--- a/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
+++ b/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
@@ -31,7 +31,10 @@ mock.module("../util/image-conversion.js", () => ({
   normalizeImageBase64: (mimeType: string, dataBase64: string) =>
     mimeType === "image/heic"
       ? { mimeType: "image/jpeg", dataBase64: FAKE_JPEG_B64, converted: true }
-      : { mimeType, dataBase64, converted: false },
+      : mimeType === "image/mislabeled"
+        ? // Sniff-corrected declared MIME: payload untouched, converted false.
+          { mimeType: "image/png", dataBase64, converted: false }
+        : { mimeType, dataBase64, converted: false },
 }));
 
 import {
@@ -129,6 +132,16 @@ describe("HEIC upload normalization wiring", () => {
     expect(stored.originalFilename).toBe("photo.png");
     expect(stored.mimeType).toBe("image/png");
     expect(stored.sizeBytes).toBe(HEIC_BYTES.length);
+  });
+
+  test("uploadAttachment (base64) propagates a MIME-only sniff correction", () => {
+    const stored = uploadAttachment("photo.png", "image/mislabeled", HEIC_B64);
+
+    // Corrected MIME is stored; filename and payload stay verbatim.
+    expect(stored.originalFilename).toBe("photo.png");
+    expect(stored.mimeType).toBe("image/png");
+    const row = getAttachmentById(stored.id);
+    expect(row?.dataBase64).toBe(HEIC_B64);
   });
 
   test("attachInlineAttachmentToMessage normalizes only when opted in", async () => {

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -379,6 +379,24 @@ describe("classifyConversationError", () => {
       expect(result.retryable).toBe(false);
     });
 
+    it("classifies Anthropic 400 media-type mismatch as image_media_type_mismatch (non-retryable)", () => {
+      // The rejection for an image whose declared media type disagrees with
+      // its bytes (e.g. a JPEG renamed to .png before upload). It must route
+      // to the image-recovery classification so the relabel path fires, not
+      // loop through the generic PROVIDER_API branch.
+      const err = new ProviderError(
+        'Anthropic API error (400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.50.content.0.image.source.base64.data: Image does not match the provided media type image/png"},"request_id":"req_011Ccs00000000000000000"}',
+        "anthropic",
+        400,
+      );
+      const result = classifyConversationError(err, baseCtx);
+      expect(result.code).toBe("IMAGE_TOO_LARGE");
+      expect(result.errorCategory).toBe("image_media_type_mismatch");
+      expect(result.retryable).toBe(false);
+      expect(result.userMessage).not.toContain("invalid_request_error");
+      expect(result.userMessage.toLowerCase()).toContain("image");
+    });
+
     it("classifies Anthropic 400 'Could not process image' as image_unprocessable (non-retryable)", () => {
       // The rejection Anthropic returns for images below its minimum size
       // floor (e.g. a 16×14 px upload). It must route to the image-recovery

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -14,6 +14,8 @@ import {
   jpegFilenameFor,
   normalizeImageBase64,
   normalizeImageBytes,
+  sniffBase64ImageMimeType,
+  sniffImageMimeType,
 } from "../util/image-conversion.js";
 import {
   fakeHeifHeaderBytes,
@@ -69,6 +71,48 @@ describe("jpegFilenameFor", () => {
   });
 });
 
+const JPEG_HEADER_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const GIF_HEADER_BYTES = Buffer.from("GIF89a\x01\x00\x01\x00", "latin1");
+const WEBP_HEADER_BYTES = Buffer.concat([
+  Buffer.from("RIFF"),
+  Buffer.from([0x24, 0x00, 0x00, 0x00]),
+  Buffer.from("WEBPVP8 "),
+]);
+
+describe("sniffImageMimeType", () => {
+  test("identifies PNG, JPEG, GIF, and WebP signatures", () => {
+    expect(sniffImageMimeType(PNG_1PX_BYTES)).toBe("image/png");
+    expect(sniffImageMimeType(JPEG_HEADER_BYTES)).toBe("image/jpeg");
+    expect(sniffImageMimeType(GIF_HEADER_BYTES)).toBe("image/gif");
+    expect(sniffImageMimeType(WEBP_HEADER_BYTES)).toBe("image/webp");
+  });
+
+  test("returns null for unrecognized or truncated content", () => {
+    expect(sniffImageMimeType(Buffer.from("plain text content"))).toBeNull();
+    expect(sniffImageMimeType(Buffer.alloc(0))).toBeNull();
+    expect(sniffImageMimeType(fakeHeifHeaderBytes())).toBeNull();
+    // RIFF container that is not WebP (e.g. WAV audio).
+    expect(
+      sniffImageMimeType(
+        Buffer.concat([
+          Buffer.from("RIFF"),
+          Buffer.from([0x24, 0x00, 0x00, 0x00]),
+          Buffer.from("WAVEfmt "),
+        ]),
+      ),
+    ).toBeNull();
+  });
+
+  test("base64 variant sniffs from the encoded head", () => {
+    expect(sniffBase64ImageMimeType(PNG_1PX_BYTES.toString("base64"))).toBe(
+      "image/png",
+    );
+    expect(
+      sniffBase64ImageMimeType(Buffer.from("not an image").toString("base64")),
+    ).toBeNull();
+  });
+});
+
 describe("normalizeImageBytes passthrough", () => {
   test("non-HEIF bytes pass through untouched", () => {
     const result = normalizeImageBytes("image/png", PNG_1PX_BYTES);
@@ -93,6 +137,32 @@ describe("normalizeImageBase64 passthrough", () => {
     const result = normalizeImageBase64("image/png", b64);
     expect(result.converted).toBe(false);
     expect(result.dataBase64).toBe(b64);
+  });
+});
+
+describe("declared-MIME correction from sniffed bytes", () => {
+  test("normalizeImageBytes relabels a mislabeled image, bytes untouched", () => {
+    // A JPEG renamed to .png arrives declared as image/png; providers reject
+    // the mismatch, so the sniffed format wins.
+    const result = normalizeImageBytes("image/png", JPEG_HEADER_BYTES);
+    expect(result.converted).toBe(false);
+    expect(result.mimeType).toBe("image/jpeg");
+    expect(result.bytes).toBe(JPEG_HEADER_BYTES);
+  });
+
+  test("normalizeImageBase64 relabels a mislabeled image, payload untouched", () => {
+    const b64 = PNG_1PX_BYTES.toString("base64");
+    const result = normalizeImageBase64("image/jpeg", b64);
+    expect(result.converted).toBe(false);
+    expect(result.mimeType).toBe("image/png");
+    expect(result.dataBase64).toBe(b64);
+  });
+
+  test("unrecognized bytes keep the declared MIME", () => {
+    const bytes = Buffer.from("plain text content");
+    const result = normalizeImageBytes("text/plain", bytes);
+    expect(result.mimeType).toBe("text/plain");
+    expect(result.bytes).toBe(bytes);
   });
 });
 

--- a/assistant/src/__tests__/image-recovery-hook.test.ts
+++ b/assistant/src/__tests__/image-recovery-hook.test.ts
@@ -241,6 +241,52 @@ describe("image-recovery post-model-call hook — direct", () => {
     });
   });
 
+  test("media-type-mismatch rejection → relabels the mislabeled image and continues", async () => {
+    // GIVEN a stored history holding a normally-sized PNG declared as
+    // image/jpeg (a renamed file — clients derive the MIME from the
+    // extension), and the provider rejection that mismatch produces.
+    const pngData = makePngBase64(1024, 768);
+    const mislabeled: ContentBlock = {
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: pngData },
+    };
+    const conv = createConversation();
+    await addMessage(conv.id, "user", JSON.stringify([mislabeled]), {
+      skipIndexing: true,
+    });
+    const ctx = makePostModelCallCtx({
+      conversationId: conv.id,
+      messages: [{ role: "user", content: [structuredClone(mislabeled)] }],
+      error: new Error(
+        'Anthropic API error (400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.0.content.0.image.source.base64.data: Image does not match the provided media type image/jpeg"}}',
+      ),
+    });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN it retries with the image relabeled to its sniffed type — bytes
+    // kept — both in the working history and in the stored row, so the
+    // mismatch cannot re-reject on this or any later turn.
+    expect(ctx.decision).toBe("continue");
+    const workingImage = ctx.messages[0].content[0] as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    expect(workingImage.source).toMatchObject({
+      media_type: "image/png",
+      data: pngData,
+    });
+    const storedImage = getMessages(conv.id)[0].content[0] as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    expect(storedImage.source).toMatchObject({
+      media_type: "image/png",
+      data: pngData,
+    });
+  });
+
   test("durably persists the downgrade so the image cannot resurface", async () => {
     // GIVEN a conversation whose stored history holds an oversized image.
     const conv = createConversation();

--- a/assistant/src/__tests__/image-recovery-hook.test.ts
+++ b/assistant/src/__tests__/image-recovery-hook.test.ts
@@ -287,6 +287,43 @@ describe("image-recovery post-model-call hook — direct", () => {
     });
   });
 
+  test("media-type-mismatch on an unrecognized format → no retry, error surfaces", async () => {
+    // GIVEN a mismatch rejection for an image whose actual format the sniffer
+    // cannot identify (a renamed BMP: "BM" magic, not in the sniff set), so no
+    // relabel is possible and the image is within size limits.
+    const bmpData = Buffer.concat([
+      Buffer.from("BM"),
+      Buffer.alloc(64, 0),
+    ]).toString("base64");
+    const unrecognized: ContentBlock = {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: bmpData },
+    };
+    const ctx = makePostModelCallCtx({
+      messages: [{ role: "user", content: [structuredClone(unrecognized)] }],
+      error: new Error(
+        'Anthropic API error (400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.0.content.0.image.source.base64.data: Image does not match the provided media type image/png"}}',
+      ),
+    });
+
+    // WHEN the hook runs.
+    await postModelCall(ctx);
+
+    // THEN it does not retry (nothing could be corrected) and leaves the
+    // history untouched, so the original error surfaces instead of a false
+    // "corrected — resend" loop.
+    expect(ctx.decision).toBe("stop");
+    expect(isImageRecoveryAttempted(ctx.conversationId)).toBe(false);
+    const image = ctx.messages[0].content[0] as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    expect(image.source).toMatchObject({
+      media_type: "image/png",
+      data: bmpData,
+    });
+  });
+
   test("durably persists the downgrade so the image cannot resurface", async () => {
     // GIVEN a conversation whose stored history holds an oversized image.
     const conv = createConversation();

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -172,7 +172,7 @@ describe("handleListMessages attachments", () => {
       "user",
       JSON.stringify([{ type: "text", text: "here are files" }]),
     );
-    const imgStored = uploadAttachment("photo.jpg", "image/jpeg", IMAGE_BASE64);
+    const imgStored = uploadAttachment("photo.png", "image/png", IMAGE_BASE64);
     const docStored = uploadAttachment(
       "doc.pdf",
       "application/pdf",
@@ -187,7 +187,7 @@ describe("handleListMessages attachments", () => {
     const attachments = body.messages[0].attachments!;
     expect(attachments).toHaveLength(2);
 
-    const imgAtt = attachments.find((a) => a.mimeType === "image/jpeg");
+    const imgAtt = attachments.find((a) => a.mimeType === "image/png");
     const docAtt = attachments.find((a) => a.mimeType === "application/pdf");
     expect(imgAtt!.data).toBe(IMAGE_BASE64);
     expect(docAtt!.data).toBeUndefined();

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -83,10 +83,10 @@ function makePngBase64(width: number, height: number, padBytes = 0): string {
   return padBytes > 0 ? header + "A".repeat(padBytes) : header;
 }
 
-function imageBlock(data: string): ContentBlock {
+function imageBlock(data: string, mediaType = "image/png"): ContentBlock {
   return {
     type: "image",
-    source: { type: "base64", media_type: "image/png", data },
+    source: { type: "base64", media_type: mediaType, data },
   };
 }
 
@@ -286,6 +286,41 @@ describe("persistUnsendableImageDowngrades", () => {
     );
   });
 
+  /** A stored image whose declared media type disagrees with its bytes (e.g.
+   *  a JPEG renamed to .png before upload) is relabeled in place — bytes kept,
+   *  media_type corrected — so it stops re-rejecting on every later turn. */
+  test("relabels a mislabeled image instead of removing it", async () => {
+    // GIVEN a normally-sized PNG stored with a declared type of image/jpeg
+    const conv = createConversation();
+    const pngData = makePngBase64(1024, 768);
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([imageBlock(pngData, "image/jpeg")]),
+      { skipIndexing: true },
+    );
+
+    // WHEN the downgrade is persisted
+    const rewritten = persistUnsendableImageDowngrades(conv.id);
+
+    // THEN the image survives with its media type corrected to the sniffed one
+    expect(rewritten).toBe(1);
+    const [content] = storedContent(conv.id);
+    const image = content.find((b) => b.type === "image") as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    expect(image).toBeDefined();
+    expect(image.source).toMatchObject({
+      type: "base64",
+      media_type: "image/png",
+      data: pngData,
+    });
+
+    // AND a second run is a no-op (the corrected block no longer mismatches)
+    expect(persistUnsendableImageDowngrades(conv.id)).toBe(0);
+  });
+
   /** Re-running after a rewrite is a safe no-op (no image blocks remain). */
   test("is idempotent — a second run rewrites nothing", async () => {
     // GIVEN a conversation whose oversized image has already been downgraded
@@ -339,5 +374,20 @@ describe("unsendableImageReplacement", () => {
     >;
     const replacement = unsendableImageReplacement(undersized);
     expect(replacement?.type).toBe("text");
+  });
+
+  /** A within-limits image whose declared media type disagrees with its bytes
+   *  is relabeled with the sniffed type instead of being noted out. */
+  test("relabels a mislabeled image with its sniffed media type", () => {
+    const pngData = makePngBase64(1024, 768);
+    const mislabeled = imageBlock(pngData, "image/jpeg") as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    const replacement = unsendableImageReplacement(mislabeled);
+    expect(replacement).toMatchObject({
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: pngData },
+    });
   });
 });

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -14,6 +14,7 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { uploadAttachment } from "../persistence/attachments-store.js";
 import {
   addMessage,
   createConversation,
@@ -389,5 +390,38 @@ describe("unsendableImageReplacement", () => {
       type: "image",
       source: { type: "base64", media_type: "image/png", data: pngData },
     });
+  });
+
+  /** Relabeling a persisted (workspace_ref) image keeps the reference shape —
+   *  inlining it would bake the full payload into the stored message row. */
+  test("relabels a mislabeled workspace_ref without inlining the payload", () => {
+    const pngData = makePngBase64(1024, 768);
+    const stored = uploadAttachment("photo.png", "image/png", pngData);
+    const mislabeledRef = {
+      type: "image",
+      source: {
+        type: "workspace_ref",
+        media_type: "image/jpeg",
+        attachmentId: stored.id,
+        sizeBytes: Buffer.from(pngData, "base64").length,
+      },
+    } as Extract<ContentBlock, { type: "image" }>;
+
+    const replacement = unsendableImageReplacement(mislabeledRef);
+
+    expect(replacement).toMatchObject({
+      type: "image",
+      source: {
+        type: "workspace_ref",
+        media_type: "image/png",
+        attachmentId: stored.id,
+      },
+    });
+    // AND the corrected reference no longer matches on a second pass
+    expect(
+      unsendableImageReplacement(
+        replacement as Extract<ContentBlock, { type: "image" }>,
+      ),
+    ).toBeNull();
   });
 });

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -75,6 +75,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../agent/image-optimize.js",
     "../../../context/image-dimensions.js",
     "../../../persistence/conversation-crud.js",
+    "../../../util/image-conversion.js",
     "../../../util/logger.js",
   ],
   memory: [

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -475,11 +475,14 @@ function classifyCore(
         };
       }
       if (isImageMediaTypeMismatchError(message)) {
-        // Same wire-code reuse as image_unprocessable above.
+        // Same wire-code reuse as image_unprocessable above. This surfaces only
+        // when auto-correction could not resolve the mismatch — a recognized
+        // format is relabeled and the retry succeeds without ever reaching here,
+        // so the copy must not claim a fix that didn't happen.
         return {
           code: "IMAGE_TOO_LARGE",
           userMessage:
-            "An image in this conversation was labeled with a format that doesn't match its actual contents. It was automatically corrected — send your message again to continue.",
+            "An image in this conversation is in a format the AI provider can't read, and it couldn't be converted automatically. Re-save it as PNG or JPEG and upload it again.",
           retryable: false,
           errorCategory: "image_media_type_mismatch",
         };

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -8,6 +8,7 @@ import {
 } from "../plugins/defaults/history-repair/terminal.js";
 import {
   isImageDimensionsTooLargeError,
+  isImageMediaTypeMismatchError,
   isImageUnprocessableError,
 } from "../plugins/defaults/image-recovery/detect.js";
 import { ConnectionResolutionError } from "../providers/connection-resolution.js";
@@ -471,6 +472,16 @@ function classifyCore(
             "An image in this conversation could not be processed by the AI provider — it may be below the provider's minimum image size. It was automatically adjusted where possible; send your message again to continue.",
           retryable: false,
           errorCategory: "image_unprocessable",
+        };
+      }
+      if (isImageMediaTypeMismatchError(message)) {
+        // Same wire-code reuse as image_unprocessable above.
+        return {
+          code: "IMAGE_TOO_LARGE",
+          userMessage:
+            "An image in this conversation was labeled with a format that doesn't match its actual contents. It was automatically corrected — send your message again to continue.",
+          retryable: false,
+          errorCategory: "image_media_type_mismatch",
         };
       }
       if (isVisionNotSupportedError(message)) {

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -779,10 +779,11 @@ function normalizeUploadedImageBase64(
   dataBase64: string,
 ): { filename: string; mimeType: string; dataBase64: string } {
   const norm = normalizeImageBase64(mimeType, dataBase64);
-  if (
-    !norm.converted ||
-    computeSizeBytesFromBase64(norm.dataBase64) > MAX_UPLOAD_BYTES
-  ) {
+  if (!norm.converted) {
+    // Bytes untouched, but the declared MIME may have been sniff-corrected.
+    return { filename, mimeType: norm.mimeType, dataBase64 };
+  }
+  if (computeSizeBytesFromBase64(norm.dataBase64) > MAX_UPLOAD_BYTES) {
     return { filename, mimeType, dataBase64 };
   }
   return {

--- a/assistant/src/plugins/defaults/image-recovery/detect.ts
+++ b/assistant/src/plugins/defaults/image-recovery/detect.ts
@@ -7,8 +7,11 @@
  * ("image exceeds 5 MB maximum: 7465044 bytes > 5242880 bytes"). The
  * unprocessable pattern matches "Could not process image", which Anthropic
  * returns for images below its (undocumented) minimum size and for payloads
- * it cannot decode. Distinct classification matters because retrying with the
- * same image is futile — the recovery path must resize or note it instead.
+ * it cannot decode. The mismatch pattern matches "Image does not match the
+ * provided media type image/png", returned when the declared media type
+ * disagrees with the actual bytes (e.g. a JPEG renamed to `.png`). Distinct
+ * classification matters because retrying with the same image is futile — the
+ * recovery path must resize, relabel, or note it instead.
  *
  * Exported as the single source of truth: the image-recovery hook reads these
  * to recognize the rejections it can recover, and `daemon/conversation-error`
@@ -25,6 +28,10 @@ export const IMAGE_UNPROCESSABLE_PATTERNS: readonly RegExp[] = [
   /could not process image/i,
 ];
 
+export const IMAGE_MEDIA_TYPE_MISMATCH_PATTERNS: readonly RegExp[] = [
+  /image does not match the provided media type/i,
+];
+
 /** Whether an error message indicates an image-input dimension/payload failure. */
 export function isImageDimensionsTooLargeError(message: string): boolean {
   return IMAGE_DIMENSIONS_TOO_LARGE_PATTERNS.some((p) => p.test(message));
@@ -38,10 +45,19 @@ export function isImageUnprocessableError(message: string): boolean {
   return IMAGE_UNPROCESSABLE_PATTERNS.some((p) => p.test(message));
 }
 
+/**
+ * Whether an error message indicates the declared media type disagrees with
+ * the image's actual bytes.
+ */
+export function isImageMediaTypeMismatchError(message: string): boolean {
+  return IMAGE_MEDIA_TYPE_MISMATCH_PATTERNS.some((p) => p.test(message));
+}
+
 /** Any image-input rejection the recovery hook knows how to act on. */
 export function isRecoverableImageError(message: string): boolean {
   return (
     isImageDimensionsTooLargeError(message) ||
-    isImageUnprocessableError(message)
+    isImageUnprocessableError(message) ||
+    isImageMediaTypeMismatchError(message)
   );
 }

--- a/assistant/src/plugins/defaults/image-recovery/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/image-recovery/hooks/post-model-call.ts
@@ -44,8 +44,16 @@ const postModelCall: HookFunction<PostModelCallContext> = async (ctx) => {
     isRecoverableImageError(ctx.error.message) &&
     !isImageRecoveryAttempted(ctx.conversationId)
   ) {
+    const { messages, changed } = recoverUnsendableImages(ctx.messages);
+    // A rejection can be classified as recoverable yet leave nothing to fix —
+    // e.g. a media-type mismatch on a format the sniffer cannot identify. Retrying
+    // an unchanged history would resend the identical rejected image and surface a
+    // "corrected" notice that isn't true, so let the original error stand instead.
+    if (!changed) {
+      return;
+    }
     markImageRecoveryAttempted(ctx.conversationId);
-    ctx.messages = recoverUnsendableImages(ctx.messages);
+    ctx.messages = messages;
     // Make the downgrade durable so the rejected image can't rehydrate from the
     // stored row and re-reject on later turns. This is cleanup for future
     // turns, so a persistence failure must never abort the retry that is about

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -232,11 +232,20 @@ function messageHasImageBlock(content: ReadonlyArray<ContentBlock>): boolean {
  * stays intact rather than dropping the whole tool_result. Applies the same
  * provider-cap gate as {@link persistUnsendableImageDowngrades} so the in-memory
  * retry and the durable rewrite agree on which images are unsendable.
+ *
+ * Reports whether any block was actually rewritten. A provider rejection can
+ * be classified as recoverable yet leave nothing to fix — e.g. a media-type
+ * mismatch on a format {@link sniffBase64ImageMimeType} cannot identify (a
+ * renamed BMP/TIFF/SVG, or an unconvertible HEIF) yields no replacement. The
+ * caller must not retry an unchanged history: it would resend the identical
+ * rejected image and falsely report a correction.
  */
-export function recoverUnsendableImages(
-  messages: ReadonlyArray<Message>,
-): Message[] {
-  return messages.map((msg) => {
+export function recoverUnsendableImages(messages: ReadonlyArray<Message>): {
+  messages: Message[];
+  changed: boolean;
+} {
+  let changed = false;
+  const recovered = messages.map((msg) => {
     if (!Array.isArray(msg.content)) {
       return msg;
     }
@@ -247,17 +256,28 @@ export function recoverUnsendableImages(
       ...msg,
       content: msg.content.flatMap((b): ContentBlock[] => {
         if (b.type === "image") {
-          return [unsendableImageReplacement(b) ?? b];
+          const replacement = unsendableImageReplacement(b);
+          if (replacement) {
+            changed = true;
+            return [replacement];
+          }
+          return [b];
         }
         if (b.type === "tool_result" && b.contentBlocks?.length) {
           return [
             {
               ...b,
-              contentBlocks: b.contentBlocks.map((cb) =>
-                cb.type === "image"
-                  ? (unsendableImageReplacement(cb) ?? cb)
-                  : cb,
-              ),
+              contentBlocks: b.contentBlocks.map((cb) => {
+                if (cb.type !== "image") {
+                  return cb;
+                }
+                const replacement = unsendableImageReplacement(cb);
+                if (replacement) {
+                  changed = true;
+                  return replacement;
+                }
+                return cb;
+              }),
             },
           ];
         }
@@ -265,4 +285,5 @@ export function recoverUnsendableImages(
       }),
     };
   });
+  return { messages: recovered, changed };
 }

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -30,6 +30,7 @@ import {
   getMessages,
   updateMessageContent,
 } from "../../../persistence/conversation-crud.js";
+import { sniffBase64ImageMimeType } from "../../../util/image-conversion.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("image-recovery");
@@ -54,15 +55,19 @@ export const UNSENDABLE_IMAGE_NOTE =
 
 /**
  * Replacement for an image that violates a provider hard limit (per-side pixel
- * cap, payload size, or the minimum-size floor), or null when the image is
- * within limits and should be left untouched. Gating on the provider hard caps
- * is what keeps still-sendable images intact: a normally sized image is left
- * alone rather than being noted or needlessly rewritten.
+ * cap, payload size, the minimum-size floor, or a declared media type that
+ * disagrees with the actual bytes), or null when the image is within limits
+ * and should be left untouched. Gating on the provider hard caps is what
+ * keeps still-sendable images intact: a normally sized image is left alone
+ * rather than being noted or needlessly rewritten.
  *
- * An unsendable image that can be resized is rewritten to its resized form
- * (downscaled when oversized, upscaled to the minimum floor when undersized);
- * one that cannot be resized on this host (resize is a no-op, e.g. `sips` is
- * absent off macOS or the format is unsupported) is replaced with a text note.
+ * A mislabeled image (e.g. JPEG bytes declared `image/png` — clients derive
+ * the MIME from the filename extension) is relabeled with its sniffed type,
+ * bytes untouched. An unsendable image that can be resized is rewritten to
+ * its resized form (downscaled when oversized, upscaled to the minimum floor
+ * when undersized); one that cannot be resized on this host (resize is a
+ * no-op, e.g. `sips` is absent off macOS or the format is unsupported) is
+ * replaced with a text note.
  *
  * Shared by the in-memory recovery transform and the durable persist pass so
  * both apply the identical rule. Persisting the resized form is what lets a
@@ -80,8 +85,16 @@ export function unsendableImageReplacement(
   if (!resolved) {
     return null;
   }
+  const sniffed = sniffBase64ImageMimeType(resolved.data);
+  const mediaTypeMismatch = sniffed != null && sniffed !== resolved.media_type;
+  // The sniffed type also drives the resize paths: dimension parsing keyed on
+  // the wrong declared type fails, which would misroute a mislabeled image to
+  // the unsendable note.
+  const effectiveMediaType = sniffed ?? resolved.media_type;
   const payloadBytes = resolved.data.length;
-  const dims = parseImageDimensions(block.source);
+  const dims = mediaTypeMismatch
+    ? parseImageDimensions(resolved.data, effectiveMediaType)
+    : parseImageDimensions(block.source);
   const exceedsDimensionCap =
     dims != null &&
     (dims.width > PROVIDER_MAX_IMAGE_DIMENSION ||
@@ -89,6 +102,16 @@ export function unsendableImageReplacement(
   const exceedsPayloadCap = payloadBytes > PROVIDER_MAX_IMAGE_PAYLOAD_BYTES;
   const belowMinDimension = isBelowMinDimension(dims);
   if (!exceedsDimensionCap && !exceedsPayloadCap && !belowMinDimension) {
+    if (mediaTypeMismatch) {
+      return {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: effectiveMediaType,
+          data: resolved.data,
+        },
+      };
+    }
     return null;
   }
 
@@ -96,8 +119,8 @@ export function unsendableImageReplacement(
   // pre-send — the upscale runs only here, in response to an actual
   // provider rejection. Oversized images reuse the transport downscale.
   const optimized = belowMinDimension
-    ? upscaleImageToMinimum(resolved.data, resolved.media_type)
-    : optimizeImageForTransport(resolved.data, resolved.media_type);
+    ? upscaleImageToMinimum(resolved.data, effectiveMediaType)
+    : optimizeImageForTransport(resolved.data, effectiveMediaType);
   if (optimized && optimized.data !== resolved.data) {
     return {
       type: "image",

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -103,13 +103,12 @@ export function unsendableImageReplacement(
   const belowMinDimension = isBelowMinDimension(dims);
   if (!exceedsDimensionCap && !exceedsPayloadCap && !belowMinDimension) {
     if (mediaTypeMismatch) {
+      // Only the label is wrong, so keep the source shape: a workspace_ref
+      // stays a reference (inlining it would bake the full payload into the
+      // stored message row) and only media_type is corrected.
       return {
         type: "image",
-        source: {
-          type: "base64",
-          media_type: effectiveMediaType,
-          data: resolved.data,
-        },
+        source: { ...block.source, media_type: effectiveMediaType },
       };
     }
     return null;

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -215,6 +215,64 @@ export function isHeifImage(bytes: Uint8Array): boolean {
   return HEIF_FTYP_BRANDS.has(brand);
 }
 
+/**
+ * Sniff the actual image format from magic bytes, covering the formats
+ * providers accept as image blocks. Returns null for anything unrecognized
+ * (HEIF has its own detector, {@link isHeifImage}).
+ *
+ * Exists because clients derive the declared MIME from the file extension, so
+ * a JPEG renamed to `.png` arrives as `image/png` — and providers reject an
+ * image whose bytes disagree with the declared media type.
+ */
+export function sniffImageMimeType(bytes: Uint8Array): string | null {
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 && // P
+    bytes[2] === 0x4e && // N
+    bytes[3] === 0x47 // G
+  ) {
+    return "image/png";
+  }
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x47 && // G
+    bytes[1] === 0x49 && // I
+    bytes[2] === 0x46 && // F
+    bytes[3] === 0x38 // 8
+  ) {
+    return "image/gif";
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 && // R
+    bytes[1] === 0x49 && // I
+    bytes[2] === 0x46 && // F
+    bytes[3] === 0x46 && // F
+    bytes[8] === 0x57 && // W
+    bytes[9] === 0x45 && // E
+    bytes[10] === 0x42 && // B
+    bytes[11] === 0x50 // P
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
+/** Base64 variant of {@link sniffImageMimeType}; decodes only the head. */
+export function sniffBase64ImageMimeType(dataBase64: string): string | null {
+  // 16 base64 chars decode to the 12 bytes the longest signature needs.
+  return sniffImageMimeType(Buffer.from(dataBase64.slice(0, 16), "base64"));
+}
+
 const HEIF_FILENAME_RE = /\.(heic|heif)$/i;
 
 /**
@@ -245,24 +303,30 @@ export interface NormalizedImageBytes {
 
 /**
  * Normalize image bytes for storage: HEIF/HEIC becomes a full-resolution JPEG
- * master; everything else (and any conversion failure) passes through
- * unchanged. Callers that persist a filename should rewrite it with
- * {@link jpegFilenameFor} when `converted` is true.
+ * master; a declared MIME that disagrees with the sniffed format is corrected
+ * (bytes untouched); everything else (and any conversion failure) passes
+ * through unchanged. Callers that persist a filename should rewrite it with
+ * {@link jpegFilenameFor} when `converted` is true — a MIME-only correction
+ * sets `converted: false` and keeps the filename.
  */
 export function normalizeImageBytes(
   mimeType: string,
   bytes: Uint8Array,
 ): NormalizedImageBytes {
-  if (!isHeifImage(bytes)) {
-    return { mimeType, bytes, converted: false };
+  if (isHeifImage(bytes)) {
+    const converted = convertImageToJpeg(bytes, {
+      quality: STORAGE_JPEG_QUALITY,
+    });
+    if (!converted) {
+      return { mimeType, bytes, converted: false };
+    }
+    return { mimeType: "image/jpeg", bytes: converted, converted: true };
   }
-  const converted = convertImageToJpeg(bytes, {
-    quality: STORAGE_JPEG_QUALITY,
-  });
-  if (!converted) {
-    return { mimeType, bytes, converted: false };
+  const sniffed = sniffImageMimeType(bytes);
+  if (sniffed && sniffed !== mimeType) {
+    return { mimeType: sniffed, bytes, converted: false };
   }
-  return { mimeType: "image/jpeg", bytes: converted, converted: true };
+  return { mimeType, bytes, converted: false };
 }
 
 export interface NormalizedImageBase64 {
@@ -279,21 +343,25 @@ export function normalizeImageBase64(
   mimeType: string,
   dataBase64: string,
 ): NormalizedImageBase64 {
-  // 16 base64 chars decode to the 12 bytes the ftyp sniff needs.
+  // 16 base64 chars decode to the 12 bytes the ftyp/signature sniffs need.
   const head = Buffer.from(dataBase64.slice(0, 16), "base64");
-  if (!isHeifImage(head)) {
-    return { mimeType, dataBase64, converted: false };
+  if (isHeifImage(head)) {
+    const normalized = normalizeImageBytes(
+      mimeType,
+      Buffer.from(dataBase64, "base64"),
+    );
+    if (!normalized.converted) {
+      return { mimeType, dataBase64, converted: false };
+    }
+    return {
+      mimeType: normalized.mimeType,
+      dataBase64: Buffer.from(normalized.bytes).toString("base64"),
+      converted: true,
+    };
   }
-  const normalized = normalizeImageBytes(
-    mimeType,
-    Buffer.from(dataBase64, "base64"),
-  );
-  if (!normalized.converted) {
-    return { mimeType, dataBase64, converted: false };
+  const sniffed = sniffImageMimeType(head);
+  if (sniffed && sniffed !== mimeType) {
+    return { mimeType: sniffed, dataBase64, converted: false };
   }
-  return {
-    mimeType: normalized.mimeType,
-    dataBase64: Buffer.from(normalized.bytes).toString("base64"),
-    converted: true,
-  };
+  return { mimeType, dataBase64, converted: false };
 }


### PR DESCRIPTION
## Problem

A user reported their assistant could not read any uploaded image. Root cause: clients derive an upload's MIME type from the filename extension, so a JPEG renamed to `.png` reaches Anthropic declared as `image/png`, and the provider rejects the whole request with 400 `Image does not match the provided media type image/png`.

Two compounding failures:

1. **Ingress trusts the declared type.** Storage normalization only sniffed bytes for HEIF→JPEG conversion; any other mismatch passed straight through into the stored attachment.
2. **Poisoned history never healed.** Once a mislabeled image was stored (e.g. at `messages.50`), it rehydrated on every later turn and permanently wedged the conversation. The image-recovery plugin's error patterns matched only the dimension/payload/"Could not process image" rejections — the mismatch message matched nothing, so the self-heal path never fired and the only workaround was abandoning the conversation.

## Fix

- **`util/image-conversion.ts`** — new `sniffImageMimeType`/`sniffBase64ImageMimeType` (PNG/JPEG/GIF/WebP magic numbers, alongside the existing HEIF `ftyp` sniff). `normalizeImageBytes`/`normalizeImageBase64` override a declared MIME that disagrees with the sniffed bytes — payload and filename untouched. The attachments-store base64 wrapper now propagates a MIME-only correction (it previously discarded any change when no HEIF conversion happened).
- **`plugins/defaults/image-recovery/`** — `detect.ts` gains `isImageMediaTypeMismatchError`, wired into `isRecoverableImageError` so the post-model-call hook fires on the mismatch rejection. `unsendableImageReplacement` sniffs the resolved bytes and relabels a mislabeled image with its actual type — in the working history for an immediate retry and durably via `persistUnsendableImageDowngrades` — so an already-poisoned conversation self-heals on the user's next message. The sniffed type also feeds the resize paths, where dimension parsing keyed on the wrong declared type previously failed and misrouted mislabeled images to the unsendable-image note.
- **`daemon/conversation-error.ts`** — the mismatch gets its own classification (`image_media_type_mismatch`, reusing the `IMAGE_TOO_LARGE` wire code like `image_unprocessable`) with an accurate user-facing message instead of the raw `PROVIDER_API` banner.

## Tests

- `image-conversion.test.ts` — sniff signatures (incl. RIFF-but-not-WebP negative), relabel in both normalize variants, unrecognized bytes keep the declared type.
- `persist-unsendable-image.test.ts` — mislabeled stored image is relabeled in place (not noted out), idempotent on re-run; `unsendableImageReplacement` relabel unit case.
- `image-recovery-hook.test.ts` — end-to-end: real Anthropic mismatch error → hook relabels working history + stored row and retries.
- `attachments-store-heic-normalize.test.ts` — MIME-only correction propagates through `uploadAttachment`.
- `conversation-error.test.ts` — classification for the mismatch message.
- Fixture fix: `attachment-upload-trusted-source.test.ts` used PNG bytes as a stand-in `video/x-matroska` payload, which the sniffer now (correctly) relabels — swapped to non-image bytes since the test's intent is the MIME-allowlist bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hgDgqXL4KhZQRH6KzC6p2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->