### PR TITLE
feat(cli): note plugin vs workspace processes in `assistant ps`

### DIFF
--- a/assistant/src/cli/commands/__tests__/ps.test.ts
+++ b/assistant/src/cli/commands/__tests__/ps.test.ts
@@ -133,7 +133,7 @@ describe("ps command — IPC wiring", () => {
 });
 
 describe("ps command — tree rendering", () => {
-  test("renders parent, indented children, and status labels", async () => {
+  test("renders parent, indented children, and plugin/workspace origin", async () => {
     mockResponse = {
       ok: true,
       result: {
@@ -141,9 +141,10 @@ describe("ps command — tree rendering", () => {
           {
             name: "assistant",
             status: "running",
+            origin: "workspace",
             children: [
-              { name: "qdrant", status: "running" },
-              { name: "embed-worker", status: "not_running" },
+              { name: "qdrant", status: "running", origin: "workspace" },
+              { name: "memory-worker", status: "running", origin: "plugin" },
             ],
           },
         ],
@@ -151,27 +152,82 @@ describe("ps command — tree rendering", () => {
     };
 
     await runPsCommand();
-    const out = logLines.join("\n");
+    const lines = logLines.filter((l) => l.trim().length > 0);
 
-    expect(out).toContain("assistant  [running]");
-    expect(out).toContain("  qdrant  [running]");
-    expect(out).toContain("  embed-worker  [not running]");
+    // Column 1 keeps the hierarchy indentation; the origin column follows.
+    const root = lines.find((l) => l.startsWith("assistant"))!;
+    const qdrant = lines.find((l) => l.trimStart().startsWith("qdrant"))!;
+    const worker = lines.find((l) =>
+      l.trimStart().startsWith("memory-worker"),
+    )!;
+
+    expect(qdrant).toMatch(/^ {2}qdrant/);
+    expect(root).toContain("workspace");
+    expect(qdrant).toContain("workspace");
+    expect(worker).toContain("plugin");
+
+    // The status label is gone — no [running] anywhere.
+    expect(logLines.join("\n")).not.toContain("[running]");
   });
 
-  test("appends info text when present", async () => {
+  test("aligns column 2 to the same start index across all rows", async () => {
     mockResponse = {
       ok: true,
       result: {
         processes: [
-          { name: "qdrant", status: "unreachable", info: "probe timed out" },
+          {
+            name: "assistant",
+            status: "running",
+            origin: "workspace",
+            children: [
+              {
+                name: "qdrant",
+                status: "running",
+                origin: "workspace",
+                children: [
+                  {
+                    name: "deeply-nested-child",
+                    status: "running",
+                    origin: "plugin",
+                  },
+                ],
+              },
+            ],
+          },
         ],
       },
     };
 
     await runPsCommand();
-    expect(logLines.join("\n")).toContain(
-      "qdrant  [unreachable] — probe timed out",
+    const lines = logLines.filter((l) => l.trim().length > 0);
+
+    // The origin word starts at the same column on every row regardless of
+    // the depth-driven indentation in column 1.
+    const originStarts = lines.map((l) =>
+      l.indexOf("workspace") === -1
+        ? l.indexOf("plugin")
+        : l.indexOf("workspace"),
     );
+    expect(new Set(originStarts).size).toBe(1);
+  });
+
+  test("shows the pid info column", async () => {
+    mockResponse = {
+      ok: true,
+      result: {
+        processes: [
+          {
+            name: "qdrant",
+            status: "running",
+            origin: "workspace",
+            info: "pid 4242",
+          },
+        ],
+      },
+    };
+
+    await runPsCommand();
+    expect(logLines.join("\n")).toContain("pid 4242");
   });
 
   test("prints a placeholder when no processes are reported", async () => {

--- a/assistant/src/cli/commands/ps.help.ts
+++ b/assistant/src/cli/commands/ps.help.ts
@@ -18,7 +18,8 @@ worker (when the daemon owns it), MCP servers, and any other live children.
 The tree is built from the native process table (/proc on Linux, ps on
 macOS), so it reflects what is actually running, not a fixed subsystem list.
 
-Each node shows its PID; every listed process is live by definition.
+Each node shows whether it was spawned from a plugin or from the workspace,
+plus its PID. Every listed process is live by definition.
 
 Examples:
   $ assistant ps

--- a/assistant/src/cli/commands/ps.ts
+++ b/assistant/src/cli/commands/ps.ts
@@ -19,6 +19,7 @@ import { psHelp } from "./ps.help.js";
 interface ProcessEntry {
   name: string;
   status: "running" | "not_running" | "unreachable";
+  origin: "plugin" | "workspace";
   children?: ProcessEntry[];
   info?: string;
 }
@@ -27,20 +28,44 @@ interface PsResponse {
   processes: ProcessEntry[];
 }
 
-const STATUS_LABEL: Record<ProcessEntry["status"], string> = {
-  running: "running",
-  not_running: "not running",
-  unreachable: "unreachable",
-};
+/**
+ * One flattened output row. Column 1 (`name`) carries the hierarchy
+ * indentation; the remaining columns are aligned to a common start index
+ * across all rows regardless of tree depth.
+ */
+interface Row {
+  name: string;
+  origin: string;
+  info: string;
+}
 
-/** Render one entry plus its children, indented to reflect tree depth. */
-function renderEntry(entry: ProcessEntry, depth: number): void {
-  const indent = "  ".repeat(depth);
-  const status = STATUS_LABEL[entry.status] ?? entry.status;
-  const info = entry.info ? ` — ${entry.info}` : "";
-  log.info(`${indent}${entry.name}  [${status}]${info}`);
+/** Flatten the tree into rows, indenting each name to reflect tree depth. */
+function flattenEntries(entry: ProcessEntry, depth: number, rows: Row[]): void {
+  rows.push({
+    name: "  ".repeat(depth) + entry.name,
+    origin: entry.origin,
+    info: entry.info ?? "",
+  });
   for (const child of entry.children ?? []) {
-    renderEntry(child, depth + 1);
+    flattenEntries(child, depth + 1, rows);
+  }
+}
+
+/**
+ * Render the flattened rows as aligned columns. Column 1 keeps its per-row
+ * indentation for hierarchy; columns 2..N are padded to a shared width so
+ * every row's column starts at the same index. Status is not shown — the
+ * daemon only ever reports live processes, so a `[running]` label carries no
+ * information.
+ */
+function renderRows(rows: Row[]): void {
+  const nameWidth = Math.max(...rows.map((r) => r.name.length));
+  const originWidth = Math.max(...rows.map((r) => r.origin.length));
+  for (const r of rows) {
+    const line = `${r.name.padEnd(nameWidth)}  ${r.origin.padEnd(
+      originWidth,
+    )}  ${r.info}`;
+    log.info(line.trimEnd());
   }
 }
 
@@ -67,10 +92,13 @@ export function registerPsCommand(program: Command): void {
           return;
         }
 
-        log.info("");
+        const rows: Row[] = [];
         for (const entry of processes) {
-          renderEntry(entry, 0);
+          flattenEntries(entry, 0, rows);
         }
+
+        log.info("");
+        renderRows(rows);
         log.info("");
       });
     },

--- a/assistant/src/runtime/routes/__tests__/ps-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/ps-routes.test.ts
@@ -22,17 +22,26 @@ mock.module("../../../util/process-tree.js", () => ({
     pid: rootPid,
     name: "assistant.ts",
     command: "bun run assistant.ts",
+    origin: "workspace",
     children: [
-      { pid: 200, name: "qdrant", command: "qdrant", children: [] },
+      {
+        pid: 200,
+        name: "qdrant",
+        command: "qdrant",
+        origin: "workspace",
+        children: [],
+      },
       {
         pid: 300,
-        name: "jobs-worker",
-        command: "bun run /app/jobs/worker.ts",
+        name: "memory-worker",
+        command: "bun run /app/plugins/defaults/memory/worker.ts",
+        origin: "plugin",
         children: [
           {
             pid: 400,
             name: "embed-helper",
             command: "embed-helper",
+            origin: "workspace",
             children: [],
           },
         ],
@@ -50,6 +59,7 @@ function getHandler() {
     processes: Array<{
       name: string;
       status: string;
+      origin: string;
       info?: string;
       children?: unknown[];
     }>;
@@ -58,7 +68,9 @@ function getHandler() {
 
 describe("ps route handler", () => {
   test("maps the process tree to running ProcessEntry nodes", async () => {
-    procsToReturn = [{ pid: process.pid, ppid: 1, command: "bun" }];
+    procsToReturn = [
+      { pid: process.pid, ppid: 1, command: "bun", origin: "workspace" },
+    ];
     listShouldThrow = false;
 
     const { processes } = await getHandler()();
@@ -78,8 +90,32 @@ describe("ps route handler", () => {
     const { processes } = await getHandler()();
     const names = JSON.stringify(processes);
 
-    expect(names).toContain("jobs-worker");
+    expect(names).toContain("memory-worker");
     expect(names).toContain("embed-helper");
+  });
+
+  test("carries each node's plugin/workspace origin onto the wire shape", async () => {
+    procsToReturn = [];
+    listShouldThrow = false;
+
+    const { processes } = await getHandler()();
+    const root = processes[0];
+    expect(root.origin).toBe("workspace");
+
+    const byName = new Map<string, string>();
+    const walk = (n: {
+      name: string;
+      origin: string;
+      children?: unknown[];
+    }) => {
+      byName.set(n.name, n.origin);
+      for (const c of (n.children ?? []) as Array<typeof n>) walk(c);
+    };
+    walk(root as never);
+
+    expect(byName.get("qdrant")).toBe("workspace");
+    expect(byName.get("memory-worker")).toBe("plugin");
+    expect(byName.get("embed-helper")).toBe("workspace");
   });
 
   test("every node is reported as running with a pid info field", async () => {
@@ -108,6 +144,7 @@ describe("ps route handler", () => {
     expect(processes[0]).toEqual({
       name: "assistant",
       status: "running",
+      origin: "workspace",
       info: `pid ${process.pid}`,
     });
   });

--- a/assistant/src/runtime/routes/ps-routes.ts
+++ b/assistant/src/runtime/routes/ps-routes.ts
@@ -24,9 +24,13 @@ const log = getLogger("ps-routes");
 
 type ProcessStatus = "running" | "not_running" | "unreachable";
 
+type ProcessOrigin = "plugin" | "workspace";
+
 interface ProcessEntry {
   name: string;
   status: ProcessStatus;
+  /** Whether the process was spawned from a plugin or from the workspace. */
+  origin: ProcessOrigin;
   children?: ProcessEntry[];
   info?: string;
 }
@@ -36,6 +40,7 @@ const processEntrySchema: z.ZodType<ProcessEntry> = z
     z.object({
       name: z.string(),
       status: z.enum(["running", "not_running", "unreachable"]),
+      origin: z.enum(["plugin", "workspace"]),
       children: z.array(processEntrySchema).optional(),
       info: z.string().optional(),
     }),
@@ -52,6 +57,7 @@ function toEntry(node: ProcTreeNode): ProcessEntry {
     name: node.name,
     // Every node in the walk is a live process by definition.
     status: "running",
+    origin: node.origin,
     info: `pid ${node.pid}`,
   };
   if (node.children.length > 0) {
@@ -72,6 +78,7 @@ async function getProcessStatus() {
     entry = {
       name: "assistant",
       status: "running",
+      origin: "workspace",
       info: `pid ${process.pid}`,
     };
   }

--- a/assistant/src/util/__tests__/process-tree.test.ts
+++ b/assistant/src/util/__tests__/process-tree.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildProcessTree,
   deriveName,
+  deriveOrigin,
   type ProcInfo,
 } from "../process-tree.js";
 
@@ -57,13 +58,60 @@ describe("deriveName", () => {
   });
 });
 
+describe("deriveOrigin", () => {
+  test("classifies commands running plugin-owned code as plugin", () => {
+    expect(
+      deriveOrigin(
+        "bun --smol run /home/u/.vellum/workspace/plugins/foo/server.ts",
+      ),
+    ).toBe("plugin");
+    // Bundled default plugins live under a plugins/ dir too.
+    expect(
+      deriveOrigin("bun --smol run /app/src/plugins/defaults/memory/worker.ts"),
+    ).toBe("plugin");
+  });
+
+  test("classifies the daemon and workspace subsystems as workspace", () => {
+    expect(deriveOrigin("bun run /app/daemon/main.ts")).toBe("workspace");
+    expect(deriveOrigin("bun --smol run /app/monitoring/worker.ts")).toBe(
+      "workspace",
+    );
+    expect(deriveOrigin("/usr/local/bin/qdrant --config foo")).toBe(
+      "workspace",
+    );
+  });
+
+  test("does not match the plugins-data state directory", () => {
+    expect(
+      deriveOrigin(
+        "bun run /home/u/.vellum/workspace/plugins-data/foo/index.ts",
+      ),
+    ).toBe("workspace");
+  });
+});
+
 describe("buildProcessTree", () => {
   const procs: ProcInfo[] = [
-    { pid: 100, ppid: 1, command: "bun run /app/daemon/main.ts" },
-    { pid: 200, ppid: 100, command: "/usr/bin/qdrant" },
-    { pid: 300, ppid: 100, command: "bun run /app/jobs/worker.ts" },
-    { pid: 400, ppid: 300, command: "/usr/bin/embed-helper" },
-    { pid: 999, ppid: 1, command: "unrelated" },
+    {
+      pid: 100,
+      ppid: 1,
+      command: "bun run /app/daemon/main.ts",
+      origin: "workspace",
+    },
+    { pid: 200, ppid: 100, command: "/usr/bin/qdrant", origin: "workspace" },
+    {
+      pid: 300,
+      ppid: 100,
+      command: "bun run /app/jobs/worker.ts",
+      origin: "plugin",
+    },
+    {
+      pid: 400,
+      ppid: 300,
+      command: "/usr/bin/embed-helper",
+      origin: "workspace",
+    },
+    { pid: 999, ppid: 1, command: "unrelated", origin: "workspace" },
   ];
 
   test("builds the subtree rooted at the daemon PID", () => {
@@ -83,6 +131,18 @@ describe("buildProcessTree", () => {
     expect(worker.children[0].name).toBe("embed-helper");
   });
 
+  test("propagates each process's origin onto its tree node", () => {
+    const tree = buildProcessTree(procs, 100);
+    expect(tree.origin).toBe("workspace");
+    expect(tree.children.find((c) => c.pid === 200)!.origin).toBe("workspace");
+    expect(tree.children.find((c) => c.pid === 300)!.origin).toBe("plugin");
+  });
+
+  test("synthesizes a workspace origin when the root PID is absent", () => {
+    const tree = buildProcessTree(procs, 55555);
+    expect(tree.origin).toBe("workspace");
+  });
+
   test("excludes processes not descended from the root", () => {
     const tree = buildProcessTree(procs, 100);
     const allPids = (n: typeof tree): number[] => [
@@ -94,10 +154,10 @@ describe("buildProcessTree", () => {
 
   test("orders children by PID", () => {
     const shuffled: ProcInfo[] = [
-      { pid: 1, ppid: 0, command: "root" },
-      { pid: 30, ppid: 1, command: "c" },
-      { pid: 10, ppid: 1, command: "a" },
-      { pid: 20, ppid: 1, command: "b" },
+      { pid: 1, ppid: 0, command: "root", origin: "workspace" },
+      { pid: 30, ppid: 1, command: "c", origin: "workspace" },
+      { pid: 10, ppid: 1, command: "a", origin: "workspace" },
+      { pid: 20, ppid: 1, command: "b", origin: "workspace" },
     ];
     const tree = buildProcessTree(shuffled, 1);
     expect(tree.children.map((c) => c.pid)).toEqual([10, 20, 30]);
@@ -111,7 +171,9 @@ describe("buildProcessTree", () => {
   });
 
   test("does not loop on a self-parented process", () => {
-    const cyclic: ProcInfo[] = [{ pid: 7, ppid: 7, command: "weird" }];
+    const cyclic: ProcInfo[] = [
+      { pid: 7, ppid: 7, command: "weird", origin: "workspace" },
+    ];
     const tree = buildProcessTree(cyclic, 7);
     expect(tree.pid).toBe(7);
     expect(tree.children).toEqual([]);
@@ -119,8 +181,8 @@ describe("buildProcessTree", () => {
 
   test("does not loop on a parent/child cycle", () => {
     const cyclic: ProcInfo[] = [
-      { pid: 1, ppid: 2, command: "a" },
-      { pid: 2, ppid: 1, command: "b" },
+      { pid: 1, ppid: 2, command: "a", origin: "workspace" },
+      { pid: 2, ppid: 1, command: "b", origin: "workspace" },
     ];
     const tree = buildProcessTree(cyclic, 1);
     // 1 -> 2 -> (1 already visited, stop)

--- a/assistant/src/util/process-tree.ts
+++ b/assistant/src/util/process-tree.ts
@@ -15,6 +15,13 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Whether a process runs plugin-owned code (`plugin`) or is the daemon itself
+ * / one of its workspace subsystems (`workspace`). Classified at collection
+ * time from the raw command line via {@link deriveOrigin}.
+ */
+export type ProcessOrigin = "plugin" | "workspace";
+
 export interface ProcInfo {
   pid: number;
   ppid: number;
@@ -27,6 +34,8 @@ export interface ProcInfo {
    * snapshot files.
    */
   command: string;
+  /** Whether this process was spawned from a plugin or from the workspace. */
+  origin: ProcessOrigin;
 }
 
 export interface ProcTreeNode {
@@ -35,6 +44,8 @@ export interface ProcTreeNode {
   name: string;
   /** Safe process descriptor (redacted via deriveName at collection time). */
   command: string;
+  /** Whether this process was spawned from a plugin or from the workspace. */
+  origin: ProcessOrigin;
   children: ProcTreeNode[];
 }
 
@@ -80,19 +91,47 @@ function scriptName(scriptPath: string): string {
  */
 export function deriveName(command: string): string {
   const tokens = command.trim().split(/\s+/).filter(Boolean);
-  if (tokens.length === 0) {return "(unknown)";}
+  if (tokens.length === 0) {
+    return "(unknown)";
+  }
 
   const argv0 = basename(tokens[0]);
   if (RUNTIMES.has(argv0)) {
     const args = tokens.slice(1);
     const script = args.find((t) => SCRIPT_EXT_RE.test(t));
-    if (script) {return scriptName(script);}
+    if (script) {
+      return scriptName(script);
+    }
     // No script to summarize: show the non-flag arguments so the entry reads as
     // "what was run" rather than an opaque `bun`. Flags are dropped as noise.
     const meaningful = args.filter((t) => !t.startsWith("-"));
-    if (meaningful.length > 0) {return `${argv0} ${meaningful.join(" ")}`;}
+    if (meaningful.length > 0) {
+      return `${argv0} ${meaningful.join(" ")}`;
+    }
   }
   return argv0;
+}
+
+/**
+ * Marks a command whose executable/script path lives under a `plugins/<name>/`
+ * directory. Matches both user plugins (`<workspaceDir>/plugins/<name>/`) and
+ * bundled defaults (`.../plugins/defaults/<name>/`). The `plugins-data/` state
+ * directory is deliberately not matched — the trailing slash after `plugins`
+ * excludes it.
+ */
+const PLUGIN_PATH_RE = /(?:^|\/)plugins\/[^/\s]+/;
+
+/**
+ * Classify whether a raw command line belongs to plugin-owned code. A process
+ * spawned from a plugin runs an entry script that lives under a
+ * `plugins/<name>/` directory (e.g. the memory worker at
+ * `…/plugins/defaults/memory/worker.ts`); the daemon itself and its workspace
+ * subsystems (qdrant, the embed worker, the resource monitor) do not. This is
+ * a best-effort heuristic on the command path — a plugin that shells out to a
+ * bare binary with no plugin path in its argv reads as `workspace`.
+ */
+export function deriveOrigin(command: string): ProcessOrigin {
+  return PLUGIN_PATH_RE.test(command) ? "plugin" : "workspace";
 }
 
 /**
@@ -104,12 +143,16 @@ export function deriveName(command: string): string {
 function parseProcStat(content: string): { comm: string; ppid: number } | null {
   const lparen = content.indexOf("(");
   const rparen = content.lastIndexOf(")");
-  if (lparen === -1 || rparen === -1 || rparen < lparen) {return null;}
+  if (lparen === -1 || rparen === -1 || rparen < lparen) {
+    return null;
+  }
   const comm = content.slice(lparen + 1, rparen);
   // After ")" come: " <state> <ppid> …" — split the remainder on spaces.
   const rest = content.slice(rparen + 2).split(" ");
   const ppid = Number(rest[1]);
-  if (!Number.isInteger(ppid)) {return null;}
+  if (!Number.isInteger(ppid)) {
+    return null;
+  }
   return { comm, ppid };
 }
 
@@ -119,13 +162,17 @@ function listProcessesFromProc(): ProcInfo[] {
   const procs: ProcInfo[] = [];
   for (const entry of entries) {
     const pid = Number(entry);
-    if (!Number.isInteger(pid) || pid <= 0) {continue;}
+    if (!Number.isInteger(pid) || pid <= 0) {
+      continue;
+    }
 
     let ppid: number;
     let comm: string;
     try {
       const parsed = parseProcStat(readFileSync(`/proc/${pid}/stat`, "utf8"));
-      if (!parsed) {continue;}
+      if (!parsed) {
+        continue;
+      }
       ({ ppid, comm } = parsed);
     } catch {
       // Process exited between readdir and read — skip.
@@ -138,15 +185,21 @@ function listProcessesFromProc(): ProcInfo[] {
     // The raw command line is read here but never stored — only the derived
     // safe descriptor is kept.
     let command = comm;
+    // Origin is derived from the raw command path (which carries the plugin
+    // directory), so it is classified before deriveName redacts the path away.
+    let origin: ProcessOrigin = "workspace";
     try {
       const raw = readFileSync(`/proc/${pid}/cmdline`, "utf8");
       const joined = raw.split("\0").filter(Boolean).join(" ");
-      if (joined) {command = deriveName(joined);}
+      if (joined) {
+        command = deriveName(joined);
+        origin = deriveOrigin(joined);
+      }
     } catch {
       // Fall back to comm.
     }
 
-    procs.push({ pid, ppid, command });
+    procs.push({ pid, ppid, command, origin });
   }
   return procs;
 }
@@ -162,11 +215,15 @@ async function listProcessesFromPs(): Promise<ProcInfo[]> {
   const procs: ProcInfo[] = [];
   for (const line of stdout.split("\n")) {
     const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
-    if (!m) {continue;}
+    if (!m) {
+      continue;
+    }
+    const raw = m[3].trim();
     procs.push({
       pid: Number(m[1]),
       ppid: Number(m[2]),
-      command: deriveName(m[3].trim()),
+      command: deriveName(raw),
+      origin: deriveOrigin(raw),
     });
   }
   return procs;
@@ -198,8 +255,11 @@ export function buildProcessTree(
   for (const p of procs) {
     byPid.set(p.pid, p);
     const siblings = childrenOf.get(p.ppid);
-    if (siblings) {siblings.push(p.pid);}
-    else {childrenOf.set(p.ppid, [p.pid]);}
+    if (siblings) {
+      siblings.push(p.pid);
+    } else {
+      childrenOf.set(p.ppid, [p.pid]);
+    }
   }
 
   const visited = new Set<number>();
@@ -215,6 +275,8 @@ export function buildProcessTree(
       pid,
       name: info ? deriveName(command) : "assistant",
       command,
+      // A synthesized root (daemon PID absent from the table) is the workspace.
+      origin: info?.origin ?? "workspace",
       children,
     };
   };


### PR DESCRIPTION
## Prompt / plan

> extend `assistant ps` such that if a process was spawned from a plugin, we note the difference between plugin vs workspace. also the `[running]` is now redundant, so let's remove, and let's make the spacing consistent so that columns 2 - N have the same start index (keep the indentation for hierarchy in column 1)

**Approach:** classify each process in the daemon's tree by *origin* — plugin vs workspace — at collection time from the raw command path, carry it through the `ps` route onto the wire, and rework the CLI table.

- **Origin classification** (`util/process-tree.ts`): a new `deriveOrigin()` marks a process as `plugin` when its executable/script path lives under a `plugins/<name>/` directory (both user plugins under `<workspaceDir>/plugins/<name>/` and bundled defaults under `.../plugins/defaults/<name>/`, e.g. the memory worker at `…/plugins/defaults/memory/worker.ts`); everything else — the daemon itself, qdrant, the embed worker, the resource monitor — is `workspace`. Classification runs before `deriveName` redacts the path, so no raw command line is stored. `plugins-data/` (state, not code) is deliberately excluded. This is a best-effort heuristic on the command path: a plugin that shells out to a bare binary with no plugin path in its argv reads as `workspace`. The field is threaded through `ProcInfo` → `ProcTreeNode` → the `ps` route's `ProcessEntry` (new required `origin` on the wire).
- **CLI rendering** (`cli/commands/ps.ts`):
  - Removed the `[running]` status label — the route only ever reports live processes, so it was invariant and carried no information.
  - Added a plugin/workspace origin column.
  - Aligned columns 2..N to a shared start index by padding column 1 to the widest row, while keeping the depth indentation in column 1 for hierarchy.

Example output:

```
assistant           workspace  pid 100
  qdrant            workspace  pid 200
  memory-worker     plugin     pid 300
    embed-worker    plugin     pid 400
  resource-monitor  workspace  pid 500
```

The `--json` payload is unchanged in shape apart from the additive `origin` field.

## Test plan

- Unit tests updated/added and passing (30 tests across the three affected files):
  - `util/__tests__/process-tree.test.ts` — `deriveOrigin` classification (plugin paths, workspace subsystems, `plugins-data/` exclusion) + origin propagation through `buildProcessTree`.
  - `runtime/routes/__tests__/ps-routes.test.ts` — origin carried onto the wire shape.
  - `cli/commands/__tests__/ps.test.ts` — origin column rendered, no `[running]`, and column 2 aligned to a single start index regardless of tree depth.
- `tsgo --noEmit`: 0 errors. Prettier + eslint clean (only a pre-existing warning on an untouched line).

## CLI verb checklist

No new IPC route added — this extends the existing `ps` route/command with an additional field and reworked rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qkdA2ovTYVRDPMc6TQ4UV

---
_Generated by [Claude Code](https://claude.ai/code/session_015qkdA2ovTYVRDPMc6TQ4UV)_