### PR TITLE
fix(macos): allow hosted voice-preview audio through the CSP

### DIFF
--- a/clients/macos/src/main/csp.test.ts
+++ b/clients/macos/src/main/csp.test.ts
@@ -45,6 +45,17 @@ describe("CSP_POLICY", () => {
     expect(scriptSrc).toContain("https://*.vellum.ai");
   });
 
+  test("media-src allows the hosted voice-preview sources", () => {
+    const mediaSrc = directiveValue("media-src")!;
+    // ElevenLabs premade previews are path-scoped to their public bucket
+    // so the rest of GCS stays blocked for media.
+    expect(mediaSrc).toContain(
+      "https://storage.googleapis.com/eleven-public-prod/",
+    );
+    expect(mediaSrc).toContain("https://static.deepgram.com/");
+    expect(mediaSrc).not.toContain("https://storage.googleapis.com ");
+  });
+
   test("object-src is 'none'", () => {
     expect(directiveValue("object-src")).toBe("'none'");
   });

--- a/clients/macos/src/main/csp.ts
+++ b/clients/macos/src/main/csp.ts
@@ -43,7 +43,10 @@ export const CSP_POLICY = [
   "style-src 'self' 'unsafe-inline'",
   `connect-src 'self' blob: data: https://${WILDCARD_HOST} wss://${WILDCARD_HOST} https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com https://storage.googleapis.com https://*.storage.googleapis.com ws://localhost:* ws://127.0.0.1:*`,
   "img-src 'self' https: data: blob:",
-  "media-src 'self' blob:",
+  // Hosted voice-preview samples: ElevenLabs premades live in the
+  // eleven-public-prod GCS bucket (path-scoped so the rest of GCS stays
+  // blocked for media), Deepgram Aura previews on static.deepgram.com.
+  "media-src 'self' blob: https://storage.googleapis.com/eleven-public-prod/ https://static.deepgram.com/",
   "worker-src 'self' blob: https://cdn.jsdelivr.net",
   "font-src 'self' data:",
   "object-src 'none'",


### PR DESCRIPTION
## Summary

- Adds the two hosted voice-preview sources to the Electron `media-src` CSP directive: `https://storage.googleapis.com/eleven-public-prod/` (path-scoped to ElevenLabs' public premade bucket — the rest of GCS stays blocked for media) and `https://static.deepgram.com/`. Previously `media-src 'self' blob:` blocked the settings voice picker's preview button for **every** hosted sample in the desktop app — Deepgram previews included, not just the new ElevenLabs ones. `connect-src` already trusted these hosts.
- Test asserts both sources are present and that the ElevenLabs entry stays path-scoped rather than granting all of `storage.googleapis.com`.

## Repro

Observed live in the Dev app (2026-07-20): clicking Preview for an ElevenLabs voice logged `Loading media from 'https://storage.googleapis.com/eleven-public-prod/…mp3' violates the following Content Security Policy directive` in the renderer. Found while verifying the ElevenLabs managed-TTS rollout end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RixYT2EcehgsxSCqvjJD9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->