### PR TITLE
feat(voice): count spoken progress updates in turn metrics

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -335,7 +335,30 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(completed).not.toHaveProperty("ackSpoken");
   });
 
-  test("omits endpoint and ack fields for turns that never touch the features", () => {
+  test("accumulates spoken progress updates on the turn and aggregate fields", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-prog",
+      conversationId: "conversation-prog",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-prog");
+    const frame = collector.markProgressSpoken("turn-prog");
+    expect(frame.event).toBe("progress_spoken");
+    collector.markProgressSpoken("turn-prog");
+    const completed = collector.completeTurn();
+
+    expect(completed).toMatchObject({
+      turnId: "turn-prog",
+      progressUpdatesSpoken: 2,
+    });
+    expect(
+      getLiveVoiceMetricsAggregateFields(collector.getSnapshot(), "turn-prog"),
+    ).toMatchObject({ progressUpdatesSpoken: 2 });
+  });
+
+  test("omits endpoint, ack, and progress fields for turns that never touch the features", () => {
     const clock = makeClock(0);
     const collector = new LiveVoiceMetricsCollector({
       sessionId: "session-off",
@@ -350,6 +373,7 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(completed).not.toHaveProperty("endpointHoldCount");
     expect(completed).not.toHaveProperty("endpointDecisionMaxLatencyMs");
     expect(completed).not.toHaveProperty("ackSpoken");
+    expect(completed).not.toHaveProperty("progressUpdatesSpoken");
 
     const aggregateFields = getLiveVoiceMetricsAggregateFields(
       collector.getSnapshot(),
@@ -358,6 +382,7 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(aggregateFields).not.toHaveProperty("endpointHoldCount");
     expect(aggregateFields).not.toHaveProperty("endpointDecisionMaxLatencyMs");
     expect(aggregateFields).not.toHaveProperty("ackSpoken");
+    expect(aggregateFields).not.toHaveProperty("progressUpdatesSpoken");
   });
 
   test("markBargeIn records a first-wins timestamp on the active turn", () => {

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -153,6 +153,7 @@ function progressConfig(
 function createProgressHarness(options: {
   frontModelConfig: Partial<LiveVoiceFrontModelConfig>;
   frontDecider: VoiceFrontDecider;
+  emitMetrics?: boolean;
 }) {
   const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
   const { streamTtsAudio, ttsTexts } = createRecordingTtsStreamer();
@@ -164,6 +165,7 @@ function createProgressHarness(options: {
     frontModelConfig: options.frontModelConfig,
     frontDecider: options.frontDecider,
     createTurnId: () => "live-turn-1",
+    emitMetrics: options.emitMetrics ?? false,
   });
 
   return { frames, session, getCallbacks, ttsTexts };
@@ -536,6 +538,35 @@ describe("LiveVoiceSession progress narration", () => {
 
     expect(generateProgressText).toHaveBeenCalledTimes(1);
     expect(ttsTexts).toEqual([]);
+  });
+
+  test("a spoken narration lands progressUpdatesSpoken on the turn's metrics frame", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ idleIntervalMs: 40, maxPerTurn: 1 }),
+      frontDecider: makeProgressDecider(generateProgressText),
+      emitMetrics: true,
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([GENERATED_NARRATION]);
+
+    emitMessageComplete(getCallbacks);
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+
+    const completedMetrics = frames.find(
+      (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+    );
+    expect(completedMetrics).toMatchObject({
+      type: "metrics",
+      turnId: "live-turn-1",
+      progressUpdatesSpoken: 1,
+    });
   });
 
   test("progress.enabled false: zero narrations and zero decider calls", async () => {

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -19,6 +19,7 @@ export type LiveVoiceMetricsEvent =
   | "final_transcript"
   | "first_assistant_delta"
   | "ack_spoken"
+  | "progress_spoken"
   | "first_tts_audio"
   | "turn_completed"
   | "turn_cancelled"
@@ -103,11 +104,12 @@ interface LiveVoiceTurnMetrics {
   timestamps: LiveVoiceTurnTimestamps;
   durations: LiveVoiceTurnDurations;
   // Present only when the semantic-endpointing decider was consulted for the
-  // turn / when an ack actually spoke, so turns that never touch the
-  // features carry no trace of them.
+  // turn / when an ack actually spoke / when a progress narration spoke, so
+  // turns that never touch the features carry no trace of them.
   endpointHoldCount?: number;
   endpointDecisionMaxLatencyMs?: number;
   ackSpoken?: LiveVoiceSpokenAckKind;
+  progressUpdatesSpoken?: number;
 }
 
 interface LiveVoiceDurationSummary {
@@ -149,6 +151,7 @@ interface LiveVoiceMetricsAggregateFields {
   endpointHoldCount?: number;
   endpointDecisionMaxLatencyMs?: number;
   ackSpoken?: LiveVoiceSpokenAckKind;
+  progressUpdatesSpoken?: number;
 }
 
 export interface LiveVoiceMetricsFrame {
@@ -170,6 +173,7 @@ interface MutableTurn {
   // decision was ever recorded for the turn.
   endpointDecisionMaxLatencyMs: number | null;
   ackSpoken: LiveVoiceSpokenAckKind | null;
+  progressUpdatesSpoken: number;
 }
 
 const DEFAULT_RECENT_TURN_LIMIT = 50;
@@ -234,6 +238,7 @@ export class LiveVoiceMetricsCollector {
       endpointHoldCount: 0,
       endpointDecisionMaxLatencyMs: null,
       ackSpoken: null,
+      progressUpdatesSpoken: 0,
     };
     this.applySeedMarks(this.activeTurn, seedMarks);
     this.emit("turn_started", turnId);
@@ -330,6 +335,14 @@ export class LiveVoiceMetricsCollector {
       turn.ackSpoken = kind;
     }
     return this.emit("ack_spoken", turn.turnId);
+  }
+
+  // A counter, not a first-wins mark: every spoken progress narration bumps
+  // the per-turn count.
+  markProgressSpoken(turnId?: string): LiveVoiceMetricsFrame {
+    const turn = this.ensureActiveTurn(turnId);
+    turn.progressUpdatesSpoken += 1;
+    return this.emit("progress_spoken", turn.turnId);
   }
 
   markBargeIn(turnId?: string): LiveVoiceMetricsFrame {
@@ -525,24 +538,30 @@ function aggregateFieldsForTurn(
     ttsFirstAudioMs: turn.durations.firstAssistantDeltaToFirstTtsAudioMs,
     roundTripMs: turn.durations.roundTripMs,
     totalMs: turn.durations.totalTurnDurationMs,
-    ...endpointAndAckFields(turn),
+    ...frontModelFields(turn),
   };
 }
 
 // Shared optional front-model fields for turn snapshots and aggregate
 // frame fields: absent unless the endpoint decider was consulted / an ack
-// spoke, so turns that never touch the features are unchanged.
-function endpointAndAckFields(
+// spoke / a progress narration spoke, so turns that never touch the
+// features are unchanged.
+function frontModelFields(
   // Accepts both MutableTurn (null = unset) and snapshot (absent = unset).
   turn: {
     endpointHoldCount?: number | null;
     endpointDecisionMaxLatencyMs?: number | null;
     ackSpoken?: LiveVoiceSpokenAckKind | null;
+    progressUpdatesSpoken?: number | null;
   },
 ): Pick<
   LiveVoiceTurnMetrics,
-  "endpointHoldCount" | "endpointDecisionMaxLatencyMs" | "ackSpoken"
+  | "endpointHoldCount"
+  | "endpointDecisionMaxLatencyMs"
+  | "ackSpoken"
+  | "progressUpdatesSpoken"
 > {
+  const progressUpdatesSpoken = turn.progressUpdatesSpoken ?? 0;
   return {
     ...(turn.endpointDecisionMaxLatencyMs != null
       ? {
@@ -551,6 +570,7 @@ function endpointAndAckFields(
         }
       : {}),
     ...(turn.ackSpoken != null ? { ackSpoken: turn.ackSpoken } : {}),
+    ...(progressUpdatesSpoken > 0 ? { progressUpdatesSpoken } : {}),
   };
 }
 
@@ -588,6 +608,7 @@ function cloneMutableTurn(turn: MutableTurn): MutableTurn {
     endpointHoldCount: turn.endpointHoldCount,
     endpointDecisionMaxLatencyMs: turn.endpointDecisionMaxLatencyMs,
     ackSpoken: turn.ackSpoken,
+    progressUpdatesSpoken: turn.progressUpdatesSpoken,
   };
 }
 
@@ -598,7 +619,7 @@ function snapshotTurn(turn: MutableTurn): LiveVoiceTurnMetrics {
     status: turn.status,
     cancellationReason: turn.cancellationReason,
     timestamps,
-    ...endpointAndAckFields(turn),
+    ...frontModelFields(turn),
     durations: {
       firstAudioToFirstPartialMs: duration(
         timestamps.firstAudioAtMs,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2903,6 +2903,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       progress.opsSinceNarration = 0;
       progress.updatesSpoken += 1;
       progress.lastFloorHolderAtMs = Date.now();
+      // Like the ack mark, recorded only when narration audio actually
+      // enqueued (decider text or static fallback alike).
+      this.markProgressSpoken(turn);
       // Restart the dead-air countdown from this narration.
       this.armProgressIdleTimer(turn);
     } finally {
@@ -3418,6 +3421,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
     this.metrics.markAckSpoken(activeTurn.turnId, kind);
+  }
+
+  private markProgressSpoken(activeTurn: ActiveAssistantTurn): void {
+    const { utterance } = activeTurn;
+    if (!this.startMetricsTurnIfNeeded(utterance, activeTurn.turnId)) {
+      return;
+    }
+    this.metrics.markProgressSpoken(activeTurn.turnId);
   }
 
   private ensureTurnId(utterance: UtteranceCycle): string {

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -265,6 +265,12 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly endpointDecisionMaxLatencyMs?: number;
   /** Which floor-holding ack actually spoke during the turn, if any. */
   readonly ackSpoken?: "first_delta" | "tool_use";
+  /**
+   * Spoken progress narrations during the turn. Present only when at least
+   * one progress update spoke (otherwise the field is absent, keeping frames
+   * unchanged).
+   */
+  readonly progressUpdatesSpoken?: number;
 }
 
 export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -244,6 +244,12 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly endpointDecisionMaxLatencyMs?: number;
   /** Which floor-holding ack actually spoke during the turn, if any. */
   readonly ackSpoken?: "first_delta" | "tool_use";
+  /**
+   * Spoken progress narrations during the turn. Present only when at least
+   * one progress update spoke (otherwise the field is absent, keeping frames
+   * unchanged).
+   */
+  readonly progressUpdatesSpoken?: number;
 }
 
 export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {


### PR DESCRIPTION
## Summary
- Optional progressUpdatesSpoken on turn snapshot + aggregate metrics frames (absent unless > 0)
- markProgressSpoken recorded where narration audio actually enqueues
- Assistant + web protocol mirrors

Part of plan: front-model-progress-narration.md (PR 4 of 4)