### PR TITLE
feat(memory): add POST /v1/memory/remember route wrapping handleRemember

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17334,6 +17334,42 @@ paths:
                   - confident
                   - notes
                 additionalProperties: false
+  /v1/memory/remember:
+    post:
+      operationId: memory_remember_post
+      summary: Create a memory by remembering a fact
+      description:
+        Append a user-authored fact to the memory buffer via handleRemember; it is materialized into a graph node
+        later by consolidation.
+      tags:
+        - memory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+              required:
+                - content
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                required:
+                  - message
+                  - success
+                additionalProperties: false
   /v1/memory/v2/backfill:
     post:
       operationId: memory_v2_backfill_post

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
@@ -4,7 +4,11 @@
  * Covers: list with filters, get by ID, create + duplicate rejection,
  * update + fingerprint collision, delete + 404.
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  afterAll,
   afterEach,
   beforeAll,
   beforeEach,
@@ -1050,6 +1054,68 @@ describe("Memory Item Routes", () => {
       expect(after.nodes.map((n) => n.content)).toContain(
         "User prefers TypeScript and Bun",
       );
+    });
+  });
+
+  // ── Create memory (remember) ──────────────────────────────────────────────
+
+  describe("POST /v1/memory/remember (createMemory)", () => {
+    // handleRemember writes to getWorkspaceDir(); point it at a throwaway
+    // tmpdir so the buffer/archive writes stay isolated. Enable memory v2 so
+    // writes take the memory/ path and skip PKB re-index jobs.
+    let tmpWorkspace: string;
+    let previousWorkspaceEnv: string | undefined;
+
+    beforeAll(() => {
+      tmpWorkspace = mkdtempSync(join(tmpdir(), "create-memory-route-test-"));
+      previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+      process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+    });
+
+    afterAll(() => {
+      if (previousWorkspaceEnv === undefined) {
+        delete process.env.VELLUM_WORKSPACE_DIR;
+      } else {
+        process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+      }
+      rmSync(tmpWorkspace, { recursive: true, force: true });
+    });
+
+    beforeEach(() => {
+      setConfig("memory", { v2: { enabled: true } });
+    });
+
+    afterEach(() => {
+      setConfig("memory", { v2: { enabled: false } });
+    });
+
+    interface RememberBody {
+      success: boolean;
+      message: string;
+    }
+
+    test("appends a valid fact and returns { success, message }", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: { content: "User prefers dark mode" },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RememberBody;
+      expect(body.success).toBe(true);
+      expect(body.message.length).toBeGreaterThan(0);
+    });
+
+    test("rejects a missing content body as 400", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: {},
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects a non-string content field as 400", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: { content: 42 },
+      });
+      expect(res.status).toBe(400);
     });
   });
 });

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -56,6 +56,7 @@ import { createNode, deleteNode, getNode, updateNode } from "../graph/store.js";
 import {
   handleDeleteMemory,
   handleListMemory,
+  handleRemember,
   handleUpdateMemory,
 } from "../graph/tool-handlers.js";
 import type {
@@ -942,6 +943,33 @@ export const ROUTES: RouteDefinition[] = [
           new_content: parsed.data.newContent,
         },
         "cli",
+        getConfig(),
+      );
+    },
+  },
+
+  {
+    operationId: "createMemory",
+    endpoint: "memory/remember",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Create a memory by remembering a fact",
+    description:
+      "Append a user-authored fact to the memory buffer via handleRemember; it is materialized into a graph node later by consolidation.",
+    tags: ["memory"],
+    requestBody: z.object({ content: z.string() }),
+    responseBody: z.object({ message: z.string(), success: z.boolean() }),
+    handler: ({ body }) => {
+      const parsed = z.object({ content: z.string() }).safeParse(body ?? {});
+      if (!parsed.success) {
+        throw new BadRequestError("content (string) is required");
+      }
+      return handleRemember(
+        { content: parsed.data.content },
+        "web",
         getConfig(),
       );
     },


### PR DESCRIPTION
## Summary
- New create_memory route in the shared ROUTES array wrapping handleRemember (settings.write)
- Regenerated assistant/openapi.yaml; web SDK will expose memoryRememberPost
- Test covers valid + missing-content cases

Part of plan: memory-viz-v2.md (PR 1 of 8)