### PR TITLE
fix: finish-setup nudge correctness + wizard cleanup from plan self-review

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -3,7 +3,9 @@
  *
  * `?pro_onboarding` reopens the post-checkout onboarding wizard without a
  * Stripe `session_id`, and the "Finish Pro setup" nudge renders only for a
- * Pro subscription whose domain setup is still available.
+ * Pro subscription with no assistant email domain registered yet (the
+ * platform's `domain_setup_available` flag stays true forever, so the domains
+ * list is the real signal).
  *
  * Strategy mirrors plans-page-checkout.test.tsx: mock the generated SDK with
  * mutable responses, force the platform-hosted gate open, and stub the heavy
@@ -17,12 +19,15 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router";
 
 import {
+    assistantsDomainsListQueryKey,
     organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
     organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type {
+    Assistant,
     OnboardingStateResponse,
+    PaginatedAssistantDomainList,
     SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import * as platformGate from "@/hooks/use-platform-gate";
@@ -30,7 +35,11 @@ import * as authStore from "@/stores/auth-store";
 
 let subscriptionResponse: SubscriptionResponse;
 let onboardingResponse: OnboardingStateResponse;
+let domainsResponse: PaginatedAssistantDomainList;
 let onboardingCalls = 0;
+let domainsCalls = 0;
+
+const ACTIVE_ASSISTANT = { id: "assistant-1" } as unknown as Assistant;
 
 mock.module("@/generated/api/sdk.gen", () => ({
     ...sdkGen,
@@ -42,6 +51,12 @@ mock.module("@/generated/api/sdk.gen", () => ({
             data: onboardingResponse,
             response: { ok: true },
         });
+    },
+    assistantsActiveRetrieve: () =>
+        Promise.resolve({ data: ACTIVE_ASSISTANT, response: { ok: true } }),
+    assistantsDomainsList: () => {
+        domainsCalls += 1;
+        return Promise.resolve({ data: domainsResponse, response: { ok: true } });
     },
 }));
 
@@ -128,6 +143,27 @@ function makeOnboarding(domainSetupAvailable: boolean): OnboardingStateResponse 
     };
 }
 
+function makeDomains(hasDomain: boolean): PaginatedAssistantDomainList {
+    return {
+        count: hasDomain ? 1 : 0,
+        next: null,
+        previous: null,
+        results: hasDomain
+            ? [
+                  {
+                      id: "domain-1",
+                      subdomain: "velly",
+                      created: "2026-07-01T00:00:00Z",
+                      modified: "2026-07-01T00:00:00Z",
+                  },
+              ]
+            : [],
+    };
+}
+
+const domainsQueryKey = () =>
+    assistantsDomainsListQueryKey({ path: { assistant_id: "assistant-1" } });
+
 function LocationProbe() {
     const location = useLocation();
     return <div data-testid="loc">{location.pathname + location.search}</div>;
@@ -151,7 +187,9 @@ function renderPage(search = "?tab=billing") {
 beforeEach(() => {
     subscriptionResponse = makeSubscription("pro");
     onboardingResponse = makeOnboarding(true);
+    domainsResponse = makeDomains(false);
     onboardingCalls = 0;
+    domainsCalls = 0;
 });
 
 afterEach(() => {
@@ -174,7 +212,7 @@ describe("BillingTab ?pro_onboarding param", () => {
 });
 
 describe("Finish Pro setup nudge", () => {
-    test("renders for Pro with domain setup available and reopens the wizard", async () => {
+    test("renders for Pro with no domain registered and reopens the wizard", async () => {
         const { getByTestId } = renderPage();
 
         await waitFor(() =>
@@ -197,7 +235,20 @@ describe("Finish Pro setup nudge", () => {
         );
     });
 
-    test("hidden on the base plan, and the onboarding endpoint is never queried", async () => {
+    test("hidden for Pro when a domain is already registered", async () => {
+        // `domain_setup_available` is still true (the platform hard-codes it
+        // for every active-Pro org) — the registered domain alone must hide
+        // the nudge.
+        domainsResponse = makeDomains(true);
+        const { client, queryByTestId } = renderPage();
+
+        await waitFor(() =>
+            expect(client.getQueryData(domainsQueryKey())).toBeTruthy(),
+        );
+        expect(queryByTestId("finish-pro-setup-notice")).toBeNull();
+    });
+
+    test("hidden on the base plan; onboarding and domains endpoints are never queried", async () => {
         subscriptionResponse = makeSubscription("base");
         const { client, queryByTestId } = renderPage();
 
@@ -210,9 +261,10 @@ describe("Finish Pro setup nudge", () => {
         );
         expect(queryByTestId("finish-pro-setup-notice")).toBeNull();
         expect(onboardingCalls).toBe(0);
+        expect(domainsCalls).toBe(0);
     });
 
-    test("hidden for Pro when domain setup is unavailable", async () => {
+    test("hidden for Pro when domain setup is unavailable, without querying domains", async () => {
         onboardingResponse = makeOnboarding(false);
         const { client, queryByTestId } = renderPage();
 
@@ -224,5 +276,6 @@ describe("Finish Pro setup nudge", () => {
             ).toBeTruthy(),
         );
         expect(queryByTestId("finish-pro-setup-notice")).toBeNull();
+        expect(domainsCalls).toBe(0);
     });
 });

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -19,6 +19,7 @@ import { InvoicesTable } from "@/domains/settings/components/invoices-table";
 import { PlanCard } from "@/domains/settings/components/plan-card";
 import { ReferralPanel } from "@/domains/settings/components/referral-panel";
 import { TierUpgradeResizeModal } from "@/domains/settings/components/tier-upgrade-resize-modal";
+import { useAssistantDomains } from "@/domains/settings/billing/pro-onboarding/use-assistant-domains";
 import {
     organizationsBillingSubscriptionOnboardingRetrieveOptions,
     organizationsBillingSubscriptionRetrieveOptions,
@@ -72,8 +73,7 @@ function BillingStatusHandler() {
 
 /**
  * Re-entry nudge into the pro onboarding wizard: shown while the org is on Pro
- * but the assistant email/subdomain offered by the onboarding flow is still
- * unconfigured (`domain_setup_available`).
+ * with domain setup offered but no assistant email domain registered yet.
  */
 function FinishProSetupNotice({ onFinishSetup }: { onFinishSetup: () => void }) {
     const { data: subscription } = useQuery(
@@ -84,8 +84,15 @@ function FinishProSetupNotice({ onFinishSetup }: { onFinishSetup: () => void }) 
         ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
         enabled: isPro,
     });
+    // `domain_setup_available` only says the platform offers domain setup — it
+    // stays true after a domain is registered, so the real "still unconfigured"
+    // signal is the assistant's domains list being loaded and empty.
+    const domainSetupOffered =
+        isPro && onboarding?.domain_setup_available === true;
+    const { domains } = useAssistantDomains(domainSetupOffered);
+    const domainMissing = domains !== undefined && domains.results.length === 0;
 
-    if (!isPro || onboarding?.domain_setup_available !== true) {
+    if (!domainSetupOffered || !domainMissing) {
         return null;
     }
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * DomainStep query invalidation: registering a domain must refresh the caches
+ * the "Finish Pro setup" nudge reads (domains list + onboarding state) in
+ * addition to the assistants list.
+ *
+ * Strategy mirrors billing-page.test.tsx: mock the generated SDK so the active
+ * assistant loads (prefilling the subdomain from its handle) and the domain
+ * mutation resolves, then spy on the query client's invalidations.
+ */
+
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import {
+  assistantsDomainsListQueryKey,
+  assistantsListQueryKey,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import * as sdkGen from "@/generated/api/sdk.gen";
+import type { Assistant } from "@/generated/api/types.gen";
+
+let domainCreateCalls = 0;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  assistantsActiveRetrieve: () =>
+    Promise.resolve({
+      data: { id: "assistant-1", handle: "velly" } as unknown as Assistant,
+      response: { ok: true },
+    }),
+  assistantsDomainsList: () =>
+    Promise.resolve({
+      data: { count: 0, next: null, previous: null, results: [] },
+      response: { ok: true },
+    }),
+  organizationsBillingSubscriptionOnboardingDomainCreate: () => {
+    domainCreateCalls += 1;
+    return Promise.resolve({ data: {}, response: { ok: true } });
+  },
+}));
+
+const { DomainStep } = await import("./domain-step");
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DomainStep domain registration", () => {
+  test("invalidates the domains-list and onboarding caches on success", async () => {
+    domainCreateCalls = 0;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = spyOn(client, "invalidateQueries");
+
+    const { getByTestId } = render(
+      <QueryClientProvider client={client}>
+        <DomainStep onExit={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    // The active assistant's handle prefills the subdomain, enabling the CTA.
+    await waitFor(() => {
+      const btn = getByTestId("onboarding-domain-set") as HTMLButtonElement;
+      if (btn.disabled) {
+        throw new Error("button not enabled yet");
+      }
+    });
+
+    fireEvent.click(getByTestId("onboarding-domain-set"));
+
+    await waitFor(() => expect(domainCreateCalls).toBe(1));
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map((call) =>
+      JSON.stringify(call[0]?.queryKey),
+    );
+    expect(invalidatedKeys).toContain(JSON.stringify(assistantsListQueryKey()));
+    expect(invalidatedKeys).toContain(
+      JSON.stringify(
+        assistantsDomainsListQueryKey({
+          path: { assistant_id: "assistant-1" },
+        }),
+      ),
+    );
+    expect(invalidatedKeys).toContain(
+      JSON.stringify(
+        organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+      ),
+    );
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -1,13 +1,13 @@
 import { Mail } from "lucide-react";
 import { useEffect, useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
-    assistantsActiveRetrieveOptions,
-    assistantsDomainsListOptions,
+    assistantsDomainsListQueryKey,
     assistantsListQueryKey,
     organizationsBillingSubscriptionOnboardingDomainCreateMutation,
+    organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { Button } from "@vellumai/design-library/components/button";
@@ -16,7 +16,8 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import { DomainField } from "@/domains/settings/components/domain-field";
-import { IconBadge, StepDots } from "./primitives";
+import { IconBadge } from "./primitives";
+import { useAssistantDomains } from "./use-assistant-domains";
 import { DOMAIN_EXIT_DELAY_MS, extractOnboardingErrorMessage } from "./utils";
 
 export function DomainStep({
@@ -29,16 +30,8 @@ export function DomainStep({
 }) {
   const queryClient = useQueryClient();
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
-  const { data: activeAssistant } = useQuery(assistantsActiveRetrieveOptions());
-  const assistantId = activeAssistant?.id;
-
-  const { data: domainsData } = useQuery({
-    ...assistantsDomainsListOptions({
-      path: { assistant_id: assistantId ?? "" },
-    }),
-    enabled: !!assistantId,
-  });
-  const existingDomain = domainsData?.results?.[0];
+  const { activeAssistant, assistantId, domains } = useAssistantDomains();
+  const existingDomain = domains?.results[0];
 
   const [subdomain, setSubdomain] = useState("");
   const [emailUsername, setEmailUsername] = useState("hi");
@@ -87,6 +80,14 @@ export function DomainStep({
           setErrorMsg(null);
           setConfirmed(true);
           void queryClient.invalidateQueries({ queryKey: assistantsListQueryKey() });
+          void queryClient.invalidateQueries({
+            queryKey: assistantsDomainsListQueryKey({
+              path: { assistant_id: assistantId ?? "" },
+            }),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+          });
         },
         onError: (err) => {
           setErrorMsg(
@@ -110,10 +111,7 @@ export function DomainStep({
 
   return (
     <>
-      <Modal.Body
-        className="min-h-[320px] space-y-5 pt-10 pb-4"
-        style={{ animation: "onboarding-step-in 350ms ease-out" }}
-      >
+      <Modal.Body className="min-h-[320px] animate-[onboarding-step-in_350ms_ease-out] space-y-5 pt-10 pb-4 motion-reduce:animate-none">
         <div className="flex flex-col items-center gap-3 pb-2 text-center">
           <IconBadge icon={Mail} />
           <div className="space-y-2">
@@ -184,40 +182,35 @@ export function DomainStep({
           <Notice tone="success">Domain set — redirecting…</Notice>
         ) : null}
       </Modal.Body>
-      <Modal.Footer className="relative items-center justify-end">
-        <div className="pointer-events-none absolute inset-x-0 flex justify-center">
-          <StepDots current={0} />
-        </div>
-        <div className="flex items-center gap-2">
-          {isLocked ? (
+      <Modal.Footer className="items-center">
+        {isLocked ? (
+          <Button
+            variant="primary"
+            data-testid="onboarding-domain-continue"
+            onClick={onExit}
+          >
+            Continue
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="ghost"
+              data-testid="onboarding-domain-skip"
+              disabled={busy}
+              onClick={handleSkip}
+            >
+              Do later
+            </Button>
             <Button
               variant="primary"
-              data-testid="onboarding-domain-continue"
-              onClick={onExit}
+              data-testid="onboarding-domain-set"
+              disabled={!subdomain || busy || machineBusy}
+              onClick={handleSet}
             >
-              Continue
+              Set domain
             </Button>
-          ) : (
-            <>
-              <Button
-                variant="ghost"
-                data-testid="onboarding-domain-skip"
-                disabled={busy}
-                onClick={handleSkip}
-              >
-                Do later
-              </Button>
-              <Button
-                variant="primary"
-                data-testid="onboarding-domain-set"
-                disabled={!subdomain || busy || machineBusy}
-                onClick={handleSet}
-              >
-                Set domain
-              </Button>
-            </>
-          )}
-        </div>
+          </>
+        )}
       </Modal.Footer>
     </>
   );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
@@ -1,26 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import { ArrowRight, Loader2 } from "lucide-react";
 
-export function StepDots({ current, total = 2 }: { current: number; total?: number }) {
-  return (
-    <div className="flex items-center justify-center gap-1.5">
-      {Array.from({ length: total }, (_, i) => (
-        <div
-          key={i}
-          className="h-1.5 rounded-full transition-all duration-300"
-          style={{
-            width: i === current ? 20 : 6,
-            backgroundColor:
-              i <= current
-                ? "var(--content-default)"
-                : "var(--border-element)",
-          }}
-        />
-      ))}
-    </div>
-  );
-}
-
 export function IconBadge({
   icon: Icon,
   tone = "positive",
@@ -54,20 +34,18 @@ export function GlowSpinner() {
   return (
     <div className="relative flex h-11 w-11 items-center justify-center">
       <div
-        className="absolute h-14 w-14 rounded-full"
+        className="absolute h-14 w-14 animate-[onboarding-glow_2.4s_ease-in-out_infinite] rounded-full motion-reduce:animate-none"
         style={{
           backgroundColor:
             "color-mix(in oklab, var(--system-positive-strong) 10%, transparent)",
-          animation: "onboarding-glow 2.4s ease-in-out infinite",
         }}
         aria-hidden="true"
       />
       <div
-        className="absolute h-9 w-9 rounded-full"
+        className="absolute h-9 w-9 animate-[onboarding-glow_2.4s_ease-in-out_infinite_0.4s] rounded-full motion-reduce:animate-none"
         style={{
           backgroundColor:
             "color-mix(in oklab, var(--system-positive-strong) 8%, transparent)",
-          animation: "onboarding-glow 2.4s ease-in-out infinite 0.4s",
         }}
         aria-hidden="true"
       />

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-assistant-domains.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-assistant-domains.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  assistantsActiveRetrieveOptions,
+  assistantsDomainsListOptions,
+} from "@/generated/api/@tanstack/react-query.gen";
+
+/**
+ * The active assistant and its registered email domains — the single source
+ * for "does the assistant have a domain yet", shared by the onboarding
+ * wizard's domain step and the billing page's finish-setup nudge so the two
+ * can't drift apart.
+ */
+export function useAssistantDomains(enabled = true) {
+  const { data: activeAssistant } = useQuery({
+    ...assistantsActiveRetrieveOptions(),
+    enabled,
+  });
+  const assistantId = activeAssistant?.id;
+  const { data: domains } = useQuery({
+    ...assistantsDomainsListOptions({
+      path: { assistant_id: assistantId ?? "" },
+    }),
+    enabled: enabled && !!assistantId,
+  });
+  return { activeAssistant, assistantId, domains };
+}

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -24,6 +24,7 @@ import type {
   PlanListResponse,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
+import * as runtimeBrowser from "@/runtime/browser";
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -31,6 +32,7 @@ import type {
 
 type Captured = { body?: unknown };
 let upgradeCall: Captured | null = null;
+let upgradeResponse: Record<string, unknown> = { status: "ok" };
 let changeCreditTierCall: Captured | null = null;
 let changeMachineTierCall: Captured | null = null;
 let changeStorageTierCall: Captured | null = null;
@@ -39,7 +41,7 @@ mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
   organizationsBillingSubscriptionUpgradeCreate: (opts: Captured) => {
     upgradeCall = opts;
-    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+    return Promise.resolve({ data: upgradeResponse, response: { ok: true } });
   },
   organizationsBillingSubscriptionChangeCreditTierCreate: (opts: Captured) => {
     changeCreditTierCall = opts;
@@ -72,6 +74,18 @@ mock.module("@/domains/settings/hooks/use-billing-portal-session", () => ({
   useBillingPortalSession: () => ({ isPending: false, mutate: () => {} }),
 }));
 
+// Capture the Stripe checkout redirect instead of opening a browser.
+let openedUrl: string | null = null;
+mock.module("@/runtime/browser", () => ({
+  ...runtimeBrowser,
+  openUrl: (url: string) => {
+    openedUrl = url;
+    return Promise.resolve();
+  },
+  openUrlFinishedListener: () => () => {},
+}));
+
+import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { AdjustPlanModal } from "./adjust-plan-modal";
 
 const CREDIT_TIERS: CreditTier[] = [
@@ -238,9 +252,12 @@ function clickOption(label: string): void {
 
 beforeEach(() => {
   upgradeCall = null;
+  upgradeResponse = { status: "ok" };
   changeCreditTierCall = null;
   changeMachineTierCall = null;
   changeStorageTierCall = null;
+  openedUrl = null;
+  sessionStorage.clear();
 });
 
 afterEach(() => {
@@ -281,6 +298,50 @@ describe("AdjustPlanModal credit bundle — upgrade", () => {
     expect(
       (upgradeCall!.body as Record<string, unknown>).credit_tier,
     ).toBeNull();
+  });
+});
+
+describe("AdjustPlanModal upgrade — checkout intent stash", () => {
+  test("stashes the selected tiers before redirecting to Stripe checkout", async () => {
+    upgradeResponse = { checkout_url: "https://checkout.example.com/session" };
+    const { getByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    fireEvent.click(getByTestId("modal-upgrade-to-pro-button"));
+
+    await waitFor(() => {
+      if (!openedUrl) {
+        throw new Error("checkout not opened");
+      }
+    });
+    expect(openedUrl).toBe("https://checkout.example.com/session");
+    // The stash captures the seeded defaults (cheapest machine/storage, no
+    // bundle) so the post-checkout provisioning screen can render them.
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "custom",
+      machineTier: "machine_small",
+      storageTier: "storage_10",
+      creditTier: null,
+    });
+  });
+
+  test("does not stash when the upgrade response has no checkout URL", async () => {
+    const { getByTestId } = renderModal(
+      subscription("base", null),
+      proPlansResponse(CREDIT_TIERS),
+    );
+
+    fireEvent.click(getByTestId("modal-upgrade-to-pro-button"));
+
+    await waitFor(() => {
+      if (!upgradeCall) {
+        throw new Error("upgrade not called");
+      }
+    });
+    expect(readCheckoutIntent()).toBeNull();
+    expect(openedUrl).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/settings/components/tier-upgrade-resize-modal.tsx
+++ b/clients/web/src/domains/settings/components/tier-upgrade-resize-modal.tsx
@@ -1,8 +1,9 @@
-import { ArrowRight, Cpu, HardDrive, Loader2, Server } from "lucide-react";
+import { Cpu, HardDrive, Loader2, Server } from "lucide-react";
 import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
+import { ResourceCard } from "@/domains/settings/billing/pro-onboarding/primitives";
 import { extractResizeError } from "@/domains/settings/components/resize-errors";
 import {
     assistantsActiveRetrieveOptions,
@@ -23,45 +24,6 @@ import { toast } from "@vellumai/design-library/components/toast";
 export interface TierUpgradeResizeModalProps {
   open: boolean;
   onClose: () => void;
-}
-
-function ResourceCard({
-  icon: Icon,
-  label,
-  from,
-  to,
-}: {
-  icon: typeof Server;
-  label: string;
-  from: string;
-  to: string;
-}) {
-  return (
-    <div className="flex items-center gap-3 rounded-lg bg-[var(--surface-base)] p-3">
-      <span
-        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
-        style={{
-          backgroundColor: "color-mix(in oklab, var(--system-positive-strong) 10%, transparent)",
-        }}
-      >
-        <Icon className="h-4 w-4 text-[var(--system-positive-strong)]" />
-      </span>
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="text-label-small-default text-[var(--content-tertiary)]">
-          {label}
-        </span>
-        <div className="flex items-center gap-2">
-          <span className="text-label-medium-default text-[var(--content-tertiary)] line-through">
-            {from}
-          </span>
-          <ArrowRight className="h-3 w-3 shrink-0 text-[var(--content-tertiary)]" />
-          <span className="text-label-medium-default text-[var(--content-default)]">
-            {to}
-          </span>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export function TierUpgradeResizeModal({

--- a/clients/web/src/lib/billing/checkout-intent.ts
+++ b/clients/web/src/lib/billing/checkout-intent.ts
@@ -23,10 +23,13 @@ export type CheckoutIntent =
       savedAt: number;
     };
 
+/** `Omit` distributed over each member of a union. */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
 /** A `CheckoutIntent` before `saveCheckoutIntent` stamps `savedAt`. */
-export type UnsavedCheckoutIntent =
-  | Omit<Extract<CheckoutIntent, { kind: "package" }>, "savedAt">
-  | Omit<Extract<CheckoutIntent, { kind: "custom" }>, "savedAt">;
+type UnsavedCheckoutIntent = DistributiveOmit<CheckoutIntent, "savedAt">;
 
 const STORAGE_KEY = "vellum.pro-checkout-intent";
 const MAX_AGE_MS = 30 * 60 * 1000;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for pro-onboarding-wizard-revamp.md: derive the Finish Pro setup nudge from real domain state (platform flag is hard-coded true), invalidate nudge queries on domain success, remove vestigial StepDots, dedupe ResourceCard, test the adjust-plan stash path, simplify checkout-intent types, reduced-motion in domain-step/primitives.