### PR TITLE
fix: silence post-handoff tool acks and tidy front-model residuals

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -776,6 +776,19 @@ describe("LiveVoiceSession spoken ack (voice-front-model)", () => {
     setCachedOverrides({ "voice-front-model": true }, { fromGateway: true });
   }
 
+  const EXPECTED_BRIDGE = sanitizeForTts(FALLBACK_ESCALATION_BRIDGE).trim();
+
+  function enableFrontModelWithEscalation(): void {
+    setCachedOverrides(
+      {
+        "voice-front-model": true,
+        "voice-mode": true,
+        [VOICE_TRIAGE_ESCALATE_FLAG]: true,
+      },
+      { fromGateway: true },
+    );
+  }
+
   function createCapturingTurnStarter(): {
     startVoiceTurn: LiveVoiceTurnStarter;
     getCallbacks: () => VoiceTurnCallbacks | undefined;
@@ -1118,15 +1131,7 @@ describe("LiveVoiceSession spoken ack (voice-front-model)", () => {
   });
 
   test("llmAckText on: a generation resolving after escalation hand-off speaks no ack", async () => {
-    const EXPECTED_BRIDGE = sanitizeForTts(FALLBACK_ESCALATION_BRIDGE).trim();
-    setCachedOverrides(
-      {
-        "voice-front-model": true,
-        "voice-mode": true,
-        [VOICE_TRIAGE_ESCALATE_FLAG]: true,
-      },
-      { fromGateway: true },
-    );
+    enableFrontModelWithEscalation();
     let resolveGeneration!: (text: string | null) => void;
     const generateAckText = mock(
       () =>
@@ -1162,6 +1167,71 @@ describe("LiveVoiceSession spoken ack (voice-front-model)", () => {
 
     // The escalated leg (whose callbacks the capturing starter now holds)
     // finishes the turn normally.
+    getCallbacks()?.assistant_text_delta?.(
+      makeTextDelta("Here is the careful answer."),
+    );
+    getCallbacks()?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsTexts).toEqual([EXPECTED_BRIDGE, "Here is the careful answer."]);
+  });
+
+  test("static ack: a tool started on the escalated leg speaks nothing past the bridge", async () => {
+    enableFrontModelWithEscalation();
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      // Long first-delta budget so only the tool-use trigger could speak.
+      frontModelConfig: { ackFirstDeltaTimeoutMs: 5_000 },
+    });
+
+    await startReleasedTurn(session);
+    // A bare hand-off enqueues the canned bridge, which holds the floor.
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("[ESCALATE]"));
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([EXPECTED_BRIDGE]);
+
+    // The escalated leg starts a tool before its first delta: no static ack
+    // may stack on the bridge.
+    getCallbacks()?.tool_use_start?.("web_search");
+    await flushAsyncCallbacks();
+    expect(ttsTexts).toEqual([EXPECTED_BRIDGE]);
+
+    getCallbacks()?.assistant_text_delta?.(
+      makeTextDelta("Here is the careful answer."),
+    );
+    getCallbacks()?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsTexts).toEqual([EXPECTED_BRIDGE, "Here is the careful answer."]);
+  });
+
+  test("llmAckText on: tools started on the escalated leg trigger no ack generation", async () => {
+    enableFrontModelWithEscalation();
+    const generateAckText = mock(async () => "Never spoken.");
+    const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+    const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+      // Long first-delta budget so only the tool-use trigger could generate.
+      frontModelConfig: { ackFirstDeltaTimeoutMs: 5_000, llmAckText: true },
+      frontDecider: makeStubFrontDecider(generateAckText),
+    });
+
+    await startReleasedTurn(session);
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("[ESCALATE]"));
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([EXPECTED_BRIDGE]);
+
+    // Post-handoff tool starts must not each burn a generation call whose
+    // result is always discarded.
+    getCallbacks()?.tool_use_start?.("web_search");
+    getCallbacks()?.tool_use_start?.("file_read");
+    await flushAsyncCallbacks();
+    expect(generateAckText).not.toHaveBeenCalled();
+    expect(ttsTexts).toEqual([EXPECTED_BRIDGE]);
+
     getCallbacks()?.assistant_text_delta?.(
       makeTextDelta("Here is the careful answer."),
     );

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2354,11 +2354,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // Definitive tool use means the turn is guaranteed slow: speak
             // the floor-holding ack now instead of waiting out the
             // first-delta timer (same one-ack-per-turn `ackSpoken` budget).
+            // Post-handoff the escalation bridge phrase holds the floor and
+            // front-door deltas never set firstDeltaSeen, so the escalated
+            // leg's tool starts must not stack another filler on the bridge.
             if (
               this.streamTtsAudio &&
               isVoiceFrontModelEnabled(getConfig()) &&
               !current.firstDeltaSeen &&
-              !current.ackSpoken
+              !current.ackSpoken &&
+              !current.escalationHandedOff
             ) {
               this.clearAckTimer(current);
               this.speakAck(current, "tool_use", toolName);
@@ -2611,7 +2615,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       .generateAckText(
         {
           transcriptSoFar: transcript,
-          ...(toolName !== undefined ? { toolName } : {}),
+          toolName,
         },
         activeTurn.abortController.signal,
       )
@@ -2629,8 +2633,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       !this.isActiveAssistantTurn(token) ||
       activeTurn.firstDeltaSeen ||
       activeTurn.escalationHandedOff ||
-      activeTurn.assistantCompleted ||
-      activeTurn.ttsDone
+      activeTurn.assistantCompleted
     ) {
       activeTurn.ackSpoken = false;
       return;
@@ -3404,8 +3407,11 @@ export function createLiveVoiceSession(
   // absent config falls through to the in-code defaults.
   const liveVoiceConfig = getConfig().liveVoice;
   const vadConfig = liveVoiceConfig?.vad;
-  const frontModelConfig =
-    options.frontModelConfig ?? liveVoiceConfig?.frontModel;
+  // Parsed once here into a complete config, shared by the decider and the
+  // session (the constructor's own parse is then a no-op re-validation).
+  const frontModelConfig = LiveVoiceFrontModelConfigSchema.parse(
+    options.frontModelConfig ?? liveVoiceConfig?.frontModel ?? {},
+  );
   return new LiveVoiceSession(context, {
     ...options,
     turnDetectorConfig:
@@ -3429,11 +3435,7 @@ export function createLiveVoiceSession(
     frontDecider:
       options.frontDecider !== undefined
         ? options.frontDecider
-        : createVoiceFrontDecider({
-            config: LiveVoiceFrontModelConfigSchema.parse(
-              frontModelConfig ?? {},
-            ),
-          }),
+        : createVoiceFrontDecider({ config: frontModelConfig }),
     resolveCredentialReadiness:
       options.resolveCredentialReadiness === undefined
         ? defaultResolveLiveVoiceCredentialReadiness


### PR DESCRIPTION
## Summary
Round-2 review fixes for voice-mouth-brain.md (incl. Codex P2 on #38496).

- tool_use_start ack now gated on escalation handoff: no static ack stacked on the bridge phrase, no dead LLM ack-generation calls on escalated legs
- Front-model config parsed once per production session
- Unreachable ttsDone bail clause and conditional toolName spread tidied