### PR TITLE
feat(memory): + Create memory modal on the Memory tab

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
@@ -36,7 +36,15 @@ export function CreateMemoryModal({
 
     setIsSaving(true);
     try {
-      await createMemory(assistantId, trimmed);
+      // The route returns HTTP 200 with `{ success: false }` for business
+      // failures (e.g. memory disabled, empty fact), so `throwOnError` won't
+      // reject — honor the flag before claiming success. Keep the modal open on
+      // failure so the fact isn't lost and the user can retry.
+      const result = await createMemory(assistantId, trimmed);
+      if (!result.success) {
+        toast.error(result.message || "Couldn't save that memory.");
+        return;
+      }
       toast.success("Got it — I'll remember that.");
       setContent("");
       onOpenChange(false);

--- a/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
@@ -1,0 +1,101 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { createMemory } from "@/domains/intelligence/memory-graph/create-memory";
+import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
+import { Button, Modal, toast, Typography } from "@vellumai/design-library";
+import { Textarea } from "@vellumai/design-library/components/input";
+
+export interface CreateMemoryModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  assistantId: string;
+}
+
+/**
+ * "New memory" modal on the Memory tab: a user types a fact and we POST it to
+ * the daemon `memory/remember` route. Consolidation materializes it into a
+ * graph node LATER, so the memory does not appear instantly — on success we
+ * invalidate the `memory-graph` query so the node surfaces on the next map
+ * update rather than promising an immediate node. Mirrors the controlled
+ * `open`/`onOpenChange` + local `isSaving` pattern of `vercel-token-dialog.tsx`.
+ */
+export function CreateMemoryModal({
+  open,
+  onOpenChange,
+  assistantId,
+}: CreateMemoryModalProps) {
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleCreate = useCallback(async () => {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+
+    setIsSaving(true);
+    try {
+      await createMemory(assistantId, trimmed);
+      toast.success("Got it — I'll remember that.");
+      setContent("");
+      onOpenChange(false);
+      // The node materializes on the next consolidation, not now — invalidate
+      // so the graph refetches and the memory appears as the map updates.
+      await queryClient.invalidateQueries({
+        queryKey: memoryGraphOptions(assistantId).queryKey,
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to create memory.";
+      toast.error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [assistantId, content, onOpenChange, queryClient]);
+
+  return (
+    <Modal.Root open={open} onOpenChange={onOpenChange}>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.Title>New memory</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="flex flex-col gap-4">
+            <Textarea
+              label="What should I remember?"
+              placeholder="e.g. I prefer concise, bulleted summaries."
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              disabled={isSaving}
+              rows={3}
+              fullWidth
+            />
+            <Typography
+              as="p"
+              variant="body-medium-lighter"
+              className="text-(--content-secondary)"
+            >
+              A new memory is forming — it'll appear as the map updates.
+            </Typography>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close asChild>
+            <Button variant="outlined" disabled={isSaving}>
+              Cancel
+            </Button>
+          </Modal.Close>
+          <Button
+            variant="primary"
+            onClick={handleCreate}
+            disabled={isSaving || !content.trim()}
+            leftIcon={isSaving ? <Loader2 className="animate-spin" /> : undefined}
+          >
+            {isSaving ? "Creating…" : "Create memory"}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/intelligence/memory-graph/create-memory.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/create-memory.ts
@@ -1,0 +1,32 @@
+/**
+ * Thin wrapper over the daemon `POST /memory/remember` route. The daemon spec
+ * transform rewrites `/v1/memory/remember` → `/v1/assistants/{assistant_id}/…`,
+ * so the assistant id travels in the path. Appends a user-authored fact to the
+ * memory buffer via `handleRemember`; consolidation materializes it into a
+ * graph node LATER, so the new memory is not visible immediately — callers
+ * should invalidate the memory-graph query and rely on the next consolidation
+ * to surface the node. Mirrors the thin-wrapper style of the sibling
+ * `get-memory-graph.ts` / `get-memory-graph-node.ts` read helpers.
+ */
+
+import { memoryRememberPost } from "@/generated/daemon/sdk.gen";
+
+export interface CreateMemoryResult {
+  message: string;
+  success: boolean;
+}
+
+export async function createMemory(
+  assistantId: string,
+  content: string,
+): Promise<CreateMemoryResult> {
+  // `throwOnError: true` narrows `data` to the 200 body and throws on any
+  // transport / non-2xx error, so the caller can `try/catch` and surface
+  // `error.message` in a toast.
+  const { data } = await memoryRememberPost({
+    path: { assistant_id: assistantId },
+    body: { content },
+    throwOnError: true,
+  });
+  return data;
+}

--- a/clients/web/src/domains/intelligence/memory-page.tsx
+++ b/clients/web/src/domains/intelligence/memory-page.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useRef } from "react";
+import { Plus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { ConceptGraphView } from "@/domains/intelligence/components/concept-graph/concept-graph-view";
+import { CreateMemoryModal } from "@/domains/intelligence/components/concept-graph/create-memory-modal";
 import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { Button } from "@vellumai/design-library";
 
 interface MemoryPageProps {
   onOpenThread?: (message: string) => void;
@@ -18,6 +22,16 @@ interface MemoryPageProps {
  */
 export function MemoryPage({ onOpenThread }: MemoryPageProps) {
   const assistantId = useActiveAssistantId();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  // The button lets a user seed a memory by hand. Gate it on the same
+  // `memory-concept-graph` flag as the tab, and wait for `hasHydrated` before
+  // trusting a `false`: the store starts on registry defaults until the first
+  // `/feature-flags` response, so gating on the raw flag would flash the button
+  // then hide it (or vice-versa) on load. See the store's `hasHydrated` docs.
+  const flagsHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
+  const memoryFlag = useAssistantFeatureFlagStore.use.memoryConceptGraph();
+  const showCreate = flagsHydrated && memoryFlag;
 
   // Report the tab open exactly once per mount. The ref guard keeps React
   // strict-mode's double-invoke (dev) from emitting a duplicate.
@@ -31,12 +45,35 @@ export function MemoryPage({ onOpenThread }: MemoryPageProps) {
   }, []);
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div className="relative flex h-full min-h-0 flex-col">
       <ConceptGraphView
         assistantId={assistantId}
         className="h-full w-full"
         onOpenThread={onOpenThread}
       />
+
+      {showCreate ? (
+        <>
+          {/* Overlay CTA. It lives on the page wrapper (a sibling of the graph
+              view, not a child) so it stays off the shared view file and its
+              pointer events never reach the canvas orbit-drag handlers. Offset
+              from the view's top-right zoom cluster (right-4). */}
+          <Button
+            variant="primary"
+            size="compact"
+            leftIcon={<Plus />}
+            onClick={() => setCreateOpen(true)}
+            className="absolute right-16 top-4 z-10"
+          >
+            Create memory
+          </Button>
+          <CreateMemoryModal
+            open={createOpen}
+            onOpenChange={setCreateOpen}
+            assistantId={assistantId}
+          />
+        </>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- New flag-gated '+ Create memory' button + 'New memory' modal on the Memory tab
- Posts {content} to the create-memory daemon route; toast confirmation; eventual-consistency note
- Client wrapper mirrors the memory-graph get wrappers

Part of plan: memory-viz-v2.md (PR 8 of 8)