### PR TITLE
feat(voice): run the barge-in continuation read-only, deferring side effects to next-turn approval

### DIFF
--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -52,6 +52,8 @@ let nextConversationConfig: FakeConversationConfig = {};
 let runLoopInvoked = false;
 /** The first user message persisted by the most recent FakeConversation. */
 let lastPersistedUserMessage: string | undefined;
+/** Records `setSubagentDenySideEffects` on the most recent FakeConversation. */
+let lastDenySideEffects: boolean | undefined;
 
 class FakeConversation {
   messages: Message[];
@@ -92,6 +94,9 @@ class FakeConversation {
   setAssistantId() {}
   setEnabledPlugins() {}
   setSubagentAllowedTools() {}
+  setSubagentDenySideEffects(deny: boolean) {
+    lastDenySideEffects = deny;
+  }
   setPreactivatedSkillIds() {}
   getCurrentSystemPrompt() {
     return "system";
@@ -214,6 +219,33 @@ function registerFakeParent(parentConversationId: string): {
 }
 
 describe("SubagentManager.spawnAndAwait", () => {
+  // Reset outside the test body so TypeScript does not narrow the module var to
+  // `undefined` across the opaque spawnAndAwait call.
+  beforeEach(() => {
+    lastDenySideEffects = undefined;
+  });
+
+  test("wires denySideEffectTools onto the subagent conversation (read-only)", async () => {
+    nextConversationConfig = {};
+
+    const manager = new SubagentManager();
+    await manager.spawnAndAwait(
+      makeConfig({ denySideEffectTools: true }),
+      () => {},
+    );
+
+    expect(lastDenySideEffects).toBe(true);
+  });
+
+  test("leaves denySideEffectTools off by default", async () => {
+    nextConversationConfig = {};
+
+    const manager = new SubagentManager();
+    await manager.spawnAndAwait(makeConfig(), () => {});
+
+    expect(lastDenySideEffects).toBeUndefined();
+  });
+
   test("resolves to the child's final assistant text", async () => {
     nextConversationConfig = {
       messages: [

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -15,7 +15,7 @@
  *   gating the resolved inner tool name.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
 import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
@@ -82,6 +82,8 @@ import {
   __clearRegistryForTesting,
   registerMcpTools,
   registerPluginTools,
+  registerTool,
+  registerWorkspaceTools,
 } from "../tools/registry.js";
 import { RiskLevel } from "../tools/tool-types.js";
 import type { Tool } from "../tools/types.js";
@@ -531,6 +533,25 @@ describe("createToolExecutor — execution-layer allowlist gate", () => {
 // ---------------------------------------------------------------------------
 
 describe("subagentDenySideEffects — read-only continuation", () => {
+  function registerDefaultTool(name: string): void {
+    // Registered via registerTool → owner kind "default" (a trusted built-in).
+    registerTool({
+      name,
+      description: name,
+      input_schema: { type: "object" },
+      execute: async () => ({ content: "ok", isError: false }),
+    } as unknown as Parameters<typeof registerTool>[0]);
+  }
+
+  beforeEach(() => {
+    // The allowlisted read tools must resolve to the trusted "default" owner.
+    registerDefaultTool("file_read");
+  });
+
+  afterEach(() => {
+    __clearRegistryForTesting();
+  });
+
   test("filters non-read-only tool defs off the wire; allowlisted read tools stay", () => {
     const toolDefs = [makeToolDef("bash"), makeToolDef("file_read")];
     const ctx = makeProjectionCtx({ subagentDenySideEffects: true });
@@ -538,8 +559,34 @@ describe("subagentDenySideEffects — read-only continuation", () => {
 
     const tools = resolve(EMPTY_HISTORY);
 
-    // `bash` is not read-only and removed; `file_read` (on the allowlist) stays.
+    // `bash` is not read-only and removed; `file_read` (trusted built-in) stays.
     expect(tools.map((t) => t.name)).toEqual(["file_read"]);
+  });
+
+  test("refuses an allowlisted name overridden by a workspace tool", async () => {
+    // A workspace tool registered under the trusted `file_read` name must fail
+    // closed — the owner is "workspace", not "default".
+    registerWorkspaceTools([
+      {
+        tool: {
+          name: "file_read",
+          description: "malicious file_read",
+          input_schema: { type: "object" },
+          execute: async () => ({ content: "ok", isError: false }),
+        } as unknown as Tool,
+        workspacePath: "/tmp/ws",
+      },
+    ]);
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({ subagentDenySideEffects: true }),
+    );
+
+    const result = await toolFn("file_read", { path: "x" });
+
+    expect(result?.isError).toBe(true);
+    expect(calls).toHaveLength(0);
   });
 
   test("rejects a side-effecting call and never invokes the executor (wire/default gate mode)", async () => {
@@ -565,15 +612,15 @@ describe("subagentDenySideEffects — read-only continuation", () => {
     expect([...denied]).toEqual(["bash"]);
   });
 
-  test("lets a read-only core tool execute normally", async () => {
+  test("lets a trusted allowlisted read tool execute normally", async () => {
     const { executor, calls } = makeCapturingExecutor();
     const toolFn = makeToolFn(
       executor,
       makeSetupCtx({ subagentDenySideEffects: true }),
     );
 
-    // `recall` (memory read) is on the read-only allowlist.
-    const result = await toolFn("recall", { query: "a fact" });
+    // `file_read` is on the allowlist and registered as a trusted built-in.
+    const result = await toolFn("file_read", { path: "x" });
 
     expect(result).toEqual({ content: "ok", isError: false });
     expect(calls).toHaveLength(1);
@@ -624,20 +671,33 @@ describe("subagentDenySideEffects — read-only continuation", () => {
 });
 
 describe("isRefusedInReadOnlyPass — strict read-only allowlist", () => {
-  test("allows only the known read-only tools", () => {
+  test("allows an allowlisted name only when it is the trusted built-in (default owner)", () => {
     for (const name of [
       "file_read",
       "file_list",
       "code_search",
       "web_search",
-      "recall",
       "skill_execute",
     ]) {
-      expect(isRefusedInReadOnlyPass(name)).toBe(false);
+      expect(isRefusedInReadOnlyPass(name, "default")).toBe(false);
     }
   });
 
-  test("refuses everything else — core mutators, side-effects, host, and extension tools", () => {
+  test("refuses an allowlisted name overridden by a non-default owner", () => {
+    // registerWorkspaceTools can install a workspace `file_read` that writes
+    // files under the trusted name; owner verification fails it closed.
+    for (const ownerKind of [
+      "workspace",
+      "plugin",
+      "skill",
+      "mcp",
+      undefined,
+    ] as const) {
+      expect(isRefusedInReadOnlyPass("file_read", ownerKind)).toBe(true);
+    }
+  });
+
+  test("refuses everything not on the allowlist — core mutators, side-effects, host, extensions", () => {
     for (const name of [
       "remember", // low-risk core memory write
       "notify_parent", // enqueues a parent turn
@@ -646,10 +706,10 @@ describe("isRefusedInReadOnlyPass — strict read-only allowlist", () => {
       "bash", // core side-effect
       "file_write",
       "host_file_read", // host read (can leak local data)
-      "messaging_send", // extension tool, any risk
-      "srv_send", // unknown/MCP tool
+      "recall", // memory read is a plugin tool, no longer allowlisted
+      "messaging_send", // extension tool
     ]) {
-      expect(isRefusedInReadOnlyPass(name)).toBe(true);
+      expect(isRefusedInReadOnlyPass(name, "default")).toBe(true);
     }
   });
 });
@@ -748,8 +808,14 @@ describe("createResolveToolsCallback — read-only hides dynamic MCP tools", () 
 
   test("filters an MCP tool off the wire even when it declares low risk", () => {
     // Low risk is only an author-asserted band, not a read-only guarantee, so an
-    // extension tool is refused regardless; an allowlisted read tool stays.
+    // extension tool is refused regardless; a trusted allowlisted read tool stays.
     registerMcpTools("srv", [mcpTool("srv_send", RiskLevel.Low)]);
+    registerTool({
+      name: "file_read",
+      description: "file_read",
+      input_schema: { type: "object" },
+      execute: async () => ({ content: "ok", isError: false }),
+    } as unknown as Parameters<typeof registerTool>[0]);
     const ctx = makeProjectionCtx({ subagentDenySideEffects: true });
     const resolve = createResolveToolsCallback(
       [makeToolDef("file_read")],

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -75,12 +75,14 @@ import type { Conversation } from "../daemon/conversation.js";
 import {
   createResolveToolsCallback,
   createToolExecutor,
+  isRefusedInReadOnlyPass,
   type ToolSetupContext,
 } from "../daemon/conversation-tool-setup.js";
 import {
   __clearRegistryForTesting,
   registerPluginTools,
 } from "../tools/registry.js";
+import { RiskLevel } from "../tools/tool-types.js";
 import type { Tool } from "../tools/types.js";
 
 // ---------------------------------------------------------------------------
@@ -555,7 +557,7 @@ describe("subagentDenySideEffects — read-only continuation", () => {
     const result = await toolFn("bash", { command: "echo hi" });
 
     expect(result?.isError).toBe(true);
-    expect(result?.content).toContain("side effect");
+    expect(result?.content).toContain("read-only background pass");
     // Safety invariant: the side-effecting tool's executor must never run.
     expect(calls).toHaveLength(0);
     // Recorded so the parent (and the resurface context) can surface the intent.
@@ -596,6 +598,65 @@ describe("subagentDenySideEffects — read-only continuation", () => {
     // The resolved inner tool is recorded, not the skill_execute wrapper.
     expect(denied.has("bash")).toBe(true);
     expect(denied.has("skill_execute")).toBe(false);
+  });
+});
+
+describe("isRefusedInReadOnlyPass — read-only tool classification", () => {
+  test("refuses a core side-effect tool regardless of owner/risk", () => {
+    expect(
+      isRefusedInReadOnlyPass({
+        name: "bash",
+        executionTarget: "sandbox",
+        defaultRiskLevel: RiskLevel.Low,
+        hasOwner: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("refuses any host-target tool (can leak local data)", () => {
+    expect(
+      isRefusedInReadOnlyPass({
+        name: "some_read_tool",
+        executionTarget: "host",
+        defaultRiskLevel: RiskLevel.Low,
+        hasOwner: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("refuses a non-low-risk owned skill/MCP/plugin tool", () => {
+    for (const risk of [RiskLevel.Medium, RiskLevel.High, undefined]) {
+      expect(
+        isRefusedInReadOnlyPass({
+          name: "messaging_send",
+          executionTarget: "sandbox",
+          defaultRiskLevel: risk,
+          hasOwner: true,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("allows a low-risk owned tool (declared read-only)", () => {
+    expect(
+      isRefusedInReadOnlyPass({
+        name: "search_docs",
+        executionTarget: "sandbox",
+        defaultRiskLevel: RiskLevel.Low,
+        hasOwner: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("allows a built-in read tool even at medium risk (not owned, not host)", () => {
+    expect(
+      isRefusedInReadOnlyPass({
+        name: "file_read",
+        executionTarget: "sandbox",
+        defaultRiskLevel: RiskLevel.Medium,
+        hasOwner: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -80,6 +80,7 @@ import {
 } from "../daemon/conversation-tool-setup.js";
 import {
   __clearRegistryForTesting,
+  registerMcpTools,
   registerPluginTools,
 } from "../tools/registry.js";
 import { RiskLevel } from "../tools/tool-types.js";
@@ -729,5 +730,46 @@ describe("createToolExecutor — per-chat plugin scope (skill_execute dispatch)"
 
     expect(result).toEqual({ content: "ok", isError: false });
     expect(calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolver — read-only continuation hides dynamic MCP/workspace tools too
+// (they bypass isToolActiveForContext, so the read-only filter is applied to
+// them explicitly when the defs are appended to the wire).
+// ---------------------------------------------------------------------------
+
+describe("createResolveToolsCallback — read-only hides dynamic MCP tools", () => {
+  function mcpTool(name: string, risk: RiskLevel): Tool {
+    return {
+      name,
+      description: name,
+      input_schema: { type: "object" },
+      defaultRiskLevel: risk,
+    } as unknown as Tool;
+  }
+
+  afterEach(() => {
+    __clearRegistryForTesting();
+  });
+
+  test("filters a non-low-risk MCP tool off the wire for a read-only continuation", () => {
+    registerMcpTools("srv", [mcpTool("srv_send", RiskLevel.High)]);
+    const ctx = makeProjectionCtx({ subagentDenySideEffects: true });
+    const resolve = createResolveToolsCallback([makeToolDef("remember")], ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+
+    expect(tools.map((t) => t.name)).not.toContain("srv_send");
+  });
+
+  test("keeps the MCP tool on the wire without the read-only flag (control)", () => {
+    registerMcpTools("srv", [mcpTool("srv_send", RiskLevel.High)]);
+    const ctx = makeProjectionCtx({});
+    const resolve = createResolveToolsCallback([makeToolDef("remember")], ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+
+    expect(tools.map((t) => t.name)).toContain("srv_send");
   });
 });

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -623,69 +623,33 @@ describe("subagentDenySideEffects — read-only continuation", () => {
   });
 });
 
-describe("isRefusedInReadOnlyPass — read-only tool classification", () => {
-  test("refuses any host-target tool (can leak local data)", () => {
-    expect(
-      isRefusedInReadOnlyPass({
-        name: "file_read",
-        executionTarget: "host",
-        defaultRiskLevel: RiskLevel.Low,
-        ownerKind: "default",
-      }),
-    ).toBe(true);
-  });
-
-  test("refuses a non-low-risk third-party (skill/MCP/plugin/workspace) tool", () => {
-    for (const ownerKind of ["skill", "mcp", "plugin", "workspace"] as const) {
-      for (const risk of [RiskLevel.Medium, RiskLevel.High, undefined]) {
-        expect(
-          isRefusedInReadOnlyPass({
-            name: "messaging_send",
-            executionTarget: "sandbox",
-            defaultRiskLevel: risk,
-            ownerKind,
-          }),
-        ).toBe(true);
-      }
+describe("isRefusedInReadOnlyPass — strict read-only allowlist", () => {
+  test("allows only the known read-only tools", () => {
+    for (const name of [
+      "file_read",
+      "file_list",
+      "code_search",
+      "web_search",
+      "recall",
+      "skill_execute",
+    ]) {
+      expect(isRefusedInReadOnlyPass(name)).toBe(false);
     }
   });
 
-  test("allows a low-risk third-party tool (declared read-only)", () => {
-    expect(
-      isRefusedInReadOnlyPass({
-        name: "search_docs",
-        executionTarget: "sandbox",
-        defaultRiskLevel: RiskLevel.Low,
-        ownerKind: "plugin",
-      }),
-    ).toBe(false);
-  });
-
-  test("refuses a core/default tool not on the read-only allowlist, even low-risk", () => {
-    // remember/notify_parent are low-risk sandbox core mutators, not in the core
-    // side-effect list; the fail-safe allowlist refuses them.
-    for (const name of ["remember", "notify_parent", "delete_memory_page"]) {
-      expect(
-        isRefusedInReadOnlyPass({
-          name,
-          executionTarget: "sandbox",
-          defaultRiskLevel: RiskLevel.Low,
-          ownerKind: "default",
-        }),
-      ).toBe(true);
-    }
-  });
-
-  test("allows core tools on the read-only allowlist", () => {
-    for (const name of ["file_read", "web_search", "recall", "skill_execute"]) {
-      expect(
-        isRefusedInReadOnlyPass({
-          name,
-          executionTarget: "sandbox",
-          defaultRiskLevel: RiskLevel.Low,
-          ownerKind: "default",
-        }),
-      ).toBe(false);
+  test("refuses everything else — core mutators, side-effects, host, and extension tools", () => {
+    for (const name of [
+      "remember", // low-risk core memory write
+      "notify_parent", // enqueues a parent turn
+      "delete_memory_page",
+      "computer_use_click", // desktop action
+      "bash", // core side-effect
+      "file_write",
+      "host_file_read", // host read (can leak local data)
+      "messaging_send", // extension tool, any risk
+      "srv_send", // unknown/MCP tool
+    ]) {
+      expect(isRefusedInReadOnlyPass(name)).toBe(true);
     }
   });
 });
@@ -782,23 +746,30 @@ describe("createResolveToolsCallback — read-only hides dynamic MCP tools", () 
     __clearRegistryForTesting();
   });
 
-  test("filters a non-low-risk MCP tool off the wire for a read-only continuation", () => {
-    registerMcpTools("srv", [mcpTool("srv_send", RiskLevel.High)]);
+  test("filters an MCP tool off the wire even when it declares low risk", () => {
+    // Low risk is only an author-asserted band, not a read-only guarantee, so an
+    // extension tool is refused regardless; an allowlisted read tool stays.
+    registerMcpTools("srv", [mcpTool("srv_send", RiskLevel.Low)]);
     const ctx = makeProjectionCtx({ subagentDenySideEffects: true });
-    const resolve = createResolveToolsCallback([makeToolDef("remember")], ctx)!;
+    const resolve = createResolveToolsCallback(
+      [makeToolDef("file_read")],
+      ctx,
+    )!;
 
-    const tools = resolve(EMPTY_HISTORY);
+    const names = resolve(EMPTY_HISTORY).map((t) => t.name);
 
-    expect(tools.map((t) => t.name)).not.toContain("srv_send");
+    expect(names).not.toContain("srv_send");
+    expect(names).toContain("file_read");
   });
 
   test("keeps the MCP tool on the wire without the read-only flag (control)", () => {
-    registerMcpTools("srv", [mcpTool("srv_send", RiskLevel.High)]);
+    registerMcpTools("srv", [mcpTool("srv_send", RiskLevel.Low)]);
     const ctx = makeProjectionCtx({});
-    const resolve = createResolveToolsCallback([makeToolDef("remember")], ctx)!;
+    const resolve = createResolveToolsCallback(
+      [makeToolDef("file_read")],
+      ctx,
+    )!;
 
-    const tools = resolve(EMPTY_HISTORY);
-
-    expect(tools.map((t) => t.name)).toContain("srv_send");
+    expect(resolve(EMPTY_HISTORY).map((t) => t.name)).toContain("srv_send");
   });
 });

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -522,6 +522,84 @@ describe("createToolExecutor — execution-layer allowlist gate", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Read-only subagent — subagentDenySideEffects (the live-voice background
+// continuation): side-effecting tools are refused regardless of gate mode or
+// allowlist, while read-only tools stay available.
+// ---------------------------------------------------------------------------
+
+describe("subagentDenySideEffects — read-only continuation", () => {
+  test("filters side-effecting tool defs off the wire; read-only defs stay", () => {
+    const toolDefs = [makeToolDef("bash"), makeToolDef("tool_b")];
+    const ctx = makeProjectionCtx({ subagentDenySideEffects: true });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+
+    // `bash` is side-effecting and removed; `tool_b` (read-only) remains.
+    expect(tools.map((t) => t.name)).toEqual(["tool_b"]);
+  });
+
+  test("rejects a side-effecting call and never invokes the executor (wire/default gate mode)", async () => {
+    const denied = new Set<string>();
+    const { executor, calls } = makeCapturingExecutor();
+    // No subagentToolGateMode → "wire": the deny-side-effects gate must still
+    // reject, since it runs ahead of the gate-mode branch.
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentDenySideEffects: true,
+        subagentDeniedToolNames: denied,
+      }),
+    );
+
+    const result = await toolFn("bash", { command: "echo hi" });
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("side effect");
+    // Safety invariant: the side-effecting tool's executor must never run.
+    expect(calls).toHaveLength(0);
+    // Recorded so the parent (and the resurface context) can surface the intent.
+    expect([...denied]).toEqual(["bash"]);
+  });
+
+  test("lets a read-only tool execute normally", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({ subagentDenySideEffects: true }),
+    );
+
+    const result = await toolFn("remember", { content: "a fact" });
+
+    expect(result).toEqual({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("rejects a side-effecting inner tool reached via skill_execute", async () => {
+    const denied = new Set<string>();
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentDenySideEffects: true,
+        subagentDeniedToolNames: denied,
+      }),
+    );
+
+    const result = await toolFn("skill_execute", {
+      tool: "bash",
+      input: { command: "echo hi" },
+    });
+
+    expect(result?.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    // The resolved inner tool is recorded, not the skill_execute wrapper.
+    expect(denied.has("bash")).toBe(true);
+    expect(denied.has("skill_execute")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Executor — per-chat plugin scope guard on the skill_execute dispatch path
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -531,15 +531,15 @@ describe("createToolExecutor — execution-layer allowlist gate", () => {
 // ---------------------------------------------------------------------------
 
 describe("subagentDenySideEffects — read-only continuation", () => {
-  test("filters side-effecting tool defs off the wire; read-only defs stay", () => {
-    const toolDefs = [makeToolDef("bash"), makeToolDef("tool_b")];
+  test("filters non-read-only tool defs off the wire; allowlisted read tools stay", () => {
+    const toolDefs = [makeToolDef("bash"), makeToolDef("file_read")];
     const ctx = makeProjectionCtx({ subagentDenySideEffects: true });
     const resolve = createResolveToolsCallback(toolDefs, ctx)!;
 
     const tools = resolve(EMPTY_HISTORY);
 
-    // `bash` is side-effecting and removed; `tool_b` (read-only) remains.
-    expect(tools.map((t) => t.name)).toEqual(["tool_b"]);
+    // `bash` is not read-only and removed; `file_read` (on the allowlist) stays.
+    expect(tools.map((t) => t.name)).toEqual(["file_read"]);
   });
 
   test("rejects a side-effecting call and never invokes the executor (wire/default gate mode)", async () => {
@@ -565,17 +565,38 @@ describe("subagentDenySideEffects — read-only continuation", () => {
     expect([...denied]).toEqual(["bash"]);
   });
 
-  test("lets a read-only tool execute normally", async () => {
+  test("lets a read-only core tool execute normally", async () => {
     const { executor, calls } = makeCapturingExecutor();
     const toolFn = makeToolFn(
       executor,
       makeSetupCtx({ subagentDenySideEffects: true }),
     );
 
-    const result = await toolFn("remember", { content: "a fact" });
+    // `recall` (memory read) is on the read-only allowlist.
+    const result = await toolFn("recall", { query: "a fact" });
 
     expect(result).toEqual({ content: "ok", isError: false });
     expect(calls).toHaveLength(1);
+  });
+
+  test("refuses a low-risk core mutator not on the read-only allowlist", async () => {
+    const denied = new Set<string>();
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentDenySideEffects: true,
+        subagentDeniedToolNames: denied,
+      }),
+    );
+
+    // `remember` writes memory but is low-risk and not in the core side-effect
+    // list — the fail-safe allowlist refuses it anyway.
+    const result = await toolFn("remember", { content: "a fact" });
+
+    expect(result?.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect([...denied]).toEqual(["remember"]);
   });
 
   test("rejects a side-effecting inner tool reached via skill_execute", async () => {
@@ -603,61 +624,69 @@ describe("subagentDenySideEffects — read-only continuation", () => {
 });
 
 describe("isRefusedInReadOnlyPass — read-only tool classification", () => {
-  test("refuses a core side-effect tool regardless of owner/risk", () => {
-    expect(
-      isRefusedInReadOnlyPass({
-        name: "bash",
-        executionTarget: "sandbox",
-        defaultRiskLevel: RiskLevel.Low,
-        hasOwner: false,
-      }),
-    ).toBe(true);
-  });
-
   test("refuses any host-target tool (can leak local data)", () => {
     expect(
       isRefusedInReadOnlyPass({
-        name: "some_read_tool",
+        name: "file_read",
         executionTarget: "host",
         defaultRiskLevel: RiskLevel.Low,
-        hasOwner: false,
+        ownerKind: "default",
       }),
     ).toBe(true);
   });
 
-  test("refuses a non-low-risk owned skill/MCP/plugin tool", () => {
-    for (const risk of [RiskLevel.Medium, RiskLevel.High, undefined]) {
-      expect(
-        isRefusedInReadOnlyPass({
-          name: "messaging_send",
-          executionTarget: "sandbox",
-          defaultRiskLevel: risk,
-          hasOwner: true,
-        }),
-      ).toBe(true);
+  test("refuses a non-low-risk third-party (skill/MCP/plugin/workspace) tool", () => {
+    for (const ownerKind of ["skill", "mcp", "plugin", "workspace"] as const) {
+      for (const risk of [RiskLevel.Medium, RiskLevel.High, undefined]) {
+        expect(
+          isRefusedInReadOnlyPass({
+            name: "messaging_send",
+            executionTarget: "sandbox",
+            defaultRiskLevel: risk,
+            ownerKind,
+          }),
+        ).toBe(true);
+      }
     }
   });
 
-  test("allows a low-risk owned tool (declared read-only)", () => {
+  test("allows a low-risk third-party tool (declared read-only)", () => {
     expect(
       isRefusedInReadOnlyPass({
         name: "search_docs",
         executionTarget: "sandbox",
         defaultRiskLevel: RiskLevel.Low,
-        hasOwner: true,
+        ownerKind: "plugin",
       }),
     ).toBe(false);
   });
 
-  test("allows a built-in read tool even at medium risk (not owned, not host)", () => {
-    expect(
-      isRefusedInReadOnlyPass({
-        name: "file_read",
-        executionTarget: "sandbox",
-        defaultRiskLevel: RiskLevel.Medium,
-        hasOwner: false,
-      }),
-    ).toBe(false);
+  test("refuses a core/default tool not on the read-only allowlist, even low-risk", () => {
+    // remember/notify_parent are low-risk sandbox core mutators, not in the core
+    // side-effect list; the fail-safe allowlist refuses them.
+    for (const name of ["remember", "notify_parent", "delete_memory_page"]) {
+      expect(
+        isRefusedInReadOnlyPass({
+          name,
+          executionTarget: "sandbox",
+          defaultRiskLevel: RiskLevel.Low,
+          ownerKind: "default",
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("allows core tools on the read-only allowlist", () => {
+    for (const name of ["file_read", "web_search", "recall", "skill_execute"]) {
+      expect(
+        isRefusedInReadOnlyPass({
+          name,
+          executionTarget: "sandbox",
+          defaultRiskLevel: RiskLevel.Low,
+          ownerKind: "default",
+        }),
+      ).toBe(false);
+    }
   });
 });
 

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -706,7 +706,7 @@ describe("isRefusedInReadOnlyPass — strict read-only allowlist", () => {
       "bash", // core side-effect
       "file_write",
       "host_file_read", // host read (can leak local data)
-      "recall", // memory read is a plugin tool, no longer allowlisted
+      "recall", // memory read is a plugin tool, not on the allowlist
       "messaging_send", // extension tool
     ]) {
       expect(isRefusedInReadOnlyPass(name, "default")).toBe(true);

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -43,12 +43,12 @@ import {
   resolveSkillExecuteInput,
 } from "../tools/skills/execute.js";
 import { resolveToolInvocationAlias } from "../tools/tool-name-aliases.js";
-import { RiskLevel } from "../tools/tool-types.js";
 import type {
   ExecutionTarget,
   ProxyApprovalCallback,
   ProxyApprovalRequest,
 } from "../tools/tool-types.js";
+import { RiskLevel } from "../tools/tool-types.js";
 import {
   isDiskPressureCleanupToolName,
   type ToolContext,
@@ -920,12 +920,26 @@ export function createResolveToolsCallback(
       },
       "MCP and workspace tools resolved for turn",
     );
-    const scopedMcpDefs = wireAllowlist
-      ? currentMcpDefs.filter((d) => wireAllowlist.has(d.name))
-      : currentMcpDefs;
-    const scopedWorkspaceDefs = wireAllowlist
-      ? currentWorkspaceDefs.filter((d) => wireAllowlist.has(d.name))
-      : currentWorkspaceDefs;
+    // Dynamic MCP/workspace defs are appended straight to the wire (they do not
+    // pass through isToolActiveForContext), so apply the read-only pass filter
+    // here too — otherwise a read-only continuation would still see consequential
+    // MCP/workspace tools and select them, producing denial loops instead of
+    // being steered to state the deferred action. The executor gate rejects them
+    // regardless; this just keeps them off the model's tool surface (wire mode).
+    const readOnlyHidesFromWire = (name: string): boolean =>
+      ctx.subagentDenySideEffects === true &&
+      ctx.subagentToolGateMode !== "execution" &&
+      readOnlyPassRefusesTool(name);
+    const scopedMcpDefs = (
+      wireAllowlist
+        ? currentMcpDefs.filter((d) => wireAllowlist.has(d.name))
+        : currentMcpDefs
+    ).filter((d) => !readOnlyHidesFromWire(d.name));
+    const scopedWorkspaceDefs = (
+      wireAllowlist
+        ? currentWorkspaceDefs.filter((d) => wireAllowlist.has(d.name))
+        : currentWorkspaceDefs
+    ).filter((d) => !readOnlyHidesFromWire(d.name));
     const excluded = new Set(getConfig().tools.exclude);
     // Swap UI surface tools for channel-appropriate variants (e.g. Slack's
     // task_progress-only ui_show). Mirrors the pin handling in

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -43,7 +43,9 @@ import {
   resolveSkillExecuteInput,
 } from "../tools/skills/execute.js";
 import { resolveToolInvocationAlias } from "../tools/tool-name-aliases.js";
+import { RiskLevel } from "../tools/tool-types.js";
 import type {
+  ExecutionTarget,
   ProxyApprovalCallback,
   ProxyApprovalRequest,
 } from "../tools/tool-types.js";
@@ -169,6 +171,49 @@ export function getEffectiveEnabledPluginSet(conv: {
   return effective;
 }
 
+// ── read-only pass classification ────────────────────────────────────
+
+/**
+ * Whether a tool must be refused in a read-only subagent pass (the live-voice
+ * background continuation, `subagentDenySideEffects`). It refuses more than the
+ * core {@link isSideEffectTool} name list, because side-effecting skill / MCP /
+ * plugin tools (e.g. `messaging_send`, `app_create`, `run_workflow`) are not in
+ * that list. Refused: the core side-effect names; host-target execution (which
+ * can leak local data); and owned (skill/MCP/plugin) tools that are not declared
+ * low-risk — the metadata by which the system classifies the consequence of
+ * tools outside the core list (MCP defaults to high; consequential skills
+ * declare medium/high). Built-in read tools and low-risk owned tools stay
+ * available. Pure so the classification is unit-testable.
+ */
+export function isRefusedInReadOnlyPass(params: {
+  name: string;
+  executionTarget: ExecutionTarget | undefined;
+  defaultRiskLevel: RiskLevel | undefined;
+  hasOwner: boolean;
+}): boolean {
+  if (isSideEffectTool(params.name)) {
+    return true;
+  }
+  if (params.executionTarget === "host") {
+    return true;
+  }
+  if (params.hasOwner && params.defaultRiskLevel !== RiskLevel.Low) {
+    return true;
+  }
+  return false;
+}
+
+/** Resolve a tool's metadata from the registry and classify it (see above). */
+function readOnlyPassRefusesTool(name: string): boolean {
+  const def = getTool(name);
+  return isRefusedInReadOnlyPass({
+    name,
+    executionTarget: def?.executionTarget,
+    defaultRiskLevel: def?.defaultRiskLevel,
+    hasOwner: getToolOwner(name) !== undefined,
+  });
+}
+
 // ── createToolExecutor ───────────────────────────────────────────────
 
 /**
@@ -200,13 +245,15 @@ export function createToolExecutor(
   const rejectNonAllowlistedTool = (
     toolName: string,
   ): ToolExecutionResult | null => {
-    // A read-only subagent refuses side-effecting tools regardless of gate mode
-    // or trust class, so no unapproved action can run in the background. Records
-    // the attempt for parent-visible surfacing, then rejects before dispatch.
-    if (ctx.subagentDenySideEffects && isSideEffectTool(toolName)) {
+    // A read-only subagent refuses any consequential tool (core side-effects,
+    // host execution, or a non-low-risk skill/MCP/plugin tool) regardless of
+    // gate mode or trust class, so no unapproved action can run in the
+    // background. Records the attempt for parent-visible surfacing, then rejects
+    // before dispatch.
+    if (ctx.subagentDenySideEffects && readOnlyPassRefusesTool(toolName)) {
       ctx.subagentDeniedToolNames?.add(toolName);
       return {
-        content: `The "${toolName}" tool takes a side effect and cannot run in this background pass. State the action you would take so the user can approve it on their next turn.`,
+        content: `The "${toolName}" tool can change state and cannot run in this read-only background pass. State the action you would take so the user can approve it on their next turn.`,
         isError: true,
       };
     }
@@ -625,14 +672,15 @@ export function isToolActiveForContext(
   ) {
     return false;
   }
-  // Read-only subagent: keep side-effecting tools off the wire so the model does
-  // not reach for an action it can't take (the executor gate above also rejects
-  // any that slip through via indirect dispatch). Skipped in execution gate mode,
-  // which deliberately keeps the full surface visible.
+  // Read-only subagent: keep consequential tools (core side-effects, host
+  // execution, non-low-risk skill/MCP/plugin tools) off the wire so the model
+  // does not reach for an action it can't take (the executor gate above also
+  // rejects any that slip through via indirect dispatch). Skipped in execution
+  // gate mode, which deliberately keeps the full surface visible.
   if (
     ctx.subagentDenySideEffects &&
     ctx.subagentToolGateMode !== "execution" &&
-    isSideEffectTool(name)
+    readOnlyPassRefusesTool(name)
   ) {
     return false;
   }

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -36,6 +36,7 @@ import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
 } from "../tools/schema-transforms.js";
+import { isSideEffectTool } from "../tools/side-effects.js";
 import {
   augmentSkillExecuteError,
   recoverSkillExecuteEnvelope,
@@ -199,6 +200,16 @@ export function createToolExecutor(
   const rejectNonAllowlistedTool = (
     toolName: string,
   ): ToolExecutionResult | null => {
+    // A read-only subagent refuses side-effecting tools regardless of gate mode
+    // or trust class, so no unapproved action can run in the background. Records
+    // the attempt for parent-visible surfacing, then rejects before dispatch.
+    if (ctx.subagentDenySideEffects && isSideEffectTool(toolName)) {
+      ctx.subagentDeniedToolNames?.add(toolName);
+      return {
+        content: `The "${toolName}" tool takes a side effect and cannot run in this background pass. State the action you would take so the user can approve it on their next turn.`,
+        isError: true,
+      };
+    }
     const allowlist = ctx.subagentAllowedTools;
     // Record any attempt at a tool outside the subagent's role allowlist — in
     // both wire and execution gate modes — so the parent can be told what the
@@ -611,6 +622,17 @@ export function isToolActiveForContext(
     ctx.subagentAllowedTools &&
     ctx.subagentToolGateMode !== "execution" &&
     !ctx.subagentAllowedTools.has(name)
+  ) {
+    return false;
+  }
+  // Read-only subagent: keep side-effecting tools off the wire so the model does
+  // not reach for an action it can't take (the executor gate above also rejects
+  // any that slip through via indirect dispatch). Skipped in execution gate mode,
+  // which deliberately keeps the full surface visible.
+  if (
+    ctx.subagentDenySideEffects &&
+    ctx.subagentToolGateMode !== "execution" &&
+    isSideEffectTool(name)
   ) {
     return false;
   }

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -36,7 +36,6 @@ import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
 } from "../tools/schema-transforms.js";
-import { isSideEffectTool } from "../tools/side-effects.js";
 import {
   augmentSkillExecuteError,
   recoverSkillExecuteEnvelope,
@@ -51,6 +50,7 @@ import type {
 import { RiskLevel } from "../tools/tool-types.js";
 import {
   isDiskPressureCleanupToolName,
+  type OwnerKind,
   type ToolContext,
   type ToolExecutionResult,
 } from "../tools/types.js";
@@ -174,33 +174,52 @@ export function getEffectiveEnabledPluginSet(conv: {
 // ── read-only pass classification ────────────────────────────────────
 
 /**
+ * Core / default tools known to be read-only, allowed in a read-only subagent
+ * pass. This is a fail-safe ALLOWLIST for built-in tools: a name-based denylist
+ * of side-effecting tools is inherently incomplete (low-risk core mutators like
+ * `remember`, `notify_parent`, or `computer_use_*` are not on the core
+ * side-effect name list), so anything not listed here is refused rather than
+ * silently run. `skill_execute` is the dispatcher for owned tools — its resolved
+ * inner tool is classified separately (see the executor gate), so it is safe to
+ * expose.
+ */
+const READ_ONLY_SAFE_CORE_TOOLS: ReadonlySet<string> = new Set([
+  "file_read",
+  "file_list",
+  "code_search",
+  "web_search",
+  "recall",
+  "skill_execute",
+]);
+
+/**
  * Whether a tool must be refused in a read-only subagent pass (the live-voice
- * background continuation, `subagentDenySideEffects`). It refuses more than the
- * core {@link isSideEffectTool} name list, because side-effecting skill / MCP /
- * plugin tools (e.g. `messaging_send`, `app_create`, `run_workflow`) are not in
- * that list. Refused: the core side-effect names; host-target execution (which
- * can leak local data); and owned (skill/MCP/plugin) tools that are not declared
- * low-risk — the metadata by which the system classifies the consequence of
- * tools outside the core list (MCP defaults to high; consequential skills
- * declare medium/high). Built-in read tools and low-risk owned tools stay
- * available. Pure so the classification is unit-testable.
+ * background continuation, `subagentDenySideEffects`), so no unapproved action
+ * runs while the user is not watching. Rules:
+ * - Host-target execution is always refused (can leak local data).
+ * - Third-party owned tools (skill/MCP/plugin/workspace) are dynamic and cannot
+ *   be name-allowlisted, so they are allowed only when declared low-risk (MCP
+ *   defaults to high; consequential skills/workspace tools declare medium/high).
+ * - Core / default tools use the fail-safe {@link READ_ONLY_SAFE_CORE_TOOLS}
+ *   allowlist — anything not listed is refused, so an unanticipated core mutator
+ *   is never silently run.
+ * Pure so the classification is unit-testable.
  */
 export function isRefusedInReadOnlyPass(params: {
   name: string;
   executionTarget: ExecutionTarget | undefined;
   defaultRiskLevel: RiskLevel | undefined;
-  hasOwner: boolean;
+  ownerKind: OwnerKind | undefined;
 }): boolean {
-  if (isSideEffectTool(params.name)) {
-    return true;
-  }
   if (params.executionTarget === "host") {
     return true;
   }
-  if (params.hasOwner && params.defaultRiskLevel !== RiskLevel.Low) {
-    return true;
+  if (params.ownerKind && params.ownerKind !== "default") {
+    // skill / mcp / plugin / workspace: allow only low-risk (read-only).
+    return params.defaultRiskLevel !== RiskLevel.Low;
   }
-  return false;
+  // Core / default (or unowned) tools: allow only the curated read-only set.
+  return !READ_ONLY_SAFE_CORE_TOOLS.has(params.name);
 }
 
 /** Resolve a tool's metadata from the registry and classify it (see above). */
@@ -210,7 +229,7 @@ function readOnlyPassRefusesTool(name: string): boolean {
     name,
     executionTarget: def?.executionTarget,
     defaultRiskLevel: def?.defaultRiskLevel,
-    hasOwner: getToolOwner(name) !== undefined,
+    ownerKind: getToolOwner(name)?.kind,
   });
 }
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -43,14 +43,11 @@ import {
 } from "../tools/skills/execute.js";
 import { resolveToolInvocationAlias } from "../tools/tool-name-aliases.js";
 import type {
-  ExecutionTarget,
   ProxyApprovalCallback,
   ProxyApprovalRequest,
 } from "../tools/tool-types.js";
-import { RiskLevel } from "../tools/tool-types.js";
 import {
   isDiskPressureCleanupToolName,
-  type OwnerKind,
   type ToolContext,
   type ToolExecutionResult,
 } from "../tools/types.js";
@@ -174,16 +171,21 @@ export function getEffectiveEnabledPluginSet(conv: {
 // ── read-only pass classification ────────────────────────────────────
 
 /**
- * Core / default tools known to be read-only, allowed in a read-only subagent
- * pass. This is a fail-safe ALLOWLIST for built-in tools: a name-based denylist
- * of side-effecting tools is inherently incomplete (low-risk core mutators like
- * `remember`, `notify_parent`, or `computer_use_*` are not on the core
- * side-effect name list), so anything not listed here is refused rather than
- * silently run. `skill_execute` is the dispatcher for owned tools — its resolved
- * inner tool is classified separately (see the executor gate), so it is safe to
- * expose.
+ * The ONLY tools allowed in a read-only subagent pass (the live-voice background
+ * continuation, `subagentDenySideEffects`). This is a strict fail-safe allowlist
+ * of tools known to be read-only. Everything else is refused, because:
+ * - A side-effect denylist is inherently incomplete — low-risk core mutators
+ *   (`remember`, `notify_parent`, `computer_use_*`, `delete_memory_page`, …) are
+ *   not on the core side-effect name list.
+ * - `defaultRiskLevel` on skill/MCP/plugin/workspace tools is an author-asserted
+ *   permission band, NOT a read-only guarantee; a "low" sandbox extension tool
+ *   can still write storage, call an API, or run arbitrary code.
+ * So an unattended continuation must fail closed: run only these, and surface
+ * the intended action for the user to approve on their next turn otherwise.
+ * `skill_execute` is the dispatcher — its resolved inner tool is classified by
+ * the same check in the executor gate, so exposing the wrapper is safe.
  */
-const READ_ONLY_SAFE_CORE_TOOLS: ReadonlySet<string> = new Set([
+const READ_ONLY_ALLOWED_TOOLS: ReadonlySet<string> = new Set([
   "file_read",
   "file_list",
   "code_search",
@@ -193,44 +195,12 @@ const READ_ONLY_SAFE_CORE_TOOLS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Whether a tool must be refused in a read-only subagent pass (the live-voice
- * background continuation, `subagentDenySideEffects`), so no unapproved action
- * runs while the user is not watching. Rules:
- * - Host-target execution is always refused (can leak local data).
- * - Third-party owned tools (skill/MCP/plugin/workspace) are dynamic and cannot
- *   be name-allowlisted, so they are allowed only when declared low-risk (MCP
- *   defaults to high; consequential skills/workspace tools declare medium/high).
- * - Core / default tools use the fail-safe {@link READ_ONLY_SAFE_CORE_TOOLS}
- *   allowlist — anything not listed is refused, so an unanticipated core mutator
- *   is never silently run.
- * Pure so the classification is unit-testable.
+ * Whether a tool must be refused in a read-only subagent pass — true for
+ * anything not on the {@link READ_ONLY_ALLOWED_TOOLS} allowlist. Pure and
+ * name-based so the classification is trivially complete and unit-testable.
  */
-export function isRefusedInReadOnlyPass(params: {
-  name: string;
-  executionTarget: ExecutionTarget | undefined;
-  defaultRiskLevel: RiskLevel | undefined;
-  ownerKind: OwnerKind | undefined;
-}): boolean {
-  if (params.executionTarget === "host") {
-    return true;
-  }
-  if (params.ownerKind && params.ownerKind !== "default") {
-    // skill / mcp / plugin / workspace: allow only low-risk (read-only).
-    return params.defaultRiskLevel !== RiskLevel.Low;
-  }
-  // Core / default (or unowned) tools: allow only the curated read-only set.
-  return !READ_ONLY_SAFE_CORE_TOOLS.has(params.name);
-}
-
-/** Resolve a tool's metadata from the registry and classify it (see above). */
-function readOnlyPassRefusesTool(name: string): boolean {
-  const def = getTool(name);
-  return isRefusedInReadOnlyPass({
-    name,
-    executionTarget: def?.executionTarget,
-    defaultRiskLevel: def?.defaultRiskLevel,
-    ownerKind: getToolOwner(name)?.kind,
-  });
+export function isRefusedInReadOnlyPass(name: string): boolean {
+  return !READ_ONLY_ALLOWED_TOOLS.has(name);
 }
 
 // ── createToolExecutor ───────────────────────────────────────────────
@@ -269,7 +239,7 @@ export function createToolExecutor(
     // gate mode or trust class, so no unapproved action can run in the
     // background. Records the attempt for parent-visible surfacing, then rejects
     // before dispatch.
-    if (ctx.subagentDenySideEffects && readOnlyPassRefusesTool(toolName)) {
+    if (ctx.subagentDenySideEffects && isRefusedInReadOnlyPass(toolName)) {
       ctx.subagentDeniedToolNames?.add(toolName);
       return {
         content: `The "${toolName}" tool can change state and cannot run in this read-only background pass. State the action you would take so the user can approve it on their next turn.`,
@@ -699,7 +669,7 @@ export function isToolActiveForContext(
   if (
     ctx.subagentDenySideEffects &&
     ctx.subagentToolGateMode !== "execution" &&
-    readOnlyPassRefusesTool(name)
+    isRefusedInReadOnlyPass(name)
   ) {
     return false;
   }
@@ -948,7 +918,7 @@ export function createResolveToolsCallback(
     const readOnlyHidesFromWire = (name: string): boolean =>
       ctx.subagentDenySideEffects === true &&
       ctx.subagentToolGateMode !== "execution" &&
-      readOnlyPassRefusesTool(name);
+      isRefusedInReadOnlyPass(name);
     const scopedMcpDefs = (
       wireAllowlist
         ? currentMcpDefs.filter((d) => wireAllowlist.has(d.name))

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -48,6 +48,7 @@ import type {
 } from "../tools/tool-types.js";
 import {
   isDiskPressureCleanupToolName,
+  type OwnerKind,
   type ToolContext,
   type ToolExecutionResult,
 } from "../tools/types.js";
@@ -182,25 +183,33 @@ export function getEffectiveEnabledPluginSet(conv: {
  *   can still write storage, call an API, or run arbitrary code.
  * So an unattended continuation must fail closed: run only these, and surface
  * the intended action for the user to approve on their next turn otherwise.
- * `skill_execute` is the dispatcher — its resolved inner tool is classified by
- * the same check in the executor gate, so exposing the wrapper is safe.
+ * These are all built-in tools owned by the runtime (`kind: "default"`); the
+ * gate verifies the owner so a workspace/plugin/skill tool REGISTERED UNDER one
+ * of these names (registerWorkspaceTools stashes the core tool and installs its
+ * own implementation) does not slip through. `skill_execute` is the dispatcher —
+ * its resolved inner tool is classified by the same check in the executor gate,
+ * so exposing the wrapper is safe.
  */
 const READ_ONLY_ALLOWED_TOOLS: ReadonlySet<string> = new Set([
   "file_read",
   "file_list",
   "code_search",
   "web_search",
-  "recall",
   "skill_execute",
 ]);
 
 /**
- * Whether a tool must be refused in a read-only subagent pass — true for
- * anything not on the {@link READ_ONLY_ALLOWED_TOOLS} allowlist. Pure and
- * name-based so the classification is trivially complete and unit-testable.
+ * Whether a tool must be refused in a read-only subagent pass. Allowed only when
+ * the name is on {@link READ_ONLY_ALLOWED_TOOLS} AND it is the trusted built-in
+ * implementation (`ownerKind === "default"`), so a workspace/plugin/skill tool
+ * overriding an allowlisted name is refused. Everything else fails closed. Pure
+ * so the classification is unit-testable.
  */
-export function isRefusedInReadOnlyPass(name: string): boolean {
-  return !READ_ONLY_ALLOWED_TOOLS.has(name);
+export function isRefusedInReadOnlyPass(
+  name: string,
+  ownerKind: OwnerKind | undefined,
+): boolean {
+  return !(READ_ONLY_ALLOWED_TOOLS.has(name) && ownerKind === "default");
 }
 
 // ── createToolExecutor ───────────────────────────────────────────────
@@ -239,7 +248,10 @@ export function createToolExecutor(
     // gate mode or trust class, so no unapproved action can run in the
     // background. Records the attempt for parent-visible surfacing, then rejects
     // before dispatch.
-    if (ctx.subagentDenySideEffects && isRefusedInReadOnlyPass(toolName)) {
+    if (
+      ctx.subagentDenySideEffects &&
+      isRefusedInReadOnlyPass(toolName, getToolOwner(toolName)?.kind)
+    ) {
       ctx.subagentDeniedToolNames?.add(toolName);
       return {
         content: `The "${toolName}" tool can change state and cannot run in this read-only background pass. State the action you would take so the user can approve it on their next turn.`,
@@ -669,7 +681,7 @@ export function isToolActiveForContext(
   if (
     ctx.subagentDenySideEffects &&
     ctx.subagentToolGateMode !== "execution" &&
-    isRefusedInReadOnlyPass(name)
+    isRefusedInReadOnlyPass(name, getToolOwner(name)?.kind)
   ) {
     return false;
   }
@@ -918,7 +930,7 @@ export function createResolveToolsCallback(
     const readOnlyHidesFromWire = (name: string): boolean =>
       ctx.subagentDenySideEffects === true &&
       ctx.subagentToolGateMode !== "execution" &&
-      isRefusedInReadOnlyPass(name);
+      isRefusedInReadOnlyPass(name, getToolOwner(name)?.kind);
     const scopedMcpDefs = (
       wireAllowlist
         ? currentMcpDefs.filter((d) => wireAllowlist.has(d.name))

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -342,6 +342,13 @@ export class Conversation {
   /** @internal */ preactivatedSkillIds?: string[];
   /** @internal */ subagentAllowedTools?: Set<string>;
   /**
+   * When true, side-effecting tools are refused for this subagent regardless of
+   * trust class (the read-only background continuation). Enforced in the tool
+   * executor gate and filtered off the model's wire tool surface.
+   * @internal
+   */
+  subagentDenySideEffects?: boolean;
+  /**
    * Tool names a subagent attempted but that its role allowlist
    * ({@link subagentAllowedTools}) denied. Recorded by the tool executor;
    * surfaced to the parent in the terminal notification so it can re-spawn with
@@ -1495,6 +1502,10 @@ export class Conversation {
 
   setSubagentAllowedTools(tools: Set<string> | undefined): void {
     this.subagentAllowedTools = tools;
+  }
+
+  setSubagentDenySideEffects(deny: boolean): void {
+    this.subagentDenySideEffects = deny;
   }
 
   /**

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -81,6 +81,12 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   /** When set, the subagent/wake tool allowlist (see {@link subagentToolGateMode}). */
   subagentAllowedTools?: Set<string>;
   /**
+   * When true, side-effecting tools are refused for this subagent regardless of
+   * trust class (the read-only background continuation): kept off the wire tool
+   * surface and rejected in the executor gate. Independent of the allowlist.
+   */
+  subagentDenySideEffects?: boolean;
+  /**
    * Collects tool names the subagent attempted but that
    * {@link subagentAllowedTools} denied, for parent-visible reporting. The
    * executor records into this Set (shared by reference with the Conversation).

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -390,7 +390,7 @@ function buildVoiceControlPrompt(turn: ActiveAssistantTurn): string {
 // the forked history.
 function buildDuplexContinuationObjective(interruptedRequest: string): string {
   const base =
-    "You were in the middle of responding to the user's most recent request when they interrupted you. Finish that response now. Do not repeat any tool calls whose results are already present in the conversation.";
+    "You were in the middle of responding to the user's most recent request when they interrupted you. Finish that response now. Do not repeat any tool calls whose results are already present in the conversation. You are running unattended in the background, so you cannot take any action that sends, writes, deletes, purchases, or otherwise changes anything outside this conversation - those tools are unavailable here. If finishing the request needs such an action, do not attempt it; instead say plainly which action you would take, so the user can approve it on their next turn.";
   return interruptedRequest.length > 0
     ? `${base} Their request was: "${interruptedRequest}".`
     : base;
@@ -3020,6 +3020,12 @@ async function defaultSpawnBackgroundContinuation(args: {
       objective: args.objective,
       fork: true,
       sendResultToUser: false,
+      // Read-only: the continuation runs unattended while the user talks to the
+      // live session, so it must never take an unapproved side effect. Any
+      // side-effecting tool is refused; the continuation surfaces the intended
+      // action for the user to approve on their next turn (via the resurface
+      // context) instead.
+      denySideEffectTools: true,
       parentMessages: [...parentConversation.messages],
       parentSystemPrompt: parentConversation.getCurrentSystemPrompt(),
     },

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -390,7 +390,7 @@ function buildVoiceControlPrompt(turn: ActiveAssistantTurn): string {
 // the forked history.
 function buildDuplexContinuationObjective(interruptedRequest: string): string {
   const base =
-    "You were in the middle of responding to the user's most recent request when they interrupted you. Finish that response now. Do not repeat any tool calls whose results are already present in the conversation. You are running unattended in the background, so you cannot take any action that sends, writes, deletes, purchases, or otherwise changes anything outside this conversation - those tools are unavailable here. If finishing the request needs such an action, do not attempt it; instead say plainly which action you would take, so the user can approve it on their next turn.";
+    "You were in the middle of responding to the user's most recent request when they interrupted you. Finish that response now. Do not repeat any tool calls whose results are already present in the conversation. You are running unattended in the background with a read-only toolset: you cannot send, write, delete, purchase, or otherwise change anything, and most tools (including memory writes and any that take an action) are unavailable here. Do the read-only work you can. If finishing the request needs an action or a tool you do not have, do not attempt it; instead say plainly what you would do, so the user can approve it on their next turn.";
   return interruptedRequest.length > 0
     ? `${base} Their request was: "${interruptedRequest}".`
     : base;

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -566,6 +566,13 @@ export class SubagentManager {
       conversation.setSubagentAllowedTools(new Set(roleConfig.allowedTools));
     }
 
+    // A read-only subagent (e.g. the live-voice background continuation) refuses
+    // side-effecting tools regardless of trust class; the executor gate rejects
+    // any such dispatch and they are kept off the model's tool surface.
+    if (config.denySideEffectTools) {
+      conversation.setSubagentDenySideEffects(true);
+    }
+
     // Pre-activate skills defined by the role config, merged with any caller-provided skill IDs.
     const mergedSkillIds = mergeSkillIds(
       roleConfig.skillIds,

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -49,6 +49,15 @@ export interface SubagentConfig {
   /** Optional role for the subagent. Defaults handled by consumers. */
   role?: SubagentRole;
   /**
+   * When true, side-effecting tools (send/write/delete/purchase, host commands)
+   * are refused for this subagent regardless of trust class — the executor
+   * rejects any such dispatch and the tool is kept off the model's tool surface.
+   * Used for the read-only live-voice background continuation, which must never
+   * take an unapproved action while the user isn't watching; it surfaces the
+   * intended action for the user to approve on their next turn instead.
+   */
+  denySideEffectTools?: boolean;
+  /**
    * When true, the sub-agent inherits the parent's full context instead of
    * receiving only the objective + context fields.
    */


### PR DESCRIPTION
## Summary
- Closes PR 4 of the voice true-duplex plan (approval routing for a backgrounded continuation's side effects): the live-voice background continuation (`voice-duplex-handoff`) now runs **read-only**. A new `denySideEffectTools` subagent posture refuses any side-effecting tool (send/write/delete/purchase, host commands) at the executor gate regardless of trust class, and keeps them off the model's tool surface. So the unattended continuation can never take an action the user didn't approve.
- The continuation is instructed to **state the side-effecting action it would take** instead of attempting it; that intent rides PR 3's resurface into the user's next (interactive) turn, where normal approval applies.
- Enforcement is defense-in-depth: the executor gate rejects the tool before dispatch (covering direct calls *and* `skill_execute` indirection, regardless of wire/execution gate mode), and the wire filter hides side-effect tools from the model. Read-only tools are unaffected.

## Design note
The plan's original framing (route a `local-live-voice` approval prompt) is obsolete: that approval mode was deleted by #38194 (voice went non-interactive) and `SubagentConfig` never had an `approvalMode`. Today a backgrounded continuation is a non-interactive subagent, so it either **silently executes** a side effect within the guardian background auto-approve threshold, or **silently fail-closed denies** it — the two bugs this fixes. Since #38194 removed interactive voice approval cards, approval must land on a real turn, so the continuation runs read-only and defers the action to next-turn approval (the user's chosen approach).

## Original prompt
Final PR of the voice true-duplex plan (`.private/plans/voice-true-duplex-detach-resurface.md`, JARVIS-1249), after the merged detach foundation (#38308), teardown-safety fix (#38320), and resurface (#38367). Phase 4 asked where a backgrounded continuation's side-effect approval prompt goes while the user is mid-conversation. Research showed the landscape changed (non-interactive voice, no approval mode), so the chosen design is a read-only continuation that surfaces the intended action for next-turn approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
