### PR TITLE
feat(voice): VoiceFrontDecider fast-model endpoint decision service

### DIFF
--- a/assistant/src/live-voice/__tests__/front-decision.test.ts
+++ b/assistant/src/live-voice/__tests__/front-decision.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for the VoiceFrontDecider endpoint-decision service.
+ *
+ * The provider is injected via the `getProvider` seam (live-voice DI
+ * convention), so no module mocking is needed. The tests pin the fail-open
+ * contract: every failure mode (null provider, timeout, thrown error, caller
+ * abort) resolves to "release" within the configured budget.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { LiveVoiceFrontModelConfigSchema } from "../../config/schemas/live-voice.js";
+import type { Provider, ProviderResponse } from "../../providers/types.js";
+import {
+  createVoiceFrontDecider,
+  type VoiceEndpointDecisionInput,
+} from "../front-decision.js";
+
+const config = LiveVoiceFrontModelConfigSchema.parse({});
+
+const input: VoiceEndpointDecisionInput = {
+  transcriptSoFar: "so what I was thinking is",
+  latestPartial: null,
+  silenceThresholdMs: 1200,
+  extensionCount: 0,
+};
+
+function stubProvider(sendMessage: Provider["sendMessage"]): Provider {
+  return { name: "stub", sendMessage };
+}
+
+function toolResponse(
+  inputBlock: Record<string, unknown>,
+  name = "turn_decision",
+): ProviderResponse {
+  return {
+    content: [{ type: "tool_use", id: "tu_1", name, input: inputBlock }],
+    model: "stub-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "tool_use",
+  };
+}
+
+describe("createVoiceFrontDecider — decideEndpoint", () => {
+  test("tool result complete:false → hold", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => toolResponse({ complete: false })),
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "hold" });
+  });
+
+  test("tool result complete:true → release", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => toolResponse({ complete: true })),
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+  });
+
+  test("sends transcript, forced turn_decision tool, and call-site config", async () => {
+    let captured: Parameters<Provider["sendMessage"]> | undefined;
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async (...args) => {
+          captured = args;
+          return toolResponse({ complete: true });
+        }),
+    });
+    await decider.decideEndpoint({ ...input, latestPartial: "and then" });
+
+    const [messages, options] = captured!;
+    expect(messages).toHaveLength(1);
+    const text = (messages[0].content[0] as { text: string }).text;
+    expect(text).toContain("so what I was thinking is");
+    expect(text).toContain("and then");
+    expect(options?.config).toMatchObject({
+      max_tokens: 64,
+      callSite: "voiceFrontDecision",
+      tool_choice: { type: "tool", name: "turn_decision" },
+      disableCache: true,
+    });
+    expect(options?.tools?.map((t) => t.name)).toEqual(["turn_decision"]);
+    expect(options?.systemPrompt).toContain("finished");
+  });
+
+  test("null provider → release (fail-open)", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () => null,
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+  });
+
+  test("provider resolution throws → release", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () => {
+        throw new Error("resolution boom");
+      },
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+  });
+
+  test("sendMessage that never resolves → release after endpointDecisionTimeoutMs", async () => {
+    const decider = createVoiceFrontDecider({
+      config: LiveVoiceFrontModelConfigSchema.parse({
+        endpointDecisionTimeoutMs: 20,
+      }),
+      // Never settles and ignores the abort signal entirely — the decider's
+      // own timeout race must still bound the call.
+      getProvider: async () =>
+        stubProvider(() => new Promise<ProviderResponse>(() => {})),
+    });
+    const start = Date.now();
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  test("sendMessage throws → release", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => {
+          throw new Error("provider boom");
+        }),
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+  });
+
+  test("caller-signal abort → release promptly", async () => {
+    const decider = createVoiceFrontDecider({
+      // Long timeout so only the caller's abort can end the call early.
+      config: LiveVoiceFrontModelConfigSchema.parse({
+        endpointDecisionTimeoutMs: 60_000,
+      }),
+      getProvider: async () =>
+        stubProvider(() => new Promise<ProviderResponse>(() => {})),
+    });
+    const controller = new AbortController();
+    const pending = decider.decideEndpoint(input, controller.signal);
+    controller.abort();
+    const start = Date.now();
+    expect(await pending).toEqual({ action: "release" });
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  test("missing/foreign tool block → release", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () =>
+          toolResponse({ complete: false }, "some_other_tool"),
+        ),
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+  });
+
+  test("malformed tool input (complete not boolean) → release", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () => stubProvider(async () => toolResponse({})),
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+  });
+});

--- a/assistant/src/live-voice/front-decision.ts
+++ b/assistant/src/live-voice/front-decision.ts
@@ -1,0 +1,196 @@
+/**
+ * VoiceFrontDecider — fast-model endpoint decision for live voice.
+ *
+ * When VAD fires a silence-based turn-end, the front model looks at the
+ * transcript and decides whether the speaker has actually finished their
+ * thought ("release" → launch the agent turn) or is mid-thought ("hold" →
+ * keep the utterance open through a bounded extension window; wired up by
+ * the semantic-endpointing consumer).
+ *
+ * Fail-open is load-bearing: every failure mode — no configured provider,
+ * timeout, provider error, caller abort, unparseable output — resolves to
+ * "release" within `endpointDecisionTimeoutMs`, so the front model can only
+ * ever add a bounded latency and never break turn-taking.
+ */
+
+import type { LiveVoiceFrontModelConfig } from "../config/schemas/live-voice.js";
+import {
+  createTimeout,
+  extractToolUse,
+  getConfiguredProvider,
+  userMessage,
+} from "../providers/provider-send-message.js";
+import type { Provider, ToolDefinition } from "../providers/types.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("voice-front-decision");
+
+export interface VoiceEndpointDecisionInput {
+  /** Finalized transcript of the utterance so far. */
+  transcriptSoFar: string;
+  /** Latest non-final STT partial, when one is trailing the finals. */
+  latestPartial: string | null;
+  /** The silence duration (ms) that triggered this turn-end. */
+  silenceThresholdMs: number;
+  /** How many "hold" extensions this utterance has already consumed. */
+  extensionCount: number;
+}
+
+export type VoiceEndpointDecision = { action: "release" } | { action: "hold" };
+
+export interface VoiceFrontDecider {
+  /**
+   * Decide whether a silence-fired turn-end should release the turn to the
+   * agent or hold the utterance open. Never rejects — all failures resolve
+   * to `{ action: "release" }`.
+   */
+  decideEndpoint(
+    input: VoiceEndpointDecisionInput,
+    signal?: AbortSignal,
+  ): Promise<VoiceEndpointDecision>;
+}
+
+const RELEASE: VoiceEndpointDecision = { action: "release" };
+const HOLD: VoiceEndpointDecision = { action: "hold" };
+
+const TURN_DECISION_TOOL_NAME = "turn_decision";
+
+const TURN_DECISION_TOOL: ToolDefinition = {
+  name: TURN_DECISION_TOOL_NAME,
+  description:
+    "Record whether the speaker's turn is complete. Call this exactly once.",
+  input_schema: {
+    type: "object",
+    properties: {
+      complete: {
+        type: "boolean",
+        description:
+          "true when the speaker has finished their thought; false when they are mid-thought and more speech is likely coming.",
+      },
+    },
+    required: ["complete"],
+  },
+};
+
+const SYSTEM_PROMPT =
+  "You decide whether the speaker has finished their thought or is mid-thought/thinking. " +
+  "You see a live-voice transcript captured up to a pause. Treat trailing conjunctions, " +
+  "dangling prepositions, or an obviously unfinished clause as mid-thought. " +
+  "Bias toward finished: when in doubt, mark the turn complete.";
+
+function buildPrompt(input: VoiceEndpointDecisionInput): string {
+  const parts = [
+    `Transcript so far: ${input.transcriptSoFar || "(empty)"}`,
+    `Latest partial: ${input.latestPartial ?? "(none)"}`,
+    `Pause length: ${input.silenceThresholdMs}ms`,
+    `Prior extensions this utterance: ${input.extensionCount}`,
+  ];
+  return parts.join("\n");
+}
+
+/**
+ * Resolve `promise`, or reject with the abort reason as soon as `signal`
+ * fires. The title-service pattern trusts the provider to honor the abort
+ * signal; here the timeout bound is a hard product guarantee, so the race
+ * holds even against a provider that ignores it.
+ */
+function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () =>
+      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+    if (signal.aborted) {
+      // Still attach handlers so a later rejection of `promise` is observed
+      // (avoids an unhandled-rejection warning), then bail.
+      promise.then(
+        () => {},
+        () => {},
+      );
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export function createVoiceFrontDecider(options: {
+  config: LiveVoiceFrontModelConfig;
+  /**
+   * Provider resolver, injectable for tests (live-voice DI convention).
+   * Defaults to the configured `voiceFrontDecision` call site.
+   */
+  getProvider?: () => Promise<Provider | null>;
+}): VoiceFrontDecider {
+  const { config } = options;
+  const getProvider =
+    options.getProvider ?? (() => getConfiguredProvider("voiceFrontDecision"));
+
+  return {
+    async decideEndpoint(input, signal) {
+      if (signal?.aborted) {
+        return RELEASE;
+      }
+      let provider: Provider | null;
+      try {
+        provider = await getProvider();
+      } catch (error) {
+        log.debug({ error }, "Endpoint decision provider resolution failed");
+        return RELEASE;
+      }
+      if (!provider) {
+        // No configured provider — fail open.
+        return RELEASE;
+      }
+
+      const { signal: timeoutSignal, cleanup } = createTimeout(
+        config.endpointDecisionTimeoutMs,
+      );
+      const combinedSignal = signal
+        ? AbortSignal.any([signal, timeoutSignal])
+        : timeoutSignal;
+      try {
+        const response = await raceAbort(
+          provider.sendMessage([userMessage(buildPrompt(input))], {
+            tools: [TURN_DECISION_TOOL],
+            systemPrompt: SYSTEM_PROMPT,
+            config: {
+              max_tokens: 64,
+              callSite: "voiceFrontDecision",
+              tool_choice: { type: "tool", name: TURN_DECISION_TOOL_NAME },
+              disableCache: true,
+            },
+            signal: combinedSignal,
+          }),
+          combinedSignal,
+        );
+        const toolBlock = extractToolUse(response);
+        if (
+          toolBlock?.name === TURN_DECISION_TOOL_NAME &&
+          (toolBlock.input as { complete?: unknown }).complete === false
+        ) {
+          return HOLD;
+        }
+        // `complete: true`, a missing/foreign tool block, or a malformed
+        // input all release — only an explicit "not finished" holds.
+        return RELEASE;
+      } catch (error) {
+        log.debug(
+          { error, extensionCount: input.extensionCount },
+          "Endpoint decision failed — releasing turn",
+        );
+        return RELEASE;
+      } finally {
+        cleanup();
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- New front-decision service: fast-model hold/release endpoint decision via the voiceFrontDecision call site
- Fail-open on every path (null provider, timeout, error, abort → release) within endpointDecisionTimeoutMs
- No production consumers yet (wired up by the semantic-endpointing PR)

Part of plan: voice-mouth-brain.md (PR 4 of 10)