### PR TITLE
feat(voice): optional front-model-generated ack phrasing

### DIFF
--- a/assistant/src/live-voice/__tests__/front-decision.test.ts
+++ b/assistant/src/live-voice/__tests__/front-decision.test.ts
@@ -13,6 +13,7 @@ import { LiveVoiceFrontModelConfigSchema } from "../../config/schemas/live-voice
 import type { Provider, ProviderResponse } from "../../providers/types.js";
 import {
   createVoiceFrontDecider,
+  type VoiceAckTextInput,
   type VoiceEndpointDecisionInput,
 } from "../front-decision.js";
 
@@ -165,5 +166,151 @@ describe("createVoiceFrontDecider — decideEndpoint", () => {
       getProvider: async () => stubProvider(async () => toolResponse({})),
     });
     expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+  });
+});
+
+describe("createVoiceFrontDecider — generateAckText", () => {
+  const ackInput: VoiceAckTextInput = {
+    transcriptSoFar: "can you check my calendar for tomorrow",
+  };
+
+  test("generated text returned in time → trimmed text", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () =>
+          toolResponse({ ack: "  Sure, give me a second.  " }, "ack"),
+        ),
+    });
+    expect(await decider.generateAckText(ackInput)).toBe(
+      "Sure, give me a second.",
+    );
+  });
+
+  test("sends transcript + tool name, forced ack tool, and call-site config", async () => {
+    let captured: Parameters<Provider["sendMessage"]> | undefined;
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async (...args) => {
+          captured = args;
+          return toolResponse({ ack: "On it." }, "ack");
+        }),
+    });
+    await decider.generateAckText({ ...ackInput, toolName: "web_search" });
+
+    const [messages, options] = captured!;
+    expect(messages).toHaveLength(1);
+    const text = (messages[0].content[0] as { text: string }).text;
+    expect(text).toContain("can you check my calendar for tomorrow");
+    expect(text).toContain("web_search");
+    expect(options?.config).toMatchObject({
+      max_tokens: 64,
+      callSite: "voiceFrontDecision",
+      tool_choice: { type: "tool", name: "ack" },
+      disableCache: true,
+    });
+    expect(options?.tools?.map((t) => t.name)).toEqual(["ack"]);
+    // The prompt constrains the ack to acknowledgment-only: the brain owns
+    // all content.
+    expect(options?.systemPrompt).toContain("without answering");
+    expect(options?.systemPrompt).toContain("no facts");
+  });
+
+  test("null provider → null", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () => null,
+    });
+    expect(await decider.generateAckText(ackInput)).toBeNull();
+  });
+
+  test("provider resolution throws → null", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () => {
+        throw new Error("resolution boom");
+      },
+    });
+    expect(await decider.generateAckText(ackInput)).toBeNull();
+  });
+
+  test("sendMessage that never resolves → null after ackGenerationTimeoutMs", async () => {
+    const decider = createVoiceFrontDecider({
+      config: LiveVoiceFrontModelConfigSchema.parse({
+        ackGenerationTimeoutMs: 20,
+      }),
+      // Never settles and ignores the abort signal entirely — the decider's
+      // own timeout race must still bound the call.
+      getProvider: async () =>
+        stubProvider(() => new Promise<ProviderResponse>(() => {})),
+    });
+    const start = Date.now();
+    expect(await decider.generateAckText(ackInput)).toBeNull();
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  test("sendMessage throws → null", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => {
+          throw new Error("provider boom");
+        }),
+    });
+    expect(await decider.generateAckText(ackInput)).toBeNull();
+  });
+
+  test("caller-signal abort → null promptly", async () => {
+    const decider = createVoiceFrontDecider({
+      // Long timeout so only the caller's abort can end the call early.
+      config: LiveVoiceFrontModelConfigSchema.parse({
+        ackGenerationTimeoutMs: 60_000,
+      }),
+      getProvider: async () =>
+        stubProvider(() => new Promise<ProviderResponse>(() => {})),
+    });
+    const controller = new AbortController();
+    const pending = decider.generateAckText(ackInput, controller.signal);
+    controller.abort();
+    const start = Date.now();
+    expect(await pending).toBeNull();
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  test("empty/whitespace ack → null", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => toolResponse({ ack: "   " }, "ack")),
+    });
+    expect(await decider.generateAckText(ackInput)).toBeNull();
+  });
+
+  test("overlong ack (> 120 chars) → null", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => toolResponse({ ack: "x".repeat(121) }, "ack")),
+    });
+    expect(await decider.generateAckText(ackInput)).toBeNull();
+  });
+
+  test("missing/foreign tool block → null", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => toolResponse({ ack: "Hi." }, "other_tool")),
+    });
+    expect(await decider.generateAckText(ackInput)).toBeNull();
+  });
+
+  test("malformed tool input (ack not a string) → null", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => toolResponse({ ack: 42 }, "ack")),
+    });
+    expect(await decider.generateAckText(ackInput)).toBeNull();
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -15,6 +15,10 @@ import type {
   SttStreamServerEvent,
 } from "../../stt/types.js";
 import { pickAckPhrase } from "../ack-phrases.js";
+import type {
+  VoiceAckTextInput,
+  VoiceFrontDecider,
+} from "../front-decision.js";
 import {
   LiveVoiceSession,
   type LiveVoiceTtsStreamer,
@@ -94,6 +98,7 @@ function createSessionHarness(options: {
   startVoiceTurn: LiveVoiceTurnStarter;
   streamTtsAudio: LiveVoiceTtsStreamer | null;
   frontModelConfig?: Partial<LiveVoiceFrontModelConfig>;
+  frontDecider?: VoiceFrontDecider | null;
 }) {
   const transcriber = new MockStreamingTranscriber();
   const { context, frames } = createContext();
@@ -103,6 +108,9 @@ function createSessionHarness(options: {
     streamTtsAudio: options.streamTtsAudio,
     ...(options.frontModelConfig
       ? { frontModelConfig: options.frontModelConfig }
+      : {}),
+    ...(options.frontDecider !== undefined
+      ? { frontDecider: options.frontDecider }
       : {}),
     createTurnId: () => "live-turn-1",
   });
@@ -944,5 +952,129 @@ describe("LiveVoiceSession spoken ack (voice-front-model)", () => {
       type: "tts_done",
       turnId: "live-turn-1",
     });
+  });
+
+  function makeStubFrontDecider(
+    generateAckText: VoiceFrontDecider["generateAckText"],
+  ): VoiceFrontDecider {
+    return {
+      decideEndpoint: async () => ({ action: "release" }),
+      generateAckText,
+    };
+  }
+
+  test("llmAckText on: speaks the front-model-phrased ack", async () => {
+    enableFrontModel();
+    const GENERATED = "Sure — one moment.";
+    // The generated text passes through the same TTS sanitizer as the
+    // static phrase.
+    const EXPECTED_GENERATED = sanitizeForTts(GENERATED).trim();
+    const generateAckText = mock(async (ackInput: VoiceAckTextInput) => {
+      expect(ackInput.transcriptSoFar).toBe("hello");
+      return GENERATED;
+    });
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      frontModelConfig: {
+        ackFirstDeltaTimeoutMs: ACK_TIMEOUT_MS,
+        llmAckText: true,
+      },
+      frontDecider: makeStubFrontDecider(generateAckText),
+    });
+
+    await startReleasedTurn(session);
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([EXPECTED_GENERATED]);
+    expect(generateAckText).toHaveBeenCalledTimes(1);
+
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("Hello there."));
+    getCallbacks()?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsTexts).toEqual([EXPECTED_GENERATED, "Hello there."]);
+  });
+
+  test("llmAckText on: null generation falls back to the static phrase", async () => {
+    enableFrontModel();
+    const generateAckText = mock(async () => null);
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      frontModelConfig: {
+        ackFirstDeltaTimeoutMs: ACK_TIMEOUT_MS,
+        llmAckText: true,
+      },
+      frontDecider: makeStubFrontDecider(generateAckText),
+    });
+
+    await startReleasedTurn(session);
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([EXPECTED_ACK]);
+    expect(generateAckText).toHaveBeenCalledTimes(1);
+
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("Hello there."));
+    getCallbacks()?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+  });
+
+  test("llmAckText off (default): the decider is never consulted", async () => {
+    enableFrontModel();
+    const generateAckText = mock(async () => "Never spoken.");
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      frontModelConfig: { ackFirstDeltaTimeoutMs: ACK_TIMEOUT_MS },
+      frontDecider: makeStubFrontDecider(generateAckText),
+    });
+
+    await startReleasedTurn(session);
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([EXPECTED_ACK]);
+    expect(generateAckText).not.toHaveBeenCalled();
+
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("Hello there."));
+    getCallbacks()?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+  });
+
+  test("llmAckText on: a first delta during generation skips the ack entirely", async () => {
+    enableFrontModel();
+    let resolveGeneration!: (text: string | null) => void;
+    const generateAckText = mock(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveGeneration = resolve;
+        }),
+    );
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      frontModelConfig: {
+        ackFirstDeltaTimeoutMs: ACK_TIMEOUT_MS,
+        llmAckText: true,
+      },
+      frontDecider: makeStubFrontDecider(generateAckText),
+    });
+
+    await startReleasedTurn(session);
+    await waitFor(() => generateAckText.mock.calls.length === 1);
+
+    // The brain's first delta lands while the ack text is still generating —
+    // a late generation must not speak over real output.
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("Hello there."));
+    resolveGeneration("Too late to say this.");
+    getCallbacks()?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsTexts).toEqual(["Hello there."]);
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:Hello there.")]);
   });
 });

--- a/assistant/src/live-voice/front-decision.ts
+++ b/assistant/src/live-voice/front-decision.ts
@@ -11,6 +11,11 @@
  * timeout, provider error, caller abort, unparseable output — resolves to
  * "release" within `endpointDecisionTimeoutMs`, so the front model can only
  * ever add a bounded latency and never break turn-taking.
+ *
+ * The same service optionally phrases the spoken ack (`generateAckText`,
+ * behind `liveVoice.frontModel.llmAckText`): one short contextual sentence
+ * that acknowledges without answering, bounded by `ackGenerationTimeoutMs`,
+ * `null` on any failure so the caller's static phrase always covers it.
  */
 
 import type { LiveVoiceFrontModelConfig } from "../config/schemas/live-voice.js";
@@ -20,7 +25,11 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../providers/provider-send-message.js";
-import type { Provider, ToolDefinition } from "../providers/types.js";
+import type {
+  Provider,
+  ToolDefinition,
+  ToolUseContent,
+} from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("voice-front-decision");
@@ -38,6 +47,13 @@ export interface VoiceEndpointDecisionInput {
 
 export type VoiceEndpointDecision = { action: "release" } | { action: "hold" };
 
+export interface VoiceAckTextInput {
+  /** Final transcript of the utterance the ack acknowledges. */
+  transcriptSoFar: string;
+  /** Tool the turn just started, when the ack is tool-triggered. */
+  toolName?: string;
+}
+
 export interface VoiceFrontDecider {
   /**
    * Decide whether a silence-fired turn-end should release the turn to the
@@ -48,6 +64,17 @@ export interface VoiceFrontDecider {
     input: VoiceEndpointDecisionInput,
     signal?: AbortSignal,
   ): Promise<VoiceEndpointDecision>;
+
+  /**
+   * Phrase one short contextual spoken ack for the utterance. Never rejects —
+   * every failure mode (no provider, timeout past `ackGenerationTimeoutMs`,
+   * provider error, caller abort, empty or overlong output) resolves to
+   * `null`, and the caller falls back to a static phrase.
+   */
+  generateAckText(
+    input: VoiceAckTextInput,
+    signal?: AbortSignal,
+  ): Promise<string | null>;
 }
 
 const RELEASE: VoiceEndpointDecision = { action: "release" };
@@ -77,6 +104,45 @@ const SYSTEM_PROMPT =
   "You see a live-voice transcript captured up to a pause. Treat trailing conjunctions, " +
   "dangling prepositions, or an obviously unfinished clause as mid-thought. " +
   "Bias toward finished: when in doubt, mark the turn complete.";
+
+const ACK_TOOL_NAME = "ack";
+
+// Defensive cap on generated ack length: an ack is a floor-holder, never
+// content, so anything long enough to carry content is rejected in favor of
+// the static fallback phrase.
+const ACK_MAX_CHARS = 120;
+
+const ACK_TOOL: ToolDefinition = {
+  name: ACK_TOOL_NAME,
+  description:
+    "Record the single short spoken acknowledgment sentence. Call this exactly once.",
+  input_schema: {
+    type: "object",
+    properties: {
+      ack: {
+        type: "string",
+        description:
+          "One short spoken sentence acknowledging the request without answering it.",
+      },
+    },
+    required: ["ack"],
+  },
+};
+
+const ACK_SYSTEM_PROMPT =
+  "You phrase a brief spoken acknowledgment for a voice assistant that needs a moment " +
+  "before answering. Produce exactly one short spoken sentence (under ten words) that " +
+  "acknowledges the user's request without answering it: no facts, no answers, no " +
+  "commitments, no questions — the assistant's main model owns all content. " +
+  "Sound natural and conversational.";
+
+function buildAckPrompt(input: VoiceAckTextInput): string {
+  const parts = [`User's request: ${input.transcriptSoFar || "(empty)"}`];
+  if (input.toolName) {
+    parts.push(`The assistant just started using this tool: ${input.toolName}`);
+  }
+  return parts.join("\n");
+}
 
 function buildPrompt(input: VoiceEndpointDecisionInput): string {
   const parts = [
@@ -122,6 +188,51 @@ function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
   });
 }
 
+/**
+ * One bounded front-model call with a forced tool: resolve the provider, race
+ * the request against `timeoutMs` (and the caller's signal, when given), and
+ * return the response's tool_use block. `undefined` when no provider is
+ * configured or the response carries no tool block; throws on provider
+ * failure, timeout, or abort — callers map every failure to their fail-open
+ * value.
+ */
+async function requestForcedToolUse(args: {
+  getProvider: () => Promise<Provider | null>;
+  timeoutMs: number;
+  tool: ToolDefinition;
+  systemPrompt: string;
+  prompt: string;
+  signal?: AbortSignal;
+}): Promise<ToolUseContent | undefined> {
+  const provider = await args.getProvider();
+  if (!provider) {
+    return undefined;
+  }
+  const { signal: timeoutSignal, cleanup } = createTimeout(args.timeoutMs);
+  const combinedSignal = args.signal
+    ? AbortSignal.any([args.signal, timeoutSignal])
+    : timeoutSignal;
+  try {
+    const response = await raceAbort(
+      provider.sendMessage([userMessage(args.prompt)], {
+        tools: [args.tool],
+        systemPrompt: args.systemPrompt,
+        config: {
+          max_tokens: 64,
+          callSite: "voiceFrontDecision",
+          tool_choice: { type: "tool", name: args.tool.name },
+          disableCache: true,
+        },
+        signal: combinedSignal,
+      }),
+      combinedSignal,
+    );
+    return extractToolUse(response);
+  } finally {
+    cleanup();
+  }
+}
+
 export function createVoiceFrontDecider(options: {
   config: LiveVoiceFrontModelConfig;
   /**
@@ -139,48 +250,23 @@ export function createVoiceFrontDecider(options: {
       if (signal?.aborted) {
         return RELEASE;
       }
-      let provider: Provider | null;
       try {
-        provider = await getProvider();
-      } catch (error) {
-        log.debug({ error }, "Endpoint decision provider resolution failed");
-        return RELEASE;
-      }
-      if (!provider) {
-        // No configured provider — fail open.
-        return RELEASE;
-      }
-
-      const { signal: timeoutSignal, cleanup } = createTimeout(
-        config.endpointDecisionTimeoutMs,
-      );
-      const combinedSignal = signal
-        ? AbortSignal.any([signal, timeoutSignal])
-        : timeoutSignal;
-      try {
-        const response = await raceAbort(
-          provider.sendMessage([userMessage(buildPrompt(input))], {
-            tools: [TURN_DECISION_TOOL],
-            systemPrompt: SYSTEM_PROMPT,
-            config: {
-              max_tokens: 64,
-              callSite: "voiceFrontDecision",
-              tool_choice: { type: "tool", name: TURN_DECISION_TOOL_NAME },
-              disableCache: true,
-            },
-            signal: combinedSignal,
-          }),
-          combinedSignal,
-        );
-        const toolBlock = extractToolUse(response);
+        const toolBlock = await requestForcedToolUse({
+          getProvider,
+          timeoutMs: config.endpointDecisionTimeoutMs,
+          tool: TURN_DECISION_TOOL,
+          systemPrompt: SYSTEM_PROMPT,
+          prompt: buildPrompt(input),
+          signal,
+        });
         if (
           toolBlock?.name === TURN_DECISION_TOOL_NAME &&
           (toolBlock.input as { complete?: unknown }).complete === false
         ) {
           return HOLD;
         }
-        // `complete: true`, a missing/foreign tool block, or a malformed
-        // input all release — only an explicit "not finished" holds.
+        // No provider, `complete: true`, a missing/foreign tool block, or a
+        // malformed input all release — only an explicit "not finished" holds.
         return RELEASE;
       } catch (error) {
         log.debug(
@@ -188,8 +274,37 @@ export function createVoiceFrontDecider(options: {
           "Endpoint decision failed — releasing turn",
         );
         return RELEASE;
-      } finally {
-        cleanup();
+      }
+    },
+
+    async generateAckText(input, signal) {
+      if (signal?.aborted) {
+        return null;
+      }
+      try {
+        const toolBlock = await requestForcedToolUse({
+          getProvider,
+          timeoutMs: config.ackGenerationTimeoutMs,
+          tool: ACK_TOOL,
+          systemPrompt: ACK_SYSTEM_PROMPT,
+          prompt: buildAckPrompt(input),
+          signal,
+        });
+        if (toolBlock?.name !== ACK_TOOL_NAME) {
+          return null;
+        }
+        const ack = (toolBlock.input as { ack?: unknown }).ack;
+        if (typeof ack !== "string") {
+          return null;
+        }
+        const trimmed = ack.trim();
+        if (trimmed.length === 0 || trimmed.length > ACK_MAX_CHARS) {
+          return null;
+        }
+        return trimmed;
+      } catch (error) {
+        log.debug({ error }, "Ack generation failed — static phrase fallback");
+        return null;
       }
     },
   };

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -56,6 +56,10 @@ import { getSubagentManager } from "../subagent/index.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { getLogger } from "../util/logger.js";
 import { pickAckPhrase } from "./ack-phrases.js";
+import {
+  createVoiceFrontDecider,
+  type VoiceFrontDecider,
+} from "./front-decision.js";
 import type {
   LiveVoiceAudioArchiveResult,
   LiveVoiceAudioArchiveRole,
@@ -215,6 +219,12 @@ export interface LiveVoiceSessionOptions {
    * back to in-code defaults.
    */
   frontModelConfig?: Partial<LiveVoiceFrontModelConfig>;
+  /**
+   * Front-model decision/phrasing service (LLM-phrased acks). The production
+   * factory constructs it from `liveVoice.frontModel` config when unset;
+   * `null` disables front-model LLM calls (static ack phrasing only).
+   */
+  frontDecider?: VoiceFrontDecider | null;
   /**
    * Spawns the background continuation for a barged-in turn when the
    * `voice-duplex-handoff` flag is on. The factory wires the real
@@ -550,6 +560,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly ackFirstDeltaTimeoutMs: number;
   // Rotates through the ack phrase list across the session's turns.
   private ackPhraseCounter = 0;
+  // LLM-phrased contextual acks (liveVoice.frontModel.llmAckText): when on
+  // and a decider is wired, the ack text comes from the front model with the
+  // static phrase as fallback.
+  private readonly llmAckText: boolean;
+  private readonly frontDecider: VoiceFrontDecider | null;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -591,6 +606,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.ackFirstDeltaTimeoutMs =
       options.frontModelConfig?.ackFirstDeltaTimeoutMs ??
       DEFAULT_ACK_FIRST_DELTA_TIMEOUT_MS;
+    this.llmAckText = options.frontModelConfig?.llmAckText ?? false;
+    this.frontDecider = options.frontDecider ?? null;
     const turnDetectorConfig: TurnDetectorConfig = {
       ...(options.turnDetectorConfig ?? {}),
       ...(context.startFrame.silenceThresholdMs !== undefined
@@ -2342,9 +2359,53 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // first segment.
   private speakAck(activeTurn: ActiveAssistantTurn): void {
     activeTurn.ackSpoken = true;
-    const phrase = sanitizeForTts(
-      pickAckPhrase(this.ackPhraseCounter++),
-    ).trim();
+    if (this.llmAckText && this.frontDecider) {
+      // Optimistic ackSpoken above keeps the one-per-turn budget honest for
+      // any other ack trigger while the generation is in flight; the async
+      // path undoes it if the ack turns out moot.
+      void this.speakGeneratedAck(activeTurn, this.frontDecider);
+      return;
+    }
+    this.enqueueAckPhrase(activeTurn, pickAckPhrase(this.ackPhraseCounter++));
+  }
+
+  // LLM-phrased ack (liveVoice.frontModel.llmAckText): ask the front model
+  // for one short contextual sentence, static phrase on null. The decider
+  // internally bounds the call by `ackGenerationTimeoutMs` and resolves null
+  // on every failure mode, so the enqueue never waits beyond that budget.
+  private async speakGeneratedAck(
+    activeTurn: ActiveAssistantTurn,
+    frontDecider: VoiceFrontDecider,
+  ): Promise<void> {
+    const { token } = activeTurn;
+    const transcript = activeTurn.utterance.finalTranscriptSegments
+      .join(" ")
+      .trim();
+    const generated = await frontDecider
+      .generateAckText(
+        { transcriptSoFar: transcript },
+        activeTurn.abortController.signal,
+      )
+      // The decider contract never rejects; belt-and-braces for a stub.
+      .catch(() => null);
+    // Liveness re-check after the await: the turn may have been cancelled or
+    // finalized while generating, or the brain's first delta may have arrived
+    // — in every such case the ack is moot and must not speak over real
+    // output. Undo the optimistic ackSpoken so the flag reflects reality.
+    if (!this.isActiveAssistantTurn(token) || activeTurn.firstDeltaSeen) {
+      activeTurn.ackSpoken = false;
+      return;
+    }
+    this.enqueueAckPhrase(
+      activeTurn,
+      generated ?? pickAckPhrase(this.ackPhraseCounter++),
+    );
+  }
+
+  // Sanitize and enqueue one ack sentence on the turn's ordered TTS queue
+  // (shared tail of the static and LLM-phrased ack paths).
+  private enqueueAckPhrase(activeTurn: ActiveAssistantTurn, raw: string): void {
+    const phrase = sanitizeForTts(raw).trim();
     if (phrase.length === 0) {
       return;
     }
@@ -3089,6 +3150,16 @@ export function createLiveVoiceSession(
     bargeInMinSpeechMs:
       options.bargeInMinSpeechMs ?? vadConfig?.bargeInMinSpeechMs,
     frontModelConfig: options.frontModelConfig ?? liveVoiceConfig?.frontModel,
+    // An explicit option (incl. `null`) wins — the test seam. Without a
+    // parsed `liveVoice.frontModel` config there is no decider (hand-built
+    // test configs may predate the namespace); its features are all off in
+    // that case anyway.
+    frontDecider:
+      options.frontDecider !== undefined
+        ? options.frontDecider
+        : liveVoiceConfig?.frontModel
+          ? createVoiceFrontDecider({ config: liveVoiceConfig.frontModel })
+          : null,
     resolveCredentialReadiness:
       options.resolveCredentialReadiness === undefined
         ? defaultResolveLiveVoiceCredentialReadiness


### PR DESCRIPTION
## Summary
- VoiceFrontDecider.generateAckText: one short contextual ack sentence, hard ackGenerationTimeoutMs budget, null on any failure
- Session ack path uses it only when liveVoice.frontModel.llmAckText is true; static phrase fallback otherwise
- Post-await turn-liveness re-check so a late generation never speaks over the brain

Part of plan: voice-mouth-brain.md (PR 9 of 10)