### PR TITLE
chore(assistant): regenerate openapi.yaml for latency subPhases

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -8745,6 +8745,22 @@ paths:
                                         type: string
                                       ms:
                                         type: number
+                                      subPhases:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            label:
+                                              type: string
+                                            ms:
+                                              type: number
+                                          required:
+                                            - key
+                                            - label
+                                            - ms
+                                          additionalProperties: false
                                     required:
                                       - key
                                       - label
@@ -16526,6 +16542,22 @@ paths:
                                   type: string
                                 ms:
                                   type: number
+                                subPhases:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      label:
+                                        type: string
+                                      ms:
+                                        type: number
+                                    required:
+                                      - key
+                                      - label
+                                      - ms
+                                    additionalProperties: false
                               required:
                                 - key
                                 - label
@@ -19532,6 +19564,22 @@ paths:
                                         type: string
                                       ms:
                                         type: number
+                                      subPhases:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            label:
+                                              type: string
+                                            ms:
+                                              type: number
+                                          required:
+                                            - key
+                                            - label
+                                            - ms
+                                          additionalProperties: false
                                     required:
                                       - key
                                       - label


### PR DESCRIPTION
## Summary
- Regenerates `assistant/openapi.yaml` for the optional `subPhases` field #38480 added to `LatencyPhaseSchema` — fixes the red **OpenAPI Spec Check** on main (the schema change shipped without the regen).
- Pure generated output: `bun run meta/sync-bundled-copies.ts` then `bun run generate:openapi` in `assistant/`; +48 lines at the three sites the phase schema appears.

## Original prompt
Follow-up to #38480 (memory & context retrieval latency sub-step breakdown): main's Assistant Checks run failed only on the OpenAPI spec-freshness check after the merge; this commits the regenerated spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)