### PR TITLE
feat(voice): narrate brain tool activity during long-running turns

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -13,7 +13,11 @@ import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
-import { pickAckPhrase, pickProgressPhrase } from "../ack-phrases.js";
+import {
+  pickAckPhrase,
+  pickProgressPhrase,
+  PROGRESS_FALLBACK_PHRASES,
+} from "../ack-phrases.js";
 import type {
   VoiceFrontDecider,
   VoiceProgressTextInput,
@@ -327,6 +331,31 @@ describe("LiveVoiceSession progress narration", () => {
     emitMessageComplete(getCallbacks);
   });
 
+  test("no-ops idle fallback stays neutral: no phrase claims tool activity", async () => {
+    // List invariant: the fallback can speak on a slow turn with zero tool
+    // activity, so no phrase may claim tools or tasks are running.
+    for (const phrase of PROGRESS_FALLBACK_PHRASES) {
+      expect(phrase.toLowerCase()).not.toMatch(
+        /\b(run|runs|running|tool|tools|thing|things|task|tasks|check|checking|look|looking|search|searching)\b/,
+      );
+    }
+
+    // Behavior: a slow turn with no tool events falls back to that list.
+    const generateProgressText = mock(async () => null);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ idleIntervalMs: 40, maxPerTurn: 1 }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await waitFor(() => ttsTexts.length === 1);
+    expect(
+      PROGRESS_FALLBACK_PHRASES.map((phrase) => sanitizeForTts(phrase).trim()),
+    ).toContain(ttsTexts[0]);
+
+    emitMessageComplete(getCallbacks);
+  });
+
   test("ops trigger with a null decider result stays silent and keeps the update budget", async () => {
     const generateProgressText = mock(async () => null);
     const { session, getCallbacks, ttsTexts } = createProgressHarness({
@@ -380,6 +409,54 @@ describe("LiveVoiceSession progress narration", () => {
     await waitFor(() => ttsTexts.length === 2);
     expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
     expect(generateProgressText).toHaveBeenCalledTimes(1);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("llmAckText: narration resolving during ack generation bails instead of stacking filler", async () => {
+    const ackGeneration = deferred<string | null>();
+    const generateAckText = mock(() => ackGeneration.promise);
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const frontDecider: VoiceFrontDecider = {
+      decideEndpoint: async () => ({ action: "release" }),
+      generateAckText,
+      generateProgressText,
+    };
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: {
+        llmAckText: true,
+        ...progressConfig({ opsThreshold: 1, minGapMs: 150 }),
+      },
+      frontDecider,
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    // The tool start speaks a generated ack (generation still pending) and
+    // simultaneously crosses the ops threshold; with no floor-holder stamped
+    // yet, the entry guard lets a narration generation start concurrently.
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => generateProgressText.mock.calls.length === 1);
+    // The narration resolves while the ack is still generating: it must bail
+    // rather than enqueue ahead of (and back-to-back with) the ack.
+    await sleep(30);
+    expect(ttsTexts).toEqual([]);
+
+    ackGeneration.resolve("Generated ack.");
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual(["Generated ack."]);
+
+    // Inside the ack's minGapMs window nothing else speaks even as tool
+    // activity continues.
+    emitToolResult(getCallbacks, "web_search", "tool-1");
+    await sleep(30);
+    expect(ttsTexts).toEqual(["Generated ack."]);
+
+    // The bail preserved the update budget: once the gap elapses, the next
+    // ops trigger narrates normally.
+    await sleep(150);
+    emitToolStart(getCallbacks, "file_read", "tool-2");
+    await waitFor(() => ttsTexts.length === 2);
+    expect(ttsTexts).toEqual(["Generated ack.", GENERATED_NARRATION]);
 
     emitMessageComplete(getCallbacks);
   });

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -1,0 +1,489 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
+import type {
+  VoiceTurnCallbacks,
+  VoiceTurnOptions,
+} from "../../calls/voice-session-bridge.js";
+import type {
+  LiveVoiceFrontModelConfig,
+  LiveVoiceProgressConfig,
+} from "../../config/schemas/live-voice.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import { pickAckPhrase, pickProgressPhrase } from "../ack-phrases.js";
+import type {
+  VoiceFrontDecider,
+  VoiceProgressTextInput,
+} from "../front-decision.js";
+import {
+  LiveVoiceSession,
+  type LiveVoiceTtsStreamer,
+  type LiveVoiceTurnStarter,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type { LiveVoiceTtsOptions } from "../live-voice-tts.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+// Generous enough that the slow-first-delta ack never fires during a test;
+// the immediate tool-start ack still speaks and is asserted where relevant.
+const GENEROUS_ACK_TIMEOUT_MS = 60_000;
+
+const GENERATED_NARRATION = "Progress text.";
+// Acks and narrations pass through the same TTS sanitizer; each fresh
+// session's phrase counters start at 0.
+const EXPECTED_TOOL_ACK = sanitizeForTts(pickAckPhrase("tool_use", 0)).trim();
+const EXPECTED_PROGRESS_FALLBACK = sanitizeForTts(pickProgressPhrase(0)).trim();
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(): void {}
+
+  stop(): void {
+    this.onEvent?.({ type: "final", text: "hello" });
+    this.onEvent?.({ type: "closed" });
+  }
+}
+
+function createContext(): {
+  context: LiveVoiceSessionFactoryContext;
+  frames: LiveVoiceServerFrame[];
+} {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+
+  return {
+    frames,
+    context: {
+      sessionId: "session-123",
+      startFrame: START_FRAME,
+      sendFrame: mock(async (payload) => {
+        const frame = sequencer.next(payload);
+        frames.push(frame);
+        return frame;
+      }),
+    },
+  };
+}
+
+function createCapturingTurnStarter(): {
+  startVoiceTurn: LiveVoiceTurnStarter;
+  getCallbacks: () => VoiceTurnCallbacks | undefined;
+} {
+  let callbacks: VoiceTurnCallbacks | undefined;
+  const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+    callbacks = options.callbacks;
+    return { turnId: "bridge-turn-1", abort: mock() };
+  });
+  return { startVoiceTurn, getCallbacks: () => callbacks };
+}
+
+function createRecordingTtsStreamer(): {
+  streamTtsAudio: LiveVoiceTtsStreamer;
+  ttsTexts: string[];
+} {
+  const ttsTexts: string[] = [];
+  const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+    ttsTexts.push(options.text);
+    return {
+      provider: "fish-audio" as const,
+      contentType: "audio/pcm",
+      sampleRate: 24_000,
+      chunks: 1,
+      bytes: Buffer.byteLength(options.text),
+    };
+  });
+  return { streamTtsAudio, ttsTexts };
+}
+
+function makeProgressDecider(
+  generateProgressText: VoiceFrontDecider["generateProgressText"],
+): VoiceFrontDecider {
+  return {
+    decideEndpoint: async () => ({ action: "release" }),
+    generateAckText: async () => null,
+    generateProgressText,
+  };
+}
+
+function progressConfig(
+  overrides: Partial<LiveVoiceProgressConfig> = {},
+): Partial<LiveVoiceFrontModelConfig> {
+  return {
+    ackFirstDeltaTimeoutMs: GENEROUS_ACK_TIMEOUT_MS,
+    progress: {
+      enabled: true,
+      opsThreshold: 3,
+      idleIntervalMs: 60_000,
+      minGapMs: 10,
+      maxPerTurn: 3,
+      generationTimeoutMs: 1_500,
+      ...overrides,
+    },
+  };
+}
+
+function createProgressHarness(options: {
+  frontModelConfig: Partial<LiveVoiceFrontModelConfig>;
+  frontDecider: VoiceFrontDecider;
+}) {
+  const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+  const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
+  const { context, frames } = createContext();
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+    startVoiceTurn,
+    streamTtsAudio,
+    frontModelConfig: options.frontModelConfig,
+    frontDecider: options.frontDecider,
+    createTurnId: () => "live-turn-1",
+  });
+
+  return { frames, session, getCallbacks, ttsTexts };
+}
+
+async function startReleasedTurn(
+  session: LiveVoiceSession,
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+): Promise<void> {
+  await session.start();
+  await session.handleClientFrame({ type: "ptt_release" });
+  await waitFor(() => getCallbacks() !== undefined);
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for live voice progress test condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function emitToolStart(
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+  toolName: string,
+  toolUseId: string,
+): void {
+  getCallbacks()?.tool_use_start?.(toolName, { input: {}, toolUseId });
+}
+
+function emitToolResult(
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+  toolName: string,
+  toolUseId: string,
+  resultPreview = "ok",
+): void {
+  getCallbacks()?.tool_result?.({ toolName, toolUseId, resultPreview });
+}
+
+function emitTextDelta(
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+  text: string,
+): void {
+  getCallbacks()?.assistant_text_delta?.({
+    type: "assistant_text_delta",
+    text,
+    conversationId: "conversation-123",
+  });
+}
+
+function emitMessageComplete(
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+): void {
+  getCallbacks()?.message_complete?.({
+    type: "message_complete",
+    conversationId: "conversation-123",
+    messageId: "assistant-message-123",
+  });
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("LiveVoiceSession progress narration", () => {
+  test("ops threshold: three tool ops speak exactly one narration with the accumulated activity", async () => {
+    const inputs: VoiceProgressTextInput[] = [];
+    const generateProgressText = mock(async (input: VoiceProgressTextInput) => {
+      inputs.push(input);
+      return GENERATED_NARRATION;
+    });
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ opsThreshold: 3, minGapMs: 10 }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK]);
+
+    emitToolResult(getCallbacks, "web_search", "tool-1", "found 3 results");
+    emitToolStart(getCallbacks, "file_read", "tool-2");
+    emitToolResult(getCallbacks, "file_read", "tool-2", "file contents");
+    // Let the ack's minGapMs spacing elapse before the threshold-crossing op.
+    await sleep(30);
+    emitToolStart(getCallbacks, "web_search", "tool-3");
+    await waitFor(() => ttsTexts.length === 2);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
+    expect(generateProgressText).toHaveBeenCalledTimes(1);
+    expect(inputs[0]).toMatchObject({
+      transcriptSoFar: "hello",
+      completedOps: [
+        { toolName: "web_search", resultPreview: "found 3 results" },
+        { toolName: "file_read", resultPreview: "file contents" },
+      ],
+      currentOp: { toolName: "web_search" },
+      updateIndex: 1,
+    });
+
+    // The counter reset with the narration, so the trailing result stays
+    // below the threshold: still exactly one narration.
+    emitToolResult(getCallbacks, "web_search", "tool-3");
+    await sleep(30);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
+    expect(generateProgressText).toHaveBeenCalledTimes(1);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("idle trigger: dead air narrates with the decider text, audio-only", async () => {
+    const inputs: VoiceProgressTextInput[] = [];
+    const generateProgressText = mock(async (input: VoiceProgressTextInput) => {
+      inputs.push(input);
+      return GENERATED_NARRATION;
+    });
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ idleIntervalMs: 40, maxPerTurn: 1 }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([GENERATED_NARRATION]);
+    expect(inputs[0]).toMatchObject({
+      transcriptSoFar: "hello",
+      completedOps: [],
+      currentOp: null,
+      updateIndex: 1,
+    });
+
+    // Narration is audio-only: no caption frame carries it.
+    expect(frames.some((frame) => frame.type === "assistant_text_delta")).toBe(
+      false,
+    );
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("idle trigger with a null decider result speaks the static fallback", async () => {
+    const generateProgressText = mock(async () => null);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ idleIntervalMs: 40, maxPerTurn: 1 }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([EXPECTED_PROGRESS_FALLBACK]);
+    expect(generateProgressText).toHaveBeenCalledTimes(1);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("ops trigger with a null decider result stays silent and keeps the update budget", async () => {
+    const generateProgressText = mock(async () => null);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        opsThreshold: 1,
+        idleIntervalMs: 120,
+        minGapMs: 10,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK]);
+
+    // Past the ack gap, the ops trigger fires but generation returns null:
+    // nothing speaks and no update is consumed.
+    await sleep(30);
+    emitToolResult(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => generateProgressText.mock.calls.length === 1);
+    await sleep(10);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK]);
+
+    // The idle trigger still has the full budget: its own null falls back to
+    // the static phrase.
+    await waitFor(() => ttsTexts.length === 2);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, EXPECTED_PROGRESS_FALLBACK]);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("minGapMs: a tool-start ack suppresses narration until the gap elapses", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ opsThreshold: 1, minGapMs: 150 }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+    // Threshold already met, but the just-spoken ack holds the floor.
+    emitToolResult(getCallbacks, "web_search", "tool-1");
+    await sleep(30);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK]);
+    expect(generateProgressText).not.toHaveBeenCalled();
+
+    await sleep(150);
+    emitToolStart(getCallbacks, "file_read", "tool-2");
+    await waitFor(() => ttsTexts.length === 2);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
+    expect(generateProgressText).toHaveBeenCalledTimes(1);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("maxPerTurn caps narration for the rest of the turn", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        opsThreshold: 1,
+        minGapMs: 1,
+        maxPerTurn: 1,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+    await sleep(10);
+    emitToolResult(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 2);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
+
+    await sleep(10);
+    emitToolStart(getCallbacks, "file_read", "tool-2");
+    emitToolResult(getCallbacks, "file_read", "tool-2");
+    await sleep(30);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
+    expect(generateProgressText).toHaveBeenCalledTimes(1);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("first delta stops the idle timer and discards an in-flight generation", async () => {
+    const generation = deferred<string | null>();
+    const generateProgressText = mock(() => generation.promise);
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        opsThreshold: 1,
+        idleIntervalMs: 40,
+        minGapMs: 10,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    // The idle trigger starts a generation…
+    await waitFor(() => generateProgressText.mock.calls.length === 1);
+    // …then the brain's first delta arrives before it resolves.
+    emitTextDelta(getCallbacks, "Hello there.");
+    generation.resolve("Late narration.");
+    await sleep(120);
+
+    // The stale generation never speaks and the idle timer never re-fires.
+    expect(generateProgressText).toHaveBeenCalledTimes(1);
+    expect(ttsTexts).toEqual(["Hello there."]);
+
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsTexts).toEqual(["Hello there."]);
+  });
+
+  test("cancel clears the idle timer and an in-flight generation speaks nothing", async () => {
+    const generation = deferred<string | null>();
+    const generateProgressText = mock(() => generation.promise);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ idleIntervalMs: 40 }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await waitFor(() => generateProgressText.mock.calls.length === 1);
+
+    await session.handleClientFrame({ type: "interrupt" });
+    generation.resolve("Late narration.");
+    await sleep(120);
+
+    expect(generateProgressText).toHaveBeenCalledTimes(1);
+    expect(ttsTexts).toEqual([]);
+  });
+
+  test("progress.enabled false: zero narrations and zero decider calls", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        enabled: false,
+        opsThreshold: 1,
+        idleIntervalMs: 30,
+        minGapMs: 1,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    emitToolResult(getCallbacks, "web_search", "tool-1");
+    emitToolStart(getCallbacks, "file_read", "tool-2");
+    emitToolResult(getCallbacks, "file_read", "tool-2");
+    await sleep(100);
+
+    // Only the tool-start ack spoke; the decider was never consulted.
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK]);
+    expect(generateProgressText).not.toHaveBeenCalled();
+
+    emitMessageComplete(getCallbacks);
+  });
+});

--- a/assistant/src/live-voice/ack-phrases.ts
+++ b/assistant/src/live-voice/ack-phrases.ts
@@ -30,11 +30,14 @@ const PHRASES_BY_KIND: Record<LiveVoiceSpokenAckKind, readonly string[]> = {
 
 // Static fallbacks for an idle-triggered progress narration whose LLM
 // phrasing failed — the one case where prolonged silence is actively harmful.
+// The idle trigger can fire on a slow turn with zero tool activity, so every
+// phrase stays strictly neutral: no claims about running tools or tasks.
 // Same rules as the ack lists: persona-neutral, no domain content, ≤ 8 words.
-const PROGRESS_FALLBACK_PHRASES: readonly string[] = [
-  "Still on it — running a few things.",
-  "Working through it, one moment.",
-  "Still working — almost there.",
+// Exported so tests can assert the neutrality invariant against the list.
+export const PROGRESS_FALLBACK_PHRASES: readonly string[] = [
+  "Still on it — one moment.",
+  "Still thinking this through.",
+  "Almost there — thanks for waiting.",
 ];
 
 // Deterministic rotation through the kind's phrase list: callers hold a

--- a/assistant/src/live-voice/ack-phrases.ts
+++ b/assistant/src/live-voice/ack-phrases.ts
@@ -28,6 +28,15 @@ const PHRASES_BY_KIND: Record<LiveVoiceSpokenAckKind, readonly string[]> = {
   tool_use: TOOL_ACK_PHRASES,
 };
 
+// Static fallbacks for an idle-triggered progress narration whose LLM
+// phrasing failed — the one case where prolonged silence is actively harmful.
+// Same rules as the ack lists: persona-neutral, no domain content, ≤ 8 words.
+const PROGRESS_FALLBACK_PHRASES: readonly string[] = [
+  "Still on it — running a few things.",
+  "Working through it, one moment.",
+  "Still working — almost there.",
+];
+
 // Deterministic rotation through the kind's phrase list: callers hold a
 // nonnegative monotonic counter, so consecutive acks vary while tests stay
 // reproducible.
@@ -37,4 +46,9 @@ export function pickAckPhrase(
 ): string {
   const phrases = PHRASES_BY_KIND[kind];
   return phrases[counter % phrases.length];
+}
+
+// Same rotation contract as pickAckPhrase, over the progress fallbacks.
+export function pickProgressPhrase(counter: number): string {
+  return PROGRESS_FALLBACK_PHRASES[counter % PROGRESS_FALLBACK_PHRASES.length];
 }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -437,6 +437,11 @@ interface ActiveAssistantTurn {
   // A spoken ack was enqueued this turn. Every ack trigger shares this
   // one-per-turn budget so a slow turn never stacks fillers.
   ackSpoken: boolean;
+  // An LLM-phrased ack generation is awaiting the decider (llmAckText).
+  // While true, the ack has not yet stamped `lastFloorHolderAtMs`, so
+  // narration must treat it as a floor-holder-in-waiting and stand down —
+  // otherwise a progress phrase could land back-to-back with the ack.
+  ackGenerationPending: boolean;
   // Pending slow-first-delta ack timer; null once cleared or fired.
   ackTimer: ReturnType<typeof setTimeout> | null;
   // Triage-and-escalate (Voice Mode): the front-door leg emitted [ESCALATE]
@@ -2254,6 +2259,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       toolUseStarted: false,
       firstDeltaSeen: false,
       ackSpoken: false,
+      ackGenerationPending: false,
       ackTimer: null,
       escalationHandedOff: false,
       ttsBuffer: "",
@@ -2862,12 +2868,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // have been cancelled or finalized, the brain's first delta may have
       // arrived, an escalation hand-off may have enqueued its bridge phrase,
       // or the turn may have completed outright — in every such case the
-      // narration is moot and must not speak over real output.
+      // narration is moot and must not speak over real output. The floor
+      // re-check covers a generated ack (llmAckText) that raced this
+      // generation: while the ack is pending it has not yet stamped
+      // `lastFloorHolderAtMs` (so the entry guard could not see it), and once
+      // it enqueues the minGapMs spacing must be re-applied from that stamp —
+      // either way, enqueueing now would stack back-to-back filler. A bail
+      // here is silent and keeps the update budget, exactly like the
+      // stale-turn bail.
       if (
         !this.isActiveAssistantTurn(token) ||
         turn.firstDeltaSeen ||
         turn.escalationHandedOff ||
-        turn.assistantCompleted
+        turn.assistantCompleted ||
+        turn.ackGenerationPending ||
+        (progress.lastFloorHolderAtMs !== null &&
+          Date.now() - progress.lastFloorHolderAtMs <
+            this.frontModelConfig.progress.minGapMs)
       ) {
         return;
       }
@@ -2936,41 +2953,46 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     toolName?: string,
   ): Promise<void> {
     const { token } = activeTurn;
-    const transcript = activeTurn.utterance.finalTranscriptSegments
-      .join(" ")
-      .trim();
-    const generated = await frontDecider
-      .generateAckText(
-        {
-          transcriptSoFar: transcript,
-          toolName,
-        },
-        activeTurn.abortController.signal,
-      )
-      // The decider contract never rejects; belt-and-braces for a stub.
-      .catch(() => null);
-    // Liveness re-check after the await: while generating, the turn may have
-    // been cancelled or finalized, the brain's first delta may have arrived,
-    // an escalation hand-off may have enqueued its bridge phrase (which holds
-    // the floor itself), or the turn may have completed outright — a
-    // tool-only/no-text turn completes with firstDeltaSeen still false. In
-    // every such case the ack is moot and must not speak over real output,
-    // stack on the escalation bridge, or voice a finished turn. Undo the
-    // optimistic ackSpoken so the flag reflects reality.
-    if (
-      !this.isActiveAssistantTurn(token) ||
-      activeTurn.firstDeltaSeen ||
-      activeTurn.escalationHandedOff ||
-      activeTurn.assistantCompleted
-    ) {
-      activeTurn.ackSpoken = false;
-      return;
+    activeTurn.ackGenerationPending = true;
+    try {
+      const transcript = activeTurn.utterance.finalTranscriptSegments
+        .join(" ")
+        .trim();
+      const generated = await frontDecider
+        .generateAckText(
+          {
+            transcriptSoFar: transcript,
+            toolName,
+          },
+          activeTurn.abortController.signal,
+        )
+        // The decider contract never rejects; belt-and-braces for a stub.
+        .catch(() => null);
+      // Liveness re-check after the await: while generating, the turn may have
+      // been cancelled or finalized, the brain's first delta may have arrived,
+      // an escalation hand-off may have enqueued its bridge phrase (which holds
+      // the floor itself), or the turn may have completed outright — a
+      // tool-only/no-text turn completes with firstDeltaSeen still false. In
+      // every such case the ack is moot and must not speak over real output,
+      // stack on the escalation bridge, or voice a finished turn. Undo the
+      // optimistic ackSpoken so the flag reflects reality.
+      if (
+        !this.isActiveAssistantTurn(token) ||
+        activeTurn.firstDeltaSeen ||
+        activeTurn.escalationHandedOff ||
+        activeTurn.assistantCompleted
+      ) {
+        activeTurn.ackSpoken = false;
+        return;
+      }
+      this.enqueueAckPhrase(
+        activeTurn,
+        generated ?? this.pickStaticAckPhrase(kind),
+        kind,
+      );
+    } finally {
+      activeTurn.ackGenerationPending = false;
     }
-    this.enqueueAckPhrase(
-      activeTurn,
-      generated ?? this.pickStaticAckPhrase(kind),
-      kind,
-    );
   }
 
   // Sanitize and enqueue one ack sentence on the turn's ordered TTS queue

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -56,11 +56,12 @@ import { getSubagentManager } from "../subagent/index.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
-import { pickAckPhrase } from "./ack-phrases.js";
+import { pickAckPhrase, pickProgressPhrase } from "./ack-phrases.js";
 import {
   createVoiceFrontDecider,
   type VoiceEndpointAction,
   type VoiceFrontDecider,
+  type VoiceProgressTextInput,
 } from "./front-decision.js";
 import type {
   LiveVoiceAudioArchiveResult,
@@ -353,12 +354,64 @@ interface TtsSegmentJob {
   frames: Promise<void>;
 }
 
+// One tool operation observed on a turn, fed by the bridge's structured tool
+// callbacks. `completedAtMs`/`isError`/`resultPreview` land with tool_result.
+interface TurnProgressOp {
+  toolName: string;
+  toolUseId?: string;
+  startedAtMs: number;
+  completedAtMs?: number;
+  isError?: boolean;
+  resultPreview?: string;
+}
+
+// Per-turn tool-activity log and narration cadence state for spoken progress
+// updates (liveVoice.frontModel.progress).
+interface TurnProgressState {
+  // Tool operations this turn, in start order.
+  ops: TurnProgressOp[];
+  // Ops accumulated toward the next ops-triggered narration. Counted once per
+  // op, on start (not completion), so a burst of slow tools still trips the
+  // threshold while they run.
+  opsSinceNarration: number;
+  // Narrations actually spoken this turn; bounded by progress.maxPerTurn.
+  updatesSpoken: number;
+  // When the last spoken floor-holder (ack or narration) enqueued — gates the
+  // progress.minGapMs spacing guard. Null until something speaks.
+  lastFloorHolderAtMs: number | null;
+  // Self-re-arming dead-air narration timer; null once cleared or fired.
+  idleTimer: ReturnType<typeof setTimeout> | null;
+  // A narration generation is awaiting the decider; serializes narrations.
+  narrationInFlight: boolean;
+}
+
+// Newest incomplete op, optionally restricted to a tool name (the
+// tool_result fallback match when no toolUseId correlates).
+function findLastIncompleteOp(
+  ops: TurnProgressOp[],
+  toolName?: string,
+): TurnProgressOp | undefined {
+  for (let i = ops.length - 1; i >= 0; i -= 1) {
+    const op = ops[i];
+    if (
+      op.completedAtMs === undefined &&
+      (toolName === undefined || op.toolName === toolName)
+    ) {
+      return op;
+    }
+  }
+  return undefined;
+}
+
 interface ActiveAssistantTurn {
   token: symbol;
   turnId: string;
   utterance: UtteranceCycle;
   abortController: AbortController;
   handle: VoiceTurnHandle | null;
+  // When the turn launched, for narration's turnElapsedMs.
+  launchedAtMs: number;
+  progress: TurnProgressState;
   assistantCompleted: boolean;
   ttsDone: boolean;
   // A tts_audio frame actually went out to the client — latches on the first
@@ -599,6 +652,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private readonly finalizeGraceMs: number;
   // Rotates through the ack phrase list across the session's turns.
   private ackPhraseCounter = 0;
+  // Rotates through the progress fallback phrases across the session's turns.
+  private progressPhraseCounter = 0;
   // Front-model service: semantic endpointing on
   // silence-fired turn-ends and LLM-phrased acks; null disables both LLM
   // capabilities (energy endpointing + static ack phrasing remain).
@@ -1306,6 +1361,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // immediately invalidates every earlier still-running continuation.
     const detachSeq = ++this.detachSequence;
     this.clearAckTimer(turn);
+    this.clearProgressIdleTimer(turn);
     // Tagged reason: provider catch-sites classify untagged caller aborts as
     // retryable transport failures (ERROR log + futile retry against the
     // aborted signal). This signal reaches the brain leg and, with llmAckText
@@ -2180,6 +2236,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       utterance,
       abortController,
       handle: null,
+      launchedAtMs: Date.now(),
+      progress: {
+        ops: [],
+        opsSinceNarration: 0,
+        updatesSpoken: 0,
+        lastFloorHolderAtMs: null,
+        idleTimer: null,
+        narrationInFlight: false,
+      },
       assistantCompleted: false,
       ttsDone: false,
       ttsAudioStarted: false,
@@ -2213,6 +2278,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // sessions — a text-only session has no audio gap to bridge.
     if (this.streamTtsAudio) {
       this.armAckTimer(activeTurn);
+    }
+
+    // Progress narration speaks into pre-first-delta dead air on a cadence;
+    // without TTS or a decider there is nothing to speak (the idle trigger's
+    // static fallback still needs a generation attempt to fall back from).
+    if (
+      this.frontModelConfig.progress.enabled &&
+      this.streamTtsAudio &&
+      this.frontDecider
+    ) {
+      this.armProgressIdleTimer(activeTurn);
     }
 
     // Triage-and-escalate (Voice Mode): active only when BOTH the voice-mode
@@ -2418,12 +2494,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             }
             current.assistantMessageId = messageId;
           },
-          tool_use_start: (toolName) => {
+          tool_use_start: (toolName, detail) => {
             const current = this.activeAssistantTurn;
             if (current?.token !== token) {
               return;
             }
             current.toolUseStarted = true;
+            // The op counts toward the narration threshold on start (not
+            // completion) so a burst of slow tools still trips the ops
+            // trigger while they run.
+            current.progress.ops.push({
+              toolName,
+              ...(detail?.toolUseId !== undefined
+                ? { toolUseId: detail.toolUseId }
+                : {}),
+              startedAtMs: Date.now(),
+            });
+            current.progress.opsSinceNarration += 1;
             log.debug({ turnId, toolName }, "Live voice turn started tool use");
             // Definitive tool use means the turn is guaranteed slow: speak
             // the floor-holding ack now instead of waiting out the
@@ -2440,6 +2527,31 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               this.clearAckTimer(current);
               this.speakAck(current, "tool_use", toolName);
             }
+            this.maybeNarrateProgress(current, "ops");
+          },
+          tool_result: (event) => {
+            const current = this.activeAssistantTurn;
+            if (current?.token !== token) {
+              return;
+            }
+            // Match by toolUseId when present; otherwise the last-started
+            // incomplete op with the same name (parallel same-name ops
+            // resolve newest-first).
+            const op =
+              (event.toolUseId !== undefined
+                ? current.progress.ops.find(
+                    (o) => o.toolUseId === event.toolUseId,
+                  )
+                : undefined) ??
+              findLastIncompleteOp(current.progress.ops, event.toolName);
+            if (op) {
+              op.completedAtMs = Date.now();
+              if (event.isError !== undefined) {
+                op.isError = event.isError;
+              }
+              op.resultPreview = event.resultPreview;
+            }
+            this.maybeNarrateProgress(current, "ops");
           },
         },
         onError: (message) => {
@@ -2488,6 +2600,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
 
       this.clearAckTimer(activeTurn);
+      this.clearProgressIdleTimer(activeTurn);
       this.activeAssistantTurn = null;
       await this.sendFrame({
         type: "error",
@@ -2517,8 +2630,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     activeTurn.escalationHandedOff = true;
     // The escalation bridge below holds the floor, so a pending
-    // slow-first-delta ack would only stack a second filler on top of it.
+    // slow-first-delta ack or progress narration would only stack a second
+    // filler on top of it.
     this.clearAckTimer(activeTurn);
+    this.clearProgressIdleTimer(activeTurn);
     // Abort the front-door leg so a model that keeps generating past the marker
     // adds no latency before the escalated leg starts.
     activeTurn.handle?.abort();
@@ -2550,6 +2665,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.activeAssistantTurn = null;
     if (turn) {
       this.clearAckTimer(turn);
+      this.clearProgressIdleTimer(turn);
       // Tagged for the same reason as the barge-in abort: untagged caller
       // aborts misclassify as retryable transport failures downstream.
       turn.abortController.abort(
@@ -2636,10 +2752,145 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
   }
 
-  // The model produced real output for this turn, so a pending ack is moot.
+  // The model produced real output for this turn, so a pending ack is moot —
+  // and so is progress narration: firstDeltaSeen latches for the rest of the
+  // turn, so narration stays off even if the model goes quiet again.
   private markFirstDeltaForAck(turn: ActiveAssistantTurn): void {
     turn.firstDeltaSeen = true;
     this.clearAckTimer(turn);
+    this.clearProgressIdleTimer(turn);
+  }
+
+  // Arms (or re-arms) the dead-air narration timer: on expiry, if the turn is
+  // still live and silent, an idle-triggered narration may speak, and the
+  // timer re-arms for the next interval.
+  private armProgressIdleTimer(turn: ActiveAssistantTurn): void {
+    const { token } = turn;
+    this.clearProgressIdleTimer(turn);
+    turn.progress.idleTimer = setTimeout(() => {
+      turn.progress.idleTimer = null;
+      if (!this.isActiveAssistantTurn(token) || turn.firstDeltaSeen) {
+        return;
+      }
+      this.maybeNarrateProgress(turn, "idle");
+      this.armProgressIdleTimer(turn);
+    }, this.frontModelConfig.progress.idleIntervalMs);
+  }
+
+  private clearProgressIdleTimer(turn: ActiveAssistantTurn): void {
+    if (turn.progress.idleTimer !== null) {
+      clearTimeout(turn.progress.idleTimer);
+      turn.progress.idleTimer = null;
+    }
+  }
+
+  // Gatekeeper for spoken progress narration: it speaks only into
+  // pre-first-delta dead air, spaced `minGapMs` from any spoken floor-holder
+  // (ack or narration), at most `maxPerTurn` times, one generation at a time,
+  // and — on the ops trigger — only once `opsThreshold` ops accumulated.
+  // Every failing guard short-circuits silently.
+  private maybeNarrateProgress(
+    turn: ActiveAssistantTurn,
+    trigger: "ops" | "idle",
+  ): void {
+    const cfg = this.frontModelConfig.progress;
+    const { progress } = turn;
+    const frontDecider = this.frontDecider;
+    if (
+      !cfg.enabled ||
+      !this.streamTtsAudio ||
+      !frontDecider ||
+      !this.isActiveAssistantTurn(turn.token) ||
+      turn.firstDeltaSeen ||
+      turn.escalationHandedOff ||
+      turn.assistantCompleted ||
+      progress.narrationInFlight ||
+      progress.updatesSpoken >= cfg.maxPerTurn ||
+      (progress.lastFloorHolderAtMs !== null &&
+        Date.now() - progress.lastFloorHolderAtMs < cfg.minGapMs) ||
+      (trigger === "ops" && progress.opsSinceNarration < cfg.opsThreshold)
+    ) {
+      return;
+    }
+    void this.speakProgressUpdate(turn, frontDecider, trigger);
+  }
+
+  // Generate and speak one progress narration. Like the ack, it is audio-only
+  // — no assistant_text_delta frame — and enqueues as a standalone sentence
+  // on the turn's ordered TTS queue. The decider internally bounds the call
+  // by `progress.generationTimeoutMs` and resolves null on every failure
+  // mode; on null the idle trigger falls back to a static phrase (silence is
+  // actively harmful there) while the ops trigger stays silent — a generic
+  // filler is not worth it when narration was merely opportunistic.
+  private async speakProgressUpdate(
+    turn: ActiveAssistantTurn,
+    frontDecider: VoiceFrontDecider,
+    trigger: "ops" | "idle",
+  ): Promise<void> {
+    const { token, progress } = turn;
+    progress.narrationInFlight = true;
+    try {
+      const now = Date.now();
+      const currentOp = findLastIncompleteOp(progress.ops);
+      const input: VoiceProgressTextInput = {
+        transcriptSoFar: turn.utterance.finalTranscriptSegments
+          .join(" ")
+          .trim(),
+        completedOps: progress.ops
+          .filter((op) => op.completedAtMs !== undefined)
+          .map((op) => ({
+            toolName: op.toolName,
+            ...(op.isError !== undefined ? { isError: op.isError } : {}),
+            ...(op.resultPreview !== undefined
+              ? { resultPreview: op.resultPreview }
+              : {}),
+          })),
+        currentOp: currentOp
+          ? {
+              toolName: currentOp.toolName,
+              elapsedMs: now - currentOp.startedAtMs,
+            }
+          : null,
+        turnElapsedMs: now - turn.launchedAtMs,
+        updateIndex: progress.updatesSpoken + 1,
+      };
+      const generated = await frontDecider
+        .generateProgressText(input, turn.abortController.signal)
+        // The decider contract never rejects; belt-and-braces for a stub.
+        .catch(() => null);
+      // Liveness re-check after the await: while generating, the turn may
+      // have been cancelled or finalized, the brain's first delta may have
+      // arrived, an escalation hand-off may have enqueued its bridge phrase,
+      // or the turn may have completed outright — in every such case the
+      // narration is moot and must not speak over real output.
+      if (
+        !this.isActiveAssistantTurn(token) ||
+        turn.firstDeltaSeen ||
+        turn.escalationHandedOff ||
+        turn.assistantCompleted
+      ) {
+        return;
+      }
+      let raw = generated;
+      if (raw === null) {
+        if (trigger === "ops") {
+          return;
+        }
+        raw = pickProgressPhrase(this.progressPhraseCounter++);
+      }
+      const phrase = sanitizeForTts(raw).trim();
+      if (phrase.length === 0) {
+        return;
+      }
+      this.enqueueTtsSegment(token, phrase, { countsAsFirstSegment: false });
+      progress.opsSinceNarration = 0;
+      progress.updatesSpoken += 1;
+      progress.lastFloorHolderAtMs = Date.now();
+      // Restart the dead-air countdown from this narration.
+      this.armProgressIdleTimer(turn);
+    } finally {
+      progress.narrationInFlight = false;
+    }
   }
 
   // Speak the turn's one floor-holding ack (every ack trigger shares the
@@ -2737,6 +2988,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.enqueueTtsSegment(activeTurn.token, phrase, {
       countsAsFirstSegment: false,
     });
+    // A spoken ack holds the floor, so narration's minGapMs spaces from it.
+    activeTurn.progress.lastFloorHolderAtMs = Date.now();
     this.markAckSpoken(activeTurn, kind);
   }
 
@@ -2761,6 +3014,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     this.clearAckTimer(activeTurn);
+    this.clearProgressIdleTimer(activeTurn);
     this.flushTtsBuffer(token, true);
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
@@ -3230,6 +3484,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     turn.finalized = true;
     this.clearAckTimer(turn);
+    this.clearProgressIdleTimer(turn);
     turn.utterance.completed = true;
     await this.archiveBufferedAudio({
       turnId: turn.turnId,


### PR DESCRIPTION
## Summary
- Per-turn tool-activity log fed by the bridge's structured tool callbacks
- Front-model progress narration on ops-threshold (3) and idle (5s) triggers, min-gap + per-turn cap, fail-open
- Audio-only via the ordered TTS queue; static fallback on idle-trigger decider failure

Part of plan: front-model-progress-narration.md (PR 3 of 4)