### PR TITLE
fix(cli): stop test mock.module leaks from failing the suite

### DIFF
--- a/cli/src/__tests__/clean.test.ts
+++ b/cli/src/__tests__/clean.test.ts
@@ -19,6 +19,13 @@ const stopProcessMock = mock(
   async (_pid: number, _label: string): Promise<boolean> => true,
 );
 
+// Snapshot the real modules so the afterAll below can restore them. Bun runs
+// every test file in one process with a shared loader, and `mock.restore()`
+// does not undo `mock.module()`; without restoring, these mocks (notably the
+// partial `process.js` mock) leak into sibling test files.
+const realOrphanDetection = { ...(await import("../lib/orphan-detection.js")) };
+const realProcess = { ...(await import("../lib/process.js")) };
+
 beforeAll(() => {
   mock.module("../lib/orphan-detection.js", () => ({
     detectOrphanedProcesses: detectOrphansMock,
@@ -65,6 +72,9 @@ afterEach(() => {
 
 afterAll(() => {
   process.argv = [...originalArgv];
+  // Restore the real modules so the mocks do not leak into sibling test files.
+  mock.module("../lib/orphan-detection.js", () => realOrphanDetection);
+  mock.module("../lib/process.js", () => realProcess);
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -10,14 +10,21 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 
+const realChildProcess = { ...childProcess };
 const execFileSyncMock = mock(childProcess.execFileSync);
 
 mock.module("node:child_process", () => ({
   ...childProcess,
   execFileSync: execFileSyncMock,
 }));
+
+// Restore the real module once this file finishes so the mock does not leak
+// into sibling test files in the same `bun test` run.
+afterAll(() => {
+  mock.module("node:child_process", () => realChildProcess);
+});
 
 import {
   buildIngressNginxConfig,

--- a/cli/src/__tests__/preload.ts
+++ b/cli/src/__tests__/preload.ts
@@ -25,7 +25,14 @@ afterAll(() => {
     /* best-effort cleanup */
   }
 
-  // Reset all module mocks so mock.module() calls in one test file
-  // don't leak into the next file in the same bun test run.
+  // Restore spies created via spyOn()/mock() at the end of the run.
+  //
+  // NOTE: this does NOT prevent inter-file leaks of `mock.module()`. This
+  // `afterAll` runs once, after ALL files complete (a preload's afterAll wraps
+  // the whole run, not each file), and `mock.restore()` does not undo
+  // `mock.module()` registrations anyway. A file that calls `mock.module()`
+  // must restore the real module itself in its own `afterAll` by re-registering
+  // the captured real exports (see e.g. teleport.test.ts / recover.test.ts),
+  // otherwise the mock leaks into whichever file Bun runs next.
   mock.restore();
 });

--- a/cli/src/__tests__/retire-local.test.ts
+++ b/cli/src/__tests__/retire-local.test.ts
@@ -17,10 +17,22 @@ import type { AssistantEntry } from "../lib/assistant-config.js";
 const testDir = mkdtempSync(join(tmpdir(), "retire-local-test-"));
 const originalLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
 
+// Snapshot the real modules before mocking so the module-scoped `afterAll`
+// below can restore them. Bun runs every test file in one process with a
+// shared loader, and `mock.restore()` does not undo `mock.module()`. Without
+// restoring, the `retire-archive.js` mock in particular leaks its hardcoded
+// `test-assistant.*` paths into sibling files (e.g. `recover.test.ts`), which
+// then fail to find their own archives.
+const realProcess = { ...(await import("../lib/process.js")) };
+const realNginxIngress = { ...(await import("../lib/nginx-ingress.js")) };
+const realRetireArchive = { ...(await import("../lib/retire-archive.js")) };
+
 const stopProcessByPidFileMock = mock(
   async (_pidFile: string, _label: string): Promise<boolean> => true,
 );
-const stopOrphanedDaemonProcessesMock = mock(async (): Promise<boolean> => false);
+const stopOrphanedDaemonProcessesMock = mock(
+  async (): Promise<boolean> => false,
+);
 const stopIngressNginxMock = mock(async (): Promise<boolean> => false);
 
 mock.module("../lib/process.js", () => ({
@@ -39,6 +51,14 @@ mock.module("../lib/retire-archive.js", () => ({
   getArchivePath: () => join(retiredStagingDir, "test-assistant.tar.gz"),
   getMetadataPath: () => join(retiredStagingDir, "test-assistant.meta.json"),
 }));
+
+// Restore the real modules once this file finishes so the mocks above do not
+// leak into other test files in the same `bun test` run.
+afterAll(() => {
+  mock.module("../lib/process.js", () => realProcess);
+  mock.module("../lib/nginx-ingress.js", () => realNginxIngress);
+  mock.module("../lib/retire-archive.js", () => realRetireArchive);
+});
 
 import { retireLocal } from "../lib/retire-local.js";
 

--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -23,10 +23,18 @@ const isProcessAliveMock = mock((): { alive: boolean; pid: number | null } => ({
   pid: null,
 }));
 
+const realProcess = { ...(await import("../lib/process.js")) };
+
 mock.module("../lib/process.js", () => ({
   isProcessAlive: isProcessAliveMock,
   stopProcessByPidFile: stopProcessByPidFileMock,
 }));
+
+// Restore the real module once this file finishes so the mock does not leak
+// into other test files in the same `bun test` run.
+afterAll(() => {
+  mock.module("../lib/process.js", () => realProcess);
+});
 
 import { sleep } from "../commands/sleep.js";
 import {

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -282,6 +282,17 @@ mock.module("../lib/local-runtime-client.js", () => ({
   localRuntimePreflightFromGcs: localRuntimePreflightFromGcsMock,
 }));
 
+// Snapshot the remaining real modules before mocking so `afterAll` can
+// restore them too — otherwise these mocks leak into sibling test files that
+// import the same modules in the same `bun test` run.
+const realHatchLocal = { ...(await import("../lib/hatch-local.js")) };
+const realDocker = { ...(await import("../lib/docker.js")) };
+const realProcess = { ...(await import("../lib/process.js")) };
+const realRetireLocal = { ...(await import("../lib/retire-local.js")) };
+const realUpgradeLifecycle = {
+  ...(await import("../lib/upgrade-lifecycle.js")),
+};
+
 const hatchLocalMock = mock(async () => {});
 
 mock.module("../lib/hatch-local.js", () => ({
@@ -350,6 +361,11 @@ afterAll(() => {
   mock.module("../lib/guardian-token.js", () => realGuardianToken);
   mock.module("../lib/platform-client.js", () => realPlatformClient);
   mock.module("../lib/local-runtime-client.js", () => realLocalRuntimeClient);
+  mock.module("../lib/hatch-local.js", () => realHatchLocal);
+  mock.module("../lib/docker.js", () => realDocker);
+  mock.module("../lib/process.js", () => realProcess);
+  mock.module("../lib/retire-local.js", () => realRetireLocal);
+  mock.module("../lib/upgrade-lifecycle.js", () => realUpgradeLifecycle);
   rmSync(testDir, { recursive: true, force: true });
   delete process.env.VELLUM_LOCKFILE_DIR;
 });

--- a/cli/src/lib/__tests__/local-ces.test.ts
+++ b/cli/src/lib/__tests__/local-ces.test.ts
@@ -15,6 +15,15 @@ import { startCes } from "../local.js";
 // Mocks
 // ---------------------------------------------------------------------------
 
+// Snapshot the real modules before any `mock.module()` call so we can
+// re-register them in a module-scoped `afterAll` below. Bun runs every test
+// file in one process with a shared loader; without restoring, these mocks
+// leak into sibling files (e.g. `step-runner.test.ts`, whose real `spawn`
+// then returns this file's fake child with no `stdin` and a no-op `on`).
+const realChildProcess = { ...(await import("node:child_process")) };
+const realXdgLog = { ...(await import("../xdg-log.js")) };
+const realProcess = { ...(await import("../process.js")) };
+
 // Capture spawn calls so we can assert on cmd/env.
 let lastSpawnCall: {
   cmd: string[];
@@ -54,6 +63,15 @@ mock.module("../process.js", () => ({
   isProcessAlive: mock(() => false),
   stopProcessGracefully: mock(async () => {}),
 }));
+
+// Restore the real modules once this file finishes so the mocks above do not
+// leak into other test files in the same `bun test` run. `mock.restore()` does
+// not undo `mock.module()`, so we re-register the captured real exports.
+afterAll(() => {
+  mock.module("node:child_process", () => realChildProcess);
+  mock.module("../xdg-log.js", () => realXdgLog);
+  mock.module("../process.js", () => realProcess);
+});
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/cli/src/lib/environments/__tests__/paths.test.ts
+++ b/cli/src/lib/environments/__tests__/paths.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { join } from "path";
 
 const TEST_HOME = "/test/home";
@@ -17,6 +25,13 @@ mock.module("os", () => ({
   ...realOs,
   homedir: () => TEST_HOME,
 }));
+
+// Restore the real `os` module once this file finishes so the `homedir()`
+// override does not leak into other test files in the same `bun test` run.
+afterAll(() => {
+  mock.module("node:os", () => realOs);
+  mock.module("os", () => realOs);
+});
 
 // Imports that depend on the mocked `os` module must come after the
 // mock.module() calls above.


### PR DESCRIPTION
## Prompt / plan

The CLI `test` check was failing on `main` ([run](https://github.com/vellum-ai/vellum-assistant/actions/runs/29577812329/job/88395502783)) with 12 failures across `step-runner`, `recover`, and `nginx-ingress` tests — none of which fail in isolation.

**Root cause:** Bun runs every CLI test file in a single process with a shared module loader. Several test files register `mock.module()` overrides at module scope but never restore the real modules, so a mock leaks into whichever file Bun runs next and breaks it — and *which* files break depends on run order (hence the CI-only failures):

- `local-ces.test.ts` replaced `node:child_process` with a fake `spawn` returning a child with **no `stdin`** and a no-op `on()`. The real `step-runner` tests then hit `child.stdin.end` (undefined) or timed out waiting for a `close` event that never fired.
- `retire-local.test.ts` replaced `retire-archive.js` with hardcoded `test-assistant.*` paths, so `recover.test.ts` could no longer find its own archives (`No retired archive found`).
- `teleport`, `sleep`, `clean`, `nginx-ingress`, and `paths` leaked mocks of shared modules (`process.js`, `node:child_process`, `node:os`, …) that could break sibling files under other orderings.

The preload's `mock.restore()` did **not** guard against this: a preload's `afterAll` runs once after the whole run (not per file), and `mock.restore()` does not undo `mock.module()` registrations in any case. The fix is per-file — snapshot the real exports up front and re-register them in the file's own `afterAll` (the pattern `recover.test.ts` already uses). The misleading preload comment is corrected to document this.

## Test plan

- `bun test` in `cli/`: **793 pass / 0 fail** (was 12 fail on CI).
- Reproduced the original failures locally first (after `bun install` for workspace deps), bisected each leak to its source file, then confirmed the fix.
- Stress-tested several run orderings (e.g. `paths → recover`, `teleport → sleep → clean`, `nginx-ingress → step-runner`, `local-ces → nginx-ingress → step-runner → recover`) — all 0 fail.
- `bunx tsc --noEmit`, `eslint`, and `prettier --check` all clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VGbpG4YeszqNEtwcA3CdeM)_