### PR TITLE
feat(web): pre-flight voice readiness before opening the live-voice room

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -11,7 +11,7 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createRef } from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 
 import { type ChatAttachment, useComposerStore } from "@/domains/chat/composer-store";
 import type { VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
@@ -154,11 +154,50 @@ mock.module("@/domains/chat/voice/voice-recording-store", () => ({
   },
 }));
 
+// Live-voice readiness preflight. The composer awaits this BEFORE opening the
+// room; mock it so no real daemon call is made and the verdict is controllable
+// per-test. Defaults to `ready` so every existing entry-point test keeps
+// starting the session. The not-ready cases below flip `mockPreflightVerdict`.
+type PreflightVerdict = {
+  status: "ready" | "not-ready";
+  missing?: Array<{ kind: "stt" | "tts"; providerId: string; reason: string }>;
+  userMessage?: string;
+};
+let mockPreflightVerdict: PreflightVerdict | null = { status: "ready" };
+const preflightSpy = mock(
+  (_assistantId: string): Promise<PreflightVerdict | null> =>
+    Promise.resolve(mockPreflightVerdict),
+);
+mock.module("@/domains/chat/voice/live-voice/use-live-voice-preflight", () => ({
+  preflightLiveVoice: preflightSpy,
+}));
+
+// `useNavigate` — the composer deep-links to voice settings from the
+// "configure voice" prompt. Mock the whole module (the composer's only
+// react-router import is `useNavigate`) so the not-tree-mounted composer can
+// still call it, and so a test can assert the destination.
+const navigateSpy = mock((_to: string) => {});
+mock.module("react-router", () => ({
+  useNavigate: () => navigateSpy,
+}));
+
+// Flush the microtask/timer queue so the composer's awaited preflight
+// resolves and the follow-on `starter` call / notice render settle. Wrapped in
+// `act` to absorb the post-await state updates.
+async function flushPreflight() {
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  });
+}
+
 function resetLiveVoiceMocks() {
   mockIsElectron = false;
   mockIsNativeIOS = false;
   mockVoiceMode = false;
   mockVoicePhase = "idle";
+  mockPreflightVerdict = { status: "ready" };
+  preflightSpy.mockClear();
+  navigateSpy.mockClear();
   setAudioLevelSpy.mockClear();
   liveStarterSpy.mockClear();
   liveControls.stop.mockClear();
@@ -849,17 +888,67 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByLabelText("Start voice mode")).toBeNull();
   });
 
-  test("clicking the live-voice button starts a session through the store-registered starter", () => {
-    // GIVEN the flag is on with no active session
+  test("clicking the live-voice button preflights, then starts a session through the store-registered starter", async () => {
+    // GIVEN the flag is on with no active session and a `ready` verdict
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
+    mockPreflightVerdict = { status: "ready" };
 
     // WHEN the user clicks the entry-point mic
     const { getByLabelText } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
+    await flushPreflight();
 
-    // THEN the layout-owned controller is asked to start with the bound
-    // context (the composer holds no controller of its own)
+    // THEN the readiness preflight ran first, and only then the layout-owned
+    // controller is asked to start with the bound context (the composer holds
+    // no controller of its own)
+    expect(preflightSpy).toHaveBeenCalledWith("asst_test");
+    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+  });
+
+  test("a not-ready verdict keeps the room closed and surfaces the configure-voice prompt", async () => {
+    // GIVEN the flag is on but no usable STT/TTS provider can be configured
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockPreflightVerdict = {
+      status: "not-ready",
+      missing: [{ kind: "tts", providerId: "elevenlabs", reason: "no key" }],
+      userMessage: "Add a voice provider to start talking.",
+    };
+
+    // WHEN the user clicks the entry-point mic
+    const { getByLabelText, getByText, queryByText } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+    await flushPreflight();
+
+    // THEN the session never starts (the room stays closed / idle) and the
+    // daemon's configure-voice message is shown instead
+    expect(preflightSpy).toHaveBeenCalledWith("asst_test");
+    expect(liveStarterSpy).not.toHaveBeenCalled();
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+    expect(getByText("Add a voice provider to start talking.")).toBeTruthy();
+
+    // AND the prompt's action deep-links to the voice settings page
+    fireEvent.click(getByText("Configure voice"));
+    expect(navigateSpy).toHaveBeenCalledWith("/assistant/settings/voice");
+    // ...and dismisses itself on navigation
+    expect(queryByText("Add a voice provider to start talking.")).toBeNull();
+  });
+
+  test("a preflight error fails OPEN — the session still starts", async () => {
+    // GIVEN the flag is on and the preflight call itself fails (returns null)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockPreflightVerdict = null;
+
+    // WHEN the user clicks the entry-point mic
+    const { getByLabelText } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+    await flushPreflight();
+
+    // THEN a preflight outage does not block voice — the session starts and
+    // the WS-level handshake surfaces any real credential problem
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
   });
@@ -883,7 +972,7 @@ describe("ChatComposer — live-voice integration", () => {
     expect(liveStarterSpy).not.toHaveBeenCalled();
   });
 
-  test("first-run card Start persists the flag then starts the session", () => {
+  test("first-run card Start persists the flag then starts the session", async () => {
     // GIVEN the first-run card is open
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
@@ -893,8 +982,10 @@ describe("ChatComposer — live-voice integration", () => {
 
     // WHEN the user commits via Start
     fireEvent.click(getByText("first-run-start"));
+    await flushPreflight();
 
     // THEN the first run is consumed, the card closes, and the session starts
+    // (after the readiness preflight)
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
     expect(queryByTestId("first-run-card")).toBeNull();
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
@@ -943,7 +1034,7 @@ describe("ChatComposer — live-voice integration", () => {
     expect(liveStarterSpy).not.toHaveBeenCalled();
   });
 
-  test("Capacitor iOS: returning-user entry still starts directly (unchanged)", () => {
+  test("Capacitor iOS: returning-user entry still starts directly (unchanged)", async () => {
     // GIVEN the native iOS shell with the first run already consumed
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
@@ -953,6 +1044,7 @@ describe("ChatComposer — live-voice integration", () => {
     // WHEN the user clicks the entry-point mic
     const { getByLabelText, queryByTestId } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
+    await flushPreflight();
 
     // THEN it behaves exactly like the returning-user path on any platform
     expect(queryByTestId("first-run-card")).toBeNull();

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -11,6 +11,7 @@ import {
     useState,
 } from "react";
 import { flushSync } from "react-dom";
+import { useNavigate } from "react-router";
 
 import {
     AttachFileButton,
@@ -46,6 +47,7 @@ import {
     useIsLiveVoiceSessionOwnedBy,
     useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { preflightLiveVoice } from "@/domains/chat/voice/live-voice/use-live-voice-preflight";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { VoiceFirstRunCard } from "@/domains/chat/voice/voice-room/voice-first-run-card";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
@@ -55,6 +57,7 @@ import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { isNativeIOS } from "@/runtime/platform-detection";
 import { isPointerCoarse } from "@/utils/pointer";
+import { routes } from "@/utils/routes";
 import { Button, Notice, Popover } from "@vellumai/design-library";
 
 import {
@@ -334,10 +337,47 @@ export function ChatComposer({
   // grows from the on-screen control, not screen-center. Stashed here because
   // the first-run card path defers the actual start to its own handler.
   const liveVoiceEntryOriginRef = useRef<{ x: number; y: number } | null>(null);
-  const startLiveVoiceSession = useCallback(() => {
-    if (!assistantId) {
+  const navigate = useNavigate();
+  // "Configure voice" copy surfaced when the pre-open preflight returns
+  // `not-ready` — the daemon's human-readable `userMessage`. Non-null renders
+  // the notice below (with a deep-link to voice settings) and the room stays
+  // closed. Cleared on dismiss or on the next successful start.
+  const [voiceConfigNotice, setVoiceConfigNotice] = useState<string | null>(
+    null,
+  );
+  // Re-entrancy guard: the preflight is awaited before the room opens, so a
+  // second click while it's in flight must be ignored (else two sessions could
+  // race to start). A ref, not state — this must gate synchronously and never
+  // trigger a re-render.
+  const liveVoicePreflightPendingRef = useRef(false);
+  const startLiveVoiceSession = useCallback(async () => {
+    if (!assistantId || liveVoicePreflightPendingRef.current) {
       return;
     }
+    // Gate the open on the daemon's readiness verdict BEFORE starting, so the
+    // room never flashes open then immediately closes for a user with no
+    // usable STT/TTS provider. The daemon runs managed-speech defaulting as
+    // part of the preflight, so a user who *can* be auto-configured comes back
+    // `ready` here.
+    liveVoicePreflightPendingRef.current = true;
+    let verdict;
+    try {
+      verdict = await preflightLiveVoice(assistantId);
+    } finally {
+      liveVoicePreflightPendingRef.current = false;
+    }
+    // Fail OPEN on a null verdict (preflight network/daemon error): a preflight
+    // outage must not block voice entirely — proceed to `starter` and let the
+    // WS-level start handshake surface any real credential problem via the
+    // existing failure `Notice`. Only an explicit `not-ready` keeps us closed.
+    if (verdict?.status === "not-ready") {
+      setVoiceConfigNotice(
+        verdict.userMessage ??
+          "Voice isn't set up yet. Configure a voice provider to start talking.",
+      );
+      return;
+    }
+    setVoiceConfigNotice(null);
     // Grow the room's entrance from the assistant avatar the user sees — the
     // empty-state greeting avatar, or the latest-turn avatar below the most
     // recent response (both tagged `data-voice-origin`). Fall back to the
@@ -519,6 +559,32 @@ export function ChatComposer({
         <div className="mb-2">
           <Notice tone="error" onDismiss={dismissLiveVoiceFailure}>
             {liveVoiceError}
+          </Notice>
+        </div>
+      )}
+      {/* Pre-open "configure voice" prompt — surfaced when the readiness
+          preflight returns `not-ready` (no usable STT/TTS provider that
+          couldn't be auto-configured). The room stays closed; the action
+          deep-links to voice settings so the user can wire a provider. */}
+      {showVoiceInput && voiceConfigNotice && (
+        <div className="mb-2">
+          <Notice
+            tone="warning"
+            onDismiss={() => setVoiceConfigNotice(null)}
+            actions={
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={() => {
+                  setVoiceConfigNotice(null);
+                  navigate(routes.settings.voice);
+                }}
+              >
+                Configure voice
+              </Button>
+            }
+          >
+            {voiceConfigNotice}
           </Notice>
         </div>
       )}

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-preflight.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-preflight.ts
@@ -1,0 +1,47 @@
+import { livevoicePreflightPost } from "@/generated/daemon/sdk.gen";
+import type { LivevoicePreflightPostResponse } from "@/generated/daemon/types.gen";
+
+/**
+ * The parsed readiness verdict from `POST /v1/live-voice/preflight`.
+ *
+ * `ready` → the daemon has a usable STT and TTS provider (managed defaulting
+ * has already run server-side) and the live-voice room can be opened.
+ * `not-ready` → no usable provider; `missing` lists what's absent and
+ * `userMessage` carries the human-readable "configure voice" copy to surface.
+ */
+export type LiveVoicePreflightVerdict = LivevoicePreflightPostResponse;
+
+/**
+ * POST /v1/live-voice/preflight
+ *
+ * Imperative one-shot call made at voice-entry time (NOT a long-lived query):
+ * the daemon runs `maybeDefaultSpeechToManaged()` then reports whether live
+ * voice can start. The composer awaits this before opening the room so it
+ * never flashes open then immediately closes for a user with no usable
+ * STT/TTS provider.
+ *
+ * Returns `null` when the call itself fails (network/daemon error) so the
+ * caller can decide how to degrade — the composer fails OPEN on `null` so a
+ * preflight outage never blocks voice entirely (the WS-level start handshake
+ * still surfaces any real credential problem).
+ *
+ * Mirrors the imperative daemon-call shape in `postDictation`.
+ */
+export async function preflightLiveVoice(
+  assistantId: string,
+  signal?: AbortSignal,
+): Promise<LiveVoicePreflightVerdict | null> {
+  try {
+    const { data, response } = await livevoicePreflightPost({
+      path: { assistant_id: assistantId },
+      throwOnError: false,
+      signal,
+    });
+    if (!response || !response.ok || !data) {
+      return null;
+    }
+    return data;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Before opening the live-voice room, call the new POST live-voice/preflight route; open only when ready, otherwise show a configure-voice prompt (deep-link to voice settings) and keep the room closed.
- Prevents the room from flashing open then immediately closing for users with no usable STT/TTS provider.

Part of plan: voice-config-preflight.md (PR 3 of 3)