### PR TITLE
fix(memory): 400 on empty create-memory content

### DIFF
--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
@@ -1130,6 +1130,20 @@ describe("Memory Item Routes", () => {
       });
       expect(res.status).toBe(400);
     });
+
+    test("rejects empty content as 400", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: { content: "" },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects whitespace-only content as 400", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: { content: "   " },
+      });
+      expect(res.status).toBe(400);
+    });
   });
 
   // ── Memory stats (page-index concept count) ───────────────────────────────

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -1005,6 +1005,9 @@ export const ROUTES: RouteDefinition[] = [
       if (!parsed.success) {
         throw new BadRequestError("content (string) is required");
       }
+      if (parsed.data.content.trim().length === 0) {
+        throw new BadRequestError("content (non-empty string) is required");
+      }
       return handleRemember(
         { content: parsed.data.content },
         "web",


### PR DESCRIPTION
## Summary
- createMemory route now 400s on empty/whitespace content (was 200 {success:false}), matching PR 1's documented acceptance; added a test. openapi.yaml unchanged (handler-side guard).

Fixes a self-review gap for plan memory-viz-v2.md.