### PR TITLE
fix(web): reload platform assistants on re-auth (ATL-1100)

### DIFF
--- a/clients/web/src/assistant/platform-assistants-sync.test.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.test.ts
@@ -17,12 +17,21 @@ mock.module("@/lib/auth/gateway-session", () => ({
 }));
 
 // The platform assistants fetch. Default to a well-formed empty ok result;
-// tests override to exercise the ok / not-ok / thrown branches.
+// tests override to exercise the ok / not-ok / thrown branches. When
+// `listAssistantsGates` is set, each call parks until its resolver (pushed here
+// in call order) is invoked, so a test can hold reloads in flight and settle
+// them in a chosen order.
 let mockListAssistantsResult: unknown = { ok: true, status: 200, data: [] };
 let mockListAssistantsError: Error | null = null;
+let listAssistantsGates: Array<(result: unknown) => void> | null = null;
 const listAssistantsMock = mock(async () => {
   if (mockListAssistantsError) {
     throw mockListAssistantsError;
+  }
+  if (listAssistantsGates) {
+    return await new Promise<unknown>((resolve) => {
+      listAssistantsGates!.push(resolve);
+    });
   }
   return mockListAssistantsResult;
 });
@@ -54,14 +63,15 @@ mock.module("@/lib/sentry/capture-error", () => ({
 }));
 
 // Auth store: a getState + subscribe seam the sync module wires onto. Tests
-// drive transitions by invoking the captured subscriber with (next, prev).
-let authState: { platformSession: PlatformSessionStatus } = {
-  platformSession: "unknown",
+// drive transitions by invoking the captured subscriber with (next, prev) and
+// mutate `authState` directly to simulate logout / account-switch mid-load.
+type AuthUser = { id: string } | null;
+type AuthSnapshot = {
+  platformSession: PlatformSessionStatus;
+  user: AuthUser;
 };
-type AuthSubscriber = (
-  state: typeof authState,
-  prevState: typeof authState,
-) => void;
+let authState: AuthSnapshot = { platformSession: "unknown", user: null };
+type AuthSubscriber = (state: AuthSnapshot, prevState: AuthSnapshot) => void;
 let subscriber: AuthSubscriber | null = null;
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
@@ -79,10 +89,10 @@ const { reloadPlatformAssistants, setupPlatformAssistantsSync } = await import(
   "@/assistant/platform-assistants-sync"
 );
 
-/** Move the mocked auth store to `next` and notify the subscriber. */
+/** Move the mocked auth store to `next` (keeping the user) and notify. */
 function transition(next: PlatformSessionStatus): void {
   const prevState = authState;
-  authState = { platformSession: next };
+  authState = { platformSession: next, user: prevState.user };
   subscriber?.(authState, prevState);
 }
 
@@ -95,7 +105,8 @@ beforeEach(() => {
   mockIsGatewayAuthEnabled = false;
   mockListAssistantsResult = { ok: true, status: 200, data: [] };
   mockListAssistantsError = null;
-  authState = { platformSession: "unknown" };
+  listAssistantsGates = null;
+  authState = { platformSession: "unknown", user: null };
   subscriber = null;
   listAssistantsMock.mockClear();
   fetchOrganizationsMock.mockClear();
@@ -198,6 +209,7 @@ describe("reloadPlatformAssistants", () => {
       { id: "a1", name: "One", is_local: false, created: "2026-01-01T00:00:00Z" },
     ];
     mockListAssistantsResult = { ok: true, status: 200, data };
+    authState = { platformSession: "present", user: { id: "u1" } };
 
     await reloadPlatformAssistants();
 
@@ -208,6 +220,7 @@ describe("reloadPlatformAssistants", () => {
 
   test("marks the list hydrated when listAssistants returns a failure", async () => {
     mockListAssistantsResult = { ok: false, status: 500, error: {} };
+    authState = { platformSession: "present", user: { id: "u1" } };
 
     await reloadPlatformAssistants();
 
@@ -217,6 +230,7 @@ describe("reloadPlatformAssistants", () => {
 
   test("marks the list hydrated and reports when the fetch throws", async () => {
     mockListAssistantsError = new Error("network down");
+    authState = { platformSession: "present", user: { id: "u1" } };
 
     await reloadPlatformAssistants();
 
@@ -226,5 +240,67 @@ describe("reloadPlatformAssistants", () => {
       expect.any(Error),
       expect.objectContaining({ context: "reloadPlatformAssistants" }),
     );
+  });
+
+  test("does not write when the platform session flips away from present mid-load", async () => {
+    const gates: Array<(result: unknown) => void> = [];
+    listAssistantsGates = gates;
+    authState = { platformSession: "present", user: { id: "u1" } };
+
+    const pending = reloadPlatformAssistants();
+    await tick();
+    expect(gates.length).toBe(1);
+
+    // The user logs out while the fetch is in flight.
+    authState = { platformSession: "absent", user: null };
+    gates[0]!({ ok: true, status: 200, data: [{ id: "a1" }] });
+    await pending;
+
+    expect(setFromApiMock).not.toHaveBeenCalled();
+    expect(markHydratedMock).not.toHaveBeenCalled();
+  });
+
+  test("does not write when the platform user changes mid-load", async () => {
+    const gates: Array<(result: unknown) => void> = [];
+    listAssistantsGates = gates;
+    authState = { platformSession: "present", user: { id: "u1" } };
+
+    const pending = reloadPlatformAssistants();
+    await tick();
+    expect(gates.length).toBe(1);
+
+    // A different account is now signed in.
+    authState = { platformSession: "present", user: { id: "u2" } };
+    gates[0]!({ ok: true, status: 200, data: [{ id: "a1" }] });
+    await pending;
+
+    expect(setFromApiMock).not.toHaveBeenCalled();
+    expect(markHydratedMock).not.toHaveBeenCalled();
+  });
+
+  test("latest-wins: a superseded reload does not write, the newest does", async () => {
+    const gates: Array<(result: unknown) => void> = [];
+    listAssistantsGates = gates;
+    authState = { platformSession: "present", user: { id: "u1" } };
+
+    const first = reloadPlatformAssistants();
+    await tick();
+    const second = reloadPlatformAssistants();
+    await tick();
+    expect(gates.length).toBe(2);
+
+    const staleData = [{ id: "stale" }];
+    const freshData = [{ id: "fresh" }];
+
+    // Settle the older (superseded) reload first — it must not write.
+    gates[0]!({ ok: true, status: 200, data: staleData });
+    await first;
+    expect(setFromApiMock).not.toHaveBeenCalled();
+
+    // The newest reload writes.
+    gates[1]!({ ok: true, status: 200, data: freshData });
+    await second;
+    expect(setFromApiMock).toHaveBeenCalledTimes(1);
+    expect(setFromApiMock).toHaveBeenCalledWith(freshData);
   });
 });

--- a/clients/web/src/assistant/platform-assistants-sync.test.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { PlatformSessionStatus } from "@/stores/session-status";
+
+// Mode predicates that select whether the load runs.
+let mockIsLocalMode = false;
+let mockIsRemoteGatewayMode = false;
+let mockIsGatewayAuthEnabled = false;
+
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => mockIsLocalMode,
+  isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
+}));
+
+mock.module("@/lib/auth/gateway-session", () => ({
+  isGatewayAuthEnabled: () => mockIsGatewayAuthEnabled,
+}));
+
+// The platform assistants fetch. Default to a well-formed empty ok result;
+// tests override to exercise the ok / not-ok / thrown branches.
+let mockListAssistantsResult: unknown = { ok: true, status: 200, data: [] };
+let mockListAssistantsError: Error | null = null;
+const listAssistantsMock = mock(async () => {
+  if (mockListAssistantsError) {
+    throw mockListAssistantsError;
+  }
+  return mockListAssistantsResult;
+});
+mock.module("@/assistant/api", () => ({
+  listAssistants: listAssistantsMock,
+}));
+
+const fetchOrganizationsMock = mock(async () => {});
+mock.module("@/stores/organization-store", () => ({
+  useOrganizationStore: {
+    getState: () => ({ fetchOrganizations: fetchOrganizationsMock }),
+  },
+}));
+
+const setFromApiMock = mock((_assistants: unknown) => {});
+const markHydratedMock = mock(() => {});
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: {
+    getState: () => ({
+      setFromApi: setFromApiMock,
+      markHydrated: markHydratedMock,
+    }),
+  },
+}));
+
+const captureErrorMock = mock((_error: unknown, _opts: unknown) => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+// Auth store: a getState + subscribe seam the sync module wires onto. Tests
+// drive transitions by invoking the captured subscriber with (next, prev).
+let authState: { platformSession: PlatformSessionStatus } = {
+  platformSession: "unknown",
+};
+type AuthSubscriber = (
+  state: typeof authState,
+  prevState: typeof authState,
+) => void;
+let subscriber: AuthSubscriber | null = null;
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    getState: () => authState,
+    subscribe: (listener: AuthSubscriber) => {
+      subscriber = listener;
+      return () => {
+        subscriber = null;
+      };
+    },
+  },
+}));
+
+const { reloadPlatformAssistants, setupPlatformAssistantsSync } = await import(
+  "@/assistant/platform-assistants-sync"
+);
+
+/** Move the mocked auth store to `next` and notify the subscriber. */
+function transition(next: PlatformSessionStatus): void {
+  const prevState = authState;
+  authState = { platformSession: next };
+  subscriber?.(authState, prevState);
+}
+
+const tick = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  mockIsLocalMode = false;
+  mockIsRemoteGatewayMode = false;
+  mockIsGatewayAuthEnabled = false;
+  mockListAssistantsResult = { ok: true, status: 200, data: [] };
+  mockListAssistantsError = null;
+  authState = { platformSession: "unknown" };
+  subscriber = null;
+  listAssistantsMock.mockClear();
+  fetchOrganizationsMock.mockClear();
+  setFromApiMock.mockClear();
+  markHydratedMock.mockClear();
+  captureErrorMock.mockClear();
+});
+
+describe("setupPlatformAssistantsSync", () => {
+  test("reloads on an unknown → present transition", async () => {
+    setupPlatformAssistantsSync();
+
+    transition("present");
+    await tick();
+
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("reloads on an absent → present transition", async () => {
+    setupPlatformAssistantsSync();
+
+    transition("absent");
+    await tick();
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+
+    transition("present");
+    await tick();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not reload on present → present or present → absent", async () => {
+    setupPlatformAssistantsSync();
+
+    transition("present");
+    await tick();
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+
+    transition("present");
+    transition("absent");
+    await tick();
+
+    expect(listAssistantsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not reload on transitions that never reach present", async () => {
+    setupPlatformAssistantsSync();
+
+    transition("absent");
+    transition("unknown");
+    await tick();
+
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+  });
+
+  test("unsubscribing stops further reloads", async () => {
+    const cleanup = setupPlatformAssistantsSync();
+    cleanup();
+
+    transition("present");
+    await tick();
+
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("reloadPlatformAssistants", () => {
+  test("early-returns in local mode without touching the resolved store", async () => {
+    mockIsLocalMode = true;
+
+    await reloadPlatformAssistants();
+
+    expect(fetchOrganizationsMock).not.toHaveBeenCalled();
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+    expect(setFromApiMock).not.toHaveBeenCalled();
+    expect(markHydratedMock).not.toHaveBeenCalled();
+  });
+
+  test("early-returns in remote-gateway mode", async () => {
+    mockIsRemoteGatewayMode = true;
+
+    await reloadPlatformAssistants();
+
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+    expect(setFromApiMock).not.toHaveBeenCalled();
+    expect(markHydratedMock).not.toHaveBeenCalled();
+  });
+
+  test("early-returns when gateway auth is enabled", async () => {
+    mockIsGatewayAuthEnabled = true;
+
+    await reloadPlatformAssistants();
+
+    expect(listAssistantsMock).not.toHaveBeenCalled();
+    expect(setFromApiMock).not.toHaveBeenCalled();
+    expect(markHydratedMock).not.toHaveBeenCalled();
+  });
+
+  test("populates the resolved store from a successful listAssistants", async () => {
+    const data = [
+      { id: "a1", name: "One", is_local: false, created: "2026-01-01T00:00:00Z" },
+    ];
+    mockListAssistantsResult = { ok: true, status: 200, data };
+
+    await reloadPlatformAssistants();
+
+    expect(fetchOrganizationsMock).toHaveBeenCalledTimes(1);
+    expect(setFromApiMock).toHaveBeenCalledWith(data);
+    expect(markHydratedMock).not.toHaveBeenCalled();
+  });
+
+  test("marks the list hydrated when listAssistants returns a failure", async () => {
+    mockListAssistantsResult = { ok: false, status: 500, error: {} };
+
+    await reloadPlatformAssistants();
+
+    expect(markHydratedMock).toHaveBeenCalledTimes(1);
+    expect(setFromApiMock).not.toHaveBeenCalled();
+  });
+
+  test("marks the list hydrated and reports when the fetch throws", async () => {
+    mockListAssistantsError = new Error("network down");
+
+    await reloadPlatformAssistants();
+
+    expect(markHydratedMock).toHaveBeenCalledTimes(1);
+    expect(setFromApiMock).not.toHaveBeenCalled();
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ context: "reloadPlatformAssistants" }),
+    );
+  });
+});

--- a/clients/web/src/assistant/platform-assistants-sync.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.ts
@@ -1,0 +1,71 @@
+/**
+ * Platform assistants sync.
+ *
+ * Loads the platform assistants list into the resolved-assistants store as a
+ * reaction to the platform session becoming present, rather than baking the
+ * load into a single session action. Every path that confirms a platform
+ * session — cold `initSession`, the OAuth provider callback's `refreshSession`,
+ * app-resume revalidation — flips `platformSession` to `"present"`, so one
+ * subscription repopulates the list on all of them. This is the fix for the
+ * re-login case (ATL-1100): after logout and a fresh sign-in the provider
+ * callback's refresh repopulates the list, so an established user is no longer
+ * routed into create-an-assistant onboarding.
+ *
+ * Pure platform/cloud only. Local mode drives the resolved store from the
+ * lockfile subscription (see resolved-assistants-store.ts), and the gateway /
+ * remote-gateway modes have no platform assistants list, so the load
+ * early-returns in those modes and never overwrites the lockfile-driven list.
+ */
+import { listAssistants } from "@/assistant/api";
+import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
+import { isLocalMode, isRemoteGatewayMode } from "@/lib/local-mode";
+import { captureError } from "@/lib/sentry/capture-error";
+import { useAuthStore } from "@/stores/auth-store";
+import { useOrganizationStore } from "@/stores/organization-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+/**
+ * Load the platform assistants list into the resolved-assistants store.
+ *
+ * No-ops outside pure platform/cloud mode: local mode's list is lockfile-driven
+ * and the gateway modes have none, so writing the resolved store there would
+ * clobber correct state. On failure it still marks the list hydrated so the
+ * route guard's hydration wait can't stall navigation forever.
+ */
+export async function reloadPlatformAssistants(): Promise<void> {
+  if (isLocalMode() || isRemoteGatewayMode() || isGatewayAuthEnabled()) {
+    return;
+  }
+  try {
+    await useOrganizationStore.getState().fetchOrganizations();
+    const apiAssistants = await listAssistants();
+    if (apiAssistants.ok) {
+      useResolvedAssistantsStore.getState().setFromApi(apiAssistants.data);
+    } else {
+      useResolvedAssistantsStore.getState().markHydrated();
+    }
+  } catch (err) {
+    captureError(err, {
+      context: "reloadPlatformAssistants",
+      bestEffort: true,
+    });
+    useResolvedAssistantsStore.getState().markHydrated();
+  }
+}
+
+/**
+ * Subscribe to the auth store and reload the platform assistants list whenever
+ * the platform session transitions to `"present"`. Register once at startup,
+ * before `initSession`, so the boot `unknown → present` transition is caught.
+ * Returns an unsubscribe cleanup.
+ */
+export function setupPlatformAssistantsSync(): () => void {
+  return useAuthStore.subscribe((state, prevState) => {
+    if (
+      prevState.platformSession !== "present" &&
+      state.platformSession === "present"
+    ) {
+      void reloadPlatformAssistants();
+    }
+  });
+}

--- a/clients/web/src/assistant/platform-assistants-sync.ts
+++ b/clients/web/src/assistant/platform-assistants-sync.ts
@@ -2,14 +2,10 @@
  * Platform assistants sync.
  *
  * Loads the platform assistants list into the resolved-assistants store as a
- * reaction to the platform session becoming present, rather than baking the
- * load into a single session action. Every path that confirms a platform
- * session — cold `initSession`, the OAuth provider callback's `refreshSession`,
- * app-resume revalidation — flips `platformSession` to `"present"`, so one
- * subscription repopulates the list on all of them. This is the fix for the
- * re-login case (ATL-1100): after logout and a fresh sign-in the provider
- * callback's refresh repopulates the list, so an established user is no longer
- * routed into create-an-assistant onboarding.
+ * reaction to the platform session becoming present. `initSession`,
+ * `refreshSession`, and app-resume revalidation all flip `platformSession` to
+ * `"present"` when they confirm a session, so one subscription repopulates the
+ * list on every path.
  *
  * Pure platform/cloud only. Local mode drives the resolved store from the
  * lockfile subscription (see resolved-assistants-store.ts), and the gateway /
@@ -24,21 +20,44 @@ import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
+// Monotonic id stamped on each reload. The load is fire-and-forget and awaits
+// two network hops, so a logout or account switch can land while it's in
+// flight; only the newest reload for the still-present same-user session is
+// allowed to write the resolved store, mirroring the auth store's own
+// `latestPlatformProbe` guard.
+let latestReload = 0;
+
 /**
  * Load the platform assistants list into the resolved-assistants store.
  *
  * No-ops outside pure platform/cloud mode: local mode's list is lockfile-driven
  * and the gateway modes have none, so writing the resolved store there would
- * clobber correct state. On failure it still marks the list hydrated so the
- * route guard's hydration wait can't stall navigation forever.
+ * clobber correct state. On failure it marks the list hydrated so the route
+ * guard's hydration wait can't stall navigation forever.
+ *
+ * Every write to the resolved store is gated on the reload still being current:
+ * the same session (`platformSession` still `"present"`, same `user.id`) and
+ * not superseded by a newer reload. A stale reload writes nothing — a
+ * signed-out session's route guard doesn't wait on `assistantsHydrated`, so
+ * skipping the write there is correct.
  */
 export async function reloadPlatformAssistants(): Promise<void> {
   if (isLocalMode() || isRemoteGatewayMode() || isGatewayAuthEnabled()) {
     return;
   }
+  const gen = ++latestReload;
+  const startUserId = useAuthStore.getState().user?.id ?? null;
+  const isStale = (): boolean =>
+    gen !== latestReload ||
+    useAuthStore.getState().platformSession !== "present" ||
+    (useAuthStore.getState().user?.id ?? null) !== startUserId;
+
   try {
     await useOrganizationStore.getState().fetchOrganizations();
     const apiAssistants = await listAssistants();
+    if (isStale()) {
+      return;
+    }
     if (apiAssistants.ok) {
       useResolvedAssistantsStore.getState().setFromApi(apiAssistants.data);
     } else {
@@ -49,6 +68,9 @@ export async function reloadPlatformAssistants(): Promise<void> {
       context: "reloadPlatformAssistants",
       bestEffort: true,
     });
+    if (isStale()) {
+      return;
+    }
     useResolvedAssistantsStore.getState().markHydrated();
   }
 }

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -16,6 +16,7 @@ import { isLocalMode, loadLockfile } from "@/lib/local-mode";
 import { initSentry } from "@/lib/sentry/sentry-init";
 import { installTranslateDomGuard } from "@/lib/translate-dom-guard";
 import { initSessionReplay } from "@/lib/session-replay/session-replay-init";
+import { setupPlatformAssistantsSync } from "@/assistant/platform-assistants-sync";
 import { setupAuthListeners, useAuthStore } from "@/stores/auth-store";
 import { setupOrganizationStore } from "@/stores/organization-store";
 import { router } from "./routes";
@@ -38,6 +39,9 @@ async function boot() {
   installConsentRefreshListeners();
 
   setupOrganizationStore();
+  // Register before initSession so the boot `unknown → present` transition it
+  // drives is caught and the platform assistants list is loaded.
+  setupPlatformAssistantsSync();
   if (isLocalMode()) {
     await loadLockfile();
     await useAuthStore.getState().initSession();

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -276,9 +276,10 @@ mock.module("@/lib/auth/session-cleanup", () => ({
   clearUserScopedStorage: clearUserScopedStorageMock,
 }));
 
-// Use the REAL resolved-assistants store: the auth-store init path calls its
-// `.getState().setFromApi(...)`, which a plain stub can't provide. It's
-// dependency-light, so loading it for real is cheap.
+// Use the REAL resolved-assistants store: it's dependency-light, so loading it
+// for real is cheap, and the `beforeEach` resets it between tests. (The list is
+// now loaded by the platform-assistants-sync subscription, not the auth store —
+// see platform-assistants-sync.test.ts for that coverage.)
 
 // Auth-store writes the selection through the public wrapper, not the store
 // action — mock the wrapper module so the real one (and its local-mode deps)
@@ -1338,18 +1339,6 @@ describe("auth store onboarding flag reconciliation", () => {
     sessionUser = null;
     await useAuthStore.getState().initSession();
     expect(setConsentHydratedMock).toHaveBeenCalledWith(true);
-  });
-
-  test("initSession marks the assistants list hydrated even when the platform fetch fails", async () => {
-    sessionUser = { id: "user-1", email: "user@example.com" };
-    useResolvedAssistantsStore.setState({ assistantsHydrated: false });
-    listAssistantsMock.mockImplementationOnce(async () => {
-      throw new Error("Network error");
-    });
-
-    await useAuthStore.getState().initSession();
-
-    expect(useResolvedAssistantsStore.getState().assistantsHydrated).toBe(true);
   });
 
   test("initSession falls back to device keys when fetchConsent fails", async () => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -54,7 +54,6 @@ import {
 } from "@/lib/local-mode";
 import { bootstrapLocalAssistantPlatformIdentity } from "@/lib/local-platform-identity";
 import { listAssistants } from "@/assistant/api";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
 import { unregisterFromRemotePush } from "@/runtime/push-registration";
 import {
@@ -816,22 +815,9 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
         await syncUserScopedState(user?.id ?? null);
-        try {
-          await useOrganizationStore.getState().fetchOrganizations();
-          const apiAssistants = await listAssistants();
-          if (apiAssistants.ok) {
-            useResolvedAssistantsStore
-              .getState()
-              .setFromApi(apiAssistants.data);
-          } else {
-            useResolvedAssistantsStore.getState().markHydrated();
-          }
-        } catch {
-          // Best effort — but the route guard gates on hydration, so a failed
-          // fetch must still mark the list settled or navigation would stall
-          // against its hydration timeout on every route change.
-          useResolvedAssistantsStore.getState().markHydrated();
-        }
+        // The resolved assistants list is loaded by the platform-session
+        // subscription (setupPlatformAssistantsSync), which fires when the
+        // transition below flips `platformSession` to "present".
         set(authenticatedPlatformUser(user));
         return;
       }
@@ -859,21 +845,9 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
           if (retryResult.ok && retryResult.data.user) {
             const user = toAuthUser(retryResult.data.user);
             await syncUserScopedState(user?.id ?? null);
-            try {
-              await useOrganizationStore.getState().fetchOrganizations();
-              const apiAssistants = await listAssistants();
-              if (apiAssistants.ok) {
-                useResolvedAssistantsStore
-                  .getState()
-                  .setFromApi(apiAssistants.data);
-              } else {
-                useResolvedAssistantsStore.getState().markHydrated();
-              }
-            } catch {
-              // Best effort — a failed fetch still marks the list settled so
-              // the route guard's hydration wait can't stall navigation.
-              useResolvedAssistantsStore.getState().markHydrated();
-            }
+            // The resolved assistants list loads via the platform-session
+            // subscription (setupPlatformAssistantsSync) when the transition
+            // below flips `platformSession` to "present".
             set(authenticatedPlatformUser(user));
             return;
           }

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -12,8 +12,9 @@
  * Population:
  *  - Local mode: assistant list auto-syncs with the lockfile store via
  *    subscription, so every hatch / sync / retire is reflected.
- *  - Platform mode: populated from the `listAssistants` API during
- *    `initSession` in the auth store.
+ *  - Platform mode: populated from the `listAssistants` API by
+ *    `reloadPlatformAssistants` (assistant/platform-assistants-sync.ts),
+ *    which runs whenever the platform session becomes present.
  *
  * Do NOT confuse with `lockfile-store.ts`, which is the raw on-disk
  * lockfile cache used internally by `lib/local-mode.ts` for host IPC.


### PR DESCRIPTION
The platform assistants list now reloads as a reaction to the platform session becoming present, rather than being baked into `initSession`. Every path that confirms a session — cold boot, the OAuth provider callback's `refreshSession`, app-resume revalidation — flips `platformSession` to "present", and a single subscription repopulates the resolved-assistants store on all of them. This fixes the re-login case where an established user was sent to create-an-assistant onboarding: the callback's refresh now repopulates the list, so the route guard no longer reads an empty list as a brand-new user. Local mode is untouched (its list stays lockfile-driven).

Refs ATL-1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)