### PR TITLE
feat(telemetry): track memory.v3.live in config_setting events

### DIFF
--- a/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
+++ b/assistant/src/telemetry/__tests__/config-setting-snapshot.test.ts
@@ -14,9 +14,14 @@ import {
 function makeConfig(
   memoryEnabled: boolean,
   v2Enabled: boolean,
+  v3Live = false,
 ): AssistantConfig {
   return {
-    memory: { enabled: memoryEnabled, v2: { enabled: v2Enabled } },
+    memory: {
+      enabled: memoryEnabled,
+      v2: { enabled: v2Enabled },
+      v3: { live: v3Live },
+    },
   } as AssistantConfig;
 }
 
@@ -40,6 +45,7 @@ describe("config-setting-snapshot", () => {
     expect(recordedPairs().sort()).toEqual([
       ["memory.enabled", "true"],
       ["memory.v2.enabled", "false"],
+      ["memory.v3.live", "false"],
     ]);
   });
 
@@ -48,7 +54,7 @@ describe("config-setting-snapshot", () => {
     recordConfigSettingSnapshot(makeConfig(true, true));
     recordConfigSettingSnapshot(makeConfig(true, true));
 
-    expect(recordedPairs()).toHaveLength(2);
+    expect(recordedPairs()).toHaveLength(3);
   });
 
   test("a changed value records only the changed key", () => {
@@ -58,6 +64,16 @@ describe("config-setting-snapshot", () => {
     recordConfigSettingSnapshot(makeConfig(true, false));
 
     expect(recordedPairs()).toEqual([["memory.v2.enabled", "false"]]);
+  });
+
+  test("memory.v3.live is tracked and its flip is captured", () => {
+    recordConfigSettingSnapshot(makeConfig(true, true, false));
+    expect(recordedPairs()).toContainEqual(["memory.v3.live", "false"]);
+    resetOutboxTable();
+
+    recordConfigSettingSnapshot(makeConfig(true, true, true));
+
+    expect(recordedPairs()).toEqual([["memory.v3.live", "true"]]);
   });
 
   test("unknown consent skips entirely — no rows, no memo", () => {
@@ -75,6 +91,7 @@ describe("config-setting-snapshot", () => {
     expect(recordedPairs().sort()).toEqual([
       ["memory.enabled", "true"],
       ["memory.v2.enabled", "false"],
+      ["memory.v3.live", "false"],
     ]);
   });
 
@@ -88,13 +105,13 @@ describe("config-setting-snapshot", () => {
     // once consent resolves).
     setShareAnalytics(true);
     recordConfigSettingSnapshot(makeConfig(true, true));
-    expect(recordedPairs()).toHaveLength(2);
+    expect(recordedPairs()).toHaveLength(3);
   });
 
   test("re-opt-in after an opt-out re-records the full snapshot", () => {
     // Recorded while opted in.
     recordConfigSettingSnapshot(makeConfig(true, true));
-    expect(recordedPairs()).toHaveLength(2);
+    expect(recordedPairs()).toHaveLength(3);
     resetOutboxTable();
 
     // Opt out: the reporter's opt-out flush discards any pending rows, so the
@@ -110,6 +127,7 @@ describe("config-setting-snapshot", () => {
     expect(recordedPairs().sort()).toEqual([
       ["memory.enabled", "true"],
       ["memory.v2.enabled", "true"],
+      ["memory.v3.live", "false"],
     ]);
   });
 

--- a/assistant/src/telemetry/config-setting-snapshot.ts
+++ b/assistant/src/telemetry/config-setting-snapshot.ts
@@ -32,6 +32,7 @@ function trackedConfigSettings(
   const pairs: ReadonlyArray<readonly [string, boolean | undefined]> = [
     ["memory.enabled", config.memory?.enabled],
     ["memory.v2.enabled", config.memory?.v2?.enabled],
+    ["memory.v3.live", config.memory?.v3?.live],
   ];
   return pairs
     .filter((pair): pair is readonly [string, boolean] => pair[1] != null)


### PR DESCRIPTION
## Prompt / plan

> we want to add `memory.v3.live` to the telemetry events

`memory.v3.live` is the config flag that determines whether memory-v3 is the live injected memory source (suppressing v2 injection). The `config_setting` telemetry event already reports an allowlist of non-sensitive config settings as `(config_key, config_value)` pairs, snapshotted per boot and on hourly cadence in the resource-monitor process. This adds `memory.v3.live` to that allowlist alongside `memory.enabled` and `memory.v2.enabled`, so downstream consumers can observe the effective v3-live state across the fleet.

No platform wire-contract change is required: this reuses the existing `config_setting` event type — it's just another `config_key`/`config_value` pair, not a new event type (which per `assistant/src/telemetry/AGENTS.md` would have to start platform-side).

The value flows through the same consent gating, per-key memoization, and opt-out memo-clearing as the existing tracked keys — no behavior change beyond one more tracked key.

## Test plan

- Updated `config-setting-snapshot.test.ts`: `makeConfig` now sets `memory.v3.live`, the full-snapshot assertions include the new key, count-based assertions bumped 2 → 3, and a new dedicated test verifies `memory.v3.live` is tracked and its flip (`false` → `true`) is captured as a single changed-key row.
- `bun test src/telemetry/__tests__/config-setting-snapshot.test.ts` — 8 pass.
- `bun run typecheck:fast` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WwWbLwC1uPbsJ43uArGL9Y)_