### PR TITLE
fix(tests): unbreak main CI — retryLastTurn capability expectation, orphan-reaper transient-zombie race

### DIFF
--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -162,7 +162,10 @@ describe("identity routes — health endpoint", () => {
       expect(body.memory).toBeDefined();
       expect(body.cpu).toBeDefined();
       expect(body.migrations).toBeDefined();
-      expect(body.capabilities).toEqual({ memoryOptOut: true });
+      expect(body.capabilities).toEqual({
+        memoryOptOut: true,
+        retryLastTurn: true,
+      });
 
       // Profiler should either be absent or show enabled: false
       if ("profiler" in body) {

--- a/assistant/src/daemon/orphan-reaper.test.ts
+++ b/assistant/src/daemon/orphan-reaper.test.ts
@@ -157,11 +157,15 @@ itLinux(
       trackedChildExited = true;
     });
 
-    // AND we wait for that orphan to surface as our zombie child
+    // AND we wait for libuv to reap A before polling for the orphan —
+    // between A's exit and libuv's waitpid, A is itself transiently a zombie
+    // with our pid as parent, so an ungated poll can match A instead of B
     let zombies: number[] = [];
     for (let i = 0; i < 40 && zombies.length === 0; i++) {
       await sleep(50);
-      zombies = zombieChildPids();
+      if (trackedChildExited) {
+        zombies = zombieChildPids();
+      }
     }
     expect(zombies.length).toBeGreaterThan(0);
     expect(trackedChildExited).toBe(true); // libuv reaped A independently


### PR DESCRIPTION
## Summary
- Update the `/v1/health` backward-compat expectation in `identity-routes.test.ts` to include the `retryLastTurn: true` capability added by #38490.
- Deflake the orphan-reaper Linux integration test: gate the zombie poll on `trackedChildExited` so the loop cannot match tracked child A during its transient zombie window (between A's exit and libuv's waitpid) and exit before A's exit event fires — once A is reaped, any zombie with our pid as parent is genuinely the orphan B.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29642731450/job/88075812257 (the `Test` job of `CI Main Assistant Checks` on main, broken by the push of #38490 — `identity-routes.test.ts` capability-shape mismatch plus an `orphan-reaper.test.ts` race).