### PR TITLE
fix(plugins): omit peer deps on plugin install; fold node_modules exclusion into walkPluginTree

### DIFF
--- a/assistant/src/cli/lib/__tests__/install-plugin-dependencies.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-plugin-dependencies.test.ts
@@ -15,6 +15,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  DEPENDENCY_INSTALL_ARGS,
   type DependencyInstaller,
   installPluginDependencies,
 } from "../install-plugin-dependencies.js";
@@ -115,5 +116,21 @@ describe("installPluginDependencies", () => {
     // Resolves rather than rejecting — a dep-install failure must never abort
     // the install that already materialized the plugin tree.
     await expect(installPluginDependencies(dir, run)).resolves.toBeUndefined();
+  });
+
+  test("bun argv omits peer dependencies so it never plants a plugin-api shadow", () => {
+    // --omit=peer is load-bearing: without it bun resolves the
+    // `@vellumai/plugin-api` peer every adapted plugin declares and installs a
+    // detached registry copy that shadows the daemon-wired workspace shim.
+    expect(DEPENDENCY_INSTALL_ARGS).toContain("--omit=peer");
+    // Runtime deps only (no devDependencies), no lifecycle scripts, and no
+    // package.json/lockfile writes.
+    expect(DEPENDENCY_INSTALL_ARGS).toEqual([
+      "install",
+      "--omit=dev",
+      "--omit=peer",
+      "--ignore-scripts",
+      "--no-save",
+    ]);
   });
 });

--- a/assistant/src/cli/lib/install-plugin-dependencies.ts
+++ b/assistant/src/cli/lib/install-plugin-dependencies.ts
@@ -14,8 +14,16 @@
  * `<pluginDir>/node_modules/` so Node-style resolution walking up from a
  * hook/tool file finds them. The install is:
  *
- * - **`--production`** — only runtime `dependencies`, never `devDependencies`
+ * - **`--omit=dev`** — only runtime `dependencies`, never `devDependencies`
  *   (a plugin's build-time tooling has no place in an installed copy).
+ * - **`--omit=peer`** — peer dependencies are the *host's* to satisfy, not the
+ *   plugin's. Every adapted plugin declares `@vellumai/plugin-api` as a peer
+ *   (see {@link ./install-from-github} `normalizeInstalledManifest`), but that
+ *   package is a workspace shim materialized at daemon startup
+ *   (`../../plugins/ensure-plugin-api-shim.ts`), not a registry package.
+ *   Resolving it would either fail (a dev/unpublished version) or plant a
+ *   detached registry copy under the plugin's `node_modules/` that *shadows*
+ *   the live, daemon-wired shim — so peers are omitted entirely.
  * - **`--ignore-scripts`** — no dependency (or root) lifecycle script runs, so
  *   installing a plugin never executes arbitrary `postinstall` code. Curated
  *   adapter transforms run through their own vetted path (see
@@ -47,6 +55,21 @@ const log = getLogger("plugin-deps");
 
 /** Cap on a single dependency install; a plugin's dependency set is small. */
 const DEPENDENCY_INSTALL_TIMEOUT_MS = 120_000;
+
+/**
+ * `bun install` argv for a plugin's dependencies. `--omit=peer` is load-bearing:
+ * without it bun resolves the `@vellumai/plugin-api` peer every adapted plugin
+ * declares and plants a detached registry copy that shadows the daemon-wired
+ * workspace shim (see the module docstring). Exported so a guard test pins the
+ * flag set against silent regressions.
+ */
+export const DEPENDENCY_INSTALL_ARGS: readonly string[] = Object.freeze([
+  "install",
+  "--omit=dev",
+  "--omit=peer",
+  "--ignore-scripts",
+  "--no-save",
+]);
 
 /**
  * Installs a staged plugin's dependencies in `cwd`. Injected so tests can
@@ -119,8 +142,9 @@ export async function installPluginDependencies(
 
 /**
  * Production dependency installer: runs `bun install` with a real `bun` binary
- * resolved via {@link ensureBun}, under a timeout. `--production` skips
- * devDependencies, `--ignore-scripts` blocks all lifecycle scripts, and
+ * resolved via {@link ensureBun}, under a timeout. `--omit=dev` skips
+ * devDependencies, `--omit=peer` skips peer dependencies (host-provided; see the
+ * module docstring), `--ignore-scripts` blocks all lifecycle scripts, and
  * `--no-save` leaves `package.json` untouched and writes no lockfile.
  *
  * `process.execPath` is unusable here: inside a `bun build --compile` binary it
@@ -132,17 +156,13 @@ export const defaultDependencyInstaller: DependencyInstaller = async ({
   cwd,
 }) => {
   const bun = await ensureBun();
-  await execFileAsync(
-    bun,
-    ["install", "--production", "--ignore-scripts", "--no-save"],
-    {
-      cwd,
-      encoding: "utf8",
-      timeout: DEPENDENCY_INSTALL_TIMEOUT_MS,
-      maxBuffer: 32 * 1024 * 1024,
-      env: dependencyInstallEnv(bun),
-    },
-  );
+  await execFileAsync(bun, [...DEPENDENCY_INSTALL_ARGS], {
+    cwd,
+    encoding: "utf8",
+    timeout: DEPENDENCY_INSTALL_TIMEOUT_MS,
+    maxBuffer: 32 * 1024 * 1024,
+    env: dependencyInstallEnv(bun),
+  });
 };
 
 /**

--- a/assistant/src/cli/lib/plugin-fingerprint.ts
+++ b/assistant/src/cli/lib/plugin-fingerprint.ts
@@ -19,7 +19,6 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
 import {
-  EXCLUDED_DIRS_ANYWHERE,
   GENERATED_APP_BUILD_DIR,
   walkPluginTree,
 } from "../../plugins/plugin-tree-walk.js";
@@ -70,10 +69,7 @@ export function computeFingerprint(
   const files: Record<string, string> = {};
   walkPluginTree(
     root,
-    {
-      excludeRootEntries: [...exclude, GENERATED_APP_BUILD_DIR],
-      excludeDirsAnywhere: EXCLUDED_DIRS_ANYWHERE,
-    },
+    { excludeRootEntries: [...exclude, GENERATED_APP_BUILD_DIR] },
     (rel, abs) => {
       files[rel] = hashFile(abs);
     },
@@ -191,10 +187,7 @@ export function computeContentHash(
   const entries: Array<{ rel: string; abs: string }> = [];
   walkPluginTree(
     root,
-    {
-      excludeRootEntries: [...exclude, GENERATED_APP_BUILD_DIR],
-      excludeDirsAnywhere: EXCLUDED_DIRS_ANYWHERE,
-    },
+    { excludeRootEntries: [...exclude, GENERATED_APP_BUILD_DIR] },
     (rel, abs) => {
       entries.push({ rel, abs });
     },

--- a/assistant/src/plugins/plugin-tree-walk.ts
+++ b/assistant/src/plugins/plugin-tree-walk.ts
@@ -6,7 +6,7 @@
  * (`../cli/lib/plugin-fingerprint.ts`, drift detection against the pinned
  * commit) and the live-reload source fingerprint
  * (`./source-fingerprint.ts`, change detection for redeploys). This module
- * owns the walk and the excluded-entry constants so the two can't drift.
+ * owns the walk and its excluded-entry rules so the two can't drift.
  *
  * Symlinks are never followed, at any depth: install never materializes
  * them, and following a symlinked directory would let a link like
@@ -41,18 +41,18 @@ export const PRESERVED_ENTRIES = [
 ] as const;
 
 /**
- * Directory names skipped at any depth by every plugin-tree walk. `node_modules`
- * holds a plugin's installed dependencies — derived from the pinned
- * `package.json` and re-installed on every (re)install and upgrade (see
+ * Directory names {@link walkPluginTree} skips at any depth, unconditionally.
+ * `node_modules` holds a plugin's installed dependencies — derived from the
+ * pinned `package.json` and re-installed on every (re)install and upgrade (see
  * `../cli/lib/install-plugin-dependencies.ts`), never tracked source. Excluding
  * it keeps installed dependencies out of the install fingerprint / content hash
  * (`../cli/lib/plugin-fingerprint.ts`) and the live-reload source fingerprint
  * (`./source-fingerprint.ts`), so a re-materialized baseline — which has no
- * `node_modules/` — still matches what install recorded.
+ * `node_modules/` — still matches what install recorded. It is baked into the
+ * walk rather than opted into per call because no plugin-tree walk ever wants
+ * to descend it.
  */
-export const EXCLUDED_DIRS_ANYWHERE: ReadonlySet<string> = new Set([
-  "node_modules",
-]);
+const ALWAYS_EXCLUDED_DIRS: ReadonlySet<string> = new Set(["node_modules"]);
 
 /**
  * Generated app build output: `apps/<app>/dist`. This is compiled output (the
@@ -82,8 +82,6 @@ export interface PluginTreeWalkOptions {
    * GENERATED_APP_BUILD_DIR}).
    */
   readonly excludeRootEntries?: Iterable<string | RegExp>;
-  /** Directory names skipped at any depth (e.g. `node_modules`). */
-  readonly excludeDirsAnywhere?: ReadonlySet<string>;
   /** Skip entries whose name starts with `.`, at any depth. */
   readonly excludeDotEntries?: boolean;
   /**
@@ -144,7 +142,7 @@ export function walkPluginTree(
         continue;
       }
       if (entry.isDirectory()) {
-        if (options.excludeDirsAnywhere?.has(name) === true) {
+        if (ALWAYS_EXCLUDED_DIRS.has(name)) {
           continue;
         }
         walk(rel);

--- a/assistant/src/plugins/source-fingerprint.ts
+++ b/assistant/src/plugins/source-fingerprint.ts
@@ -33,7 +33,6 @@
 import { realpathSync, statSync } from "node:fs";
 
 import {
-  EXCLUDED_DIRS_ANYWHERE,
   GENERATED_APP_BUILD_DIR,
   PRESERVED_ENTRIES,
   walkPluginTree,
@@ -81,7 +80,6 @@ export function snapshotPluginSource(pluginDir: string): SourceSnapshot {
     realRoot,
     {
       excludeRootEntries: [...PRESERVED_ENTRIES, GENERATED_APP_BUILD_DIR],
-      excludeDirsAnywhere: EXCLUDED_DIRS_ANYWHERE,
       excludeDotEntries: true,
       bestEffort: true,
     },


### PR DESCRIPTION
## Prompt / plan

Follow-up to the two review comments left on #38441 (merged).

### 1. `--omit=peer` — stop planting a `@vellumai/plugin-api` shadow (P2, from the Codex reviewer)

Every adapted plugin declares `@vellumai/plugin-api` as a **peerDependency** (`normalizeInstalledManifest` in `install-from-github.ts`), but that package is a **workspace shim materialized at daemon startup** (`ensure-plugin-api-shim.ts`), not a registry package. bun installs peer deps by default, so `bun install` did one of two wrong things for exactly the plugins this feature targets:

- **Failed** to resolve the peer (a dev/unpublished version) → the fail-soft installer swallowed the nonzero exit, leaving the plugin's *real* `dependencies` uninstalled.
- **Resolved** it (when the version happened to publish) → planted a detached registry copy of `@vellumai/plugin-api` (and its own `zod`) under the plugin's `node_modules/`, which **shadows the live, daemon-wired shim** — the plugin would import a dead copy of the API instead of the one bound to the running daemon.

Fix: add `--omit=peer` (and switch `--production` → the equivalent `--omit=dev`) so only the plugin's own runtime `dependencies` are installed. Peers are the host's to satisfy. The argv is now exported as `DEPENDENCY_INSTALL_ARGS` and pinned by a guard test, since dropping `--omit=peer` would silently reintroduce the shadow with no other test catching it.

Verified with Bun 1.3.11: a manifest with a real runtime dep + the plugin-api peer installs only the runtime dep and its transitives — no `@vellumai/*` or `zod` under the plugin's `node_modules`, no devDependency, no lockfile.

### 2. Fold the `node_modules` exclusion into `walkPluginTree` (from @dvargasfuertes)

> I would expect a single exclusion array, not multiple. And I would expect `walkPluginTree` to have that defined internally instead of accepted as input.

`node_modules` is never part of any plugin-tree walk's notion of source, so it's now excluded **unconditionally inside `walkPluginTree`** rather than threaded through a per-call `excludeDirsAnywhere` set. That option and the exported `EXCLUDED_DIRS_ANYWHERE` constant are removed; each call site (`plugin-fingerprint.ts`, `source-fingerprint.ts`) now passes a single `excludeRootEntries` array.

## Test plan

- New guard test pins `DEPENDENCY_INSTALL_ARGS` (asserts `--omit=peer` present + full flag set).
- `install-plugin-dependencies` (8), `install-from-github` (41), `upgrade-plugin` (24), `diff-plugin` (9), `inspect-plugin` (15), `plugin-fingerprint` (18), `source-fingerprint` (6), `mtime-cache` (35) — all green individually.
- End-to-end: drove the real installer against a temp plugin declaring a runtime dep + devDep + the `@vellumai/plugin-api` peer — runtime dep + transitives present, no plugin-api/zod shadow, devDep excluded, no lockfile, `package.json` untouched.
- `bunx tsc --noEmit`, `eslint`, `prettier` clean (pre-commit hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxCZhuSCqMLfu48or8NCJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxCZhuSCqMLfu48or8NCJv)_