### PR TITLE
feat(voice): register voiceFrontDecision LLM call site

### DIFF
--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -113,6 +113,11 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     effort: "low",
     thinking: { enabled: false },
   },
+  voiceFrontDecision: {
+    profile: "cost-optimized",
+    effort: "low",
+    thinking: { enabled: false },
+  },
   inviteInstructionGenerator: {
     profile: "cost-optimized",
     effort: "low",

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -289,6 +289,13 @@ const CATALOG_RECORD: CatalogRecord = {
       "Captions images via a vision-capable profile for text-only model fallback.",
     domain: "skills",
   },
+  voiceFrontDecision: {
+    id: "voiceFrontDecision",
+    displayName: "Voice Front Decision",
+    description:
+      "Fast turn-taking and presence decisions during live voice (semantic endpointing, ack generation).",
+    domain: "skills",
+  },
   homeGreeting: {
     id: "homeGreeting",
     displayName: "Home Greeting",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -88,6 +88,7 @@ export const LLMCallSiteEnum = z.enum([
   "skillCategoryInference",
   "inference",
   "vision",
+  "voiceFrontDecision",
   "trustRuleSuggestion",
   "homeGreeting",
   "homeSuggestedPrompts",


### PR DESCRIPTION
## Summary
- Adds voiceFrontDecision to LLMCallSiteEnum and the call-site catalog
- No consumers yet; consumed by the VoiceFrontDecider service in a later PR

Part of plan: voice-mouth-brain.md (PR 2 of 10)