### PR TITLE
fix(plugins): make plugin-api peer strip crash-safe; abort finalize if the manifest can't be restored

### DIFF
--- a/assistant/src/cli/lib/__tests__/install-plugin-dependencies.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-plugin-dependencies.test.ts
@@ -9,7 +9,13 @@
  * contract; the wiring into the install/upgrade flow is covered by those suites.
  */
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -18,6 +24,7 @@ import {
   DEPENDENCY_INSTALL_ARGS,
   type DependencyInstaller,
   installPluginDependencies,
+  PluginManifestRestoreError,
 } from "../install-plugin-dependencies.js";
 
 describe("installPluginDependencies", () => {
@@ -178,6 +185,39 @@ describe("installPluginDependencies", () => {
     await installPluginDependencies(dir, run);
 
     expect(readFileSync(pkgPath, "utf8")).toBe(original);
+  });
+
+  test("leaves no temp file behind after a strip/restore cycle", async () => {
+    writePkg({
+      name: "p",
+      dependencies: { "date-fns": "3.0.0" },
+      peerDependencies: { "@vellumai/plugin-api": ">=0.8.0" },
+    });
+    const run: DependencyInstaller = async () => {};
+
+    await installPluginDependencies(dir, run);
+
+    // The atomic write renames its temp file into place; none must linger.
+    const leftovers = readdirSync(dir).filter((n) => n.includes(".tmp"));
+    expect(leftovers).toEqual([]);
+  });
+
+  test("throws to abort finalization when the manifest cannot be restored", async () => {
+    writePkg({
+      name: "p",
+      dependencies: { "date-fns": "3.0.0" },
+      peerDependencies: { "@vellumai/plugin-api": ">=0.8.0" },
+    });
+    // Simulate the manifest becoming unrestorable during the install (e.g. the
+    // dir vanished / the disk filled) by removing the plugin directory, so the
+    // post-install atomic restore write fails.
+    const run: DependencyInstaller = async ({ cwd }) => {
+      rmSync(cwd, { recursive: true, force: true });
+    };
+
+    await expect(installPluginDependencies(dir, run)).rejects.toBeInstanceOf(
+      PluginManifestRestoreError,
+    );
   });
 
   test("is fail-soft: an installer error is swallowed, not thrown", async () => {

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -551,8 +551,15 @@ export async function finalizeStagedInstall(
 ): Promise<{ target: string; fingerprint: Fingerprint }> {
   // Install the plugin's own runtime dependencies into the staged tree before
   // it is fingerprinted and swapped, so its hooks/tools can resolve their bare
-  // imports. A no-op for a plugin that declares none.
-  await installPluginDependencies(stagingDir, installDependencies);
+  // imports. A no-op for a plugin that declares none. A hard failure here (e.g.
+  // the manifest could not be restored to its materialized bytes) must not leave
+  // the half-finalized staging dir behind, so drop it before propagating.
+  try {
+    await installPluginDependencies(stagingDir, installDependencies);
+  } catch (err) {
+    rmSync(stagingDir, { recursive: true, force: true });
+    throw err;
+  }
 
   // Hash the materialized tree before the sidecar is written (so the sidecar
   // never hashes itself) — the baseline `plugins inspect` uses to detect later

--- a/assistant/src/cli/lib/install-plugin-dependencies.ts
+++ b/assistant/src/cli/lib/install-plugin-dependencies.ts
@@ -47,7 +47,13 @@
  */
 
 import { execFile } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 
@@ -92,6 +98,43 @@ export type DependencyInstaller = (opts: {
   /** The staged plugin directory whose `dependencies` are installed. */
   readonly cwd: string;
 }) => Promise<void>;
+
+/**
+ * The plugin's `package.json` could not be restored to its original bytes after
+ * the dependency install temporarily stripped the `@vellumai/plugin-api` peer.
+ * Thrown so {@link ./install-from-github.finalizeStagedInstall} aborts rather
+ * than fingerprint and swap in a plugin whose manifest is left shim-stripped.
+ */
+export class PluginManifestRestoreError extends Error {
+  constructor(
+    readonly pluginDir: string,
+    readonly cause: unknown,
+  ) {
+    super(
+      `Failed to restore package.json for the plugin at ${pluginDir} after installing its dependencies; aborting to avoid installing a shim-stripped manifest.`,
+    );
+    this.name = "PluginManifestRestoreError";
+  }
+}
+
+/**
+ * Write `contents` to `path` atomically: a full write to a sibling temp file
+ * followed by a rename. `package.json` is therefore only ever the complete old
+ * bytes or the complete new bytes — never a truncated/partial write a failed
+ * `writeFileSync` could otherwise leave behind. The temp file shares `path`'s
+ * directory so the rename stays on one filesystem (atomic on POSIX); a failed
+ * write cleans the temp file up before rethrowing.
+ */
+function writeFileAtomic(path: string, contents: string): void {
+  const tmp = `${path}.deps-install.${process.pid}.tmp`;
+  try {
+    writeFileSync(tmp, contents);
+    renameSync(tmp, path);
+  } catch (err) {
+    rmSync(tmp, { force: true });
+    throw err;
+  }
+}
 
 /** How a plugin's dependencies should be installed, or `null` to skip. */
 interface ManifestInstallPlan {
@@ -191,13 +234,19 @@ function planManifestForInstall(pluginDir: string): ManifestInstallPlan | null {
  * daemon-provided shim is never resolved or shadowed and `package.json` ends
  * byte-for-byte as materialized.
  *
- * Fail-soft by design: a dependency-install failure (offline, an unresolvable
- * version, a registry outage) is logged and swallowed rather than aborting the
- * install. The plugin's code is already materialized; a plugin that then can't
- * resolve a missing dependency fails at load with a clear module-not-found the
- * user can act on by reinstalling once connectivity returns — strictly better
- * than throwing away a completed materialization over a transient network
- * error.
+ * Fail-soft by design for the *install* itself: a dependency-install failure
+ * (offline, an unresolvable version, a registry outage) is logged and swallowed
+ * rather than aborting the install. The plugin's code is already materialized; a
+ * plugin that then can't resolve a missing dependency fails at load with a clear
+ * module-not-found the user can act on by reinstalling once connectivity returns
+ * — strictly better than throwing away a completed materialization over a
+ * transient network error.
+ *
+ * Manifest integrity is *not* fail-soft. The stripped copy is written and
+ * restored atomically, so `package.json` is never a truncated/partial write. If
+ * the manifest cannot be restored to its original bytes afterward, this throws
+ * {@link PluginManifestRestoreError} so the caller aborts rather than swap in a
+ * plugin whose manifest is left shim-stripped.
  */
 export async function installPluginDependencies(
   pluginDir: string,
@@ -211,10 +260,11 @@ export async function installPluginDependencies(
   const pkgPath = join(pluginDir, "package.json");
   if (plan.installManifest !== null) {
     try {
-      writeFileSync(pkgPath, plan.installManifest);
+      writeFileAtomic(pkgPath, plan.installManifest);
     } catch (err) {
-      // Could not stage the plugin-api-stripped manifest — skip rather than run
-      // an install that would resolve (and shadow) the shim.
+      // The atomic stage failed, so package.json is untouched (still the
+      // original) — skip the install rather than resolve (and shadow) the shim.
+      // Nothing to restore.
       log.warn(
         { err, pluginDir },
         "could not stage manifest for plugin dependency install — skipping",
@@ -234,12 +284,12 @@ export async function installPluginDependencies(
   } finally {
     if (plan.installManifest !== null) {
       try {
-        writeFileSync(pkgPath, plan.originalManifest);
+        writeFileAtomic(pkgPath, plan.originalManifest);
       } catch (err) {
-        log.error(
-          { err, pluginDir },
-          "failed to restore plugin manifest after dependency install — package.json may be left with the plugin-api peer stripped",
-        );
+        // The manifest is left with the plugin-api peer stripped (a complete
+        // file — the write is atomic — but not the materialized bytes). Abort
+        // finalization rather than swap a shim-stripped plugin into place.
+        throw new PluginManifestRestoreError(pluginDir, err);
       }
     }
   }


### PR DESCRIPTION
## Prompt / plan

Follow-up to the P2 review comment on #38453 (merged).

> If `writeFileSync` fails after truncating `package.json` (e.g. ENOSPC or an I/O error during the write), this catch returns without restoring `plan.originalManifest`. `finalizeStagedInstall` treats the dependency install as fail-soft and continues to fingerprint and swap that staging directory, so the user can receive an installed plugin with a truncated or shim-stripped manifest that the loader rejects or loads without its compatibility declaration. Use an atomic temporary-file replacement or attempt restoration in this error path and prevent finalization if restoration fails.

Correct — two gaps in the strip/restore that guards the `@vellumai/plugin-api` peer:

### 1. `package.json` could be truncated

`writeFileSync` truncates before writing, so a failure mid-write could leave a partial `package.json`. Both the stripped-copy write and the restore now go through an **atomic temp-file + rename** (`writeFileAtomic`), so `package.json` is only ever the complete old bytes or the complete new bytes — never a partial write. The temp file shares the target's directory (same filesystem → atomic rename) and is cleaned up if the write throws.

### 2. A failed restore still finalized a shim-stripped plugin

Previously a restore failure logged and returned, and `finalizeStagedInstall` went on to fingerprint and swap in a plugin whose manifest was left shim-stripped (the loader would load it without its host-compat claim; drift/merge baselines would mismatch on `package.json`).

Manifest integrity is now **non-fail-soft**: a restore failure throws `PluginManifestRestoreError`, and `finalizeStagedInstall` drops the staging dir and aborts rather than swap a shim-stripped plugin into place. The install target is left untouched.

The dependency *install* itself stays fail-soft (a network/resolution failure still leaves the plugin installed, just without its deps — a clear module-not-found at load, retryable with `--force`). And a **staging** failure needs no restore — the atomic stage leaves `package.json` untouched — so that path still skips the install fail-soft.

## Test plan

- `install-plugin-dependencies` (14): leaves no temp file after a strip/restore cycle; throws `PluginManifestRestoreError` when the manifest can't be restored (simulated by the dir vanishing mid-install); plus the existing strip-only-plugin-api / restore-on-install-failure / non-host-peer coverage.
- Regression suites green individually: `install-from-github` (41), `upgrade-plugin` (24), `install-from-platform` (15), `diff-plugin` (9), `inspect-plugin` (15), `plugin-fingerprint` (18), `source-fingerprint` (6).
- End-to-end with the real installer (deps + `{ @vellumai/plugin-api, is-even }` peers): non-host peer installed, no `@vellumai/*` shadow, `package.json` restored byte-for-byte, no leftover `.tmp`.
- `bunx tsc --noEmit`, `eslint`, `prettier` clean (pre-commit hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxCZhuSCqMLfu48or8NCJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxCZhuSCqMLfu48or8NCJv)_