### PR TITLE
feat(web): allow VoiceTranscriptText color overrides

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Tests for `VoiceTranscriptText`.
+ *
+ * Two load-bearing contracts: the plain sentence is exactly the rendered
+ * `textContent` (so the caller's `aria-live` region announces it verbatim),
+ * and the optional color overrides land on the right spans — the leading edge
+ * (last word) gets `leadingColor`, the settled words get `baseColor`.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { VoiceTranscriptText } from "@/domains/chat/voice/voice-room/voice-transcript-text";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("VoiceTranscriptText", () => {
+  test("exposes the plain sentence as textContent", () => {
+    const { container } = render(<VoiceTranscriptText text="hello world" />);
+    expect(container.textContent).toBe("hello world");
+  });
+
+  test("applies color overrides to the leading vs. non-leading spans", () => {
+    const { container } = render(
+      <VoiceTranscriptText
+        text="hello world"
+        leadingColor="rgb(1, 2, 3)"
+        baseColor="rgb(4, 5, 6)"
+      />,
+    );
+    const spans = container.querySelectorAll("span");
+    expect(spans.length).toBe(2);
+    // The last word is the leading edge; earlier words settle to the base tone.
+    expect(spans[spans.length - 1]!.style.color).toBe("rgb(1, 2, 3)");
+    expect(spans[0]!.style.color).toBe("rgb(4, 5, 6)");
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -26,7 +26,17 @@
 import { Fragment, useMemo } from "react";
 import { motion, useReducedMotion } from "motion/react";
 
-export function VoiceTranscriptText({ text }: { text: string }) {
+export function VoiceTranscriptText({
+  text,
+  leadingColor = "var(--room-fg, var(--content-secondary))",
+  baseColor = "var(--room-fg-muted, var(--content-tertiary))",
+}: {
+  text: string;
+  /** Tone for the most recent ("leading edge") word. */
+  leadingColor?: string;
+  /** Tone for the settled words trailing the leading edge. */
+  baseColor?: string;
+}) {
   const reduce = useReducedMotion();
   // Collapse runs of whitespace to single spaces — the words are laid out with
   // real space text nodes between them (so they wrap and select naturally, and
@@ -43,9 +53,7 @@ export function VoiceTranscriptText({ text }: { text: string }) {
             <motion.span
               className="inline-block"
               style={{
-                color: leading
-                  ? "var(--room-fg, var(--content-secondary))"
-                  : "var(--room-fg-muted, var(--content-tertiary))",
+                color: leading ? leadingColor : baseColor,
                 // The leading-edge tone eases back to the base as the next word
                 // takes over (the motion entrance below owns transform/opacity).
                 transition: "color 0.45s ease",


### PR DESCRIPTION
## Summary
- Add optional leadingColor/baseColor props to VoiceTranscriptText (defaults preserve current room-fg tones)
- New voice-transcript-text.test.tsx

Part of plan: voice-room-transcript-rail.md (PR 2 of 4)