### PR TITLE
feat(web): provisioning screen for the pro onboarding wizard

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/pending-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/pending-state.tsx
@@ -1,34 +1,11 @@
-import { Loader2 } from "lucide-react";
-
 import { Typography } from "@vellumai/design-library/components/typography";
+
+import { GlowSpinner } from "./primitives";
 
 export function PendingState({ title, body }: { title: string; body: string }) {
   return (
     <div className="flex min-h-[280px] flex-col items-center justify-center gap-4 px-6 py-10 text-center">
-      <div className="relative flex h-11 w-11 items-center justify-center">
-        <div
-          className="absolute h-14 w-14 rounded-full"
-          style={{
-            backgroundColor:
-              "color-mix(in oklab, var(--system-positive-strong) 10%, transparent)",
-            animation: "onboarding-glow 2.4s ease-in-out infinite",
-          }}
-          aria-hidden="true"
-        />
-        <div
-          className="absolute h-9 w-9 rounded-full"
-          style={{
-            backgroundColor:
-              "color-mix(in oklab, var(--system-positive-strong) 8%, transparent)",
-            animation: "onboarding-glow 2.4s ease-in-out infinite 0.4s",
-          }}
-          aria-hidden="true"
-        />
-        <Loader2
-          className="relative h-5 w-5 animate-spin text-[var(--system-positive-strong)]"
-          aria-hidden="true"
-        />
-      </div>
+      <GlowSpinner />
       <div className="space-y-1.5">
         <Typography variant="title-small" as="h1">
           {title}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
@@ -1,4 +1,5 @@
 import type { LucideIcon } from "lucide-react";
+import { ArrowRight, Loader2 } from "lucide-react";
 
 export function StepDots({ current, total = 2 }: { current: number; total?: number }) {
   return (
@@ -46,5 +47,91 @@ export function IconBadge({
         aria-hidden="true"
       />
     </span>
+  );
+}
+
+export function GlowSpinner() {
+  return (
+    <div className="relative flex h-11 w-11 items-center justify-center">
+      <div
+        className="absolute h-14 w-14 rounded-full"
+        style={{
+          backgroundColor:
+            "color-mix(in oklab, var(--system-positive-strong) 10%, transparent)",
+          animation: "onboarding-glow 2.4s ease-in-out infinite",
+        }}
+        aria-hidden="true"
+      />
+      <div
+        className="absolute h-9 w-9 rounded-full"
+        style={{
+          backgroundColor:
+            "color-mix(in oklab, var(--system-positive-strong) 8%, transparent)",
+          animation: "onboarding-glow 2.4s ease-in-out infinite 0.4s",
+        }}
+        aria-hidden="true"
+      />
+      <Loader2
+        className="relative h-5 w-5 animate-spin text-[var(--system-positive-strong)]"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+export function ResourceCard({
+  icon: Icon,
+  label,
+  from,
+  fromDetail,
+  to,
+  toDetail,
+}: {
+  icon: LucideIcon;
+  label: string;
+  from: string;
+  fromDetail?: string;
+  to: string;
+  toDetail?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg bg-[var(--surface-base)] p-3">
+      <span
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+        style={{
+          backgroundColor: "color-mix(in oklab, var(--system-positive-strong) 10%, transparent)",
+        }}
+      >
+        <Icon className="h-4 w-4 text-[var(--system-positive-strong)]" />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-label-small-default text-[var(--content-tertiary)]">
+          {label}
+        </span>
+        <div className="flex items-center gap-2">
+          <div className="flex flex-col">
+            <span className="text-label-medium-default text-[var(--content-tertiary)] line-through">
+              {from}
+            </span>
+            {fromDetail && (
+              <span className="text-label-small-default text-[var(--content-tertiary)] line-through">
+                {fromDetail}
+              </span>
+            )}
+          </div>
+          <ArrowRight className="h-3 w-3 shrink-0 text-[var(--content-tertiary)]" />
+          <div className="flex flex-col">
+            <span className="text-label-medium-default text-[var(--content-default)]">
+              {to}
+            </span>
+            {toDetail && (
+              <span className="text-label-small-default text-[var(--content-tertiary)]">
+                {toDetail}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * Tests for the pure-props `ProvisioningState` screen. Renders via
+ * `@testing-library/react` (happy-dom registered in test-setup.ts); no
+ * network mocks — every phase is driven entirely through props.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import type { ProvisioningStateProps } from "./provisioning-state";
+import { ProvisioningState } from "./provisioning-state";
+
+afterEach(() => {
+  cleanup();
+});
+
+function baseProps(
+  overrides: Partial<ProvisioningStateProps> = {},
+): ProvisioningStateProps {
+  return {
+    state: "confirming",
+    softWaiting: false,
+    intent: null,
+    targets: { machineSize: null, storageGib: null },
+    fromSnapshot: { machineSize: null, storageGib: null },
+    celebrating: false,
+    onCelebrationEnd: () => {},
+    escapeAvailable: false,
+    onEscape: () => {},
+    stalledAction: { onApply: () => {}, pending: false, error: null },
+    confirm: { expired: false, onRetry: () => {}, onGoToBilling: () => {} },
+    ...overrides,
+  };
+}
+
+function renderState(overrides: Partial<ProvisioningStateProps> = {}) {
+  return render(<ProvisioningState {...baseProps(overrides)} />);
+}
+
+describe("confirming", () => {
+  test("renders the payment-confirmed headline with a package chip", () => {
+    const { getByText } = renderState({
+      state: "confirming",
+      intent: { kind: "package", packageKey: "mighty" },
+    });
+
+    expect(
+      getByText("Payment confirmed — setting up your upgrade…"),
+    ).toBeTruthy();
+    expect(getByText("Mighty package")).toBeTruthy();
+  });
+
+  test("renders custom-intent tier chips, omitting the credits chip when null", () => {
+    const { getByText, queryByText } = renderState({
+      state: "confirming",
+      intent: {
+        kind: "custom",
+        machineTier: "large",
+        storageTier: "xl",
+        creditTier: null,
+      },
+    });
+
+    expect(getByText("Large machine")).toBeTruthy();
+    expect(getByText("XL storage")).toBeTruthy();
+    expect(queryByText(/credits/)).toBeNull();
+  });
+
+  test("renders a credits chip when the custom intent bundles credits", () => {
+    const { getByText } = renderState({
+      state: "confirming",
+      intent: {
+        kind: "custom",
+        machineTier: "medium",
+        storageTier: "s",
+        creditTier: "credits_50",
+      },
+    });
+
+    expect(getByText("50 credits")).toBeTruthy();
+  });
+
+  test("shows the payment-safe timeout screen once confirm.expired is set", () => {
+    const onRetry = mock(() => {});
+    const { getByText, getByTestId } = renderState({
+      state: "confirming",
+      confirm: { expired: true, onRetry, onGoToBilling: () => {} },
+    });
+
+    expect(
+      getByText(
+        "Your payment went through safely — we're still confirming your upgrade with Stripe. This can take a minute.",
+      ),
+    ).toBeTruthy();
+    fireEvent.click(getByTestId("onboarding-retry"));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("waiting / resizing", () => {
+  test("renders machine and storage cards with the from-snapshot and restart warning", () => {
+    const { getByText } = renderState({
+      state: "waiting",
+      targets: { machineSize: "large", storageGib: 100 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+    });
+
+    expect(getByText("Setting up your new resources…")).toBeTruthy();
+    expect(getByText("Machine")).toBeTruthy();
+    expect(getByText("Small")).toBeTruthy();
+    expect(getByText("Large")).toBeTruthy();
+    expect(getByText("Storage")).toBeTruthy();
+    expect(getByText("30 GiB")).toBeTruthy();
+    expect(getByText("100 GiB")).toBeTruthy();
+    expect(
+      getByText(
+        "Your assistant is restarting itself — it may look offline for a minute.",
+      ),
+    ).toBeTruthy();
+  });
+
+  test("storage-only targets render a single storage card and no machine card", () => {
+    const { getByText, queryByText } = renderState({
+      state: "resizing",
+      targets: { machineSize: null, storageGib: 100 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+    });
+
+    expect(getByText("Resizing your assistant…")).toBeTruthy();
+    expect(getByText("Storage")).toBeTruthy();
+    expect(queryByText("Machine")).toBeNull();
+  });
+
+  test("softWaiting swaps in the softened sub-copy", () => {
+    const { getByText, rerender } = renderState({
+      state: "waiting",
+      targets: { machineSize: "medium", storageGib: null },
+    });
+
+    expect(getByText("This usually takes under a minute.")).toBeTruthy();
+
+    rerender(
+      <ProvisioningState
+        {...baseProps({
+          state: "waiting",
+          softWaiting: true,
+          targets: { machineSize: "medium", storageGib: null },
+        })}
+      />,
+    );
+    expect(
+      getByText(
+        "Still working — this can take a few minutes. Everything is on track.",
+      ),
+    ).toBeTruthy();
+  });
+});
+
+describe("done / not_applicable", () => {
+  test("done renders the celebration headline and fires onCelebrationEnd after the dwell", async () => {
+    const onCelebrationEnd = mock(() => {});
+    const { getByText } = renderState({
+      state: "done",
+      celebrating: true,
+      onCelebrationEnd,
+      dwellMs: 10,
+    });
+
+    expect(getByText("Your upgrade is ready")).toBeTruthy();
+    await waitFor(() => expect(onCelebrationEnd).toHaveBeenCalledTimes(1));
+  });
+
+  test("done does not fire onCelebrationEnd when not celebrating", async () => {
+    const onCelebrationEnd = mock(() => {});
+    renderState({
+      state: "done",
+      celebrating: false,
+      onCelebrationEnd,
+      dwellMs: 10,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(onCelebrationEnd).not.toHaveBeenCalled();
+  });
+
+  test("not_applicable renders the plan-ready notice without cards or an Apply button", async () => {
+    const onCelebrationEnd = mock(() => {});
+    const { getByText, queryByText, queryByTestId } = renderState({
+      state: "not_applicable",
+      celebrating: true,
+      onCelebrationEnd,
+      dwellMs: 10,
+    });
+
+    expect(getByText("Your plan is ready")).toBeTruthy();
+    expect(
+      getByText("No resource changes were needed — you're all set."),
+    ).toBeTruthy();
+    expect(queryByText("Machine")).toBeNull();
+    expect(queryByTestId("provisioning-apply")).toBeNull();
+    await waitFor(() => expect(onCelebrationEnd).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("stalled", () => {
+  test("renders the amber notice and Apply & Restart invokes the callback", () => {
+    const onApply = mock(() => {});
+    const { getByText, getByTestId } = renderState({
+      state: "stalled",
+      targets: { machineSize: "large", storageGib: null },
+      fromSnapshot: { machineSize: "small", storageGib: null },
+      stalledAction: { onApply, pending: false, error: null },
+    });
+
+    expect(
+      getByText(
+        "We couldn't finish this automatically. Apply the changes below to finish setting up your upgrade.",
+      ),
+    ).toBeTruthy();
+    fireEvent.click(getByTestId("provisioning-apply"));
+    expect(onApply).toHaveBeenCalledTimes(1);
+  });
+
+  test("disables the Apply button while pending and renders the extracted error", () => {
+    const onApply = mock(() => {});
+    const { getByText, getByTestId } = renderState({
+      state: "stalled",
+      stalledAction: {
+        onApply,
+        pending: true,
+        error: { detail: "Resize already in progress." },
+      },
+    });
+
+    expect(getByText("Resize already in progress.")).toBeTruthy();
+    const apply = getByTestId("provisioning-apply") as HTMLButtonElement;
+    expect(apply.disabled).toBe(true);
+    fireEvent.click(apply);
+    expect(onApply).not.toHaveBeenCalled();
+  });
+});
+
+describe("confirm_timeout", () => {
+  test("renders the payment-safety reassurance with retry and billing actions", () => {
+    const onGoToBilling = mock(() => {});
+    const { getByText, getByTestId } = renderState({
+      state: "confirm_timeout",
+      confirm: { expired: false, onRetry: () => {}, onGoToBilling },
+    });
+
+    expect(
+      getByText(
+        "Your payment went through safely — we're still confirming your upgrade with Stripe. This can take a minute.",
+      ),
+    ).toBeTruthy();
+    fireEvent.click(getByTestId("onboarding-go-to-billing"));
+    expect(onGoToBilling).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("escape hatch", () => {
+  test("renders the background-continue button only when available", () => {
+    const onEscape = mock(() => {});
+    const { getByTestId } = renderState({
+      state: "waiting",
+      targets: { machineSize: "medium", storageGib: null },
+      escapeAvailable: true,
+      onEscape,
+    });
+
+    fireEvent.click(getByTestId("provisioning-escape"));
+    expect(onEscape).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    const { queryByTestId } = renderState({
+      state: "waiting",
+      targets: { machineSize: "medium", storageGib: null },
+      escapeAvailable: false,
+    });
+    expect(queryByTestId("provisioning-escape")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -1,0 +1,331 @@
+import { AlertCircle, Check, Cpu, HardDrive, PartyPopper } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+import type {
+    CreditTierEnum,
+    MachineSizeEnum,
+    MachineTierEnum,
+    StorageTierEnum,
+} from "@/generated/api/types.gen";
+import { SIZE_DESCRIPTION, SIZE_LABEL } from "@/lib/billing/machine-sizes";
+import { Button } from "@vellumai/design-library/components/button";
+import { Notice } from "@vellumai/design-library/components/notice";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+import { TimeoutState } from "./error-states";
+import { GlowSpinner, IconBadge, ResourceCard } from "./primitives";
+import { extractOnboardingErrorMessage } from "./utils";
+
+/** Minimum time the celebration beat stays on screen before advancing. */
+const PROVISION_MIN_DWELL_MS = 2_500;
+
+export type ProvisioningStateKind =
+  | "confirming"
+  | "waiting"
+  | "resizing"
+  | "done"
+  | "not_applicable"
+  | "stalled"
+  | "confirm_timeout";
+
+/** The checkout selection stashed before the Stripe redirect. */
+export type ProvisioningCheckoutIntent =
+  | { kind: "package"; packageKey: string }
+  | {
+      kind: "custom";
+      machineTier: MachineTierEnum;
+      storageTier: StorageTierEnum;
+      creditTier: CreditTierEnum | null;
+    };
+
+/** Machine/storage dimensions; a null dimension means "not changing". */
+export interface ProvisioningResources {
+  machineSize: MachineSizeEnum | null;
+  storageGib: number | null;
+}
+
+export interface ProvisioningStateProps {
+  state: ProvisioningStateKind;
+  /** Softens the waiting sub-copy once the grace period has elapsed. */
+  softWaiting: boolean;
+  intent: ProvisioningCheckoutIntent | null;
+  targets: ProvisioningResources;
+  /** Pre-resize actuals rendered as the "from" side of the resource cards. */
+  fromSnapshot: ProvisioningResources;
+  celebrating: boolean;
+  onCelebrationEnd: () => void;
+  escapeAvailable: boolean;
+  onEscape: () => void;
+  stalledAction: { onApply: () => void; pending: boolean; error: unknown };
+  confirm: { expired: boolean; onRetry: () => void; onGoToBilling: () => void };
+  /** Test hook — overrides the celebration min dwell. */
+  dwellMs?: number;
+}
+
+const MACHINE_TIER_LABEL: Record<MachineTierEnum, string> = {
+  medium: "Medium",
+  large: "Large",
+  xl: "XL",
+};
+
+function intentChipLabels(intent: ProvisioningCheckoutIntent): string[] {
+  if (intent.kind === "package") {
+    const name =
+      intent.packageKey.charAt(0).toUpperCase() + intent.packageKey.slice(1);
+    return [`${name} package`];
+  }
+  const labels = [
+    `${MACHINE_TIER_LABEL[intent.machineTier]} machine`,
+    `${intent.storageTier.toUpperCase()} storage`,
+  ];
+  if (intent.creditTier != null) {
+    labels.push(`${intent.creditTier.replace("credits_", "")} credits`);
+  }
+  return labels;
+}
+
+function IntentChips({ intent }: { intent: ProvisioningCheckoutIntent }) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-1.5">
+      {intentChipLabels(intent).map((label) => (
+        <span
+          key={label}
+          className="rounded-full border border-[var(--border-element)] bg-[var(--surface-base)] px-2.5 py-1 text-label-small-default text-[var(--content-secondary)]"
+        >
+          {label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function ResourceCardList({
+  targets,
+  fromSnapshot,
+}: {
+  targets: ProvisioningResources;
+  fromSnapshot: ProvisioningResources;
+}) {
+  return (
+    <div className="flex w-full flex-col gap-2">
+      {targets.machineSize != null && (
+        <ResourceCard
+          icon={Cpu}
+          label="Machine"
+          from={
+            fromSnapshot.machineSize != null
+              ? SIZE_LABEL[fromSnapshot.machineSize]
+              : "—"
+          }
+          fromDetail={
+            fromSnapshot.machineSize != null
+              ? SIZE_DESCRIPTION[fromSnapshot.machineSize]
+              : undefined
+          }
+          to={SIZE_LABEL[targets.machineSize]}
+          toDetail={SIZE_DESCRIPTION[targets.machineSize]}
+        />
+      )}
+      {targets.storageGib != null && (
+        <ResourceCard
+          icon={HardDrive}
+          label="Storage"
+          from={
+            fromSnapshot.storageGib != null
+              ? `${fromSnapshot.storageGib} GiB`
+              : "—"
+          }
+          to={`${targets.storageGib} GiB`}
+        />
+      )}
+    </div>
+  );
+}
+
+function Headline({ title, body }: { title: string; body?: string }) {
+  return (
+    <div className="space-y-1.5">
+      <Typography variant="title-small" as="h1">
+        {title}
+      </Typography>
+      {body && (
+        <Typography
+          variant="body-medium-lighter"
+          as="p"
+          className="text-[var(--content-secondary)]"
+        >
+          {body}
+        </Typography>
+      )}
+    </div>
+  );
+}
+
+export function ProvisioningState({
+  state,
+  softWaiting,
+  intent,
+  targets,
+  fromSnapshot,
+  celebrating,
+  onCelebrationEnd,
+  escapeAvailable,
+  onEscape,
+  stalledAction,
+  confirm,
+  dwellMs = PROVISION_MIN_DWELL_MS,
+}: ProvisioningStateProps) {
+  const onCelebrationEndRef = useRef(onCelebrationEnd);
+  useEffect(() => {
+    onCelebrationEndRef.current = onCelebrationEnd;
+  }, [onCelebrationEnd]);
+
+  const dwelling =
+    celebrating && (state === "done" || state === "not_applicable");
+  useEffect(() => {
+    if (!dwelling) {
+      return;
+    }
+    const t = setTimeout(() => onCelebrationEndRef.current(), dwellMs);
+    return () => clearTimeout(t);
+  }, [dwelling, dwellMs]);
+
+  if (
+    state === "confirm_timeout" ||
+    (state === "confirming" && confirm.expired)
+  ) {
+    return (
+      <TimeoutState
+        message="Your payment went through safely — we're still confirming your upgrade with Stripe. This can take a minute."
+        onRetry={confirm.onRetry}
+        onGoToBilling={confirm.onGoToBilling}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="flex min-h-[320px] flex-col items-center justify-center gap-4 px-6 py-10 text-center"
+      style={{ animation: "onboarding-step-in 350ms ease-out" }}
+    >
+      {renderPhase()}
+      {escapeAvailable && (
+        <Button
+          variant="ghost"
+          data-testid="provisioning-escape"
+          onClick={onEscape}
+        >
+          Continue in the background
+        </Button>
+      )}
+    </div>
+  );
+
+  function renderPhase() {
+    if (state === "confirming") {
+      return (
+        <>
+          <GlowSpinner />
+          <Headline
+            title="Payment confirmed — setting up your upgrade…"
+            body="We're getting your new plan's resources ready. This usually takes a few seconds."
+          />
+          {intent && (
+            <div style={{ animation: "welcome-reveal 600ms ease-out 150ms both" }}>
+              <IntentChips intent={intent} />
+            </div>
+          )}
+        </>
+      );
+    }
+
+    if (state === "waiting" || state === "resizing") {
+      return (
+        <>
+          <GlowSpinner />
+          <Headline
+            title={
+              state === "resizing"
+                ? "Resizing your assistant…"
+                : "Setting up your new resources…"
+            }
+            body={
+              softWaiting
+                ? "Still working — this can take a few minutes. Everything is on track."
+                : "This usually takes under a minute."
+            }
+          />
+          <ResourceCardList targets={targets} fromSnapshot={fromSnapshot} />
+          <Notice tone="neutral" className="w-full text-left">
+            Your assistant is restarting itself — it may look offline for a
+            minute.
+          </Notice>
+        </>
+      );
+    }
+
+    if (state === "done") {
+      return (
+        <>
+          <div style={{ animation: "welcome-reveal 600ms ease-out both" }}>
+            <IconBadge icon={PartyPopper} />
+          </div>
+          <div style={{ animation: "welcome-reveal 600ms ease-out 150ms both" }}>
+            <Headline
+              title="Your upgrade is ready"
+              body="Your assistant is back online with its new resources."
+            />
+          </div>
+        </>
+      );
+    }
+
+    if (state === "not_applicable") {
+      return (
+        <>
+          <div style={{ animation: "welcome-reveal 600ms ease-out both" }}>
+            <IconBadge icon={Check} />
+          </div>
+          <div style={{ animation: "welcome-reveal 600ms ease-out 150ms both" }}>
+            <Headline title="Your plan is ready" />
+          </div>
+          <Notice tone="neutral" className="w-full text-left">
+            No resource changes were needed — you&apos;re all set.
+          </Notice>
+        </>
+      );
+    }
+
+    if (state === "stalled") {
+      return (
+        <>
+          <IconBadge icon={AlertCircle} tone="warning" />
+          <Headline title="One more step" />
+          <Notice tone="warning" className="w-full text-left">
+            We couldn&apos;t finish this automatically. Apply the changes below
+            to finish setting up your upgrade.
+          </Notice>
+          <ResourceCardList targets={targets} fromSnapshot={fromSnapshot} />
+          {stalledAction.error != null && (
+            <Notice tone="error" className="w-full text-left">
+              {extractOnboardingErrorMessage(
+                stalledAction.error,
+                "Couldn't apply changes. Please try again.",
+              )}
+            </Notice>
+          )}
+          <Button
+            variant="primary"
+            data-testid="provisioning-apply"
+            disabled={stalledAction.pending}
+            onClick={stalledAction.onApply}
+          >
+            Apply &amp; Restart
+          </Button>
+        </>
+      );
+    }
+
+    return null;
+  }
+}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/setup-step.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, ArrowRight, Cpu, HardDrive, Server } from "lucide-react";
+import { ArrowLeft, Cpu, HardDrive } from "lucide-react";
 import { useState } from "react";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -17,68 +17,11 @@ import { Modal } from "@vellumai/design-library/components/modal";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Typography } from "@vellumai/design-library/components/typography";
 
-import { IconBadge, StepDots } from "./primitives";
+import { IconBadge, ResourceCard, StepDots } from "./primitives";
 import {
     allowedMachineSizesForTier,
     extractOnboardingErrorMessage,
 } from "./utils";
-
-function ResourceCard({
-  icon: Icon,
-  label,
-  from,
-  fromDetail,
-  to,
-  toDetail,
-}: {
-  icon: typeof Server;
-  label: string;
-  from: string;
-  fromDetail?: string;
-  to: string;
-  toDetail?: string;
-}) {
-  return (
-    <div className="flex items-center gap-3 rounded-lg bg-[var(--surface-base)] p-3">
-      <span
-        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
-        style={{
-          backgroundColor: "color-mix(in oklab, var(--system-positive-strong) 10%, transparent)",
-        }}
-      >
-        <Icon className="h-4 w-4 text-[var(--system-positive-strong)]" />
-      </span>
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <span className="text-label-small-default text-[var(--content-tertiary)]">
-          {label}
-        </span>
-        <div className="flex items-center gap-2">
-          <div className="flex flex-col">
-            <span className="text-label-medium-default text-[var(--content-tertiary)] line-through">
-              {from}
-            </span>
-            {fromDetail && (
-              <span className="text-label-small-default text-[var(--content-tertiary)] line-through">
-                {fromDetail}
-              </span>
-            )}
-          </div>
-          <ArrowRight className="h-3 w-3 shrink-0 text-[var(--content-tertiary)]" />
-          <div className="flex flex-col">
-            <span className="text-label-medium-default text-[var(--content-default)]">
-              {to}
-            </span>
-            {toDetail && (
-              <span className="text-label-small-default text-[var(--content-tertiary)]">
-                {toDetail}
-              </span>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export function SetupStep({
   storageGib,
@@ -111,7 +54,9 @@ export function SetupStep({
   const resizeMutation = useMutation(assistantsResizeMutation());
 
   const handleContinue = () => {
-    if (resizeMutation.isPending || !activeAssistant?.id) return;
+    if (resizeMutation.isPending || !activeAssistant?.id) {
+      return;
+    }
     resizeMutation.mutate(
       {
         path: { id: activeAssistant.id },


### PR DESCRIPTION
## Summary
- pure-props ProvisioningState screen covering confirming/waiting/resizing/done/not-applicable/stalled/timeout phases
- from→to ResourceCards (moved to primitives), stalled manual-apply fallback, payment-safe timeout copy
- min-dwell celebration beat and escape hatch

Part of plan: pro-onboarding-wizard-revamp.md (PR 3 of 6)