### PR TITLE
feat(voice): add voice-front-model rollout flag

### DIFF
--- a/assistant/src/config/__tests__/assistant-feature-flags.test.ts
+++ b/assistant/src/config/__tests__/assistant-feature-flags.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  clearFeatureFlagOverridesCache,
+  isVoiceFrontModelEnabled,
+  VOICE_FRONT_MODEL_FLAG,
+} from "../assistant-feature-flags.js";
+import { setCachedOverrides } from "../feature-flag-cache.js";
+import type { AssistantConfig } from "../schema.js";
+
+// The gate ignores the config arg (flags resolve from the override cache +
+// bundled registry), so a bare cast is sufficient.
+const CONFIG = {} as AssistantConfig;
+
+afterEach(() => {
+  clearFeatureFlagOverridesCache();
+});
+
+describe("isVoiceFrontModelEnabled", () => {
+  test("is off by default (registry defaultEnabled: false)", () => {
+    clearFeatureFlagOverridesCache();
+    expect(isVoiceFrontModelEnabled(CONFIG)).toBe(false);
+  });
+
+  test("is on when the flag override is set", () => {
+    setCachedOverrides(
+      { [VOICE_FRONT_MODEL_FLAG]: true },
+      { fromGateway: true },
+    );
+    expect(isVoiceFrontModelEnabled(CONFIG)).toBe(true);
+  });
+
+  test("is off when the flag override is explicitly false", () => {
+    setCachedOverrides(
+      { [VOICE_FRONT_MODEL_FLAG]: false },
+      { fromGateway: true },
+    );
+    expect(isVoiceFrontModelEnabled(CONFIG)).toBe(false);
+  });
+});

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -326,3 +326,18 @@ export function isAssistantFeatureFlagEnabled(
 ): boolean {
   return !!getAssistantFeatureFlagValue(key, config);
 }
+
+/**
+ * Temporary rollout flag for the live-voice front-model presence layer
+ * (semantic endpointing + spoken acks). Delete once default-on; permanent
+ * tunables live in `liveVoice.frontModel` config.
+ */
+export const VOICE_FRONT_MODEL_FLAG = "voice-front-model" as const;
+
+/**
+ * Whether the front-model presence layer is active for live voice.
+ * When false, every live-voice turn behaves exactly as before.
+ */
+export function isVoiceFrontModelEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(VOICE_FRONT_MODEL_FLAG, config);
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -124,6 +124,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "voice-front-model",
+      "scope": "assistant",
+      "key": "voice-front-model",
+      "label": "Voice Front Model",
+      "description": "Front-model presence layer for live voice (semantic endpointing + spoken acks). Temporary rollout flag: delete once default-on; permanent tunables live in liveVoice.frontModel config.",
+      "defaultEnabled": false
+    },
+    {
       "id": "fast-mode",
       "scope": "assistant",
       "key": "fast-mode",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -124,6 +124,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "voice-front-model",
+      "scope": "assistant",
+      "key": "voice-front-model",
+      "label": "Voice Front Model",
+      "description": "Front-model presence layer for live voice (semantic endpointing + spoken acks). Temporary rollout flag: delete once default-on; permanent tunables live in liveVoice.frontModel config.",
+      "defaultEnabled": false
+    },
+    {
       "id": "fast-mode",
       "scope": "assistant",
       "key": "fast-mode",


### PR DESCRIPTION
## Summary
- Adds the temporary voice-front-model rollout flag (defaultEnabled: false) to the meta registry and bundled copy
- Adds isVoiceFrontModelEnabled predicate + test

Part of plan: voice-mouth-brain.md (PR 1 of 10)