### PR TITLE
Memory tier telemetry (daemon emit)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33662,6 +33662,11 @@ components:
             - running
             - not_running
             - unreachable
+        origin:
+          type: string
+          enum:
+            - plugin
+            - workspace
         children:
           type: array
           items:
@@ -33671,6 +33676,7 @@ components:
       required:
         - name
         - status
+        - origin
       additionalProperties: false
     AuthOutput:
       oneOf:

--- a/assistant/src/config/memory-tier.test.ts
+++ b/assistant/src/config/memory-tier.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { memoryTier } from "./memory-tier.js";
+import type { AssistantConfig } from "./schema.js";
+
+describe("memoryTier", () => {
+  test("off when memory is explicitly disabled", () => {
+    const config = { memory: { enabled: false } } as AssistantConfig;
+    expect(memoryTier(config)).toBe("off");
+  });
+
+  test("off wins even when v3 is live (OFF over v3 precedence)", () => {
+    const config = {
+      memory: { enabled: false, v3: { live: true } },
+    } as AssistantConfig;
+    expect(memoryTier(config)).toBe("off");
+  });
+
+  test("v3 when memory-v3 is live", () => {
+    const config = { memory: { v3: { live: true } } } as AssistantConfig;
+    expect(memoryTier(config)).toBe("v3");
+  });
+
+  test("v2 when v2 is enabled and v3 is not live", () => {
+    const config = {
+      memory: { v2: { enabled: true }, v3: { live: false } },
+    } as AssistantConfig;
+    expect(memoryTier(config)).toBe("v2");
+  });
+
+  test("v3 wins over v2 when both are truthy (v3 over v2 precedence)", () => {
+    const config = {
+      memory: { v2: { enabled: true }, v3: { live: true } },
+    } as AssistantConfig;
+    expect(memoryTier(config)).toBe("v3");
+  });
+
+  test("v1 when memory is on but neither v2 nor v3 is selected", () => {
+    const config = {
+      memory: { enabled: true, v2: { enabled: false }, v3: { live: false } },
+    } as AssistantConfig;
+    expect(memoryTier(config)).toBe("v1");
+  });
+});

--- a/assistant/src/config/memory-tier.ts
+++ b/assistant/src/config/memory-tier.ts
@@ -1,0 +1,31 @@
+import { isMemoryV3Live } from "./memory-v3-gate.js";
+import type { AssistantConfig } from "./schema.js";
+
+export type MemoryTier = "off" | "v1" | "v2" | "v3";
+
+/**
+ * Derive the coarse memory tier for an assistant, as a single bucket for
+ * telemetry. Precedence mirrors the runtime memory-source semantics:
+ *
+ * - `"off"` wins over everything: an explicit `memory.enabled === false`
+ *   disables the whole memory system regardless of v2/v3 settings.
+ * - `"v3"` wins over `"v2"`: when memory-v3 is live it suppresses v2 injection
+ *   (see {@link isMemoryV3Live}).
+ * - `"v2"` when v2 is explicitly enabled and v3 is not live.
+ * - `"v1"` otherwise (memory on, neither v2 nor v3 selected).
+ *
+ * Optional chaining is defensive — a partial config (e.g. a mocked config in
+ * tests) resolves to the correct bucket rather than throwing.
+ */
+export function memoryTier(config: AssistantConfig): MemoryTier {
+  if (config.memory?.enabled === false) {
+    return "off";
+  }
+  if (isMemoryV3Live(config)) {
+    return "v3";
+  }
+  if (config.memory?.v2?.enabled === true) {
+    return "v2";
+  }
+  return "v1";
+}

--- a/assistant/src/monitoring/worker.ts
+++ b/assistant/src/monitoring/worker.ts
@@ -23,6 +23,10 @@ import {
   stopConfigSnapshotReporter,
 } from "../telemetry/config-setting-snapshot.js";
 import {
+  startMemoryTierReporter,
+  stopMemoryTierReporter,
+} from "../telemetry/memory-tier-reporter.js";
+import {
   startMonitorUsageTelemetryReporter,
   stopUsageTelemetryReporter,
 } from "../telemetry/usage-telemetry-reporter.js";
@@ -94,6 +98,9 @@ async function main(): Promise<void> {
   // process flushes.
   startConfigSnapshotReporter();
 
+  // Emit the coarse memory tier as a periodic per-assistant watchdog heartbeat.
+  startMemoryTierReporter();
+
   let shuttingDown = false;
   let disposePidGuard: (() => void) | null = null;
   const shutdown = async (signal: string) => {
@@ -104,6 +111,7 @@ async function main(): Promise<void> {
     log.info({ signal }, "Resource monitor process shutting down");
     recovery.stop();
     stopConfigSnapshotReporter();
+    stopMemoryTierReporter();
     sourceWatch.stop();
     sampler.stop();
     // Bounded final telemetry flush, mirroring the daemon's shutdown. This

--- a/assistant/src/telemetry/memory-tier-reporter.test.ts
+++ b/assistant/src/telemetry/memory-tier-reporter.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { memoryTier } from "../config/memory-tier.js";
+import type { AssistantConfig } from "../config/schema.js";
+import type { ConsentState } from "../platform/consent-cache.js";
+import type { WatchdogEventRecord } from "./watchdog-events-store.js";
+
+// Mutable stubs flipped per test. bun's `mock.module` patches retroactively
+// (live bindings), so the reporter's imports resolve to these regardless of
+// import order (mirrors `outbox-test-harness.ts`). Kept off the outbox/DB path
+// on purpose: mocking `recordWatchdogEvent` lets these assert emission without
+// standing up the telemetry DB.
+let consent: ConsentState = true;
+let currentConfig: AssistantConfig = {} as AssistantConfig;
+let recorded: WatchdogEventRecord[] = [];
+
+mock.module("../platform/consent-cache.js", () => ({
+  getRawShareAnalytics: () => consent,
+}));
+mock.module("../config/loader.js", () => ({
+  getConfigReadOnly: () => currentConfig,
+}));
+mock.module("./watchdog-events-store.js", () => ({
+  recordWatchdogEvent: (record: WatchdogEventRecord) => {
+    recorded.push(record);
+  },
+}));
+
+import {
+  recordMemoryTierOnce,
+  startMemoryTierReporter,
+  stopMemoryTierReporter,
+} from "./memory-tier-reporter.js";
+
+function makeConfig(
+  enabled: boolean,
+  v2Enabled: boolean,
+  v3Live = false,
+): AssistantConfig {
+  return {
+    memory: {
+      enabled,
+      v2: { enabled: v2Enabled },
+      v3: { live: v3Live },
+    },
+  } as AssistantConfig;
+}
+
+describe("memory-tier-reporter", () => {
+  beforeEach(() => {
+    consent = true;
+    currentConfig = {} as AssistantConfig;
+    recorded = [];
+    // Clear any interval/boot-retry timer a prior test's start left behind.
+    stopMemoryTierReporter();
+  });
+
+  afterEach(() => {
+    stopMemoryTierReporter();
+    delete process.env.VELLUM_DEV;
+  });
+
+  test("emits a memory_tier watchdog carrying the current tier", () => {
+    const config = makeConfig(true, true); // memory on, v2 enabled → "v2"
+    currentConfig = config;
+
+    recordMemoryTierOnce();
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toEqual({
+      checkName: "memory_tier",
+      detail: { tier: memoryTier(config) },
+    });
+    expect(recorded[0]?.detail?.tier).toBe("v2");
+  });
+
+  test("reflects a different tier for a different config (v3 live)", () => {
+    currentConfig = makeConfig(true, true, true); // v3 live wins over v2
+    recordMemoryTierOnce();
+
+    expect(recorded[0]?.detail).toEqual({ tier: "v3" });
+  });
+
+  test("emits every invocation — no memo", () => {
+    currentConfig = makeConfig(true, false); // "v1"
+    recordMemoryTierOnce();
+    recordMemoryTierOnce();
+    recordMemoryTierOnce();
+
+    expect(recorded).toHaveLength(3);
+    for (const event of recorded) {
+      expect(event).toEqual({
+        checkName: "memory_tier",
+        detail: { tier: "v1" },
+      });
+    }
+  });
+
+  test("unknown consent emits nothing", () => {
+    consent = "unknown";
+    currentConfig = makeConfig(true, true);
+
+    recordMemoryTierOnce();
+
+    expect(recorded).toHaveLength(0);
+  });
+
+  test("a confirmed opt-out still calls through (recordWatchdogEvent no-ops)", () => {
+    // The reporter only skips the UNKNOWN state; the `false` opt-out is
+    // honored one layer down in `recordWatchdogEvent`. Here that layer is the
+    // stub, so the call is observed — the drop is the real store's concern.
+    consent = false;
+    currentConfig = makeConfig(true, true);
+
+    recordMemoryTierOnce();
+
+    expect(recorded).toHaveLength(1);
+  });
+
+  test("startMemoryTierReporter is a no-op under VELLUM_DEV=1", () => {
+    process.env.VELLUM_DEV = "1";
+    consent = true; // consent known → a non-dev start would emit immediately
+    currentConfig = makeConfig(true, true);
+
+    startMemoryTierReporter();
+
+    // No boot emit and no interval scheduled.
+    expect(recorded).toHaveLength(0);
+  });
+});

--- a/assistant/src/telemetry/memory-tier-reporter.ts
+++ b/assistant/src/telemetry/memory-tier-reporter.ts
@@ -1,0 +1,103 @@
+import { getConfigReadOnly } from "../config/loader.js";
+import { memoryTier } from "../config/memory-tier.js";
+import { getRawShareAnalytics } from "../platform/consent-cache.js";
+import { getLogger } from "../util/logger.js";
+import { recordWatchdogEvent } from "./watchdog-events-store.js";
+
+const log = getLogger("memory-tier-reporter");
+
+/**
+ * How often each assistant re-asserts its coarse memory tier as a
+ * `memory_tier` watchdog event. Unlike the config-setting snapshot this emits
+ * UNCONDITIONALLY every cycle (no memo): the platform-side query wants a
+ * periodic per-assistant heartbeat of the current tier, so a gap in the series
+ * is meaningful (assistant offline) rather than "value unchanged". Six-hourly
+ * keeps the volume trivial while giving a same-day read on the fleet's tier
+ * mix, and every boot re-asserts the tier regardless.
+ */
+const MEMORY_TIER_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/** Watchdog `check_name` carrying the coarse memory tier in `detail.tier`. */
+const MEMORY_TIER_CHECK_NAME = "memory_tier";
+
+// The boot-time emit races the first consent refresh (fire-and-forget in the
+// monitor's startup), so consent is usually still "unknown" on the first call
+// and the emit is skipped. Retry on a short timer until consent resolves
+// rather than waiting a full six-hour interval for the per-boot assertion.
+const BOOT_RETRY_INTERVAL_MS = 60_000;
+
+/**
+ * Emit one `memory_tier` watchdog event for this assistant's current tier.
+ *
+ * Consent-gated like the config-setting snapshot but with NO memo: every
+ * invocation emits, so the platform sees a periodic heartbeat of the current
+ * tier rather than only edges. An UNKNOWN consent state skips entirely
+ * (consent resolves asynchronously after boot; the boot-retry loop re-invokes
+ * once it lands) — deferring loses nothing since the tier is re-derivable
+ * state. A confirmed opt-out is honored inside `recordWatchdogEvent`, which
+ * no-ops on a `false` share_analytics, so the call still goes through and the
+ * record layer drops it. Never throws: a storage failure is logged and
+ * retried on the next cycle.
+ */
+export function recordMemoryTierOnce(): void {
+  if (getRawShareAnalytics() === "unknown") {
+    return;
+  }
+  try {
+    // `getConfigReadOnly()` re-reads config.json on change (capturing live
+    // edits) and never writes to disk — safe for the monitor process.
+    const tier = memoryTier(getConfigReadOnly());
+    recordWatchdogEvent({
+      checkName: MEMORY_TIER_CHECK_NAME,
+      detail: { tier },
+    });
+  } catch (err) {
+    log.warn({ err }, "memory_tier watchdog emit failed (non-fatal)");
+  }
+}
+
+let tierTimer: ReturnType<typeof setInterval> | null = null;
+let bootRetryTimer: ReturnType<typeof setTimeout> | null = null;
+
+function recordBootTierOnceConsentKnown(): void {
+  if (getRawShareAnalytics() === "unknown") {
+    bootRetryTimer = setTimeout(
+      recordBootTierOnceConsentKnown,
+      BOOT_RETRY_INTERVAL_MS,
+    );
+    bootRetryTimer.unref?.();
+    return;
+  }
+  bootRetryTimer = null;
+  recordMemoryTierOnce();
+}
+
+/**
+ * Start the memory-tier reporter in the resource monitor process: emit the
+ * current tier once at boot (once consent resolves), then every six hours,
+ * UNCONDITIONALLY. No-op in dev mode (VELLUM_DEV=1) and idempotent if already
+ * started. Runs alongside {@link import("./config-setting-snapshot.js").startConfigSnapshotReporter}
+ * in the monitor worker.
+ */
+export function startMemoryTierReporter(): void {
+  if (process.env.VELLUM_DEV === "1") {
+    return;
+  }
+  if (tierTimer) {
+    return;
+  }
+  recordBootTierOnceConsentKnown();
+  tierTimer = setInterval(recordMemoryTierOnce, MEMORY_TIER_INTERVAL_MS);
+}
+
+/** Stop the memory-tier reporter loop. Idempotent. */
+export function stopMemoryTierReporter(): void {
+  if (tierTimer) {
+    clearInterval(tierTimer);
+    tierTimer = null;
+  }
+  if (bootRetryTimer) {
+    clearTimeout(bootRetryTimer);
+    bootRetryTimer = null;
+  }
+}


### PR DESCRIPTION
## Summary
Emit a per-assistant `memory_tier` watchdog telemetry event (off/v1/v2/v3) on boot + every 6h, unconditionally, for every assistant — so the admin dashboard can count assistants/users by memory tier. Rides the already-registered `watchdog` wire type (open `check_name` + `detail`), so no wire-contract/serializer/dbt/terraform change. Producer half of a cross-repo feature; the platform consumer (admin analytics card) is a separate plan in vellum-assistant-platform.

## Self-review result
PASS — no gaps. Correct OFF→v3→v2→v1 precedence, `getConfigReadOnly()` in the monitor process, consent-gated, idempotent, timers cleaned up; faithful mirror of the config-setting-snapshot reporter.

## PRs merged into feature branch
- #38531: memoryTier(config) helper (off/v1/v2/v3) — also carries a small pre-existing `openapi.yaml` drift regen (an `origin` enum field) unrelated to this feature but required for green CI
- #38536: periodic per-assistant memory_tier watchdog reporter wired into the monitor worker

Part of plan: memory-tier-telemetry.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)