### PR TITLE
feat(tts): fetch managed voices from the platform voices endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -30085,6 +30085,53 @@ paths:
                   - description
                   - scopeOptions
                 additionalProperties: false
+  /v1/tts/managed-voices:
+    get:
+      operationId: tts_managedvoices_get
+      summary: List managed TTS voices
+      description:
+        Return the voices offered by Vellum managed TTS, fetched live from the platform. Only currently-usable
+        voices are returned; defaultModel is always one of them (null when none are offered).
+      tags:
+        - tts
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  voices:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        model:
+                          type: string
+                        label:
+                          type: string
+                        description:
+                          type: string
+                        sampleUrl:
+                          type: string
+                        source:
+                          type: string
+                      required:
+                        - model
+                        - label
+                        - description
+                        - sampleUrl
+                        - source
+                      additionalProperties: false
+                  defaultModel:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - voices
+                  - defaultModel
+                additionalProperties: false
   /v1/tts/providers:
     get:
       operationId: tts_providers_get

--- a/assistant/src/platform/managed-speech.test.ts
+++ b/assistant/src/platform/managed-speech.test.ts
@@ -16,6 +16,7 @@ mock.module("./client.js", () => ({
 import {
   managedSpeechSynthesize,
   managedSpeechTranscribe,
+  managedSpeechVoices,
 } from "./managed-speech.js";
 
 const AUDIO = Buffer.from([0x01, 0x02, 0x03, 0xff]);
@@ -129,6 +130,84 @@ describe("managedSpeechTranscribe", () => {
       mimeType: "audio/wav",
     });
     expect(result).toMatchObject({ ok: false, kind: "platform-error" });
+  });
+});
+
+describe("managedSpeechVoices", () => {
+  const CATALOG = {
+    voices: [
+      {
+        model: "aura-2-thalia-en",
+        label: "Thalia",
+        description: "American · clear, confident, energetic",
+        sampleUrl: "https://static.deepgram.com/examples/Aura-2-thalia.wav",
+        source: "deepgram",
+      },
+    ],
+    defaultModel: "aura-2-thalia-en",
+  };
+
+  beforeEach(() => {
+    mockClient = {
+      platformAssistantId: "asst-123",
+      fetch: mock(async () => Response.json(CATALOG)),
+    };
+  });
+
+  afterEach(() => {
+    mockClient = null;
+  });
+
+  test("fetches and parses the platform voice catalog", async () => {
+    const result = await managedSpeechVoices();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(CATALOG);
+    }
+    const [path, init] = mockClient!.fetch.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(path).toBe("/v1/assistants/asst-123/managed-speech/tts/voices/");
+    expect(init.method).toBe("GET");
+  });
+
+  test("drops malformed voice entries and tolerates a null default", async () => {
+    mockClient!.fetch = mock(async () =>
+      Response.json({
+        voices: [CATALOG.voices[0], { model: "missing-fields" }],
+        defaultModel: null,
+      }),
+    );
+    const result = await managedSpeechVoices();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.voices).toEqual(CATALOG.voices);
+      expect(result.value.defaultModel).toBeNull();
+    }
+  });
+
+  test("treats a malformed body as a platform error", async () => {
+    mockClient!.fetch = mock(async () => Response.json({ nope: true }));
+    const result = await managedSpeechVoices();
+    expect(result).toMatchObject({ ok: false, kind: "platform-error" });
+  });
+
+  test("propagates platform error responses", async () => {
+    mockClient!.fetch = mock(
+      async () =>
+        new Response(JSON.stringify({ code: "x", detail: "nope" }), {
+          status: 502,
+        }),
+    );
+    const result = await managedSpeechVoices();
+    expect(result).toMatchObject({
+      ok: false,
+      kind: "platform-error",
+      status: 502,
+    });
   });
 });
 

--- a/assistant/src/platform/managed-speech.ts
+++ b/assistant/src/platform/managed-speech.ts
@@ -186,6 +186,83 @@ export async function managedSpeechSynthesize(input: {
   };
 }
 
+export interface ManagedSpeechVoice {
+  model: string;
+  label: string;
+  description: string;
+  sampleUrl: string;
+  /** Upstream provider that synthesizes this voice (e.g. "deepgram"). */
+  source: string;
+}
+
+export interface ManagedSpeechVoiceCatalog {
+  /** Offered voices in display order; only currently-usable voices. */
+  voices: ManagedSpeechVoice[];
+  /** Always one of `voices`; null when no voices are offered. */
+  defaultModel: string | null;
+}
+
+function parseVoice(value: unknown): ManagedSpeechVoice | null {
+  const voice = value as Partial<Record<keyof ManagedSpeechVoice, unknown>>;
+  if (
+    typeof voice?.model !== "string" ||
+    typeof voice.label !== "string" ||
+    typeof voice.description !== "string" ||
+    typeof voice.sampleUrl !== "string" ||
+    typeof voice.source !== "string"
+  ) {
+    return null;
+  }
+  return {
+    model: voice.model,
+    label: voice.label,
+    description: voice.description,
+    sampleUrl: voice.sampleUrl,
+    source: voice.source,
+  };
+}
+
+export async function managedSpeechVoices(input?: {
+  signal?: AbortSignal;
+}): Promise<ManagedSpeechResult<ManagedSpeechVoiceCatalog>> {
+  const resolved = await resolveClient();
+  if ("error" in resolved) {
+    return resolved.error;
+  }
+  const { client } = resolved;
+
+  const response = await client.fetch(
+    `/v1/assistants/${encodeURIComponent(client.platformAssistantId)}/managed-speech/tts/voices/`,
+    { method: "GET", signal: input?.signal },
+  );
+
+  if (!response.ok) {
+    return await platformError(response, "voice listing");
+  }
+
+  const body: unknown = await response.json().catch(() => null);
+  const raw = body as { voices?: unknown; defaultModel?: unknown } | null;
+  const voices = Array.isArray(raw?.voices)
+    ? raw.voices.map(parseVoice).filter((v): v is ManagedSpeechVoice => !!v)
+    : null;
+  if (!voices) {
+    return {
+      ok: false,
+      kind: "platform-error",
+      status: response.status,
+      message: "Managed speech voice listing returned a malformed response.",
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      voices,
+      defaultModel:
+        typeof raw?.defaultModel === "string" ? raw.defaultModel : null,
+    },
+  };
+}
+
 async function platformError(
   response: Response,
   operation: string,

--- a/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/tts-routes.test.ts
@@ -121,12 +121,16 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("tts-routes", () => {
-  test("exports route definitions for tts/providers, tts/synthesize, and tts/synthesize-cli", () => {
-    expect(ROUTES).toHaveLength(3);
+  test("exports route definitions for tts/providers, tts/managed-voices, tts/synthesize, and tts/synthesize-cli", () => {
+    expect(ROUTES).toHaveLength(4);
 
     const providers = getRoute("tts/providers");
     expect(providers.method).toBe("GET");
     expect(providers.policy?.requiredScopes).toContain("settings.read");
+
+    const managedVoices = getRoute("tts/managed-voices");
+    expect(managedVoices.method).toBe("GET");
+    expect(managedVoices.policy?.requiredScopes).toContain("settings.read");
 
     const synthesize = getRoute("tts/synthesize");
     expect(synthesize.method).toBe("POST");

--- a/assistant/src/runtime/routes/tts-routes.ts
+++ b/assistant/src/runtime/routes/tts-routes.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import { getConfig } from "../../config/loader.js";
+import { managedSpeechVoices } from "../../platform/managed-speech.js";
 import { listCatalogProvidersForDisplay } from "../../tts/provider-catalog.js";
 import {
   synthesizeText,
@@ -131,6 +132,17 @@ function handleListTtsProviders() {
   return { providers: listCatalogProvidersForDisplay() };
 }
 
+async function handleListManagedVoices() {
+  const result = await managedSpeechVoices();
+  if (!result.ok) {
+    if (result.kind === "unavailable") {
+      throw new ServiceUnavailableError(result.message);
+    }
+    throw new BadGatewayError(result.message);
+  }
+  return result.value;
+}
+
 async function handleSynthesizeTts({ body }: RouteHandlerArgs) {
   if (!body?.text || typeof body.text !== "string") {
     throw new BadRequestError("text is required");
@@ -221,6 +233,32 @@ export const ROUTES: RouteDefinition[] = [
       ),
     }),
     handler: handleListTtsProviders,
+  },
+  {
+    operationId: "tts_managed_voices",
+    endpoint: "tts/managed-voices",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List managed TTS voices",
+    description:
+      "Return the voices offered by Vellum managed TTS, fetched live from the platform. Only currently-usable voices are returned; defaultModel is always one of them (null when none are offered).",
+    tags: ["tts"],
+    responseBody: z.object({
+      voices: z.array(
+        z.object({
+          model: z.string(),
+          label: z.string(),
+          description: z.string(),
+          sampleUrl: z.string(),
+          source: z.string(),
+        }),
+      ),
+      defaultModel: z.string().nullable(),
+    }),
+    handler: handleListManagedVoices,
   },
   {
     operationId: "tts_synthesize",

--- a/clients/web/src/domains/settings/ai/managed-voice-catalog.ts
+++ b/clients/web/src/domains/settings/ai/managed-voice-catalog.ts
@@ -14,7 +14,10 @@
  */
 export type ManagedVoiceSource = "deepgram";
 
-export const MANAGED_VOICE_SOURCE_LABELS: Record<ManagedVoiceSource, string> = {
+// Keyed loosely (not by ManagedVoiceSource) so labels also resolve for
+// sources that arrive from the platform voices endpoint before this file
+// learns about them; callers fall back to the raw source string on a miss.
+export const MANAGED_VOICE_SOURCE_LABELS: Record<string, string> = {
   deepgram: "Deepgram",
 };
 
@@ -36,7 +39,7 @@ function sample(name: string): string {
 export const MANAGED_VOICES: ManagedVoice[] = [
   {
     model: "aura-2-thalia-en",
-    label: "Thalia (default)",
+    label: "Thalia",
     description: "American · clear, confident, energetic",
     source: "deepgram",
     sampleUrl: sample("thalia"),

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -328,6 +328,35 @@ describe("TextToSpeechCard — Vellum provider", () => {
     expect(options?.join(" ")).not.toContain("Thalia");
   });
 
+  test("a successful empty catalog hides the voice picker instead of falling back", () => {
+    // An empty catalog is authoritative ("nothing offered right now") — the
+    // static fallback must not resurface voices the platform would reject.
+    orgReady = true;
+    daemonConfigData = { services: { tts: { provider: "vellum" } } };
+    ttsCatalogData = {
+      providers: [
+        {
+          id: "vellum",
+          displayName: "Vellum",
+          subtitle: "Managed TTS.",
+          supportsVoiceSelection: true,
+          apiKeyPlaceholder: "",
+          credentialsGuide: { description: "", url: "", linkLabel: "" },
+        },
+      ],
+    };
+    managedVoicesData = { voices: [], defaultModel: null };
+    renderCard();
+
+    expect(
+      document.querySelector('button[aria-label="Managed voice"]'),
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Preview voice" })).toBeNull();
+    expect(
+      screen.getByText("No managed voices are currently available."),
+    ).toBeTruthy();
+  });
+
   test("grafts the Vellum option onto a fetched catalog that lacks it", () => {
     // A daemon serving the pre-vellum catalog omits the managed option; the
     // card must still offer it, or a legacy managed config has no selectable

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.test.tsx
@@ -41,6 +41,8 @@ let daemonConfigData: { services: Record<string, unknown> } = { services: {} };
 // When set, the tts-providers query resolves to this catalog (as `initialData`,
 // so no async settling) — lets tests exercise a daemon-fetched provider list.
 let ttsCatalogData: { providers: unknown[] } | undefined;
+let managedVoicesData:
+  { voices: unknown[]; defaultModel: string | null } | undefined;
 mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
   ttsProvidersGetOptions: () => ({
     queryKey: ["tts-providers-test"],
@@ -53,6 +55,14 @@ mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
     initialData: daemonConfigData,
   }),
   configGetQueryKey: () => ["config-get-test"],
+  // The card falls back to the static managed-voice catalog when this
+  // query has no data, which is the state these tests exercise.
+  ttsManagedvoicesGetOptions: () => ({
+    queryKey: ["tts-managed-voices-test"],
+    queryFn: () =>
+      Promise.resolve(managedVoicesData ?? { voices: [], defaultModel: null }),
+    ...(managedVoicesData ? { initialData: managedVoicesData } : {}),
+  }),
 }));
 
 interface SdkCall {
@@ -111,6 +121,7 @@ describe("TextToSpeechCard — daemon provisioning on Save", () => {
     daemonConfigData = { services: {} };
     orgReady = false;
     ttsCatalogData = undefined;
+    managedVoicesData = undefined;
   });
 
   afterEach(() => {
@@ -199,6 +210,7 @@ describe("TextToSpeechCard — Vellum provider", () => {
     daemonConfigData = { services: {} };
     orgReady = false;
     ttsCatalogData = undefined;
+    managedVoicesData = undefined;
   });
 
   afterEach(() => {
@@ -265,6 +277,55 @@ describe("TextToSpeechCard — Vellum provider", () => {
     expect(configPatchCalls[0]!.body).toMatchObject({
       services: { tts: { provider: "fish-audio", mode: "your-own" } },
     });
+  });
+
+  test("a fetched managed-voice catalog replaces the static list and default", () => {
+    // Daemon advertises voice selection and the platform serves the catalog;
+    // the dropdown must offer the fetched voices (not the static fallback)
+    // and decorate the platform's default.
+    orgReady = true;
+    daemonConfigData = { services: { tts: { provider: "vellum" } } };
+    ttsCatalogData = {
+      providers: [
+        {
+          id: "vellum",
+          displayName: "Vellum",
+          subtitle: "Managed TTS.",
+          supportsVoiceSelection: true,
+          apiKeyPlaceholder: "",
+          credentialsGuide: { description: "", url: "", linkLabel: "" },
+        },
+      ],
+    };
+    managedVoicesData = {
+      voices: [
+        {
+          model: "aura-2-zeus-en",
+          label: "Zeus",
+          description: "American · deep, trustworthy, smooth",
+          sampleUrl: "https://static.deepgram.com/examples/Aura-2-zeus.wav",
+          source: "deepgram",
+        },
+      ],
+      defaultModel: "aura-2-zeus-en",
+    };
+    renderCard();
+
+    const voiceTrigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="Managed voice"]',
+    );
+    expect(voiceTrigger).not.toBeNull();
+    fireEvent.click(voiceTrigger!);
+    const options = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[role="option"]:not([aria-label])',
+      ),
+    ).map((o) => o.textContent?.trim());
+    expect(options).toContain(
+      "Zeus (default) — American · deep, trustworthy, smooth",
+    );
+    // Static-catalog-only voices must not appear once the fetch supplies data.
+    expect(options?.join(" ")).not.toContain("Thalia");
   });
 
   test("grafts the Vellum option onto a fetched catalog that lacks it", () => {

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -128,21 +128,27 @@ export function TextToSpeechCard() {
     // Old daemons 404 this route; the static fallback covers them.
     retry: false,
   });
-  const managedVoices = managedVoiceData?.voices?.length
+  // A successful response is authoritative even when empty — an empty
+  // catalog means the platform offers nothing right now, and substituting
+  // the static list would show voices the platform would reject. The static
+  // catalog only stands in when there is no response at all (loading,
+  // errors, daemons that predate the route).
+  const managedVoices = managedVoiceData
     ? managedVoiceData.voices
     : MANAGED_VOICES;
-  const defaultManagedVoice =
-    managedVoiceData?.defaultModel ?? DEFAULT_MANAGED_VOICE;
+  const defaultManagedVoice = managedVoiceData
+    ? managedVoiceData.defaultModel
+    : DEFAULT_MANAGED_VOICE;
 
   // Managed voice selection. Server value comes from daemon config; absent
   // means the platform default voice.
   const serverManagedVoice =
-    daemonTts?.providers?.vellum?.model ?? defaultManagedVoice;
+    daemonTts?.providers?.vellum?.model ?? defaultManagedVoice ?? "";
   const [draftManagedVoice, setDraftManagedVoice] =
     useDraftOverride(serverManagedVoice);
   const selectedManagedVoice =
     managedVoices.find((v) => v.model === draftManagedVoice) ??
-    managedVoices[0]!;
+    managedVoices[0];
 
   const selectedProvider = useMemo(() => {
     return providers.find((p) => p.id === draftProvider) ?? providers[0]!;
@@ -306,6 +312,9 @@ export function TextToSpeechCard() {
   // no billing, works before saving.
   const [previewing, setPreviewing] = useState(false);
   const handlePreviewVoice = useCallback(async () => {
+    if (!selectedManagedVoice) {
+      return;
+    }
     setPreviewing(true);
     try {
       const audio = new Audio(selectedManagedVoice.sampleUrl);
@@ -424,7 +433,7 @@ export function TextToSpeechCard() {
           </div>
         )}
 
-        {managedVoiceSupported && (
+        {managedVoiceSupported && selectedManagedVoice && (
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
               Voice
@@ -446,6 +455,11 @@ export function TextToSpeechCard() {
                 selectedManagedVoice.source}
             </p>
           </div>
+        )}
+        {managedVoiceSupported && !selectedManagedVoice && (
+          <p className="text-body-small-default text-[var(--content-tertiary)]">
+            No managed voices are currently available.
+          </p>
         )}
 
         {selectedProvider.supportsVoiceSelection && !isManaged && (
@@ -471,7 +485,7 @@ export function TextToSpeechCard() {
               {testing ? "Testing…" : "Test"}
             </Button>
           )}
-          {managedVoiceSupported && (
+          {managedVoiceSupported && selectedManagedVoice && (
             <Button
               variant="outlined"
               onClick={handlePreviewVoice}

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -6,6 +6,7 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import {
   configGetOptions,
   configGetQueryKey,
+  ttsManagedvoicesGetOptions,
   ttsProvidersGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { configPatch, credentialsSetPost } from "@/generated/daemon/sdk.gen";
@@ -117,15 +118,31 @@ export function TextToSpeechCard() {
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  // Managed (Vellum) voice selection. Server value comes from daemon config;
-  // absent means the platform default voice.
+  // Managed (Vellum) voices, fetched live from the platform via the daemon so
+  // the offered list and default track the platform's rate card. The static
+  // catalog stands in while loading and for daemons that predate the route.
+  const { data: managedVoiceData } = useQuery({
+    ...ttsManagedvoicesGetOptions({ path: { assistant_id: assistantId } }),
+    enabled: isOrgReady && draftProvider === "vellum",
+    staleTime: 60_000,
+    // Old daemons 404 this route; the static fallback covers them.
+    retry: false,
+  });
+  const managedVoices = managedVoiceData?.voices?.length
+    ? managedVoiceData.voices
+    : MANAGED_VOICES;
+  const defaultManagedVoice =
+    managedVoiceData?.defaultModel ?? DEFAULT_MANAGED_VOICE;
+
+  // Managed voice selection. Server value comes from daemon config; absent
+  // means the platform default voice.
   const serverManagedVoice =
-    daemonTts?.providers?.vellum?.model ?? DEFAULT_MANAGED_VOICE;
+    daemonTts?.providers?.vellum?.model ?? defaultManagedVoice;
   const [draftManagedVoice, setDraftManagedVoice] =
     useDraftOverride(serverManagedVoice);
   const selectedManagedVoice =
-    MANAGED_VOICES.find((v) => v.model === draftManagedVoice) ??
-    MANAGED_VOICES[0]!;
+    managedVoices.find((v) => v.model === draftManagedVoice) ??
+    managedVoices[0]!;
 
   const selectedProvider = useMemo(() => {
     return providers.find((p) => p.id === draftProvider) ?? providers[0]!;
@@ -415,15 +432,18 @@ export function TextToSpeechCard() {
             <Dropdown
               value={draftManagedVoice}
               onChange={setDraftManagedVoice}
-              options={MANAGED_VOICES.map((v) => ({
+              options={managedVoices.map((v) => ({
                 value: v.model,
-                label: `${v.label} — ${v.description}`,
+                label: `${v.label}${
+                  v.model === defaultManagedVoice ? " (default)" : ""
+                } — ${v.description}`,
               }))}
               aria-label="Managed voice"
             />
             <p className="text-body-small-default text-[var(--content-tertiary)]">
               Voice by{" "}
-              {MANAGED_VOICE_SOURCE_LABELS[selectedManagedVoice.source]}
+              {MANAGED_VOICE_SOURCE_LABELS[selectedManagedVoice.source] ??
+                selectedManagedVoice.source}
             </p>
           </div>
         )}


### PR DESCRIPTION
## What

Final piece of the managed-voice-selection series: the settings voice dropdown now sources its list **live from the platform** ([vellum-assistant-platform#9274](https://github.com/vellum-ai/vellum-assistant-platform/pull/9274)) instead of only the shipped static catalog. Offered voices, ordering, and the default now track the platform's rate card with no client releases.

### Daemon
- `managedSpeechVoices()` in `platform/managed-speech.ts` — GETs `/v1/assistants/{id}/managed-speech/tts/voices/`, validates the shape, drops malformed entries.
- New route `GET tts/managed-voices` (`settings.read`, actor principals) proxying it for web/UI consumers; `unavailable` → 503, platform errors → 502.

### Web settings card
- Fetches the catalog when the Vellum provider is selected (`retry: false` — old daemons 404 this route).
- **The static catalog demotes to fallback**: used while loading, on any error, and against daemons that predate the route. Selection, save, and preview behave identically in both modes.
- "(default)" label decoration now follows the platform's `defaultModel`; the "Voice by …" source caption falls back to the raw source string for upstream providers this bundle doesn't know yet (ready for ElevenLabs).

## Compatibility

- New web bundle ↔ old daemon: fetch 404s once, static fallback covers it — same behavior as before this PR.
- Old web bundle ↔ new daemon: route simply unused.
- No config-shape, daemon-behavior, or platform changes. Requires #9274 (already merged/deployed) to return data; degrades to the fallback otherwise.

## Checks

- `bunx tsc --noEmit` clean in `assistant/` and `clients/web/`
- `managed-speech` tests: 4 new cases (parse, malformed-entry filtering, malformed body, error propagation)
- Card tests: new case proving a fetched catalog replaces the static list and default decoration; all existing cases pass
- Daemon OpenAPI spec + generated web SDK regenerated

Skipped deliberately: a route-handler test for `tts/managed-voices` — it is a thin pass-through over the tested `managedSpeechVoices()` with two-line error mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wzyf9DgGaff6ALaUnwcdzh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->