### PR TITLE
feat(voice): live-voice metrics for endpoint decisions and spoken acks

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -271,6 +271,95 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(turn.timestamps.utteranceEndAtMs).toBe(2_000);
   });
 
+  test("accumulates endpoint decisions and records the first ack kind", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-ep",
+      conversationId: "conversation-ep",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-ep");
+    collector.markEndpointDecision("turn-ep", {
+      action: "hold",
+      latencyMs: 120,
+    });
+    collector.markEndpointDecision("turn-ep", {
+      action: "hold",
+      latencyMs: 80,
+    });
+    collector.markEndpointDecision("turn-ep", {
+      action: "release",
+      latencyMs: 210,
+    });
+    collector.markAckSpoken("turn-ep", "tool_use");
+    // First ack kind wins — the per-turn budget allows one spoken ack, so a
+    // second mark must not overwrite the recorded kind.
+    collector.markAckSpoken("turn-ep", "first_delta");
+    const completed = collector.completeTurn();
+
+    expect(completed).toMatchObject({
+      turnId: "turn-ep",
+      endpointHoldCount: 2,
+      endpointDecisionMaxLatencyMs: 210,
+      ackSpoken: "tool_use",
+    });
+    expect(
+      getLiveVoiceMetricsAggregateFields(collector.getSnapshot(), "turn-ep"),
+    ).toMatchObject({
+      endpointHoldCount: 2,
+      endpointDecisionMaxLatencyMs: 210,
+      ackSpoken: "tool_use",
+    });
+  });
+
+  test("release-only decisions report zero holds with the observed latency", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-rel",
+      conversationId: "conversation-rel",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-rel");
+    collector.markEndpointDecision("turn-rel", {
+      action: "release",
+      latencyMs: 95,
+    });
+    const completed = collector.completeTurn();
+
+    expect(completed).toMatchObject({
+      endpointHoldCount: 0,
+      endpointDecisionMaxLatencyMs: 95,
+    });
+    expect(completed).not.toHaveProperty("ackSpoken");
+  });
+
+  test("omits endpoint and ack fields for turns that never touch the features", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-off",
+      conversationId: "conversation-off",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-off");
+    collector.markFirstAudio();
+    const completed = collector.completeTurn();
+
+    expect(completed).not.toHaveProperty("endpointHoldCount");
+    expect(completed).not.toHaveProperty("endpointDecisionMaxLatencyMs");
+    expect(completed).not.toHaveProperty("ackSpoken");
+
+    const aggregateFields = getLiveVoiceMetricsAggregateFields(
+      collector.getSnapshot(),
+      "turn-off",
+    );
+    expect(aggregateFields).not.toHaveProperty("endpointHoldCount");
+    expect(aggregateFields).not.toHaveProperty("endpointDecisionMaxLatencyMs");
+    expect(aggregateFields).not.toHaveProperty("ackSpoken");
+  });
+
   test("markBargeIn records a first-wins timestamp on the active turn", () => {
     const clock = makeClock(3_000);
     const collector = new LiveVoiceMetricsCollector({

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -13,13 +13,24 @@ export type LiveVoiceMetricsEvent =
   | "vad_speech_start"
   | "ptt_release"
   | "utterance_end"
+  | "endpoint_decision"
   | "barge_in"
   | "final_transcript"
   | "first_assistant_delta"
+  | "ack_spoken"
   | "first_tts_audio"
   | "turn_completed"
   | "turn_cancelled"
   | "session_ended";
+
+// Semantic-endpointing decision on a silence boundary (voice-front-model).
+export interface LiveVoiceEndpointDecisionMark {
+  action: "hold" | "release";
+  latencyMs: number;
+}
+
+// Which floor-holding ack actually spoke during a turn (voice-front-model).
+export type LiveVoiceSpokenAckKind = "first_delta" | "tool_use";
 
 type LiveVoiceTurnStatus = "active" | "completed" | "cancelled";
 
@@ -90,6 +101,12 @@ interface LiveVoiceTurnMetrics {
   cancellationReason: string | null;
   timestamps: LiveVoiceTurnTimestamps;
   durations: LiveVoiceTurnDurations;
+  // Present only when the semantic-endpointing decider was consulted for the
+  // turn (voice-front-model on) / when an ack actually spoke, so turns that
+  // never touch the features carry no trace of them.
+  endpointHoldCount?: number;
+  endpointDecisionMaxLatencyMs?: number;
+  ackSpoken?: LiveVoiceSpokenAckKind;
 }
 
 interface LiveVoiceDurationSummary {
@@ -126,6 +143,11 @@ interface LiveVoiceMetricsAggregateFields {
   ttsFirstAudioMs: number | null;
   roundTripMs: number | null;
   totalMs: number | null;
+  // Optional so metrics frames stay byte-identical when the voice-front-model
+  // features are off (see the matching fields on LiveVoiceTurnMetrics).
+  endpointHoldCount?: number;
+  endpointDecisionMaxLatencyMs?: number;
+  ackSpoken?: LiveVoiceSpokenAckKind;
 }
 
 export interface LiveVoiceMetricsFrame {
@@ -142,6 +164,11 @@ interface MutableTurn {
   status: LiveVoiceTurnStatus;
   cancellationReason: string | null;
   timestamps: LiveVoiceTurnTimestamps;
+  endpointHoldCount: number;
+  // Doubles as the "decider was consulted" latch: null means no endpoint
+  // decision was ever recorded for the turn.
+  endpointDecisionMaxLatencyMs: number | null;
+  ackSpoken: LiveVoiceSpokenAckKind | null;
 }
 
 const DEFAULT_RECENT_TURN_LIMIT = 50;
@@ -203,6 +230,9 @@ export class LiveVoiceMetricsCollector {
         completedAtMs: null,
         cancelledAtMs: null,
       },
+      endpointHoldCount: 0,
+      endpointDecisionMaxLatencyMs: null,
+      ackSpoken: null,
     };
     this.applySeedMarks(this.activeTurn, seedMarks);
     this.emit("turn_started", turnId);
@@ -268,6 +298,37 @@ export class LiveVoiceMetricsCollector {
       turn.timestamps.utteranceEndAtMs = this.timestamp();
     }
     return this.emit("utterance_end", turn.turnId);
+  }
+
+  // Unlike the first-wins timestamp marks, every decision accumulates: holds
+  // bump the per-turn count and both outcomes feed the worst-latency figure.
+  markEndpointDecision(
+    turnId: string | undefined,
+    decision: LiveVoiceEndpointDecisionMark,
+  ): LiveVoiceMetricsFrame {
+    const turn = this.ensureActiveTurn(turnId);
+    if (decision.action === "hold") {
+      turn.endpointHoldCount += 1;
+    }
+    const latencyMs = Number.isFinite(decision.latencyMs)
+      ? Math.max(0, decision.latencyMs)
+      : 0;
+    turn.endpointDecisionMaxLatencyMs = Math.max(
+      turn.endpointDecisionMaxLatencyMs ?? 0,
+      latencyMs,
+    );
+    return this.emit("endpoint_decision", turn.turnId);
+  }
+
+  markAckSpoken(
+    turnId: string | undefined,
+    kind: LiveVoiceSpokenAckKind,
+  ): LiveVoiceMetricsFrame {
+    const turn = this.ensureActiveTurn(turnId);
+    if (turn.ackSpoken === null) {
+      turn.ackSpoken = kind;
+    }
+    return this.emit("ack_spoken", turn.turnId);
   }
 
   markBargeIn(turnId?: string): LiveVoiceMetricsFrame {
@@ -463,6 +524,32 @@ function aggregateFieldsForTurn(
     ttsFirstAudioMs: turn.durations.firstAssistantDeltaToFirstTtsAudioMs,
     roundTripMs: turn.durations.roundTripMs,
     totalMs: turn.durations.totalTurnDurationMs,
+    ...endpointAndAckFields(turn),
+  };
+}
+
+// Shared optional voice-front-model fields for turn snapshots and aggregate
+// frame fields: absent unless the endpoint decider was consulted / an ack
+// spoke, so flag-off turns and frames are unchanged.
+function endpointAndAckFields(
+  // Accepts both MutableTurn (null = unset) and snapshot (absent = unset).
+  turn: {
+    endpointHoldCount?: number | null;
+    endpointDecisionMaxLatencyMs?: number | null;
+    ackSpoken?: LiveVoiceSpokenAckKind | null;
+  },
+): Pick<
+  LiveVoiceTurnMetrics,
+  "endpointHoldCount" | "endpointDecisionMaxLatencyMs" | "ackSpoken"
+> {
+  return {
+    ...(turn.endpointDecisionMaxLatencyMs != null
+      ? {
+          endpointHoldCount: turn.endpointHoldCount ?? 0,
+          endpointDecisionMaxLatencyMs: turn.endpointDecisionMaxLatencyMs,
+        }
+      : {}),
+    ...(turn.ackSpoken != null ? { ackSpoken: turn.ackSpoken } : {}),
   };
 }
 
@@ -497,6 +584,9 @@ function cloneMutableTurn(turn: MutableTurn): MutableTurn {
     status: turn.status,
     cancellationReason: turn.cancellationReason,
     timestamps: { ...turn.timestamps },
+    endpointHoldCount: turn.endpointHoldCount,
+    endpointDecisionMaxLatencyMs: turn.endpointDecisionMaxLatencyMs,
+    ackSpoken: turn.ackSpoken,
   };
 }
 
@@ -507,6 +597,7 @@ function snapshotTurn(turn: MutableTurn): LiveVoiceTurnMetrics {
     status: turn.status,
     cancellationReason: turn.cancellationReason,
     timestamps,
+    ...endpointAndAckFields(turn),
     durations: {
       firstAudioToFirstPartialMs: duration(
         timestamps.firstAudioAtMs,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1504,12 +1504,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     latestPartial: string | null,
   ): Promise<boolean> {
     const generation = this.vadSpeechGeneration;
+    const decisionStartedAtMs = this.metricsClock();
     const decision = await decider.decideEndpoint({
       transcriptSoFar,
       latestPartial,
       silenceThresholdMs: this.silenceThresholdMs,
       extensionCount: utterance.endpointExtensionCount,
     });
+    const decisionLatencyMs = Math.max(
+      0,
+      this.metricsClock() - decisionStartedAtMs,
+    );
     // Re-check the world after the await: the decision window is bounded but
     // real, and a release based on a stale snapshot could cut off speech.
     if (
@@ -1521,9 +1526,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     if (generation !== this.vadSpeechGeneration) {
       // Speech resumed during the decision: the utterance keeps accumulating
-      // and the detector's next turn-end re-runs the whole decision.
+      // and the detector's next turn-end re-runs the whole decision. The
+      // discarded decision is not recorded — only acted-on outcomes count.
       return true;
     }
+    this.markEndpointDecision(utterance, decision.action, decisionLatencyMs);
     if (decision.action !== "hold") {
       return false;
     }
@@ -2562,7 +2569,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       void this.speakGeneratedAck(activeTurn, this.frontDecider, kind);
       return;
     }
-    this.enqueueAckPhrase(activeTurn, this.pickStaticAckPhrase(kind));
+    this.enqueueAckPhrase(activeTurn, this.pickStaticAckPhrase(kind), kind);
   }
 
   private pickStaticAckPhrase(kind: "slow-first-delta" | "tool-use"): string {
@@ -2601,12 +2608,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.enqueueAckPhrase(
       activeTurn,
       generated ?? this.pickStaticAckPhrase(kind),
+      kind,
     );
   }
 
   // Sanitize and enqueue one ack sentence on the turn's ordered TTS queue
-  // (shared tail of the static and LLM-phrased ack paths).
-  private enqueueAckPhrase(activeTurn: ActiveAssistantTurn, raw: string): void {
+  // (shared tail of the static and LLM-phrased ack paths). Records the
+  // ack-spoken metric only when a phrase actually enqueues.
+  private enqueueAckPhrase(
+    activeTurn: ActiveAssistantTurn,
+    raw: string,
+    kind: "slow-first-delta" | "tool-use",
+  ): void {
     const phrase = sanitizeForTts(raw).trim();
     if (phrase.length === 0) {
       return;
@@ -2614,6 +2627,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.enqueueTtsSegment(activeTurn.token, phrase, {
       countsAsFirstSegment: false,
     });
+    this.markAckSpoken(
+      activeTurn,
+      kind === "tool-use" ? "tool_use" : "first_delta",
+    );
   }
 
   private bufferAssistantTextForTts(token: symbol, text: string): void {
@@ -2995,6 +3012,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
     this.metrics.markFirstAssistantDelta(turnId);
+  }
+
+  private markEndpointDecision(
+    utterance: UtteranceCycle,
+    action: "hold" | "release",
+    latencyMs: number,
+  ): void {
+    const turnId = this.ensureTurnId(utterance);
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) {
+      return;
+    }
+    this.metrics.markEndpointDecision(turnId, { action, latencyMs });
+  }
+
+  private markAckSpoken(
+    activeTurn: ActiveAssistantTurn,
+    kind: "first_delta" | "tool_use",
+  ): void {
+    const { utterance } = activeTurn;
+    if (!this.startMetricsTurnIfNeeded(utterance, activeTurn.turnId)) {
+      return;
+    }
+    this.metrics.markAckSpoken(activeTurn.turnId, kind);
   }
 
   private ensureTurnId(utterance: UtteranceCycle): string {

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -255,6 +255,16 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   /** End-of-speech (utterance_end, or ptt_release in manual mode) to first TTS audio. */
   readonly roundTripMs: number | null;
   readonly totalMs: number | null;
+  /**
+   * Semantic-endpointing "hold" decisions taken during the turn. Present only
+   * when the voice-front-model endpoint decider was consulted (with the
+   * feature off the field is absent, keeping frames unchanged).
+   */
+  readonly endpointHoldCount?: number;
+  /** Worst endpoint-decision latency observed during the turn. */
+  readonly endpointDecisionMaxLatencyMs?: number;
+  /** Which floor-holding ack actually spoke during the turn, if any. */
+  readonly ackSpoken?: "first_delta" | "tool_use";
 }
 
 export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -234,6 +234,16 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
    */
   readonly roundTripMs?: number | null;
   readonly totalMs: number | null;
+  /**
+   * Semantic-endpointing "hold" decisions taken during the turn. Present only
+   * when the voice-front-model endpoint decider was consulted (with the
+   * feature off the field is absent, keeping frames unchanged).
+   */
+  readonly endpointHoldCount?: number;
+  /** Worst endpoint-decision latency observed during the turn. */
+  readonly endpointDecisionMaxLatencyMs?: number;
+  /** Which floor-holding ack actually spoke during the turn, if any. */
+  readonly ackSpoken?: "first_delta" | "tool_use";
 }
 
 export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {


### PR DESCRIPTION
## Summary
- Per-turn marks for endpoint decisions (hold count, max latency) and spoken acks (kind)
- metrics frame carries the new optional fields; browser protocol mirror updated
- Fields absent when the voice-front-model flag is off

Part of plan: voice-mouth-brain.md (PR 10 of 10)