### PR TITLE
fix(assistant): preserve inference send profile

### DIFF
--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -4,7 +4,10 @@
  * and response extraction helpers.
  */
 
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  resolveCallSiteConfig,
+  type ResolveCallSiteOpts,
+} from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { getDb } from "../persistence/db-connection.js";
@@ -31,6 +34,11 @@ export interface ConfiguredProviderResult {
   provider: Provider;
   configuredProviderName: string;
 }
+
+export type ConfiguredProviderOptions = Pick<
+  ResolveCallSiteOpts,
+  "overrideProfile" | "forceOverrideProfile" | "selectionSeed"
+>;
 
 /**
  * Cached promise for the lazy initialization path inside
@@ -111,7 +119,7 @@ export class CallSiteConfiguredProvider implements Provider {
  */
 export async function resolveConfiguredProvider(
   callSite: LLMCallSite,
-  opts: { overrideProfile?: string; forceOverrideProfile?: boolean } = {},
+  opts: ConfiguredProviderOptions = {},
 ): Promise<ConfiguredProviderResult | null> {
   const config = getConfig();
 
@@ -223,7 +231,7 @@ export async function resolveConfiguredProvider(
  */
 export async function getConfiguredProvider(
   callSite: LLMCallSite,
-  opts: { overrideProfile?: string; forceOverrideProfile?: boolean } = {},
+  opts: ConfiguredProviderOptions = {},
 ): Promise<Provider | null> {
   const result = await resolveConfiguredProvider(callSite, opts);
   return result?.provider ?? null;

--- a/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
@@ -10,7 +10,10 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ProviderResponse } from "../../../providers/types.js";
+import type {
+  ProviderResponse,
+  SendMessageOptions,
+} from "../../../providers/types.js";
 
 // ---------------------------------------------------------------------------
 // Mock: the handler resolves a provider and sends one message. We stub the
@@ -19,12 +22,25 @@ import type { ProviderResponse } from "../../../providers/types.js";
 // ---------------------------------------------------------------------------
 
 let nextResponse: ProviderResponse;
+let getConfiguredProviderOptions:
+  | { overrideProfile?: string; forceOverrideProfile?: boolean }
+  | undefined;
+let sendMessageOptions: SendMessageOptions | undefined;
 
 mock.module("../../../providers/provider-send-message.js", () => ({
-  getConfiguredProvider: async () => ({
-    name: "stub",
-    sendMessage: async () => nextResponse,
-  }),
+  getConfiguredProvider: async (
+    _callSite: string,
+    options: { overrideProfile?: string; forceOverrideProfile?: boolean },
+  ) => {
+    getConfiguredProviderOptions = options;
+    return {
+      name: "stub",
+      sendMessage: async (_messages: unknown, options: SendMessageOptions) => {
+        sendMessageOptions = options;
+        return nextResponse;
+      },
+    };
+  },
   extractAllText: (response: ProviderResponse) =>
     response.content.map((b) => (b.type === "text" ? b.text : "")).join(""),
   userMessage: (text: string) => ({
@@ -55,6 +71,23 @@ function baseResponse(overrides: Partial<ProviderResponse>): ProviderResponse {
 
 beforeEach(() => {
   nextResponse = baseResponse({});
+  getConfiguredProviderOptions = undefined;
+  sendMessageOptions = undefined;
+});
+
+describe("inference_send profile routing", () => {
+  test("forwards the requested profile through provider resolution and send options", async () => {
+    const requestedProfile = "quality-optimized";
+
+    await inferenceSendHandler()({
+      body: { message: "hi", profile: requestedProfile },
+    });
+
+    expect(getConfiguredProviderOptions?.overrideProfile).toBe(
+      requestedProfile,
+    );
+    expect(sendMessageOptions?.config?.overrideProfile).toBe(requestedProfile);
+  });
 });
 
 describe("inference_send evidence", () => {

--- a/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
@@ -10,6 +10,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { ConfiguredProviderOptions } from "../../../providers/provider-send-message.js";
 import type {
   ProviderResponse,
   SendMessageOptions,
@@ -22,15 +23,13 @@ import type {
 // ---------------------------------------------------------------------------
 
 let nextResponse: ProviderResponse;
-let getConfiguredProviderOptions:
-  | { overrideProfile?: string; forceOverrideProfile?: boolean }
-  | undefined;
+let getConfiguredProviderOptions: ConfiguredProviderOptions | undefined;
 let sendMessageOptions: SendMessageOptions | undefined;
 
 mock.module("../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async (
     _callSite: string,
-    options: { overrideProfile?: string; forceOverrideProfile?: boolean },
+    options: ConfiguredProviderOptions,
   ) => {
     getConfiguredProviderOptions = options;
     return {
@@ -76,7 +75,7 @@ beforeEach(() => {
 });
 
 describe("inference_send profile routing", () => {
-  test("forwards the requested profile through provider resolution and send options", async () => {
+  test("forwards the requested profile and one selection seed through both resolution stages", async () => {
     const requestedProfile = "quality-optimized";
 
     await inferenceSendHandler()({
@@ -87,6 +86,12 @@ describe("inference_send profile routing", () => {
       requestedProfile,
     );
     expect(sendMessageOptions?.config?.overrideProfile).toBe(requestedProfile);
+    expect(getConfiguredProviderOptions?.selectionSeed).toEqual(
+      expect.any(String),
+    );
+    expect(sendMessageOptions?.config?.selectionSeed).toBe(
+      getConfiguredProviderOptions?.selectionSeed,
+    );
   });
 });
 

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -48,8 +48,10 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
     }
   }
 
+  const selectionSeed = crypto.randomUUID();
   const provider = await getConfiguredProvider("inference", {
     overrideProfile: profile,
+    selectionSeed,
   });
   if (!provider) {
     throw new BadRequestError(
@@ -64,6 +66,7 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
       max_tokens: maxTokens,
       model,
       overrideProfile: profile,
+      selectionSeed,
     },
   });
 

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -63,6 +63,7 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
       callSite: "inference",
       max_tokens: maxTokens,
       model,
+      overrideProfile: profile,
     },
   });
 


### PR DESCRIPTION
## Summary

- carry the requested inference profile into the per-send provider config so retries resolve the same profile and model
- add a direct route regression test that captures both getConfiguredProvider options and sendMessage config

## Original prompt

Fix assistant inference send --profile routing without a generic provider-wrapper refactor. The route selected the requested profile connection initially, but omitted overrideProfile from sendMessage while setting an explicit inference call site, so RetryProvider re-resolved the cost-optimized default model and produced a hybrid request.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->