### PR TITLE
feat(web): pro provisioning state machine + polling hook

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
@@ -14,6 +14,7 @@ function baseInput(
     planId: "pro",
     targets: { machineSize: "large", storageGib: 50 },
     actuals: { machineSize: "small", storageGib: 10 },
+    initialActuals: { machineSize: "small", storageGib: 10 },
     resizeOperationInFlight: false,
     sawOperation: false,
     msSinceProConfirmed: 1000,
@@ -146,6 +147,16 @@ describe("deriveProvisioningState — DONE", () => {
       ).state,
     ).toBe("DONE");
   });
+
+  test("resize that completed without ever being observed → DONE", () => {
+    // The first observed actuals were below the targets, so a resize must
+    // have run even though no operation was caught between polls.
+    expect(
+      deriveProvisioningState(
+        baseInput({ actuals: { machineSize: "large", storageGib: 50 } }),
+      ),
+    ).toEqual({ state: "DONE", softWaiting: false });
+  });
 });
 
 describe("deriveProvisioningState — NOT_APPLICABLE", () => {
@@ -164,6 +175,28 @@ describe("deriveProvisioningState — NOT_APPLICABLE", () => {
     expect(
       deriveProvisioningState(
         baseInput({ targets: { machineSize: null, storageGib: null } }),
+      ).state,
+    ).toBe("NOT_APPLICABLE");
+  });
+
+  test("first observed actuals already met the targets → NOT_APPLICABLE", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "large", storageGib: 50 },
+          initialActuals: { machineSize: "large", storageGib: 50 },
+        }),
+      ).state,
+    ).toBe("NOT_APPLICABLE");
+  });
+
+  test("no snapshot yet and targets met on the first observation → NOT_APPLICABLE", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "large", storageGib: 50 },
+          initialActuals: null,
+        }),
       ).state,
     ).toBe("NOT_APPLICABLE");
   });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  deriveProvisioningState,
+  type DeriveProvisioningInput,
+} from "./provisioning-machine";
+import { PROVISION_STALL_MS, PROVISION_WAIT_GRACE_MS } from "./utils";
+
+/** Pro confirmed, targets unmet, no operation observed yet → WAITING. */
+function baseInput(
+  overrides: Partial<DeriveProvisioningInput> = {},
+): DeriveProvisioningInput {
+  return {
+    planId: "pro",
+    targets: { machineSize: "large", storageGib: 50 },
+    actuals: { machineSize: "small", storageGib: 10 },
+    resizeOperationInFlight: false,
+    sawOperation: false,
+    msSinceProConfirmed: 1000,
+    confirmExpired: false,
+    serverVerdict: null,
+    ...overrides,
+  };
+}
+
+describe("deriveProvisioningState — confirm phase", () => {
+  test("plan not yet pro → CONFIRMING", () => {
+    expect(deriveProvisioningState(baseInput({ planId: "base" }))).toEqual({
+      state: "CONFIRMING",
+      softWaiting: false,
+    });
+  });
+
+  test("plan unknown (subscription not loaded) → CONFIRMING", () => {
+    expect(deriveProvisioningState(baseInput({ planId: null })).state).toBe(
+      "CONFIRMING",
+    );
+  });
+
+  test("confirm poll timed out → CONFIRM_TIMEOUT", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ planId: "base", confirmExpired: true }),
+      ).state,
+    ).toBe("CONFIRM_TIMEOUT");
+  });
+});
+
+describe("deriveProvisioningState — WAITING", () => {
+  test("pro confirmed, targets unmet, no operation observed → WAITING", () => {
+    expect(deriveProvisioningState(baseInput())).toEqual({
+      state: "WAITING",
+      softWaiting: false,
+    });
+  });
+
+  test("targets not loaded yet → WAITING", () => {
+    expect(deriveProvisioningState(baseInput({ targets: null })).state).toBe(
+      "WAITING",
+    );
+  });
+
+  test("actuals not loaded yet → WAITING", () => {
+    expect(deriveProvisioningState(baseInput({ actuals: null })).state).toBe(
+      "WAITING",
+    );
+  });
+
+  test("past the grace window → still WAITING but softWaiting", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ msSinceProConfirmed: PROVISION_WAIT_GRACE_MS }),
+      ),
+    ).toEqual({ state: "WAITING", softWaiting: true });
+  });
+});
+
+describe("deriveProvisioningState — RESIZING", () => {
+  test("resize operation in flight → RESIZING", () => {
+    expect(
+      deriveProvisioningState(baseInput({ resizeOperationInFlight: true })),
+    ).toEqual({ state: "RESIZING", softWaiting: false });
+  });
+
+  test("operation seen earlier but momentarily gone → stays RESIZING", () => {
+    expect(
+      deriveProvisioningState(baseInput({ sawOperation: true })).state,
+    ).toBe("RESIZING");
+  });
+});
+
+describe("deriveProvisioningState — DONE", () => {
+  test("actuals meet both targets after an observed operation → DONE", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "large", storageGib: 50 },
+          sawOperation: true,
+        }),
+      ),
+    ).toEqual({ state: "DONE", softWaiting: false });
+  });
+
+  test("machine compared by rank — a larger size than the target counts", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "extra_large", storageGib: 50 },
+          sawOperation: true,
+        }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("machine met but storage still short → not DONE", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "large", storageGib: 25 },
+          sawOperation: true,
+        }),
+      ).state,
+    ).toBe("RESIZING");
+  });
+
+  test("null machine target (Mighty) is satisfied by storage alone", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          targets: { machineSize: null, storageGib: 25 },
+          actuals: { machineSize: "small", storageGib: 25 },
+          sawOperation: true,
+        }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("null storage target dimension is treated as satisfied", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          targets: { machineSize: "medium", storageGib: null },
+          actuals: { machineSize: "medium", storageGib: null },
+          sawOperation: true,
+        }),
+      ).state,
+    ).toBe("DONE");
+  });
+});
+
+describe("deriveProvisioningState — NOT_APPLICABLE", () => {
+  test("targets already met with no operation ever observed (Mighty at ceiling)", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          targets: { machineSize: null, storageGib: 10 },
+          actuals: { machineSize: "small", storageGib: 10 },
+        }),
+      ),
+    ).toEqual({ state: "NOT_APPLICABLE", softWaiting: false });
+  });
+
+  test("both target dimensions null → NOT_APPLICABLE", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ targets: { machineSize: null, storageGib: null } }),
+      ).state,
+    ).toBe("NOT_APPLICABLE");
+  });
+});
+
+describe("deriveProvisioningState — STALLED", () => {
+  test("WAITING past the stall threshold → STALLED", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ msSinceProConfirmed: PROVISION_STALL_MS }),
+      ),
+    ).toEqual({ state: "STALLED", softWaiting: false });
+  });
+
+  test("RESIZING past the stall threshold → STALLED", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          resizeOperationInFlight: true,
+          msSinceProConfirmed: PROVISION_STALL_MS,
+        }),
+      ).state,
+    ).toBe("STALLED");
+  });
+
+  test("just under the stall threshold stays WAITING", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ msSinceProConfirmed: PROVISION_STALL_MS - 1 }),
+      ).state,
+    ).toBe("WAITING");
+  });
+});
+
+describe("deriveProvisioningState — server verdict overrides", () => {
+  test("already_done → DONE even with stale unmet actuals", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ serverVerdict: "already_done" }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("started → RESIZING", () => {
+    expect(
+      deriveProvisioningState(baseInput({ serverVerdict: "started" })).state,
+    ).toBe("RESIZING");
+  });
+
+  test("in_progress → RESIZING", () => {
+    expect(
+      deriveProvisioningState(baseInput({ serverVerdict: "in_progress" }))
+        .state,
+    ).toBe("RESIZING");
+  });
+
+  test("not_applicable → NOT_APPLICABLE", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ serverVerdict: "not_applicable" }),
+      ).state,
+    ).toBe("NOT_APPLICABLE");
+  });
+
+  test("DONE-by-actuals beats a stale in_progress verdict", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "large", storageGib: 50 },
+          sawOperation: true,
+          serverVerdict: "in_progress",
+        }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("verdict never applies before pro is confirmed", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ planId: "base", serverVerdict: "already_done" }),
+      ).state,
+    ).toBe("CONFIRMING");
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
@@ -1,0 +1,152 @@
+/**
+ * Pure state machine for the post-checkout provisioning screen.
+ *
+ * The platform auto-resizes the assistant machine/storage from the Stripe
+ * subscribe webhook, so the client only *observes*: first that the
+ * subscription flipped to Pro (CONFIRMING), then that the assistant's actual
+ * machine size / provisioned storage caught up to the purchased targets
+ * (WAITING → RESIZING → DONE). No React here — `deriveProvisioningState` is a
+ * pure function over polled inputs so every transition is unit-testable.
+ */
+
+import type { MachineSizeEnum } from "@/generated/api/types.gen";
+import { machineSizeRank } from "@/lib/billing/machine-sizes";
+
+import { PROVISION_STALL_MS, PROVISION_WAIT_GRACE_MS } from "./utils";
+
+export type ProvisioningStateKind =
+  | "CONFIRMING"
+  | "CONFIRM_TIMEOUT"
+  | "WAITING"
+  | "RESIZING"
+  | "DONE"
+  | "NOT_APPLICABLE"
+  | "STALLED";
+
+/**
+ * Server-reported provisioning verdict (from the ensure-provisioned endpoint,
+ * adopted by a later PR). Overrides client-side inference, except that
+ * DONE-by-actuals beats a stale verdict.
+ */
+export type ProvisioningServerVerdict =
+  | "already_done"
+  | "in_progress"
+  | "started"
+  | "not_applicable";
+
+export interface ProvisioningDimensions {
+  machineSize: MachineSizeEnum | null;
+  storageGib: number | null;
+}
+
+export interface DeriveProvisioningInput {
+  planId: string | null | undefined;
+  /** Purchased ceilings; a null dimension means nothing to provision there. */
+  targets: ProvisioningDimensions | null;
+  /** Last-known assistant machine size / provisioned storage. */
+  actuals: ProvisioningDimensions | null;
+  /** A resize operation is currently observed in flight. */
+  resizeOperationInFlight: boolean;
+  /** A resize operation was observed at some point (latched by the hook). */
+  sawOperation: boolean;
+  /** Elapsed ms since plan_id was first observed as "pro"; null before then. */
+  msSinceProConfirmed: number | null;
+  /** The confirm-phase poll timed out without observing plan_id == "pro". */
+  confirmExpired: boolean;
+  serverVerdict?: ProvisioningServerVerdict | null;
+}
+
+export interface ProvisioningSnapshot {
+  state: ProvisioningStateKind;
+  /** Still WAITING past the grace window — the UI softens its copy. */
+  softWaiting: boolean;
+}
+
+/**
+ * A dimension with a null target is satisfied (e.g. the Mighty package has no
+ * machine tier); a non-null target needs a known actual at or above it.
+ * Machine sizes compare by rank, storage by GiB.
+ */
+function targetsMet(
+  targets: ProvisioningDimensions | null,
+  actuals: ProvisioningDimensions | null,
+): boolean {
+  if (!targets) return false;
+  const machineMet =
+    targets.machineSize == null ||
+    (actuals?.machineSize != null &&
+      machineSizeRank(actuals.machineSize) >=
+        machineSizeRank(targets.machineSize));
+  const storageMet =
+    targets.storageGib == null ||
+    (actuals?.storageGib != null && actuals.storageGib >= targets.storageGib);
+  return machineMet && storageMet;
+}
+
+export function deriveProvisioningState(
+  input: DeriveProvisioningInput,
+): ProvisioningSnapshot {
+  const {
+    planId,
+    targets,
+    actuals,
+    resizeOperationInFlight,
+    sawOperation,
+    msSinceProConfirmed,
+    confirmExpired,
+    serverVerdict = null,
+  } = input;
+
+  if (planId !== "pro") {
+    return {
+      state: confirmExpired ? "CONFIRM_TIMEOUT" : "CONFIRMING",
+      softWaiting: false,
+    };
+  }
+
+  const operationObserved = sawOperation || resizeOperationInFlight;
+
+  if (targetsMet(targets, actuals)) {
+    // DONE-by-actuals wins over a stale in_progress/started verdict. Without
+    // any observed operation or a verdict saying one ran, the targets resolved
+    // to nothing above the current actuals — nothing was ever needed.
+    if (
+      operationObserved ||
+      serverVerdict === "already_done" ||
+      serverVerdict === "started" ||
+      serverVerdict === "in_progress"
+    ) {
+      return { state: "DONE", softWaiting: false };
+    }
+    return { state: "NOT_APPLICABLE", softWaiting: false };
+  }
+
+  if (serverVerdict === "already_done") {
+    return { state: "DONE", softWaiting: false };
+  }
+  if (serverVerdict === "not_applicable") {
+    return { state: "NOT_APPLICABLE", softWaiting: false };
+  }
+
+  if (
+    msSinceProConfirmed != null &&
+    msSinceProConfirmed >= PROVISION_STALL_MS
+  ) {
+    return { state: "STALLED", softWaiting: false };
+  }
+
+  if (
+    operationObserved ||
+    serverVerdict === "started" ||
+    serverVerdict === "in_progress"
+  ) {
+    return { state: "RESIZING", softWaiting: false };
+  }
+
+  return {
+    state: "WAITING",
+    softWaiting:
+      msSinceProConfirmed != null &&
+      msSinceProConfirmed >= PROVISION_WAIT_GRACE_MS,
+  };
+}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
@@ -45,6 +45,8 @@ export interface DeriveProvisioningInput {
   targets: ProvisioningDimensions | null;
   /** Last-known assistant machine size / provisioned storage. */
   actuals: ProvisioningDimensions | null;
+  /** First non-null actuals ever observed (frozen by the hook). */
+  initialActuals: ProvisioningDimensions | null;
   /** A resize operation is currently observed in flight. */
   resizeOperationInFlight: boolean;
   /** A resize operation was observed at some point (latched by the hook). */
@@ -90,6 +92,7 @@ export function deriveProvisioningState(
     planId,
     targets,
     actuals,
+    initialActuals,
     resizeOperationInFlight,
     sawOperation,
     msSinceProConfirmed,
@@ -107,14 +110,20 @@ export function deriveProvisioningState(
   const operationObserved = sawOperation || resizeOperationInFlight;
 
   if (targetsMet(targets, actuals)) {
-    // DONE-by-actuals wins over a stale in_progress/started verdict. Without
-    // any observed operation or a verdict saying one ran, the targets resolved
-    // to nothing above the current actuals — nothing was ever needed.
+    // DONE-by-actuals wins over a stale in_progress/started verdict. A quick
+    // resize can also finish between polls (or behind transient endpoint
+    // failures) without ever being observed, so when no operation was seen,
+    // disambiguate by the first actuals ever observed: if they were below the
+    // targets, a resize must have run → DONE. NOT_APPLICABLE is reserved for
+    // first-observed actuals that already met the targets (null initialActuals
+    // means the current actuals ARE the first observation — the hook freezes
+    // them as the snapshot one render later).
     if (
       operationObserved ||
       serverVerdict === "already_done" ||
       serverVerdict === "started" ||
-      serverVerdict === "in_progress"
+      serverVerdict === "in_progress" ||
+      (initialActuals != null && !targetsMet(targets, initialActuals))
     ) {
       return { state: "DONE", softWaiting: false };
     }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -198,6 +198,34 @@ describe("useProProvisioning", () => {
     expect(latest!.confirmExpired).toBe(false);
   });
 
+  test("resize completing between polls (never observed) → DONE, not NOT_APPLICABLE", async () => {
+    const client = renderProbe();
+    await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+
+    subscriptionPlanId = "pro";
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+      timeout: 5000,
+    });
+    // Below-target actuals must be frozen as the snapshot before the jump.
+    await waitFor(() =>
+      expect(latest!.actualsSnapshot).toEqual({
+        machineSize: "small",
+        storageGib: 10,
+      }),
+    );
+
+    // The resize starts and finishes entirely between two polls, so the
+    // operational status never reports it — actuals just jump to the targets.
+    assistantResponse = makeAssistant("large", 50);
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
+    expect(latest!.actualsSnapshot).toEqual({
+      machineSize: "small",
+      storageGib: 10,
+    });
+  });
+
   test("transient 5xx from assistant endpoints during RESIZING does not error", async () => {
     const client = renderProbe();
     await reachResizing(client);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Interaction tests for the useProProvisioning polling hook.
+ *
+ * Strategy mirrors plans-page-checkout.test.tsx: mock the generated SDK with
+ * mutable responses, render a probe component inside a QueryClientProvider,
+ * and drive the polls deterministically with queryClient.invalidateQueries()
+ * instead of waiting out real refetch intervals.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { useEffect } from "react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import type {
+  Assistant,
+  OnboardingStateResponse,
+  OperationalStatus,
+  SubscriptionResponse,
+} from "@/generated/api/types.gen";
+import type { ProProvisioningResult } from "./use-pro-provisioning";
+
+function makeSubscription(
+  planId: SubscriptionResponse["plan_id"],
+): SubscriptionResponse {
+  return {
+    plan_id: planId,
+    status: "active",
+    renewal_date: null,
+    current_period_end: "2026-08-01T00:00:00Z",
+    cancel_at_period_end: false,
+    cancel_at: null,
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
+function makeOnboarding(): OnboardingStateResponse {
+  return {
+    max_machine_tier: "large",
+    selected_storage_tier: "md",
+    selected_storage_gib: 50,
+    pvc_ready: false,
+    domain_setup_available: true,
+    primary_assistant_id: "assistant-1",
+  };
+}
+
+function makeAssistant(
+  machineSize: Assistant["machine_size"],
+  storageGib: number | null,
+): Assistant {
+  return {
+    id: "assistant-1",
+    machine_size: machineSize,
+    provisioned_storage_gib: storageGib,
+  } as Assistant;
+}
+
+function makeOperationalStatus(
+  state: OperationalStatus["state"],
+): OperationalStatus {
+  return {
+    state,
+    detail_state: state,
+    poll_after_ms: 5000,
+    updated_at: "2026-08-01T00:00:00Z",
+    state_started_at: null,
+    active_operation: null,
+    storage: null,
+    detail: { reason: null, message: null },
+  } as OperationalStatus;
+}
+
+let subscriptionPlanId: SubscriptionResponse["plan_id"] = "base";
+let onboardingResponse = makeOnboarding();
+let assistantResponse = makeAssistant("small", 10);
+let operationalStatusResponse = makeOperationalStatus("active");
+let assistantEndpointsFail = false;
+let assistantCalls = 0;
+let operationalStatusCalls = 0;
+let subscriptionCalls = 0;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingSubscriptionRetrieve: () => {
+    subscriptionCalls += 1;
+    return Promise.resolve({
+      data: makeSubscription(subscriptionPlanId),
+      response: { ok: true },
+    });
+  },
+  organizationsBillingSubscriptionOnboardingRetrieve: () =>
+    Promise.resolve({ data: onboardingResponse, response: { ok: true } }),
+  assistantsActiveRetrieve: () => {
+    assistantCalls += 1;
+    if (assistantEndpointsFail) {
+      return Promise.reject(new Error("502 Bad Gateway"));
+    }
+    return Promise.resolve({ data: assistantResponse, response: { ok: true } });
+  },
+  assistantsOperationalStatusDetailRead: () => {
+    operationalStatusCalls += 1;
+    if (assistantEndpointsFail) {
+      return Promise.reject(new Error("502 Bad Gateway"));
+    }
+    return Promise.resolve({
+      data: operationalStatusResponse,
+      response: { ok: true },
+    });
+  },
+}));
+
+const { useProProvisioning } = await import("./use-pro-provisioning");
+
+let latest: ProProvisioningResult | null = null;
+
+function Probe() {
+  const result = useProProvisioning({ open: true });
+  useEffect(() => {
+    latest = result;
+  });
+  return null;
+}
+
+function renderProbe() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <Probe />
+    </QueryClientProvider>,
+  );
+  return client;
+}
+
+async function refetchAll(client: QueryClient) {
+  await client.invalidateQueries();
+}
+
+/** Drive the hook from a fresh mount to a confirmed-pro RESIZING state. */
+async function reachResizing(client: QueryClient) {
+  await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+
+  subscriptionPlanId = "pro";
+  await refetchAll(client);
+  await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+    timeout: 5000,
+  });
+
+  operationalStatusResponse = makeOperationalStatus("resizing_machine");
+  await refetchAll(client);
+  await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+    timeout: 5000,
+  });
+}
+
+beforeEach(() => {
+  subscriptionPlanId = "base";
+  onboardingResponse = makeOnboarding();
+  assistantResponse = makeAssistant("small", 10);
+  operationalStatusResponse = makeOperationalStatus("active");
+  assistantEndpointsFail = false;
+  assistantCalls = 0;
+  operationalStatusCalls = 0;
+  subscriptionCalls = 0;
+  latest = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useProProvisioning", () => {
+  test("progresses CONFIRMING → WAITING → RESIZING → DONE as polls land", async () => {
+    const client = renderProbe();
+    await reachResizing(client);
+
+    expect(latest!.targets).toEqual({ machineSize: "large", storageGib: 50 });
+    // First actuals observed are frozen as the before/after "from" side.
+    expect(latest!.actualsSnapshot).toEqual({
+      machineSize: "small",
+      storageGib: 10,
+    });
+
+    assistantResponse = makeAssistant("large", 50);
+    operationalStatusResponse = makeOperationalStatus("active");
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
+
+    // The snapshot must not be mutated by later polls.
+    expect(latest!.actualsSnapshot).toEqual({
+      machineSize: "small",
+      storageGib: 10,
+    });
+    expect(latest!.confirmError).toBe(false);
+    expect(latest!.confirmExpired).toBe(false);
+  });
+
+  test("transient 5xx from assistant endpoints during RESIZING does not error", async () => {
+    const client = renderProbe();
+    await reachResizing(client);
+
+    assistantEndpointsFail = true;
+    await refetchAll(client);
+    // Give the rejected refetches time to settle into query error state.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(latest!.state).toBe("RESIZING");
+    expect(latest!.confirmError).toBe(false);
+    expect(latest!.actualsSnapshot).toEqual({
+      machineSize: "small",
+      storageGib: 10,
+    });
+
+    // The pod comes back with the resize applied — the hook recovers to DONE.
+    assistantEndpointsFail = false;
+    assistantResponse = makeAssistant("large", 50);
+    operationalStatusResponse = makeOperationalStatus("active");
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
+  });
+
+  test("polling stops once DONE", async () => {
+    const client = renderProbe();
+    await reachResizing(client);
+
+    assistantResponse = makeAssistant("large", 50);
+    operationalStatusResponse = makeOperationalStatus("active");
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
+
+    // One clock tick may still be in flight when DONE lands; let it drain,
+    // then assert no further polls fire across a full poll interval.
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    const settledAssistantCalls = assistantCalls;
+    const settledStatusCalls = operationalStatusCalls;
+    const settledSubscriptionCalls = subscriptionCalls;
+    await new Promise((resolve) => setTimeout(resolve, 2600));
+
+    expect(assistantCalls).toBe(settledAssistantCalls);
+    expect(operationalStatusCalls).toBe(settledStatusCalls);
+    expect(subscriptionCalls).toBe(settledSubscriptionCalls);
+    expect(latest!.state).toBe("DONE");
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -1,0 +1,259 @@
+/**
+ * Polling hook behind the provisioning screen of the pro onboarding wizard.
+ *
+ * Composes the subscription poll (is the checkout webhook done?), the
+ * onboarding state (what machine/storage did the package buy?), and the
+ * assistant + operational-status polls (has the server-driven resize landed?)
+ * into a single `ProvisioningSnapshot` derived by the pure state machine in
+ * `provisioning-machine.ts`.
+ *
+ * While WAITING/RESIZING the assistant pod is restarting, so errors from the
+ * assistant endpoints are expected — the hook keeps last-known data and never
+ * surfaces them. Only a CONFIRMING-phase subscription error maps to
+ * `confirmError`.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  assistantsActiveRetrieveOptions,
+  assistantsOperationalStatusDetailReadOptions,
+  organizationsBillingSubscriptionOnboardingRetrieveOptions,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveOptions,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type {
+  MachineTierEnum,
+  OperationalStatus,
+} from "@/generated/api/types.gen";
+
+import {
+  deriveProvisioningState,
+  type ProvisioningDimensions,
+  type ProvisioningServerVerdict,
+  type ProvisioningStateKind,
+} from "./provisioning-machine";
+import {
+  allowedMachineSizesForTier,
+  PRO_POLL_INTERVAL_MS,
+  PRO_POLL_TIMEOUT_MS,
+} from "./utils";
+
+const ACTUALS_POLL_INTERVAL_MS = 2000;
+/** Re-derive elapsed-time transitions (grace/stall) between poll responses. */
+const CLOCK_TICK_MS = 1000;
+
+const TERMINAL_STATES: readonly ProvisioningStateKind[] = [
+  "DONE",
+  "NOT_APPLICABLE",
+  "STALLED",
+  "CONFIRM_TIMEOUT",
+];
+
+function isResizeOperationInFlight(
+  status: OperationalStatus | null | undefined,
+): boolean {
+  if (!status) return false;
+  if (
+    status.state === "resizing_machine" ||
+    status.state === "resizing_storage"
+  ) {
+    return true;
+  }
+  const operation = status.active_operation?.operation;
+  return typeof operation === "string" && operation.startsWith("resize");
+}
+
+export interface UseProProvisioningOptions {
+  open: boolean;
+  serverVerdict?: ProvisioningServerVerdict | null;
+}
+
+export interface ProProvisioningResult {
+  state: ProvisioningStateKind;
+  softWaiting: boolean;
+  targets: ProvisioningDimensions | null;
+  /** First actuals observed, frozen — the "from" side of before/after cards. */
+  actualsSnapshot: ProvisioningDimensions | null;
+  /** The CONFIRMING-phase subscription fetch failed. */
+  confirmError: boolean;
+  /** The CONFIRMING-phase poll timed out without observing plan_id "pro". */
+  confirmExpired: boolean;
+  /** Reset the confirm timeout and re-poll the subscription. */
+  retryConfirm: () => void;
+}
+
+export function useProProvisioning({
+  open,
+  serverVerdict = null,
+}: UseProProvisioningOptions): ProProvisioningResult {
+  const queryClient = useQueryClient();
+  const [confirmExpired, setConfirmExpired] = useState(false);
+  const [confirmGeneration, setConfirmGeneration] = useState(0);
+  const [proConfirmedAt, setProConfirmedAt] = useState<number | null>(null);
+  const [sawOperation, setSawOperation] = useState(false);
+  const [actualsSnapshot, setActualsSnapshot] =
+    useState<ProvisioningDimensions | null>(null);
+  // Wall-clock time as React state so elapsed-time transitions (grace/stall)
+  // re-derive between poll responses without impure Date.now() calls in render.
+  const [now, setNow] = useState(() => Date.now());
+  // Whether the actuals polls should keep refetching. Synced from the derived
+  // state after each render (it isn't known yet when the queries are
+  // declared); the one-render lag is invisible at these poll intervals.
+  const [tracking, setTracking] = useState(true);
+
+  useEffect(() => {
+    if (open) return;
+    setConfirmExpired(false);
+    setConfirmGeneration(0);
+    setProConfirmedAt(null);
+    setSawOperation(false);
+    setActualsSnapshot(null);
+    setTracking(true);
+  }, [open]);
+
+  // Drop pre-checkout caches so we never confirm on a stale plan_id or read a
+  // pre-upgrade tier ceiling as the resize target.
+  useEffect(() => {
+    if (!open) return;
+    void queryClient.invalidateQueries({
+      queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+    });
+  }, [open, queryClient]);
+
+  const proConfirmed = proConfirmedAt != null;
+
+  const subscriptionQuery = useQuery({
+    ...organizationsBillingSubscriptionRetrieveOptions(),
+    refetchInterval: (query) => {
+      const planId = query.state.data?.plan_id;
+      if (planId === "pro" || confirmExpired) return false;
+      return PRO_POLL_INTERVAL_MS;
+    },
+    refetchIntervalInBackground: false,
+    enabled: open && !proConfirmed,
+  });
+
+  const observedPlanId = subscriptionQuery.data?.plan_id ?? null;
+
+  useEffect(() => {
+    if (!open || proConfirmed || observedPlanId !== "pro") return;
+    const confirmedAt = Date.now();
+    setProConfirmedAt(confirmedAt);
+    setNow(confirmedAt);
+  }, [open, proConfirmed, observedPlanId]);
+
+  useEffect(() => {
+    if (!open || proConfirmed) return;
+    const t = setTimeout(() => setConfirmExpired(true), PRO_POLL_TIMEOUT_MS);
+    return () => clearTimeout(t);
+  }, [open, proConfirmed, confirmGeneration]);
+
+  const retryConfirm = useCallback(() => {
+    setConfirmExpired(false);
+    setConfirmGeneration((g) => g + 1);
+    void queryClient.invalidateQueries({
+      queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
+    });
+  }, [queryClient]);
+
+  const onboardingQuery = useQuery({
+    ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
+    enabled: open && proConfirmed,
+  });
+
+  const pollInterval = tracking ? ACTUALS_POLL_INTERVAL_MS : false;
+
+  const activeAssistantQuery = useQuery({
+    ...assistantsActiveRetrieveOptions(),
+    enabled: open && proConfirmed,
+    refetchInterval: pollInterval,
+    retry: false,
+  });
+  const assistantId = activeAssistantQuery.data?.id ?? null;
+
+  const operationalStatusQuery = useQuery({
+    ...assistantsOperationalStatusDetailReadOptions({
+      path: { id: assistantId ?? "unresolved" },
+    }),
+    enabled: open && proConfirmed && assistantId != null,
+    refetchInterval: pollInterval,
+    retry: false,
+  });
+
+  const resizeOperationInFlight = isResizeOperationInFlight(
+    operationalStatusQuery.data,
+  );
+
+  useEffect(() => {
+    if (resizeOperationInFlight) setSawOperation(true);
+  }, [resizeOperationInFlight]);
+
+  const onboarding = onboardingQuery.data;
+  const targets = useMemo<ProvisioningDimensions | null>(() => {
+    if (!onboarding) return null;
+    const tier = (onboarding.max_machine_tier ?? null) as MachineTierEnum | null;
+    return {
+      // No machine tier on the package (e.g. Mighty) → no machine target.
+      machineSize: tier
+        ? (allowedMachineSizesForTier(tier).at(-1) ?? null)
+        : null,
+      storageGib: onboarding.selected_storage_gib ?? null,
+    };
+  }, [onboarding]);
+
+  const assistant = activeAssistantQuery.data;
+  const actuals = useMemo<ProvisioningDimensions | null>(() => {
+    if (!assistant) return null;
+    return {
+      machineSize: assistant.machine_size ?? null,
+      storageGib: assistant.provisioned_storage_gib ?? null,
+    };
+  }, [assistant]);
+
+  useEffect(() => {
+    if (!open || !actuals) return;
+    setActualsSnapshot((prev) => prev ?? actuals);
+  }, [open, actuals]);
+
+  const { state, softWaiting } = deriveProvisioningState({
+    planId: proConfirmed ? "pro" : observedPlanId,
+    targets,
+    actuals,
+    resizeOperationInFlight,
+    sawOperation,
+    msSinceProConfirmed:
+      proConfirmedAt == null ? null : Math.max(0, now - proConfirmedAt),
+    confirmExpired,
+    serverVerdict,
+  });
+
+  const isTerminal = TERMINAL_STATES.includes(state);
+  const shouldTrack = open && proConfirmed && !isTerminal;
+
+  useEffect(() => {
+    setTracking(shouldTrack);
+  }, [shouldTrack]);
+
+  useEffect(() => {
+    if (!open || !proConfirmed || isTerminal) return;
+    const t = setInterval(() => setNow(Date.now()), CLOCK_TICK_MS);
+    return () => clearInterval(t);
+  }, [open, proConfirmed, isTerminal]);
+
+  return {
+    state,
+    softWaiting,
+    targets,
+    actualsSnapshot,
+    confirmError: !proConfirmed && subscriptionQuery.isError,
+    confirmExpired,
+    retryConfirm,
+  };
+}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -226,6 +226,7 @@ export function useProProvisioning({
     planId: proConfirmed ? "pro" : observedPlanId,
     targets,
     actuals,
+    initialActuals: actualsSnapshot,
     resizeOperationInFlight,
     sawOperation,
     msSinceProConfirmed:

--- a/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
@@ -6,6 +6,13 @@ export const DOMAIN_EXIT_DELAY_MS = 800;
 export const PRO_POLL_INTERVAL_MS = 1000;
 export const PRO_POLL_TIMEOUT_MS = 10_000;
 
+/** How long WAITING can run before the UI softens its copy ("still working…"). */
+export const PROVISION_WAIT_GRACE_MS = 30_000;
+/** How long WAITING/RESIZING can run before we give up and show STALLED. */
+export const PROVISION_STALL_MS = 90_000;
+/** Minimum time a provisioning phase stays on screen so it doesn't flash. */
+export const PROVISION_MIN_DWELL_MS = 2_500;
+
 export const RESTART_NOTICE =
   "Your assistant will briefly restart and be unreachable while this is set up.";
 


### PR DESCRIPTION
## Summary
- pure deriveProvisioningState state machine (CONFIRMING/WAITING/RESIZING/DONE/NOT_APPLICABLE/STALLED) with serverVerdict override slot
- useProProvisioning polling hook over subscription/onboarding/assistant/operational-status queries, restart-tolerant
- timer constants for grace/stall/min-dwell

Part of plan: pro-onboarding-wizard-revamp.md (PR 2 of 6)