### PR TITLE
feat(web): voice-room transcript as a right-side chat rail

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -6,7 +6,7 @@
  * selectors: transcript fields via the live-voice store, the two visibility
  * toggles via the voice-prefs store. The load-bearing contract is the
  * pref-gating — both prefs default OFF, so the room stays text-free — plus the
- * user-above / assistant-below ordering.
+ * user-before-assistant DOM ordering.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -142,7 +142,7 @@ describe("VoiceAmbientTranscript — sourcing and ordering", () => {
     expect(userText()?.textContent).toContain("what I said");
   });
 
-  test("renders user ABOVE assistant (DOM order) when both are ON", () => {
+  test("renders user before assistant in DOM order when both are ON", () => {
     seedUser("my question");
     seedAssistant("my answer");
     setPrefs({ user: true, assistant: true });
@@ -156,6 +156,23 @@ describe("VoiceAmbientTranscript — sourcing and ordering", () => {
       user!.compareDocumentPosition(assistant!) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  test("user half renders a bubble tied to the room bubble-bg var", () => {
+    seedUser("hello there");
+    setPrefs({ user: true, assistant: false });
+    render(<VoiceAmbientTranscript />);
+    const bubble = screen.queryByTestId("voice-ambient-user-bubble");
+    expect(bubble).not.toBeNull();
+    expect(bubble!.getAttribute("style")).toContain("--room-bubble-bg");
+  });
+
+  test("assistant half is plain text with no bubble wrapper", () => {
+    seedAssistant("my answer");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    expect(screen.queryByTestId("voice-ambient-user-bubble")).toBeNull();
+    expect(assistantText()?.textContent).toContain("my answer");
   });
 
   test("streams assistant deltas without remounting", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -78,10 +78,21 @@ export function VoiceAmbientTranscript() {
   // bottom-anchored column.
   const fadeMask = "linear-gradient(to bottom, transparent, #000 12%)";
 
+  // Absolute children are positioned against the padding box, so the overlay's
+  // safe-area padding does not inset this rail — fold the right inset into the
+  // rail's own right padding (as the room's corner controls do) so transcript
+  // text clears the notch / rounded edge in landscape on notched shells.
+  const railRightPad =
+    "calc(1.5rem + var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))";
+
   return (
     <div
-      className="pointer-events-none absolute right-0 top-0 bottom-0 z-0 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pr-6 pt-20 pb-28"
-      style={{ maskImage: fadeMask, WebkitMaskImage: fadeMask }}
+      className="pointer-events-none absolute right-0 top-0 bottom-0 z-0 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pt-20 pb-28"
+      style={{
+        paddingRight: railRightPad,
+        maskImage: fadeMask,
+        WebkitMaskImage: fadeMask,
+      }}
     >
       <AnimatePresence>
         {showUserHalf ? (
@@ -94,7 +105,7 @@ export function VoiceAmbientTranscript() {
           >
             <div
               data-testid="voice-ambient-user-bubble"
-              className="max-w-[85%] rounded-2xl px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
+              className="max-w-[85%] break-words rounded-2xl px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
               style={{ backgroundColor: "var(--room-bubble-bg)" }}
             >
               <VoiceTranscriptText
@@ -114,7 +125,7 @@ export function VoiceAmbientTranscript() {
             className="flex justify-start"
             {...fade}
           >
-            <div className="max-w-[95%] text-[clamp(15px,2vmin,19px)] leading-relaxed">
+            <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
               <VoiceTranscriptText text={assistantTranscript} />
             </div>
           </motion.div>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -1,28 +1,29 @@
 /**
- * Ambient floating transcript for the voice room — muted, secondary text that
- * hovers near the centered avatar without ever becoming a chat bubble or
- * displacing the avatar. Two independently pref-gated halves:
+ * Live transcript for the voice room, styled as a right-side chat rail. A
+ * bottom-anchored column pinned to the room's right edge, newest content at the
+ * bottom, with a top fade mask so older lines dissolve as they scroll up. Two
+ * independently pref-gated halves:
  *
- * - USER speech ABOVE the avatar — `partialTranscript || finalTranscript` from
- *   the live-voice store, shown only when `showUserTranscript` is on.
- * - ASSISTANT speech BELOW the avatar — `assistantTranscript`, shown only when
- *   `showAssistantTranscript` is on AND the assistant isn't idle behind a new
- *   `listening` turn (the transcript lingers until the next response starts, so
- *   without this it would sit under the low-sunk listening eyes).
+ * - USER speech as a right-aligned "raised surface" bubble —
+ *   `partialTranscript || finalTranscript` from the live-voice store, shown only
+ *   when `showUserTranscript` is on. The bubble uses the room's bubble tone vars
+ *   (white surface / dark text over dark avatars, inverted for the light one).
+ * - ASSISTANT speech as left-aligned muted plain text (no bubble) —
+ *   `assistantTranscript`, shown only when `showAssistantTranscript` is on AND
+ *   the assistant isn't idle behind a new `listening` turn (the transcript
+ *   lingers until the next response starts).
  *
  * Both prefs default OFF, so by default this renders nothing and the room stays
- * text-free. The avatar (centered by the room) is the primary anchor; each half
- * is absolutely positioned relative to the room overlay so text appearing or
- * clearing never shifts the avatar. Words reveal one at a time via
- * {@link VoiceTranscriptText}, with a per-half clearance that keeps the text off
- * the centered eyes at any window size.
+ * text-free. The rail is `pointer-events-none`, so it never blocks the room's
+ * ✕/gear controls or the mic/stop cluster. Words reveal one at a time via
+ * {@link VoiceTranscriptText}.
  *
  * Subscriptions are deliberately narrow — the three transcript fields, the two
  * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
  * listening gate) — so the high-frequency `inputAmplitude` churn on the
  * live-voice store never re-renders this component. The full transcript still
  * lands in the chat thread on exit via the engine path; this is a live, ambient
- * echo only.
+ * echo of the current turn only.
  */
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -32,24 +33,6 @@ import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
 import { VoiceTranscriptText } from "./voice-transcript-text";
-
-/**
- * Shared constrained-width, centered treatment for both halves. Base tone comes
- * from the per-word {@link VoiceTranscriptText} (room-fg-muted, leading word
- * brighter); this only owns layout + wrapping.
- */
-const AMBIENT_TEXT_CLASS =
-  "pointer-events-none absolute left-1/2 z-0 max-w-[38rem] -translate-x-1/2 px-6 text-center text-[clamp(19px,2.6vmin,30px)] leading-relaxed text-balance whitespace-pre-wrap break-words";
-
-/**
- * Vertical clearance from the room center to each transcript half. The centered
- * eyes reach up to `EYE_TARGET_HEIGHT` (30%) of the smaller viewport dimension
- * tall — i.e. 15vmin above and below center — so anchoring the text past
- * `15vmin` plus a gap keeps it clear of the eyes (color look) and the centered
- * avatar (void look) at every window size, where the old fixed rem offset let
- * the big eyes ride into the text.
- */
-const TRANSCRIPT_CLEARANCE = "calc(50% + 15vmin + 2.5rem)";
 
 export function VoiceAmbientTranscript() {
   const showUser = useVoicePrefsStore.use.showUserTranscript();
@@ -71,14 +54,18 @@ export function VoiceAmbientTranscript() {
 
   // The assistant transcript is only cleared when the NEXT response starts
   // thinking, so a finished response lingers in the store through the following
-  // `listening` turn — where the eyes sink low, right onto the below-center
-  // assistant caption. Hide that half while listening (the assistant isn't
-  // speaking then anyway); in thinking/responding the eyes are centered and the
-  // clearance clears them.
+  // `listening` turn. Hide that half while listening (the assistant isn't
+  // speaking then anyway); in thinking/responding it stays.
   const visual = toVoiceAvatarVisual(state, reconnecting, assistantAudioActive);
   const showUserHalf = showUser && userText.length > 0;
   const showAssistantHalf =
     showAssistant && assistantTranscript.length > 0 && visual !== "listening";
+
+  // Text-free contract: with both halves gated off there is no rail at all, so
+  // the room renders nothing.
+  if (!showUserHalf && !showAssistantHalf) {
+    return null;
+  }
 
   const fade = {
     initial: reduce ? false : { opacity: 0 },
@@ -87,36 +74,52 @@ export function VoiceAmbientTranscript() {
     transition: { duration: reduce ? 0 : 0.3 },
   } as const;
 
-  return (
-    <AnimatePresence>
-      {showUserHalf ? (
-        <motion.p
-          key="user"
-          data-testid="voice-ambient-user"
-          aria-live="polite"
-          // Above the centered avatar; bottom-anchored so it grows upward and
-          // never creeps toward the orb.
-          className={AMBIENT_TEXT_CLASS}
-          style={{ bottom: TRANSCRIPT_CLEARANCE }}
-          {...fade}
-        >
-          <VoiceTranscriptText text={userText} />
-        </motion.p>
-      ) : null}
+  // A top-to-bottom fade so older lines dissolve as newer ones push up from the
+  // bottom-anchored column.
+  const fadeMask = "linear-gradient(to bottom, transparent, #000 12%)";
 
-      {showAssistantHalf ? (
-        <motion.p
-          key="assistant"
-          data-testid="voice-ambient-assistant"
-          aria-live="polite"
-          // Below the centered avatar; top-anchored so it grows downward.
-          className={AMBIENT_TEXT_CLASS}
-          style={{ top: TRANSCRIPT_CLEARANCE }}
-          {...fade}
-        >
-          <VoiceTranscriptText text={assistantTranscript} />
-        </motion.p>
-      ) : null}
-    </AnimatePresence>
+  return (
+    <div
+      className="pointer-events-none absolute right-0 top-0 bottom-0 z-0 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pr-6 pt-20 pb-28"
+      style={{ maskImage: fadeMask, WebkitMaskImage: fadeMask }}
+    >
+      <AnimatePresence>
+        {showUserHalf ? (
+          <motion.div
+            key="user"
+            data-testid="voice-ambient-user"
+            aria-live="polite"
+            className="flex justify-end"
+            {...fade}
+          >
+            <div
+              data-testid="voice-ambient-user-bubble"
+              className="max-w-[85%] rounded-2xl px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
+              style={{ backgroundColor: "var(--room-bubble-bg)" }}
+            >
+              <VoiceTranscriptText
+                text={userText}
+                leadingColor="var(--room-bubble-fg)"
+                baseColor="var(--room-bubble-fg)"
+              />
+            </div>
+          </motion.div>
+        ) : null}
+
+        {showAssistantHalf ? (
+          <motion.div
+            key="assistant"
+            data-testid="voice-ambient-assistant"
+            aria-live="polite"
+            className="flex justify-start"
+            {...fade}
+          >
+            <div className="max-w-[95%] text-[clamp(15px,2vmin,19px)] leading-relaxed">
+              <VoiceTranscriptText text={assistantTranscript} />
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -191,6 +191,8 @@ function VoiceRoomOverlay() {
     "--room-fg-muted": tone?.fgMuted ?? "rgba(255,255,255,0.7)",
     "--room-wash": tone?.wash ?? "rgba(255,255,255,0.1)",
     "--room-border": tone?.wash ?? "rgba(255,255,255,0.15)",
+    "--room-bubble-bg": tone?.bubbleBg ?? "#FFFFFF",
+    "--room-bubble-fg": tone?.bubbleFg ?? "#1A1A1A",
   } as CSSProperties;
 
   // Global Escape, live only while the room is mounted: ends the session,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -51,7 +51,10 @@ export function VoiceTranscriptText({
         return (
           <Fragment key={i}>
             <motion.span
-              className="inline-block"
+              // `max-w-full` + break-anywhere so a single long token (URL, code)
+              // wraps within its container instead of overflowing the narrow
+              // transcript rail and being clipped.
+              className="inline-block max-w-full [overflow-wrap:anywhere]"
               style={{
                 color: leading ? leadingColor : baseColor,
                 // The leading-edge tone eases back to the base as the next word


### PR DESCRIPTION
## Summary
- Restyle the voice-room live transcript into a right-side, bottom-anchored chat rail: user speech as a right-aligned bubble, assistant speech as left-aligned muted plain text, with a top fade mask
- Publish --room-bubble-bg / --room-bubble-fg on the room root (both looks)
- Still pref-gated; current-turn data only; tests updated

Part of plan: voice-room-transcript-rail.md (PR 3 of 4)