### PR TITLE
style(daemon): brace latency sub-span control statements

### DIFF
--- a/assistant/src/daemon/turn-latency-sub-spans.ts
+++ b/assistant/src/daemon/turn-latency-sub-spans.ts
@@ -61,7 +61,9 @@ export function recordLatencySubSpan(
   ms: number,
 ): void {
   const scope = storage.getStore();
-  if (!scope || ms < MIN_SUB_SPAN_MS) return;
+  if (!scope || ms < MIN_SUB_SPAN_MS) {
+    return;
+  }
   scope.tracker.recordSubSpan(scope.parentKey, key, label, ms);
 }
 

--- a/assistant/src/daemon/turn-latency-tracker.ts
+++ b/assistant/src/daemon/turn-latency-tracker.ts
@@ -83,7 +83,9 @@ export class TurnLatencyTracker {
     label: string,
     ms: number,
   ): void {
-    if (ms < 0) return;
+    if (ms < 0) {
+      return;
+    }
     const existing = this.subSpansByPhase.get(parentPhaseKey);
     if (existing) {
       existing.push({ key, label, ms });


### PR DESCRIPTION
## Summary
- Braces the two one-liner `if` guards introduced in #38480 (`recordLatencySubSpan` floor check, `TurnLatencyTracker.recordSubSpan` negative-duration guard) per the repo's curly rule for touched control statements.

## Original prompt
Follow-up to #38480 (memory & context retrieval latency sub-step breakdown): the ship-time lint flagged the two new braceless guards at warn level; this brings them in line with the Control-Flow Braces convention.