### PR TITLE
fix(voice): auto-configure managed speech before the live-voice credential preflight

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-session-preflight.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-preflight.test.ts
@@ -128,6 +128,64 @@ describe("live-voice session credential preflight gating", () => {
     await session.close("websocket_close");
   });
 
+  test("ensureSpeechConfigured is awaited before the credential preflight", async () => {
+    const { context } = createContext();
+    const callOrder: string[] = [];
+    const ensureSpeechConfigured = mock(async () => {
+      callOrder.push("ensureSpeechConfigured");
+    });
+    const resolveCredentialReadiness = mock(
+      async (): Promise<LiveVoiceCredentialReadiness> => {
+        callOrder.push("resolveCredentialReadiness");
+        return { status: "ready" };
+      },
+    );
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+      resolveCredentialReadiness,
+      ensureSpeechConfigured,
+    });
+
+    await session.start();
+
+    expect(ensureSpeechConfigured).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual([
+      "ensureSpeechConfigured",
+      "resolveCredentialReadiness",
+    ]);
+
+    await session.close("websocket_close");
+  });
+
+  test("ensureSpeechConfigured flipping readiness to ready lets start proceed", async () => {
+    const { context, frames } = createContext();
+    let managedConfigured = false;
+    const ensureSpeechConfigured = mock(async () => {
+      managedConfigured = true;
+    });
+    const resolveCredentialReadiness = mock(
+      async (): Promise<LiveVoiceCredentialReadiness> =>
+        managedConfigured ? { status: "ready" } : NOT_READY,
+    );
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+      resolveCredentialReadiness,
+      ensureSpeechConfigured,
+    });
+
+    await session.start();
+
+    expect(ensureSpeechConfigured).toHaveBeenCalledTimes(1);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      type: "ready",
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+    });
+
+    await session.close("websocket_close");
+  });
+
   test("a rejected start frees the manager slot for a retry", async () => {
     const manager = new LiveVoiceSessionManager({
       createSession: (context) =>

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -170,6 +170,12 @@ export interface LiveVoiceSessionOptions {
    * `null` skips the preflight.
    */
   resolveCredentialReadiness?: LiveVoiceCredentialReadinessResolver | null;
+  /**
+   * Runs once at session start, before the credential preflight, to
+   * auto-configure managed speech for platform-connected users who have no
+   * BYOK STT/TTS key. `null` skips it (test seam).
+   */
+  ensureSpeechConfigured?: (() => Promise<void>) | null;
   startVoiceTurn?: LiveVoiceTurnStarter;
   streamTtsAudio?: LiveVoiceTtsStreamer | null;
   archiveAudio?: LiveVoiceSessionAudioArchiver | null;
@@ -415,6 +421,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly context: LiveVoiceSessionFactoryContext;
   private readonly resolveTranscriber: LiveVoiceStreamingTranscriberResolver;
   private readonly resolveCredentialReadiness: LiveVoiceCredentialReadinessResolver | null;
+  private readonly ensureSpeechConfigured: (() => Promise<void>) | null;
   private readonly startVoiceTurn: LiveVoiceTurnStarter | null;
   private readonly streamTtsAudio: LiveVoiceTtsStreamer | null;
   private readonly archiveAudio: LiveVoiceSessionAudioArchiver | null;
@@ -531,6 +538,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       options.resolveTranscriber ?? defaultResolveStreamingTranscriber;
     this.resolveCredentialReadiness =
       options.resolveCredentialReadiness ?? null;
+    this.ensureSpeechConfigured = options.ensureSpeechConfigured ?? null;
     this.startVoiceTurn = options.startVoiceTurn ?? null;
     this.streamTtsAudio = options.streamTtsAudio ?? null;
     this.archiveAudio = options.archiveAudio ?? null;
@@ -584,6 +592,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   async start(): Promise<void> {
     if (this.state !== "initializing") {
+      return;
+    }
+
+    // Auto-configure managed speech for connected users with no BYOK speech
+    // key so the preflight below passes instead of failing the start frame.
+    // Awaited (not fire-and-forget) so the preflight reads the updated config;
+    // maybeDefaultSpeechToManaged() invalidates the config cache internally.
+    if (this.ensureSpeechConfigured) {
+      await this.ensureSpeechConfigured();
+    }
+    // Re-check for a close that raced the ensure step.
+    if (this.isClosed) {
       return;
     }
 
@@ -2970,6 +2990,10 @@ export function createLiveVoiceSession(
       options.resolveCredentialReadiness === undefined
         ? defaultResolveLiveVoiceCredentialReadiness
         : options.resolveCredentialReadiness,
+    ensureSpeechConfigured:
+      options.ensureSpeechConfigured === undefined
+        ? defaultEnsureSpeechConfigured
+        : options.ensureSpeechConfigured,
     startVoiceTurn: options.startVoiceTurn ?? defaultStartVoiceTurn,
     streamTtsAudio:
       options.streamTtsAudio === undefined
@@ -3042,6 +3066,12 @@ async function defaultResolveLiveVoiceCredentialReadiness(): Promise<LiveVoiceCr
   const { resolveLiveVoiceCredentialReadiness } =
     await import("./live-voice-credential-preflight.js");
   return resolveLiveVoiceCredentialReadiness();
+}
+
+async function defaultEnsureSpeechConfigured(): Promise<void> {
+  const { maybeDefaultSpeechToManaged } =
+    await import("../config/managed-speech-defaults.js");
+  await maybeDefaultSpeechToManaged();
 }
 
 async function defaultStartVoiceTurn(


### PR DESCRIPTION
## Summary
- Run maybeDefaultSpeechToManaged() at LiveVoiceSession.start() before the credential preflight, via a new injectable ensureSpeechConfigured seam.
- Platform-connected users with no BYOK STT/TTS key now auto-default to managed (vellum) and go ready instead of failing with credentials_unavailable (the open-then-immediately-close bug).

Part of plan: voice-config-preflight.md (PR 1 of 3)