### PR TITLE
refactor(web): self-review cleanups for the voice transcript rail

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -73,7 +73,7 @@ describe("VoiceAmbientTranscript — pref gating", () => {
     expect(assistantText()).toBeNull();
   });
 
-  test("shows the user text (above) only when showUserTranscript is ON", () => {
+  test("shows the user text only when showUserTranscript is ON", () => {
     seedUser("hello there");
     seedAssistant("hi, how can I help");
     setPrefs({ user: true, assistant: false });
@@ -82,7 +82,7 @@ describe("VoiceAmbientTranscript — pref gating", () => {
     expect(assistantText()).toBeNull();
   });
 
-  test("shows the assistant text (below) only when showAssistantTranscript is ON", () => {
+  test("shows the assistant text only when showAssistantTranscript is ON", () => {
     seedUser("hello there");
     seedAssistant("hi, how can I help");
     setPrefs({ user: false, assistant: true });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -61,11 +61,11 @@ export function VoiceAmbientTranscript() {
   const showAssistantHalf =
     showAssistant && assistantTranscript.length > 0 && visual !== "listening";
 
-  // Text-free contract: with both halves gated off there is no rail at all, so
-  // the room renders nothing.
-  if (!showUserHalf && !showAssistantHalf) {
-    return null;
-  }
+  // The rail shows whenever either half is present. An empty rail renders no DOM
+  // (the text-free room), and presence-managing the container through the outer
+  // AnimatePresence below lets the last remaining half fade out instead of
+  // popping when it clears.
+  const railVisible = showUserHalf || showAssistantHalf;
 
   const fade = {
     initial: reduce ? false : { opacity: 0 },
@@ -86,51 +86,56 @@ export function VoiceAmbientTranscript() {
     "calc(1.5rem + var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))";
 
   return (
-    <div
-      className="pointer-events-none absolute right-0 top-0 bottom-0 z-0 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pt-20 pb-28"
-      style={{
-        paddingRight: railRightPad,
-        maskImage: fadeMask,
-        WebkitMaskImage: fadeMask,
-      }}
-    >
-      <AnimatePresence>
-        {showUserHalf ? (
-          <motion.div
-            key="user"
-            data-testid="voice-ambient-user"
-            aria-live="polite"
-            className="flex justify-end"
-            {...fade}
-          >
-            <div
-              data-testid="voice-ambient-user-bubble"
-              className="max-w-[85%] break-words rounded-2xl px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
-              style={{ backgroundColor: "var(--room-bubble-bg)" }}
-            >
-              <VoiceTranscriptText
-                text={userText}
-                leadingColor="var(--room-bubble-fg)"
-                baseColor="var(--room-bubble-fg)"
-              />
-            </div>
-          </motion.div>
-        ) : null}
+    <AnimatePresence>
+      {railVisible ? (
+        <motion.div
+          key="rail"
+          className="pointer-events-none absolute right-0 top-0 bottom-0 z-0 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pt-20 pb-28"
+          style={{
+            paddingRight: railRightPad,
+            maskImage: fadeMask,
+            WebkitMaskImage: fadeMask,
+          }}
+          {...fade}
+        >
+          <AnimatePresence>
+            {showUserHalf ? (
+              <motion.div
+                key="user"
+                data-testid="voice-ambient-user"
+                aria-live="polite"
+                className="flex justify-end"
+                {...fade}
+              >
+                <div
+                  data-testid="voice-ambient-user-bubble"
+                  className="max-w-[85%] break-words rounded-2xl px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
+                  style={{ backgroundColor: "var(--room-bubble-bg)" }}
+                >
+                  <VoiceTranscriptText
+                    text={userText}
+                    color="var(--room-bubble-fg)"
+                  />
+                </div>
+              </motion.div>
+            ) : null}
 
-        {showAssistantHalf ? (
-          <motion.div
-            key="assistant"
-            data-testid="voice-ambient-assistant"
-            aria-live="polite"
-            className="flex justify-start"
-            {...fade}
-          >
-            <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
-              <VoiceTranscriptText text={assistantTranscript} />
-            </div>
-          </motion.div>
-        ) : null}
-      </AnimatePresence>
-    </div>
+            {showAssistantHalf ? (
+              <motion.div
+                key="assistant"
+                data-testid="voice-ambient-assistant"
+                aria-live="polite"
+                className="flex justify-start"
+                {...fade}
+              >
+                <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
+                  <VoiceTranscriptText text={assistantTranscript} />
+                </div>
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -252,10 +252,10 @@ function VoiceRoomOverlay() {
           visual={visual}
           getAmplitude={getLiveVoiceInputAmplitude}
           getResponseAmplitude={getLiveVoiceOutputAmplitude}
-          // Only the *assistant* transcript occupies the space below the eyes
-          // (the user transcript floats above), so the state caption stands down
-          // for that pref alone — enabling only user captions must not blank the
-          // lower zone the caption fills.
+          // While assistant captions are on, the right-side transcript rail
+          // already narrates the turn, so the centered state caption stands down
+          // to avoid doubling it. The user-only caption pref leaves the caption
+          // up (a user bubble alone doesn't name the assistant's state).
           showStateCaption={!showAssistantTranscript}
           entryOrigin={entryOrigin}
         />
@@ -279,19 +279,19 @@ function VoiceRoomOverlay() {
           {visual === "responding" ? (
             <VoiceRespondingRings getAmplitude={getLiveVoiceOutputAmplitude} />
           ) : null}
-          {/* Same state caption + gating as the color look (stands down only for
-              the assistant-transcript pref), anchored below the centered avatar
-              instead of the eyes. */}
+          {/* Same state caption + gating as the color look (stands down while
+              the assistant transcript rail is on), anchored below the centered
+              avatar instead of the eyes. */}
           {!showAssistantTranscript ? (
             <VoiceStateCaption visual={visual} top={VOID_CAPTION_TOP} />
           ) : null}
         </>
       )}
 
-      {/* Optional muted echo of the live transcript, floating above (user) and
-          below (assistant) the centered avatar. Pref-gated (the captions
-          control above) and absolutely positioned, so it never shifts the
-          avatar and stays absent by default. */}
+      {/* Optional live transcript, rendered as a right-side chat rail (user
+          bubbles, assistant plain text). Pref-gated (the captions control
+          above) and absolutely positioned in the right margin, so it never
+          shifts the centered avatar and stays absent by default. */}
       <VoiceAmbientTranscript />
 
       {/* Backwards-compat fallback card for assistants that can still raise

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
@@ -3,8 +3,8 @@
  *
  * Two load-bearing contracts: the plain sentence is exactly the rendered
  * `textContent` (so the caller's `aria-live` region announces it verbatim),
- * and the optional color overrides land on the right spans — the leading edge
- * (last word) gets `leadingColor`, the settled words get `baseColor`.
+ * and an optional `color` flattens every word to that single tone (the default
+ * two-tone leading-edge look applies only when `color` is omitted).
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -23,18 +23,15 @@ describe("VoiceTranscriptText", () => {
     expect(container.textContent).toBe("hello world");
   });
 
-  test("applies color overrides to the leading vs. non-leading spans", () => {
+  test("paints every word the single color override when given", () => {
     const { container } = render(
-      <VoiceTranscriptText
-        text="hello world"
-        leadingColor="rgb(1, 2, 3)"
-        baseColor="rgb(4, 5, 6)"
-      />,
+      <VoiceTranscriptText text="hello world" color="rgb(1, 2, 3)" />,
     );
     const spans = container.querySelectorAll("span");
     expect(spans.length).toBe(2);
-    // The last word is the leading edge; earlier words settle to the base tone.
-    expect(spans[spans.length - 1]!.style.color).toBe("rgb(1, 2, 3)");
-    expect(spans[0]!.style.color).toBe("rgb(4, 5, 6)");
+    // A single `color` flattens the reveal — leading edge and settled words alike.
+    for (const span of spans) {
+      expect(span.style.color).toBe("rgb(1, 2, 3)");
+    }
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -28,16 +28,21 @@ import { motion, useReducedMotion } from "motion/react";
 
 export function VoiceTranscriptText({
   text,
-  leadingColor = "var(--room-fg, var(--content-secondary))",
-  baseColor = "var(--room-fg-muted, var(--content-tertiary))",
+  color,
 }: {
   text: string;
-  /** Tone for the most recent ("leading edge") word. */
-  leadingColor?: string;
-  /** Tone for the settled words trailing the leading edge. */
-  baseColor?: string;
+  /**
+   * Paints every word this single tone (a flat reveal). Omit to keep the
+   * two-tone look — the leading-edge word brighter (`--room-fg`), the settled
+   * words muted (`--room-fg-muted`).
+   */
+  color?: string;
 }) {
   const reduce = useReducedMotion();
+  // A caller-supplied `color` flattens the reveal to one tone; otherwise the
+  // leading edge reads brighter than the settled words.
+  const leadingColor = color ?? "var(--room-fg, var(--content-secondary))";
+  const baseColor = color ?? "var(--room-fg-muted, var(--content-tertiary))";
   // Collapse runs of whitespace to single spaces — the words are laid out with
   // real space text nodes between them (so they wrap and select naturally, and
   // `textContent` reads back as the plain sentence).

--- a/clients/web/src/utils/avatar-tone.ts
+++ b/clients/web/src/utils/avatar-tone.ts
@@ -92,14 +92,16 @@ export function contrastForeground(bg: string): string {
 /** Build a tone object from a background hex. */
 export function toneForBg(bg: string): AvatarTone {
   const isLight = brightness(bg) > 0.6;
+  const fg = isLight ? FG_DARK : FG_LIGHT;
   return {
     bg,
     isLight,
-    fg: isLight ? FG_DARK : FG_LIGHT,
+    fg,
     fgDeep: darkenHex(bg, 0.6),
     fgMuted: isLight ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.65)",
     wash: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)",
-    bubbleBg: isLight ? FG_DARK : FG_LIGHT,
+    // A raised surface reads as the foreground tone; its text is the inverse.
+    bubbleBg: fg,
     bubbleFg: isLight ? FG_LIGHT : FG_DARK,
   };
 }


### PR DESCRIPTION
## Summary
Self-review remediation for the voice-room transcript rail (plan voice-room-transcript-rail.md):
- Restore the transcript's exit fade: presence-manage the rail container via an outer AnimatePresence so the last-visible half fades out instead of popping (still renders no DOM when empty — text-free room preserved).
- Collapse VoiceTranscriptText's unused two-prop leadingColor/baseColor split into a single optional `color` (the only override set both to the same value); defaults keep the two-tone leading edge.
- Dedupe `bubbleBg` (compute `fg` once and reference it) in toneForBg.
- Correct now-stale comments in voice-room.tsx (transcript is a right-side rail, not a centered float) and drop positional `(above)/(below)` test names.

Behavior note: the centered state caption still stands down while assistant captions are on (kept intentionally — matches the design and stays in the plan's scope); only the rationale comment was corrected.