### PR TITLE
fix(web): don't flash "Assistant fatal error" during a restart

### DIFF
--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -632,6 +632,29 @@ describe("StatusBanner", () => {
     expect(screen.queryByText("Assistant fatal error")).toBeNull();
   });
 
+  test("shows fatal error when crash_loop follows a failed restart", async () => {
+    // GIVEN the restart has terminally failed
+    operationalStatusQueryMock = {
+      data: { state: "restarting", detail_state: "failed" },
+      isError: false,
+    };
+
+    const { rerender } = render(<StatusBanner />);
+
+    // WHEN the assistant subsequently reports a crash loop
+    operationalStatusQueryMock = {
+      data: { state: "crash_loop" },
+      isError: false,
+    };
+    rerender(<StatusBanner />);
+
+    // THEN the fatal error is not suppressed
+    await waitFor(() => {
+      expect(screen.getByText("Assistant fatal error")).toBeTruthy();
+    });
+    expect(screen.queryByText("Assistant is restarting")).toBeNull();
+  });
+
   test("renders maintenance mode from lifecycle state when operational status is absent", () => {
     assistantStateMock = {
       kind: "active",

--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -609,6 +609,29 @@ describe("StatusBanner", () => {
     expect(screen.queryByText("Assistant is unreachable")).toBeNull();
   });
 
+  test("shows restarting banner instead of fatal error when a restart briefly reads as crash_loop", async () => {
+    // GIVEN the operational status is restarting
+    operationalStatusQueryMock = {
+      data: { state: "restarting" },
+      isError: false,
+    };
+
+    const { rerender } = render(<StatusBanner />);
+
+    // WHEN the pod bounce is briefly classified as a crash loop
+    operationalStatusQueryMock = {
+      data: { state: "crash_loop" },
+      isError: false,
+    };
+    rerender(<StatusBanner />);
+
+    // THEN the banner keeps showing "restarting" instead of the fatal error
+    await waitFor(() => {
+      expect(screen.getByText("Assistant is restarting")).toBeTruthy();
+    });
+    expect(screen.queryByText("Assistant fatal error")).toBeNull();
+  });
+
   test("renders maintenance mode from lifecycle state when operational status is absent", () => {
     assistantStateMock = {
       kind: "active",

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -596,6 +596,33 @@ function useAssistantBannerConfig(): BannerConfig | null {
     }, 15_000);
     return () => clearTimeout(timeout);
   }, [wasRecentlyActive, operationalStatus?.state]);
+
+  // Suppress the brief "crash_loop" flash during a restart. The pod bounce
+  // bumps the container restart counter, which the platform can briefly
+  // classify as a crash loop before the assistant settles back to active.
+  const [wasRecentlyRestarting, setWasRecentlyRestarting] = useState(false);
+  useEffect(() => {
+    if (operationalStatus?.state === "restarting") {
+      setWasRecentlyRestarting(true);
+    } else if (
+      operationalStatus?.state === "active" ||
+      operationalStatus?.state === "sleeping" ||
+      operationalStatus?.state === "not_found"
+    ) {
+      setWasRecentlyRestarting(false);
+    }
+  }, [operationalStatus?.state]);
+
+  // Auto-clear after 60s so a genuine crash loop surfaces the fatal error.
+  useEffect(() => {
+    if (!wasRecentlyRestarting || operationalStatus?.state !== "crash_loop") {
+      return;
+    }
+    const timeout = setTimeout(() => {
+      setWasRecentlyRestarting(false);
+    }, 60_000);
+    return () => clearTimeout(timeout);
+  }, [wasRecentlyRestarting, operationalStatus?.state]);
   // Track dismissed failed-operation banners so the user can clear
   // terminal error messages (e.g. "Assistant upgrade failed"). The
   // dismissal is keyed on the operation state so it auto-resets when
@@ -827,6 +854,8 @@ function useAssistantBannerConfig(): BannerConfig | null {
   // Conversely, when the status transitions from active directly to
   // unreachable, the pod is shutting down for sleep. Show "sleeping" so
   // the user sees a smooth active → sleeping progression.
+  // Similarly, a restart can briefly read as "crash_loop"; keep showing
+  // "restarting" until the grace window expires.
   const effectiveStatus =
     operationalStatus?.state === "unreachable" && wasRecentlySleeping
       ? { ...operationalStatus, state: "waking" as AssistantOperationalState }
@@ -835,7 +864,12 @@ function useAssistantBannerConfig(): BannerConfig | null {
             ...operationalStatus,
             state: "sleeping" as AssistantOperationalState,
           }
-        : operationalStatus;
+        : operationalStatus?.state === "crash_loop" && wasRecentlyRestarting
+          ? {
+              ...operationalStatus,
+              state: "restarting" as AssistantOperationalState,
+            }
+          : operationalStatus;
 
   const isFailedOperationDismissed =
     effectiveStatus?.detail_state === "failed" &&

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -607,7 +607,11 @@ function useAssistantBannerConfig(): BannerConfig | null {
   useEffect(() => {
     if (!assistantId) return;
     if (operationalStatus?.state === "restarting") {
-      setRecentlyRestartingAssistantId(assistantId);
+      // A failed restart disarms the suppression so a follow-up
+      // crash_loop surfaces immediately instead of reading as a restart.
+      setRecentlyRestartingAssistantId(
+        operationalStatus.detail_state === "failed" ? null : assistantId,
+      );
     } else if (
       operationalStatus?.state === "active" ||
       operationalStatus?.state === "sleeping" ||
@@ -615,7 +619,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
     ) {
       setRecentlyRestartingAssistantId(null);
     }
-  }, [assistantId, operationalStatus?.state]);
+  }, [assistantId, operationalStatus?.state, operationalStatus?.detail_state]);
   const wasRecentlyRestarting =
     recentlyRestartingAssistantId !== null &&
     recentlyRestartingAssistantId === assistantId;

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -600,18 +600,25 @@ function useAssistantBannerConfig(): BannerConfig | null {
   // Suppress the brief "crash_loop" flash during a restart. The pod bounce
   // bumps the container restart counter, which the platform can briefly
   // classify as a crash loop before the assistant settles back to active.
-  const [wasRecentlyRestarting, setWasRecentlyRestarting] = useState(false);
+  // Keyed by assistant id so a polling-target switch can't carry the
+  // suppression over to a different assistant's genuine crash loop.
+  const [recentlyRestartingAssistantId, setRecentlyRestartingAssistantId] =
+    useState<string | null>(null);
   useEffect(() => {
+    if (!assistantId) return;
     if (operationalStatus?.state === "restarting") {
-      setWasRecentlyRestarting(true);
+      setRecentlyRestartingAssistantId(assistantId);
     } else if (
       operationalStatus?.state === "active" ||
       operationalStatus?.state === "sleeping" ||
       operationalStatus?.state === "not_found"
     ) {
-      setWasRecentlyRestarting(false);
+      setRecentlyRestartingAssistantId(null);
     }
-  }, [operationalStatus?.state]);
+  }, [assistantId, operationalStatus?.state]);
+  const wasRecentlyRestarting =
+    recentlyRestartingAssistantId !== null &&
+    recentlyRestartingAssistantId === assistantId;
 
   // Auto-clear after 60s so a genuine crash loop surfaces the fatal error.
   useEffect(() => {
@@ -619,7 +626,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
       return;
     }
     const timeout = setTimeout(() => {
-      setWasRecentlyRestarting(false);
+      setRecentlyRestartingAssistantId(null);
     }, 60_000);
     return () => clearTimeout(timeout);
   }, [wasRecentlyRestarting, operationalStatus?.state]);


### PR DESCRIPTION
## Summary
- During an assistant restart, the pod bounce bumps the container restart counter and the platform can briefly report `crash_loop`, which the status banner rendered as the error-toned "Assistant fatal error" before settling back to healthy.
- Adds a `wasRecentlyRestarting` suppression mirroring the existing `wasRecentlySleeping`/`wasRecentlyActive` transient-flash patterns: while the assistant was recently `restarting`, a `crash_loop` report keeps rendering the "Assistant is restarting" banner.
- A 60s grace window auto-clears the suppression so a genuine crash loop still surfaces the fatal error with the Doctor action.

## Original prompt
A user restarted their assistant and the web UI briefly showed the scary "Assistant fatal error" banner mid-restart before it resolved on its own. Maddie asked to stop showing this misleading error state during an expected restart — the UI should keep indicating the restart is in progress and only surface the fatal error if it persists.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->