### PR TITLE
fix(web/sse): stop churning the conversation SSE stream on tab visibility flaps

### DIFF
--- a/clients/web/src/assistant/sse-service.test.ts
+++ b/clients/web/src/assistant/sse-service.test.ts
@@ -59,7 +59,16 @@ mock.module("@/lib/streaming/reconnect-cursor", () => ({
   resetReconnectCursor: resetReconnectCursorMock,
 }));
 
-const { sseService } = await import("@/assistant/sse-service");
+const { sseService, __setHiddenTeardownGraceMsForTesting } = await import(
+  "@/assistant/sse-service"
+);
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// A tiny grace window used by the debounce specs so a hidden-tab teardown
+// can be awaited in a few ms rather than the production 5s. Kept well
+// below the 1s resume dedup window so both can be exercised together.
+const TEST_HIDDEN_GRACE_MS = 20;
 
 // The real bus has the pub/sub semantics we need to exercise — no
 // reason to maintain a parallel mock. `__resetForTesting` gives
@@ -70,6 +79,11 @@ const publishSpy = spyOn(eventBus, "publish");
 
 beforeEach(() => {
   eventBus.__resetForTesting();
+  // Default to a grace window long enough that a hidden-tab teardown never
+  // fires during a synchronous test — otherwise a leaked timer would call
+  // the shared `cancelMock` during a later test. Debounce specs opt into a
+  // tiny window locally and await it.
+  __setHiddenTeardownGraceMsForTesting(10_000);
   activeOnEvent = null;
   activeOnError = null;
   activeOnReconnect = null;
@@ -180,11 +194,14 @@ describe("sseService.attach — connection lifecycle", () => {
     expect(cancelMock).toHaveBeenCalledTimes(1);
   });
 
-  test("does not publish sse.closed for intentional teardowns (app.hidden, reachability retry)", () => {
+  test("does not publish sse.closed for intentional teardowns (app.hidden, reachability retry)", async () => {
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
     sseService.attach("asst-1");
     publishSpy.mockClear();
 
     eventBus.publish("app.hidden", { signal: "visibility" });
+    // Let the debounced hidden teardown actually fire.
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
     eventBus.publish("reachability.retry-requested", {});
 
     const closedCalls = publishSpy.mock.calls.filter(
@@ -289,12 +306,17 @@ describe("sseService.attach — SSE-connected store wiring", () => {
     expect(useSSEConnectedStore.getState().isConnected).toBe(false);
   });
 
-  test("marks the store disconnected on a graceful teardown (app.hidden)", () => {
+  test("marks the store disconnected on a graceful teardown (app.hidden) after the grace window", async () => {
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
     sseService.attach("asst-1");
     activeOnStreamOpen!();
     expect(useSSEConnectedStore.getState().isConnected).toBe(true);
 
     eventBus.publish("app.hidden", { signal: "visibility" });
+    // Debounced: still connected until the grace window elapses.
+    expect(useSSEConnectedStore.getState().isConnected).toBe(true);
+
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
     expect(useSSEConnectedStore.getState().isConnected).toBe(false);
   });
 
@@ -309,23 +331,57 @@ describe("sseService.attach — SSE-connected store wiring", () => {
 });
 
 describe("sseService.attach — visibility-driven bounce", () => {
-  test("tears down on app.hidden and reopens on app.resume after the dedup window", async () => {
+  test("does NOT tear down immediately on app.hidden — the teardown is debounced", async () => {
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
     sseService.attach("asst-1");
     expect(subscribeEventsMock).toHaveBeenCalledTimes(1);
 
     eventBus.publish("app.hidden", { signal: "visibility" });
+    // A brief tab-out must not kill the live socket synchronously.
+    expect(cancelMock).toHaveBeenCalledTimes(0);
+
+    // Only once the grace window elapses does the teardown fire.
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a resume inside the grace window keeps the live socket (no teardown, no reopen)", async () => {
+    // The core of the fix for the report: a quick tab-out-and-back must
+    // NOT churn the connection. The grace timer is cancelled on resume and
+    // the same stream keeps streaming — nothing is torn down or reopened.
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
+    sseService.attach("asst-1");
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(1);
+
+    eventBus.publish("app.hidden", { signal: "visibility" });
+    eventBus.publish("app.resume", { signal: "visibility" });
+
+    // Wait past the (now-cancelled) grace window to prove it never fires.
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
+    expect(cancelMock).toHaveBeenCalledTimes(0);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("tears down after the grace window and reopens on app.resume", async () => {
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
+    sseService.attach("asst-1");
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(1);
+
+    eventBus.publish("app.hidden", { signal: "visibility" });
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
     expect(cancelMock).toHaveBeenCalledTimes(1);
 
-    await new Promise((resolve) => setTimeout(resolve, 1100));
     eventBus.publish("app.resume", { signal: "visibility" });
 
     expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
     expect(checkAssistantMock).toHaveBeenCalledTimes(1);
-  }, 5_000);
+  });
 
-  test("app.resume inside the dedup window does NOT reopen the SSE", () => {
+  test("app.resume inside the dedup window does NOT reopen the SSE", async () => {
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
     sseService.attach("asst-1");
     eventBus.publish("app.hidden", { signal: "visibility" });
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
     expect(cancelMock).toHaveBeenCalledTimes(1);
 
     // Two rapid resumes inside the 1s dedup window — only the first
@@ -337,27 +393,30 @@ describe("sseService.attach — visibility-driven bounce", () => {
     expect(checkAssistantMock).toHaveBeenCalledTimes(1);
   });
 
-  test("app.resume inside the dedup window still reopens a torn-down SSE (hidden between two resumes)", () => {
-    // A quick tab-out-and-back can complete inside the 1s dedup window:
-    // hidden → resume(open) → hidden → resume(deduped). The first hidden
-    // opened a fresh SSE; the second hidden tore it down. The deduped
-    // second resume MUST reopen it — a blanket early-return would strand
-    // the connection torn-down until the next foreground, which surfaces
-    // to the user as a frozen transcript that only a refresh recovers.
+  test("app.resume inside the dedup window still reopens a torn-down SSE", async () => {
+    // Regression for the resume-dedup stranding bug: a hidden whose grace
+    // teardown fires between two resumes leaves `current === null`; the
+    // second (deduped) resume MUST still reopen rather than strand the
+    // connection torn-down until the next foreground — the frozen
+    // transcript the user could only clear with a refresh.
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
     sseService.attach("asst-1");
-    eventBus.publish("app.hidden", { signal: "visibility" });
+
+    // First resume opens the dedup window (socket still live → no reopen).
     eventBus.publish("app.resume", { signal: "visibility" });
-    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(1);
     expect(checkAssistantMock).toHaveBeenCalledTimes(1);
 
-    // Second hidden→resume cycle, synchronous so it lands inside the
-    // dedup window against the first resume.
+    // Hidden → its grace teardown fires, tearing the socket down...
     eventBus.publish("app.hidden", { signal: "visibility" });
-    expect(cancelMock).toHaveBeenCalledTimes(2);
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+
+    // ...then a second resume lands still inside the 1s dedup window.
     eventBus.publish("app.resume", { signal: "app_state" });
 
     // The torn-down socket is reopened despite the dedup window...
-    expect(subscribeEventsMock).toHaveBeenCalledTimes(3);
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
     // ...but the redundant daemon health check stays deduped.
     expect(checkAssistantMock).toHaveBeenCalledTimes(1);
   });
@@ -375,18 +434,19 @@ describe("sseService.attach — visibility-driven bounce", () => {
   });
 
   test("app.resume after app.hidden labels the reopen with cause='resume'", async () => {
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
     sseService.attach("asst-1");
     publishSpy.mockClear();
 
     eventBus.publish("app.hidden", { signal: "visibility" });
-    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
     eventBus.publish("app.resume", { signal: "visibility" });
 
     expect(publishSpy).toHaveBeenCalledWith("sse.opened", {
       assistantId: "asst-1",
       cause: "resume",
     });
-  }, 5_000);
+  });
 });
 
 describe("sseService.attach — power-driven bounce", () => {
@@ -424,28 +484,30 @@ describe("sseService.attach — power-driven bounce", () => {
   });
 
   test("power.resume reopens the SSE after teardown — same dedup window as app.resume", async () => {
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
     sseService.attach("asst-1");
     eventBus.publish("app.hidden", { signal: "visibility" });
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
     expect(cancelMock).toHaveBeenCalledTimes(1);
 
-    await new Promise((resolve) => setTimeout(resolve, 1100));
     eventBus.publish("power.resume", {});
 
     expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
     expect(checkAssistantMock).toHaveBeenCalledTimes(1);
-  }, 5_000);
+  });
 
   test("power.unlock reopens the SSE after teardown", async () => {
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
     sseService.attach("asst-1");
     eventBus.publish("app.hidden", { signal: "visibility" });
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
     expect(cancelMock).toHaveBeenCalledTimes(1);
 
-    await new Promise((resolve) => setTimeout(resolve, 1100));
     eventBus.publish("power.unlock", {});
 
     expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
     expect(checkAssistantMock).toHaveBeenCalledTimes(1);
-  }, 5_000);
+  });
 
   test("app.resume no-op (current non-null) does NOT suppress a follow-up power.resume bounce", () => {
     // Real-world trace: tray-resident Electron, system sleeps, wifi
@@ -474,9 +536,10 @@ describe("sseService.attach — power-driven bounce", () => {
     // One extra teardown + reopen, <100ms — acceptable cost for
     // closing the missed-bounce bug in the more common tray-resident
     // case.
+    __setHiddenTeardownGraceMsForTesting(TEST_HIDDEN_GRACE_MS);
     sseService.attach("asst-1");
     eventBus.publish("app.hidden", { signal: "visibility" });
-    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await sleep(TEST_HIDDEN_GRACE_MS + 20);
     eventBus.publish("app.resume", { signal: "visibility" });
     expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
 
@@ -484,7 +547,7 @@ describe("sseService.attach — power-driven bounce", () => {
 
     expect(subscribeEventsMock).toHaveBeenCalledTimes(3);
     expect(cancelMock).toHaveBeenCalledTimes(2);
-  }, 5_000);
+  });
 
   test("power.suspend is a no-op when no SSE is open", () => {
     const detach = sseService.attach("asst-1");

--- a/clients/web/src/assistant/sse-service.test.ts
+++ b/clients/web/src/assistant/sse-service.test.ts
@@ -337,6 +337,31 @@ describe("sseService.attach — visibility-driven bounce", () => {
     expect(checkAssistantMock).toHaveBeenCalledTimes(1);
   });
 
+  test("app.resume inside the dedup window still reopens a torn-down SSE (hidden between two resumes)", () => {
+    // A quick tab-out-and-back can complete inside the 1s dedup window:
+    // hidden → resume(open) → hidden → resume(deduped). The first hidden
+    // opened a fresh SSE; the second hidden tore it down. The deduped
+    // second resume MUST reopen it — a blanket early-return would strand
+    // the connection torn-down until the next foreground, which surfaces
+    // to the user as a frozen transcript that only a refresh recovers.
+    sseService.attach("asst-1");
+    eventBus.publish("app.hidden", { signal: "visibility" });
+    eventBus.publish("app.resume", { signal: "visibility" });
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(2);
+    expect(checkAssistantMock).toHaveBeenCalledTimes(1);
+
+    // Second hidden→resume cycle, synchronous so it lands inside the
+    // dedup window against the first resume.
+    eventBus.publish("app.hidden", { signal: "visibility" });
+    expect(cancelMock).toHaveBeenCalledTimes(2);
+    eventBus.publish("app.resume", { signal: "app_state" });
+
+    // The torn-down socket is reopened despite the dedup window...
+    expect(subscribeEventsMock).toHaveBeenCalledTimes(3);
+    // ...but the redundant daemon health check stays deduped.
+    expect(checkAssistantMock).toHaveBeenCalledTimes(1);
+  });
+
   test("does NOT reopen the SSE on app.resume while a connection is still live", () => {
     sseService.attach("asst-1");
     expect(subscribeEventsMock).toHaveBeenCalledTimes(1);

--- a/clients/web/src/assistant/sse-service.ts
+++ b/clients/web/src/assistant/sse-service.ts
@@ -41,6 +41,28 @@ import { useSSEConnectedStore } from "@/stores/sse-connected-store";
 
 const RESUME_DEDUP_WINDOW_MS = 1000;
 
+// Grace window before a hidden tab tears its SSE connection down. A
+// brief tab-out — alt-tab, a glance at another window, tapping a
+// notification — shouldn't kill a live streaming turn: tearing down
+// forces a cold reopen + reconcile on return, which the user perceives
+// as a frozen transcript they have to refresh to clear. Only a tab that
+// stays hidden past this window is treated as real backgrounding and
+// torn down; a resume inside the window cancels the pending teardown and
+// keeps the socket. `power.suspend` (system sleep) is deliberately NOT
+// debounced — it still tears down immediately so the daemon sees a clean
+// disconnect.
+let hiddenTeardownGraceMs = 5_000;
+
+/**
+ * Override the hidden-teardown grace window. Test-only seam so specs can
+ * exercise the debounce without real-time waits; never call from
+ * production code.
+ * @internal
+ */
+export function __setHiddenTeardownGraceMsForTesting(ms: number): void {
+  hiddenTeardownGraceMs = ms;
+}
+
 export interface SseService {
   /**
    * Open the SSE connection for `assistantId`, wire the bounce-policy
@@ -60,8 +82,9 @@ export const sseService: SseService = {
     // so this attachment starts cold (like a fresh page load): the first
     // connect omits `lastSeenSeq` and the conversation's snapshot
     // watermark re-anchors the cursor via `anchorColdStartReplay`. A
-    // transport reconnect within this attachment goes through `open()`,
-    // not `attach()`, so a live cursor is preserved across reconnects.
+    // transport reconnect within this attachment goes through
+    // `openConnection()`, not `attach()`, so a live cursor is preserved
+    // across reconnects.
     resetReconnectCursor();
 
     let current: EventStream | null = null;
@@ -106,8 +129,17 @@ export const sseService: SseService = {
     // Pending timer for a delayed debug-triggered reconnect, so detach
     // can cancel a reconnect that hasn't fired yet.
     let debugReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // Pending grace timer for a hidden-tab teardown, so a resume within
+    // the grace window (or a detach / other teardown) can cancel it.
+    let hiddenTeardownTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearHiddenTeardownTimer = () => {
+      if (hiddenTeardownTimer !== null) {
+        clearTimeout(hiddenTeardownTimer);
+        hiddenTeardownTimer = null;
+      }
+    };
 
-    const open = () => {
+    const openConnection = () => {
       if (cancelled || current) return;
       const causeAtOpen = nextOpenCause;
       nextOpenCause = "resume";
@@ -157,30 +189,44 @@ export const sseService: SseService = {
     };
 
     const teardown = () => {
+      // A teardown by any path (grace timer, power, reachability, debug,
+      // detach) makes a still-pending grace teardown moot — clear it so a
+      // late fire can't cancel a connection opened after it.
+      clearHiddenTeardownTimer();
       current?.cancel();
       setCurrent(null);
       setConnected(false);
     };
 
-    // App lifecycle (renderer-visibility resume): tear down on
-    // hidden, reopen on resume IF the connection was already torn
-    // down. The self-dedup window collapses double-fires from
-    // visibilitychange + Capacitor appStateChange (both arrive in
-    // close succession on foregrounding the iOS native shell).
+    // App lifecycle (renderer-visibility): a hidden tab does NOT tear the
+    // connection down immediately — see `handleAppHidden`, which debounces
+    // it behind `hiddenTeardownGraceMs`. On resume we cancel any pending
+    // grace teardown (so a brief tab-out keeps its live socket) and reopen
+    // only if the connection was actually torn down. The self-dedup window
+    // collapses double-fires from visibilitychange + Capacitor
+    // appStateChange (both arrive in close succession on foregrounding the
+    // iOS native shell).
     const handleAppResume = () => {
+      // Resumed within the grace window → the socket was never torn down;
+      // cancel the pending teardown and keep it. Resumed after it fired →
+      // no-op here, and the reopen below handles the down connection.
+      clearHiddenTeardownTimer();
       const now = Date.now();
       if (now - lastAppResumeAt < RESUME_DEDUP_WINDOW_MS) {
         // Inside the dedup window. This collapses the iOS double-fire
         // (visibilitychange + Capacitor appStateChange deliver two
         // resumes ms apart for a single foreground) so the health check
         // below runs once. But the window must NOT suppress a genuine
-        // reopen: an `app.hidden` can land *between* two resumes and tear
-        // the socket down (`current === null`), and a blanket early-return
-        // would then strand the connection torn-down until the next
-        // foreground — the user sees a frozen transcript and has to
-        // refresh to get streaming back. Reopen whenever the connection is
-        // down; only the redundant health check is skipped here.
-        if (!current) open();
+        // reopen: an `app.hidden` can land *between* two resumes and (once
+        // its grace elapses) tear the socket down (`current === null`),
+        // and a blanket early-return would then strand the connection
+        // torn-down until the next foreground — the user sees a frozen
+        // transcript and has to refresh to get streaming back. Reopen
+        // whenever the connection is down; only the redundant health check
+        // is skipped here.
+        if (!current) {
+          openConnection();
+        }
         return;
       }
       lastAppResumeAt = now;
@@ -193,7 +239,26 @@ export const sseService: SseService = {
       // connection is already live, it was either never torn down
       // or just opened moments ago — either way, leave it alone.
       if (current) return;
-      open();
+      openConnection();
+    };
+
+    // Renderer went hidden. Debounce the teardown: schedule it behind the
+    // grace window instead of cancelling the stream now, so a brief
+    // tab-out doesn't drop a live turn. A resume inside the window clears
+    // this timer; if the tab is still hidden when it fires, tear down for
+    // real. Idempotent — a repeat `app.hidden` while already scheduled is
+    // ignored.
+    const handleAppHidden = () => {
+      if (!current) {
+        return;
+      }
+      if (hiddenTeardownTimer !== null) {
+        return;
+      }
+      hiddenTeardownTimer = setTimeout(() => {
+        hiddenTeardownTimer = null;
+        teardownIfOpen();
+      }, hiddenTeardownGraceMs);
     };
 
     // System-level resume (Electron host): bounce the connection
@@ -212,7 +277,7 @@ export const sseService: SseService = {
       lastPowerActionAt = now;
       void lifecycleService.checkAssistant();
       teardown();
-      open();
+      openConnection();
     };
 
     const teardownIfOpen = () => {
@@ -241,7 +306,7 @@ export const sseService: SseService = {
           return;
         }
         nextOpenCause = "debug";
-        open();
+        openConnection();
       };
       if (delayMs <= 0) {
         reopen();
@@ -250,10 +315,10 @@ export const sseService: SseService = {
       }
     };
 
-    open();
+    openConnection();
     setSseReconnectHandler(reconnectForDebug);
 
-    const unsubHidden = subscribe("app.hidden", teardownIfOpen);
+    const unsubHidden = subscribe("app.hidden", handleAppHidden);
     // System-level suspend: gracefully close the SSE so the daemon
     // sees us go away cleanly instead of waiting for TCP timeouts.
     // The resume / unlock handlers above will reopen on wake; if
@@ -272,7 +337,7 @@ export const sseService: SseService = {
         // tab-foreground recovery from a reachability-driven retry.
         teardown();
         nextOpenCause = "error";
-        open();
+        openConnection();
       },
     );
     // Cold-start anchored replay (see `cold-anchor.ts`): the cold
@@ -290,7 +355,7 @@ export const sseService: SseService = {
       }
       teardown();
       nextOpenCause = "anchor";
-      open();
+      openConnection();
     });
 
     return () => {
@@ -300,6 +365,7 @@ export const sseService: SseService = {
         clearTimeout(debugReconnectTimer);
         debugReconnectTimer = null;
       }
+      clearHiddenTeardownTimer();
       unsubHidden();
       unsubPowerSuspend();
       unsubResume();

--- a/clients/web/src/assistant/sse-service.ts
+++ b/clients/web/src/assistant/sse-service.ts
@@ -169,7 +169,20 @@ export const sseService: SseService = {
     // close succession on foregrounding the iOS native shell).
     const handleAppResume = () => {
       const now = Date.now();
-      if (now - lastAppResumeAt < RESUME_DEDUP_WINDOW_MS) return;
+      if (now - lastAppResumeAt < RESUME_DEDUP_WINDOW_MS) {
+        // Inside the dedup window. This collapses the iOS double-fire
+        // (visibilitychange + Capacitor appStateChange deliver two
+        // resumes ms apart for a single foreground) so the health check
+        // below runs once. But the window must NOT suppress a genuine
+        // reopen: an `app.hidden` can land *between* two resumes and tear
+        // the socket down (`current === null`), and a blanket early-return
+        // would then strand the connection torn-down until the next
+        // foreground — the user sees a frozen transcript and has to
+        // refresh to get streaming back. Reopen whenever the connection is
+        // down; only the redundant health check is skipped here.
+        if (!current) open();
+        return;
+      }
       lastAppResumeAt = now;
       // Daemon health check via the lifecycle store. The no-op
       // default covers the pre-registration window but no


### PR DESCRIPTION
## Prompt / plan

Investigating a web-app user report: *"noticing some SSE issues on web-app today: I need to refresh to see the output from the assistant."* A Vellum Feedback export (client context, chat diagnostics, SSE liveness triage, durable lifecycle ring, **and the nested platform/daemon logs**) was analyzed to root-cause why streamed assistant output stalls until a manual refresh.

### What the logs show

The affected session (conversation `bb967abf…`, ~1h40m) is dominated by tab-visibility flapping: **45 `app.hidden` / 42 `app.resume`** cycles (median hidden ~25s; several under 10s). Per `EVENT_BUS.md` / `sse-service.ts`, every `app.hidden` tore the SSE connection down immediately and every `app.resume` reopened it cold — so the stream was cold-cycled every time the user tabbed in and out, each reopen paying a fresh connect + reconcile.

The daemon logs corroborate this from the server side and clear the daemon of a latency bug:
- `GET /v1/events` is accepted in **~1ms** every time; no 5xx, no slow requests in the window.
- The `assistant-event-hub` `subscriber registered / disposed stale / unregistered` churn exactly mirrors the client's teardown-on-hidden flapping.
- The post-refresh connection that *looked* like "17s to establish" was simply **idle** — `POST /v1/messages` (the user's next message) didn't arrive until 11:23:07, and the first frame followed ~30ms later. No dead-air delivery bug.
- The genuine "no output" window was the client tearing its SSE down while the tab was **backgrounded for ~11 min during an assistant turn**, then reloading ~2s after returning — before reconcile-on-resume could catch up. The output existed server-side; it just wasn't delivered live.

So the "SSE issues / need to refresh" is a **client churn** story, not a server one.

## Changes

**1. Debounce the `app.hidden` teardown behind a grace window (`hiddenTeardownGraceMs`, 5s).** A brief tab-out — alt-tab, a glance at another window, tapping a notification — no longer kills a live streaming turn. The teardown is scheduled; a resume inside the window cancels it and the same socket keeps streaming with no cold reopen + reconcile. Only a tab hidden past the window is treated as real backgrounding and torn down. `power.suspend` (system sleep) is deliberately **not** debounced — it still tears down immediately so the daemon sees a clean disconnect. This targets the bulk of the 42 flaps.

**2. Fix a resume-dedup stranding bug.** The 1s dedup window that collapses the iOS double-fire (`visibilitychange` + Capacitor `appStateChange`) was gating the *reopen* as well as the redundant health check. A `hidden` whose teardown fires between two resumes left the socket down (`current === null`) and a blanket early-return stranded it until the next foreground. Now the reopen fires whenever the connection is down; only the duplicate health check is deduped.

**3. Review follow-ups:** renamed the per-attachment `open()` → `openConnection()` (it read as `window.open` at call sites), and braced the new control-flow branches per the repo-root `AGENTS.md` rule.

## Test plan

- `bun test src/assistant/sse-service.test.ts` → **42 pass / 0 fail**. New coverage: teardown is debounced (not synchronous) on hidden; a resume inside the grace window keeps the live socket (no teardown, no reopen); teardown fires after the window and reopens on resume; the deduped resume still reopens a torn-down socket. Visibility/power/store specs updated for the grace window via a `__setHiddenTeardownGraceMsForTesting` test seam (keeps specs in ms).
- `bun test src/assistant/sse-service.test.ts src/hooks/use-event-bus-init.test.tsx` → 45 pass. Pre-existing unrelated failures elsewhere in `src/assistant/` (selection/lockfile specs) are present on `main` and untouched here.
- Pre-commit hook ran full `eslint` + `tsc --noEmit` for `clients/web` — both clean.

## Notes / follow-ups (not in this PR)

- The 5s grace helps frequent short/medium tab-outs but not a multi-minute background (teardown is correct there); reliability of that path depends on **reconcile-on-resume**, which the user short-circuited by reloading immediately on return. Worth a look at making the on-resume/`anchor` reconcile land faster / more visibly.
- The daemon logged a recurring `conversation-agent-loop: Turn-boundary commit timed out — continuing without waiting (commit still runs in background)` WARN. It's a persistence-commit latency note (not a stream-delivery bug — the rolling snapshot + reconcile cover it), but it's a candidate for separate investigation.
