### PR TITLE
fix: bound provider resolution by decision timeout and fail open on decider rejection

### DIFF
--- a/assistant/src/live-voice/__tests__/front-decision.test.ts
+++ b/assistant/src/live-voice/__tests__/front-decision.test.ts
@@ -106,6 +106,20 @@ describe("createVoiceFrontDecider — decideEndpoint", () => {
     expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
   });
 
+  test("getProvider that never resolves → release after endpointDecisionTimeoutMs", async () => {
+    const decider = createVoiceFrontDecider({
+      config: LiveVoiceFrontModelConfigSchema.parse({
+        endpointDecisionTimeoutMs: 20,
+      }),
+      // Stalled lazy provider initialization — the timeout must bound the
+      // whole call including resolution, not just sendMessage.
+      getProvider: () => new Promise<Provider | null>(() => {}),
+    });
+    const start = Date.now();
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
   test("sendMessage that never resolves → release after endpointDecisionTimeoutMs", async () => {
     const decider = createVoiceFrontDecider({
       config: LiveVoiceFrontModelConfigSchema.parse({
@@ -233,6 +247,20 @@ describe("createVoiceFrontDecider — generateAckText", () => {
       },
     });
     expect(await decider.generateAckText(ackInput)).toBeNull();
+  });
+
+  test("getProvider that never resolves → null after ackGenerationTimeoutMs", async () => {
+    const decider = createVoiceFrontDecider({
+      config: LiveVoiceFrontModelConfigSchema.parse({
+        ackGenerationTimeoutMs: 20,
+      }),
+      // Stalled lazy provider initialization — the timeout must bound the
+      // whole call including resolution, not just sendMessage.
+      getProvider: () => new Promise<Provider | null>(() => {}),
+    });
+    const start = Date.now();
+    expect(await decider.generateAckText(ackInput)).toBeNull();
+    expect(Date.now() - start).toBeLessThan(1000);
   });
 
   test("sendMessage that never resolves → null after ackGenerationTimeoutMs", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -2747,6 +2747,94 @@ describe("LiveVoiceSession semantic endpointing", () => {
     ).toMatchObject({ reason: "silence" });
   });
 
+  test("a rejecting decider still releases the boundary with the normal frame sequence", async () => {
+    enableFrontModel();
+    // The decider contract never rejects, but a buggy injected stub (or a
+    // future regression) must not silently drop the silence boundary: the
+    // session's belt catches the rejection and releases.
+    const calls: VoiceEndpointDecisionInput[] = [];
+    const decider: VoiceFrontDecider = {
+      decideEndpoint: async (input) => {
+        calls.push(input);
+        throw new Error("stub decider boom");
+      },
+      generateAckText: async () => null,
+    };
+    const turnStarter = makeAutoCompletingTurnStarter(["Hi there."]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: turnStarter.startVoiceTurn,
+      frontDecider: decider,
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(calls).toHaveLength(1);
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "stt_partial",
+      "speech_started",
+      "utterance_end",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+    expect(
+      frames.find((frame) => frame.type === "utterance_end"),
+    ).toMatchObject({ reason: "silence" });
+    expect(turnStarter.calls[0]).toMatchObject({ content: "hello world" });
+  });
+
+  test("a slow decider adds only its own bounded delay and then releases normally", async () => {
+    enableFrontModel();
+    // Resolves "release" only after a delay comfortably longer than every
+    // other timer in the flow — the boundary must wait it out and then run
+    // the unchanged release sequence.
+    const calls: VoiceEndpointDecisionInput[] = [];
+    const decider: VoiceFrontDecider = {
+      decideEndpoint: async (input) => {
+        calls.push(input);
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        return { action: "release" };
+      },
+      generateAckText: async () => null,
+    };
+    const turnStarter = makeAutoCompletingTurnStarter(["Hi there."]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: turnStarter.startVoiceTurn,
+      frontDecider: decider,
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+
+    // While the decision is pending, the boundary stays unreleased.
+    await waitFor(() => calls.length === 1);
+    expect(countType(frames, "utterance_end")).toBe(0);
+    expect(countType(frames, "thinking")).toBe(0);
+
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(calls).toHaveLength(1);
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "stt_partial",
+      "speech_started",
+      "utterance_end",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_done",
+    ]);
+    expect(
+      frames.find((frame) => frame.type === "utterance_end"),
+    ).toMatchObject({ reason: "silence" });
+    expect(turnStarter.calls[0]).toMatchObject({ content: "hello world" });
+  });
+
   test("endpointMaxExtensions caps consecutive holds and forces the release", async () => {
     enableFrontModel();
     const { decider, calls } = makeFrontDecider(["hold", "hold", "hold"]);

--- a/assistant/src/live-voice/front-decision.ts
+++ b/assistant/src/live-voice/front-decision.ts
@@ -189,9 +189,12 @@ function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
 }
 
 /**
- * One bounded front-model call with a forced tool: resolve the provider, race
- * the request against `timeoutMs` (and the caller's signal, when given), and
- * return the response's tool_use block. `undefined` when no provider is
+ * One bounded front-model call with a forced tool: arm the `timeoutMs` bound
+ * first, then resolve the provider and the request both raced against it (and
+ * the caller's signal, when given), and return the response's tool_use block.
+ * Provider resolution can await lazy initialization, so it must sit inside
+ * the timeout — otherwise a stalled resolver would breach the contract that
+ * every call settles within `timeoutMs`. `undefined` when no provider is
  * configured or the response carries no tool block; throws on provider
  * failure, timeout, or abort — callers map every failure to their fail-open
  * value.
@@ -204,15 +207,15 @@ async function requestForcedToolUse(args: {
   prompt: string;
   signal?: AbortSignal;
 }): Promise<ToolUseContent | undefined> {
-  const provider = await args.getProvider();
-  if (!provider) {
-    return undefined;
-  }
   const { signal: timeoutSignal, cleanup } = createTimeout(args.timeoutMs);
   const combinedSignal = args.signal
     ? AbortSignal.any([args.signal, timeoutSignal])
     : timeoutSignal;
   try {
+    const provider = await raceAbort(args.getProvider(), combinedSignal);
+    if (!provider) {
+      return undefined;
+    }
     const response = await raceAbort(
       provider.sendMessage([userMessage(args.prompt)], {
         tools: [args.tool],

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1505,12 +1505,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   ): Promise<boolean> {
     const generation = this.vadSpeechGeneration;
     const decisionStartedAtMs = this.metricsClock();
-    const decision = await decider.decideEndpoint({
-      transcriptSoFar,
-      latestPartial,
-      silenceThresholdMs: this.silenceThresholdMs,
-      extensionCount: utterance.endpointExtensionCount,
-    });
+    const decision = await decider
+      .decideEndpoint({
+        transcriptSoFar,
+        latestPartial,
+        silenceThresholdMs: this.silenceThresholdMs,
+        extensionCount: utterance.endpointExtensionCount,
+      })
+      // The decider contract never rejects, but the enclosing boundary flow
+      // swallows rejections — a rejecting decider (a buggy stub, a future
+      // regression) would silently drop the silence boundary. Belt and
+      // braces: rejection degrades to release, mirroring speakGeneratedAck.
+      .catch(() => ({ action: "release" as const }));
     const decisionLatencyMs = Math.max(
       0,
       this.metricsClock() - decisionStartedAtMs,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-mouth-brain.md (also raised by Codex on #38473/#38476).

**Gap A:** getProvider() awaited before the timeout was armed — a stalled provider init could block turn release indefinitely.
**Gap B:** a rejecting decideEndpoint dropped the silence boundary entirely (fail-closed).
**Fix:** timeout armed first with resolution raced under it; decideUtteranceHold catches rejection → release. Session tests for rejecting and slow deciders added.