### PR TITLE
feat(voice): add liveVoice.frontModel config schema

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -826,6 +826,14 @@ describe("AssistantConfigSchema", () => {
         maxTurnDurationMs: 30000,
         bargeInMinSpeechMs: 250,
       },
+      frontModel: {
+        endpointDecisionTimeoutMs: 250,
+        endpointExtensionMs: 1500,
+        endpointMaxExtensions: 2,
+        ackFirstDeltaTimeoutMs: 2500,
+        ackGenerationTimeoutMs: 600,
+        llmAckText: false,
+      },
       maxSessionDurationSeconds: 1800,
       archiveAudio: false,
     });
@@ -1371,9 +1379,9 @@ describe("AssistantConfigSchema", () => {
     expect(TtsServiceSchema.safeParse({ provider: "vellum" }).success).toBe(
       true,
     );
-    expect(TtsServiceSchema.safeParse({ provider: "self-hosted" }).success).toBe(
-      false,
-    );
+    expect(
+      TtsServiceSchema.safeParse({ provider: "self-hosted" }).success,
+    ).toBe(false);
   });
 
   // ── services.stt config ──────────────────────────────────────────────

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -2,9 +2,19 @@ import { describe, expect, test } from "bun:test";
 
 import {
   LiveVoiceConfigSchema,
+  LiveVoiceFrontModelConfigSchema,
   LiveVoiceVadConfigSchema,
   VALID_LIVE_VOICE_MODES,
 } from "../live-voice.js";
+
+const FRONT_MODEL_DEFAULTS = {
+  endpointDecisionTimeoutMs: 250,
+  endpointExtensionMs: 1500,
+  endpointMaxExtensions: 2,
+  ackFirstDeltaTimeoutMs: 2500,
+  ackGenerationTimeoutMs: 600,
+  llmAckText: false,
+};
 
 describe("LiveVoiceVadConfigSchema", () => {
   test("empty object parses to defaults", () => {
@@ -57,6 +67,55 @@ describe("LiveVoiceVadConfigSchema", () => {
   });
 });
 
+describe("LiveVoiceFrontModelConfigSchema", () => {
+  test("empty object parses to defaults", () => {
+    const parsed = LiveVoiceFrontModelConfigSchema.parse({});
+    expect(parsed).toEqual(FRONT_MODEL_DEFAULTS);
+  });
+
+  test("accepts overrides", () => {
+    const parsed = LiveVoiceFrontModelConfigSchema.parse({
+      endpointDecisionTimeoutMs: 400,
+      endpointMaxExtensions: 0,
+      llmAckText: true,
+    });
+    expect(parsed.endpointDecisionTimeoutMs).toBe(400);
+    expect(parsed.endpointMaxExtensions).toBe(0);
+    expect(parsed.llmAckText).toBe(true);
+    // Unspecified fields still get defaults
+    expect(parsed.endpointExtensionMs).toBe(1500);
+    expect(parsed.ackFirstDeltaTimeoutMs).toBe(2500);
+    expect(parsed.ackGenerationTimeoutMs).toBe(600);
+  });
+
+  test("rejects non-positive endpointDecisionTimeoutMs", () => {
+    const result = LiveVoiceFrontModelConfigSchema.safeParse({
+      endpointDecisionTimeoutMs: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative endpointMaxExtensions", () => {
+    const result = LiveVoiceFrontModelConfigSchema.safeParse({
+      endpointMaxExtensions: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a non-boolean llmAckText", () => {
+    const result = LiveVoiceFrontModelConfigSchema.safeParse({
+      llmAckText: "yes",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("liveVoice.frontModel.llmAckText")),
+      ).toBe(true);
+    }
+  });
+});
+
 describe("LiveVoiceConfigSchema", () => {
   test("empty object parses to defaults", () => {
     const parsed = LiveVoiceConfigSchema.parse({});
@@ -68,6 +127,7 @@ describe("LiveVoiceConfigSchema", () => {
         maxTurnDurationMs: 30_000,
         bargeInMinSpeechMs: 250,
       },
+      frontModel: FRONT_MODEL_DEFAULTS,
       maxSessionDurationSeconds: 1800,
       // Off by default: voice turns carry only their transcript, no audio
       // artifacts on the conversation messages (JARVIS-1283).
@@ -94,6 +154,7 @@ describe("LiveVoiceConfigSchema", () => {
     const parsed = LiveVoiceConfigSchema.parse({
       mode: "ptt",
       vad: { silenceThresholdMs: 900 },
+      frontModel: { endpointDecisionTimeoutMs: 300 },
       maxSessionDurationSeconds: 600,
     });
     expect(parsed.mode).toBe("ptt");
@@ -101,6 +162,9 @@ describe("LiveVoiceConfigSchema", () => {
     // Unspecified vad fields still get defaults
     expect(parsed.vad.speechEnergyThreshold).toBe(800);
     expect(parsed.vad.maxTurnDurationMs).toBe(30_000);
+    // Partial frontModel overrides merge with defaults
+    expect(parsed.frontModel.endpointDecisionTimeoutMs).toBe(300);
+    expect(parsed.frontModel.endpointExtensionMs).toBe(1500);
     expect(parsed.maxSessionDurationSeconds).toBe(600);
   });
 

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -47,6 +47,76 @@ export const LiveVoiceVadConfigSchema = z
     "Voice-activity-detection tuning for live voice sessions (open-mic turn segmentation)",
   );
 
+export const LiveVoiceFrontModelConfigSchema = z
+  .object({
+    endpointDecisionTimeoutMs: z
+      .number({
+        error:
+          "liveVoice.frontModel.endpointDecisionTimeoutMs must be a number",
+      })
+      .int("liveVoice.frontModel.endpointDecisionTimeoutMs must be an integer")
+      .positive(
+        "liveVoice.frontModel.endpointDecisionTimeoutMs must be a positive integer",
+      )
+      .default(250)
+      .describe(
+        "Hard budget (ms) for the endpoint decision LLM call. This adds to end-of-turn latency when semantic endpointing is on, so keep it tight.",
+      ),
+    endpointExtensionMs: z
+      .number({
+        error: "liveVoice.frontModel.endpointExtensionMs must be a number",
+      })
+      .int("liveVoice.frontModel.endpointExtensionMs must be an integer")
+      .positive(
+        "liveVoice.frontModel.endpointExtensionMs must be a positive integer",
+      )
+      .default(1500)
+      .describe(
+        "How long (ms) a 'hold' decision keeps the turn open before turn-end replays",
+      ),
+    endpointMaxExtensions: z
+      .number({
+        error: "liveVoice.frontModel.endpointMaxExtensions must be a number",
+      })
+      .int("liveVoice.frontModel.endpointMaxExtensions must be an integer")
+      .nonnegative(
+        "liveVoice.frontModel.endpointMaxExtensions must be a nonnegative integer",
+      )
+      .default(2)
+      .describe("Cap on consecutive 'hold' extensions per utterance"),
+    ackFirstDeltaTimeoutMs: z
+      .number({
+        error: "liveVoice.frontModel.ackFirstDeltaTimeoutMs must be a number",
+      })
+      .int("liveVoice.frontModel.ackFirstDeltaTimeoutMs must be an integer")
+      .positive(
+        "liveVoice.frontModel.ackFirstDeltaTimeoutMs must be a positive integer",
+      )
+      .default(2500)
+      .describe(
+        "Keyword-delay budget (ms): a spoken ack fires if no first assistant delta has arrived by then",
+      ),
+    ackGenerationTimeoutMs: z
+      .number({
+        error: "liveVoice.frontModel.ackGenerationTimeoutMs must be a number",
+      })
+      .int("liveVoice.frontModel.ackGenerationTimeoutMs must be an integer")
+      .positive(
+        "liveVoice.frontModel.ackGenerationTimeoutMs must be a positive integer",
+      )
+      .default(600)
+      .describe("Budget (ms) for LLM-generated ack text"),
+    llmAckText: z
+      .boolean({ error: "liveVoice.frontModel.llmAckText must be a boolean" })
+      .default(false)
+      .describe(
+        "Use the front model to phrase spoken acks; static phrases otherwise",
+      ),
+  })
+  .describe(
+    "Front-model presence layer tuning for live voice sessions (semantic endpointing + spoken acks)",
+  );
+
 export const LiveVoiceConfigSchema = z
   .object({
     mode: z
@@ -58,6 +128,9 @@ export const LiveVoiceConfigSchema = z
         "Default microphone mode for live voice sessions — hands-free (open-mic) or push-to-talk (ptt)",
       ),
     vad: LiveVoiceVadConfigSchema.default(LiveVoiceVadConfigSchema.parse({})),
+    frontModel: LiveVoiceFrontModelConfigSchema.default(
+      LiveVoiceFrontModelConfigSchema.parse({}),
+    ),
     maxSessionDurationSeconds: z
       .number({
         error: "liveVoice.maxSessionDurationSeconds must be a number",
@@ -81,3 +154,6 @@ export const LiveVoiceConfigSchema = z
 
 export type LiveVoiceConfig = z.infer<typeof LiveVoiceConfigSchema>;
 export type LiveVoiceVadConfig = z.infer<typeof LiveVoiceVadConfigSchema>;
+export type LiveVoiceFrontModelConfig = z.infer<
+  typeof LiveVoiceFrontModelConfigSchema
+>;


### PR DESCRIPTION
## Summary
- Adds LiveVoiceFrontModelConfigSchema (endpointing + ack tunables) nested as liveVoice.frontModel
- Defaults-only change; no consumers yet

Part of plan: voice-mouth-brain.md (PR 3 of 10)