### PR TITLE
feat(web): reopen pro onboarding from billing when setup was abandoned

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * BillingTab pro-onboarding re-entry wiring.
+ *
+ * `?pro_onboarding` reopens the post-checkout onboarding wizard without a
+ * Stripe `session_id`, and the "Finish Pro setup" nudge renders only for a
+ * Pro subscription whose domain setup is still available.
+ *
+ * Strategy mirrors plans-page-checkout.test.tsx: mock the generated SDK with
+ * mutable responses, force the platform-hosted gate open, and stub the heavy
+ * billing children so the page wiring under test is the only moving part. The
+ * onboarding modal stub reports its `open` prop via a data attribute.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, useLocation } from "react-router";
+
+import {
+    organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
+    organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import * as sdkGen from "@/generated/api/sdk.gen";
+import type {
+    OnboardingStateResponse,
+    SubscriptionResponse,
+} from "@/generated/api/types.gen";
+import * as platformGate from "@/hooks/use-platform-gate";
+import * as authStore from "@/stores/auth-store";
+
+let subscriptionResponse: SubscriptionResponse;
+let onboardingResponse: OnboardingStateResponse;
+let onboardingCalls = 0;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+    ...sdkGen,
+    organizationsBillingSubscriptionRetrieve: () =>
+        Promise.resolve({ data: subscriptionResponse, response: { ok: true } }),
+    organizationsBillingSubscriptionOnboardingRetrieve: () => {
+        onboardingCalls += 1;
+        return Promise.resolve({
+            data: onboardingResponse,
+            response: { ok: true },
+        });
+    },
+}));
+
+// Force the platform-hosted gate open so BillingTab mounts its plan-management
+// body instead of the login notice / unavailable states.
+mock.module("@/hooks/use-platform-gate", () => ({
+    ...platformGate,
+    usePlatformGate: () => "full",
+    useActiveAssistantIsPlatformHosted: () => true,
+    useActiveAssistantLifecycleIsLoading: () => false,
+}));
+
+mock.module("@/stores/auth-store", () => ({
+    ...authStore,
+    useIsPlatformSessionSettled: () => true,
+}));
+
+mock.module(
+    "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal",
+    () => ({
+        BillingOnboardingModal: ({ open }: { open: boolean }) => (
+            <div
+                data-testid="onboarding-modal"
+                data-open={open ? "true" : "false"}
+            />
+        ),
+    }),
+);
+mock.module("@/domains/settings/billing/usage/usage-tab", () => ({
+    UsageTab: () => null,
+}));
+mock.module("@/domains/settings/components/adjust-plan-modal", () => ({
+    AdjustPlanModal: () => null,
+}));
+mock.module("@/domains/settings/components/billing-panel", () => ({
+    BillingPanel: () => null,
+}));
+mock.module(
+    "@/domains/settings/components/billing-portal-return-handler",
+    () => ({ BillingPortalReturnHandler: () => null }),
+);
+mock.module(
+    "@/domains/settings/components/billing-usage/billing-usage-panel",
+    () => ({ BillingUsagePanel: () => null }),
+);
+mock.module("@/domains/settings/components/grace-period-banner", () => ({
+    GracePeriodBanner: () => null,
+}));
+mock.module("@/domains/settings/components/invoices-table", () => ({
+    InvoicesTable: () => null,
+}));
+mock.module("@/domains/settings/components/plan-card", () => ({
+    PlanCard: () => null,
+}));
+mock.module("@/domains/settings/components/referral-panel", () => ({
+    ReferralPanel: () => null,
+}));
+mock.module("@/domains/settings/components/tier-upgrade-resize-modal", () => ({
+    TierUpgradeResizeModal: () => null,
+}));
+
+const { BillingPage } = await import("./billing-page");
+
+function makeSubscription(planId: "base" | "pro"): SubscriptionResponse {
+    return {
+        plan_id: planId,
+        status: "active",
+        renewal_date: null,
+        current_period_end: "2026-08-01T00:00:00Z",
+        cancel_at_period_end: false,
+        cancel_at: null,
+        entitlements: { managed_email: false, phone_number: false },
+    };
+}
+
+function makeOnboarding(domainSetupAvailable: boolean): OnboardingStateResponse {
+    return {
+        max_machine_tier: "large",
+        selected_storage_tier: "md",
+        selected_storage_gib: 50,
+        pvc_ready: true,
+        domain_setup_available: domainSetupAvailable,
+        primary_assistant_id: "assistant-1",
+    };
+}
+
+function LocationProbe() {
+    const location = useLocation();
+    return <div data-testid="loc">{location.pathname + location.search}</div>;
+}
+
+function renderPage(search = "?tab=billing") {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    const view = render(
+        <MemoryRouter initialEntries={[`/assistant/settings/usage${search}`]}>
+            <QueryClientProvider client={client}>
+                <BillingPage />
+                <LocationProbe />
+            </QueryClientProvider>
+        </MemoryRouter>,
+    );
+    return { client, ...view };
+}
+
+beforeEach(() => {
+    subscriptionResponse = makeSubscription("pro");
+    onboardingResponse = makeOnboarding(true);
+    onboardingCalls = 0;
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("BillingTab ?pro_onboarding param", () => {
+    test("opens the onboarding modal without a session_id and strips the param", async () => {
+        const { getByTestId } = renderPage("?tab=billing&pro_onboarding");
+
+        await waitFor(() =>
+            expect(
+                getByTestId("onboarding-modal").getAttribute("data-open"),
+            ).toBe("true"),
+        );
+        expect(getByTestId("loc").textContent).toBe(
+            "/assistant/settings/usage?tab=billing",
+        );
+    });
+});
+
+describe("Finish Pro setup nudge", () => {
+    test("renders for Pro with domain setup available and reopens the wizard", async () => {
+        const { getByTestId } = renderPage();
+
+        await waitFor(() =>
+            expect(getByTestId("finish-pro-setup-notice")).toBeTruthy(),
+        );
+        expect(getByTestId("onboarding-modal").getAttribute("data-open")).toBe(
+            "false",
+        );
+
+        fireEvent.click(getByTestId("finish-pro-setup-button"));
+
+        await waitFor(() =>
+            expect(
+                getByTestId("onboarding-modal").getAttribute("data-open"),
+            ).toBe("true"),
+        );
+        // The transient param is consumed straight back out of the URL.
+        expect(getByTestId("loc").textContent).toBe(
+            "/assistant/settings/usage?tab=billing",
+        );
+    });
+
+    test("hidden on the base plan, and the onboarding endpoint is never queried", async () => {
+        subscriptionResponse = makeSubscription("base");
+        const { client, queryByTestId } = renderPage();
+
+        await waitFor(() =>
+            expect(
+                client.getQueryData(
+                    organizationsBillingSubscriptionRetrieveQueryKey(),
+                ),
+            ).toBeTruthy(),
+        );
+        expect(queryByTestId("finish-pro-setup-notice")).toBeNull();
+        expect(onboardingCalls).toBe(0);
+    });
+
+    test("hidden for Pro when domain setup is unavailable", async () => {
+        onboardingResponse = makeOnboarding(false);
+        const { client, queryByTestId } = renderPage();
+
+        await waitFor(() =>
+            expect(
+                client.getQueryData(
+                    organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+                ),
+            ).toBeTruthy(),
+        );
+        expect(queryByTestId("finish-pro-setup-notice")).toBeNull();
+    });
+});

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -3,7 +3,7 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 
 import { useNavigate, useSearchParams } from "react-router";
 
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { PlatformLoginNotice } from "@/components/platform-login-notice";
@@ -19,7 +19,11 @@ import { InvoicesTable } from "@/domains/settings/components/invoices-table";
 import { PlanCard } from "@/domains/settings/components/plan-card";
 import { ReferralPanel } from "@/domains/settings/components/referral-panel";
 import { TierUpgradeResizeModal } from "@/domains/settings/components/tier-upgrade-resize-modal";
-import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import {
+    organizationsBillingSubscriptionOnboardingRetrieveOptions,
+    organizationsBillingSubscriptionRetrieveOptions,
+    organizationsBillingSummaryRetrieveOptions,
+} from "@/generated/api/@tanstack/react-query.gen";
 import {
     useActiveAssistantIsPlatformHosted,
     useActiveAssistantLifecycleIsLoading,
@@ -27,6 +31,7 @@ import {
 } from "@/hooks/use-platform-gate";
 import { useIsPlatformSessionSettled } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
+import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tabs } from "@vellumai/design-library/components/tabs";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -65,6 +70,46 @@ function BillingStatusHandler() {
     return null;
 }
 
+/**
+ * Re-entry nudge into the pro onboarding wizard: shown while the org is on Pro
+ * but the assistant email/subdomain offered by the onboarding flow is still
+ * unconfigured (`domain_setup_available`).
+ */
+function FinishProSetupNotice({ onFinishSetup }: { onFinishSetup: () => void }) {
+    const { data: subscription } = useQuery(
+        organizationsBillingSubscriptionRetrieveOptions(),
+    );
+    const isPro = subscription?.plan_id === "pro";
+    const { data: onboarding } = useQuery({
+        ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
+        enabled: isPro,
+    });
+
+    if (!isPro || onboarding?.domain_setup_available !== true) {
+        return null;
+    }
+
+    return (
+        <Notice
+            tone="info"
+            title="Finish setting up your Pro plan"
+            actions={
+                <Button
+                    variant="outlined"
+                    size="compact"
+                    onClick={onFinishSetup}
+                    data-testid="finish-pro-setup-button"
+                >
+                    Finish setup
+                </Button>
+            }
+            data-testid="finish-pro-setup-notice"
+        >
+            Your assistant&apos;s email address hasn&apos;t been set up yet.
+        </Notice>
+    );
+}
+
 function BillingTab() {
     const platformGate = usePlatformGate({ platformHostedOnly: true });
     const billingGate = usePlatformGate();
@@ -77,30 +122,50 @@ function BillingTab() {
     const closePlanModal = useCallback(() => setPlanModalOpen(false), []);
     const [resizeModalOpen, setResizeModalOpen] = useState(false);
     const onTierUpgraded = useCallback(() => setResizeModalOpen(true), []);
+    const [proOnboardingOpen, setProOnboardingOpen] = useState(false);
 
     useEffect(() => {
-        // Only consume `adjust_plan` once billing is usable (signed in). While
-        // the tab shows the login notice (`"disabled"`), leave the param in the
-        // URL so PlatformLoginNotice carries it through sign-in and the
-        // manage-plan modal opens on return instead of being silently dropped.
+        // Only consume the modal-opening params once billing is usable (signed
+        // in). While the tab shows the login notice (`"disabled"`), leave them
+        // in the URL so PlatformLoginNotice carries them through sign-in and
+        // the target modal opens on return instead of being silently dropped.
         if (billingGate !== "full") {
             return;
         }
-        if (searchParams.has("adjust_plan")) {
-            setPlanModalOpen(true);
-            setSearchParams((prev) => {
-                const next = new URLSearchParams(prev);
-                next.delete("adjust_plan");
-                return next;
-            }, { replace: true });
+        const hasAdjustPlan = searchParams.has("adjust_plan");
+        const hasProOnboarding = searchParams.has("pro_onboarding");
+        if (!hasAdjustPlan && !hasProOnboarding) {
+            return;
         }
+        if (hasAdjustPlan) {
+            setPlanModalOpen(true);
+        }
+        if (hasProOnboarding) {
+            setProOnboardingOpen(true);
+        }
+        setSearchParams((prev) => {
+            const next = new URLSearchParams(prev);
+            next.delete("adjust_plan");
+            next.delete("pro_onboarding");
+            return next;
+        }, { replace: true });
     }, [billingGate, searchParams, setSearchParams]);
 
     const hasSessionId = searchParams.has("session_id");
     const closeOnboarding = useCallback(() => {
+        setProOnboardingOpen(false);
         setSearchParams((prev) => {
             const next = new URLSearchParams(prev);
             next.delete("session_id");
+            return next;
+        }, { replace: true });
+    }, [setSearchParams]);
+    // Routed through `?pro_onboarding` (rather than opening state directly) so
+    // the nudge exercises the same path as a deeplink.
+    const openProOnboarding = useCallback(() => {
+        setSearchParams((prev) => {
+            const next = new URLSearchParams(prev);
+            next.set("pro_onboarding", "");
             return next;
         }, { replace: true });
     }, [setSearchParams]);
@@ -145,6 +210,9 @@ function BillingTab() {
                 <BillingPortalReturnHandler />
             </Suspense>
             {showPlanManagement && <GracePeriodBanner />}
+            {showPlanManagement && (
+                <FinishProSetupNotice onFinishSetup={openProOnboarding} />
+            )}
             {showPlanManagement && <PlanCard onManage={openPlanModal} />}
             {showPlanManagement && (
                 <AdjustPlanModal open={planModalOpen} onClose={closePlanModal} onTierUpgraded={onTierUpgraded} />
@@ -157,7 +225,10 @@ function BillingTab() {
                 <InvoicesTable />
             </Suspense>
             {showPlanManagement && (
-                <BillingOnboardingModal open={hasSessionId} onClose={closeOnboarding} />
+                <BillingOnboardingModal
+                    open={hasSessionId || proOnboardingOpen}
+                    onClose={closeOnboarding}
+                />
             )}
             {showPlanManagement && (
                 <TierUpgradeResizeModal

--- a/clients/web/src/domains/settings/billing/billing-tab-visibility.test.ts
+++ b/clients/web/src/domains/settings/billing/billing-tab-visibility.test.ts
@@ -11,6 +11,7 @@ describe("hasBillingIntent", () => {
   test("true for billing-intent params", () => {
     expect(hasBillingIntent(params("tab=billing"))).toBe(true);
     expect(hasBillingIntent(params("adjust_plan=1"))).toBe(true);
+    expect(hasBillingIntent(params("pro_onboarding"))).toBe(true);
     expect(hasBillingIntent(params("billing_status=success"))).toBe(true);
     expect(hasBillingIntent(params("session_id=cs_test_123"))).toBe(true);
   });
@@ -41,6 +42,7 @@ describe("shouldShowBillingTab", () => {
       shouldShowBillingTab("disabled", params("session_id=cs_test_123")),
     ).toBe(true);
     expect(shouldShowBillingTab("disabled", params("adjust_plan=1"))).toBe(true);
+    expect(shouldShowBillingTab("disabled", params("pro_onboarding"))).toBe(true);
   });
 
   test("gated (no platform): never shown, even with billing intent", () => {

--- a/clients/web/src/domains/settings/billing/billing-tab-visibility.ts
+++ b/clients/web/src/domains/settings/billing/billing-tab-visibility.ts
@@ -7,12 +7,14 @@ import type { PlatformGateState } from "@/hooks/use-platform-gate";
  *   - `?tab=billing` — a direct deeplink to the Billing sub-tab.
  *   - `?adjust_plan` — an upgrade / manage-plan CTA (resize card, disk-pressure
  *     banner, managed-content prompts, General page).
+ *   - `?pro_onboarding` — a deeplink that reopens the pro onboarding wizard.
  *   - `?billing_status` / `?session_id` — a Stripe checkout/portal return.
  */
 export function hasBillingIntent(searchParams: URLSearchParams): boolean {
   return (
     searchParams.get("tab") === "billing" ||
     searchParams.has("adjust_plan") ||
+    searchParams.has("pro_onboarding") ||
     searchParams.has("billing_status") ||
     searchParams.has("session_id")
   );


### PR DESCRIPTION
## Summary
- ?pro_onboarding param reopens the onboarding wizard (mirrors adjust_plan handling)
- subtle Finish Pro setup nudge on billing when Pro + domain setup still available

Part of plan: pro-onboarding-wizard-revamp.md (PR 5 of 6)