### PR TITLE
feat(voice): add live-voice preflight route that ensures managed speech and reports readiness

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16286,6 +16286,50 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/live-voice/preflight:
+    post:
+      operationId: livevoice_preflight_post
+      summary: Live voice preflight
+      description: Ensure managed speech defaulting has run, then report whether live voice can start.
+      tags:
+        - live-voice
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ready
+                      - not-ready
+                  missing:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum:
+                            - stt
+                            - tts
+                        providerId:
+                          type: string
+                        reason:
+                          type: string
+                      required:
+                        - kind
+                        - providerId
+                        - reason
+                      additionalProperties: false
+                  userMessage:
+                    type: string
+                required:
+                  - status
+                additionalProperties: false
   /v1/llm-request-logs/{id}/context:
     get:
       operationId: llmrequestlogs_by_id_context_get

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -101,6 +101,7 @@ import { ROUTES as VERCEL_ROUTES } from "./integrations/vercel.js";
 import { ROUTES as INTERNAL_OAUTH_ROUTES } from "./internal-oauth-routes.js";
 import { ROUTES as INTERNAL_TELEMETRY_ROUTES } from "./internal-telemetry-routes.js";
 import { ROUTES as INTERNAL_TWILIO_ROUTES } from "./internal-twilio-routes.js";
+import { ROUTES as LIVE_VOICE_ROUTES } from "./live-voice-routes.js";
 import { ROUTES as LLM_CALL_SITES_ROUTES } from "./llm-call-sites-routes.js";
 import { ROUTES as LOG_EXPORT_ROUTES } from "./log-export-routes.js";
 import { ROUTES as MCP_AUTH_ROUTES } from "./mcp-auth-routes.js";
@@ -239,6 +240,7 @@ export const ROUTES: RouteDefinition[] = [
   ...MCP_AUTH_ROUTES,
   ...OAUTH_CONNECT_ROUTES,
   ...INTERNAL_TWILIO_ROUTES,
+  ...LIVE_VOICE_ROUTES,
   ...LOG_EXPORT_ROUTES,
   ...LLM_CALL_SITES_ROUTES,
   ...MEMORY_EVAL_ROUTES,

--- a/assistant/src/runtime/routes/live-voice-routes.test.ts
+++ b/assistant/src/runtime/routes/live-voice-routes.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the live-voice preflight route.
+ *
+ * The handler must run managed-speech defaulting first, then return the
+ * live-voice credential readiness verdict verbatim:
+ * - ready → { status: "ready" }
+ * - not-ready → passes through the missing gaps + userMessage
+ * - defaulting is invoked BEFORE readiness is resolved
+ *
+ * NOTE: `bun mock.module` leaks across files. Run this file on its own
+ * (`bun test <thisfile>`) — a multi-file run may report a spurious failure.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { LiveVoiceCredentialReadiness } from "../../live-voice/live-voice-credential-preflight.js";
+
+const calls: string[] = [];
+let readiness: LiveVoiceCredentialReadiness = { status: "ready" };
+
+mock.module("../../config/managed-speech-defaults.js", () => ({
+  maybeDefaultSpeechToManaged: async () => {
+    calls.push("default");
+  },
+}));
+
+mock.module("../../live-voice/live-voice-credential-preflight.js", () => ({
+  resolveLiveVoiceCredentialReadiness: async () => {
+    calls.push("resolve");
+    return readiness;
+  },
+}));
+
+const { ROUTES } = await import("./live-voice-routes.js");
+
+const preflightRoute = ROUTES.find(
+  (r) => r.operationId === "live_voice_preflight_post",
+)!;
+
+describe("live_voice_preflight_post", () => {
+  test("returns { status: 'ready' } when readiness reports ready", async () => {
+    calls.length = 0;
+    readiness = { status: "ready" };
+
+    const result = await preflightRoute.handler({});
+
+    expect(result).toEqual({ status: "ready" });
+  });
+
+  test("passes through the missing list and userMessage when not-ready", async () => {
+    calls.length = 0;
+    readiness = {
+      status: "not-ready",
+      missing: [
+        { kind: "tts", providerId: "vellum", reason: "needs a connection" },
+      ],
+      userMessage: "Live voice is unavailable because it requires X.",
+    };
+
+    const result = await preflightRoute.handler({});
+
+    expect(result).toEqual(readiness);
+  });
+
+  test("runs managed-speech defaulting before resolving readiness", async () => {
+    calls.length = 0;
+    readiness = { status: "ready" };
+
+    await preflightRoute.handler({});
+
+    expect(calls).toEqual(["default", "resolve"]);
+  });
+});

--- a/assistant/src/runtime/routes/live-voice-routes.ts
+++ b/assistant/src/runtime/routes/live-voice-routes.ts
@@ -1,0 +1,61 @@
+/**
+ * Transport-agnostic route definitions for live-voice preflight.
+ *
+ * POST /v1/live-voice/preflight — ensure managed-speech defaulting has run,
+ * then report whether the daemon can run both audio legs of a live voice
+ * session. Lets the web client verify voice is configured BEFORE opening the
+ * voice-room WebSocket, instead of opening it and reacting to an error frame.
+ */
+
+import { z } from "zod";
+
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import type { RouteDefinition } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async function handleLiveVoicePreflight() {
+  const { maybeDefaultSpeechToManaged } =
+    await import("../../config/managed-speech-defaults.js");
+  const { resolveLiveVoiceCredentialReadiness } =
+    await import("../../live-voice/live-voice-credential-preflight.js");
+
+  await maybeDefaultSpeechToManaged();
+  return resolveLiveVoiceCredentialReadiness();
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "live_voice_preflight_post",
+    endpoint: "live-voice/preflight",
+    method: "POST",
+    policy: {
+      requiredScopes: ["chat.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Live voice preflight",
+    description:
+      "Ensure managed speech defaulting has run, then report whether live voice can start.",
+    tags: ["live-voice"],
+    responseBody: z.object({
+      status: z.enum(["ready", "not-ready"]),
+      missing: z
+        .array(
+          z.object({
+            kind: z.enum(["stt", "tts"]),
+            providerId: z.string(),
+            reason: z.string(),
+          }),
+        )
+        .optional(),
+      userMessage: z.string().optional(),
+    }),
+    handler: handleLiveVoicePreflight,
+  },
+];


### PR DESCRIPTION
## Summary
- New POST live-voice/preflight route: runs maybeDefaultSpeechToManaged() then returns the live-voice credential readiness verdict.
- Lets the web client verify voice is configured before opening the room instead of opening the WS and reacting to an error frame.

Part of plan: voice-config-preflight.md (PR 2 of 3)