### PR TITLE
feat(web): add bubble surface tokens to avatar tone

### DIFF
--- a/clients/web/src/utils/avatar-tone.test.ts
+++ b/clients/web/src/utils/avatar-tone.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for `toneForBg`'s user-bubble surface tokens (`bubbleBg`/`bubbleFg`).
+ *
+ * Pins the contract that the bubble is a raised surface contrasting the
+ * avatar color — white/near-black over dark or saturated avatars, inverted
+ * to dark/white over the one light avatar color (yellow) — and that adding
+ * these fields left the pre-existing tone values untouched.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { toneForBg } from "./avatar-tone";
+
+describe("toneForBg bubble tokens", () => {
+  test("dark bg yields a white bubble with near-black text", () => {
+    const surface = toneForBg("#17191C");
+    expect(surface.bubbleBg).toBe("#FFFFFF");
+    expect(surface.bubbleFg).toBe("#1A1A1A");
+
+    const teal = toneForBg("#3E9B87");
+    expect(teal.bubbleBg).toBe("#FFFFFF");
+    expect(teal.bubbleFg).toBe("#1A1A1A");
+  });
+
+  test("light bg (yellow) inverts to a dark bubble with white text", () => {
+    const tone = toneForBg("#F2C94C");
+    expect(tone.isLight).toBe(true);
+    expect(tone.bubbleBg).toBe("#1A1A1A");
+    expect(tone.bubbleFg).toBe("#FFFFFF");
+  });
+
+  test("pre-existing fields are unchanged (additive-only)", () => {
+    const tone = toneForBg("#17191C");
+    expect(tone.fg).toBe("#FFFFFF");
+    expect(tone.fgMuted).toBe("rgba(255,255,255,0.65)");
+  });
+});

--- a/clients/web/src/utils/avatar-tone.test.ts
+++ b/clients/web/src/utils/avatar-tone.test.ts
@@ -3,8 +3,8 @@
  *
  * Pins the contract that the bubble is a raised surface contrasting the
  * avatar color — white/near-black over dark or saturated avatars, inverted
- * to dark/white over the one light avatar color (yellow) — and that adding
- * these fields left the pre-existing tone values untouched.
+ * to dark/white over the one light avatar color (yellow) — while the base
+ * tone fields (`fg`/`fgMuted`) keep their established values.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -29,7 +29,7 @@ describe("toneForBg bubble tokens", () => {
     expect(tone.bubbleFg).toBe("#FFFFFF");
   });
 
-  test("pre-existing fields are unchanged (additive-only)", () => {
+  test("base tone fields keep their established values", () => {
     const tone = toneForBg("#17191C");
     expect(tone.fg).toBe("#FFFFFF");
     expect(tone.fgMuted).toBe("rgba(255,255,255,0.65)");

--- a/clients/web/src/utils/avatar-tone.ts
+++ b/clients/web/src/utils/avatar-tone.ts
@@ -26,6 +26,13 @@ export interface AvatarTone {
   fgMuted: string;
   /** A subtle hover/fill wash at the matching tone. */
   wash: string;
+  /**
+   * Solid raised-surface fill for a user speech bubble that contrasts the
+   * avatar color: white over dark/saturated avatars, dark over the light one.
+   */
+  bubbleBg: string;
+  /** Text color drawn on that bubble (the inverse of {@link bubbleBg}). */
+  bubbleFg: string;
 }
 
 const FG_DARK = "#1A1A1A";
@@ -92,5 +99,7 @@ export function toneForBg(bg: string): AvatarTone {
     fgDeep: darkenHex(bg, 0.6),
     fgMuted: isLight ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.65)",
     wash: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)",
+    bubbleBg: isLight ? FG_DARK : FG_LIGHT,
+    bubbleFg: isLight ? FG_LIGHT : FG_DARK,
   };
 }


### PR DESCRIPTION
## Summary
- Add bubbleBg/bubbleFg to AvatarTone / toneForBg for user speech-bubble surfaces in the voice room
- New avatar-tone.test.ts covering light + dark tones

Part of plan: voice-room-transcript-rail.md (PR 1 of 4)