### PR TITLE
fix(assistant): forward QDRANT_HTTP_PORT to skill/bash subprocesses

### DIFF
--- a/assistant/src/tools/terminal/__tests__/safe-env.test.ts
+++ b/assistant/src/tools/terminal/__tests__/safe-env.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { buildSanitizedEnv, SAFE_ENV_VARS } from "../safe-env.js";
+
+describe("safe-env Qdrant forwarding", () => {
+  const priorPort = process.env.QDRANT_HTTP_PORT;
+  const priorUrl = process.env.QDRANT_URL;
+
+  afterEach(() => {
+    if (priorPort == null) {
+      delete process.env.QDRANT_HTTP_PORT;
+    } else {
+      process.env.QDRANT_HTTP_PORT = priorPort;
+    }
+    if (priorUrl == null) {
+      delete process.env.QDRANT_URL;
+    } else {
+      process.env.QDRANT_URL = priorUrl;
+    }
+  });
+
+  test("QDRANT_HTTP_PORT is on the allowlist and forwarded to subprocesses", () => {
+    expect(SAFE_ENV_VARS).toContain("QDRANT_HTTP_PORT");
+
+    process.env.QDRANT_HTTP_PORT = "6543";
+    const env = buildSanitizedEnv();
+    expect(env.QDRANT_HTTP_PORT).toBe("6543");
+  });
+
+  test("QDRANT_URL is stripped — it would flip QdrantManager to external mode", () => {
+    expect(SAFE_ENV_VARS).not.toContain("QDRANT_URL");
+
+    process.env.QDRANT_URL = "http://external:6333";
+    const env = buildSanitizedEnv();
+    expect(env.QDRANT_URL).toBeUndefined();
+  });
+});

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -51,6 +51,12 @@ export const SAFE_ENV_VARS = [
   "CES_CREDENTIAL_URL",
   "CES_MANAGED_MODE",
   "CES_LOCAL_SOCKET",
+  // Per-instance port of the assistant-managed Qdrant sidecar, so skill and
+  // bash-tool subprocesses that use the vector helpers (e.g. embed/search over
+  // `@vellumai/plugin-api`) resolve the same local sidecar as the daemon
+  // (127.0.0.1:<port>). `QDRANT_URL` is intentionally excluded — it flips
+  // QdrantManager into external mode and bypasses the local managed lifecycle.
+  "QDRANT_HTTP_PORT",
   "IS_CONTAINERIZED",
   "IS_PLATFORM",
   "VELLUM_CLOUD",


### PR DESCRIPTION
## Prompt / plan

While investigating why `@vellumai/plugin-api` doesn't resolve usably from a skill script (skill scripts run in a sandboxed subprocess, not in the daemon process), we classified the plugin-api export surface by process-coupling. Most exports are pure or read shared on-disk state and already work out-of-process because `VELLUM_WORKSPACE_DIR` is forwarded. A smaller set is coupled to daemon-private resources.

The Qdrant-backed vector helpers (`embedAndUpsert`, `searchMessageIdsLexical`'s vector path, `sweepOrphanedGraphNodePoints`) are the one case in that set that needs nothing from the daemon itself — they talk to the assistant-managed Qdrant sidecar, which is a networked server that tolerates concurrent clients. The only reason they fail from a subprocess is that the sidecar's port isn't forwarded. This PR is that fix.

`buildSanitizedEnv()` (`assistant/src/tools/terminal/safe-env.ts`) strips every env var not on the `SAFE_ENV_VARS` allowlist before spawning skill/bash subprocesses. `resolveQdrantUrl` resolves the sidecar with precedence `QDRANT_HTTP_PORT` → `QDRANT_URL` → `config.memory.qdrant.url`, and the CLI sets the per-instance port via `env.QDRANT_HTTP_PORT` (`cli/src/lib/local.ts`). Without the port on the allowlist, a subprocess falls through to the config URL and misses the daemon's per-instance managed sidecar at `127.0.0.1:<port>`.

- Add `QDRANT_HTTP_PORT` to `SAFE_ENV_VARS`.
- `QDRANT_URL` is intentionally **not** added — per the repo's Qdrant Port Override rule it flips `QdrantManager` into external mode and bypasses the local managed lifecycle (the CLI already deletes it from instance-daemon envs for the same reason).

## Test plan

- New unit test `assistant/src/tools/terminal/__tests__/safe-env.test.ts`: asserts `QDRANT_HTTP_PORT` is on the allowlist and forwarded by `buildSanitizedEnv()`, and that `QDRANT_URL` is stripped. `bun test` → 2 pass.
- `bun run typecheck:fast` → clean.
- `eslint` on both changed files → clean.
- Manually reproduced the underlying problem end-to-end: hatched a local instance, added a skill whose script imports `@vellumai/plugin-api`, and confirmed the sandbox subprocess env is governed by this allowlist.

<!-- CLI verb checklist omitted: this PR adds no routes under assistant/src/runtime/routes/. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_