### PR TITLE
fix(assistant): regenerate OpenAPI spec for ProcessEntry.origin

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33664,9 +33664,10 @@ components:
             - unreachable
         origin:
           type: string
-          enum:
-            - plugin
-            - workspace
+          pattern: ^(workspace|plugin:.+)$
+          description:
+            "Process origin: 'workspace' for the daemon and its subsystems, or 'plugin:<name>' for a process spawned
+            from a plugin (e.g. 'plugin:default-memory', 'plugin:cognee')."
         children:
           type: array
           items:

--- a/assistant/src/runtime/routes/ps-routes.ts
+++ b/assistant/src/runtime/routes/ps-routes.ts
@@ -41,7 +41,10 @@ interface ProcessEntry {
 
 const processOriginSchema = z
   .string()
-  .regex(/^(workspace|plugin:.+)$/) as z.ZodType<ProcessOrigin>;
+  .regex(/^(workspace|plugin:.+)$/)
+  .describe(
+    "Process origin: 'workspace' for the daemon and its subsystems, or 'plugin:<name>' for a process spawned from a plugin (e.g. 'plugin:default-memory', 'plugin:cognee').",
+  ) as z.ZodType<ProcessOrigin>;
 
 const processEntrySchema: z.ZodType<ProcessEntry> = z
   .lazy(() =>


### PR DESCRIPTION
## Prompt / plan

> I merged the PR, but openapi checks were failing and are worth fixing

Follow-up to #38529 (merged). The repo commits a generated `assistant/openapi.yaml` and CI runs `generate:openapi -- --check` to guarantee it matches the route schemas.

**Why it was failing:** the `plugin:<name>` change in #38529 widened `ProcessEntry.origin` from a two-value `z.enum(["plugin", "workspace"])` to a regex-validated string, but the committed spec still carried the old `enum: [plugin, workspace]`. (An interim regen, #38532, had synced the spec to the *enum* form, so the later `plugin:<name>` change re-drifted it.) The OpenAPI Spec Check has been failing on every PR since.

**Fix:**
- Regenerated `openapi.yaml` — `origin` is now `type: string` with `pattern: ^(workspace|plugin:.+)$`, the honest representation of a dynamic value (the plugin name can't be enumerated).
- Added a `.describe(...)` to the `origin` schema so the `workspace` / `plugin:<name>` format is self-documenting in the generated API docs.

```diff
         origin:
           type: string
-          enum:
-            - plugin
-            - workspace
+          pattern: ^(workspace|plugin:.+)$
+          description: "Process origin: 'workspace' for the daemon and its subsystems, or
+            'plugin:<name>' for a process spawned from a plugin (e.g. 'plugin:default-memory', 'plugin:cognee')."
```

## Test plan

- `bun run generate:openapi -- --check` → `openapi.yaml is up to date`, exit 0 (the exact CI command).
- Regeneration is idempotent; `ps-routes` tests pass; `tsgo --noEmit` clean; prettier + eslint clean.

## CLI verb checklist

No new route — regenerates the committed spec for the existing `ps` route and adds a schema description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qkdA2ovTYVRDPMc6TQ4UV

---
_Generated by [Claude Code](https://claude.ai/code/session_015qkdA2ovTYVRDPMc6TQ4UV)_