### PR TITLE
feat(inspector): break down memory & context retrieval latency into sub-steps

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -109,6 +109,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../daemon/message-protocol.js",
     "../../../../daemon/message-types/memory.js",
     "../../../../daemon/trust-context.js",
+    "../../../../daemon/turn-latency-sub-spans.js",
     "../../../../notifications/emit-signal.js",
     "../../../../persistence/checkpoints.js",
     "../../../../persistence/db-connection.js",

--- a/assistant/src/api/responses/llm-request-log-entry.ts
+++ b/assistant/src/api/responses/llm-request-log-entry.ts
@@ -21,14 +21,31 @@
 import { z } from "zod";
 
 /**
+ * One instrumented sub-step inside a phase (`graph_memory`, `v3_lanes`,
+ * `injector:<name>`, …). Sub-steps are leaf measurements — chosen to be
+ * non-overlapping so the inspector can render an honest "Other" remainder
+ * against the phase total. Nesting stops at this level by design.
+ */
+export const LatencySubPhaseSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  ms: z.number(),
+});
+
+export type LatencySubPhase = z.infer<typeof LatencySubPhaseSchema>;
+
+/**
  * One segment of the turn's first-token latency waterfall. `key` is a
  * stable machine id (`queue`, `memory_context`, `ttft`, …); `label` is
  * the human row title; `ms` is the wall-clock duration of that phase.
+ * `subPhases` lists the phase's instrumented sub-steps in execution
+ * order (today only the memory & context retrieval phase records them).
  */
 export const LatencyPhaseSchema = z.object({
   key: z.string(),
   label: z.string(),
   ms: z.number(),
+  subPhases: z.array(LatencySubPhaseSchema).optional(),
 });
 
 export type LatencyPhase = z.infer<typeof LatencyPhaseSchema>;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -119,7 +119,11 @@ import type {
 } from "./message-protocol.js";
 import type { TrustContext } from "./trust-context-types.js";
 import { resolveTurnCallSite } from "./turn-call-site.js";
-import { TurnLatencyTracker } from "./turn-latency-tracker.js";
+import { runWithLatencySubSpans } from "./turn-latency-sub-spans.js";
+import {
+  MEMORY_CONTEXT_PHASE_KEY,
+  TurnLatencyTracker,
+} from "./turn-latency-tracker.js";
 
 const log = getLogger("conversation-agent-loop");
 
@@ -987,9 +991,13 @@ export async function runAgentLoopImpl(
       isNonInteractive,
     };
     latencyTracker.mark("prompt_hook_start");
-    const finalUserPromptCtx = await runHook(
-      HOOKS.USER_PROMPT_SUBMIT,
-      userPromptCtx,
+    // The scope lets instrumented steps deep inside the hook chain (memory
+    // retrieval, injectors) record sub-spans of the memory_context phase
+    // without the tracker being threaded through the plugin contracts.
+    const finalUserPromptCtx = await runWithLatencySubSpans(
+      latencyTracker,
+      MEMORY_CONTEXT_PHASE_KEY,
+      () => runHook(HOOKS.USER_PROMPT_SUBMIT, userPromptCtx),
     );
     latencyTracker.mark("prompt_hook_end");
     const runMessages = finalUserPromptCtx.latestMessages;

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -83,6 +83,7 @@ import type {
 } from "./message-protocol.js";
 import { filterMessagesForUntrustedActor } from "./message-provenance.js";
 import type { TrustContext } from "./trust-context-types.js";
+import { timeLatencySubSpan } from "./turn-latency-sub-spans.js";
 
 // The compaction strip lives in the compaction layer (`context/`) so the agent
 // loop can own it; re-exported here for this module's existing consumers.
@@ -1753,9 +1754,22 @@ export interface RuntimeInjectionResult {
 }
 
 /**
+ * Injectors whose interior records its own latency sub-spans (the `v3_*`
+ * spans in the memory-v3 orchestration) — timing the injector wrapper too
+ * would double-count the same wall clock. Sub-spans must stay
+ * non-overlapping so the inspector's "Other" remainder is honest. The
+ * names are pinned by `injector-registry-order-guard.test.ts`.
+ */
+const SELF_INSTRUMENTED_INJECTORS = new Set([
+  "memory-v3-shadow",
+  "memory-v3-spotlight",
+]);
+
+/**
  * Run every {@link Injector} in the chain ({@link getRegisteredInjectors},
  * already sorted by ascending `order`) and return every non-null block it
- * produced.
+ * produced, timing each non-self-instrumented injector as a latency
+ * sub-span.
  *
  * `runMessages` is the turn's working message array, forwarded to each
  * injector so producers that need the current prompt contents read it from a
@@ -1774,7 +1788,13 @@ async function collectInjectorBlocks(
 ): Promise<InjectionBlock[]> {
   const out: InjectionBlock[] = [];
   for (const injector of getRegisteredInjectors()) {
-    const block = await injector.produce(ctx, runMessages);
+    const block = SELF_INSTRUMENTED_INJECTORS.has(injector.name)
+      ? await injector.produce(ctx, runMessages)
+      : await timeLatencySubSpan(
+          `injector:${injector.name}`,
+          `Injector: ${injector.name}`,
+          () => injector.produce(ctx, runMessages),
+        );
     if (block) {
       out.push(block);
     }

--- a/assistant/src/daemon/turn-latency-sub-spans.test.ts
+++ b/assistant/src/daemon/turn-latency-sub-spans.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
+
+import {
+  MIN_SUB_SPAN_MS,
+  recordLatencySubSpan,
+  runWithLatencySubSpans,
+  timeLatencySubSpan,
+} from "./turn-latency-sub-spans.js";
+import {
+  MEMORY_CONTEXT_PHASE_KEY,
+  TurnLatencyTracker,
+} from "./turn-latency-tracker.js";
+
+// Drive `Date.now()` deterministically so measured spans are exact.
+let clock = 0;
+const nowSpy = spyOn(Date, "now").mockImplementation(() => clock);
+afterAll(() => nowSpy.mockRestore());
+
+/**
+ * Serialize the tracker's `memory_context` phase and return its sub-phases.
+ * Marks advance the mocked clock so every phase span is non-negative.
+ */
+function subPhasesOf(t: TurnLatencyTracker) {
+  t.mark("turn_start");
+  clock += 10;
+  t.mark("prompt_hook_start");
+  clock += 10;
+  t.mark("prompt_hook_end");
+  return t
+    .serializeSince(0)
+    .breakdown?.phases.find((p) => p.key === MEMORY_CONTEXT_PHASE_KEY)
+    ?.subPhases;
+}
+
+describe("turn-latency-sub-spans", () => {
+  test("timeLatencySubSpan records into the scoped tracker and preserves the return value", async () => {
+    const tracker = new TurnLatencyTracker();
+    const result = await runWithLatencySubSpans(
+      tracker,
+      MEMORY_CONTEXT_PHASE_KEY,
+      () =>
+        timeLatencySubSpan("stage", "Stage", async () => {
+          clock += 25;
+          return "ok";
+        }),
+    );
+    expect(result).toBe("ok");
+    expect(subPhasesOf(tracker)).toEqual([
+      { key: "stage", label: "Stage", ms: 25 },
+    ]);
+  });
+
+  test("outside a scope both helpers are pass-through no-ops", async () => {
+    expect(
+      await timeLatencySubSpan("stage", "Stage", () => Promise.resolve(7)),
+    ).toBe(7);
+    expect(() => recordLatencySubSpan("stage", "Stage", 500)).not.toThrow();
+  });
+
+  test("spans under the floor are dropped; the floor itself records", () => {
+    const tracker = new TurnLatencyTracker();
+    runWithLatencySubSpans(tracker, MEMORY_CONTEXT_PHASE_KEY, () => {
+      recordLatencySubSpan("under", "Under", MIN_SUB_SPAN_MS - 1);
+      recordLatencySubSpan("at", "At", MIN_SUB_SPAN_MS);
+    });
+    expect(subPhasesOf(tracker)).toEqual([
+      { key: "at", label: "At", ms: MIN_SUB_SPAN_MS },
+    ]);
+  });
+
+  test("a throwing stage records its span and rethrows", async () => {
+    const tracker = new TurnLatencyTracker();
+    await runWithLatencySubSpans(
+      tracker,
+      MEMORY_CONTEXT_PHASE_KEY,
+      async () => {
+        await expect(
+          timeLatencySubSpan("boom", "Boom", async () => {
+            clock += 30;
+            throw new Error("boom");
+          }),
+        ).rejects.toThrow("boom");
+      },
+    );
+    expect(subPhasesOf(tracker)).toEqual([
+      { key: "boom", label: "Boom", ms: 30 },
+    ]);
+  });
+
+  test("concurrent scopes with distinct trackers stay isolated", async () => {
+    const a = new TurnLatencyTracker();
+    const b = new TurnLatencyTracker();
+    await Promise.all([
+      runWithLatencySubSpans(a, MEMORY_CONTEXT_PHASE_KEY, () =>
+        timeLatencySubSpan("a-span", "A", async () => {
+          await Promise.resolve();
+          clock += 20;
+        }),
+      ),
+      runWithLatencySubSpans(b, MEMORY_CONTEXT_PHASE_KEY, () =>
+        timeLatencySubSpan("b-span", "B", async () => {
+          await Promise.resolve();
+          clock += 20;
+        }),
+      ),
+    ]);
+    expect(subPhasesOf(a)?.map((s) => s.key)).toEqual(["a-span"]);
+    expect(subPhasesOf(b)?.map((s) => s.key)).toEqual(["b-span"]);
+  });
+});

--- a/assistant/src/daemon/turn-latency-sub-spans.ts
+++ b/assistant/src/daemon/turn-latency-sub-spans.ts
@@ -1,0 +1,87 @@
+/**
+ * Sub-span instrumentation for the "Memory & context retrieval" latency
+ * phase.
+ *
+ * The phase is the span of the USER_PROMPT_SUBMIT hook chain, but the work
+ * inside it — graph memory retrieval, runtime injectors, memory-v3 lane
+ * search and selection — happens layers below the orchestrator that owns
+ * the {@link TurnLatencyTracker}. Rather than threading the tracker through
+ * the hook/injector/plugin contracts, the orchestrator opens an
+ * {@link AsyncLocalStorage} scope around the hook chain and instrumented
+ * call sites record into it. The store propagates across `await`
+ * boundaries (including `Promise.all` fan-outs); when no scope is active —
+ * overflow re-injection, compaction re-assembly, `composeInjectorChain`,
+ * tests — every helper is a pass-through no-op, so out-of-turn callers
+ * need no guards.
+ *
+ * Sub-spans are leaf measurements chosen to be non-overlapping, so the
+ * inspector can render an honest "Other" remainder against the phase
+ * total. Never wrap a call whose interior records its own sub-spans.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { TurnLatencyTracker } from "./turn-latency-tracker.js";
+
+/**
+ * Spans shorter than this are dropped: they add blob and UI noise without
+ * diagnostic value, and the inspector's "Other" remainder row absorbs
+ * them. The inspector's own remainder threshold mirrors this value.
+ */
+export const MIN_SUB_SPAN_MS = 10;
+
+interface SubSpanScope {
+  tracker: TurnLatencyTracker;
+  /** Phase key the recorded sub-spans attach to (e.g. `memory_context`). */
+  parentKey: string;
+}
+
+const storage = new AsyncLocalStorage<SubSpanScope>();
+
+/**
+ * Run `fn` with sub-span recording bound to `tracker` under `parentKey`.
+ * The returned value (including a promise) carries the scope across its
+ * async continuations.
+ */
+export function runWithLatencySubSpans<T>(
+  tracker: TurnLatencyTracker,
+  parentKey: string,
+  fn: () => T,
+): T {
+  return storage.run({ tracker, parentKey }, fn);
+}
+
+/**
+ * Record an already-measured sub-span. No-op when no scope is active or
+ * the duration is under {@link MIN_SUB_SPAN_MS}.
+ */
+export function recordLatencySubSpan(
+  key: string,
+  label: string,
+  ms: number,
+): void {
+  const scope = storage.getStore();
+  if (!scope || ms < MIN_SUB_SPAN_MS) return;
+  scope.tracker.recordSubSpan(scope.parentKey, key, label, ms);
+}
+
+/**
+ * Measure `fn` as a sub-span. Outside a scope this is a plain call with no
+ * clock reads. The span records in `finally`, so a throwing stage still
+ * reports the time it spent.
+ */
+export async function timeLatencySubSpan<T>(
+  key: string,
+  label: string,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  if (storage.getStore() === undefined) {
+    return await fn();
+  }
+  const startedAt = Date.now();
+  try {
+    return await fn();
+  } finally {
+    recordLatencySubSpan(key, label, Date.now() - startedAt);
+  }
+}

--- a/assistant/src/daemon/turn-latency-tracker.test.ts
+++ b/assistant/src/daemon/turn-latency-tracker.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, describe, expect, spyOn, test } from "bun:test";
 
-import { TurnLatencyTracker } from "./turn-latency-tracker.js";
+import { LatencyBreakdownSchema } from "../api/responses/llm-request-log-entry.js";
+import {
+  MEMORY_CONTEXT_PHASE_KEY,
+  TurnLatencyTracker,
+} from "./turn-latency-tracker.js";
 
 // Drive `Date.now()` deterministically so phase durations are exact.
 let clock = 0;
@@ -226,5 +230,160 @@ describe("TurnLatencyTracker", () => {
     t.mark("call_complete");
     const { cursor } = t.serializeSince(0);
     expect(t.serializeSince(cursor).breakdown).toBeNull();
+  });
+});
+
+describe("TurnLatencyTracker — sub-spans", () => {
+  /** Stamp a complete first-call waterfall so `memory_context` serializes. */
+  function markFirstCall(t: TurnLatencyTracker): void {
+    clock = 0;
+    t.mark("turn_start");
+    clock = 10;
+    t.mark("prompt_hook_start");
+    clock = 110;
+    t.mark("prompt_hook_end");
+    clock = 120;
+    t.mark("tools_resolved");
+    clock = 130;
+    t.mark("request_sent");
+    clock = 430;
+    t.markFirstToken("text");
+    clock = 700;
+    t.mark("call_complete");
+  }
+
+  function memoryPhase(t: TurnLatencyTracker, cursor = 0) {
+    return t
+      .serializeSince(cursor)
+      .breakdown?.phases.find((p) => p.key === MEMORY_CONTEXT_PHASE_KEY);
+  }
+
+  test("sub-spans attach to their phase in recorded order; other phases carry none", () => {
+    const t = new TurnLatencyTracker();
+    t.recordSubSpan(MEMORY_CONTEXT_PHASE_KEY, "v3_lanes", "Memory search", 40);
+    t.recordSubSpan(
+      MEMORY_CONTEXT_PHASE_KEY,
+      "v3_selection",
+      "Memory selection",
+      55,
+    );
+    markFirstCall(t);
+    const { breakdown } = t.serializeSince(0);
+    const memory = breakdown!.phases.find(
+      (p) => p.key === MEMORY_CONTEXT_PHASE_KEY,
+    )!;
+    expect(memory.subPhases).toEqual([
+      { key: "v3_lanes", label: "Memory search", ms: 40 },
+      { key: "v3_selection", label: "Memory selection", ms: 55 },
+    ]);
+    for (const phase of breakdown!.phases) {
+      if (phase.key !== MEMORY_CONTEXT_PHASE_KEY) {
+        expect(phase.subPhases).toBeUndefined();
+      }
+    }
+  });
+
+  test("sub-spans are consumed on first attach — a re-serialize emits the phase bare", () => {
+    const t = new TurnLatencyTracker();
+    t.recordSubSpan(MEMORY_CONTEXT_PHASE_KEY, "v3_lanes", "Memory search", 40);
+    markFirstCall(t);
+    expect(memoryPhase(t)?.subPhases).toHaveLength(1);
+    expect(memoryPhase(t)?.subPhases).toBeUndefined();
+  });
+
+  test("a second-call segment carries no sub-phases", () => {
+    const t = new TurnLatencyTracker();
+    t.recordSubSpan(MEMORY_CONTEXT_PHASE_KEY, "v3_lanes", "Memory search", 40);
+    markFirstCall(t);
+    const first = t.serializeSince(0);
+    clock = 1000;
+    t.mark("tools_resolved");
+    clock = 1010;
+    t.mark("request_sent");
+    clock = 1200;
+    t.markFirstToken("text");
+    clock = 1260;
+    t.mark("call_complete");
+    const { breakdown } = t.serializeSince(first.cursor);
+    expect(breakdown!.phases.every((p) => p.subPhases === undefined)).toBe(
+      true,
+    );
+  });
+
+  test("a sub-span recorded after the phase's closing mark still attaches at serialize time", () => {
+    const t = new TurnLatencyTracker();
+    markFirstCall(t);
+    t.recordSubSpan(MEMORY_CONTEXT_PHASE_KEY, "late", "Late stage", 25);
+    expect(memoryPhase(t)?.subPhases).toEqual([
+      { key: "late", label: "Late stage", ms: 25 },
+    ]);
+  });
+
+  test("sub-spans for a phase that never serializes are inert", () => {
+    const t = new TurnLatencyTracker();
+    t.recordSubSpan(MEMORY_CONTEXT_PHASE_KEY, "v3_lanes", "Memory search", 40);
+    clock = 0;
+    t.mark("turn_start");
+    clock = 10;
+    t.mark("request_sent");
+    clock = 50;
+    t.markFirstToken("text");
+    clock = 90;
+    t.mark("call_complete");
+    const { breakdown } = t.serializeSince(0);
+    expect(breakdown!.phases.every((p) => p.subPhases === undefined)).toBe(
+      true,
+    );
+  });
+
+  test("negative-duration sub-spans are dropped", () => {
+    const t = new TurnLatencyTracker();
+    t.recordSubSpan(MEMORY_CONTEXT_PHASE_KEY, "bad", "Bad clock", -5);
+    markFirstCall(t);
+    expect(memoryPhase(t)?.subPhases).toBeUndefined();
+  });
+
+  test("sub-spans survive a failed-attempt splice", () => {
+    const t = new TurnLatencyTracker();
+    t.recordSubSpan(MEMORY_CONTEXT_PHASE_KEY, "v3_lanes", "Memory search", 40);
+    clock = 0;
+    t.mark("turn_start");
+    clock = 10;
+    t.mark("prompt_hook_start");
+    clock = 110;
+    t.mark("prompt_hook_end");
+    // Failed first attempt (no call_complete), then the retry succeeds.
+    clock = 120;
+    t.mark("tools_resolved");
+    clock = 130;
+    t.mark("request_sent");
+    clock = 1000;
+    t.mark("tools_resolved");
+    clock = 1010;
+    t.mark("request_sent");
+    clock = 1200;
+    t.markFirstToken("text");
+    clock = 1260;
+    t.mark("call_complete");
+    expect(memoryPhase(t)?.subPhases).toEqual([
+      { key: "v3_lanes", label: "Memory search", ms: 40 },
+    ]);
+  });
+
+  test("sub-phases round-trip through the wire schema", () => {
+    const t = new TurnLatencyTracker();
+    t.recordSubSpan(MEMORY_CONTEXT_PHASE_KEY, "v3_lanes", "Memory search", 40);
+    markFirstCall(t);
+    const { breakdown } = t.serializeSince(0);
+    const parsed = LatencyBreakdownSchema.safeParse(
+      JSON.parse(JSON.stringify(breakdown)),
+    );
+    expect(parsed.success).toBe(true);
+    const memory = parsed.data!.phases.find(
+      (p) => p.key === MEMORY_CONTEXT_PHASE_KEY,
+    );
+    expect(memory?.subPhases).toEqual([
+      { key: "v3_lanes", label: "Memory search", ms: 40 },
+    ]);
   });
 });

--- a/assistant/src/daemon/turn-latency-tracker.ts
+++ b/assistant/src/daemon/turn-latency-tracker.ts
@@ -18,6 +18,7 @@
 import type {
   LatencyBreakdown,
   LatencyPhase,
+  LatencySubPhase,
 } from "../api/responses/llm-request-log-entry.js";
 
 /** Canonical mark names, in the order they fire on the first call of a turn. */
@@ -31,6 +32,13 @@ export type LatencyMark =
   | "call_complete";
 
 /**
+ * Phase key for the memory & context retrieval span. Exported so the
+ * orchestrator can open a sub-span recording scope
+ * (`turn-latency-sub-spans.ts`) keyed to this phase around the hook chain.
+ */
+export const MEMORY_CONTEXT_PHASE_KEY = "memory_context";
+
+/**
  * Phase metadata keyed by the mark that closes the span. A mark with no
  * entry here (e.g. `turn_start`, which only opens the first phase) emits
  * no phase of its own.
@@ -38,7 +46,7 @@ export type LatencyMark =
 const PHASE_BY_CLOSING_MARK: Record<string, { key: string; label: string }> = {
   prompt_hook_start: { key: "queue", label: "Queue & turn setup" },
   prompt_hook_end: {
-    key: "memory_context",
+    key: MEMORY_CONTEXT_PHASE_KEY,
     label: "Memory & context retrieval",
   },
   tools_resolved: { key: "setup", label: "Budget gate & tool resolution" },
@@ -53,6 +61,36 @@ export class TurnLatencyTracker {
     at: number;
     kind?: "thinking" | "text";
   }[] = [];
+
+  /**
+   * Sub-spans accumulated against a phase key, attached to that phase the
+   * first time it serializes (consume-on-attach, so multi-call turns emit
+   * them exactly once). Entries for a phase that never serializes die with
+   * the per-turn tracker.
+   */
+  private readonly subSpansByPhase = new Map<string, LatencySubPhase[]>();
+
+  /**
+   * Record a caller-measured sub-span inside the phase identified by
+   * `parentPhaseKey` (e.g. {@link MEMORY_CONTEXT_PHASE_KEY}). Insertion
+   * order is preserved — the inspector renders sub-steps in execution
+   * order. A negative duration (non-monotonic clock) is dropped, mirroring
+   * the phase-level guard in {@link serializeSince}.
+   */
+  recordSubSpan(
+    parentPhaseKey: string,
+    key: string,
+    label: string,
+    ms: number,
+  ): void {
+    if (ms < 0) return;
+    const existing = this.subSpansByPhase.get(parentPhaseKey);
+    if (existing) {
+      existing.push({ key, label, ms });
+    } else {
+      this.subSpansByPhase.set(parentPhaseKey, [{ key, label, ms }]);
+    }
+  }
 
   /** Stamp a point-in-time mark. Cheap (`Date.now()`); safe to over-call. */
   mark(name: LatencyMark): void {
@@ -131,7 +169,13 @@ export class TurnLatencyTracker {
       // A non-monotonic clock would yield a negative span; drop it rather
       // than render misleading noise.
       if (ms < 0) continue;
-      phases.push({ key: meta.key, label: meta.label, ms });
+      const phase: LatencyPhase = { key: meta.key, label: meta.label, ms };
+      const subPhases = this.subSpansByPhase.get(meta.key);
+      if (subPhases) {
+        phase.subPhases = subPhases;
+        this.subSpansByPhase.delete(meta.key);
+      }
+      phases.push(phase);
     }
     if (phases.length === 0) return { breakdown: null, cursor: end };
 

--- a/assistant/src/plugins/defaults/memory/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/user-prompt-submit.ts
@@ -44,6 +44,7 @@ import {
 } from "../../../../daemon/conversation-runtime-assembly.js";
 import type { MemoryRecalled } from "../../../../daemon/message-types/memory.js";
 import { resolveTrustClass } from "../../../../daemon/trust-context.js";
+import { timeLatencySubSpan } from "../../../../daemon/turn-latency-sub-spans.js";
 import { broadcastMessage } from "../../../../runtime/assistant-event-hub.js";
 import type { GraphMemoryResult } from "../graph/conversation-graph-memory.js";
 import { recordMemoryRecallLog } from "../memory-recall-log-store.js";
@@ -297,11 +298,16 @@ const userPromptSubmitMemoryRetrieval: HookFunction<
     // publish to the shared `broadcastMessage` hub — the sink every turn
     // publisher converges to — rather than a threaded event callback. This
     // keeps any raw client-emit capability off the hook contract.
-    const graphResult = await conversation.graphMemory.prepareMemory(
-      ctx.latestMessages,
-      config,
-      abortSignal,
-      broadcastMessage,
+    const graphResult = await timeLatencySubSpan(
+      "graph_memory",
+      "Graph memory retrieval",
+      () =>
+        conversation.graphMemory.prepareMemory(
+          ctx.latestMessages,
+          config,
+          abortSignal,
+          broadcastMessage,
+        ),
     );
 
     await recordRecallSideEffects(graphResult, ctx);

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -15,10 +15,23 @@
  * end-to-end.
  */
 
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 
 import type { Message, Provider, ProviderResponse } from "@vellumai/plugin-api";
 
+import { runWithLatencySubSpans } from "../../../../../daemon/turn-latency-sub-spans.js";
+import {
+  MEMORY_CONTEXT_PHASE_KEY,
+  TurnLatencyTracker,
+} from "../../../../../daemon/turn-latency-tracker.js";
 import type { PageIndexEntry } from "../../v2/page-index.js";
 import { renderCard } from "../card.js";
 import type { EdgeGraph } from "../edge.js";
@@ -1591,5 +1604,73 @@ describe("orchestrate — injection gate", () => {
     await orchestrate(makeTurn(2, "apple"), depsOf(lanes));
 
     expect(recordedGateEvents).toEqual([]);
+  });
+});
+
+describe("latency sub-spans", () => {
+  test("orchestration inside a sub-span scope records v3_lanes / v3_expand / v3_selection", async () => {
+    // Each `Date.now()` call advances the clock 20ms so every measured span
+    // clears the recorder's floor without real waiting. Scoped to this test.
+    let clock = 0;
+    const nowSpy = spyOn(Date, "now").mockImplementation(() => (clock += 20));
+    try {
+      const lanes = await buildLanes();
+      denseHits = [{ article: "topic-b", section: 0 }];
+      providerStub = selectProvider(["topic-a"]);
+      const tracker = new TurnLatencyTracker();
+
+      await runWithLatencySubSpans(tracker, MEMORY_CONTEXT_PHASE_KEY, () =>
+        orchestrate(
+          makeTurn(1, "apple banana"),
+          depsOf(lanes, { denseK: 100 }),
+        ),
+      );
+
+      tracker.mark("turn_start");
+      tracker.mark("prompt_hook_start");
+      tracker.mark("prompt_hook_end");
+      const memory = tracker
+        .serializeSince(0)
+        .breakdown?.phases.find((p) => p.key === MEMORY_CONTEXT_PHASE_KEY);
+      expect(memory?.subPhases?.map((s) => s.key)).toEqual([
+        "v3_lanes",
+        "v3_expand",
+        "v3_selection",
+      ]);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  test("a gate hard-skip records no v3_expand and no v3_selection", async () => {
+    let clock = 0;
+    const nowSpy = spyOn(Date, "now").mockImplementation(() => (clock += 20));
+    try {
+      const lanes = await buildLanes();
+      // Low dense score against a high threshold closes the gate; no bypass.
+      denseHits = [{ article: "topic-b", section: 0, score: 0.01 }];
+      providerStub = selectProvider(["topic-a"]);
+      const tracker = new TurnLatencyTracker();
+
+      await runWithLatencySubSpans(tracker, MEMORY_CONTEXT_PHASE_KEY, () =>
+        orchestrate(
+          makeTurn(1, "apple banana"),
+          depsOf(lanes, {
+            denseK: 100,
+            gateConfig: gateConfigOf({ enabled: true, bypassForCore: false }),
+          }),
+        ),
+      );
+
+      tracker.mark("turn_start");
+      tracker.mark("prompt_hook_start");
+      tracker.mark("prompt_hook_end");
+      const memory = tracker
+        .serializeSince(0)
+        .breakdown?.phases.find((p) => p.key === MEMORY_CONTEXT_PHASE_KEY);
+      expect(memory?.subPhases?.map((s) => s.key)).toEqual(["v3_lanes"]);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -55,6 +55,10 @@
  */
 
 import type { AssistantConfig } from "../../../../config/schema.js";
+import {
+  recordLatencySubSpan,
+  timeLatencySubSpan,
+} from "../../../../daemon/turn-latency-sub-spans.js";
 import { recordWatchdogEvent } from "../../../../telemetry/watchdog-events-store.js";
 import { getLogger } from "../logging.js";
 import { denseLaneScored } from "./dense.js";
@@ -323,9 +327,11 @@ export async function orchestrate(
   // profile). Shared by the normal step-3 selection and the gate's
   // bypass-to-stable path so the two cannot diverge.
   const runSelection = async (pool: SelectorPool): Promise<SelectedPage[]> =>
-    deps.selectorEnabled === false
-      ? selectAllPoolCandidates(pool)
-      : selectPool(pool, turn, deps.selectorPrompt);
+    timeLatencySubSpan("v3_selection", "Memory selection", () =>
+      deps.selectorEnabled === false
+        ? selectAllPoolCandidates(pool)
+        : selectPool(pool, turn, deps.selectorPrompt),
+    );
 
   // Step 1: needle (sync BM25) and the enabled dense lane (async embed +
   // Qdrant) run in parallel. Both return distinct articles each tagged with
@@ -340,18 +346,31 @@ export async function orchestrate(
   const replyQuery =
     replyK > 0 ? (turn.previousAssistantMessage ?? "").trim() : "";
   const denseEnabled = denseK > 0;
-  const [needled, densed, replyNeedled, replyDensed] = await Promise.all([
-    Promise.resolve(deps.needle.queryScored(turn.currentMessage, needleK)),
-    denseEnabled
-      ? denseLaneScored(deps.denseConfig, turn.currentMessage, denseK)
-      : Promise.resolve([]),
-    Promise.resolve(
-      replyQuery.length > 0 ? deps.needle.queryScored(replyQuery, replyK) : [],
-    ),
-    replyQuery.length > 0 && denseEnabled
-      ? denseLaneScored(deps.denseConfig, replyQuery, replyK)
-      : Promise.resolve([]),
-  ]);
+  const [needled, densed, replyNeedled, replyDensed] = await timeLatencySubSpan(
+    "v3_lanes",
+    "Memory search",
+    () =>
+      Promise.all([
+        Promise.resolve(deps.needle.queryScored(turn.currentMessage, needleK)),
+        denseEnabled
+          ? denseLaneScored(deps.denseConfig, turn.currentMessage, denseK)
+          : Promise.resolve([]),
+        Promise.resolve(
+          replyQuery.length > 0
+            ? deps.needle.queryScored(replyQuery, replyK)
+            : [],
+        ),
+        replyQuery.length > 0 && denseEnabled
+          ? denseLaneScored(deps.denseConfig, replyQuery, replyK)
+          : Promise.resolve([]),
+      ]),
+  );
+  // Everything from here to the step-3 selection — finder assembly, the
+  // entity lane, the injection gate, edge + learned-edge expansion, pool
+  // assembly — is synchronous in-memory work, measured as one `v3_expand`
+  // region rather than wrapped calls. Gate-closed early returns skip the
+  // record on purpose: the expansion work didn't happen on those turns.
+  const expandStartedAt = Date.now();
 
   // Dense hits restricted to pages still in the live section index. A deleted
   // page's points can linger in Qdrant; the candidate pool already drops those
@@ -717,6 +736,11 @@ export async function orchestrate(
   // contract. `selectorPrompt` is the (optionally overridden) instruction
   // scaffold; `undefined` falls through to the bundled default.
   const pool = { stable, finder: finderTail };
+  recordLatencySubSpan(
+    "v3_expand",
+    "Gate & edge expansion",
+    Date.now() - expandStartedAt,
+  );
   const selections = await runSelection(pool);
   recordSelection(selections, stable.length + finderTail.length);
 

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -30,6 +30,10 @@ import {
 
 import { getConfig } from "../../../../config/loader.js";
 import type { AssistantConfig } from "../../../../config/schema.js";
+import {
+  recordLatencySubSpan,
+  timeLatencySubSpan,
+} from "../../../../daemon/turn-latency-sub-spans.js";
 import { stripCommentLines } from "../host-utils.js";
 import { getLogger } from "../logging.js";
 import { memorySqliteOrNull } from "../memory-db.js";
@@ -623,7 +627,14 @@ export async function observeTurn(
     if (cfg.memory.enabled === false) {
       return null;
     }
-    const lanes = await getLanes(cfg);
+    // Lane init is module-memoized: the first turn after daemon start pays
+    // the full build (section index, BM25/entity lanes, prefix cards) here;
+    // warm turns record ~0ms and are floored away by the recorder.
+    const lanes = await timeLatencySubSpan(
+      "v3_lanes_init",
+      "Memory lane init",
+      () => getLanes(cfg),
+    );
     const v3 = cfg.memory.v3;
     // Resolve the effective gate enable once for the turn: the feature flag
     // AND the `memory.v3.gate.enabled` config kill-switch. Tuning lives in
@@ -686,8 +697,14 @@ export async function observeTurn(
       );
     }
 
+    const persistStartedAt = Date.now();
     const rows = attributeSelections(result);
     writeSelections(conversationId, turnIndex, rows);
+    recordLatencySubSpan(
+      "v3_persist",
+      "Selection persistence",
+      Date.now() - persistStartedAt,
+    );
     return result;
   } catch (err) {
     // Infrastructure failures are surfaced to callers that want distinct

--- a/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.test.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.test.tsx
@@ -1,13 +1,17 @@
 /**
- * Tests for the OverviewTab's handling of failed calls. A rejected call
- * must read as a failure (banner + "Failed" status) and show a $0.00
- * estimated cost rather than the "Unavailable" placeholder.
+ * Tests for the OverviewTab: failed-call handling (a rejected call must
+ * read as a failure — banner + "Failed" status + $0.00 cost, not the
+ * "Unavailable" placeholder) and the first-token latency card's
+ * sub-phase rendering.
  */
 
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import type { LLMRequestLogEntry } from "@vellumai/assistant-api";
+import type {
+  LatencyBreakdown,
+  LLMRequestLogEntry,
+} from "@vellumai/assistant-api";
 
 import { OverviewTab } from "./overview-tab";
 
@@ -66,5 +70,87 @@ describe("OverviewTab — failed calls", () => {
     expect(html).toContain("Call failed");
     // The provider-only summary fallback must not hijack a failed call.
     expect(html).not.toContain("Normalized summary unavailable");
+  });
+});
+
+describe("OverviewTab — first-token latency sub-phases", () => {
+  function latencyEntry(latency: LatencyBreakdown): LLMRequestLogEntry {
+    return makeEntry({
+      summary: {
+        provider: "anthropic",
+        model: "test-model",
+        requestMessageCount: 3,
+        requestToolCount: 2,
+      },
+      latency,
+    });
+  }
+
+  function memoryPhase(
+    ms: number,
+    subPhases?: LatencyBreakdown["phases"][number]["subPhases"],
+  ) {
+    return {
+      key: "memory_context",
+      label: "Memory & context retrieval",
+      ms,
+      ...(subPhases ? { subPhases } : {}),
+    };
+  }
+
+  test("renders indented sub-rows in execution order plus the Other remainder", () => {
+    const html = render(
+      latencyEntry({
+        phases: [
+          { key: "queue", label: "Queue & turn setup", ms: 7 },
+          memoryPhase(5211, [
+            { key: "v3_lanes", label: "Memory search", ms: 1200 },
+            { key: "v3_selection", label: "Memory selection", ms: 3800 },
+          ]),
+        ],
+        totalToFirstTokenMs: 8284,
+      }),
+    );
+
+    expect(html).toContain("First-token latency");
+    expect(html).toContain("Memory search");
+    expect(html).toContain("Memory selection");
+    expect(html).toContain(">1,200 ms<");
+    expect(html).toContain(">3,800 ms<");
+    // Remainder: 5211 − (1200 + 3800) = 211.
+    expect(html).toContain("Other");
+    expect(html).toContain(">211 ms<");
+    // Sub-rows are inset and follow recorded order.
+    expect(html).toContain("pl-4");
+    expect(html.indexOf("Memory search")).toBeLessThan(
+      html.indexOf("Memory selection"),
+    );
+    expect(html.indexOf("Memory selection")).toBeLessThan(
+      html.indexOf("Other"),
+    );
+  });
+
+  test("omits the Other row when the remainder is under the threshold", () => {
+    const html = render(
+      latencyEntry({
+        phases: [
+          memoryPhase(5211, [
+            { key: "v3_lanes", label: "Memory search", ms: 1200 },
+            { key: "v3_selection", label: "Memory selection", ms: 4005 },
+          ]),
+        ],
+      }),
+    );
+
+    expect(html).toContain("Memory search");
+    expect(html).not.toContain("Other");
+  });
+
+  test("a breakdown without sub-phases renders flat", () => {
+    const html = render(latencyEntry({ phases: [memoryPhase(5211)] }));
+
+    expect(html).toContain(">5,211 ms<");
+    expect(html).not.toContain("pl-4");
+    expect(html).not.toContain("Other");
   });
 });

--- a/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
@@ -26,6 +26,10 @@ interface OverviewTabProps {
 interface MetadataRow {
   label: string;
   value: string;
+  /** Render inset under the preceding top-level row (latency sub-steps). */
+  indent?: boolean;
+  /** Explicit render key for rows whose label isn't unique in the card. */
+  rowKey?: string;
 }
 
 /**
@@ -109,10 +113,20 @@ function formatMs(ms: number): string {
 }
 
 /**
+ * The daemon floors recorded sub-spans at 10ms (`MIN_SUB_SPAN_MS` in
+ * `assistant/src/daemon/turn-latency-sub-spans.ts`); the remainder row uses
+ * the same threshold so a residue made purely of floored-away noise stays
+ * hidden.
+ */
+const OTHER_MIN_MS = 10;
+
+/**
  * Build the first-token latency waterfall rows: the total-to-first-token
  * headline (first call of a turn only), then one row per phase
  * (queue → memory/context → setup → request prep → time-to-first-token →
- * generation), and the streamed first-token kind when known.
+ * generation), and the streamed first-token kind when known. A phase with
+ * instrumented sub-steps gets an indented row per sub-step (execution
+ * order) plus an "Other" remainder for wall clock no sub-step claimed.
  */
 function buildLatencyRows(latency: LatencyBreakdown): MetadataRow[] {
   const rows: MetadataRow[] = [];
@@ -127,6 +141,27 @@ function buildLatencyRows(latency: LatencyBreakdown): MetadataRow[] {
   }
   for (const phase of latency.phases) {
     rows.push({ label: phase.label, value: formatMs(phase.ms) });
+    const subPhases = phase.subPhases ?? [];
+    for (const sub of subPhases) {
+      rows.push({
+        label: sub.label,
+        value: formatMs(sub.ms),
+        indent: true,
+        rowKey: `${phase.key}:${sub.key}`,
+      });
+    }
+    if (subPhases.length > 0) {
+      const attributed = subPhases.reduce((total, sub) => total + sub.ms, 0);
+      const remainder = phase.ms - attributed;
+      if (remainder >= OTHER_MIN_MS) {
+        rows.push({
+          label: "Other",
+          value: formatMs(remainder),
+          indent: true,
+          rowKey: `${phase.key}:other`,
+        });
+      }
+    }
   }
   if (latency.firstTokenKind) {
     rows.push({ label: "First token kind", value: latency.firstTokenKind });
@@ -262,7 +297,7 @@ function MetadataCard({
         <CardHeader title={title} subtitle={subtitle} />
         <div className="flex flex-col gap-2">
           {rows.map((row) => (
-            <MetadataRowItem key={row.label} row={row} />
+            <MetadataRowItem key={row.rowKey ?? row.label} row={row} />
           ))}
         </div>
       </div>
@@ -291,10 +326,20 @@ function FallbackCard({ message }: { message: string }): ReactNode {
 
 function MetadataRowItem({ row }: { row: MetadataRow }): ReactNode {
   return (
-    <div className="flex items-baseline gap-3">
+    <div
+      className={
+        row.indent
+          ? "flex items-baseline gap-3 pl-4"
+          : "flex items-baseline gap-3"
+      }
+    >
       <span
         className="shrink-0 text-label-default"
-        style={{ color: "var(--content-secondary)" }}
+        style={{
+          color: row.indent
+            ? "var(--content-tertiary)"
+            : "var(--content-secondary)",
+        }}
       >
         {row.label}
       </span>


### PR DESCRIPTION
## Summary
- The inspector's "First-token latency" card now breaks **Memory & context retrieval** into instrumented sub-steps — v2 graph retrieval, per-injector timings, and memory-v3 lane init / search / gate+edge expansion / selection / persistence — rendered as indented rows plus a client-computed "Other" remainder so the sub-rows always reconcile against the phase total.
- Plumbing is an AsyncLocalStorage scope (`assistant/src/daemon/turn-latency-sub-spans.ts`, same pattern as `plugin-execution-context.ts`) opened around the USER_PROMPT_SUBMIT hook chain — no plugin-api / hook-ctx / TurnContext contract changes, and every helper no-ops outside a scope (overflow re-entry, compaction, `composeInjectorChain`). Sub-spans are non-overlapping leaf measurements floored at 10ms, attached consume-on-attach to the `memory_context` phase in `TurnLatencyTracker.serializeSince`, and ride the existing `latency_breakdown` JSON column — no DB migration; old rows render exactly as before.
- Reviewer note: a worktree-local web `tsc` run shows 4 errors on `overview-tab.*` because the shared `@vellumai/assistant-api` workspace symlink resolves to the pre-change main checkout; in CI the symlink resolves within the PR's own checkout and those errors do not exist.

## Original prompt
Sidd shared a screenshot of the inspector's First-token latency card where "Memory & context retrieval" was a single opaque 5,211 ms row and asked for a breakdown of the latency of the steps inside it. The approved plan instruments sub-spans deep in the hook chain via an ALS scope (avoiding plugin-contract churn), keeps them non-overlapping so the remainder row is honest, and renders them indented in the web inspector.