### PR TITLE
fix(streaming): prevent SSE seq re-issue after crash-restart; recover clients from stale seq generations

### DIFF
--- a/assistant/src/__tests__/assistant-stream-state.test.ts
+++ b/assistant/src/__tests__/assistant-stream-state.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
@@ -11,6 +11,7 @@ import {
   _peekStreamForTesting,
   _resetStreamStateForTesting,
   _simulateRestartForTesting,
+  floorSeqAbove,
   getCurrentSeq,
   getReplayWindow,
   stampAndBuffer,
@@ -572,6 +573,106 @@ describe("assistant-stream-state", () => {
   // Per-conversation persisted seq now lives on the `conversations.seq`
   // column (see conversation-crud `getConversationPersistedSeq` /
   // `recordConversationPersistedSeq`); its tests live with that module.
+
+  describe("seq re-issue guards", () => {
+    const reservationPath = () =>
+      join(process.env.VELLUM_WORKSPACE_DIR!, "data", "stream-seq.json");
+
+    test("reservation writes are raise-only: a higher on-disk ceiling is adopted, not overwritten", () => {
+      // GIVEN this process reserved 1..1024 and another writer then
+      // persisted a higher ceiling
+      stampAndBuffer(mkEvent());
+      writeFileSync(
+        reservationPath(),
+        JSON.stringify({ reservedSeqCeiling: 5000 }),
+      );
+
+      // WHEN the counter crosses its in-memory ceiling and re-reserves
+      for (let i = 0; i < 1023; i++) {
+        stampAndBuffer(mkEvent());
+      }
+      const crossing = mkEvent();
+      stampAndBuffer(crossing);
+
+      // THEN issuance jumps above the on-disk ceiling instead of
+      // regressing the file below seqs the other writer may have issued
+      expect(crossing.seq).toBe(5001);
+      const persisted = JSON.parse(readFileSync(reservationPath(), "utf8")) as {
+        reservedSeqCeiling: number;
+      };
+      expect(persisted.reservedSeqCeiling).toBeGreaterThan(5000);
+    });
+
+    test("floorSeqAbove raises the counter above a persisted anchor and the floor survives restart", () => {
+      stampAndBuffer(mkEvent());
+
+      floorSeqAbove(907779);
+
+      // getCurrentSeq now claims exactly through the floored anchor
+      expect(getCurrentSeq()).toBe(907779);
+      const a = mkEvent();
+      stampAndBuffer(a);
+      expect(a.seq).toBe(907780);
+
+      // The floor is persisted: a restart resumes above it
+      _simulateRestartForTesting();
+      const b = mkEvent();
+      stampAndBuffer(b);
+      expect(b.seq).toBeGreaterThan(907780);
+    });
+
+    test("floorSeqAbove at or below the current counter is a no-op", () => {
+      stampAndBuffer(mkEvent());
+      stampAndBuffer(mkEvent());
+
+      floorSeqAbove(1);
+      floorSeqAbove(2);
+      floorSeqAbove(Number.NaN);
+      floorSeqAbove(Number.POSITIVE_INFINITY);
+
+      const a = mkEvent();
+      stampAndBuffer(a);
+      expect(a.seq).toBe(3);
+    });
+
+    test("a counter that outran failed reservation writes cannot re-issue anchored seqs once floored", () => {
+      /**
+       * Incident shape (2026-07-18): reservation writes fail (e.g. disk
+       * pressure) while the counter keeps issuing; anchors served to
+       * clients then exceed the on-disk ceiling, and a restarted counter
+       * resumes below them. The startup floor repairs the resume point.
+       */
+      // GIVEN a process whose reservation writes start failing (the
+      // reservation path is occupied by a directory, so the atomic
+      // rename fails) while stamping continues past the last persisted
+      // ceiling
+      stampAndBuffer(mkEvent());
+      rmSync(reservationPath(), { force: true });
+      mkdirSync(reservationPath(), { recursive: true });
+      for (let i = 0; i < 1200; i++) {
+        stampAndBuffer(mkEvent());
+      }
+      const issuedMax = getCurrentSeq();
+      expect(issuedMax).toBeGreaterThan(1024);
+
+      // AND only stale reservation state survives to the next boot
+      rmSync(reservationPath(), { recursive: true, force: true });
+      writeFileSync(
+        reservationPath(),
+        JSON.stringify({ reservedSeqCeiling: 1024 }),
+      );
+      _simulateRestartForTesting();
+
+      // WHEN startup floors the counter at the highest persisted anchor
+      floorSeqAbove(issuedMax);
+
+      // THEN issuance resumes strictly above every seq the previous
+      // process handed out
+      const a = mkEvent();
+      stampAndBuffer(a);
+      expect(a.seq).toBeGreaterThan(issuedMax);
+    });
+  });
 
   describe("seq persistence across restarts", () => {
     test("counter resumes above the persisted reservation after a restart", () => {

--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -24,6 +24,7 @@ mock.module("../daemon/identity-helpers.js", () => ({
 import { writeSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import {
   createConversation,
+  getMaxPersistedConversationSeq,
   recordConversationPersistedSeq,
   setConversationProcessingStartedAt,
 } from "../persistence/conversation-crud.js";
@@ -147,6 +148,19 @@ describe("handleListMessages page=latest", () => {
   });
 
   describe("persisted seq", () => {
+    test("getMaxPersistedConversationSeq reports the highest anchor across conversations", () => {
+      /**
+       * The startup seq floor resumes issuance above this value, so it
+       * must reflect the highest anchor any conversation has served.
+       */
+      const a = createConversation();
+      const b = createConversation();
+      recordConversationPersistedSeq(a.id, 41);
+      recordConversationPersistedSeq(b.id, 907779);
+
+      expect(getMaxPersistedConversationSeq()).toBe(907779);
+    });
+
     test("returns the recorded persisted seq for the conversation", () => {
       /**
        * The snapshot must advertise the `seq` of the last durably-persisted

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -21,6 +21,7 @@ import { startGatewayFlagListener } from "../ipc/gateway-flag-listener.js";
 import { startMonitoring } from "../monitoring/control.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
+import { getMaxPersistedConversationSeq } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { startEmbeddingRuntimeManager } from "../persistence/embeddings/embedding-backend.js";
@@ -30,6 +31,7 @@ import { syncWorkspaceIdentityToPlatform } from "../platform/sync-identity.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
 import { initializeProviders } from "../providers/registry.js";
+import { floorSeqAbove } from "../runtime/assistant-stream-state.js";
 import {
   initAuthSigningKey,
   resolveSigningKey,
@@ -230,6 +232,22 @@ export async function runDaemon(): Promise<void> {
   try {
     const { migrationsOk } = await initializeDb();
     dbReady = true;
+    // Floor the stream seq counter above every persisted conversation
+    // anchor before turns can stamp events. Anchors are getCurrentSeq()
+    // snapshots already served to clients, and a crashed process can have
+    // outrun its last successful seq-reservation write — resuming below an
+    // anchor re-issues seqs, and anchored clients then discard every live
+    // event as an already-applied replay. Own try/catch: on a
+    // failed-migration DB the column may be unreadable, and that must not
+    // flip startup into the migration-failed path.
+    try {
+      floorSeqAbove(getMaxPersistedConversationSeq());
+    } catch (err) {
+      log.warn(
+        { err },
+        "stream seq floor from persisted anchors failed — continuing startup",
+      );
+    }
     if (migrationsOk) {
       setDbReady(true);
       log.info("Daemon startup: DB initialized");

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -2707,6 +2707,22 @@ export function recordConversationPersistedSeq(id: string, seq: number): void {
 }
 
 /**
+ * Highest `conversations.seq` anchor across all conversations, or 0 when
+ * none is recorded. Every anchor is a `getCurrentSeq()` snapshot that has
+ * been served to clients on `/messages`, so at startup the stream seq
+ * counter is floored above this value (`floorSeqAbove` in
+ * `runtime/assistant-stream-state`) — resuming below it would re-issue
+ * seqs that clients already treat as applied.
+ */
+export function getMaxPersistedConversationSeq(): number {
+  const row = rawGet<{ maxSeq: number | null }>(
+    "conversation:maxPersistedSeq",
+    "SELECT MAX(seq) AS maxSeq FROM conversations",
+  );
+  return row?.maxSeq ?? 0;
+}
+
+/**
  * Set or clear the `surfaced_at` promotion marker for a conversation.
  *
  * A non-null `surfaced_at` promotes a background/scheduled conversation

--- a/assistant/src/runtime/assistant-stream-state.ts
+++ b/assistant/src/runtime/assistant-stream-state.ts
@@ -27,7 +27,11 @@
  * above every seq the previous process could have emitted. Clients
  * therefore never observe the counter moving backwards — a restart
  * shows up as (at most) a bounded forward gap, which the normal
- * gap-reconcile / snapshot-resync path already handles. The ring is
+ * gap-reconcile / snapshot-resync path already handles. Reservation
+ * writes are raise-only, and at startup the counter is additionally
+ * floored above the highest persisted conversation anchor
+ * ({@link floorSeqAbove}), so even a process that outran its last
+ * successful reservation write cannot cause seq re-issue. The ring is
  * sized generously enough that a typical refresh round-trip (~1-3s)
  * is well within window.
  *
@@ -50,7 +54,13 @@
  * the new process assigns -- never ambiguous against it.
  */
 
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 
 import {
@@ -287,13 +297,40 @@ export function getCurrentSeq(): number {
 }
 
 /**
+ * Raise the counter so the next issued seq is strictly above
+ * `highestIssuedSeq`, persisting a fresh reservation block over the new
+ * floor.
+ *
+ * Called at daemon startup (once the DB is open) with the highest
+ * per-conversation persisted anchor (`MAX(conversations.seq)`). Anchors
+ * are {@link getCurrentSeq} snapshots served to clients on `/messages`,
+ * so the counter must resume above every one of them: a previous process
+ * can outrun its last successful reservation write (the write is
+ * best-effort — e.g. under disk pressure) and persist anchors beyond the
+ * on-disk ceiling. Resuming below such an anchor re-issues seqs, and a
+ * client holding the anchor then discards every live event as an
+ * already-applied replay. A floor at or below the current counter is a
+ * no-op.
+ */
+export function floorSeqAbove(highestIssuedSeq: number): void {
+  loadSeqReservation();
+  if (!Number.isFinite(highestIssuedSeq) || highestIssuedSeq < state.nextSeq) {
+    return;
+  }
+  state.nextSeq = Math.floor(highestIssuedSeq) + 1;
+  reserveSeqCapacity();
+}
+
+/**
  * Reset all stream state. Test-only.
  */
 export function _resetStreamStateForTesting(): void {
   state.nextSeq = 1;
-  // Mark the reservation as loaded with no ceiling so the next stamp
-  // re-reserves from 1, ignoring any reservation file a previous test
-  // wrote into the (per-process temp) workspace.
+  // Mark the reservation as loaded with no ceiling AND remove any
+  // reservation file a previous test wrote into the (per-process temp)
+  // workspace — reservation writes re-read the file and are raise-only,
+  // so a leftover file would leak one test's ceiling into the next.
+  rmSync(seqReservationPath(), { force: true });
   state.reservedSeqCeiling = 0;
   state.seqReservationLoaded = true;
   state.firstStampedSeq = 0;
@@ -374,6 +411,18 @@ function reserveSeqCapacity(): void {
     return;
   }
 
+  // Raise-only write: re-read the file first, and when it holds a ceiling
+  // at or above this instance's counter, jump the counter over it instead
+  // of overwriting. The on-disk ceiling is a promise that every seq at or
+  // below it may already have been handed out — a writer with a lower
+  // in-memory counter regressing the file would let the next process
+  // re-issue seqs, which poisons every client holding an anchor from the
+  // higher range.
+  const onDisk = readReservedCeiling();
+  if (onDisk >= state.nextSeq) {
+    state.nextSeq = onDisk + 1;
+  }
+
   const ceiling = state.nextSeq + SEQ_RESERVATION_BLOCK - 1;
   try {
     const path = seqReservationPath();
@@ -381,8 +430,15 @@ function reserveSeqCapacity(): void {
     const tmp = `${path}.tmp`;
     writeFileSync(tmp, JSON.stringify({ reservedSeqCeiling: ceiling }));
     renameSync(tmp, path);
-  } catch {
-    // Degraded mode: keep stamping from memory.
+  } catch (err) {
+    // Degraded mode: keep stamping from memory. Seqs issued past the last
+    // successfully persisted ceiling are not crash-safe — after a restart
+    // the counter re-issues them unless the persisted-anchor floor
+    // ({@link floorSeqAbove} at daemon startup) repairs the resume point.
+    log.warn(
+      { err },
+      "seq reservation write failed — seqs issued beyond the persisted ceiling are not crash-safe",
+    );
   }
   state.reservedSeqCeiling = ceiling;
 }

--- a/clients/web/src/domains/chat/streaming/sse-event-consumer.test.ts
+++ b/clients/web/src/domains/chat/streaming/sse-event-consumer.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   __resetLocalSeqForTesting,
   getLocalSeq,
+  recordLocalSeq,
 } from "@/lib/streaming/local-seq";
+import { SSE_REPLAY_RING_COUNT_LIMIT } from "@vellumai/assistant-api";
 import type { AssistantEvent } from "@/types/event-types";
 
 let mockStreamEpoch = 7;
@@ -692,5 +694,107 @@ describe("sse-event-consumer — per-conversation idempotent apply", () => {
       expect.objectContaining({ conversationId: "conv-1", eventSeq: 5 }),
     );
     expect(getLocalSeq("conv-1")).toBe(5);
+  });
+});
+
+describe("sse-event-consumer — stale seq-generation recovery", () => {
+  test("a generation reset drops per-conversation frontiers so the new seq space applies", () => {
+    /**
+     * Incident shape (2026-07-18): the daemon resumed its counter below
+     * anchors it had already served, so the stored cursor and the
+     * conversation frontier both sat far above every live seq. The reset
+     * must clear the frontiers along with the cursor — otherwise every
+     * live event is classified as an already-applied replay.
+     */
+    // GIVEN a cursor and a conversation frontier from the old seq space
+    globalCursor = 907779;
+    recordLocalSeq("conv-1", 907779);
+    const { deps, handleStreamEvent, reconcileActive } = makeDeps({
+      activeConversationId: "conv-1",
+    });
+    const consumer = createSseEventConsumer(deps);
+
+    // WHEN the first event of the new (lower) seq space arrives
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: 905854,
+        message: { type: "assistant_text_delta", text: "a" },
+      }),
+    );
+
+    // THEN the event dispatches instead of being dropped as a replay,
+    // and cursor + frontier are re-seeded from the new space
+    expect(handleStreamEvent).toHaveBeenCalledTimes(1);
+    expect(getLocalSeq("conv-1")).toBe(905854);
+    expect(globalCursor).toBe(905854);
+    expect(reconcileActive).toHaveBeenCalledTimes(1);
+    expect(recordDiagnosticMock).toHaveBeenCalledWith(
+      "sse_seq_generation_reset",
+      expect.objectContaining({ stored: 907779, observed: 905854 }),
+    );
+  });
+
+  test("a frontier further ahead than the replay ring is dropped as stale generation", () => {
+    /**
+     * A `/messages` snapshot anchor persisted before a daemon counter
+     * reset re-poisons the frontier even after the cursor healed. A
+     * genuine replay can only trail the frontier by what the ring can
+     * re-deliver, so a larger lead proves a stale generation.
+     */
+    // GIVEN a cursor already in the live seq space but a frontier from
+    // the old one (re-recorded from a stale snapshot anchor)
+    globalCursor = 905853;
+    recordLocalSeq("conv-1", 907779);
+    const { deps, handleStreamEvent } = makeDeps({
+      activeConversationId: "conv-1",
+    });
+    const consumer = createSseEventConsumer(deps);
+
+    // WHEN the next live event arrives contiguously
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: 905854,
+        message: { type: "assistant_text_delta", text: "a" },
+      }),
+    );
+
+    // THEN the stale frontier is dropped and the event applies as the
+    // conversation's new frontier
+    expect(handleStreamEvent).toHaveBeenCalledTimes(1);
+    expect(getLocalSeq("conv-1")).toBe(905854);
+    expect(recordDiagnosticMock).toHaveBeenCalledWith(
+      "sse_local_seq_stale_generation",
+      expect.objectContaining({ eventSeq: 905854, localSeq: 907779 }),
+    );
+  });
+
+  test("a frontier lead within the replay ring still skips as an ordinary replay", () => {
+    // GIVEN a frontier ahead of the live event by less than the ring
+    // window (a snapshot applied slightly ahead of the stream)
+    const frontier = 100 + SSE_REPLAY_RING_COUNT_LIMIT - 1;
+    recordLocalSeq("conv-1", frontier);
+    const { deps, handleStreamEvent } = makeDeps({
+      activeConversationId: "conv-1",
+    });
+    const consumer = createSseEventConsumer(deps);
+
+    // WHEN an event below the frontier arrives on a cold cursor
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: 100,
+        message: { type: "assistant_text_delta", text: "a" },
+      }),
+    );
+
+    // THEN it is skipped as a replay and the frontier holds
+    expect(handleStreamEvent).not.toHaveBeenCalled();
+    expect(getLocalSeq("conv-1")).toBe(frontier);
+    expect(recordDiagnosticMock).toHaveBeenCalledWith(
+      "sse_event_seq_replayed",
+      expect.objectContaining({ eventSeq: 100, localSeq: frontier }),
+    );
   });
 });

--- a/clients/web/src/domains/chat/streaming/sse-event-consumer.ts
+++ b/clients/web/src/domains/chat/streaming/sse-event-consumer.ts
@@ -38,7 +38,9 @@
  *   - The first event on a cold connection seeds the cursor without
  *     reconciling.
  *   - An event whose seq < cursor: the daemon's counter restarted
- *     (daemon restart). Replace the stale cursor and reconcile.
+ *     (daemon restart). Replace the stale cursor, drop the
+ *     per-conversation frontiers recorded against the old seq space,
+ *     and reconcile.
  *   - An event whose seq > cursor + 1: a discontinuity. Whether it is a
  *     benign withheld-event skip or a real out-of-ring loss is decided
  *     against BOTH ring bounds. Live delivery is concurrent with stamping,
@@ -76,7 +78,11 @@
  *   so it is skipped rather than re-applied — re-running a delta handler
  *   would double-append. This is the stream-side half of the monotonic
  *   merge: the frontier is what tells the snapshot/stream reconcile how
- *   far the stream has carried the conversation.
+ *   far the stream has carried the conversation. A frontier further
+ *   ahead of a live event than the replay ring can re-deliver is not a
+ *   replay but a stale-generation anchor (recorded from a snapshot of a
+ *   pre-reset seq space) — it is dropped and re-seeded from the live
+ *   event rather than allowed to swallow the stream.
  *
  * Reconnect handling:
  *   On reconnect the transport sends the cursor as `lastSeenSeq` and
@@ -95,7 +101,12 @@ import {
 import { useStreamStore } from "@/domains/chat/stream-store";
 import { isConversationScopedStreamEvent } from "@/domains/chat/utils/chat";
 import { recordDiagnostic } from "@/lib/diagnostics";
-import { getLocalSeq, recordLocalSeq } from "@/lib/streaming/local-seq";
+import {
+  clearLocalSeq,
+  getLocalSeq,
+  recordLocalSeq,
+  resetLocalSeqs,
+} from "@/lib/streaming/local-seq";
 import {
   advanceReconnectCursor,
   getReconnectCursor,
@@ -179,13 +190,17 @@ export function createSseEventConsumer(
         } else if (eventSeq < stored) {
           // Server seq counter restarted (daemon restart). Replace the
           // stale cursor and reconcile to pick up any state changes
-          // from the restart.
+          // from the restart. Per-conversation frontiers recorded against
+          // the old seq space are dropped with it — they sit above every
+          // seq the new space issues, so keeping them would classify all
+          // live events as already-applied replays.
           recordDiagnostic("sse_seq_generation_reset", {
             conversationId: eventConversationId,
             stored,
             observed: eventSeq,
           });
           replaceReconnectCursor(eventSeq);
+          resetLocalSeqs();
           gapDeferred = true;
           // Fire-and-forget: cursor is already replaced above (the old
           // seq space is meaningless after a restart). Swallow rejection
@@ -299,19 +314,18 @@ export function createSseEventConsumer(
         // the transcript (a replay after reconnect, or overlap with an
         // in-flight reconcile). Re-applying would double-append deltas,
         // so skip it and leave the frontier untouched.
+        //
+        // Stale-frontier guard: a genuine replay can only trail the
+        // frontier by what the daemon's ring can re-deliver
+        // (`SSE_REPLAY_RING_COUNT_LIMIT`). A frontier further ahead of a
+        // live event than that was recorded against a stale seq
+        // generation — a `/messages` snapshot anchor persisted before the
+        // daemon's counter reset — and treating the live stream as
+        // replayed against it would silently drop every event until the
+        // counter re-passes the stale anchor. Drop the frontier and apply
+        // the live event as the conversation's new frontier instead.
         const localSeq = getLocalSeq(eventConversationId);
-        if (
-          eventSeq != null &&
-          localSeq != null &&
-          eventSeq <= localSeq
-        ) {
-          recordDiagnostic("sse_event_seq_replayed", {
-            conversationId: eventConversationId,
-            eventType: event.type,
-            eventSeq,
-            localSeq,
-          });
-        } else {
+        const applyAndAdvance = () => {
           deps.handleStreamEvent(event, useStreamStore.getState().streamEpoch);
           // Advance the per-conversation frontier once the event is
           // applied so the snapshot/stream merge knows how far the
@@ -319,6 +333,27 @@ export function createSseEventConsumer(
           // of this seq is recognised as a no-op above.
           // `recordLocalSeq` ignores a null/undefined seq itself.
           recordLocalSeq(eventConversationId, eventSeq);
+        };
+        if (
+          eventSeq != null &&
+          localSeq != null &&
+          eventSeq <= localSeq
+        ) {
+          const seqDiagnostic = {
+            conversationId: eventConversationId,
+            eventType: event.type,
+            eventSeq,
+            localSeq,
+          };
+          if (localSeq - eventSeq >= SSE_REPLAY_RING_COUNT_LIMIT) {
+            recordDiagnostic("sse_local_seq_stale_generation", seqDiagnostic);
+            clearLocalSeq(eventConversationId);
+            applyAndAdvance();
+          } else {
+            recordDiagnostic("sse_event_seq_replayed", seqDiagnostic);
+          }
+        } else {
+          applyAndAdvance();
         }
       } else {
         recordDiagnostic("sse_event_wrong_conversation_filtered", {

--- a/clients/web/src/lib/streaming/local-seq.ts
+++ b/clients/web/src/lib/streaming/local-seq.ts
@@ -62,7 +62,27 @@ export function getLocalSeq(conversationId: string): number | null {
   return localSeqByConversation.get(conversationId) ?? null;
 }
 
+/**
+ * Drop every recorded frontier. Called when connection-wide gap detection
+ * observes a seq generation reset (the daemon's counter restarted below
+ * the stored cursor): frontiers recorded against the old seq space sit
+ * above every seq the new space issues, so keeping them would classify
+ * all live events as already-applied replays.
+ */
+export function resetLocalSeqs(): void {
+  localSeqByConversation.clear();
+}
+
+/**
+ * Drop one conversation's frontier. Used when the frontier is discovered
+ * to belong to a stale seq generation (see `sse-event-consumer`'s
+ * stale-frontier guard) so the live event can apply and re-seed it.
+ */
+export function clearLocalSeq(conversationId: string): void {
+  localSeqByConversation.delete(conversationId);
+}
+
 /** Reset state. Test-only. */
 export function __resetLocalSeqForTesting(): void {
-  localSeqByConversation.clear();
+  resetLocalSeqs();
 }


### PR DESCRIPTION
## Summary
- **Daemon — make the seq resume guarantee unbreakable.** The global SSE `seq` must never be re-issued across restarts, and `getCurrentSeq()` snapshots must never exceed what a future process resumes above. `reserveSeqCapacity()` now re-reads `data/stream-seq.json` before writing and is raise-only: a writer with a lower in-memory counter jumps over a higher on-disk ceiling instead of regressing the file. Failed reservation writes now log at warn (previously swallowed — chronic failure under disk pressure was invisible). At startup, `floorSeqAbove(getMaxPersistedConversationSeq())` floors the counter above every persisted per-conversation anchor (`MAX(conversations.seq)`), covering a crashed process that outran its last successful reservation write and served anchors beyond the on-disk ceiling.
- **Web client — recover instead of starving when the seq space regresses.** A detected seq generation reset (live seq below the stored cursor) now also drops the per-conversation `local-seq` frontiers — previously only the connection cursor was replaced, so frontiers recorded against the old seq space kept classifying every live event as an already-applied replay (`sse_event_seq_replayed`), and replies only appeared at turn end via the reconciliation refetch. Additionally, a frontier further ahead of a live event than the replay ring can re-deliver (`SSE_REPLAY_RING_COUNT_LIMIT`) is provably not an ordinary replay overlap: it is diagnosed as `sse_local_seq_stale_generation`, dropped, and re-seeded from the live event — this also self-heals a frontier re-poisoned by a stale `/messages` anchor fetched mid-session.
- **Tests** pin the raise-only file repair, the startup floor surviving restart, the incident shape end-to-end (counter outruns failed writes → floor prevents re-issue), generation-reset frontier clearing, the stale-frontier guard, the ordinary-replay path within the ring window, and the `MAX(seq)` anchor query.

## Original prompt
Live streaming broke for all clients of a local daemon after a crash-restart on 2026-07-18: the daemon resumed its counter ~2,500 seqs below anchors it had already served on `/messages` (`stored: 907779` vs `observed: 905854` in client diagnostics), so clients — correctly, per the documented contract — dropped every live delta as a replay; full replies popped in only at turn end through the unscoped `sync_changed`-triggered refetch. The task was to ship the durable two-sided fix (daemon root cause + client defense) as one PR, after the affected instance was manually remediated by raising `reservedSeqCeiling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)