### PR TITLE
chore(assistant): regenerate the OpenAPI spec for ProcessEntry.origin

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33662,6 +33662,11 @@ components:
             - running
             - not_running
             - unreachable
+        origin:
+          type: string
+          enum:
+            - plugin
+            - workspace
         children:
           type: array
           items:
@@ -33671,6 +33676,7 @@ components:
       required:
         - name
         - status
+        - origin
       additionalProperties: false
     AuthOutput:
       oneOf:


### PR DESCRIPTION
## Summary

- Regenerates `assistant/openapi.yaml` to include `ProcessEntry.origin` (`plugin | workspace`), which a merged change added to the schema without regenerating the committed spec. The **OpenAPI Spec Check currently fails on every open PR** (verified on #38529/#38530/#38531) — this unblocks them all. Six added lines, produced by `bun run generate:openapi`; `--check` passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RixYT2EcehgsxSCqvjJD9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->