### PR TITLE
fix: harden generated-ack liveness checks and thread toolName into LLM acks

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -6,6 +6,10 @@ import type {
   VoiceTurnOptions,
 } from "../../calls/voice-session-bridge.js";
 import {
+  FALLBACK_ESCALATION_BRIDGE,
+  VOICE_TRIAGE_ESCALATE_FLAG,
+} from "../../calls/voice-triage-escalate.js";
+import {
   clearCachedOverrides,
   setCachedOverrides,
 } from "../../config/feature-flag-cache.js";
@@ -1041,6 +1045,129 @@ describe("LiveVoiceSession spoken ack (voice-front-model)", () => {
     getCallbacks()?.assistant_text_delta?.(makeTextDelta("Hello there."));
     getCallbacks()?.message_complete?.(makeMessageComplete());
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+  });
+
+  test("llmAckText on: a generation resolving around turn completion speaks no ack", async () => {
+    enableFrontModel();
+    let resolveGeneration!: (text: string | null) => void;
+    const generateAckText = mock(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveGeneration = resolve;
+        }),
+    );
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      frontModelConfig: {
+        ackFirstDeltaTimeoutMs: ACK_TIMEOUT_MS,
+        llmAckText: true,
+      },
+      frontDecider: makeStubFrontDecider(generateAckText),
+    });
+
+    await startReleasedTurn(session);
+    await waitFor(() => generateAckText.mock.calls.length === 1);
+
+    // A tool-only/no-text turn completes while the ack text is still
+    // generating: the resolving generation must not become the turn's only
+    // audible output (nor enqueue behind the finale).
+    resolveGeneration("Too late to say this.");
+    getCallbacks()?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    await flushAsyncCallbacks();
+
+    // No ack synthesized or sent — and since the ack-spoken metric only
+    // records on an actual enqueue, no phantom ack metric either.
+    expect(ttsTexts).toEqual([]);
+    expect(frames.some((frame) => frame.type === "tts_audio")).toBe(false);
+  });
+
+  test("llmAckText on: a tool-use ack passes the tool name to the decider", async () => {
+    enableFrontModel();
+    const GENERATED = "Let me search for that.";
+    const generateAckText = mock(
+      async (_input: VoiceAckTextInput) => GENERATED,
+    );
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      // Long first-delta budget so only the tool-use trigger can speak.
+      frontModelConfig: { ackFirstDeltaTimeoutMs: 5_000, llmAckText: true },
+      frontDecider: makeStubFrontDecider(generateAckText),
+    });
+
+    await startReleasedTurn(session);
+    getCallbacks()?.tool_use_start?.("web_search");
+    await waitFor(() => ttsTexts.length === 1);
+
+    expect(generateAckText).toHaveBeenCalledTimes(1);
+    expect(generateAckText.mock.calls[0]?.[0]).toEqual({
+      transcriptSoFar: "hello",
+      toolName: "web_search",
+    });
+    expect(ttsTexts).toEqual([sanitizeForTts(GENERATED).trim()]);
+
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("Hello there."));
+    getCallbacks()?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+  });
+
+  test("llmAckText on: a generation resolving after escalation hand-off speaks no ack", async () => {
+    const EXPECTED_BRIDGE = sanitizeForTts(FALLBACK_ESCALATION_BRIDGE).trim();
+    setCachedOverrides(
+      {
+        "voice-front-model": true,
+        "voice-mode": true,
+        [VOICE_TRIAGE_ESCALATE_FLAG]: true,
+      },
+      { fromGateway: true },
+    );
+    let resolveGeneration!: (text: string | null) => void;
+    const generateAckText = mock(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveGeneration = resolve;
+        }),
+    );
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      frontModelConfig: {
+        ackFirstDeltaTimeoutMs: ACK_TIMEOUT_MS,
+        llmAckText: true,
+      },
+      frontDecider: makeStubFrontDecider(generateAckText),
+    });
+
+    await startReleasedTurn(session);
+    await waitFor(() => generateAckText.mock.calls.length === 1);
+
+    // The front-door leg escalates with no holding phrase of its own, so the
+    // canned bridge is enqueued — exactly the case where a late-resolving
+    // generation would stack a second filler on top of it.
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("[ESCALATE]"));
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([EXPECTED_BRIDGE]);
+
+    resolveGeneration("Stacked filler.");
+    await flushAsyncCallbacks();
+    expect(ttsTexts).toEqual([EXPECTED_BRIDGE]);
+
+    // The escalated leg (whose callbacks the capturing starter now holds)
+    // finishes the turn normally.
+    getCallbacks()?.assistant_text_delta?.(
+      makeTextDelta("Here is the careful answer."),
+    );
+    getCallbacks()?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsTexts).toEqual([EXPECTED_BRIDGE, "Here is the careful answer."]);
   });
 
   test("llmAckText on: a first delta during generation skips the ack entirely", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2350,7 +2350,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               !current.ackSpoken
             ) {
               this.clearAckTimer(current);
-              this.speakAck(current, "tool-use");
+              this.speakAck(current, "tool-use", toolName);
             }
           },
         },
@@ -2560,13 +2560,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private speakAck(
     activeTurn: ActiveAssistantTurn,
     kind: "slow-first-delta" | "tool-use",
+    toolName?: string,
   ): void {
     activeTurn.ackSpoken = true;
     if (this.llmAckText && this.frontDecider) {
       // Optimistic ackSpoken above keeps the one-per-turn budget honest for
       // any other ack trigger while the generation is in flight; the async
       // path undoes it if the ack turns out moot.
-      void this.speakGeneratedAck(activeTurn, this.frontDecider, kind);
+      void this.speakGeneratedAck(
+        activeTurn,
+        this.frontDecider,
+        kind,
+        toolName,
+      );
       return;
     }
     this.enqueueAckPhrase(activeTurn, this.pickStaticAckPhrase(kind), kind);
@@ -2585,6 +2591,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     activeTurn: ActiveAssistantTurn,
     frontDecider: VoiceFrontDecider,
     kind: "slow-first-delta" | "tool-use",
+    toolName?: string,
   ): Promise<void> {
     const { token } = activeTurn;
     const transcript = activeTurn.utterance.finalTranscriptSegments
@@ -2592,16 +2599,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       .trim();
     const generated = await frontDecider
       .generateAckText(
-        { transcriptSoFar: transcript },
+        {
+          transcriptSoFar: transcript,
+          ...(toolName !== undefined ? { toolName } : {}),
+        },
         activeTurn.abortController.signal,
       )
       // The decider contract never rejects; belt-and-braces for a stub.
       .catch(() => null);
-    // Liveness re-check after the await: the turn may have been cancelled or
-    // finalized while generating, or the brain's first delta may have arrived
-    // — in every such case the ack is moot and must not speak over real
-    // output. Undo the optimistic ackSpoken so the flag reflects reality.
-    if (!this.isActiveAssistantTurn(token) || activeTurn.firstDeltaSeen) {
+    // Liveness re-check after the await: while generating, the turn may have
+    // been cancelled or finalized, the brain's first delta may have arrived,
+    // an escalation hand-off may have enqueued its bridge phrase (which holds
+    // the floor itself), or the turn may have completed outright — a
+    // tool-only/no-text turn completes with firstDeltaSeen still false. In
+    // every such case the ack is moot and must not speak over real output,
+    // stack on the escalation bridge, or voice a finished turn. Undo the
+    // optimistic ackSpoken so the flag reflects reality.
+    if (
+      !this.isActiveAssistantTurn(token) ||
+      activeTurn.firstDeltaSeen ||
+      activeTurn.escalationHandedOff ||
+      activeTurn.assistantCompleted ||
+      activeTurn.ttsDone
+    ) {
       activeTurn.ackSpoken = false;
       return;
     }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-mouth-brain.md.

**Gap A:** in-flight LLM ack generation could stack on the escalation bridge phrase or speak/record after turn completion — post-await bail-out now covers escalation handoff, assistantCompleted, and ttsDone.
**Gap B:** toolName was never threaded into generateAckText (prompt branch was production-dead) — tool-use acks now carry the tool name.