### PR TITLE
feat(web): stash the pro checkout selection for the onboarding wizard

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -35,6 +35,7 @@ import type {
   ProPackage,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
+import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
 
@@ -195,6 +196,7 @@ function renderPage(subscription: SubscriptionResponse) {
 beforeEach(() => {
   upgradeCall = null;
   openedUrl = null;
+  sessionStorage.clear();
 });
 
 afterEach(() => {
@@ -221,6 +223,10 @@ describe("PlansPage checkout — base subscriber", () => {
         confirm: true,
       });
       await waitFor(() => expect(openedUrl).toBe(CHECKOUT_URL));
+      expect(readCheckoutIntent()).toMatchObject({
+        kind: "package",
+        packageKey: pkg,
+      });
     });
   }
 });
@@ -239,5 +245,6 @@ describe("PlansPage checkout — Pro subscriber", () => {
     // The upgrade endpoint no-ops for an active Pro org, so no checkout fires.
     expect(upgradeCall).toBeNull();
     expect(openedUrl).toBeNull();
+    expect(readCheckoutIntent()).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -35,6 +35,7 @@ import {
   useActiveAssistantLifecycleIsLoading,
   usePlatformGate,
 } from "@/hooks/use-platform-gate";
+import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { SIZE_LABEL } from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
@@ -152,6 +153,18 @@ export function PlansPage() {
     try {
       const result = await upgradeMutation.mutateAsync({ body });
       if (result.status === "redirect" && result.checkout_url) {
+        // Stash the selection so the post-checkout provisioning screen can
+        // show the purchased upgrade before the subscribe webhook lands.
+        saveCheckoutIntent(
+          body.package
+            ? { kind: "package", packageKey: body.package }
+            : {
+                kind: "custom",
+                machineTier: body.machine_tier ?? null,
+                storageTier: body.storage_tier ?? null,
+                creditTier: body.credit_tier ?? null,
+              },
+        );
         openUrl(result.checkout_url);
       } else {
         await queryClient.invalidateQueries({

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -27,6 +27,7 @@ import type {
     ProPlan,
     StorageTierEnum,
 } from "@/generated/api/types.gen";
+import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
@@ -233,6 +234,14 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
       {
         onSuccess: (data) => {
           if (data.checkout_url) {
+            // Stash the selection so the post-checkout provisioning screen
+            // can show the purchased upgrade before the webhook lands.
+            saveCheckoutIntent({
+              kind: "custom",
+              machineTier: selectedMachineTier,
+              storageTier: selectedStorageTier,
+              creditTier: displayCreditTier,
+            });
             void openUrl(data.checkout_url);
             return;
           }

--- a/clients/web/src/lib/billing/checkout-intent.test.ts
+++ b/clients/web/src/lib/billing/checkout-intent.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  clearCheckoutIntent,
+  readCheckoutIntent,
+  saveCheckoutIntent,
+} from "@/lib/billing/checkout-intent";
+
+const STORAGE_KEY = "vellum.pro-checkout-intent";
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("saveCheckoutIntent / readCheckoutIntent", () => {
+  test("round-trips a package intent and stamps savedAt", () => {
+    const before = Date.now();
+    saveCheckoutIntent({ kind: "package", packageKey: "super" });
+
+    const intent = readCheckoutIntent();
+    expect(intent).not.toBeNull();
+    expect(intent!.kind).toBe("package");
+    if (intent!.kind === "package") {
+      expect(intent!.packageKey).toBe("super");
+    }
+    expect(intent!.savedAt).toBeGreaterThanOrEqual(before);
+    expect(intent!.savedAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  test("round-trips a custom intent, including null tiers", () => {
+    saveCheckoutIntent({
+      kind: "custom",
+      machineTier: "large",
+      storageTier: "m",
+      creditTier: null,
+    });
+
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "custom",
+      machineTier: "large",
+      storageTier: "m",
+      creditTier: null,
+    });
+  });
+
+  test("returns null when nothing is stashed", () => {
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("a stash older than 30 minutes reads as null and self-clears", () => {
+    const stale = {
+      kind: "package",
+      packageKey: "super",
+      savedAt: Date.now() - 31 * 60 * 1000,
+    };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stale));
+
+    expect(readCheckoutIntent()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  test("a stash just inside the TTL still reads", () => {
+    const fresh = {
+      kind: "package",
+      packageKey: "mighty",
+      savedAt: Date.now() - 29 * 60 * 1000,
+    };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(fresh));
+
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "package",
+      packageKey: "mighty",
+    });
+  });
+
+  test("corrupt JSON reads as null and self-clears", () => {
+    sessionStorage.setItem(STORAGE_KEY, "{not json");
+
+    expect(readCheckoutIntent()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  test("a parseable but malformed stash reads as null and self-clears", () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ kind: "package", savedAt: "not-a-number" }),
+    );
+
+    expect(readCheckoutIntent()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("clearCheckoutIntent", () => {
+  test("removes the stash", () => {
+    saveCheckoutIntent({ kind: "package", packageKey: "ultra" });
+    clearCheckoutIntent();
+
+    expect(readCheckoutIntent()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/clients/web/src/lib/billing/checkout-intent.ts
+++ b/clients/web/src/lib/billing/checkout-intent.ts
@@ -1,0 +1,90 @@
+import type {
+  CreditTierEnum,
+  MachineTierEnum,
+  StorageTierEnum,
+} from "@/generated/api/types.gen";
+
+/**
+ * The plan selection captured at the moment a Stripe checkout redirect fires,
+ * so the post-checkout provisioning screen can render the purchased upgrade
+ * instantly — before the subscribe webhook lands and any API reflects it.
+ *
+ * Stored in sessionStorage (per-tab, survives the Stripe redirect round-trip,
+ * dies with the tab) under a 30-minute TTL: a checkout abandoned longer than
+ * that shouldn't resurface as a phantom "provisioning" state.
+ */
+export type CheckoutIntent =
+  | { kind: "package"; packageKey: string; savedAt: number }
+  | {
+      kind: "custom";
+      machineTier: MachineTierEnum | null;
+      storageTier: StorageTierEnum | null;
+      creditTier: CreditTierEnum | null;
+      savedAt: number;
+    };
+
+/** A `CheckoutIntent` before `saveCheckoutIntent` stamps `savedAt`. */
+export type UnsavedCheckoutIntent =
+  | Omit<Extract<CheckoutIntent, { kind: "package" }>, "savedAt">
+  | Omit<Extract<CheckoutIntent, { kind: "custom" }>, "savedAt">;
+
+const STORAGE_KEY = "vellum.pro-checkout-intent";
+const MAX_AGE_MS = 30 * 60 * 1000;
+
+export function saveCheckoutIntent(intent: UnsavedCheckoutIntent): void {
+  try {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...intent, savedAt: Date.now() }),
+    );
+  } catch {
+    // sessionStorage may be unavailable (private mode, quota). The stash is a
+    // display-only optimization — never block the checkout redirect on it.
+  }
+}
+
+/**
+ * The stashed intent, or `null` when absent, unparsable, malformed, or older
+ * than the TTL — anything unusable is cleared so it can't resurface.
+ */
+export function readCheckoutIntent(): CheckoutIntent | null {
+  if (typeof sessionStorage === "undefined") return null;
+  let raw: string | null = null;
+  try {
+    raw = sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    clearCheckoutIntent();
+    return null;
+  }
+  if (!isCheckoutIntent(parsed) || Date.now() - parsed.savedAt > MAX_AGE_MS) {
+    clearCheckoutIntent();
+    return null;
+  }
+  return parsed;
+}
+
+export function clearCheckoutIntent(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // see saveCheckoutIntent
+  }
+}
+
+function isCheckoutIntent(value: unknown): value is CheckoutIntent {
+  if (typeof value !== "object" || value === null) return false;
+  const intent = value as Partial<CheckoutIntent>;
+  if (typeof intent.savedAt !== "number") return false;
+  if (intent.kind === "package") {
+    return typeof intent.packageKey === "string";
+  }
+  return intent.kind === "custom";
+}


### PR DESCRIPTION
## Summary
- sessionStorage stash of the package/custom tiers selected at checkout, with 30-min TTL
- written by both checkout entry points before the Stripe redirect
- consumed by the upcoming provisioning screen for instant optimistic display

Part of plan: pro-onboarding-wizard-revamp.md (PR 1 of 6)