### PR TITLE
fix(streaming): make the daemon the sole SSE seq authority — workers stop stamping

### DIFF
--- a/assistant/src/__tests__/assistant-stream-state.test.ts
+++ b/assistant/src/__tests__/assistant-stream-state.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
@@ -11,6 +17,7 @@ import {
   _peekStreamForTesting,
   _resetStreamStateForTesting,
   _simulateRestartForTesting,
+  disableStreamSeqStamping,
   floorSeqAbove,
   getCurrentSeq,
   getReplayWindow,
@@ -789,6 +796,50 @@ describe("assistant-stream-state", () => {
         join(process.env.VELLUM_WORKSPACE_DIR!, "data", "stream-seq.json"),
         { force: true },
       );
+      _simulateRestartForTesting();
+      const a = mkEvent();
+      stampAndBuffer(a);
+      expect(a.seq).toBe(1);
+    });
+  });
+
+  describe("disableStreamSeqStamping", () => {
+    const reservationPath = () =>
+      join(process.env.VELLUM_WORKSPACE_DIR!, "data", "stream-seq.json");
+
+    test("stamping is a complete no-op in a disabled process", () => {
+      disableStreamSeqStamping();
+      const a = mkEvent();
+      stampAndBuffer(a);
+      expect(a.seq).toBeUndefined();
+      expect(_peekStreamForTesting().ringLength).toBe(0);
+      expect(existsSync(reservationPath())).toBe(false);
+    });
+
+    test("getCurrentSeq reports no honest position in a disabled process", () => {
+      // A reservation exists on disk from an authoritative process; a
+      // disabled process must not adopt it as a reportable position.
+      stampAndBuffer(mkEvent());
+      disableStreamSeqStamping();
+      expect(getCurrentSeq()).toBe(0);
+    });
+
+    test("floorSeqAbove leaves the reservation file untouched in a disabled process", () => {
+      disableStreamSeqStamping();
+      floorSeqAbove(5_000);
+      expect(existsSync(reservationPath())).toBe(false);
+    });
+
+    test("_resetStreamStateForTesting restores stamping", () => {
+      disableStreamSeqStamping();
+      _resetStreamStateForTesting();
+      const a = mkEvent();
+      stampAndBuffer(a);
+      expect(a.seq).toBe(1);
+    });
+
+    test("_simulateRestartForTesting restores stamping (a fresh process defaults authoritative)", () => {
+      disableStreamSeqStamping();
       _simulateRestartForTesting();
       const a = mkEvent();
       stampAndBuffer(a);

--- a/assistant/src/__tests__/worker-seq-stamping-guard.test.ts
+++ b/assistant/src/__tests__/worker-seq-stamping-guard.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { Glob } from "bun";
+
+/**
+ * Guard: every sidecar worker-process entrypoint must disable SSE seq
+ * stamping at bootstrap. The daemon is the sole seq authority — a worker
+ * that stamps issues seqs from its own counter (overlapping the daemon's
+ * range, so clients seq-dedupe real events into drops) and races the
+ * daemon's writes to the shared reservation file
+ * (`data/stream-seq.json`).
+ *
+ * Worker entrypoints are the `worker.ts` files under `src/` that run as
+ * their own OS processes. `src/cli/**` is excluded: files there are CLI
+ * subcommands (IPC wrappers around worker lifecycle), not process
+ * entrypoints.
+ */
+
+const DISABLE_CALL = "disableStreamSeqStamping()";
+
+function findWorkerEntrypoints(): string[] {
+  const srcRoot = join(process.cwd(), "src");
+  const glob = new Glob("**/worker.ts");
+  const files: string[] = [];
+  for (const match of glob.scanSync({ cwd: srcRoot })) {
+    if (match.includes("__tests__") || match.startsWith("cli/")) {
+      continue;
+    }
+    files.push(match);
+  }
+  return files.sort();
+}
+
+describe("worker seq-stamping guard", () => {
+  test("finds the known worker entrypoints", () => {
+    // If this shrinks, the glob broke — not the workers.
+    expect(findWorkerEntrypoints().length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("every worker entrypoint disables seq stamping at bootstrap", () => {
+    const missing = findWorkerEntrypoints().filter((file) => {
+      const source = readFileSync(join(process.cwd(), "src", file), "utf8");
+      return !source.includes(DISABLE_CALL);
+    });
+    expect(
+      missing,
+      `Worker entrypoints must call ${DISABLE_CALL} before any event can ` +
+        "be published — the daemon is the sole SSE seq authority.",
+    ).toEqual([]);
+  });
+});

--- a/assistant/src/monitoring/worker.ts
+++ b/assistant/src/monitoring/worker.ts
@@ -17,6 +17,7 @@ import { getConfig } from "../config/loader.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
 import { resetDb } from "../persistence/db-connection.js";
 import { startConsentRefresh } from "../platform/consent-cache.js";
+import { disableStreamSeqStamping } from "../runtime/assistant-stream-state.js";
 import {
   startConfigSnapshotReporter,
   stopConfigSnapshotReporter,
@@ -54,6 +55,8 @@ function cleanupPidFile(): void {
 }
 
 async function main(): Promise<void> {
+  // Only the daemon stamps SSE seqs and writes the shared reservation file.
+  disableStreamSeqStamping();
   const config = getConfig();
   const pidPath = getMonitoringPidPath();
 

--- a/assistant/src/plugins/defaults/memory/worker.ts
+++ b/assistant/src/plugins/defaults/memory/worker.ts
@@ -15,6 +15,7 @@ import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { getConfig } from "../../../config/loader.js";
 import { rehydratePlatformCredentials } from "../../../config/platform-rehydration.js";
 import { resetDb } from "../../../persistence/db-connection.js";
+import { disableStreamSeqStamping } from "../../../runtime/assistant-stream-state.js";
 import { initializeTools } from "../../../tools/registry.js";
 import { registerMemoryPluginJobHandlers } from "./job-handler-registration.js";
 import { startMemoryJobsWorkerLoop } from "./jobs-worker.js";
@@ -35,6 +36,8 @@ function cleanupPidFile(): void {
 }
 
 async function main(): Promise<void> {
+  // Only the daemon stamps SSE seqs and writes the shared reservation file.
+  disableStreamSeqStamping();
   const config = getConfig();
   const pidPath = getMemoryWorkerPidPath();
 

--- a/assistant/src/runtime/assistant-stream-state.ts
+++ b/assistant/src/runtime/assistant-stream-state.ts
@@ -160,12 +160,39 @@ const state: AssistantStreamState = {
   totalSizeBytes: 0,
 };
 
+/**
+ * Whether seq stamping is disabled in this process. The daemon is the
+ * sole seq authority: sidecar worker processes run their own instance of
+ * this module but share the workspace reservation file, so a worker that
+ * stamped would issue seqs from its own counter — overlapping the
+ * daemon's range (two different events carrying the same seq, which
+ * clients seq-dedupe into dropped real events) — and race the daemon's
+ * reservation writes. Worker-side hub publishes reach no SSE subscribers
+ * (those live in the daemon), so an unstamped event loses nothing.
+ */
+let stampingDisabled = false;
+
 // ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Mark this process as a non-authoritative seq bystander: stamping, ring
+ * buffering, reservation loads/writes, and {@link getCurrentSeq}
+ * snapshots all become inert. Worker-process entrypoints call this once
+ * at bootstrap, before any event can be published (enforced by
+ * `worker-seq-stamping-guard.test.ts`). `getCurrentSeq` then reports
+ * `0`, which persistence already treats as "no honest position"
+ * (`recordConversationPersistedSeq` ignores it; conversation creation
+ * stores it as NULL).
+ */
+export function disableStreamSeqStamping(): void {
+  stampingDisabled = true;
+}
 
 /**
  * Assign a monotonic global `seq` to a conversation-scoped event and push
  * it onto the ring buffer. No-op when `event.conversationId` is absent
- * (unscoped broadcasts are never replayable).
+ * (unscoped broadcasts are never replayable) and in processes where
+ * stamping is disabled ({@link disableStreamSeqStamping}).
  *
  * When `options.targeting` is provided, the metadata is stored on the
  * ring entry so that {@link getReplayWindow} can re-apply the same
@@ -179,6 +206,9 @@ export function stampAndBuffer(
   event: AssistantEvent,
   options?: { targeting?: EventTargeting },
 ): void {
+  if (stampingDisabled) {
+    return;
+  }
   if (event.conversationId == null) {
     return;
   }
@@ -292,6 +322,9 @@ export function getReplayWindow(
  * returning and this read on the single-threaded event loop.
  */
 export function getCurrentSeq(): number {
+  if (stampingDisabled) {
+    return 0;
+  }
   loadSeqReservation();
   return state.nextSeq - 1;
 }
@@ -313,6 +346,9 @@ export function getCurrentSeq(): number {
  * no-op.
  */
 export function floorSeqAbove(highestIssuedSeq: number): void {
+  if (stampingDisabled) {
+    return;
+  }
   loadSeqReservation();
   if (!Number.isFinite(highestIssuedSeq) || highestIssuedSeq < state.nextSeq) {
     return;
@@ -325,6 +361,7 @@ export function floorSeqAbove(highestIssuedSeq: number): void {
  * Reset all stream state. Test-only.
  */
 export function _resetStreamStateForTesting(): void {
+  stampingDisabled = false;
   state.nextSeq = 1;
   // Mark the reservation as loaded with no ceiling AND remove any
   // reservation file a previous test wrote into the (per-process temp)
@@ -343,6 +380,7 @@ export function _resetStreamStateForTesting(): void {
  * next stamp to reload the persisted seq reservation. Test-only.
  */
 export function _simulateRestartForTesting(): void {
+  stampingDisabled = false;
   state.nextSeq = 1;
   state.reservedSeqCeiling = 0;
   state.seqReservationLoaded = false;

--- a/assistant/src/schedule/worker.ts
+++ b/assistant/src/schedule/worker.ts
@@ -16,6 +16,7 @@ import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { getConfig } from "../config/loader.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
 import { resetDb } from "../persistence/db-connection.js";
+import { disableStreamSeqStamping } from "../runtime/assistant-stream-state.js";
 import { initializeTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
 import { getScheduleWorkerPidPath } from "../util/platform.js";
@@ -38,6 +39,8 @@ function cleanupPidFile(): void {
 }
 
 async function main(): Promise<void> {
+  // Only the daemon stamps SSE seqs and writes the shared reservation file.
+  disableStreamSeqStamping();
   // Load config up front so a broken config fails the spawn (before the PID
   // file is written) instead of surfacing on the first tick.
   getConfig();


### PR DESCRIPTION
## Summary
- `disableStreamSeqStamping()` in `assistant-stream-state.ts` marks a process as a seq bystander: `stampAndBuffer` becomes a complete no-op (no seq assignment, no ring append, no reservation load/write), `getCurrentSeq()` reports 0 (which persistence already treats as "no honest position" — `recordConversationPersistedSeq` ignores it and conversation creation stores NULL), and `floorSeqAbove` is inert. The daemon never calls it, so daemon behavior is unchanged; the three sidecar worker entrypoints (schedule, monitoring, memory) call it first thing in `main()`. Shipped as opt-out rather than the initially sketched opt-in-authority default-off flag: default-off would also inert every bun-test process, and the test preload must not import `src/` — an explicit worker-side disable plus a guard test achieves the same invariant without touching every events test.
- New guard test `worker-seq-stamping-guard.test.ts` sweeps `assistant/src/**/worker.ts` (excluding `cli/`, which holds IPC-wrapper subcommands, not process entrypoints) and fails if any worker entrypoint omits the call, so future workers cannot silently become stampers.
- Composes with #38483: raise-only reservation writes and the startup floor stop the shared file from regressing, but two processes stamping still issue overlapping seq ranges — two different events carrying the same seq, which clients seq-dedupe into dropped real events. Worker-side hub publishes also reach zero SSE subscribers (the hub with real clients lives in the daemon), so worker stamping was pure downside. Worker-side `broadcastMessage` call sites are left in place (now harmless delivery-wise); routing them through IPC is separate work.

## Original prompt
Companion fix to #38483 from the same root-caused incident: an orphaned schedule worker — a separate bun process with its own instance of the stream-state module sharing `data/stream-seq.json` — stamped events via `runDueSchedulesOnce → broadcastMessage` and rewrote the reservation file from its stale counter, regressing it ~2,500 seqs. After a daemon restart the counter resumed inside the already-served range and clients dropped all live SSE events as replays ("replies pop in at the end", surviving app restarts). #38483 covers the file-regression half; this PR was requested to make the daemon the sole SSE seq authority so multi-process stamping cannot produce duplicate seqs at all.