### PR TITLE
Memory Visualization v2

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17370,6 +17370,29 @@ paths:
                   - message
                   - success
                 additionalProperties: false
+  /v1/memory/stats:
+    get:
+      operationId: memory_stats_get
+      summary: Get lightweight memory stats
+      description:
+        Return a cheap count of concept pages from the cached memory page index, for glanceable surfaces like the
+        identity Memory card. Counts concept pages only and never builds the memory-concept graph.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  concepts:
+                    type: number
+                    description: Number of concept pages in memory
+                required:
+                  - concepts
+                additionalProperties: false
   /v1/memory/v2/backfill:
     post:
       operationId: memory_v2_backfill_post

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17334,6 +17334,42 @@ paths:
                   - confident
                   - notes
                 additionalProperties: false
+  /v1/memory/remember:
+    post:
+      operationId: memory_remember_post
+      summary: Create a memory by remembering a fact
+      description:
+        Append a user-authored fact to the memory buffer via handleRemember; it is materialized into a graph node
+        later by consolidation.
+      tags:
+        - memory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+              required:
+                - content
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                required:
+                  - message
+                  - success
+                additionalProperties: false
   /v1/memory/v2/backfill:
     post:
       operationId: memory_v2_backfill_post

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
@@ -4,7 +4,11 @@
  * Covers: list with filters, get by ID, create + duplicate rejection,
  * update + fingerprint collision, delete + 404.
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  afterAll,
   afterEach,
   beforeAll,
   beforeEach,
@@ -1050,6 +1054,68 @@ describe("Memory Item Routes", () => {
       expect(after.nodes.map((n) => n.content)).toContain(
         "User prefers TypeScript and Bun",
       );
+    });
+  });
+
+  // ── Create memory (remember) ──────────────────────────────────────────────
+
+  describe("POST /v1/memory/remember (createMemory)", () => {
+    // handleRemember writes to getWorkspaceDir(); point it at a throwaway
+    // tmpdir so the buffer/archive writes stay isolated. Enable memory v2 so
+    // writes take the memory/ path and skip PKB re-index jobs.
+    let tmpWorkspace: string;
+    let previousWorkspaceEnv: string | undefined;
+
+    beforeAll(() => {
+      tmpWorkspace = mkdtempSync(join(tmpdir(), "create-memory-route-test-"));
+      previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+      process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+    });
+
+    afterAll(() => {
+      if (previousWorkspaceEnv === undefined) {
+        delete process.env.VELLUM_WORKSPACE_DIR;
+      } else {
+        process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+      }
+      rmSync(tmpWorkspace, { recursive: true, force: true });
+    });
+
+    beforeEach(() => {
+      setConfig("memory", { v2: { enabled: true } });
+    });
+
+    afterEach(() => {
+      setConfig("memory", { v2: { enabled: false } });
+    });
+
+    interface RememberBody {
+      success: boolean;
+      message: string;
+    }
+
+    test("appends a valid fact and returns { success, message }", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: { content: "User prefers dark mode" },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RememberBody;
+      expect(body.success).toBe(true);
+      expect(body.message.length).toBeGreaterThan(0);
+    });
+
+    test("rejects a missing content body as 400", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: {},
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects a non-string content field as 400", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: { content: 42 },
+      });
+      expect(res.status).toBe(400);
     });
   });
 });

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
@@ -63,6 +63,16 @@ mock.module(
   }),
 );
 
+// Programmable synthetic skill list for the memory-stats page-index count.
+// `getPageIndex` dynamically imports skill-store, so mocking it here lets the
+// stats test seed synthetic (modifiedAt: 0) rows and assert they're excluded.
+let mockSkillEntries: Array<{ id: string; content: string }> = [];
+
+mock.module("../v2/skill-store.js", () => ({
+  SKILL_SLUG_PREFIX: "skills/",
+  listSkillEntries: () => mockSkillEntries,
+}));
+
 import { eq } from "drizzle-orm";
 
 import { setConfig } from "../../../../__tests__/helpers/set-config.js";
@@ -82,6 +92,9 @@ import {
   NotFoundError,
 } from "../../../../runtime/routes/errors.js";
 import type { RouteDefinition } from "../../../../runtime/routes/types.js";
+import { invalidatePageIndex } from "../v2/page-index.js";
+import { writePage } from "../v2/page-store.js";
+import type { ConceptPage } from "../v2/types.js";
 import { ROUTES } from "./memory-item-routes.js";
 
 // ---------------------------------------------------------------------------
@@ -1116,6 +1129,81 @@ describe("Memory Item Routes", () => {
         body: { content: 42 },
       });
       expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Memory stats (page-index concept count) ───────────────────────────────
+
+  describe("GET /v1/memory/stats (getMemoryStats)", () => {
+    // handleGetMemoryStats reads concept pages from getWorkspaceDir(); point
+    // it at a throwaway tmpdir so the page scan stays isolated from ~/.vellum.
+    // A fresh workspace per test keeps each concept count independent.
+    let tmpWorkspace: string;
+    let previousWorkspaceEnv: string | undefined;
+
+    beforeEach(() => {
+      tmpWorkspace = mkdtempSync(join(tmpdir(), "memory-stats-route-test-"));
+      previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+      process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+      // A no-skill baseline; the exclusion test seeds synthetic rows itself.
+      mockSkillEntries = [];
+      // Drop any cached index so each run re-scans this fresh workspace.
+      invalidatePageIndex();
+    });
+
+    afterEach(() => {
+      if (previousWorkspaceEnv === undefined) {
+        delete process.env.VELLUM_WORKSPACE_DIR;
+      } else {
+        process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+      }
+      rmSync(tmpWorkspace, { recursive: true, force: true });
+      invalidatePageIndex();
+    });
+
+    const route = getRoute("memory/stats", "GET");
+
+    function makeConceptPage(slug: string): ConceptPage {
+      return {
+        slug,
+        frontmatter: { edges: [], ref_files: [], ref_urls: [] },
+        body: `Body for ${slug}`,
+      };
+    }
+
+    test("counts concept pages in the workspace", async () => {
+      await writePage(tmpWorkspace, makeConceptPage("alice"));
+      await writePage(tmpWorkspace, makeConceptPage("bob"));
+      await writePage(tmpWorkspace, makeConceptPage("carol"));
+
+      const res = await callHandler(route);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { concepts: number };
+      expect(body.concepts).toBe(3);
+    });
+
+    test("returns zero for an empty workspace", async () => {
+      const res = await callHandler(route);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { concepts: number };
+      expect(body.concepts).toBe(0);
+    });
+
+    test("excludes synthetic (modifiedAt <= 0) skill entries", async () => {
+      // Synthetic skill rows (seeded skills / CLI commands) carry
+      // modifiedAt: 0 and must not inflate the concept count.
+      mockSkillEntries = [
+        { id: "agent-mail", content: "Send and read email" },
+        { id: "calendar", content: "Manage the calendar" },
+      ];
+      await writePage(tmpWorkspace, makeConceptPage("alice"));
+      await writePage(tmpWorkspace, makeConceptPage("bob"));
+
+      const res = await callHandler(route);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { concepts: number };
+      // Two real concept pages; the two synthetic skill rows are excluded.
+      expect(body.concepts).toBe(2);
     });
   });
 });

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.test.ts
@@ -1130,6 +1130,20 @@ describe("Memory Item Routes", () => {
       });
       expect(res.status).toBe(400);
     });
+
+    test("rejects empty content as 400", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: { content: "" },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects whitespace-only content as 400", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: { content: "   " },
+      });
+      expect(res.status).toBe(400);
+    });
   });
 
   // ── Memory stats (page-index concept count) ───────────────────────────────

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -56,6 +56,7 @@ import { createNode, deleteNode, getNode, updateNode } from "../graph/store.js";
 import {
   handleDeleteMemory,
   handleListMemory,
+  handleRemember,
   handleUpdateMemory,
 } from "../graph/tool-handlers.js";
 import type {
@@ -942,6 +943,33 @@ export const ROUTES: RouteDefinition[] = [
           new_content: parsed.data.newContent,
         },
         "cli",
+        getConfig(),
+      );
+    },
+  },
+
+  {
+    operationId: "createMemory",
+    endpoint: "memory/remember",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Create a memory by remembering a fact",
+    description:
+      "Append a user-authored fact to the memory buffer via handleRemember; it is materialized into a graph node later by consolidation.",
+    tags: ["memory"],
+    requestBody: z.object({ content: z.string() }),
+    responseBody: z.object({ message: z.string(), success: z.boolean() }),
+    handler: ({ body }) => {
+      const parsed = z.object({ content: z.string() }).safeParse(body ?? {});
+      if (!parsed.success) {
+        throw new BadRequestError("content (string) is required");
+      }
+      return handleRemember(
+        { content: parsed.data.content },
+        "web",
         getConfig(),
       );
     },

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -67,6 +67,8 @@ import type {
   NewNode,
 } from "../graph/types.js";
 import { getLogger } from "../logging.js";
+import { getWorkspaceDir } from "../paths.js";
+import { getPageIndex } from "../v2/page-index.js";
 
 const log = getLogger("memory-item-routes");
 
@@ -463,6 +465,22 @@ function handleGetMemoryItem(id: string) {
   return { item: nodeToPayload(node) };
 }
 
+/**
+ * Cheap concept count for glanceable surfaces (the identity Memory card).
+ *
+ * Read straight from the CACHED page index and count only real concept pages:
+ * those carry a real file mtime (`modifiedAt > 0`), while synthetic rows
+ * (seeded skills and CLI commands) carry `modifiedAt: 0`. This mirrors the
+ * concepts-only filter in `build-memory-graph.ts`, but never triggers the
+ * expensive `getMemoryGraph` build (edge / learned / cluster graph) — the
+ * concept graph is deliberately kept off identity-page load.
+ */
+async function handleGetMemoryStats(): Promise<{ concepts: number }> {
+  const pageIndex = await getPageIndex(getWorkspaceDir());
+  const concepts = pageIndex.entries.filter((e) => e.modifiedAt > 0).length;
+  return { concepts };
+}
+
 async function handleCreateMemoryItem(body: Record<string, unknown>) {
   const { kind, subject, statement, importance } = body as {
     kind?: string;
@@ -735,6 +753,26 @@ export const ROUTES: RouteDefinition[] = [
         .describe("Memory item with graph metadata"),
     }),
     handler: ({ pathParams }) => handleGetMemoryItem(pathParams!.id),
+  },
+
+  {
+    operationId: "getMemoryStats",
+    endpoint: "memory/stats",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get lightweight memory stats",
+    description:
+      "Return a cheap count of concept pages from the cached memory page " +
+      "index, for glanceable surfaces like the identity Memory card. Counts " +
+      "concept pages only and never builds the memory-concept graph.",
+    tags: ["memory"],
+    responseBody: z.object({
+      concepts: z.number().describe("Number of concept pages in memory"),
+    }),
+    handler: () => handleGetMemoryStats(),
   },
 
   {

--- a/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/routes/memory-item-routes.ts
@@ -1005,6 +1005,9 @@ export const ROUTES: RouteDefinition[] = [
       if (!parsed.success) {
         throw new BadRequestError("content (string) is required");
       }
+      if (parsed.data.content.trim().length === 0) {
+        throw new BadRequestError("content (non-empty string) is required");
+      }
       return handleRemember(
         { content: parsed.data.content },
         "web",

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
@@ -1,10 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
-import { MessageCircle, Sparkles, X } from "lucide-react";
+import { ChevronLeft, MessageCircle, Sparkles, X } from "lucide-react";
 import { useEffect } from "react";
 
 import { FileMarkdown } from "@/components/file-markdown";
 import { memoryGraphNodeOptions } from "@/domains/intelligence/memory-graph/get-memory-graph-node";
 import { Button } from "@vellumai/design-library";
+
+import { EDGE_LEARNED_COLOR } from "./constants";
 
 export interface ConceptDetailNode {
   id: string;
@@ -15,6 +17,20 @@ export interface ConceptDetailNode {
 interface ConceptDetailPanelProps {
   assistantId: string;
   node: ConceptDetailNode;
+  /**
+   * The navigable trail of opened concepts (root → current). Rendered as a
+   * clickable breadcrumb header so deeper travels can be rewound in place.
+   */
+  trail: ConceptDetailNode[];
+  /**
+   * Direct neighbors of the open concept for the flat WIRED-TO list. `kind`
+   * (link vs learned) tags each row without grouping them.
+   */
+  neighbors: { id: string; label: string; kind?: string }[];
+  /** Travel to a neighbor: pushes the trail and re-centers, panel stays open. */
+  onTravel: (node: ConceptDetailNode) => void;
+  /** Jump to a breadcrumb: truncates the trail to `index` and re-centers. */
+  onCrumb: (index: number) => void;
   onClose: () => void;
   /**
    * Opens a fresh chat seeded with a message about this concept. When absent,
@@ -22,6 +38,22 @@ interface ConceptDetailPanelProps {
    * identity page, which navigates to a draft conversation and auto-sends.
    */
   onOpenThread?: (message: string) => void;
+}
+
+type Crumb = { node: ConceptDetailNode; index: number };
+
+// Collapse a deep trail to first + last few so the breadcrumb never overflows:
+// A › … › X › Y › Z. The "ellipsis" marker is inert; every rendered crumb keeps
+// its original trail index so clicking one truncates to exactly that node.
+function buildCrumbs(trail: ConceptDetailNode[]): (Crumb | "ellipsis")[] {
+  const TAIL = 3;
+  if (trail.length <= TAIL + 1) {
+    return trail.map((node, index) => ({ node, index }));
+  }
+  const tail: Crumb[] = trail
+    .slice(-TAIL)
+    .map((node, i) => ({ node, index: trail.length - TAIL + i }));
+  return [{ node: trail[0], index: 0 }, "ellipsis", ...tail];
 }
 
 function formatUpdated(ms: number | undefined): string | null {
@@ -35,12 +67,18 @@ function formatUpdated(ms: number | undefined): string | null {
 
 /**
  * Slide-over drawer that renders a concept's own page (its markdown) when a
- * node is opened from the graph. The brain keeps rotating behind the translucent
- * backdrop; click the backdrop, the close button, or Escape to return.
+ * node is opened from the graph. A clickable breadcrumb header rewinds the
+ * travel trail, and a flat WIRED-TO list travels to a neighbor without closing
+ * the drawer. The brain keeps rotating behind the light backdrop; click the
+ * backdrop, the close button, or Escape to return.
  */
 export function ConceptDetailPanel({
   assistantId,
   node,
+  trail,
+  neighbors,
+  onTravel,
+  onCrumb,
   onClose,
   onOpenThread,
 }: ConceptDetailPanelProps) {
@@ -48,6 +86,7 @@ export function ConceptDetailPanel({
   const detail = query.data;
   const updated = formatUpdated(node.updatedAtMs);
   const title = detail?.title ?? node.label;
+  const crumbs = buildCrumbs(trail);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -66,9 +105,12 @@ export function ConceptDetailPanel({
       onPointerMove={(e) => e.stopPropagation()}
       onPointerUp={(e) => e.stopPropagation()}
     >
+      {/* Light scrim — kept clickable (backdrop-to-close) but barely tinted so
+          the ego-dimmed focused node + its labeled neighbors stay visible on the
+          canvas beside the drawer instead of being blacked out. */}
       <div
         className="absolute inset-0"
-        style={{ backgroundColor: "color-mix(in srgb, var(--surface-base) 55%, transparent)" }}
+        style={{ backgroundColor: "color-mix(in srgb, var(--surface-base) 16%, transparent)" }}
         onClick={onClose}
       />
       <aside
@@ -78,6 +120,57 @@ export function ConceptDetailPanel({
           borderLeft: "1px solid var(--border-base)",
         }}
       >
+        {/* Breadcrumb header — only when the trail runs deeper than the current
+            node (the single-crumb case just repeats the title below). Crumbs
+            jump back + re-center via onCrumb; the ‹ back control mirrors it. */}
+        {trail.length > 1 ? (
+          <nav
+            aria-label="Concept trail"
+            className="flex shrink-0 items-center gap-1 overflow-hidden border-b px-5 py-2 text-body-small-default"
+            style={{ borderColor: "var(--border-base)", color: "var(--content-tertiary)" }}
+          >
+            <button
+              type="button"
+              onClick={() => onCrumb(trail.length - 2)}
+              aria-label="Back"
+              className="-ml-1 mr-0.5 flex shrink-0 items-center rounded p-0.5 hover:bg-[color-mix(in_srgb,var(--content-tertiary)_14%,transparent)]"
+              style={{ color: "var(--content-tertiary)" }}
+            >
+              <ChevronLeft size={16} aria-hidden />
+            </button>
+            {crumbs.map((crumb, i) => (
+              // Key by trail position, not node id: travel is push-only, so the
+              // same concept can sit at more than one depth (A › B › A).
+              <span
+                key={crumb === "ellipsis" ? "ellipsis" : crumb.index}
+                className="flex min-w-0 items-center gap-1"
+              >
+                {i > 0 ? <span aria-hidden>›</span> : null}
+                {crumb === "ellipsis" ? (
+                  <span aria-hidden>…</span>
+                ) : crumb.index === trail.length - 1 ? (
+                  <span
+                    aria-current="page"
+                    className="max-w-[9rem] truncate"
+                    style={{ color: "var(--content-default)" }}
+                  >
+                    {crumb.node.label}
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onCrumb(crumb.index)}
+                    className="max-w-[8rem] truncate rounded hover:underline"
+                    style={{ color: "var(--content-tertiary)" }}
+                  >
+                    {crumb.node.label}
+                  </button>
+                )}
+              </span>
+            ))}
+          </nav>
+        ) : null}
+
         <header
           className="flex shrink-0 items-start justify-between gap-3 border-b px-5 py-4"
           style={{ borderColor: "var(--border-base)" }}
@@ -134,6 +227,57 @@ export function ConceptDetailPanel({
               in the graph, but its page is empty.
             </p>
           )}
+
+          {/* WIRED-TO — a flat neighbor list (no category grouping) with a
+              connection count. Clicking a neighbor travels to it: pushes the
+              trail and re-centers the canvas without closing the drawer. */}
+          {neighbors.length > 0 ? (
+            <section
+              className="mt-6 border-t pt-4"
+              style={{ borderColor: "var(--border-base)" }}
+            >
+              <div className="mb-2 flex items-baseline justify-between gap-2">
+                <h3
+                  className="text-body-small-default uppercase tracking-wide"
+                  style={{ color: "var(--content-tertiary)" }}
+                >
+                  Wired to
+                </h3>
+                <span
+                  className="text-body-small-default tabular-nums"
+                  style={{ color: "var(--content-tertiary)" }}
+                >
+                  {neighbors.length} connection{neighbors.length === 1 ? "" : "s"}
+                </span>
+              </div>
+              <ul className="flex list-none flex-col gap-0.5">
+                {neighbors.map((neighbor) => (
+                  <li key={neighbor.id}>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        onTravel({ id: neighbor.id, label: neighbor.label })
+                      }
+                      className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-body-medium-default hover:bg-[color-mix(in_srgb,var(--content-tertiary)_12%,transparent)]"
+                      style={{ color: "var(--content-default)" }}
+                    >
+                      <span
+                        aria-hidden
+                        className="h-1.5 w-1.5 shrink-0 rounded-full"
+                        style={{
+                          backgroundColor:
+                            neighbor.kind === "learned"
+                              ? EDGE_LEARNED_COLOR
+                              : "var(--content-tertiary)",
+                        }}
+                      />
+                      <span className="truncate">{neighbor.label}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
         </div>
 
         {onOpenThread ? (

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
@@ -7,7 +7,7 @@ import {
   Sparkles,
   X,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { FileMarkdown } from "@/components/file-markdown";
 import { memoryGraphNodeOptions } from "@/domains/intelligence/memory-graph/get-memory-graph-node";
@@ -72,31 +72,38 @@ function formatUpdated(ms: number | undefined): string | null {
   });
 }
 
-// Only clamp once a note runs past roughly a screenful. Character count is a
+// Only preview once a note runs past roughly a screenful. Character count is a
 // cheap proxy for rendered height that avoids measuring the markdown; below
 // this the note renders whole with no toggle.
 const LONG_NOTE_THRESHOLD = 600;
 
 /**
- * The concept's own markdown body. Long notes clamp to a preview with a fade
- * and a "Read full note" / "Show less" toggle; short notes render whole with
- * no toggle.
+ * Slice a long note down to a preview of at most ~`LONG_NOTE_THRESHOLD` chars.
+ * Prefer cutting at the last newline before the threshold so we don't slice
+ * through mid-markdown syntax (a link, a heading, a list marker); fall back to
+ * a hard character slice when there's no usable newline. Only honor a newline
+ * that keeps a substantial preview, so a stray early line break doesn't
+ * collapse it to almost nothing.
+ */
+function buildNotePreview(content: string): string {
+  const hardSlice = content.slice(0, LONG_NOTE_THRESHOLD);
+  const lastNewline = hardSlice.lastIndexOf("\n");
+  if (lastNewline > LONG_NOTE_THRESHOLD / 2) {
+    return content.slice(0, lastNewline);
+  }
+  return hardSlice;
+}
+
+/**
+ * The concept's own markdown body. Long notes render a sliced preview with a
+ * "Read full note" / "Show less" toggle; short notes render whole with no
+ * toggle. Because only the currently-shown content is in the DOM (a real
+ * content slice rather than a clipped-and-hidden full body), everything visible
+ * is in the a11y tree and nothing off-screen is focusable — the preview reads
+ * the same for screen-reader and sighted users.
  */
 function ConceptNote({ content }: { content: string }) {
   const [expanded, setExpanded] = useState(false);
-  const clampRef = useRef<HTMLDivElement>(null);
-
-  // The collapse is visual only (overflow-hidden), so keep the clipped content
-  // out of the tab order and AT tree while collapsed — otherwise links below
-  // the fold stay focusable. `inert` is set imperatively so it works regardless
-  // of the installed React version's prop typing; the toggle button lives
-  // outside this container, so it remains reachable.
-  useEffect(() => {
-    const el = clampRef.current;
-    if (el) {
-      el.inert = !expanded;
-    }
-  }, [expanded]);
 
   if (content.length <= LONG_NOTE_THRESHOLD) {
     return <FileMarkdown content={content} />;
@@ -104,25 +111,7 @@ function ConceptNote({ content }: { content: string }) {
 
   return (
     <>
-      <div
-        ref={clampRef}
-        className="relative overflow-hidden"
-        style={expanded ? undefined : { maxHeight: "18rem" }}
-      >
-        <FileMarkdown content={content} />
-        {expanded ? null : (
-          // Fade the clamped edge into the drawer surface so the cut reads as
-          // "there's more" rather than an abrupt crop.
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 bottom-0 h-16"
-            style={{
-              background:
-                "linear-gradient(to bottom, transparent, var(--surface-lift))",
-            }}
-          />
-        )}
-      </div>
+      <FileMarkdown content={expanded ? content : buildNotePreview(content)} />
       <Button
         variant="ghost"
         size="compact"

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-detail-panel.tsx
@@ -1,6 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, MessageCircle, Sparkles, X } from "lucide-react";
-import { useEffect } from "react";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronUp,
+  MessageCircle,
+  Sparkles,
+  X,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 import { FileMarkdown } from "@/components/file-markdown";
 import { memoryGraphNodeOptions } from "@/domains/intelligence/memory-graph/get-memory-graph-node";
@@ -63,6 +70,76 @@ function formatUpdated(ms: number | undefined): string | null {
     month: "short",
     year: "numeric",
   });
+}
+
+// Only clamp once a note runs past roughly a screenful. Character count is a
+// cheap proxy for rendered height that avoids measuring the markdown; below
+// this the note renders whole with no toggle.
+const LONG_NOTE_THRESHOLD = 600;
+
+/**
+ * The concept's own markdown body. Long notes clamp to a preview with a fade
+ * and a "Read full note" / "Show less" toggle; short notes render whole with
+ * no toggle.
+ */
+function ConceptNote({ content }: { content: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const clampRef = useRef<HTMLDivElement>(null);
+
+  // The collapse is visual only (overflow-hidden), so keep the clipped content
+  // out of the tab order and AT tree while collapsed — otherwise links below
+  // the fold stay focusable. `inert` is set imperatively so it works regardless
+  // of the installed React version's prop typing; the toggle button lives
+  // outside this container, so it remains reachable.
+  useEffect(() => {
+    const el = clampRef.current;
+    if (el) {
+      el.inert = !expanded;
+    }
+  }, [expanded]);
+
+  if (content.length <= LONG_NOTE_THRESHOLD) {
+    return <FileMarkdown content={content} />;
+  }
+
+  return (
+    <>
+      <div
+        ref={clampRef}
+        className="relative overflow-hidden"
+        style={expanded ? undefined : { maxHeight: "18rem" }}
+      >
+        <FileMarkdown content={content} />
+        {expanded ? null : (
+          // Fade the clamped edge into the drawer surface so the cut reads as
+          // "there's more" rather than an abrupt crop.
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-16"
+            style={{
+              background:
+                "linear-gradient(to bottom, transparent, var(--surface-lift))",
+            }}
+          />
+        )}
+      </div>
+      <Button
+        variant="ghost"
+        size="compact"
+        className="-ml-2 mt-1"
+        onClick={() => setExpanded((prev) => !prev)}
+        rightIcon={
+          expanded ? (
+            <ChevronUp size={16} aria-hidden />
+          ) : (
+            <ChevronDown size={16} aria-hidden />
+          )
+        }
+      >
+        {expanded ? "Show less" : "Read full note"}
+      </Button>
+    </>
+  );
 }
 
 /**
@@ -220,7 +297,9 @@ export function ConceptDetailPanel({
               Couldn't load this concept. Try again in a moment.
             </p>
           ) : detail?.found && detail.content?.trim() ? (
-            <FileMarkdown content={detail.content} />
+            // Keyed by node id so travelling to a new concept remounts the note
+            // and starts it collapsed again.
+            <ConceptNote key={node.id} content={detail.content} />
           ) : (
             <p className="text-body-medium-lighter" style={{ color: "var(--content-tertiary)" }}>
               This concept doesn't have written content yet — it exists as a link

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -58,6 +58,14 @@ const FOG_FULL_BELOW = 80;
 const FOG_FLOOR_ABOVE = 340;
 const FOG_FLOOR = 0.12;
 
+// Focus ego-dim: while a concept is open in the detail drawer, its immediate
+// neighborhood (the node + direct neighbors) stays lit and everything else
+// fades to near-zero — a stronger dim than hover — so the focused node reads
+// clearly (e.g. beside the panel). Non-neighbor edges dim to the same near-zero
+// as an already-ghosted edge.
+const SELECTION_DIM_NODE = 0.05;
+const SELECTION_DIM_EDGE = 0.03;
+
 // Below this node count the graph is small enough to scan by eye — no search box.
 const SEARCH_MIN_NODES = 12;
 
@@ -116,6 +124,19 @@ function isStale(
     return false;
   }
   return updatedAtMs == null || now - updatedAtMs > windowMs;
+}
+
+// Predicate for the selected concept's ego-network — the node itself plus its
+// direct neighbors. The neighbor set is resolved once so per-node checks stay
+// O(1). Shared by the render loop and the hit-test so click targets always
+// match what's drawn lit (like isStale for the recency lens).
+function makeEgoTest(
+  adjacency: Map<string, Set<string>>,
+  selectedId: string | null,
+): (id: string) => boolean {
+  const neighbors = selectedId ? adjacency.get(selectedId) : undefined;
+  return (id) =>
+    selectedId != null && (id === selectedId || (neighbors?.has(id) ?? false));
 }
 
 export interface ConceptGraphViewProps {
@@ -281,6 +302,16 @@ export function ConceptGraphView({
     emitMemoryEvent("node_opened");
     setTrail((t) => [...t, node]);
   }, []);
+  // The trail's current concept, mirrored into a ref the 60fps render loop and
+  // hit-test read (matches filterRef / recencyRef / edgeFilterRef) so opening,
+  // travelling, or closing a concept re-runs the ego-dim without re-running the
+  // render effect. `dirty` is bumped so the reduced-motion path redraws on a
+  // selection change; emptying the trail (id → null) restores normal rendering.
+  const selectedIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    selectedIdRef.current = openNode?.id ?? null;
+    view.current.dirty = true;
+  }, [openNode?.id]);
 
   // First-run explainer: shown over the graph (empty or populated) until the
   // user dismisses it; the dismissal sticks per-assistant.
@@ -372,12 +403,13 @@ export function ConceptGraphView({
   }, [edgeFilter]);
   // Reset every lens when the active assistant changes: this component is reused
   // across assistants (IdentityTab doesn't key it), so a stale search, recency
-  // window, or hidden edge kind would otherwise ghost/blank the new assistant's
-  // freshly-loaded graph.
+  // window, hidden edge kind, or open selection would otherwise ghost/blank the
+  // new assistant's freshly-loaded graph.
   useEffect(() => {
     setSearch("");
     setRecency("all");
     setEdgeFilter({ link: true, learned: true });
+    setTrail([]);
     searchEmittedRef.current = false;
   }, [assistantId]);
 
@@ -455,6 +487,10 @@ export function ConceptGraphView({
     const nodeClusters = clusters;
     const hubIds = clusterHubs;
     const adj = adjacency;
+    // Ids present in the current graph — used to ignore a stale selection (e.g.
+    // a same-assistant refetch that drops the open node) so focus-dim never
+    // blanks the whole map against a node that no longer exists.
+    const presentNodeIds = new Set(nodes.map((n) => n.id));
     const R = massRadius;
 
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -573,6 +609,14 @@ export function ConceptGraphView({
       // Edge-kind toggle: a hidden kind is skipped entirely below.
       const edgeKinds = edgeFilterRef.current;
 
+      // Focus ego-dim: while a concept is open, spotlight its neighborhood (the
+      // node + direct neighbors) and fade everything else to near-zero. The
+      // selected ego-network overrides the recency window and edge-kind filter
+      // so it always reads and stays interactive; search still narrows normally.
+      const selectedId = selectedIdRef.current;
+      const selectionActive = selectedId != null && presentNodeIds.has(selectedId);
+      const inSelectedEgo = makeEgoTest(adj, selectionActive ? selectedId : null);
+
       // Density fog: fade the resting learned-edge web as the corpus grows.
       const learnedFog =
         nodes.length <= FOG_FULL_BELOW
@@ -625,20 +669,28 @@ export function ConceptGraphView({
         const b = posById.get(e.toId);
         if (!a || !b) {continue;}
         const learned = e.kind === "learned";
+        // Spine of the focused ego-network: an edge touching the selected node
+        // (selected ↔ neighbor). It overrides the edge-kind filter and the
+        // recency window so the neighborhood stays wired and interactive.
+        const egoEdge =
+          selectedId != null &&
+          (e.fromId === selectedId || e.toId === selectedId);
         // A hidden kind is neither drawn nor collected for edge-hover, so the
-        // hit-test stays consistent with what's on screen.
-        if (learned ? !edgeKinds.learned : !edgeKinds.link) {
+        // hit-test stays consistent with what's on screen — unless it's an ego
+        // edge, which selection keeps visible even when its kind is filtered.
+        if (!egoEdge && (learned ? !edgeKinds.learned : !edgeKinds.link)) {
           continue;
         }
-        // An edge ghosts if either endpoint is ghosted by search or recency.
+        // An edge ghosts if either endpoint is ghosted by search or recency;
+        // selection overrides the recency window for the ego edges.
         const ghost =
           (searchActive && (!isMatch(e.fromId) || !isMatch(e.toId))) ||
-          isRecencyGhost(a.node) ||
-          isRecencyGhost(b.node);
+          (!egoEdge && (isRecencyGhost(a.node) || isRecencyGhost(b.node)));
         const incident = activeId != null && (e.fromId === activeId || e.toId === activeId);
         const depth = (a.depth + b.depth) / 2;
-        // Only offer hover on edges that read as present — skip faded ones.
-        if (!ghost) {
+        // Only offer hover on edges that read as present — skip faded ones. With
+        // a selection, only the lit ego edges are hit-testable (the rest dim).
+        if (!ghost && (!selectionActive || egoEdge)) {
           projEdges.push({
             ax: a.sx,
             ay: a.sy,
@@ -657,6 +709,10 @@ export function ConceptGraphView({
         let alpha: number;
         if (ghost) {
           alpha = 0.03;
+        } else if (selectionActive) {
+          // Ego-dim: only edges touching the selected node stay bright; every
+          // other edge fades to near-zero so the neighborhood reads.
+          alpha = egoEdge ? 0.9 : SELECTION_DIM_EDGE;
         } else if (activeId != null) {
           alpha = incident ? 0.9 : isLit(e.fromId) && isLit(e.toId) ? litAlpha : 0.05;
         } else {
@@ -664,7 +720,9 @@ export function ConceptGraphView({
         }
         ctx.globalAlpha = alpha;
         ctx.strokeStyle = learned ? EDGE_LEARNED_COLOR : colors.tertiary;
-        ctx.lineWidth = (incident ? 2 : 1) * (0.6 + 0.6 * depth);
+        ctx.lineWidth =
+          (incident || (selectionActive && egoEdge) ? 2 : 1) *
+          (0.6 + 0.6 * depth);
         ctx.setLineDash(learned ? [4, 4] : []);
         ctx.beginPath();
         ctx.moveTo(a.sx, a.sy);
@@ -684,11 +742,25 @@ export function ConceptGraphView({
             ? CLUSTER_PALETTE[(nodeClusters.get(node.id) ?? 0) % CLUSTER_PALETTE.length]
             : NODE_KIND_COLORS[node.kind];
         const searchGhost = searchActive && !isMatch(node.id);
-        const ghost = searchGhost || isRecencyGhost(node);
-        const lit = !ghost && isLit(node.id);
+        // Selection overrides the recency window for the focused ego-network so
+        // it stays lit; search still narrows normally.
+        const inEgo = inSelectedEgo(node.id);
+        const ghost = searchGhost || (isRecencyGhost(node) && !inEgo);
+        // With a selection, only its neighborhood is lit; otherwise fall back to
+        // the hover neighborhood.
+        const lit = selectionActive
+          ? inEgo && !ghost
+          : !ghost && isLit(node.id);
         const isActive = node.id === activeId;
         const depthA = DEPTH_ALPHA_MIN + (1 - DEPTH_ALPHA_MIN) * p.depth;
-        const alpha = ghost ? depthA * 0.08 : lit ? depthA : depthA * 0.18;
+        const alpha =
+          selectionActive && !inEgo
+            ? depthA * SELECTION_DIM_NODE
+            : ghost
+              ? depthA * 0.08
+              : lit
+                ? depthA
+                : depthA * 0.18;
 
         let glow = (isActive ? 16 : node.degree >= HUB_LABEL_DEGREE ? 8 : 4) * p.depth;
         // Recency: fresh concepts glow brighter; the very newest pulse. Static
@@ -733,16 +805,28 @@ export function ConceptGraphView({
         // the dense middle of the mass doesn't turn into unreadable label soup —
         // but always label each cluster's hub so every theme reads with a name.
         // While searching, label the matches instead (that's what you're after).
-        // Ghosted nodes (search or recency) never get labels.
-        if ((searchActive && !isMatch(node.id)) || isRecencyGhost(node)) {continue;}
-        const showLabel = searchActive
-          ? p.depth > 0.3
-          : activeId != null
-            ? isLit(node.id)
-            : hubIds.has(node.id) ||
-              (node.degree >= HUB_LABEL_DEGREE && p.depth > 0.55);
+        // With a selection, name the whole focused neighborhood. Ghosted nodes
+        // (search or recency) never get labels — but the selected ego-network
+        // overrides the recency window.
+        const inEgo = inSelectedEgo(node.id);
+        if (
+          (searchActive && !isMatch(node.id)) ||
+          (isRecencyGhost(node) && !inEgo)
+        ) {
+          continue;
+        }
+        const showLabel = selectionActive
+          ? inEgo
+          : searchActive
+            ? p.depth > 0.3
+            : activeId != null
+              ? isLit(node.id)
+              : hubIds.has(node.id) ||
+                (node.degree >= HUB_LABEL_DEGREE && p.depth > 0.55);
         if (!showLabel) {continue;}
-        ctx.globalAlpha = (node.id === activeId ? 1 : 0.85) * (0.4 + 0.6 * p.depth);
+        ctx.globalAlpha =
+          (node.id === activeId || node.id === selectedId ? 1 : 0.85) *
+          (0.4 + 0.6 * p.depth);
         ctx.fillStyle = colors.content;
         const label = node.label.length > 22 ? `${node.label.slice(0, 21)}…` : node.label;
         ctx.fillText(label, p.sx, p.sy + p.sr + 3);
@@ -772,16 +856,24 @@ export function ConceptGraphView({
   // Nearest node under a screen point; nearest-in-front wins. Ghosted nodes are
   // skipped so hover/click land on a live node, not a faded background one: both
   // search non-matches and, when a recency window is set, concepts older than it
-  // (a missing timestamp counts as stale). Mirrors the render-loop ghosting.
+  // (a missing timestamp counts as stale). A selected concept's ego-network is
+  // exempt from the recency skip so the focused neighborhood stays clickable.
+  // Mirrors the render-loop ghosting.
   const hitTest = useCallback((x: number, y: number): string | null => {
     const filter = filterRef.current;
     const recencyWindowMs = recencyRef.current;
+    // The focused ego-network stays clickable even when a recency window would
+    // otherwise skip it (selection overrides the filter); search still narrows.
+    const inSelectedEgo = makeEgoTest(adjacency, selectedIdRef.current);
     const now = Date.now();
     let best: string | null = null;
     let bestDepth = -1;
     for (const p of projectedRef.current) {
       if (filter.active && !(filter.matches?.has(p.id) ?? false)) {continue;}
-      if (isStale(p.updatedAtMs, recencyWindowMs, now)) {
+      if (
+        !inSelectedEgo(p.id) &&
+        isStale(p.updatedAtMs, recencyWindowMs, now)
+      ) {
         continue;
       }
       const dx = x - p.sx;
@@ -792,7 +884,7 @@ export function ConceptGraphView({
       }
     }
     return best;
-  }, []);
+  }, [adjacency]);
 
   // Nearest EDGE segment under a screen point, within ~5px (point-to-segment
   // distance); on ties the one nearer the front (higher depth) wins. Only the

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -269,14 +269,17 @@ export function ConceptGraphView({
   // Set while the pointer is over an EDGE (and no node) — the tooltip then
   // explains why two concepts connect. Node hover always wins (onPointerMove).
   const [edgeLabel, setEdgeLabel] = useState<string | null>(null);
-  // The concept opened into the detail drawer (null = graph only).
-  const [openNode, setOpenNode] = useState<ConceptDetailNode | null>(null);
+  // Navigable trail of opened concepts: each open pushes onto the stack, and the
+  // top (`trail.at(-1)`) is the concept the detail drawer shows. `back()` pops;
+  // emptying the trail returns to the overview (drawer closed).
+  const [trail, setTrail] = useState<ConceptDetailNode[]>([]);
+  const openNode = trail.at(-1) ?? null;
   // Opening a concept into the detail drawer (canvas click or search result)
   // is a tracked memory interaction. Route every open through here so
   // "node_opened" is emitted exactly once per open, from one place.
   const openNodeDetail = useCallback((node: ConceptDetailNode) => {
     emitMemoryEvent("node_opened");
-    setOpenNode(node);
+    setTrail((t) => [...t, node]);
   }, []);
 
   // First-run explainer: shown over the graph (empty or populated) until the
@@ -412,6 +415,30 @@ export function ConceptGraphView({
     view.current.lastInteractAt = performance.now();
     view.current.dirty = true;
   }, []);
+
+  // Travel to a concept: open it into the detail drawer (pushing it onto the
+  // trail, emitting "node_opened" once) and fly the camera to center it, reusing
+  // the search jump-to ease.
+  const travelTo = useCallback(
+    (node: ConceptDetailNode) => {
+      openNodeDetail(node);
+      focusOn(node.id);
+    },
+    [openNodeDetail, focusOn],
+  );
+
+  // Step back through the trail: pop the current concept and re-center the new
+  // top; emptying the trail clears the selection and returns to the overview.
+  const back = useCallback(() => {
+    const next = trail.slice(0, -1);
+    setTrail(next);
+    const top = next.at(-1);
+    if (top) {
+      focusOn(top.id);
+    } else {
+      setFocusLabel(null);
+    }
+  }, [trail, focusOn]);
 
   useEffect(() => {
     if (!ready) {return;}
@@ -873,10 +900,10 @@ export function ConceptGraphView({
         const { x, y } = localPoint(e);
         const hit = hitTest(x, y);
         if (hit) {
-          // Click a node → open its concept page in the detail drawer.
+          // Click a node → travel to it: center the camera and open its page.
           const n = layout.nodes.find((nn) => nn.id === hit);
           if (n) {
-            openNodeDetail({
+            travelTo({
               id: n.id,
               label: n.label,
               updatedAtMs: n.updatedAtMs,
@@ -887,7 +914,7 @@ export function ConceptGraphView({
         }
       }
     },
-    [hitTest, layout.nodes, openNodeDetail],
+    [hitTest, layout.nodes, travelTo],
   );
 
   // Hover is only ever rewritten by moves inside the container, so without
@@ -1085,14 +1112,13 @@ export function ConceptGraphView({
                   <li key={node.id}>
                     <button
                       type="button"
-                      onClick={() => {
-                        focusOn(node.id);
-                        openNodeDetail({
+                      onClick={() =>
+                        travelTo({
                           id: node.id,
                           label: node.label,
                           updatedAtMs: node.updatedAtMs,
-                        });
-                      }}
+                        })
+                      }
                       className="block w-full truncate px-3 py-1 text-left text-[12px] hover:bg-[color-mix(in_srgb,var(--content-tertiary)_14%,transparent)]"
                       style={{ color: "var(--content-default)" }}
                     >
@@ -1236,7 +1262,7 @@ export function ConceptGraphView({
         <ConceptDetailPanel
           assistantId={assistantId}
           node={openNode}
-          onClose={() => setOpenNode(null)}
+          onClose={back}
           onOpenThread={onOpenThread}
         />
       ) : null}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -974,9 +974,35 @@ export function ConceptGraphView({
       />
     );
   } else {
+    // Brain-vocabulary stat header: neurons (nodes), synapses (edges), and
+    // lobes (distinct detected clusters). Only reached inside the ready body
+    // (nodes.length > 0), so it always has live counts to show.
+    const neurons = layout.nodes.length;
+    const synapses = layout.edges.length;
+    const lobes = new Set(clusters.values()).size;
+    const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "s"}`;
+
     body = (
       <>
         <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
+
+        {/* Brain-vocabulary stat header. Tagged data-graph-control so a
+            pointer-down on it bails the orbit-drag. Yields the top-center slot
+            to the intro banner and to a hover tooltip so the pills never stack. */}
+        {!showIntro && focusLabel == null && edgeLabel == null ? (
+          <div
+            data-graph-control
+            className="absolute left-1/2 top-4 -translate-x-1/2 rounded-full px-3 py-1 text-[11px] tabular-nums"
+            style={{
+              backgroundColor: "color-mix(in srgb, var(--surface-base) 82%, transparent)",
+              border: "1px solid var(--border-base)",
+              color: "var(--content-tertiary)",
+            }}
+          >
+            {plural(neurons, "neuron")} · {plural(synapses, "synapse")} ·{" "}
+            {plural(lobes, "lobe")}
+          </div>
+        ) : null}
 
         {/* Keep the box visible whenever a search is active, even if the graph
             shrank below the threshold (e.g. a refetch) — otherwise an active

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -291,8 +291,9 @@ export function ConceptGraphView({
   // explains why two concepts connect. Node hover always wins (onPointerMove).
   const [edgeLabel, setEdgeLabel] = useState<string | null>(null);
   // Navigable trail of opened concepts: each open pushes onto the stack, and the
-  // top (`trail.at(-1)`) is the concept the detail drawer shows. `back()` pops;
-  // emptying the trail returns to the overview (drawer closed).
+  // top (`trail.at(-1)`) is the concept the detail drawer shows. Crumbs pop back
+  // to a level; dismiss empties the trail, returning to the overview (drawer
+  // closed).
   const [trail, setTrail] = useState<ConceptDetailNode[]>([]);
   const openNode = trail.at(-1) ?? null;
   // Opening a concept into the detail drawer (canvas click or search result)
@@ -459,25 +460,26 @@ export function ConceptGraphView({
     [openNodeDetail, focusOn],
   );
 
-  // Step back through the trail: pop the current concept and re-center the new
-  // top; emptying the trail clears the selection and returns to the overview.
-  const back = useCallback(() => {
-    const next = trail.slice(0, -1);
-    setTrail(next);
-    const top = next.at(-1);
-    if (top) {
-      focusOn(top.id);
-    } else {
-      setFocusLabel(null);
-    }
-  }, [trail, focusOn]);
+  // Fully dismiss the detail drawer back to the overview: empty the trail
+  // (closing the drawer), clear any active search (the box hides behind the
+  // drawer, so a stale search would ghost the map after close), and drop the
+  // focus label. Wired to the panel's X / Escape / backdrop so any of those
+  // closes the whole drawer from any trail depth — not just one level.
+  const dismiss = useCallback(() => {
+    setTrail([]);
+    setSearch("");
+    setFocusLabel(null);
+  }, []);
 
-  // Jump to a breadcrumb: truncate the trail to `index` (keep 0..index) and
-  // re-center on that concept — mirrors back()'s trail-truncation + focus ease.
-  // Unlike back() this keeps the panel open (index stays >= 0 for a real crumb),
-  // so crumb clicks rewind the multi-level trail without closing the drawer.
+  // Jump to a breadcrumb (the ‹ back control and crumb clicks): truncate the
+  // trail to `index` (keep 0..index) and re-center on that concept. A real crumb
+  // index is always >= 0, so the panel stays open — crumb clicks rewind the
+  // multi-level trail without closing the drawer. Clears any active search first:
+  // the box is hidden behind the open drawer, so a stale search would leave a
+  // traveled-to non-match node centered but ghosted with no way to clear it.
   const goToCrumb = useCallback(
     (index: number) => {
+      setSearch("");
       const next = trail.slice(0, index + 1);
       setTrail(next);
       const top = next.at(-1);
@@ -490,24 +492,18 @@ export function ConceptGraphView({
     [trail, focusOn],
   );
 
-  // In-panel navigation (WIRED-TO neighbors, breadcrumbs) clears any active
-  // search first: the search box is hidden behind the open drawer, so a stale
-  // search would leave a traveled-to non-match node centered but ghosted with
-  // no way to clear it. Canvas + search-result travel keep the box visible, so
-  // they intentionally don't clear it.
+  // WIRED-TO travel from the panel clears any active search first: the search
+  // box is hidden behind the open drawer, so a stale search would leave a
+  // traveled-to non-match node centered but ghosted with no way to clear it.
+  // Canvas + search-result travel keep the box visible, so they intentionally
+  // don't clear it (that's plain travelTo). Breadcrumb navigation clears the
+  // search too, but does so inside goToCrumb itself.
   const travelFromPanel = useCallback(
     (node: ConceptDetailNode) => {
       setSearch("");
       travelTo(node);
     },
     [travelTo],
-  );
-  const crumbFromPanel = useCallback(
-    (index: number) => {
-      setSearch("");
-      goToCrumb(index);
-    },
-    [goToCrumb],
   );
 
   // Direct neighbors of the open concept, resolved to { id, label, kind } for the
@@ -1428,8 +1424,8 @@ export function ConceptGraphView({
           trail={trail}
           neighbors={neighbors}
           onTravel={travelFromPanel}
-          onCrumb={crumbFromPanel}
-          onClose={back}
+          onCrumb={goToCrumb}
+          onClose={dismiss}
           onOpenThread={onOpenThread}
         />
       ) : null}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -472,6 +472,77 @@ export function ConceptGraphView({
     }
   }, [trail, focusOn]);
 
+  // Jump to a breadcrumb: truncate the trail to `index` (keep 0..index) and
+  // re-center on that concept — mirrors back()'s trail-truncation + focus ease.
+  // Unlike back() this keeps the panel open (index stays >= 0 for a real crumb),
+  // so crumb clicks rewind the multi-level trail without closing the drawer.
+  const goToCrumb = useCallback(
+    (index: number) => {
+      const next = trail.slice(0, index + 1);
+      setTrail(next);
+      const top = next.at(-1);
+      if (top) {
+        focusOn(top.id);
+      } else {
+        setFocusLabel(null);
+      }
+    },
+    [trail, focusOn],
+  );
+
+  // In-panel navigation (WIRED-TO neighbors, breadcrumbs) clears any active
+  // search first: the search box is hidden behind the open drawer, so a stale
+  // search would leave a traveled-to non-match node centered but ghosted with
+  // no way to clear it. Canvas + search-result travel keep the box visible, so
+  // they intentionally don't clear it.
+  const travelFromPanel = useCallback(
+    (node: ConceptDetailNode) => {
+      setSearch("");
+      travelTo(node);
+    },
+    [travelTo],
+  );
+  const crumbFromPanel = useCallback(
+    (index: number) => {
+      setSearch("");
+      goToCrumb(index);
+    },
+    [goToCrumb],
+  );
+
+  // Direct neighbors of the open concept, resolved to { id, label, kind } for the
+  // detail panel's WIRED-TO list. Neighbor ids come from the adjacency map;
+  // labels from layout.nodes; the connecting edge's kind (link vs learned) tags
+  // each neighbor without grouping them. Sorted by label so the list is scannable.
+  const neighbors = useMemo(() => {
+    const currentId = openNode?.id;
+    if (!currentId) {
+      return [];
+    }
+    const ids = adjacency.get(currentId);
+    if (!ids || ids.size === 0) {
+      return [];
+    }
+    const labelById = new Map(layout.nodes.map((n) => [n.id, n.label]));
+    const kindById = new Map<string, string>();
+    for (const e of layout.edges) {
+      if (e.fromId === currentId) {
+        kindById.set(e.toId, e.kind);
+      } else if (e.toId === currentId) {
+        kindById.set(e.fromId, e.kind);
+      }
+    }
+    const out: { id: string; label: string; kind?: string }[] = [];
+    for (const id of ids) {
+      const label = labelById.get(id);
+      if (label != null) {
+        out.push({ id, label, kind: kindById.get(id) });
+      }
+    }
+    out.sort((a, b) => a.label.localeCompare(b.label));
+    return out;
+  }, [openNode?.id, adjacency, layout.nodes, layout.edges]);
+
   useEffect(() => {
     if (!ready) {return;}
     const canvas = canvasRef.current;
@@ -1354,6 +1425,10 @@ export function ConceptGraphView({
         <ConceptDetailPanel
           assistantId={assistantId}
           node={openNode}
+          trail={trail}
+          neighbors={neighbors}
+          onTravel={travelFromPanel}
+          onCrumb={crumbFromPanel}
           onClose={back}
           onOpenThread={onOpenThread}
         />

--- a/clients/web/src/domains/intelligence/components/concept-graph/constants.ts
+++ b/clients/web/src/domains/intelligence/components/concept-graph/constants.ts
@@ -1,33 +1,47 @@
 import type { ConceptNodeKind } from "./types";
 
-/** Node fill/stroke color per taxonomy kind. Hex (like the skills category
- * palette) so nodes read consistently across light/dark; labels use theme
- * tokens. */
+/** Node fill/stroke color per taxonomy kind. Values are the resolved hex of
+ * Vellum brand tokens (canvas `fillStyle` can't read CSS `var()`), so nodes
+ * read consistently across light/dark; labels use theme tokens.
+ * - concept    → `--system-info-strong` (brand blue)
+ * - skill      → `--feed-nudge-strong` (brand pink accent)
+ * - capability → `--credits-accent` / `--feed-digest-strong` (brand teal)
+ * - other      → `--content-quiet` / stone-500 (brand neutral) */
 export const NODE_KIND_COLORS: Record<ConceptNodeKind, string> = {
-  concept: "#5B8DEF",
-  skill: "#A665C9",
+  concept: "#467CC8",
+  skill: "#DB4B77",
   capability: "#0E9B8B",
   other: "#8D99A5",
 };
 
 /** Categorical fills for concept clusters/themes, indexed by the compact
- * cluster id from `detectClusters`. Ten distinct hues, ordered so adjacent
- * cluster ids (0,1,2,…) contrast strongly, tuned bright enough to read on the
- * dark graph surface. These are data-viz *series* colors — semantic by cluster,
- * not by theme surface — so raw hex is correct here (see STYLE_GUIDE "Color →
- * When raw hex is acceptable" and the `BAR_CHART_PALETTE` precedent). Callers
- * index modulo the length; `NODE_KIND_COLORS` stays as the per-kind fallback. */
+ * cluster id from `detectClusters`. Ten hues derived from Vellum's brand
+ * ramps/accent tokens (see `packages/design-library/src/tokens.css`), ordered
+ * so adjacent cluster ids (0,1,2,…) contrast, and tuned bright enough to read
+ * on the dark graph surface. These are data-viz *series* colors — semantic by
+ * cluster, not by theme surface — and the canvas needs resolved hex (no
+ * `var()`), so each entry is the literal value of the brand token named in the
+ * trailing comment. Vellum has no ready-made categorical/series palette (its
+ * accent hues are curated one-offs), so this brand-derived ramp lives here.
+ * Callers index modulo the length; `NODE_KIND_COLORS` stays as the per-kind
+ * fallback. No entry reuses the `skill`/`capability` hues from
+ * `NODE_KIND_COLORS`: concepts are drawn from this palette but non-concept
+ * nodes from `NODE_KIND_COLORS`, so a themed concept must stay distinguishable
+ * from a skill/capability node if those ever render alongside concepts.
+ *
+ * TODO(design): confirm exact Vellum brand ramp — see
+ * .private/plans/memory-viz-v2-spec.md open question */
 export const CLUSTER_PALETTE: string[] = [
-  "#5B8DEF", // blue
-  "#FB923C", // orange
-  "#2DD4BF", // teal
-  "#F472B6", // pink
-  "#A3E635", // lime
-  "#C084FC", // violet
-  "#FACC15", // yellow
-  "#38BDF8", // sky
-  "#F87171", // red
-  "#4ADE80", // green
+  "#467CC8", // system-info-strong — blue
+  "#E86B40", // danger-600 / system-negative-hover — orange
+  "#7A5AF5", // violet — fills a brand hue gap; distinct from node-kind colors
+  "#22B8CF", // cyan — distinct from capability teal + skill pink
+  "#3DB85E", // forest-500 — green
+  "#E9C91A", // feed-thread-strong — yellow
+  "#E83F5B", // velvet primary-base — brand red
+  "#6ECF87", // forest-400 — mint
+  "#F39B74", // danger-500 — peach
+  "#F5C94E", // amber-500 — gold
 ];
 
 export const NODE_KIND_LABELS: Record<ConceptNodeKind, string> = {
@@ -38,6 +52,8 @@ export const NODE_KIND_LABELS: Record<ConceptNodeKind, string> = {
 };
 
 /** Authored/structural links use a neutral theme token; learned associations
- * use a warm accent + dashes so the two edge kinds read apart at a glance. */
+ * use Vellum's warm accent (`--system-mid-strong` / amber-600) + dashes so the
+ * two edge kinds read apart at a glance. The learned color is drawn on the
+ * canvas, so it's the resolved hex rather than a `var()`. */
 export const EDGE_LINK_COLOR = "var(--content-tertiary)";
-export const EDGE_LEARNED_COLOR = "#E9A23B";
+export const EDGE_LEARNED_COLOR = "#F1B21E";

--- a/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 
 import { createMemory } from "@/domains/intelligence/memory-graph/create-memory";
 import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
+import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memory-stats";
 import { Button, Modal, toast, Typography } from "@vellumai/design-library";
 import { Textarea } from "@vellumai/design-library/components/input";
 
@@ -49,10 +50,17 @@ export function CreateMemoryModal({
       setContent("");
       onOpenChange(false);
       // The node materializes on the next consolidation, not now — invalidate
-      // so the graph refetches and the memory appears as the map updates.
-      await queryClient.invalidateQueries({
-        queryKey: memoryGraphOptions(assistantId).queryKey,
-      });
+      // the graph so it refetches and the memory appears as the map updates, and
+      // the stats query so the identity Memory card's count refreshes too (it's
+      // a separate query with a 5-min staleTime that wouldn't otherwise refire).
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: memoryGraphOptions(assistantId).queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: memoryStatsOptions(assistantId).queryKey,
+        }),
+      ]);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to create memory.";

--- a/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
@@ -1,0 +1,109 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import { createMemory } from "@/domains/intelligence/memory-graph/create-memory";
+import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
+import { Button, Modal, toast, Typography } from "@vellumai/design-library";
+import { Textarea } from "@vellumai/design-library/components/input";
+
+export interface CreateMemoryModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  assistantId: string;
+}
+
+/**
+ * "New memory" modal on the Memory tab: a user types a fact and we POST it to
+ * the daemon `memory/remember` route. Consolidation materializes it into a
+ * graph node LATER, so the memory does not appear instantly — on success we
+ * invalidate the `memory-graph` query so the node surfaces on the next map
+ * update rather than promising an immediate node. Mirrors the controlled
+ * `open`/`onOpenChange` + local `isSaving` pattern of `vercel-token-dialog.tsx`.
+ */
+export function CreateMemoryModal({
+  open,
+  onOpenChange,
+  assistantId,
+}: CreateMemoryModalProps) {
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleCreate = useCallback(async () => {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+
+    setIsSaving(true);
+    try {
+      // The route returns HTTP 200 with `{ success: false }` for business
+      // failures (e.g. memory disabled, empty fact), so `throwOnError` won't
+      // reject — honor the flag before claiming success. Keep the modal open on
+      // failure so the fact isn't lost and the user can retry.
+      const result = await createMemory(assistantId, trimmed);
+      if (!result.success) {
+        toast.error(result.message || "Couldn't save that memory.");
+        return;
+      }
+      toast.success("Got it — I'll remember that.");
+      setContent("");
+      onOpenChange(false);
+      // The node materializes on the next consolidation, not now — invalidate
+      // so the graph refetches and the memory appears as the map updates.
+      await queryClient.invalidateQueries({
+        queryKey: memoryGraphOptions(assistantId).queryKey,
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to create memory.";
+      toast.error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [assistantId, content, onOpenChange, queryClient]);
+
+  return (
+    <Modal.Root open={open} onOpenChange={onOpenChange}>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.Title>New memory</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="flex flex-col gap-4">
+            <Textarea
+              label="What should I remember?"
+              placeholder="e.g. I prefer concise, bulleted summaries."
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              disabled={isSaving}
+              rows={3}
+              fullWidth
+            />
+            <Typography
+              as="p"
+              variant="body-medium-lighter"
+              className="text-(--content-secondary)"
+            >
+              A new memory is forming — it'll appear as the map updates.
+            </Typography>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close asChild>
+            <Button variant="outlined" disabled={isSaving}>
+              Cancel
+            </Button>
+          </Modal.Close>
+          <Button
+            variant="primary"
+            onClick={handleCreate}
+            disabled={isSaving || !content.trim()}
+            leftIcon={isSaving ? <Loader2 className="animate-spin" /> : undefined}
+          >
+            {isSaving ? "Creating…" : "Create memory"}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -10,7 +10,7 @@
  * small stat line).
  */
 
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Brain,
   CalendarClock,
@@ -39,6 +39,7 @@ import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { contrastForeground } from "@/utils/avatar-tone";
 
 import { applyRename } from "../identity-actions/apply-rename";
+import { memoryStatsOptions } from "../memory-graph/get-memory-stats";
 import {
   assistantIdentityDetailsQueryKey,
   useAssistantIdentityDetails,
@@ -171,6 +172,24 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
     supportsPlugins,
     showChannels,
   });
+  // The Memory card's measurement is the cheap page-index concept count
+  // (get-memory-stats) — NOT the concept-graph build, which is kept off
+  // identity-page load. Gated on `showMemory` so no request fires while the
+  // Memory card is hidden.
+  const memoryStats = useQuery({
+    ...memoryStatsOptions(assistantId),
+    enabled: showMemory,
+  });
+  const sectionStats: Record<string, IdentitySectionStat | undefined> = {
+    ...stats,
+    memory:
+      memoryStats.data !== undefined
+        ? {
+            value: memoryStats.data.concepts,
+            label: memoryStats.data.concepts === 1 ? "memory" : "memories",
+          }
+        : undefined,
+  };
 
   const [modalOpen, setModalOpen] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
@@ -234,7 +253,7 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
           customImageUrl={customImageUrl}
           name={identityQuery.data?.identity?.name || "Assistant"}
           sections={sections}
-          stats={stats}
+          stats={sectionStats}
           avatarHex={avatarHex}
           isRenaming={isRenaming}
           onOpenAvatarModal={() => setModalOpen(true)}

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -182,8 +182,12 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
   });
   const sectionStats: Record<string, IdentitySectionStat | undefined> = {
     ...stats,
+    // Only show a count when the daemon actually answered one (`ready`). An
+    // older daemon predating `/memory/stats` reads `unsupported`, and a loading
+    // query is `undefined` — both leave the measurement off (as the card was
+    // before this feature) rather than render a wrong "0 memories".
     memory:
-      memoryStats.data !== undefined
+      memoryStats.data?.kind === "ready"
         ? {
             value: memoryStats.data.concepts,
             label: memoryStats.data.concepts === 1 ? "memory" : "memories",

--- a/clients/web/src/domains/intelligence/memory-graph/create-memory.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/create-memory.ts
@@ -1,0 +1,32 @@
+/**
+ * Thin wrapper over the daemon `POST /memory/remember` route. The daemon spec
+ * transform rewrites `/v1/memory/remember` → `/v1/assistants/{assistant_id}/…`,
+ * so the assistant id travels in the path. Appends a user-authored fact to the
+ * memory buffer via `handleRemember`; consolidation materializes it into a
+ * graph node LATER, so the new memory is not visible immediately — callers
+ * should invalidate the memory-graph query and rely on the next consolidation
+ * to surface the node. Mirrors the thin-wrapper style of the sibling
+ * `get-memory-graph.ts` / `get-memory-graph-node.ts` read helpers.
+ */
+
+import { memoryRememberPost } from "@/generated/daemon/sdk.gen";
+
+export interface CreateMemoryResult {
+  message: string;
+  success: boolean;
+}
+
+export async function createMemory(
+  assistantId: string,
+  content: string,
+): Promise<CreateMemoryResult> {
+  // `throwOnError: true` narrows `data` to the 200 body and throws on any
+  // transport / non-2xx error, so the caller can `try/catch` and surface
+  // `error.message` in a toast.
+  const { data } = await memoryRememberPost({
+    path: { assistant_id: assistantId },
+    body: { content },
+    throwOnError: true,
+  });
+  return data;
+}

--- a/clients/web/src/domains/intelligence/memory-graph/get-memory-stats.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/get-memory-stats.ts
@@ -1,0 +1,58 @@
+/**
+ * TanStack Query options for the lightweight `GET /memory/stats` daemon
+ * endpoint — a cheap concept-page count for glanceable surfaces (the identity
+ * Memory card). Unlike `memoryGraphOptions`, this never triggers the memory
+ * concept-graph build; it reads a single count off the cached page index.
+ *
+ * A 404 (an older assistant predating the route) degrades to `{ concepts: 0 }`
+ * so the card shows "0 memories" rather than an error (see
+ * `docs/BACKWARDS_COMPAT.md`). Other non-2xx / transport errors throw.
+ */
+
+import { queryOptions } from "@tanstack/react-query";
+
+import { memoryStatsGet } from "@/generated/daemon/sdk.gen";
+import {
+  ApiError,
+  assertHasResponse,
+  extractErrorMessage,
+} from "@/utils/api-errors";
+
+export interface MemoryStats {
+  concepts: number;
+}
+
+const FAILURE_MESSAGE = "Failed to load memory stats.";
+
+export function memoryStatsOptions(assistantId: string) {
+  return queryOptions<MemoryStats>({
+    queryKey: ["memory-stats", assistantId] as const,
+    // A glanceable count that only changes on the timescale of memory writes —
+    // don't refire it on every window refocus.
+    staleTime: 5 * 60_000,
+    queryFn: async (): Promise<MemoryStats> => {
+      const { data, error, response } = await memoryStatsGet({
+        path: { assistant_id: assistantId },
+        throwOnError: false,
+      });
+
+      assertHasResponse(response, error, FAILURE_MESSAGE);
+
+      // An assistant/daemon predating the `/memory/stats` route answers 404;
+      // treat that as an empty memory so the card degrades to "0 memories"
+      // instead of an error (BACKWARDS_COMPAT read rule).
+      if (response.status === 404) {
+        return { concepts: 0 };
+      }
+
+      if (!response.ok) {
+        throw new ApiError(
+          response.status,
+          extractErrorMessage(error, response, FAILURE_MESSAGE),
+        );
+      }
+
+      return { concepts: data?.concepts ?? 0 };
+    },
+  });
+}

--- a/clients/web/src/domains/intelligence/memory-graph/get-memory-stats.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/get-memory-stats.ts
@@ -4,9 +4,12 @@
  * Memory card). Unlike `memoryGraphOptions`, this never triggers the memory
  * concept-graph build; it reads a single count off the cached page index.
  *
- * A 404 (an older assistant predating the route) degrades to `{ concepts: 0 }`
- * so the card shows "0 memories" rather than an error (see
- * `docs/BACKWARDS_COMPAT.md`). Other non-2xx / transport errors throw.
+ * A 404 (an older assistant predating the route) maps to
+ * `{ kind: "unsupported" }` — a success-shaped result, mirroring
+ * `memoryGraphOptions` — so callers omit the count entirely rather than showing
+ * a wrong "0 memories" (an older daemon may hold plenty of concepts; it just
+ * can't count them here). See `docs/BACKWARDS_COMPAT.md`. Other non-2xx /
+ * transport errors throw.
  */
 
 import { queryOptions } from "@tanstack/react-query";
@@ -18,19 +21,24 @@ import {
   extractErrorMessage,
 } from "@/utils/api-errors";
 
-export interface MemoryStats {
-  concepts: number;
-}
+/**
+ * Two-state result mirroring `MemoryGraphResult`. `unsupported` is a
+ * success-shaped outcome (the daemon predates the `/memory/stats` route) that
+ * callers render as "no count" — not an error, and not a misleading zero.
+ */
+export type MemoryStatsResult =
+  | { kind: "ready"; concepts: number }
+  | { kind: "unsupported" };
 
 const FAILURE_MESSAGE = "Failed to load memory stats.";
 
 export function memoryStatsOptions(assistantId: string) {
-  return queryOptions<MemoryStats>({
+  return queryOptions<MemoryStatsResult>({
     queryKey: ["memory-stats", assistantId] as const,
     // A glanceable count that only changes on the timescale of memory writes —
     // don't refire it on every window refocus.
     staleTime: 5 * 60_000,
-    queryFn: async (): Promise<MemoryStats> => {
+    queryFn: async (): Promise<MemoryStatsResult> => {
       const { data, error, response } = await memoryStatsGet({
         path: { assistant_id: assistantId },
         throwOnError: false,
@@ -39,10 +47,10 @@ export function memoryStatsOptions(assistantId: string) {
       assertHasResponse(response, error, FAILURE_MESSAGE);
 
       // An assistant/daemon predating the `/memory/stats` route answers 404;
-      // treat that as an empty memory so the card degrades to "0 memories"
-      // instead of an error (BACKWARDS_COMPAT read rule).
+      // treat that as "not supported here" so the card omits its count instead
+      // of showing a wrong 0 (BACKWARDS_COMPAT read rule).
       if (response.status === 404) {
-        return { concepts: 0 };
+        return { kind: "unsupported" };
       }
 
       if (!response.ok) {
@@ -52,7 +60,7 @@ export function memoryStatsOptions(assistantId: string) {
         );
       }
 
-      return { concepts: data?.concepts ?? 0 };
+      return { kind: "ready", concepts: data?.concepts ?? 0 };
     },
   });
 }

--- a/clients/web/src/domains/intelligence/memory-page.tsx
+++ b/clients/web/src/domains/intelligence/memory-page.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useRef } from "react";
+import { Plus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { ConceptGraphView } from "@/domains/intelligence/components/concept-graph/concept-graph-view";
+import { CreateMemoryModal } from "@/domains/intelligence/components/concept-graph/create-memory-modal";
 import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { Button } from "@vellumai/design-library";
 
 interface MemoryPageProps {
   onOpenThread?: (message: string) => void;
@@ -18,6 +22,16 @@ interface MemoryPageProps {
  */
 export function MemoryPage({ onOpenThread }: MemoryPageProps) {
   const assistantId = useActiveAssistantId();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  // The button lets a user seed a memory by hand. Gate it on the same
+  // `memory-concept-graph` flag as the tab, and wait for `hasHydrated` before
+  // trusting a `false`: the store starts on registry defaults until the first
+  // `/feature-flags` response, so gating on the raw flag would flash the button
+  // then hide it (or vice-versa) on load. See the store's `hasHydrated` docs.
+  const flagsHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
+  const memoryFlag = useAssistantFeatureFlagStore.use.memoryConceptGraph();
+  const showCreate = flagsHydrated && memoryFlag;
 
   // Report the tab open exactly once per mount. The ref guard keeps React
   // strict-mode's double-invoke (dev) from emitting a duplicate.
@@ -31,12 +45,35 @@ export function MemoryPage({ onOpenThread }: MemoryPageProps) {
   }, []);
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div className="relative flex h-full min-h-0 flex-col">
       <ConceptGraphView
         assistantId={assistantId}
         className="h-full w-full"
         onOpenThread={onOpenThread}
       />
+
+      {showCreate ? (
+        <>
+          {/* Overlay CTA. It lives on the page wrapper (a sibling of the graph
+              view, not a child) so it stays off the shared view file and its
+              pointer events never reach the canvas orbit-drag handlers. Offset
+              from the view's top-right zoom cluster (right-4). */}
+          <Button
+            variant="primary"
+            size="compact"
+            leftIcon={<Plus />}
+            onClick={() => setCreateOpen(true)}
+            className="absolute right-16 top-4 z-10"
+          >
+            Create memory
+          </Button>
+          <CreateMemoryModal
+            open={createOpen}
+            onOpenChange={setCreateOpen}
+            assistantId={assistantId}
+          />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/clients/web/src/domains/intelligence/memory-page.tsx
+++ b/clients/web/src/domains/intelligence/memory-page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { ConceptGraphView } from "@/domains/intelligence/components/concept-graph/concept-graph-view";
 import { CreateMemoryModal } from "@/domains/intelligence/components/concept-graph/create-memory-modal";
+import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
 import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memory-stats";
 import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -35,18 +36,32 @@ export function MemoryPage({ onOpenThread }: MemoryPageProps) {
   const memoryFlag = useAssistantFeatureFlagStore.use.memoryConceptGraph();
   const flagGate = flagsHydrated && memoryFlag;
 
-  // The `memory-concept-graph` flag predates the write route the button posts
-  // to (`POST /memory/remember`), so the flag alone can be on against a daemon
-  // that would 404 the create. The write route and `GET /memory/stats` shipped
-  // in the same release, so the stats route's availability is a reliable
-  // capability proxy for the write route — only reveal the CTA once stats reads
-  // `ready`. React Query dedupes this with the identity card's own stats query.
-  // Gated on `flagGate` so no request fires while the flag/tab is off.
+  // Two backend conditions must hold before revealing the CTA, beyond the flag:
+  //  1. The graph backend is actually supported. The `memory-concept-graph`
+  //     flag can be on against a backend that doesn't expose the graph (e.g.
+  //     `memory.v3.live` is false), where `ConceptGraphView` renders its
+  //     "not available" copy. `GET /memory/stats` still reads `ready` there —
+  //     it only counts page-index entries and doesn't check graph support — so
+  //     it can't stand in for graph readiness. Gate on the graph query's own
+  //     `ready` state (React Query dedupes it with the view's query) so the CTA
+  //     never sits over an unsupported page promising a map that can't update.
+  //  2. The write route exists. The flag also predates `POST /memory/remember`;
+  //     that route and `GET /memory/stats` shipped together, so stats-route
+  //     availability is a reliable capability proxy for the write route on
+  //     daemons that support the graph but predate the create route.
+  // Both gated on `flagGate` so no request fires while the flag/tab is off.
+  const memoryGraph = useQuery({
+    ...memoryGraphOptions(assistantId),
+    enabled: flagGate,
+  });
   const memoryStats = useQuery({
     ...memoryStatsOptions(assistantId),
     enabled: flagGate,
   });
-  const showCreate = flagGate && memoryStats.data?.kind === "ready";
+  const showCreate =
+    flagGate &&
+    memoryGraph.data?.kind === "ready" &&
+    memoryStats.data?.kind === "ready";
 
   // Report the tab open exactly once per mount. The ref guard keeps React
   // strict-mode's double-invoke (dev) from emitting a duplicate.

--- a/clients/web/src/domains/intelligence/memory-page.tsx
+++ b/clients/web/src/domains/intelligence/memory-page.tsx
@@ -1,9 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { ConceptGraphView } from "@/domains/intelligence/components/concept-graph/concept-graph-view";
 import { CreateMemoryModal } from "@/domains/intelligence/components/concept-graph/create-memory-modal";
+import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memory-stats";
 import { emitMemoryEvent } from "@/domains/intelligence/memory-telemetry";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { Button } from "@vellumai/design-library";
@@ -31,7 +33,20 @@ export function MemoryPage({ onOpenThread }: MemoryPageProps) {
   // then hide it (or vice-versa) on load. See the store's `hasHydrated` docs.
   const flagsHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
   const memoryFlag = useAssistantFeatureFlagStore.use.memoryConceptGraph();
-  const showCreate = flagsHydrated && memoryFlag;
+  const flagGate = flagsHydrated && memoryFlag;
+
+  // The `memory-concept-graph` flag predates the write route the button posts
+  // to (`POST /memory/remember`), so the flag alone can be on against a daemon
+  // that would 404 the create. The write route and `GET /memory/stats` shipped
+  // in the same release, so the stats route's availability is a reliable
+  // capability proxy for the write route — only reveal the CTA once stats reads
+  // `ready`. React Query dedupes this with the identity card's own stats query.
+  // Gated on `flagGate` so no request fires while the flag/tab is off.
+  const memoryStats = useQuery({
+    ...memoryStatsOptions(assistantId),
+    enabled: flagGate,
+  });
+  const showCreate = flagGate && memoryStats.data?.kind === "ready";
 
   // Report the tab open exactly once per mount. The ref guard keeps React
   // strict-mode's double-invoke (dev) from emitting a duplicate.


### PR DESCRIPTION
## Summary
Implements the Memory Visualization v2 design (`.private/plans/memory-viz-v2.md`), all behind the existing `memory-concept-graph` flag and the concepts-only direction:
- **Create memory** — user-authored `POST /v1/memory/remember` route (wrapping `handleRemember`, zero LLM at create) + a "New memory" modal on the Memory tab, eventual-consistency reveal with an inline confirmation.
- **Trail + breadcrumbs** — click-to-center navigation with a back stack, clickable WIRED-TO neighbor list, breadcrumb header, and connection count.
- **Focus dimming** — ego-dim that spotlights the selected node's neighborhood; selection overrides recency/edge filters.
- **Brain vocabulary + brand colors** — neurons/synapses/lobes stat header; Vellum-branded palette.
- **Read full note** — long concept notes collapse behind an (a11y-safe) expander.
- **Identity Memory count** — the identity nav card now shows "N memories" from a lightweight page-index count (no graph build).

## Self-review result
PASS — 3 gaps found across the self-review passes and fixed across 2 fix PRs (panel close-vs-back semantics + search-clear, memory-stats invalidation on create, empty-content 400). Re-review verified all fixes with no regressions.

## PRs merged into feature branch
- #38458: Vellum-brand the graph palette
- #38457: neurons / synapses / lobes stat header
- #38459: POST /v1/memory/remember route (create memory)
- #38464: navigable trail — click-to-center with a back stack
- #38465: "+ Create memory" modal on the Memory tab
- #38507: focus dimming — spotlight the selected node's neighborhood
- #38510: memory count on the identity Memory card
- #38512: breadcrumbs + clickable WIRED-TO in the detail panel
- #38514: collapse long concept notes behind "Read full note"

### Fix PRs (self-review remediation)
- #38516: panel close semantics + memory-stats invalidation
- #38515: 400 on empty create-memory content

Part of plan: memory-viz-v2.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)