### PR TITLE
feat(memory): surface a memory count on the identity Memory card

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17370,6 +17370,29 @@ paths:
                   - message
                   - success
                 additionalProperties: false
+  /v1/memory/stats:
+    get:
+      operationId: memory_stats_get
+      summary: Get lightweight memory stats
+      description:
+        Return a cheap count of concept pages from the cached memory page index, for glanceable surfaces like the
+        identity Memory card. Counts concept pages only and never builds the memory-concept graph.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  concepts:
+                    type: number
+                    description: Number of concept pages in memory
+                required:
+                  - concepts
+                additionalProperties: false
   /v1/memory/v2/backfill:
     post:
       operationId: memory_v2_backfill_post

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
@@ -63,6 +63,16 @@ mock.module(
   }),
 );
 
+// Programmable synthetic skill list for the memory-stats page-index count.
+// `getPageIndex` dynamically imports skill-store, so mocking it here lets the
+// stats test seed synthetic (modifiedAt: 0) rows and assert they're excluded.
+let mockSkillEntries: Array<{ id: string; content: string }> = [];
+
+mock.module("../v2/skill-store.js", () => ({
+  SKILL_SLUG_PREFIX: "skills/",
+  listSkillEntries: () => mockSkillEntries,
+}));
+
 import { eq } from "drizzle-orm";
 
 import { setConfig } from "../../../../__tests__/helpers/set-config.js";
@@ -82,6 +92,9 @@ import {
   NotFoundError,
 } from "../../../../runtime/routes/errors.js";
 import type { RouteDefinition } from "../../../../runtime/routes/types.js";
+import { invalidatePageIndex } from "../v2/page-index.js";
+import { writePage } from "../v2/page-store.js";
+import type { ConceptPage } from "../v2/types.js";
 import { ROUTES } from "./memory-item-routes.js";
 
 // ---------------------------------------------------------------------------
@@ -1116,6 +1129,81 @@ describe("Memory Item Routes", () => {
         body: { content: 42 },
       });
       expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Memory stats (page-index concept count) ───────────────────────────────
+
+  describe("GET /v1/memory/stats (getMemoryStats)", () => {
+    // handleGetMemoryStats reads concept pages from getWorkspaceDir(); point
+    // it at a throwaway tmpdir so the page scan stays isolated from ~/.vellum.
+    // A fresh workspace per test keeps each concept count independent.
+    let tmpWorkspace: string;
+    let previousWorkspaceEnv: string | undefined;
+
+    beforeEach(() => {
+      tmpWorkspace = mkdtempSync(join(tmpdir(), "memory-stats-route-test-"));
+      previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+      process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+      // A no-skill baseline; the exclusion test seeds synthetic rows itself.
+      mockSkillEntries = [];
+      // Drop any cached index so each run re-scans this fresh workspace.
+      invalidatePageIndex();
+    });
+
+    afterEach(() => {
+      if (previousWorkspaceEnv === undefined) {
+        delete process.env.VELLUM_WORKSPACE_DIR;
+      } else {
+        process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+      }
+      rmSync(tmpWorkspace, { recursive: true, force: true });
+      invalidatePageIndex();
+    });
+
+    const route = getRoute("memory/stats", "GET");
+
+    function makeConceptPage(slug: string): ConceptPage {
+      return {
+        slug,
+        frontmatter: { edges: [], ref_files: [], ref_urls: [] },
+        body: `Body for ${slug}`,
+      };
+    }
+
+    test("counts concept pages in the workspace", async () => {
+      await writePage(tmpWorkspace, makeConceptPage("alice"));
+      await writePage(tmpWorkspace, makeConceptPage("bob"));
+      await writePage(tmpWorkspace, makeConceptPage("carol"));
+
+      const res = await callHandler(route);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { concepts: number };
+      expect(body.concepts).toBe(3);
+    });
+
+    test("returns zero for an empty workspace", async () => {
+      const res = await callHandler(route);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { concepts: number };
+      expect(body.concepts).toBe(0);
+    });
+
+    test("excludes synthetic (modifiedAt <= 0) skill entries", async () => {
+      // Synthetic skill rows (seeded skills / CLI commands) carry
+      // modifiedAt: 0 and must not inflate the concept count.
+      mockSkillEntries = [
+        { id: "agent-mail", content: "Send and read email" },
+        { id: "calendar", content: "Manage the calendar" },
+      ];
+      await writePage(tmpWorkspace, makeConceptPage("alice"));
+      await writePage(tmpWorkspace, makeConceptPage("bob"));
+
+      const res = await callHandler(route);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { concepts: number };
+      // Two real concept pages; the two synthetic skill rows are excluded.
+      expect(body.concepts).toBe(2);
     });
   });
 });

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -67,6 +67,8 @@ import type {
   NewNode,
 } from "../graph/types.js";
 import { getLogger } from "../logging.js";
+import { getWorkspaceDir } from "../paths.js";
+import { getPageIndex } from "../v2/page-index.js";
 
 const log = getLogger("memory-item-routes");
 
@@ -463,6 +465,22 @@ function handleGetMemoryItem(id: string) {
   return { item: nodeToPayload(node) };
 }
 
+/**
+ * Cheap concept count for glanceable surfaces (the identity Memory card).
+ *
+ * Read straight from the CACHED page index and count only real concept pages:
+ * those carry a real file mtime (`modifiedAt > 0`), while synthetic rows
+ * (seeded skills and CLI commands) carry `modifiedAt: 0`. This mirrors the
+ * concepts-only filter in `build-memory-graph.ts`, but never triggers the
+ * expensive `getMemoryGraph` build (edge / learned / cluster graph) — the
+ * concept graph is deliberately kept off identity-page load.
+ */
+async function handleGetMemoryStats(): Promise<{ concepts: number }> {
+  const pageIndex = await getPageIndex(getWorkspaceDir());
+  const concepts = pageIndex.entries.filter((e) => e.modifiedAt > 0).length;
+  return { concepts };
+}
+
 async function handleCreateMemoryItem(body: Record<string, unknown>) {
   const { kind, subject, statement, importance } = body as {
     kind?: string;
@@ -735,6 +753,26 @@ export const ROUTES: RouteDefinition[] = [
         .describe("Memory item with graph metadata"),
     }),
     handler: ({ pathParams }) => handleGetMemoryItem(pathParams!.id),
+  },
+
+  {
+    operationId: "getMemoryStats",
+    endpoint: "memory/stats",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get lightweight memory stats",
+    description:
+      "Return a cheap count of concept pages from the cached memory page " +
+      "index, for glanceable surfaces like the identity Memory card. Counts " +
+      "concept pages only and never builds the memory-concept graph.",
+    tags: ["memory"],
+    responseBody: z.object({
+      concepts: z.number().describe("Number of concept pages in memory"),
+    }),
+    handler: () => handleGetMemoryStats(),
   },
 
   {

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -10,7 +10,7 @@
  * small stat line).
  */
 
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Brain,
   CalendarClock,
@@ -39,6 +39,7 @@ import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { contrastForeground } from "@/utils/avatar-tone";
 
 import { applyRename } from "../identity-actions/apply-rename";
+import { memoryStatsOptions } from "../memory-graph/get-memory-stats";
 import {
   assistantIdentityDetailsQueryKey,
   useAssistantIdentityDetails,
@@ -171,6 +172,24 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
     supportsPlugins,
     showChannels,
   });
+  // The Memory card's measurement is the cheap page-index concept count
+  // (get-memory-stats) — NOT the concept-graph build, which is kept off
+  // identity-page load. Gated on `showMemory` so no request fires while the
+  // Memory card is hidden.
+  const memoryStats = useQuery({
+    ...memoryStatsOptions(assistantId),
+    enabled: showMemory,
+  });
+  const sectionStats: Record<string, IdentitySectionStat | undefined> = {
+    ...stats,
+    memory:
+      memoryStats.data !== undefined
+        ? {
+            value: memoryStats.data.concepts,
+            label: memoryStats.data.concepts === 1 ? "memory" : "memories",
+          }
+        : undefined,
+  };
 
   const [modalOpen, setModalOpen] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
@@ -234,7 +253,7 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
           customImageUrl={customImageUrl}
           name={identityQuery.data?.identity?.name || "Assistant"}
           sections={sections}
-          stats={stats}
+          stats={sectionStats}
           avatarHex={avatarHex}
           isRenaming={isRenaming}
           onOpenAvatarModal={() => setModalOpen(true)}

--- a/clients/web/src/domains/intelligence/memory-graph/get-memory-stats.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/get-memory-stats.ts
@@ -1,0 +1,58 @@
+/**
+ * TanStack Query options for the lightweight `GET /memory/stats` daemon
+ * endpoint — a cheap concept-page count for glanceable surfaces (the identity
+ * Memory card). Unlike `memoryGraphOptions`, this never triggers the memory
+ * concept-graph build; it reads a single count off the cached page index.
+ *
+ * A 404 (an older assistant predating the route) degrades to `{ concepts: 0 }`
+ * so the card shows "0 memories" rather than an error (see
+ * `docs/BACKWARDS_COMPAT.md`). Other non-2xx / transport errors throw.
+ */
+
+import { queryOptions } from "@tanstack/react-query";
+
+import { memoryStatsGet } from "@/generated/daemon/sdk.gen";
+import {
+  ApiError,
+  assertHasResponse,
+  extractErrorMessage,
+} from "@/utils/api-errors";
+
+export interface MemoryStats {
+  concepts: number;
+}
+
+const FAILURE_MESSAGE = "Failed to load memory stats.";
+
+export function memoryStatsOptions(assistantId: string) {
+  return queryOptions<MemoryStats>({
+    queryKey: ["memory-stats", assistantId] as const,
+    // A glanceable count that only changes on the timescale of memory writes —
+    // don't refire it on every window refocus.
+    staleTime: 5 * 60_000,
+    queryFn: async (): Promise<MemoryStats> => {
+      const { data, error, response } = await memoryStatsGet({
+        path: { assistant_id: assistantId },
+        throwOnError: false,
+      });
+
+      assertHasResponse(response, error, FAILURE_MESSAGE);
+
+      // An assistant/daemon predating the `/memory/stats` route answers 404;
+      // treat that as an empty memory so the card degrades to "0 memories"
+      // instead of an error (BACKWARDS_COMPAT read rule).
+      if (response.status === 404) {
+        return { concepts: 0 };
+      }
+
+      if (!response.ok) {
+        throw new ApiError(
+          response.status,
+          extractErrorMessage(error, response, FAILURE_MESSAGE),
+        );
+      }
+
+      return { concepts: data?.concepts ?? 0 };
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- New lightweight GET /v1/memory/stats route (page-index concept count; no graph build)
- Identity Memory card now shows a '{n} memories' measurement like the sibling cards, gated on the memory flag

Part of plan: memory-viz-v2.md (PR 9 of 9)