### PR TITLE
fix(tests): deflake use-tip-card rotation tests — poll the boundary with waitFor

### DIFF
--- a/clients/web/src/hooks/use-tip-card.test.ts
+++ b/clients/web/src/hooks/use-tip-card.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import {
   createElement,
   Fragment,
@@ -227,13 +227,17 @@ describe("useTipCard rotation", () => {
       });
     });
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 120));
-    });
+    // The boundary timer's fire time is scheduler-dependent, so poll for the
+    // restamp rather than sleeping a fixed interval it could overshoot.
+    await waitFor(
+      () => {
+        expect(tipRecordsStorage.load()[FIRST_TIP_ID]?.shownCount).toBe(2);
+      },
+      { timeout: 4000 },
+    );
 
     expect(result.current.tip?.id).toBe(FIRST_TIP_ID);
     const record = tipRecordsStorage.load()[FIRST_TIP_ID];
-    expect(record?.shownCount).toBe(2);
     expect(Date.now() - (record?.lastShownAt ?? 0)).toBeLessThan(
       TIP_ROTATION_INTERVAL_MS,
     );
@@ -268,13 +272,15 @@ describe("useTipCard rotation", () => {
     // Still within the window: the slot stays blank until the boundary.
     expect(result.current.tip).toBeNull();
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 120));
-    });
-
-    // No remount: the boundary timer refreshed the clock and the successor
-    // took the slot (and stamped its own impression).
-    expect(result.current.tip?.id).toBe(SECOND_UNGATED_TIP_ID);
+    // No remount: the boundary timer refreshes the clock and the successor
+    // takes the slot (and stamps its own impression). Its fire time is
+    // scheduler-dependent, so poll rather than sleeping a fixed interval.
+    await waitFor(
+      () => {
+        expect(result.current.tip?.id).toBe(SECOND_UNGATED_TIP_ID);
+      },
+      { timeout: 4000 },
+    );
     expect(
       tipRecordsStorage.load()[SECOND_UNGATED_TIP_ID]?.lastShownAt,
     ).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Deflakes the two `useTipCard` rotation tests that raced a fixed 120ms real-time sleep against the hook's ~40ms rotation-boundary timer — under CI load the timer could fire after the sleep (and outside `act`), leaving the assertion reading pre-boundary state. This broke main's **CI Main Web** run for b8c8414ca2 (`shows a dismissed tip's successor…` expected `app-builder`, got `undefined`, with the telltale act warning).
- Replaces the fixed sleeps with RTL `waitFor` (act-aware, 4s deadline) polling the post-boundary observable: the successor tip id in the dismissal test, the restamped `shownCount` in the pinned-tip test. Same pattern as the VAD deflake (#38488); explicit timeouts match existing call sites.
- Verified 8/8 consecutive green runs of the file (19 tests); the file also runs faster since `waitFor` resolves on first successful poll.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29642731428/job/88075812328 — the Test job of CI Main Web on main, whose single failure was the `use-tip-card.test.ts` rotation test. The tip-card code itself is untouched (#38143); the merged PR that triggered the run (#38490) is unrelated, so this is a test-only deflake.