### PR TITLE
fix: use regular-size Connect button in one-step ACP connect card

### DIFF
--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -232,7 +232,7 @@ function OneStepCard({
       </div>
 
       {canConnect ? (
-        <Button variant="primary" size="compact" onClick={() => void connect()}>
+        <Button variant="primary" onClick={() => void connect()}>
           Connect
         </Button>
       ) : busy ? (


### PR DESCRIPTION
## Summary
- The one-step (desktop/loopback) "Connect Claude Code" card rendered its Connect button with `size="compact"` (24px), which reads too small next to the 36px brand icon; drop the override so it uses the regular size.
- The two-step (browser/cloud) card's Connect and Save buttons already use the regular default, so all buttons across both card shapes now match — including when the card self-corrects from the one-step guess to the two-step paste flow on a cloud assistant.

## Testing
- `bun test src/domains/chat/transcript/acp-connect-affordance.test.tsx` — 9/9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)