### PR TITLE
feat(telemetry): memoryTier(config) helper (off/v1/v2/v3)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33662,6 +33662,11 @@ components:
             - running
             - not_running
             - unreachable
+        origin:
+          type: string
+          enum:
+            - plugin
+            - workspace
         children:
           type: array
           items:
@@ -33671,6 +33676,7 @@ components:
       required:
         - name
         - status
+        - origin
       additionalProperties: false
     AuthOutput:
       oneOf:

--- a/assistant/src/config/memory-tier.test.ts
+++ b/assistant/src/config/memory-tier.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { memoryTier } from "./memory-tier.js";
+import type { AssistantConfig } from "./schema.js";
+
+describe("memoryTier", () => {
+  test("off when memory is explicitly disabled", () => {
+    const config = { memory: { enabled: false } } as AssistantConfig;
+    expect(memoryTier(config)).toBe("off");
+  });
+
+  test("off wins even when v3 is live (OFF over v3 precedence)", () => {
+    const config = {
+      memory: { enabled: false, v3: { live: true } },
+    } as AssistantConfig;
+    expect(memoryTier(config)).toBe("off");
+  });
+
+  test("v3 when memory-v3 is live", () => {
+    const config = { memory: { v3: { live: true } } } as AssistantConfig;
+    expect(memoryTier(config)).toBe("v3");
+  });
+
+  test("v2 when v2 is enabled and v3 is not live", () => {
+    const config = {
+      memory: { v2: { enabled: true }, v3: { live: false } },
+    } as AssistantConfig;
+    expect(memoryTier(config)).toBe("v2");
+  });
+
+  test("v3 wins over v2 when both are truthy (v3 over v2 precedence)", () => {
+    const config = {
+      memory: { v2: { enabled: true }, v3: { live: true } },
+    } as AssistantConfig;
+    expect(memoryTier(config)).toBe("v3");
+  });
+
+  test("v1 when memory is on but neither v2 nor v3 is selected", () => {
+    const config = {
+      memory: { enabled: true, v2: { enabled: false }, v3: { live: false } },
+    } as AssistantConfig;
+    expect(memoryTier(config)).toBe("v1");
+  });
+});

--- a/assistant/src/config/memory-tier.ts
+++ b/assistant/src/config/memory-tier.ts
@@ -1,0 +1,31 @@
+import { isMemoryV3Live } from "./memory-v3-gate.js";
+import type { AssistantConfig } from "./schema.js";
+
+export type MemoryTier = "off" | "v1" | "v2" | "v3";
+
+/**
+ * Derive the coarse memory tier for an assistant, as a single bucket for
+ * telemetry. Precedence mirrors the runtime memory-source semantics:
+ *
+ * - `"off"` wins over everything: an explicit `memory.enabled === false`
+ *   disables the whole memory system regardless of v2/v3 settings.
+ * - `"v3"` wins over `"v2"`: when memory-v3 is live it suppresses v2 injection
+ *   (see {@link isMemoryV3Live}).
+ * - `"v2"` when v2 is explicitly enabled and v3 is not live.
+ * - `"v1"` otherwise (memory on, neither v2 nor v3 selected).
+ *
+ * Optional chaining is defensive — a partial config (e.g. a mocked config in
+ * tests) resolves to the correct bucket rather than throwing.
+ */
+export function memoryTier(config: AssistantConfig): MemoryTier {
+  if (config.memory?.enabled === false) {
+    return "off";
+  }
+  if (isMemoryV3Live(config)) {
+    return "v3";
+  }
+  if (config.memory?.v2?.enabled === true) {
+    return "v2";
+  }
+  return "v1";
+}


### PR DESCRIPTION
## Summary
- Pure memoryTier(config) helper deriving off/v1/v2/v3 with OFF>v3>v2>v1 precedence
- Unit test covers all buckets + precedence

Part of plan: memory-tier-telemetry.md (PR 1 of 2)