### PR TITLE
fix(memory-graph): panel close semantics + memory-stats invalidation

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -291,8 +291,9 @@ export function ConceptGraphView({
   // explains why two concepts connect. Node hover always wins (onPointerMove).
   const [edgeLabel, setEdgeLabel] = useState<string | null>(null);
   // Navigable trail of opened concepts: each open pushes onto the stack, and the
-  // top (`trail.at(-1)`) is the concept the detail drawer shows. `back()` pops;
-  // emptying the trail returns to the overview (drawer closed).
+  // top (`trail.at(-1)`) is the concept the detail drawer shows. Crumbs pop back
+  // to a level; dismiss empties the trail, returning to the overview (drawer
+  // closed).
   const [trail, setTrail] = useState<ConceptDetailNode[]>([]);
   const openNode = trail.at(-1) ?? null;
   // Opening a concept into the detail drawer (canvas click or search result)
@@ -459,25 +460,26 @@ export function ConceptGraphView({
     [openNodeDetail, focusOn],
   );
 
-  // Step back through the trail: pop the current concept and re-center the new
-  // top; emptying the trail clears the selection and returns to the overview.
-  const back = useCallback(() => {
-    const next = trail.slice(0, -1);
-    setTrail(next);
-    const top = next.at(-1);
-    if (top) {
-      focusOn(top.id);
-    } else {
-      setFocusLabel(null);
-    }
-  }, [trail, focusOn]);
+  // Fully dismiss the detail drawer back to the overview: empty the trail
+  // (closing the drawer), clear any active search (the box hides behind the
+  // drawer, so a stale search would ghost the map after close), and drop the
+  // focus label. Wired to the panel's X / Escape / backdrop so any of those
+  // closes the whole drawer from any trail depth — not just one level.
+  const dismiss = useCallback(() => {
+    setTrail([]);
+    setSearch("");
+    setFocusLabel(null);
+  }, []);
 
-  // Jump to a breadcrumb: truncate the trail to `index` (keep 0..index) and
-  // re-center on that concept — mirrors back()'s trail-truncation + focus ease.
-  // Unlike back() this keeps the panel open (index stays >= 0 for a real crumb),
-  // so crumb clicks rewind the multi-level trail without closing the drawer.
+  // Jump to a breadcrumb (the ‹ back control and crumb clicks): truncate the
+  // trail to `index` (keep 0..index) and re-center on that concept. A real crumb
+  // index is always >= 0, so the panel stays open — crumb clicks rewind the
+  // multi-level trail without closing the drawer. Clears any active search first:
+  // the box is hidden behind the open drawer, so a stale search would leave a
+  // traveled-to non-match node centered but ghosted with no way to clear it.
   const goToCrumb = useCallback(
     (index: number) => {
+      setSearch("");
       const next = trail.slice(0, index + 1);
       setTrail(next);
       const top = next.at(-1);
@@ -490,24 +492,18 @@ export function ConceptGraphView({
     [trail, focusOn],
   );
 
-  // In-panel navigation (WIRED-TO neighbors, breadcrumbs) clears any active
-  // search first: the search box is hidden behind the open drawer, so a stale
-  // search would leave a traveled-to non-match node centered but ghosted with
-  // no way to clear it. Canvas + search-result travel keep the box visible, so
-  // they intentionally don't clear it.
+  // WIRED-TO travel from the panel clears any active search first: the search
+  // box is hidden behind the open drawer, so a stale search would leave a
+  // traveled-to non-match node centered but ghosted with no way to clear it.
+  // Canvas + search-result travel keep the box visible, so they intentionally
+  // don't clear it (that's plain travelTo). Breadcrumb navigation clears the
+  // search too, but does so inside goToCrumb itself.
   const travelFromPanel = useCallback(
     (node: ConceptDetailNode) => {
       setSearch("");
       travelTo(node);
     },
     [travelTo],
-  );
-  const crumbFromPanel = useCallback(
-    (index: number) => {
-      setSearch("");
-      goToCrumb(index);
-    },
-    [goToCrumb],
   );
 
   // Direct neighbors of the open concept, resolved to { id, label, kind } for the
@@ -1428,8 +1424,8 @@ export function ConceptGraphView({
           trail={trail}
           neighbors={neighbors}
           onTravel={travelFromPanel}
-          onCrumb={crumbFromPanel}
-          onClose={back}
+          onCrumb={goToCrumb}
+          onClose={dismiss}
           onOpenThread={onOpenThread}
         />
       ) : null}

--- a/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 
 import { createMemory } from "@/domains/intelligence/memory-graph/create-memory";
 import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
+import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memory-stats";
 import { Button, Modal, toast, Typography } from "@vellumai/design-library";
 import { Textarea } from "@vellumai/design-library/components/input";
 
@@ -49,10 +50,17 @@ export function CreateMemoryModal({
       setContent("");
       onOpenChange(false);
       // The node materializes on the next consolidation, not now — invalidate
-      // so the graph refetches and the memory appears as the map updates.
-      await queryClient.invalidateQueries({
-        queryKey: memoryGraphOptions(assistantId).queryKey,
-      });
+      // the graph so it refetches and the memory appears as the map updates, and
+      // the stats query so the identity Memory card's count refreshes too (it's
+      // a separate query with a 5-min staleTime that wouldn't otherwise refire).
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: memoryGraphOptions(assistantId).queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: memoryStatsOptions(assistantId).queryKey,
+        }),
+      ]);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to create memory.";


### PR DESCRIPTION
## Summary
- Panel X/Escape/backdrop now fully dismiss to the overview and clear the search (was popping one trail level via back(), which duplicated goToCrumb and left a stale hidden search); consolidated nav callbacks
- Create-memory modal now also invalidates the memory-stats query so the identity count refreshes

Fixes self-review gaps for plan memory-viz-v2.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)