### PR TITLE
feat(memory-graph): focus dimming — spotlight the selected node's neighborhood

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -403,12 +403,13 @@ export function ConceptGraphView({
   }, [edgeFilter]);
   // Reset every lens when the active assistant changes: this component is reused
   // across assistants (IdentityTab doesn't key it), so a stale search, recency
-  // window, or hidden edge kind would otherwise ghost/blank the new assistant's
-  // freshly-loaded graph.
+  // window, hidden edge kind, or open selection would otherwise ghost/blank the
+  // new assistant's freshly-loaded graph.
   useEffect(() => {
     setSearch("");
     setRecency("all");
     setEdgeFilter({ link: true, learned: true });
+    setTrail([]);
     searchEmittedRef.current = false;
   }, [assistantId]);
 
@@ -486,6 +487,10 @@ export function ConceptGraphView({
     const nodeClusters = clusters;
     const hubIds = clusterHubs;
     const adj = adjacency;
+    // Ids present in the current graph — used to ignore a stale selection (e.g.
+    // a same-assistant refetch that drops the open node) so focus-dim never
+    // blanks the whole map against a node that no longer exists.
+    const presentNodeIds = new Set(nodes.map((n) => n.id));
     const R = massRadius;
 
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -609,8 +614,8 @@ export function ConceptGraphView({
       // selected ego-network overrides the recency window and edge-kind filter
       // so it always reads and stays interactive; search still narrows normally.
       const selectedId = selectedIdRef.current;
-      const selectionActive = selectedId != null;
-      const inSelectedEgo = makeEgoTest(adj, selectedId);
+      const selectionActive = selectedId != null && presentNodeIds.has(selectedId);
+      const inSelectedEgo = makeEgoTest(adj, selectionActive ? selectedId : null);
 
       // Density fog: fade the resting learned-edge web as the corpus grows.
       const learnedFog =

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -58,6 +58,14 @@ const FOG_FULL_BELOW = 80;
 const FOG_FLOOR_ABOVE = 340;
 const FOG_FLOOR = 0.12;
 
+// Focus ego-dim: while a concept is open in the detail drawer, its immediate
+// neighborhood (the node + direct neighbors) stays lit and everything else
+// fades to near-zero — a stronger dim than hover — so the focused node reads
+// clearly (e.g. beside the panel). Non-neighbor edges dim to the same near-zero
+// as an already-ghosted edge.
+const SELECTION_DIM_NODE = 0.05;
+const SELECTION_DIM_EDGE = 0.03;
+
 // Below this node count the graph is small enough to scan by eye — no search box.
 const SEARCH_MIN_NODES = 12;
 
@@ -116,6 +124,19 @@ function isStale(
     return false;
   }
   return updatedAtMs == null || now - updatedAtMs > windowMs;
+}
+
+// Predicate for the selected concept's ego-network — the node itself plus its
+// direct neighbors. The neighbor set is resolved once so per-node checks stay
+// O(1). Shared by the render loop and the hit-test so click targets always
+// match what's drawn lit (like isStale for the recency lens).
+function makeEgoTest(
+  adjacency: Map<string, Set<string>>,
+  selectedId: string | null,
+): (id: string) => boolean {
+  const neighbors = selectedId ? adjacency.get(selectedId) : undefined;
+  return (id) =>
+    selectedId != null && (id === selectedId || (neighbors?.has(id) ?? false));
 }
 
 export interface ConceptGraphViewProps {
@@ -281,6 +302,16 @@ export function ConceptGraphView({
     emitMemoryEvent("node_opened");
     setTrail((t) => [...t, node]);
   }, []);
+  // The trail's current concept, mirrored into a ref the 60fps render loop and
+  // hit-test read (matches filterRef / recencyRef / edgeFilterRef) so opening,
+  // travelling, or closing a concept re-runs the ego-dim without re-running the
+  // render effect. `dirty` is bumped so the reduced-motion path redraws on a
+  // selection change; emptying the trail (id → null) restores normal rendering.
+  const selectedIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    selectedIdRef.current = openNode?.id ?? null;
+    view.current.dirty = true;
+  }, [openNode?.id]);
 
   // First-run explainer: shown over the graph (empty or populated) until the
   // user dismisses it; the dismissal sticks per-assistant.
@@ -573,6 +604,14 @@ export function ConceptGraphView({
       // Edge-kind toggle: a hidden kind is skipped entirely below.
       const edgeKinds = edgeFilterRef.current;
 
+      // Focus ego-dim: while a concept is open, spotlight its neighborhood (the
+      // node + direct neighbors) and fade everything else to near-zero. The
+      // selected ego-network overrides the recency window and edge-kind filter
+      // so it always reads and stays interactive; search still narrows normally.
+      const selectedId = selectedIdRef.current;
+      const selectionActive = selectedId != null;
+      const inSelectedEgo = makeEgoTest(adj, selectedId);
+
       // Density fog: fade the resting learned-edge web as the corpus grows.
       const learnedFog =
         nodes.length <= FOG_FULL_BELOW
@@ -625,20 +664,28 @@ export function ConceptGraphView({
         const b = posById.get(e.toId);
         if (!a || !b) {continue;}
         const learned = e.kind === "learned";
+        // Spine of the focused ego-network: an edge touching the selected node
+        // (selected ↔ neighbor). It overrides the edge-kind filter and the
+        // recency window so the neighborhood stays wired and interactive.
+        const egoEdge =
+          selectedId != null &&
+          (e.fromId === selectedId || e.toId === selectedId);
         // A hidden kind is neither drawn nor collected for edge-hover, so the
-        // hit-test stays consistent with what's on screen.
-        if (learned ? !edgeKinds.learned : !edgeKinds.link) {
+        // hit-test stays consistent with what's on screen — unless it's an ego
+        // edge, which selection keeps visible even when its kind is filtered.
+        if (!egoEdge && (learned ? !edgeKinds.learned : !edgeKinds.link)) {
           continue;
         }
-        // An edge ghosts if either endpoint is ghosted by search or recency.
+        // An edge ghosts if either endpoint is ghosted by search or recency;
+        // selection overrides the recency window for the ego edges.
         const ghost =
           (searchActive && (!isMatch(e.fromId) || !isMatch(e.toId))) ||
-          isRecencyGhost(a.node) ||
-          isRecencyGhost(b.node);
+          (!egoEdge && (isRecencyGhost(a.node) || isRecencyGhost(b.node)));
         const incident = activeId != null && (e.fromId === activeId || e.toId === activeId);
         const depth = (a.depth + b.depth) / 2;
-        // Only offer hover on edges that read as present — skip faded ones.
-        if (!ghost) {
+        // Only offer hover on edges that read as present — skip faded ones. With
+        // a selection, only the lit ego edges are hit-testable (the rest dim).
+        if (!ghost && (!selectionActive || egoEdge)) {
           projEdges.push({
             ax: a.sx,
             ay: a.sy,
@@ -657,6 +704,10 @@ export function ConceptGraphView({
         let alpha: number;
         if (ghost) {
           alpha = 0.03;
+        } else if (selectionActive) {
+          // Ego-dim: only edges touching the selected node stay bright; every
+          // other edge fades to near-zero so the neighborhood reads.
+          alpha = egoEdge ? 0.9 : SELECTION_DIM_EDGE;
         } else if (activeId != null) {
           alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? litAlpha : 0.05;
         } else {
@@ -664,7 +715,9 @@ export function ConceptGraphView({
         }
         ctx.globalAlpha = alpha;
         ctx.strokeStyle = learned ? EDGE_LEARNED_COLOR : colors.tertiary;
-        ctx.lineWidth = (incident ? 2 : 1) * (0.6 + 0.6 * depth);
+        ctx.lineWidth =
+          (incident || (selectionActive && egoEdge) ? 2 : 1) *
+          (0.6 + 0.6 * depth);
         ctx.setLineDash(learned ? [4, 4] : []);
         ctx.beginPath();
         ctx.moveTo(a.sx, a.sy);
@@ -684,11 +737,25 @@ export function ConceptGraphView({
             ? CLUSTER_PALETTE[(nodeClusters.get(node.id) ?? 0) % CLUSTER_PALETTE.length]
             : NODE_KIND_COLORS[node.kind];
         const searchGhost = searchActive && !isMatch(node.id);
-        const ghost = searchGhost || isRecencyGhost(node);
-        const lit = !ghost && isLit(node.id);
+        // Selection overrides the recency window for the focused ego-network so
+        // it stays lit; search still narrows normally.
+        const inEgo = inSelectedEgo(node.id);
+        const ghost = searchGhost || (isRecencyGhost(node) && !inEgo);
+        // With a selection, only its neighborhood is lit; otherwise fall back to
+        // the hover neighborhood.
+        const lit = selectionActive
+          ? inEgo && !ghost
+          : !ghost && isLit(node.id);
         const isActive = node.id === activeId;
         const depthA = DEPTH_ALPHA_MIN + (1 - DEPTH_ALPHA_MIN) * p.depth;
-        const alpha = ghost ? depthA * 0.08 : lit ? depthA : depthA * 0.18;
+        const alpha =
+          selectionActive && !inEgo
+            ? depthA * SELECTION_DIM_NODE
+            : ghost
+              ? depthA * 0.08
+              : lit
+                ? depthA
+                : depthA * 0.18;
 
         let glow = (isActive ? 16 : node.degree >= HUB_LABEL_DEGREE ? 8 : 4) * p.depth;
         // Recency: fresh concepts glow brighter; the very newest pulse. Static
@@ -733,16 +800,28 @@ export function ConceptGraphView({
         // the dense middle of the mass doesn't turn into unreadable label soup —
         // but always label each cluster's hub so every theme reads with a name.
         // While searching, label the matches instead (that's what you're after).
-        // Ghosted nodes (search or recency) never get labels.
-        if ((searchActive && !isMatch(node.id)) || isRecencyGhost(node)) {continue;}
-        const showLabel = searchActive
-          ? p.depth > 0.3
-          : activeId != null
-            ? isLit(node.id)
-            : hubIds.has(node.id) ||
-              (node.degree >= HUB_LABEL_DEGREE && p.depth > 0.55);
+        // With a selection, name the whole focused neighborhood. Ghosted nodes
+        // (search or recency) never get labels — but the selected ego-network
+        // overrides the recency window.
+        const inEgo = inSelectedEgo(node.id);
+        if (
+          (searchActive && !isMatch(node.id)) ||
+          (isRecencyGhost(node) && !inEgo)
+        ) {
+          continue;
+        }
+        const showLabel = selectionActive
+          ? inEgo
+          : searchActive
+            ? p.depth > 0.3
+            : activeId != null
+              ? isLit(node.id)
+              : hubIds.has(node.id) ||
+                (node.degree >= HUB_LABEL_DEGREE && p.depth > 0.55);
         if (!showLabel) {continue;}
-        ctx.globalAlpha = (node.id === activeId ? 1 : 0.85) * (0.4 + 0.6 * p.depth);
+        ctx.globalAlpha =
+          (node.id === activeId || node.id === selectedId ? 1 : 0.85) *
+          (0.4 + 0.6 * p.depth);
         ctx.fillStyle = colors.content;
         const label = node.label.length > 22 ? `${node.label.slice(0, 21)}…` : node.label;
         ctx.fillText(label, p.sx, p.sy + p.sr + 3);
@@ -772,16 +851,24 @@ export function ConceptGraphView({
   // Nearest node under a screen point; nearest-in-front wins. Ghosted nodes are
   // skipped so hover/click land on a live node, not a faded background one: both
   // search non-matches and, when a recency window is set, concepts older than it
-  // (a missing timestamp counts as stale). Mirrors the render-loop ghosting.
+  // (a missing timestamp counts as stale). A selected concept's ego-network is
+  // exempt from the recency skip so the focused neighborhood stays clickable.
+  // Mirrors the render-loop ghosting.
   const hitTest = useCallback((x: number, y: number): string | null => {
     const filter = filterRef.current;
     const recencyWindowMs = recencyRef.current;
+    // The focused ego-network stays clickable even when a recency window would
+    // otherwise skip it (selection overrides the filter); search still narrows.
+    const inSelectedEgo = makeEgoTest(adjacency, selectedIdRef.current);
     const now = Date.now();
     let best: string | null = null;
     let bestDepth = -1;
     for (const p of projectedRef.current) {
       if (filter.active && !(filter.matches?.has(p.id) ?? false)) {continue;}
-      if (isStale(p.updatedAtMs, recencyWindowMs, now)) {
+      if (
+        !inSelectedEgo(p.id) &&
+        isStale(p.updatedAtMs, recencyWindowMs, now)
+      ) {
         continue;
       }
       const dx = x - p.sx;
@@ -792,7 +879,7 @@ export function ConceptGraphView({
       }
     }
     return best;
-  }, []);
+  }, [adjacency]);
 
   // Nearest EDGE segment under a screen point, within ~5px (point-to-segment
   // distance); on ties the one nearer the front (higher depth) wins. Only the


### PR DESCRIPTION
## Summary
- On select, fade non-neighbors to near-zero + label the direct neighbors (ego-dim), read from a selectedIdRef in the 60fps loop
- Selection overrides recency/edge filters: focused node + neighbors stay lit and hit-testable

Part of plan: memory-viz-v2.md (PR 5 of 8)