### PR TITLE
fix(tests): unbreak main CI — baseline worker stream-state import, deflake VAD waitFor

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -189,6 +189,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../prompts/template-detection.js",
     "../../../runtime/actor-trust-resolver.js",
     "../../../runtime/agent-wake.js",
+    "../../../runtime/assistant-stream-state.js",
     "../../../runtime/background-job-runner.js",
     "../../../runtime/capabilities.js",
     "../../../runtime/services/auto-analysis-guard.js",

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -275,7 +275,11 @@ async function waitFor(
   predicate: () => boolean,
   message = "Timed out waiting for live voice VAD test condition",
 ): Promise<void> {
-  for (let attempt = 0; attempt < 80; attempt += 1) {
+  // 5ms timers stretch under CI load, so the budget is wall-clock rather
+  // than a poll count. 4s stays under bun's 5s per-test timeout so this
+  // message, not bun's, reports a failure.
+  const deadline = Date.now() + 4_000;
+  while (Date.now() < deadline) {
     if (predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 5));
   }


### PR DESCRIPTION
## Summary
- Add `../../../runtime/assistant-stream-state.js` to the memory plugin's entry in the import-boundary baseline: the worker entrypoint's `disableStreamSeqStamping()` call from #38486 is an intentional host coupling (required by `worker-seq-stamping-guard.test.ts` — the daemon is the sole SSE seq authority), with no `@vellumai/plugin-api` equivalent.
- Deflake `live-voice-vad.test.ts`: `waitFor` polled 80×5ms (~400ms of sleeps), which bounds almost no real time on a loaded CI runner — the failing run's test spent 890ms before timing out. It now polls against a 4s wall-clock deadline, kept under bun's 5s per-test timeout so the descriptive message still reports failures. The sibling copies of this helper in `live-voice-integration` / `live-voice-triage-escalate` didn't fail in this job and are left untouched.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29642246793/job/88074561062 — the `CI Main Assistant Checks / Test` job that went red on main after #38486 landed, with two failing test files (`plugin-import-boundary-guard.test.ts` and `live-voice-vad.test.ts`).