### PR TITLE
feat(chat): retry button on the latest assistant turn

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7459,6 +7459,55 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/conversations/{id}/retry:
+    post:
+      operationId: conversations_by_id_retry_post
+      summary: Retry the last assistant turn
+      description:
+        Permanently discard the most recent assistant display turn (the assistant rows and tool-result rows after
+        the last turn-starting user message), keep that user message, and re-run generation from it. Accepted
+        immediately; the regenerated turn streams over SSE like a normal send.
+      tags:
+        - conversations
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                    const: true
+                  conversationId:
+                    type: string
+                  userMessageId:
+                    type: string
+                    description: The user message the turn is re-running from
+                  discardedCount:
+                    type: integer
+                    minimum: -9007199254740991
+                    maximum: 9007199254740991
+                    description: Number of message rows discarded from the tail
+                required:
+                  - accepted
+                  - conversationId
+                  - userMessageId
+                  - discardedCount
+                additionalProperties: false
+        "404":
+          description: Conversation not found
+        "409":
+          description: The assistant is currently responding
+        "422":
+          description: No user message exists to retry from
   /v1/conversations/{id}/slash:
     post:
       operationId: conversations_by_id_slash_post
@@ -12125,8 +12174,11 @@ paths:
                     properties:
                       memoryOptOut:
                         type: boolean
+                      retryLastTurn:
+                        type: boolean
                     required:
                       - memoryOptOut
+                      - retryLastTurn
                     additionalProperties: false
                   profiler:
                     type: object
@@ -12324,8 +12376,11 @@ paths:
                     properties:
                       memoryOptOut:
                         type: boolean
+                      retryLastTurn:
+                        type: boolean
                     required:
                       - memoryOptOut
+                      - retryLastTurn
                     additionalProperties: false
                   profiler:
                     type: object

--- a/assistant/src/__tests__/conversation-retry-discard.test.ts
+++ b/assistant/src/__tests__/conversation-retry-discard.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for `discardLastAssistantDisplayTurn` and `extractUserPromptText` —
+ * the retry endpoint's truncation primitives. DB-backed: exercises the real
+ * message CRUD (deleteMessageById cascade, metadata merge) against the test
+ * database rather than mocking persistence.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  discardLastAssistantDisplayTurn,
+  extractUserPromptText,
+} from "../daemon/conversation-history.js";
+import { addMessage, getMessages } from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { conversations, messages } from "../persistence/schema/index.js";
+
+await initializeDb();
+
+const CONV_ID = "conv-retry-discard-test";
+
+function seedConversation(): void {
+  const now = Date.now();
+  getDb()
+    .insert(conversations)
+    .values({
+      id: CONV_ID,
+      title: "Retry discard test",
+      createdAt: now,
+      updatedAt: now,
+      source: "test",
+      conversationType: "standard",
+    })
+    .run();
+}
+
+function clearAll(): void {
+  getDb().delete(messages).run();
+  getDb().delete(conversations).run();
+}
+
+const text = (t: string) => JSON.stringify([{ type: "text", text: t }]);
+const toolUse = (t: string) =>
+  JSON.stringify([
+    { type: "text", text: t },
+    { type: "tool_use", id: "tool-1", name: "web_search", input: {} },
+  ]);
+const toolResultOnly = () =>
+  JSON.stringify([
+    { type: "tool_result", tool_use_id: "tool-1", content: "result" },
+  ]);
+
+async function seed(
+  rows: Array<{
+    role: "user" | "assistant";
+    content: string;
+    metadata?: Record<string, unknown>;
+  }>,
+): Promise<string[]> {
+  const ids: string[] = [];
+  for (const row of rows) {
+    const inserted = await addMessage(CONV_ID, row.role, row.content, {
+      metadata: row.metadata,
+    });
+    ids.push(inserted.id);
+  }
+  return ids;
+}
+
+beforeEach(() => {
+  clearAll();
+  seedConversation();
+});
+
+describe("discardLastAssistantDisplayTurn", () => {
+  test("deletes the assistant reply, keeps the user anchor", async () => {
+    const [userId, assistantId] = await seed([
+      { role: "user", content: text("hello") },
+      { role: "assistant", content: text("Processing failed: boom") },
+    ]);
+
+    const result = discardLastAssistantDisplayTurn(CONV_ID);
+
+    expect(result).not.toBeNull();
+    expect(result!.anchor.id).toBe(userId);
+    expect(result!.deletedMessageIds).toEqual([assistantId]);
+    expect(getMessages(CONV_ID).map((m) => m.id)).toEqual([userId]);
+  });
+
+  test("deletes a multi-row display turn (assistant, tool_result, assistant)", async () => {
+    const [userId, a1, tr, a2] = await seed([
+      { role: "user", content: text("look this up") },
+      { role: "assistant", content: toolUse("searching…") },
+      { role: "user", content: toolResultOnly() },
+      { role: "assistant", content: text("found it") },
+    ]);
+
+    const result = discardLastAssistantDisplayTurn(CONV_ID);
+
+    expect(result!.anchor.id).toBe(userId);
+    // Newest-first: an interrupted run leaves a well-formed shorter tail.
+    expect(result!.deletedMessageIds).toEqual([a2, tr, a1]);
+    expect(getMessages(CONV_ID).map((m) => m.id)).toEqual([userId]);
+  });
+
+  test("never anchors on a tool-result-only user row", async () => {
+    const [userId, a1, tr] = await seed([
+      { role: "user", content: text("run the tool") },
+      { role: "assistant", content: toolUse("running…") },
+      { role: "user", content: toolResultOnly() },
+    ]);
+
+    const result = discardLastAssistantDisplayTurn(CONV_ID);
+
+    expect(result!.anchor.id).toBe(userId);
+    expect(result!.deletedMessageIds).toEqual([tr, a1]);
+  });
+
+  test("a hidden machine-signal user row is a valid anchor", async () => {
+    const [, , wakeId, replyId] = await seed([
+      { role: "user", content: text("earlier prompt") },
+      { role: "assistant", content: text("earlier reply") },
+      {
+        role: "user",
+        content: text(
+          '<background_event source="schedule">tick</background_event>',
+        ),
+        metadata: { backgroundEventSource: "schedule" },
+      },
+      { role: "assistant", content: text("Processing failed: boom") },
+    ]);
+
+    const result = discardLastAssistantDisplayTurn(CONV_ID);
+
+    expect(result!.anchor.id).toBe(wakeId);
+    expect(result!.deletedMessageIds).toEqual([replyId]);
+    expect(getMessages(CONV_ID)).toHaveLength(3);
+  });
+
+  test("earlier turns are untouched", async () => {
+    const [u1, a1, u2, a2] = await seed([
+      { role: "user", content: text("first question") },
+      { role: "assistant", content: text("first answer") },
+      { role: "user", content: text("second question") },
+      { role: "assistant", content: text("second answer") },
+    ]);
+
+    const result = discardLastAssistantDisplayTurn(CONV_ID);
+
+    expect(result!.anchor.id).toBe(u2);
+    expect(result!.deletedMessageIds).toEqual([a2]);
+    expect(getMessages(CONV_ID).map((m) => m.id)).toEqual([u1, a1, u2]);
+  });
+
+  test("no turn-starting user row → null, nothing deleted", async () => {
+    const [assistantId] = await seed([
+      { role: "assistant", content: text("orphan assistant row") },
+    ]);
+
+    expect(discardLastAssistantDisplayTurn(CONV_ID)).toBeNull();
+    expect(getMessages(CONV_ID).map((m) => m.id)).toEqual([assistantId]);
+  });
+
+  test("empty tail → anchor returned with no deletions", async () => {
+    const [userId] = await seed([
+      { role: "user", content: text("no reply yet") },
+    ]);
+
+    const result = discardLastAssistantDisplayTurn(CONV_ID);
+
+    expect(result!.anchor.id).toBe(userId);
+    expect(result!.deletedMessageIds).toEqual([]);
+    expect(getMessages(CONV_ID).map((m) => m.id)).toEqual([userId]);
+  });
+
+  test("clears the anchor's turnOutcome failure stamp", async () => {
+    const [userId] = await seed([
+      {
+        role: "user",
+        content: text("doomed prompt"),
+        metadata: { turnOutcome: "failed", turnFailureCode: "PROVIDER_ERROR" },
+      },
+      { role: "assistant", content: text("Processing failed: boom") },
+    ]);
+
+    discardLastAssistantDisplayTurn(CONV_ID);
+
+    const anchor = getMessages(CONV_ID).find((m) => m.id === userId)!;
+    const metadata = JSON.parse(anchor.metadata!) as Record<string, unknown>;
+    expect(metadata.turnOutcome).toBeNull();
+    expect(metadata.turnFailureCode).toBeNull();
+  });
+});
+
+describe("extractUserPromptText", () => {
+  test("joins text blocks and skips system_notice and non-text blocks", () => {
+    expect(
+      extractUserPromptText([
+        { type: "text", text: "line one" },
+        {
+          type: "text",
+          text: "<system_notice>internal nudge</system_notice>",
+        },
+        { type: "tool_result", tool_use_id: "t1", content: "ignored" },
+        { type: "text", text: "line two" },
+      ] as never),
+    ).toBe("line one\nline two");
+  });
+
+  test("empty content → empty string", () => {
+    expect(extractUserPromptText([])).toBe("");
+  });
+});

--- a/assistant/src/__tests__/conversation-retry-route.test.ts
+++ b/assistant/src/__tests__/conversation-retry-route.test.ts
@@ -1,0 +1,451 @@
+/**
+ * Tests for POST /v1/conversations/:id/retry ("retry last assistant turn").
+ *
+ * Validates that:
+ * - The route 202s immediately after synchronously claiming processing and
+ *   discarding the tail, then re-runs the agent loop against the anchor
+ *   user message (no new user row).
+ * - Busy conversations are rejected with 409 without touching processing.
+ * - A conversation with no turn-starting user row 422s and unwinds the claim.
+ * - The messages-changed sync invalidation is published (origin-less) only
+ *   when rows were actually discarded.
+ * - Hidden machine-signal anchors re-run as hidden prompts.
+ * - A loop failure broadcasts a retryable conversation_error and clears
+ *   processing.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { z } from "zod";
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+mock.module("../daemon/conversation-process.js", () => ({
+  formatSummarizeUpToResult: () => "",
+  isEchoSuppressedUserMessage: (
+    metadata: Record<string, unknown> | undefined,
+  ) =>
+    metadata?.hidden === true ||
+    typeof metadata?.backgroundEventSource === "string",
+}));
+
+mock.module("../daemon/handlers/conversations.js", () => ({
+  cancelGeneration: () => true,
+  clearAllConversations: async () => 0,
+  resolveMetaSlashCommand: async () => null,
+  switchConversation: async () => null,
+  undoLastMessage: async () => null,
+}));
+
+const touchConversationMock = mock((_conversationId: string) => {});
+mock.module("../daemon/conversation-evictor.js", () => ({
+  touchConversation: touchConversationMock,
+}));
+
+// Each test configures the primitive's result here.
+let discardResult: {
+  anchor: MessageRowLike;
+  deletedMessageIds: string[];
+} | null = null;
+const discardMock = mock((_conversationId: string) => discardResult);
+mock.module("../daemon/conversation-history.js", () => ({
+  discardLastAssistantDisplayTurn: discardMock,
+  extractUserPromptText: (content: Array<{ text?: string }>) =>
+    content.map((b) => b.text ?? "").join("\n"),
+}));
+
+interface MessageRowLike {
+  id: string;
+  content: Array<{ type: string; text?: string }>;
+  metadata: string | null;
+}
+
+const getConversationMock = mock((id: string) =>
+  id === "conv-retry-test" ? { id } : null,
+);
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  addMessage: async () => ({ id: "unused", deduplicated: false }),
+  archiveConversation: () => true,
+  batchSetDisplayOrders: () => {},
+  countConversationsByScheduleJobId: () => 0,
+  deleteConversation: () => ({ segmentIds: [], deletedSummaryIds: [] }),
+  extractImageSourcePaths: () => undefined,
+  forkConversation: () => ({ id: "forked" }),
+  getConversation: getConversationMock,
+  provenanceFromTrustContext: () => ({ provenanceTrustClass: "unknown" }),
+  setConversationSurfaced: () => null,
+  unarchiveConversation: () => true,
+  updateConversationTitle: () => {},
+  wipeConversation: () => ({
+    segmentIds: [],
+    deletedSummaryIds: [],
+    cancelledJobCount: 0,
+  }),
+}));
+
+mock.module("../persistence/conversation-key-store.js", () => ({
+  getOrCreateConversation: () => ({
+    conversationId: "conv-retry-test",
+    created: false,
+  }),
+  resolveConversationId: (id: string) => id,
+  setConversationKeyIfAbsent: () => {},
+}));
+
+mock.module("../persistence/jobs-store.js", () => ({
+  enqueueMemoryJob: () => {},
+}));
+
+mock.module("../persistence/llm-request-log-store.js", () => ({
+  linkRequestLogsToMessage: () => {},
+}));
+
+mock.module("../schedule/schedule-store.js", () => ({
+  deleteSchedule: async () => {},
+}));
+
+mock.module("../home/feed-writer.js", () => ({
+  stripConversationIds: async () => {},
+}));
+
+const broadcastEvents: Array<Record<string, unknown>> = [];
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: Record<string, unknown>) => {
+    broadcastEvents.push(msg);
+  },
+}));
+
+mock.module("../runtime/services/conversation-serializer.js", () => ({
+  buildConversationDetailResponse: () => null,
+}));
+
+const publishConversationMessagesChangedMock = mock(
+  (_conversationId: string, _originClientId?: string) => {},
+);
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationListAndMetadataChanged: () => {},
+  publishConversationListChanged: () => {},
+  publishConversationMessagesChanged: publishConversationMessagesChangedMock,
+  publishConversationTitleChanged: () => {},
+}));
+
+mock.module("../runtime/routes/inference-profile-session-handler.js", () => ({
+  setInferenceProfileSession: async () => ({}),
+}));
+
+mock.module("../runtime/routes/conversation-list-routes.js", () => ({
+  conversationSummarySchema: z.object({}),
+}));
+
+const trustContext = { trustClass: "guardian" };
+const resolveTrustMock = mock(async (_principalId?: string) => trustContext);
+mock.module("../runtime/routes/vellum-actor-trust.js", () => ({
+  resolveVellumActorTrustContext: resolveTrustMock,
+}));
+
+const resolveActorMock = mock(async (_principalId?: string) => "actor-123");
+mock.module("../runtime/local-actor-identity.js", () => ({
+  resolveActorPrincipalIdForLocalGuardian: resolveActorMock,
+}));
+
+// Each test installs its fake conversation here for the store mock to serve.
+let activeConversation: ReturnType<typeof makeConversation>["conversation"];
+mock.module("../daemon/conversation-store.js", () => ({
+  destroyActiveConversation: () => {},
+  getOrCreateConversation: async () => activeConversation,
+}));
+
+import { ROUTES } from "../runtime/routes/conversation-management-routes.js";
+import { callHandler } from "./helpers/call-route-handler.js";
+
+const retryRoute = ROUTES.find(
+  (r) => r.operationId === "retryLastAssistantTurn",
+)!;
+const retryHandler = async (args: Parameters<typeof retryRoute.handler>[0]) =>
+  retryRoute.handler(args);
+
+function makeConversation(opts: { processing?: boolean } = {}) {
+  let processing = opts.processing ?? false;
+  const setProcessing = mock((value: boolean) => {
+    processing = value;
+  });
+  const setTrustContext = mock((_ctx: unknown) => {});
+  const loadFromDb = mock(async () => ({ rows: [], rowToHistoryIndex: [] }));
+  const runAgentLoop = mock(
+    async (
+      _content: string,
+      _userMessageId: string,
+      _options?: Record<string, unknown>,
+    ) => {},
+  );
+  const emitActivityState = mock(
+    (_phase: string, _reason: string, _options?: unknown) => {},
+  );
+  const conversation = {
+    conversationId: "conv-retry-test",
+    trustContext: undefined,
+    currentRequestId: undefined as string | undefined,
+    currentTurnSourceActorPrincipalId: undefined as string | undefined,
+    abortController: null as AbortController | null,
+    isProcessing: () => processing,
+    setProcessing,
+    setTrustContext,
+    loadFromDb,
+    runAgentLoop,
+    emitActivityState,
+  };
+  return {
+    conversation,
+    setProcessing,
+    setTrustContext,
+    loadFromDb,
+    runAgentLoop,
+    emitActivityState,
+  };
+}
+
+function makeRequest(
+  conversationId = "conv-retry-test",
+  extraHeaders: Record<string, string> = {},
+) {
+  return new Request(
+    `http://localhost/v1/conversations/${conversationId}/retry`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...extraHeaders },
+    },
+  );
+}
+
+function anchorRow(overrides: Partial<MessageRowLike> = {}): MessageRowLike {
+  return {
+    id: "user-msg-1",
+    content: [{ type: "text", text: "the original prompt" }],
+    metadata: null,
+    ...overrides,
+  };
+}
+
+/** Flush the fire-and-forget async block (macrotask + queued microtasks). */
+async function settle() {
+  for (let i = 0; i < 3; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+beforeEach(() => {
+  getConversationMock.mockClear();
+  discardMock.mockClear();
+  publishConversationMessagesChangedMock.mockClear();
+  resolveTrustMock.mockClear();
+  resolveActorMock.mockClear();
+  touchConversationMock.mockClear();
+  broadcastEvents.length = 0;
+  discardResult = {
+    anchor: anchorRow(),
+    deletedMessageIds: ["assistant-msg-1"],
+  };
+});
+
+describe("POST /v1/conversations/:id/retry", () => {
+  test("202s, discards the tail, and re-runs the loop from the anchor", async () => {
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest("conv-retry-test", {
+        "X-Vellum-Actor-Principal-Id": "principal-1",
+      }),
+      { id: "conv-retry-test" },
+      202,
+    );
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({
+      accepted: true,
+      conversationId: "conv-retry-test",
+      userMessageId: "user-msg-1",
+      discardedCount: 1,
+    });
+
+    // Trust is bound from the requesting actor before the turn.
+    expect(resolveTrustMock).toHaveBeenCalledWith("principal-1", {
+      healResetDrift: true,
+    });
+    expect(ctx.setTrustContext).toHaveBeenCalledWith(trustContext);
+    expect(ctx.conversation.currentTurnSourceActorPrincipalId).toBe(
+      "actor-123",
+    );
+
+    // The claim landed before the discard and stays held for the loop.
+    expect(ctx.setProcessing).toHaveBeenCalledWith(true);
+    expect(ctx.conversation.isProcessing()).toBe(true);
+    expect(ctx.conversation.abortController).not.toBeNull();
+    expect(discardMock).toHaveBeenCalledWith("conv-retry-test");
+
+    // Origin-less invalidation: the initiating client reconciles too.
+    expect(publishConversationMessagesChangedMock).toHaveBeenCalledTimes(1);
+    expect(publishConversationMessagesChangedMock.mock.calls[0]).toEqual([
+      "conv-retry-test",
+    ]);
+
+    await settle();
+
+    // In-memory history resyncs to the truncated DB state before the loop.
+    expect(ctx.loadFromDb).toHaveBeenCalledTimes(1);
+    expect(ctx.emitActivityState).toHaveBeenCalledWith(
+      "thinking",
+      "message_dequeued",
+      expect.objectContaining({ requestId: expect.any(String) }),
+    );
+    expect(ctx.runAgentLoop).toHaveBeenCalledTimes(1);
+    const [content, userMessageId, options] = ctx.runAgentLoop.mock.calls[0];
+    expect(content).toBe("the original prompt");
+    expect(userMessageId).toBe("user-msg-1");
+    expect(options).toMatchObject({
+      isUserMessage: true,
+      isInteractive: true,
+    });
+    expect(options).not.toHaveProperty("isHiddenPrompt");
+    expect(typeof (options as { onEvent?: unknown }).onEvent).toBe("function");
+  });
+
+  test("hidden machine-signal anchor re-runs as a hidden prompt", async () => {
+    discardResult = {
+      anchor: anchorRow({
+        metadata: JSON.stringify({ backgroundEventSource: "schedule" }),
+      }),
+      deletedMessageIds: ["assistant-msg-1"],
+    };
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest(),
+      { id: "conv-retry-test" },
+      202,
+    );
+    expect(res.status).toBe(202);
+    await settle();
+
+    const [, , options] = ctx.runAgentLoop.mock.calls[0];
+    expect(options).toMatchObject({ isHiddenPrompt: true });
+  });
+
+  test("busy conversation → 409 without claiming processing", async () => {
+    const ctx = makeConversation({ processing: true });
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest(),
+      { id: "conv-retry-test" },
+      202,
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("currently responding");
+    expect(ctx.setProcessing).not.toHaveBeenCalled();
+    expect(discardMock).not.toHaveBeenCalled();
+  });
+
+  test("unknown conversation → 404 before any claim", async () => {
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest("conv-missing"),
+      { id: "conv-missing" },
+      202,
+    );
+
+    expect(res.status).toBe(404);
+    expect(ctx.setProcessing).not.toHaveBeenCalled();
+    expect(discardMock).not.toHaveBeenCalled();
+  });
+
+  test("no user message to retry from → 422 and the claim unwinds", async () => {
+    discardResult = null;
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest(),
+      { id: "conv-retry-test" },
+      202,
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("No user message to retry from");
+    // Claimed, then released: true followed by false, controller cleared.
+    expect(ctx.setProcessing.mock.calls.map((c) => c[0])).toEqual([
+      true,
+      false,
+    ]);
+    expect(ctx.conversation.isProcessing()).toBe(false);
+    expect(ctx.conversation.abortController).toBeNull();
+    expect(publishConversationMessagesChangedMock).not.toHaveBeenCalled();
+  });
+
+  test("empty tail → no invalidation published, loop still re-runs", async () => {
+    discardResult = { anchor: anchorRow(), deletedMessageIds: [] };
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest(),
+      { id: "conv-retry-test" },
+      202,
+    );
+
+    expect(res.status).toBe(202);
+    expect(
+      ((await res.json()) as { discardedCount: number }).discardedCount,
+    ).toBe(0);
+    expect(publishConversationMessagesChangedMock).not.toHaveBeenCalled();
+
+    await settle();
+    expect(ctx.runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+
+  test("loop failure → retryable conversation_error and processing cleared", async () => {
+    const ctx = makeConversation();
+    ctx.runAgentLoop.mockImplementationOnce(async () => {
+      throw new Error("provider exploded");
+    });
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest(),
+      { id: "conv-retry-test" },
+      202,
+    );
+    expect(res.status).toBe(202);
+
+    await settle();
+
+    const error = broadcastEvents.find((e) => e.type === "conversation_error");
+    expect(error).toBeDefined();
+    expect(error?.code).toBe("UNKNOWN");
+    expect(error?.retryable).toBe(true);
+    expect(String(error?.userMessage)).toContain("provider exploded");
+    expect(ctx.conversation.isProcessing()).toBe(false);
+    expect(ctx.conversation.abortController).toBeNull();
+    expect(ctx.emitActivityState).toHaveBeenLastCalledWith(
+      "idle",
+      "error_terminal",
+      expect.objectContaining({ requestId: expect.any(String) }),
+    );
+  });
+});

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -1,9 +1,11 @@
+import type { MessageRow } from "../persistence/conversation-crud.js";
 import {
   deleteLastExchange,
   deleteMessageById,
   getMessages,
   relinkAttachments,
   updateMessageContent,
+  updateMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { isLastUserMessageToolResult } from "../persistence/conversation-queries.js";
 import { withQdrantBreaker } from "../persistence/embeddings/qdrant-circuit-breaker.js";
@@ -14,6 +16,7 @@ import { relinkLlmRequestLogs } from "../persistence/llm-request-log-store.js";
 import { getSummaryFromContextMessage } from "../plugins/defaults/compaction/window-manager.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
+import { startsNewTurn } from "./summarize-boundary.js";
 
 const log = getLogger("conversation-history");
 
@@ -402,4 +405,92 @@ export function undo(conversation: HistoryConversationContext): number {
   }
 
   return removed;
+}
+
+// ── Retry ────────────────────────────────────────────────────────────
+
+export interface DiscardedAssistantTail {
+  /** The turn-starting user row the retry re-runs from. Never deleted. */
+  anchor: MessageRow;
+  /** Ids of the deleted tail rows, newest first. */
+  deletedMessageIds: string[];
+}
+
+/**
+ * Flatten a persisted user row's text blocks into the prompt string a re-run
+ * passes to the agent loop. Only feeds the prompt-submit hook (memory
+ * retrieval + title seed) — the LLM history comes from the persisted rows —
+ * so tool_result/attachment blocks are irrelevant and system_notice blocks
+ * (retry nudges, progress checks) are excluded like the undo path excludes
+ * them from user content.
+ */
+export function extractUserPromptText(content: ContentBlock[]): string {
+  return content
+    .filter((block) => block.type === "text" && !isSystemNoticeBlock(block))
+    .map((block) => (block as { text?: string }).text ?? "")
+    .join("\n")
+    .trim();
+}
+
+/**
+ * Delete the latest assistant display turn — every row after the last
+ * turn-starting user message (assistant rows plus tool-result-only user
+ * rows) — keeping the user row itself so the turn can be re-run from it.
+ *
+ * Returns null when the conversation has no turn-starting user row. Rows
+ * are deleted newest-first so an interrupted run leaves a well-formed
+ * shorter tail that a subsequent retry can finish. `deleteMessageById`
+ * owns the per-row cleanup (attachments, memory segments, lexical index,
+ * `lastMessageAt`); Qdrant vector deletion for the removed segments is
+ * fired asynchronously here. The anchor's `turnOutcome` failure stamp is
+ * cleared — it described the discarded turn.
+ */
+export function discardLastAssistantDisplayTurn(
+  conversationId: string,
+): DiscardedAssistantTail | null {
+  const rows = getMessages(conversationId);
+  let anchorIndex = -1;
+  for (let i = rows.length - 1; i >= 0; i--) {
+    if (startsNewTurn(rows[i])) {
+      anchorIndex = i;
+      break;
+    }
+  }
+  if (anchorIndex === -1) {
+    return null;
+  }
+
+  const tail = rows.slice(anchorIndex + 1);
+  const deletedMessageIds: string[] = [];
+  const segmentIds: string[] = [];
+  for (let i = tail.length - 1; i >= 0; i--) {
+    const deleted = deleteMessageById(tail[i].id);
+    deletedMessageIds.push(tail[i].id);
+    segmentIds.push(...deleted.segmentIds);
+  }
+
+  const anchor = rows[anchorIndex];
+  updateMessageMetadata(anchor.id, {
+    turnOutcome: null,
+    turnFailureCode: null,
+  });
+
+  if (segmentIds.length > 0) {
+    cleanupQdrantVectors(conversationId, segmentIds).catch((err) => {
+      log.warn(
+        { err, conversationId },
+        "Qdrant cleanup after retry discard failed (non-fatal)",
+      );
+    });
+  }
+
+  log.info(
+    {
+      conversationId,
+      anchorMessageId: anchor.id,
+      deletedCount: deletedMessageIds.length,
+    },
+    "Discarded last assistant display turn for retry",
+  );
+  return { anchor, deletedMessageIds };
 }

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -82,7 +82,7 @@ const log = getLogger("conversation-process");
  * skips their echo, and the persisted `hidden` metadata keeps them out of
  * the fetched transcript.
  */
-function isEchoSuppressedUserMessage(
+export function isEchoSuppressedUserMessage(
   metadata: Record<string, unknown> | undefined,
 ): boolean {
   return (

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -16,13 +16,23 @@
  * POST   /v1/conversations/:id/surface    — promote to / demote from Recents
  * POST   /v1/conversations/:id/cancel     — cancel generation
  * POST   /v1/conversations/:id/undo       — undo last message
+ * POST   /v1/conversations/:id/retry      — retry the last assistant turn
  * POST   /v1/conversations/reorder        — reorder / pin conversations
  */
 
+import { v7 as uuidv7 } from "uuid";
 import { z } from "zod";
 
 import { isUserCancellation } from "../../daemon/conversation-error.js";
-import { formatSummarizeUpToResult } from "../../daemon/conversation-process.js";
+import { touchConversation } from "../../daemon/conversation-evictor.js";
+import {
+  discardLastAssistantDisplayTurn,
+  extractUserPromptText,
+} from "../../daemon/conversation-history.js";
+import {
+  formatSummarizeUpToResult,
+  isEchoSuppressedUserMessage,
+} from "../../daemon/conversation-process.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import {
   destroyActiveConversation,
@@ -58,15 +68,18 @@ import { enqueueMemoryJob } from "../../persistence/jobs-store.js";
 import { linkRequestLogsToMessage } from "../../persistence/llm-request-log-store.js";
 import { deleteSchedule } from "../../schedule/schedule-store.js";
 import { UserError } from "../../util/errors.js";
+import { safeParseRecord } from "../../util/json.js";
 import { getLogger } from "../../util/logger.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import { buildConversationDetailResponse } from "../services/conversation-serializer.js";
 import {
   publishConversationEnabledPluginsChanged,
   publishConversationListAndMetadataChanged,
   publishConversationListChanged,
+  publishConversationMessagesChanged,
   publishConversationTitleChanged,
 } from "../sync/resource-sync-events.js";
 import { persistCannedAssistantCard } from "./canned-message-complete.js";
@@ -77,9 +90,11 @@ import {
   ConflictError,
   InternalError,
   NotFoundError,
+  UnprocessableEntityError,
 } from "./errors.js";
 import { setInferenceProfileSession } from "./inference-profile-session-handler.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+import { resolveVellumActorTrustContext } from "./vellum-actor-trust.js";
 
 const log = getLogger("conversation-management-routes");
 
@@ -620,6 +635,135 @@ async function handleUndoLastMessage({ pathParams = {} }: RouteHandlerArgs) {
   };
 }
 
+/**
+ * Retry the last assistant turn: permanently discard the latest assistant
+ * display turn, keep its anchoring user message, and re-run generation from
+ * that message. Accepted with 202; the regenerated turn streams over SSE
+ * exactly like a normal send (`assistant_activity_state` thinking →
+ * text/tool deltas → `message_complete`), and the discarded rows reach other
+ * clients through the `conversation:<id>:messages` sync invalidation.
+ */
+async function handleRetryLastAssistantTurn({
+  pathParams = {},
+  headers,
+}: RouteHandlerArgs) {
+  const rawId = pathParams.id!;
+  const conversationId = resolveConversationId(rawId) ?? rawId;
+  // Gate on DB existence first: `getOrCreateConversationInstance` would
+  // otherwise create a fresh conversation and mask the not-found case.
+  if (!getConversation(conversationId)) {
+    throw new NotFoundError(`Conversation ${rawId} not found`);
+  }
+  const conversation = await getOrCreateConversationInstance(conversationId);
+  touchConversation(conversationId);
+
+  // Bind the requesting actor's trust before the turn. A freshly hydrated
+  // conversation has no trust context, and `loadFromDb` under an unset
+  // context filters guardian-provenance history — the re-run would see an
+  // empty transcript.
+  const actorPrincipalId = headers?.["x-vellum-actor-principal-id"];
+  conversation.setTrustContext(
+    await resolveVellumActorTrustContext(actorPrincipalId, {
+      healResetDrift: true,
+    }),
+  );
+  conversation.currentTurnSourceActorPrincipalId =
+    await resolveActorPrincipalIdForLocalGuardian(actorPrincipalId);
+
+  // Synchronous check-then-claim (no await between them) so a concurrent
+  // request cannot slip past the busy gate. Everything through the tail
+  // deletion below is synchronous, so the claim can't be raced.
+  if (conversation.isProcessing()) {
+    throw new ConflictError(
+      "The assistant is currently responding — try again when it finishes",
+    );
+  }
+  conversation.setProcessing(true);
+
+  const requestId = uuidv7();
+  const abortController = new AbortController();
+  let discarded: ReturnType<typeof discardLastAssistantDisplayTurn>;
+  try {
+    conversation.currentRequestId = requestId;
+    // runAgentLoop requires a live controller; it is also what Stop signals.
+    conversation.abortController = abortController;
+    discarded = discardLastAssistantDisplayTurn(conversationId);
+    if (!discarded) {
+      throw new UnprocessableEntityError("No user message to retry from");
+    }
+  } catch (err) {
+    if (conversation.abortController === abortController) {
+      conversation.abortController = null;
+    }
+    conversation.currentRequestId = undefined;
+    conversation.setProcessing(false);
+    throw err;
+  }
+
+  if (discarded.deletedMessageIds.length > 0) {
+    // Published without an origin client id: the initiating client must
+    // reconcile too — it discovers the discarded tail the same way other
+    // clients do.
+    publishConversationMessagesChanged(conversationId);
+  }
+
+  const anchor = discarded.anchor;
+  // A machine-signal anchor (wake trigger, subagent/ACP notification, hidden
+  // send) re-runs as a hidden turn so it stays out of the titler, mirroring
+  // how the original turn ran.
+  const isHiddenPrompt = isEchoSuppressedUserMessage(
+    anchor.metadata ? safeParseRecord(anchor.metadata) : undefined,
+  );
+  const contentText = extractUserPromptText(anchor.content);
+
+  // Fire-and-forget: return 202 immediately, stream the re-run over SSE. The
+  // loop's own teardown clears processing, publishes the metadata sync
+  // invalidation, and drains anything queued during the turn.
+  (async () => {
+    try {
+      conversation.emitActivityState("thinking", "message_dequeued", {
+        requestId,
+      });
+      // Unconditional resync of the in-memory history to the truncated DB
+      // state. `loadFromDb`'s tail-row rehydration leaves the anchor in
+      // exactly the "next turn re-injects fresh" shape the loop expects.
+      await conversation.loadFromDb();
+      await conversation.runAgentLoop(contentText, anchor.id, {
+        onEvent: broadcastMessage,
+        isUserMessage: true,
+        isInteractive: true,
+        ...(isHiddenPrompt ? { isHiddenPrompt: true } : {}),
+      });
+    } catch (err) {
+      log.error({ err, conversationId }, "Retry turn failed");
+      broadcastMessage({
+        type: "conversation_error",
+        conversationId,
+        code: "UNKNOWN",
+        userMessage: `Retry failed: ${err instanceof Error ? err.message : String(err)}`,
+        retryable: true,
+      });
+      // The loop's finally owns teardown once it starts; this guard covers
+      // a throw before that claim (e.g. loadFromDb). Identity-guarded: a
+      // newer turn may already own the controller field.
+      if (conversation.abortController === abortController) {
+        conversation.abortController = null;
+        conversation.setProcessing(false);
+        conversation.emitActivityState("idle", "error_terminal", {
+          requestId,
+        });
+      }
+    }
+  })();
+
+  return {
+    accepted: true as const,
+    conversationId,
+    userMessageId: anchor.id,
+    discardedCount: discarded.deletedMessageIds.length,
+  };
+}
+
 async function handleResolveMetaSlashCommand({
   pathParams = {},
   body = {},
@@ -1027,6 +1171,41 @@ export const ROUTES: RouteDefinition[] = [
       conversationId: z.string(),
     }),
     handler: handleUndoLastMessage,
+  },
+  {
+    operationId: "retryLastAssistantTurn",
+    endpoint: "conversations/:id/retry",
+    method: "POST",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Retry the last assistant turn",
+    description:
+      "Permanently discard the most recent assistant display turn (the assistant rows and " +
+      "tool-result rows after the last turn-starting user message), keep that user message, " +
+      "and re-run generation from it. Accepted immediately; the regenerated turn streams " +
+      "over SSE like a normal send.",
+    tags: ["conversations"],
+    pathParams: [{ name: "id", type: "uuid" }],
+    responseBody: z.object({
+      accepted: z.literal(true),
+      conversationId: z.string(),
+      userMessageId: z
+        .string()
+        .describe("The user message the turn is re-running from"),
+      discardedCount: z
+        .number()
+        .int()
+        .describe("Number of message rows discarded from the tail"),
+    }),
+    responseStatus: "202",
+    additionalResponses: {
+      "404": { description: "Conversation not found" },
+      "409": { description: "The assistant is currently responding" },
+      "422": { description: "No user message exists to retry from" },
+    },
+    handler: handleRetryLastAssistantTurn,
   },
   {
     operationId: "resolveConversationSlashCommand",

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -299,6 +299,7 @@ function getDetailedHealth() {
     },
     capabilities: {
       memoryOptOut: true,
+      retryLastTurn: true,
     },
     ...(profiler ? { profiler } : {}),
     ...migrationHealthFields,
@@ -420,6 +421,7 @@ const cesHealthSchema = z.object({
 
 const healthCapabilitiesSchema = z.object({
   memoryOptOut: z.boolean(),
+  retryLastTurn: z.boolean(),
 });
 
 const healthDiskSchema = z.object({

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -49,6 +49,7 @@ import { useDraftPersistence } from "@/domains/chat/hooks/use-draft-persistence"
 import { useOnboardingOrchestrator } from "@/domains/chat/hooks/use-onboarding-orchestrator";
 
 import { useConversationSecondaryActions } from "@/domains/chat/hooks/use-conversation-secondary-actions";
+import { useAssistantCapability } from "@/hooks/use-assistant-capability";
 import { useSupportsSummarizeUpToHere } from "@/lib/backwards-compat/use-supports-summarize-up-to-here";
 import { useCanUseLlmInspector } from "@/domains/chat/inspector/access";
 import { useSendMessage } from "@/domains/chat/hooks/use-send-message";
@@ -402,6 +403,7 @@ export function ActiveChatView() {
     handleForkConversation,
     handleForkConversationFromMenu,
     handleSummarizeUpToMessage,
+    handleRetryLatestTurn,
     handleOpenInNewWindow,
     handleInspectConversation,
     handleInspectMessage,
@@ -436,6 +438,30 @@ export function ActiveChatView() {
   }, [pendingSummarizeMessageId, handleSummarizeUpToMessage]);
   const handleCancelSummarize = useCallback(() => {
     setPendingSummarizeMessageId(null);
+  }, []);
+
+  // "Retry" confirm dialog. Same shape as summarize: the hover action only
+  // opens the dialog; the POST fires from its confirm button — retry
+  // permanently discards the latest assistant response, so it always goes
+  // through an explicit confirmation. Capability-gated at the callback
+  // source: daemons without the retry endpoint get no `onRetryLatestTurn`,
+  // so the hover button never renders and the dialog is unreachable.
+  const supportsRetryTurn = useAssistantCapability("retryLastTurn");
+  const [retryConfirmOpen, setRetryConfirmOpen] = useState(false);
+  const [retryPending, setRetryPending] = useState(false);
+  const handleRetryLatestTurnRequested = useCallback(() => {
+    setRetryConfirmOpen(true);
+  }, []);
+  const handleConfirmRetry = useCallback(() => {
+    setRetryPending(true);
+    // Errors toast inside the handler; the dialog just closes.
+    void handleRetryLatestTurn().finally(() => {
+      setRetryPending(false);
+      setRetryConfirmOpen(false);
+    });
+  }, [handleRetryLatestTurn]);
+  const handleCancelRetry = useCallback(() => {
+    setRetryConfirmOpen(false);
   }, []);
 
   // Manual "Refresh" menu item — re-fetch the latest history page through the
@@ -505,6 +531,9 @@ export function ActiveChatView() {
     onSummarizeUpToHere: supportsSummarizeUpToHere
       ? handleSummarizeUpToHere
       : undefined,
+    onRetryLatestTurn: supportsRetryTurn
+      ? handleRetryLatestTurnRequested
+      : undefined,
     handleInspectMessage: showLlmInspector ? handleInspectMessage : undefined,
 
     // History pagination
@@ -559,6 +588,15 @@ export function ActiveChatView() {
         isPending={summarizePending}
         onConfirm={handleConfirmSummarize}
         onCancel={handleCancelSummarize}
+      />
+      <ConfirmDialog
+        open={retryConfirmOpen}
+        title="Retry this response?"
+        message="The latest response will be discarded and regenerated. This can't be undone."
+        confirmLabel="Retry"
+        isPending={retryPending}
+        onConfirm={handleConfirmRetry}
+        onCancel={handleCancelRetry}
       />
       <MobileChatOverlays />
     </>

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -133,6 +133,8 @@ export interface ChatMainPanelProps {
   handleForkConversation: (throughMessageId: string) => Promise<void>;
   /** Opens the "Summarize up to here" confirm dialog for a message. */
   onSummarizeUpToHere?: (messageId: string) => void;
+  /** Opens the "Retry" confirm dialog for the latest assistant turn. */
+  onRetryLatestTurn?: () => void;
   handleInspectMessage?: (messageId: string) => void;
 
   // History pagination (from useConversationLoader in ActiveChatView)
@@ -214,6 +216,7 @@ export function ChatMainPanel({
   handleEditQueueTail,
   handleForkConversation,
   onSummarizeUpToHere,
+  onRetryLatestTurn,
   handleInspectMessage,
   historyPagination,
   diskPressure,
@@ -894,6 +897,9 @@ export function ChatMainPanel({
     onAllowAndCreateRule: handleAllowAndCreateRule,
     onForkConversation: handleForkConversationCallback,
     onSummarizeUpToHere,
+    // Hidden while a turn is in flight: retrying mid-generation would 409,
+    // and the affordance targets the settled latest response.
+    onRetryLatestTurn: isAssistantBusy ? undefined : onRetryLatestTurn,
     onInspectMessage: handleInspectMessage,
     renderAvatar,
     onPullRefresh: handlePullRefresh,

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -68,4 +68,30 @@ describe("MessageHoverActions", () => {
 
     expect(html).not.toContain('title="Summarize up to here"');
   });
+
+  test("renders retry action when the callback is provided", () => {
+    const message: DisplayMessage = {
+      id: "m5",
+      role: "assistant",
+      timestamp: Date.UTC(2026, 0, 2, 12, 34),
+      ...textBody("hello"),
+    };
+    const html = renderToStaticMarkup(
+      <MessageHoverActions message={message} onRetry={() => {}} />,
+    );
+
+    expect(html).toContain('title="Retry"');
+  });
+
+  test("omits retry action when the callback is absent", () => {
+    const message: DisplayMessage = {
+      id: "m6",
+      role: "assistant",
+      timestamp: Date.UTC(2026, 0, 2, 12, 34),
+      ...textBody("hello"),
+    };
+    const html = renderToStaticMarkup(<MessageHoverActions message={message} />);
+
+    expect(html).not.toContain('title="Retry"');
+  });
 });

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -1,5 +1,5 @@
 
-import { Bookmark, Check, Copy, ExternalLink, FileCode, GitBranch, ListCollapse } from "lucide-react";
+import { Bookmark, Check, Copy, ExternalLink, FileCode, GitBranch, ListCollapse, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
@@ -24,6 +24,10 @@ export type MessageHoverActionsProps = {
   onSummarizeUpToHere?: () => void;
   /** Callback when "Inspect" is clicked. */
   onInspect?: () => void;
+  /** Callback when "Retry" is clicked. Only provided on the latest assistant
+   *  message while no turn is in flight — retry discards that response and
+   *  regenerates it. */
+  onRetry?: () => void;
 };
 
 function formatTimestamp(epoch: number): string {
@@ -95,6 +99,7 @@ export function MessageHoverActions({
   onFork,
   onSummarizeUpToHere,
   onInspect,
+  onRetry,
 }: MessageHoverActionsProps) {
   const { role } = message;
 
@@ -178,6 +183,17 @@ export function MessageHoverActions({
           ) : (
             <Copy className="h-3.5 w-3.5" />
           )}
+        </button>
+      )}
+
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          title="Retry"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
         </button>
       )}
 

--- a/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
@@ -19,6 +19,7 @@ import { toast } from "@vellumai/design-library";
 
 import type { Conversation } from "@/types/conversation-types";
 import {
+  conversationsByIdRetryPost,
   conversationsForkPost,
   conversationsSummarizePost,
 } from "@/generated/daemon/sdk.gen";
@@ -51,6 +52,7 @@ export interface UseConversationSecondaryActionsReturn {
   handleForkConversation: (throughMessageId: string) => Promise<void>;
   handleForkConversationFromMenu: () => void;
   handleSummarizeUpToMessage: (beforeMessageId: string) => Promise<void>;
+  handleRetryLatestTurn: () => Promise<void>;
   handleOpenInNewWindow: (conversation: Conversation) => void;
   handleInspectConversation: (conversation: Conversation) => void;
   handleInspectMessage: (messageId: string) => void;
@@ -158,6 +160,34 @@ export function useConversationSecondaryActions({
     [],
   );
 
+  // Discards the latest assistant display turn and re-runs generation from
+  // its user message. Fire-and-forget like summarize: the daemon acknowledges
+  // with 202, the regenerated turn streams over the existing SSE events, and
+  // the discarded rows disappear via the messages sync invalidation — no
+  // local state to update here.
+  const handleRetryLatestTurn = useCallback(async () => {
+    const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
+    const activeConversationId = useConversationStore.getState().activeConversationId;
+    if (!assistantId || !activeConversationId) {
+      return;
+    }
+    haptic.light();
+
+    try {
+      await conversationsByIdRetryPost({
+        path: { assistant_id: assistantId, id: activeConversationId },
+        throwOnError: true,
+      });
+    } catch (err) {
+      captureError(err, { context: "retry_latest_turn" });
+      toast.error(
+        err instanceof ApiError && err.status === 409
+          ? "The assistant is busy — try again when the current response finishes"
+          : "Couldn't retry the response",
+      );
+    }
+  }, []);
+
   const handleForkConversationFromMenu = useCallback(() => {
     const latestPersisted = transcriptRef.current.findLast(
       (m) => m.id != null,
@@ -242,6 +272,7 @@ export function useConversationSecondaryActions({
     handleForkConversation,
     handleForkConversationFromMenu,
     handleSummarizeUpToMessage,
+    handleRetryLatestTurn,
     handleOpenInNewWindow,
     handleInspectConversation,
     handleInspectMessage,

--- a/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -31,6 +31,7 @@ export interface LatestTurnRowProps {
   ) => void;
   onForkConversation?: (messageId: string) => void;
   onSummarizeUpToHere?: (messageId: string) => void;
+  onRetryLatestTurn?: () => void;
   onInspectMessage?: (messageId: string) => void;
   renderOnboardingChoice?: () => ReactNode;
   onOpenRuleEditor?: (context: {
@@ -74,6 +75,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
   onSurfaceAction,
   onForkConversation,
   onSummarizeUpToHere,
+  onRetryLatestTurn,
   onInspectMessage,
   renderOnboardingChoice,
   onOpenRuleEditor,
@@ -112,6 +114,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
         onSurfaceAction={onSurfaceAction}
         onForkConversation={onForkConversation}
         onSummarizeUpToHere={onSummarizeUpToHere}
+        onRetryLatestTurn={onRetryLatestTurn}
         onInspectMessage={onInspectMessage}
         renderOnboardingChoice={renderOnboardingChoice}
         onOpenRuleEditor={onOpenRuleEditor}
@@ -137,6 +140,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
             onSurfaceAction={onSurfaceAction}
             onForkConversation={onForkConversation}
             onSummarizeUpToHere={onSummarizeUpToHere}
+            onRetryLatestTurn={onRetryLatestTurn}
             onInspectMessage={onInspectMessage}
             renderOnboardingChoice={renderOnboardingChoice}
             onOpenRuleEditor={onOpenRuleEditor}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -48,6 +48,9 @@ export interface TranscriptMessageBodyProps {
   ) => void;
   onForkConversation?: (messageId: string) => void;
   onSummarizeUpToHere?: (messageId: string) => void;
+  /** Opens the "Retry" confirm dialog. Bound to the hover-actions row only on
+   *  the latest assistant message (see the `retryHandler` derivation). */
+  onRetryLatestTurn?: () => void;
   onInspectMessage?: (messageId: string) => void;
   onOpenRuleEditor?: (context: OpenRuleEditorContext) => void;
   /** Tool-call ids whose chip should display the "command not recognized"

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -100,6 +100,7 @@ export function TranscriptMessageBody({
   onSurfaceAction,
   onForkConversation,
   onSummarizeUpToHere,
+  onRetryLatestTurn,
   onInspectMessage,
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
@@ -172,6 +173,16 @@ export function TranscriptMessageBody({
   const inspectHandler =
     inspectMessageId && onInspectMessage
       ? () => onInspectMessage(inspectMessageId)
+      : undefined;
+  // Retry only attaches to the latest persisted assistant message — the turn
+  // the daemon's retry endpoint would discard and re-run. Everything else
+  // (user rows, older assistant rows, optimistic rows) gets no button.
+  const retryHandler =
+    isLatestMessage &&
+    message.role === "assistant" &&
+    !message.isOptimistic &&
+    message.id
+      ? onRetryLatestTurn
       : undefined;
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -908,6 +919,7 @@ export function TranscriptMessageBody({
           onFork={forkHandler}
           onSummarizeUpToHere={summarizeHandler}
           onInspect={inspectHandler}
+          onRetry={retryHandler}
         />
       </div>
     </>

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -33,6 +33,7 @@ export interface TranscriptRowProps {
   ) => void;
   onForkConversation?: (messageId: string) => void;
   onSummarizeUpToHere?: (messageId: string) => void;
+  onRetryLatestTurn?: () => void;
   onInspectMessage?: (messageId: string) => void;
   /** Render-prop for `kind: "onboardingChoice"` items. Onboarding depends on
    *  props from the parent (sendMessage, didOnboarding, etc.) and has a
@@ -90,6 +91,7 @@ export const TranscriptRow = memo(function TranscriptRow({
   onSurfaceAction,
   onForkConversation,
   onSummarizeUpToHere,
+  onRetryLatestTurn,
   onInspectMessage,
   renderOnboardingChoice,
   onOpenRuleEditor,
@@ -122,6 +124,7 @@ export const TranscriptRow = memo(function TranscriptRow({
           onSurfaceAction={onSurfaceAction}
           onForkConversation={onForkConversation}
           onSummarizeUpToHere={onSummarizeUpToHere}
+          onRetryLatestTurn={onRetryLatestTurn}
           onInspectMessage={onInspectMessage}
           onOpenRuleEditor={onOpenRuleEditor}
           unknownNudgeToolCallIds={unknownNudgeToolCallIds}

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -49,6 +49,8 @@ export interface TranscriptProps {
   onForkConversation?: (messageId: string) => void;
   /** Callback for "Summarize up to here" from a message's hover actions. */
   onSummarizeUpToHere?: (messageId: string) => void;
+  /** Callback for "Retry" from the latest assistant message's hover actions. */
+  onRetryLatestTurn?: () => void;
   /** Callback for "Inspect" from a message's hover actions. */
   onInspectMessage?: (messageId: string) => void;
 
@@ -247,6 +249,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       onSurfaceAction: rest.onSurfaceAction,
       onForkConversation: rest.onForkConversation,
       onSummarizeUpToHere: rest.onSummarizeUpToHere,
+      onRetryLatestTurn: rest.onRetryLatestTurn,
       onInspectMessage: rest.onInspectMessage,
       renderOnboardingChoice: rest.renderOnboardingChoice,
       assistantDisplayName: rest.assistantDisplayName,

--- a/clients/web/src/domains/schedules/schedules-page.tsx
+++ b/clients/web/src/domains/schedules/schedules-page.tsx
@@ -1,13 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 
-import { getAssistantHealthz } from "@/assistant/api";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailDrawer, MobileDetailOverlay } from "@/components/detail-drawer";
 import { CreateScheduleModal } from "@/domains/settings/components/create-schedule-modal";
 import { SystemTasksSection } from "@/domains/settings/components/system-tasks-section";
 import { useSystemTasks } from "@/domains/settings/hooks/use-system-tasks";
+import { useAssistantCapability } from "@/hooks/use-assistant-capability";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { navigateToNewConversation } from "@/utils/conversation-navigation";
@@ -42,15 +41,7 @@ export function SchedulesPage() {
 
   // Gates the consolidation/retrospective "Memory settings" link the same way
   // the schedules surface always has.
-  const { data: hasMemoryOptOutCapability = false } = useQuery({
-    queryKey: ["assistant-memory-opt-out-capability", assistantId],
-    queryFn: async () => {
-      const result = await getAssistantHealthz(assistantId);
-      return result.ok && result.data.capabilities?.memoryOptOut === true;
-    },
-    retry: false,
-    staleTime: 10_000,
-  });
+  const hasMemoryOptOutCapability = useAssistantCapability("memoryOptOut");
   // The memory toggle lives on the Memory tab of the flag-gated Developer
   // page, so the link is only offered when that destination is reachable.
   const settingsDeveloperNav =

--- a/clients/web/src/hooks/use-assistant-capability.ts
+++ b/clients/web/src/hooks/use-assistant-capability.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getAssistantHealthz } from "@/assistant/api";
+import type { HealthzGetResponse } from "@/generated/daemon/types.gen";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+type AssistantCapability = keyof NonNullable<HealthzGetResponse["capabilities"]>;
+
+/**
+ * Whether the active assistant advertises a healthz `capabilities` flag.
+ *
+ * Capability flags gate features that ship behind a new daemon endpoint
+ * where a version gate can't work: released daemons without the endpoint
+ * share a base version with source-built daemons that have it, so semver
+ * can't separate the two. Daemons that omit the capability (including all
+ * older releases) simply never light the feature up.
+ *
+ * Reads the raw selection store (not `useActiveAssistantId()`) so callers
+ * on surfaces that render across pre-active lifecycle states — the chat
+ * route — don't trip the gated accessor's throw.
+ */
+export function useAssistantCapability(
+  capability: AssistantCapability,
+): boolean {
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const { data: supported = false } = useQuery({
+    queryKey: ["assistant-capability", capability, assistantId],
+    enabled: assistantId != null,
+    queryFn: async () => {
+      if (!assistantId) {
+        return false;
+      }
+      const result = await getAssistantHealthz(assistantId);
+      return result.ok && result.data.capabilities?.[capability] === true;
+    },
+    retry: false,
+    // Capabilities are static per daemon process; they only change across a
+    // restart/upgrade, so a long stale window avoids re-pinging healthz on
+    // every mount.
+    staleTime: 60_000,
+  });
+  return supported;
+}


### PR DESCRIPTION
## Summary
- New `POST /v1/conversations/:id/retry`: synchronously claims processing, discards the latest assistant display turn via a new `discardLastAssistantDisplayTurn` primitive (anchor = last `startsNewTurn` user row; newest-first `deleteMessageById` loop; Qdrant cleanup; clears the anchor's `turnOutcome` stamp), publishes an origin-less `conversation:<id>:messages` invalidation, then fire-and-forgets `runAgentLoop` against the existing user message (no new user row) — 202 + SSE, modeled on the summarize handler (trust stamped via `resolveVellumActorTrustContext`, abort controller installed so Stop works, `loadFromDb` resync before the run, hidden machine-signal anchors re-run as hidden prompts).
- Web: `RotateCcw` hover action on the latest persisted assistant message, hidden while a turn is in flight; confirm-dialog-first (mirrors Summarize — retry permanently discards the response); fire-and-forget handler with 409-busy toast. Discarded rows disappear through the existing sync-invalidation reconcile path on every client including the initiator.
- Gating is a new `capabilities.retryLastTurn` healthz flag, not a version gate: released daemons without the endpoint share a base version with source-built daemons that have it, so semver can't separate them. Extracted the healthz-capability query into a shared `useAssistantCapability` hook and migrated the schedules page's `memoryOptOut` query to it.
- Tests: DB-backed primitive suite (multi-row display turns, tool-result anchors, hidden anchors, outcome-stamp clearing), mock-based route suite (409/404/422/claim-unwind/hidden/loop-failure), hover-action render tests.

## Original prompt
Add a retry button to the action row under the most recent assistant turn in the web client, so failed generations (persisted "Processing failed:" replies) can be retried and odd responses rerolled. Planned in-conversation: a daemon endpoint rather than client-side undo+resend (preserves the user message exactly and works for scheduled/hidden turns), confirm-dialog-first UX, permanent discard semantics (no variant history).