### PR TITLE
feat(web): onboarding "Hear my voice" audition on the face step (JARVIS-1299)

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-voice-sample.ts
+++ b/clients/web/src/domains/onboarding/onboarding-voice-sample.ts
@@ -1,0 +1,36 @@
+/**
+ * Synthesizes a short sample of the assistant's voice for the onboarding
+ * "Hear my voice" audition.
+ *
+ * SPIKE — research-onboarding flow (voice-mode gated).
+ *
+ * Hits the assistant runtime's TTS synthesize endpoint through the daemon SDK
+ * (forwarded to the self-hosted gateway, so it works locally). It uses whatever
+ * TTS provider the assistant is configured with — which for onboarding assistants
+ * is the default Vellum managed voice (managed → Deepgram with a preselected
+ * voice), so no provider API key is needed in the browser and the sample matches
+ * what the assistant will actually sound like.
+ *
+ * Returns the audio blob, or null on any failure (assistant not ready, TTS
+ * unavailable, network) — the caller decides how to surface that.
+ */
+
+import { ttsSynthesizePost } from "@/generated/daemon/sdk.gen";
+
+export async function synthesizeManagedVoiceSample(
+  assistantId: string,
+  text: string,
+): Promise<Blob | null> {
+  try {
+    const { data, error, response } = await ttsSynthesizePost({
+      path: { assistant_id: assistantId },
+      body: { text },
+      parseAs: "blob",
+      throwOnError: false,
+    });
+    if (error || !response?.ok || !data) return null;
+    return data as Blob;
+  } catch {
+    return null;
+  }
+}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -229,6 +229,10 @@ mock.module("@/domains/onboarding/screens/give-me-a-face-screen", () => ({
   GiveMeAFaceScreen: () => <div data-testid="face-step" />,
 }));
 
+mock.module("@/domains/onboarding/use-onboarding-voice-flag", () => ({
+  useOnboardingVoiceFlag: () => false,
+}));
+
 mock.module("@/domains/onboarding/screens/introduction-screen", () => ({
   IntroductionScreen: () => <div data-testid="intro-step" />,
 }));

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -72,7 +72,7 @@ import {
   GiveMeAFaceScreen,
   type GiveMeAFaceValues,
 } from "@/domains/onboarding/screens/give-me-a-face-screen";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { useOnboardingVoiceFlag } from "@/domains/onboarding/use-onboarding-voice-flag";
 import { IntroductionScreen } from "@/domains/onboarding/screens/introduction-screen";
 import { PitchStep } from "@/domains/onboarding/screens/intro-pitch-steps";
 import { IntegrationStep } from "@/domains/onboarding/screens/integration-step";
@@ -141,12 +141,6 @@ export function ResearchOnboardingRoute() {
   // the legacy pre-chat funnel and is no longer flag-gated, so the route always
   // renders and the "Create my personality" step is always shown.
   const personalityEnabled = true;
-  // Surface the assistant's voice on the face/name step behind the assistant-
-  // scoped `voice-mode` flag (a "Hear my voice" audition — every assistant gets
-  // the default Vellum managed voice). The background hatch fires on mount, so by
-  // the face step the assistant's flags are usually hydrated; before that this
-  // reads the registry default (false), which fails safe (button just hidden).
-  const voiceEnabled = useAssistantFeatureFlagStore.use.voiceMode();
 
   // Sub-steps share this route: details form → avatar/name picker →
   // introduction → pitch (the "different" step, which carousels its lines to
@@ -304,6 +298,12 @@ export function ResearchOnboardingRoute() {
     adoptExisting: adoptExistingAssistant,
     adoptAssistantId,
   });
+  // Gate the face-step "Hear my voice" audition on the HATCHED assistant's
+  // voice-mode flag — not the app's active assistant. Onboarding hatches a
+  // separate assistant and only selects it at handoff, so the shared flag store
+  // would report the wrong assistant (or the default for a brand-new user with
+  // nothing selected). Fails safe to hidden until the hatch id + flags land.
+  const voiceEnabled = useOnboardingVoiceFlag(hatchedAssistantId);
   const research = useResearchRunner();
   // Stable across renders (useCallback in the runner); safe as effect deps.
   const { start: startResearch, hydrate: hydrateResearch } = research;

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -72,6 +72,7 @@ import {
   GiveMeAFaceScreen,
   type GiveMeAFaceValues,
 } from "@/domains/onboarding/screens/give-me-a-face-screen";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { IntroductionScreen } from "@/domains/onboarding/screens/introduction-screen";
 import { PitchStep } from "@/domains/onboarding/screens/intro-pitch-steps";
 import { IntegrationStep } from "@/domains/onboarding/screens/integration-step";
@@ -140,6 +141,12 @@ export function ResearchOnboardingRoute() {
   // the legacy pre-chat funnel and is no longer flag-gated, so the route always
   // renders and the "Create my personality" step is always shown.
   const personalityEnabled = true;
+  // Surface the assistant's voice on the face/name step behind the assistant-
+  // scoped `voice-mode` flag (a "Hear my voice" audition — every assistant gets
+  // the default Vellum managed voice). The background hatch fires on mount, so by
+  // the face step the assistant's flags are usually hydrated; before that this
+  // reads the registry default (false), which fails safe (button just hidden).
+  const voiceEnabled = useAssistantFeatureFlagStore.use.voiceMode();
 
   // Sub-steps share this route: details form → avatar/name picker →
   // introduction → pitch (the "different" step, which carousels its lines to
@@ -698,6 +705,10 @@ export function ResearchOnboardingRoute() {
     // Stage the chosen avatar traits; OnboardingAvatarApplier applies them once
     // the assistant is hatched (they're not part of the pre-chat context).
     setPendingAvatarTraits(face?.traits ?? null);
+    // Onboarding assistants use the default Vellum managed voice via their TTS
+    // config; the face step's "Hear my voice" only auditions it. Per-voice
+    // selection is deferred until the managed-speech endpoint can take a Deepgram
+    // model override (needs platform work — see the follow-up ticket).
 
     // The research pass renders in the focused presentation; entering from a
     // suggestion (or skipping) is a normal chat, so only focus for research.
@@ -1157,6 +1168,10 @@ export function ResearchOnboardingRoute() {
   if (step === "face" && formValues) {
     return (
       <GiveMeAFaceScreen
+        // Surface the "Hear my voice" audition on this step when voice is on;
+        // it synthesizes the managed-voice sample against the hatched assistant.
+        voiceEnabled={voiceEnabled}
+        assistantId={hatchedAssistantId}
         onContinue={(face) => {
           setFaceValues(face);
           goForwardTo("intro");

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests for the face/name step's voice surface — the only place voice appears in
+ * onboarding: a "Hear my voice" audition, shown only behind the `voice-mode`
+ * flag, that synthesizes the assistant's managed voice on demand (never on
+ * landing) and plays it.
+ *
+ * The decorative avatar layer + audio playback are mocked so the test exercises
+ * the voice affordance + wiring, not the carousel or a real <audio> element.
+ */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  // Truthy so the scene renders + the pool generates; `colors: []` keeps
+  // `useOnboardingTone` (read by the shared top bar) happy.
+  useBundledAvatarComponents: () => ({ colors: [] }),
+}));
+mock.module("@/domains/onboarding/components/onboarding-character-stage", () => ({
+  OnboardingCharacterStage: () => null,
+}));
+
+const synthesize = mock(
+  (_assistantId: string, _text: string): Promise<Blob | null> =>
+    Promise.resolve(new Blob(["audio"])),
+);
+mock.module("@/domains/onboarding/onboarding-voice-sample", () => ({
+  synthesizeManagedVoiceSample: synthesize,
+}));
+
+import { GiveMeAFaceScreen } from "@/domains/onboarding/screens/give-me-a-face-screen";
+
+beforeAll(() => {
+  // jsdom/happy-dom don't implement media playback or object URLs.
+  (URL as unknown as { createObjectURL: () => string }).createObjectURL = () =>
+    "blob:test";
+  (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = () => {};
+  (
+    window.HTMLMediaElement.prototype as unknown as { play: () => Promise<void> }
+  ).play = () => Promise.resolve();
+  (
+    window.HTMLMediaElement.prototype as unknown as { pause: () => void }
+  ).pause = () => {};
+});
+
+function renderScreen(
+  props: Partial<Parameters<typeof GiveMeAFaceScreen>[0]> = {},
+) {
+  return render(
+    <GiveMeAFaceScreen onContinue={() => {}} onBack={() => {}} {...props} />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  synthesize.mockClear();
+});
+
+describe("GiveMeAFaceScreen voice surface", () => {
+  test("no 'Hear my voice' affordance when voice is off", () => {
+    renderScreen({ assistantId: "asst_1" });
+    expect(screen.queryByRole("button", { name: "Hear my voice" })).toBeNull();
+  });
+
+  test("auditions the managed voice on click (never on landing)", async () => {
+    renderScreen({ voiceEnabled: true, assistantId: "asst_1" });
+
+    const hear = screen.getByRole("button", { name: "Hear my voice" });
+    // No synthesis on landing.
+    expect(synthesize).not.toHaveBeenCalled();
+
+    fireEvent.click(hear);
+    await waitFor(() => expect(synthesize).toHaveBeenCalledTimes(1));
+    // Synthesized against the hatched assistant.
+    expect(synthesize.mock.calls[0]?.[0]).toBe("asst_1");
+  });
+
+  test("does not synthesize before the assistant is ready", () => {
+    renderScreen({ voiceEnabled: true, assistantId: null });
+
+    fireEvent.click(screen.getByRole("button", { name: "Hear my voice" }));
+    expect(synthesize).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -174,6 +174,10 @@ export function GiveMeAFaceScreen({
   const [voiceLoading, setVoiceLoading] = useState(false);
   const voiceAudioRef = useRef<HTMLAudioElement | null>(null);
   const voiceUrlRef = useRef<string | null>(null);
+  // Bumped on every request AND on unmount, so an in-flight synthesis that
+  // resolves after the user has left the step (or after a newer click) bails
+  // instead of starting playback on the next screen with no later cleanup.
+  const voiceRequestRef = useRef(0);
   function stopVoice() {
     voiceAudioRef.current?.pause();
     voiceAudioRef.current = null;
@@ -182,7 +186,13 @@ export function GiveMeAFaceScreen({
       voiceUrlRef.current = null;
     }
   }
-  useEffect(() => () => stopVoice(), []);
+  useEffect(
+    () => () => {
+      voiceRequestRef.current++;
+      stopVoice();
+    },
+    [],
+  );
 
   async function hearVoice() {
     if (!assistantId) {
@@ -190,6 +200,8 @@ export function GiveMeAFaceScreen({
       return;
     }
     stopVoice();
+    const requestId = ++voiceRequestRef.current;
+    const isCurrent = () => voiceRequestRef.current === requestId;
     setVoiceLoading(true);
     try {
       const trimmed = name.trim();
@@ -197,6 +209,9 @@ export function GiveMeAFaceScreen({
         ? `Hi! It's ${trimmed}. This is how I sound.`
         : "Hi there! This is how I sound.";
       const blob = await synthesizeManagedVoiceSample(assistantId, sampleText);
+      // Unmounted or superseded by a newer click while synthesizing — don't
+      // start playback on a step the user has already left.
+      if (!isCurrent()) return;
       if (!blob) {
         toast.error("Couldn't play a sample just now — give it another try.");
         return;
@@ -208,9 +223,11 @@ export function GiveMeAFaceScreen({
       audio.onended = () => stopVoice();
       await audio.play();
     } catch {
-      toast.error("Couldn't play a sample just now — give it another try.");
+      if (isCurrent()) {
+        toast.error("Couldn't play a sample just now — give it another try.");
+      }
     } finally {
-      setVoiceLoading(false);
+      if (isCurrent()) setVoiceLoading(false);
     }
   }
 

--- a/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/give-me-a-face-screen.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, ArrowRight, Dices, Pencil } from "lucide-react";
+import { ArrowLeft, ArrowRight, Dices, Loader2, Pencil, Volume2 } from "lucide-react";
 
 import { OnboardingCharacterStage } from "@/domains/onboarding/components/onboarding-character-stage";
 import { OnboardingTopBar } from "@/domains/onboarding/components/onboarding-top-bar";
@@ -24,9 +24,11 @@ import {
   useElementSize,
 } from "@/domains/onboarding/hooks/use-onboarding-stage-size";
 import { useOnboardingAvatarPoolStore } from "@/domains/onboarding/onboarding-avatar-pool-store";
+import { synthesizeManagedVoiceSample } from "@/domains/onboarding/onboarding-voice-sample";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import type { CharacterTraits } from "@/types/avatar";
 import { Button } from "@vellumai/design-library/components/button";
+import { toast } from "@vellumai/design-library/components/toast";
 
 export interface GiveMeAFaceValues {
   traits: CharacterTraits;
@@ -38,6 +40,17 @@ interface GiveMeAFaceScreenProps {
   onBack: () => void;
   /** Redo into the next step — only set when the user has stepped back. */
   onForward?: () => void;
+  /**
+   * When true (the `voice-mode` flag), show a "Hear my voice" audition — every
+   * assistant gets the default Vellum managed voice. This is the only place voice
+   * is surfaced in onboarding.
+   */
+  voiceEnabled?: boolean;
+  /**
+   * The background-hatched assistant, needed to synthesize the managed-voice
+   * sample. Null until the hatch is ready — the audition warns and no-ops.
+   */
+  assistantId?: string | null;
 }
 
 /** Prefill names, cycled across the pool and swapped in as you change avatars. */
@@ -61,6 +74,8 @@ export function GiveMeAFaceScreen({
   onContinue,
   onBack,
   onForward,
+  voiceEnabled = false,
+  assistantId = null,
 }: GiveMeAFaceScreenProps) {
   const components = useBundledAvatarComponents();
   const characters = useOnboardingAvatarPoolStore.use.characters();
@@ -152,6 +167,53 @@ export function GiveMeAFaceScreen({
     if (centeredTraits) onContinue({ traits: centeredTraits, name: name.trim() });
   }
 
+  // Audition the assistant's voice (the default Vellum managed voice) on demand.
+  // Synthesis is a network round-trip, so a loading state covers the wait; the
+  // audio + its object URL are torn down on a repeat tap, when it ends, or on
+  // unmount so nothing leaks or double-plays.
+  const [voiceLoading, setVoiceLoading] = useState(false);
+  const voiceAudioRef = useRef<HTMLAudioElement | null>(null);
+  const voiceUrlRef = useRef<string | null>(null);
+  function stopVoice() {
+    voiceAudioRef.current?.pause();
+    voiceAudioRef.current = null;
+    if (voiceUrlRef.current) {
+      URL.revokeObjectURL(voiceUrlRef.current);
+      voiceUrlRef.current = null;
+    }
+  }
+  useEffect(() => () => stopVoice(), []);
+
+  async function hearVoice() {
+    if (!assistantId) {
+      toast.error("Your assistant is still warming up — try again in a moment.");
+      return;
+    }
+    stopVoice();
+    setVoiceLoading(true);
+    try {
+      const trimmed = name.trim();
+      const sampleText = trimmed
+        ? `Hi! It's ${trimmed}. This is how I sound.`
+        : "Hi there! This is how I sound.";
+      const blob = await synthesizeManagedVoiceSample(assistantId, sampleText);
+      if (!blob) {
+        toast.error("Couldn't play a sample just now — give it another try.");
+        return;
+      }
+      const url = URL.createObjectURL(blob);
+      voiceUrlRef.current = url;
+      const audio = new Audio(url);
+      voiceAudioRef.current = audio;
+      audio.onended = () => stopVoice();
+      await audio.play();
+    } catch {
+      toast.error("Couldn't play a sample just now — give it another try.");
+    } finally {
+      setVoiceLoading(false);
+    }
+  }
+
   // Roll a random name from the pool (different from the current one). Counts as
   // a deliberate pick, so — like editing — it sticks across avatar cycling
   // instead of being re-prefilled from the centered avatar.
@@ -230,7 +292,8 @@ export function GiveMeAFaceScreen({
       </button>
 
       {/* Name (view ↔ edit) + Continue, grouped with room between them. */}
-      <div className="absolute left-1/2 top-[51%] z-10 flex -translate-x-1/2 flex-col items-center gap-12">
+      <div className="absolute left-1/2 top-[51%] z-10 flex -translate-x-1/2 flex-col items-center gap-10">
+        <div className="flex flex-col items-center gap-4">
         {editingName ? (
           <input
             ref={nameInputRef}
@@ -276,6 +339,27 @@ export function GiveMeAFaceScreen({
             </button>
           </div>
         )}
+
+        {/* The only place voice is surfaced in onboarding: an audition of the
+            assistant's (managed) voice. Its presence implies "I can speak". */}
+        {voiceEnabled && (
+          <button
+            type="button"
+            onClick={hearVoice}
+            disabled={voiceLoading}
+            title="Hear my voice"
+            aria-label="Hear my voice"
+            className="flex cursor-pointer items-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--content-default)_22%,transparent)] px-4 py-2 text-sm text-[var(--content-default)] transition-colors duration-150 hover:bg-[color-mix(in_srgb,var(--content-default)_10%,transparent)] disabled:cursor-default disabled:opacity-70"
+          >
+            {voiceLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Volume2 className="h-4 w-4" />
+            )}
+            Hear my voice
+          </button>
+        )}
+        </div>
 
         <Button
           type="button"

--- a/clients/web/src/domains/onboarding/use-onboarding-voice-flag.ts
+++ b/clients/web/src/domains/onboarding/use-onboarding-voice-flag.ts
@@ -1,0 +1,41 @@
+/**
+ * Reads the `voice-mode` flag for the BACKGROUND-HATCHED onboarding assistant.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * The shared assistant-feature-flag store (`useAssistantFeatureFlagStore`) is
+ * keyed to the app's *active* assistant, hydrated by `RootLayout`. Onboarding
+ * hatches/adopts a SEPARATE assistant (`hatchedAssistantId`) and only selects it
+ * at the final handoff — so reading the shared store during onboarding reports
+ * the previously-selected assistant's value, or the registry default (`false`)
+ * for a brand-new user with nothing selected, which would hide the audition for
+ * exactly the users the flag targets.
+ *
+ * So query the hatched assistant's flags directly (mirroring
+ * `useAssistantFeatureFlagSync`) and read voice-mode locally, WITHOUT writing to
+ * the shared store (which must keep reflecting the active assistant). Returns
+ * `false` until the hatch id is known and the flags land — fails safe.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { assistantFeatureFlagsGetOptions } from "@/generated/gateway/@tanstack/react-query.gen";
+import { flagKeyToStoreKey } from "@/lib/feature-flags/feature-flag-catalog";
+import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
+
+export function useOnboardingVoiceFlag(assistantId: string | null): boolean {
+  const freshness = useFlagQueryFreshness();
+  const { data } = useQuery({
+    ...assistantFeatureFlagsGetOptions({
+      path: { assistant_id: assistantId ?? "" },
+    }),
+    enabled: assistantId !== null,
+    ...freshness,
+    retry: 1,
+  });
+  return (
+    data?.flags?.some(
+      (flag) => flagKeyToStoreKey(flag.key) === "voiceMode" && flag.enabled === true,
+    ) ?? false
+  );
+}


### PR DESCRIPTION
## What
Surfaces voice in onboarding as a single **"Hear my voice"** audition on the "Give me a face and a name" step, gated behind the `voice-mode` assistant flag. Its presence implies the assistant can speak — there's no separate voice step and no voice name (which would clash with the assistant's own name).

## Why this shape
Explored a few directions (separate voice step, a multi-voice picker, per-avatar assignment) and landed here: the assistant already has a face, name, and personality, so a *fourth* choice (its voice) is one decision too many. One managed voice + an audition keeps it cohesive and low-friction.

## How
- Every onboarding assistant uses the **default Vellum managed voice**. The button synthesizes a short, name-personalized sample via the daemon `POST /v1/assistants/{id}/tts/synthesize` (managed → Deepgram), which routes through the gateway and needs **no client API key**.
- **Audition on demand only** — never on landing (autoplay is commonly blocked / jarring) — with a loading state. Audio + its object URL are torn down on repeat tap, playback end, or unmount.
- Gated on `voice-mode`; when off, the face step is unchanged. Requires the background-hatched assistant to be ready (`assistantId` null → a "still warming up" toast).

## Deferred
Per-voice selection (a Deepgram Aura model per option) needs a managed-speech **model override on the platform side** (+ billing rate-card rows). Scoped and tracked in **JARVIS-1301**.

## Test plan
- `bun test` (onboarding): face-screen voice surface (gating + on-demand audition + assistant-not-ready guard), route, persistence, funnel — all green. tsc + lint clean.
- ⚠️ **Manual confirm needed:** verify "Hear my voice" actually plays in a live onboarding (voice-mode on, assistant hatched, managed TTS). The endpoint was switched from the platform managed-speech route (not in the self-hosted allowlist) to the daemon `tts/synthesize` route after a local failure; the daemon path routes through the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)