### PR TITLE
feat(voice): forward structured tool events through the voice bridge

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -652,6 +652,13 @@ describe("web_search_tool_result structural guard", () => {
     // provider, not the local tool executor, so they never flow here.
     "agent/loop.ts",
 
+    // Matches the `tool_result` ServerMessage SSE event (api/events/
+    // tool-result.ts), not a conversation content block. There is no
+    // web_search_tool_result SSE event — web-search activity travels as
+    // activityMetadata on the same tool_result event. Same event-vs-block
+    // distinction as agent/loop.ts, one hop downstream.
+    "calls/voice-session-bridge.ts",
+
     // Counts consecutive errors for locally-executed tools to bound retry
     // coaching. Server-side web search results (web_search_tool_result) carry
     // no is_error flag and are not produced by the tool executor, so only

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1018,3 +1018,107 @@ describe("startVoiceTurn race-loss state restore", () => {
     expect(waited.assistantId).toBe(winnerState.assistantId);
   });
 });
+
+describe("startVoiceTurn tool-event forwarding", () => {
+  // The agent loop's tool_use_start / tool_result events reach the voice
+  // callbacks so the session can track per-turn tool activity. The bridge is
+  // the single truncation point for tool results — the raw result can be
+  // huge and must never travel further into the voice layer.
+
+  /** Scripts runAgentLoop to emit the given agent-loop events in order. */
+  function makeEventEmittingConversation(events: unknown[]) {
+    const fake = makeFakeConversation({ processing: false });
+    fake.conversation.runAgentLoop = async (...args: unknown[]) => {
+      const { onEvent } = args[2] as { onEvent: (msg: unknown) => void };
+      for (const event of events) {
+        onEvent(event);
+      }
+    };
+    fakeConversation = fake.conversation;
+  }
+
+  test("tool_use_start delivers the tool name with input and toolUseId", async () => {
+    makeEventEmittingConversation([
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "weather" },
+        toolUseId: "toolu-1",
+      },
+    ]);
+
+    const starts: Array<{ toolName: string; detail?: unknown }> = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_use_start: (toolName, detail) => starts.push({ toolName, detail }),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(starts).toEqual([
+      {
+        toolName: "web_search",
+        detail: { input: { query: "weather" }, toolUseId: "toolu-1" },
+      },
+    ]);
+  });
+
+  test("tool_result delivers name, id, isError, and a 200-char-truncated preview", async () => {
+    const longResult = "x".repeat(500);
+    makeEventEmittingConversation([
+      {
+        type: "tool_result",
+        toolName: "web_search",
+        result: longResult,
+        isError: true,
+        toolUseId: "toolu-1",
+      },
+    ]);
+
+    const results: unknown[] = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_result: (event) => results.push(event),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(results).toEqual([
+      {
+        toolName: "web_search",
+        toolUseId: "toolu-1",
+        isError: true,
+        // The shared `truncate` util caps at 200 chars including its "..."
+        // truncation marker.
+        resultPreview: `${"x".repeat(197)}...`,
+      },
+    ]);
+  });
+
+  test("a callbacks object without the tool-event members doesn't throw", async () => {
+    makeEventEmittingConversation([
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: {},
+        toolUseId: "toolu-1",
+      },
+      {
+        type: "tool_result",
+        toolName: "web_search",
+        result: "ok",
+        toolUseId: "toolu-1",
+      },
+    ]);
+
+    const handle = await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {},
+    });
+    await flushMicrotasks();
+
+    expect(handle.turnId).toBeString();
+  });
+});

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -30,6 +30,7 @@ import { publishConversationMessagesChanged } from "../runtime/sync/resource-syn
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
+import { truncate } from "../util/truncate.js";
 import {
   CALL_OPENING_MARKER,
   CALL_VERIFICATION_COMPLETE_MARKER,
@@ -150,6 +151,12 @@ export function getConversationTurnTeardown(
 // ---------------------------------------------------------------------------
 
 /**
+ * Max length of the tool-result preview forwarded to voice callbacks. The
+ * single truncation point for tool results entering the voice layer.
+ */
+export const TOOL_RESULT_PREVIEW_MAX_CHARS = 200;
+
+/**
  * Real-time event sink for voice TTS streaming. Agent-loop events are
  * forwarded here for real-time text-to-speech without modifying the
  * standard channel path.
@@ -165,7 +172,18 @@ export interface VoiceRunEventSink {
     >,
   ): void;
   onError(message: string): void;
-  onToolUse(toolName: string, input: Record<string, unknown>): void;
+  onToolUse(
+    toolName: string,
+    input: Record<string, unknown>,
+    toolUseId?: string,
+  ): void;
+  /** Optional: sinks that don't consume tool results can omit this. */
+  onToolResult?(
+    toolName: string,
+    toolUseId: string | undefined,
+    isError: boolean | undefined,
+    resultPreview: string,
+  ): void;
 }
 
 export interface VoiceTurnCallbacks {
@@ -181,7 +199,22 @@ export interface VoiceTurnCallbacks {
   persisted_user_message_id?: (messageId: string) => void;
   persisted_assistant_message_id?: (messageId: string) => void;
   /** Fired when the agent run starts a definitive tool use this turn. */
-  tool_use_start?: (toolName: string) => void;
+  tool_use_start?: (
+    toolName: string,
+    detail?: { input: Record<string, unknown>; toolUseId?: string },
+  ) => void;
+  /**
+   * Fired when a tool invocation finishes. `resultPreview` is the result
+   * truncated to {@link TOOL_RESULT_PREVIEW_MAX_CHARS} at the bridge — the
+   * raw result can be huge and must never travel further into the voice
+   * layer.
+   */
+  tool_result?: (event: {
+    toolName: string;
+    toolUseId?: string;
+    isError?: boolean;
+    resultPreview: string;
+  }) => void;
 }
 
 export interface VoiceTurnOptions {
@@ -420,9 +453,17 @@ export async function startVoiceTurn(
     onError: (message) => {
       opts.onError?.(message);
     },
-    onToolUse: (toolName, input) => {
+    onToolUse: (toolName, input, toolUseId) => {
       log.debug({ toolName, input }, "Voice turn tool_use event");
-      opts.callbacks?.tool_use_start?.(toolName);
+      opts.callbacks?.tool_use_start?.(toolName, { input, toolUseId });
+    },
+    onToolResult: (toolName, toolUseId, isError, resultPreview) => {
+      opts.callbacks?.tool_result?.({
+        toolName,
+        toolUseId,
+        isError,
+        resultPreview,
+      });
     },
   };
 
@@ -1011,7 +1052,14 @@ export async function startVoiceTurn(
           } else if (msg.type === "conversation_error") {
             eventSink.onError(msg.userMessage);
           } else if (msg.type === "tool_use_start") {
-            eventSink.onToolUse(msg.toolName, msg.input);
+            eventSink.onToolUse(msg.toolName, msg.input, msg.toolUseId);
+          } else if (msg.type === "tool_result") {
+            eventSink.onToolResult?.(
+              msg.toolName,
+              msg.toolUseId,
+              msg.isError,
+              truncate(msg.result, TOOL_RESULT_PREVIEW_MAX_CHARS),
+            );
           }
           // Note: tool_use_preview_start is intentionally not handled here.
           // Voice only reacts to the definitive tool_use_start event.


### PR DESCRIPTION
## Summary
- VoiceTurnCallbacks.tool_use_start now carries { input, toolUseId } (additive param)
- New optional tool_result callback with 200-char resultPreview truncated at the bridge
- RealTimeEventSink gains optional onToolResult; phone sink unchanged

Part of plan: front-model-progress-narration.md (PR 1 of 4)