### PR TITLE
feat(voice): plumb tool_use_start through VoiceTurnCallbacks to the live-voice session

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -180,6 +180,8 @@ export interface VoiceTurnCallbacks {
   ) => void;
   persisted_user_message_id?: (messageId: string) => void;
   persisted_assistant_message_id?: (messageId: string) => void;
+  /** Fired when the agent run starts a definitive tool use this turn. */
+  tool_use_start?: (toolName: string) => void;
 }
 
 export interface VoiceTurnOptions {
@@ -420,6 +422,7 @@ export async function startVoiceTurn(
     },
     onToolUse: (toolName, input) => {
       log.debug({ toolName, input }, "Voice turn tool_use event");
+      opts.callbacks?.tool_use_start?.(toolName);
     },
   };
 

--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -359,6 +359,49 @@ describe("LiveVoiceSession assistant turn", () => {
     });
   });
 
+  test("records tool_use_start on the active turn without emitting frames", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { frames, session } = createSessionHarness({ startVoiceTurn });
+
+    await session.start();
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitForFrameCount(frames, 3);
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_final",
+      "thinking",
+    ]);
+
+    const frameCountBefore = frames.length;
+    callbacks?.tool_use_start?.("some_tool");
+    await flushAsyncCallbacks();
+
+    const activeTurn = (
+      session as unknown as {
+        activeAssistantTurn: { toolUseStarted: boolean } | null;
+      }
+    ).activeAssistantTurn;
+    expect(activeTurn?.toolUseStarted).toBe(true);
+    expect(frames).toHaveLength(frameCountBefore);
+
+    callbacks?.message_complete?.({
+      type: "message_complete",
+      conversationId: "conversation-123",
+      messageId: "assistant-message-123",
+    });
+    await waitForFrameCount(frames, 4);
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_final",
+      "thinking",
+      "tts_done",
+    ]);
+  });
+
   test("interrupt aborts the in-flight turn and ignores late bridge events", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     let signal: AbortSignal | undefined;

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -320,6 +320,9 @@ interface ActiveAssistantTurn {
   // or reference it in reply to the user, without ever speaking it unprompted.
   // Null when no continuation result is pending for this turn.
   continuationResult: string | null;
+  // The agent run started a definitive tool use this turn — tool use implies
+  // a guaranteed-slow turn, so acknowledgment logic can key off this.
+  toolUseStarted: boolean;
   // Triage-and-escalate (Voice Mode): the front-door leg emitted [ESCALATE]
   // and the strong "escalated" leg has taken over this same turn. Guards the
   // front-door leg's trailing completion from finalizing the turn, and makes
@@ -1862,6 +1865,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       finalized: false,
       interruptedRequest: opts?.interruptedRequest ?? null,
       continuationResult: opts?.continuationResult ?? null,
+      toolUseStarted: false,
       escalationHandedOff: false,
       ttsBuffer: "",
       ttsSegmentEnqueued: false,
@@ -2079,6 +2083,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               return;
             }
             current.assistantMessageId = messageId;
+          },
+          tool_use_start: (toolName) => {
+            const current = this.activeAssistantTurn;
+            if (current?.token !== token) {
+              return;
+            }
+            current.toolUseStarted = true;
+            log.debug({ turnId, toolName }, "Live voice turn started tool use");
           },
         },
         onError: (message) => {


### PR DESCRIPTION
## Summary
- Extends VoiceTurnCallbacks with optional tool_use_start and forwards it from the bridge event sink
- Live-voice session records toolUseStarted on the active turn (no behavior change)

Part of plan: voice-mouth-brain.md (PR 5 of 10)