### PR TITLE
fix(web): route to login when a platform session expires mid-use (ATL-1100)

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -53,14 +53,42 @@ mock.module("@/lib/local-mode", () => ({
   syncPlatformAssistantsToLockfile: async () => {},
 }));
 
+// Auth store — mocked so the interceptor's `useAuthStore.getState()` reads a
+// controllable `sessionStatus` + `refreshSession` without pulling in the real
+// store's heavy dependency graph. `subscribe` is a no-op the (unrelated)
+// organization-store binds but never calls in these tests.
+type MockSessionStatus = "initializing" | "authenticated" | "unauthenticated";
+
+const mockAuthState: {
+  sessionStatus: MockSessionStatus;
+  refreshSession: () => Promise<boolean>;
+} = {
+  sessionStatus: "authenticated",
+  refreshSession: async () => true,
+};
+
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    getState: () => mockAuthState,
+    subscribe: () => () => {},
+  },
+}));
+
+const hardNavigateMock = mock((_url: string) => {});
+mock.module("@/lib/auth/hard-navigate", () => ({
+  hardNavigate: hardNavigateMock,
+}));
+
 import {
   authorizeRemoteGatewayRequest,
   daemonErrorInterceptor,
   daemonRequestInterceptor,
   localGatewayAuthRecoveryInterceptor,
+  platformAuthRecoveryInterceptor,
   platformFeaturesGate,
   requestInterceptor,
   resetGw401RecoveryFlag,
+  resetPlatformAuthRecoveryFlag,
   rewriteForSelfHostedIngress,
 } from "@/lib/api-interceptors";
 import { ApiError } from "@/utils/api-errors";
@@ -1254,5 +1282,139 @@ describe("api-interceptors / local-mode body buffering", () => {
     } finally {
       blobSpy.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Platform session mid-use expiry recovery interceptor
+// ---------------------------------------------------------------------------
+//
+// When a cookie-authenticated request comes back 401/403/410 while the app
+// still believes it is signed in, the interceptor re-verifies the session via
+// `refreshSession` and, when it is truly gone, hard-navigates to login.
+// Self-hosted / remote-gateway bearer 401s are left to
+// `localGatewayAuthRecoveryInterceptor`.
+
+describe("api-interceptors / platformAuthRecoveryInterceptor", () => {
+  const PLATFORM_URL = "https://platform.test/v1/assistants/123/messages";
+  const LOGIN_PREFIX = "/account/login?returnTo=";
+
+  function makeResponse(status: number, url: string): Response {
+    const response = new Response(null, { status });
+    Object.defineProperty(response, "url", { value: url });
+    return response;
+  }
+
+  // The interceptor kicks off recovery fire-and-forget; flush the microtask
+  // queue so the async `refreshSession` + redirect settle before asserting.
+  const flush = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, 0));
+
+  beforeEach(() => {
+    resetPlatformAuthRecoveryFlag();
+    setSelfHostedConnection(null);
+    mockAuthState.sessionStatus = "authenticated";
+    mockAuthState.refreshSession = mock(async () => true);
+    hardNavigateMock.mockClear();
+  });
+
+  afterEach(() => {
+    resetPlatformAuthRecoveryFlag();
+    setSelfHostedConnection(null);
+  });
+
+  test("401 while authenticated re-verifies; a dead session redirects to login", async () => {
+    const refreshSession = mock(async () => {
+      mockAuthState.sessionStatus = "unauthenticated";
+      return false;
+    });
+    mockAuthState.refreshSession = refreshSession;
+
+    const response = makeResponse(401, PLATFORM_URL);
+    expect(platformAuthRecoveryInterceptor(response)).toBe(response);
+    await flush();
+
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(hardNavigateMock).toHaveBeenCalledTimes(1);
+    expect(hardNavigateMock.mock.calls[0][0].startsWith(LOGIN_PREFIX)).toBe(
+      true,
+    );
+  });
+
+  test("403 that leaves the session live does not redirect and reopens the latch", async () => {
+    const refreshSession = mock(async () => true); // session stays authenticated
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(hardNavigateMock).not.toHaveBeenCalled();
+
+    // Latch reopened → a later genuine rejection triggers another re-probe.
+    platformAuthRecoveryInterceptor(makeResponse(403, PLATFORM_URL));
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("non-rejection statuses (200, 502) are no-ops", async () => {
+    const refreshSession = mock(async () => true);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(200, PLATFORM_URL));
+    platformAuthRecoveryInterceptor(makeResponse(502, PLATFORM_URL));
+    await flush();
+
+    expect(refreshSession).not.toHaveBeenCalled();
+    expect(hardNavigateMock).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when the app is not authenticated at entry", async () => {
+    const refreshSession = mock(async () => false);
+    mockAuthState.refreshSession = refreshSession;
+
+    for (const status of ["initializing", "unauthenticated"] as const) {
+      mockAuthState.sessionStatus = status;
+      platformAuthRecoveryInterceptor(makeResponse(401, PLATFORM_URL));
+    }
+    await flush();
+
+    expect(refreshSession).not.toHaveBeenCalled();
+    expect(hardNavigateMock).not.toHaveBeenCalled();
+  });
+
+  test("ignores a self-hosted gateway 401 — deferred to the gateway handler", async () => {
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    const refreshSession = mock(async () => false);
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(
+      makeResponse(401, `${INGRESS}/v1/assistants/123/messages`),
+    );
+    await flush();
+
+    expect(refreshSession).not.toHaveBeenCalled();
+    expect(hardNavigateMock).not.toHaveBeenCalled();
+  });
+
+  test("a second rejection while recovery is in-flight is a no-op (one refreshSession)", async () => {
+    let resolveRefresh: (value: boolean) => void = () => {};
+    const refreshSession = mock(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    mockAuthState.refreshSession = refreshSession;
+
+    platformAuthRecoveryInterceptor(makeResponse(401, PLATFORM_URL));
+    platformAuthRecoveryInterceptor(makeResponse(401, PLATFORM_URL));
+
+    // Latch set synchronously on the first hit → the second short-circuits.
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+
+    resolveRefresh(true);
+    await flush();
+    expect(refreshSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -50,6 +50,13 @@ import { getDeviceId } from "@/runtime/device-id";
 import { isElectron } from "@/runtime/is-electron";
 import { getElectronSessionToken } from "@/runtime/session-token";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
+import { hardNavigate } from "@/lib/auth/hard-navigate";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  isAuthenticated,
+  isSettledSessionRejection,
+} from "@/stores/session-status";
+import { routes } from "@/utils/routes";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const ELECTRON_RENDERER_ORIGIN_HEADER = "X-Vellum-Electron-Renderer-Origin";
@@ -442,6 +449,73 @@ export function localGatewayAuthRecoveryInterceptor(response: Response): Respons
   return response;
 }
 
+// In-memory latch so a burst of concurrent session rejections triggers only
+// one recovery. Reset in the recovery's `finally` so a genuine expiry after a
+// permission-403 that left the session live is still caught later.
+let platformAuthRecoveryFired = false;
+
+/** @internal Exposed for test teardown only. */
+export function resetPlatformAuthRecoveryFlag(): void {
+  platformAuthRecoveryFired = false;
+}
+
+async function recoverFromPlatformSessionRejection(): Promise<void> {
+  try {
+    // Authoritative re-probe. `refreshSession` calls `getSession()` and only
+    // ends the session on a genuine settled rejection, so an ambiguous
+    // permission-403 on a still-live session does not log anyone out. In
+    // local/gateway mode a platform rejection only drops `platformSession`
+    // and keeps `sessionStatus` authenticated, so the redirect below is
+    // skipped there.
+    await useAuthStore.getState().refreshSession();
+    if (!isAuthenticated(useAuthStore.getState().sessionStatus)) {
+      hardNavigate(
+        `${routes.account.login}?returnTo=${encodeURIComponent(
+          window.location.pathname + window.location.search,
+        )}`,
+      );
+    }
+  } finally {
+    platformAuthRecoveryFired = false;
+  }
+}
+
+/**
+ * Response interceptor for a platform session that expires mid-use.
+ *
+ * A cookie-authenticated request that comes back 401/403/410 while the app
+ * still believes it is signed in means the platform session may have ended.
+ * Nothing else notices this between boot and app-resume, so the rejection
+ * would otherwise surface only as a generic chat error. This re-verifies the
+ * session and, when it is truly gone, routes to login via a full reload.
+ *
+ * No-ops unless the rejection is settled, the app currently reads as
+ * authenticated (excludes boot probes and the already-logged-out login flow,
+ * and prevents a redirect loop), and the response did not come from the
+ * self-hosted / remote-gateway bearer path — those 401s are recovered by
+ * {@link localGatewayAuthRecoveryInterceptor}.
+ */
+export function platformAuthRecoveryInterceptor(response: Response): Response {
+  if (!isSettledSessionRejection({ ok: response.ok, status: response.status })) {
+    return response;
+  }
+  if (platformAuthRecoveryFired) {
+    return response;
+  }
+  if (!isAuthenticated(useAuthStore.getState().sessionStatus)) {
+    return response;
+  }
+  const ingressUrl = getSelfHostedIngressUrl();
+  if (ingressUrl && response.url.startsWith(ingressUrl)) {
+    return response;
+  }
+
+  platformAuthRecoveryFired = true;
+  void recoverFromPlatformSessionRejection();
+
+  return response;
+}
+
 /**
  * Normalizes HeyAPI's raw thrown errors into {@link ApiError} instances
  * for `throwOnError: true` calls only.
@@ -476,12 +550,14 @@ export function daemonErrorInterceptor(
 daemonClient.interceptors.request.use(daemonRequestInterceptor);
 daemonClient.interceptors.response.use(daemonUnreachableInterceptor);
 daemonClient.interceptors.response.use(localGatewayAuthRecoveryInterceptor);
+daemonClient.interceptors.response.use(platformAuthRecoveryInterceptor);
 daemonClient.interceptors.error.use(daemonErrorInterceptor);
 
 // Gateway client uses the same routing as daemon — all gateway endpoints
 // are proxied through the same self-hosted ingress / platform gateway path.
 gatewayClient.interceptors.request.use(daemonRequestInterceptor);
 gatewayClient.interceptors.response.use(daemonUnreachableInterceptor);
+gatewayClient.interceptors.response.use(platformAuthRecoveryInterceptor);
 gatewayClient.interceptors.error.use(daemonErrorInterceptor);
 
 // Force JSON body parsing for all three generated clients. The default
@@ -502,6 +578,12 @@ for (const apiClient of [daemonClient, gatewayClient, platformClient, authClient
 for (const apiClient of [authClient, platformClient]) {
   apiClient.interceptors.request.use(requestInterceptor);
 }
+
+// A chat send in cloud mode goes through the daemon client; other platform
+// calls go through the platform client. Not installed on `authClient` — the
+// allauth session endpoints manage their own 401 semantics, and adding it
+// there risks re-entrancy with the `getSession()` inside `refreshSession`.
+platformClient.interceptors.response.use(platformAuthRecoveryInterceptor);
 
 function arePlatformFeaturesEnabled(): boolean {
   return !isPlatformDisabled();


### PR DESCRIPTION
When a platform session expires while the user is actively in the app, a chat send comes back 401/403/410, and until now nothing centrally noticed — the rejection surfaced as a generic chat error whose only action was "Go to Doctor", leaving the user stranded until a manual reload. This adds a response interceptor on the daemon, gateway, and platform clients that, on a settled session rejection while the app still reads as authenticated, re-verifies the session via `refreshSession` and hard-navigates to login when it is truly gone. An ambiguous permission-403 on a still-live session keeps the user signed in, and self-hosted gateway 401s stay with the existing local recovery interceptor. Fixes ATL-1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)