### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14300,7 +14300,7 @@ paths:
             type: string
           description:
             "Filter by provider id. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
-            vercel-ai-gateway, openai-compatible, minimax, atlascloud, baseten"
+            vercel-ai-gateway, litellm, openai-compatible, minimax, atlascloud, baseten"
       responses:
         "200":
           description: Successful response
@@ -14531,7 +14531,7 @@ paths:
             type: string
           description:
             "Filter by provider. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
-            vercel-ai-gateway, openai-compatible, minimax, atlascloud, baseten, vellum"
+            vercel-ai-gateway, litellm, openai-compatible, minimax, atlascloud, baseten, vellum"
       responses:
         "200":
           description: Successful response
@@ -32278,6 +32278,7 @@ components:
         - minimax
         - atlascloud
         - together
+        - litellm
         - baseten
     ProfilePatchEntry:
       type: object
@@ -32652,6 +32653,7 @@ components:
         - together
         - openrouter
         - vercel-ai-gateway
+        - litellm
         - openai-compatible
         - minimax
         - atlascloud

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -31,6 +31,7 @@ export const LLMProvider = z
     "minimax",
     "atlascloud",
     "together",
+    "litellm",
     "baseten",
   ])
   .meta({ id: "LLMProvider" });

--- a/assistant/src/providers/inference/__tests__/adapter-factory-litellm.test.ts
+++ b/assistant/src/providers/inference/__tests__/adapter-factory-litellm.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import { OpenAIChatCompletionsProvider } from "../../openai/chat-completions-provider.js";
+import {
+  buildProviderAdapter,
+  createAdapterFromConnection,
+} from "../adapter-factory.js";
+import type { ProviderConnection, ResolvedAuth } from "../auth.js";
+
+describe("litellm adapter factory", () => {
+  test("buildProviderAdapter returns an OpenAIChatCompletionsProvider", () => {
+    const adapter = buildProviderAdapter("litellm", {
+      apiKey: "sk-litellm-test",
+      model: "anthropic/claude-sonnet-4-6",
+      streamTimeoutMs: 60_000,
+      baseURL: "http://localhost:4000/v1",
+      useNativeWebSearch: false,
+    });
+    expect(adapter).toBeInstanceOf(OpenAIChatCompletionsProvider);
+  });
+
+  test("buildProviderAdapter works without baseURL (uses proxy default)", () => {
+    const adapter = buildProviderAdapter("litellm", {
+      apiKey: "sk-litellm-test",
+      model: "openai/gpt-4o",
+      streamTimeoutMs: 60_000,
+      useNativeWebSearch: false,
+    });
+    expect(adapter).toBeInstanceOf(OpenAIChatCompletionsProvider);
+  });
+
+  test("buildProviderAdapter preserves provider/model format", () => {
+    const models = [
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-4o",
+      "bedrock/anthropic.claude-sonnet-4-6-v1",
+      "vertex_ai/gemini-2.5-flash",
+      "groq/llama-4-scout-17b-16e-instruct",
+    ];
+
+    for (const model of models) {
+      const adapter = buildProviderAdapter("litellm", {
+        apiKey: "sk-test",
+        model,
+        streamTimeoutMs: 60_000,
+        useNativeWebSearch: false,
+      });
+      expect(adapter).toBeInstanceOf(OpenAIChatCompletionsProvider);
+    }
+  });
+
+  test("createAdapterFromConnection wires baseURL from ResolvedAuth", () => {
+    const connection: ProviderConnection = {
+      name: "my-litellm",
+      provider: "litellm",
+      auth: { type: "api_key", credential: "cred-litellm" },
+      label: "LiteLLM Gateway",
+      baseUrl: "http://litellm.internal:4000/v1",
+      models: [{ id: "anthropic/claude-sonnet-4-6" }],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isManaged: false,
+    };
+
+    const resolvedAuth: ResolvedAuth = {
+      kind: "header",
+      headers: { Authorization: "Bearer sk-litellm-key" },
+      baseUrl: "http://litellm.internal:4000/v1",
+    };
+
+    const adapter = createAdapterFromConnection(connection, resolvedAuth, {
+      model: "anthropic/claude-sonnet-4-6",
+      streamTimeoutMs: 60_000,
+    });
+
+    expect(adapter).not.toBeNull();
+  });
+
+  test("createAdapterFromConnection rejects 'none' auth for litellm", () => {
+    const connection: ProviderConnection = {
+      name: "my-litellm",
+      provider: "litellm",
+      auth: { type: "none" },
+      label: null,
+      baseUrl: "http://localhost:4000/v1",
+      models: [{ id: "openai/gpt-4o" }],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      isManaged: false,
+    };
+
+    const resolvedAuth: ResolvedAuth = {
+      kind: "none",
+    };
+
+    const adapter = createAdapterFromConnection(connection, resolvedAuth, {
+      model: "openai/gpt-4o",
+      streamTimeoutMs: 60_000,
+    });
+
+    expect(adapter).toBeNull();
+  });
+});

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -121,6 +121,13 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
       streamTimeoutMs,
       ...(baseURL ? { baseURL } : {}),
     }),
+  litellm: ({ apiKey, model, streamTimeoutMs, baseURL }) =>
+    new OpenAIChatCompletionsProvider(apiKey, model, {
+      providerName: "litellm",
+      providerLabel: "LiteLLM",
+      streamTimeoutMs,
+      ...(baseURL ? { baseURL } : {}),
+    }),
   // Keyless openai-compatible endpoints (e.g. LM Studio) ignore the key; the
   // placeholder satisfies the OpenAI SDK, which requires a non-empty key.
   "openai-compatible": ({ apiKey, model, streamTimeoutMs, baseURL }) =>

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1882,6 +1882,25 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     apiKeyPlaceholder: "vck_...",
   },
   {
+    id: "litellm",
+    displayName: "LiteLLM",
+    subtitle:
+      "AI gateway proxy for 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, etc.).",
+    setupMode: "api-key",
+    setupHint:
+      "Enter your LiteLLM proxy base URL and API key. Models are auto-discovered from the proxy.",
+    envVar: "LITELLM_API_KEY",
+    credentialsGuide: {
+      description:
+        "Set up a LiteLLM proxy, then use the master key or a virtual key.",
+      url: "https://docs.litellm.ai/docs/proxy/quick_start",
+      linkLabel: "LiteLLM Proxy Quick Start",
+    },
+    apiKeyPlaceholder: "sk-...",
+    models: [],
+    defaultModel: "",
+  },
+  {
     id: "openai-compatible",
     displayName: "OpenAI-compatible",
     subtitle:

--- a/cli/src/shared/provider-env-vars.ts
+++ b/cli/src/shared/provider-env-vars.ts
@@ -30,6 +30,7 @@ export const LLM_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
   minimax: "MINIMAX_API_KEY",
   atlascloud: "ATLASCLOUD_API_KEY",
   together: "TOGETHER_API_KEY",
+  litellm: "LITELLM_API_KEY",
   baseten: "BASETEN_API_KEY",
 };
 

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -844,6 +844,7 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
   ],
+  litellm: [],
   baseten: [
     {
       id: "thinkingmachines/inkling",
@@ -870,6 +871,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
   "vercel-ai-gateway": "anthropic/claude-sonnet-4.6",
   minimax: "MiniMax-M2.7",
   atlascloud: "deepseek-ai/deepseek-v4-pro",
+  litellm: "",
   baseten: "thinkingmachines/inkling",
   "openai-compatible": "",
 };
@@ -896,6 +898,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   "openai-compatible": "OpenAI-compatible",
   minimax: "MiniMax",
   atlascloud: "Atlas Cloud",
+  litellm: "LiteLLM",
   baseten: "Baseten",
 };
 
@@ -918,6 +921,7 @@ export const PROVIDER_SUPPORTS_PLATFORM_AUTH: Record<string, boolean> = {
   "openai-compatible": false,
   minimax: false,
   atlascloud: false,
+  litellm: false,
   baseten: false,
 };
 

--- a/clients/web/src/domains/settings/ai/constants.ts
+++ b/clients/web/src/domains/settings/ai/constants.ts
@@ -20,6 +20,7 @@ export const INFERENCE_PROVIDERS = [
   "ollama",
   "minimax",
   "atlascloud",
+  "litellm",
   "baseten",
 ] as const;
 

--- a/clients/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/clients/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -33,6 +33,7 @@ export const CONNECTION_PROVIDERS: ConnectionProvider[] = [
   "vercel-ai-gateway",
   "minimax",
   "atlascloud",
+  "litellm",
   "baseten",
   "openai-compatible",
 ];

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1926,6 +1926,23 @@
       ]
     },
     {
+      "id": "litellm",
+      "displayName": "LiteLLM",
+      "subtitle": "AI gateway proxy for 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, etc.).",
+      "setupMode": "api-key",
+      "setupHint": "Enter your LiteLLM proxy base URL and API key. Models are auto-discovered from the proxy.",
+      "envVar": "LITELLM_API_KEY",
+      "apiKeyPlaceholder": "sk-...",
+      "credentialsGuide": {
+        "description": "Set up a LiteLLM proxy, then use the master key or a virtual key.",
+        "url": "https://docs.litellm.ai/docs/proxy/quick_start",
+        "linkLabel": "LiteLLM Proxy Quick Start"
+      },
+      "supportsPlatformAuth": false,
+      "defaultModel": "",
+      "models": []
+    },
+    {
       "id": "openai-compatible",
       "displayName": "OpenAI-compatible",
       "subtitle": "Bring your own OpenAI-compatible endpoint (vLLM, LMStudio, Groq, Together, etc.).",


### PR DESCRIPTION
## Prompt / plan

Rebase of #38207 ("Feat/add litellm provider") onto the latest `main`, with the CI failure fixed. That PR lives on a contributor fork, so this is a fresh PR off `main` carrying the same work in a mergeable state.

Registers **LiteLLM** as a first-class LLM provider. LiteLLM is an OpenAI-compatible AI gateway proxy that fronts 100+ providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, etc.), so it reuses the existing `OpenAIChatCompletionsProvider` adapter with no new transport code.

**Why a new PR / what was fixed:** #38207's last merge with `main` was resolved incorrectly, leaving invalid TypeScript in `clients/web/src/assistant/llm-model-catalog.ts` (an unclosed `litellm: [` array and a duplicated `"openai-compatible"` key) and malformed YAML in `openapi.yaml`. That was failing Build, Type Check, Lint, and Test. The hand-written litellm source here is otherwise identical to #38207; the corrupted block is replaced with a correct `litellm: []` entry, and the generated specs are regenerated cleanly on the current `main` base.

## Changes

- `assistant/src/config/schemas/llm.ts` — add `litellm` to the `LLMProvider` enum
- `assistant/src/providers/inference/adapter-factory.ts` — litellm adapter factory using `OpenAIChatCompletionsProvider`
- `assistant/src/providers/model-catalog.ts` — LiteLLM catalog entry (api-key setup, empty models list, auto-discovered from the proxy)
- `assistant/src/providers/inference/__tests__/adapter-factory-litellm.test.ts` — adapter factory tests
- `cli/src/shared/provider-env-vars.ts` — `litellm: "LITELLM_API_KEY"`
- `clients/web/src/assistant/llm-model-catalog.ts` — litellm entries in `MODELS_BY_PROVIDER`, `DEFAULT_MODEL_BY_PROVIDER`, `PROVIDER_DISPLAY_NAMES`, `PROVIDER_SUPPORTS_PLATFORM_AUTH`
- `clients/web/src/domains/settings/ai/constants.ts` — add to `INFERENCE_PROVIDERS`
- `clients/web/src/domains/settings/ai/provider-editor-constants.ts` — add to `CONNECTION_PROVIDERS`
- `assistant/openapi.yaml` — regenerated
- `meta/llm-provider-catalog.json` — regenerated

## Test plan

Run locally against the current `main` base — all green:

- `assistant` litellm adapter tests: 5/5 pass
- `cli` `llm-provider-env-var-parity.test.ts`: 1/1 pass
- `clients/web` `llm-model-catalog.test.ts`: 43/43 pass
- `assistant` `chat-credential-redaction.test.ts`: 98/98 pass
- `clients/web` `profile-param-visibility.test.ts`: 21/21 pass
- Type check: assistant, cli, and web all pass
- `bun run generate:openapi`, `bun run sync:llm-catalog`, and web `openapi-ts` regenerate with no drift
- Prettier + ESLint clean on all changed files; pre-push hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012G6yVuQpGeQM1yr519Kwyv

---
_Generated by [Claude Code](https://claude.ai/code/session_012G6yVuQpGeQM1yr519Kwyv)_