### PR TITLE
fix(voice): tolerate brief gaps in the barge-in guard so interruptions land during TTS playback

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -2535,6 +2535,28 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     await waitFor(() => abort.mock.calls.length === 1);
   });
 
+  test("sparse periodic blips separated by boundary gaps do not accumulate into a barge-in", async () => {
+    const { frames, session, abort, speakFirstReply } =
+      createSpeakingTurnHarness({ bargeInMinSpeechMs: 60 });
+    await speakFirstReply();
+
+    // A 10 ms blip every 200 ms models residual echo/noise, not sustained
+    // speech: each blip clears the consecutive-gap timer while the boundary gap
+    // (20 chunks = 200 ms) escapes the per-gap reset. Enough cycles to reach the
+    // 60 ms guard by pure blip-summing (6 blips) plus margin. The duty-cycle
+    // ceiling (cumulative tolerated silence > bargeInMinSpeechMs * 4 = 240 ms)
+    // resets the run every few cycles, so the blips never sum into a barge-in.
+    for (let cycle = 0; cycle < 9; cycle += 1) {
+      await session.handleBinaryAudio(LOUD_CHUNK);
+      for (let index = 0; index < 20; index += 1) {
+        await session.handleBinaryAudio(DUCKED_CHUNK);
+      }
+    }
+    await flushAsyncCallbacks();
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(abort).not.toHaveBeenCalled();
+  });
+
   test("bargeInMinSpeechMs 0 restores instant barge-in", async () => {
     const { frames, session, abort, speakFirstReply } =
       createSpeakingTurnHarness({ bargeInMinSpeechMs: 0 });

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -2461,9 +2461,9 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     await flushAsyncCallbacks();
     expect(countType(frames, "turn_cancelled")).toBe(0);
 
-    // A single further speech chunk carries the retained 50 ms run to the 60 ms
-    // guard and cancels — proof the gap did not reset it (the old hard-reset
-    // guard would have needed a fresh 60 ms run and never cancelled).
+    // A single further speech chunk carries the retained 50 ms run across the
+    // gap to the 60 ms guard and cancels: the gap left the accumulator intact,
+    // so one more 10 ms chunk is enough rather than a fresh 60 ms run.
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -73,6 +73,12 @@ const LOUD_CHUNK = pcm(8_000);
 // chunk trips barge-in. Must stay above that default.
 const SUSTAINED_LOUD_CHUNK = pcm(8_000, 7_200);
 const SILENT_CHUNK = pcm(0);
+// A sub-threshold "ducked" chunk. While the assistant is audibly playing, the
+// browser's half-duplex echo canceller attenuates the user's near-end voice, so
+// the server classifies the post-AEC audio as below the speech-energy gate:
+// a barge-in mid-playback arrives as loud runs split by these ducked gaps.
+// 10 ms at 24 kHz, mean amplitude well under the 800 threshold.
+const DUCKED_CHUNK = pcm(200);
 
 class MockStreamingTranscriber implements StreamingTranscriber {
   readonly providerId = "deepgram" as const;
@@ -2439,25 +2445,63 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     await waitFor(() => abort.mock.calls.length === 1);
   });
 
-  test("a non-speech chunk resets the sustained-speech run", async () => {
-    const { frames, session, speakFirstReply } = createSpeakingTurnHarness({
-      bargeInMinSpeechMs: 60,
-    });
+  test("a brief sub-threshold gap does not reset the sustained-speech run", async () => {
+    const { frames, session, abort, speakFirstReply } =
+      createSpeakingTurnHarness({ bargeInMinSpeechMs: 60 });
     await speakFirstReply();
 
-    // 50 ms of speech, a silence blip, then 50 ms more: neither run reaches
-    // the guard because the blip zeroes the accumulator.
+    // 50 ms of speech, then one ducked gap: while the assistant is playing, the
+    // half-duplex echo canceller attenuates the user's voice, so the server
+    // sees a sub-threshold chunk mid-utterance. The gap (10 ms) is far shorter
+    // than BARGE_IN_GAP_TOLERANCE_MS, so it must NOT zero the run.
     for (let index = 0; index < 5; index += 1) {
       await session.handleBinaryAudio(LOUD_CHUNK);
     }
-    await session.handleBinaryAudio(SILENT_CHUNK);
+    await session.handleBinaryAudio(DUCKED_CHUNK);
+    await flushAsyncCallbacks();
+    expect(countType(frames, "turn_cancelled")).toBe(0);
+
+    // A single further speech chunk carries the retained 50 ms run to the 60 ms
+    // guard and cancels — proof the gap did not reset it (the old hard-reset
+    // guard would have needed a fresh 60 ms run and never cancelled).
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ type: "turn_cancelled", turnId: "live-turn-1" });
+    await waitFor(() => abort.mock.calls.length === 1);
+  });
+
+  test("a gap longer than the tolerance resets the sustained-speech run", async () => {
+    const { frames, session, abort, speakFirstReply } =
+      createSpeakingTurnHarness({ bargeInMinSpeechMs: 60 });
+    await speakFirstReply();
+
+    // 50 ms of speech, then a ducked gap longer than BARGE_IN_GAP_TOLERANCE_MS
+    // (25 chunks = 250 ms): a real pause rather than a syllable boundary, so the
+    // run resets. The harness silence threshold is 5 s, so the detector never
+    // ends the utterance here — the reset is the gap-tolerance logic, not
+    // utterance end.
+    for (let index = 0; index < 5; index += 1) {
+      await session.handleBinaryAudio(LOUD_CHUNK);
+    }
+    for (let index = 0; index < 25; index += 1) {
+      await session.handleBinaryAudio(DUCKED_CHUNK);
+    }
+    // 50 ms more speech: because the run reset, this accumulates from zero and
+    // stays under the 60 ms guard — the two stretches do not sum across the long
+    // gap into a false barge-in.
     for (let index = 0; index < 5; index += 1) {
       await session.handleBinaryAudio(LOUD_CHUNK);
     }
     await flushAsyncCallbacks();
     expect(countType(frames, "turn_cancelled")).toBe(0);
+    expect(abort).not.toHaveBeenCalled();
 
-    // A 6th consecutive speech chunk completes a full 60 ms run.
+    // A 6th consecutive speech chunk (with the 5 above) completes a fresh 60 ms
+    // run after the reset and cancels normally.
     await session.handleBinaryAudio(LOUD_CHUNK);
     await waitFor(() =>
       frames.some((frame) => frame.type === "turn_cancelled"),

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -2508,6 +2508,33 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
     );
   });
 
+  test("a gap of exactly the tolerance is tolerated and does not reset the run", async () => {
+    const { frames, session, abort, speakFirstReply } =
+      createSpeakingTurnHarness({ bargeInMinSpeechMs: 60 });
+    await speakFirstReply();
+
+    // 50 ms of speech, then a ducked gap of exactly BARGE_IN_GAP_TOLERANCE_MS
+    // (20 chunks = 200 ms). The tolerance is inclusive — the web client batches
+    // PCM into 50 ms frames, so a ducked run lands on the boundary exactly — so
+    // this gap does not reset the accumulated speech.
+    for (let index = 0; index < 5; index += 1) {
+      await session.handleBinaryAudio(LOUD_CHUNK);
+    }
+    for (let index = 0; index < 20; index += 1) {
+      await session.handleBinaryAudio(DUCKED_CHUNK);
+    }
+    // One more speech chunk carries the retained 50 ms run to the 60 ms guard
+    // and cancels — proof the exactly-200 ms gap left the accumulator intact.
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() =>
+      frames.some((frame) => frame.type === "turn_cancelled"),
+    );
+    expect(
+      frames.find((frame) => frame.type === "turn_cancelled"),
+    ).toMatchObject({ type: "turn_cancelled", turnId: "live-turn-1" });
+    await waitFor(() => abort.mock.calls.length === 1);
+  });
+
   test("bargeInMinSpeechMs 0 restores instant barge-in", async () => {
     const { frames, session, abort, speakFirstReply } =
       createSpeakingTurnHarness({ bargeInMinSpeechMs: 0 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -118,6 +118,15 @@ const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
 // longer continuous silence (a real end of speech, or an isolated cough) resets
 // the run.
 const BARGE_IN_GAP_TOLERANCE_MS = 200;
+// Ceiling on cumulative sub-threshold time across a whole barge-in run, as a
+// multiple of bargeInMinSpeechMs. Per-gap tolerance alone lets sparse isolated
+// blips (e.g. a 10 ms echo spike every 200 ms) each clear the consecutive-gap
+// timer while retaining prior speech, so they would sum to the guard over
+// several seconds and fire a barge-in with no sustained user speech. Capping the
+// run's total tolerated silence imposes a minimum above-gate duty cycle
+// (1 / (1 + ratio) ≈ 20%): once the run is mostly silence it resets, so genuine
+// choppy speech still lands but periodic noise cannot accumulate into one.
+const BARGE_IN_MAX_TOLERATED_SILENCE_RATIO = 4;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one
 // prefetching job. The prefetch buffers its chunks in memory until promoted;
@@ -469,9 +478,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // assistant turn is audibly speaking: above-gate speech-chunk duration
   // accumulates until it reaches bargeInMinSpeechMs, then the deferred
   // speech_started + barge-in fire (at most once per onset). Brief sub-threshold
-  // gaps are tolerated (see BARGE_IN_GAP_TOLERANCE_MS); only a continuous
-  // silence longer than that resets the run. The detector's utterance end
-  // discards the guard.
+  // gaps are tolerated (see BARGE_IN_GAP_TOLERANCE_MS); the run resets on a
+  // single longer continuous silence, or once cumulative tolerated silence
+  // exceeds the duty-cycle ceiling (see BARGE_IN_MAX_TOLERATED_SILENCE_RATIO).
+  // The detector's utterance end discards the guard.
   private pendingBargeIn: {
     // Null when guarding only the post-tts_done drain window (the turn is
     // already finalized but the client is still playing its tail).
@@ -480,6 +490,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Consecutive sub-threshold (non-speech) time since the last speech chunk;
     // resets speechMs once it exceeds BARGE_IN_GAP_TOLERANCE_MS.
     silenceMs: number;
+    // Cumulative sub-threshold time over the whole run (not reset by speech
+    // chunks); resets speechMs once it exceeds the duty-cycle ceiling so sparse
+    // periodic blips cannot sum into a barge-in.
+    toleratedSilenceMs: number;
   } | null = null;
   // Estimated wall-clock ms until the client finishes draining the
   // assistant audio sent so far. The server clears the turn right after
@@ -1105,7 +1119,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if ((bargeableTurn || drainingPlayback) && this.bargeInMinSpeechMs > 0) {
       // Onset audio keeps flowing into the cycle/pre-roll while the guard
       // accumulates (trackBargeInGuard), so no speech is lost either way.
-      this.pendingBargeIn = { turn: bargeableTurn, speechMs: 0, silenceMs: 0 };
+      this.pendingBargeIn = {
+        turn: bargeableTurn,
+        speechMs: 0,
+        silenceMs: 0,
+        toleratedSilenceMs: 0,
+      };
       return;
     }
 
@@ -1119,8 +1138,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   // Advances the sustained-speech barge-in guard by one server-VAD chunk:
   // above-gate speech accumulates toward bargeInMinSpeechMs while brief
-  // sub-threshold gaps are tolerated (only a continuous silence longer than
-  // BARGE_IN_GAP_TOLERANCE_MS zeroes the run), and once met the deferred
+  // sub-threshold gaps are tolerated (a single continuous silence longer than
+  // BARGE_IN_GAP_TOLERANCE_MS, or cumulative tolerated silence past the
+  // duty-cycle ceiling, zeroes the run), and once met the deferred
   // speech_started + barge-in fire.
   private trackBargeInGuard(hasSpeech: boolean, chunk: Buffer): void {
     const guard = this.pendingBargeIn;
@@ -1133,13 +1153,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     );
     if (!hasSpeech) {
       guard.silenceMs += chunkMs;
-      // Strictly greater: a gap of exactly BARGE_IN_GAP_TOLERANCE_MS is still
-      // tolerated. The web client batches PCM into 50 ms frames, so a run of
-      // ducked frames lands on the boundary exactly (e.g. four frames = 200 ms);
-      // only a longer continuous silence resets the accumulated speech.
-      if (guard.silenceMs > BARGE_IN_GAP_TOLERANCE_MS) {
+      guard.toleratedSilenceMs += chunkMs;
+      // Strictly greater on the per-gap check: a gap of exactly
+      // BARGE_IN_GAP_TOLERANCE_MS is still tolerated. The web client batches PCM
+      // into 50 ms frames, so a run of ducked frames lands on the boundary
+      // exactly (e.g. four frames = 200 ms). The run also resets once its total
+      // tolerated silence outweighs the speech by the duty-cycle ceiling, so
+      // sparse periodic blips can never sum to the guard.
+      if (
+        guard.silenceMs > BARGE_IN_GAP_TOLERANCE_MS ||
+        guard.toleratedSilenceMs >
+          this.bargeInMinSpeechMs * BARGE_IN_MAX_TOLERATED_SILENCE_RATIO
+      ) {
         guard.speechMs = 0;
         guard.silenceMs = 0;
+        guard.toleratedSilenceMs = 0;
       }
       return;
     }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -109,14 +109,14 @@ const FINALIZE_GRACE_MS = 1_000;
 // liveVoice.vad.bargeInMinSpeechMs schema default; 0 disables the guard for
 // instant barge-in.
 const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
-// Brief sub-threshold gaps within a barge-in run must NOT reset the accumulated
-// speech: a syllable boundary, or the choppy energy the browser's half-duplex
-// echo canceller produces while the assistant is still playing (it ducks the
-// user's near-end voice, so post-AEC user speech arrives as intermittent
-// above-gate chunks). Only a continuous silence longer than this (a real end of
-// speech, or an isolated cough) resets the run. Without this tolerance, a single
-// quiet chunk zeroes the run, so speech during playback never reaches
-// bargeInMinSpeechMs and the interruption never lands.
+// Longest continuous sub-threshold gap the sustained-speech barge-in run
+// tolerates without resetting. A gap this short is a syllable boundary, or the
+// choppy energy the browser's half-duplex echo canceller produces while the
+// assistant is still playing (it ducks the user's near-end voice, so post-AEC
+// user speech arrives as intermittent above-gate chunks) — so the run keeps
+// accumulating across it and a barge-in during playback still lands. Only a
+// longer continuous silence (a real end of speech, or an isolated cough) resets
+// the run.
 const BARGE_IN_GAP_TOLERANCE_MS = 200;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -109,6 +109,15 @@ const FINALIZE_GRACE_MS = 1_000;
 // liveVoice.vad.bargeInMinSpeechMs schema default; 0 disables the guard for
 // instant barge-in.
 const DEFAULT_BARGE_IN_MIN_SPEECH_MS = 250;
+// Brief sub-threshold gaps within a barge-in run must NOT reset the accumulated
+// speech: a syllable boundary, or the choppy energy the browser's half-duplex
+// echo canceller produces while the assistant is still playing (it ducks the
+// user's near-end voice, so post-AEC user speech arrives as intermittent
+// above-gate chunks). Only a continuous silence longer than this (a real end of
+// speech, or an isolated cough) resets the run. Without this tolerance, a single
+// quiet chunk zeroes the run, so speech during playback never reaches
+// bargeInMinSpeechMs and the interruption never lands.
+const BARGE_IN_GAP_TOLERANCE_MS = 200;
 // At most this many TTS segment jobs are open (provider stream started,
 // frames not yet fully emitted) per turn: the emitting job plus one
 // prefetching job. The prefetch buffers its chunks in memory until promoted;
@@ -457,15 +466,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // sensitivity" live (see applyConfigUpdate).
   private bargeInMinSpeechMs: number;
   // Sustained-speech barge-in guard, armed at speech onset while the
-  // assistant turn is audibly speaking: consecutive speech-chunk duration
+  // assistant turn is audibly speaking: above-gate speech-chunk duration
   // accumulates until it reaches bargeInMinSpeechMs, then the deferred
-  // speech_started + barge-in fire (at most once per onset). A non-speech
-  // chunk zeroes the run; the detector's utterance end discards the guard.
+  // speech_started + barge-in fire (at most once per onset). Brief sub-threshold
+  // gaps are tolerated (see BARGE_IN_GAP_TOLERANCE_MS); only a continuous
+  // silence longer than that resets the run. The detector's utterance end
+  // discards the guard.
   private pendingBargeIn: {
     // Null when guarding only the post-tts_done drain window (the turn is
     // already finalized but the client is still playing its tail).
     turn: ActiveAssistantTurn | null;
     speechMs: number;
+    // Consecutive sub-threshold (non-speech) time since the last speech chunk;
+    // resets speechMs once it exceeds BARGE_IN_GAP_TOLERANCE_MS.
+    silenceMs: number;
   } | null = null;
   // Estimated wall-clock ms until the client finishes draining the
   // assistant audio sent so far. The server clears the turn right after
@@ -1091,7 +1105,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if ((bargeableTurn || drainingPlayback) && this.bargeInMinSpeechMs > 0) {
       // Onset audio keeps flowing into the cycle/pre-roll while the guard
       // accumulates (trackBargeInGuard), so no speech is lost either way.
-      this.pendingBargeIn = { turn: bargeableTurn, speechMs: 0 };
+      this.pendingBargeIn = { turn: bargeableTurn, speechMs: 0, silenceMs: 0 };
       return;
     }
 
@@ -1104,22 +1118,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   // Advances the sustained-speech barge-in guard by one server-VAD chunk:
-  // consecutive speech accumulates toward bargeInMinSpeechMs (a non-speech
-  // chunk zeroes the run) and, once met, the deferred speech_started +
-  // barge-in fire.
+  // above-gate speech accumulates toward bargeInMinSpeechMs while brief
+  // sub-threshold gaps are tolerated (only a continuous silence longer than
+  // BARGE_IN_GAP_TOLERANCE_MS zeroes the run), and once met the deferred
+  // speech_started + barge-in fire.
   private trackBargeInGuard(hasSpeech: boolean, chunk: Buffer): void {
     const guard = this.pendingBargeIn;
     if (!guard) {
       return;
     }
-    if (!hasSpeech) {
-      guard.speechMs = 0;
-      return;
-    }
-    guard.speechMs += pcm16DurationMs(
+    const chunkMs = pcm16DurationMs(
       chunk.byteLength,
       this.context.startFrame.audio.sampleRate,
     );
+    if (!hasSpeech) {
+      guard.silenceMs += chunkMs;
+      if (guard.silenceMs >= BARGE_IN_GAP_TOLERANCE_MS) {
+        guard.speechMs = 0;
+        guard.silenceMs = 0;
+      }
+      return;
+    }
+    guard.silenceMs = 0;
+    guard.speechMs += chunkMs;
     if (guard.speechMs < this.bargeInMinSpeechMs) {
       return;
     }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1133,7 +1133,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     );
     if (!hasSpeech) {
       guard.silenceMs += chunkMs;
-      if (guard.silenceMs >= BARGE_IN_GAP_TOLERANCE_MS) {
+      // Strictly greater: a gap of exactly BARGE_IN_GAP_TOLERANCE_MS is still
+      // tolerated. The web client batches PCM into 50 ms frames, so a run of
+      // ducked frames lands on the boundary exactly (e.g. four frames = 200 ms);
+      // only a longer continuous silence resets the accumulated speech.
+      if (guard.silenceMs > BARGE_IN_GAP_TOLERANCE_MS) {
         guard.speechMs = 0;
         guard.silenceMs = 0;
       }


### PR DESCRIPTION
## Summary
- The sustained-speech barge-in guard (`trackBargeInGuard`) hard-zeroed its accumulated run on any single sub-threshold chunk. While the assistant is audibly playing, the browser's half-duplex echo canceller ducks the user's near-end voice, so the server classifies the interruption as **choppy** (intermittent above-gate chunks). The guard kept resetting, never reached `bargeInMinSpeechMs`, never sent `speech_started`, and the fully-generated reply played to completion over the user. (The user's speech was still captured by the persistent transcriber, so the interruption 'registered' as an appended turn — but never stopped the reply.)
- Make the guard **tolerant of brief gaps**: accumulate sub-threshold time in a new `silenceMs` and reset the run only once a *continuous* silence exceeds `BARGE_IN_GAP_TOLERANCE_MS` (200ms, inclusive) — a real end-of-speech or an isolated cough. Speech split by short ducked gaps now accumulates across them, so the interruption lands.
- **Bound cumulative tolerated silence** so sparse periodic blips (residual echo/noise) cannot each clear the per-gap timer and sum into a false barge-in: the run also resets once total tolerated silence exceeds `bargeInMinSpeechMs * BARGE_IN_MAX_TOLERATED_SILENCE_RATIO`, imposing a ~20% minimum above-gate duty cycle. Genuine choppy speech still lands; periodic noise does not.
- **Thinking-phase barge-in already worked** (no audio playing → no AEC ducking → clean user energy), which is why only the *speaking* phase failed. Scoped to server-VAD/hands-free; the energy gate, detector, client, and drain-tail estimate are unchanged.
- Tests: a choppy/ducked-gap run now barges in (verified to **fail** against the old hard-reset guard); a gap of exactly the tolerance is tolerated while a longer one resets; and sparse periodic blips do **not** accumulate into a barge-in (verified to fire without the duty-cycle bound).

Note: the trailing-clip tail-padding (a reply's last words clipped as client playback drains after `tts_done`) is a separate follow-up, out of scope here.

## Original prompt
On last night's dev build, the assistant kept speaking a fully-generated reply and ignored spoken interruptions in hands-free voice — the interruption *registered* (STT captured it and a response was generated) but the reply didn't stop. Root-caused to the barge-in guard never reaching its threshold while the assistant is audibly playing: AEC ducking makes the user's speech arrive as choppy sub-threshold chunks that the guard's hard reset kept zeroing. This makes the guard tolerate brief gaps (bounded so noise can't accumulate) so speaking-phase interruptions land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)