### PR TITLE
feat(cli): include plugin name in `assistant ps` origin

### DIFF
--- a/assistant/src/cli/commands/__tests__/ps.test.ts
+++ b/assistant/src/cli/commands/__tests__/ps.test.ts
@@ -144,7 +144,11 @@ describe("ps command — tree rendering", () => {
             origin: "workspace",
             children: [
               { name: "qdrant", status: "running", origin: "workspace" },
-              { name: "memory-worker", status: "running", origin: "plugin" },
+              {
+                name: "memory-worker",
+                status: "running",
+                origin: "plugin:default-memory",
+              },
             ],
           },
         ],
@@ -164,7 +168,8 @@ describe("ps command — tree rendering", () => {
     expect(qdrant).toMatch(/^ {2}qdrant/);
     expect(root).toContain("workspace");
     expect(qdrant).toContain("workspace");
-    expect(worker).toContain("plugin");
+    // The plugin's name is shown alongside the plugin tag.
+    expect(worker).toContain("plugin:default-memory");
 
     // The status label is gone — no [running] anywhere.
     expect(logLines.join("\n")).not.toContain("[running]");
@@ -188,7 +193,7 @@ describe("ps command — tree rendering", () => {
                   {
                     name: "deeply-nested-child",
                     status: "running",
-                    origin: "plugin",
+                    origin: "plugin:cognee",
                   },
                 ],
               },

--- a/assistant/src/cli/commands/ps.help.ts
+++ b/assistant/src/cli/commands/ps.help.ts
@@ -18,8 +18,10 @@ worker (when the daemon owns it), MCP servers, and any other live children.
 The tree is built from the native process table (/proc on Linux, ps on
 macOS), so it reflects what is actually running, not a fixed subsystem list.
 
-Each node shows whether it was spawned from a plugin or from the workspace,
-plus its PID. Every listed process is live by definition.
+Each node shows its origin — 'workspace' for the daemon and its subsystems,
+or 'plugin:<name>' for a process spawned from a plugin (e.g.
+'plugin:default-memory', 'plugin:cognee') — plus its PID. Every listed
+process is live by definition.
 
 Examples:
   $ assistant ps

--- a/assistant/src/cli/commands/ps.ts
+++ b/assistant/src/cli/commands/ps.ts
@@ -19,7 +19,8 @@ import { psHelp } from "./ps.help.js";
 interface ProcessEntry {
   name: string;
   status: "running" | "not_running" | "unreachable";
-  origin: "plugin" | "workspace";
+  /** `workspace`, or `plugin:<name>` when spawned from a plugin. */
+  origin: "workspace" | `plugin:${string}`;
   children?: ProcessEntry[];
   info?: string;
 }

--- a/assistant/src/runtime/routes/__tests__/ps-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/ps-routes.test.ts
@@ -35,7 +35,7 @@ mock.module("../../../util/process-tree.js", () => ({
         pid: 300,
         name: "memory-worker",
         command: "bun run /app/plugins/defaults/memory/worker.ts",
-        origin: "plugin",
+        origin: "plugin:default-memory",
         children: [
           {
             pid: 400,
@@ -114,7 +114,7 @@ describe("ps route handler", () => {
     walk(root as never);
 
     expect(byName.get("qdrant")).toBe("workspace");
-    expect(byName.get("memory-worker")).toBe("plugin");
+    expect(byName.get("memory-worker")).toBe("plugin:default-memory");
     expect(byName.get("embed-helper")).toBe("workspace");
   });
 

--- a/assistant/src/runtime/routes/ps-routes.ts
+++ b/assistant/src/runtime/routes/ps-routes.ts
@@ -24,23 +24,31 @@ const log = getLogger("ps-routes");
 
 type ProcessStatus = "running" | "not_running" | "unreachable";
 
-type ProcessOrigin = "plugin" | "workspace";
+/**
+ * `workspace` for the daemon and its subsystems; `plugin:<name>` for a
+ * process spawned from a plugin (e.g. `plugin:default-memory`, `plugin:cognee`).
+ */
+type ProcessOrigin = "workspace" | `plugin:${string}`;
 
 interface ProcessEntry {
   name: string;
   status: ProcessStatus;
-  /** Whether the process was spawned from a plugin or from the workspace. */
+  /** `workspace`, or `plugin:<name>` when spawned from a plugin. */
   origin: ProcessOrigin;
   children?: ProcessEntry[];
   info?: string;
 }
+
+const processOriginSchema = z
+  .string()
+  .regex(/^(workspace|plugin:.+)$/) as z.ZodType<ProcessOrigin>;
 
 const processEntrySchema: z.ZodType<ProcessEntry> = z
   .lazy(() =>
     z.object({
       name: z.string(),
       status: z.enum(["running", "not_running", "unreachable"]),
-      origin: z.enum(["plugin", "workspace"]),
+      origin: processOriginSchema,
       children: z.array(processEntrySchema).optional(),
       info: z.string().optional(),
     }),

--- a/assistant/src/util/__tests__/process-tree.test.ts
+++ b/assistant/src/util/__tests__/process-tree.test.ts
@@ -59,16 +59,18 @@ describe("deriveName", () => {
 });
 
 describe("deriveOrigin", () => {
-  test("classifies commands running plugin-owned code as plugin", () => {
+  test("tags a user plugin with its name", () => {
     expect(
       deriveOrigin(
-        "bun --smol run /home/u/.vellum/workspace/plugins/foo/server.ts",
+        "bun --smol run /home/u/.vellum/workspace/plugins/cognee/server.ts",
       ),
-    ).toBe("plugin");
-    // Bundled default plugins live under a plugins/ dir too.
+    ).toBe("plugin:cognee");
+  });
+
+  test("tags a bundled default plugin as default-<name>", () => {
     expect(
       deriveOrigin("bun --smol run /app/src/plugins/defaults/memory/worker.ts"),
-    ).toBe("plugin");
+    ).toBe("plugin:default-memory");
   });
 
   test("classifies the daemon and workspace subsystems as workspace", () => {
@@ -103,7 +105,7 @@ describe("buildProcessTree", () => {
       pid: 300,
       ppid: 100,
       command: "bun run /app/jobs/worker.ts",
-      origin: "plugin",
+      origin: "plugin:default-memory",
     },
     {
       pid: 400,
@@ -135,7 +137,9 @@ describe("buildProcessTree", () => {
     const tree = buildProcessTree(procs, 100);
     expect(tree.origin).toBe("workspace");
     expect(tree.children.find((c) => c.pid === 200)!.origin).toBe("workspace");
-    expect(tree.children.find((c) => c.pid === 300)!.origin).toBe("plugin");
+    expect(tree.children.find((c) => c.pid === 300)!.origin).toBe(
+      "plugin:default-memory",
+    );
   });
 
   test("synthesizes a workspace origin when the root PID is absent", () => {

--- a/assistant/src/util/process-tree.ts
+++ b/assistant/src/util/process-tree.ts
@@ -16,11 +16,14 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 /**
- * Whether a process runs plugin-owned code (`plugin`) or is the daemon itself
- * / one of its workspace subsystems (`workspace`). Classified at collection
- * time from the raw command line via {@link deriveOrigin}.
+ * Whether a process runs plugin-owned code or is the daemon itself / one of its
+ * workspace subsystems. Classified at collection time from the raw command line
+ * via {@link deriveOrigin}. Plugin processes carry their plugin identity as
+ * `plugin:<name>` — bundled defaults read as `plugin:default-<name>` (e.g.
+ * `plugin:default-memory`), user plugins as `plugin:<name>` (e.g.
+ * `plugin:cognee`).
  */
-export type ProcessOrigin = "plugin" | "workspace";
+export type ProcessOrigin = "workspace" | `plugin:${string}`;
 
 export interface ProcInfo {
   pid: number;
@@ -113,25 +116,38 @@ export function deriveName(command: string): string {
 }
 
 /**
- * Marks a command whose executable/script path lives under a `plugins/<name>/`
- * directory. Matches both user plugins (`<workspaceDir>/plugins/<name>/`) and
- * bundled defaults (`.../plugins/defaults/<name>/`). The `plugins-data/` state
- * directory is deliberately not matched — the trailing slash after `plugins`
- * excludes it.
+ * Captures the plugin path segment(s) from a command whose executable/script
+ * path lives under a `plugins/<name>/` directory. Group 1 is the first segment
+ * after `plugins/`; group 2 is the next segment (present for bundled defaults,
+ * where the layout is `plugins/defaults/<name>/`). Matches both user plugins
+ * (`<workspaceDir>/plugins/<name>/`) and bundled defaults
+ * (`.../plugins/defaults/<name>/`). The `plugins-data/` state directory is
+ * deliberately not matched — the slash after `plugins` excludes it.
  */
-const PLUGIN_PATH_RE = /(?:^|\/)plugins\/[^/\s]+/;
+const PLUGIN_PATH_RE = /(?:^|\/)plugins\/([^/\s]+)(?:\/([^/\s]+))?/;
 
 /**
- * Classify whether a raw command line belongs to plugin-owned code. A process
- * spawned from a plugin runs an entry script that lives under a
- * `plugins/<name>/` directory (e.g. the memory worker at
- * `…/plugins/defaults/memory/worker.ts`); the daemon itself and its workspace
- * subsystems (qdrant, the embed worker, the resource monitor) do not. This is
- * a best-effort heuristic on the command path — a plugin that shells out to a
- * bare binary with no plugin path in its argv reads as `workspace`.
+ * Classify whether a raw command line belongs to plugin-owned code, and if so
+ * which plugin. A process spawned from a plugin runs an entry script that lives
+ * under a `plugins/<name>/` directory; the daemon itself and its workspace
+ * subsystems (qdrant, the embed worker, the resource monitor) do not.
+ *
+ * Plugin identity is folded into the origin:
+ *   - bundled defaults at `…/plugins/defaults/memory/worker.ts` → `plugin:default-memory`
+ *   - user plugins at `…/plugins/cognee/server.ts`             → `plugin:cognee`
+ *
+ * This is a best-effort heuristic on the command path — a plugin that shells
+ * out to a bare binary with no plugin path in its argv reads as `workspace`.
  */
 export function deriveOrigin(command: string): ProcessOrigin {
-  return PLUGIN_PATH_RE.test(command) ? "plugin" : "workspace";
+  const m = PLUGIN_PATH_RE.exec(command);
+  if (!m) {
+    return "workspace";
+  }
+  const [, first, second] = m;
+  // Bundled defaults nest the plugin name one level deeper under `defaults/`.
+  const name = first === "defaults" && second ? `default-${second}` : first;
+  return `plugin:${name}`;
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

> fix the spec and include the name of the plugin like `plugin:default-memory` or `plugin:cognee`

Follow-up to #38524 (merged). That PR classified each process in the daemon's tree as `plugin` or `workspace`; this PR carries the plugin's *identity* in the origin instead of a bare flag.

**Change:** `deriveOrigin` (`util/process-tree.ts`) now captures the plugin path segment and returns `plugin:<name>`:
- bundled defaults at `…/plugins/defaults/memory/worker.ts` → `plugin:default-memory`
- user plugins at `…/plugins/cognee/server.ts` → `plugin:cognee`
- everything else (the daemon, qdrant, the embed worker, the resource monitor) → `workspace`, unchanged

The origin type widens from the two-value enum to `` "workspace" | `plugin:${string}` `` across the process-tree util, the `ps` route (a regex-validated string schema `^(workspace|plugin:.+)$` replacing `z.enum`), and the CLI. The renderer already prints the origin verbatim, so the plugin name shows in the column with no render change:

```
assistant           workspace           pid 100
  qdrant            workspace           pid 200
  memory-worker     plugin:default-memory  pid 300
  cognee-server     plugin:cognee       pid 400
```

The `plugins-data/` state directory is still excluded (it's not code). This remains a best-effort heuristic on the command path — a plugin that shells out to a bare binary with no plugin path in its argv reads as `workspace`.

## Test plan

- Unit tests updated/passing (31 across the three affected files):
  - `util/__tests__/process-tree.test.ts` — `deriveOrigin` returns `plugin:cognee` for a user plugin and `plugin:default-memory` for a bundled default; workspace + `plugins-data/` exclusion cases retained; origin propagation through `buildProcessTree`.
  - `runtime/__tests__/ps-routes.test.ts` — `plugin:default-memory` carried onto the wire.
  - `cli/commands/__tests__/ps.test.ts` — plugin name rendered in the column; column alignment preserved.
- `tsgo --noEmit`: 0 errors. Prettier + eslint clean (only a pre-existing warning on an untouched line).

## CLI verb checklist

No new IPC route — extends the existing `ps` route's `origin` field shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qkdA2ovTYVRDPMc6TQ4UV

---
_Generated by [Claude Code](https://claude.ai/code/session_015qkdA2ovTYVRDPMc6TQ4UV)_