### PR TITLE
refactor(live-voice): extract message handling into an importable connection

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-connection.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-connection.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  createLiveVoiceConnection,
+  type LiveVoiceConnection,
+} from "../live-voice-connection.js";
+import { setLiveVoiceSessionManagerForTesting } from "../live-voice-manager.js";
+import {
+  type LiveVoiceSession,
+  type LiveVoiceSessionCloseReason,
+  LiveVoiceSessionManager,
+} from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceClientFrame,
+  LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const START_MESSAGE = JSON.stringify({
+  type: "start",
+  conversationId: "conversation-123",
+  audio: { mimeType: "audio/pcm", sampleRate: 24_000, channels: 1 },
+});
+
+interface TestSession extends LiveVoiceSession {
+  readonly clientFrames: LiveVoiceClientFrame[];
+  readonly binaryChunks: Uint8Array[];
+  readonly closeReasons: LiveVoiceSessionCloseReason[];
+}
+
+/**
+ * Wire a real {@link LiveVoiceSessionManager} to fake sessions and install it
+ * as the process singleton so {@link createLiveVoiceConnection} drives it.
+ * Returns the manager and the list of sessions it has created (each `start`
+ * emits a `ready` frame through the session's sink, like the real one).
+ */
+function installFakeManager(
+  overrides: (
+    session: TestSession,
+    ctx: { sessionId: string },
+  ) => Partial<LiveVoiceSession> = () => ({}),
+): { manager: LiveVoiceSessionManager; sessions: TestSession[] } {
+  const sessions: TestSession[] = [];
+  let counter = 0;
+  const manager = new LiveVoiceSessionManager({
+    createSessionId: () => `session-${(counter += 1)}`,
+    createSession: (context) => {
+      const session: TestSession = {
+        clientFrames: [],
+        binaryChunks: [],
+        closeReasons: [],
+        start: mock(async () => {
+          await context.sendFrame({
+            type: "ready",
+            sessionId: context.sessionId,
+            conversationId:
+              context.startFrame.conversationId ?? "conversation-new",
+          });
+        }),
+        handleClientFrame: mock((frame: LiveVoiceClientFrame) => {
+          session.clientFrames.push(frame);
+        }),
+        handleBinaryAudio: mock((chunk: Uint8Array) => {
+          session.binaryChunks.push(chunk);
+        }),
+        close: mock((reason: LiveVoiceSessionCloseReason) => {
+          session.closeReasons.push(reason);
+        }),
+      };
+      Object.assign(
+        session,
+        overrides(session, { sessionId: context.sessionId }),
+      );
+      sessions.push(session);
+      return session;
+    },
+  });
+  setLiveVoiceSessionManagerForTesting(manager);
+  return { manager, sessions };
+}
+
+function createConnection(): {
+  connection: LiveVoiceConnection;
+  frames: LiveVoiceServerFrame[];
+} {
+  const frames: LiveVoiceServerFrame[] = [];
+  const connection = createLiveVoiceConnection({
+    send: (frame) => {
+      frames.push(frame);
+    },
+  });
+  return { connection, frames };
+}
+
+afterEach(() => {
+  setLiveVoiceSessionManagerForTesting(null);
+});
+
+describe("createLiveVoiceConnection", () => {
+  test("accepts a start frame and emits the session's ready frame", async () => {
+    const { sessions } = installFakeManager();
+    const { connection, frames } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE);
+
+    expect(connection.sessionId).toBe("session-1");
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.start).toHaveBeenCalledTimes(1);
+    expect(frames).toEqual([
+      {
+        type: "ready",
+        seq: 1,
+        sessionId: "session-1",
+        conversationId: "conversation-123",
+      },
+    ]);
+  });
+
+  test("assigns monotonically increasing sequence numbers", async () => {
+    installFakeManager();
+    const { connection, frames } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE); // ready → seq 1
+    await connection.handleMessage("not json"); // error → seq 2
+
+    expect(frames.map((f) => f.seq)).toEqual([1, 2]);
+    expect(frames[1]).toMatchObject({ type: "error", seq: 2 });
+  });
+
+  test("forwards client frames to the active session", async () => {
+    const { sessions } = installFakeManager();
+    const { connection } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE);
+    await connection.handleMessage(JSON.stringify({ type: "interrupt" }));
+
+    expect(sessions[0]?.clientFrames).toEqual([{ type: "interrupt" }]);
+  });
+
+  test("forwards binary audio to the active session", async () => {
+    const { sessions } = installFakeManager();
+    const { connection } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE);
+    const audio = new Uint8Array([1, 2, 3, 4]);
+    await connection.handleMessage(audio.buffer);
+
+    expect(sessions[0]?.binaryChunks).toHaveLength(1);
+    expect(Array.from(sessions[0]!.binaryChunks[0]!)).toEqual([1, 2, 3, 4]);
+  });
+
+  test("rejects a second start while a session is active", async () => {
+    installFakeManager();
+    const { connection, frames } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE);
+    await connection.handleMessage(START_MESSAGE);
+
+    expect(connection.sessionId).toBe("session-1");
+    expect(frames.at(-1)).toMatchObject({
+      type: "error",
+      code: "invalid_frame",
+      message: "Live voice session already started",
+    });
+  });
+
+  test("errors on a non-start frame before start", async () => {
+    installFakeManager();
+    const { connection, frames } = createConnection();
+
+    await connection.handleMessage(JSON.stringify({ type: "ptt_release" }));
+
+    expect(connection.sessionId).toBeUndefined();
+    expect(frames.at(-1)).toMatchObject({
+      type: "error",
+      code: "invalid_frame",
+      message: "Live voice ptt_release frame received before start",
+    });
+  });
+
+  test("errors on binary audio before start", async () => {
+    installFakeManager();
+    const { connection, frames } = createConnection();
+
+    await connection.handleMessage(new Uint8Array([1, 2]).buffer);
+
+    expect(frames.at(-1)).toMatchObject({
+      type: "error",
+      message: "Live voice binary audio received before start",
+    });
+  });
+
+  test("clears the session id on an end frame", async () => {
+    const { sessions } = installFakeManager();
+    const { connection } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE);
+    await connection.handleMessage(JSON.stringify({ type: "end" }));
+
+    expect(connection.sessionId).toBeUndefined();
+    expect(sessions[0]?.clientFrames).toEqual([{ type: "end" }]);
+  });
+
+  test("heals a stale binding when the manager dropped the session", async () => {
+    const { manager } = installFakeManager();
+    const { connection, frames } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE);
+    // The session's slot is released out-of-band (e.g. a post-ready failure)
+    // without a frame crossing this connection.
+    await manager.releaseSession("session-1", "error");
+
+    await connection.handleMessage(JSON.stringify({ type: "interrupt" }));
+
+    expect(connection.sessionId).toBeUndefined();
+    expect(frames.at(-1)).toMatchObject({
+      type: "error",
+      message: "Live voice session is not active",
+    });
+  });
+
+  test("starts a fresh session after the previous slot was released", async () => {
+    const { manager } = installFakeManager();
+    const { connection } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE);
+    await manager.releaseSession("session-1", "error");
+    await connection.handleMessage(START_MESSAGE);
+
+    expect(connection.sessionId).toBe("session-2");
+  });
+
+  test("reports handler failures as an error frame instead of rejecting", async () => {
+    installFakeManager((_session) => ({
+      handleClientFrame: mock(() => {
+        throw new Error("boom");
+      }),
+    }));
+    const { connection, frames } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE);
+    await expect(
+      connection.handleMessage(JSON.stringify({ type: "interrupt" })),
+    ).resolves.toBeUndefined();
+
+    expect(frames.at(-1)).toMatchObject({
+      type: "error",
+      code: "invalid_frame",
+      message: "Live voice frame handling failed",
+    });
+  });
+
+  test("release closes the active session with transport_closed", async () => {
+    const { sessions } = installFakeManager();
+    const { connection } = createConnection();
+
+    await connection.handleMessage(START_MESSAGE);
+    connection.release();
+    // releaseSession runs asynchronously inside release().
+    await Promise.resolve();
+
+    expect(connection.sessionId).toBeUndefined();
+    expect(sessions[0]?.closeReasons).toEqual(["transport_closed"]);
+  });
+
+  test("release is a no-op when no session is active", () => {
+    installFakeManager();
+    const { connection } = createConnection();
+
+    expect(() => connection.release()).not.toThrow();
+  });
+});

--- a/assistant/src/live-voice/live-voice-connection.ts
+++ b/assistant/src/live-voice/live-voice-connection.ts
@@ -1,0 +1,225 @@
+/**
+ * Transport-agnostic live voice connection — the importable entry point for
+ * driving a single client's live voice session.
+ *
+ * A connection wraps one bidirectional audio transport (a WebSocket, a
+ * WebRTC data channel, an in-process pipe — the caller decides). It owns the
+ * per-connection framing state (the outbound sequence counter and the active
+ * session id) and translates raw inbound messages into
+ * {@link LiveVoiceSessionManager} calls, sending server frames back through
+ * the caller-supplied {@link LiveVoiceFrameSender}.
+ *
+ * The manager is resolved from the process-wide singleton
+ * ({@link getLiveVoiceSessionManager}), so every connection — the runtime
+ * HTTP WebSocket and any plugin bringing its own transport — shares one
+ * single-active-session lock. Callers therefore never construct or pass a
+ * manager; they bring only a `send` callback.
+ *
+ * Typical wiring:
+ *
+ *     const connection = createLiveVoiceConnection({
+ *       send: (frame) => socket.send(JSON.stringify(frame)),
+ *     });
+ *     socket.on("message", (msg) => void connection.handleMessage(msg));
+ *     socket.on("close", () => connection.release());
+ */
+
+import { getLogger } from "../util/logger.js";
+import { getLiveVoiceSessionManager } from "./live-voice-manager.js";
+import type { LiveVoiceSessionManager } from "./live-voice-session-manager.js";
+import type { LiveVoiceSessionCloseReason } from "./live-voice-session-manager.js";
+import {
+  type LiveVoiceClientFrame,
+  type LiveVoiceProtocolError,
+  LiveVoiceProtocolErrorCode,
+  type LiveVoiceServerFrame,
+  parseLiveVoiceBinaryAudioFrame,
+  parseLiveVoiceClientTextFrame,
+} from "./protocol.js";
+
+const log = getLogger("live-voice-connection");
+
+/**
+ * Sends one fully-sequenced server frame to the client over the caller's
+ * transport. The frame is a plain object; the caller is responsible for wire
+ * encoding (e.g. `JSON.stringify` for a text WebSocket).
+ */
+export type LiveVoiceFrameSender = (frame: LiveVoiceServerFrame) => void;
+
+export interface LiveVoiceConnection {
+  /**
+   * The active session id once a `start` frame has been accepted, else
+   * `undefined`. Read-only — the connection assigns it on `start` and clears
+   * it on `end`, teardown, or a session that the manager no longer knows.
+   */
+  readonly sessionId: string | undefined;
+  /**
+   * Handle one inbound transport message — a JSON text frame or a binary
+   * audio chunk. Never rejects: protocol and handler failures are reported
+   * back to the client as `error` frames.
+   */
+  handleMessage(message: string | ArrayBuffer | ArrayBufferView): Promise<void>;
+  /**
+   * Release the session bound to this connection when the transport closes.
+   * Idempotent — a no-op when no session is active.
+   */
+  release(reason?: LiveVoiceSessionCloseReason): void;
+}
+
+/** Create a live voice connection bound to the caller's `send` transport. */
+export function createLiveVoiceConnection(options: {
+  send: LiveVoiceFrameSender;
+}): LiveVoiceConnection {
+  return new LiveVoiceConnectionImpl(
+    options.send,
+    getLiveVoiceSessionManager(),
+  );
+}
+
+class LiveVoiceConnectionImpl implements LiveVoiceConnection {
+  private activeSessionId: string | undefined;
+  private lastSeq = 0;
+
+  constructor(
+    private readonly send: LiveVoiceFrameSender,
+    private readonly manager: LiveVoiceSessionManager,
+  ) {}
+
+  get sessionId(): string | undefined {
+    return this.activeSessionId;
+  }
+
+  async handleMessage(
+    message: string | ArrayBuffer | ArrayBufferView,
+  ): Promise<void> {
+    try {
+      if (typeof message === "string") {
+        const result = parseLiveVoiceClientTextFrame(message);
+        if (!result.ok) {
+          this.sendError(result.error);
+          return;
+        }
+        await this.dispatchClientFrame(result.frame);
+        return;
+      }
+
+      const result = parseLiveVoiceBinaryAudioFrame(message);
+      if (!result.ok) {
+        this.sendError(result.error);
+        return;
+      }
+
+      const sessionId = this.activeSessionId;
+      if (!sessionId) {
+        this.sendStateError("Live voice binary audio received before start");
+        return;
+      }
+
+      const handled = await this.manager.handleBinaryAudio(
+        sessionId,
+        result.frame.data,
+      );
+      if (handled.status === "not_found") {
+        this.activeSessionId = undefined;
+        this.sendStateError("Live voice session is not active");
+      }
+    } catch (err) {
+      log.warn(
+        { error: err instanceof Error ? err.message : String(err) },
+        "Live voice message handler failed",
+      );
+      this.sendError({
+        code: LiveVoiceProtocolErrorCode.InvalidFrame,
+        message: "Live voice frame handling failed",
+      });
+    }
+  }
+
+  release(reason: LiveVoiceSessionCloseReason = "transport_closed"): void {
+    const sessionId = this.activeSessionId;
+    this.activeSessionId = undefined;
+    if (!sessionId) {
+      return;
+    }
+
+    void this.manager.releaseSession(sessionId, reason).catch((err) => {
+      log.warn(
+        {
+          error: err instanceof Error ? err.message : String(err),
+          sessionId,
+        },
+        "Failed to release live voice session",
+      );
+    });
+  }
+
+  private async dispatchClientFrame(
+    frame: LiveVoiceClientFrame,
+  ): Promise<void> {
+    if (frame.type === "start") {
+      if (this.activeSessionId) {
+        // A session that failed after `ready` releases its manager slot
+        // without a frame crossing this transport — heal the stale binding so
+        // the client can retry on the same connection.
+        if (this.manager.isSessionActive(this.activeSessionId)) {
+          this.sendStateError("Live voice session already started");
+          return;
+        }
+        this.activeSessionId = undefined;
+      }
+
+      const result = await this.manager.startSession(frame, {
+        sendFrame: (serverFrame) => {
+          this.sendFrame(serverFrame);
+        },
+      });
+      if (result.status === "accepted") {
+        this.activeSessionId = result.sessionId;
+      }
+      return;
+    }
+
+    const sessionId = this.activeSessionId;
+    if (!sessionId) {
+      this.sendStateError(
+        `Live voice ${frame.type} frame received before start`,
+      );
+      return;
+    }
+
+    const handled = await this.manager.handleClientFrame(sessionId, frame);
+    if (handled.status === "not_found") {
+      this.activeSessionId = undefined;
+      this.sendStateError("Live voice session is not active");
+      return;
+    }
+
+    if (frame.type === "end") {
+      this.activeSessionId = undefined;
+    }
+  }
+
+  private sendStateError(message: string): void {
+    this.sendError({
+      code: LiveVoiceProtocolErrorCode.InvalidFrame,
+      message,
+    });
+  }
+
+  private sendError(
+    error: Pick<LiveVoiceProtocolError, "code" | "message">,
+  ): void {
+    this.sendFrame({
+      type: "error",
+      seq: this.lastSeq + 1,
+      code: error.code,
+      message: error.message,
+    });
+  }
+
+  private sendFrame(frame: LiveVoiceServerFrame): void {
+    const seq = Math.max(this.lastSeq + 1, frame.seq);
+    this.lastSeq = seq;
+    this.send({ ...frame, seq });
+  }
+}

--- a/assistant/src/live-voice/live-voice-manager.ts
+++ b/assistant/src/live-voice/live-voice-manager.ts
@@ -1,0 +1,39 @@
+/**
+ * Process-wide {@link LiveVoiceSessionManager} accessor.
+ *
+ * Live voice enforces a single active session per daemon (the mic is a
+ * shared, exclusive resource), so the manager is a singleton rather than a
+ * per-transport instance. Every entry point that drives live voice — the
+ * runtime HTTP WebSocket and any plugin bringing its own transport via
+ * {@link createLiveVoiceConnection} — resolves the same manager here, so they
+ * share one busy lock instead of racing for the mic.
+ */
+
+import { createLiveVoiceSession } from "./live-voice-session.js";
+import { LiveVoiceSessionManager } from "./live-voice-session-manager.js";
+
+let manager: LiveVoiceSessionManager | null = null;
+
+/**
+ * The daemon-wide live voice session manager, lazily constructed on first
+ * use. Sessions are produced by {@link createLiveVoiceSession}.
+ */
+export function getLiveVoiceSessionManager(): LiveVoiceSessionManager {
+  if (manager === null) {
+    manager = new LiveVoiceSessionManager({
+      createSession: (context) => createLiveVoiceSession(context),
+    });
+  }
+  return manager;
+}
+
+/**
+ * Override (or clear, with `null`) the singleton so a test can drive
+ * {@link createLiveVoiceConnection} against a manager wired to fake sessions.
+ * Test-only.
+ */
+export function setLiveVoiceSessionManagerForTesting(
+  override: LiveVoiceSessionManager | null,
+): void {
+  manager = override;
+}

--- a/assistant/src/live-voice/live-voice-manager.ts
+++ b/assistant/src/live-voice/live-voice-manager.ts
@@ -9,19 +9,33 @@
  * share one busy lock instead of racing for the mic.
  */
 
-import { createLiveVoiceSession } from "./live-voice-session.js";
+import { createRequire } from "node:module";
+
 import { LiveVoiceSessionManager } from "./live-voice-session-manager.js";
+
+const require = createRequire(import.meta.url);
 
 let manager: LiveVoiceSessionManager | null = null;
 
 /**
  * The daemon-wide live voice session manager, lazily constructed on first
- * use. Sessions are produced by {@link createLiveVoiceSession}.
+ * use. Sessions are produced by `createLiveVoiceSession`.
  */
 export function getLiveVoiceSessionManager(): LiveVoiceSessionManager {
   if (manager === null) {
     manager = new LiveVoiceSessionManager({
-      createSession: (context) => createLiveVoiceSession(context),
+      // `live-voice-session` is loaded lazily, on first session creation,
+      // rather than statically imported. It drags in a large graph (subagent
+      // manager, providers, persistence), and this module is reachable from
+      // `@vellumai/plugin-api` via the connection factory — a static edge
+      // would pull that whole graph into every plugin-api consumer at
+      // module-load time. `require` keeps the factory synchronous, so the
+      // manager still claims its single-session slot without an await gap.
+      createSession: (context) => {
+        const { createLiveVoiceSession } =
+          require("./live-voice-session.js") as typeof import("./live-voice-session.js");
+        return createLiveVoiceSession(context);
+      },
     });
   }
   return manager;

--- a/assistant/src/live-voice/live-voice-session-manager.ts
+++ b/assistant/src/live-voice/live-voice-session-manager.ts
@@ -14,6 +14,7 @@ export type LiveVoiceSessionCloseReason =
   | "client_end"
   | "error"
   | "websocket_close"
+  | "transport_closed"
   | "manager_shutdown";
 
 export interface LiveVoiceSession {

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -301,3 +301,18 @@ export type {
   RunConversationTurnResult,
 } from "./conversation-turn.js";
 export { runConversationTurn } from "./conversation-turn.js";
+// Live voice — drive a single client's real-time voice session (STT → agent
+// turn → TTS, with server-VAD turn-taking, pauses, and barge-in) over a
+// transport the plugin owns. The plugin brings only a `send` callback (e.g.
+// its own WebSocket route under `/x/plugins/<name>/`); `createLiveVoiceConnection`
+// resolves the daemon-wide session manager internally, so a plugin session
+// shares the same single-active-session lock as the built-in HTTP transport.
+// Feed inbound frames to `handleMessage` and call `release` when the transport
+// closes. `LiveVoiceServerFrame` types the frames handed to `send`.
+export type {
+  LiveVoiceConnection,
+  LiveVoiceFrameSender,
+} from "../live-voice/live-voice-connection.js";
+export { createLiveVoiceConnection } from "../live-voice/live-voice-connection.js";
+export type { LiveVoiceSessionCloseReason } from "../live-voice/live-voice-session-manager.js";
+export type { LiveVoiceServerFrame } from "../live-voice/protocol.js";

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -5,8 +5,6 @@
  * configured port (default: 7821).
  */
 
-import type { ServerWebSocket } from "bun";
-
 import {
   activeMediaStreamSessions,
   MediaStreamCallSession,
@@ -27,16 +25,11 @@ import {
   isDbMigrationGateBypassed,
 } from "../daemon/daemon-readiness.js";
 import { processMessage } from "../daemon/process-message.js";
-import { createLiveVoiceSession } from "../live-voice/live-voice-session.js";
-import { LiveVoiceSessionManager } from "../live-voice/live-voice-session-manager.js";
 import {
-  type LiveVoiceClientFrame,
-  type LiveVoiceProtocolError,
-  LiveVoiceProtocolErrorCode,
-  type LiveVoiceServerFrame,
-  parseLiveVoiceBinaryAudioFrame,
-  parseLiveVoiceClientTextFrame,
-} from "../live-voice/protocol.js";
+  createLiveVoiceConnection,
+  type LiveVoiceConnection,
+} from "../live-voice/live-voice-connection.js";
+import { getLiveVoiceSessionManager } from "../live-voice/live-voice-manager.js";
 import { resolveStreamingTranscriber } from "../providers/speech-to-text/resolve.js";
 import {
   activeSttStreamSessions,
@@ -160,8 +153,12 @@ interface SttStreamWebSocketData {
  */
 interface LiveVoiceWebSocketData {
   wsType: "live-voice";
-  sessionId?: string;
-  lastSeq: number;
+  /**
+   * The per-connection live voice handler. Created in the WebSocket `open`
+   * handler (once `ws` exists to bind the frame sender), so it is absent for
+   * the brief window between upgrade and open.
+   */
+  connection?: LiveVoiceConnection;
 }
 
 export class RuntimeHttpServer {
@@ -173,16 +170,12 @@ export class RuntimeHttpServer {
   private sweepInProgress = false;
   private sweepsStarted = false;
 
-  private readonly liveVoiceSessionManager: LiveVoiceSessionManager;
   private router: HttpRouter;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
     this.port = options.port ?? DEFAULT_PORT;
     this.hostname = options.hostname ?? DEFAULT_HOSTNAME;
 
-    this.liveVoiceSessionManager = new LiveVoiceSessionManager({
-      createSession: (context) => createLiveVoiceSession(context),
-    });
     this.router = new HttpRouter();
   }
 
@@ -294,6 +287,11 @@ export class RuntimeHttpServer {
             return;
           }
           if (data.wsType === "live-voice") {
+            data.connection = createLiveVoiceConnection({
+              send: (frame) => {
+                ws.send(JSON.stringify(frame));
+              },
+            });
             log.info("Live voice WebSocket opened");
             return;
           }
@@ -329,22 +327,7 @@ export class RuntimeHttpServer {
             return;
           }
           if (data.wsType === "live-voice") {
-            void this.handleLiveVoiceMessage(
-              ws as ServerWebSocket<LiveVoiceWebSocketData>,
-              message,
-            ).catch((err) => {
-              log.warn(
-                { error: err instanceof Error ? err.message : String(err) },
-                "Live voice WebSocket message handler failed",
-              );
-              this.sendLiveVoiceError(
-                ws as ServerWebSocket<LiveVoiceWebSocketData>,
-                {
-                  code: LiveVoiceProtocolErrorCode.InvalidFrame,
-                  message: "Live voice frame handling failed",
-                },
-              );
-            });
+            void data.connection?.handleMessage(message);
             return;
           }
           log.warn("WebSocket message on unknown data type — closing");
@@ -405,13 +388,13 @@ export class RuntimeHttpServer {
           if (data.wsType === "live-voice") {
             log.info(
               {
-                sessionId: data.sessionId,
+                sessionId: data.connection?.sessionId,
                 code,
                 reason: reason?.toString(),
               },
               "Live voice WebSocket closed",
             );
-            this.releaseLiveVoiceSession(data, "websocket_close");
+            data.connection?.release();
             return;
           }
           log.warn(
@@ -522,9 +505,10 @@ export class RuntimeHttpServer {
       activeSttStreamSessions.delete(sessionId);
     }
 
-    const liveVoiceSessionId = this.liveVoiceSessionManager.activeSessionId;
+    const liveVoiceManager = getLiveVoiceSessionManager();
+    const liveVoiceSessionId = liveVoiceManager.activeSessionId;
     if (liveVoiceSessionId) {
-      await this.liveVoiceSessionManager.releaseSession(
+      await liveVoiceManager.releaseSession(
         liveVoiceSessionId,
         "manager_shutdown",
       );
@@ -893,160 +877,12 @@ export class RuntimeHttpServer {
     const upgraded = server.upgrade(req, {
       data: {
         wsType: "live-voice",
-        lastSeq: 0,
       } satisfies LiveVoiceWebSocketData,
     });
     if (!upgraded) {
       return new Response("WebSocket upgrade failed", { status: 500 });
     }
     return undefined!;
-  }
-
-  private async handleLiveVoiceMessage(
-    ws: ServerWebSocket<LiveVoiceWebSocketData>,
-    message: string | ArrayBuffer | ArrayBufferView,
-  ): Promise<void> {
-    if (typeof message === "string") {
-      const result = parseLiveVoiceClientTextFrame(message);
-      if (!result.ok) {
-        this.sendLiveVoiceError(ws, result.error);
-        return;
-      }
-      await this.dispatchLiveVoiceClientFrame(ws, result.frame);
-      return;
-    }
-
-    const result = parseLiveVoiceBinaryAudioFrame(message);
-    if (!result.ok) {
-      this.sendLiveVoiceError(ws, result.error);
-      return;
-    }
-
-    const sessionId = ws.data.sessionId;
-    if (!sessionId) {
-      this.sendLiveVoiceStateError(
-        ws,
-        "Live voice binary audio received before start",
-      );
-      return;
-    }
-
-    const handled = await this.liveVoiceSessionManager.handleBinaryAudio(
-      sessionId,
-      result.frame.data,
-    );
-    if (handled.status === "not_found") {
-      ws.data.sessionId = undefined;
-      this.sendLiveVoiceStateError(ws, "Live voice session is not active");
-    }
-  }
-
-  private async dispatchLiveVoiceClientFrame(
-    ws: ServerWebSocket<LiveVoiceWebSocketData>,
-    frame: LiveVoiceClientFrame,
-  ): Promise<void> {
-    if (frame.type === "start") {
-      if (ws.data.sessionId) {
-        // A session that failed after `ready` releases its manager slot
-        // without a frame crossing this socket — heal the stale binding so
-        // the client can retry on the same connection.
-        if (this.liveVoiceSessionManager.isSessionActive(ws.data.sessionId)) {
-          this.sendLiveVoiceStateError(
-            ws,
-            "Live voice session already started",
-          );
-          return;
-        }
-        ws.data.sessionId = undefined;
-      }
-
-      const result = await this.liveVoiceSessionManager.startSession(frame, {
-        sendFrame: async (serverFrame) => {
-          this.sendLiveVoiceFrame(ws, serverFrame);
-        },
-      });
-      if (result.status === "accepted") {
-        ws.data.sessionId = result.sessionId;
-      }
-      return;
-    }
-
-    const sessionId = ws.data.sessionId;
-    if (!sessionId) {
-      this.sendLiveVoiceStateError(
-        ws,
-        `Live voice ${frame.type} frame received before start`,
-      );
-      return;
-    }
-
-    const handled = await this.liveVoiceSessionManager.handleClientFrame(
-      sessionId,
-      frame,
-    );
-    if (handled.status === "not_found") {
-      ws.data.sessionId = undefined;
-      this.sendLiveVoiceStateError(ws, "Live voice session is not active");
-      return;
-    }
-
-    if (frame.type === "end") {
-      ws.data.sessionId = undefined;
-    }
-  }
-
-  private sendLiveVoiceStateError(
-    ws: ServerWebSocket<LiveVoiceWebSocketData>,
-    message: string,
-  ): void {
-    this.sendLiveVoiceError(ws, {
-      code: LiveVoiceProtocolErrorCode.InvalidFrame,
-      message,
-    });
-  }
-
-  private sendLiveVoiceError(
-    ws: ServerWebSocket<LiveVoiceWebSocketData>,
-    error: Pick<LiveVoiceProtocolError, "code" | "message">,
-  ): void {
-    this.sendLiveVoiceFrame(ws, {
-      type: "error",
-      seq: ws.data.lastSeq + 1,
-      code: error.code,
-      message: error.message,
-    });
-  }
-
-  private sendLiveVoiceFrame(
-    ws: ServerWebSocket<LiveVoiceWebSocketData>,
-    frame: LiveVoiceServerFrame,
-  ): void {
-    const seq = Math.max(ws.data.lastSeq + 1, frame.seq);
-    ws.data.lastSeq = seq;
-    ws.send(JSON.stringify({ ...frame, seq }));
-  }
-
-  private releaseLiveVoiceSession(
-    data: LiveVoiceWebSocketData,
-    reason: "websocket_close",
-  ): void {
-    const sessionId = data.sessionId;
-    data.sessionId = undefined;
-    if (!sessionId) {
-      return;
-    }
-
-    void this.liveVoiceSessionManager
-      .releaseSession(sessionId, reason)
-      .catch((err) => {
-        log.warn(
-          {
-            error: err instanceof Error ? err.message : String(err),
-            sessionId,
-          },
-          "Failed to release live voice session",
-        );
-      });
   }
 
   private async handleTwilioWebhook(

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -5,6 +5,8 @@
  * configured port (default: 7821).
  */
 
+import type { ServerWebSocket } from "bun";
+
 import {
   activeMediaStreamSessions,
   MediaStreamCallSession,
@@ -153,12 +155,6 @@ interface SttStreamWebSocketData {
  */
 interface LiveVoiceWebSocketData {
   wsType: "live-voice";
-  /**
-   * The per-connection live voice handler. Created in the WebSocket `open`
-   * handler (once `ws` exists to bind the frame sender), so it is absent for
-   * the brief window between upgrade and open.
-   */
-  connection?: LiveVoiceConnection;
 }
 
 export class RuntimeHttpServer {
@@ -169,6 +165,17 @@ export class RuntimeHttpServer {
   private retrySweepTimer: ReturnType<typeof setInterval> | null = null;
   private sweepInProgress = false;
   private sweepsStarted = false;
+
+  /**
+   * Live voice handlers, one per open `/v1/live-voice` socket, keyed by the
+   * socket. The server owns this registry (mirroring the media-stream / STT
+   * session maps) rather than parking the handler on `ws.data`; the manager's
+   * single-active-session lock still bounds how many can hold a session.
+   */
+  private readonly liveVoiceConnections = new Map<
+    ServerWebSocket<LiveVoiceWebSocketData>,
+    LiveVoiceConnection
+  >();
 
   private router: HttpRouter;
 
@@ -287,11 +294,15 @@ export class RuntimeHttpServer {
             return;
           }
           if (data.wsType === "live-voice") {
-            data.connection = createLiveVoiceConnection({
-              send: (frame) => {
-                ws.send(JSON.stringify(frame));
-              },
-            });
+            const liveVoiceWs = ws as ServerWebSocket<LiveVoiceWebSocketData>;
+            this.liveVoiceConnections.set(
+              liveVoiceWs,
+              createLiveVoiceConnection({
+                send: (frame) => {
+                  ws.send(JSON.stringify(frame));
+                },
+              }),
+            );
             log.info("Live voice WebSocket opened");
             return;
           }
@@ -327,7 +338,10 @@ export class RuntimeHttpServer {
             return;
           }
           if (data.wsType === "live-voice") {
-            void data.connection?.handleMessage(message);
+            const connection = this.liveVoiceConnections.get(
+              ws as ServerWebSocket<LiveVoiceWebSocketData>,
+            );
+            void connection?.handleMessage(message);
             return;
           }
           log.warn("WebSocket message on unknown data type — closing");
@@ -386,15 +400,18 @@ export class RuntimeHttpServer {
             return;
           }
           if (data.wsType === "live-voice") {
+            const liveVoiceWs = ws as ServerWebSocket<LiveVoiceWebSocketData>;
+            const connection = this.liveVoiceConnections.get(liveVoiceWs);
+            this.liveVoiceConnections.delete(liveVoiceWs);
             log.info(
               {
-                sessionId: data.connection?.sessionId,
+                sessionId: connection?.sessionId,
                 code,
                 reason: reason?.toString(),
               },
               "Live voice WebSocket closed",
             );
-            data.connection?.release();
+            connection?.release();
             return;
           }
           log.warn(


### PR DESCRIPTION
## Prompt / plan

`handleLiveVoiceMessage` is the entrypoint we want to expose for the plugin API, but it lived as a private method on `RuntimeHttpServer`, bound to Bun's `ServerWebSocket`. The goal was to make it an importable entrypoint from `assistant/src/live-voice/` that a plugin can drive over its own transport.

Design (settled before building):
- `createLiveVoiceConnection` resolves the session manager internally — the plugin doesn't pass one, which structurally guarantees a single shared single-active-session lock across HTTP and plugins.
- The transport is a single unnested `send` callback, not a wrapper object.
- Session id is observed via a read-only getter, not injected (injecting it wouldn't rewire an existing session's outbound sink, so it would be misleading dead surface).

## What changed

- **New `LiveVoiceConnection`** (`live-voice/live-voice-connection.ts`): a transport-agnostic per-connection handler that owns the framing state (outbound sequence counter, active session id) and translates inbound frames into `LiveVoiceSessionManager` calls, sending server frames back through the caller's `send`. `handleMessage` fully owns its error path — parse and handler failures are reported as `error` frames rather than rejecting — so callers no longer replicate the try/catch.
- **New manager singleton** (`live-voice/live-voice-manager.ts`): `getLiveVoiceSessionManager()` lazily constructs the one daemon-wide manager (sessions via `createLiveVoiceSession`). Every entry point shares it, so they share the single-active-session lock. Includes a test-only override seam.
- **`RuntimeHttpServer` is now a thin adapter**: it creates a connection on WS `open` with `send: (f) => ws.send(JSON.stringify(f))` and forwards message/close/shutdown to it. The six live-voice private methods and the local `lastSeq`/`sessionId` socket state are gone (net −185 lines in `http-server.ts`).
- **Transport-neutral close reason**: added `transport_closed` to `LiveVoiceSessionCloseReason` (the connection's default) so the API no longer leaks websocket-specific naming.
- **Plugin API surface**: exported `createLiveVoiceConnection`, `LiveVoiceConnection`, `LiveVoiceFrameSender`, `LiveVoiceServerFrame`, and `LiveVoiceSessionCloseReason` from `@vellumai/plugin-api`. Verified the runtime export is picked up by the boot-time shim namespace.

## Test plan

- New `live-voice-connection.test.ts` (13 tests) drives the connection against a real `LiveVoiceSessionManager` wired to fake sessions: start→ready, sequence monotonicity, busy/already-started, before-start errors (text + binary), client-frame and binary forwarding, stale-binding healing + fresh restart, `end` clearing, `release` closing with `transport_closed`, and handler-failure reporting.
- Full live-voice suite + plugin-api shim test: **299 pass, 0 fail**.
- `tsc --noEmit`, `eslint`, and `prettier` all clean (enforced by the pre-commit hook).

## CLI verb checklist

Not applicable — no new IPC route under `assistant/src/runtime/routes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjqMuWPDsf7iVbioH9LGgf)_