### PR TITLE
fix(gateway): forward the TTS voice model through the speech relay

### DIFF
--- a/gateway/src/__tests__/speech-relay-websocket.test.ts
+++ b/gateway/src/__tests__/speech-relay-websocket.test.ts
@@ -244,6 +244,26 @@ describe("createSpeechRelayUpgradeHandler — gate", () => {
     );
   });
 
+  test("forwards the tts voice model to velay", async () => {
+    // Regression: the daemon sends the selected managed voice as `model`;
+    // a gateway that rejects it silently breaks voice selection (the
+    // daemon's synthesis fails before velay ever sees the session).
+    const server = makeFakeServer();
+    const handler = createSpeechRelayUpgradeHandler(makeConfig(), "tts", {
+      credentials: makeCredentials("vk-1"),
+    });
+    const req = new Request(
+      `http://127.0.0.1:7830/v1/speech/tts/stream?key=${TOKEN}&encoding=linear16&sample_rate=16000&container=none&model=cjVigY5qzO86Huf0OWal`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    expect(await handler(req, server)).toBeUndefined();
+    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
+    const upstream = new URL(data.data.upstreamWsUrl);
+    expect(upstream.searchParams.get("model")).toBe("cjVigY5qzO86Huf0OWal");
+  });
+
   test("rejects a missing token", async () => {
     const handler = createSpeechRelayUpgradeHandler(makeConfig(), "stt", {
       credentials: makeCredentials("vk-1"),

--- a/gateway/src/http/routes/speech-relay-websocket.ts
+++ b/gateway/src/http/routes/speech-relay-websocket.ts
@@ -74,7 +74,10 @@ const ALLOWED_PARAMS: Record<SpeechRelayOperation, ReadonlySet<string>> = {
     "vad_events",
     "punctuate",
   ]),
-  tts: new Set(["encoding", "sample_rate", "container"]),
+  // `model` is the client-selected TTS voice; velay only dials it after
+  // Django's rate-card guard prices and echoes that exact model, so
+  // forwarding it does not widen what the assistant API key can spend on.
+  tts: new Set(["encoding", "sample_rate", "container", "model"]),
 };
 
 type WebSocketConstructorWithHeaders = new (


### PR DESCRIPTION
## Summary

- Adds `model` to the gateway speech relay's TTS param allowlist (`ALLOWED_PARAMS.tts`), with a regression test asserting the voice id is forwarded to velay. STT still rejects `model` — its model is pinned server-side.
- **Root cause of managed voice selection being silently broken end-to-end**: the daemon sends the selected voice as `?model=` (voice-selection series) and velay+Django validate/price it, but the gateway — the policy boundary between daemon and velay — kept its pre-voice-selection allowlist and rejected the websocket upgrade with `400 unsupported query parameter: model` before velay ever saw the session. The daemon's diagnostic probe carries the same param, so it hit the same 400, and live voice degraded to text-only with `ttsFirstAudioMs: null` and zero platform-side traces. Every explicit voice (Deepgram or ElevenLabs) was affected; only the no-param default synthesized.
- Security note: forwarding `model` does not widen what the stored assistant API key can spend — velay dials a voice only after Django's rate-card guard prices and echoes that exact model (fail-closed otherwise).

## Debugging trail

Reproduced live on nonprod (assistant `019f5e70…`, warm-pool pod): daemon logged "Starting managed streaming TTS synthesis" per turn, gateway showed no TTS relay connection, velay/Django showed nothing. The gateway container's `ALLOWED_PARAMS.tts` lacked `model` at current HEAD — the prior test even used `model` as its example of a rejected param (kept, but on STT where it remains correct).

Found while verifying the ElevenLabs managed-TTS rollout (vellum-assistant-platform#9275/#9288/#9291, #38511): selecting Eric produced text-only responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RixYT2EcehgsxSCqvjJD9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->