### PR TITLE
feat(voice): flag-gated semantic endpointing on silence turn-end

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -14,10 +14,15 @@ import {
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
+import type { LiveVoiceFrontModelConfig } from "../../config/schemas/live-voice.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
+import type {
+  VoiceEndpointDecisionInput,
+  VoiceFrontDecider,
+} from "../front-decision.js";
 import type { LiveVoiceAudioArchiveResult } from "../live-voice-archive.js";
 import {
   createLiveVoiceSession,
@@ -123,6 +128,8 @@ function createHarness(options: {
   turnDetectorConfig?: TurnDetectorConfig;
   speechEnergyThreshold?: number;
   bargeInMinSpeechMs?: number;
+  frontDecider?: VoiceFrontDecider | null;
+  frontModelConfig?: Partial<LiveVoiceFrontModelConfig>;
   emitMetrics?: boolean;
   metricsClock?: () => number;
   // Return a promise to hold a frame's transport write open (a backed-up
@@ -187,6 +194,12 @@ function createHarness(options: {
       (options.viaFactory ? undefined : { silenceThresholdMs: 40 }),
     speechEnergyThreshold: options.speechEnergyThreshold,
     bargeInMinSpeechMs: options.bargeInMinSpeechMs,
+    ...(options.frontDecider !== undefined
+      ? { frontDecider: options.frontDecider }
+      : {}),
+    ...(options.frontModelConfig
+      ? { frontModelConfig: options.frontModelConfig }
+      : {}),
     ...(options.spawnBackgroundContinuation
       ? { spawnBackgroundContinuation: options.spawnBackgroundContinuation }
       : {}),
@@ -2574,5 +2587,259 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       frames.find((frame) => frame.type === "turn_cancelled"),
     ).toMatchObject({ type: "turn_cancelled", turnId: "live-turn-1" });
     await waitFor(() => abort.mock.calls.length === 1);
+  });
+});
+
+// Stub semantic-endpointing decider: scripted hold/release decisions consumed
+// in order, with every consulted input captured. Falls back to "release" once
+// the script is exhausted, mirroring the real decider's fail-open bias.
+function makeFrontDecider(decisions: Array<"hold" | "release">): {
+  decider: VoiceFrontDecider;
+  calls: VoiceEndpointDecisionInput[];
+} {
+  const calls: VoiceEndpointDecisionInput[] = [];
+  return {
+    calls,
+    decider: {
+      decideEndpoint: async (input) => {
+        calls.push(input);
+        return { action: decisions[calls.length - 1] ?? "release" };
+      },
+    },
+  };
+}
+
+describe("LiveVoiceSession semantic endpointing", () => {
+  afterEach(() => clearCachedOverrides());
+
+  const enableFrontModel = () =>
+    setCachedOverrides({ "voice-front-model": true }, { fromGateway: true });
+
+  // Arms the harness session, waits for its transcriber, and seeds a partial
+  // so the silence boundary has transcript text for the decider to judge.
+  async function startWithPartial(
+    session: LiveVoiceSession,
+    transcribers: MockStreamingTranscriber[],
+    partialText = "hello wor",
+  ): Promise<void> {
+    await session.start();
+    await waitFor(() => transcribers.length === 1);
+    // Let the transcriber's start() wiring settle before emitting events.
+    await flushAsyncCallbacks();
+    transcribers[0]?.emit({ type: "partial", text: partialText });
+  }
+
+  test("a held silence boundary sends no utterance_end and replays after the extension", async () => {
+    enableFrontModel();
+    const { decider, calls } = makeFrontDecider(["hold", "release"]);
+    const turnStarter = makeAutoCompletingTurnStarter(["Hi there."]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: turnStarter.startVoiceTurn,
+      frontDecider: decider,
+      frontModelConfig: { endpointExtensionMs: 30 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+
+    // First silence boundary: the decider holds — no utterance_end, no turn.
+    await waitFor(() => calls.length === 1);
+    expect(calls[0]).toEqual({
+      transcriptSoFar: "",
+      latestPartial: "hello wor",
+      silenceThresholdMs: 40,
+      extensionCount: 0,
+    });
+    expect(countType(frames, "utterance_end")).toBe(0);
+    expect(countType(frames, "thinking")).toBe(0);
+
+    // The extension elapses in continued silence: the boundary replays, the
+    // decider releases, and the turn launches normally.
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toMatchObject({ extensionCount: 1 });
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "stt_partial",
+      "speech_started",
+      "utterance_end",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+    expect(
+      frames.find((frame) => frame.type === "utterance_end"),
+    ).toMatchObject({ reason: "silence" });
+    expect(turnStarter.calls[0]).toMatchObject({ content: "hello world" });
+  });
+
+  test("speech resuming during a hold cancels the replay and the utterance keeps accumulating", async () => {
+    enableFrontModel();
+    const { decider, calls } = makeFrontDecider(["hold", "release"]);
+    const turnStarter = makeAutoCompletingTurnStarter(["Okay."]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello there world"],
+      startVoiceTurn: turnStarter.startVoiceTurn,
+      frontDecider: decider,
+      // Comfortably longer than the resumed speech's own silence boundary,
+      // so a leaked (uncancelled) replay would surface as a third decider
+      // consult / second utterance_end below.
+      frontModelConfig: { endpointExtensionMs: 200 },
+    });
+
+    await startWithPartial(session, transcribers, "hello");
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.length === 1);
+    expect(countType(frames, "utterance_end")).toBe(0);
+
+    // Speech resumes during the hold; the fresh silence boundary after it —
+    // not the cancelled replay timer — drives the next decision.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.length === 2);
+    expect(calls[1]).toMatchObject({ extensionCount: 1 });
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // Wait out the original extension window: the cancelled replay never
+    // re-fires the boundary.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(calls).toHaveLength(2);
+    expect(countType(frames, "utterance_end")).toBe(1);
+    // Both speech bursts fed the same utterance's transcriber (the second
+    // resolves only when the completed turn re-arms), producing one released
+    // turn end-to-end.
+    expect(transcribers[0]?.received.length).toBeGreaterThanOrEqual(2);
+    expect(turnStarter.calls).toHaveLength(1);
+    expect(turnStarter.calls[0]).toMatchObject({
+      content: "hello there world",
+    });
+  });
+
+  test("a release decision produces the same frame sequence as the flag-off path", async () => {
+    enableFrontModel();
+    const { decider, calls } = makeFrontDecider(["release"]);
+    const turnStarter = makeAutoCompletingTurnStarter(["Hi there."]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: turnStarter.startVoiceTurn,
+      frontDecider: decider,
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(calls).toHaveLength(1);
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "stt_partial",
+      "speech_started",
+      "utterance_end",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+    expect(
+      frames.find((frame) => frame.type === "utterance_end"),
+    ).toMatchObject({ reason: "silence" });
+  });
+
+  test("endpointMaxExtensions caps consecutive holds and forces the release", async () => {
+    enableFrontModel();
+    const { decider, calls } = makeFrontDecider(["hold", "hold", "hold"]);
+    const turnStarter = makeAutoCompletingTurnStarter(["Hi there."]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: turnStarter.startVoiceTurn,
+      frontDecider: decider,
+      frontModelConfig: { endpointExtensionMs: 20, endpointMaxExtensions: 1 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The single allowed hold consumed the decider's one consult; the replay
+    // hit the cap and released without asking again.
+    expect(calls).toHaveLength(1);
+    expect(countType(frames, "utterance_end")).toBe(1);
+    expect(turnStarter.calls).toHaveLength(1);
+    expect(turnStarter.calls[0]).toMatchObject({ content: "hello world" });
+  });
+
+  test("with the voice-front-model flag off the decider is never consulted", async () => {
+    const { decider, calls } = makeFrontDecider(["hold"]);
+    const turnStarter = makeAutoCompletingTurnStarter(["Hi there."]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: turnStarter.startVoiceTurn,
+      frontDecider: decider,
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(calls).toHaveLength(0);
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "stt_partial",
+      "speech_started",
+      "utterance_end",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+  });
+
+  test("a max-duration boundary bypasses the decider entirely", async () => {
+    enableFrontModel();
+    const { decider, calls } = makeFrontDecider(["hold"]);
+    const turnStarter = makeAutoCompletingTurnStarter(["Hi there."]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: turnStarter.startVoiceTurn,
+      frontDecider: decider,
+      // Silence can never fire; the max-duration cap ends the turn instead.
+      turnDetectorConfig: { silenceThresholdMs: 10_000, maxTurnDurationMs: 40 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(calls).toHaveLength(0);
+    expect(
+      frames.find((frame) => frame.type === "utterance_end"),
+    ).toMatchObject({ reason: "max-duration" });
+    expect(turnStarter.calls).toHaveLength(1);
+  });
+
+  test("session close during a hold clears the extension timer", async () => {
+    enableFrontModel();
+    const { decider, calls } = makeFrontDecider(["hold", "hold"]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      frontDecider: decider,
+      frontModelConfig: { endpointExtensionMs: 30 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.length === 1);
+    expect(countType(frames, "utterance_end")).toBe(0);
+
+    await session.close("client_end");
+    const framesAtClose = frames.length;
+
+    // Well past the extension window: the cleared timer never replays the
+    // boundary — no utterance_end, no second decider consult, no new frames.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(calls).toHaveLength(1);
+    expect(countType(frames, "utterance_end")).toBe(0);
+    expect(frames.length).toBe(framesAtClose);
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -2605,6 +2605,7 @@ function makeFrontDecider(decisions: Array<"hold" | "release">): {
         calls.push(input);
         return { action: decisions[calls.length - 1] ?? "release" };
       },
+      generateAckText: async () => null,
     },
   };
 }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -35,7 +35,10 @@ import {
   isVoiceFrontModelEnabled,
 } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
-import type { LiveVoiceFrontModelConfig } from "../config/schemas/live-voice.js";
+import {
+  type LiveVoiceFrontModelConfig,
+  LiveVoiceFrontModelConfigSchema,
+} from "../config/schemas/live-voice.js";
 import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
@@ -56,6 +59,10 @@ import { getSubagentManager } from "../subagent/index.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { getLogger } from "../util/logger.js";
 import { pickAckPhrase } from "./ack-phrases.js";
+import {
+  createVoiceFrontDecider,
+  type VoiceFrontDecider,
+} from "./front-decision.js";
 import type {
   LiveVoiceAudioArchiveResult,
   LiveVoiceAudioArchiveRole,
@@ -118,6 +125,17 @@ const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
 // (voice-front-model). Mirrors the `liveVoice.frontModel.ackFirstDeltaTimeoutMs`
 // schema default.
 const DEFAULT_ACK_FIRST_DELTA_TIMEOUT_MS = 2_500;
+// How long (ms) a semantic-endpointing "hold" keeps the utterance open before
+// the silence turn-end replays (voice-front-model). Mirrors the
+// `liveVoice.frontModel.endpointExtensionMs` schema default.
+const DEFAULT_ENDPOINT_EXTENSION_MS = 1_500;
+// Cap on consecutive "hold" extensions per utterance (voice-front-model).
+// Mirrors the `liveVoice.frontModel.endpointMaxExtensions` schema default.
+const DEFAULT_ENDPOINT_MAX_EXTENSIONS = 2;
+// Mirrors MediaTurnDetector's DEFAULT_SILENCE_THRESHOLD_MS: the session
+// tracks the effective trailing-silence threshold (the detector keeps its own
+// copy private) so the endpoint decider can report the pause length.
+const DEFAULT_SILENCE_THRESHOLD_MS = 800;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one
 // prefetching job. The prefetch buffers its chunks in memory until promoted;
@@ -210,11 +228,19 @@ export interface LiveVoiceSessionOptions {
    */
   finalizeGraceMs?: number;
   /**
-   * Front-model presence tuning (spoken acks). The production factory seeds
-   * this from `liveVoice.frontModel` config when unset; absent fields fall
-   * back to in-code defaults.
+   * Front-model presence tuning (semantic endpointing + spoken acks). The
+   * production factory seeds this from `liveVoice.frontModel` config when
+   * unset; absent fields fall back to in-code defaults.
    */
   frontModelConfig?: Partial<LiveVoiceFrontModelConfig>;
+  /**
+   * Semantic-endpointing decider consulted on silence-fired turn-ends when
+   * the voice-front-model flag is on: a "hold" keeps the utterance open
+   * through a bounded extension window instead of releasing the turn. The
+   * production factory seeds the config-backed decider when unset; `null`
+   * disables semantic endpointing.
+   */
+  frontDecider?: VoiceFrontDecider | null;
   /**
    * Spawns the background continuation for a barged-in turn when the
    * `voice-duplex-handoff` flag is on. The factory wires the real
@@ -267,6 +293,12 @@ interface UtteranceCycle {
   pendingAudioChunks: Buffer[];
   pendingAudioBytes: number;
   finalTranscriptSegments: string[];
+  // Latest non-final STT partial trailing the finals, fed to the semantic
+  // endpoint decider (voice-front-model). Cleared when a final commits it.
+  latestPartialText: string | null;
+  // Consecutive semantic-endpointing "hold" extensions this utterance has
+  // consumed, bounded by `endpointMaxExtensions`.
+  endpointExtensionCount: number;
   turnId: string | null;
   userMessageId: string | null;
   userAudioChunks: Buffer[];
@@ -550,6 +582,24 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly ackFirstDeltaTimeoutMs: number;
   // Rotates through the ack phrase list across the session's turns.
   private ackPhraseCounter = 0;
+  // Semantic endpointing (voice-front-model): consulted on silence-fired
+  // turn-ends; null disables the capability entirely.
+  private readonly frontDecider: VoiceFrontDecider | null;
+  private readonly endpointExtensionMs: number;
+  private readonly endpointMaxExtensions: number;
+  // Effective trailing-silence threshold, mirroring the detector's private
+  // copy (constructor seed + update_config), reported to the endpoint decider.
+  private silenceThresholdMs: number;
+  // Pending replay of a held silence turn-end. The detector cannot extend an
+  // in-flight countdown (setSilenceThresholdMs applies only from the next
+  // arm), so this timer IS the extension mechanism: on expiry it replays
+  // handleVadUtteranceEnd("silence") iff the held utterance is still current
+  // and speech has not resumed.
+  private endpointExtensionTimer: ReturnType<typeof setTimeout> | null = null;
+  // Bumped on every VAD speech onset so an endpoint decision that resolves
+  // after speech resumed defers to the detector's fresh boundary instead of
+  // releasing an utterance the user is still adding to.
+  private vadSpeechGeneration = 0;
 
   constructor(
     context: LiveVoiceSessionFactoryContext,
@@ -591,12 +641,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.ackFirstDeltaTimeoutMs =
       options.frontModelConfig?.ackFirstDeltaTimeoutMs ??
       DEFAULT_ACK_FIRST_DELTA_TIMEOUT_MS;
+    this.frontDecider = options.frontDecider ?? null;
+    this.endpointExtensionMs =
+      options.frontModelConfig?.endpointExtensionMs ??
+      DEFAULT_ENDPOINT_EXTENSION_MS;
+    this.endpointMaxExtensions =
+      options.frontModelConfig?.endpointMaxExtensions ??
+      DEFAULT_ENDPOINT_MAX_EXTENSIONS;
     const turnDetectorConfig: TurnDetectorConfig = {
       ...(options.turnDetectorConfig ?? {}),
       ...(context.startFrame.silenceThresholdMs !== undefined
         ? { silenceThresholdMs: context.startFrame.silenceThresholdMs }
         : {}),
     };
+    this.silenceThresholdMs =
+      turnDetectorConfig.silenceThresholdMs ?? DEFAULT_SILENCE_THRESHOLD_MS;
     this.turnDetector =
       context.startFrame.turnDetection === "server_vad"
         ? new MediaTurnDetector(turnDetectorConfig, {
@@ -685,6 +744,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private applyConfigUpdate(frame: LiveVoiceClientUpdateConfigFrame): void {
     if (frame.silenceThresholdMs !== undefined) {
       this.turnDetector?.setSilenceThresholdMs(frame.silenceThresholdMs);
+      this.silenceThresholdMs = frame.silenceThresholdMs;
     }
     if (frame.bargeInMinSpeechMs !== undefined) {
       this.bargeInMinSpeechMs = frame.bargeInMinSpeechMs;
@@ -703,6 +763,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
     this.turnDetector?.dispose();
+    this.clearEndpointExtensionTimer();
     this.stopSessionTranscriber();
     this.abortDetachedRuns();
     await this.cancelAssistantTurn("session_closed");
@@ -729,6 +790,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       pendingAudioChunks: [],
       pendingAudioBytes: 0,
       finalTranscriptSegments: [],
+      latestPartialText: null,
+      endpointExtensionCount: 0,
       turnId: null,
       userMessageId: null,
       userAudioChunks: [],
@@ -888,6 +951,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     this.state = "failed";
+    this.clearEndpointExtensionTimer();
     await this.sendFrame({
       type: "error",
       code:
@@ -1109,6 +1173,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     this.vadSpeechStartPending = true;
+    // Speech resumed: an endpoint decision still in flight is stale (the
+    // generation bump defers it), and a pending hold replay is moot — the
+    // utterance keeps accumulating and the detector fires a fresh turn-end.
+    this.vadSpeechGeneration += 1;
+    this.clearEndpointExtensionTimer();
 
     const turn = this.activeAssistantTurn;
     // Any in-flight, non-finalized turn is interruptible, whether it is still
@@ -1353,6 +1422,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // The detector turn is over: an untripped guard was noise, not
       // barge-in — leave playback untouched.
       this.pendingBargeIn = null;
+      if (reason === "max-duration") {
+        // A max-duration boundary always releases: drop any pending hold
+        // replay so it cannot re-fire a boundary this one already owns.
+        this.clearEndpointExtensionTimer();
+      }
       const utterance = this.currentUtterance;
       if (!utterance || utterance.released || utterance.completed) {
         // The ended turn's speech sits parked in the pre-roll ring (the
@@ -1363,9 +1437,121 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         }
         return;
       }
+      // Semantic endpointing (voice-front-model): a silence boundary may be a
+      // thinking pause — let the front decider hold the utterance open. Only
+      // silence boundaries qualify; max-duration always releases. The gate is
+      // synchronous (null) whenever the decider is not consulted, so the
+      // flag-off release path keeps its exact event ordering — an extra await
+      // here would shift utterance release across the persistent-transcriber
+      // flush attribution.
+      if (reason === "silence") {
+        const holdDecision = this.maybeHoldUtteranceOpen(utterance);
+        if (holdDecision && (await holdDecision)) {
+          return;
+        }
+      }
       await this.sendFrame({ type: "utterance_end", reason });
       await this.releaseUtterance();
     })().catch(() => {});
+  }
+
+  /**
+   * Semantic-endpointing gate for a silence-fired turn-end. Returns `null`
+   * synchronously when the decider is not consulted (feature off, no decider,
+   * extension cap reached, nothing transcribed) — the boundary then releases
+   * exactly as before. Otherwise resolves `true` when the boundary must NOT
+   * release the utterance now: either the decider held it open (the extension
+   * timer replays the boundary), or the world moved on during the decision
+   * (speech resumed, utterance superseded) and a fresh boundary owns the
+   * release. Every decider failure resolves as "release" within
+   * `endpointDecisionTimeoutMs` (fail-open), so consulting it adds at most
+   * that much end-of-turn latency.
+   */
+  private maybeHoldUtteranceOpen(
+    utterance: UtteranceCycle,
+  ): Promise<boolean> | null {
+    const decider = this.frontDecider;
+    if (!decider || !isVoiceFrontModelEnabled(getConfig())) {
+      return null;
+    }
+    if (utterance.endpointExtensionCount >= this.endpointMaxExtensions) {
+      return null;
+    }
+    const transcriptSoFar = utterance.finalTranscriptSegments.join(" ").trim();
+    const latestPartial = utterance.latestPartialText;
+    if (transcriptSoFar.length === 0 && !latestPartial) {
+      // Nothing transcribed yet: there is no text to judge.
+      return null;
+    }
+    return this.decideUtteranceHold(
+      decider,
+      utterance,
+      transcriptSoFar,
+      latestPartial,
+    );
+  }
+
+  private async decideUtteranceHold(
+    decider: VoiceFrontDecider,
+    utterance: UtteranceCycle,
+    transcriptSoFar: string,
+    latestPartial: string | null,
+  ): Promise<boolean> {
+    const generation = this.vadSpeechGeneration;
+    const decision = await decider.decideEndpoint({
+      transcriptSoFar,
+      latestPartial,
+      silenceThresholdMs: this.silenceThresholdMs,
+      extensionCount: utterance.endpointExtensionCount,
+    });
+    // Re-check the world after the await: the decision window is bounded but
+    // real, and a release based on a stale snapshot could cut off speech.
+    if (
+      this.isUtteranceStale(utterance) ||
+      utterance.released ||
+      utterance.completed
+    ) {
+      return true;
+    }
+    if (generation !== this.vadSpeechGeneration) {
+      // Speech resumed during the decision: the utterance keeps accumulating
+      // and the detector's next turn-end re-runs the whole decision.
+      return true;
+    }
+    if (decision.action !== "hold") {
+      return false;
+    }
+    utterance.endpointExtensionCount += 1;
+    this.armEndpointExtensionTimer(utterance);
+    return true;
+  }
+
+  // Arms the hold-extension replay: after `endpointExtensionMs` of continued
+  // silence the deferred silence boundary re-fires (and the decider is
+  // consulted again, bounded by `endpointMaxExtensions`).
+  private armEndpointExtensionTimer(utterance: UtteranceCycle): void {
+    this.clearEndpointExtensionTimer();
+    this.endpointExtensionTimer = setTimeout(() => {
+      this.endpointExtensionTimer = null;
+      if (
+        this.currentUtterance !== utterance ||
+        utterance.released ||
+        utterance.completed ||
+        // Speech resumed (the detector owns the next boundary). Onset also
+        // clears this timer, so this is a belt to that suspender.
+        this.turnDetector?.isActive
+      ) {
+        return;
+      }
+      this.handleVadUtteranceEnd("silence");
+    }, this.endpointExtensionMs);
+  }
+
+  private clearEndpointExtensionTimer(): void {
+    if (this.endpointExtensionTimer !== null) {
+      clearTimeout(this.endpointExtensionTimer);
+      this.endpointExtensionTimer = null;
+    }
   }
 
   // In server_vad mode a client ptt_release still works as a manual
@@ -1562,6 +1748,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     switch (event.type) {
       case "partial":
+        utterance.latestPartialText = event.text;
         this.markFirstPartial(utterance);
         await this.sendFrame({ type: "stt_partial", text: event.text });
         return;
@@ -1634,6 +1821,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         if (!target || target.assistantTurnStarted || target.completed) {
           return;
         }
+        target.latestPartialText = event.text;
         this.markFirstPartial(target);
         await this.sendFrame({ type: "stt_partial", text: event.text });
         return;
@@ -1741,6 +1929,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (transcript.length > 0) {
       utterance.finalTranscriptSegments.push(transcript);
     }
+    // The final commits (and supersedes) whatever partial was trailing it.
+    utterance.latestPartialText = null;
     this.markFinalTranscript(utterance);
     await this.sendFrame({ type: "stt_final", text });
     await this.startAssistantTurnIfReady();
@@ -1774,6 +1964,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.assistantPlaybackTailUntilMs = 0;
     this.takeVadPreRoll();
     this.vadPendingTurnEnd = null;
+    // ...and abandons any semantic-endpointing hold still awaiting replay.
+    this.clearEndpointExtensionTimer();
     // A client interrupt is a hard reset: any barge-in merge context waiting for
     // the next turn is now stale (the interrupted utterance may be discarded
     // without ever reaching finalizePendingUtterance).
@@ -3074,6 +3266,8 @@ export function createLiveVoiceSession(
   // absent config falls through to the in-code defaults.
   const liveVoiceConfig = getConfig().liveVoice;
   const vadConfig = liveVoiceConfig?.vad;
+  const frontModelConfig =
+    options.frontModelConfig ?? liveVoiceConfig?.frontModel;
   return new LiveVoiceSession(context, {
     ...options,
     turnDetectorConfig:
@@ -3088,7 +3282,19 @@ export function createLiveVoiceSession(
       options.speechEnergyThreshold ?? vadConfig?.speechEnergyThreshold,
     bargeInMinSpeechMs:
       options.bargeInMinSpeechMs ?? vadConfig?.bargeInMinSpeechMs,
-    frontModelConfig: options.frontModelConfig ?? liveVoiceConfig?.frontModel,
+    frontModelConfig,
+    // The decider only runs when the voice-front-model flag allows it (the
+    // session checks per boundary), so eager construction is flag-safe. An
+    // explicit option (incl. `null`) always wins — the test seam.
+    frontDecider:
+      options.frontDecider !== undefined
+        ? options.frontDecider
+        : createVoiceFrontDecider({
+            config: {
+              ...LiveVoiceFrontModelConfigSchema.parse({}),
+              ...frontModelConfig,
+            },
+          }),
     resolveCredentialReadiness:
       options.resolveCredentialReadiness === undefined
         ? defaultResolveLiveVoiceCredentialReadiness


### PR DESCRIPTION
## Summary
- Consults VoiceFrontDecider on silence-fired turn-end: hold keeps the utterance open through a bounded replay window
- Extension capped by endpointMaxExtensions; every decider failure degrades to release within budget
- Behind the voice-front-model flag; max-duration turn-end bypasses the decider

Part of plan: voice-mouth-brain.md (PR 6 of 10)