### PR TITLE
fix(assistant): persist python package installs across saves on kata runtimes

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -238,6 +238,22 @@ RUN printf '%s\n' \
 RUN ln -s /app/assistant/docker-kata-pip.sh /usr/local/bin/pip && \
     ln -s /app/assistant/docker-kata-pip.sh /usr/local/bin/pip3
 
+# .pth files (pip install -e) are only processed for site directories, not
+# PYTHONPATH entries — register the persistent chroot dirs as site dirs.
+RUN cp /app/assistant/docker-sitecustomize.py /usr/lib/python3/dist-packages/sitecustomize.py
+
+# Reword Debian's externally-managed refusal: `python3 -m pip install` bypasses
+# the pip wrappers and would install into the ephemeral image rootfs, so steer
+# users to the persisting paths instead.
+RUN printf '%s\n' \
+    '[externally-managed]' \
+    'Error=Installing into the image Python is disabled: the image rootfs is' \
+    ' ephemeral on managed machines, so packages installed here are lost on' \
+    ' every save. Use `pip install <pkg>` (persists via the system root) or a' \
+    ' virtualenv under /workspace. Pass --break-system-packages to override' \
+    ' (the install will NOT survive a save).' \
+    > "/usr/lib/python$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')/EXTERNALLY-MANAGED"
+
 # Ensure the CES bootstrap socket volume is writable by the non-root CES user.
 RUN mkdir -p /run/ces-bootstrap && chmod 777 /run/ces-bootstrap
 

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -242,16 +242,19 @@ RUN ln -s /app/assistant/docker-kata-pip.sh /usr/local/bin/pip && \
 # PYTHONPATH entries — register the persistent chroot dirs as site dirs.
 RUN cp /app/assistant/docker-sitecustomize.py /usr/lib/python3/dist-packages/sitecustomize.py
 
-# Reword Debian's externally-managed refusal: `python3 -m pip install` bypasses
-# the pip wrappers and would install into the ephemeral image rootfs, so steer
-# users to the persisting paths instead.
+# Reword Debian's stock externally-managed refusal (shipped with python3, so
+# this refusal exists on every runtime regardless): `python3 -m pip install`
+# bypasses the pip wrappers, so its error must steer users to paths that
+# actually work. Venv advice is correct everywhere; the bare `pip install`
+# route only persists on kata-family machines, so it is worded conditionally.
 RUN printf '%s\n' \
     '[externally-managed]' \
-    'Error=Installing into the image Python is disabled: the image rootfs is' \
-    ' ephemeral on managed machines, so packages installed here are lost on' \
-    ' every save. Use `pip install <pkg>` (persists via the system root) or a' \
-    ' virtualenv under /workspace. Pass --break-system-packages to override' \
-    ' (the install will NOT survive a save).' \
+    'Error=This Python environment is part of the container image and does not' \
+    ' persist. Create a virtualenv under a persistent directory instead, e.g.' \
+    ' `python3 -m venv /workspace/.venv`. On managed machines with a' \
+    ' persistent system root, `sudo pip install <pkg>` (not `python3 -m pip`)' \
+    ' also persists. Passing --break-system-packages installs into the image' \
+    ' rootfs and will NOT survive a machine save or container restart.' \
     > "/usr/lib/python$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')/EXTERNALLY-MANAGED"
 
 # Ensure the CES bootstrap socket volume is writable by the non-root CES user.

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -255,6 +255,7 @@ RUN chmod +x \
     /app/assistant/docker-init-apt-root.sh \
     /app/assistant/docker-kata-apt-env.sh \
     /app/assistant/docker-kata-pip.sh \
+    /app/assistant/docker-kata-pip-chroot.sh \
     /app/assistant/docker-kata-runtime-family.sh \
     /usr/local/bin/vellum-block-volume-common.sh \
     /usr/local/bin/vellum-block-volume-init.sh \

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -98,6 +98,7 @@ RUN apt-get update && apt-get install -y \
     openssl \
     procps \
     python3 \
+    python3-pip \
     sqlite3 \
     sudo \
     util-linux \
@@ -232,6 +233,11 @@ RUN printf '%s\n' \
     > /usr/local/bin/dpkg && \
     chmod +x /usr/local/bin/dpkg
 
+# pip must persist like apt: on Kata-family runtimes the wrapper routes root
+# installs into the persistent apt chroot.
+RUN ln -s /app/assistant/docker-kata-pip.sh /usr/local/bin/pip && \
+    ln -s /app/assistant/docker-kata-pip.sh /usr/local/bin/pip3
+
 # Ensure the CES bootstrap socket volume is writable by the non-root CES user.
 RUN mkdir -p /run/ces-bootstrap && chmod 777 /run/ces-bootstrap
 
@@ -248,6 +254,7 @@ RUN chmod +x \
     /app/assistant/docker-entrypoint.sh \
     /app/assistant/docker-init-apt-root.sh \
     /app/assistant/docker-kata-apt-env.sh \
+    /app/assistant/docker-kata-pip.sh \
     /app/assistant/docker-kata-runtime-family.sh \
     /usr/local/bin/vellum-block-volume-common.sh \
     /usr/local/bin/vellum-block-volume-init.sh \

--- a/assistant/docker-kata-apt-env.sh
+++ b/assistant/docker-kata-apt-env.sh
@@ -55,12 +55,14 @@ export LD_LIBRARY_PATH
 # Make python packages installed into the chroot importable by the image
 # python: apt packages land in the unversioned dist-packages dir, chroot pip
 # installs in the versioned /usr/local one. The chroot suite matches the image
-# suite, so the image python's version selects the right pip dir.
+# suite, so the image python's version selects the right pip dir. The pip dir
+# must precede the apt dir, mirroring Debian's sys.path order, so a
+# pip-upgraded package wins over an older apt one.
 _vellum_kata_python_version="$(/usr/bin/python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || true)"
-_vellum_kata_append_pythonpath "${VELLUM_APT_DATA_ROOT}/usr/lib/python3/dist-packages"
 if [ -n "${_vellum_kata_python_version}" ]; then
   _vellum_kata_append_pythonpath "${VELLUM_APT_DATA_ROOT}/usr/local/lib/python${_vellum_kata_python_version}/dist-packages"
 fi
+_vellum_kata_append_pythonpath "${VELLUM_APT_DATA_ROOT}/usr/lib/python3/dist-packages"
 unset _vellum_kata_python_version
 export PYTHONPATH
 

--- a/assistant/docker-kata-apt-env.sh
+++ b/assistant/docker-kata-apt-env.sh
@@ -15,6 +15,20 @@ _vellum_kata_append_path() {
   esac
 }
 
+_vellum_kata_prepend_path() {
+  case ":${PATH:-}:" in
+    *":$1:"*) ;;
+    *) PATH="$1${PATH:+:${PATH}}" ;;
+  esac
+}
+
+_vellum_kata_append_pythonpath() {
+  case ":${PYTHONPATH:-}:" in
+    *":$1:"*) ;;
+    *) PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}$1" ;;
+  esac
+}
+
 _vellum_kata_prepend_library_path() {
   case ":${LD_LIBRARY_PATH:-}:" in
     *":$1:"*) ;;
@@ -38,4 +52,27 @@ _vellum_kata_prepend_library_path "${VELLUM_APT_DATA_ROOT}/usr/lib"
 _vellum_kata_prepend_library_path "${VELLUM_APT_DATA_ROOT}/usr/local/lib"
 export LD_LIBRARY_PATH
 
-unset -f _vellum_kata_append_path _vellum_kata_prepend_library_path
+# Make python packages installed into the chroot importable by the image
+# python: apt packages land in the unversioned dist-packages dir, chroot pip
+# installs in the versioned /usr/local one. The chroot suite matches the image
+# suite, so the image python's version selects the right pip dir.
+_vellum_kata_python_version="$(/usr/bin/python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || true)"
+_vellum_kata_append_pythonpath "${VELLUM_APT_DATA_ROOT}/usr/lib/python3/dist-packages"
+if [ -n "${_vellum_kata_python_version}" ]; then
+  _vellum_kata_append_pythonpath "${VELLUM_APT_DATA_ROOT}/usr/local/lib/python${_vellum_kata_python_version}/dist-packages"
+fi
+unset _vellum_kata_python_version
+export PYTHONPATH
+
+# The image bakes these under /home/assistant, which is ephemeral rootfs; on
+# kata pods $HOME is the persistent data volume, so user-level installs there
+# survive machine saves.
+if [ -n "${HOME:-}" ]; then
+  export PYTHONUSERBASE="${HOME}/.python"
+  export BUN_INSTALL="${HOME}/.bun"
+  _vellum_kata_prepend_path "${BUN_INSTALL}/bin"
+  _vellum_kata_prepend_path "${PYTHONUSERBASE}/bin"
+fi
+export PATH
+
+unset -f _vellum_kata_append_path _vellum_kata_prepend_path _vellum_kata_append_pythonpath _vellum_kata_prepend_library_path

--- a/assistant/docker-kata-pip-chroot.sh
+++ b/assistant/docker-kata-pip-chroot.sh
@@ -11,7 +11,7 @@ CALLER_CWD="$2"
 PIP_BIN="$3"
 shift 3
 
-for dir in /workspace /data; do
+for dir in /workspace /data /tmp /var/tmp; do
   [ -d "${dir}" ] || continue
   mkdir -p "${DATA_ROOT}${dir}"
   mount --bind "${dir}" "${DATA_ROOT}${dir}" 2>/dev/null || true

--- a/assistant/docker-kata-pip-chroot.sh
+++ b/assistant/docker-kata-pip-chroot.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# Runs pip inside the persistent apt chroot. Must be invoked under `unshare -m`
+# (see docker-kata-pip.sh): the bind mounts below live in a private mount
+# namespace so they disappear with the pip process and are never visible to
+# other processes — a lingering /data bind inside the chroot would create a
+# path cycle (/data/system/data/system/...) for anything walking /data.
+set -eu
+
+DATA_ROOT="$1"
+CALLER_CWD="$2"
+PIP_BIN="$3"
+shift 3
+
+for dir in /workspace /data; do
+  [ -d "${dir}" ] || continue
+  mkdir -p "${DATA_ROOT}${dir}"
+  mount --bind "${dir}" "${DATA_ROOT}${dir}" 2>/dev/null || true
+done
+
+# chroot(1) always chdirs to /; restore the caller's cwd when it exists inside
+# the chroot so relative paths keep working.
+exec chroot "${DATA_ROOT}" /bin/sh -c 'cd "$1" 2>/dev/null || cd /; shift; exec "$@"' sh "${CALLER_CWD}" "${PIP_BIN}" "$@"

--- a/assistant/docker-kata-pip.sh
+++ b/assistant/docker-kata-pip.sh
@@ -34,7 +34,14 @@ if [ "$(id -u)" = "0" ]; then
       # (inside a private mount namespace) and restores the caller's cwd, so
       # path-based installs (pip install ., -r requirements.txt) and --user
       # installs into $PYTHONUSERBASE resolve to the same files as outside.
-      exec unshare -m /app/assistant/docker-kata-pip-chroot.sh "${DATA_ROOT}" "${PWD}" "/usr/bin/${PIP_NAME}" "$@"
+      # Platform kata pods are privileged inside their per-assistant VM, so
+      # unshare -m works there; if this environment can't create a mount
+      # namespace, fall back to a bare chroot — index installs still persist,
+      # only caller-path installs lose visibility.
+      if unshare -m true 2>/dev/null; then
+        exec unshare -m /app/assistant/docker-kata-pip-chroot.sh "${DATA_ROOT}" "${PWD}" "/usr/bin/${PIP_NAME}" "$@"
+      fi
+      exec chroot "${DATA_ROOT}" /bin/sh -c 'cd "$1" 2>/dev/null || cd /; shift; exec "$@"' sh "${PWD}" "/usr/bin/${PIP_NAME}" "$@"
     fi
   fi
   echo "Warning: persistent pip root unavailable; falling back to the image pip (installs will not survive a save)" >&2

--- a/assistant/docker-kata-pip.sh
+++ b/assistant/docker-kata-pip.sh
@@ -30,7 +30,11 @@ if [ "$(id -u)" = "0" ]; then
       chroot "${DATA_ROOT}" sh -c "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3-pip" >&2 || true
     fi
     if [ -x "${DATA_ROOT}/usr/bin/${PIP_NAME}" ]; then
-      exec chroot "${DATA_ROOT}" "/usr/bin/${PIP_NAME}" "$@"
+      # The helper bind-mounts /workspace and /data into the chroot (inside a
+      # private mount namespace) and restores the caller's cwd, so path-based
+      # installs (pip install ., -r requirements.txt) and --user installs into
+      # $PYTHONUSERBASE resolve to the same files as outside the chroot.
+      exec unshare -m /app/assistant/docker-kata-pip-chroot.sh "${DATA_ROOT}" "${PWD}" "/usr/bin/${PIP_NAME}" "$@"
     fi
   fi
   echo "Warning: persistent pip root unavailable; falling back to the image pip (installs will not survive a save)" >&2

--- a/assistant/docker-kata-pip.sh
+++ b/assistant/docker-kata-pip.sh
@@ -30,10 +30,10 @@ if [ "$(id -u)" = "0" ]; then
       chroot "${DATA_ROOT}" sh -c "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3-pip" >&2 || true
     fi
     if [ -x "${DATA_ROOT}/usr/bin/${PIP_NAME}" ]; then
-      # The helper bind-mounts /workspace and /data into the chroot (inside a
-      # private mount namespace) and restores the caller's cwd, so path-based
-      # installs (pip install ., -r requirements.txt) and --user installs into
-      # $PYTHONUSERBASE resolve to the same files as outside the chroot.
+      # The helper bind-mounts caller-visible source dirs into the chroot
+      # (inside a private mount namespace) and restores the caller's cwd, so
+      # path-based installs (pip install ., -r requirements.txt) and --user
+      # installs into $PYTHONUSERBASE resolve to the same files as outside.
       exec unshare -m /app/assistant/docker-kata-pip-chroot.sh "${DATA_ROOT}" "${PWD}" "/usr/bin/${PIP_NAME}" "$@"
     fi
   fi

--- a/assistant/docker-kata-pip.sh
+++ b/assistant/docker-kata-pip.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+# pip/pip3 wrapper (symlinked from /usr/local/bin). On Kata-family runtimes,
+# root pip installs are routed into the persistent apt chroot — like the
+# apt/apt-get/dpkg wrappers — so they survive machine saves; the image rootfs
+# is discarded on every save. Non-root invocations fall through to the image
+# pip, where PIP_BREAK_SYSTEM_PACKAGES makes pip default to a user install
+# under the persistent PYTHONUSERBASE.
+set -eu
+
+PIP_NAME="$(basename "$0")"
+case "${PIP_NAME}" in
+  pip | pip3) ;;
+  *) PIP_NAME="pip3" ;;
+esac
+
+. /app/assistant/docker-kata-runtime-family.sh
+
+if ! vellum_is_kata_family_runtime; then
+  exec "/usr/bin/${PIP_NAME}" "$@"
+fi
+
+export PIP_BREAK_SYSTEM_PACKAGES=1
+DATA_ROOT="${VELLUM_APT_DATA_ROOT:-/data/system}"
+
+if [ "$(id -u)" = "0" ]; then
+  /app/assistant/docker-init-apt-root.sh
+  if [ -x "${DATA_ROOT}/bin/sh" ] && [ -f "${DATA_ROOT}/.rootfs-initialized" ] && ! grep -qs " ${DATA_ROOT} .*noexec" /proc/mounts; then
+    if [ ! -x "${DATA_ROOT}/usr/bin/${PIP_NAME}" ]; then
+      echo "Installing pip into the persistent system root (one-time setup)..." >&2
+      chroot "${DATA_ROOT}" sh -c "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3-pip" >&2 || true
+    fi
+    if [ -x "${DATA_ROOT}/usr/bin/${PIP_NAME}" ]; then
+      exec chroot "${DATA_ROOT}" "/usr/bin/${PIP_NAME}" "$@"
+    fi
+  fi
+  echo "Warning: persistent pip root unavailable; falling back to the image pip (installs will not survive a save)" >&2
+fi
+
+exec "/usr/bin/${PIP_NAME}" "$@"

--- a/assistant/docker-sitecustomize.py
+++ b/assistant/docker-sitecustomize.py
@@ -1,0 +1,29 @@
+"""Vellum: expose the persistent apt/pip chroot as site directories.
+
+Installed at /usr/lib/python3/dist-packages/sitecustomize.py in the assistant
+image. PYTHONPATH (set by docker-kata-apt-env.sh and buildSanitizedEnv) makes
+plain modules importable, but .pth files (e.g. from `pip install -e`) are only
+processed for site directories, so the chroot dirs must also be registered
+here. Virtualenvs without --system-site-packages never import this module,
+which is intended — venvs are self-contained.
+"""
+
+import os
+
+if os.environ.get("VELLUM_SANDBOX_RUNTIME") in (
+    "kata",
+    "firecracker",
+    "cloud-hypervisor",
+):
+    import site
+    import sys
+
+    _root = os.environ.get("VELLUM_APT_DATA_ROOT", "/data/system")
+    _version = "%d.%d" % sys.version_info[:2]
+    # pip dir before apt dir, matching the PYTHONPATH precedence.
+    for _dir in (
+        "%s/usr/local/lib/python%s/dist-packages" % (_root, _version),
+        "%s/usr/lib/python3/dist-packages" % _root,
+    ):
+        if os.path.isdir(_dir):
+            site.addsitedir(_dir)

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -123,12 +123,17 @@ describe("buildSanitizedEnv", () => {
   test("only includes Kata apt variables for Kata-family sandbox runtimes", () => {
     process.env.VELLUM_SANDBOX_RUNTIME = "gvisor";
     process.env.PATH = "/usr/bin";
+    process.env.HOME = "/data";
     process.env.VELLUM_APT_DATA_ROOT = "/data/system";
     process.env.LD_LIBRARY_PATH = "/host/lib";
+    process.env.PYTHONPATH = "/host/python";
 
     let env = buildSanitizedEnv();
     expect(env.VELLUM_APT_DATA_ROOT).toBeUndefined();
     expect(env.LD_LIBRARY_PATH).toBeUndefined();
+    expect(env.PYTHONPATH).toBeUndefined();
+    expect(env.PYTHONUSERBASE).toBeUndefined();
+    expect(env.BUN_INSTALL).toBeUndefined();
     expect(env.PATH.split(":")).not.toContain("/data/system/usr/bin");
 
     process.env.VELLUM_SANDBOX_RUNTIME = "kata";
@@ -141,6 +146,14 @@ describe("buildSanitizedEnv", () => {
       "/data/system/usr/local/lib",
     );
     expect(env.LD_LIBRARY_PATH.split(":")).not.toContain("/host/lib");
+    expect(env.PYTHONPATH.split(":")).toContain(
+      "/data/system/usr/lib/python3/dist-packages",
+    );
+    expect(env.PYTHONPATH.split(":")).not.toContain("/host/python");
+    expect(env.PYTHONUSERBASE).toBe("/data/.python");
+    expect(env.BUN_INSTALL).toBe("/data/.bun");
+    expect(env.PATH.split(":")).toContain("/data/.python/bin");
+    expect(env.PATH.split(":")).toContain("/data/.bun/bin");
 
     process.env.VELLUM_SANDBOX_RUNTIME = "cloud-hypervisor";
     env = buildSanitizedEnv();

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -124,20 +124,29 @@ function kataAptLibraryPaths(dataRoot: string): string[] {
 
 // Python packages installed into the chroot: apt packages land in the
 // unversioned dist-packages dir, chroot pip installs in versioned
-// /usr/local/lib/python3.X dirs (discovered on disk since they only exist
-// after the first install).
+// /usr/local/lib/python3.X dirs. Versions come from the image's /usr/lib
+// (present before any install, so the path works within the same tool call
+// that first runs pip) plus the chroot's /usr/local/lib as a fallback for
+// any version drift between image and chroot.
 function kataPythonPaths(dataRoot: string): string[] {
-  const paths = [`${dataRoot}/usr/lib/python3/dist-packages`];
-  try {
-    for (const entry of readdirSync(`${dataRoot}/usr/local/lib`)) {
-      if (/^python3(\.\d+)?$/.test(entry)) {
-        paths.push(`${dataRoot}/usr/local/lib/${entry}/dist-packages`);
+  const versions = new Set<string>();
+  for (const libDir of ["/usr/lib", `${dataRoot}/usr/local/lib`]) {
+    try {
+      for (const entry of readdirSync(libDir)) {
+        if (/^python3\.\d+$/.test(entry)) {
+          versions.add(entry);
+        }
       }
+    } catch {
+      // Directory missing (e.g. chroot not bootstrapped yet) — skip.
     }
-  } catch {
-    // Chroot not bootstrapped yet — the unversioned apt path is enough.
   }
-  return paths;
+  return [
+    `${dataRoot}/usr/lib/python3/dist-packages`,
+    ...[...versions].map(
+      (version) => `${dataRoot}/usr/local/lib/${version}/dist-packages`,
+    ),
+  ];
 }
 
 /**

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -141,11 +141,13 @@ function kataPythonPaths(dataRoot: string): string[] {
       // Directory missing (e.g. chroot not bootstrapped yet) — skip.
     }
   }
+  // pip's /usr/local dirs must precede the apt dir, mirroring Debian's
+  // sys.path order, so a pip-upgraded package wins over an older apt one.
   return [
-    `${dataRoot}/usr/lib/python3/dist-packages`,
     ...[...versions].map(
       (version) => `${dataRoot}/usr/local/lib/${version}/dist-packages`,
     ),
+    `${dataRoot}/usr/lib/python3/dist-packages`,
   ];
 }
 

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -5,6 +5,8 @@
  *
  * Shared by the sandbox bash tool and skill sandbox runner.
  */
+import { readdirSync } from "node:fs";
+
 import { getGatewayInternalBaseUrl } from "../../config/env.js";
 import { getDataDir, getWorkspaceDir } from "../../util/platform.js";
 
@@ -80,7 +82,12 @@ export const KATA_SAFE_ENV_VARS = [
   "VELLUM_APT_DATA_MIRROR",
 ] as const;
 
-export const KATA_INJECTED_ENV_VARS = ["LD_LIBRARY_PATH"] as const;
+export const KATA_INJECTED_ENV_VARS = [
+  "LD_LIBRARY_PATH",
+  "PYTHONPATH",
+  "PYTHONUSERBASE",
+  "BUN_INSTALL",
+] as const;
 
 const KATA_APT_DATA_ROOT = "/data/system";
 const KATA_FAMILY_SANDBOX_RUNTIMES = new Set([
@@ -113,6 +120,24 @@ function kataAptLibraryPaths(dataRoot: string): string[] {
     `${dataRoot}/usr/lib/x86_64-linux-gnu`,
     `${dataRoot}/usr/lib/aarch64-linux-gnu`,
   ];
+}
+
+// Python packages installed into the chroot: apt packages land in the
+// unversioned dist-packages dir, chroot pip installs in versioned
+// /usr/local/lib/python3.X dirs (discovered on disk since they only exist
+// after the first install).
+function kataPythonPaths(dataRoot: string): string[] {
+  const paths = [`${dataRoot}/usr/lib/python3/dist-packages`];
+  try {
+    for (const entry of readdirSync(`${dataRoot}/usr/local/lib`)) {
+      if (/^python3(\.\d+)?$/.test(entry)) {
+        paths.push(`${dataRoot}/usr/local/lib/${entry}/dist-packages`);
+      }
+    }
+  } catch {
+    // Chroot not bootstrapped yet — the unversioned apt path is enough.
+  }
+  return paths;
 }
 
 /**
@@ -159,6 +184,21 @@ export function buildSanitizedEnv(): Record<string, string> {
       undefined,
       kataAptLibraryPaths(kataAptDataRoot),
     );
+    env.PYTHONPATH = appendUniquePathEntries(
+      undefined,
+      kataPythonPaths(kataAptDataRoot),
+    );
+    // The image bakes these under ephemeral /home/assistant; $HOME is the
+    // persistent data volume on kata pods, so user-level installs survive
+    // machine saves.
+    if (env.HOME) {
+      env.PYTHONUSERBASE = `${env.HOME}/.python`;
+      env.BUN_INSTALL = `${env.HOME}/.bun`;
+      env.PATH = appendUniquePathEntries(
+        `${env.PYTHONUSERBASE}/bin:${env.BUN_INSTALL}/bin`,
+        env.PATH.split(":").filter(Boolean),
+      );
+    }
   }
   // Always inject an internal gateway base for local control-plane/API calls.
   const internalGatewayBase = getGatewayInternalBaseUrl();


### PR DESCRIPTION
## Summary
- Add `pip`/`pip3` wrappers (mirroring the existing `apt`/`apt-get`/`dpkg` wrappers) that route root pip installs into the persistent apt chroot at `/data/system` on Kata-family runtimes, auto-installing `python3-pip` into the chroot on first use; the image now also ships `python3-pip` so non-root and non-kata invocations work.
- Export `PYTHONPATH` pointing at the chroot's dist-packages dirs — in `docker-kata-apt-env.sh` for interactive shells and in `buildSanitizedEnv()` for daemon-spawned processes — so python packages installed via `apt` (e.g. `python3-cryptography`) or chroot pip are importable by the image python. Previously they persisted but were invisible, which read as "not persisted".
- Repoint `PYTHONUSERBASE` and `BUN_INSTALL` from the ephemeral `/home/assistant` rootfs to `$HOME` (the persistent data volume on platform kata pods), so `pip install --user` and `bun add -g` survive saves too.

Note: the original plan sourced `docker-kata-apt-env.sh` from `docker-entrypoint.sh` for daemon-spawned processes, but the repo intentionally keeps the daemon's own env free of chroot loader paths (locked by a test — chroot `LD_LIBRARY_PATH` in the daemon's bun process would be unsafe). The env injection landed in `buildSanitizedEnv()` instead, which is the sanctioned path for everything the daemon spawns.

Rollout: takes effect when the sandbox image is next pushed (release cut), not on merge.

## Original prompt
Users on kata-runtime assistant machines report that installing python system packages (e.g. `cryptography`, `bq`) does not persist across machine saves — only the `/data`, `/workspace`, and dockerd volumes survive, and all python install paths landed on the ephemeral image rootfs (or persisted invisibly in the apt chroot without being importable). Requested fix: make python installs persist the same way apt installs already do, covering PYTHONPATH exposure of the chroot, persistent PYTHONUSERBASE/BUN_INSTALL, and pip wrappers routing system installs into the chroot.