### PR TITLE
Voice room: restyle live transcript as a right-side chat rail (JARVIS-1306)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -6,7 +6,7 @@
  * selectors: transcript fields via the live-voice store, the two visibility
  * toggles via the voice-prefs store. The load-bearing contract is the
  * pref-gating — both prefs default OFF, so the room stays text-free — plus the
- * user-above / assistant-below ordering.
+ * user-before-assistant DOM ordering.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -142,7 +142,7 @@ describe("VoiceAmbientTranscript — sourcing and ordering", () => {
     expect(userText()?.textContent).toContain("what I said");
   });
 
-  test("renders user ABOVE assistant (DOM order) when both are ON", () => {
+  test("renders user before assistant in DOM order when both are ON", () => {
     seedUser("my question");
     seedAssistant("my answer");
     setPrefs({ user: true, assistant: true });
@@ -156,6 +156,23 @@ describe("VoiceAmbientTranscript — sourcing and ordering", () => {
       user!.compareDocumentPosition(assistant!) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  test("user half renders a bubble tied to the room bubble-bg var", () => {
+    seedUser("hello there");
+    setPrefs({ user: true, assistant: false });
+    render(<VoiceAmbientTranscript />);
+    const bubble = screen.queryByTestId("voice-ambient-user-bubble");
+    expect(bubble).not.toBeNull();
+    expect(bubble!.getAttribute("style")).toContain("--room-bubble-bg");
+  });
+
+  test("assistant half is plain text with no bubble wrapper", () => {
+    seedAssistant("my answer");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    expect(screen.queryByTestId("voice-ambient-user-bubble")).toBeNull();
+    expect(assistantText()?.textContent).toContain("my answer");
   });
 
   test("streams assistant deltas without remounting", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -73,7 +73,7 @@ describe("VoiceAmbientTranscript — pref gating", () => {
     expect(assistantText()).toBeNull();
   });
 
-  test("shows the user text (above) only when showUserTranscript is ON", () => {
+  test("shows the user text only when showUserTranscript is ON", () => {
     seedUser("hello there");
     seedAssistant("hi, how can I help");
     setPrefs({ user: true, assistant: false });
@@ -82,7 +82,7 @@ describe("VoiceAmbientTranscript — pref gating", () => {
     expect(assistantText()).toBeNull();
   });
 
-  test("shows the assistant text (below) only when showAssistantTranscript is ON", () => {
+  test("shows the assistant text only when showAssistantTranscript is ON", () => {
     seedUser("hello there");
     seedAssistant("hi, how can I help");
     setPrefs({ user: false, assistant: true });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -90,7 +90,7 @@ export function VoiceAmbientTranscript() {
       {railVisible ? (
         <motion.div
           key="rail"
-          className="pointer-events-none absolute right-0 top-0 bottom-0 z-0 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pt-20 pb-28"
+          className="pointer-events-none absolute right-0 top-0 bottom-0 z-10 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pt-20 pb-28"
           style={{
             paddingRight: railRightPad,
             maskImage: fadeMask,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -61,11 +61,11 @@ export function VoiceAmbientTranscript() {
   const showAssistantHalf =
     showAssistant && assistantTranscript.length > 0 && visual !== "listening";
 
-  // Text-free contract: with both halves gated off there is no rail at all, so
-  // the room renders nothing.
-  if (!showUserHalf && !showAssistantHalf) {
-    return null;
-  }
+  // The rail shows whenever either half is present. An empty rail renders no DOM
+  // (the text-free room), and presence-managing the container through the outer
+  // AnimatePresence below lets the last remaining half fade out instead of
+  // popping when it clears.
+  const railVisible = showUserHalf || showAssistantHalf;
 
   const fade = {
     initial: reduce ? false : { opacity: 0 },
@@ -86,51 +86,56 @@ export function VoiceAmbientTranscript() {
     "calc(1.5rem + var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))";
 
   return (
-    <div
-      className="pointer-events-none absolute right-0 top-0 bottom-0 z-0 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pt-20 pb-28"
-      style={{
-        paddingRight: railRightPad,
-        maskImage: fadeMask,
-        WebkitMaskImage: fadeMask,
-      }}
-    >
-      <AnimatePresence>
-        {showUserHalf ? (
-          <motion.div
-            key="user"
-            data-testid="voice-ambient-user"
-            aria-live="polite"
-            className="flex justify-end"
-            {...fade}
-          >
-            <div
-              data-testid="voice-ambient-user-bubble"
-              className="max-w-[85%] break-words rounded-2xl px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
-              style={{ backgroundColor: "var(--room-bubble-bg)" }}
-            >
-              <VoiceTranscriptText
-                text={userText}
-                leadingColor="var(--room-bubble-fg)"
-                baseColor="var(--room-bubble-fg)"
-              />
-            </div>
-          </motion.div>
-        ) : null}
+    <AnimatePresence>
+      {railVisible ? (
+        <motion.div
+          key="rail"
+          className="pointer-events-none absolute right-0 top-0 bottom-0 z-0 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pt-20 pb-28"
+          style={{
+            paddingRight: railRightPad,
+            maskImage: fadeMask,
+            WebkitMaskImage: fadeMask,
+          }}
+          {...fade}
+        >
+          <AnimatePresence>
+            {showUserHalf ? (
+              <motion.div
+                key="user"
+                data-testid="voice-ambient-user"
+                aria-live="polite"
+                className="flex justify-end"
+                {...fade}
+              >
+                <div
+                  data-testid="voice-ambient-user-bubble"
+                  className="max-w-[85%] break-words rounded-2xl px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
+                  style={{ backgroundColor: "var(--room-bubble-bg)" }}
+                >
+                  <VoiceTranscriptText
+                    text={userText}
+                    color="var(--room-bubble-fg)"
+                  />
+                </div>
+              </motion.div>
+            ) : null}
 
-        {showAssistantHalf ? (
-          <motion.div
-            key="assistant"
-            data-testid="voice-ambient-assistant"
-            aria-live="polite"
-            className="flex justify-start"
-            {...fade}
-          >
-            <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
-              <VoiceTranscriptText text={assistantTranscript} />
-            </div>
-          </motion.div>
-        ) : null}
-      </AnimatePresence>
-    </div>
+            {showAssistantHalf ? (
+              <motion.div
+                key="assistant"
+                data-testid="voice-ambient-assistant"
+                aria-live="polite"
+                className="flex justify-start"
+                {...fade}
+              >
+                <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
+                  <VoiceTranscriptText text={assistantTranscript} />
+                </div>
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -1,28 +1,29 @@
 /**
- * Ambient floating transcript for the voice room — muted, secondary text that
- * hovers near the centered avatar without ever becoming a chat bubble or
- * displacing the avatar. Two independently pref-gated halves:
+ * Live transcript for the voice room, styled as a right-side chat rail. A
+ * bottom-anchored column pinned to the room's right edge, newest content at the
+ * bottom, with a top fade mask so older lines dissolve as they scroll up. Two
+ * independently pref-gated halves:
  *
- * - USER speech ABOVE the avatar — `partialTranscript || finalTranscript` from
- *   the live-voice store, shown only when `showUserTranscript` is on.
- * - ASSISTANT speech BELOW the avatar — `assistantTranscript`, shown only when
- *   `showAssistantTranscript` is on AND the assistant isn't idle behind a new
- *   `listening` turn (the transcript lingers until the next response starts, so
- *   without this it would sit under the low-sunk listening eyes).
+ * - USER speech as a right-aligned "raised surface" bubble —
+ *   `partialTranscript || finalTranscript` from the live-voice store, shown only
+ *   when `showUserTranscript` is on. The bubble uses the room's bubble tone vars
+ *   (white surface / dark text over dark avatars, inverted for the light one).
+ * - ASSISTANT speech as left-aligned muted plain text (no bubble) —
+ *   `assistantTranscript`, shown only when `showAssistantTranscript` is on AND
+ *   the assistant isn't idle behind a new `listening` turn (the transcript
+ *   lingers until the next response starts).
  *
  * Both prefs default OFF, so by default this renders nothing and the room stays
- * text-free. The avatar (centered by the room) is the primary anchor; each half
- * is absolutely positioned relative to the room overlay so text appearing or
- * clearing never shifts the avatar. Words reveal one at a time via
- * {@link VoiceTranscriptText}, with a per-half clearance that keeps the text off
- * the centered eyes at any window size.
+ * text-free. The rail is `pointer-events-none`, so it never blocks the room's
+ * ✕/gear controls or the mic/stop cluster. Words reveal one at a time via
+ * {@link VoiceTranscriptText}.
  *
  * Subscriptions are deliberately narrow — the three transcript fields, the two
  * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
  * listening gate) — so the high-frequency `inputAmplitude` churn on the
  * live-voice store never re-renders this component. The full transcript still
  * lands in the chat thread on exit via the engine path; this is a live, ambient
- * echo only.
+ * echo of the current turn only.
  */
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -32,24 +33,6 @@ import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
 import { VoiceTranscriptText } from "./voice-transcript-text";
-
-/**
- * Shared constrained-width, centered treatment for both halves. Base tone comes
- * from the per-word {@link VoiceTranscriptText} (room-fg-muted, leading word
- * brighter); this only owns layout + wrapping.
- */
-const AMBIENT_TEXT_CLASS =
-  "pointer-events-none absolute left-1/2 z-0 max-w-[38rem] -translate-x-1/2 px-6 text-center text-[clamp(19px,2.6vmin,30px)] leading-relaxed text-balance whitespace-pre-wrap break-words";
-
-/**
- * Vertical clearance from the room center to each transcript half. The centered
- * eyes reach up to `EYE_TARGET_HEIGHT` (30%) of the smaller viewport dimension
- * tall — i.e. 15vmin above and below center — so anchoring the text past
- * `15vmin` plus a gap keeps it clear of the eyes (color look) and the centered
- * avatar (void look) at every window size, where the old fixed rem offset let
- * the big eyes ride into the text.
- */
-const TRANSCRIPT_CLEARANCE = "calc(50% + 15vmin + 2.5rem)";
 
 export function VoiceAmbientTranscript() {
   const showUser = useVoicePrefsStore.use.showUserTranscript();
@@ -71,14 +54,18 @@ export function VoiceAmbientTranscript() {
 
   // The assistant transcript is only cleared when the NEXT response starts
   // thinking, so a finished response lingers in the store through the following
-  // `listening` turn — where the eyes sink low, right onto the below-center
-  // assistant caption. Hide that half while listening (the assistant isn't
-  // speaking then anyway); in thinking/responding the eyes are centered and the
-  // clearance clears them.
+  // `listening` turn. Hide that half while listening (the assistant isn't
+  // speaking then anyway); in thinking/responding it stays.
   const visual = toVoiceAvatarVisual(state, reconnecting, assistantAudioActive);
   const showUserHalf = showUser && userText.length > 0;
   const showAssistantHalf =
     showAssistant && assistantTranscript.length > 0 && visual !== "listening";
+
+  // Text-free contract: with both halves gated off there is no rail at all, so
+  // the room renders nothing.
+  if (!showUserHalf && !showAssistantHalf) {
+    return null;
+  }
 
   const fade = {
     initial: reduce ? false : { opacity: 0 },
@@ -87,36 +74,63 @@ export function VoiceAmbientTranscript() {
     transition: { duration: reduce ? 0 : 0.3 },
   } as const;
 
-  return (
-    <AnimatePresence>
-      {showUserHalf ? (
-        <motion.p
-          key="user"
-          data-testid="voice-ambient-user"
-          aria-live="polite"
-          // Above the centered avatar; bottom-anchored so it grows upward and
-          // never creeps toward the orb.
-          className={AMBIENT_TEXT_CLASS}
-          style={{ bottom: TRANSCRIPT_CLEARANCE }}
-          {...fade}
-        >
-          <VoiceTranscriptText text={userText} />
-        </motion.p>
-      ) : null}
+  // A top-to-bottom fade so older lines dissolve as newer ones push up from the
+  // bottom-anchored column.
+  const fadeMask = "linear-gradient(to bottom, transparent, #000 12%)";
 
-      {showAssistantHalf ? (
-        <motion.p
-          key="assistant"
-          data-testid="voice-ambient-assistant"
-          aria-live="polite"
-          // Below the centered avatar; top-anchored so it grows downward.
-          className={AMBIENT_TEXT_CLASS}
-          style={{ top: TRANSCRIPT_CLEARANCE }}
-          {...fade}
-        >
-          <VoiceTranscriptText text={assistantTranscript} />
-        </motion.p>
-      ) : null}
-    </AnimatePresence>
+  // Absolute children are positioned against the padding box, so the overlay's
+  // safe-area padding does not inset this rail — fold the right inset into the
+  // rail's own right padding (as the room's corner controls do) so transcript
+  // text clears the notch / rounded edge in landscape on notched shells.
+  const railRightPad =
+    "calc(1.5rem + var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))";
+
+  return (
+    <div
+      className="pointer-events-none absolute right-0 top-0 bottom-0 z-0 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pt-20 pb-28"
+      style={{
+        paddingRight: railRightPad,
+        maskImage: fadeMask,
+        WebkitMaskImage: fadeMask,
+      }}
+    >
+      <AnimatePresence>
+        {showUserHalf ? (
+          <motion.div
+            key="user"
+            data-testid="voice-ambient-user"
+            aria-live="polite"
+            className="flex justify-end"
+            {...fade}
+          >
+            <div
+              data-testid="voice-ambient-user-bubble"
+              className="max-w-[85%] break-words rounded-2xl px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
+              style={{ backgroundColor: "var(--room-bubble-bg)" }}
+            >
+              <VoiceTranscriptText
+                text={userText}
+                leadingColor="var(--room-bubble-fg)"
+                baseColor="var(--room-bubble-fg)"
+              />
+            </div>
+          </motion.div>
+        ) : null}
+
+        {showAssistantHalf ? (
+          <motion.div
+            key="assistant"
+            data-testid="voice-ambient-assistant"
+            aria-live="polite"
+            className="flex justify-start"
+            {...fade}
+          >
+            <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
+              <VoiceTranscriptText text={assistantTranscript} />
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -191,6 +191,8 @@ function VoiceRoomOverlay() {
     "--room-fg-muted": tone?.fgMuted ?? "rgba(255,255,255,0.7)",
     "--room-wash": tone?.wash ?? "rgba(255,255,255,0.1)",
     "--room-border": tone?.wash ?? "rgba(255,255,255,0.15)",
+    "--room-bubble-bg": tone?.bubbleBg ?? "#FFFFFF",
+    "--room-bubble-fg": tone?.bubbleFg ?? "#1A1A1A",
   } as CSSProperties;
 
   // Global Escape, live only while the room is mounted: ends the session,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -252,10 +252,10 @@ function VoiceRoomOverlay() {
           visual={visual}
           getAmplitude={getLiveVoiceInputAmplitude}
           getResponseAmplitude={getLiveVoiceOutputAmplitude}
-          // Only the *assistant* transcript occupies the space below the eyes
-          // (the user transcript floats above), so the state caption stands down
-          // for that pref alone — enabling only user captions must not blank the
-          // lower zone the caption fills.
+          // While assistant captions are on, the right-side transcript rail
+          // already narrates the turn, so the centered state caption stands down
+          // to avoid doubling it. The user-only caption pref leaves the caption
+          // up (a user bubble alone doesn't name the assistant's state).
           showStateCaption={!showAssistantTranscript}
           entryOrigin={entryOrigin}
         />
@@ -279,19 +279,19 @@ function VoiceRoomOverlay() {
           {visual === "responding" ? (
             <VoiceRespondingRings getAmplitude={getLiveVoiceOutputAmplitude} />
           ) : null}
-          {/* Same state caption + gating as the color look (stands down only for
-              the assistant-transcript pref), anchored below the centered avatar
-              instead of the eyes. */}
+          {/* Same state caption + gating as the color look (stands down while
+              the assistant transcript rail is on), anchored below the centered
+              avatar instead of the eyes. */}
           {!showAssistantTranscript ? (
             <VoiceStateCaption visual={visual} top={VOID_CAPTION_TOP} />
           ) : null}
         </>
       )}
 
-      {/* Optional muted echo of the live transcript, floating above (user) and
-          below (assistant) the centered avatar. Pref-gated (the captions
-          control above) and absolutely positioned, so it never shifts the
-          avatar and stays absent by default. */}
+      {/* Optional live transcript, rendered as a right-side chat rail (user
+          bubbles, assistant plain text). Pref-gated (the captions control
+          above) and absolutely positioned in the right margin, so it never
+          shifts the centered avatar and stays absent by default. */}
       <VoiceAmbientTranscript />
 
       {/* Backwards-compat fallback card for assistants that can still raise

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
@@ -3,8 +3,8 @@
  *
  * Two load-bearing contracts: the plain sentence is exactly the rendered
  * `textContent` (so the caller's `aria-live` region announces it verbatim),
- * and the optional color overrides land on the right spans — the leading edge
- * (last word) gets `leadingColor`, the settled words get `baseColor`.
+ * and an optional `color` flattens every word to that single tone (the default
+ * two-tone leading-edge look applies only when `color` is omitted).
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -23,18 +23,15 @@ describe("VoiceTranscriptText", () => {
     expect(container.textContent).toBe("hello world");
   });
 
-  test("applies color overrides to the leading vs. non-leading spans", () => {
+  test("paints every word the single color override when given", () => {
     const { container } = render(
-      <VoiceTranscriptText
-        text="hello world"
-        leadingColor="rgb(1, 2, 3)"
-        baseColor="rgb(4, 5, 6)"
-      />,
+      <VoiceTranscriptText text="hello world" color="rgb(1, 2, 3)" />,
     );
     const spans = container.querySelectorAll("span");
     expect(spans.length).toBe(2);
-    // The last word is the leading edge; earlier words settle to the base tone.
-    expect(spans[spans.length - 1]!.style.color).toBe("rgb(1, 2, 3)");
-    expect(spans[0]!.style.color).toBe("rgb(4, 5, 6)");
+    // A single `color` flattens the reveal — leading edge and settled words alike.
+    for (const span of spans) {
+      expect(span.style.color).toBe("rgb(1, 2, 3)");
+    }
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Tests for `VoiceTranscriptText`.
+ *
+ * Two load-bearing contracts: the plain sentence is exactly the rendered
+ * `textContent` (so the caller's `aria-live` region announces it verbatim),
+ * and the optional color overrides land on the right spans — the leading edge
+ * (last word) gets `leadingColor`, the settled words get `baseColor`.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { VoiceTranscriptText } from "@/domains/chat/voice/voice-room/voice-transcript-text";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("VoiceTranscriptText", () => {
+  test("exposes the plain sentence as textContent", () => {
+    const { container } = render(<VoiceTranscriptText text="hello world" />);
+    expect(container.textContent).toBe("hello world");
+  });
+
+  test("applies color overrides to the leading vs. non-leading spans", () => {
+    const { container } = render(
+      <VoiceTranscriptText
+        text="hello world"
+        leadingColor="rgb(1, 2, 3)"
+        baseColor="rgb(4, 5, 6)"
+      />,
+    );
+    const spans = container.querySelectorAll("span");
+    expect(spans.length).toBe(2);
+    // The last word is the leading edge; earlier words settle to the base tone.
+    expect(spans[spans.length - 1]!.style.color).toBe("rgb(1, 2, 3)");
+    expect(spans[0]!.style.color).toBe("rgb(4, 5, 6)");
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -26,7 +26,17 @@
 import { Fragment, useMemo } from "react";
 import { motion, useReducedMotion } from "motion/react";
 
-export function VoiceTranscriptText({ text }: { text: string }) {
+export function VoiceTranscriptText({
+  text,
+  leadingColor = "var(--room-fg, var(--content-secondary))",
+  baseColor = "var(--room-fg-muted, var(--content-tertiary))",
+}: {
+  text: string;
+  /** Tone for the most recent ("leading edge") word. */
+  leadingColor?: string;
+  /** Tone for the settled words trailing the leading edge. */
+  baseColor?: string;
+}) {
   const reduce = useReducedMotion();
   // Collapse runs of whitespace to single spaces — the words are laid out with
   // real space text nodes between them (so they wrap and select naturally, and
@@ -43,9 +53,7 @@ export function VoiceTranscriptText({ text }: { text: string }) {
             <motion.span
               className="inline-block"
               style={{
-                color: leading
-                  ? "var(--room-fg, var(--content-secondary))"
-                  : "var(--room-fg-muted, var(--content-tertiary))",
+                color: leading ? leadingColor : baseColor,
                 // The leading-edge tone eases back to the base as the next word
                 // takes over (the motion entrance below owns transform/opacity).
                 transition: "color 0.45s ease",

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -28,16 +28,21 @@ import { motion, useReducedMotion } from "motion/react";
 
 export function VoiceTranscriptText({
   text,
-  leadingColor = "var(--room-fg, var(--content-secondary))",
-  baseColor = "var(--room-fg-muted, var(--content-tertiary))",
+  color,
 }: {
   text: string;
-  /** Tone for the most recent ("leading edge") word. */
-  leadingColor?: string;
-  /** Tone for the settled words trailing the leading edge. */
-  baseColor?: string;
+  /**
+   * Paints every word this single tone (a flat reveal). Omit to keep the
+   * two-tone look — the leading-edge word brighter (`--room-fg`), the settled
+   * words muted (`--room-fg-muted`).
+   */
+  color?: string;
 }) {
   const reduce = useReducedMotion();
+  // A caller-supplied `color` flattens the reveal to one tone; otherwise the
+  // leading edge reads brighter than the settled words.
+  const leadingColor = color ?? "var(--room-fg, var(--content-secondary))";
+  const baseColor = color ?? "var(--room-fg-muted, var(--content-tertiary))";
   // Collapse runs of whitespace to single spaces — the words are laid out with
   // real space text nodes between them (so they wrap and select naturally, and
   // `textContent` reads back as the plain sentence).

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -51,7 +51,10 @@ export function VoiceTranscriptText({
         return (
           <Fragment key={i}>
             <motion.span
-              className="inline-block"
+              // `max-w-full` + break-anywhere so a single long token (URL, code)
+              // wraps within its container instead of overflowing the narrow
+              // transcript rail and being clipped.
+              className="inline-block max-w-full [overflow-wrap:anywhere]"
               style={{
                 color: leading ? leadingColor : baseColor,
                 // The leading-edge tone eases back to the base as the next word

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
@@ -15,9 +15,9 @@ import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceTranscriptText } from "./voice-transcript-text";
 
 /**
- * Iteration harness for the voice room's live captions — the ambient,
- * word-by-word transcript that floats above (user) and below (assistant) the
- * centered avatar without ever becoming a chat bubble.
+ * Iteration harness for the voice room's live captions — a right-side chat rail
+ * that streams the current turn word-by-word: user speech as a right-aligned
+ * bubble, assistant speech as left-aligned muted plain text.
  *
  * The scenes simulate a live session by streaming a canned utterance into the
  * real live-voice store one word at a time (no mic / STT / TTS), so the reveal,
@@ -84,12 +84,14 @@ function AmbientTranscriptScene({
   role,
   wordMs,
   replay,
-  minHeight = 520,
+  minHeight = 600,
 }: SceneProps) {
   const tone = toneForBg(SAMPLE_HEX);
   const toneVars = {
     "--room-fg": tone.fg,
     "--room-fg-muted": tone.fgMuted,
+    "--room-bubble-bg": tone.bubbleBg,
+    "--room-bubble-fg": tone.bubbleFg,
   } as Record<string, string>;
 
   // Prefs gate each half; turn on whichever role this scene streams.
@@ -138,7 +140,7 @@ function AmbientTranscriptScene({
       className="relative flex items-center justify-center overflow-hidden rounded-lg"
       style={{ minHeight, backgroundColor: SAMPLE_HEX, ...toneVars }}
     >
-      {/* Stand-in for the centered avatar so the above/below anchoring reads. */}
+      {/* Stand-in for the centered avatar so the rail reads against the right edge. */}
       <div
         className="size-40 rounded-full"
         style={{ backgroundColor: "var(--room-fg)", opacity: 0.12 }}
@@ -164,7 +166,8 @@ const meta: Meta<typeof AmbientTranscriptScene> = {
     role: {
       options: ["user", "assistant", "both"] satisfies Role[],
       control: { type: "inline-radio" },
-      description: "Which half streams — user (above), assistant (below), or both.",
+      description:
+        "Which half streams — user (right bubble), assistant (left plain text), or both.",
     },
     wordMs: {
       control: { type: "range", min: 80, max: 600, step: 20 },
@@ -182,8 +185,9 @@ type Story = StoryObj<typeof AmbientTranscriptScene>;
 
 /**
  * The ambient captions over a live-streamed turn: each word fades + rises +
- * de-blurs in, the newest word carries the brighter leading-edge tone, and the
- * text stays anchored clear of the avatar. Scrub `role` and `wordMs`.
+ * de-blurs in and the newest word carries the brighter leading-edge tone. The
+ * rail sits against the room's right edge — the user's speech as a right-aligned
+ * bubble, the assistant's as left-aligned muted text. Scrub `role` and `wordMs`.
  */
 export const Playground: Story = {};
 

--- a/clients/web/src/utils/avatar-tone.test.ts
+++ b/clients/web/src/utils/avatar-tone.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for `toneForBg`'s user-bubble surface tokens (`bubbleBg`/`bubbleFg`).
+ *
+ * Pins the contract that the bubble is a raised surface contrasting the
+ * avatar color — white/near-black over dark or saturated avatars, inverted
+ * to dark/white over the one light avatar color (yellow) — while the base
+ * tone fields (`fg`/`fgMuted`) keep their established values.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { toneForBg } from "./avatar-tone";
+
+describe("toneForBg bubble tokens", () => {
+  test("dark bg yields a white bubble with near-black text", () => {
+    const surface = toneForBg("#17191C");
+    expect(surface.bubbleBg).toBe("#FFFFFF");
+    expect(surface.bubbleFg).toBe("#1A1A1A");
+
+    const teal = toneForBg("#3E9B87");
+    expect(teal.bubbleBg).toBe("#FFFFFF");
+    expect(teal.bubbleFg).toBe("#1A1A1A");
+  });
+
+  test("light bg (yellow) inverts to a dark bubble with white text", () => {
+    const tone = toneForBg("#F2C94C");
+    expect(tone.isLight).toBe(true);
+    expect(tone.bubbleBg).toBe("#1A1A1A");
+    expect(tone.bubbleFg).toBe("#FFFFFF");
+  });
+
+  test("base tone fields keep their established values", () => {
+    const tone = toneForBg("#17191C");
+    expect(tone.fg).toBe("#FFFFFF");
+    expect(tone.fgMuted).toBe("rgba(255,255,255,0.65)");
+  });
+});

--- a/clients/web/src/utils/avatar-tone.ts
+++ b/clients/web/src/utils/avatar-tone.ts
@@ -92,14 +92,16 @@ export function contrastForeground(bg: string): string {
 /** Build a tone object from a background hex. */
 export function toneForBg(bg: string): AvatarTone {
   const isLight = brightness(bg) > 0.6;
+  const fg = isLight ? FG_DARK : FG_LIGHT;
   return {
     bg,
     isLight,
-    fg: isLight ? FG_DARK : FG_LIGHT,
+    fg,
     fgDeep: darkenHex(bg, 0.6),
     fgMuted: isLight ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.65)",
     wash: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)",
-    bubbleBg: isLight ? FG_DARK : FG_LIGHT,
+    // A raised surface reads as the foreground tone; its text is the inverse.
+    bubbleBg: fg,
     bubbleFg: isLight ? FG_LIGHT : FG_DARK,
   };
 }

--- a/clients/web/src/utils/avatar-tone.ts
+++ b/clients/web/src/utils/avatar-tone.ts
@@ -26,6 +26,13 @@ export interface AvatarTone {
   fgMuted: string;
   /** A subtle hover/fill wash at the matching tone. */
   wash: string;
+  /**
+   * Solid raised-surface fill for a user speech bubble that contrasts the
+   * avatar color: white over dark/saturated avatars, dark over the light one.
+   */
+  bubbleBg: string;
+  /** Text color drawn on that bubble (the inverse of {@link bubbleBg}). */
+  bubbleFg: string;
 }
 
 const FG_DARK = "#1A1A1A";
@@ -92,5 +99,7 @@ export function toneForBg(bg: string): AvatarTone {
     fgDeep: darkenHex(bg, 0.6),
     fgMuted: isLight ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.65)",
     wash: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)",
+    bubbleBg: isLight ? FG_DARK : FG_LIGHT,
+    bubbleFg: isLight ? FG_LIGHT : FG_DARK,
   };
 }


### PR DESCRIPTION
## Summary
Restyles the voice-room live transcript to match the design: a right-side, bottom-anchored chat rail — user speech as a right-aligned "raised surface" bubble, assistant speech as left-aligned muted plain text, with a top fade mask. Scope stays narrow: current-turn data only (no live-voice store/history changes), still pref-gated behind the Captions toggle (room stays text-free by default), applied to both looks via the shared `--room-*` tone vars.

Closes JARVIS-1306.

## Self-review result
PASS. 4 self-review passes surfaced 2 substantive integration findings (transcript exit-fade lost to the text-free early-return; stale state-caption coupling rationale) plus slop/doc nits — all remediated in #38547 and re-reviewed clean over 2 rounds.

## PRs merged into feature branch
- #38539: add bubble surface tokens to avatar tone (`bubbleBg`/`bubbleFg`)
- #38540: allow VoiceTranscriptText color override
- #38542: voice-room transcript as a right-side chat rail
- #38546: update voice transcript story for the rail
- #38547: self-review cleanups (restore exit fade, collapse color props to a single `color`, dedupe `bubbleBg`, correct stale comments/test names)

### Behavior note
The centered "Listening/Thinking/Speaking" state caption still stands down while assistant captions are on — kept intentionally (the rail already narrates the turn; matches the design and stays in the restyle-only scope). A follow-up could show it alongside the rail if desired.

Part of plan: voice-room-transcript-rail.md